### PR TITLE
Add compile time option to only include CVM boot logger in dev builds

### DIFF
--- a/flowey/flowey_lib_hvlite/src/build_openhcl_boot.rs
+++ b/flowey/flowey_lib_hvlite/src/build_openhcl_boot.rs
@@ -6,6 +6,7 @@
 use crate::common::CommonArch;
 use crate::run_cargo_build::BuildProfile;
 use flowey::node::prelude::*;
+use flowey_lib_common::run_cargo_build::CargoFeatureSet;
 use std::collections::BTreeMap;
 
 #[derive(Serialize, Deserialize)]
@@ -72,12 +73,20 @@ impl FlowNode for Node {
                 OpenhclBootBuildProfile::Release => BuildProfile::BootRelease,
             };
 
+            // Enable cvm_boot_log in debug builds to include TDX/SNP
+            // serial logging support.
+            let features = if matches!(profile, BuildProfile::BootDev) {
+                CargoFeatureSet::Specific(vec!["cvm_boot_log".into()])
+            } else {
+                CargoFeatureSet::None
+            };
+
             let output = ctx.reqv(|v| crate::run_cargo_build::Request {
                 crate_name: "openhcl_boot".into(),
                 out_name: "openhcl_boot".into(),
                 crate_type: flowey_lib_common::run_cargo_build::CargoCrateType::Bin,
                 profile,
-                features: Default::default(),
+                features,
                 target,
                 no_split_dbg_info: false,
                 extra_env: Some(ReadVar::from_static(

--- a/openhcl/openhcl_boot/Cargo.toml
+++ b/openhcl/openhcl_boot/Cargo.toml
@@ -6,6 +6,9 @@ name = "openhcl_boot"
 edition.workspace = true
 rust-version.workspace = true
 
+[features]
+cvm_boot_log = []
+
 [dependencies]
 aarch64defs.workspace = true
 minimal_rt.workspace = true

--- a/openhcl/openhcl_boot/src/arch/x86_64/tdx.rs
+++ b/openhcl/openhcl_boot/src/arch/x86_64/tdx.rs
@@ -137,8 +137,10 @@ pub fn change_page_visibility(range: MemoryRange, host_visible: bool) {
 }
 
 /// Tdcall based io port access.
+#[cfg(feature = "cvm_boot_log")]
 pub struct TdxIoAccess;
 
+#[cfg(feature = "cvm_boot_log")]
 impl minimal_rt::arch::IoAccess for TdxIoAccess {
     unsafe fn inb(&self, port: u16) -> u8 {
         tdcall::tdcall_io_in(&mut TdcallInstruction, port, 1).unwrap() as u8

--- a/openhcl/openhcl_boot/src/boot_logger.rs
+++ b/openhcl/openhcl_boot/src/boot_logger.rs
@@ -8,7 +8,7 @@
 //! or any guest code is executed, and therefore it can not leak anything
 //! sensitive.
 
-#[cfg(target_arch = "x86_64")]
+#[cfg(all(target_arch = "x86_64", feature = "cvm_boot_log"))]
 use crate::arch::tdx::TdxIoAccess;
 use crate::host_params::shim_params::IsolationType;
 use crate::single_threaded::SingleThreaded;
@@ -26,7 +26,7 @@ enum Logger {
     Serial(Serial<InstrIoAccess>),
     #[cfg(target_arch = "aarch64")]
     Serial(Serial),
-    #[cfg(target_arch = "x86_64")]
+    #[cfg(all(target_arch = "x86_64", feature = "cvm_boot_log"))]
     TdxSerial(Serial<TdxIoAccess>),
     None,
 }
@@ -35,7 +35,7 @@ impl Logger {
     fn write_str(&mut self, s: &str) -> fmt::Result {
         match self {
             Logger::Serial(serial) => serial.write_str(s),
-            #[cfg(target_arch = "x86_64")]
+            #[cfg(all(target_arch = "x86_64", feature = "cvm_boot_log"))]
             Logger::TdxSerial(serial) => serial.write_str(s),
             Logger::None => Ok(()),
         }
@@ -86,7 +86,7 @@ pub fn boot_logger_runtime_init(isolation_type: IsolationType, com3_serial_avail
         (IsolationType::None, true) => Logger::Serial(Serial::init(InstrIoAccess)),
         #[cfg(target_arch = "aarch64")]
         (IsolationType::None, true) => Logger::Serial(Serial::init()),
-        #[cfg(target_arch = "x86_64")]
+        #[cfg(all(target_arch = "x86_64", feature = "cvm_boot_log"))]
         (IsolationType::Tdx, true) => Logger::TdxSerial(Serial::init(TdxIoAccess)),
         _ => Logger::None,
     };


### PR DESCRIPTION
This change removes unnecessary code from the release binary.