### PR TITLE
consomme: remove tcp connections in closing state after timeout

### DIFF
--- a/Guide/src/reference/backends/consomme.md
+++ b/Guide/src/reference/backends/consomme.md
@@ -141,6 +141,14 @@ ramp up to a large window. Embedders can override the bounds via the
 `[16 KiB, 4 MiB]` and rounded up to a power of two. Setting
 `initial == max` pins a fixed size and disables growth.
 
+Connections waiting for a TCP close handshake to make progress use a
+60-second inactivity timeout by default, including connections closed before
+their initial handshake completes. ACKs and newly accepted data restart the
+timeout. Embedders can override it with the `tcp_close_timeout` field on
+`ConsommeParams`. The same duration is used for `TimeWait`, where it
+represents the 2*MSL wait required by RFC 9293. A separate fixed 60-second
+timeout bounds initial handshakes that receive no close request.
+
 Inbound connections require explicit port forwarding — OpenVMM can
 programmatically bind host ports and forward them into the guest.
 

--- a/Guide/src/reference/backends/consomme.md
+++ b/Guide/src/reference/backends/consomme.md
@@ -141,9 +141,11 @@ ramp up to a large window. Embedders can override the bounds via the
 `[16 KiB, 4 MiB]` and rounded up to a power of two. Setting
 `initial == max` pins a fixed size and disables growth.
 
-Connections waiting for a TCP close handshake to make progress use a
+Connections waiting for the peer to advance a TCP close handshake use a
 60-second inactivity timeout by default, including connections closed before
-their initial handshake completes. ACKs and newly accepted data restart the
+their initial handshake completes. `CloseWait` is excluded because the local
+backend can still produce data; its timeout starts when the backend closes and
+the connection enters `LastAck`. ACKs and newly accepted data restart the
 timeout. Embedders can override it with the `tcp_close_timeout` field on
 `ConsommeParams`. The same duration is used for `TimeWait`, where it
 represents the 2*MSL wait required by RFC 9293. A separate fixed 60-second

--- a/vm/devices/net/net_consomme/consomme/src/lib.rs
+++ b/vm/devices/net/net_consomme/consomme/src/lib.rs
@@ -140,6 +140,11 @@ pub struct ConsommeParams {
     /// Idle timeout for UDP connections.
     #[inspect(debug)]
     pub udp_timeout: Duration,
+    /// Timeout for TCP connections sitting in any half-closed state
+    /// (`FinWait1`, `FinWait2`, `Closing`, `LastAck`, or `TimeWait`), after
+    /// which the connection is forcibly cleaned up.
+    #[inspect(debug)]
+    pub tcp_close_timeout: Duration,
     /// If true, skip checks for host IPv6 support and assume the host has a
     /// routable IPv6 address.
     #[inspect(display)]
@@ -176,6 +181,8 @@ impl ConsommeParams {
             client_ip_ipv6_routable: None,
             // Per RFC 4787, UDP NAT bindings, by default, should timeout after 5 minutes, but can be configured.
             udp_timeout: Duration::from_secs(300),
+            // Defaults to 2*MSL per RFC 793 for the `TimeWait` case.
+            tcp_close_timeout: Duration::from_secs(60),
             skip_ipv6_checks: false,
         })
     }
@@ -668,7 +675,7 @@ impl Consomme {
                     None
                 }
             };
-        let timeout = params.udp_timeout;
+        let udp_timeout = params.udp_timeout;
         Self {
             state: ConsommeState {
                 params,
@@ -676,7 +683,7 @@ impl Consomme {
                 local_addr_map: local_addr_map::LocalAddrMap::new(),
             },
             tcp: tcp::Tcp::new(),
-            udp: udp::Udp::new(timeout),
+            udp: udp::Udp::new(udp_timeout),
             icmp: icmp::Icmp::new(),
             dns,
             host_has_ipv6,

--- a/vm/devices/net/net_consomme/consomme/src/lib.rs
+++ b/vm/devices/net/net_consomme/consomme/src/lib.rs
@@ -179,6 +179,11 @@ pub struct ConsommeParams {
     pub client_ip_ipv6_routable: Option<Ipv6Address>,
     /// Idle timeout for UDP connections.
     pub udp_timeout: Duration,
+    /// Inactivity timeout for TCP connections waiting for a close handshake
+    /// to make progress, including closes initiated before the initial
+    /// handshake completes. ACKs and newly accepted data restart the timeout.
+    /// The same duration is used as the `TimeWait` interval.
+    pub tcp_close_timeout: Duration,
     /// If true, skip checks for host IPv6 support and assume the host has a
     /// routable IPv6 address.
     pub skip_ipv6_checks: bool,
@@ -248,6 +253,8 @@ impl ConsommeParams {
             client_ip_ipv6_routable: None,
             // Per RFC 4787, UDP NAT bindings, by default, should timeout after 5 minutes, but can be configured.
             udp_timeout: Duration::from_secs(300),
+            // Defaults to 2*MSL per RFC 9293 for the `TimeWait` case.
+            tcp_close_timeout: Duration::from_secs(60),
             skip_ipv6_checks: false,
             allow_host_local_access: false,
             tcp_rx_buffer: DEFAULT_TCP_BUFFER_BOUNDS,
@@ -826,9 +833,9 @@ impl Consomme {
                     )
                 }
             };
-        let timeout = params.udp_timeout;
         let tcp_rx_buffer = params.tcp_rx_buffer;
         let tcp_tx_buffer = params.tcp_tx_buffer;
+        let udp_timeout = params.udp_timeout;
         Self {
             state: ConsommeState {
                 params,
@@ -836,7 +843,7 @@ impl Consomme {
                 local_addr_map: local_addr_map::LocalAddrMap::new(),
             },
             tcp: tcp::Tcp::new(tcp_rx_buffer, tcp_tx_buffer),
-            udp: udp::Udp::new(timeout),
+            udp: udp::Udp::new(udp_timeout),
             icmp: icmp::Icmp::new(),
             dns,
             host_has_ipv6,

--- a/vm/devices/net/net_consomme/consomme/src/tcp.rs
+++ b/vm/devices/net/net_consomme/consomme/src/tcp.rs
@@ -58,6 +58,8 @@ use std::net::SocketAddrV6;
 use std::pin::Pin;
 use std::task::Context;
 use std::task::Poll;
+use std::time::Duration;
+use std::time::Instant;
 use thiserror::Error;
 
 #[derive(InspectMut)]
@@ -82,6 +84,8 @@ struct TcpAggregateStats {
     connections_closed_peer_rst: Counter,
     /// Connections closed due to local errors (socket failures, invalid handshake).
     connections_closed_local_error: Counter,
+    /// Connections reaped after the peer did not finish the shutdown handshake.
+    connections_closed_timeout: Counter,
 }
 
 impl TcpAggregateStats {
@@ -91,6 +95,10 @@ impl TcpAggregateStats {
             ConnectionCloseReason::PeerRst => self.connections_closed_peer_rst.increment(),
             ConnectionCloseReason::LocalError => self.connections_closed_local_error.increment(),
         }
+    }
+
+    fn record_timeout_close(&mut self) {
+        self.connections_closed_timeout.increment();
     }
 }
 
@@ -161,6 +169,12 @@ struct TcpConnection {
 struct TcpConnectionInner {
     loopback_port: LoopbackPortInfo,
     state: TcpState,
+
+    /// Deadline at which a connection in a half-closed state (`FinWait1`,
+    /// `FinWait2`, `Closing`, `LastAck`, or `TimeWait`) should be forcibly
+    /// reclaimed.
+    #[inspect(with = "|x| x.is_some()")]
+    close_deadline: Option<Instant>,
 
     #[inspect(with = "|x| x.len()")]
     rx_buffer: ring::Ring,
@@ -395,7 +409,38 @@ impl<T: Client> Access<'_, T> {
                 Err(_) => false,
             });
         // Check for any new incoming data
+        let now = Instant::now();
         self.inner.tcp.connections.retain(|ft, conn| {
+            // Reap connections whose half-closed cleanup timer has expired.
+            // This covers FinWait1/FinWait2/Closing/LastAck/TimeWait.
+            // Without this, sockets that reach these states can sit in the
+            // map indefinitely (e.g. the host socket may already be closed,
+            // so no I/O event will wake them up), leaking the connection
+            // entry.
+            if conn.inner.close_deadline.is_some_and(|d| now >= d) {
+                tracing::debug!(
+                    src = %ft.src,
+                    dst = %ft.dst,
+                    state = ?conn.inner.state,
+                    "half-closed timer expired, reclaiming connection",
+                );
+                match &conn.inner.state {
+                    TcpState::FinWait1
+                    | TcpState::FinWait2
+                    | TcpState::Closing
+                    | TcpState::LastAck => self.inner.tcp.aggregate_stats.record_timeout_close(),
+                    TcpState::TimeWait => self
+                        .inner
+                        .tcp
+                        .aggregate_stats
+                        .record_close(ConnectionCloseReason::Normal),
+                    state => {
+                        unreachable!("close deadline armed in unexpected TCP state: {state:?}")
+                    }
+                }
+                return false;
+            }
+
             let mut sender = Sender {
                 ft,
                 state: &mut self.inner.state,
@@ -723,6 +768,7 @@ impl TcpConnection {
         TcpConnectionInner {
             loopback_port: LoopbackPortInfo::None,
             state: TcpState::Connecting,
+            close_deadline: None,
             rx_buffer: ring::Ring::new(0),
             rx_window_cap: rx_buffer_size,
             rx_window_scale,
@@ -925,7 +971,7 @@ impl TcpConnectionInner {
                     if n == 0 {
                         // EOF — close the connection.
                         if !self.state.tx_fin() {
-                            self.close();
+                            self.close(sender.state.params.tcp_close_timeout);
                         }
                         break;
                     }
@@ -1041,7 +1087,7 @@ impl TcpConnectionInner {
                     match Pin::new(&mut *socket).poll_read_vectored(cx, &mut bufs) {
                         Poll::Ready(Ok(n)) => {
                             if n == 0 {
-                                self.close();
+                                self.close(sender.state.params.tcp_close_timeout);
                                 break;
                             }
                             self.tx_buffer.extend_by(n);
@@ -1324,14 +1370,16 @@ impl TcpConnectionInner {
         assert!(self.tx_send <= tx_end);
     }
 
-    fn close(&mut self) {
+    fn close(&mut self, close_timeout: Duration) {
         tracing::trace!("fin");
         match self.state {
             TcpState::SynSent | TcpState::SynReceived | TcpState::Established => {
                 self.state = TcpState::FinWait1;
+                self.arm_close_deadline(close_timeout);
             }
             TcpState::CloseWait => {
                 self.state = TcpState::LastAck;
+                self.arm_close_deadline(close_timeout);
             }
             TcpState::Connecting
             | TcpState::FinWait1
@@ -1341,6 +1389,16 @@ impl TcpConnectionInner {
             | TcpState::LastAck => unreachable!("fin in {:?}", self.state),
         }
         self.tx_fin_buffered = true;
+    }
+
+    /// Arm (or reset) the half-closed cleanup timer. Called on entry to any
+    /// of `FinWait1`, `FinWait2`, `Closing`, `LastAck`, or `TimeWait` so
+    /// that the connection cannot leak if the peer never completes the
+    /// shutdown handshake. Also called from the `TimeWait` packet handler
+    /// per RFC 793 (the TIME_WAIT timer must restart on any received
+    /// segment so that retransmitted FINs can still be ack'd).
+    fn arm_close_deadline(&mut self, close_timeout: Duration) {
+        self.close_deadline = Some(Instant::now() + close_timeout);
     }
 
     /// Send an ACK using the current state of the connection.
@@ -1498,8 +1556,14 @@ impl TcpConnectionInner {
                 self.tx_fin_buffered = false;
                 consumed -= 1;
                 match self.state {
-                    TcpState::FinWait1 => self.state = TcpState::FinWait2,
-                    TcpState::Closing => self.state = TcpState::TimeWait,
+                    TcpState::FinWait1 => {
+                        self.state = TcpState::FinWait2;
+                        self.arm_close_deadline(sender.state.params.tcp_close_timeout);
+                    }
+                    TcpState::Closing => {
+                        self.state = TcpState::TimeWait;
+                        self.arm_close_deadline(sender.state.params.tcp_close_timeout);
+                    }
                     TcpState::LastAck => {
                         self.last_close_reason = ConnectionCloseReason::Normal;
                         return Ok(false);
@@ -1598,7 +1662,9 @@ impl TcpConnectionInner {
             TcpState::CloseWait | TcpState::Closing | TcpState::LastAck => {}
             TcpState::TimeWait => {
                 self.ack(sender);
-                // TODO: restart timer
+                // Per RFC 793, restart the TIME_WAIT timer on any received
+                // segment so that retransmitted FINs can still be ack'd.
+                self.arm_close_deadline(sender.state.params.tcp_close_timeout);
             }
         }
 
@@ -1611,10 +1677,13 @@ impl TcpConnectionInner {
                 }
                 TcpState::FinWait1 => {
                     self.state = TcpState::Closing;
+                    self.arm_close_deadline(sender.state.params.tcp_close_timeout);
                 }
                 TcpState::FinWait2 => {
                     self.state = TcpState::TimeWait;
-                    // TODO: start timer
+                    // RFC 793 also mentions the need for FIN retransmission, but no packet loss
+                    // is expected.
+                    self.arm_close_deadline(sender.state.params.tcp_close_timeout);
                 }
                 TcpState::CloseWait
                 | TcpState::Closing

--- a/vm/devices/net/net_consomme/consomme/src/tcp.rs
+++ b/vm/devices/net/net_consomme/consomme/src/tcp.rs
@@ -27,6 +27,8 @@ use pal_async::driver::Driver;
 use pal_async::interest::PollEvents;
 use pal_async::socket::PollReady;
 use pal_async::socket::PolledSocket;
+use pal_async::timer::Instant as TimerInstant;
+use pal_async::timer::PolledTimer as TcpTimer;
 use smoltcp::phy::ChecksumCapabilities;
 use smoltcp::wire::ETHERNET_HEADER_LEN;
 use smoltcp::wire::EthernetFrame;
@@ -61,6 +63,7 @@ use std::net::SocketAddrV6;
 use std::pin::Pin;
 use std::task::Context;
 use std::task::Poll;
+use std::time::Duration;
 use thiserror::Error;
 
 #[derive(InspectMut)]
@@ -69,6 +72,8 @@ pub(crate) struct Tcp {
     connections: HashMap<FourTuple, TcpConnection>,
     #[inspect(iter_by_key)]
     listeners: HashMap<PortForwardKey, TcpListener>,
+    #[inspect(skip)]
+    timer: Option<TcpTimer>,
     connection_params: ConnectionParams,
     aggregate_stats: TcpAggregateStats,
 }
@@ -84,6 +89,8 @@ struct TcpAggregateStats {
     connections_closed_peer_rst: Counter,
     /// Connections closed due to local errors (socket failures, invalid handshake).
     connections_closed_local_error: Counter,
+    /// Connections reaped after the peer did not finish a handshake or shutdown.
+    connections_closed_timeout: Counter,
 }
 
 impl TcpAggregateStats {
@@ -93,6 +100,10 @@ impl TcpAggregateStats {
             ConnectionCloseReason::PeerRst => self.connections_closed_peer_rst.increment(),
             ConnectionCloseReason::LocalError => self.connections_closed_local_error.increment(),
         }
+    }
+
+    fn record_timeout_close(&mut self) {
+        self.connections_closed_timeout.increment();
     }
 }
 
@@ -139,6 +150,7 @@ impl Tcp {
         Self {
             connections: HashMap::new(),
             listeners: HashMap::new(),
+            timer: None,
             connection_params: ConnectionParams {
                 rx_buffer: NormalizedBufferBounds::from_bounds(rx_buffer),
                 tx_buffer: NormalizedBufferBounds::from_bounds(tx_buffer),
@@ -241,6 +253,9 @@ struct TcpConnectionInner {
     loopback_port: LoopbackPortInfo,
     state: TcpState,
 
+    lifetime_timer: LifetimeTimer,
+    retransmission: RetransmissionState,
+
     #[inspect(with = "|x| x.len()")]
     rx_buffer: ring::Ring,
     #[inspect(hex)]
@@ -274,7 +289,8 @@ struct TcpConnectionInner {
     tx_acked: TcpSeqNumber,
     #[inspect(with = "inspect_seq")]
     tx_send: TcpSeqNumber,
-    tx_fin_buffered: bool,
+    tx_syn: TxSynState,
+    tx_fin: TxFinState,
     #[inspect(hex)]
     tx_window_len: u16,
     tx_window_scale: u8,
@@ -291,6 +307,326 @@ struct TcpConnectionInner {
     #[inspect(skip)]
     last_close_reason: ConnectionCloseReason,
     stats: TcpConnStats,
+}
+
+const INITIAL_RTO: Duration = Duration::from_secs(1);
+const MIN_RTO: Duration = Duration::from_secs(1);
+const MAX_RTO: Duration = Duration::from_secs(60);
+const CLOCK_GRANULARITY: Duration = Duration::from_millis(1);
+const HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(60);
+
+#[derive(Clone, Copy, Default, Inspect)]
+#[inspect(tag = "kind")]
+enum LifetimeTimer {
+    #[default]
+    None,
+    Handshake(#[inspect(skip)] TimerInstant),
+    Close(#[inspect(skip)] TimerInstant),
+}
+
+impl LifetimeTimer {
+    fn deadline(self) -> Option<TimerInstant> {
+        match self {
+            Self::None => None,
+            Self::Handshake(deadline) | Self::Close(deadline) => Some(deadline),
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Default, Inspect, PartialEq, Eq)]
+enum TxSynState {
+    #[default]
+    None,
+    Syn,
+    SynAck,
+}
+
+#[derive(Clone, Copy, Default, Inspect, PartialEq, Eq)]
+enum TxFinState {
+    #[default]
+    None,
+    Buffered,
+    Sent,
+}
+
+impl TxFinState {
+    fn is_pending(self) -> bool {
+        self != Self::None
+    }
+}
+
+#[derive(Clone, Copy, Default, Inspect)]
+#[inspect(tag = "kind")]
+enum RetransmissionTimer {
+    #[default]
+    None,
+    Rto {
+        #[inspect(skip)]
+        deadline: TimerInstant,
+        #[inspect(skip)]
+        recover: Option<TcpSeqNumber>,
+    },
+    Persist {
+        #[inspect(skip)]
+        deadline: TimerInstant,
+        backoff: u8,
+        #[inspect(skip)]
+        recover: Option<TcpSeqNumber>,
+    },
+    Recovery {
+        #[inspect(skip)]
+        deadline: TimerInstant,
+        #[inspect(skip)]
+        recover: TcpSeqNumber,
+    },
+}
+
+impl RetransmissionTimer {
+    fn deadline(self) -> Option<TimerInstant> {
+        match self {
+            Self::None => None,
+            Self::Rto { deadline, .. }
+            | Self::Persist { deadline, .. }
+            | Self::Recovery { deadline, .. } => Some(deadline),
+        }
+    }
+}
+
+#[derive(Inspect)]
+struct RetransmissionState {
+    rto: Duration,
+    timer: RetransmissionTimer,
+    srtt: Option<Duration>,
+    rttvar: Option<Duration>,
+    #[inspect(skip)]
+    sample: Option<RttSample>,
+    syn_retransmitted: bool,
+    duplicate_acks: u8,
+}
+
+struct RttSample {
+    sequence_end: TcpSeqNumber,
+    sent_at: TimerInstant,
+}
+
+impl RetransmissionState {
+    fn new() -> Self {
+        Self {
+            rto: INITIAL_RTO,
+            timer: RetransmissionTimer::None,
+            srtt: None,
+            rttvar: None,
+            sample: None,
+            syn_retransmitted: false,
+            duplicate_acks: 0,
+        }
+    }
+
+    fn on_send(&mut self, sequence_end: TcpSeqNumber) {
+        match self.timer {
+            RetransmissionTimer::Rto {
+                recover: Some(_), ..
+            }
+            | RetransmissionTimer::Recovery { .. } => return,
+            RetransmissionTimer::Rto { .. } if self.sample.is_some() => return,
+            _ => {}
+        }
+        self.on_send_at(sequence_end, TimerInstant::now());
+    }
+
+    fn on_send_at(&mut self, sequence_end: TcpSeqNumber, now: TimerInstant) {
+        if !matches!(
+            self.timer,
+            RetransmissionTimer::Rto { .. } | RetransmissionTimer::Recovery { .. }
+        ) {
+            self.timer = RetransmissionTimer::Rto {
+                deadline: now + self.rto,
+                recover: None,
+            };
+        }
+        if self.sample.is_none() {
+            self.sample = Some(RttSample {
+                sequence_end,
+                sent_at: now,
+            });
+        }
+    }
+
+    fn on_ack(&mut self, ack_number: TcpSeqNumber, tx_send: TcpSeqNumber, now: TimerInstant) {
+        self.duplicate_acks = 0;
+        let recover = match self.timer {
+            RetransmissionTimer::Rto { recover, .. } => recover,
+            RetransmissionTimer::Persist { recover, .. } => recover,
+            RetransmissionTimer::Recovery { recover, .. } => Some(recover),
+            _ => None,
+        };
+        if let Some(sample) = self
+            .sample
+            .take_if(|sample| ack_number >= sample.sequence_end)
+        {
+            self.update_rto(now.saturating_sub(sample.sent_at));
+        }
+
+        self.timer = if ack_number < tx_send {
+            if let Some(recover) = recover.filter(|recover| ack_number < *recover) {
+                RetransmissionTimer::Recovery {
+                    deadline: now,
+                    recover,
+                }
+            } else {
+                RetransmissionTimer::Rto {
+                    deadline: now + self.rto,
+                    recover: None,
+                }
+            }
+        } else {
+            RetransmissionTimer::None
+        };
+    }
+
+    fn record_duplicate_ack(&mut self, is_duplicate: bool) -> bool {
+        if !is_duplicate {
+            return false;
+        }
+        self.duplicate_acks = self.duplicate_acks.saturating_add(1);
+        self.duplicate_acks == 3
+    }
+
+    fn on_fast_retransmit(&mut self, now: TimerInstant, recover: TcpSeqNumber) {
+        self.sample = None;
+        self.timer = RetransmissionTimer::Rto {
+            deadline: now + self.rto,
+            recover: Some(recover),
+        };
+    }
+
+    fn retry_fast_retransmit(&mut self) {
+        self.duplicate_acks = 2;
+    }
+
+    fn on_retransmit(&mut self, now: TimerInstant, recover: TcpSeqNumber) {
+        // Karn's algorithm: an ACK after a retransmission is ambiguous and
+        // cannot be used as an RTT sample.
+        self.duplicate_acks = 0;
+        self.sample = None;
+        self.rto = self.rto.saturating_mul(2).min(MAX_RTO);
+        self.timer = RetransmissionTimer::Rto {
+            deadline: now + self.rto,
+            recover: Some(recover),
+        };
+    }
+
+    fn on_recovery_retransmit(&mut self, now: TimerInstant, recover: TcpSeqNumber) {
+        self.sample = None;
+        self.timer = RetransmissionTimer::Rto {
+            deadline: now + self.rto,
+            recover: Some(recover),
+        };
+    }
+
+    fn update_persist(&mut self, blocked: bool, outstanding: bool) {
+        if blocked {
+            if !matches!(self.timer, RetransmissionTimer::Persist { .. }) {
+                let recover = self.recovery_boundary();
+                self.sample = None;
+                self.timer = RetransmissionTimer::Persist {
+                    deadline: TimerInstant::now() + self.rto,
+                    backoff: 0,
+                    recover,
+                };
+            }
+        } else if matches!(self.timer, RetransmissionTimer::Persist { .. }) {
+            let recover = self.recovery_boundary();
+            self.timer = if outstanding {
+                RetransmissionTimer::Rto {
+                    deadline: TimerInstant::now() + self.rto,
+                    recover,
+                }
+            } else {
+                RetransmissionTimer::None
+            };
+        }
+    }
+
+    fn rearm_persist(&mut self, now: TimerInstant, backoff: u8, recover: Option<TcpSeqNumber>) {
+        let backoff = backoff.saturating_add(1).min(u32::BITS as u8 - 1);
+        let multiplier = 1_u32 << backoff;
+        let interval = self.rto.saturating_mul(multiplier).min(MAX_RTO);
+        self.timer = RetransmissionTimer::Persist {
+            deadline: now + interval,
+            backoff,
+            recover,
+        };
+    }
+
+    fn retry_persist(&mut self, now: TimerInstant, backoff: u8, recover: Option<TcpSeqNumber>) {
+        self.timer = RetransmissionTimer::Persist {
+            deadline: now + self.rto,
+            backoff,
+            recover,
+        };
+    }
+
+    fn on_early_retransmit(&mut self, now: TimerInstant) {
+        // Karn's algorithm still applies, but RFC 6298 only backs off the RTO
+        // after its timer expires.
+        self.duplicate_acks = 0;
+        self.sample = None;
+        self.timer = RetransmissionTimer::Rto {
+            deadline: now + self.rto,
+            recover: self.recovery_boundary(),
+        };
+    }
+
+    fn recovery_boundary(&self) -> Option<TcpSeqNumber> {
+        match self.timer {
+            RetransmissionTimer::Rto { recover, .. }
+            | RetransmissionTimer::Persist { recover, .. } => recover,
+            RetransmissionTimer::Recovery { recover, .. } => Some(recover),
+            RetransmissionTimer::None => None,
+        }
+    }
+
+    fn on_syn_retransmit(&mut self) {
+        self.syn_retransmitted = true;
+    }
+
+    fn on_handshake_complete(&mut self) {
+        // RFC 6298 section 5.7 requires at least a 3-second RTO for data
+        // after a SYN retransmission when the backed-off RTO is smaller.
+        if self.syn_retransmitted {
+            self.rto = self.rto.max(Duration::from_secs(3));
+            self.syn_retransmitted = false;
+        }
+    }
+
+    fn update_rto(&mut self, sample: Duration) {
+        let (srtt, rttvar) = if let (Some(srtt), Some(rttvar)) = (self.srtt, self.rttvar) {
+            let error = srtt.abs_diff(sample);
+            let rttvar = duration_weighted_average(rttvar, 3, error, 1, 4);
+            let srtt = duration_weighted_average(srtt, 7, sample, 1, 8);
+            (srtt, rttvar)
+        } else {
+            (sample, sample / 2)
+        };
+        self.srtt = Some(srtt);
+        self.rttvar = Some(rttvar);
+
+        let variance = rttvar.saturating_mul(4).max(CLOCK_GRANULARITY);
+        self.rto = (srtt + variance).clamp(MIN_RTO, MAX_RTO);
+    }
+}
+
+fn duration_weighted_average(
+    a: Duration,
+    a_weight: u32,
+    b: Duration,
+    b_weight: u32,
+    divisor: u32,
+) -> Duration {
+    a.saturating_mul(a_weight)
+        .saturating_add(b.saturating_mul(b_weight))
+        / divisor
 }
 
 /// Why a connection was closed, for aggregate stats categorization.
@@ -356,6 +692,12 @@ struct TcpConnStats {
     tx_buffer_grows: Counter,
     /// Number of times the rx_buffer ring capacity was grown by autotune.
     rx_buffer_grows: Counter,
+    /// Retransmission timeouts.
+    retransmission_timeouts: Counter,
+    /// Retransmitted segments.
+    retransmitted_segments: Counter,
+    /// Retransmitted payload bytes.
+    retransmitted_bytes: Counter,
 }
 
 fn inspect_seq(seq: &TcpSeqNumber) -> inspect::AsHex<u32> {
@@ -496,13 +838,53 @@ impl<T: Client> Access<'_, T> {
                 }
                 Err(_) => false,
             });
-        // Check for any new incoming data
+        // Check for any new incoming data.
+        let mut now = None;
+        let mut next_deadline: Option<TimerInstant> = None;
         self.inner.tcp.connections.retain(|ft, conn| {
             let mut sender = Sender {
                 ft,
                 state: &mut self.inner.state,
                 client: self.client,
             };
+            let timed_out = conn.inner.next_timer_deadline().is_some_and(|deadline| {
+                let now = *now.get_or_insert_with(TimerInstant::now);
+                deadline <= now && conn.inner.process_expired_timers(now, &mut sender)
+            });
+            if timed_out {
+                tracing::debug!(
+                    src = %ft.src,
+                    dst = %ft.dst,
+                    state = ?conn.inner.state,
+                    "TCP connection timer expired, reclaiming connection",
+                );
+                if matches!(
+                    conn.backend,
+                    TcpBackend::Dns(ref handler) if handler.is_in_flight()
+                ) {
+                    self.inner.dns.complete_tcp_query();
+                }
+                match conn.inner.state {
+                    TcpState::TimeWait => self
+                        .inner
+                        .tcp
+                        .aggregate_stats
+                        .record_close(ConnectionCloseReason::Normal),
+                    _ => {
+                        let guest_has_seen_connection = !matches!(
+                            conn.inner.state,
+                            TcpState::Connecting | TcpState::SynSent | TcpState::SynReceived
+                        ) || conn.inner.tx_syn != TxSynState::None;
+                        if guest_has_seen_connection && sender.client.rx_mtu() != 0 {
+                            sender.rst(conn.inner.tx_send, Some(conn.inner.rx_seq));
+                            conn.inner.stats.rsts_tx.increment();
+                        }
+                        self.inner.tcp.aggregate_stats.record_timeout_close();
+                    }
+                }
+                return false;
+            }
+
             let keep = match &mut conn.backend {
                 TcpBackend::Dns(dns_handler) => {
                     if self.inner.dns.can_answer_queries() {
@@ -532,12 +914,28 @@ impl<T: Client> Access<'_, T> {
                     .tcp
                     .aggregate_stats
                     .record_close(conn.inner.last_close_reason);
+            } else if let Some(deadline) = conn.inner.next_timer_deadline() {
+                next_deadline = Some(
+                    next_deadline.map_or(deadline, |next_deadline| next_deadline.min(deadline)),
+                );
             }
             keep
-        })
+        });
+
+        if let Some(deadline) = next_deadline {
+            let timer = self
+                .inner
+                .tcp
+                .timer
+                .get_or_insert_with(|| TcpTimer::new(self.client.driver()));
+            if timer.poll_until(cx, deadline).is_ready() {
+                cx.waker().wake_by_ref();
+            }
+        }
     }
 
     pub(crate) fn refresh_tcp_driver(&mut self) {
+        self.inner.tcp.timer = Some(TcpTimer::new(self.client.driver()));
         self.inner.tcp.connections.retain(|ft, conn| {
             let TcpBackend::Socket {
                 socket: opt_socket, ..
@@ -601,6 +999,24 @@ impl<T: Client> Access<'_, T> {
         );
         let inspect_static_dns =
             ft.dst.port() == crate::DNS_PORT && self.inner.dns.should_intercept_static_queries();
+
+        let replace_time_wait = tcp.control == TcpControl::Syn
+            && tcp.ack_number.is_none()
+            && self.inner.tcp.connections.get(&ft).is_some_and(|conn| {
+                conn.inner.state == TcpState::TimeWait && tcp.seq_number > conn.inner.rx_seq
+            });
+        if replace_time_wait && let Some(conn) = self.inner.tcp.connections.remove(&ft) {
+            if matches!(
+                conn.backend,
+                TcpBackend::Dns(ref handler) if handler.is_in_flight()
+            ) {
+                self.inner.dns.complete_tcp_query();
+            }
+            self.inner
+                .tcp
+                .aggregate_stats
+                .record_close(ConnectionCloseReason::Normal);
+        }
 
         let mut sender = Sender {
             ft: &ft,
@@ -897,6 +1313,10 @@ impl TcpConnection {
         TcpConnectionInner {
             loopback_port: LoopbackPortInfo::None,
             state: TcpState::Connecting,
+            lifetime_timer: LifetimeTimer::Handshake(
+                TimerInstant::now().saturating_add(HANDSHAKE_TIMEOUT),
+            ),
+            retransmission: RetransmissionState::new(),
             rx_buffer: ring::Ring::new(0),
             rx_window_cap: rx_bounds.initial,
             rx_window_scale,
@@ -911,6 +1331,7 @@ impl TcpConnection {
             tx_buffer_max: tx_bounds.max,
             tx_acked: tx_seq,
             tx_send: tx_seq,
+            tx_syn: TxSynState::None,
             tx_window_len: 1,
             tx_window_scale: 0,
             tx_window_scale_active: false,
@@ -919,7 +1340,7 @@ impl TcpConnection {
             // The TCPv4 default maximum segment size is 536. This can be bigger for
             // IPv6.
             tx_mss: 536,
-            tx_fin_buffered: false,
+            tx_fin: TxFinState::None,
             last_close_reason: ConnectionCloseReason::LocalError,
             stats: TcpConnStats::default(),
         }
@@ -1127,7 +1548,7 @@ impl TcpConnectionInner {
                     if n == 0 {
                         // EOF — close the connection.
                         if !self.state.tx_fin() {
-                            self.close();
+                            self.close(sender.state.params.tcp_close_timeout);
                         }
                         break;
                     }
@@ -1152,13 +1573,7 @@ impl TcpConnectionInner {
 
         // Flush any deferred pure-ACK from per-packet `handle_tcp` calls.
         self.send_next(sender, AckPolicy::Flush);
-        let closing = self.state == TcpState::TimeWait
-            || self.state == TcpState::LastAck
-            || (self.state.tx_fin() && self.state.rx_fin() && self.tx_buffer.is_empty());
-        if closing {
-            self.last_close_reason = ConnectionCloseReason::Normal;
-        }
-        !closing
+        true
     }
 
     /// Poll the real-socket TCP connection backend.
@@ -1196,6 +1611,7 @@ impl TcpConnectionInner {
             }
         } else if self.state == TcpState::SynSent {
             // Need to establish connection with client before sending data.
+            self.send_next(sender, AckPolicy::Flush);
             return true;
         }
 
@@ -1236,7 +1652,7 @@ impl TcpConnectionInner {
                         match Pin::new(&mut *socket).poll_read_vectored(cx, &mut bufs) {
                             Poll::Ready(Ok(n)) => {
                                 if n == 0 {
-                                    self.close();
+                                    self.close(sender.state.params.tcp_close_timeout);
                                     break 'read;
                                 }
                                 if let Some(static_dns) = static_dns.as_mut() {
@@ -1297,6 +1713,7 @@ impl TcpConnectionInner {
         // read from the socket and no ACK is pending, send_data will find
         // nothing to do anyway.
         self.send_next(sender, AckPolicy::Flush);
+        self.compact_closed_buffers();
         true
     }
 
@@ -1379,7 +1796,8 @@ impl TcpConnectionInner {
         // empty because `Ring::resize` only preserves contiguous bytes
         // in `[head, tail)` — any out-of-order data staged past `tail`
         // via `write_at` would be lost.
-        if self.rx_buffer.is_empty()
+        if !self.state.rx_fin()
+            && self.rx_buffer.is_empty()
             && self.rx_assembler.is_empty()
             && self.rx_window_cap < self.rx_buffer_max
             && rx_high_water * 4 >= self.rx_window_cap * 3
@@ -1552,6 +1970,7 @@ impl TcpConnectionInner {
     fn send_next(&mut self, sender: &mut Sender<'_, impl Client>, ack_policy: AckPolicy) {
         match self.state {
             TcpState::Connecting => {}
+            TcpState::SynSent => self.send_syn(sender, None),
             TcpState::SynReceived => self.send_syn(sender, Some(self.rx_seq)),
             _ => self.send_data(sender, ack_policy),
         }
@@ -1595,6 +2014,12 @@ impl TcpConnectionInner {
 
         sender.send_packet(&tcp, None);
         self.tx_send += 1;
+        self.tx_syn = if ack_number.is_some() {
+            TxSynState::SynAck
+        } else {
+            TxSynState::Syn
+        };
+        self.retransmission.on_send(self.tx_send);
         if ack_number.is_some() {
             // The guest reads the SYN-ACK window unscaled, so record that value.
             self.rx_window_last_adv = window_len as usize;
@@ -1613,15 +2038,18 @@ impl TcpConnectionInner {
             0
         };
         let tx_payload_end = self.tx_acked + self.tx_buffer.len();
-        let tx_end = tx_payload_end + self.tx_fin_buffered as usize;
+        let tx_end = tx_payload_end + self.tx_fin.is_pending() as usize;
         let tx_window_end = self.tx_acked + ((self.tx_window_len as usize) << scale);
         let tx_done = seq_min([tx_end, tx_window_end]);
+        let mut send_fin_probe = self.tx_fin == TxFinState::Buffered
+            && self.tx_buffer.is_empty()
+            && self.tx_send == self.tx_acked;
 
         if self.tx_send < tx_end && tx_window_end <= self.tx_send {
             self.stats.tx_blocked_window_full.increment();
         }
 
-        while self.needs_ack || self.tx_send < tx_done {
+        while self.needs_ack || self.tx_send < tx_done || send_fin_probe {
             let rx_mtu = sender.client.rx_mtu();
             if rx_mtu == 0 {
                 // Out of receive buffers.
@@ -1679,17 +2107,19 @@ impl TcpConnectionInner {
             // Set PSH on the segment that drains all currently-buffered data.
             // This tells the guest TCP stack to deliver the data to the
             // application immediately rather than waiting for more.
-            // Note: when tx_fin_buffered is true, the FIN block below will
+            // Note: when a FIN is pending, the FIN block below will
             // override tcp.control to Fin, which takes priority over Psh.
-            if payload_len > 0 && tx_next == tx_payload_end && !self.tx_fin_buffered {
+            if payload_len > 0 && tx_next == tx_payload_end && !self.tx_fin.is_pending() {
                 tcp.control = TcpControl::Psh;
             }
 
-            // Include the fin if present if there is still room.
-            if self.tx_fin_buffered
+            // Include the FIN if it fits in the peer window. A FIN-only close
+            // is also sent through a zero window as a probe so a lost window
+            // update cannot stall the close until the lifetime timeout.
+            if self.tx_fin.is_pending()
                 && tcp.control != TcpControl::Fin
                 && tx_next == tx_payload_end
-                && tx_next < tx_window_end
+                && (tx_next < tx_window_end || send_fin_probe)
             {
                 tcp.control = TcpControl::Fin;
                 tx_next += 1;
@@ -1720,21 +2150,41 @@ impl TcpConnectionInner {
             self.stats.bytes_tx_to_guest.add(payload_len as u64);
             self.stats.tx_segment_size.add_sample(payload_len as u64);
             self.tx_send = tx_next;
+            if tcp.control == TcpControl::Fin {
+                self.tx_fin = TxFinState::Sent;
+                send_fin_probe = false;
+            }
+            if tx_next > tcp.seq_number {
+                self.retransmission.on_send(tx_next);
+            }
             self.needs_ack = false;
             self.record_advertised_window(window_len);
         }
 
+        self.retransmission.update_persist(
+            !self.tx_buffer.is_empty() && self.tx_window_len == 0,
+            self.tx_acked < self.tx_send,
+        );
         assert!(self.tx_send <= tx_end);
+        self.compact_closed_buffers();
     }
 
-    fn close(&mut self) {
+    fn close(&mut self, close_timeout: Duration) {
+        if self.tx_fin.is_pending() {
+            return;
+        }
         tracing::trace!("fin");
         match self.state {
-            TcpState::SynSent | TcpState::SynReceived | TcpState::Established => {
+            TcpState::SynSent | TcpState::SynReceived => {
+                self.start_close_deadline(close_timeout);
+            }
+            TcpState::Established => {
                 self.state = TcpState::FinWait1;
+                self.start_close_deadline(close_timeout);
             }
             TcpState::CloseWait => {
                 self.state = TcpState::LastAck;
+                self.start_close_deadline(close_timeout);
             }
             TcpState::Connecting
             | TcpState::FinWait1
@@ -1743,7 +2193,275 @@ impl TcpConnectionInner {
             | TcpState::TimeWait
             | TcpState::LastAck => unreachable!("fin in {:?}", self.state),
         }
-        self.tx_fin_buffered = true;
+        self.tx_fin = TxFinState::Buffered;
+    }
+
+    /// Start the user timeout for a graceful close. State transitions do not
+    /// extend it unless the connection makes forward progress.
+    fn start_close_deadline(&mut self, close_timeout: Duration) {
+        if !matches!(self.lifetime_timer, LifetimeTimer::Close(_)) {
+            self.lifetime_timer =
+                LifetimeTimer::Close(TimerInstant::now().saturating_add(close_timeout));
+        }
+    }
+
+    fn refresh_close_deadline(&mut self, now: TimerInstant, close_timeout: Duration) {
+        if matches!(self.lifetime_timer, LifetimeTimer::Close(_)) {
+            self.lifetime_timer = LifetimeTimer::Close(now.saturating_add(close_timeout));
+        }
+    }
+
+    /// Start or restart the 2*MSL TIME-WAIT interval.
+    fn restart_time_wait(&mut self, close_timeout: Duration) {
+        self.lifetime_timer =
+            LifetimeTimer::Close(TimerInstant::now().saturating_add(close_timeout));
+        self.compact_closed_buffers();
+    }
+
+    fn compact_closed_buffers(&mut self) {
+        if self.state.tx_fin() && self.tx_buffer.is_empty() && self.tx_buffer.capacity() != 0 {
+            self.tx_buffer = ring::Ring::new(0);
+        }
+
+        if self.state.rx_fin() && self.rx_buffer.is_empty() && self.rx_buffer.capacity() != 0 {
+            assert!(self.rx_assembler.is_empty());
+            self.rx_buffer = ring::Ring::new(0);
+        }
+    }
+
+    fn next_timer_deadline(&self) -> Option<TimerInstant> {
+        [
+            self.lifetime_timer.deadline(),
+            self.retransmission.timer.deadline(),
+        ]
+        .into_iter()
+        .flatten()
+        .min()
+    }
+
+    /// Process expired retransmission and connection-lifetime timers. Returns
+    /// `true` when the connection should be reclaimed.
+    fn process_expired_timers(
+        &mut self,
+        now: TimerInstant,
+        sender: &mut Sender<'_, impl Client>,
+    ) -> bool {
+        if self
+            .lifetime_timer
+            .deadline()
+            .is_some_and(|deadline| now >= deadline)
+        {
+            return true;
+        }
+
+        match self.retransmission.timer {
+            RetransmissionTimer::Rto { deadline, recover } if now >= deadline => {
+                self.stats.retransmission_timeouts.increment();
+                if self.retransmit_earliest(sender) {
+                    self.retransmission
+                        .on_retransmit(now, recover.unwrap_or(self.tx_send));
+                } else {
+                    self.retransmission.timer = RetransmissionTimer::Rto {
+                        deadline: now + self.retransmission.rto,
+                        recover,
+                    };
+                }
+            }
+            RetransmissionTimer::Recovery { deadline, .. } if now >= deadline => {
+                self.process_recovery_retransmit(now, sender);
+            }
+            RetransmissionTimer::Persist {
+                deadline,
+                backoff,
+                recover,
+            } if now >= deadline => {
+                if self.send_zero_window_probe(sender) {
+                    self.retransmission.rearm_persist(now, backoff, recover);
+                } else {
+                    self.retransmission.retry_persist(now, backoff, recover);
+                }
+            }
+            _ => {}
+        }
+        false
+    }
+
+    fn process_recovery_retransmit(
+        &mut self,
+        now: TimerInstant,
+        sender: &mut Sender<'_, impl Client>,
+    ) {
+        let RetransmissionTimer::Recovery { recover, .. } = self.retransmission.timer else {
+            return;
+        };
+        if self.retransmit_earliest(sender) {
+            self.retransmission.on_recovery_retransmit(now, recover);
+        } else {
+            self.retransmission.timer = RetransmissionTimer::Rto {
+                deadline: now + self.retransmission.rto,
+                recover: Some(recover),
+            };
+        }
+    }
+
+    /// Retransmit the earliest unacknowledged segment per RFC 6298 section 5.4.
+    fn retransmit_earliest(&mut self, sender: &mut Sender<'_, impl Client>) -> bool {
+        if self.tx_syn != TxSynState::None {
+            let retransmitted = self.retransmit_syn(sender);
+            if retransmitted {
+                self.retransmission.on_syn_retransmit();
+            }
+            return retransmitted;
+        }
+
+        if self.tx_acked >= self.tx_send || sender.client.rx_mtu() == 0 {
+            return false;
+        }
+
+        let window_len = self.rx_window_len();
+        let tx_payload_end = self.tx_acked + self.tx_buffer.len();
+        let ip_header_len = match sender.ft.dst {
+            SocketAddr::V4(_) => IPV4_HEADER_LEN,
+            SocketAddr::V6(_) => IPV6_HEADER_LEN,
+        };
+        let tcp_header_len = 20;
+        let mtu = sender.client.rx_mtu().min(sender.state.buffer.len());
+        let max_payload = mtu.saturating_sub(ETHERNET_HEADER_LEN + ip_header_len + tcp_header_len);
+        let scale = if self.tx_window_scale_active {
+            self.tx_window_scale
+        } else {
+            0
+        };
+        let tx_window_end = self.tx_acked + ((self.tx_window_len as usize) << scale);
+        let payload_len = (tx_payload_end - self.tx_acked)
+            .min(self.tx_mss)
+            .min(max_payload)
+            .min(tx_window_end - self.tx_acked)
+            .min(self.tx_send - self.tx_acked);
+
+        let mut tcp = TcpRepr {
+            src_port: sender.ft.dst.port(),
+            dst_port: sender.ft.src.port(),
+            control: TcpControl::None,
+            seq_number: self.tx_acked,
+            ack_number: Some(self.rx_seq),
+            window_len,
+            window_scale: None,
+            max_seg_size: None,
+            sack_permitted: false,
+            sack_ranges: [None, None, None],
+            timestamp: None,
+            payload: &[],
+        };
+        let segment_end = self.tx_acked + payload_len;
+        if self.tx_fin == TxFinState::Sent && segment_end == tx_payload_end {
+            tcp.control = TcpControl::Fin;
+        } else if payload_len > 0 && segment_end == tx_payload_end {
+            tcp.control = TcpControl::Psh;
+        }
+
+        if payload_len == 0 && tcp.control != TcpControl::Fin {
+            return false;
+        }
+
+        trace_tcp_packet(sender.ft, &tcp, payload_len, "retransmit");
+        let payload = self.tx_buffer.view(0..payload_len);
+        sender.send_packet(&tcp, Some(payload));
+        self.stats.pkts_tx_to_guest.increment();
+        self.stats.bytes_tx_to_guest.add(payload_len as u64);
+        self.stats.tx_segment_size.add_sample(payload_len as u64);
+        self.stats.retransmitted_segments.increment();
+        self.stats.retransmitted_bytes.add(payload_len as u64);
+        self.record_advertised_window(window_len);
+        true
+    }
+
+    fn retransmit_syn(&mut self, sender: &mut Sender<'_, impl Client>) -> bool {
+        if self.tx_syn == TxSynState::None || sender.client.rx_mtu() == 0 {
+            return false;
+        }
+
+        let ack_number = (self.tx_syn == TxSynState::SynAck).then_some(self.rx_seq);
+        self.emit_syn(sender, self.tx_acked, ack_number);
+        self.stats.retransmitted_segments.increment();
+        true
+    }
+
+    #[must_use]
+    fn send_zero_window_probe(&mut self, sender: &mut Sender<'_, impl Client>) -> bool {
+        if self.tx_buffer.is_empty() {
+            return false;
+        }
+
+        let rx_mtu = sender.client.rx_mtu();
+        let ip_header_len = match sender.ft.dst {
+            SocketAddr::V4(_) => IPV4_HEADER_LEN,
+            SocketAddr::V6(_) => IPV6_HEADER_LEN,
+        };
+        let header_len = ETHERNET_HEADER_LEN + ip_header_len + 20;
+        if rx_mtu.min(sender.state.buffer.len()) <= header_len {
+            return false;
+        }
+
+        let window_len = self.rx_window_len();
+        let tcp = TcpRepr {
+            src_port: sender.ft.dst.port(),
+            dst_port: sender.ft.src.port(),
+            control: TcpControl::None,
+            seq_number: self.tx_acked,
+            ack_number: Some(self.rx_seq),
+            window_len,
+            window_scale: None,
+            max_seg_size: None,
+            sack_permitted: false,
+            sack_ranges: [None, None, None],
+            timestamp: None,
+            payload: &[],
+        };
+        let payload = self.tx_buffer.view(0..1);
+        trace_tcp_packet(sender.ft, &tcp, payload.len(), "zero window probe");
+        sender.send_packet(&tcp, Some(payload));
+        if self.tx_send == self.tx_acked {
+            self.tx_send += 1;
+        } else {
+            self.stats.retransmitted_segments.increment();
+            self.stats.retransmitted_bytes.increment();
+        }
+        self.stats.pkts_tx_to_guest.increment();
+        self.stats.bytes_tx_to_guest.increment();
+        self.stats.tx_segment_size.add_sample(1_u64);
+        self.record_advertised_window(window_len);
+        true
+    }
+
+    fn emit_syn(
+        &mut self,
+        sender: &mut Sender<'_, impl Client>,
+        sequence_number: TcpSeqNumber,
+        ack_number: Option<TcpSeqNumber>,
+    ) {
+        let window_scale = self.enable_window_scaling.then_some(self.rx_window_scale);
+        let window_len = if ack_number.is_some() {
+            self.rx_window_avail().min(u16::MAX as usize) as u16
+        } else {
+            0
+        };
+        let tcp = TcpRepr {
+            src_port: sender.ft.dst.port(),
+            dst_port: sender.ft.src.port(),
+            control: TcpControl::Syn,
+            seq_number: sequence_number,
+            ack_number,
+            window_len,
+            window_scale,
+            max_seg_size: Some(u16::MAX),
+            sack_permitted: false,
+            sack_ranges: [None, None, None],
+            timestamp: None,
+            payload: &[],
+        };
+        trace_tcp_packet(sender.ft, &tcp, 0, "retransmit");
+        sender.send_packet(&tcp, None);
     }
 
     /// Send an ACK using the current state of the connection.
@@ -1781,27 +2499,59 @@ impl TcpConnectionInner {
         sender: &mut Sender<'_, impl Client>,
         tcp: &TcpRepr<'_>,
     ) -> Result<bool, DropReason> {
+        let ack_acceptable = tcp
+            .ack_number
+            .is_some_and(|ack| ack > self.tx_acked && ack <= self.tx_send);
+
+        if let Some(ack_number) = tcp.ack_number
+            && !ack_acceptable
+        {
+            if tcp.control != TcpControl::Rst {
+                sender.rst(ack_number, None);
+                self.stats.rsts_tx.increment();
+            }
+            return Ok(true);
+        }
+
+        if tcp.control == TcpControl::Rst {
+            if ack_acceptable {
+                tracing::debug!(
+                    src = %sender.ft.src,
+                    dst = %sender.ft.dst,
+                    "connection reset while waiting for SYN"
+                );
+                self.last_close_reason = ConnectionCloseReason::PeerRst;
+                return Ok(false);
+            }
+            return Ok(true);
+        }
+
         if tcp.control != TcpControl::Syn || tcp.segment_len() != 1 {
-            tracing::error!(?tcp.control, "invalid packet waiting for syn, drop connection");
-            return Ok(false);
+            return Ok(true);
         }
-
         let ack_number = tcp.ack_number.ok_or(TcpError::MissingAck)?;
-        if ack_number <= self.tx_acked || ack_number > self.tx_send {
-            sender.rst(ack_number, None);
-            self.stats.rsts_tx.increment();
-            return Ok(false);
-        }
-        self.tx_acked = ack_number;
-
         self.initialize_from_first_client_packet(tcp)?;
+
+        self.tx_acked = ack_number;
+        self.tx_syn = TxSynState::None;
+        self.retransmission
+            .on_ack(ack_number, self.tx_send, TimerInstant::now());
+        self.retransmission.on_handshake_complete();
+
         self.tx_window_tx_seq = ack_number;
         self.tx_window_len = tcp.window_len;
 
         // Send an ACK to complete the initial SYN handshake.
         self.ack(sender);
 
-        self.state = TcpState::Established;
+        if !self.tx_fin.is_pending() {
+            self.lifetime_timer = LifetimeTimer::None;
+        }
+        self.state = if self.tx_fin.is_pending() {
+            TcpState::FinWait1
+        } else {
+            TcpState::Established
+        };
         Ok(true)
     }
 
@@ -1822,6 +2572,19 @@ impl TcpConnectionInner {
         let rx_window_len = self.rx_window_cap - self.rx_buffer.len();
         let rx_window_end = self.rx_seq + rx_window_len;
         let segment_end = tcp.seq_number + tcp.segment_len();
+
+        // RFC 9293 section 3.10.7.4: ACK a retransmitted FIN in TIME-WAIT
+        // and restart the 2*MSL timer. The FIN is one byte to the left of
+        // RCV.NXT, so handle it before the normal sequence acceptability test.
+        if self.state == TcpState::TimeWait
+            && tcp.control == TcpControl::Fin
+            && tcp.segment_len() == 1
+            && tcp.seq_number + 1 == self.rx_seq
+        {
+            self.ack(sender);
+            self.restart_time_wait(sender.state.params.tcp_close_timeout);
+            return Ok(true);
+        }
 
         // Validate the sequence number per RFC 793.
         let seq_acceptable = if rx_window_len != 0 {
@@ -1873,6 +2636,10 @@ impl TcpConnectionInner {
 
         // ACK should always be set at this point.
         let ack_number = tcp.ack_number.ok_or(TcpError::MissingAck)?;
+        let previous_tx_acked = self.tx_acked;
+        let tx_window_was_zero = self.tx_window_len == 0;
+        let previous_tx_window_len = self.tx_window_len;
+        let mut packet_now = None;
 
         // FUTURE: validate ack number per RFC 5961.
 
@@ -1887,7 +2654,16 @@ impl TcpConnectionInner {
             self.tx_window_rx_seq = tcp.seq_number;
             self.tx_window_tx_seq = ack_number;
             self.tx_acked += 1;
-            self.state = TcpState::Established;
+            self.tx_syn = TxSynState::None;
+            if !self.tx_fin.is_pending() {
+                self.lifetime_timer = LifetimeTimer::None;
+            }
+            self.state = if self.tx_fin.is_pending() {
+                TcpState::FinWait1
+            } else {
+                TcpState::Established
+            };
+            self.retransmission.on_handshake_complete();
         }
 
         // Ignore ACKs for segments that have not been sent.
@@ -1899,12 +2675,19 @@ impl TcpConnectionInner {
         // Retire the ACKed segments.
         if ack_number > self.tx_acked {
             let mut consumed = ack_number - self.tx_acked;
-            if self.tx_fin_buffered && ack_number == self.tx_acked + self.tx_buffer.len() + 1 {
-                self.tx_fin_buffered = false;
+            if self.tx_fin == TxFinState::Sent
+                && ack_number == self.tx_acked + self.tx_buffer.len() + 1
+            {
+                self.tx_fin = TxFinState::None;
                 consumed -= 1;
                 match self.state {
-                    TcpState::FinWait1 => self.state = TcpState::FinWait2,
-                    TcpState::Closing => self.state = TcpState::TimeWait,
+                    TcpState::FinWait1 => {
+                        self.state = TcpState::FinWait2;
+                    }
+                    TcpState::Closing => {
+                        self.state = TcpState::TimeWait;
+                        self.restart_time_wait(sender.state.params.tcp_close_timeout);
+                    }
                     TcpState::LastAck => {
                         self.last_close_reason = ConnectionCloseReason::Normal;
                         return Ok(false);
@@ -1915,6 +2698,20 @@ impl TcpConnectionInner {
             self.tx_buffer.consume(consumed);
             self.tx_acked = ack_number;
         }
+        if self.tx_acked > previous_tx_acked {
+            let now = *packet_now.get_or_insert_with(TimerInstant::now);
+            self.retransmission.on_ack(self.tx_acked, self.tx_send, now);
+            self.refresh_close_deadline(now, sender.state.params.tcp_close_timeout);
+        }
+
+        let is_duplicate_ack = self.tx_acked == previous_tx_acked
+            && ack_number == self.tx_acked
+            && self.tx_acked < self.tx_send
+            && previous_tx_window_len != 0
+            && tcp.window_len == previous_tx_window_len
+            && tcp.control == TcpControl::None
+            && tcp.payload.is_empty();
+        let fast_retransmit = self.retransmission.record_duplicate_ack(is_duplicate_ack);
 
         // Update the send window.
         if ack_number >= self.tx_acked
@@ -1927,6 +2724,24 @@ impl TcpConnectionInner {
             // RFC 1323 §2.2: window scaling becomes active after the
             // handshake. The SYN/SYN-ACK window field is unscaled.
             self.tx_window_scale_active = true;
+
+            if tx_window_was_zero
+                && tcp.window_len > 0
+                && self.tx_acked < self.tx_send
+                && self.retransmit_earliest(sender)
+            {
+                let now = *packet_now.get_or_insert_with(TimerInstant::now);
+                self.retransmission.on_early_retransmit(now);
+            }
+        }
+
+        if fast_retransmit {
+            if self.retransmit_earliest(sender) {
+                let now = *packet_now.get_or_insert_with(TimerInstant::now);
+                self.retransmission.on_fast_retransmit(now, self.tx_send);
+            } else {
+                self.retransmission.retry_fast_retransmit();
+            }
         }
 
         // Scope the data payload and FIN to the in-window portion of the segment.
@@ -1972,15 +2787,23 @@ impl TcpConnectionInner {
 
                     // Stage 2: Record the range in the assembler. Do this
                     // *before* writing to the ring so that rejected segments
-                    // (TooManyGaps) don't leave stale bytes in unwritten
+                    // don't leave stale bytes in unwritten
                     // ring space.
+                    let made_progress = self.rx_assembler.would_make_progress(
+                        seq_offset as u32,
+                        payload.len() as u32,
+                        fin,
+                    );
                     let (rx_consumed, assembler_fin, accepted) =
                         match self
                             .rx_assembler
                             .add(seq_offset as u32, payload.len() as u32, fin)
                         {
                             Ok(result) => (result.consumed as usize, result.fin, true),
-                            Err(assembler::TooManyGaps) => (0, false, false),
+                            Err(err) => {
+                                tracing::trace!(?err, "assembler rejected segment");
+                                (0, false, false)
+                            }
                         };
 
                     // Stage 3: Write payload into the ring and advance the
@@ -1988,6 +2811,14 @@ impl TcpConnectionInner {
                     // accepted the segment.
                     if accepted && !payload.is_empty() {
                         self.rx_buffer.write_at(ring_offset, payload);
+                    }
+                    if accepted
+                        && made_progress
+                        && (!payload.is_empty() || fin)
+                        && matches!(self.lifetime_timer, LifetimeTimer::Close(_))
+                    {
+                        let now = *packet_now.get_or_insert_with(TimerInstant::now);
+                        self.refresh_close_deadline(now, sender.state.params.tcp_close_timeout);
                     }
                     self.rx_buffer.extend_by(rx_consumed);
                     self.rx_seq += rx_consumed;
@@ -2003,7 +2834,6 @@ impl TcpConnectionInner {
             TcpState::CloseWait | TcpState::Closing | TcpState::LastAck => {}
             TcpState::TimeWait => {
                 self.ack(sender);
-                // TODO: restart timer
             }
         }
 
@@ -2013,19 +2843,28 @@ impl TcpConnectionInner {
                 TcpState::Connecting | TcpState::SynReceived | TcpState::SynSent => unreachable!(),
                 TcpState::Established => {
                     self.state = TcpState::CloseWait;
+                    self.start_close_deadline(sender.state.params.tcp_close_timeout);
                 }
                 TcpState::FinWait1 => {
                     self.state = TcpState::Closing;
                 }
                 TcpState::FinWait2 => {
                     self.state = TcpState::TimeWait;
-                    // TODO: start timer
+                    self.restart_time_wait(sender.state.params.tcp_close_timeout);
                 }
                 TcpState::CloseWait
                 | TcpState::Closing
                 | TcpState::LastAck
                 | TcpState::TimeWait => {}
             }
+        }
+
+        if matches!(
+            self.retransmission.timer,
+            RetransmissionTimer::Recovery { .. }
+        ) {
+            let now = *packet_now.get_or_insert_with(TimerInstant::now);
+            self.process_recovery_retransmit(now, sender);
         }
 
         Ok(true)

--- a/vm/devices/net/net_consomme/consomme/src/tcp.rs
+++ b/vm/devices/net/net_consomme/consomme/src/tcp.rs
@@ -400,6 +400,8 @@ struct RetransmissionState {
     rttvar: Option<Duration>,
     #[inspect(skip)]
     sample: Option<RttSample>,
+    #[inspect(skip)]
+    window_reopen_retransmit: Option<TcpSeqNumber>,
     syn_retransmitted: bool,
     duplicate_acks: u8,
 }
@@ -417,6 +419,7 @@ impl RetransmissionState {
             srtt: None,
             rttvar: None,
             sample: None,
+            window_reopen_retransmit: None,
             syn_retransmitted: false,
             duplicate_acks: 0,
         }
@@ -454,12 +457,8 @@ impl RetransmissionState {
 
     fn on_ack(&mut self, ack_number: TcpSeqNumber, tx_send: TcpSeqNumber, now: TimerInstant) {
         self.duplicate_acks = 0;
-        let recover = match self.timer {
-            RetransmissionTimer::Rto { recover, .. } => recover,
-            RetransmissionTimer::Persist { recover, .. } => recover,
-            RetransmissionTimer::Recovery { recover, .. } => Some(recover),
-            _ => None,
-        };
+        self.window_reopen_retransmit = None;
+        let recover = self.recovery_boundary();
         if let Some(sample) = self
             .sample
             .take_if(|sample| ack_number >= sample.sequence_end)
@@ -567,11 +566,16 @@ impl RetransmissionState {
         };
     }
 
-    fn on_early_retransmit(&mut self, now: TimerInstant) {
+    fn can_retransmit_on_window_reopen(&self, ack_number: TcpSeqNumber) -> bool {
+        self.window_reopen_retransmit != Some(ack_number)
+    }
+
+    fn on_early_retransmit(&mut self, now: TimerInstant, ack_number: TcpSeqNumber) {
         // Karn's algorithm still applies, but RFC 6298 only backs off the RTO
         // after its timer expires.
         self.duplicate_acks = 0;
         self.sample = None;
+        self.window_reopen_retransmit = Some(ack_number);
         self.timer = RetransmissionTimer::Rto {
             deadline: now + self.rto,
             recover: self.recovery_boundary(),
@@ -876,7 +880,9 @@ impl<T: Client> Access<'_, T> {
                             TcpState::Connecting | TcpState::SynSent | TcpState::SynReceived
                         ) || conn.inner.tx_syn != TxSynState::None;
                         if guest_has_seen_connection && sender.client.rx_mtu() != 0 {
-                            sender.rst(conn.inner.tx_send, Some(conn.inner.rx_seq));
+                            let ack_number =
+                                (conn.inner.tx_syn != TxSynState::Syn).then_some(conn.inner.rx_seq);
+                            sender.rst(conn.inner.tx_send, ack_number);
                             conn.inner.stats.rsts_tx.increment();
                         }
                         self.inner.tcp.aggregate_stats.record_timeout_close();
@@ -2184,7 +2190,7 @@ impl TcpConnectionInner {
             }
             TcpState::CloseWait => {
                 self.state = TcpState::LastAck;
-                self.start_close_deadline(close_timeout);
+                self.restart_close_deadline(close_timeout);
             }
             TcpState::Connecting
             | TcpState::FinWait1
@@ -2211,10 +2217,14 @@ impl TcpConnectionInner {
         }
     }
 
-    /// Start or restart the 2*MSL TIME-WAIT interval.
-    fn restart_time_wait(&mut self, close_timeout: Duration) {
+    fn restart_close_deadline(&mut self, close_timeout: Duration) {
         self.lifetime_timer =
             LifetimeTimer::Close(TimerInstant::now().saturating_add(close_timeout));
+    }
+
+    /// Start or restart the 2*MSL TIME-WAIT interval.
+    fn restart_time_wait(&mut self, close_timeout: Duration) {
+        self.restart_close_deadline(close_timeout);
         self.compact_closed_buffers();
     }
 
@@ -2619,6 +2629,17 @@ impl TcpConnectionInner {
         // Send ack and drop packets with unacceptable sequence numbers.
         if !seq_acceptable {
             self.stats.out_of_window_pkts.increment();
+            let is_zero_window_probe = rx_window_len == 0
+                && tcp.control == TcpControl::None
+                && tcp.ack_number.is_some()
+                && tcp.payload.len() == 1
+                && (tcp.seq_number == self.rx_seq || tcp.seq_number + 1 == self.rx_seq);
+            if is_zero_window_probe {
+                self.refresh_close_deadline(
+                    TimerInstant::now(),
+                    sender.state.params.tcp_close_timeout,
+                );
+            }
             self.ack(sender);
             return Err(TcpError::Unacceptable.into());
         }
@@ -2738,10 +2759,13 @@ impl TcpConnectionInner {
             if tx_window_was_zero
                 && tcp.window_len > 0
                 && self.tx_acked < self.tx_send
+                && self
+                    .retransmission
+                    .can_retransmit_on_window_reopen(self.tx_acked)
                 && self.retransmit_earliest(sender)
             {
                 let now = *packet_now.get_or_insert_with(TimerInstant::now);
-                self.retransmission.on_early_retransmit(now);
+                self.retransmission.on_early_retransmit(now, self.tx_acked);
             }
         }
 
@@ -2853,7 +2877,6 @@ impl TcpConnectionInner {
                 TcpState::Connecting | TcpState::SynReceived | TcpState::SynSent => unreachable!(),
                 TcpState::Established => {
                     self.state = TcpState::CloseWait;
-                    self.start_close_deadline(sender.state.params.tcp_close_timeout);
                 }
                 TcpState::FinWait1 => {
                     self.state = TcpState::Closing;

--- a/vm/devices/net/net_consomme/consomme/src/tcp.rs
+++ b/vm/devices/net/net_consomme/consomme/src/tcp.rs
@@ -882,8 +882,9 @@ impl<T: Client> Access<'_, T> {
                         if guest_has_seen_connection && sender.client.rx_mtu() != 0 {
                             let ack_number =
                                 (conn.inner.tx_syn != TxSynState::Syn).then_some(conn.inner.rx_seq);
-                            sender.rst(conn.inner.tx_send, ack_number);
-                            conn.inner.stats.rsts_tx.increment();
+                            if sender.try_rst(conn.inner.tx_send, ack_number) {
+                                conn.inner.stats.rsts_tx.increment();
+                            }
                         }
                         self.inner.tcp.aggregate_stats.record_timeout_close();
                     }
@@ -1278,6 +1279,14 @@ impl<T: Client> Sender<'_, T> {
     }
 
     fn rst(&mut self, seq: TcpSeqNumber, ack: Option<TcpSeqNumber>) {
+        let _ = self.try_rst(seq, ack);
+    }
+
+    fn try_rst(&mut self, seq: TcpSeqNumber, ack: Option<TcpSeqNumber>) -> bool {
+        if self.client.rx_mtu() == 0 {
+            return false;
+        }
+
         let tcp = TcpRepr {
             src_port: self.ft.dst.port(),
             dst_port: self.ft.src.port(),
@@ -1296,6 +1305,7 @@ impl<T: Client> Sender<'_, T> {
         trace_tcp_packet(self.ft, &tcp, 0, "rst xmit");
 
         self.send_packet(&tcp, None);
+        true
     }
 }
 
@@ -1539,8 +1549,9 @@ impl TcpConnectionInner {
             Ok(_) => {}
             Err(_) => {
                 // The DNS TCP query could not be processed; reset the connection.
-                sender.rst(self.tx_send, Some(self.rx_seq));
-                self.stats.rsts_tx.increment();
+                if sender.try_rst(self.tx_send, Some(self.rx_seq)) {
+                    self.stats.rsts_tx.increment();
+                }
                 return false;
             }
         }
@@ -1569,8 +1580,9 @@ impl TcpConnectionInner {
                     );
                 }
                 Poll::Ready(Err(_)) => {
-                    sender.rst(self.tx_send, Some(self.rx_seq));
-                    self.stats.rsts_tx.increment();
+                    if sender.try_rst(self.tx_send, Some(self.rx_seq)) {
+                        self.stats.rsts_tx.increment();
+                    }
                     return false;
                 }
                 Poll::Pending => break,
@@ -1636,8 +1648,9 @@ impl TcpConnectionInner {
                                 "socket failure after fin"
                             ),
                         }
-                        sender.rst(self.tx_send, Some(self.rx_seq));
-                        self.stats.rsts_tx.increment();
+                        if sender.try_rst(self.tx_send, Some(self.rx_seq)) {
+                            self.stats.rsts_tx.increment();
+                        }
                         return false;
                     }
 
@@ -1685,8 +1698,9 @@ impl TcpConnectionInner {
                                         "socket read error"
                                     ),
                                 }
-                                sender.rst(self.tx_send, Some(self.rx_seq));
-                                self.stats.rsts_tx.increment();
+                                if sender.try_rst(self.tx_send, Some(self.rx_seq)) {
+                                    self.stats.rsts_tx.increment();
+                                }
                                 return false;
                             }
                             Poll::Pending => break 'read,
@@ -1783,8 +1797,9 @@ impl TcpConnectionInner {
                             );
                         }
                     }
-                    sender.rst(self.tx_send, Some(self.rx_seq));
-                    self.stats.rsts_tx.increment();
+                    if sender.try_rst(self.tx_send, Some(self.rx_seq)) {
+                        self.stats.rsts_tx.increment();
+                    }
                     return false;
                 }
             }
@@ -1830,8 +1845,9 @@ impl TcpConnectionInner {
                     dst = %sender.ft.dst,
                     "shutdown error"
                 );
-                sender.rst(self.tx_send, Some(self.rx_seq));
-                self.stats.rsts_tx.increment();
+                if sender.try_rst(self.tx_send, Some(self.rx_seq)) {
+                    self.stats.rsts_tx.increment();
+                }
                 return false;
             }
             self.is_shutdown = true;
@@ -1933,8 +1949,9 @@ impl TcpConnectionInner {
             );
         } else {
             log_connect_error(sender.ft, &err);
-            sender.rst(self.tx_send, Some(self.rx_seq));
-            self.stats.rsts_tx.increment();
+            if sender.try_rst(self.tx_send, Some(self.rx_seq)) {
+                self.stats.rsts_tx.increment();
+            }
         }
     }
 
@@ -2481,6 +2498,20 @@ impl TcpConnectionInner {
     /// shouldn't be combined with data so that they are interpreted correctly
     /// by the peer.
     fn ack(&mut self, sender: &mut Sender<'_, impl Client>) {
+        let _ = self.try_ack(sender);
+    }
+
+    fn ack_or_defer(&mut self, sender: &mut Sender<'_, impl Client>) {
+        if !self.try_ack(sender) {
+            self.needs_ack = true;
+        }
+    }
+
+    fn try_ack(&mut self, sender: &mut Sender<'_, impl Client>) -> bool {
+        if sender.client.rx_mtu() == 0 {
+            return false;
+        }
+
         let window_len = self.rx_window_len();
         let tcp = TcpRepr {
             src_port: sender.ft.dst.port(),
@@ -2502,6 +2533,7 @@ impl TcpConnectionInner {
         sender.send_packet(&tcp, None);
         self.stats.standalone_acks_tx.increment();
         self.record_advertised_window(window_len);
+        true
     }
 
     fn handle_listen_syn(
@@ -2517,8 +2549,9 @@ impl TcpConnectionInner {
             && !ack_acceptable
         {
             if tcp.control != TcpControl::Rst {
-                sender.rst(ack_number, None);
-                self.stats.rsts_tx.increment();
+                if sender.try_rst(ack_number, None) {
+                    self.stats.rsts_tx.increment();
+                }
             }
             return Ok(true);
         }
@@ -2552,7 +2585,7 @@ impl TcpConnectionInner {
         self.tx_window_len = tcp.window_len;
 
         // Send an ACK to complete the initial SYN handshake.
-        self.ack(sender);
+        self.ack_or_defer(sender);
 
         if !self.tx_fin.is_pending() {
             self.lifetime_timer = LifetimeTimer::None;
@@ -2591,7 +2624,7 @@ impl TcpConnectionInner {
             && tcp.segment_len() == 1
             && tcp.seq_number + 1 == self.rx_seq
         {
-            self.ack(sender);
+            self.ack_or_defer(sender);
             self.restart_time_wait(sender.state.params.tcp_close_timeout);
             return Ok(true);
         }
@@ -2630,9 +2663,9 @@ impl TcpConnectionInner {
         if !seq_acceptable {
             self.stats.out_of_window_pkts.increment();
             let is_zero_window_probe = rx_window_len == 0
-                && tcp.control == TcpControl::None
+                && matches!(tcp.control, TcpControl::None | TcpControl::Psh)
                 && tcp.ack_number.is_some()
-                && tcp.payload.len() == 1
+                && tcp.payload.len() <= 1
                 && (tcp.seq_number == self.rx_seq || tcp.seq_number + 1 == self.rx_seq);
             if is_zero_window_probe {
                 self.refresh_close_deadline(
@@ -2667,8 +2700,9 @@ impl TcpConnectionInner {
         // Handle ACK of our SYN.
         if self.state == TcpState::SynReceived {
             if ack_number <= self.tx_acked || ack_number > self.tx_send {
-                sender.rst(ack_number, None);
-                self.stats.rsts_tx.increment();
+                if sender.try_rst(ack_number, None) {
+                    self.stats.rsts_tx.increment();
+                }
                 return Ok(false);
             }
             self.tx_window_len = tcp.window_len;
@@ -2867,7 +2901,7 @@ impl TcpConnectionInner {
             }
             TcpState::CloseWait | TcpState::Closing | TcpState::LastAck => {}
             TcpState::TimeWait => {
-                self.ack(sender);
+                self.ack_or_defer(sender);
             }
         }
 

--- a/vm/devices/net/net_consomme/consomme/src/tcp.rs
+++ b/vm/devices/net/net_consomme/consomme/src/tcp.rs
@@ -2702,6 +2702,16 @@ impl TcpConnectionInner {
             let now = *packet_now.get_or_insert_with(TimerInstant::now);
             self.retransmission.on_ack(self.tx_acked, self.tx_send, now);
             self.refresh_close_deadline(now, sender.state.params.tcp_close_timeout);
+        } else if ack_number == self.tx_acked
+            && (self.tx_acked < self.tx_send || !self.tx_buffer.is_empty())
+            && tcp.control == TcpControl::None
+            && tcp.payload.is_empty()
+        {
+            // A pure ACK for pending data confirms that a flow-controlled peer
+            // is still responsive, even when its zero window prevents the ACK
+            // number from advancing.
+            let now = *packet_now.get_or_insert_with(TimerInstant::now);
+            self.refresh_close_deadline(now, sender.state.params.tcp_close_timeout);
         }
 
         let is_duplicate_ack = self.tx_acked == previous_tx_acked

--- a/vm/devices/net/net_consomme/consomme/src/tcp/assembler.rs
+++ b/vm/devices/net/net_consomme/consomme/src/tcp/assembler.rs
@@ -9,10 +9,16 @@ use inspect::Inspect;
 /// segments are dropped — the sender retransmits and gaps fill over time.
 const MAX_RANGES: usize = 4;
 
-/// The assembler's range table is full and the new segment does not overlap
-/// or touch any existing range, so it cannot be tracked.
 #[derive(Debug, PartialEq, Eq)]
-pub struct TooManyGaps;
+pub enum AddError {
+    /// The range table is full and the new segment does not overlap or touch
+    /// any existing range, so it cannot be tracked.
+    TooManyGaps,
+    /// The segment contains data beyond an already-latched FIN.
+    DataPastFin,
+    /// The segment's FIN precedes data already tracked by the assembler.
+    FinBeforeData,
+}
 
 /// Result of an `add` call.
 #[derive(Debug, PartialEq, Eq)]
@@ -75,10 +81,42 @@ impl Assembler {
         self.count == 0
     }
 
+    /// Returns whether accepting this segment would add data or FIN state that
+    /// is not already represented by the assembler.
+    pub fn would_make_progress(&self, offset: u32, len: u32, fin: bool) -> bool {
+        let end = offset + len;
+        if self.validate_fin(offset, len, fin).is_err() {
+            return false;
+        }
+        let adds_data = len != 0
+            && !self.ranges[..self.count as usize]
+                .iter()
+                .any(|&(start, range_end)| offset >= start && end <= range_end);
+        let adds_fin = fin && self.fin_offset.is_none();
+        adds_data || adds_fin
+    }
+
+    fn validate_fin(&self, offset: u32, len: u32, fin: bool) -> Result<(), AddError> {
+        let end = offset + len;
+        if len != 0 && self.fin_offset.is_some_and(|fin_offset| end > fin_offset) {
+            return Err(AddError::DataPastFin);
+        }
+        if fin && self.fin_offset.is_none() {
+            if self.ranges[..self.count as usize]
+                .last()
+                .is_some_and(|&(_, range_end)| range_end > end)
+            {
+                return Err(AddError::FinBeforeData);
+            }
+        }
+        Ok(())
+    }
+
     /// Record that bytes `[offset, offset + len)` have been received.
     /// If `fin` is true, a FIN is present at offset `offset + len` (i.e.,
-    /// immediately after this segment's data). The FIN is latched and will
-    /// be delivered when the contiguous prefix reaches it.
+    /// immediately after this segment's data). The first FIN is latched and
+    /// will be delivered when the contiguous prefix reaches it. Conflicting
+    /// FIN offsets are ignored.
     ///
     /// If this extends the contiguous prefix starting at offset 0, the prefix
     /// is consumed: the first range is removed and all remaining ranges are
@@ -86,25 +124,22 @@ impl Assembler {
     /// bytes consumed. `AddResult::fin` is true if the FIN is now in-order
     /// (all preceding data received).
     ///
-    /// Returns `Err(TooManyGaps)` if the range table is full and the segment
-    /// doesn't merge with any existing range. In that case the assembler is
-    /// unchanged (the FIN is still latched if `fin` was true) and the caller
-    /// should drop the segment (don't write it to the ring).
-    pub fn add(&mut self, offset: u32, len: u32, fin: bool) -> Result<AddResult, TooManyGaps> {
-        // Latch the FIN if present. The FIN sits at offset + len in
-        // data-offset space. We record it *before* processing the data
-        // range so that if this segment also completes the contiguous
-        // prefix, the FIN is delivered in the same call.
-        if fin {
-            self.fin_offset = Some(offset + len);
-        }
-
+    /// Returns an error if the range table cannot track the segment or the
+    /// segment contains data beyond an already-latched FIN. The assembler is
+    /// unchanged on error, and the caller should drop the segment without
+    /// writing it to the ring.
+    pub fn add(&mut self, offset: u32, len: u32, fin: bool) -> Result<AddResult, AddError> {
+        self.validate_fin(offset, len, fin)?;
+        let end = offset + len;
         if len == 0 {
+            if fin && self.fin_offset.is_none() {
+                self.fin_offset = Some(end);
+            }
             return Ok(self.try_fin(0));
         }
 
         let new_start = offset;
-        let new_end = offset + len;
+        let new_end = end;
 
         // Find the range of existing entries that overlap or are adjacent to
         // the new range. Two half-open ranges [s,e) and [ns,ne)
@@ -116,6 +151,16 @@ impl Assembler {
         let last = ranges
             .iter()
             .rposition(|&(s, e)| s <= new_end && new_start <= e);
+
+        if first.is_none() && self.count as usize >= MAX_RANGES {
+            return Err(AddError::TooManyGaps);
+        }
+
+        // Latch the FIN only after all rejection checks so errors leave the
+        // assembler unchanged.
+        if fin && self.fin_offset.is_none() {
+            self.fin_offset = Some(end);
+        }
 
         match (first, last) {
             (Some(first), Some(last)) => {
@@ -133,9 +178,6 @@ impl Assembler {
             (None, None) => {
                 // No overlap: insert as a new entry.
                 let count = self.count as usize;
-                if count >= MAX_RANGES {
-                    return Err(TooManyGaps);
-                }
                 let pos = ranges
                     .iter()
                     .position(|&(s, _)| s > new_start)
@@ -458,9 +500,21 @@ mod tests {
         assert_eq!(a.ranges(), &[(10, 11), (20, 21), (30, 31), (40, 41)]);
 
         let r = a.add(50, 1, false);
-        assert_eq!(r, Err(TooManyGaps));
+        assert_eq!(r, Err(AddError::TooManyGaps));
         // State unchanged.
         assert_eq!(a.ranges(), &[(10, 11), (20, 21), (30, 31), (40, 41)]);
+    }
+
+    #[test]
+    fn test_table_full_reject_does_not_latch_fin() {
+        let mut a = Assembler::new();
+        a.add(10, 1, false).unwrap();
+        a.add(20, 1, false).unwrap();
+        a.add(30, 1, false).unwrap();
+        a.add(40, 1, false).unwrap();
+
+        assert_eq!(a.add(50, 1, true), Err(AddError::TooManyGaps));
+        assert_eq!(a.fin_offset, None);
     }
 
     #[test]
@@ -517,6 +571,7 @@ mod tests {
     #[test]
     fn test_duplicate_segment() {
         let mut a = Assembler::new();
+        assert!(a.would_make_progress(5, 5, false));
         let r = a.add(5, 5, false).unwrap();
         assert_eq!(
             r,
@@ -525,6 +580,7 @@ mod tests {
                 fin: false
             }
         );
+        assert!(!a.would_make_progress(5, 5, false));
         let r = a.add(5, 5, false).unwrap();
         assert_eq!(
             r,
@@ -620,6 +676,73 @@ mod tests {
             }
         );
         assert_eq!(a.ranges(), &[]);
+    }
+
+    #[test]
+    fn test_conflicting_fin_does_not_replace_latched_fin() {
+        let mut a = Assembler::new();
+        assert!(a.would_make_progress(10, 0, true));
+        a.add(10, 0, true).unwrap();
+        assert_eq!(a.fin_offset, Some(10));
+
+        assert!(!a.would_make_progress(20, 0, true));
+        a.add(20, 0, true).unwrap();
+        assert_eq!(a.fin_offset, Some(10));
+    }
+
+    #[test]
+    fn test_data_past_fin_is_rejected() {
+        let mut a = Assembler::new();
+        a.add(10, 0, true).unwrap();
+
+        assert!(!a.would_make_progress(0, 20, false));
+        assert_eq!(a.add(0, 20, false), Err(AddError::DataPastFin));
+        assert_eq!(a.fin_offset, Some(10));
+        assert!(a.ranges().is_empty());
+
+        assert_eq!(
+            a.add(0, 10, false).unwrap(),
+            AddResult {
+                consumed: 10,
+                fin: true,
+            }
+        );
+    }
+
+    #[test]
+    fn test_fin_before_buffered_data_is_rejected() {
+        let mut a = Assembler::new();
+        a.add(3, 7, false).unwrap();
+
+        assert!(!a.would_make_progress(3, 0, true));
+        assert_eq!(a.add(3, 0, true), Err(AddError::FinBeforeData));
+        assert_eq!(a.fin_offset, None);
+        assert_eq!(a.ranges(), &[(3, 10)]);
+
+        assert_eq!(
+            a.add(0, 3, false).unwrap(),
+            AddResult {
+                consumed: 10,
+                fin: false,
+            }
+        );
+    }
+
+    #[test]
+    fn test_fin_after_buffered_data_is_accepted() {
+        let mut a = Assembler::new();
+        a.add(5, 5, false).unwrap();
+
+        assert!(a.would_make_progress(0, 10, true));
+        assert_eq!(
+            a.add(0, 10, true).unwrap(),
+            AddResult {
+                consumed: 10,
+                fin: true,
+            }
+        );
+        assert_eq!(a.fin_offset, None);
+        assert!(a.ranges().is_empty());
     }
 
     #[test]

--- a/vm/devices/net/net_consomme/consomme/src/tcp/assembler.rs
+++ b/vm/devices/net/net_consomme/consomme/src/tcp/assembler.rs
@@ -101,13 +101,13 @@ impl Assembler {
         if len != 0 && self.fin_offset.is_some_and(|fin_offset| end > fin_offset) {
             return Err(AddError::DataPastFin);
         }
-        if fin && self.fin_offset.is_none() {
-            if self.ranges[..self.count as usize]
+        if fin
+            && self.fin_offset.is_none()
+            && self.ranges[..self.count as usize]
                 .last()
                 .is_some_and(|&(_, range_end)| range_end > end)
-            {
-                return Err(AddError::FinBeforeData);
-            }
+        {
+            return Err(AddError::FinBeforeData);
         }
         Ok(())
     }

--- a/vm/devices/net/net_consomme/consomme/src/tcp/tests.rs
+++ b/vm/devices/net/net_consomme/consomme/src/tcp/tests.rs
@@ -17,6 +17,8 @@ use smoltcp::wire::Ipv4Repr;
 use std::net::Ipv4Addr;
 use std::net::SocketAddrV4;
 use std::sync::Arc;
+use std::time::Duration;
+use std::time::Instant;
 
 // ── Mock client ────────────────────────────────────────────────────
 
@@ -1341,5 +1343,280 @@ async fn test_tcp_loopback_port_remap(driver: DefaultDriver) {
     assert!(
         !src_ip.is_loopback(),
         "loopback SYN source IP should not be 127.x.x.x, got {src_ip}"
+    );
+}
+
+/// Test that connections sitting in a half-closed state are reaped after
+/// the configured `tcp_close_timeout` elapses, preventing leaks. Covers
+/// both `TimeWait` (server-initiated close) and `LastAck` (guest-initiated
+/// close that the guest never finalizes).
+#[pal_async::async_test]
+async fn test_tcp_time_wait_cleanup(driver: DefaultDriver) {
+    let mut h = TcpTestHarness::connect(driver).await;
+
+    // Server initiates close: shutting down the host write side causes
+    // consomme's socket to read EOF, which transitions the connection
+    // from Established → FinWait1 and sends a FIN to the guest.
+    h.clear_guest_packets();
+    h.host_shutdown_write();
+
+    // Wait for the FIN from consomme to the guest and ack it.
+    let fin_pkt = h
+        .poll_until_guest_packet(|t| t.control == TcpControl::Fin)
+        .await;
+    let (_, _, fin_tcp) = parse_tcp_packet(&fin_pkt);
+    // Update server_ack to consume the FIN's sequence byte.
+    h.server_ack = fin_tcp.seq_number + fin_tcp.segment_len();
+
+    // Guest acks the server's FIN (FinWait1 → FinWait2).
+    h.send_segment(TcpControl::None, h.guest_seq, &[]);
+
+    // Guest sends its own FIN (FinWait2 → TimeWait).
+    h.send_fin();
+
+    // Drive the stack once so the FIN is processed.
+    std::future::poll_fn(|cx| {
+        h.consomme.access(&mut h.client).poll(cx);
+        Poll::Ready(())
+    })
+    .await;
+
+    // The connection should now be in TimeWait with a deadline set.
+    {
+        let access = h.consomme.access(&mut h.client);
+        assert_eq!(access.inner.tcp.connections.len(), 1);
+        let conn = access.inner.tcp.connections.values_mut().next().unwrap();
+        assert_eq!(conn.inner.state, TcpState::TimeWait);
+        assert!(
+            conn.inner.close_deadline.is_some(),
+            "close deadline must be armed in TimeWait"
+        );
+        // Force the deadline into the past to simulate timeout expiry.
+        conn.inner.close_deadline = Some(Instant::now() - Duration::from_secs(1));
+    }
+
+    // Polling should reap the expired TimeWait connection.
+    std::future::poll_fn(|cx| {
+        h.consomme.access(&mut h.client).poll(cx);
+        Poll::Ready(())
+    })
+    .await;
+
+    assert_eq!(
+        h.consomme.access(&mut h.client).inner.tcp.connections.len(),
+        0,
+        "expired TimeWait connection should be removed"
+    );
+    assert_eq!(
+        h.consomme
+            .access(&mut h.client)
+            .inner
+            .tcp
+            .aggregate_stats
+            .connections_closed_timeout
+            .get(),
+        0,
+        "expired TimeWait connection should not be counted as a timeout close"
+    );
+    assert_eq!(
+        h.consomme
+            .access(&mut h.client)
+            .inner
+            .tcp
+            .aggregate_stats
+            .connections_closed_normal
+            .get(),
+        1,
+        "expired TimeWait connection should be counted as a normal close"
+    );
+}
+
+/// Test that half-closed connections waiting on guest shutdown progress are
+/// counted as timeout closes when their cleanup deadline expires.
+#[pal_async::async_test]
+async fn test_tcp_guest_action_timeout_cleanup(driver: DefaultDriver) {
+    for (state, state_name) in [
+        (TcpState::FinWait1, "FinWait1"),
+        (TcpState::FinWait2, "FinWait2"),
+    ] {
+        let mut h = TcpTestHarness::connect(driver.clone()).await;
+
+        {
+            let access = h.consomme.access(&mut h.client);
+            assert_eq!(access.inner.tcp.connections.len(), 1);
+            let conn = access.inner.tcp.connections.values_mut().next().unwrap();
+            conn.inner.state = state;
+            conn.inner.close_deadline = Some(Instant::now() - Duration::from_secs(1));
+        }
+
+        std::future::poll_fn(|cx| {
+            h.consomme.access(&mut h.client).poll(cx);
+            Poll::Ready(())
+        })
+        .await;
+
+        assert_eq!(
+            h.consomme.access(&mut h.client).inner.tcp.connections.len(),
+            0,
+            "expired {state_name} connection should be removed"
+        );
+        assert_eq!(
+            h.consomme
+                .access(&mut h.client)
+                .inner
+                .tcp
+                .aggregate_stats
+                .connections_closed_timeout
+                .get(),
+            1,
+            "expired {state_name} connection should be counted as a timeout close"
+        );
+        assert_eq!(
+            h.consomme
+                .access(&mut h.client)
+                .inner
+                .tcp
+                .aggregate_stats
+                .connections_closed_normal
+                .get(),
+            0,
+            "expired {state_name} connection should not be counted as a normal close"
+        );
+    }
+}
+
+/// Test that a simultaneous close reaches `Closing`, arms the cleanup
+/// deadline, and is counted as a timeout close if the guest never ACKs our FIN.
+#[pal_async::async_test]
+async fn test_tcp_closing_cleanup(driver: DefaultDriver) {
+    let mut h = TcpTestHarness::connect(driver).await;
+
+    // Server initiates close and consomme sends a FIN to the guest.
+    h.clear_guest_packets();
+    h.host_shutdown_write();
+    let _ = h
+        .poll_until_guest_packet(|t| t.control == TcpControl::Fin)
+        .await;
+
+    // Guest sends its own FIN without ACKing the server FIN, causing the
+    // simultaneous-close FinWait1 -> Closing transition.
+    h.send_fin();
+
+    {
+        let access = h.consomme.access(&mut h.client);
+        assert_eq!(access.inner.tcp.connections.len(), 1);
+        let conn = access.inner.tcp.connections.values_mut().next().unwrap();
+        assert_eq!(conn.inner.state, TcpState::Closing);
+        assert!(
+            conn.inner.close_deadline.is_some(),
+            "close deadline must be armed in Closing"
+        );
+        conn.inner.close_deadline = Some(Instant::now() - Duration::from_secs(1));
+    }
+
+    std::future::poll_fn(|cx| {
+        h.consomme.access(&mut h.client).poll(cx);
+        Poll::Ready(())
+    })
+    .await;
+
+    assert_eq!(
+        h.consomme.access(&mut h.client).inner.tcp.connections.len(),
+        0,
+        "expired Closing connection should be removed"
+    );
+    assert_eq!(
+        h.consomme
+            .access(&mut h.client)
+            .inner
+            .tcp
+            .aggregate_stats
+            .connections_closed_timeout
+            .get(),
+        1,
+        "expired Closing connection should be counted as a timeout close"
+    );
+    assert_eq!(
+        h.consomme
+            .access(&mut h.client)
+            .inner
+            .tcp
+            .aggregate_stats
+            .connections_closed_normal
+            .get(),
+        0,
+        "expired Closing connection should not be counted as a normal close"
+    );
+}
+
+/// Test that a connection stuck in `LastAck` (guest never acks our FIN
+/// after a guest-initiated close) is reaped after the `tcp_close_timeout`
+/// elapses.
+#[pal_async::async_test]
+async fn test_tcp_last_ack_cleanup(driver: DefaultDriver) {
+    let mut h = TcpTestHarness::connect(driver).await;
+
+    // Guest initiates close: send FIN (Established → CloseWait).
+    h.clear_guest_packets();
+    h.send_fin();
+
+    // Drive the stack so consomme processes the FIN, sees host EOF via
+    // the shutdown(Read) implicitly forwarded, and we eventually transition
+    // to LastAck. We need the host stream to also close so consomme calls
+    // close() on its end (CloseWait → LastAck).
+    h.host_shutdown_write();
+
+    // Wait for consomme to send its own FIN to the guest, which means
+    // we have entered LastAck.
+    let _ = h
+        .poll_until_guest_packet(|t| t.control == TcpControl::Fin)
+        .await;
+
+    // Intentionally do NOT ack the FIN. Verify the state and force the
+    // deadline into the past.
+    {
+        let access = h.consomme.access(&mut h.client);
+        assert_eq!(access.inner.tcp.connections.len(), 1);
+        let conn = access.inner.tcp.connections.values_mut().next().unwrap();
+        assert_eq!(conn.inner.state, TcpState::LastAck);
+        assert!(
+            conn.inner.close_deadline.is_some(),
+            "close deadline must be armed in LastAck"
+        );
+        conn.inner.close_deadline = Some(Instant::now() - Duration::from_secs(1));
+    }
+
+    std::future::poll_fn(|cx| {
+        h.consomme.access(&mut h.client).poll(cx);
+        Poll::Ready(())
+    })
+    .await;
+
+    assert_eq!(
+        h.consomme.access(&mut h.client).inner.tcp.connections.len(),
+        0,
+        "expired LastAck connection should be removed"
+    );
+    assert_eq!(
+        h.consomme
+            .access(&mut h.client)
+            .inner
+            .tcp
+            .aggregate_stats
+            .connections_closed_timeout
+            .get(),
+        1,
+        "expired LastAck connection should be counted as a timeout close"
+    );
+    assert_eq!(
+        h.consomme
+            .access(&mut h.client)
+            .inner
+            .tcp
+            .aggregate_stats
+            .connections_closed_normal
+            .get(),
+        0,
+        "expired LastAck connection should not be counted as a normal close"
     );
 }

--- a/vm/devices/net/net_consomme/consomme/src/tcp/tests.rs
+++ b/vm/devices/net/net_consomme/consomme/src/tcp/tests.rs
@@ -1322,7 +1322,6 @@ async fn test_tcp_port_forward_recovers_from_stale_ack(driver: DefaultDriver) {
         dst: SocketAddr::V4(SocketAddrV4::new(syn_src_ip, syn.src_port)),
     };
     received.lock().clear();
-    client.add_rx_buffers(2);
 
     let stale_ack = TcpRepr {
         src_port: guest_port,
@@ -1351,7 +1350,16 @@ async fn test_tcp_port_forward_recovers_from_stale_ack(driver: DefaultDriver) {
         .access(&mut client)
         .send(&buf[..len], &ChecksumState::NONE)
         .unwrap();
+    assert!(
+        received.lock().is_empty(),
+        "a stale ACK must not emit an RST without an RX buffer"
+    );
 
+    client.add_rx_buffers(2);
+    consomme
+        .access(&mut client)
+        .send(&buf[..len], &ChecksumState::NONE)
+        .unwrap();
     {
         let packets = received.lock();
         let (_, _, rst) = parse_tcp_packet(
@@ -1416,7 +1424,8 @@ async fn test_tcp_port_forward_recovers_from_stale_ack(driver: DefaultDriver) {
     assert_eq!(retry_syn.seq_number, syn.seq_number);
     assert!(retry_syn.ack_number.is_none());
 
-    client.add_rx_buffers(1);
+    client.rx_buffers = Some(0);
+    received.lock().clear();
     let syn_ack = TcpRepr {
         src_port: guest_port,
         dst_port: retry_syn.src_port,
@@ -1466,6 +1475,35 @@ async fn test_tcp_port_forward_recovers_from_stale_ack(driver: DefaultDriver) {
             LifetimeTimer::None
         ),
         "completed handshake should clear its deadline"
+    );
+    assert!(
+        consomme.tcp.connections.get(&ft).unwrap().inner.needs_ack,
+        "final handshake ACK should remain pending without an RX buffer"
+    );
+    assert!(
+        received.lock().is_empty(),
+        "final handshake ACK must not be emitted without an RX buffer"
+    );
+
+    client.add_rx_buffers(1);
+    std::future::poll_fn(|cx| {
+        consomme.access(&mut client).poll(cx);
+        Poll::Ready(())
+    })
+    .await;
+
+    assert!(
+        received.lock().iter().any(|packet| {
+            TcpTestHarness::is_tcp_packet(packet).is_some_and(|tcp| {
+                tcp.control == TcpControl::None
+                    && tcp.ack_number == Some(syn_ack.seq_number + syn_ack.segment_len())
+            })
+        }),
+        "final handshake ACK should be sent once an RX buffer is available"
+    );
+    assert!(
+        !consomme.tcp.connections.get(&ft).unwrap().inner.needs_ack,
+        "sending the final handshake ACK should clear the pending state"
     );
 }
 
@@ -2637,9 +2675,20 @@ async fn test_tcp_time_wait_cleanup(driver: DefaultDriver) {
         "an unacceptable FIN must not restart the TimeWait deadline"
     );
 
-    // A retransmitted FIN must be ACKed and restart the 2*MSL timer.
+    // A retransmitted FIN must restart the 2*MSL timer and defer its ACK
+    // until an RX buffer is available.
     h.clear_guest_packets();
+    h.client.rx_buffers = Some(0);
     h.send_segment(TcpControl::Fin, h.guest_seq - 1, &[]);
+    assert!(h.client.received_packets.lock().is_empty());
+    assert!(h.connection_inner().needs_ack);
+
+    h.client.add_rx_buffers(1);
+    std::future::poll_fn(|cx| {
+        h.consomme.access(&mut h.client).poll(cx);
+        Poll::Ready(())
+    })
+    .await;
     assert!(h.client.received_packets.lock().iter().any(|packet| {
         TcpTestHarness::is_tcp_packet(packet).is_some_and(|tcp| {
             tcp.control == TcpControl::None && tcp.ack_number == Some(h.guest_seq)
@@ -2816,7 +2865,7 @@ async fn test_tcp_last_ack_restarts_timeout_after_close_wait(driver: DefaultDriv
 }
 
 #[pal_async::async_test]
-async fn test_tcp_fin_wait_zero_window_probe_refreshes_timeout(driver: DefaultDriver) {
+async fn test_tcp_fin_wait_zero_window_probes_refresh_timeout(driver: DefaultDriver) {
     let mut h = TcpTestHarness::connect(driver).await;
 
     h.clear_guest_packets();
@@ -2849,7 +2898,41 @@ async fn test_tcp_fin_wait_zero_window_probe_refreshes_timeout(driver: DefaultDr
     assert!(
         h.connection_inner().lifetime_timer.deadline()
             > Some(Instant::now() + Duration::from_secs(1)),
-        "a zero-window probe should refresh the close timeout"
+        "a one-byte zero-window probe should refresh the close timeout"
+    );
+
+    {
+        let conn = h.consomme.tcp.connections.get_mut(&ft).unwrap();
+        conn.inner.lifetime_timer = LifetimeTimer::Close(Instant::now() + Duration::from_millis(1));
+    }
+
+    assert!(
+        h.try_send_segment(TcpControl::None, h.guest_seq - 1, &[], 64240)
+            .is_err(),
+        "a zero-length zero-window probe should follow the unacceptable-segment path"
+    );
+
+    assert!(
+        h.connection_inner().lifetime_timer.deadline()
+            > Some(Instant::now() + Duration::from_secs(1)),
+        "a zero-length zero-window probe should refresh the close timeout"
+    );
+
+    {
+        let conn = h.consomme.tcp.connections.get_mut(&ft).unwrap();
+        conn.inner.lifetime_timer = LifetimeTimer::Close(Instant::now() + Duration::from_millis(1));
+    }
+
+    assert!(
+        h.try_send_segment(TcpControl::Psh, h.guest_seq, b"x", 64240)
+            .is_err(),
+        "a PSH-marked zero-window probe should follow the unacceptable-segment path"
+    );
+
+    assert!(
+        h.connection_inner().lifetime_timer.deadline()
+            > Some(Instant::now() + Duration::from_secs(1)),
+        "a PSH-marked zero-window probe should refresh the close timeout"
     );
 }
 

--- a/vm/devices/net/net_consomme/consomme/src/tcp/tests.rs
+++ b/vm/devices/net/net_consomme/consomme/src/tcp/tests.rs
@@ -15,6 +15,7 @@ use futures::AsyncRead;
 use futures::AsyncWrite;
 use pal_async::DefaultDriver;
 use pal_async::socket::PolledSocket;
+use pal_async::timer::Instant;
 use parking_lot::Mutex;
 use smoltcp::wire::DnsQueryType;
 use smoltcp::wire::EthernetAddress;
@@ -27,12 +28,14 @@ use std::net::Ipv6Addr;
 use std::net::SocketAddrV4;
 use std::net::SocketAddrV6;
 use std::sync::Arc;
+use std::time::Duration;
 
 // ── Mock client ────────────────────────────────────────────────────
 
 struct TestClient {
     driver: DefaultDriver,
     received_packets: Arc<Mutex<Vec<Vec<u8>>>>,
+    rx_buffers: Option<usize>,
 }
 
 #[test]
@@ -255,7 +258,20 @@ impl TestClient {
         Self {
             driver,
             received_packets: Arc::new(Mutex::new(Vec::new())),
+            rx_buffers: None,
         }
+    }
+
+    fn with_rx_buffers(driver: DefaultDriver, rx_buffers: usize) -> Self {
+        Self {
+            driver,
+            received_packets: Arc::new(Mutex::new(Vec::new())),
+            rx_buffers: Some(rx_buffers),
+        }
+    }
+
+    fn add_rx_buffers(&mut self, count: usize) {
+        *self.rx_buffers.as_mut().unwrap() += count;
     }
 }
 
@@ -265,11 +281,15 @@ impl Client for TestClient {
     }
 
     fn recv(&mut self, data: &[u8], _checksum: &ChecksumState) {
+        if let Some(rx_buffers) = &mut self.rx_buffers {
+            assert_ne!(*rx_buffers, 0, "packet sent without an RX buffer");
+            *rx_buffers -= 1;
+        }
         self.received_packets.lock().push(data.to_vec());
     }
 
     fn rx_mtu(&mut self) -> usize {
-        1514
+        if self.rx_buffers == Some(0) { 0 } else { 1514 }
     }
 }
 
@@ -339,6 +359,8 @@ fn parse_tcp_packet(data: &[u8]) -> (Ipv4Address, Ipv4Address, TcpRepr<'_>) {
 struct TcpTestHarness {
     consomme: Consomme,
     client: TestClient,
+    /// Keep the listener alive so tests can reuse the same four-tuple.
+    _listener: PolledSocket<std::net::TcpListener>,
     /// The accepted host-side TCP connection.
     host_stream: PolledSocket<std::net::TcpStream>,
     guest_mac: EthernetAddress,
@@ -452,6 +474,7 @@ impl TcpTestHarness {
         let mut harness = Self {
             consomme,
             client,
+            _listener: listener,
             host_stream,
             guest_mac,
             gateway_mac,
@@ -494,13 +517,23 @@ impl TcpTestHarness {
     /// Send a TCP segment from the guest with the given control, sequence
     /// number, and payload. Uses the connection's ACK and window values.
     fn send_segment(&mut self, control: TcpControl, seq: TcpSeqNumber, payload: &[u8]) {
+        self.try_send_segment(control, seq, payload, 64240).unwrap();
+    }
+
+    fn try_send_segment(
+        &mut self,
+        control: TcpControl,
+        seq: TcpSeqNumber,
+        payload: &[u8],
+        window_len: u16,
+    ) -> Result<(), DropReason> {
         let tcp = TcpRepr {
             src_port: self.guest_port,
             dst_port: self.dst_port,
             control,
             seq_number: seq,
             ack_number: Some(self.server_ack),
-            window_len: 64240,
+            window_len,
             window_scale: None,
             max_seg_size: None,
             sack_permitted: false,
@@ -508,17 +541,31 @@ impl TcpTestHarness {
             timestamp: None,
             payload,
         };
+        self.try_send_repr(&tcp)
+    }
+
+    fn try_send_repr(&mut self, tcp: &TcpRepr<'_>) -> Result<(), DropReason> {
         let len = build_tcp_packet(
             &mut self.buf,
             self.guest_mac,
             self.gateway_mac,
             self.guest_ip,
             self.dst_ip,
-            &tcp,
+            tcp,
         );
         self.consomme
             .access(&mut self.client)
             .send(&self.buf[..len], &ChecksumState::NONE)
+    }
+
+    fn send_segment_with_window(
+        &mut self,
+        control: TcpControl,
+        seq: TcpSeqNumber,
+        payload: &[u8],
+        window_len: u16,
+    ) {
+        self.try_send_segment(control, seq, payload, window_len)
             .unwrap();
     }
 
@@ -1112,6 +1159,298 @@ async fn test_tcp_bind_port_forward(driver: DefaultDriver) {
     let (_, _, tcp) = parse_tcp_packet(syn_pkt);
     assert_eq!(tcp.dst_port, guest_port);
     assert_eq!(tcp.control, TcpControl::Syn);
+}
+
+/// Test that an accepted connection sends its initial SYN after RX capacity
+/// becomes available.
+#[pal_async::async_test]
+async fn test_tcp_port_forward_defers_initial_syn_without_rx_buffer(driver: DefaultDriver) {
+    let mut consomme = Consomme::new(ConsommeParams::new().unwrap());
+    let mut client = TestClient::with_rx_buffers(driver.clone(), 0);
+
+    let guest_port = 7777;
+    let received = client.received_packets.clone();
+    let socket = Socket::new(Domain::IPV4, Type::STREAM, None).unwrap();
+    socket
+        .bind(&SocketAddrV4::new(Ipv4Addr::LOCALHOST, 0).into())
+        .unwrap();
+    let host_addr = socket.local_addr().unwrap().as_socket().unwrap();
+
+    consomme
+        .access(&mut client)
+        .bind_tcp_port(socket, guest_port)
+        .expect("bind should succeed");
+
+    let connector = std::net::TcpStream::connect(host_addr).unwrap();
+    connector.set_nonblocking(true).unwrap();
+
+    let deadline = std::time::Instant::now() + Duration::from_secs(5);
+    loop {
+        std::future::poll_fn(|cx| {
+            consomme.access(&mut client).poll(cx);
+            Poll::Ready(())
+        })
+        .await;
+
+        if !consomme.tcp.connections.is_empty() {
+            break;
+        }
+        assert!(
+            std::time::Instant::now() < deadline,
+            "timed out waiting for forwarded TCP connection"
+        );
+        pal_async::timer::PolledTimer::new(&driver)
+            .sleep(Duration::from_millis(10))
+            .await;
+    }
+
+    assert!(
+        received.lock().is_empty(),
+        "SYN should wait for an RX buffer"
+    );
+
+    client.add_rx_buffers(1);
+    std::future::poll_fn(|cx| {
+        consomme.access(&mut client).poll(cx);
+        Poll::Ready(())
+    })
+    .await;
+
+    let syn_packet = {
+        let packets = received.lock();
+        packets
+            .iter()
+            .find(|packet| {
+                TcpTestHarness::is_tcp_packet(packet)
+                    .is_some_and(|tcp| tcp.control == TcpControl::Syn && tcp.dst_port == guest_port)
+            })
+            .cloned()
+            .expect("initial SYN should be sent when an RX buffer is available")
+    };
+    let (_, _, syn) = parse_tcp_packet(&syn_packet);
+    assert!(syn.ack_number.is_none());
+
+    let connection = consomme.tcp.connections.values_mut().next().unwrap();
+    assert!(matches!(
+        connection.inner.lifetime_timer,
+        LifetimeTimer::Handshake(_)
+    ));
+    connection.inner.lifetime_timer =
+        LifetimeTimer::Handshake(TimerInstant::now() - Duration::from_millis(1));
+    std::future::poll_fn(|cx| {
+        consomme.access(&mut client).poll(cx);
+        Poll::Ready(())
+    })
+    .await;
+    assert!(
+        consomme.tcp.connections.is_empty(),
+        "expired handshake should be reclaimed"
+    );
+}
+
+/// Test that a stale ACK from a recently closed guest connection resets the
+/// stale tuple without allowing guest packets to accelerate SYN retransmits.
+#[pal_async::async_test]
+async fn test_tcp_port_forward_recovers_from_stale_ack(driver: DefaultDriver) {
+    let mut consomme = Consomme::new(ConsommeParams::new().unwrap());
+    let mut client = TestClient::with_rx_buffers(driver.clone(), 1);
+
+    let guest_mac = consomme.params_mut().client_mac;
+    let gateway_mac = consomme.params_mut().gateway_mac;
+    let guest_ip = consomme.params_mut().client_ip;
+    let guest_port = 7777;
+    let received = client.received_packets.clone();
+
+    let socket = Socket::new(Domain::IPV4, Type::STREAM, None).unwrap();
+    socket
+        .bind(&SocketAddrV4::new(Ipv4Addr::LOCALHOST, 0).into())
+        .unwrap();
+    let host_addr = socket.local_addr().unwrap().as_socket().unwrap();
+
+    consomme
+        .access(&mut client)
+        .bind_tcp_port(socket, guest_port)
+        .expect("bind should succeed");
+
+    let connector = std::net::TcpStream::connect(host_addr).unwrap();
+    connector.set_nonblocking(true).unwrap();
+
+    let deadline = std::time::Instant::now() + Duration::from_secs(5);
+    let syn_packet = loop {
+        std::future::poll_fn(|cx| {
+            consomme.access(&mut client).poll(cx);
+            Poll::Ready(())
+        })
+        .await;
+
+        if let Some(packet) = received.lock().iter().find_map(|packet| {
+            TcpTestHarness::is_tcp_packet(packet)
+                .is_some_and(|tcp| tcp.control == TcpControl::Syn && tcp.dst_port == guest_port)
+                .then(|| packet.clone())
+        }) {
+            break packet;
+        }
+
+        assert!(
+            std::time::Instant::now() < deadline,
+            "timed out waiting for forwarded TCP SYN"
+        );
+        pal_async::timer::PolledTimer::new(&driver)
+            .sleep(Duration::from_millis(10))
+            .await;
+    };
+
+    let (syn_src_ip, _, syn) = parse_tcp_packet(&syn_packet);
+    let ft = FourTuple {
+        src: SocketAddr::V4(SocketAddrV4::new(guest_ip, guest_port)),
+        dst: SocketAddr::V4(SocketAddrV4::new(syn_src_ip, syn.src_port)),
+    };
+    received.lock().clear();
+    client.add_rx_buffers(2);
+
+    let stale_ack = TcpRepr {
+        src_port: guest_port,
+        dst_port: syn.src_port,
+        control: TcpControl::None,
+        seq_number: TcpSeqNumber(9000),
+        ack_number: Some(syn.seq_number),
+        window_len: 64240,
+        window_scale: None,
+        max_seg_size: None,
+        sack_permitted: false,
+        sack_ranges: [None, None, None],
+        timestamp: None,
+        payload: &[],
+    };
+    let mut buf = vec![0u8; 1514];
+    let len = build_tcp_packet(
+        &mut buf,
+        guest_mac,
+        gateway_mac,
+        guest_ip,
+        syn_src_ip,
+        &stale_ack,
+    );
+    consomme
+        .access(&mut client)
+        .send(&buf[..len], &ChecksumState::NONE)
+        .unwrap();
+
+    {
+        let packets = received.lock();
+        let (_, _, rst) = parse_tcp_packet(
+            packets
+                .iter()
+                .find(|packet| {
+                    TcpTestHarness::is_tcp_packet(packet)
+                        .is_some_and(|tcp| tcp.control == TcpControl::Rst)
+                })
+                .expect("stale connection should be reset"),
+        );
+        assert_eq!(rst.seq_number, syn.seq_number);
+        assert!(
+            !packets.iter().any(|packet| {
+                TcpTestHarness::is_tcp_packet(packet)
+                    .is_some_and(|tcp| tcp.control == TcpControl::Syn)
+            }),
+            "stale ACK must not trigger an early SYN retransmit"
+        );
+    }
+
+    received.lock().clear();
+    client.add_rx_buffers(1);
+    consomme
+        .access(&mut client)
+        .send(&buf[..len], &ChecksumState::NONE)
+        .unwrap();
+    assert!(
+        !received.lock().iter().any(|packet| {
+            TcpTestHarness::is_tcp_packet(packet).is_some_and(|tcp| tcp.control == TcpControl::Syn)
+        }),
+        "retry should wait for an RX buffer"
+    );
+
+    client.add_rx_buffers(1);
+    consomme
+        .tcp
+        .connections
+        .get_mut(&ft)
+        .unwrap()
+        .inner
+        .retransmission
+        .timer = RetransmissionTimer::Rto {
+        deadline: TimerInstant::now(),
+        recover: None,
+    };
+    std::future::poll_fn(|cx| {
+        consomme.access(&mut client).poll(cx);
+        Poll::Ready(())
+    })
+    .await;
+
+    let retry_syn_packet = received
+        .lock()
+        .iter()
+        .find(|packet| {
+            TcpTestHarness::is_tcp_packet(packet).is_some_and(|tcp| tcp.control == TcpControl::Syn)
+        })
+        .cloned()
+        .expect("outstanding SYN should be retransmitted");
+    let (_, _, retry_syn) = parse_tcp_packet(&retry_syn_packet);
+    assert_eq!(retry_syn.seq_number, syn.seq_number);
+    assert!(retry_syn.ack_number.is_none());
+
+    client.add_rx_buffers(1);
+    let syn_ack = TcpRepr {
+        src_port: guest_port,
+        dst_port: retry_syn.src_port,
+        control: TcpControl::Syn,
+        seq_number: TcpSeqNumber(10000),
+        ack_number: Some(retry_syn.seq_number + 1),
+        window_len: 64240,
+        window_scale: Some(7),
+        max_seg_size: Some(1460),
+        sack_permitted: false,
+        sack_ranges: [None, None, None],
+        timestamp: None,
+        payload: &[],
+    };
+    let len = build_tcp_packet(
+        &mut buf,
+        guest_mac,
+        gateway_mac,
+        guest_ip,
+        syn_src_ip,
+        &syn_ack,
+    );
+    consomme
+        .access(&mut client)
+        .send(&buf[..len], &ChecksumState::NONE)
+        .unwrap();
+
+    assert_eq!(
+        consomme
+            .tcp
+            .connections
+            .get(&ft)
+            .expect("connection should remain active")
+            .inner
+            .state,
+        TcpState::Established
+    );
+    assert!(
+        matches!(
+            consomme
+                .tcp
+                .connections
+                .get(&ft)
+                .unwrap()
+                .inner
+                .lifetime_timer,
+            LifetimeTimer::None
+        ),
+        "completed handshake should clear its deadline"
+    );
 }
 
 /// Test that when a loopback connection is forwarded to the guest, the source
@@ -1729,6 +2068,61 @@ async fn test_tcp_port_forward_window_scale_guard(driver: DefaultDriver) {
         "server should offer window scaling"
     );
 
+    let ft = FourTuple {
+        src: SocketAddr::V4(SocketAddrV4::new(guest_ip, guest_port)),
+        dst: SocketAddr::V4(SocketAddrV4::new(syn_src_ip, syn_tcp.src_port)),
+    };
+
+    // An invalid SYN-ACK must not commit any handshake state. A subsequent
+    // valid retransmission should still be able to complete the handshake.
+    let invalid_syn_ack = TcpRepr {
+        src_port: guest_port,
+        dst_port: syn_tcp.src_port,
+        control: TcpControl::Syn,
+        seq_number: TcpSeqNumber(5000),
+        ack_number: Some(server_isn + 1),
+        window_len: 200,
+        window_scale: Some(15),
+        max_seg_size: Some(1460),
+        sack_permitted: false,
+        sack_ranges: [None, None, None],
+        timestamp: None,
+        payload: &[],
+    };
+    received.lock().clear();
+    let mut conn = consomme
+        .tcp
+        .connections
+        .remove(&ft)
+        .expect("connection should be pending");
+    let result = {
+        let mut sender = Sender {
+            ft: &ft,
+            client: &mut client,
+            state: &mut consomme.state,
+        };
+        conn.inner.handle_listen_syn(&mut sender, &invalid_syn_ack)
+    };
+    assert!(
+        result.is_err(),
+        "invalid window scale should reject the SYN-ACK"
+    );
+    assert_eq!(conn.inner.state, TcpState::SynSent);
+    assert_eq!(conn.inner.tx_acked, server_isn);
+    assert_eq!(conn.inner.tx_send, server_isn + 1);
+    assert_eq!(conn.inner.tx_syn, TxSynState::Syn);
+    consomme.tcp.connections.insert(ft, conn);
+
+    std::future::poll_fn(|cx| {
+        consomme.access(&mut client).poll(cx);
+        Poll::Ready(())
+    })
+    .await;
+    assert!(
+        received.lock().is_empty(),
+        "rejected SYN-ACK must not trigger another SYN"
+    );
+
     // Guest replies with SYN-ACK. Advertise a small unscaled window (200
     // bytes) with window_scale=7 offered. The SYN-ACK window is unscaled
     // per RFC 1323, so consomme must treat 200 as the actual byte limit
@@ -1770,10 +2164,6 @@ async fn test_tcp_port_forward_window_scale_guard(driver: DefaultDriver) {
 
     // Verify internal state: tx_window_scale_active should be FALSE
     // because handle_listen_syn doesn't activate it.
-    let ft = FourTuple {
-        src: SocketAddr::V4(SocketAddrV4::new(guest_ip, guest_port)),
-        dst: SocketAddr::V4(SocketAddrV4::new(syn_src_ip, syn_tcp.src_port)),
-    };
     let conn = consomme
         .tcp
         .connections
@@ -2167,4 +2557,1115 @@ fn tcp_checksum_matches_smoltcp() {
             }
         }
     }
+}
+
+/// Test that connections sitting in a half-closed state are reaped after
+/// the configured `tcp_close_timeout` elapses, preventing leaks. Covers
+/// both `TimeWait` (server-initiated close) and `LastAck` (guest-initiated
+/// close that the guest never finalizes).
+#[pal_async::async_test]
+async fn test_tcp_time_wait_cleanup(driver: DefaultDriver) {
+    let mut h = TcpTestHarness::connect(driver).await;
+
+    // Server initiates close: shutting down the host write side causes
+    // consomme's socket to read EOF, which transitions the connection
+    // from Established → FinWait1 and sends a FIN to the guest.
+    h.clear_guest_packets();
+    h.host_shutdown_write();
+
+    // Wait for the FIN from consomme to the guest and ack it.
+    let fin_pkt = h
+        .poll_until_guest_packet(|t| t.control == TcpControl::Fin)
+        .await;
+    let (_, _, fin_tcp) = parse_tcp_packet(&fin_pkt);
+    // Update server_ack to consume the FIN's sequence byte.
+    h.server_ack = fin_tcp.seq_number + fin_tcp.segment_len();
+
+    // Guest acks the server's FIN (FinWait1 → FinWait2).
+    h.send_segment(TcpControl::None, h.guest_seq, &[]);
+
+    // Guest sends its own FIN (FinWait2 → TimeWait).
+    h.send_fin();
+
+    // Drive the stack once so the FIN is processed.
+    std::future::poll_fn(|cx| {
+        h.consomme.access(&mut h.client).poll(cx);
+        Poll::Ready(())
+    })
+    .await;
+
+    // The connection should now be in TimeWait with a deadline set.
+    {
+        let access = h.consomme.access(&mut h.client);
+        assert_eq!(access.inner.tcp.connections.len(), 1);
+        let conn = access.inner.tcp.connections.values_mut().next().unwrap();
+        assert_eq!(conn.inner.state, TcpState::TimeWait);
+        assert_eq!(conn.inner.rx_buffer.capacity(), 0);
+        assert_eq!(conn.inner.tx_buffer.capacity(), 0);
+        assert!(
+            matches!(conn.inner.lifetime_timer, LifetimeTimer::Close(_)),
+            "close deadline must be armed in TimeWait"
+        );
+        conn.inner.lifetime_timer = LifetimeTimer::Close(Instant::now() + Duration::from_millis(1));
+    }
+
+    let close_deadline = h.connection_inner().lifetime_timer.deadline();
+    assert!(
+        h.try_send_segment(TcpControl::Fin, h.guest_seq - 2, b"x", 64240)
+            .is_err(),
+        "a payload-bearing old FIN should fail normal sequence validation"
+    );
+    assert_eq!(
+        h.connection_inner().lifetime_timer.deadline(),
+        close_deadline,
+        "an unacceptable FIN must not restart the TimeWait deadline"
+    );
+
+    // A retransmitted FIN must be ACKed and restart the 2*MSL timer.
+    h.clear_guest_packets();
+    h.send_segment(TcpControl::Fin, h.guest_seq - 1, &[]);
+    assert!(h.client.received_packets.lock().iter().any(|packet| {
+        TcpTestHarness::is_tcp_packet(packet).is_some_and(|tcp| {
+            tcp.control == TcpControl::None && tcp.ack_number == Some(h.guest_seq)
+        })
+    }));
+
+    {
+        let access = h.consomme.access(&mut h.client);
+        let conn = access.inner.tcp.connections.values_mut().next().unwrap();
+        assert!(
+            conn.inner.lifetime_timer.deadline() > Some(Instant::now() + Duration::from_secs(1)),
+            "retransmitted FIN must restart the TimeWait deadline"
+        );
+        // Force the deadline into the past to simulate timeout expiry.
+        conn.inner.lifetime_timer = LifetimeTimer::Close(Instant::now() - Duration::from_secs(1));
+    }
+
+    // Polling should reap the expired TimeWait connection.
+    std::future::poll_fn(|cx| {
+        h.consomme.access(&mut h.client).poll(cx);
+        Poll::Ready(())
+    })
+    .await;
+
+    assert_eq!(
+        h.consomme.access(&mut h.client).inner.tcp.connections.len(),
+        0,
+        "expired TimeWait connection should be removed"
+    );
+    assert_eq!(
+        h.consomme
+            .access(&mut h.client)
+            .inner
+            .tcp
+            .aggregate_stats
+            .connections_closed_timeout
+            .get(),
+        0,
+        "expired TimeWait connection should not be counted as a timeout close"
+    );
+    assert_eq!(
+        h.consomme
+            .access(&mut h.client)
+            .inner
+            .tcp
+            .aggregate_stats
+            .connections_closed_normal
+            .get(),
+        1,
+        "expired TimeWait connection should be counted as a normal close"
+    );
+}
+
+/// Test that half-closed connections waiting on guest shutdown progress are
+/// counted as timeout closes when their cleanup deadline expires.
+#[pal_async::async_test]
+async fn test_tcp_guest_action_timeout_cleanup(driver: DefaultDriver) {
+    for (state, state_name) in [
+        (TcpState::FinWait1, "FinWait1"),
+        (TcpState::FinWait2, "FinWait2"),
+    ] {
+        let mut h = TcpTestHarness::connect(driver.clone()).await;
+
+        {
+            let access = h.consomme.access(&mut h.client);
+            assert_eq!(access.inner.tcp.connections.len(), 1);
+            let conn = access.inner.tcp.connections.values_mut().next().unwrap();
+            conn.inner.state = state;
+            conn.inner.lifetime_timer =
+                LifetimeTimer::Close(Instant::now() - Duration::from_secs(1));
+        }
+
+        std::future::poll_fn(|cx| {
+            h.consomme.access(&mut h.client).poll(cx);
+            Poll::Ready(())
+        })
+        .await;
+
+        assert_eq!(
+            h.consomme.access(&mut h.client).inner.tcp.connections.len(),
+            0,
+            "expired {state_name} connection should be removed"
+        );
+        assert_eq!(
+            h.consomme
+                .access(&mut h.client)
+                .inner
+                .tcp
+                .aggregate_stats
+                .connections_closed_timeout
+                .get(),
+            1,
+            "expired {state_name} connection should be counted as a timeout close"
+        );
+        assert_eq!(
+            h.consomme
+                .access(&mut h.client)
+                .inner
+                .tcp
+                .aggregate_stats
+                .connections_closed_normal
+                .get(),
+            0,
+            "expired {state_name} connection should not be counted as a normal close"
+        );
+    }
+}
+
+/// Test that a guest-initiated half-close is reclaimed even if the host keeps
+/// its write side open indefinitely.
+#[pal_async::async_test]
+async fn test_tcp_close_wait_cleanup(driver: DefaultDriver) {
+    let mut h = TcpTestHarness::connect(driver).await;
+
+    h.clear_guest_packets();
+    h.send_fin();
+
+    {
+        let access = h.consomme.access(&mut h.client);
+        let conn = access.inner.tcp.connections.values_mut().next().unwrap();
+        assert_eq!(conn.inner.state, TcpState::CloseWait);
+        assert!(
+            matches!(conn.inner.lifetime_timer, LifetimeTimer::Close(_)),
+            "close deadline must be armed in CloseWait"
+        );
+        conn.inner.lifetime_timer = LifetimeTimer::Close(Instant::now() - Duration::from_secs(1));
+    }
+
+    std::future::poll_fn(|cx| {
+        h.consomme.access(&mut h.client).poll(cx);
+        Poll::Ready(())
+    })
+    .await;
+
+    assert!(
+        h.consomme
+            .access(&mut h.client)
+            .inner
+            .tcp
+            .connections
+            .is_empty(),
+        "expired CloseWait connection should be removed"
+    );
+    assert_eq!(
+        h.consomme
+            .access(&mut h.client)
+            .inner
+            .tcp
+            .aggregate_stats
+            .connections_closed_timeout
+            .get(),
+        1,
+        "expired CloseWait connection should be counted as a timeout close"
+    );
+}
+
+/// Test that a simultaneous close reaches `Closing`, arms the cleanup
+/// deadline, and is counted as a timeout close if the guest never ACKs our FIN.
+#[pal_async::async_test]
+async fn test_tcp_closing_cleanup(driver: DefaultDriver) {
+    let mut h = TcpTestHarness::connect(driver).await;
+
+    // Server initiates close and consomme sends a FIN to the guest.
+    h.clear_guest_packets();
+    h.host_shutdown_write();
+    let _ = h
+        .poll_until_guest_packet(|t| t.control == TcpControl::Fin)
+        .await;
+
+    // Guest sends its own FIN without ACKing the server FIN, causing the
+    // simultaneous-close FinWait1 -> Closing transition.
+    h.send_fin();
+
+    {
+        let access = h.consomme.access(&mut h.client);
+        assert_eq!(access.inner.tcp.connections.len(), 1);
+        let conn = access.inner.tcp.connections.values_mut().next().unwrap();
+        assert_eq!(conn.inner.state, TcpState::Closing);
+        assert_eq!(conn.inner.rx_buffer.capacity(), 0);
+        assert!(
+            matches!(conn.inner.lifetime_timer, LifetimeTimer::Close(_)),
+            "close deadline must be armed in Closing"
+        );
+        conn.inner.lifetime_timer = LifetimeTimer::Close(Instant::now() - Duration::from_secs(1));
+    }
+
+    std::future::poll_fn(|cx| {
+        h.consomme.access(&mut h.client).poll(cx);
+        Poll::Ready(())
+    })
+    .await;
+
+    assert_eq!(
+        h.consomme.access(&mut h.client).inner.tcp.connections.len(),
+        0,
+        "expired Closing connection should be removed"
+    );
+    assert_eq!(
+        h.consomme
+            .access(&mut h.client)
+            .inner
+            .tcp
+            .aggregate_stats
+            .connections_closed_timeout
+            .get(),
+        1,
+        "expired Closing connection should be counted as a timeout close"
+    );
+    assert_eq!(
+        h.consomme
+            .access(&mut h.client)
+            .inner
+            .tcp
+            .aggregate_stats
+            .connections_closed_normal
+            .get(),
+        0,
+        "expired Closing connection should not be counted as a normal close"
+    );
+}
+
+/// Test that a connection stuck in `LastAck` (guest never acks our FIN
+/// after a guest-initiated close) is reaped after the `tcp_close_timeout`
+/// elapses.
+#[pal_async::async_test]
+async fn test_tcp_last_ack_cleanup(driver: DefaultDriver) {
+    let mut h = TcpTestHarness::connect(driver).await;
+
+    // Guest initiates close: send FIN (Established → CloseWait).
+    h.clear_guest_packets();
+    h.send_fin();
+
+    // Drive the stack so consomme processes the FIN, sees host EOF via
+    // the shutdown(Read) implicitly forwarded, and we eventually transition
+    // to LastAck. We need the host stream to also close so consomme calls
+    // close() on its end (CloseWait → LastAck).
+    h.host_shutdown_write();
+
+    // Wait for consomme to send its own FIN to the guest, which means
+    // we have entered LastAck.
+    let _ = h
+        .poll_until_guest_packet(|t| t.control == TcpControl::Fin)
+        .await;
+
+    // Intentionally do NOT ack the FIN. Verify the state and force the
+    // deadline into the past.
+    {
+        let access = h.consomme.access(&mut h.client);
+        assert_eq!(access.inner.tcp.connections.len(), 1);
+        let conn = access.inner.tcp.connections.values_mut().next().unwrap();
+        assert_eq!(conn.inner.state, TcpState::LastAck);
+        assert_eq!(conn.inner.rx_buffer.capacity(), 0);
+        assert_eq!(conn.inner.tx_buffer.capacity(), 0);
+        assert!(
+            matches!(conn.inner.lifetime_timer, LifetimeTimer::Close(_)),
+            "close deadline must be armed in LastAck"
+        );
+        conn.inner.lifetime_timer = LifetimeTimer::Close(Instant::now() - Duration::from_secs(1));
+    }
+
+    std::future::poll_fn(|cx| {
+        h.consomme.access(&mut h.client).poll(cx);
+        Poll::Ready(())
+    })
+    .await;
+
+    assert_eq!(
+        h.consomme.access(&mut h.client).inner.tcp.connections.len(),
+        0,
+        "expired LastAck connection should be removed"
+    );
+    assert_eq!(
+        h.consomme
+            .access(&mut h.client)
+            .inner
+            .tcp
+            .aggregate_stats
+            .connections_closed_timeout
+            .get(),
+        1,
+        "expired LastAck connection should be counted as a timeout close"
+    );
+    assert_eq!(
+        h.consomme
+            .access(&mut h.client)
+            .inner
+            .tcp
+            .aggregate_stats
+            .connections_closed_normal
+            .get(),
+        0,
+        "expired LastAck connection should not be counted as a normal close"
+    );
+}
+
+#[pal_async::async_test]
+async fn test_tcp_retransmits_unacknowledged_data(driver: DefaultDriver) {
+    let mut h = TcpTestHarness::connect(driver).await;
+    h.clear_guest_packets();
+    h.host_write(b"retransmit me").await;
+
+    let first = h
+        .poll_until_guest_packet(|tcp| !tcp.payload.is_empty())
+        .await;
+    let (_, _, first_tcp) = parse_tcp_packet(&first);
+    let sequence_number = first_tcp.seq_number;
+    let sequence_end = first_tcp.seq_number + first_tcp.segment_len();
+    let payload = first_tcp.payload.to_vec();
+    let initial_rto = h.connection_inner().retransmission.rto;
+
+    h.clear_guest_packets();
+    {
+        let access = h.consomme.access(&mut h.client);
+        let conn = access.inner.tcp.connections.values_mut().next().unwrap();
+        conn.inner.retransmission.timer = RetransmissionTimer::Rto {
+            deadline: Instant::now() - Duration::from_millis(1),
+            recover: None,
+        };
+    }
+    std::future::poll_fn(|cx| {
+        h.consomme.access(&mut h.client).poll(cx);
+        Poll::Ready(())
+    })
+    .await;
+
+    let packets = h.client.received_packets.lock();
+    let retransmission = packets
+        .iter()
+        .find_map(|packet| TcpTestHarness::is_tcp_packet(packet))
+        .expect("RTO should retransmit the oldest segment");
+    assert_eq!(retransmission.seq_number, sequence_number);
+    assert_eq!(retransmission.payload, payload);
+    drop(packets);
+    assert_eq!(
+        h.connection_inner().retransmission.rto,
+        initial_rto.saturating_mul(2)
+    );
+    assert_eq!(h.connection_inner().stats.retransmission_timeouts.get(), 1);
+    assert_eq!(h.connection_inner().stats.retransmitted_segments.get(), 1);
+
+    h.server_ack = sequence_end;
+    h.send_segment(TcpControl::None, h.guest_seq, &[]);
+    assert!(matches!(
+        h.connection_inner().retransmission.timer,
+        RetransmissionTimer::None
+    ));
+    assert!(h.connection_inner().tx_buffer.is_empty());
+}
+
+#[pal_async::async_test]
+async fn test_tcp_retransmits_fin_until_acknowledged(driver: DefaultDriver) {
+    let mut h = TcpTestHarness::connect(driver).await;
+    h.clear_guest_packets();
+    h.host_shutdown_write();
+
+    let first = h
+        .poll_until_guest_packet(|tcp| tcp.control == TcpControl::Fin)
+        .await;
+    let (_, _, first_fin) = parse_tcp_packet(&first);
+    let fin_sequence = first_fin.seq_number;
+
+    h.clear_guest_packets();
+    {
+        let access = h.consomme.access(&mut h.client);
+        let conn = access.inner.tcp.connections.values_mut().next().unwrap();
+        conn.inner.retransmission.timer = RetransmissionTimer::Rto {
+            deadline: Instant::now() - Duration::from_millis(1),
+            recover: None,
+        };
+    }
+    std::future::poll_fn(|cx| {
+        h.consomme.access(&mut h.client).poll(cx);
+        Poll::Ready(())
+    })
+    .await;
+
+    let packets = h.client.received_packets.lock();
+    let retransmitted_fin = packets
+        .iter()
+        .find_map(|packet| TcpTestHarness::is_tcp_packet(packet))
+        .expect("RTO should retransmit FIN");
+    assert_eq!(retransmitted_fin.control, TcpControl::Fin);
+    assert_eq!(retransmitted_fin.seq_number, fin_sequence);
+    assert!(retransmitted_fin.payload.is_empty());
+}
+
+#[pal_async::async_test]
+async fn test_tcp_sends_fin_through_zero_window(driver: DefaultDriver) {
+    let mut h = TcpTestHarness::connect(driver).await;
+    h.send_segment_with_window(TcpControl::None, h.guest_seq, &[], 0);
+    h.clear_guest_packets();
+
+    h.host_shutdown_write();
+    let fin_packet = h
+        .poll_until_guest_packet(|tcp| tcp.control == TcpControl::Fin)
+        .await;
+    let (_, _, fin) = parse_tcp_packet(&fin_packet);
+    assert!(fin.payload.is_empty());
+    assert_eq!(fin.seq_number, h.server_ack);
+    assert!(h.connection_inner().tx_fin == TxFinState::Sent);
+    assert!(matches!(
+        h.connection_inner().retransmission.timer,
+        RetransmissionTimer::Rto { .. }
+    ));
+}
+
+#[pal_async::async_test]
+async fn test_tcp_close_before_syn_ack_retransmits_syn_then_fin(driver: DefaultDriver) {
+    let mut h = TcpTestHarness::connect(driver).await;
+    h.clear_guest_packets();
+
+    {
+        let access = h.consomme.access(&mut h.client);
+        let conn = access.inner.tcp.connections.values_mut().next().unwrap();
+        conn.inner.state = TcpState::SynReceived;
+        conn.inner.tx_acked = conn.inner.tx_acked - 1;
+        conn.inner.tx_syn = TxSynState::SynAck;
+        conn.inner.close(Duration::from_secs(60));
+        conn.inner.retransmission.timer = RetransmissionTimer::Rto {
+            deadline: Instant::now() - Duration::from_millis(1),
+            recover: None,
+        };
+        assert_eq!(conn.inner.state, TcpState::SynReceived);
+    }
+
+    std::future::poll_fn(|cx| {
+        h.consomme.access(&mut h.client).poll(cx);
+        Poll::Ready(())
+    })
+    .await;
+
+    {
+        let packets = h.client.received_packets.lock();
+        assert!(packets.iter().any(|packet| {
+            TcpTestHarness::is_tcp_packet(packet).is_some_and(|tcp| tcp.control == TcpControl::Syn)
+        }));
+        assert!(!packets.iter().any(|packet| {
+            TcpTestHarness::is_tcp_packet(packet).is_some_and(|tcp| tcp.control == TcpControl::Fin)
+        }));
+    }
+
+    h.clear_guest_packets();
+    h.send_segment(TcpControl::None, h.guest_seq, &[]);
+    assert_eq!(h.connection_inner().state, TcpState::FinWait1);
+    assert_eq!(h.connection_inner().tx_syn, TxSynState::None);
+    assert!(h.client.received_packets.lock().iter().any(|packet| {
+        TcpTestHarness::is_tcp_packet(packet).is_some_and(|tcp| tcp.control == TcpControl::Fin)
+    }));
+}
+
+#[pal_async::async_test]
+async fn test_tcp_zero_window_persist_probe(driver: DefaultDriver) {
+    let mut h = TcpTestHarness::connect(driver).await;
+    h.send_segment_with_window(TcpControl::None, h.guest_seq, &[], 0);
+    h.clear_guest_packets();
+    h.host_write(b"probe").await;
+    h.poll_until(|inner| inner.tx_buffer.len() == 5).await;
+
+    {
+        let access = h.consomme.access(&mut h.client);
+        let conn = access.inner.tcp.connections.values_mut().next().unwrap();
+        assert_eq!(conn.inner.tx_send, conn.inner.tx_acked);
+        assert_eq!(conn.inner.tx_buffer.len(), 5);
+        assert!(matches!(
+            conn.inner.retransmission.timer,
+            RetransmissionTimer::Persist { .. }
+        ));
+        conn.inner.retransmission.timer = RetransmissionTimer::Persist {
+            deadline: Instant::now() - Duration::from_millis(1),
+            backoff: 0,
+            recover: None,
+        };
+    }
+
+    h.clear_guest_packets();
+    std::future::poll_fn(|cx| {
+        h.consomme.access(&mut h.client).poll(cx);
+        Poll::Ready(())
+    })
+    .await;
+
+    {
+        let packets = h.client.received_packets.lock();
+        let probe = packets
+            .iter()
+            .find_map(|packet| TcpTestHarness::is_tcp_packet(packet))
+            .expect("persist timeout should send a zero-window probe");
+        assert_eq!(probe.payload, b"p");
+    }
+    assert!(matches!(
+        h.connection_inner().retransmission.timer,
+        RetransmissionTimer::Persist { backoff: 1, .. }
+    ));
+    assert_eq!(
+        h.connection_inner().tx_send,
+        h.connection_inner().tx_acked + 1
+    );
+
+    {
+        let access = h.consomme.access(&mut h.client);
+        let conn = access.inner.tcp.connections.values_mut().next().unwrap();
+        conn.inner.retransmission.timer = RetransmissionTimer::Persist {
+            deadline: Instant::now() - Duration::from_millis(1),
+            backoff: 1,
+            recover: None,
+        };
+    }
+    h.client.rx_buffers = Some(0);
+    h.clear_guest_packets();
+    std::future::poll_fn(|cx| {
+        h.consomme.access(&mut h.client).poll(cx);
+        Poll::Ready(())
+    })
+    .await;
+    assert!(
+        h.client.received_packets.lock().is_empty(),
+        "persist timeout cannot send without an RX buffer"
+    );
+    assert!(matches!(
+        h.connection_inner().retransmission.timer,
+        RetransmissionTimer::Persist { backoff: 1, .. }
+    ));
+
+    h.client.add_rx_buffers(1);
+    {
+        let access = h.consomme.access(&mut h.client);
+        let conn = access.inner.tcp.connections.values_mut().next().unwrap();
+        conn.inner.retransmission.timer = RetransmissionTimer::Persist {
+            deadline: Instant::now() - Duration::from_millis(1),
+            backoff: 1,
+            recover: None,
+        };
+    }
+    h.clear_guest_packets();
+    std::future::poll_fn(|cx| {
+        h.consomme.access(&mut h.client).poll(cx);
+        Poll::Ready(())
+    })
+    .await;
+    {
+        let packets = h.client.received_packets.lock();
+        let repeated_probe = packets
+            .iter()
+            .find_map(|packet| TcpTestHarness::is_tcp_packet(packet))
+            .expect("persist timer should repeat the zero-window probe");
+        assert_eq!(repeated_probe.seq_number, h.server_ack);
+        assert_eq!(repeated_probe.payload, b"p");
+    }
+    assert_eq!(
+        h.connection_inner().tx_send,
+        h.connection_inner().tx_acked + 1,
+        "repeated probes must not consume additional sequence space"
+    );
+    assert!(matches!(
+        h.connection_inner().retransmission.timer,
+        RetransmissionTimer::Persist { backoff: 2, .. }
+    ));
+    h.client.rx_buffers = None;
+
+    h.clear_guest_packets();
+    h.send_segment_with_window(TcpControl::None, h.guest_seq, &[], 64240);
+    let packets = h.client.received_packets.lock();
+    let first = packets
+        .iter()
+        .find_map(|packet| TcpTestHarness::is_tcp_packet(packet))
+        .expect("opening the window should retransmit the probe immediately");
+    assert_eq!(first.seq_number, h.server_ack);
+    assert_eq!(first.payload, b"p");
+    drop(packets);
+    assert!(matches!(
+        h.connection_inner().retransmission.timer,
+        RetransmissionTimer::Rto { recover: None, .. }
+    ));
+}
+
+#[pal_async::async_test]
+async fn test_tcp_zero_window_persist_preserves_recovery(driver: DefaultDriver) {
+    let mut h = TcpTestHarness::connect(driver).await;
+    h.clear_guest_packets();
+    h.host_write(&[0x5a; 3 * 536]).await;
+    h.poll_until(|inner| inner.tx_send == inner.tx_acked + 3 * 536)
+        .await;
+
+    let first_sequence = h.connection_inner().tx_acked;
+    let recover = h.connection_inner().tx_send;
+    {
+        let access = h.consomme.access(&mut h.client);
+        let conn = access.inner.tcp.connections.values_mut().next().unwrap();
+        conn.inner.retransmission.timer = RetransmissionTimer::Rto {
+            deadline: Instant::now() - Duration::from_millis(1),
+            recover: None,
+        };
+    }
+    std::future::poll_fn(|cx| {
+        h.consomme.access(&mut h.client).poll(cx);
+        Poll::Ready(())
+    })
+    .await;
+
+    h.clear_guest_packets();
+    h.server_ack = first_sequence + 536;
+    h.send_segment_with_window(TcpControl::None, h.guest_seq, &[], 0);
+    assert!(matches!(
+        h.connection_inner().retransmission.timer,
+        RetransmissionTimer::Persist {
+            recover: Some(boundary),
+            ..
+        } if boundary == recover
+    ));
+
+    {
+        let access = h.consomme.access(&mut h.client);
+        let conn = access.inner.tcp.connections.values_mut().next().unwrap();
+        conn.inner.retransmission.timer = RetransmissionTimer::Persist {
+            deadline: Instant::now() - Duration::from_millis(1),
+            backoff: 0,
+            recover: Some(recover),
+        };
+    }
+    h.clear_guest_packets();
+    std::future::poll_fn(|cx| {
+        h.consomme.access(&mut h.client).poll(cx);
+        Poll::Ready(())
+    })
+    .await;
+    {
+        let packets = h.client.received_packets.lock();
+        let probe = packets
+            .iter()
+            .find_map(|packet| TcpTestHarness::is_tcp_packet(packet))
+            .expect("persist should probe the earliest unacknowledged byte");
+        assert_eq!(probe.seq_number, first_sequence + 536);
+        assert_eq!(probe.payload, &[0x5a]);
+    }
+    assert_eq!(h.connection_inner().tx_send, recover);
+
+    h.client.rx_buffers = Some(0);
+    h.clear_guest_packets();
+    h.send_segment_with_window(TcpControl::None, h.guest_seq, &[], 64240);
+    assert!(
+        h.client.received_packets.lock().is_empty(),
+        "window reopening cannot retransmit without an RX buffer"
+    );
+    assert!(matches!(
+        h.connection_inner().retransmission.timer,
+        RetransmissionTimer::Rto {
+            recover: Some(boundary),
+            ..
+        } if boundary == recover
+    ));
+
+    h.client.add_rx_buffers(1);
+    {
+        let access = h.consomme.access(&mut h.client);
+        let conn = access.inner.tcp.connections.values_mut().next().unwrap();
+        conn.inner.retransmission.timer = RetransmissionTimer::Rto {
+            deadline: Instant::now() - Duration::from_millis(1),
+            recover: Some(recover),
+        };
+    }
+    std::future::poll_fn(|cx| {
+        h.consomme.access(&mut h.client).poll(cx);
+        Poll::Ready(())
+    })
+    .await;
+    {
+        let packets = h.client.received_packets.lock();
+        let retransmission = packets
+            .iter()
+            .find_map(|packet| TcpTestHarness::is_tcp_packet(packet))
+            .expect("RTO should retransmit after an RX buffer becomes available");
+        assert_eq!(retransmission.seq_number, first_sequence + 536);
+    }
+
+    h.client.add_rx_buffers(1);
+    h.clear_guest_packets();
+    h.server_ack = first_sequence + 2 * 536;
+    h.send_segment(TcpControl::None, h.guest_seq, &[]);
+    let packets = h.client.received_packets.lock();
+    let retransmission = packets
+        .iter()
+        .find_map(|packet| TcpTestHarness::is_tcp_packet(packet))
+        .expect("partial ACK should continue immediate recovery");
+    assert_eq!(retransmission.seq_number, first_sequence + 2 * 536);
+}
+
+#[pal_async::async_test]
+async fn test_tcp_close_timeout_refreshes_on_progress(driver: DefaultDriver) {
+    let mut h = TcpTestHarness::connect(driver).await;
+    h.clear_guest_packets();
+    h.host_shutdown_write();
+
+    let fin_packet = h
+        .poll_until_guest_packet(|tcp| tcp.control == TcpControl::Fin)
+        .await;
+    let (_, _, fin) = parse_tcp_packet(&fin_packet);
+    h.server_ack = fin.seq_number + fin.segment_len();
+
+    {
+        let access = h.consomme.access(&mut h.client);
+        let conn = access.inner.tcp.connections.values_mut().next().unwrap();
+        conn.inner.lifetime_timer = LifetimeTimer::Close(Instant::now() + Duration::from_millis(1));
+    }
+    h.send_segment(TcpControl::None, h.guest_seq, &[]);
+
+    assert_eq!(h.connection_inner().state, TcpState::FinWait2);
+    assert!(
+        h.connection_inner().lifetime_timer.deadline()
+            > Some(Instant::now() + Duration::from_secs(1)),
+        "ACK progress should refresh the close inactivity timeout"
+    );
+}
+
+#[pal_async::async_test]
+async fn test_tcp_close_timeout_ignores_duplicate_out_of_order_data(driver: DefaultDriver) {
+    let mut h = TcpTestHarness::connect(driver).await;
+    h.clear_guest_packets();
+    h.host_shutdown_write();
+
+    let fin_packet = h
+        .poll_until_guest_packet(|tcp| tcp.control == TcpControl::Fin)
+        .await;
+    let (_, _, fin) = parse_tcp_packet(&fin_packet);
+    h.server_ack = fin.seq_number + fin.segment_len();
+    h.send_segment(TcpControl::None, h.guest_seq, &[]);
+    assert_eq!(h.connection_inner().state, TcpState::FinWait2);
+
+    let out_of_order_seq = h.guest_seq + 100;
+    h.send_segment(TcpControl::None, out_of_order_seq, b"new");
+    let deadline = Instant::now() + Duration::from_millis(10);
+    h.consomme
+        .tcp
+        .connections
+        .get_mut(&h.four_tuple())
+        .unwrap()
+        .inner
+        .lifetime_timer = LifetimeTimer::Close(deadline);
+
+    h.send_segment(TcpControl::None, out_of_order_seq, b"new");
+    assert_eq!(
+        h.connection_inner().lifetime_timer.deadline(),
+        Some(deadline),
+        "duplicate out-of-order data must not extend the close timeout"
+    );
+}
+
+#[pal_async::async_test]
+async fn test_tcp_time_wait_accepts_newer_syn(driver: DefaultDriver) {
+    let mut h = TcpTestHarness::connect(driver).await;
+    let old_rx_seq = h.connection_inner().rx_seq;
+    {
+        let connection = h.consomme.tcp.connections.get_mut(&h.four_tuple()).unwrap();
+        connection.inner.state = TcpState::TimeWait;
+        connection.inner.lifetime_timer =
+            LifetimeTimer::Close(Instant::now() + Duration::from_secs(60));
+    }
+
+    let new_isn = old_rx_seq + 10_000;
+    let syn = TcpRepr {
+        src_port: h.guest_port,
+        dst_port: h.dst_port,
+        control: TcpControl::Syn,
+        seq_number: new_isn,
+        ack_number: None,
+        window_len: 64240,
+        window_scale: Some(7),
+        max_seg_size: Some(1460),
+        sack_permitted: false,
+        sack_ranges: [None, None, None],
+        timestamp: None,
+        payload: &[],
+    };
+    h.try_send_repr(&syn).unwrap();
+
+    let replacement = h
+        .consomme
+        .tcp
+        .connections
+        .get(&h.four_tuple())
+        .expect("new SYN should replace the TIME-WAIT connection");
+    assert_eq!(replacement.inner.state, TcpState::Connecting);
+    assert_eq!(replacement.inner.rx_seq, new_isn + 1);
+    assert!(
+        matches!(
+            replacement.inner.lifetime_timer,
+            LifetimeTimer::Handshake(_)
+        ),
+        "the handshake timeout must include the pending host connection"
+    );
+}
+
+#[pal_async::async_test]
+async fn test_tcp_close_timeout_wakes_driver(driver: DefaultDriver) {
+    let mut params = ConsommeParams::new().unwrap();
+    params.tcp_close_timeout = Duration::from_millis(100);
+    let mut h = TcpTestHarness::connect_with_params(driver, params).await;
+    h.clear_guest_packets();
+    h.host_shutdown_write();
+    let _ = h
+        .poll_until_guest_packet(|tcp| tcp.control == TcpControl::Fin)
+        .await;
+
+    std::future::poll_fn(|cx| {
+        h.consomme.access(&mut h.client).poll(cx);
+        if h.consomme.tcp.connections.is_empty() {
+            Poll::Ready(())
+        } else {
+            Poll::Pending
+        }
+    })
+    .await;
+    assert!(h.client.received_packets.lock().iter().any(|packet| {
+        TcpTestHarness::is_tcp_packet(packet).is_some_and(|tcp| tcp.control == TcpControl::Rst)
+    }));
+}
+
+#[pal_async::async_test]
+async fn test_tcp_close_timeout_saturates(driver: DefaultDriver) {
+    let mut h = TcpTestHarness::connect(driver).await;
+    let ft = h.four_tuple();
+    h.consomme
+        .tcp
+        .connections
+        .get_mut(&ft)
+        .unwrap()
+        .inner
+        .start_close_deadline(Duration::MAX);
+    assert_eq!(
+        h.connection_inner().lifetime_timer.deadline(),
+        Some(Instant::from_nanos(u64::MAX))
+    );
+}
+
+#[pal_async::async_test]
+async fn test_tcp_rto_recovery_advances_on_each_ack(driver: DefaultDriver) {
+    let mut h = TcpTestHarness::connect(driver).await;
+    h.clear_guest_packets();
+    {
+        let access = h.consomme.access(&mut h.client);
+        let conn = access.inner.tcp.connections.values_mut().next().unwrap();
+        conn.inner.tx_window_len = 3 * 536;
+        conn.inner.tx_window_scale = 0;
+    }
+    h.host_write(&[0x5a; 4 * 536]).await;
+    h.poll_until(|inner| inner.tx_send == inner.tx_acked + 3 * 536)
+        .await;
+
+    let first_sequence = h.connection_inner().tx_acked;
+    {
+        let access = h.consomme.access(&mut h.client);
+        let conn = access.inner.tcp.connections.values_mut().next().unwrap();
+        conn.inner.retransmission.timer = RetransmissionTimer::Rto {
+            deadline: Instant::now() - Duration::from_millis(1),
+            recover: None,
+        };
+    }
+    h.clear_guest_packets();
+    std::future::poll_fn(|cx| {
+        h.consomme.access(&mut h.client).poll(cx);
+        Poll::Ready(())
+    })
+    .await;
+
+    h.clear_guest_packets();
+    h.server_ack = first_sequence + 536;
+    h.send_segment(TcpControl::None, h.guest_seq, &[]);
+
+    {
+        let packets = h.client.received_packets.lock();
+        let second = packets
+            .iter()
+            .find_map(|packet| TcpTestHarness::is_tcp_packet(packet))
+            .expect("ACK should retransmit the next missing segment immediately");
+        assert_eq!(second.seq_number, first_sequence + 536);
+    }
+
+    let recover = first_sequence + 3 * 536;
+    h.poll_until(|inner| inner.tx_send == recover + 536).await;
+
+    h.clear_guest_packets();
+    h.server_ack = recover;
+    h.send_segment(TcpControl::None, h.guest_seq, &[]);
+    std::future::poll_fn(|cx| {
+        h.consomme.access(&mut h.client).poll(cx);
+        Poll::Ready(())
+    })
+    .await;
+    assert!(matches!(
+        h.connection_inner().retransmission.timer,
+        RetransmissionTimer::Rto { recover: None, .. }
+    ));
+
+    h.clear_guest_packets();
+    h.server_ack = recover + 536;
+    h.send_segment(TcpControl::None, h.guest_seq, &[]);
+    std::future::poll_fn(|cx| {
+        h.consomme.access(&mut h.client).poll(cx);
+        Poll::Ready(())
+    })
+    .await;
+    assert!(
+        h.client.received_packets.lock().is_empty(),
+        "ACKs beyond the recovery boundary must not trigger duplicate retransmissions"
+    );
+}
+
+#[pal_async::async_test]
+async fn test_tcp_fast_retransmit_after_three_duplicate_acks(driver: DefaultDriver) {
+    let mut h = TcpTestHarness::connect(driver).await;
+    h.clear_guest_packets();
+    h.host_write(&[0x5a; 3 * 536]).await;
+    h.poll_until(|inner| inner.tx_send == inner.tx_acked + 3 * 536)
+        .await;
+
+    let first_sequence = h.connection_inner().tx_acked;
+    let recover = h.connection_inner().tx_send;
+    let rto = h.connection_inner().retransmission.rto;
+    h.clear_guest_packets();
+
+    for duplicate in 1..=3 {
+        h.send_segment(TcpControl::None, h.guest_seq, &[]);
+        let retransmitted = h.client.received_packets.lock().iter().any(|packet| {
+            TcpTestHarness::is_tcp_packet(packet)
+                .is_some_and(|tcp| !tcp.payload.is_empty() && tcp.seq_number == first_sequence)
+        });
+        assert_eq!(
+            retransmitted,
+            duplicate == 3,
+            "fast retransmit should fire on exactly the third duplicate ACK"
+        );
+
+        if duplicate == 1 {
+            h.send_segment(TcpControl::None, h.guest_seq, b"x");
+            h.guest_seq += 1;
+            assert_eq!(
+                h.connection_inner().retransmission.duplicate_acks,
+                duplicate,
+                "interleaved guest data must not reset duplicate ACK evidence"
+            );
+        }
+    }
+
+    assert_eq!(h.connection_inner().retransmission.rto, rto);
+    assert!(matches!(
+        h.connection_inner().retransmission.timer,
+        RetransmissionTimer::Rto {
+            recover: Some(boundary),
+            ..
+        } if boundary == recover
+    ));
+
+    h.clear_guest_packets();
+    h.send_segment(TcpControl::None, h.guest_seq, b"y");
+    h.guest_seq += 1;
+    assert!(
+        !h.client.received_packets.lock().iter().any(|packet| {
+            TcpTestHarness::is_tcp_packet(packet)
+                .is_some_and(|tcp| !tcp.payload.is_empty() && tcp.seq_number == first_sequence)
+        }),
+        "traffic after fast retransmit must not retransmit the same segment again"
+    );
+}
+
+#[pal_async::async_test]
+async fn test_tcp_fast_retransmit_retries_after_rx_buffer_starvation(driver: DefaultDriver) {
+    let mut h = TcpTestHarness::connect(driver).await;
+    h.clear_guest_packets();
+    h.host_write(&[0x5a; 536]).await;
+    h.poll_until(|inner| inner.tx_send == inner.tx_acked + 536)
+        .await;
+
+    let first_sequence = h.connection_inner().tx_acked;
+    h.clear_guest_packets();
+    h.client.rx_buffers = Some(0);
+    for _ in 0..3 {
+        h.send_segment(TcpControl::None, h.guest_seq, &[]);
+    }
+    assert_eq!(h.connection_inner().retransmission.duplicate_acks, 2);
+    assert!(h.client.received_packets.lock().is_empty());
+
+    h.client.add_rx_buffers(1);
+    h.send_segment(TcpControl::None, h.guest_seq, &[]);
+    assert!(h.client.received_packets.lock().iter().any(|packet| {
+        TcpTestHarness::is_tcp_packet(packet)
+            .is_some_and(|tcp| !tcp.payload.is_empty() && tcp.seq_number == first_sequence)
+    }));
+}
+
+#[test]
+fn test_retransmission_state_follows_rfc_6298() {
+    let mut state = RetransmissionState::new();
+    let start = Instant::from_nanos(1_000_000_000);
+
+    state.on_send_at(TcpSeqNumber(1), start);
+    state.on_ack(
+        TcpSeqNumber(1),
+        TcpSeqNumber(1),
+        start + Duration::from_secs(2),
+    );
+    assert_eq!(state.srtt, Some(Duration::from_secs(2)));
+    assert_eq!(state.rttvar, Some(Duration::from_secs(1)));
+    assert_eq!(state.rto, Duration::from_secs(6));
+    assert!(matches!(state.timer, RetransmissionTimer::None));
+
+    state.on_send_at(TcpSeqNumber(2), start + Duration::from_secs(2));
+    state.on_ack(
+        TcpSeqNumber(2),
+        TcpSeqNumber(2),
+        start + Duration::from_secs(3),
+    );
+    assert_eq!(state.srtt, Some(Duration::from_millis(1875)));
+    assert_eq!(state.rttvar, Some(Duration::from_secs(1)));
+    assert_eq!(state.rto, Duration::from_millis(5875));
+
+    state.on_send_at(TcpSeqNumber(3), start + Duration::from_secs(3));
+    let rto_before_early_retransmit = state.rto;
+    state.duplicate_acks = 2;
+    state.on_early_retransmit(start + Duration::from_secs(4));
+    assert_eq!(state.rto, rto_before_early_retransmit);
+    assert!(matches!(
+        state.timer,
+        RetransmissionTimer::Rto {
+            deadline,
+            recover: None,
+        } if deadline == start + Duration::from_secs(4) + rto_before_early_retransmit
+    ));
+    assert!(state.sample.is_none());
+    assert_eq!(state.duplicate_acks, 0);
+
+    state.duplicate_acks = 2;
+    state.on_retransmit(start + Duration::from_secs(9), TcpSeqNumber(3));
+    assert_eq!(state.rto, Duration::from_millis(11750));
+    assert!(
+        state.sample.is_none(),
+        "Karn's algorithm discards the sample"
+    );
+    assert_eq!(state.duplicate_acks, 0);
+
+    let mut syn_state = RetransmissionState::new();
+    syn_state.on_send_at(TcpSeqNumber(1), start);
+    syn_state.on_retransmit(start + INITIAL_RTO, TcpSeqNumber(1));
+    syn_state.on_syn_retransmit();
+    syn_state.on_handshake_complete();
+    assert_eq!(syn_state.rto, Duration::from_secs(3));
 }

--- a/vm/devices/net/net_consomme/consomme/src/tcp/tests.rs
+++ b/vm/devices/net/net_consomme/consomme/src/tcp/tests.rs
@@ -2780,6 +2780,54 @@ async fn test_tcp_close_wait_cleanup(driver: DefaultDriver) {
     );
 }
 
+#[pal_async::async_test]
+async fn test_tcp_close_wait_zero_window_ack_refreshes_timeout(driver: DefaultDriver) {
+    let mut h = TcpTestHarness::connect(driver).await;
+
+    h.send_segment_with_window(TcpControl::Fin, h.guest_seq, &[], 0);
+    h.guest_seq += 1;
+    assert_eq!(h.connection_inner().state, TcpState::CloseWait);
+
+    h.host_write(b"flow controlled").await;
+    h.poll_until(|inner| !inner.tx_buffer.is_empty()).await;
+    {
+        let access = h.consomme.access(&mut h.client);
+        let conn = access.inner.tcp.connections.values_mut().next().unwrap();
+        conn.inner.retransmission.timer = RetransmissionTimer::Persist {
+            deadline: Instant::now() - Duration::from_millis(1),
+            backoff: 0,
+            recover: None,
+        };
+    }
+    std::future::poll_fn(|cx| {
+        h.consomme.access(&mut h.client).poll(cx);
+        Poll::Ready(())
+    })
+    .await;
+    assert_eq!(
+        h.connection_inner().tx_send,
+        h.connection_inner().tx_acked + 1,
+        "the persist probe should remain unacknowledged through a zero window"
+    );
+
+    let expiring_deadline = Instant::now() + Duration::from_millis(1);
+    h.consomme
+        .tcp
+        .connections
+        .get_mut(&h.four_tuple())
+        .unwrap()
+        .inner
+        .lifetime_timer = LifetimeTimer::Close(expiring_deadline);
+
+    h.send_segment_with_window(TcpControl::None, h.guest_seq, &[], 0);
+
+    assert!(
+        h.connection_inner().lifetime_timer.deadline()
+            > Some(Instant::now() + Duration::from_secs(1)),
+        "a zero-window ACK for pending data should refresh the close timeout"
+    );
+}
+
 /// Test that a simultaneous close reaches `Closing`, arms the cleanup
 /// deadline, and is counted as a timeout close if the guest never ACKs our FIN.
 #[pal_async::async_test]

--- a/vm/devices/net/net_consomme/consomme/src/tcp/tests.rs
+++ b/vm/devices/net/net_consomme/consomme/src/tcp/tests.rs
@@ -1237,6 +1237,8 @@ async fn test_tcp_port_forward_defers_initial_syn_without_rx_buffer(driver: Defa
     ));
     connection.inner.lifetime_timer =
         LifetimeTimer::Handshake(TimerInstant::now() - Duration::from_millis(1));
+    received.lock().clear();
+    client.add_rx_buffers(1);
     std::future::poll_fn(|cx| {
         consomme.access(&mut client).poll(cx);
         Poll::Ready(())
@@ -1245,6 +1247,20 @@ async fn test_tcp_port_forward_defers_initial_syn_without_rx_buffer(driver: Defa
     assert!(
         consomme.tcp.connections.is_empty(),
         "expired handshake should be reclaimed"
+    );
+    let rst_packet = received
+        .lock()
+        .iter()
+        .find(|packet| {
+            TcpTestHarness::is_tcp_packet(packet).is_some_and(|tcp| tcp.control == TcpControl::Rst)
+        })
+        .cloned()
+        .expect("expired handshake should reset the guest connection");
+    let (_, _, rst) = parse_tcp_packet(&rst_packet);
+    assert_eq!(rst.seq_number, syn.seq_number + 1);
+    assert!(
+        rst.ack_number.is_none(),
+        "a pre-handshake reset must not acknowledge an unknown guest sequence"
     );
 }
 
@@ -2732,10 +2748,10 @@ async fn test_tcp_guest_action_timeout_cleanup(driver: DefaultDriver) {
     }
 }
 
-/// Test that a guest-initiated half-close is reclaimed even if the host keeps
-/// its write side open indefinitely.
+/// Test that a guest-initiated half-close remains active while the host still
+/// owns the open direction of the connection.
 #[pal_async::async_test]
-async fn test_tcp_close_wait_cleanup(driver: DefaultDriver) {
+async fn test_tcp_close_wait_has_no_peer_progress_timeout(driver: DefaultDriver) {
     let mut h = TcpTestHarness::connect(driver).await;
 
     h.clear_guest_packets();
@@ -2746,10 +2762,9 @@ async fn test_tcp_close_wait_cleanup(driver: DefaultDriver) {
         let conn = access.inner.tcp.connections.values_mut().next().unwrap();
         assert_eq!(conn.inner.state, TcpState::CloseWait);
         assert!(
-            matches!(conn.inner.lifetime_timer, LifetimeTimer::Close(_)),
-            "close deadline must be armed in CloseWait"
+            matches!(conn.inner.lifetime_timer, LifetimeTimer::None),
+            "CloseWait must not expire while the host is still working"
         );
-        conn.inner.lifetime_timer = LifetimeTimer::Close(Instant::now() - Duration::from_secs(1));
     }
 
     std::future::poll_fn(|cx| {
@@ -2758,15 +2773,7 @@ async fn test_tcp_close_wait_cleanup(driver: DefaultDriver) {
     })
     .await;
 
-    assert!(
-        h.consomme
-            .access(&mut h.client)
-            .inner
-            .tcp
-            .connections
-            .is_empty(),
-        "expired CloseWait connection should be removed"
-    );
+    assert_eq!(h.connection_inner().state, TcpState::CloseWait);
     assert_eq!(
         h.consomme
             .access(&mut h.client)
@@ -2775,56 +2782,74 @@ async fn test_tcp_close_wait_cleanup(driver: DefaultDriver) {
             .aggregate_stats
             .connections_closed_timeout
             .get(),
-        1,
-        "expired CloseWait connection should be counted as a timeout close"
+        0,
+        "CloseWait must not be counted as a timeout close"
     );
 }
 
 #[pal_async::async_test]
-async fn test_tcp_close_wait_zero_window_ack_refreshes_timeout(driver: DefaultDriver) {
+async fn test_tcp_last_ack_restarts_timeout_after_close_wait(driver: DefaultDriver) {
     let mut h = TcpTestHarness::connect(driver).await;
 
-    h.send_segment_with_window(TcpControl::Fin, h.guest_seq, &[], 0);
-    h.guest_seq += 1;
+    h.send_fin();
     assert_eq!(h.connection_inner().state, TcpState::CloseWait);
 
-    h.host_write(b"flow controlled").await;
-    h.poll_until(|inner| !inner.tx_buffer.is_empty()).await;
+    // Ensure LastAck gets a fresh timeout even if a previous close deadline
+    // happens to be present.
     {
         let access = h.consomme.access(&mut h.client);
         let conn = access.inner.tcp.connections.values_mut().next().unwrap();
-        conn.inner.retransmission.timer = RetransmissionTimer::Persist {
-            deadline: Instant::now() - Duration::from_millis(1),
-            backoff: 0,
-            recover: None,
-        };
+        conn.inner.lifetime_timer = LifetimeTimer::Close(Instant::now() + Duration::from_millis(1));
     }
-    std::future::poll_fn(|cx| {
-        h.consomme.access(&mut h.client).poll(cx);
-        Poll::Ready(())
-    })
-    .await;
-    assert_eq!(
-        h.connection_inner().tx_send,
-        h.connection_inner().tx_acked + 1,
-        "the persist probe should remain unacknowledged through a zero window"
+
+    h.host_shutdown_write();
+    let _ = h
+        .poll_until_guest_packet(|tcp| tcp.control == TcpControl::Fin)
+        .await;
+
+    assert_eq!(h.connection_inner().state, TcpState::LastAck);
+    assert!(
+        h.connection_inner().lifetime_timer.deadline()
+            > Some(Instant::now() + Duration::from_secs(1)),
+        "LastAck must receive a fresh peer-progress timeout"
     );
+}
 
-    let expiring_deadline = Instant::now() + Duration::from_millis(1);
-    h.consomme
-        .tcp
-        .connections
-        .get_mut(&h.four_tuple())
-        .unwrap()
-        .inner
-        .lifetime_timer = LifetimeTimer::Close(expiring_deadline);
+#[pal_async::async_test]
+async fn test_tcp_fin_wait_zero_window_probe_refreshes_timeout(driver: DefaultDriver) {
+    let mut h = TcpTestHarness::connect(driver).await;
 
-    h.send_segment_with_window(TcpControl::None, h.guest_seq, &[], 0);
+    h.clear_guest_packets();
+    h.host_shutdown_write();
+    let fin_packet = h
+        .poll_until_guest_packet(|tcp| tcp.control == TcpControl::Fin)
+        .await;
+    let (_, _, fin) = parse_tcp_packet(&fin_packet);
+    h.server_ack = fin.seq_number + fin.segment_len();
+    h.send_segment(TcpControl::None, h.guest_seq, &[]);
+    assert_eq!(h.connection_inner().state, TcpState::FinWait2);
+
+    let ft = h.four_tuple();
+    {
+        let conn = h.consomme.tcp.connections.get_mut(&ft).unwrap();
+        let available = conn.inner.rx_window_cap - conn.inner.rx_buffer.len();
+        conn.inner
+            .rx_buffer
+            .write_at(conn.inner.rx_buffer.len(), &vec![0; available]);
+        conn.inner.rx_buffer.extend_by(available);
+        conn.inner.lifetime_timer = LifetimeTimer::Close(Instant::now() + Duration::from_millis(1));
+    }
+
+    assert!(
+        h.try_send_segment(TcpControl::None, h.guest_seq, b"x", 64240)
+            .is_err(),
+        "a zero-window probe should follow the unacceptable-segment path"
+    );
 
     assert!(
         h.connection_inner().lifetime_timer.deadline()
             > Some(Instant::now() + Duration::from_secs(1)),
-        "a zero-window ACK for pending data should refresh the close timeout"
+        "a zero-window probe should refresh the close timeout"
     );
 }
 
@@ -3245,6 +3270,43 @@ async fn test_tcp_zero_window_persist_probe(driver: DefaultDriver) {
         h.connection_inner().retransmission.timer,
         RetransmissionTimer::Rto { recover: None, .. }
     ));
+}
+
+#[pal_async::async_test]
+async fn test_tcp_window_reopen_retransmits_once_per_ack_boundary(driver: DefaultDriver) {
+    let mut h = TcpTestHarness::connect(driver).await;
+    h.clear_guest_packets();
+    h.host_write(&[0x5a; 2 * 536]).await;
+    h.poll_until(|inner| inner.tx_send == inner.tx_acked + 2 * 536)
+        .await;
+
+    let first_sequence = h.connection_inner().tx_acked;
+    h.clear_guest_packets();
+    h.send_segment_with_window(TcpControl::None, h.guest_seq, &[], 0);
+    h.clear_guest_packets();
+    h.send_segment_with_window(TcpControl::None, h.guest_seq, &[], 64240);
+    assert!(h.client.received_packets.lock().iter().any(|packet| {
+        TcpTestHarness::is_tcp_packet(packet)
+            .is_some_and(|tcp| !tcp.payload.is_empty() && tcp.seq_number == first_sequence)
+    }));
+
+    h.clear_guest_packets();
+    h.send_segment_with_window(TcpControl::None, h.guest_seq, &[], 0);
+    h.clear_guest_packets();
+    h.send_segment_with_window(TcpControl::None, h.guest_seq, &[], 64240);
+    assert!(
+        h.client.received_packets.lock().is_empty(),
+        "window oscillation must not repeatedly retransmit the same ACK boundary"
+    );
+
+    h.server_ack = first_sequence + 536;
+    h.send_segment_with_window(TcpControl::None, h.guest_seq, &[], 0);
+    h.clear_guest_packets();
+    h.send_segment_with_window(TcpControl::None, h.guest_seq, &[], 64240);
+    assert!(h.client.received_packets.lock().iter().any(|packet| {
+        TcpTestHarness::is_tcp_packet(packet)
+            .is_some_and(|tcp| !tcp.payload.is_empty() && tcp.seq_number == first_sequence + 536)
+    }));
 }
 
 #[pal_async::async_test]
@@ -3689,8 +3751,9 @@ fn test_retransmission_state_follows_rfc_6298() {
     state.on_send_at(TcpSeqNumber(3), start + Duration::from_secs(3));
     let rto_before_early_retransmit = state.rto;
     state.duplicate_acks = 2;
-    state.on_early_retransmit(start + Duration::from_secs(4));
+    state.on_early_retransmit(start + Duration::from_secs(4), TcpSeqNumber(2));
     assert_eq!(state.rto, rto_before_early_retransmit);
+    assert_eq!(state.window_reopen_retransmit, Some(TcpSeqNumber(2)));
     assert!(matches!(
         state.timer,
         RetransmissionTimer::Rto {


### PR DESCRIPTION
When a socket is closed, there is a small period of time before it can be reused (per RFC 793) to make sure any old, outstanding packets are properly disposed of instead of mistakenly being given to a newly opened connection. Update the TODOs in the code to actually implement this. In addition, time out any socket that has been partially closed where the handshake is not completed by the guest. This keeps the guest from being able to leak half-closed sockets indefinitely.