### PR TITLE
consomme: autotune per-connection TCP ring buffers

### DIFF
--- a/Guide/src/reference/backends/consomme.md
+++ b/Guide/src/reference/backends/consomme.md
@@ -131,6 +131,16 @@ Key implications of the split-TCP design:
 Consomme supports TCP Segmentation Offload (TSO) from the guest NIC,
 window scaling, and MSS negotiation.
 
+The per-connection ring buffers autotune. Each connection starts with a
+small buffer (16 KiB by default) and grows on demand — doubling under
+sustained throughput pressure up to a ceiling (4 MiB by default) — so
+idle and short-lived connections stay cheap while bulk transfers can
+ramp up to a large window. Embedders can override the bounds via the
+`tcp_rx_buffer` and `tcp_tx_buffer` fields on `ConsommeParams` (each a
+`TcpBufferBounds { initial, max }`); the values are clamped to
+`[16 KiB, 4 MiB]` and rounded up to a power of two. Setting
+`initial == max` pins a fixed size and disables growth.
+
 Inbound connections require explicit port forwarding — OpenVMM can
 programmatically bind host ports and forward them into the guest.
 

--- a/vm/devices/net/net_consomme/consomme/src/lib.rs
+++ b/vm/devices/net/net_consomme/consomme/src/lib.rs
@@ -33,6 +33,13 @@ mod windows;
 /// Standard DNS port number.
 const DNS_PORT: u16 = 53;
 
+/// Default per-connection TCP ring buffer bounds: start small and autotune up
+/// to a few MiB so idle/short connections stay cheap while bulk flows ramp.
+const DEFAULT_TCP_BUFFER_BOUNDS: TcpBufferBounds = TcpBufferBounds {
+    initial: 16 * 1024,
+    max: 4 * 1024 * 1024,
+};
+
 use inspect::Inspect;
 use inspect::InspectMut;
 use pal_async::driver::Driver;
@@ -171,6 +178,36 @@ pub struct ConsommeParams {
     /// routable IPv6 address.
     #[inspect(display)]
     pub skip_ipv6_checks: bool,
+    /// Per-connection TCP receive ring buffer bounds (guest-to-host).
+    pub tcp_rx_buffer: TcpBufferBounds,
+    /// Per-connection TCP transmit ring buffer bounds (host-to-guest).
+    pub tcp_tx_buffer: TcpBufferBounds,
+}
+
+/// Bounds for a per-connection TCP ring buffer.
+///
+/// The buffer is allocated at `initial` and may grow up to `max` as demand
+/// warrants. Both values are clamped to `[16 KiB, 4 MiB]` and rounded up to a
+/// power of two, then `initial` is clamped to be no greater than `max`. The
+/// advertised TCP window scale is derived from `max`, so `max` is fixed for
+/// the connection's lifetime.
+///
+/// Note that if the peer does not negotiate window scaling, the effective
+/// receive window (and thus the useful rx capacity) is capped at `u16::MAX`
+/// regardless of `max`.
+#[derive(Inspect, Clone, Copy, Debug, PartialEq, Eq)]
+pub struct TcpBufferBounds {
+    /// Starting capacity, allocated up front.
+    pub initial: usize,
+    /// Ceiling for autotuned growth.
+    pub max: usize,
+}
+
+impl TcpBufferBounds {
+    /// Use the same value for `initial` and `max`. Disables autotune growth.
+    pub const fn fixed(n: usize) -> Self {
+        Self { initial: n, max: n }
+    }
 }
 
 /// An error indicating that the CIDR is invalid.
@@ -204,6 +241,8 @@ impl ConsommeParams {
             // Per RFC 4787, UDP NAT bindings, by default, should timeout after 5 minutes, but can be configured.
             udp_timeout: Duration::from_secs(300),
             skip_ipv6_checks: false,
+            tcp_rx_buffer: DEFAULT_TCP_BUFFER_BOUNDS,
+            tcp_tx_buffer: DEFAULT_TCP_BUFFER_BOUNDS,
         })
     }
 
@@ -696,13 +735,15 @@ impl Consomme {
                 }
             };
         let timeout = params.udp_timeout;
+        let tcp_rx_buffer = params.tcp_rx_buffer;
+        let tcp_tx_buffer = params.tcp_tx_buffer;
         Self {
             state: ConsommeState {
                 params,
                 buffer: Box::new([0; 65536]),
                 local_addr_map: local_addr_map::LocalAddrMap::new(),
             },
-            tcp: tcp::Tcp::new(),
+            tcp: tcp::Tcp::new(tcp_rx_buffer, tcp_tx_buffer),
             udp: udp::Udp::new(timeout),
             icmp: icmp::Icmp::new(),
             dns,

--- a/vm/devices/net/net_consomme/consomme/src/tcp.rs
+++ b/vm/devices/net/net_consomme/consomme/src/tcp.rs
@@ -68,7 +68,6 @@ pub(crate) struct Tcp {
     connections: HashMap<FourTuple, TcpConnection>,
     #[inspect(iter_by_key)]
     listeners: HashMap<PortForwardKey, TcpListener>,
-    #[inspect(mut)]
     connection_params: ConnectionParams,
     aggregate_stats: TcpAggregateStats,
 }
@@ -96,12 +95,28 @@ impl TcpAggregateStats {
     }
 }
 
-#[derive(InspectMut)]
+#[derive(Inspect)]
 struct ConnectionParams {
-    #[inspect(mut)]
-    rx_buffer_size: usize,
-    #[inspect(mut)]
-    tx_buffer_size: usize,
+    rx_buffer: NormalizedBufferBounds,
+    tx_buffer: NormalizedBufferBounds,
+}
+
+/// Normalized version of [`crate::TcpBufferBounds`] with both values clamped
+/// to `[16 KiB, 4 MiB]` and rounded up to a power of two, then `initial`
+/// further clamped to be no greater than `max`.
+#[derive(Inspect, Clone, Copy, Debug)]
+struct NormalizedBufferBounds {
+    initial: usize,
+    max: usize,
+}
+
+impl NormalizedBufferBounds {
+    fn from_bounds(b: crate::TcpBufferBounds) -> Self {
+        let clamp = |v: usize| v.clamp(16 << 10, 4 << 20).next_power_of_two();
+        let max = clamp(b.max);
+        let initial = clamp(b.initial).min(max);
+        Self { initial, max }
+    }
 }
 
 #[derive(Debug, Error)]
@@ -119,13 +134,13 @@ pub enum TcpError {
 }
 
 impl Tcp {
-    pub fn new() -> Self {
+    pub fn new(rx_buffer: crate::TcpBufferBounds, tx_buffer: crate::TcpBufferBounds) -> Self {
         Self {
             connections: HashMap::new(),
             listeners: HashMap::new(),
             connection_params: ConnectionParams {
-                rx_buffer_size: 256 * 1024,
-                tx_buffer_size: 256 * 1024,
+                rx_buffer: NormalizedBufferBounds::from_bounds(rx_buffer),
+                tx_buffer: NormalizedBufferBounds::from_bounds(tx_buffer),
             },
             aggregate_stats: TcpAggregateStats::default(),
         }
@@ -169,6 +184,13 @@ struct TcpConnectionInner {
     #[inspect(hex)]
     rx_window_cap: usize,
     rx_window_scale: u8,
+    /// Autotune ceiling for `rx_window_cap`. Once `rx_window_cap` reaches this
+    /// value, no further grow is attempted. The backing ring is rounded up to a
+    /// power of two, so its allocated capacity can slightly exceed this value
+    /// (e.g. when window scaling is disabled and this is capped to `u16::MAX`,
+    /// the ring is 65536 while this is 65535).
+    #[inspect(hex)]
+    rx_buffer_max: usize,
     #[inspect(with = "inspect_seq")]
     rx_seq: TcpSeqNumber,
     #[inspect(flatten)]
@@ -179,6 +201,9 @@ struct TcpConnectionInner {
 
     #[inspect(with = "|x| x.len()")]
     tx_buffer: ring::Ring,
+    /// Autotune ceiling for the tx_buffer ring capacity.
+    #[inspect(hex)]
+    tx_buffer_max: usize,
     #[inspect(with = "inspect_seq")]
     tx_acked: TcpSeqNumber,
     #[inspect(with = "inspect_seq")]
@@ -262,6 +287,10 @@ struct TcpConnStats {
     tx_segment_size: Histogram<14>,
     /// Segment size distribution for packets received from guest.
     rx_segment_size: Histogram<14>,
+    /// Number of times the tx_buffer ring capacity was grown by autotune.
+    tx_buffer_grows: Counter,
+    /// Number of times the rx_buffer ring capacity was grown by autotune.
+    rx_buffer_grows: Counter,
 }
 
 fn inspect_seq(seq: &TcpSeqNumber) -> inspect::AsHex<u32> {
@@ -735,27 +764,26 @@ impl TcpConnection {
             rx_tx_seq[4..8].try_into().expect("invalid length"),
         ));
 
-        let rx_buffer_size: usize = params.rx_buffer_size.clamp(16384, 4 << 20);
+        let rx_bounds = params.rx_buffer;
         let rx_window_scale =
-            (usize::BITS - rx_buffer_size.leading_zeros()).saturating_sub(16) as u8;
+            (usize::BITS - rx_bounds.max.leading_zeros()).saturating_sub(16) as u8;
 
-        let tx_buffer_size = params
-            .tx_buffer_size
-            .clamp(16384, 4 << 20)
-            .next_power_of_two();
+        let tx_bounds = params.tx_buffer;
 
         TcpConnectionInner {
             loopback_port: LoopbackPortInfo::None,
             state: TcpState::Connecting,
             rx_buffer: ring::Ring::new(0),
-            rx_window_cap: rx_buffer_size,
+            rx_window_cap: rx_bounds.initial,
             rx_window_scale,
+            rx_buffer_max: rx_bounds.max,
             rx_seq,
             rx_assembler: assembler::Assembler::new(),
             needs_ack: false,
             is_shutdown: false,
             enable_window_scaling: false,
-            tx_buffer: ring::Ring::new(tx_buffer_size),
+            tx_buffer: ring::Ring::new(tx_bounds.initial),
+            tx_buffer_max: tx_bounds.max,
             tx_acked: tx_seq,
             tx_send: tx_seq,
             tx_window_len: 1,
@@ -906,6 +934,7 @@ impl TcpConnectionInner {
             // since without window scaling, the window field is only 16 bits.
             self.enable_window_scaling = false;
             self.rx_window_cap = self.rx_window_cap.min(u16::MAX as usize);
+            self.rx_buffer_max = self.rx_buffer_max.min(u16::MAX as usize);
             self.rx_window_scale = 0;
         }
 
@@ -1059,51 +1088,66 @@ impl TcpConnectionInner {
                     *opt_socket = None;
                 }
             } else {
-                while !self.tx_buffer.is_full() {
-                    let (a, b) = self.tx_buffer.unwritten_slices_mut();
-                    let mut bufs = [IoSliceMut::new(a), IoSliceMut::new(b)];
-                    match Pin::new(&mut *socket).poll_read_vectored(cx, &mut bufs) {
-                        Poll::Ready(Ok(n)) => {
-                            if n == 0 {
-                                self.close();
-                                break;
+                // Drain the host socket into the tx ring until the socket has
+                // no more data (Pending) or the ring reaches its autotune
+                // ceiling. When the ring fills with data still pending, grow it
+                // (doubling, capped at tx_buffer_max) and keep reading so the
+                // freshly added capacity is used in this same poll rather than
+                // waiting for a later guest ACK to re-clock the connection.
+                'read: loop {
+                    while !self.tx_buffer.is_full() {
+                        let (a, b) = self.tx_buffer.unwritten_slices_mut();
+                        let mut bufs = [IoSliceMut::new(a), IoSliceMut::new(b)];
+                        match Pin::new(&mut *socket).poll_read_vectored(cx, &mut bufs) {
+                            Poll::Ready(Ok(n)) => {
+                                if n == 0 {
+                                    self.close();
+                                    break 'read;
+                                }
+                                self.tx_buffer.extend_by(n);
                             }
-                            self.tx_buffer.extend_by(n);
-                        }
-                        Poll::Ready(Err(err)) => {
-                            match err.kind() {
-                                ErrorKind::ConnectionReset => tracing::trace!(
-                                    error = &err as &dyn std::error::Error,
-                                    src = %sender.ft.src,
-                                    dst = %sender.ft.dst,
-                                    "socket read error"
-                                ),
-                                _ => tracelimit::warn_ratelimited!(
-                                    error = &err as &dyn std::error::Error,
-                                    src = %sender.ft.src,
-                                    dst = %sender.ft.dst,
-                                    "socket read error"
-                                ),
+                            Poll::Ready(Err(err)) => {
+                                match err.kind() {
+                                    ErrorKind::ConnectionReset => tracing::trace!(
+                                        error = &err as &dyn std::error::Error,
+                                        src = %sender.ft.src,
+                                        dst = %sender.ft.dst,
+                                        "socket read error"
+                                    ),
+                                    _ => tracelimit::warn_ratelimited!(
+                                        error = &err as &dyn std::error::Error,
+                                        src = %sender.ft.src,
+                                        dst = %sender.ft.dst,
+                                        "socket read error"
+                                    ),
+                                }
+                                sender.rst(self.tx_send, Some(self.rx_seq));
+                                self.stats.rsts_tx.increment();
+                                return false;
                             }
-                            sender.rst(self.tx_send, Some(self.rx_seq));
-                            self.stats.rsts_tx.increment();
-                            return false;
+                            Poll::Pending => break 'read,
                         }
-                        Poll::Pending => break,
                     }
+
+                    // The ring is full. If we can still grow, double it (capped
+                    // at tx_buffer_max) and keep reading into the new space. At
+                    // the ceiling we stop without re-arming: the cached socket
+                    // readiness stays set and the next guest ACK that drains the
+                    // ring re-clocks the read, which is safe on edge-triggered
+                    // epoll backends.
+                    if self.tx_buffer.capacity() >= self.tx_buffer_max {
+                        break;
+                    }
+                    let new_cap = (self.tx_buffer.capacity() * 2).min(self.tx_buffer_max);
+                    self.tx_buffer.resize(new_cap);
+                    self.stats.tx_buffer_grows.increment();
                 }
-                // When the buffer fills without hitting Pending, the socket's
-                // cached readiness remains set (successful reads don't clear
-                // it). No explicit waker re-arm is needed — the next poll cycle
-                // (triggered when the guest ACKs and drains the buffer) will
-                // naturally retry the read via the still-cached readiness.
-                // Clearing readiness synthetically would be unsafe on
-                // edge-triggered epoll backends.
             }
         }
 
         // Handle the rx path.
         if let Some(socket) = opt_socket.as_mut() {
+            let rx_high_water = self.rx_buffer.len();
             while !self.rx_buffer.is_empty() {
                 let view = self.rx_buffer.view(0..self.rx_buffer.len());
                 let (a, b) = view.as_slices();
@@ -1130,6 +1174,27 @@ impl TcpConnectionInner {
                     }
                     Poll::Pending => break,
                 }
+            }
+            // Autotune: if the host kept up (drained to empty) and the buffer
+            // was at least 75% full this cycle, the guest is rx-bound. Grow
+            // both the ring and the advertised window ceiling so the next ACK
+            // tells the guest it can send more. Gated on the assembler being
+            // empty because `Ring::resize` only preserves contiguous bytes
+            // in `[head, tail)` — any out-of-order data staged past `tail`
+            // via `write_at` would be lost.
+            if self.rx_buffer.is_empty()
+                && self.rx_assembler.is_empty()
+                && self.rx_window_cap < self.rx_buffer_max
+                && rx_high_water * 4 >= self.rx_window_cap * 3
+            {
+                let new_cap = (self.rx_window_cap * 2).min(self.rx_buffer_max);
+                let new_ring_cap = new_cap.next_power_of_two();
+                if new_ring_cap > self.rx_buffer.capacity() {
+                    self.rx_buffer.resize(new_ring_cap);
+                }
+                self.rx_window_cap = new_cap;
+                self.needs_ack = true;
+                self.stats.rx_buffer_grows.increment();
             }
             if self.rx_buffer.is_empty() && self.state.rx_fin() && !self.is_shutdown {
                 if let Err(err) = socket.get().shutdown(Shutdown::Write) {

--- a/vm/devices/net/net_consomme/consomme/src/tcp/assembler.rs
+++ b/vm/devices/net/net_consomme/consomme/src/tcp/assembler.rs
@@ -71,7 +71,6 @@ impl Assembler {
         }
     }
 
-    #[cfg(test)]
     pub fn is_empty(&self) -> bool {
         self.count == 0
     }

--- a/vm/devices/net/net_consomme/consomme/src/tcp/ring.rs
+++ b/vm/devices/net/net_consomme/consomme/src/tcp/ring.rs
@@ -74,6 +74,53 @@ impl Ring {
         self.tail += n;
     }
 
+    /// Grow the ring to `new_capacity`. Preserves the bytes in `[head, tail)`.
+    ///
+    /// This is a grow-only operation: `new_capacity` must be a power of two no
+    /// smaller than the current capacity. A resize to the current capacity is a
+    /// no-op, so no reallocation occurs.
+    ///
+    /// Any bytes written via [`Ring::write_at`] past `tail` (out-of-order data
+    /// staged for a future `extend_by`) are NOT preserved. Callers using
+    /// `write_at` must ensure no such staged data exists.
+    pub fn resize(&mut self, new_capacity: usize) {
+        // Copy `src` into `buf` (a power-of-two-sized buffer) starting at logical
+        // offset `at`, wrapping around the end of `buf` as needed.
+        fn place(buf: &mut [u8], at: usize, src: &[u8]) {
+            if src.is_empty() {
+                return;
+            }
+            let mask = buf.len() - 1;
+            let start = at & mask;
+            if start + src.len() <= buf.len() {
+                buf[start..start + src.len()].copy_from_slice(src);
+            } else {
+                let mid = buf.len() - start;
+                buf[start..].copy_from_slice(&src[..mid]);
+                buf[..src.len() - mid].copy_from_slice(&src[mid..]);
+            }
+        }
+
+        assert!(new_capacity.is_power_of_two());
+        assert!(new_capacity >= self.capacity());
+        if new_capacity == self.capacity() {
+            return;
+        }
+        let len = self.len();
+        let mut new_buf = vec![0u8; new_capacity];
+        {
+            // Copy the live `[head, tail)` bytes directly from the existing ring
+            // into their new positions, without staging through a temporary
+            // buffer. `head` keeps its logical value, so its physical offset in
+            // the new buffer is `head & (new_capacity - 1)`.
+            let (a, b) = self.view(0..len).as_slices();
+            let start = self.head.0 & (new_capacity - 1);
+            place(&mut new_buf, start, a);
+            place(&mut new_buf, start + a.len(), b);
+        }
+        self.buf = new_buf;
+    }
+
     /// Write `data` into the ring at `offset` bytes past `head`, without
     /// advancing `tail`. Used for both in-order and out-of-order writes.
     pub fn write_at(&mut self, offset: usize, data: &[u8]) {
@@ -271,5 +318,121 @@ mod tests {
         // Writing empty data should be a no-op.
         ring.write_at(0, &[]);
         assert_eq!(ring.len(), 0);
+    }
+
+    #[test]
+    fn test_resize_empty() {
+        let mut ring = Ring::new(8);
+        ring.resize(64);
+        assert_eq!(ring.capacity(), 64);
+        assert_eq!(ring.len(), 0);
+    }
+
+    #[test]
+    fn test_resize_no_wrap_before_no_wrap_after() {
+        let mut ring = Ring::new(16);
+        ring.write_at(0, &[1, 2, 3, 4, 5, 6, 7, 8]);
+        ring.extend_by(8);
+        ring.resize(64);
+        assert_eq!(ring.capacity(), 64);
+        assert_eq!(ring.len(), 8);
+        let (a, b) = ring.written_slices();
+        let mut data = a.to_vec();
+        data.extend_from_slice(b);
+        assert_eq!(data, vec![1, 2, 3, 4, 5, 6, 7, 8]);
+    }
+
+    #[test]
+    fn test_resize_wrap_before_no_wrap_after() {
+        // head=6, tail=14 (logically). 8-cap ring: physical layout wraps.
+        let mut ring = Ring::new(8);
+        ring.extend_by(6);
+        ring.consume(6);
+        ring.write_at(0, &[1, 2, 3, 4, 5, 6, 7, 8]);
+        ring.extend_by(8);
+        // In the old 8-byte buffer the data wraps at offset 6.
+        let (a, b) = ring.written_slices();
+        assert_eq!(a.len(), 2);
+        assert_eq!(b.len(), 6);
+        ring.resize(32);
+        assert_eq!(ring.capacity(), 32);
+        assert_eq!(ring.len(), 8);
+        let (a, b) = ring.written_slices();
+        let mut data = a.to_vec();
+        data.extend_from_slice(b);
+        assert_eq!(data, vec![1, 2, 3, 4, 5, 6, 7, 8]);
+    }
+
+    #[test]
+    fn test_resize_same_capacity_noop_then_grow() {
+        // A same-capacity resize must be a no-op that preserves data, even when
+        // the live bytes physically wrap in the buffer. Then a real grow must
+        // also preserve them.
+        let mut ring = Ring::new(16);
+        // Advance head so head.0 == 12 (within the old buffer).
+        ring.extend_by(12);
+        ring.consume(12);
+        ring.write_at(0, &[1, 2, 3, 4, 5, 6, 7, 8]);
+        ring.extend_by(8);
+        // head & (16-1) == 12, so the data wraps: 4 bytes at 12..16, 4 at 0..4.
+        let (a, b) = ring.written_slices();
+        assert_eq!(a.len(), 4);
+        assert_eq!(b.len(), 4);
+        // Resize to the current capacity: no-op, data left in place.
+        ring.resize(16);
+        assert_eq!(ring.capacity(), 16);
+        assert_eq!(ring.len(), 8);
+        let (a, b) = ring.written_slices();
+        let mut data = a.to_vec();
+        data.extend_from_slice(b);
+        assert_eq!(data, vec![1, 2, 3, 4, 5, 6, 7, 8]);
+        // Grow to 32: head.0 == 12, mask == 31, start == 12, 12 + 8 == 20, so
+        // the data no longer wraps. It must still be preserved.
+        ring.resize(32);
+        assert_eq!(ring.capacity(), 32);
+        assert_eq!(ring.len(), 8);
+        let (a, b) = ring.written_slices();
+        let mut data = a.to_vec();
+        data.extend_from_slice(b);
+        assert_eq!(data, vec![1, 2, 3, 4, 5, 6, 7, 8]);
+    }
+
+    #[test]
+    fn test_resize_then_extend_uses_new_space() {
+        let mut ring = Ring::new(8);
+        ring.write_at(0, &[1, 2, 3, 4]);
+        ring.extend_by(4);
+        ring.resize(16);
+        assert_eq!(ring.capacity(), 16);
+        // Should have 12 bytes of free space now.
+        let (a, b) = ring.unwritten_slices_mut();
+        assert_eq!(a.len() + b.len(), 12);
+        ring.write_at(4, &[5, 6, 7, 8, 9, 10, 11, 12]);
+        ring.extend_by(8);
+        let (a, b) = ring.written_slices();
+        let mut data = a.to_vec();
+        data.extend_from_slice(b);
+        assert_eq!(data, vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]);
+    }
+
+    #[test]
+    fn test_resize_after_many_wraps() {
+        // Drive head/tail counters well past any single capacity to make sure
+        // resize relies on counter values modulo the new capacity, not the old.
+        let mut ring = Ring::new(8);
+        for _ in 0..100 {
+            ring.write_at(0, &[42, 42, 42, 42]);
+            ring.extend_by(4);
+            ring.consume(4);
+        }
+        assert_eq!(ring.len(), 0);
+        ring.write_at(0, &[1, 2, 3, 4, 5]);
+        ring.extend_by(5);
+        ring.resize(32);
+        assert_eq!(ring.len(), 5);
+        let (a, b) = ring.written_slices();
+        let mut data = a.to_vec();
+        data.extend_from_slice(b);
+        assert_eq!(data, vec![1, 2, 3, 4, 5]);
     }
 }

--- a/vm/devices/net/net_consomme/consomme/src/tcp/tests.rs
+++ b/vm/devices/net/net_consomme/consomme/src/tcp/tests.rs
@@ -10,6 +10,7 @@ use crate::ConsommeParams;
 use crate::IpVersion;
 use crate::PortForwardKey;
 use futures::AsyncRead;
+use futures::AsyncWrite;
 use pal_async::DefaultDriver;
 use pal_async::socket::PolledSocket;
 use parking_lot::Mutex;
@@ -142,11 +143,17 @@ impl TcpTestHarness {
     /// and completes with an ACK. Returns the harness with an
     /// established connection ready for data transfer.
     async fn connect(driver: DefaultDriver) -> Self {
+        Self::connect_with_params(driver, ConsommeParams::new().unwrap()).await
+    }
+
+    /// Like [`connect`](Self::connect), but with caller-provided params, e.g.
+    /// to set custom per-connection TCP buffer bounds.
+    async fn connect_with_params(driver: DefaultDriver, params: ConsommeParams) -> Self {
         let std_listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
         let dst_port = std_listener.local_addr().unwrap().port();
         let mut listener = PolledSocket::new(&driver, std_listener).unwrap();
 
-        let mut consomme = Consomme::new(ConsommeParams::new().unwrap());
+        let mut consomme = Consomme::new(params);
         let mut client = TestClient::new(driver);
 
         let guest_mac = consomme.params_mut().client_mac;
@@ -388,9 +395,77 @@ impl TcpTestHarness {
     }
 
     /// Write data from the host side into the connection.
+    ///
+    /// Polls consomme concurrently while writing so it can drain the host
+    /// socket into `tx_buffer`. Without this, a write larger than the kernel
+    /// socket buffer would block forever, since consomme is the only reader.
+    /// Returns once all of `data` has been handed to the kernel socket.
     async fn host_write(&mut self, data: &[u8]) {
-        use futures::AsyncWriteExt;
-        self.host_stream.write_all(data).await.unwrap();
+        let consomme = &mut self.consomme;
+        let client = &mut self.client;
+        let host_stream = &mut self.host_stream;
+        let mut written = 0;
+        std::future::poll_fn(move |cx| {
+            // Drive consomme so it drains the host socket into the tx ring,
+            // relieving backpressure on the write below.
+            consomme.access(client).poll(cx);
+            while written < data.len() {
+                match Pin::new(&mut *host_stream).poll_write(cx, &data[written..]) {
+                    Poll::Ready(Ok(0)) => panic!("host write returned 0"),
+                    Poll::Ready(Ok(n)) => written += n,
+                    Poll::Ready(Err(e)) => panic!("host write error: {e}"),
+                    Poll::Pending => return Poll::Pending,
+                }
+            }
+            Poll::Ready(())
+        })
+        .await;
+    }
+
+    /// Push `data` from the host side while polling consomme, returning as soon
+    /// as `done` holds for the connection (even if not all of `data` has been
+    /// written).
+    ///
+    /// This is needed when consomme intentionally stops reading the host socket
+    /// (e.g. once the tx ring caps at `max`): the unread remainder stays in the
+    /// kernel socket buffer, and a blocking `write_all` would deadlock. Polling
+    /// consomme concurrently lets it drain the socket and reach the target
+    /// state, which the caller observes via `done`.
+    async fn host_write_until(
+        &mut self,
+        data: &[u8],
+        mut done: impl FnMut(&TcpConnectionInner) -> bool,
+    ) {
+        let ft = self.four_tuple();
+        let consomme = &mut self.consomme;
+        let client = &mut self.client;
+        let host_stream = &mut self.host_stream;
+        let mut written = 0;
+        std::future::poll_fn(move |cx| {
+            consomme.access(client).poll(cx);
+            let inner = &consomme
+                .tcp
+                .connections
+                .get(&ft)
+                .expect("connection should exist")
+                .inner;
+            if done(inner) {
+                return Poll::Ready(());
+            }
+            // Feed more data until the kernel socket buffer is full, then keep
+            // polling consomme so it drains the socket and makes progress toward
+            // `done`.
+            while written < data.len() {
+                match Pin::new(&mut *host_stream).poll_write(cx, &data[written..]) {
+                    Poll::Ready(Ok(0)) => panic!("host write returned 0"),
+                    Poll::Ready(Ok(n)) => written += n,
+                    Poll::Ready(Err(e)) => panic!("host write error: {e}"),
+                    Poll::Pending => break,
+                }
+            }
+            Poll::Pending
+        })
+        .await;
     }
 
     /// Shut down the host side write half (sends EOF to consomme).
@@ -401,6 +476,50 @@ impl TcpTestHarness {
     /// Clear captured guest packets so subsequent searches don't match old ones.
     fn clear_guest_packets(&mut self) {
         self.client.received_packets.lock().clear();
+    }
+
+    /// The four-tuple identifying the established connection.
+    fn four_tuple(&self) -> FourTuple {
+        FourTuple {
+            src: SocketAddr::V4(SocketAddrV4::new(self.guest_ip, self.guest_port)),
+            dst: SocketAddr::V4(SocketAddrV4::new(self.dst_ip, self.dst_port)),
+        }
+    }
+
+    /// Borrow the established connection's inner state for assertions.
+    fn connection_inner(&self) -> &TcpConnectionInner {
+        let ft = self.four_tuple();
+        &self
+            .consomme
+            .tcp
+            .connections
+            .get(&ft)
+            .expect("connection should exist")
+            .inner
+    }
+
+    /// Poll consomme until `cond` holds for the established connection, leaving
+    /// the future pending between polls so the async reactor can run and socket
+    /// readiness can fire.
+    async fn poll_until(&mut self, mut cond: impl FnMut(&TcpConnectionInner) -> bool) {
+        let ft = self.four_tuple();
+        let consomme = &mut self.consomme;
+        let client = &mut self.client;
+        std::future::poll_fn(|cx| {
+            consomme.access(client).poll(cx);
+            let inner = &consomme
+                .tcp
+                .connections
+                .get(&ft)
+                .expect("connection should exist")
+                .inner;
+            if cond(inner) {
+                Poll::Ready(())
+            } else {
+                Poll::Pending
+            }
+        })
+        .await;
     }
 }
 
@@ -1399,5 +1518,98 @@ async fn test_tcp_loopback_port_remap(driver: DefaultDriver) {
     assert!(
         !src_ip.is_loopback(),
         "loopback SYN source IP should not be 127.x.x.x, got {src_ip}"
+    );
+}
+
+/// `NormalizedBufferBounds::from_bounds` clamps to `[16 KiB, 4 MiB]`, rounds up
+/// to a power of two, and keeps `initial <= max`.
+#[test]
+fn test_normalized_buffer_bounds() {
+    use crate::TcpBufferBounds;
+    let n = |initial, max| NormalizedBufferBounds::from_bounds(TcpBufferBounds { initial, max });
+    // Clamp up to the 16 KiB floor.
+    let b = n(1, 1);
+    assert_eq!((b.initial, b.max), (16 << 10, 16 << 10));
+    // Clamp down to the 4 MiB ceiling.
+    let b = n(64 << 20, 64 << 20);
+    assert_eq!((b.initial, b.max), (4 << 20, 4 << 20));
+    // Round non-powers-of-two up.
+    let b = n(100 << 10, 100 << 10);
+    assert_eq!((b.initial, b.max), (128 << 10, 128 << 10));
+    // initial is clamped to be no greater than max.
+    let b = n(4 << 20, 64 << 10);
+    assert_eq!((b.initial, b.max), (64 << 10, 64 << 10));
+}
+
+/// The rx window scale derived from `max` must let the advertised receive
+/// window reach `max` without renegotiating window scaling mid-connection.
+#[pal_async::async_test]
+async fn test_tcp_rx_window_scale_reaches_max(driver: DefaultDriver) {
+    let h = TcpTestHarness::connect(driver).await;
+    let c = h.connection_inner();
+    assert_eq!(c.rx_buffer_max, 4 << 20, "default rx max should be 4 MiB");
+    assert!(
+        c.rx_window_scale > 0,
+        "window scaling must be enabled to grow past 64 KiB"
+    );
+    let max_advertisable = (u16::MAX as usize) << c.rx_window_scale;
+    assert!(
+        max_advertisable >= c.rx_buffer_max,
+        "advertised window ceiling {max_advertisable} must reach rx max {}",
+        c.rx_buffer_max,
+    );
+}
+
+/// Autotune: the tx ring grows past its initial size when the host floods data
+/// faster than the guest ACKs, and stays a power of two within `max`.
+#[pal_async::async_test]
+async fn test_tcp_tx_buffer_autotune_grows(driver: DefaultDriver) {
+    let mut h = TcpTestHarness::connect(driver).await;
+    let initial = h.connection_inner().tx_buffer.capacity();
+
+    // Flood the host->guest direction without ever ACKing from the guest, so
+    // the unacked data piles up in the tx ring and forces it to grow.
+    let payload = vec![0xABu8; 64 << 10];
+    h.host_write(&payload).await;
+    h.poll_until(|c| c.tx_buffer.capacity() > initial).await;
+
+    let cap = h.connection_inner().tx_buffer.capacity();
+    assert!(
+        cap > initial,
+        "tx ring should have grown past {initial}, got {cap}"
+    );
+    assert!(
+        cap.is_power_of_two(),
+        "tx ring capacity must stay a power of two: {cap}"
+    );
+    assert!(
+        cap <= 4 << 20,
+        "tx ring must not exceed the 4 MiB ceiling: {cap}"
+    );
+}
+
+/// Autotune: tx ring growth stops at the configured `max` and never exceeds it.
+#[pal_async::async_test]
+async fn test_tcp_tx_buffer_autotune_caps_at_max(driver: DefaultDriver) {
+    let mut params = ConsommeParams::new().unwrap();
+    // Small ceiling so a modest flood saturates it.
+    params.tcp_tx_buffer = crate::TcpBufferBounds {
+        initial: 16 << 10,
+        max: 32 << 10,
+    };
+    let mut h = TcpTestHarness::connect_with_params(driver, params).await;
+
+    // 64 KiB exceeds the 32 KiB ceiling; consomme only ingests up to the cap
+    // (the rest stays in the host socket buffer). Stop writing as soon as the
+    // ring caps so the unread remainder can't block the write.
+    let payload = vec![0xABu8; 64 << 10];
+    h.host_write_until(&payload, |c| c.tx_buffer.capacity() >= 32 << 10)
+        .await;
+
+    let cap = h.connection_inner().tx_buffer.capacity();
+    assert_eq!(
+        cap,
+        32 << 10,
+        "tx ring must cap at the configured 32 KiB max"
     );
 }


### PR DESCRIPTION
Grows per-connection TCP rings in place from `initial` up to `max` (`TcpBufferBounds`) based on pressure, instead of a fixed size. The default now autotunes (16 KiB → 4 MiB), so idle/short connections start cheaper than the old fixed 256 KiB while bulk flows can ramp to a few MiB.

### What changed
- `ConsommeParams` exposes per-connection `tcp_rx_buffer`/`tcp_tx_buffer` as `TcpBufferBounds { initial, max }` so embedders can pick bounds for their workload.
- `Ring::resize`: grow a power-of-two ring in place, preserving the `[head, tail)` view. rx grow is gated on the assembler + rx buffer being empty.
- rx window scale derived from `rx.max` so the advertised window can grow without re-negotiating at SYN.
- `poll_socket_backend`: double the tx ring when it fills the host read loop; double the rx ring + window when it hit ≥75% then drained (forcing an ACK so the peer picks up the larger window). Capped at `max`. New `tx_buffer_grows`/`rx_buffer_grows` counters.
- `DEFAULT_TCP_BUFFER_BOUNDS` now `16 KiB → 4 MiB` (was fixed 256 KiB).

### Testing
`cargo nextest run -p consomme` passes (incl. new `ring::resize` tests); `cargo clippy --release -p consomme --all-targets` clean.

burette `network` benchmark (`--backend consomme --nic vmbus`, N=5, warm VM), old fixed 256 KiB vs autotune 64 KiB → 4 MiB:

| | Baseline | Autotune | Δ |
|---|---|---|---|
| TCP tx | 5.40 | 9.94 Gbps | +84% |
| TCP rx | 3.86 | 5.21 Gbps | +35% |

A fixed-4 MiB control matches autotune (9.34 / 5.27), so the win is from raising the 256 KiB ceiling — autotune gets it while still starting small.
