### PR TITLE
amd_iommu: add AMD IOMMU (AMD-Vi) emulation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -88,6 +88,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
+name = "amd_iommu"
+version = "0.0.0"
+dependencies = [
+ "bitfield-struct 0.11.0",
+ "chipset_device",
+ "guestmem",
+ "inspect",
+ "open_enum",
+ "parking_lot",
+ "pci_core",
+ "tracelimit",
+ "tracing",
+ "vmcore",
+ "zerocopy",
+]
+
+[[package]]
 name = "anes"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5377,6 +5394,7 @@ version = "0.0.0"
 dependencies = [
  "aarch64defs",
  "acpi",
+ "amd_iommu",
  "anyhow",
  "async-trait",
  "build_rs_guest_arch",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -222,6 +222,7 @@ aarch64defs = { path = "vm/aarch64/aarch64defs" }
 aarch64emu = { path = "vm/aarch64/aarch64emu" }
 acpi = { path = "vm/acpi" }
 acpi_spec = { path = "vm/acpi_spec" }
+amd_iommu = { path = "vm/devices/iommu/amd_iommu" }
 chipset_arc_mutex_device = { path = "vm/chipset_arc_mutex_device" }
 chipset_device = { path = "vm/chipset_device" }
 chipset_device_fuzz = { path = "vm/chipset_device_fuzz" }

--- a/openhcl/underhill_core/src/loader/mod.rs
+++ b/openhcl/underhill_core/src/loader/mod.rs
@@ -287,6 +287,7 @@ fn load_linux(params: LoadLinuxParams<'_>) -> Result<VpContext, Error> {
             with_psp: platform_config.general.psp_enabled,
             pm_base: chipset_resources::pm::DEFAULT_PM_PIO_BASE,
             acpi_irq: chipset_resources::pm::DEFAULT_ACPI_IRQ,
+            amd_iommu: None,
         },
     };
 
@@ -486,6 +487,7 @@ pub fn write_uefi_config(
                 with_psp: platform_config.general.psp_enabled,
                 pm_base: chipset_resources::pm::DEFAULT_PM_PIO_BASE,
                 acpi_irq: chipset_resources::pm::DEFAULT_ACPI_IRQ,
+                amd_iommu: None,
             },
             #[cfg(guest_arch = "aarch64")]
             arch: vmm_core::acpi_builder::AcpiArchConfig::Aarch64 {

--- a/openhcl/underhill_core/src/worker.rs
+++ b/openhcl/underhill_core/src/worker.rs
@@ -2642,6 +2642,7 @@ async fn new_underhill_vm(
                     with_psp: dps.general.psp_enabled,
                     pm_base: DEFAULT_PM_PIO_BASE,
                     acpi_irq: DEFAULT_ACPI_IRQ,
+                    amd_iommu: None,
                 },
             };
 

--- a/openvmm/openvmm_core/Cargo.toml
+++ b/openvmm/openvmm_core/Cargo.toml
@@ -14,6 +14,7 @@ hypervisor_resources.workspace = true
 openvmm_defs.workspace = true
 openvmm_pcat_locator.workspace = true
 membacking.workspace = true
+amd_iommu.workspace = true
 
 # vmcore
 memory_range = { workspace = true, features = ["mesh"] }

--- a/openvmm/openvmm_core/src/worker/dispatch.rs
+++ b/openvmm/openvmm_core/src/worker/dispatch.rs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+mod amd_iommu_wiring;
 mod dump;
 mod ecam_config_access;
 mod pcie_wiring;
@@ -419,6 +420,8 @@ pub(crate) struct InitializedVm {
     vtl2_framebuffer_gpa_base: Option<u64>,
     #[cfg(guest_arch = "aarch64")]
     resolved_smmu_resources: Vec<smmu_wiring::ResolvedSmmuResources>,
+    #[cfg(guest_arch = "x86_64")]
+    resolved_iommu_resources: Vec<amd_iommu_wiring::ResolvedIommuResources>,
     processor_topology: ProcessorTopology,
     igvm_file: Option<IgvmFile>,
     driver_source: VmTaskDriverSource,
@@ -449,9 +452,12 @@ impl ExtractTopologyConfig for ProcessorTopology<X86Topology> {
 }
 
 #[cfg(guest_arch = "x86_64")]
-fn build_x86_topology(
-    config: &ProcessorTopologyConfig,
-) -> anyhow::Result<ProcessorTopology<X86Topology>> {
+struct X86TopologyResult {
+    processor_topology: ProcessorTopology<X86Topology>,
+}
+
+#[cfg(guest_arch = "x86_64")]
+fn build_x86_topology(config: &ProcessorTopologyConfig) -> anyhow::Result<X86TopologyResult> {
     use vm_topology::processor::x86::X2ApicState;
 
     let arch = match &config.arch {
@@ -477,7 +483,9 @@ fn build_x86_topology(
         X2ApicConfig::Enabled => X2ApicState::Enabled,
     };
     builder.x2apic(x2apic);
-    Ok(builder.build(config.proc_count)?)
+    Ok(X86TopologyResult {
+        processor_topology: builder.build(config.proc_count)?,
+    })
 }
 
 impl ExtractTopologyConfig for ProcessorTopology<Aarch64Topology> {
@@ -506,7 +514,6 @@ impl ExtractTopologyConfig for ProcessorTopology<Aarch64Topology> {
                     None => PmuGsivConfig::Disabled,
                 },
                 gic_msi: Default::default(),
-                smmu: Vec::new(),
             })),
         }
     }
@@ -516,13 +523,13 @@ impl ExtractTopologyConfig for ProcessorTopology<Aarch64Topology> {
 struct Aarch64TopologyResult {
     processor_topology: ProcessorTopology<Aarch64Topology>,
     spi_layout: super::spi_layout::ResolvedSpiLayout,
-    smmu_count: usize,
 }
 
 #[cfg(guest_arch = "aarch64")]
 fn build_aarch64_topology(
     config: &ProcessorTopologyConfig,
     platform_info: &virt::PlatformInfo,
+    smmu_count: usize,
 ) -> anyhow::Result<Aarch64TopologyResult> {
     use openvmm_defs::config::GicMsiConfig;
     use vm_topology::processor::aarch64::Aarch64PlatformConfig;
@@ -629,7 +636,7 @@ fn build_aarch64_topology(
     let spi_layout = super::spi_layout::resolve_spi_layout(&super::spi_layout::SpiLayoutInput {
         gic_nr_irqs,
         v2m_spi_count,
-        smmu_count: arch.smmu.len(),
+        smmu_count,
     })?;
 
     // Build the GIC MSI controller from resolved SPIs.
@@ -656,8 +663,6 @@ fn build_aarch64_topology(
         gic_nr_irqs,
     };
 
-    let smmu_count = arch.smmu.len();
-
     let mut builder = TopologyBuilder::new_aarch64(platform);
     if let Some(smt) = config.enable_smt {
         builder.smt_enabled(smt);
@@ -670,7 +675,6 @@ fn build_aarch64_topology(
     Ok(Aarch64TopologyResult {
         processor_topology: builder.build(config.proc_count)?,
         spi_layout,
-        smmu_count,
     })
 }
 
@@ -745,6 +749,9 @@ struct LoadedVmInner {
     /// allow the guest to reset without notifying the client
     automatic_guest_reset: bool,
     chipset: Arc<vmotherboard::Chipset>,
+    /// Pre-built AMD IOMMU ACPI configs (one per root complex).
+    #[cfg(guest_arch = "x86_64")]
+    amd_iommu_acpi_configs: Vec<vmm_core::acpi_builder::AmdIommuAcpiConfig>,
     pcie_host_bridges: Vec<PcieHostBridge>,
     pcie_root_complexes: Vec<Arc<closeable_mutex::CloseableMutex<GenericPcieRootComplex>>>,
     /// SMMU configurations, one per instance.
@@ -754,6 +761,10 @@ struct LoadedVmInner {
     /// `None` for root complexes without an SMMU.
     #[cfg(guest_arch = "aarch64")]
     smmu_shared_states: Vec<Option<Arc<smmu::SmmuSharedState>>>,
+    /// Per-RC AMD IOMMU shared state, indexed parallel to `pcie_host_bridges`.
+    /// `None` for root complexes without an AMD IOMMU.
+    #[cfg(guest_arch = "x86_64")]
+    amd_iommu_shared_states: Vec<Option<Arc<amd_iommu::IommuSharedState>>>,
     pcie_hotplug_devices: Vec<(
         String,
         vmotherboard::DynamicDeviceUnit,
@@ -850,11 +861,11 @@ fn build_root_port_settings(rp_cfg: &PcieRootPortConfig) -> PciePortSettings {
 }
 
 /// Converts a manifest root-port entry into the runtime root-port definition.
-fn build_root_port_definition(rp_cfg: PcieRootPortConfig) -> GenericPcieRootPortDefinition {
-    let settings = build_root_port_settings(&rp_cfg);
+fn build_root_port_definition(rp_cfg: &PcieRootPortConfig) -> GenericPcieRootPortDefinition {
+    let settings = build_root_port_settings(rp_cfg);
 
     GenericPcieRootPortDefinition {
-        name: rp_cfg.name.into(),
+        name: rp_cfg.name.as_str().into(),
         hotplug: rp_cfg.hotplug,
         settings,
     }
@@ -928,16 +939,21 @@ impl InitializedVm {
         };
 
         #[cfg(guest_arch = "aarch64")]
-        let (processor_topology, spi_layout, smmu_count) = {
-            let result = build_aarch64_topology(&cfg.processor_topology, &platform_info)?;
-            (
-                result.processor_topology,
-                result.spi_layout,
-                result.smmu_count,
-            )
+        let (processor_topology, spi_layout) = {
+            let smmu_count = cfg
+                .pcie_root_complexes
+                .iter()
+                .filter(|rc| matches!(rc.iommu, Some(openvmm_defs::config::PcieIommuConfig::Smmu)))
+                .count();
+            let result =
+                build_aarch64_topology(&cfg.processor_topology, &platform_info, smmu_count)?;
+            (result.processor_topology, result.spi_layout)
         };
         #[cfg(not(guest_arch = "aarch64"))]
-        let processor_topology = build_x86_topology(&cfg.processor_topology)?;
+        let processor_topology = {
+            let result = build_x86_topology(&cfg.processor_topology)?;
+            result.processor_topology
+        };
 
         let proto = hypervisor
             .new_partition(virt::ProtoPartitionConfig {
@@ -994,11 +1010,6 @@ impl InitializedVm {
             .filter(|(bus, _)| matches!(bus, VirtioBus::Mmio))
             .count();
 
-        // SMMU is only supported on aarch64; on other architectures,
-        // no SMMU MMIO is allocated.
-        #[cfg(not(guest_arch = "aarch64"))]
-        let smmu_count = 0;
-
         // On aarch64 Linux direct boot, start RAM at 1 GiB to avoid the low GPA
         // region (128 MiB–129 MiB) that iommufd reserves for the host MSI
         // doorbell in IOVA space. Without this gap, iommufd identity-mapped DMA
@@ -1032,7 +1043,6 @@ impl InitializedVm {
             layout: cfg.layout.clone(),
             pcie_root_complexes: &cfg.pcie_root_complexes,
             virtio_mmio_count,
-            smmu_count,
             vtl2_layout,
             ram_start_address,
             vtl2_framebuffer_size,
@@ -1043,6 +1053,13 @@ impl InitializedVm {
         let resolved_pcie_root_complex_ranges = resolved_layout.pcie_root_complex_ranges;
         let virtio_mmio_region = resolved_layout.virtio_mmio_region;
         let chipset_mmio = resolved_layout.chipset_mmio;
+
+        // Combine AMD IOMMU RC configs with MMIO ranges from the layout engine.
+        #[cfg(guest_arch = "x86_64")]
+        let resolved_iommu_resources = amd_iommu_wiring::resolve_iommu_resources(
+            &cfg.pcie_root_complexes,
+            &resolved_layout.amd_iommu_ranges,
+        );
 
         // Combine SMMU MMIO ranges with SPI layout.
         #[cfg(guest_arch = "aarch64")]
@@ -1183,6 +1200,8 @@ impl InitializedVm {
             vtl2_framebuffer_gpa_base: resolved_layout.vtl2_framebuffer_gpa_base,
             #[cfg(guest_arch = "aarch64")]
             resolved_smmu_resources,
+            #[cfg(guest_arch = "x86_64")]
+            resolved_iommu_resources,
             processor_topology,
             igvm_file,
             driver_source,
@@ -1215,6 +1234,8 @@ impl InitializedVm {
             vtl2_framebuffer_gpa_base,
             #[cfg(guest_arch = "aarch64")]
             resolved_smmu_resources,
+            #[cfg(guest_arch = "x86_64")]
+            resolved_iommu_resources,
             processor_topology,
             igvm_file,
             driver_source,
@@ -1356,6 +1377,7 @@ impl InitializedVm {
                                 with_psp: cfg.chipset.with_generic_psp,
                                 pm_base: PM_BASE,
                                 acpi_irq: SYSTEM_IRQ_ACPI,
+                                amd_iommu: None,
                             },
                         };
                         let srat = acpi_tables_builder.build_srat();
@@ -1797,8 +1819,6 @@ impl InitializedVm {
         // PCI Express topology
 
         // Build the RC name→index map before consuming the RC configs.
-        // Only needed on aarch64 for SMMU setup.
-        #[cfg(guest_arch = "aarch64")]
         let pcie_rc_name_to_idx: std::collections::HashMap<String, usize> = cfg
             .pcie_root_complexes
             .iter()
@@ -1806,13 +1826,24 @@ impl InitializedVm {
             .map(|(i, rc)| (rc.name.clone(), i))
             .collect();
 
+        // Deferred MSI connections for root complexes and switches.
+        // These are wired after IOMMU setup so that interrupt remapping
+        // can be applied when an AMD IOMMU covers the root complex.
+        struct DeferredMsiConn {
+            msi_conn: pci_core::msi::MsiConnection,
+            segment: u16,
+            #[cfg_attr(not(guest_arch = "x86_64"), expect(dead_code))]
+            rc_idx: usize,
+        }
+        let mut deferred_msi_conns: Vec<DeferredMsiConn> = Vec::new();
+
         let (pcie_host_bridges, pcie_root_complexes) = {
             let mut pcie_host_bridges = Vec::new();
             let mut pcie_root_complexes = Vec::new();
 
             for (rc, ranges) in cfg
                 .pcie_root_complexes
-                .into_iter()
+                .iter()
                 .zip(resolved_pcie_root_complex_ranges)
             {
                 let cxl_port_count = rc.ports.iter().filter(|rp_cfg| rp_cfg.cxl).count() as u64;
@@ -1862,33 +1893,46 @@ impl InitializedVm {
                 rc_bus_range.set_bus_range(rc.start_bus, rc.end_bus);
                 let msi_conn = pci_core::msi::MsiConnection::new(rc_bus_range, 0);
 
+                // When the AMD IOMMU is enabled for this root complex,
+                // reserve device 0 for the IOMMU RCiEP and start root
+                // ports at device 1.
+                #[cfg(guest_arch = "x86_64")]
+                let root_port_start_device: u8 = if resolved_iommu_resources
+                    .iter()
+                    .any(|r| r.rc_name == rc.name)
+                {
+                    1
+                } else {
+                    0
+                };
+                #[cfg(not(guest_arch = "x86_64"))]
+                let root_port_start_device: u8 = 0;
+
                 let root_complex =
                     chipset_builder
                         .arc_mutex_device(device_name)
                         .try_add(|services| {
-                            let root_port_definitions = rc
-                                .ports
-                                .into_iter()
-                                .map(build_root_port_definition)
-                                .collect();
-
+                            let root_port_definitions =
+                                rc.ports.iter().map(build_root_port_definition).collect();
                             GenericPcieRootComplex::builder(
                                 &mut services.register_mmio(),
                                 rc.start_bus..=rc.end_bus,
                                 ranges.ecam_range,
                             )
                             .root_ports(root_port_definitions, msi_conn.target())
+                            .first_port_device_number(root_port_start_device)
                             .chbcr_range(chbcr_range)
                             .build()
                         })?;
 
-                if let Some(signal_msi) = partition.as_signal_msi(Vtl::Vtl0) {
-                    // Wrap the root complex's SignalMsi with platform
-                    // MSI controller translation (ITS on aarch64).
-                    let signal_msi =
-                        pcie_wiring::wrap_platform_msi(signal_msi, rc.segment, &processor_topology);
-                    msi_conn.connect(signal_msi);
-                }
+                // Defer MSI wiring to after IOMMU setup so that
+                // interrupt remapping can be applied if applicable.
+                let rc_idx = pcie_host_bridges.len();
+                deferred_msi_conns.push(DeferredMsiConn {
+                    msi_conn,
+                    segment: rc.segment,
+                    rc_idx,
+                });
 
                 let cxl = cxl_config
                     .map(|cxl| -> anyhow::Result<PcieHostBridgeCxlInfo> {
@@ -1933,16 +1977,22 @@ impl InitializedVm {
         struct PortInfo {
             segment: u16,
             bus_range: pci_core::bus_range::AssignedBusRange,
+            rc_idx: usize,
         }
         let mut port_info: std::collections::HashMap<Arc<str>, PortInfo> =
             std::collections::HashMap::new();
-        for (hb, rc) in pcie_host_bridges.iter().zip(pcie_root_complexes.iter()) {
+        for (rc_idx, (hb, rc)) in pcie_host_bridges
+            .iter()
+            .zip(pcie_root_complexes.iter())
+            .enumerate()
+        {
             for p in rc.lock().downstream_ports() {
                 if let Some(_existing) = port_info.insert(
                     p.name.clone(),
                     PortInfo {
                         segment: hb.segment,
                         bus_range: p.bus_range,
+                        rc_idx,
                     },
                 ) {
                     anyhow::bail!("duplicate PCIe port name '{}'", p.name);
@@ -1953,32 +2003,29 @@ impl InitializedVm {
         for switch in cfg.pcie_switches {
             let device_name = format!("pcie-switch:{}", switch.name);
 
-            // Inherit the segment from the switch's parent port.
-            let parent_segment = port_info
-                .get(switch.parent_port.as_str())
-                .ok_or_else(|| {
-                    anyhow::anyhow!(
-                        "switch '{}' parent port '{}' not found in any root complex",
-                        switch.name,
-                        switch.parent_port
-                    )
-                })?
-                .segment;
+            // Inherit the segment and RC index from the switch's parent port.
+            let parent_port_info = port_info.get(switch.parent_port.as_str()).ok_or_else(|| {
+                anyhow::anyhow!(
+                    "switch '{}' parent port '{}' not found in any root complex",
+                    switch.name,
+                    switch.parent_port
+                )
+            })?;
+            let parent_segment = parent_port_info.segment;
+            let parent_rc_idx = parent_port_info.rc_idx;
 
             let msi_conn =
                 pci_core::msi::MsiConnection::new(pci_core::bus_range::AssignedBusRange::new(), 0);
 
-            if let Some(signal_msi) = partition.as_signal_msi(Vtl::Vtl0) {
-                let signal_msi =
-                    pcie_wiring::wrap_platform_msi(signal_msi, parent_segment, &processor_topology);
-                msi_conn.connect(signal_msi);
-            }
-            if let Some(fd) = partition.irqfd() {
-                let fd = pcie_wiring::wrap_platform_irqfd(fd, parent_segment, &processor_topology);
-                msi_conn.connect_irqfd(fd);
-            }
-
+            // Defer MSI wiring to after IOMMU setup.
             let msi_target = msi_conn.target().clone();
+
+            deferred_msi_conns.push(DeferredMsiConn {
+                msi_conn,
+                segment: parent_segment,
+                rc_idx: parent_rc_idx,
+            });
+
             let switch_device = chipset_builder
                 .arc_mutex_device(device_name)
                 .on_pcie_port(vmotherboard::BusId::new(&switch.parent_port))
@@ -2006,6 +2053,7 @@ impl InitializedVm {
                     PortInfo {
                         segment: parent_segment,
                         bus_range: p.bus_range,
+                        rc_idx: parent_rc_idx,
                     },
                 ) {
                     anyhow::bail!("duplicate PCIe port name '{}'", p.name);
@@ -2059,16 +2107,48 @@ impl InitializedVm {
         let smmu_wiring::SmmuDevicesResult {
             shared_states: smmu_shared_states,
             configs: smmu_configs,
-            port_maps: smmu_port_maps,
         } = smmu_wiring::setup_smmu(
-            cfg.processor_topology.arch.as_ref(),
+            &cfg.pcie_root_complexes,
             &resolved_smmu_resources,
             &pcie_rc_name_to_idx,
             &pcie_host_bridges,
-            &pcie_root_complexes,
             &chipset_builder,
             &gm,
         )?;
+
+        // Instantiate an AMD IOMMU on each root complex listed in
+        // --amd-iommu. Each IOMMU is an RCiEP at device 0, function 0 on
+        // its root complex's start bus with a distinct MMIO base address.
+        // Per-device wrappers are created in the PCIe device loop below.
+        #[cfg(guest_arch = "x86_64")]
+        let amd_iommu_wiring::IommuDevicesResult {
+            acpi_configs: amd_iommu_acpi_configs,
+            shared_states: amd_iommu_shared_states,
+        } = amd_iommu_wiring::setup_amd_iommu(
+            &resolved_iommu_resources,
+            &pcie_host_bridges,
+            &pcie_rc_name_to_idx,
+            &chipset_builder,
+            partition.as_ref(),
+            &gm,
+        )?;
+
+        // Wire deferred root complex and switch MSI connections now that
+        // IOMMU setup is complete. On x86_64, this applies AMD IOMMU
+        // interrupt remapping when the segment is covered.
+        for deferred in deferred_msi_conns {
+            #[cfg(guest_arch = "x86_64")]
+            let iommu = amd_iommu_shared_states[deferred.rc_idx].as_ref();
+            pcie_wiring::PcieMsiPlatform {
+                partition: partition.as_ref(),
+                segment: deferred.segment,
+                processor_topology: &processor_topology,
+                #[cfg(guest_arch = "x86_64")]
+                iommu,
+            }
+            .wrap_msi()
+            .connect_to(&deferred.msi_conn);
+        }
 
         // Resolve PCIe devices concurrently.
         //
@@ -2078,6 +2158,9 @@ impl InitializedVm {
         // port's AssignedBusRange, which the MsiTarget resolves lazily
         // at interrupt delivery time. When SMMU is enabled, per-device
         // wrappers translate IOVAs and MSI addresses through the emulated SMMU.
+        // When the AMD IOMMU is enabled, per-device wrappers translate
+        // IOVAs using the port's assigned bus range and remap MSIs using
+        // the requester ID supplied by the PCI MSI path.
 
         try_join_all(cfg.pcie_devices.into_iter().map(|dev_cfg| {
             let chipset_builder = &chipset_builder;
@@ -2087,9 +2170,11 @@ impl InitializedVm {
             let partition = &partition;
             let mapper = &mapper;
             let port_info = &port_info;
-            #[cfg(guest_arch = "aarch64")]
-            let smmu_port_maps = &smmu_port_maps;
             let processor_topology = &processor_topology;
+            #[cfg(guest_arch = "x86_64")]
+            let iommu_shared_states = &amd_iommu_shared_states;
+            #[cfg(guest_arch = "aarch64")]
+            let smmu_states = &smmu_shared_states;
             async move {
                 let port_name: Arc<str> = dev_cfg.port_name.into();
                 let pi = port_info.get(&port_name).ok_or_else(|| {
@@ -2102,15 +2187,18 @@ impl InitializedVm {
                 let msi_conn = pci_core::msi::MsiConnection::new(pi.bus_range.clone(), 0);
 
                 let pcie_ctx =
-                    pcie_wiring::build_pcie_msi_context(&pcie_wiring::PcieWiringParams {
-                        partition: partition.as_ref(),
+                    pcie_wiring::build_device_wiring(pcie_wiring::PcieDeviceWiringParams {
+                        msi_platform: pcie_wiring::PcieMsiPlatform {
+                            partition: partition.as_ref(),
+                            segment: pi.segment,
+                            processor_topology,
+                            #[cfg(guest_arch = "x86_64")]
+                            iommu: iommu_shared_states[pi.rc_idx].as_ref(),
+                        },
                         guest_memory: gm,
-                        #[cfg(guest_arch = "aarch64")]
                         bus_range: &pi.bus_range,
-                        segment: pi.segment,
-                        processor_topology,
                         #[cfg(guest_arch = "aarch64")]
-                        smmu: smmu_port_maps.port_map.get(&port_name),
+                        smmu: smmu_states[pi.rc_idx].as_ref(),
                     });
 
                 vmm_core::device_builder::build_pcie_device(
@@ -2627,6 +2715,8 @@ impl InitializedVm {
                 client_notify_send,
                 automatic_guest_reset: cfg.automatic_guest_reset,
                 chipset: chipset.chipset.clone(),
+                #[cfg(guest_arch = "x86_64")]
+                amd_iommu_acpi_configs,
                 pcie_host_bridges,
                 pcie_root_complexes,
                 pcie_hotplug_devices: Vec::new(),
@@ -2634,6 +2724,8 @@ impl InitializedVm {
                 smmu_configs,
                 #[cfg(guest_arch = "aarch64")]
                 smmu_shared_states,
+                #[cfg(guest_arch = "x86_64")]
+                amd_iommu_shared_states,
             },
         };
 
@@ -2673,6 +2765,15 @@ impl LoadedVmInner {
                 with_pit: self.chipset_capabilities.with_pit,
                 pm_base: PM_BASE,
                 acpi_irq: SYSTEM_IRQ_ACPI,
+                amd_iommu: if self.amd_iommu_acpi_configs.is_empty() {
+                    None
+                } else {
+                    Some(vmm_core::acpi_builder::AmdIommuIvrsConfig {
+                        pa_size: amd_iommu::PA_SIZE,
+                        va_size: amd_iommu::VA_SIZE,
+                        iommus: self.amd_iommu_acpi_configs.clone(),
+                    })
+                },
             },
             #[cfg(guest_arch = "aarch64")]
             arch: vmm_core::acpi_builder::AcpiArchConfig::Aarch64 {
@@ -3216,14 +3317,17 @@ impl LoadedVm {
                             let segment = self.inner.pcie_host_bridges[rc_idx].segment;
                             let msi_conn = pci_core::msi::MsiConnection::new(bus_range.clone(), 0);
 
-                            let pcie_ctx = pcie_wiring::build_pcie_msi_context(
-                                &pcie_wiring::PcieWiringParams {
-                                    partition: self.inner.partition.as_ref(),
+                            let pcie_ctx = pcie_wiring::build_device_wiring(
+                                pcie_wiring::PcieDeviceWiringParams {
+                                    msi_platform: pcie_wiring::PcieMsiPlatform {
+                                        partition: self.inner.partition.as_ref(),
+                                        segment,
+                                        processor_topology: &self.inner.processor_topology,
+                                        #[cfg(guest_arch = "x86_64")]
+                                        iommu: self.inner.amd_iommu_shared_states[rc_idx].as_ref(),
+                                    },
                                     guest_memory: &self.inner.gm,
-                                    #[cfg(guest_arch = "aarch64")]
                                     bus_range: &bus_range,
-                                    segment,
-                                    processor_topology: &self.inner.processor_topology,
                                     #[cfg(guest_arch = "aarch64")]
                                     smmu: self.inner.smmu_shared_states[rc_idx].as_ref(),
                                 },

--- a/openvmm/openvmm_core/src/worker/dispatch/amd_iommu_wiring.rs
+++ b/openvmm/openvmm_core/src/worker/dispatch/amd_iommu_wiring.rs
@@ -1,0 +1,132 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#![cfg(guest_arch = "x86_64")]
+
+//! AMD IOMMU resource setup and wiring helpers for x86_64 VMs.
+//!
+//! This module handles instantiating AMD IOMMU chipset devices on each
+//! requested root complex.
+
+use crate::partition::HvlitePartition;
+use guestmem::GuestMemory;
+use hvdef::Vtl;
+use std::collections::HashMap;
+use std::sync::Arc;
+use vm_topology::pcie::PcieHostBridge;
+use vmotherboard::ChipsetBuilder;
+
+/// Resolved resources for a single AMD IOMMU instance, combining the
+/// topology-specified RC name with the MMIO range from the layout engine.
+pub(super) struct ResolvedIommuResources {
+    /// Name of the PCIe root complex this IOMMU covers.
+    pub rc_name: String,
+    /// MMIO base address (from the memory layout allocator).
+    pub mmio_base: u64,
+}
+
+/// Combines AMD IOMMU RC configs with MMIO ranges from the memory layout
+/// engine into resolved per-instance resources.
+pub(super) fn resolve_iommu_resources(
+    root_complexes: &[openvmm_defs::config::PcieRootComplexConfig],
+    mmio_ranges: &[memory_range::MemoryRange],
+) -> Vec<ResolvedIommuResources> {
+    root_complexes
+        .iter()
+        .filter(|rc| matches!(rc.iommu, Some(openvmm_defs::config::PcieIommuConfig::AmdVi)))
+        .zip(mmio_ranges)
+        .map(|(rc, range)| ResolvedIommuResources {
+            rc_name: rc.name.clone(),
+            mmio_base: range.start(),
+        })
+        .collect()
+}
+
+/// Result of [`setup_amd_iommu`].
+pub(super) struct IommuDevicesResult {
+    /// ACPI IVRS configuration for each IOMMU instance.
+    pub acpi_configs: Vec<vmm_core::acpi_builder::AmdIommuAcpiConfig>,
+    /// Per-RC IOMMU shared state, indexed parallel to `pcie_host_bridges`.
+    /// `None` for root complexes without an AMD IOMMU.
+    pub shared_states: Vec<Option<Arc<amd_iommu::IommuSharedState>>>,
+}
+
+/// Instantiate AMD IOMMU chipset devices.
+///
+/// Creates one `AmdIommuDevice` per root complex listed in `amd_iommu_rcs`,
+/// placed as an RCiEP at device 0 on each root complex's start bus. Returns
+/// ACPI configs for IVRS table generation and per-RC shared state for
+/// per-device DMA/MSI wiring.
+pub(super) fn setup_amd_iommu(
+    resolved_resources: &[ResolvedIommuResources],
+    pcie_host_bridges: &[PcieHostBridge],
+    pcie_rc_name_to_idx: &HashMap<String, usize>,
+    chipset_builder: &ChipsetBuilder<'_>,
+    partition: &dyn HvlitePartition,
+    gm: &GuestMemory,
+) -> anyhow::Result<IommuDevicesResult> {
+    let mut shared_states: Vec<Option<Arc<amd_iommu::IommuSharedState>>> =
+        vec![None; pcie_host_bridges.len()];
+    let mut acpi_configs: Vec<vmm_core::acpi_builder::AmdIommuAcpiConfig> = Vec::new();
+
+    for res in resolved_resources {
+        let rc_name = &res.rc_name;
+        let rc_pos = match pcie_rc_name_to_idx.get(rc_name.as_str()) {
+            Some(&i) => i,
+            None => {
+                let available: Vec<_> = pcie_rc_name_to_idx.keys().collect();
+                anyhow::bail!(
+                    "--amd-iommu references unknown root complex '{rc_name}'. \
+                     Available: {available:?}"
+                );
+            }
+        };
+
+        if shared_states[rc_pos].is_some() {
+            anyhow::bail!("duplicate AMD IOMMU for root complex '{rc_name}'");
+        }
+
+        let hb = &pcie_host_bridges[rc_pos];
+
+        let mmio_base = res.mmio_base;
+        let iommu_config = amd_iommu::AmdIommuConfig {
+            mmio_base,
+            pci_bdf: (0, 0, 0),
+        };
+
+        let device_name = format!("amd-iommu-{}", rc_name);
+        let builder = chipset_builder
+            .arc_mutex_device(device_name)
+            .on_pcie_root_complex(
+                vmotherboard::BusId::new(rc_name),
+                0, // device 0
+            );
+
+        let iommu_bus_range = pci_core::bus_range::AssignedBusRange::new();
+        iommu_bus_range.set_bus_range(hb.start_bus, hb.start_bus);
+        let iommu_msi_conn = pci_core::msi::MsiConnection::new(iommu_bus_range, 0);
+        let iommu_dev = builder.add(|_services| {
+            amd_iommu::AmdIommuDevice::new(gm.clone(), iommu_config, iommu_msi_conn.target())
+        })?;
+        if let Some(signal_msi) = partition.as_signal_msi(Vtl::Vtl0) {
+            iommu_msi_conn.connect(signal_msi);
+        }
+        let shared = iommu_dev.lock().shared_state().clone();
+        shared_states[rc_pos] = Some(shared);
+
+        acpi_configs.push(vmm_core::acpi_builder::AmdIommuAcpiConfig {
+            device_id: (hb.start_bus as u16) << 8, // device 0, function 0
+            capability_offset: amd_iommu::PCI_CAP_OFFSET,
+            mmio_base,
+            pci_segment: hb.segment,
+            ivhd_features: amd_iommu::ADVERTISED_EXT_FEAT,
+            start_bus: hb.start_bus,
+            end_bus: hb.end_bus,
+        });
+    }
+
+    Ok(IommuDevicesResult {
+        acpi_configs,
+        shared_states,
+    })
+}

--- a/openvmm/openvmm_core/src/worker/dispatch/pcie_wiring.rs
+++ b/openvmm/openvmm_core/src/worker/dispatch/pcie_wiring.rs
@@ -1,11 +1,17 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-//! PCIe device MSI/DMA wiring helpers.
+//! PCIe MSI routing and DMA wiring helpers.
 //!
-//! This module builds the layered `GuestMemory`, `SignalMsi`, and `IrqFd`
-//! for PCIe devices, applying platform-specific MSI controller wrapping
-//! (ITS on aarch64, future IR on x86) and SMMU DMA/MSI translation.
+//! This module provides layered MSI routing and DMA translation for PCIe
+//! entities (root complexes, switches, and devices).
+//!
+//! [`PcieMsiPlatform`] captures platform-specific context (ITS on aarch64,
+//! IOMMU interrupt remapping on x86_64) and wraps `SignalMsi`/`IrqFd` via
+//! [`PcieMsiPlatform::wrap_msi`] → [`PcieMsiRouting`].
+//!
+//! [`build_device_wiring`] extends this with IOMMU DMA translation
+//! (SMMU on aarch64, AMD IOMMU on x86_64) → [`PcieDeviceWiring`].
 
 use crate::partition::HvlitePartition;
 use guestmem::GuestMemory;
@@ -13,44 +19,48 @@ use hvdef::Vtl;
 use std::sync::Arc;
 use vm_topology::processor::ProcessorTopology;
 
-/// Input parameters for [`build_pcie_msi_context`].
-pub(super) struct PcieWiringParams<'a> {
+/// Platform-specific MSI wrapping context for PCIe entities.
+///
+/// Encapsulates ITS device ID composition (aarch64) and IOMMU interrupt
+/// remapping (x86_64). Construct one of these and call [`wrap_msi`] to
+/// get correctly-wrapped `SignalMsi` and `IrqFd` for any PCIe entity —
+/// root complexes, switches, and devices alike.
+///
+/// [`wrap_msi`]: PcieMsiPlatform::wrap_msi
+pub(super) struct PcieMsiPlatform<'a> {
     /// The partition providing base `SignalMsi` and `IrqFd`.
     pub partition: &'a dyn HvlitePartition,
-    /// Raw guest memory (wrapped with SMMU translation when applicable).
-    pub guest_memory: &'a GuestMemory,
-    /// The device's assigned bus range (for IOMMU stream ID composition).
-    #[cfg(guest_arch = "aarch64")]
-    pub bus_range: &'a pci_core::bus_range::AssignedBusRange,
-    /// PCIe segment number (for MSI controller device ID composition).
+    /// PCIe segment number (for ITS device ID composition on aarch64).
+    #[cfg_attr(not(guest_arch = "aarch64"), expect(dead_code))]
     pub segment: u16,
-    /// Processor topology (determines which MSI controller wrapping to apply).
+    /// Processor topology (determines ITS wrapping on aarch64).
+    #[cfg_attr(not(guest_arch = "aarch64"), expect(dead_code))]
     pub processor_topology: &'a ProcessorTopology,
-    /// SMMU shared state if this device is behind an SMMU, or `None`.
-    #[cfg(guest_arch = "aarch64")]
-    pub smmu: Option<&'a Arc<smmu::SmmuSharedState>>,
+    /// AMD IOMMU shared state for interrupt remapping, or `None` if this
+    /// entity is not behind an AMD IOMMU.
+    #[cfg(guest_arch = "x86_64")]
+    pub iommu: Option<&'a Arc<amd_iommu::IommuSharedState>>,
 }
 
-/// The layered GuestMemory, SignalMsi, and IrqFd produced by
-/// [`build_pcie_msi_context`].
-pub(super) struct PcieDeviceInterrupts {
-    /// Guest memory for the device — either the raw memory or an
-    /// SMMU-translating wrapper.
-    pub guest_memory: GuestMemory,
-    /// MSI signaling target, optionally wrapped with platform MSI controller
-    /// and/or SMMU translation. `None` if the partition does not provide
-    /// MSI support.
+/// Wrapped `SignalMsi` and `IrqFd` for a PCIe entity.
+///
+/// Produced by [`PcieMsiPlatform::wrap_msi`]. Use [`connect_to`] to
+/// wire these into an [`MsiConnection`].
+///
+/// [`connect_to`]: PcieMsiRouting::connect_to
+/// [`MsiConnection`]: pci_core::msi::MsiConnection
+pub(super) struct PcieMsiRouting {
+    /// MSI signaling target with platform wrapping applied. `None` if
+    /// the partition does not provide MSI support.
     pub signal_msi: Option<Arc<dyn pci_core::msi::SignalMsi>>,
-    /// IrqFd for kernel-accelerated MSI delivery, optionally wrapped with
-    /// platform MSI controller and/or SMMU translation. `None` if the
-    /// partition does not provide irqfd support.
+    /// IrqFd for kernel-accelerated MSI delivery with platform wrapping
+    /// applied. `None` if the partition does not provide irqfd support,
+    /// or if IOMMU interrupt remapping is active (irqfd is not yet
+    /// supported through the emulated IOMMU).
     pub irqfd: Option<Arc<dyn vmcore::irqfd::IrqFd>>,
-    /// Whether the device is behind a software IOMMU (e.g., emulated SMMU)
-    /// that cannot program the host IOMMU for passthrough DMA.
-    pub software_iommu: bool,
 }
 
-impl PcieDeviceInterrupts {
+impl PcieMsiRouting {
     /// Connect the signal_msi and irqfd to an [`MsiConnection`].
     pub fn connect_to(self, msi_conn: &pci_core::msi::MsiConnection) {
         if let Some(target) = self.signal_msi {
@@ -62,88 +72,135 @@ impl PcieDeviceInterrupts {
     }
 }
 
-/// Build the layered GuestMemory, SignalMsi, and IrqFd for a PCIe device.
-///
-/// Applies platform MSI controller wrapping (ITS on aarch64, identity on x86
-/// for now) and optional SMMU DMA/MSI translation.
-pub(super) fn build_pcie_msi_context(params: &PcieWiringParams<'_>) -> PcieDeviceInterrupts {
-    let base_signal_msi = params
-        .partition
-        .as_signal_msi(Vtl::Vtl0)
-        .map(|s| wrap_platform_msi(s, params.segment, params.processor_topology));
-    let base_irqfd = params
-        .partition
-        .irqfd()
-        .map(|fd| wrap_platform_irqfd(fd, params.segment, params.processor_topology));
+impl PcieMsiPlatform<'_> {
+    /// Wrap the partition's base `SignalMsi` and `IrqFd` with platform-
+    /// specific MSI controller translation and IOMMU interrupt remapping.
+    ///
+    /// On aarch64 with ITS: wraps with segment-based device ID composition.
+    /// On x86_64 with AMD IOMMU: wraps with interrupt remapping; irqfd
+    /// is disabled because kernel-mediated MSI routes bypass emulated
+    /// interrupt remapping.
+    pub fn wrap_msi(&self) -> PcieMsiRouting {
+        let mut signal_msi: Option<Arc<dyn pci_core::msi::SignalMsi>> =
+            self.partition.as_signal_msi(Vtl::Vtl0);
+        let mut irqfd: Option<Arc<dyn vmcore::irqfd::IrqFd>> = self.partition.irqfd();
 
-    // When an SMMU covers this device, wrap GuestMemory, SignalMsi, and
-    // IrqFd with SMMU translation. stream_id_base is 0 because each SMMU
-    // is 1:1 with its root complex — stream IDs are plain BDFs.
+        // aarch64 ITS: wrap with segment-based device ID composition.
+        #[cfg(guest_arch = "aarch64")]
+        if matches!(
+            self.processor_topology.gic_msi(),
+            vm_topology::processor::aarch64::GicMsiController::Its(_)
+        ) {
+            signal_msi =
+                signal_msi.map(|s| Arc::new(pcie::its::ItsSignalMsi::new(s, self.segment)) as _);
+            irqfd = irqfd.map(|fd| Arc::new(pcie::its::ItsIrqFd::new(fd, self.segment)) as _);
+        }
+
+        // x86_64 AMD IOMMU: wrap with interrupt remapping.
+        //
+        // TODO: irqfd is disabled because kernel-mediated MSI routes
+        // bypass our emulated interrupt remapping. We could support
+        // irqfd by wrapping IrqFdRoute::enable() to do the IRTE lookup
+        // and push the remapped address/data to the kernel, then
+        // re-pushing on INVALIDATE_INTERRUPT_TABLE commands.
+        #[cfg(guest_arch = "x86_64")]
+        if let Some(shared) = &self.iommu {
+            signal_msi = signal_msi.map(|s| shared.create_signal_msi(s) as _);
+            irqfd = None;
+        }
+
+        PcieMsiRouting { signal_msi, irqfd }
+    }
+}
+
+/// Input parameters for [`build_device_wiring`].
+pub(super) struct PcieDeviceWiringParams<'a> {
+    /// Platform MSI context (ITS, IOMMU interrupt remapping).
+    pub msi_platform: PcieMsiPlatform<'a>,
+    /// Raw guest memory (wrapped with IOMMU DMA translation when applicable).
+    pub guest_memory: &'a GuestMemory,
+    /// The device's assigned bus range (for IOMMU stream/device ID).
+    pub bus_range: &'a pci_core::bus_range::AssignedBusRange,
+    /// SMMU shared state if this device is behind an SMMU, or `None`.
+    #[cfg(guest_arch = "aarch64")]
+    pub smmu: Option<&'a Arc<smmu::SmmuSharedState>>,
+}
+
+/// The layered GuestMemory and MSI routing for a PCIe device.
+///
+/// Produced by [`build_device_wiring`]. Extends [`PcieMsiRouting`] with
+/// IOMMU DMA translation and a `software_iommu` flag.
+pub(super) struct PcieDeviceWiring {
+    /// Guest memory for the device — either the raw memory or an
+    /// IOMMU-translating wrapper.
+    pub guest_memory: GuestMemory,
+    /// Wrapped MSI routing for the device.
+    pub msi: PcieMsiRouting,
+    /// Whether the device is behind a software IOMMU (e.g., emulated
+    /// SMMU or AMD IOMMU) that cannot program the host IOMMU for
+    /// passthrough DMA.
+    pub software_iommu: bool,
+}
+
+impl PcieDeviceWiring {
+    /// Connect the MSI routing to an [`MsiConnection`].
+    pub fn connect_to(self, msi_conn: &pci_core::msi::MsiConnection) {
+        self.msi.connect_to(msi_conn);
+    }
+}
+
+/// Build the layered GuestMemory and MSI routing for a PCIe device.
+///
+/// Calls [`PcieMsiPlatform::wrap_msi`] for MSI/IrqFd wrapping, then
+/// adds IOMMU DMA translation (SMMU on aarch64, AMD IOMMU on x86_64)
+/// to produce the device's `GuestMemory`.
+pub(super) fn build_device_wiring(params: PcieDeviceWiringParams<'_>) -> PcieDeviceWiring {
+    let msi = params.msi_platform.wrap_msi();
+
+    // aarch64 SMMU: wrap GuestMemory and SignalMsi/IrqFd with SMMU
+    // translation. stream_id_base is 0 because each SMMU is 1:1 with
+    // its root complex — stream IDs are plain BDFs.
     //
-    // The translating GuestMemory is created unconditionally when an SMMU
-    // is present — DMA translation must not depend on MSI availability.
+    // The translating GuestMemory is created unconditionally when an
+    // SMMU is present — DMA translation must not depend on MSI
+    // availability.
     #[cfg(guest_arch = "aarch64")]
     if let Some(shared) = params.smmu {
         let translating_gm =
             shared.create_translating_memory(params.bus_range.clone(), 0, params.guest_memory);
-        let smmu_msi = base_signal_msi.map(|inner_msi| {
+        let smmu_msi = msi.signal_msi.map(|inner_msi| {
             Arc::new(smmu::SmmuSignalMsi::new(shared.clone(), 0, inner_msi))
                 as Arc<dyn pci_core::msi::SignalMsi>
         });
-        let irqfd =
-            base_irqfd.map(|fd| shared.create_irqfd(0, fd) as Arc<dyn vmcore::irqfd::IrqFd>);
-        return PcieDeviceInterrupts {
+        let irqfd = msi
+            .irqfd
+            .map(|fd| shared.create_irqfd(0, fd) as Arc<dyn vmcore::irqfd::IrqFd>);
+        return PcieDeviceWiring {
             guest_memory: translating_gm,
-            signal_msi: smmu_msi,
-            irqfd,
+            msi: PcieMsiRouting {
+                signal_msi: smmu_msi,
+                irqfd,
+            },
             software_iommu: true,
         };
     }
 
-    PcieDeviceInterrupts {
+    // x86_64 AMD IOMMU: wrap GuestMemory with DMA translation.
+    // MSI interrupt remapping was already applied by wrap_msi().
+    #[cfg(guest_arch = "x86_64")]
+    if let Some(shared) = params.msi_platform.iommu {
+        let translating_gm =
+            shared.create_translating_memory(params.bus_range.clone(), params.guest_memory);
+        return PcieDeviceWiring {
+            guest_memory: translating_gm,
+            msi,
+            software_iommu: true,
+        };
+    }
+
+    PcieDeviceWiring {
         guest_memory: params.guest_memory.clone(),
-        signal_msi: base_signal_msi,
-        irqfd: base_irqfd,
+        msi,
         software_iommu: false,
     }
-}
-
-/// Wrap a `SignalMsi` with platform-specific MSI controller translation.
-///
-/// On aarch64 with ITS: wraps with segment-based device ID composition.
-/// On x86: identity (future: interrupt remapping).
-pub(super) fn wrap_platform_msi(
-    signal_msi: Arc<dyn pci_core::msi::SignalMsi>,
-    #[cfg_attr(not(guest_arch = "aarch64"), expect(unused_variables))] segment: u16,
-    #[cfg_attr(not(guest_arch = "aarch64"), expect(unused_variables))]
-    processor_topology: &ProcessorTopology,
-) -> Arc<dyn pci_core::msi::SignalMsi> {
-    #[cfg(guest_arch = "aarch64")]
-    if matches!(
-        processor_topology.gic_msi(),
-        vm_topology::processor::aarch64::GicMsiController::Its(_)
-    ) {
-        return Arc::new(pcie::its::ItsSignalMsi::new(signal_msi, segment));
-    }
-    signal_msi
-}
-
-/// Wrap an `IrqFd` with platform-specific MSI controller translation.
-///
-/// On aarch64 with ITS: wraps with segment-based device ID composition.
-/// On x86: identity (future: interrupt remapping).
-pub(super) fn wrap_platform_irqfd(
-    irqfd: Arc<dyn vmcore::irqfd::IrqFd>,
-    #[cfg_attr(not(guest_arch = "aarch64"), expect(unused_variables))] segment: u16,
-    #[cfg_attr(not(guest_arch = "aarch64"), expect(unused_variables))]
-    processor_topology: &ProcessorTopology,
-) -> Arc<dyn vmcore::irqfd::IrqFd> {
-    #[cfg(guest_arch = "aarch64")]
-    if matches!(
-        processor_topology.gic_msi(),
-        vm_topology::processor::aarch64::GicMsiController::Its(_)
-    ) {
-        return Arc::new(pcie::its::ItsIrqFd::new(irqfd, segment));
-    }
-    irqfd
 }

--- a/openvmm/openvmm_core/src/worker/dispatch/smmu_wiring.rs
+++ b/openvmm/openvmm_core/src/worker/dispatch/smmu_wiring.rs
@@ -7,13 +7,10 @@
 //!
 //! This module handles combining SMMU MMIO ranges (from the memory layout
 //! allocator) with SPI assignments (from the SPI allocator) into resolved
-//! resources, instantiating SMMU chipset devices, and building the lookup
-//! maps needed for per-device wiring.
+//! resources and instantiating SMMU chipset devices.
 
 use chipset_device_resources::IRQ_LINE_SET;
-use closeable_mutex::CloseableMutex;
 use guestmem::GuestMemory;
-use pcie::root::GenericPcieRootComplex;
 use std::collections::HashMap;
 use std::sync::Arc;
 use vm_topology::pcie::PcieHostBridge;
@@ -47,12 +44,6 @@ pub(super) fn resolve_smmu_resources(
         .collect()
 }
 
-/// Lookup maps for SMMU-covered PCIe ports, used during device wiring.
-pub(super) struct SmmuPortMaps {
-    /// Maps port names to their SMMU shared state (for per-device wrapping).
-    pub port_map: HashMap<Arc<str>, Arc<smmu::SmmuSharedState>>,
-}
-
 /// Result of [`setup_smmu`].
 pub(super) struct SmmuDevicesResult {
     /// Per-RC SMMU shared state, indexed parallel to `pcie_host_bridges`.
@@ -60,61 +51,39 @@ pub(super) struct SmmuDevicesResult {
     pub shared_states: Vec<Option<Arc<smmu::SmmuSharedState>>>,
     /// ACPI IORT configuration for each SMMU instance.
     pub configs: Vec<vmm_core::acpi_builder::AcpiSmmuConfig>,
-    /// Port-level lookup maps for per-device wiring and VFIO validation.
-    pub port_maps: SmmuPortMaps,
 }
 
-/// Extract SMMU instance configs from the processor topology, instantiate
-/// SMMU chipset devices, and build the port-level lookup maps.
+/// Instantiate SMMU chipset devices for root complexes that have SMMU
+/// configured.
 ///
 /// This is the single entry point for all SMMU setup in dispatch. It
-/// extracts `SmmuInstanceConfig`s from the arch topology, creates one
-/// `SmmuDevice` per instance on the chipset builder, and builds the
-/// port-name maps needed for per-device wiring.
+/// iterates root complex configs, creates one `SmmuDevice` per RC with
+/// `iommu: Some(Smmu)`, and wires up interrupts.
 pub(super) fn setup_smmu(
-    processor_topology_arch: Option<&openvmm_defs::config::ArchTopologyConfig>,
+    root_complexes: &[openvmm_defs::config::PcieRootComplexConfig],
     resolved_smmu_resources: &[ResolvedSmmuResources],
     pcie_rc_name_to_idx: &HashMap<String, usize>,
     pcie_host_bridges: &[PcieHostBridge],
-    pcie_root_complexes: &[Arc<CloseableMutex<GenericPcieRootComplex>>],
     chipset_builder: &ChipsetBuilder<'_>,
     gm: &GuestMemory,
 ) -> anyhow::Result<SmmuDevicesResult> {
-    // Extract SMMU instance configs from the arch topology.
-    let smmu_instances: &[openvmm_defs::config::SmmuInstanceConfig] = match processor_topology_arch
-    {
-        Some(openvmm_defs::config::ArchTopologyConfig::Aarch64(
-            openvmm_defs::config::Aarch64TopologyConfig { smmu, .. },
-        )) => smmu.as_slice(),
-        _ => &[],
-    };
-
     // Instantiate SMMU chipset devices.
     let mut shared_states: Vec<Option<Arc<smmu::SmmuSharedState>>> =
         vec![None; pcie_host_bridges.len()];
     let mut configs = Vec::new();
 
-    for (idx, inst) in smmu_instances.iter().enumerate() {
-        let rc_pos = match pcie_rc_name_to_idx.get(&inst.rc_name) {
-            Some(&i) => i,
-            None => {
-                anyhow::bail!(
-                    "SMMU instance references unknown root complex {:?}",
-                    inst.rc_name
-                );
-            }
-        };
-        if shared_states[rc_pos].is_some() {
-            anyhow::bail!(
-                "duplicate SMMU instance for root complex {:?}",
-                inst.rc_name
-            );
-        }
+    // Iterate RCs with SMMU enabled, zipping with resolved MMIO+SPI resources.
+    let smmu_rcs = root_complexes
+        .iter()
+        .filter(|rc| matches!(rc.iommu, Some(openvmm_defs::config::PcieIommuConfig::Smmu)));
+
+    for (idx, rc) in smmu_rcs.enumerate() {
+        let rc_pos = pcie_rc_name_to_idx[rc.name.as_str()];
 
         let smmu = &resolved_smmu_resources[idx];
         let evtq_irq_vector = smmu.evtq_intid - *vmm_core::emuplat::gic::SPI_RANGE.start();
         let gerror_irq_vector = smmu.gerr_intid - *vmm_core::emuplat::gic::SPI_RANGE.start();
-        let device_name = format!("smmu:{}", inst.rc_name);
+        let device_name = format!("smmu:{}", rc.name);
         let smmu_config = smmu::SmmuConfig {
             sidsize: 16,
             oas: 44,
@@ -144,34 +113,8 @@ pub(super) fn setup_smmu(
         });
     }
 
-    // Build port-level lookup maps from the per-RC shared state.
-    let port_maps = build_smmu_port_maps(&shared_states, pcie_root_complexes);
-
     Ok(SmmuDevicesResult {
         shared_states,
         configs,
-        port_maps,
     })
-}
-
-/// Builds the port-level SMMU lookup maps from per-RC shared state.
-///
-/// `smmu_shared_states` is indexed parallel to `pcie_root_complexes`,
-/// with `None` for root complexes that have no SMMU.
-fn build_smmu_port_maps(
-    smmu_shared_states: &[Option<Arc<smmu::SmmuSharedState>>],
-    pcie_root_complexes: &[Arc<CloseableMutex<GenericPcieRootComplex>>],
-) -> SmmuPortMaps {
-    let mut port_map: HashMap<Arc<str>, Arc<smmu::SmmuSharedState>> = HashMap::new();
-
-    for (shared, rc) in smmu_shared_states.iter().zip(pcie_root_complexes.iter()) {
-        let ports = rc.lock().downstream_ports();
-        if let Some(shared) = shared {
-            for dpi in ports {
-                port_map.insert(dpi.name, shared.clone());
-            }
-        }
-    }
-
-    SmmuPortMaps { port_map }
 }

--- a/openvmm/openvmm_core/src/worker/memory_layout.rs
+++ b/openvmm/openvmm_core/src/worker/memory_layout.rs
@@ -22,6 +22,7 @@ use anyhow::bail;
 use cxl_spec::spec::CXL_HOST_BRIDGE_COMPONENT_REGISTERS_SIZE_BYTES;
 use cxl_spec::spec::CXL_HPA_ALIGNMENT;
 use memory_range::MemoryRange;
+use openvmm_defs::config::PcieIommuConfig;
 use openvmm_defs::config::PcieMmioRangeConfig;
 use openvmm_defs::config::PcieRootComplexConfig;
 use std::sync::Arc;
@@ -80,6 +81,10 @@ pub(super) struct ResolvedMemoryLayout {
     /// Each range is `SMMU_SIZE` bytes. Empty when no SMMUs are configured.
     #[cfg_attr(not(guest_arch = "aarch64"), expect(dead_code))]
     pub smmu_ranges: Vec<MemoryRange>,
+    /// Resolved MMIO ranges for AMD IOMMU instances, one per configured IOMMU.
+    /// Each range is 16 KiB. Empty when no AMD IOMMUs are configured.
+    #[cfg_attr(not(guest_arch = "x86_64"), expect(dead_code))]
+    pub amd_iommu_ranges: Vec<MemoryRange>,
 }
 
 #[derive(Debug)]
@@ -105,10 +110,6 @@ pub(super) struct MemoryLayoutInput<'a> {
     /// Number of virtio-mmio device slots to allocate in 32-bit MMIO space.
     /// A single contiguous region of `count * 4 KiB` is allocated.
     pub virtio_mmio_count: usize,
-    /// Number of SMMUv3 instances to allocate MMIO for (aarch64 only;
-    /// always 0 on other architectures). Each instance requires
-    /// `SMMU_SIZE` bytes (128 KiB), 128 KiB aligned, in 32-bit MMIO space.
-    pub smmu_count: usize,
     /// Optional IGVM VTL2 private-memory request. This is allocated after all
     /// VTL0-visible RAM and MMIO and is carried separately from ordinary RAM.
     pub vtl2_layout: Option<Vtl2MemoryLayoutRequest>,
@@ -302,13 +303,36 @@ pub(super) fn resolve_memory_layout(
 
     // SMMUv3: allocate one 128 KiB region per instance. Placed below 4 GiB
     // alongside other aarch64 system devices (GIC, ITS, PL011).
-    let mut smmu_ranges: Vec<MemoryRange> = vec![MemoryRange::EMPTY; input.smmu_count];
+    let smmu_count = input
+        .pcie_root_complexes
+        .iter()
+        .filter(|rc| matches!(rc.iommu, Some(PcieIommuConfig::Smmu)))
+        .count();
+    let mut smmu_ranges: Vec<MemoryRange> = vec![MemoryRange::EMPTY; smmu_count];
     for (idx, range) in smmu_ranges.iter_mut().enumerate() {
         builder.request(
             format!("smmu-{idx}"),
             range,
             SMMU_SIZE,
             SMMU_SIZE,
+            Placement::Mmio32,
+        );
+    }
+
+    // AMD IOMMU: allocate one 16 KiB region per instance, placed below 4 GiB.
+    const AMD_IOMMU_MMIO_SIZE: u64 = 0x4000; // 16 KiB per AMD IOMMU spec §3.4
+    let amd_iommu_count = input
+        .pcie_root_complexes
+        .iter()
+        .filter(|rc| matches!(rc.iommu, Some(PcieIommuConfig::AmdVi)))
+        .count();
+    let mut amd_iommu_ranges: Vec<MemoryRange> = vec![MemoryRange::EMPTY; amd_iommu_count];
+    for (idx, range) in amd_iommu_ranges.iter_mut().enumerate() {
+        builder.request(
+            format!("amd-iommu-{idx}"),
+            range,
+            AMD_IOMMU_MMIO_SIZE,
+            AMD_IOMMU_MMIO_SIZE,
             Placement::Mmio32,
         );
     }
@@ -488,6 +512,7 @@ pub(super) fn resolve_memory_layout(
             Some(vtl2_framebuffer_range.start())
         },
         smmu_ranges,
+        amd_iommu_ranges,
     })
 }
 
@@ -588,7 +613,6 @@ mod tests {
             layout: DEFAULT_LAYOUT,
             pcie_root_complexes: &[],
             virtio_mmio_count: 0,
-            smmu_count: 0,
             vtl2_layout,
             ram_start_address: 0,
             vtl2_framebuffer_size: 0,
@@ -621,6 +645,7 @@ mod tests {
             high_mmio,
             ports: Vec::new(),
             cxl: None,
+            iommu: None,
         }
     }
 
@@ -733,6 +758,7 @@ mod tests {
                 high_mmio: PcieMmioRangeConfig::Dynamic { size: GB },
                 ports: Vec::new(),
                 cxl: None,
+                iommu: None,
             },
             PcieRootComplexConfig {
                 index: 1,
@@ -744,6 +770,7 @@ mod tests {
                 high_mmio: PcieMmioRangeConfig::Dynamic { size: GB },
                 ports: Vec::new(),
                 cxl: None,
+                iommu: None,
             },
         ];
         let mut config = input(2 * GB, None, None);
@@ -779,6 +806,7 @@ mod tests {
             high_mmio: PcieMmioRangeConfig::Dynamic { size: GB },
             ports: Vec::new(),
             cxl: None,
+            iommu: None,
         }];
         let mut config = input(2 * GB, None, None);
         config.pcie_root_complexes = &root_complexes;

--- a/openvmm/openvmm_defs/src/config.rs
+++ b/openvmm/openvmm_defs/src/config.rs
@@ -218,6 +218,8 @@ pub struct PcieRootComplexConfig {
     pub ports: Vec<PcieRootPortConfig>,
     /// Optional CXL configuration for root-complex CXL mode.
     pub cxl: Option<RootComplexCxlConfig>,
+    /// Optional IOMMU for this root complex.
+    pub iommu: Option<PcieIommuConfig>,
 }
 
 #[derive(Debug, MeshPayload)]
@@ -316,15 +318,13 @@ pub enum GicMsiConfig {
     },
 }
 
-/// Per-instance SMMUv3 configuration for an aarch64 VM.
-///
-/// Each instance covers one PCIe root complex, identified by name.
-/// The SMMU's MMIO address is allocated dynamically by the memory layout
-/// engine.
-#[derive(Debug, Protobuf, Clone)]
-pub struct SmmuInstanceConfig {
-    /// Name of the PCIe root complex this SMMU covers.
-    pub rc_name: String,
+/// IOMMU configuration for a single PCIe root complex.
+#[derive(Debug, MeshPayload, Clone)]
+pub enum PcieIommuConfig {
+    /// AMD IOMMU (AMD-Vi) for x86_64 guests.
+    AmdVi,
+    /// Arm SMMUv3 for aarch64 guests.
+    Smmu,
 }
 
 #[derive(Debug, Protobuf, Default, Clone)]
@@ -332,9 +332,6 @@ pub struct Aarch64TopologyConfig {
     pub gic_config: Option<GicConfig>,
     pub pmu_gsiv: PmuGsivConfig,
     pub gic_msi: GicMsiConfig,
-    /// SMMUv3 IOMMU instances. Each entry creates an SMMU for one PCIe root
-    /// complex (identified by name). Empty means no SMMU.
-    pub smmu: Vec<SmmuInstanceConfig>,
 }
 
 /// GIC configuration for the virtual machine.

--- a/openvmm/openvmm_entry/src/cli_args.rs
+++ b/openvmm/openvmm_entry/src/cli_args.rs
@@ -927,6 +927,15 @@ options:
     #[clap(long)]
     pub default_boot_always_attempt: bool,
 
+    /// Enable AMD IOMMU (AMD-Vi) emulation on specified root complexes.
+    /// Repeat for each root complex that should have an IOMMU, e.g.:
+    ///   --amd-iommu rc0 --amd-iommu rc1
+    /// The IOMMU appears at device 0 function 0 on each specified root
+    /// complex. Requires --pcie-root-complex.
+    #[cfg(guest_arch = "x86_64")]
+    #[clap(long)]
+    pub amd_iommu: Vec<String>,
+
     /// Attach a PCI Express root complex to the VM
     #[clap(long_help = r#"
 Attach root complexes to the VM.

--- a/openvmm/openvmm_entry/src/lib.rs
+++ b/openvmm/openvmm_entry/src/lib.rs
@@ -875,7 +875,35 @@ async fn vm_config_from_command_line(
             },
             cxl,
             ports,
+            #[cfg(guest_arch = "aarch64")]
+            iommu: opt
+                .smmu
+                .iter()
+                .any(|s| s == &rc_cli.name)
+                .then_some(openvmm_defs::config::PcieIommuConfig::Smmu),
+            #[cfg(guest_arch = "x86_64")]
+            iommu: opt
+                .amd_iommu
+                .iter()
+                .any(|s| s == &rc_cli.name)
+                .then_some(openvmm_defs::config::PcieIommuConfig::AmdVi),
         });
+    }
+
+    // Validate that all --smmu / --amd-iommu names refer to known root complexes.
+    #[cfg(guest_arch = "aarch64")]
+    for name in &opt.smmu {
+        anyhow::ensure!(
+            pcie_root_complexes.iter().any(|rc| rc.name == *name),
+            "--smmu refers to unknown root complex '{name}'"
+        );
+    }
+    #[cfg(guest_arch = "x86_64")]
+    for name in &opt.amd_iommu {
+        anyhow::ensure!(
+            pcie_root_complexes.iter().any(|rc| rc.name == *name),
+            "--amd-iommu refers to unknown root complex '{name}'"
+        );
     }
 
     let pcie_switches = build_switch_list(&opt.pcie_switch);
@@ -1512,13 +1540,6 @@ async fn vm_config_from_command_line(
     }
 
     #[cfg(guest_arch = "aarch64")]
-    let smmu_instances: Vec<openvmm_defs::config::SmmuInstanceConfig> = opt
-        .smmu
-        .iter()
-        .map(|s| openvmm_defs::config::SmmuInstanceConfig { rc_name: s.clone() })
-        .collect();
-
-    #[cfg(guest_arch = "aarch64")]
     let topology_arch = openvmm_defs::config::ArchTopologyConfig::Aarch64(
         openvmm_defs::config::Aarch64TopologyConfig {
             // TODO: allow this to be configured from the command line
@@ -1531,7 +1552,6 @@ async fn vm_config_from_command_line(
                     openvmm_defs::config::GicMsiConfig::V2m { spi_count: None }
                 }
             },
-            smmu: smmu_instances,
         },
     );
     #[cfg(guest_arch = "x86_64")]

--- a/petri/src/vm/openvmm/construct.rs
+++ b/petri/src/vm/openvmm/construct.rs
@@ -692,6 +692,8 @@ impl PetriVmConfigOpenVmm {
 
             ged,
             framebuffer_view,
+
+            pending_iommu: Vec::new(),
         })
     }
 }

--- a/petri/src/vm/openvmm/mod.rs
+++ b/petri/src/vm/openvmm/mod.rs
@@ -174,6 +174,10 @@ pub struct PetriVmConfigOpenVmm {
     // Resources that are only used during startup.
     ged: Option<get_resources::ged::GuestEmulationDeviceHandle>,
     framebuffer_view: Option<framebuffer::View>,
+
+    // Deferred IOMMU configuration: (rc_name, iommu_config) pairs resolved
+    // against pcie_root_complexes at VM start time.
+    pending_iommu: Vec<(String, openvmm_defs::config::PcieIommuConfig)>,
 }
 /// Various channels and resources used to interact with the VM while it is running.
 struct PetriVmResourcesOpenVmm {

--- a/petri/src/vm/openvmm/modify.rs
+++ b/petri/src/vm/openvmm/modify.rs
@@ -25,11 +25,11 @@ use openvmm_defs::config::Config;
 use openvmm_defs::config::DeviceVtl;
 use openvmm_defs::config::LoadMode;
 use openvmm_defs::config::PcieDeviceConfig;
+use openvmm_defs::config::PcieIommuConfig;
 use openvmm_defs::config::PcieMmioRangeConfig;
 use openvmm_defs::config::PcieRootComplexConfig;
 use openvmm_defs::config::PcieRootPortConfig;
 use openvmm_defs::config::PcieSwitchConfig;
-use openvmm_defs::config::SmmuInstanceConfig;
 use openvmm_defs::config::VpciDeviceConfig;
 use openvmm_defs::config::Vtl2BaseAddressType;
 use vm_resource::IntoResource;
@@ -279,6 +279,7 @@ impl PetriVmConfigOpenVmm {
                     },
                     cxl: None,
                     ports,
+                    iommu: None,
                 });
             }
         }
@@ -311,23 +312,25 @@ impl PetriVmConfigOpenVmm {
     /// provides stage 1 IOVA translation for devices behind those root
     /// complexes.
     pub fn with_smmu(mut self, rc_names: &[&str]) -> Self {
-        let arch = self
-            .config
-            .processor_topology
-            .arch
-            .as_mut()
-            .expect("arch topology not set");
+        for name in rc_names {
+            self.pending_iommu
+                .push((name.to_string(), PcieIommuConfig::Smmu));
+        }
+        self
+    }
 
-        match arch {
-            openvmm_defs::config::ArchTopologyConfig::Aarch64(aarch64) => {
-                aarch64.smmu = rc_names
-                    .iter()
-                    .map(|name| SmmuInstanceConfig {
-                        rc_name: name.to_string(),
-                    })
-                    .collect();
-            }
-            _ => panic!("SMMU is only supported on aarch64"),
+    /// Enable AMD IOMMU (AMD-Vi) on the specified root complexes.
+    ///
+    /// Each name must match a root complex added via
+    /// [`with_pcie_root_topology`](Self::with_pcie_root_topology). The IOMMU
+    /// appears at device 0 function 0 on each listed root complex; PCIe
+    /// devices behind those root complexes have DMA translated through
+    /// guest-programmed page tables and MSIs remapped through the interrupt
+    /// remapping table.
+    pub fn with_amd_iommu(mut self, rc_names: &[&str]) -> Self {
+        for name in rc_names {
+            self.pending_iommu
+                .push((name.to_string(), PcieIommuConfig::AmdVi));
         }
         self
     }

--- a/petri/src/vm/openvmm/start.rs
+++ b/petri/src/vm/openvmm/start.rs
@@ -43,7 +43,19 @@ impl PetriVmConfigOpenVmm {
 
             ged,
             framebuffer_view,
+
+            pending_iommu,
         } = self;
+
+        // Resolve deferred IOMMU assignments.
+        for (name, iommu_config) in &pending_iommu {
+            let rc = config
+                .pcie_root_complexes
+                .iter_mut()
+                .find(|rc| rc.name == *name)
+                .with_context(|| format!("IOMMU configured for unknown root complex '{name}'"))?;
+            rc.iommu = Some(iommu_config.clone());
+        }
 
         // TODO: OpenHCL needs virt_whp support
         // TODO: PCAT needs vga device support

--- a/vm/acpi_spec/src/ivrs.rs
+++ b/vm/acpi_spec/src/ivrs.rs
@@ -1,0 +1,368 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! IVRS (I/O Virtualization Reporting Structure) types for AMD IOMMU discovery.
+//!
+//! The IVRS ACPI table describes AMD IOMMU hardware to the guest OS. It contains
+//! one or more IVHD (I/O Virtualization Hardware Definition) blocks, each
+//! describing a single IOMMU instance: its PCI BDF, MMIO base, capabilities,
+//! and the set of devices behind it.
+//!
+//! Reference: AMD I/O Virtualization Technology (IOMMU) Specification,
+//! Doc #48882, Rev 3.11, §5.
+
+use super::Table;
+use crate::packed_nums::*;
+use bitfield_struct::bitfield;
+use core::mem::size_of;
+use static_assertions::const_assert_eq;
+use zerocopy::FromBytes;
+use zerocopy::Immutable;
+use zerocopy::IntoBytes;
+use zerocopy::KnownLayout;
+use zerocopy::Unaligned;
+
+/// IVRS table revision (AMD IOMMU spec §5.2.1).
+pub const IVRS_REVISION: u8 = 2;
+
+/// IVHD type 10h: Full-featured IVHD (§5.2.2.2).
+pub const IVHD_TYPE_10: u8 = 0x10;
+
+/// IVHD type 11h: Extended IVHD with EFR (§5.2.2.3).
+pub const IVHD_TYPE_11: u8 = 0x11;
+
+/// IVHD type 40h: Maximum performance IVHD with EFR (same layout as 11h).
+pub const IVHD_TYPE_40: u8 = 0x40;
+
+/// IVHD device entry type: all devices (§5.2.2.7, Table 93).
+pub const IVHD_DEV_ALL: u8 = 0x01;
+
+/// IVHD device entry type: select single device (§5.2.2.7, Table 93).
+pub const IVHD_DEV_SELECT: u8 = 0x02;
+
+/// IVHD device entry type: start of device range (§5.2.2.7, Table 93).
+pub const IVHD_DEV_RANGE_START: u8 = 0x03;
+
+/// IVHD device entry type: end of device range (§5.2.2.7, Table 93).
+pub const IVHD_DEV_RANGE_END: u8 = 0x04;
+
+/// DTE setting: INITPass, EIntPass, NMIPass for fixed interrupt passthrough.
+pub const IVHD_DTE_SETTING_INIT_PASS: u8 = 0x01;
+pub const IVHD_DTE_SETTING_EINT_PASS: u8 = 0x02;
+pub const IVHD_DTE_SETTING_NMI_PASS: u8 = 0x04;
+
+/// IVinfo bitfield for the IVRS table header (AMD IOMMU spec §5.2.1, Table 84).
+#[bitfield(u32)]
+pub struct IvInfo {
+    /// EFRSup: Extended Feature Register supported (bit 0).
+    pub efr_sup: bool,
+    /// DMA remap support (bit 1).
+    pub dma_remap_sup: bool,
+    /// Reserved (bits 4:2).
+    #[bits(3)]
+    _reserved1: u32,
+    /// GVAsize: guest virtual address size (bits 7:5).
+    /// 0 = 48-bit, 1 = 57-bit.
+    #[bits(3)]
+    pub gva_size: u8,
+    /// PAsize: physical/guest-physical address size (bits 14:8).
+    /// Raw value, e.g. 48 for 48-bit.
+    #[bits(7)]
+    pub pa_size: u8,
+    /// VAsize: virtual address size (bits 21:15).
+    /// Raw value, e.g. 48 for 48-bit.
+    #[bits(7)]
+    pub va_size: u8,
+    /// HtAtsResv: HyperTransport ATS reserved (bit 22).
+    pub ht_ats_resv: bool,
+    /// Reserved (bits 31:23).
+    #[bits(9)]
+    _reserved2: u32,
+}
+
+/// IVRS fixed table header (follows the standard ACPI `Header`).
+///
+/// The IVRS table starts with the standard 36-byte ACPI header, followed by
+/// this 12-byte structure, followed by one or more IVHD/IVMD blocks.
+///
+/// Reference: AMD IOMMU spec §5.2.1, Table 83.
+#[repr(C)]
+#[derive(Copy, Clone, Debug, IntoBytes, Immutable, KnownLayout, FromBytes, Unaligned)]
+pub struct Ivrs {
+    /// IVinfo field (§5.2.1, Table 84). See [`IvInfo`] for the bitfield layout.
+    pub iv_info: u32_ne,
+    /// Reserved, must be zero.
+    pub reserved: [u8; 8],
+}
+
+impl Ivrs {
+    /// Create a new IVRS header with the given IVinfo value.
+    pub fn new(iv_info: u32) -> Self {
+        Self {
+            iv_info: iv_info.into(),
+            reserved: [0; 8],
+        }
+    }
+}
+
+impl Table for Ivrs {
+    const SIGNATURE: [u8; 4] = *b"IVRS";
+}
+
+const_assert_eq!(size_of::<Ivrs>(), 12);
+
+/// IVHD type 40h header (§5.2.2.3, Table 99).
+///
+/// "Mixed format" IVHD block. Types 10h, 11h, and 40h all share the same
+/// first 24 bytes; types 11h and 40h extend this with EFR/EFR2 register
+/// images (bytes 24..40). The distinction between 11h and 40h is that
+/// type 40h can contain both fixed-length (BDF-based) and variable-length
+/// (ACPI HID-based) device entries, while 11h is limited to fixed-length
+/// entries. Both types require `IVinfo[EFRSup] = 1`.
+#[repr(C)]
+#[derive(Copy, Clone, Debug, IntoBytes, Immutable, KnownLayout, FromBytes, Unaligned)]
+pub struct IvhdType40 {
+    /// IVHD type: always [`IVHD_TYPE_40`].
+    pub ivhd_type: u8,
+    /// Flags (§5.2.2.2, Table 87).
+    pub flags: u8,
+    /// Length of the entire IVHD block in bytes (header + device entries).
+    pub length: u16_ne,
+    /// DeviceID (BDF) of the IOMMU itself.
+    pub device_id: u16_ne,
+    /// Offset of the IOMMU capability block in PCI config space.
+    pub capability_offset: u16_ne,
+    /// IOMMU MMIO base address (64-bit).
+    pub iommu_base_address: u64_ne,
+    /// PCI segment group number.
+    pub pci_segment: u16_ne,
+    /// IOMMU info field (§5.2.2.2).
+    pub iommu_info: u16_ne,
+    /// IOMMU attributes (§5.2.2.3). Repurposed from the type 10h
+    /// `iommu_feature_info` field.
+    pub iommu_attributes: u32_ne,
+    /// Extended Feature Register image (same layout as MMIO 0x0030).
+    pub efr_register: u64_ne,
+    /// Extended Feature Register 2 image.
+    pub efr_register2: u64_ne,
+}
+
+impl IvhdType40 {
+    /// Create a new IVHD type 40h header.
+    pub fn new(
+        device_id: u16,
+        capability_offset: u16,
+        iommu_base_address: u64,
+        pci_segment: u16,
+        efr: u64,
+    ) -> Self {
+        Self {
+            ivhd_type: IVHD_TYPE_40,
+            flags: 0,
+            length: (size_of::<Self>() as u16).into(),
+            device_id: device_id.into(),
+            capability_offset: capability_offset.into(),
+            iommu_base_address: iommu_base_address.into(),
+            pci_segment: pci_segment.into(),
+            iommu_info: 0.into(),
+            iommu_attributes: 0.into(),
+            efr_register: efr.into(),
+            efr_register2: 0.into(),
+        }
+    }
+
+    /// Set the total length (header + device entries).
+    pub fn with_length(mut self, length: u16) -> Self {
+        self.length = length.into();
+        self
+    }
+
+    /// Set the flags byte.
+    pub fn with_flags(mut self, flags: u8) -> Self {
+        self.flags = flags;
+        self
+    }
+}
+
+const_assert_eq!(size_of::<IvhdType40>(), 40);
+
+/// IVHD 4-byte device entry (§5.2.2.7, Table 93).
+///
+/// Used for: all-devices (type 01h), select (type 02h), start-of-range
+/// (type 03h), end-of-range (type 04h).
+#[repr(C)]
+#[derive(Copy, Clone, Debug, IntoBytes, Immutable, KnownLayout, FromBytes, Unaligned)]
+pub struct IvhdDeviceEntry4 {
+    /// Entry type (see IVHD_DEV_* constants).
+    pub entry_type: u8,
+    /// DeviceID (BDF) for select/range entries. Zero for type 01h (all).
+    pub device_id: u16_ne,
+    /// DTE setting applied to matching devices (§5.2.2.7, Table 94):
+    /// - Bit 0: INITPass
+    /// - Bit 1: EIntPass
+    /// - Bit 2: NMIPass
+    /// - Bit 3: Reserved
+    /// - Bits 5:4: SysMgt
+    /// - Bit 6: Lint0Pass
+    /// - Bit 7: Lint1Pass
+    pub dte_setting: u8,
+}
+
+impl IvhdDeviceEntry4 {
+    /// Create an "all devices" entry (type 01h).
+    pub fn all(dte_setting: u8) -> Self {
+        Self {
+            entry_type: IVHD_DEV_ALL,
+            device_id: 0.into(),
+            dte_setting,
+        }
+    }
+
+    /// Create a "select" entry (type 02h) for a single device.
+    pub fn select(device_id: u16, dte_setting: u8) -> Self {
+        Self {
+            entry_type: IVHD_DEV_SELECT,
+            device_id: device_id.into(),
+            dte_setting,
+        }
+    }
+
+    /// Create a "start of range" entry (type 03h).
+    pub fn range_start(device_id: u16, dte_setting: u8) -> Self {
+        Self {
+            entry_type: IVHD_DEV_RANGE_START,
+            device_id: device_id.into(),
+            dte_setting,
+        }
+    }
+
+    /// Create an "end of range" entry (type 04h).
+    pub fn range_end(device_id: u16) -> Self {
+        Self {
+            entry_type: IVHD_DEV_RANGE_END,
+            device_id: device_id.into(),
+            dte_setting: 0,
+        }
+    }
+}
+
+const_assert_eq!(size_of::<IvhdDeviceEntry4>(), 4);
+
+#[cfg(test)]
+mod tests {
+    extern crate alloc;
+
+    use super::*;
+    use alloc::vec::Vec;
+    use zerocopy::IntoBytes;
+
+    #[test]
+    fn test_ivrs_header() {
+        let ivrs = Ivrs::new(0x0040_3000);
+        assert_eq!(ivrs.iv_info.get(), 0x0040_3000);
+        assert_eq!(ivrs.reserved, [0; 8]);
+        let bytes = ivrs.as_bytes();
+        assert_eq!(bytes.len(), 12);
+    }
+
+    #[test]
+    fn test_iv_info_bitfield() {
+        let iv_info = IvInfo::new()
+            .with_efr_sup(true)
+            .with_pa_size(48)
+            .with_va_size(48);
+        let raw = u32::from(iv_info);
+        assert_eq!(raw & 1, 1); // EFRSup = bit 0
+        assert_eq!((raw >> 8) & 0x7F, 48); // PAsize = bits 14:8
+        assert_eq!((raw >> 15) & 0x7F, 48); // VAsize = bits 21:15
+    }
+
+    #[test]
+    fn test_ivrs_signature() {
+        assert_eq!(Ivrs::SIGNATURE, *b"IVRS");
+    }
+
+    #[test]
+    fn test_ivhd_type40_defaults() {
+        let ivhd = IvhdType40::new(0x0002, 0x40, 0xFD00_0000, 0, 0xC0);
+        assert_eq!(ivhd.ivhd_type, IVHD_TYPE_40);
+        assert_eq!(ivhd.flags, 0);
+        assert_eq!(ivhd.length.get(), size_of::<IvhdType40>() as u16);
+        assert_eq!(ivhd.device_id.get(), 0x0002);
+        assert_eq!(ivhd.capability_offset.get(), 0x40);
+        assert_eq!(ivhd.iommu_base_address.get(), 0xFD00_0000);
+        assert_eq!(ivhd.pci_segment.get(), 0);
+        assert_eq!(ivhd.iommu_info.get(), 0);
+        assert_eq!(ivhd.iommu_attributes.get(), 0);
+        assert_eq!(ivhd.efr_register.get(), 0xC0);
+        assert_eq!(ivhd.efr_register2.get(), 0);
+    }
+
+    #[test]
+    fn test_ivhd_type40_with_length() {
+        let ivhd = IvhdType40::new(0x0002, 0x40, 0xFD00_0000, 0, 0).with_length(48);
+        assert_eq!(ivhd.length.get(), 48);
+    }
+
+    #[test]
+    fn test_ivhd_device_entry_all() {
+        let entry = IvhdDeviceEntry4::all(0);
+        assert_eq!(entry.entry_type, IVHD_DEV_ALL);
+        assert_eq!(entry.device_id.get(), 0);
+        assert_eq!(entry.dte_setting, 0);
+    }
+
+    #[test]
+    fn test_ivhd_device_entry_select() {
+        let entry = IvhdDeviceEntry4::select(0x0108, 0x07);
+        assert_eq!(entry.entry_type, IVHD_DEV_SELECT);
+        assert_eq!(entry.device_id.get(), 0x0108);
+        assert_eq!(entry.dte_setting, 0x07);
+    }
+
+    #[test]
+    fn test_ivhd_device_entry_range() {
+        let start = IvhdDeviceEntry4::range_start(0x0001, 0);
+        let end = IvhdDeviceEntry4::range_end(0xFFFF);
+        assert_eq!(start.entry_type, IVHD_DEV_RANGE_START);
+        assert_eq!(start.device_id.get(), 0x0001);
+        assert_eq!(end.entry_type, IVHD_DEV_RANGE_END);
+        assert_eq!(end.device_id.get(), 0xFFFF);
+    }
+
+    #[test]
+    fn test_ivhd_device_entry_size() {
+        assert_eq!(size_of::<IvhdDeviceEntry4>(), 4);
+    }
+
+    #[test]
+    fn test_ivrs_round_trip() {
+        // Build a minimal IVRS: header + IVHD + two device entries
+        let ivrs = Ivrs::new(0x0040_3000);
+        let dev_entries_size = 2 * size_of::<IvhdDeviceEntry4>() as u16;
+        let ivhd_total = size_of::<IvhdType40>() as u16 + dev_entries_size;
+        let ivhd = IvhdType40::new(0x0002, 0x40, 0xFD00_0000, 0, 0).with_length(ivhd_total);
+
+        let range_start = IvhdDeviceEntry4::range_start(0x0001, 0);
+        let range_end = IvhdDeviceEntry4::range_end(0xFFFF);
+
+        // Serialize and verify offsets
+        let mut buf = Vec::new();
+        buf.extend_from_slice(ivrs.as_bytes());
+        buf.extend_from_slice(ivhd.as_bytes());
+        buf.extend_from_slice(range_start.as_bytes());
+        buf.extend_from_slice(range_end.as_bytes());
+
+        // IVRS header = 12 bytes
+        // IVHD header = 40 bytes
+        // 2 device entries = 8 bytes
+        // Total = 60 bytes
+        assert_eq!(buf.len(), 60);
+
+        // Verify IVHD starts at offset 12
+        assert_eq!(buf[12], IVHD_TYPE_40);
+        // Verify device entries start at offset 52 (12 + 40)
+        assert_eq!(buf[52], IVHD_DEV_RANGE_START);
+        assert_eq!(buf[56], IVHD_DEV_RANGE_END);
+    }
+}

--- a/vm/acpi_spec/src/lib.rs
+++ b/vm/acpi_spec/src/lib.rs
@@ -14,6 +14,7 @@ pub mod aspt;
 pub mod fadt;
 pub mod gtdt;
 pub mod iort;
+pub mod ivrs;
 pub mod madt;
 pub mod mcfg;
 pub mod pptt;

--- a/vm/devices/iommu/amd_iommu/Cargo.toml
+++ b/vm/devices/iommu/amd_iommu/Cargo.toml
@@ -1,0 +1,25 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+[package]
+name = "amd_iommu"
+edition.workspace = true
+rust-version.workspace = true
+
+[dependencies]
+bitfield-struct.workspace = true
+chipset_device.workspace = true
+guestmem.workspace = true
+inspect.workspace = true
+open_enum.workspace = true
+parking_lot.workspace = true
+pci_core.workspace = true
+tracelimit.workspace = true
+tracing.workspace = true
+vmcore.workspace = true
+zerocopy.workspace = true
+
+[dev-dependencies]
+
+[lints]
+workspace = true

--- a/vm/devices/iommu/amd_iommu/src/lib.rs
+++ b/vm/devices/iommu/amd_iommu/src/lib.rs
@@ -1,0 +1,6254 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! AMD IOMMU (AMD-Vi) emulator for OpenVMM.
+//!
+//! Provides emulated DMA address translation (IOVA → GPA via device table and
+//! page table walking) and interrupt remapping for emulated PCI devices.
+//!
+//! The AMD IOMMU appears as a PCI function with an AMD IOMMU capability block
+//! (CapID 0x0F) pointing to a fixed MMIO register region. The guest discovers
+//! the IOMMU via PCI enumeration and reads the capability to find the MMIO base.
+
+pub mod spec;
+
+use chipset_device::ChipsetDevice;
+use chipset_device::io::IoError;
+use chipset_device::io::IoResult;
+use chipset_device::mmio::MmioIntercept;
+use chipset_device::pci::PciConfigSpace;
+use guestmem::GuestMemory;
+use guestmem::GuestMemoryBackingError;
+use inspect::Inspect;
+use inspect::InspectMut;
+use parking_lot::RwLock;
+use pci_core::capabilities::ReadOnlyCapability;
+use pci_core::cfg_space_emu::ConfigSpaceType0Emulator;
+use pci_core::cfg_space_emu::DeviceBars;
+use pci_core::msi::SignalMsi;
+use pci_core::spec::caps::CapabilityId;
+use pci_core::spec::hwid::ClassCode;
+use pci_core::spec::hwid::HardwareIds;
+use pci_core::spec::hwid::ProgrammingInterface;
+use pci_core::spec::hwid::Subclass;
+use spec::commands::CommandEntry;
+use spec::commands::CommandOpcode;
+use spec::commands::CompletionWaitDw0Dw1;
+use spec::commands::completion_wait_store_data;
+use spec::dte::DTE_SIZE;
+use spec::dte::Dte;
+use spec::dte::IntCtl;
+use spec::dte::PAGING_MODE_RESERVED;
+use spec::dte::PagingMode;
+use spec::events::EventEntry;
+use spec::irte::IRTE_SIZE;
+use spec::irte::Irte;
+use spec::pte::IommuPte;
+use spec::registers::BaseAddrHigh;
+use spec::registers::BaseAddrLow;
+use spec::registers::CapHeader;
+use spec::registers::CmdBufBase;
+use spec::registers::CmdBufHead;
+use spec::registers::CmdBufTail;
+use spec::registers::DevTabBase;
+use spec::registers::EvtLogBase;
+use spec::registers::EvtLogTail;
+use spec::registers::ExclBase;
+use spec::registers::ExclLimit;
+use spec::registers::IommuCtrl;
+use spec::registers::IommuStatus;
+use spec::registers::MiscInfo0;
+use spec::registers::MmioRegister;
+use spec::registers::Range;
+use std::ops::RangeInclusive;
+use std::ptr::NonNull;
+use std::sync::Arc;
+use vmcore::interrupt::Interrupt;
+use zerocopy::Immutable;
+use zerocopy::IntoBytes;
+use zerocopy::KnownLayout;
+
+/// MMIO region size (16KB per AMD IOMMU spec §3.4).
+pub const MMIO_REGION_SIZE: u64 = 0x4000;
+
+/// PCI config space offset of the IOMMU capability block.
+///
+/// Capabilities start at 0x40 and the IOMMU capability is the first (only)
+/// capability registered.
+pub const PCI_CAP_OFFSET: u16 = 0x40;
+
+/// PCI capability ID for AMD IOMMU (§3.2).
+const AMD_IOMMU_CAP_ID: CapabilityId = CapabilityId(spec::registers::CAP_ID);
+
+/// `ExtFeat` value advertised by this emulator.
+///
+/// This is an emulator policy choice, not a spec value. Bits set:
+///
+/// - Bit 2: `XTSup` — x2APIC support. Truthful because the 128-bit GA-format
+///   IRTE walker (`lookup_irte_inner`) already reassembles the 32-bit
+///   destination from `destination_lo` (24 bits) and `destination_hi` (8 bits)
+///   per §2.2.5.2, and `CONTROL[XTEn]`, `CONTROL[IntCapXTEn]`, and the XT
+///   Interrupt Control Registers (§3.4.13) are implemented as software-visible
+///   state. The emulator does not source MSIs from the XT Interrupt Control
+///   Registers because IOMMU-internal interrupts are not delivered to the
+///   guest — events are surfaced through `IOMMU_STATUS` only.
+/// - Bit 6: `IASup` — INVALIDATE_IOMMU_ALL command supported.
+/// - Bit 7: `GASup` — Guest virtual APIC support. Required so the Linux
+///   driver's `init_iommu_one()` reads the IVHD EFR via
+///   `early_iommu_features_init()`. Without this bit, the driver breaks out
+///   of the type-40h switch before reading the EFR, and
+///   `check_feature(FEATURE_IA)` falls back to per-entry invalidation
+///   (65536 MMIO writes = ~20s boot). The driver also enables GA_EN and uses
+///   128-bit GA-format IRTEs, which the emulator handles in
+///   `lookup_irte_inner`.
+pub const ADVERTISED_EXT_FEAT: u64 = 0x0000_0000_0000_00C4;
+
+/// Physical address size (in bits) supported by this emulator.
+pub const PA_SIZE: u8 = 48;
+
+/// Virtual address size (in bits) supported by this emulator.
+pub const VA_SIZE: u8 = 48;
+
+// =============================================================================
+// PCI Capability Data
+// =============================================================================
+
+/// Raw data for the AMD IOMMU PCI capability block (5 DWORDs = 20 bytes).
+///
+/// This struct is stored in a [`ReadOnlyCapability`] and provides the PCI
+/// capability block contents. The config space emulator patches byte 1 of the
+/// first DWORD with the next-capability pointer.
+///
+/// Layout (§3.2):
+/// - DWORD 0: Capability header (CapID, CapPtr=0, CapType, CapRev, flags)
+/// - DWORD 1: Base Address Low (Enable, MMIO base bits 31:14)
+/// - DWORD 2: Base Address High (MMIO base bits 63:32)
+/// - DWORD 3: Range (RngValid, BusNumber, FirstDevice, LastDevice)
+/// - DWORD 4: MiscInfo0 (MsiNum, PA/VA size)
+#[repr(C)]
+#[derive(Debug, Clone, Copy, IntoBytes, Immutable, KnownLayout)]
+struct IommuCapabilityData {
+    header: u32,
+    base_addr_low: u32,
+    base_addr_high: u32,
+    range: u32,
+    misc_info_0: u32,
+}
+
+impl IommuCapabilityData {
+    /// Build the capability data for the given MMIO base address.
+    fn new(mmio_base: u64) -> Self {
+        let header = CapHeader::new()
+            .with_cap_id(spec::registers::CAP_ID)
+            .with_cap_ptr(0) // Patched by config space emulator
+            .with_cap_type(0b011) // IOMMU capability type
+            .with_cap_rev(0b00001) // Revision 1
+            .with_iotlb_sup(false)
+            .with_ht_tunnel(false)
+            .with_np_cache(false)
+            .with_efr_sup(true)
+            .with_cap_ext(false);
+
+        let base_addr_low = BaseAddrLow::new()
+            .with_enable(true) // Pre-enabled (firmware has set this)
+            .with_base_addr((mmio_base >> 14) as u32);
+
+        let base_addr_high = BaseAddrHigh::new().with_base_addr((mmio_base >> 32) as u32);
+
+        let range = Range::new()
+            .with_rng_valid(true)
+            .with_bus_number(0)
+            .with_first_device(0x00)
+            .with_last_device(0xFF);
+
+        let misc_info_0 = MiscInfo0::new()
+            .with_msi_num(0)
+            .with_pa_size(48)
+            .with_va_size(48);
+
+        Self {
+            header: header.into_bits(),
+            base_addr_low: base_addr_low.into_bits(),
+            base_addr_high: base_addr_high.into_bits(),
+            range: range.into_bits(),
+            misc_info_0: misc_info_0.into_bits(),
+        }
+    }
+}
+
+// =============================================================================
+// AmdIommuDevice
+// =============================================================================
+
+/// Configuration for constructing an [`AmdIommuDevice`].
+#[derive(Debug, Clone)]
+pub struct AmdIommuConfig {
+    /// MMIO base address for IOMMU registers.
+    pub mmio_base: u64,
+    /// PCI bus/device/function for the IOMMU.
+    pub pci_bdf: (u8, u8, u8),
+}
+
+/// AMD IOMMU emulator device.
+///
+/// Appears as a PCI function on bus 0 with an AMD IOMMU capability block
+/// pointing to a fixed MMIO register region. Implements the MMIO register
+/// file for IOMMU control, command buffer, event log, and device table
+/// configuration.
+pub struct AmdIommuDevice {
+    /// PCI config space emulator with IOMMU capability block.
+    cfg_space: ConfigSpaceType0Emulator,
+
+    /// Fixed MMIO base address.
+    mmio_base: u64,
+
+    /// Static region descriptor for MmioIntercept.
+    static_regions: [(&'static str, RangeInclusive<u64>); 1],
+
+    /// PCI bus/device/function.
+    pci_bdf: (u8, u8, u8),
+
+    /// Shared IOMMU state (accessible by per-device wrappers).
+    shared: Arc<IommuSharedState>,
+}
+
+/// Internal register state of the AMD IOMMU.
+#[derive(Debug, Default, Inspect)]
+struct AmdIommuState {
+    /// Device Table Base Address Register (MMIO 0x0000).
+    #[inspect(hex)]
+    dev_tab_base: u64,
+    /// Command Buffer Base Address Register (MMIO 0x0008).
+    #[inspect(hex)]
+    cmd_buf_base: u64,
+    /// Event Log Base Address Register (MMIO 0x0010).
+    #[inspect(hex)]
+    evt_log_base: u64,
+    /// IOMMU Control Register (MMIO 0x0018).
+    #[inspect(hex)]
+    iommu_ctrl: u64,
+    /// Exclusion Base Register (MMIO 0x0020).
+    #[inspect(hex)]
+    excl_base: u64,
+    /// Exclusion Range Limit Register (MMIO 0x0028).
+    #[inspect(hex)]
+    excl_limit: u64,
+    /// Command Buffer Head Pointer (MMIO 0x2000).
+    #[inspect(hex)]
+    cmd_buf_head: u64,
+    /// Command Buffer Tail Pointer (MMIO 0x2008).
+    #[inspect(hex)]
+    cmd_buf_tail: u64,
+    /// Event Log Head Pointer (MMIO 0x2010).
+    #[inspect(hex)]
+    evt_log_head: u64,
+    /// Event Log Tail Pointer (MMIO 0x2018).
+    #[inspect(hex)]
+    evt_log_tail: u64,
+    /// IOMMU Status Register (MMIO 0x2020).
+    #[inspect(hex)]
+    iommu_status: u64,
+    /// General XT Interrupt Control Register (MMIO 0x0170).
+    ///
+    /// IOMMU's own MSI destination in x2APIC format. Per spec, sourced for
+    /// the event log / general interrupt when `CONTROL[IntCapXTEn]=1`. The
+    /// emulator stores the value for round-trip reads but does not source
+    /// MSIs from it, since IOMMU-internal interrupts are not delivered to
+    /// the guest.
+    #[inspect(hex)]
+    gen_xt_int_ctrl: u64,
+    /// PPR XT Interrupt Control Register (MMIO 0x0178). See `gen_xt_int_ctrl`.
+    #[inspect(hex)]
+    ppr_xt_int_ctrl: u64,
+}
+
+// =============================================================================
+// Shared IOMMU State
+// =============================================================================
+
+/// Shared IOMMU state accessible by per-device wrappers.
+///
+/// This struct holds the MMIO register state and guest memory reference
+/// behind a `RwLock`, allowing concurrent reads from per-device
+/// `IommuTranslatingMemory` and `IommuSignalMsi` wrappers while the
+/// `AmdIommuDevice` performs exclusive writes via MMIO.
+pub struct IommuSharedState {
+    /// Guest memory for reading device/page tables.
+    guest_memory: GuestMemory,
+    /// MMIO register state, protected by a RwLock.
+    state: RwLock<AmdIommuState>,
+    /// MSI interrupt for the IOMMU's own interrupts (completion wait,
+    /// event log). Configured by the guest via the PCI MSI capability.
+    msi_interrupt: Option<Interrupt>,
+}
+
+impl IommuSharedState {
+    /// Create new shared state with the given guest memory and MSI interrupt.
+    fn new(guest_memory: GuestMemory, msi_interrupt: Option<Interrupt>) -> Self {
+        Self {
+            guest_memory,
+            state: RwLock::new(AmdIommuState::default()),
+            msi_interrupt,
+        }
+    }
+
+    /// Deliver the IOMMU's own MSI interrupt (if configured by the guest).
+    fn deliver_interrupt(&self) {
+        if let Some(interrupt) = &self.msi_interrupt {
+            interrupt.deliver();
+        }
+    }
+
+    /// Returns whether the IOMMU is currently enabled.
+    pub fn is_enabled(&self) -> bool {
+        let state = self.state.read();
+        IommuCtrl::from_bits(state.iommu_ctrl).iommu_en()
+    }
+
+    /// Translate an IOVA to a GPA for the given device.
+    pub fn translate(&self, device_id: u16, iova: u64, write: bool) -> Result<u64, IommuFault> {
+        let state = self.state.read();
+        self.translate_inner(&state, device_id, iova, write)
+    }
+
+    /// Translate an IOVA while the caller already holds the state read lock.
+    ///
+    /// Use this when the caller needs to hold the lock across both translation
+    /// and a subsequent memory access to prevent TOCTOU races with
+    /// invalidations or config changes.
+    fn translate_locked(
+        &self,
+        state: &AmdIommuState,
+        device_id: u16,
+        iova: u64,
+        write: bool,
+    ) -> Result<u64, IommuFault> {
+        self.translate_inner(state, device_id, iova, write)
+    }
+
+    /// Remap an MSI address/data pair for the given device.
+    pub fn remap_msi(
+        &self,
+        device_id: u16,
+        address: u64,
+        data: u32,
+    ) -> Result<(u64, u32), IommuFault> {
+        let state = self.state.read();
+        self.remap_msi_inner(&state, device_id, address, data)
+    }
+
+    /// Queue a fault event to the event log.
+    pub fn queue_event(&self, event: EventEntry) {
+        let mut state = self.state.write();
+        Self::write_event_inner(
+            &self.guest_memory,
+            &mut state,
+            event,
+            self.msi_interrupt.as_ref(),
+        );
+    }
+
+    /// Look up a Device Table Entry for the given DeviceID.
+    pub fn lookup_dte(&self, device_id: u16) -> Result<Dte, IommuFault> {
+        let state = self.state.read();
+        self.lookup_dte_inner(&state, device_id)
+    }
+
+    /// Look up an IRTE for the given DTE and MSI data.
+    pub fn lookup_irte(
+        &self,
+        device_id: u16,
+        dte: &Dte,
+        msi_data: u32,
+    ) -> Result<RemappedInterrupt, IommuFault> {
+        let state = self.state.read();
+        self.lookup_irte_inner(&state, device_id, dte, msi_data)
+    }
+
+    /// Create a `GuestMemory` that translates DMA through the IOMMU's
+    /// page tables for the given device bus range.
+    pub fn create_translating_memory(
+        self: &Arc<Self>,
+        bus_range: pci_core::bus_range::AssignedBusRange,
+        inner_gm: &GuestMemory,
+    ) -> GuestMemory {
+        let initial_device_id = compose_device_id(&bus_range);
+        let label = format!("iommu-dev-{:04x}", initial_device_id.unwrap_or(0));
+        let translating = IommuTranslatingMemory {
+            bus_range,
+            shared: self.clone(),
+            inner_gm: inner_gm.clone(),
+        };
+        GuestMemory::new(label, translating)
+    }
+
+    /// Create an `IommuSignalMsi` that remaps MSIs through the IOMMU's
+    /// Interrupt Remapping Table.
+    pub fn create_signal_msi(
+        self: &Arc<Self>,
+        inner_msi: Arc<dyn SignalMsi>,
+    ) -> Arc<IommuSignalMsi> {
+        Arc::new(IommuSignalMsi {
+            shared: self.clone(),
+            inner: inner_msi,
+        })
+    }
+
+    /// Create per-device wrappers for DMA translation and MSI remapping.
+    ///
+    /// Returns a `GuestMemory` backed by IOMMU translation and an
+    /// `IommuSignalMsi` that remaps MSIs through the IOMMU's IRT.
+    pub fn create_device_context(
+        self: &Arc<Self>,
+        bus_range: pci_core::bus_range::AssignedBusRange,
+        inner_gm: &GuestMemory,
+        inner_msi: Arc<dyn SignalMsi>,
+    ) -> (GuestMemory, Arc<IommuSignalMsi>) {
+        tracing::trace!(
+            device_id = ?compose_device_id(&bus_range),
+            "create IOMMU translated device context"
+        );
+        let gm = self.create_translating_memory(bus_range, inner_gm);
+        let msi = self.create_signal_msi(inner_msi);
+        (gm, msi)
+    }
+
+    // -- Internal methods that operate with a lock already held --
+
+    fn lookup_dte_inner(&self, state: &AmdIommuState, device_id: u16) -> Result<Dte, IommuFault> {
+        let dtb = DevTabBase::from_bits(state.dev_tab_base);
+        let base_gpa = dtb.base_addr() << 12;
+        let max_entries = ((dtb.size() as u64) + 1) * 4096 / (DTE_SIZE as u64);
+
+        if (device_id as u64) >= max_entries {
+            return Err(IommuFault::IllegalDevTableEntry {
+                device_id,
+                address: 0,
+                is_interrupt: false,
+                is_write: false,
+            });
+        }
+
+        let dte_gpa = base_gpa + (device_id as u64) * (DTE_SIZE as u64);
+        let dte: Dte =
+            self.guest_memory
+                .read_plain(dte_gpa)
+                .map_err(|_| IommuFault::DevTabHardwareError {
+                    device_id,
+                    address: dte_gpa,
+                })?;
+
+        Ok(dte)
+    }
+
+    fn translate_inner(
+        &self,
+        state: &AmdIommuState,
+        device_id: u16,
+        iova: u64,
+        write: bool,
+    ) -> Result<u64, IommuFault> {
+        let ctrl = IommuCtrl::from_bits(state.iommu_ctrl);
+        if !ctrl.iommu_en() {
+            return Ok(iova);
+        }
+
+        let dte = self.lookup_dte_inner(state, device_id)?;
+
+        // Per AMD IOMMU spec §2.2.2 Table 8: when V=0, all addresses
+        // are forwarded without translation.
+        if !dte.dw0.v() {
+            tracing::trace!(device_id, iova, "translate: DTE V=0, pass-through");
+            return Ok(iova);
+        }
+
+        // V=1, TV=0: DTE control fields are valid but page translation
+        // info is not. Per spec Table 8: "If the request requires a table
+        // walk, the table walk is terminated." This is a target abort.
+        if !dte.dw0.tv() {
+            tracing::trace!(device_id, iova, "translate: V=1 TV=0, target abort");
+            return Err(IommuFault::IoPageFault {
+                device_id,
+                domain_id: dte.dw1.domain_id(),
+                address: iova,
+                is_write: write,
+            });
+        }
+
+        // Check exclusion range — addresses in the exclusion range
+        // bypass page table walking and are passed through untranslated.
+        let excl_base_reg = ExclBase::from_bits(state.excl_base);
+        if excl_base_reg.ex_en() {
+            let excl_start = excl_base_reg.base_addr() << 12;
+            let excl_limit_reg = ExclLimit::from_bits(state.excl_limit);
+            let excl_end = (excl_limit_reg.limit_addr() << 12) | 0xFFF;
+            // Per spec §2.2.4: if Allow=1, all devices bypass in the range.
+            // If Allow=0, only devices with DTE.EX=1 bypass.
+            if excl_base_reg.allow() || dte.dw1.ex() {
+                if iova >= excl_start && iova <= excl_end {
+                    return Ok(iova);
+                }
+            }
+        }
+
+        let mode = dte.dw0.mode();
+        if mode == PagingMode::DISABLED.0 {
+            tracing::trace!(device_id, iova, "translate: mode=0, pass-through");
+            return Ok(iova);
+        }
+
+        if mode == PAGING_MODE_RESERVED {
+            return Err(IommuFault::IllegalDevTableEntry {
+                device_id,
+                address: 0,
+                is_interrupt: false,
+                is_write: write,
+            });
+        }
+
+        let levels = mode;
+        let root_addr = dte.dw0.page_table_root_address();
+        let dte_ir = dte.dw0.ir();
+        let dte_iw = dte.dw0.iw();
+        let domain_id = dte.dw1.domain_id();
+
+        tracing::trace!(
+            device_id,
+            iova,
+            write,
+            levels,
+            root_addr,
+            dte_ir,
+            dte_iw,
+            domain_id,
+            "translate: walking page table"
+        );
+
+        self.walk_page_table(
+            device_id, domain_id, root_addr, iova, levels, write, dte_ir, dte_iw,
+        )
+    }
+
+    fn walk_page_table(
+        &self,
+        device_id: u16,
+        domain_id: u16,
+        root_addr: u64,
+        iova: u64,
+        levels: u8,
+        write: bool,
+        dte_ir: bool,
+        dte_iw: bool,
+    ) -> Result<u64, IommuFault> {
+        let mut table_addr = root_addr;
+        let mut current_level = levels;
+        let mut can_read = dte_ir;
+        let mut can_write = dte_iw;
+
+        loop {
+            let index = IommuPte::va_index(iova, current_level);
+            let pte_gpa = table_addr + (index as u64) * 8;
+
+            let pte: IommuPte = self.guest_memory.read_plain(pte_gpa).map_err(|_| {
+                IommuFault::PageTabHardwareError {
+                    device_id,
+                    address: pte_gpa,
+                }
+            })?;
+
+            tracing::trace!(
+                device_id,
+                iova,
+                current_level,
+                index,
+                pte_gpa,
+                pte_raw = pte.into_bits(),
+                pte_pr = pte.is_present(),
+                pte_next_level = pte.next_level(),
+                pte_addr = pte.phys_address(),
+                "walk: PTE step"
+            );
+
+            if !pte.is_present() {
+                return Err(IommuFault::IoPageFault {
+                    device_id,
+                    domain_id,
+                    address: iova,
+                    is_write: write,
+                });
+            }
+
+            can_read = can_read && pte.has_read();
+            can_write = can_write && pte.has_write();
+
+            if pte.is_leaf() || current_level == 1 {
+                // Mode-7 leaves (NextLevel = 7) encode an arbitrary
+                // power-of-two page size in the address field; mode-0 leaves
+                // use the level's natural default page size. See
+                // `IommuPte::mode7_page_size` for the encoding details.
+                let (page_base, page_size_mask) = if pte.next_level() == 7 {
+                    let raw = pte.into_bits();
+                    let Some(page_size) = IommuPte::mode7_page_size(raw) else {
+                        return Err(IommuFault::IoPageFault {
+                            device_id,
+                            domain_id,
+                            address: iova,
+                            is_write: write,
+                        });
+                    };
+                    let mask = page_size - 1;
+                    (IommuPte::mode7_page_base(raw, page_size), mask)
+                } else {
+                    (
+                        pte.phys_address(),
+                        IommuPte::page_offset_mask(current_level),
+                    )
+                };
+                let gpa = page_base | (iova & page_size_mask);
+
+                tracing::trace!(device_id, iova, gpa, current_level, "walk: leaf → GPA");
+
+                if write && !can_write {
+                    return Err(IommuFault::IoPageFault {
+                        device_id,
+                        domain_id,
+                        address: iova,
+                        is_write: true,
+                    });
+                }
+                if !write && !can_read {
+                    return Err(IommuFault::IoPageFault {
+                        device_id,
+                        domain_id,
+                        address: iova,
+                        is_write: false,
+                    });
+                }
+
+                return Ok(gpa);
+            }
+
+            let next_level = pte.next_level();
+
+            if next_level == 0 || next_level >= current_level {
+                return Err(IommuFault::IoPageFault {
+                    device_id,
+                    domain_id,
+                    address: iova,
+                    is_write: write,
+                });
+            }
+
+            table_addr = pte.phys_address();
+            current_level = next_level;
+        }
+    }
+
+    fn lookup_irte_inner(
+        &self,
+        state: &AmdIommuState,
+        device_id: u16,
+        dte: &Dte,
+        msi_data: u32,
+    ) -> Result<RemappedInterrupt, IommuFault> {
+        let dw2 = dte.dw2;
+
+        if !dw2.iv() {
+            return Err(IommuFault::IllegalDevTableEntry {
+                device_id,
+                address: 0,
+                is_interrupt: true,
+                is_write: false,
+            });
+        }
+
+        let irt_base = dw2.int_tab_address();
+        let max_entries = dw2.int_tab_entries();
+        let irte_index = msi_data & 0x7FF;
+
+        if irte_index >= max_entries {
+            return Err(IommuFault::IoPageFault {
+                device_id,
+                domain_id: dte.dw1.domain_id(),
+                address: 0,
+                is_write: false,
+            });
+        }
+
+        let ctrl = IommuCtrl::from_bits(state.iommu_ctrl);
+        if ctrl.ga_en() {
+            // 128-bit GA-format IRTE (16 bytes per entry).
+            use spec::irte::{IRTE_GA_SIZE, IrteGa};
+            let irte_gpa = irt_base + (irte_index as u64) * (IRTE_GA_SIZE as u64);
+            let irte: IrteGa = self.guest_memory.read_plain(irte_gpa).map_err(|_| {
+                IommuFault::PageTabHardwareError {
+                    device_id,
+                    address: irte_gpa,
+                }
+            })?;
+
+            if !irte.lo.remap_en() {
+                return Err(IommuFault::IoPageFault {
+                    device_id,
+                    domain_id: dte.dw1.domain_id(),
+                    address: 0,
+                    is_write: false,
+                });
+            }
+
+            Ok(RemappedInterrupt {
+                destination: irte.lo.destination() | ((irte.hi.destination_hi() as u32) << 24),
+                vector: irte.hi.vector(),
+                dm: irte.lo.dm(),
+                int_type: irte.lo.int_type(),
+            })
+        } else {
+            // Basic 32-bit IRTE (4 bytes per entry).
+            let irte_gpa = irt_base + (irte_index as u64) * (IRTE_SIZE as u64);
+            let irte: Irte = self.guest_memory.read_plain(irte_gpa).map_err(|_| {
+                IommuFault::PageTabHardwareError {
+                    device_id,
+                    address: irte_gpa,
+                }
+            })?;
+
+            if !irte.remap_en() {
+                return Err(IommuFault::IoPageFault {
+                    device_id,
+                    domain_id: dte.dw1.domain_id(),
+                    address: 0,
+                    is_write: false,
+                });
+            }
+
+            Ok(RemappedInterrupt {
+                destination: irte.destination() as u32,
+                vector: irte.vector(),
+                dm: irte.dm(),
+                int_type: irte.int_type(),
+            })
+        }
+    }
+
+    fn remap_msi_inner(
+        &self,
+        state: &AmdIommuState,
+        device_id: u16,
+        address: u64,
+        data: u32,
+    ) -> Result<(u64, u32), IommuFault> {
+        let ctrl = IommuCtrl::from_bits(state.iommu_ctrl);
+        if !ctrl.iommu_en() {
+            return Ok((address, data));
+        }
+
+        let dte = self.lookup_dte_inner(state, device_id)?;
+
+        // Per AMD IOMMU spec §2.2.2 Table 8: when V=0, interrupt
+        // requests are passed upstream without remapping.
+        if !dte.dw0.v() {
+            return Ok((address, data));
+        }
+
+        tracing::trace!(
+            device_id,
+            address,
+            data,
+            int_ctl = dte.dw2.int_ctl(),
+            iv = dte.dw2.iv(),
+            ga_en = ctrl.ga_en(),
+            "remap_msi: DTE lookup"
+        );
+
+        match dte.dw2.int_ctl_mode() {
+            IntCtl::PASS_THROUGH => Ok((address, data)),
+            IntCtl::ABORT => {
+                // Strictly per spec, IntCtl=ABORT should target-abort all
+                // interrupts. However, during device initialization the
+                // Linux driver sets IV=1 (via init_device_table) with
+                // IntCtl=00 before the IRT is configured. We pass through
+                // interrupts when IV=0 to avoid dropping MSIs during this
+                // window.
+                if !dte.dw2.iv() {
+                    return Ok((address, data));
+                }
+                Err(IommuFault::IllegalDevTableEntry {
+                    device_id,
+                    address,
+                    is_interrupt: true,
+                    is_write: false,
+                })
+            }
+            IntCtl::REMAP => {
+                let ri = self.lookup_irte_inner(state, device_id, &dte, data)?;
+
+                let new_address: u64 =
+                    MSI_ADDRESS_PREFIX | ((ri.destination as u64) << 12) | ((ri.dm as u64) << 2);
+                let new_data: u32 = (ri.vector as u32) | ((ri.int_type as u32) << 8);
+
+                tracing::trace!(
+                    device_id,
+                    address,
+                    data,
+                    new_address,
+                    new_data,
+                    dest = ri.destination,
+                    vector = ri.vector,
+                    dm = ri.dm,
+                    int_type = ri.int_type,
+                    "remap_msi: remapped"
+                );
+
+                Ok((new_address, new_data))
+            }
+            _ => Err(IommuFault::IllegalDevTableEntry {
+                device_id,
+                address,
+                is_interrupt: true,
+                is_write: false,
+            }),
+        }
+    }
+
+    fn write_event_inner(
+        guest_memory: &GuestMemory,
+        state: &mut AmdIommuState,
+        event: EventEntry,
+        msi_interrupt: Option<&Interrupt>,
+    ) {
+        let ctrl = IommuCtrl::from_bits(state.iommu_ctrl);
+        if !ctrl.iommu_en() || !ctrl.evt_log_en() {
+            return;
+        }
+
+        let buf_size_bytes = match evt_log_size_bytes(state) {
+            Some(size) => size,
+            None => {
+                tracelimit::warn_ratelimited!(
+                    "event log length below spec minimum (256 entries), dropping event"
+                );
+                return;
+            }
+        };
+        let evt_base = EvtLogBase::from_bits(state.evt_log_base);
+        let base_gpa = evt_base.base_addr() << 12;
+
+        let tail = EvtLogTail::from_bits(state.evt_log_tail);
+        // §3.4.15: "The IOMMU increments this register, rolling over at
+        // the end of the buffer" — mask to buffer size.
+        let tail_offset = ((tail.tail_ptr() as u64) << 4) % buf_size_bytes;
+
+        let head = spec::registers::EvtLogHead::from_bits(state.evt_log_head);
+        // §3.4.15: Behavior is undefined if software sets the head
+        // pointer beyond the buffer length. Mask to keep the overflow
+        // check and entry GPA within the configured ring.
+        let head_offset = ((head.head_ptr() as u64) << 4) % buf_size_bytes;
+
+        let next_tail = (tail_offset + 16) % buf_size_bytes;
+        if next_tail == head_offset {
+            let mut status = IommuStatus::from_bits(state.iommu_status);
+            status.set_evt_overflow(true);
+            state.iommu_status = status.into_bits();
+            return;
+        }
+
+        let entry_gpa = base_gpa + tail_offset;
+        if let Err(e) = guest_memory.write_plain(entry_gpa, &event) {
+            tracelimit::warn_ratelimited!(
+                error = %e,
+                gpa = entry_gpa,
+                "failed to write event log entry"
+            );
+            return;
+        }
+
+        let new_tail = EvtLogTail::new().with_tail_ptr((next_tail >> 4) as u32);
+        state.evt_log_tail = new_tail.into_bits();
+
+        if ctrl.evt_int_en() {
+            let mut status = IommuStatus::from_bits(state.iommu_status);
+            status.set_evt_log_int(true);
+            state.iommu_status = status.into_bits();
+            if let Some(interrupt) = msi_interrupt {
+                interrupt.deliver();
+            }
+        }
+    }
+}
+
+/// Composes an AMD IOMMU DeviceID from a PCIe port's assigned bus range.
+///
+/// DMA requests use the default BDF on the assigned secondary bus
+/// `(secondary_bus, device 0, function 0)`. A secondary bus value of 0 means
+/// the guest has not assigned the port's bus range yet.
+fn compose_device_id(bus_range: &pci_core::bus_range::AssignedBusRange) -> Option<u16> {
+    let (secondary, _) = bus_range.bus_range();
+    if secondary == 0 {
+        None
+    } else {
+        Some((secondary as u16) << 8)
+    }
+}
+
+// =============================================================================
+// Per-Device DMA Translation Wrapper
+// =============================================================================
+
+/// A `GuestMemoryAccess` implementation that translates IOVAs through the
+/// AMD IOMMU before accessing guest memory.
+///
+/// Each emulated PCIe device that is behind the IOMMU gets its own
+/// `IommuTranslatingMemory` with the assigned bus range for the port that
+/// owns the device.
+pub struct IommuTranslatingMemory {
+    /// The assigned bus range used to derive the DeviceID for IOMMU lookups.
+    bus_range: pci_core::bus_range::AssignedBusRange,
+    /// Reference to the shared IOMMU state.
+    shared: Arc<IommuSharedState>,
+    /// The raw (untranslated) guest memory.
+    inner_gm: GuestMemory,
+}
+
+impl IommuTranslatingMemory {
+    /// Perform a translated memory operation, splitting at page boundaries.
+    ///
+    /// Holds the IOMMU state read lock across both translation and memory
+    /// access for each page chunk, preventing config changes between
+    /// translation and the actual DMA.
+    ///
+    /// `op(gpa, offset, chunk_len)` is called for each chunk with the
+    /// translated GPA, the byte offset into the caller's buffer, and the
+    /// chunk length.
+    fn do_translated_op(
+        &self,
+        iova: u64,
+        len: usize,
+        write: bool,
+        mut op: impl FnMut(u64, usize, usize) -> Result<(), GuestMemoryBackingError>,
+    ) -> Result<(), GuestMemoryBackingError> {
+        let device_id = match compose_device_id(&self.bus_range) {
+            Some(id) => id,
+            None => {
+                // Bus not yet assigned — bypass IOMMU, use IOVA as GPA.
+                tracelimit::warn_ratelimited!(
+                    iova,
+                    len,
+                    write,
+                    "IOMMU DMA with unassigned bus, bypassing translation"
+                );
+                return self.do_passthrough_op(iova, len, write, op);
+            }
+        };
+        let mut current_iova = iova;
+        let mut offset = 0usize;
+        tracing::trace!(device_id, iova, len, write, "iommu dma op");
+        while offset < len {
+            let chunk_len = chunk_size(current_iova, len - offset);
+
+            let state = self.shared.state.read();
+            let gpa = match self
+                .shared
+                .translate_locked(&state, device_id, current_iova, write)
+            {
+                Ok(gpa) => gpa,
+                Err(fault) => {
+                    drop(state);
+                    self.shared.queue_event(fault.to_event_entry());
+                    return Err(GuestMemoryBackingError::other(
+                        iova,
+                        IommuTranslationError(fault),
+                    ));
+                }
+            };
+
+            tracing::trace!(
+                device_id,
+                iova,
+                current_iova,
+                gpa,
+                len,
+                offset,
+                chunk_len,
+                write,
+                "iommu dma op chunk"
+            );
+
+            let result = op(gpa, offset, chunk_len);
+            drop(state);
+            result?;
+
+            offset += chunk_len;
+            if offset < len {
+                // Only compute next IOVA when another chunk is needed.
+                // §2.5.3: An IOVA that overflows u64 cannot appear in
+                // any page table — report IO_PAGE_FAULT.
+                current_iova = current_iova.checked_add(chunk_len as u64).ok_or_else(|| {
+                    GuestMemoryBackingError::other(
+                        current_iova,
+                        IommuTranslationError(IommuFault::IoPageFault {
+                            device_id,
+                            domain_id: 0,
+                            address: current_iova,
+                            is_write: write,
+                        }),
+                    )
+                })?;
+            }
+        }
+        Ok(())
+    }
+
+    /// Bypass IOMMU translation — use IOVA directly as GPA.
+    /// Used when the device's bus number hasn't been assigned yet.
+    fn do_passthrough_op(
+        &self,
+        iova: u64,
+        len: usize,
+        _write: bool,
+        mut op: impl FnMut(u64, usize, usize) -> Result<(), GuestMemoryBackingError>,
+    ) -> Result<(), GuestMemoryBackingError> {
+        op(iova, 0, len)
+    }
+}
+
+// UNSAFETY: Implementing GuestMemoryAccess to provide IOVA-to-GPA translation.
+// This impl returns `mapping() = None`, forcing all accesses through the
+// fallback path where IOVAs are translated before delegating to the inner
+// GuestMemory which handles actual memory safety.
+#[expect(unsafe_code)]
+unsafe impl guestmem::GuestMemoryAccess for IommuTranslatingMemory {
+    fn mapping(&self) -> Option<NonNull<u8>> {
+        None // Force fallback path for IOVA translation.
+    }
+
+    fn max_address(&self) -> u64 {
+        u64::MAX
+    }
+
+    unsafe fn read_fallback(
+        &self,
+        addr: u64,
+        dest: *mut u8,
+        len: usize,
+    ) -> Result<(), GuestMemoryBackingError> {
+        self.do_translated_op(addr, len, false, |gpa, offset, chunk_len| {
+            // SAFETY: dest + offset is valid for writes of chunk_len bytes
+            // (caller contract guarantees dest is valid for `len` bytes).
+            let slice = unsafe { std::slice::from_raw_parts_mut(dest.add(offset), chunk_len) };
+            self.inner_gm
+                .read_at(gpa, slice)
+                .map_err(|e| GuestMemoryBackingError::other(addr, e))
+        })
+    }
+
+    unsafe fn write_fallback(
+        &self,
+        addr: u64,
+        src: *const u8,
+        len: usize,
+    ) -> Result<(), GuestMemoryBackingError> {
+        self.do_translated_op(addr, len, true, |gpa, offset, chunk_len| {
+            // SAFETY: src + offset is valid for reads of chunk_len bytes
+            // (caller contract guarantees src is valid for `len` bytes).
+            let slice = unsafe { std::slice::from_raw_parts(src.add(offset), chunk_len) };
+            let preview_len = slice.len().min(16);
+            tracing::trace!(
+                iova = addr,
+                gpa,
+                len,
+                offset,
+                chunk_len,
+                bytes = ?&slice[..preview_len],
+                "iommu dma write bytes"
+            );
+            self.inner_gm
+                .write_at(gpa, slice)
+                .map_err(|e| GuestMemoryBackingError::other(addr, e))
+        })
+    }
+
+    fn fill_fallback(&self, addr: u64, val: u8, len: usize) -> Result<(), GuestMemoryBackingError> {
+        self.do_translated_op(addr, len, true, |gpa, _offset, chunk_len| {
+            self.inner_gm
+                .fill_at(gpa, val, chunk_len)
+                .map_err(|e| GuestMemoryBackingError::other(addr, e))
+        })
+    }
+
+    fn compare_exchange_fallback(
+        &self,
+        addr: u64,
+        current: &mut [u8],
+        new: &[u8],
+    ) -> Result<bool, GuestMemoryBackingError> {
+        if current.len() != new.len() || !matches!(new.len(), 1 | 2 | 4 | 8) {
+            return Err(GuestMemoryBackingError::other(
+                addr,
+                UnsupportedIommuCompareExchange { len: new.len() },
+            ));
+        }
+
+        let len = new.len();
+        if chunk_size(addr, len) != len {
+            return Err(GuestMemoryBackingError::other(
+                addr,
+                UnsupportedIommuCompareExchange { len },
+            ));
+        }
+
+        let device_id = compose_device_id(&self.bus_range);
+        let mut state_guard = None;
+        let gpa = if let Some(device_id) = device_id {
+            state_guard = Some(self.shared.state.read());
+            match self
+                .shared
+                .translate_locked(state_guard.as_ref().unwrap(), device_id, addr, true)
+            {
+                Ok(gpa) => gpa,
+                Err(fault) => {
+                    drop(state_guard);
+                    self.shared.queue_event(fault.to_event_entry());
+                    return Err(GuestMemoryBackingError::other(
+                        addr,
+                        IommuTranslationError(fault),
+                    ));
+                }
+            }
+        } else {
+            addr
+        };
+
+        macro_rules! compare_exchange {
+            ($ty:ty, $len:literal) => {{
+                let mut current_bytes = [0; $len];
+                current_bytes.copy_from_slice(current);
+                let mut new_bytes = [0; $len];
+                new_bytes.copy_from_slice(new);
+                let result = self.inner_gm.compare_exchange(
+                    gpa,
+                    <$ty>::from_ne_bytes(current_bytes),
+                    <$ty>::from_ne_bytes(new_bytes),
+                );
+                drop(state_guard);
+                match result.map_err(|e| GuestMemoryBackingError::other(addr, e))? {
+                    Ok(_) => Ok(true),
+                    Err(actual) => {
+                        current.copy_from_slice(&actual.to_ne_bytes());
+                        Ok(false)
+                    }
+                }
+            }};
+        }
+
+        match len {
+            1 => compare_exchange!(u8, 1),
+            2 => compare_exchange!(u16, 2),
+            4 => compare_exchange!(u32, 4),
+            8 => compare_exchange!(u64, 8),
+            _ => unreachable!(),
+        }
+    }
+}
+
+/// Compute the size of the next chunk for a page-splitting DMA access.
+///
+/// Returns the number of bytes from `iova` to the end of the current 4KB
+/// page, or `remaining` if that is smaller. This ensures each chunk stays
+/// within a single translated page.
+fn chunk_size(iova: u64, remaining: usize) -> usize {
+    let page_offset = (iova & 0xFFF) as usize;
+    let bytes_in_page = 0x1000 - page_offset;
+    remaining.min(bytes_in_page)
+}
+
+/// Return a ring buffer size in bytes from a log2-entry-count field, or
+/// `None` if the value is below the spec minimum of 1000b (256 entries).
+/// §3.4.1: values 0000b–0111b are reserved for command buffer, event log,
+/// and PPR log length fields.
+fn ring_size_bytes(log2_entries: u8) -> Option<u64> {
+    if log2_entries < 8 {
+        None
+    } else {
+        Some((1u64 << (log2_entries as u64)) * 16)
+    }
+}
+
+/// Return the command buffer size in bytes, or `None` if invalid.
+fn cmd_buf_size_bytes(state: &AmdIommuState) -> Option<u64> {
+    ring_size_bytes(CmdBufBase::from_bits(state.cmd_buf_base).length())
+}
+
+/// Return the event log size in bytes, or `None` if invalid.
+fn evt_log_size_bytes(state: &AmdIommuState) -> Option<u64> {
+    ring_size_bytes(EvtLogBase::from_bits(state.evt_log_base).length())
+}
+
+/// Error type wrapping an IOMMU translation fault for `GuestMemoryBackingError`.
+#[derive(Debug)]
+struct IommuTranslationError(IommuFault);
+
+impl std::fmt::Display for IommuTranslationError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "IOMMU translation fault: {:?}", self.0)
+    }
+}
+
+impl std::error::Error for IommuTranslationError {}
+
+/// Error type for unsupported translated compare-exchange requests.
+#[derive(Debug)]
+struct UnsupportedIommuCompareExchange {
+    len: usize,
+}
+
+impl std::fmt::Display for UnsupportedIommuCompareExchange {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "unsupported IOMMU translated compare-exchange length {}",
+            self.len
+        )
+    }
+}
+
+impl std::error::Error for UnsupportedIommuCompareExchange {}
+
+// =============================================================================
+// Per-Device MSI Remapping Wrapper
+// =============================================================================
+
+/// A `SignalMsi` implementation that remaps MSIs through the AMD IOMMU's
+/// Interrupt Remapping Table before delivering them.
+///
+/// The requester ID (BDF) is taken from the `devid` parameter supplied by
+/// the PCI MSI layer at each `signal_msi` call. MSIs without a requester
+/// ID are dropped, matching the SMMU behavior.
+pub struct IommuSignalMsi {
+    /// Reference to the shared IOMMU state.
+    shared: Arc<IommuSharedState>,
+    /// The inner SignalMsi target (delivers to the partition APIC).
+    inner: Arc<dyn SignalMsi>,
+}
+
+impl SignalMsi for IommuSignalMsi {
+    fn signal_msi(&self, devid: Option<u32>, address: u64, data: u32) {
+        // Use the supplied requester ID for the DTE/IRTE lookup. The PCI
+        // MSI layer resolves the requester ID before calling SignalMsi,
+        // so `devid` is the correct BDF for interrupt remapping. Drop
+        // the MSI when no requester ID is supplied — without a BDF we
+        // cannot perform the DTE/IRTE lookup required for remapping.
+        let Some(device_id) = devid else {
+            return;
+        };
+        let device_id = device_id as u16;
+        match self.shared.remap_msi(device_id, address, data) {
+            Ok((new_address, new_data)) => {
+                self.inner.signal_msi(devid, new_address, new_data);
+            }
+            Err(fault) => {
+                self.shared.queue_event(fault.to_event_entry());
+                tracelimit::warn_ratelimited!(device_id, "MSI remapping fault, interrupt dropped");
+            }
+        }
+    }
+}
+
+impl AmdIommuDevice {
+    /// Create a new AMD IOMMU device with the given configuration.
+    ///
+    /// `msi_target` is used for the IOMMU's own MSI capability, which the
+    /// guest driver uses for completion wait and event log interrupts.
+    pub fn new(
+        guest_memory: GuestMemory,
+        config: AmdIommuConfig,
+        msi_target: &pci_core::msi::MsiTarget,
+    ) -> Self {
+        let mmio_base = config.mmio_base;
+
+        // Build the PCI capability block data.
+        let cap_data = IommuCapabilityData::new(mmio_base);
+        let capability =
+            ReadOnlyCapability::new_with_capability_id("amd-iommu", AMD_IOMMU_CAP_ID, cap_data);
+
+        // MSI capability: 1 vector, 64-bit address, no per-vector masking.
+        let msi_capability =
+            pci_core::capabilities::msi_cap::MsiCapability::new(0, true, false, msi_target);
+
+        // Extract the interrupt handle before the capability is consumed into
+        // the config space emulator. This lets the IOMMU deliver its own MSIs
+        // for completion wait and event log interrupts.
+        let msi_interrupt = msi_capability.interrupt();
+
+        // Build PCI config space with AMD IOMMU IDs and capabilities.
+        let cfg_space = ConfigSpaceType0Emulator::new(
+            HardwareIds {
+                vendor_id: spec::registers::PCI_VENDOR_ID,
+                device_id: spec::registers::PCI_DEVICE_ID,
+                revision_id: 0x00,
+                prog_if: ProgrammingInterface(spec::registers::PCI_CLASS_PROG_IF),
+                sub_class: Subclass(spec::registers::PCI_CLASS_SUB),
+                base_class: ClassCode(spec::registers::PCI_CLASS_BASE),
+                type0_sub_vendor_id: 0,
+                type0_sub_system_id: 0,
+            },
+            vec![Box::new(capability), Box::new(msi_capability)],
+            vec![],            // No extended capabilities
+            DeviceBars::new(), // No BARs — MMIO is via capability, not BAR
+        );
+
+        let static_regions = [(
+            "amd-iommu-mmio",
+            mmio_base..=mmio_base + MMIO_REGION_SIZE - 1,
+        )];
+
+        Self {
+            cfg_space,
+            mmio_base,
+            static_regions,
+            pci_bdf: config.pci_bdf,
+            shared: Arc::new(IommuSharedState::new(guest_memory, msi_interrupt)),
+        }
+    }
+
+    /// Returns the shared IOMMU state for creating per-device wrappers.
+    pub fn shared_state(&self) -> &Arc<IommuSharedState> {
+        &self.shared
+    }
+
+    /// Returns whether the IOMMU is currently enabled (IommuCtrl.IommuEn).
+    pub fn is_enabled(&self) -> bool {
+        self.shared.is_enabled()
+    }
+
+    /// Returns the current IOMMU control register value.
+    pub fn iommu_ctrl(&self) -> IommuCtrl {
+        let state = self.shared.state.read();
+        IommuCtrl::from_bits(state.iommu_ctrl)
+    }
+
+    /// Read a 64-bit MMIO register.
+    fn read_register(&self, offset: u64) -> u64 {
+        let state = self.shared.state.read();
+        match MmioRegister(offset as u16) {
+            MmioRegister::DEV_TAB_BASE => state.dev_tab_base,
+            MmioRegister::CMD_BUF_BASE => state.cmd_buf_base,
+            MmioRegister::EVT_LOG_BASE => state.evt_log_base,
+            MmioRegister::IOMMU_CTRL => state.iommu_ctrl,
+            MmioRegister::EXCL_BASE => state.excl_base,
+            MmioRegister::EXCL_LIMIT => state.excl_limit,
+            MmioRegister::EXT_FEAT => ADVERTISED_EXT_FEAT,
+            MmioRegister::EXT_FEAT2 => 0, // No EFR2 features supported.
+            MmioRegister::CMD_BUF_HEAD => state.cmd_buf_head,
+            MmioRegister::CMD_BUF_TAIL => state.cmd_buf_tail,
+            MmioRegister::EVT_LOG_HEAD => state.evt_log_head,
+            MmioRegister::EVT_LOG_TAIL => state.evt_log_tail,
+            MmioRegister::IOMMU_STATUS => state.iommu_status,
+            MmioRegister::GEN_XT_INT_CTRL => state.gen_xt_int_ctrl,
+            MmioRegister::PPR_XT_INT_CTRL => state.ppr_xt_int_ctrl,
+            _ => {
+                tracelimit::warn_ratelimited!(offset, "MMIO read from unknown register");
+                0
+            }
+        }
+    }
+
+    /// Write a 64-bit MMIO register. Returns true if the write was handled.
+    fn write_register(&mut self, offset: u64, value: u64) {
+        let mut state = self.shared.state.write();
+        let ctrl = IommuCtrl::from_bits(state.iommu_ctrl);
+
+        tracing::trace!(offset, value, "mmio_write");
+
+        match MmioRegister(offset as u16) {
+            MmioRegister::DEV_TAB_BASE => {
+                if !ctrl.iommu_en() {
+                    state.dev_tab_base = value;
+                } else {
+                    tracelimit::warn_ratelimited!(
+                        "write to DevTabBase while IOMMU enabled, ignored"
+                    );
+                }
+            }
+            MmioRegister::CMD_BUF_BASE => {
+                if !ctrl.iommu_en() {
+                    state.cmd_buf_base = value;
+                } else {
+                    tracelimit::warn_ratelimited!(
+                        "write to CmdBufBase while IOMMU enabled, ignored"
+                    );
+                }
+            }
+            MmioRegister::EVT_LOG_BASE => {
+                if !ctrl.iommu_en() {
+                    state.evt_log_base = value;
+                } else {
+                    tracelimit::warn_ratelimited!(
+                        "write to EvtLogBase while IOMMU enabled, ignored"
+                    );
+                }
+            }
+            MmioRegister::IOMMU_CTRL => {
+                let old_ctrl = IommuCtrl::from_bits(state.iommu_ctrl);
+                state.iommu_ctrl = value;
+                Self::update_status_from_ctrl(&mut state);
+                // If CmdBufEn transitions from 0→1 while IOMMU is enabled
+                // and there are pending commands, process them now.
+                let new_ctrl = IommuCtrl::from_bits(value);
+                if new_ctrl.iommu_en() && new_ctrl.cmd_buf_en() && !old_ctrl.cmd_buf_en() {
+                    Self::process_commands(&self.shared, &mut state);
+                }
+            }
+            MmioRegister::EXCL_BASE => {
+                state.excl_base = value;
+            }
+            MmioRegister::EXCL_LIMIT => {
+                state.excl_limit = value;
+            }
+            MmioRegister::EXT_FEAT | MmioRegister::EXT_FEAT2 => {
+                // Read-only registers, ignore writes.
+            }
+            MmioRegister::CMD_BUF_HEAD => {
+                if !ctrl.iommu_en() {
+                    state.cmd_buf_head = value;
+                }
+            }
+            MmioRegister::CMD_BUF_TAIL => {
+                state.cmd_buf_tail = value;
+                Self::process_commands(&self.shared, &mut state);
+            }
+            MmioRegister::EVT_LOG_HEAD => {
+                state.evt_log_head = value;
+            }
+            MmioRegister::EVT_LOG_TAIL => {
+                if !ctrl.iommu_en() {
+                    state.evt_log_tail = value;
+                }
+            }
+            MmioRegister::IOMMU_STATUS => {
+                let status = IommuStatus::from_bits(state.iommu_status);
+                let write_val = IommuStatus::from_bits(value);
+
+                let new_status = IommuStatus::new()
+                    .with_evt_overflow(status.evt_overflow() && !write_val.evt_overflow())
+                    .with_evt_log_int(status.evt_log_int() && !write_val.evt_log_int())
+                    .with_com_wait_int(status.com_wait_int() && !write_val.com_wait_int())
+                    .with_evt_log_run(status.evt_log_run())
+                    .with_cmd_buf_run(status.cmd_buf_run());
+
+                state.iommu_status = new_status.into_bits();
+            }
+            MmioRegister::GEN_XT_INT_CTRL => {
+                // IOMMU's own MSI destination in x2APIC format. Stored
+                // verbatim; the emulator does not source MSIs from this
+                // register because IOMMU-internal interrupts are not
+                // delivered to the guest.
+                state.gen_xt_int_ctrl = value;
+            }
+            MmioRegister::PPR_XT_INT_CTRL => {
+                // PPR log MSI destination in x2APIC format. Stored verbatim;
+                // the PPR log is not implemented.
+                state.ppr_xt_int_ctrl = value;
+            }
+            _ => {
+                tracelimit::warn_ratelimited!(offset, value, "MMIO write to unknown register");
+            }
+        }
+    }
+
+    /// Update IommuStatus RO bits based on the current IommuCtrl settings.
+    ///
+    /// `CmdBufRun` and `EvtLogRun` are only set when the respective buffer
+    /// has a valid (spec-minimum) length. §3.4.1: values below 1000b (256
+    /// entries) are reserved.
+    fn update_status_from_ctrl(state: &mut AmdIommuState) {
+        let ctrl = IommuCtrl::from_bits(state.iommu_ctrl);
+        let mut status = IommuStatus::from_bits(state.iommu_status);
+
+        status.set_cmd_buf_run(
+            ctrl.iommu_en() && ctrl.cmd_buf_en() && cmd_buf_size_bytes(state).is_some(),
+        );
+        status.set_evt_log_run(
+            ctrl.iommu_en() && ctrl.evt_log_en() && evt_log_size_bytes(state).is_some(),
+        );
+
+        state.iommu_status = status.into_bits();
+    }
+
+    // =========================================================================
+    // Event Log (1D)
+    // =========================================================================
+
+    /// Write an event record to the event log in guest memory.
+    #[cfg(test)]
+    fn write_event(&mut self, event: EventEntry) {
+        let mut state = self.shared.state.write();
+        IommuSharedState::write_event_inner(
+            &self.shared.guest_memory,
+            &mut state,
+            event,
+            self.shared.msi_interrupt.as_ref(),
+        );
+    }
+
+    // =========================================================================
+    // Command Buffer Processing (1C)
+    // =========================================================================
+
+    /// Process all pending commands in the command buffer.
+    fn process_commands(shared: &IommuSharedState, state: &mut AmdIommuState) {
+        let ctrl = IommuCtrl::from_bits(state.iommu_ctrl);
+        if !ctrl.iommu_en() || !ctrl.cmd_buf_en() {
+            return;
+        }
+
+        let buf_size_bytes = match cmd_buf_size_bytes(state) {
+            Some(size) => size,
+            None => {
+                tracelimit::warn_ratelimited!(
+                    "command buffer length below spec minimum (256 entries), halting"
+                );
+                let mut status = IommuStatus::from_bits(state.iommu_status);
+                status.set_cmd_buf_run(false);
+                state.iommu_status = status.into_bits();
+                return;
+            }
+        };
+        let cmd_base = CmdBufBase::from_bits(state.cmd_buf_base);
+        let base_gpa = cmd_base.base_addr() << 12;
+
+        loop {
+            let head = CmdBufHead::from_bits(state.cmd_buf_head);
+            // §3.4.15: "The IOMMU increments this register, rolling over to
+            // zero at the end of the buffer" — mask to buffer size.
+            let head_offset = ((head.head_ptr() as u64) << 4) % buf_size_bytes;
+
+            let tail = CmdBufTail::from_bits(state.cmd_buf_tail);
+            // §3.4.15: Behavior is undefined if software sets the tail
+            // pointer beyond the buffer length. Mask to prevent an
+            // unreachable comparison that would spin the command loop.
+            let tail_offset = ((tail.tail_ptr() as u64) << 4) % buf_size_bytes;
+
+            if head_offset == tail_offset {
+                break;
+            }
+
+            let entry_gpa = base_gpa + head_offset;
+            let entry: CommandEntry = match shared.guest_memory.read_plain(entry_gpa) {
+                Ok(e) => e,
+                Err(e) => {
+                    tracelimit::warn_ratelimited!(
+                        error = %e,
+                        gpa = entry_gpa,
+                        "failed to read command buffer entry"
+                    );
+                    let mut status = IommuStatus::from_bits(state.iommu_status);
+                    status.set_cmd_buf_run(false);
+                    state.iommu_status = status.into_bits();
+                    return;
+                }
+            };
+
+            tracing::trace!(opcode = entry.opcode().0, entry_gpa, "command");
+
+            match entry.opcode() {
+                CommandOpcode::COMPLETION_WAIT => {
+                    Self::process_completion_wait(shared, state, &entry);
+                }
+                CommandOpcode::INVALIDATE_DEVTAB_ENTRY
+                | CommandOpcode::INVALIDATE_IOMMU_PAGES
+                | CommandOpcode::INVALIDATE_IOTLB_PAGES
+                | CommandOpcode::INVALIDATE_INTERRUPT_TABLE
+                | CommandOpcode::PREFETCH_IOMMU_PAGES
+                | CommandOpcode::INVALIDATE_IOMMU_ALL => {
+                    // No-op: no caches to invalidate in the emulator.
+                }
+                _ => {
+                    tracelimit::warn_ratelimited!(
+                        opcode = entry.opcode().0,
+                        "unknown command opcode, halting command buffer"
+                    );
+                    let event = EventEntry::illegal_command_error(entry_gpa);
+                    IommuSharedState::write_event_inner(
+                        &shared.guest_memory,
+                        state,
+                        event,
+                        shared.msi_interrupt.as_ref(),
+                    );
+
+                    let mut status = IommuStatus::from_bits(state.iommu_status);
+                    status.set_cmd_buf_run(false);
+                    state.iommu_status = status.into_bits();
+                    return;
+                }
+            }
+
+            let next_head = (head_offset + 16) % buf_size_bytes;
+            let new_head = CmdBufHead::new().with_head_ptr((next_head >> 4) as u32);
+            state.cmd_buf_head = new_head.into_bits();
+        }
+    }
+
+    /// Process a COMPLETION_WAIT command (opcode 0x01).
+    fn process_completion_wait(
+        shared: &IommuSharedState,
+        state: &mut AmdIommuState,
+        entry: &CommandEntry,
+    ) {
+        let fields = CompletionWaitDw0Dw1::from(entry);
+
+        if fields.s() {
+            let store_addr = fields.store_address();
+            let store_data = completion_wait_store_data(entry);
+            if let Err(e) = shared
+                .guest_memory
+                .write_plain(store_addr, &store_data.to_le_bytes())
+            {
+                tracelimit::warn_ratelimited!(
+                    error = %e,
+                    addr = store_addr,
+                    "failed to write COMPLETION_WAIT store data"
+                );
+            }
+        }
+
+        if fields.i() {
+            let ctrl = IommuCtrl::from_bits(state.iommu_ctrl);
+            if ctrl.com_wait_int_en() {
+                let mut status = IommuStatus::from_bits(state.iommu_status);
+                status.set_com_wait_int(true);
+                state.iommu_status = status.into_bits();
+                shared.deliver_interrupt();
+            }
+        }
+    }
+
+    // =========================================================================
+    // Delegation to shared state (1E, 1F)
+    // =========================================================================
+
+    /// Look up a Device Table Entry for the given DeviceID (BDF).
+    pub fn lookup_dte(&self, device_id: u16) -> Result<Dte, IommuFault> {
+        self.shared.lookup_dte(device_id)
+    }
+
+    /// Translate an IOVA to a GPA for the given device.
+    pub fn translate(&self, device_id: u16, iova: u64, write: bool) -> Result<u64, IommuFault> {
+        self.shared.translate(device_id, iova, write)
+    }
+
+    /// Look up an IRTE for the given DTE and MSI data.
+    pub fn lookup_irte(
+        &self,
+        device_id: u16,
+        dte: &Dte,
+        msi_data: u32,
+    ) -> Result<RemappedInterrupt, IommuFault> {
+        self.shared.lookup_irte(device_id, dte, msi_data)
+    }
+
+    /// Remap an MSI address/data pair for the given device.
+    pub fn remap_msi(
+        &self,
+        device_id: u16,
+        address: u64,
+        data: u32,
+    ) -> Result<(u64, u32), IommuFault> {
+        self.shared.remap_msi(device_id, address, data)
+    }
+}
+
+/// x86 MSI address prefix: 0xFEE0_0000.
+const MSI_ADDRESS_PREFIX: u64 = 0xFEE0_0000;
+
+/// Result of an IRTE lookup — the remapped interrupt fields needed to
+/// construct the new MSI address/data pair.
+#[derive(Debug)]
+pub struct RemappedInterrupt {
+    /// Destination APIC ID.
+    pub destination: u32,
+    /// Interrupt vector.
+    pub vector: u8,
+    /// Destination mode — false = physical, true = logical.
+    pub dm: bool,
+    /// Interrupt type (delivery mode).
+    pub int_type: u8,
+}
+
+// =============================================================================
+// Translation Faults
+// =============================================================================
+
+/// An IOMMU translation fault.
+///
+/// These correspond to events that would be logged to the event log and
+/// indicate a translation or lookup failure.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum IommuFault {
+    /// The DeviceID is out of range or the DTE has reserved field
+    /// values (§2.5.2).
+    IllegalDevTableEntry {
+        /// The device that caused the fault (BDF).
+        device_id: u16,
+        /// The faulting address.
+        address: u64,
+        /// Whether this was an interrupt request.
+        is_interrupt: bool,
+        /// Whether this was a write access.
+        is_write: bool,
+    },
+    /// An I/O page fault — page not present, or permission violation (§2.5.3).
+    IoPageFault {
+        /// The device that caused the fault (BDF).
+        device_id: u16,
+        /// Domain ID from the DTE.
+        domain_id: u16,
+        /// The faulting IOVA.
+        address: u64,
+        /// Whether this was a write access.
+        is_write: bool,
+    },
+    /// Hardware error reading the device table (§2.5.4).
+    DevTabHardwareError {
+        /// The device that caused the fault (BDF).
+        device_id: u16,
+        /// The address that failed to read.
+        address: u64,
+    },
+    /// Hardware error reading a page table (§2.5.5).
+    PageTabHardwareError {
+        /// The device that caused the fault (BDF).
+        device_id: u16,
+        /// The address that failed to read.
+        address: u64,
+    },
+}
+
+impl IommuFault {
+    /// Convert this fault into an event log entry.
+    pub fn to_event_entry(&self) -> EventEntry {
+        match self {
+            IommuFault::IllegalDevTableEntry {
+                device_id,
+                is_interrupt,
+                is_write,
+                address,
+            } => {
+                EventEntry::illegal_dev_table_entry(*device_id, *is_interrupt, *is_write, *address)
+            }
+            IommuFault::IoPageFault {
+                device_id,
+                domain_id,
+                address,
+                is_write,
+            } => EventEntry::io_page_fault(*device_id, *domain_id, false, *is_write, *address),
+            IommuFault::DevTabHardwareError { device_id, address } => {
+                EventEntry::dev_tab_hardware_error(*device_id, *address)
+            }
+            IommuFault::PageTabHardwareError { device_id, address } => {
+                EventEntry::page_tab_hardware_error(*device_id, *address)
+            }
+        }
+    }
+}
+
+impl InspectMut for AmdIommuDevice {
+    fn inspect_mut(&mut self, req: inspect::Request<'_>) {
+        req.respond()
+            .hex("mmio_base", self.mmio_base)
+            .field(
+                "pci_bdf",
+                format!(
+                    "{:02x}:{:02x}.{}",
+                    self.pci_bdf.0, self.pci_bdf.1, self.pci_bdf.2
+                ),
+            )
+            .field("enabled", self.is_enabled())
+            .field("state", &*self.shared.state.read());
+    }
+}
+
+impl vmcore::device_state::ChangeDeviceState for AmdIommuDevice {
+    fn start(&mut self) {}
+
+    async fn stop(&mut self) {}
+
+    async fn reset(&mut self) {
+        let mut state = self.shared.state.write();
+        *state = AmdIommuState::default();
+    }
+}
+
+impl vmcore::save_restore::SaveRestore for AmdIommuDevice {
+    type SavedState = vmcore::save_restore::SavedStateNotSupported;
+
+    fn save(&mut self) -> Result<Self::SavedState, vmcore::save_restore::SaveError> {
+        Err(vmcore::save_restore::SaveError::NotSupported)
+    }
+
+    fn restore(
+        &mut self,
+        state: Self::SavedState,
+    ) -> Result<(), vmcore::save_restore::RestoreError> {
+        match state {}
+    }
+}
+
+// =============================================================================
+// ChipsetDevice trait implementation
+// =============================================================================
+
+impl ChipsetDevice for AmdIommuDevice {
+    fn supports_pci(&mut self) -> Option<&mut dyn PciConfigSpace> {
+        Some(self)
+    }
+
+    fn supports_mmio(&mut self) -> Option<&mut dyn MmioIntercept> {
+        Some(self)
+    }
+}
+
+// =============================================================================
+// PCI Config Space
+// =============================================================================
+
+impl PciConfigSpace for AmdIommuDevice {
+    fn pci_cfg_read(&mut self, offset: u16, value: &mut u32) -> IoResult {
+        self.cfg_space.read_u32(offset, value)
+    }
+
+    fn pci_cfg_write(&mut self, offset: u16, value: u32) -> IoResult {
+        self.cfg_space.write_u32(offset, value)
+    }
+
+    fn suggested_bdf(&mut self) -> Option<(u8, u8, u8)> {
+        Some(self.pci_bdf)
+    }
+}
+
+// =============================================================================
+// MMIO Register Access
+// =============================================================================
+
+impl MmioIntercept for AmdIommuDevice {
+    fn mmio_read(&mut self, addr: u64, data: &mut [u8]) -> IoResult {
+        let offset = addr - self.mmio_base;
+
+        // All IOMMU MMIO registers are 64-bit, but guests may access them
+        // as 32-bit halves (lower then upper DWORD).
+        match data.len() {
+            8 => {
+                // 64-bit aligned read of a full register.
+                let reg_offset = offset & !7;
+                let val = self.read_register(reg_offset);
+                data.copy_from_slice(&val.to_le_bytes());
+            }
+            4 => {
+                // 32-bit read of lower or upper half.
+                let reg_offset = offset & !7;
+                let val = self.read_register(reg_offset);
+                let bytes = val.to_le_bytes();
+                let half_offset = (offset & 4) as usize;
+                data.copy_from_slice(&bytes[half_offset..half_offset + 4]);
+            }
+            _ => {
+                tracelimit::warn_ratelimited!(addr, len = data.len(), "unsupported MMIO read size");
+                data.fill(0xff);
+                return IoResult::Err(IoError::InvalidAccessSize);
+            }
+        }
+
+        IoResult::Ok
+    }
+
+    fn mmio_write(&mut self, addr: u64, data: &[u8]) -> IoResult {
+        let offset = addr - self.mmio_base;
+
+        match data.len() {
+            8 => {
+                // 64-bit aligned write of a full register.
+                let reg_offset = offset & !7;
+                let val = u64::from_le_bytes(data.try_into().unwrap());
+                self.write_register(reg_offset, val);
+            }
+            4 => {
+                // 32-bit write to lower or upper half.
+                // Read-modify-write the full 64-bit register.
+                let reg_offset = offset & !7;
+                let mut val = self.read_register(reg_offset);
+                let half_offset = (offset & 4) as usize;
+                let mut bytes = val.to_le_bytes();
+                bytes[half_offset..half_offset + 4].copy_from_slice(data);
+                val = u64::from_le_bytes(bytes);
+                self.write_register(reg_offset, val);
+            }
+            _ => {
+                tracelimit::warn_ratelimited!(
+                    addr,
+                    len = data.len(),
+                    "unsupported MMIO write size"
+                );
+                return IoResult::Err(IoError::InvalidAccessSize);
+            }
+        }
+
+        IoResult::Ok
+    }
+
+    fn get_static_regions(&mut self) -> &[(&str, RangeInclusive<u64>)] {
+        &self.static_regions
+    }
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use guestmem::GuestMemory;
+    use spec::commands::CommandEntry;
+    use spec::dte::IntCtl;
+    use spec::events::EventCode;
+    use spec::events::EventEntry;
+    use spec::irte::Irte;
+    use spec::registers::CmdBufBase;
+    use spec::registers::CmdBufHead;
+    use spec::registers::CmdBufTail;
+    use spec::registers::DevTabBase;
+    use spec::registers::EvtLogHead;
+    use spec::registers::ExtFeat;
+
+    /// Test-only MMIO base address.
+    const TEST_MMIO_BASE: u64 = 0xFD00_0000;
+
+    fn test_config() -> AmdIommuConfig {
+        AmdIommuConfig {
+            mmio_base: TEST_MMIO_BASE,
+            pci_bdf: (0, 0, 0),
+        }
+    }
+
+    fn create_test_device() -> AmdIommuDevice {
+        let guest_memory = GuestMemory::empty();
+        let msi_conn =
+            pci_core::msi::MsiConnection::new(pci_core::bus_range::AssignedBusRange::new(), 0);
+        AmdIommuDevice::new(guest_memory, test_config(), msi_conn.target())
+    }
+
+    /// Helper to read a 32-bit PCI config register.
+    fn pci_read(dev: &mut AmdIommuDevice, offset: u16) -> u32 {
+        let mut value = 0u32;
+        let _ = dev.pci_cfg_read(offset, &mut value);
+        value
+    }
+
+    /// Helper to read a 64-bit MMIO register.
+    fn mmio_read64(dev: &mut AmdIommuDevice, offset: u64) -> u64 {
+        let addr = dev.mmio_base + offset;
+        let mut data = [0u8; 8];
+        let _ = dev.mmio_read(addr, &mut data);
+        u64::from_le_bytes(data)
+    }
+
+    /// Helper to write a 64-bit MMIO register.
+    fn mmio_write64(dev: &mut AmdIommuDevice, offset: u64, value: u64) {
+        let addr = dev.mmio_base + offset;
+        let _ = dev.mmio_write(addr, &value.to_le_bytes());
+    }
+
+    /// Helper to read a 32-bit MMIO value.
+    fn mmio_read32(dev: &mut AmdIommuDevice, offset: u64) -> u32 {
+        let addr = dev.mmio_base + offset;
+        let mut data = [0u8; 4];
+        let _ = dev.mmio_read(addr, &mut data);
+        u32::from_le_bytes(data)
+    }
+
+    /// Helper to write a 32-bit MMIO value.
+    fn mmio_write32(dev: &mut AmdIommuDevice, offset: u64, value: u32) {
+        let addr = dev.mmio_base + offset;
+        let _ = dev.mmio_write(addr, &value.to_le_bytes());
+    }
+
+    // =========================================================================
+    // PCI Config Space Tests (1B.2)
+    // =========================================================================
+
+    #[test]
+    fn test_pci_vendor_device_id() {
+        let mut dev = create_test_device();
+        let id = pci_read(&mut dev, 0x00);
+        assert_eq!(id & 0xFFFF, 0x1022, "vendor ID should be AMD");
+        assert_eq!(id >> 16, 0x1451, "device ID should be 0x1451");
+    }
+
+    #[test]
+    fn test_pci_class_code() {
+        let mut dev = create_test_device();
+        let class_rev = pci_read(&mut dev, 0x08);
+        assert_eq!(
+            (class_rev >> 24) & 0xFF,
+            0x08,
+            "base class: System Peripheral"
+        );
+        assert_eq!((class_rev >> 16) & 0xFF, 0x06, "sub class: IOMMU");
+        assert_eq!((class_rev >> 8) & 0xFF, 0x00, "prog_if: 0");
+    }
+
+    #[test]
+    fn test_pci_capability_pointer() {
+        let mut dev = create_test_device();
+        // Offset 0x34 = capabilities pointer, should point to 0x40.
+        let cap_ptr = pci_read(&mut dev, 0x34);
+        assert_eq!(cap_ptr & 0xFF, 0x40, "capability pointer should be 0x40");
+    }
+
+    #[test]
+    fn test_pci_capability_header() {
+        let mut dev = create_test_device();
+        // Read capability at offset 0x40 (first DWORD of capability).
+        let cap_header_raw = pci_read(&mut dev, 0x40);
+        let cap_id = cap_header_raw & 0xFF;
+        let cap_next = (cap_header_raw >> 8) & 0xFF;
+
+        assert_eq!(cap_id, 0x0F, "CapID should be 0x0F (AMD IOMMU)");
+        assert_ne!(cap_next, 0x00, "should have a next capability (MSI)");
+
+        let header = CapHeader::from_bits(cap_header_raw);
+        assert_eq!(header.cap_type(), 0b011, "CapType should be 011b");
+        assert_eq!(header.cap_rev(), 0b00001, "CapRev should be 1");
+        assert!(header.efr_sup(), "EFRSup should be set");
+        assert!(!header.iotlb_sup(), "IotlbSup should be clear");
+        assert!(!header.ht_tunnel(), "HtTunnel should be clear");
+        assert!(!header.np_cache(), "NpCache should be clear");
+        assert!(!header.cap_ext(), "CapExt should be clear");
+    }
+
+    #[test]
+    fn test_pci_capability_mmio_base() {
+        let mut dev = create_test_device();
+        // Offset 0x44 = BaseAddrLow, 0x48 = BaseAddrHigh.
+        let base_low_raw = pci_read(&mut dev, 0x44);
+        let base_high_raw = pci_read(&mut dev, 0x48);
+
+        let base_low = BaseAddrLow::from_bits(base_low_raw);
+        let base_high = BaseAddrHigh::from_bits(base_high_raw);
+
+        assert!(base_low.enable(), "Enable should be set");
+
+        let mmio_addr =
+            ((base_low.base_addr() as u64) << 14) | ((base_high.base_addr() as u64) << 32);
+        assert_eq!(mmio_addr, TEST_MMIO_BASE, "MMIO base should match");
+    }
+
+    #[test]
+    fn test_pci_capability_device_range() {
+        let mut dev = create_test_device();
+        // Offset 0x4C = Range register.
+        let range_raw = pci_read(&mut dev, 0x4C);
+        let range = Range::from_bits(range_raw);
+
+        assert!(range.rng_valid(), "RngValid should be set");
+        assert_eq!(range.bus_number(), 0, "bus number should be 0");
+        assert_eq!(range.first_device(), 0x00, "first device should be 0x00");
+        assert_eq!(range.last_device(), 0xFF, "last device should be 0xFF");
+    }
+
+    #[test]
+    fn test_pci_capability_misc_info() {
+        let mut dev = create_test_device();
+        // Offset 0x50 = MiscInfo0.
+        let misc_raw = pci_read(&mut dev, 0x50);
+        let misc = MiscInfo0::from_bits(misc_raw);
+
+        assert_eq!(misc.pa_size(), 48, "PA size should be 48 bits");
+        assert_eq!(misc.va_size(), 48, "VA size should be 48 bits");
+        assert_eq!(misc.msi_num(), 0, "MsiNum should be 0");
+    }
+
+    #[test]
+    fn test_suggested_bdf() {
+        let mut dev = create_test_device();
+        assert_eq!(
+            dev.suggested_bdf(),
+            Some((0, 0, 0)),
+            "should suggest default BDF"
+        );
+    }
+
+    // =========================================================================
+    // MMIO Register Tests (1B.3, 1B.4)
+    // =========================================================================
+
+    #[test]
+    fn test_extfeat_readback() {
+        let mut dev = create_test_device();
+        let ext_feat = mmio_read64(&mut dev, MmioRegister::EXT_FEAT.0 as u64);
+
+        assert_eq!(
+            ext_feat, ADVERTISED_EXT_FEAT,
+            "ExtFeat should match emulator constant"
+        );
+
+        let feat = ExtFeat::from_bits(ext_feat);
+        assert!(feat.ia_sup(), "IASup should be set");
+        assert!(feat.ga_sup(), "GASup should be set");
+        assert!(!feat.pref_sup(), "PrefSup should be clear");
+        assert!(!feat.ppr_sup(), "PPRSup should be clear");
+        assert!(!feat.gt_sup(), "GTSup should be clear");
+        assert_eq!(feat.hats(), 0, "HATS should be 00 (4-level)");
+    }
+
+    #[test]
+    fn test_extfeat_readonly() {
+        let mut dev = create_test_device();
+        // Write to ExtFeat should have no effect.
+        mmio_write64(&mut dev, MmioRegister::EXT_FEAT.0 as u64, 0xDEAD_BEEF);
+        let ext_feat = mmio_read64(&mut dev, MmioRegister::EXT_FEAT.0 as u64);
+        assert_eq!(
+            ext_feat, ADVERTISED_EXT_FEAT,
+            "ExtFeat should be unchanged after write"
+        );
+    }
+
+    #[test]
+    fn test_ctrl_enable_disable() {
+        let mut dev = create_test_device_with_memory();
+
+        // Initially disabled.
+        assert!(!dev.is_enabled());
+        let status =
+            IommuStatus::from_bits(mmio_read64(&mut dev, MmioRegister::IOMMU_STATUS.0 as u64));
+        assert!(!status.cmd_buf_run());
+        assert!(!status.evt_log_run());
+
+        // Configure valid buffer bases before enabling.
+        let cmd_base = CmdBufBase::new()
+            .with_base_addr(0x0000 >> 12)
+            .with_length(8);
+        mmio_write64(
+            &mut dev,
+            MmioRegister::CMD_BUF_BASE.0 as u64,
+            cmd_base.into_bits(),
+        );
+        let evt_base = EvtLogBase::new()
+            .with_base_addr(0x1000 >> 12)
+            .with_length(8);
+        mmio_write64(
+            &mut dev,
+            MmioRegister::EVT_LOG_BASE.0 as u64,
+            evt_base.into_bits(),
+        );
+
+        // Enable IOMMU with command buffer and event log.
+        let ctrl = IommuCtrl::new()
+            .with_iommu_en(true)
+            .with_cmd_buf_en(true)
+            .with_evt_log_en(true);
+        mmio_write64(
+            &mut dev,
+            MmioRegister::IOMMU_CTRL.0 as u64,
+            ctrl.into_bits(),
+        );
+
+        assert!(dev.is_enabled());
+        let status =
+            IommuStatus::from_bits(mmio_read64(&mut dev, MmioRegister::IOMMU_STATUS.0 as u64));
+        assert!(status.cmd_buf_run(), "CmdBufRun should be set");
+        assert!(status.evt_log_run(), "EvtLogRun should be set");
+
+        // Disable IOMMU.
+        mmio_write64(&mut dev, MmioRegister::IOMMU_CTRL.0 as u64, 0);
+        assert!(!dev.is_enabled());
+        let status =
+            IommuStatus::from_bits(mmio_read64(&mut dev, MmioRegister::IOMMU_STATUS.0 as u64));
+        assert!(!status.cmd_buf_run(), "CmdBufRun should be clear");
+        assert!(!status.evt_log_run(), "EvtLogRun should be clear");
+    }
+
+    #[test]
+    fn test_devtab_base_readback() {
+        let mut dev = create_test_device();
+        let base = DevTabBase::new()
+            .with_size(0x1FF) // Max table size
+            .with_base_addr(0x100_0000 >> 12);
+        let val = base.into_bits();
+
+        mmio_write64(&mut dev, MmioRegister::DEV_TAB_BASE.0 as u64, val);
+        let readback = mmio_read64(&mut dev, MmioRegister::DEV_TAB_BASE.0 as u64);
+        assert_eq!(readback, val, "DevTabBase should round-trip");
+    }
+
+    #[test]
+    fn test_cmdbuf_base_readback() {
+        let mut dev = create_test_device();
+        let base = CmdBufBase::new()
+            .with_length(8) // 256 entries
+            .with_base_addr(0x200_0000 >> 12);
+        let val = base.into_bits();
+
+        mmio_write64(&mut dev, MmioRegister::CMD_BUF_BASE.0 as u64, val);
+        let readback = mmio_read64(&mut dev, MmioRegister::CMD_BUF_BASE.0 as u64);
+        assert_eq!(readback, val, "CmdBufBase should round-trip");
+    }
+
+    #[test]
+    fn test_devtab_base_locked_when_enabled() {
+        let mut dev = create_test_device();
+
+        // Write DevTabBase while disabled — should work.
+        let val1 = 0x1234_5000;
+        mmio_write64(&mut dev, MmioRegister::DEV_TAB_BASE.0 as u64, val1);
+        assert_eq!(
+            mmio_read64(&mut dev, MmioRegister::DEV_TAB_BASE.0 as u64),
+            val1
+        );
+
+        // Enable IOMMU.
+        let ctrl = IommuCtrl::new().with_iommu_en(true);
+        mmio_write64(
+            &mut dev,
+            MmioRegister::IOMMU_CTRL.0 as u64,
+            ctrl.into_bits(),
+        );
+
+        // Write DevTabBase while enabled — should be ignored.
+        let val2 = 0xAAAA_0000;
+        mmio_write64(&mut dev, MmioRegister::DEV_TAB_BASE.0 as u64, val2);
+        assert_eq!(
+            mmio_read64(&mut dev, MmioRegister::DEV_TAB_BASE.0 as u64),
+            val1,
+            "DevTabBase should not change while IOMMU is enabled"
+        );
+    }
+
+    #[test]
+    fn test_status_rw1c() {
+        let mut dev = create_test_device();
+
+        // Manually set some status bits (simulating events).
+        let status = IommuStatus::new()
+            .with_evt_overflow(true)
+            .with_evt_log_int(true)
+            .with_com_wait_int(true);
+        dev.shared.state.write().iommu_status = status.into_bits();
+
+        // Read back — all bits should be set.
+        let readback =
+            IommuStatus::from_bits(mmio_read64(&mut dev, MmioRegister::IOMMU_STATUS.0 as u64));
+        assert!(readback.evt_overflow());
+        assert!(readback.evt_log_int());
+        assert!(readback.com_wait_int());
+
+        // Clear only EvtLogInt by writing 1 to it.
+        let clear = IommuStatus::new().with_evt_log_int(true);
+        mmio_write64(
+            &mut dev,
+            MmioRegister::IOMMU_STATUS.0 as u64,
+            clear.into_bits(),
+        );
+
+        let readback =
+            IommuStatus::from_bits(mmio_read64(&mut dev, MmioRegister::IOMMU_STATUS.0 as u64));
+        assert!(readback.evt_overflow(), "evt_overflow should remain set");
+        assert!(!readback.evt_log_int(), "evt_log_int should be cleared");
+        assert!(readback.com_wait_int(), "com_wait_int should remain set");
+    }
+
+    #[test]
+    fn test_32bit_mmio_access() {
+        let mut dev = create_test_device();
+
+        // Write a 64-bit value to DevTabBase.
+        let val: u64 = 0xDEAD_BEEF_1234_51FF;
+        mmio_write64(&mut dev, MmioRegister::DEV_TAB_BASE.0 as u64, val);
+
+        // Read back as two 32-bit halves.
+        let low = mmio_read32(&mut dev, MmioRegister::DEV_TAB_BASE.0 as u64);
+        let high = mmio_read32(&mut dev, MmioRegister::DEV_TAB_BASE.0 as u64 + 4);
+        let combined = (high as u64) << 32 | low as u64;
+        assert_eq!(
+            combined, val,
+            "32-bit halves should reconstruct the 64-bit value"
+        );
+    }
+
+    #[test]
+    fn test_32bit_mmio_write() {
+        let mut dev = create_test_device();
+
+        // Write lower 32 bits, then upper 32 bits.
+        mmio_write32(&mut dev, MmioRegister::DEV_TAB_BASE.0 as u64, 0x1234_51FF);
+        mmio_write32(
+            &mut dev,
+            MmioRegister::DEV_TAB_BASE.0 as u64 + 4,
+            0xDEAD_BEEF,
+        );
+
+        let val = mmio_read64(&mut dev, MmioRegister::DEV_TAB_BASE.0 as u64);
+        assert_eq!(val, 0xDEAD_BEEF_1234_51FF);
+    }
+
+    #[test]
+    fn test_static_mmio_region() {
+        let mut dev = create_test_device();
+        let regions = dev.get_static_regions();
+        assert_eq!(regions.len(), 1);
+        assert_eq!(regions[0].0, "amd-iommu-mmio");
+        assert_eq!(*regions[0].1.start(), TEST_MMIO_BASE);
+        assert_eq!(*regions[0].1.end(), TEST_MMIO_BASE + MMIO_REGION_SIZE - 1);
+    }
+
+    #[test]
+    fn test_initial_state() {
+        let mut dev = create_test_device();
+
+        // All registers should be zero initially.
+        assert_eq!(
+            mmio_read64(&mut dev, MmioRegister::DEV_TAB_BASE.0 as u64),
+            0
+        );
+        assert_eq!(
+            mmio_read64(&mut dev, MmioRegister::CMD_BUF_BASE.0 as u64),
+            0
+        );
+        assert_eq!(
+            mmio_read64(&mut dev, MmioRegister::EVT_LOG_BASE.0 as u64),
+            0
+        );
+        assert_eq!(mmio_read64(&mut dev, MmioRegister::IOMMU_CTRL.0 as u64), 0);
+        assert_eq!(
+            mmio_read64(&mut dev, MmioRegister::CMD_BUF_HEAD.0 as u64),
+            0
+        );
+        assert_eq!(
+            mmio_read64(&mut dev, MmioRegister::CMD_BUF_TAIL.0 as u64),
+            0
+        );
+        assert_eq!(
+            mmio_read64(&mut dev, MmioRegister::EVT_LOG_HEAD.0 as u64),
+            0
+        );
+        assert_eq!(
+            mmio_read64(&mut dev, MmioRegister::EVT_LOG_TAIL.0 as u64),
+            0
+        );
+        assert_eq!(
+            mmio_read64(&mut dev, MmioRegister::IOMMU_STATUS.0 as u64),
+            0
+        );
+
+        // ExtFeat is non-zero (read-only).
+        assert_ne!(mmio_read64(&mut dev, MmioRegister::EXT_FEAT.0 as u64), 0);
+    }
+
+    #[test]
+    fn test_evt_log_head_write() {
+        let mut dev = create_test_device();
+
+        // Software writes EvtLogHead to acknowledge consumed events.
+        let head = EvtLogHead::new().with_head_ptr(5);
+        mmio_write64(
+            &mut dev,
+            MmioRegister::EVT_LOG_HEAD.0 as u64,
+            head.into_bits(),
+        );
+        let readback = mmio_read64(&mut dev, MmioRegister::EVT_LOG_HEAD.0 as u64);
+        assert_eq!(readback, head.into_bits());
+    }
+
+    // =========================================================================
+    // Event Log Tests (1D)
+    // =========================================================================
+
+    /// Create a device with backing guest memory for command buffer / event log
+    /// testing. The memory layout:
+    ///   0x0000..0x0FFF = command buffer (4KB = 256 entries at log2=8)
+    ///   0x1000..0x1FFF = event log (4KB = 256 entries at log2=8)
+    ///   0x2000..0x2FFF = scratch space (for COMPLETION_WAIT store data)
+    fn create_test_device_with_memory() -> AmdIommuDevice {
+        let guest_memory = GuestMemory::allocate(0x10000);
+        let msi_conn =
+            pci_core::msi::MsiConnection::new(pci_core::bus_range::AssignedBusRange::new(), 0);
+        AmdIommuDevice::new(guest_memory, test_config(), msi_conn.target())
+    }
+
+    /// Configure and enable the IOMMU with command buffer and event log.
+    fn setup_iommu_enabled(dev: &mut AmdIommuDevice) {
+        // Command buffer at GPA 0x0000, 256 entries (log2=8).
+        let cmd_base = CmdBufBase::new()
+            .with_base_addr(0x0000 >> 12)
+            .with_length(8);
+        mmio_write64(
+            dev,
+            MmioRegister::CMD_BUF_BASE.0 as u64,
+            cmd_base.into_bits(),
+        );
+
+        // Event log at GPA 0x1000, 256 entries (log2=8).
+        let evt_base = EvtLogBase::new()
+            .with_base_addr(0x1000 >> 12)
+            .with_length(8);
+        mmio_write64(
+            dev,
+            MmioRegister::EVT_LOG_BASE.0 as u64,
+            evt_base.into_bits(),
+        );
+
+        // Enable IOMMU with command buffer, event log, and event interrupt.
+        let ctrl = IommuCtrl::new()
+            .with_iommu_en(true)
+            .with_cmd_buf_en(true)
+            .with_evt_log_en(true)
+            .with_evt_int_en(true)
+            .with_com_wait_int_en(true);
+        mmio_write64(dev, MmioRegister::IOMMU_CTRL.0 as u64, ctrl.into_bits());
+    }
+
+    #[test]
+    fn test_evtlog_write_and_read() {
+        let mut dev = create_test_device_with_memory();
+        setup_iommu_enabled(&mut dev);
+
+        // Write an IO_PAGE_FAULT event.
+        let event = EventEntry::io_page_fault(
+            0x0100, // device_id
+            0x0042, // domain_id
+            false,  // is_interrupt
+            true,   // is_write
+            0xDEAD_0000,
+        );
+        dev.write_event(event);
+
+        // Verify tail advanced by one entry (16 bytes).
+        let tail =
+            EvtLogTail::from_bits(mmio_read64(&mut dev, MmioRegister::EVT_LOG_TAIL.0 as u64));
+        assert_eq!(tail.tail_ptr(), 1, "tail should advance by one entry");
+
+        // Read the event back from guest memory.
+        let readback: EventEntry = dev
+            .shared
+            .guest_memory
+            .read_plain(0x1000) // event log base
+            .expect("should read event");
+        assert_eq!(readback.event_code(), EventCode::IO_PAGE_FAULT);
+        assert_eq!(readback.device_id(), 0x0100);
+    }
+
+    #[test]
+    fn test_evtlog_interrupt_signal() {
+        let mut dev = create_test_device_with_memory();
+        setup_iommu_enabled(&mut dev);
+
+        let event = EventEntry::io_page_fault(0x0100, 0x0042, false, false, 0x1000);
+        dev.write_event(event);
+
+        let status =
+            IommuStatus::from_bits(mmio_read64(&mut dev, MmioRegister::IOMMU_STATUS.0 as u64));
+        assert!(status.evt_log_int(), "EventLogInt should be set");
+    }
+
+    #[test]
+    fn test_evtlog_full() {
+        let mut dev = create_test_device_with_memory();
+        setup_iommu_enabled(&mut dev);
+
+        // Event log has 256 entries (log2=8). Fill it by writing 255 events
+        // (one slot is always empty to distinguish full from empty).
+        for i in 0..255 {
+            let event = EventEntry::io_page_fault(i as u16, 0x0001, false, false, 0x0);
+            dev.write_event(event);
+        }
+
+        // Verify tail is at 255 entries * 16 bytes / 16 = 255.
+        let tail =
+            EvtLogTail::from_bits(mmio_read64(&mut dev, MmioRegister::EVT_LOG_TAIL.0 as u64));
+        assert_eq!(tail.tail_ptr() as u64, 255);
+
+        // Clear EventLogInt so we can check the overflow path clearly.
+        mmio_write64(
+            &mut dev,
+            MmioRegister::IOMMU_STATUS.0 as u64,
+            IommuStatus::new().with_evt_log_int(true).into_bits(),
+        );
+
+        // One more event should trigger overflow.
+        let event = EventEntry::io_page_fault(0xFFFF, 0x0001, false, false, 0x0);
+        dev.write_event(event);
+
+        let status =
+            IommuStatus::from_bits(mmio_read64(&mut dev, MmioRegister::IOMMU_STATUS.0 as u64));
+        assert!(status.evt_overflow(), "EventOverflow should be set");
+
+        // Tail should NOT have advanced.
+        let tail =
+            EvtLogTail::from_bits(mmio_read64(&mut dev, MmioRegister::EVT_LOG_TAIL.0 as u64));
+        assert_eq!(tail.tail_ptr() as u64, 255);
+    }
+
+    #[test]
+    fn test_evtlog_head_frees_space() {
+        let mut dev = create_test_device_with_memory();
+        setup_iommu_enabled(&mut dev);
+
+        // Fill the event log (255 entries).
+        for i in 0..255 {
+            let event = EventEntry::io_page_fault(i as u16, 0x0001, false, false, 0x0);
+            dev.write_event(event);
+        }
+
+        // Advance head to consume one event.
+        let head = EvtLogHead::new().with_head_ptr(1);
+        mmio_write64(
+            &mut dev,
+            MmioRegister::EVT_LOG_HEAD.0 as u64,
+            head.into_bits(),
+        );
+
+        // Now there's space for one more event.
+        let event = EventEntry::io_page_fault(0xBEEF, 0x0001, false, false, 0x0);
+        dev.write_event(event);
+
+        // Tail should have advanced (wrapped to 0).
+        let tail =
+            EvtLogTail::from_bits(mmio_read64(&mut dev, MmioRegister::EVT_LOG_TAIL.0 as u64));
+        assert_eq!(tail.tail_ptr(), 0, "tail should wrap to 0");
+
+        let status =
+            IommuStatus::from_bits(mmio_read64(&mut dev, MmioRegister::IOMMU_STATUS.0 as u64));
+        assert!(!status.evt_overflow(), "no overflow after head frees space");
+    }
+
+    // =========================================================================
+    // Command Buffer Tests (1C)
+    // =========================================================================
+
+    /// Write a command entry to the command buffer at the given entry index.
+    fn write_cmd(dev: &AmdIommuDevice, index: u64, entry: &CommandEntry) {
+        let gpa = index * 16; // command buffer at GPA 0
+        dev.shared
+            .guest_memory
+            .write_plain(gpa, entry)
+            .expect("should write command");
+    }
+
+    /// Build a COMPLETION_WAIT command with the store flag set.
+    fn completion_wait_store(store_addr: u64, store_data: u64) -> CommandEntry {
+        // Build dw0/dw1 manually: opcode 0x01 in dw1[31:28], store flag in dw0[0],
+        // store address split across dw0[31:3] and dw1[19:0].
+        let dw0 = 0x01u32 // s=1
+            | ((store_addr >> 3) as u32 & 0x1FFF_FFFF) << 3; // StoreAddr[31:3]
+        let dw1 = (CommandOpcode::COMPLETION_WAIT.0 as u32) << 28
+            | ((store_addr >> 32) as u32 & 0x000F_FFFF); // StoreAddr[51:32]
+        CommandEntry {
+            dw0,
+            dw1,
+            dw2: store_data as u32,
+            dw3: (store_data >> 32) as u32,
+        }
+    }
+
+    /// Build a COMPLETION_WAIT command with the interrupt flag set.
+    fn completion_wait_interrupt() -> CommandEntry {
+        CommandEntry {
+            dw0: 0x02, // i=1 (bit 1)
+            dw1: (CommandOpcode::COMPLETION_WAIT.0 as u32) << 28,
+            dw2: 0,
+            dw3: 0,
+        }
+    }
+
+    /// Build an INVALIDATE_DEVTAB_ENTRY command for a given device ID.
+    fn invalidate_devtab_entry(device_id: u16) -> CommandEntry {
+        CommandEntry {
+            dw0: device_id as u32,
+            dw1: (CommandOpcode::INVALIDATE_DEVTAB_ENTRY.0 as u32) << 28,
+            dw2: 0,
+            dw3: 0,
+        }
+    }
+
+    /// Poke CmdBufTail to trigger command processing up to the given entry index.
+    fn poke_tail(dev: &mut AmdIommuDevice, entry_index: u64) {
+        let tail = CmdBufTail::new().with_tail_ptr(entry_index as u32);
+        mmio_write64(dev, MmioRegister::CMD_BUF_TAIL.0 as u64, tail.into_bits());
+    }
+
+    #[test]
+    fn test_cmdbuf_basic_consumption() {
+        let mut dev = create_test_device_with_memory();
+        setup_iommu_enabled(&mut dev);
+
+        // Write INVALIDATE_DEVTAB_ENTRY + COMPLETION_WAIT(S=1) to command buffer.
+        let store_addr: u64 = 0x2000;
+        let store_data: u64 = 0xCAFE_BABE_1234_5678;
+        write_cmd(&dev, 0, &invalidate_devtab_entry(0x0100));
+        write_cmd(&dev, 1, &completion_wait_store(store_addr, store_data));
+
+        // Poke tail to entry 2 (two commands).
+        poke_tail(&mut dev, 2);
+
+        // Head should have advanced to 2.
+        let head =
+            CmdBufHead::from_bits(mmio_read64(&mut dev, MmioRegister::CMD_BUF_HEAD.0 as u64));
+        assert_eq!(head.head_ptr(), 2, "head should advance to 2");
+
+        // Verify store data was written to guest memory.
+        let readback: u64 = dev
+            .shared
+            .guest_memory
+            .read_plain(store_addr)
+            .expect("should read store data");
+        assert_eq!(readback, store_data, "store data should match");
+    }
+
+    #[test]
+    fn test_cmdbuf_completion_wait_interrupt() {
+        let mut dev = create_test_device_with_memory();
+        setup_iommu_enabled(&mut dev);
+
+        write_cmd(&dev, 0, &completion_wait_interrupt());
+        poke_tail(&mut dev, 1);
+
+        let status =
+            IommuStatus::from_bits(mmio_read64(&mut dev, MmioRegister::IOMMU_STATUS.0 as u64));
+        assert!(
+            status.com_wait_int(),
+            "ComWaitInt should be set after COMPLETION_WAIT with I=1"
+        );
+    }
+
+    #[test]
+    fn test_cmdbuf_completion_wait_delivers_msi() {
+        // Create device with a connected MSI controller to verify actual
+        // MSI delivery (not just status bit).
+        let guest_memory = GuestMemory::allocate(0x10000);
+        let msi_conn =
+            pci_core::msi::MsiConnection::new(pci_core::bus_range::AssignedBusRange::new(), 0);
+        let msi_controller = pci_core::test_helpers::TestPciInterruptController::new();
+        msi_conn.connect(msi_controller.signal_msi());
+        let mut dev = AmdIommuDevice::new(guest_memory, test_config(), msi_conn.target());
+
+        // Enable MSI on the IOMMU's PCI config space.
+        // The MSI capability is the second capability. Find its offset.
+        let iommu_cap_header = pci_read(&mut dev, 0x40);
+        let msi_cap_offset = ((iommu_cap_header >> 8) & 0xFF) as u16;
+        assert_ne!(msi_cap_offset, 0, "MSI capability should exist");
+
+        // Configure MSI: address = 0xFEE00000, data = 0x41.
+        // Write address low (offset + 4).
+        let _ = dev.pci_cfg_write(msi_cap_offset + 4, 0xFEE0_0000);
+        // Write address high (offset + 8) — 64-bit capable.
+        let _ = dev.pci_cfg_write(msi_cap_offset + 8, 0);
+        // Write data (offset + 12 for 64-bit).
+        let _ = dev.pci_cfg_write(msi_cap_offset + 12, 0x41);
+        // Enable MSI (write control register at offset + 0, set enable bit).
+        let control = pci_read(&mut dev, msi_cap_offset);
+        let _ = dev.pci_cfg_write(msi_cap_offset, control | (1 << 16));
+
+        setup_iommu_enabled(&mut dev);
+
+        // No MSI should have been delivered yet.
+        assert!(
+            msi_controller.get_next_interrupt().is_none(),
+            "no MSI should be pending before COMPLETION_WAIT"
+        );
+
+        // Issue COMPLETION_WAIT with I=1 (interrupt flag).
+        write_cmd(&dev, 0, &completion_wait_interrupt());
+        poke_tail(&mut dev, 1);
+
+        // Verify ComWaitInt is set in status.
+        let status =
+            IommuStatus::from_bits(mmio_read64(&mut dev, MmioRegister::IOMMU_STATUS.0 as u64));
+        assert!(status.com_wait_int(), "ComWaitInt should be set");
+
+        // Verify the MSI was actually delivered to the controller.
+        let msi = msi_controller
+            .get_next_interrupt()
+            .expect("MSI should have been delivered");
+        assert_eq!(msi.0, 0xFEE0_0000, "MSI address should match");
+        assert_eq!(msi.1, 0x41, "MSI data should match");
+    }
+
+    #[test]
+    fn test_cmdbuf_wrap() {
+        let mut dev = create_test_device_with_memory();
+        setup_iommu_enabled(&mut dev);
+
+        // Command buffer has 256 entries (log2=8).
+        // Write a command at position 255 (last entry) and at position 0 (wrap).
+        let store_addr: u64 = 0x2000;
+        let store_data: u64 = 0xDEAD_BEEF;
+
+        // Set head to 255 (last entry).
+        dev.shared.state.write().cmd_buf_head = CmdBufHead::new().with_head_ptr(255).into_bits();
+
+        // Write command at entry 255 and entry 0 (wraps).
+        write_cmd(&dev, 255, &invalidate_devtab_entry(0x01));
+        write_cmd(&dev, 0, &completion_wait_store(store_addr, store_data));
+
+        // Set tail to 1 (which is past the wrap point from 255).
+        poke_tail(&mut dev, 1);
+
+        // Head should have wrapped to 1.
+        let head =
+            CmdBufHead::from_bits(mmio_read64(&mut dev, MmioRegister::CMD_BUF_HEAD.0 as u64));
+        assert_eq!(head.head_ptr(), 1, "head should wrap to 1");
+
+        // Verify store data was written.
+        let readback: u64 = dev
+            .shared
+            .guest_memory
+            .read_plain(store_addr)
+            .expect("should read store data");
+        assert_eq!(readback, store_data, "store data should match after wrap");
+    }
+
+    #[test]
+    fn test_cmdbuf_unknown_opcode() {
+        let mut dev = create_test_device_with_memory();
+        setup_iommu_enabled(&mut dev);
+
+        // Write a command with an invalid opcode (0x0F).
+        let bad_cmd = CommandEntry {
+            dw0: 0,
+            dw1: 0xF000_0000, // opcode = 0x0F
+            dw2: 0,
+            dw3: 0,
+        };
+        write_cmd(&dev, 0, &bad_cmd);
+        poke_tail(&mut dev, 1);
+
+        // CmdBufRun should be cleared (command buffer halted).
+        let status =
+            IommuStatus::from_bits(mmio_read64(&mut dev, MmioRegister::IOMMU_STATUS.0 as u64));
+        assert!(
+            !status.cmd_buf_run(),
+            "CmdBufRun should be clear after illegal command"
+        );
+
+        // Head should NOT have advanced (command was not consumed).
+        let head =
+            CmdBufHead::from_bits(mmio_read64(&mut dev, MmioRegister::CMD_BUF_HEAD.0 as u64));
+        assert_eq!(
+            head.head_ptr(),
+            0,
+            "head should not advance on illegal command"
+        );
+
+        // Event log should have an ILLEGAL_COMMAND_ERROR entry.
+        let tail =
+            EvtLogTail::from_bits(mmio_read64(&mut dev, MmioRegister::EVT_LOG_TAIL.0 as u64));
+        assert_eq!(tail.tail_ptr(), 1, "event log should have one entry");
+
+        let event: EventEntry = dev
+            .shared
+            .guest_memory
+            .read_plain(0x1000) // event log base
+            .expect("should read event");
+        assert_eq!(event.event_code(), EventCode::ILLEGAL_COMMAND_ERROR);
+    }
+
+    #[test]
+    fn test_cmdbuf_not_processed_when_disabled() {
+        let mut dev = create_test_device_with_memory();
+        // Do NOT enable the IOMMU.
+
+        // Configure command buffer base (while disabled, this is allowed).
+        let cmd_base = CmdBufBase::new()
+            .with_base_addr(0x0000 >> 12)
+            .with_length(8);
+        mmio_write64(
+            &mut dev,
+            MmioRegister::CMD_BUF_BASE.0 as u64,
+            cmd_base.into_bits(),
+        );
+
+        let store_addr: u64 = 0x2000;
+        let store_data: u64 = 0xBEEF;
+        write_cmd(&dev, 0, &completion_wait_store(store_addr, store_data));
+        poke_tail(&mut dev, 1);
+
+        // Head should not advance (IOMMU disabled).
+        let head =
+            CmdBufHead::from_bits(mmio_read64(&mut dev, MmioRegister::CMD_BUF_HEAD.0 as u64));
+        assert_eq!(
+            head.head_ptr(),
+            0,
+            "head should not advance when IOMMU disabled"
+        );
+
+        // Store data should NOT have been written.
+        let readback: u64 = dev
+            .shared
+            .guest_memory
+            .read_plain(store_addr)
+            .expect("should read");
+        assert_eq!(
+            readback, 0,
+            "store data should not be written when disabled"
+        );
+    }
+
+    #[test]
+    fn test_cmdbuf_multiple_commands() {
+        let mut dev = create_test_device_with_memory();
+        setup_iommu_enabled(&mut dev);
+
+        // Write 5 commands: 4 invalidates + 1 completion wait.
+        for i in 0..4 {
+            write_cmd(&dev, i, &invalidate_devtab_entry(i as u16));
+        }
+        let store_addr: u64 = 0x2000;
+        let store_data: u64 = 0x42;
+        write_cmd(&dev, 4, &completion_wait_store(store_addr, store_data));
+
+        poke_tail(&mut dev, 5);
+
+        // Head should advance to 5.
+        let head =
+            CmdBufHead::from_bits(mmio_read64(&mut dev, MmioRegister::CMD_BUF_HEAD.0 as u64));
+        assert_eq!(
+            head.head_ptr(),
+            5,
+            "head should advance past all 5 commands"
+        );
+
+        // Verify store data.
+        let readback: u64 = dev
+            .shared
+            .guest_memory
+            .read_plain(store_addr)
+            .expect("should read");
+        assert_eq!(readback, store_data);
+    }
+
+    #[test]
+    fn test_cmdbuf_invalidate_all() {
+        let mut dev = create_test_device_with_memory();
+        setup_iommu_enabled(&mut dev);
+
+        // INVALIDATE_IOMMU_ALL is a no-op but should be consumed successfully.
+        let cmd = CommandEntry {
+            dw0: 0,
+            dw1: (CommandOpcode::INVALIDATE_IOMMU_ALL.0 as u32) << 28,
+            dw2: 0,
+            dw3: 0,
+        };
+        write_cmd(&dev, 0, &cmd);
+        poke_tail(&mut dev, 1);
+
+        let head =
+            CmdBufHead::from_bits(mmio_read64(&mut dev, MmioRegister::CMD_BUF_HEAD.0 as u64));
+        assert_eq!(
+            head.head_ptr(),
+            1,
+            "INVALIDATE_IOMMU_ALL should be consumed"
+        );
+    }
+
+    #[test]
+    fn test_cmdbuf_completion_wait_store_and_interrupt() {
+        let mut dev = create_test_device_with_memory();
+        setup_iommu_enabled(&mut dev);
+
+        // Build a command with both S and I flags set.
+        let store_addr: u64 = 0x2000;
+        let store_data: u64 = 0xABCD_EF01;
+        let dw0 = 0x03u32 // s=1 (bit 0), i=1 (bit 1)
+            | ((store_addr >> 3) as u32 & 0x1FFF_FFFF) << 3;
+        let dw1 = (CommandOpcode::COMPLETION_WAIT.0 as u32) << 28
+            | ((store_addr >> 32) as u32 & 0x000F_FFFF);
+        let cmd = CommandEntry {
+            dw0,
+            dw1,
+            dw2: store_data as u32,
+            dw3: (store_data >> 32) as u32,
+        };
+        write_cmd(&dev, 0, &cmd);
+        poke_tail(&mut dev, 1);
+
+        // Verify store data.
+        let readback: u64 = dev
+            .shared
+            .guest_memory
+            .read_plain(store_addr)
+            .expect("should read");
+        assert_eq!(readback, store_data);
+
+        // Verify ComWaitInt is set.
+        let status =
+            IommuStatus::from_bits(mmio_read64(&mut dev, MmioRegister::IOMMU_STATUS.0 as u64));
+        assert!(status.com_wait_int(), "ComWaitInt should be set");
+    }
+
+    // =========================================================================
+    // DTE Lookup and DMA Translation Tests (1E)
+    // =========================================================================
+
+    /// Create a test device with enough guest memory for device table +
+    /// page tables (1MB).
+    fn create_test_device_for_translation() -> AmdIommuDevice {
+        let guest_memory = GuestMemory::allocate(0x10_0000); // 1MB
+        let msi_conn =
+            pci_core::msi::MsiConnection::new(pci_core::bus_range::AssignedBusRange::new(), 0);
+        AmdIommuDevice::new(guest_memory, test_config(), msi_conn.target())
+    }
+
+    /// Set up the IOMMU with a device table at a given GPA.
+    /// Returns the device table base GPA.
+    fn setup_iommu_with_devtab(dev: &mut AmdIommuDevice, devtab_gpa: u64, num_entries: u16) {
+        // Device table size field: (size+1) * 4096 / 32 = num_entries
+        // → size = num_entries * 32 / 4096 - 1
+        let size = (num_entries as u64 * DTE_SIZE as u64 / 4096).saturating_sub(1) as u16;
+        let dtb = DevTabBase::new()
+            .with_base_addr(devtab_gpa >> 12)
+            .with_size(size);
+        mmio_write64(dev, MmioRegister::DEV_TAB_BASE.0 as u64, dtb.into_bits());
+
+        // Command buffer at 0x8_0000, event log at 0x9_0000.
+        let cmd_base = CmdBufBase::new()
+            .with_base_addr(0x8_0000 >> 12)
+            .with_length(8);
+        mmio_write64(
+            dev,
+            MmioRegister::CMD_BUF_BASE.0 as u64,
+            cmd_base.into_bits(),
+        );
+        let evt_base = EvtLogBase::new()
+            .with_base_addr(0x9_0000 >> 12)
+            .with_length(8);
+        mmio_write64(
+            dev,
+            MmioRegister::EVT_LOG_BASE.0 as u64,
+            evt_base.into_bits(),
+        );
+
+        let ctrl = IommuCtrl::new()
+            .with_iommu_en(true)
+            .with_cmd_buf_en(true)
+            .with_evt_log_en(true);
+        mmio_write64(dev, MmioRegister::IOMMU_CTRL.0 as u64, ctrl.into_bits());
+    }
+
+    /// Write a DTE into guest memory at the device table.
+    fn write_dte(dev: &AmdIommuDevice, devtab_gpa: u64, device_id: u16, dte: &Dte) {
+        let dte_gpa = devtab_gpa + (device_id as u64) * (DTE_SIZE as u64);
+        dev.shared
+            .guest_memory
+            .write_plain(dte_gpa, dte)
+            .expect("write DTE");
+    }
+
+    /// Write a PTE into guest memory.
+    fn write_pte(dev: &AmdIommuDevice, table_gpa: u64, index: usize, pte: &IommuPte) {
+        let pte_gpa = table_gpa + (index as u64) * 8;
+        dev.shared
+            .guest_memory
+            .write_plain(pte_gpa, pte)
+            .expect("write PTE");
+    }
+
+    /// Build a simple DTE with translation enabled.
+    fn make_dte_with_translation(
+        pt_root_gpa: u64,
+        levels: u8,
+        ir: bool,
+        iw: bool,
+        domain_id: u16,
+    ) -> Dte {
+        use spec::dte::*;
+        Dte {
+            dw0: DteDw0::new()
+                .with_v(true)
+                .with_tv(true)
+                .with_mode(levels)
+                .with_host_pt_root_ptr(pt_root_gpa >> 12)
+                .with_ir(ir)
+                .with_iw(iw),
+            dw1: DteDw1::new().with_domain_id(domain_id),
+            dw2: DteDw2::new(),
+            dw3: 0,
+        }
+    }
+
+    /// Build a DTE with V=1, TV=0 (DMA aborted per spec Table 8).
+    fn make_dte_v1_tv0() -> Dte {
+        use spec::dte::*;
+        Dte {
+            dw0: DteDw0::new().with_v(true).with_tv(false),
+            dw1: DteDw1::new(),
+            dw2: DteDw2::new(),
+            dw3: 0,
+        }
+    }
+
+    #[test]
+    fn test_translate_tv0_aborts() {
+        let mut dev = create_test_device_for_translation();
+        let devtab_gpa = 0x1_0000;
+        setup_iommu_with_devtab(&mut dev, devtab_gpa, 256);
+
+        let dte = make_dte_v1_tv0();
+        write_dte(&dev, devtab_gpa, 0x01, &dte);
+
+        // Per spec Table 8: V=1, TV=0 → table walk terminated (target abort).
+        let result = dev.translate(0x01, 0x1234_5000, false);
+        assert!(result.is_err());
+        match result.unwrap_err() {
+            IommuFault::IoPageFault { device_id, .. } => {
+                assert_eq!(device_id, 0x01);
+            }
+            other => panic!("expected IoPageFault, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_translate_passthrough_mode0() {
+        let mut dev = create_test_device_for_translation();
+        let devtab_gpa = 0x1_0000;
+        setup_iommu_with_devtab(&mut dev, devtab_gpa, 256);
+
+        // DTE with V=1, TV=1, Mode=0 → pass-through.
+        let dte = make_dte_with_translation(0, 0, true, true, 1);
+        write_dte(&dev, devtab_gpa, 0x02, &dte);
+
+        let gpa = dev.translate(0x02, 0xABCD_0000, false).unwrap();
+        assert_eq!(gpa, 0xABCD_0000);
+    }
+
+    #[test]
+    fn test_translate_iommu_disabled() {
+        let dev = create_test_device_for_translation();
+        // Don't enable the IOMMU.
+
+        // Should pass through (identity mapping) when IOMMU is off.
+        let gpa = dev.translate(0x01, 0xDEAD_BEEF, false).unwrap();
+        assert_eq!(gpa, 0xDEAD_BEEF);
+    }
+
+    #[test]
+    fn test_translate_dte_v0_passthrough() {
+        let mut dev = create_test_device_for_translation();
+        let devtab_gpa = 0x1_0000;
+        setup_iommu_with_devtab(&mut dev, devtab_gpa, 256);
+
+        // DTE at device_id=0x03 is all zeros (V=0).
+        // Per spec §2.2.2 Table 8: V=0 → passthrough.
+        let gpa = dev.translate(0x03, 0x1000, false).unwrap();
+        assert_eq!(gpa, 0x1000);
+    }
+
+    #[test]
+    fn test_translate_device_id_out_of_range() {
+        let mut dev = create_test_device_for_translation();
+        let devtab_gpa = 0x1_0000;
+        // Only 128 entries.
+        setup_iommu_with_devtab(&mut dev, devtab_gpa, 128);
+
+        let result = dev.translate(200, 0x1000, false);
+        assert!(result.is_err());
+        match result.unwrap_err() {
+            IommuFault::IllegalDevTableEntry { device_id, .. } => {
+                assert_eq!(device_id, 200);
+            }
+            other => panic!("expected IllegalDevTableEntry, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_translate_4level() {
+        let mut dev = create_test_device_for_translation();
+        let devtab_gpa = 0x1_0000;
+        setup_iommu_with_devtab(&mut dev, devtab_gpa, 256);
+
+        // Set up a 4-level page table mapping IOVA 0x0 → GPA 0xA_0000.
+        //
+        // Memory layout:
+        //   L4 table at 0x2_0000
+        //   L3 table at 0x3_0000
+        //   L2 table at 0x4_0000
+        //   L1 table at 0x5_0000
+        //   Target page at GPA 0xA_0000
+        let l4_gpa = 0x2_0000u64;
+        let l3_gpa = 0x3_0000u64;
+        let l2_gpa = 0x4_0000u64;
+        let l1_gpa = 0x5_0000u64;
+        let target_gpa = 0xA_0000u64;
+
+        // L4[0] → L3 table (NextLevel=3, pointing to L3)
+        let pde_l4 = IommuPte::new()
+            .with_pr(true)
+            .with_next_level(3)
+            .with_address(l3_gpa >> 12)
+            .with_ir(true)
+            .with_iw(true);
+        write_pte(&dev, l4_gpa, 0, &pde_l4);
+
+        // L3[0] → L2 table (NextLevel=2, pointing to L2)
+        let pde_l3 = IommuPte::new()
+            .with_pr(true)
+            .with_next_level(2)
+            .with_address(l2_gpa >> 12)
+            .with_ir(true)
+            .with_iw(true);
+        write_pte(&dev, l3_gpa, 0, &pde_l3);
+
+        // L2[0] → L1 table (NextLevel=1, pointing to L1)
+        let pde_l2 = IommuPte::new()
+            .with_pr(true)
+            .with_next_level(1)
+            .with_address(l1_gpa >> 12)
+            .with_ir(true)
+            .with_iw(true);
+        write_pte(&dev, l2_gpa, 0, &pde_l2);
+
+        // L1[0] → target page (leaf, NextLevel=0)
+        let pte = IommuPte::new()
+            .with_pr(true)
+            .with_next_level(0)
+            .with_address(target_gpa >> 12)
+            .with_ir(true)
+            .with_iw(true);
+        write_pte(&dev, l1_gpa, 0, &pte);
+
+        // DTE: 4-level page table, root at L4.
+        let dte = make_dte_with_translation(l4_gpa, 4, true, true, 1);
+        write_dte(&dev, devtab_gpa, 0x10, &dte);
+
+        // Translate IOVA 0x0 → GPA 0xA_0000.
+        let gpa = dev.translate(0x10, 0x0, false).unwrap();
+        assert_eq!(gpa, target_gpa);
+    }
+
+    #[test]
+    fn test_translate_4level_with_offset() {
+        let mut dev = create_test_device_for_translation();
+        let devtab_gpa = 0x1_0000;
+        setup_iommu_with_devtab(&mut dev, devtab_gpa, 256);
+
+        let l4_gpa = 0x2_0000u64;
+        let l3_gpa = 0x3_0000u64;
+        let l2_gpa = 0x4_0000u64;
+        let l1_gpa = 0x5_0000u64;
+        let target_gpa = 0xA_0000u64;
+
+        write_pte(
+            &dev,
+            l4_gpa,
+            0,
+            &IommuPte::new()
+                .with_pr(true)
+                .with_next_level(3)
+                .with_address(l3_gpa >> 12)
+                .with_ir(true)
+                .with_iw(true),
+        );
+        write_pte(
+            &dev,
+            l3_gpa,
+            0,
+            &IommuPte::new()
+                .with_pr(true)
+                .with_next_level(2)
+                .with_address(l2_gpa >> 12)
+                .with_ir(true)
+                .with_iw(true),
+        );
+        write_pte(
+            &dev,
+            l2_gpa,
+            0,
+            &IommuPte::new()
+                .with_pr(true)
+                .with_next_level(1)
+                .with_address(l1_gpa >> 12)
+                .with_ir(true)
+                .with_iw(true),
+        );
+        write_pte(
+            &dev,
+            l1_gpa,
+            0,
+            &IommuPte::new()
+                .with_pr(true)
+                .with_next_level(0)
+                .with_address(target_gpa >> 12)
+                .with_ir(true)
+                .with_iw(true),
+        );
+
+        let dte = make_dte_with_translation(l4_gpa, 4, true, true, 1);
+        write_dte(&dev, devtab_gpa, 0x10, &dte);
+
+        // IOVA 0x123 → GPA 0xA_0123 (page offset preserved).
+        let gpa = dev.translate(0x10, 0x123, false).unwrap();
+        assert_eq!(gpa, target_gpa | 0x123);
+    }
+
+    #[test]
+    fn test_translate_3level() {
+        let mut dev = create_test_device_for_translation();
+        let devtab_gpa = 0x1_0000;
+        setup_iommu_with_devtab(&mut dev, devtab_gpa, 256);
+
+        // 3-level page table: L3→L2→L1→page
+        let l3_gpa = 0x3_0000u64;
+        let l2_gpa = 0x4_0000u64;
+        let l1_gpa = 0x5_0000u64;
+        let target_gpa = 0xA_0000u64;
+
+        write_pte(
+            &dev,
+            l3_gpa,
+            0,
+            &IommuPte::new()
+                .with_pr(true)
+                .with_next_level(2)
+                .with_address(l2_gpa >> 12)
+                .with_ir(true)
+                .with_iw(true),
+        );
+        write_pte(
+            &dev,
+            l2_gpa,
+            0,
+            &IommuPte::new()
+                .with_pr(true)
+                .with_next_level(1)
+                .with_address(l1_gpa >> 12)
+                .with_ir(true)
+                .with_iw(true),
+        );
+        write_pte(
+            &dev,
+            l1_gpa,
+            0,
+            &IommuPte::new()
+                .with_pr(true)
+                .with_next_level(0)
+                .with_address(target_gpa >> 12)
+                .with_ir(true)
+                .with_iw(true),
+        );
+
+        let dte = make_dte_with_translation(l3_gpa, 3, true, true, 1);
+        write_dte(&dev, devtab_gpa, 0x10, &dte);
+
+        let gpa = dev.translate(0x10, 0x0, false).unwrap();
+        assert_eq!(gpa, target_gpa);
+    }
+
+    #[test]
+    fn test_translate_2mb_large_page() {
+        let mut dev = create_test_device_for_translation();
+        let devtab_gpa = 0x1_0000;
+        setup_iommu_with_devtab(&mut dev, devtab_gpa, 256);
+
+        // 4-level page table with a 2MB large page at L2.
+        let l4_gpa = 0x2_0000u64;
+        let l3_gpa = 0x3_0000u64;
+        let l2_gpa = 0x4_0000u64;
+        // The large page maps IOVA 0x0 to GPA 0x20_0000 (2MB aligned).
+        let large_page_gpa = 0x20_0000u64;
+
+        write_pte(
+            &dev,
+            l4_gpa,
+            0,
+            &IommuPte::new()
+                .with_pr(true)
+                .with_next_level(3)
+                .with_address(l3_gpa >> 12)
+                .with_ir(true)
+                .with_iw(true),
+        );
+        write_pte(
+            &dev,
+            l3_gpa,
+            0,
+            &IommuPte::new()
+                .with_pr(true)
+                .with_next_level(2)
+                .with_address(l2_gpa >> 12)
+                .with_ir(true)
+                .with_iw(true),
+        );
+        // L2[0] is a leaf (NextLevel=0 at level 2 = 2MB large page).
+        write_pte(
+            &dev,
+            l2_gpa,
+            0,
+            &IommuPte::new()
+                .with_pr(true)
+                .with_next_level(0) // leaf at level 2 = 2MB page
+                .with_address(large_page_gpa >> 12)
+                .with_ir(true)
+                .with_iw(true),
+        );
+
+        let dte = make_dte_with_translation(l4_gpa, 4, true, true, 1);
+        write_dte(&dev, devtab_gpa, 0x10, &dte);
+
+        // IOVA 0x0 → GPA 0x20_0000.
+        let gpa = dev.translate(0x10, 0x0, false).unwrap();
+        assert_eq!(gpa, large_page_gpa);
+
+        // IOVA 0x1_2345 → GPA 0x21_2345 (offset within 2MB page preserved).
+        let gpa = dev.translate(0x10, 0x1_2345, false).unwrap();
+        assert_eq!(gpa, large_page_gpa | 0x1_2345);
+    }
+
+    /// Mirror Linux's `PAGE_SIZE_PTE` from `amd_iommu_types.h`:
+    /// `((address) | (pgsize - 1)) & ~(pgsize >> 1) & PM_ADDR_MASK`.
+    fn linux_page_size_pte_addr(paddr: u64, pgsize: u64) -> u64 {
+        const PM_ADDR_MASK: u64 = 0x000F_FFFF_FFFF_F000;
+        ((paddr | (pgsize - 1)) & !(pgsize >> 1)) & PM_ADDR_MASK
+    }
+
+    /// Linux's `PAGE_SIZE_PTE_COUNT`:
+    /// `1 << ((__ffs(pgsize) - 12) % 9)`.
+    fn linux_pte_count(pgsize: u64) -> usize {
+        let log2 = pgsize.trailing_zeros() as usize;
+        1 << ((log2 - 12) % 9)
+    }
+
+    /// End-to-end test for AMD IOMMU "mode 7" replicated large-page PTEs as
+    /// used by the Linux driver for non-default page sizes (e.g. 16 KiB).
+    ///
+    /// Linux's `iommu_v1_map_pages` writes a 16 KiB mapping as four identical
+    /// PTEs at the level-1 page table, each with `NextLevel = 7`, with the
+    /// page size encoded in the trailing 1-bits of the address field.
+    #[test]
+    fn test_translate_mode7_16k_large_page() {
+        let mut dev = create_test_device_for_translation();
+        let devtab_gpa = 0x1_0000;
+        setup_iommu_with_devtab(&mut dev, devtab_gpa, 256);
+
+        // 4-level page table. 16 KiB mapping at L1 (mode-7 encoded).
+        let l4_gpa = 0x2_0000u64;
+        let l3_gpa = 0x3_0000u64;
+        let l2_gpa = 0x4_0000u64;
+        let l1_gpa = 0x5_0000u64;
+        let pgsize = 0x4000u64; // 16 KiB
+        let target_gpa = 0x10_0000u64; // 16 KiB-aligned
+        let iova_base = 0x40_0000u64; // 16 KiB-aligned
+
+        // Build the chain L4 → L3 → L2 → L1.
+        write_pte(
+            &dev,
+            l4_gpa,
+            IommuPte::va_index(iova_base, 4),
+            &IommuPte::new()
+                .with_pr(true)
+                .with_next_level(3)
+                .with_address(l3_gpa >> 12)
+                .with_ir(true)
+                .with_iw(true),
+        );
+        write_pte(
+            &dev,
+            l3_gpa,
+            IommuPte::va_index(iova_base, 3),
+            &IommuPte::new()
+                .with_pr(true)
+                .with_next_level(2)
+                .with_address(l2_gpa >> 12)
+                .with_ir(true)
+                .with_iw(true),
+        );
+        write_pte(
+            &dev,
+            l2_gpa,
+            IommuPte::va_index(iova_base, 2),
+            &IommuPte::new()
+                .with_pr(true)
+                .with_next_level(1)
+                .with_address(l1_gpa >> 12)
+                .with_ir(true)
+                .with_iw(true),
+        );
+
+        // Linux writes the same level-7 PTE into `count` consecutive L1 slots.
+        let count = linux_pte_count(pgsize);
+        assert_eq!(count, 4);
+        let addr_field = linux_page_size_pte_addr(target_gpa, pgsize);
+        let leaf = IommuPte::new()
+            .with_pr(true)
+            .with_next_level(7) // mode-7 large-page marker
+            .with_address(addr_field >> 12)
+            .with_ir(true)
+            .with_iw(true)
+            .with_fc(true);
+        let base_index = IommuPte::va_index(iova_base, 1);
+        for i in 0..count {
+            write_pte(&dev, l1_gpa, base_index + i, &leaf);
+        }
+
+        let dte = make_dte_with_translation(l4_gpa, 4, true, true, 1);
+        write_dte(&dev, devtab_gpa, 0x10, &dte);
+
+        // Translate every 4 KiB offset within the 16 KiB region and verify
+        // the GPA is what Linux intended (preserving the IOVA offset
+        // within the 16 KiB large page). Without the mode-7 fix, GPAs
+        // would alias to the wrong 4 KiB sub-page.
+        for off in [0u64, 0x123, 0x1000, 0x1234, 0x2000, 0x2abc, 0x3000, 0x3fff] {
+            let iova = iova_base + off;
+            let gpa = dev.translate(0x10, iova, false).expect("translate ok");
+            assert_eq!(
+                gpa,
+                target_gpa + off,
+                "iova {:#x} should map to {:#x}, got {:#x}",
+                iova,
+                target_gpa + off,
+                gpa
+            );
+        }
+    }
+
+    /// Same as above but for a 64 KiB page (16 replicated PTEs at L1) —
+    /// the typical size for NVMe IO submission queues.
+    #[test]
+    fn test_translate_mode7_64k_large_page() {
+        let mut dev = create_test_device_for_translation();
+        let devtab_gpa = 0x1_0000;
+        setup_iommu_with_devtab(&mut dev, devtab_gpa, 256);
+
+        let l4_gpa = 0x2_0000u64;
+        let l3_gpa = 0x3_0000u64;
+        let l2_gpa = 0x4_0000u64;
+        let l1_gpa = 0x5_0000u64;
+        let pgsize = 0x10000u64; // 64 KiB
+        let target_gpa = 0x80_0000u64;
+        let iova_base = 0xC0_0000u64;
+
+        write_pte(
+            &dev,
+            l4_gpa,
+            IommuPte::va_index(iova_base, 4),
+            &IommuPte::new()
+                .with_pr(true)
+                .with_next_level(3)
+                .with_address(l3_gpa >> 12)
+                .with_ir(true)
+                .with_iw(true),
+        );
+        write_pte(
+            &dev,
+            l3_gpa,
+            IommuPte::va_index(iova_base, 3),
+            &IommuPte::new()
+                .with_pr(true)
+                .with_next_level(2)
+                .with_address(l2_gpa >> 12)
+                .with_ir(true)
+                .with_iw(true),
+        );
+        write_pte(
+            &dev,
+            l2_gpa,
+            IommuPte::va_index(iova_base, 2),
+            &IommuPte::new()
+                .with_pr(true)
+                .with_next_level(1)
+                .with_address(l1_gpa >> 12)
+                .with_ir(true)
+                .with_iw(true),
+        );
+
+        let count = linux_pte_count(pgsize);
+        assert_eq!(count, 16);
+        let addr_field = linux_page_size_pte_addr(target_gpa, pgsize);
+        let leaf = IommuPte::new()
+            .with_pr(true)
+            .with_next_level(7)
+            .with_address(addr_field >> 12)
+            .with_ir(true)
+            .with_iw(true);
+        let base_index = IommuPte::va_index(iova_base, 1);
+        for i in 0..count {
+            write_pte(&dev, l1_gpa, base_index + i, &leaf);
+        }
+
+        let dte = make_dte_with_translation(l4_gpa, 4, true, true, 1);
+        write_dte(&dev, devtab_gpa, 0x10, &dte);
+
+        // Endpoints, middles, and crossing-the-4 KiB-boundary offsets.
+        for off in [0u64, 0xFFF, 0x1000, 0x4000, 0x7000, 0xABCD, 0xFFFF] {
+            let iova = iova_base + off;
+            let gpa = dev.translate(0x10, iova, false).expect("translate ok");
+            assert_eq!(gpa, target_gpa + off);
+        }
+    }
+
+    /// Mode-7 large page at L2 (4 MiB) — Linux writes 2 replicated entries
+    /// in the level-2 table with the size encoded in the address field.
+    #[test]
+    fn test_translate_mode7_4m_at_l2() {
+        let mut dev = create_test_device_for_translation();
+        let devtab_gpa = 0x1_0000;
+        setup_iommu_with_devtab(&mut dev, devtab_gpa, 256);
+
+        let l4_gpa = 0x2_0000u64;
+        let l3_gpa = 0x3_0000u64;
+        let l2_gpa = 0x4_0000u64;
+        let pgsize = 0x40_0000u64; // 4 MiB
+        let target_gpa = 0x100_0000u64;
+        let iova_base = 0x200_0000u64;
+
+        write_pte(
+            &dev,
+            l4_gpa,
+            IommuPte::va_index(iova_base, 4),
+            &IommuPte::new()
+                .with_pr(true)
+                .with_next_level(3)
+                .with_address(l3_gpa >> 12)
+                .with_ir(true)
+                .with_iw(true),
+        );
+        write_pte(
+            &dev,
+            l3_gpa,
+            IommuPte::va_index(iova_base, 3),
+            &IommuPte::new()
+                .with_pr(true)
+                .with_next_level(2)
+                .with_address(l2_gpa >> 12)
+                .with_ir(true)
+                .with_iw(true),
+        );
+
+        let count = linux_pte_count(pgsize);
+        assert_eq!(count, 2);
+        let addr_field = linux_page_size_pte_addr(target_gpa, pgsize);
+        let leaf = IommuPte::new()
+            .with_pr(true)
+            .with_next_level(7)
+            .with_address(addr_field >> 12)
+            .with_ir(true)
+            .with_iw(true);
+        let base_index = IommuPte::va_index(iova_base, 2);
+        for i in 0..count {
+            write_pte(&dev, l2_gpa, base_index + i, &leaf);
+        }
+
+        let dte = make_dte_with_translation(l4_gpa, 4, true, true, 1);
+        write_dte(&dev, devtab_gpa, 0x10, &dte);
+
+        // Test a range of offsets across the 4 MiB region.
+        for off in [0u64, 0x1FFFFF, 0x20_0000, 0x3F_FFFF] {
+            let iova = iova_base + off;
+            let gpa = dev.translate(0x10, iova, false).expect("translate ok");
+            assert_eq!(
+                gpa,
+                target_gpa + off,
+                "iova {:#x} expected {:#x} got {:#x}",
+                iova,
+                target_gpa + off,
+                gpa
+            );
+        }
+    }
+
+    /// Read-only mode-7 page: writes must fault, reads must succeed.
+    #[test]
+    fn test_translate_mode7_read_only_denies_write() {
+        let mut dev = create_test_device_for_translation();
+        let devtab_gpa = 0x1_0000;
+        setup_iommu_with_devtab(&mut dev, devtab_gpa, 256);
+
+        let l4_gpa = 0x2_0000u64;
+        let l3_gpa = 0x3_0000u64;
+        let l2_gpa = 0x4_0000u64;
+        let l1_gpa = 0x5_0000u64;
+        let pgsize = 0x4000u64; // 16 KiB
+        let target_gpa = 0x10_0000u64;
+        let iova_base = 0x40_0000u64;
+
+        write_pte(
+            &dev,
+            l4_gpa,
+            IommuPte::va_index(iova_base, 4),
+            &IommuPte::new()
+                .with_pr(true)
+                .with_next_level(3)
+                .with_address(l3_gpa >> 12)
+                .with_ir(true)
+                .with_iw(true),
+        );
+        write_pte(
+            &dev,
+            l3_gpa,
+            IommuPte::va_index(iova_base, 3),
+            &IommuPte::new()
+                .with_pr(true)
+                .with_next_level(2)
+                .with_address(l2_gpa >> 12)
+                .with_ir(true)
+                .with_iw(true),
+        );
+        write_pte(
+            &dev,
+            l2_gpa,
+            IommuPte::va_index(iova_base, 2),
+            &IommuPte::new()
+                .with_pr(true)
+                .with_next_level(1)
+                .with_address(l1_gpa >> 12)
+                .with_ir(true)
+                .with_iw(true),
+        );
+
+        let count = linux_pte_count(pgsize);
+        let addr_field = linux_page_size_pte_addr(target_gpa, pgsize);
+        let leaf = IommuPte::new()
+            .with_pr(true)
+            .with_next_level(7)
+            .with_address(addr_field >> 12)
+            .with_ir(true) // read allowed
+            .with_iw(false); // write denied
+        let base_index = IommuPte::va_index(iova_base, 1);
+        for i in 0..count {
+            write_pte(&dev, l1_gpa, base_index + i, &leaf);
+        }
+
+        let dte = make_dte_with_translation(l4_gpa, 4, true, true, 1);
+        write_dte(&dev, devtab_gpa, 0x10, &dte);
+
+        // Read succeeds at any offset.
+        for off in [0u64, 0x2000, 0x3FFF] {
+            let gpa = dev
+                .translate(0x10, iova_base + off, false)
+                .expect("read ok");
+            assert_eq!(gpa, target_gpa + off);
+        }
+        // Write faults at any offset.
+        for off in [0u64, 0x2000, 0x3FFF] {
+            let err = dev
+                .translate(0x10, iova_base + off, true)
+                .expect_err("write must fault");
+            assert!(matches!(
+                err,
+                IommuFault::IoPageFault { is_write: true, .. }
+            ));
+        }
+    }
+
+    /// Write-only mode-7 page: reads must fault.
+    #[test]
+    fn test_translate_mode7_write_only_denies_read() {
+        let mut dev = create_test_device_for_translation();
+        let devtab_gpa = 0x1_0000;
+        setup_iommu_with_devtab(&mut dev, devtab_gpa, 256);
+
+        let l4_gpa = 0x2_0000u64;
+        let l3_gpa = 0x3_0000u64;
+        let l2_gpa = 0x4_0000u64;
+        let l1_gpa = 0x5_0000u64;
+        let pgsize = 0x4000u64;
+        let target_gpa = 0x10_0000u64;
+        let iova_base = 0x40_0000u64;
+
+        write_pte(
+            &dev,
+            l4_gpa,
+            IommuPte::va_index(iova_base, 4),
+            &IommuPte::new()
+                .with_pr(true)
+                .with_next_level(3)
+                .with_address(l3_gpa >> 12)
+                .with_ir(true)
+                .with_iw(true),
+        );
+        write_pte(
+            &dev,
+            l3_gpa,
+            IommuPte::va_index(iova_base, 3),
+            &IommuPte::new()
+                .with_pr(true)
+                .with_next_level(2)
+                .with_address(l2_gpa >> 12)
+                .with_ir(true)
+                .with_iw(true),
+        );
+        write_pte(
+            &dev,
+            l2_gpa,
+            IommuPte::va_index(iova_base, 2),
+            &IommuPte::new()
+                .with_pr(true)
+                .with_next_level(1)
+                .with_address(l1_gpa >> 12)
+                .with_ir(true)
+                .with_iw(true),
+        );
+
+        let count = linux_pte_count(pgsize);
+        let addr_field = linux_page_size_pte_addr(target_gpa, pgsize);
+        let leaf = IommuPte::new()
+            .with_pr(true)
+            .with_next_level(7)
+            .with_address(addr_field >> 12)
+            .with_ir(false) // read denied
+            .with_iw(true);
+        let base_index = IommuPte::va_index(iova_base, 1);
+        for i in 0..count {
+            write_pte(&dev, l1_gpa, base_index + i, &leaf);
+        }
+
+        let dte = make_dte_with_translation(l4_gpa, 4, true, true, 1);
+        write_dte(&dev, devtab_gpa, 0x10, &dte);
+
+        let gpa = dev.translate(0x10, iova_base + 0x1234, true).unwrap();
+        assert_eq!(gpa, target_gpa + 0x1234);
+        let err = dev
+            .translate(0x10, iova_base + 0x1234, false)
+            .expect_err("read must fault");
+        assert!(matches!(
+            err,
+            IommuFault::IoPageFault {
+                is_write: false,
+                ..
+            }
+        ));
+    }
+
+    /// PDE without write permission AND-accumulates with a fully-permissive
+    /// mode-7 PTE: writes must fault despite the leaf allowing them.
+    #[test]
+    fn test_translate_mode7_pde_permission_restricts() {
+        let mut dev = create_test_device_for_translation();
+        let devtab_gpa = 0x1_0000;
+        setup_iommu_with_devtab(&mut dev, devtab_gpa, 256);
+
+        let l4_gpa = 0x2_0000u64;
+        let l3_gpa = 0x3_0000u64;
+        let l2_gpa = 0x4_0000u64;
+        let l1_gpa = 0x5_0000u64;
+        let pgsize = 0x10000u64; // 64 KiB
+        let target_gpa = 0x20_0000u64;
+        let iova_base = 0x80_0000u64;
+
+        write_pte(
+            &dev,
+            l4_gpa,
+            IommuPte::va_index(iova_base, 4),
+            &IommuPte::new()
+                .with_pr(true)
+                .with_next_level(3)
+                .with_address(l3_gpa >> 12)
+                .with_ir(true)
+                .with_iw(true),
+        );
+        // L3 PDE: writes denied — must propagate.
+        write_pte(
+            &dev,
+            l3_gpa,
+            IommuPte::va_index(iova_base, 3),
+            &IommuPte::new()
+                .with_pr(true)
+                .with_next_level(2)
+                .with_address(l2_gpa >> 12)
+                .with_ir(true)
+                .with_iw(false),
+        );
+        write_pte(
+            &dev,
+            l2_gpa,
+            IommuPte::va_index(iova_base, 2),
+            &IommuPte::new()
+                .with_pr(true)
+                .with_next_level(1)
+                .with_address(l1_gpa >> 12)
+                .with_ir(true)
+                .with_iw(true),
+        );
+
+        let count = linux_pte_count(pgsize);
+        let addr_field = linux_page_size_pte_addr(target_gpa, pgsize);
+        let leaf = IommuPte::new()
+            .with_pr(true)
+            .with_next_level(7)
+            .with_address(addr_field >> 12)
+            .with_ir(true)
+            .with_iw(true); // leaf allows write, but PDE doesn't
+        let base_index = IommuPte::va_index(iova_base, 1);
+        for i in 0..count {
+            write_pte(&dev, l1_gpa, base_index + i, &leaf);
+        }
+
+        let dte = make_dte_with_translation(l4_gpa, 4, true, true, 1);
+        write_dte(&dev, devtab_gpa, 0x10, &dte);
+
+        // Read still works.
+        let gpa = dev.translate(0x10, iova_base + 0x4321, false).unwrap();
+        assert_eq!(gpa, target_gpa + 0x4321);
+        // Write faults because of L3 PDE.
+        let err = dev
+            .translate(0x10, iova_base + 0x4321, true)
+            .expect_err("write must fault");
+        assert!(matches!(
+            err,
+            IommuFault::IoPageFault { is_write: true, .. }
+        ));
+    }
+
+    /// Two adjacent 16 KiB mode-7 mappings must each return their own GPA;
+    /// the page-size mask must not leak across region boundaries.
+    #[test]
+    fn test_translate_mode7_adjacent_mappings_independent() {
+        let mut dev = create_test_device_for_translation();
+        let devtab_gpa = 0x1_0000;
+        setup_iommu_with_devtab(&mut dev, devtab_gpa, 256);
+
+        let l4_gpa = 0x2_0000u64;
+        let l3_gpa = 0x3_0000u64;
+        let l2_gpa = 0x4_0000u64;
+        let l1_gpa = 0x5_0000u64;
+        let pgsize = 0x4000u64; // 16 KiB
+        let target_a = 0x10_0000u64;
+        let target_b = 0x20_0000u64;
+        let iova_a = 0x40_0000u64;
+        let iova_b = iova_a + pgsize; // immediately adjacent
+
+        // L4 → L3 → L2 → L1.
+        write_pte(
+            &dev,
+            l4_gpa,
+            IommuPte::va_index(iova_a, 4),
+            &IommuPte::new()
+                .with_pr(true)
+                .with_next_level(3)
+                .with_address(l3_gpa >> 12)
+                .with_ir(true)
+                .with_iw(true),
+        );
+        write_pte(
+            &dev,
+            l3_gpa,
+            IommuPte::va_index(iova_a, 3),
+            &IommuPte::new()
+                .with_pr(true)
+                .with_next_level(2)
+                .with_address(l2_gpa >> 12)
+                .with_ir(true)
+                .with_iw(true),
+        );
+        write_pte(
+            &dev,
+            l2_gpa,
+            IommuPte::va_index(iova_a, 2),
+            &IommuPte::new()
+                .with_pr(true)
+                .with_next_level(1)
+                .with_address(l1_gpa >> 12)
+                .with_ir(true)
+                .with_iw(true),
+        );
+
+        let count = linux_pte_count(pgsize);
+        // Region A: 4 replicated PTEs.
+        let leaf_a = IommuPte::new()
+            .with_pr(true)
+            .with_next_level(7)
+            .with_address(linux_page_size_pte_addr(target_a, pgsize) >> 12)
+            .with_ir(true)
+            .with_iw(true);
+        let base_a = IommuPte::va_index(iova_a, 1);
+        for i in 0..count {
+            write_pte(&dev, l1_gpa, base_a + i, &leaf_a);
+        }
+        // Region B: 4 replicated PTEs, immediately after region A.
+        let leaf_b = IommuPte::new()
+            .with_pr(true)
+            .with_next_level(7)
+            .with_address(linux_page_size_pte_addr(target_b, pgsize) >> 12)
+            .with_ir(true)
+            .with_iw(true);
+        let base_b = IommuPte::va_index(iova_b, 1);
+        for i in 0..count {
+            write_pte(&dev, l1_gpa, base_b + i, &leaf_b);
+        }
+
+        let dte = make_dte_with_translation(l4_gpa, 4, true, true, 1);
+        write_dte(&dev, devtab_gpa, 0x10, &dte);
+
+        // Last byte of region A.
+        let gpa = dev
+            .translate(0x10, iova_a + pgsize - 1, false)
+            .expect("translate ok");
+        assert_eq!(gpa, target_a + pgsize - 1);
+        // First byte of region B — must go to target_b, not target_a + pgsize.
+        let gpa = dev.translate(0x10, iova_b, false).expect("translate ok");
+        assert_eq!(gpa, target_b);
+        // Middle of region B.
+        let gpa = dev
+            .translate(0x10, iova_b + 0x2345, false)
+            .expect("translate ok");
+        assert_eq!(gpa, target_b + 0x2345);
+    }
+
+    /// A malformed mode-7 PTE with no zero bit in the address field
+    /// (all-ones encoding) must produce a fault, not a panic or garbage GPA.
+    #[test]
+    fn test_translate_mode7_malformed_address_field_faults() {
+        let mut dev = create_test_device_for_translation();
+        let devtab_gpa = 0x1_0000;
+        setup_iommu_with_devtab(&mut dev, devtab_gpa, 256);
+
+        let l1_gpa = 0x5_0000u64;
+        // All-ones address field: ffz finds no zero bit ≤ 51 → fault.
+        let leaf = IommuPte::new()
+            .with_pr(true)
+            .with_next_level(7)
+            .with_address((1u64 << 40) - 1) // all 40 bits set
+            .with_ir(true)
+            .with_iw(true);
+        write_pte(&dev, l1_gpa, 0, &leaf);
+
+        let dte = make_dte_with_translation(l1_gpa, 1, true, true, 1);
+        write_dte(&dev, devtab_gpa, 0x10, &dte);
+
+        let err = dev
+            .translate(0x10, 0x0, false)
+            .expect_err("malformed mode-7 PTE must fault");
+        assert!(matches!(err, IommuFault::IoPageFault { .. }));
+    }
+
+    /// Mode-7 at L3: smallest non-default size is 2 GiB (count = 2). Verify
+    /// the page walk handles huge mode-7 pages above the L2 default.
+    #[test]
+    fn test_translate_mode7_2g_at_l3() {
+        let mut dev = create_test_device_for_translation();
+        let devtab_gpa = 0x1_0000;
+        setup_iommu_with_devtab(&mut dev, devtab_gpa, 256);
+
+        let l4_gpa = 0x2_0000u64;
+        let l3_gpa = 0x3_0000u64;
+        let pgsize = 0x8000_0000u64; // 2 GiB
+        let target_gpa = 0x4_0000_0000u64; // 16 GiB, 2 GiB-aligned
+        let iova_base = 0x8_0000_0000u64; // 32 GiB, 2 GiB-aligned
+
+        write_pte(
+            &dev,
+            l4_gpa,
+            IommuPte::va_index(iova_base, 4),
+            &IommuPte::new()
+                .with_pr(true)
+                .with_next_level(3)
+                .with_address(l3_gpa >> 12)
+                .with_ir(true)
+                .with_iw(true),
+        );
+
+        let count = linux_pte_count(pgsize);
+        assert_eq!(count, 2);
+        let addr_field = linux_page_size_pte_addr(target_gpa, pgsize);
+        let leaf = IommuPte::new()
+            .with_pr(true)
+            .with_next_level(7)
+            .with_address(addr_field >> 12)
+            .with_ir(true)
+            .with_iw(true);
+        let base_index = IommuPte::va_index(iova_base, 3);
+        for i in 0..count {
+            write_pte(&dev, l3_gpa, base_index + i, &leaf);
+        }
+
+        let dte = make_dte_with_translation(l4_gpa, 4, true, true, 1);
+        write_dte(&dev, devtab_gpa, 0x10, &dte);
+
+        // Test across the 2 GiB region, including past the 1 GiB L3-default
+        // boundary so a mistaken use of L3's natural mask would alias.
+        for off in [0u64, 0x3FFF_FFFF, 0x4000_0000, 0x7FFF_FFFF] {
+            let iova = iova_base + off;
+            let gpa = dev.translate(0x10, iova, false).expect("translate ok");
+            assert_eq!(
+                gpa,
+                target_gpa + off,
+                "iova {:#x} expected {:#x} got {:#x}",
+                iova,
+                target_gpa + off,
+                gpa
+            );
+        }
+    }
+
+    /// Target GPA with non-trivial high bits in the same byte-range as the
+    /// page-size encoding. Confirms the encode-decode round trip recovers the
+    /// real base even when the address field has bits set above the size
+    /// marker.
+    #[test]
+    fn test_translate_mode7_target_with_nontrivial_bits() {
+        let mut dev = create_test_device_for_translation();
+        let devtab_gpa = 0x1_0000;
+        setup_iommu_with_devtab(&mut dev, devtab_gpa, 256);
+
+        let l4_gpa = 0x2_0000u64;
+        let l3_gpa = 0x3_0000u64;
+        let l2_gpa = 0x4_0000u64;
+        let l1_gpa = 0x5_0000u64;
+        let pgsize = 0x4000u64; // 16 KiB
+        // target_gpa has bit 14 set (above the size marker at bit 13). It
+        // is still 16 KiB-aligned (0x10_4000 / 0x4000 = 0x41).
+        let target_gpa = 0x10_4000u64;
+        let iova_base = 0x40_0000u64;
+
+        write_pte(
+            &dev,
+            l4_gpa,
+            IommuPte::va_index(iova_base, 4),
+            &IommuPte::new()
+                .with_pr(true)
+                .with_next_level(3)
+                .with_address(l3_gpa >> 12)
+                .with_ir(true)
+                .with_iw(true),
+        );
+        write_pte(
+            &dev,
+            l3_gpa,
+            IommuPte::va_index(iova_base, 3),
+            &IommuPte::new()
+                .with_pr(true)
+                .with_next_level(2)
+                .with_address(l2_gpa >> 12)
+                .with_ir(true)
+                .with_iw(true),
+        );
+        write_pte(
+            &dev,
+            l2_gpa,
+            IommuPte::va_index(iova_base, 2),
+            &IommuPte::new()
+                .with_pr(true)
+                .with_next_level(1)
+                .with_address(l1_gpa >> 12)
+                .with_ir(true)
+                .with_iw(true),
+        );
+
+        let count = linux_pte_count(pgsize);
+        let addr_field = linux_page_size_pte_addr(target_gpa, pgsize);
+        // The Linux encoding sets bit 12 (the size marker is bit 13, cleared).
+        // Sanity-check the encoded field still recovers the target.
+        assert_eq!(addr_field & !(pgsize - 1), target_gpa);
+        let leaf = IommuPte::new()
+            .with_pr(true)
+            .with_next_level(7)
+            .with_address(addr_field >> 12)
+            .with_ir(true)
+            .with_iw(true);
+        let base_index = IommuPte::va_index(iova_base, 1);
+        for i in 0..count {
+            write_pte(&dev, l1_gpa, base_index + i, &leaf);
+        }
+
+        let dte = make_dte_with_translation(l4_gpa, 4, true, true, 1);
+        write_dte(&dev, devtab_gpa, 0x10, &dte);
+
+        for off in [0u64, 0xFFF, 0x1000, 0x2ABC, 0x3FFF] {
+            let iova = iova_base + off;
+            let gpa = dev.translate(0x10, iova, false).expect("translate ok");
+            assert_eq!(gpa, target_gpa + off);
+        }
+    }
+
+    #[test]
+    fn test_translate_page_not_present() {
+        let mut dev = create_test_device_for_translation();
+        let devtab_gpa = 0x1_0000;
+        setup_iommu_with_devtab(&mut dev, devtab_gpa, 256);
+
+        // 1-level page table with no entries (all zeros = not present).
+        let l1_gpa = 0x5_0000u64;
+        let dte = make_dte_with_translation(l1_gpa, 1, true, true, 1);
+        write_dte(&dev, devtab_gpa, 0x10, &dte);
+
+        let result = dev.translate(0x10, 0x1000, false);
+        assert!(result.is_err());
+        match result.unwrap_err() {
+            IommuFault::IoPageFault {
+                device_id,
+                domain_id,
+                address,
+                ..
+            } => {
+                assert_eq!(device_id, 0x10);
+                assert_eq!(domain_id, 1);
+                assert_eq!(address, 0x1000);
+            }
+            other => panic!("expected IoPageFault, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_translate_write_permission_denied() {
+        let mut dev = create_test_device_for_translation();
+        let devtab_gpa = 0x1_0000;
+        setup_iommu_with_devtab(&mut dev, devtab_gpa, 256);
+
+        // 1-level page table, read-only (IR=1, IW=0).
+        let l1_gpa = 0x5_0000u64;
+        let target_gpa = 0xA_0000u64;
+
+        write_pte(
+            &dev,
+            l1_gpa,
+            0,
+            &IommuPte::new()
+                .with_pr(true)
+                .with_next_level(0)
+                .with_address(target_gpa >> 12)
+                .with_ir(true)
+                .with_iw(false), // No write permission
+        );
+
+        // DTE allows IR and IW, but PTE only allows IR.
+        let dte = make_dte_with_translation(l1_gpa, 1, true, true, 1);
+        write_dte(&dev, devtab_gpa, 0x10, &dte);
+
+        // Read should succeed.
+        let gpa = dev.translate(0x10, 0x0, false).unwrap();
+        assert_eq!(gpa, target_gpa);
+
+        // Write should fail.
+        let result = dev.translate(0x10, 0x0, true);
+        assert!(result.is_err());
+        match result.unwrap_err() {
+            IommuFault::IoPageFault { is_write, .. } => {
+                assert!(is_write);
+            }
+            other => panic!("expected IoPageFault, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_translate_read_permission_denied() {
+        let mut dev = create_test_device_for_translation();
+        let devtab_gpa = 0x1_0000;
+        setup_iommu_with_devtab(&mut dev, devtab_gpa, 256);
+
+        // 1-level page table, write-only (IR=0, IW=1).
+        let l1_gpa = 0x5_0000u64;
+        let target_gpa = 0xA_0000u64;
+
+        write_pte(
+            &dev,
+            l1_gpa,
+            0,
+            &IommuPte::new()
+                .with_pr(true)
+                .with_next_level(0)
+                .with_address(target_gpa >> 12)
+                .with_ir(false) // No read permission
+                .with_iw(true),
+        );
+
+        let dte = make_dte_with_translation(l1_gpa, 1, true, true, 1);
+        write_dte(&dev, devtab_gpa, 0x10, &dte);
+
+        // Read should fail.
+        let result = dev.translate(0x10, 0x0, false);
+        assert!(result.is_err());
+        match result.unwrap_err() {
+            IommuFault::IoPageFault { is_write, .. } => {
+                assert!(!is_write);
+            }
+            other => panic!("expected IoPageFault, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_translate_dte_permission_restricts() {
+        let mut dev = create_test_device_for_translation();
+        let devtab_gpa = 0x1_0000;
+        setup_iommu_with_devtab(&mut dev, devtab_gpa, 256);
+
+        // PTE has full permissions, but DTE restricts write.
+        let l1_gpa = 0x5_0000u64;
+        let target_gpa = 0xA_0000u64;
+
+        write_pte(
+            &dev,
+            l1_gpa,
+            0,
+            &IommuPte::new()
+                .with_pr(true)
+                .with_next_level(0)
+                .with_address(target_gpa >> 12)
+                .with_ir(true)
+                .with_iw(true),
+        );
+
+        // DTE: IR=1, IW=0 (read-only at DTE level).
+        let dte = make_dte_with_translation(l1_gpa, 1, true, false, 1);
+        write_dte(&dev, devtab_gpa, 0x10, &dte);
+
+        // Read should succeed.
+        let gpa = dev.translate(0x10, 0x0, false).unwrap();
+        assert_eq!(gpa, target_gpa);
+
+        // Write should fail (DTE restricts IW).
+        let result = dev.translate(0x10, 0x0, true);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_translate_reserved_mode7() {
+        let mut dev = create_test_device_for_translation();
+        let devtab_gpa = 0x1_0000;
+        setup_iommu_with_devtab(&mut dev, devtab_gpa, 256);
+
+        // DTE with Mode=7 (reserved) should fault.
+        let dte = make_dte_with_translation(0, 7, true, true, 1);
+        write_dte(&dev, devtab_gpa, 0x10, &dte);
+
+        let result = dev.translate(0x10, 0x0, false);
+        assert!(result.is_err());
+        match result.unwrap_err() {
+            IommuFault::IllegalDevTableEntry { device_id, .. } => {
+                assert_eq!(device_id, 0x10);
+            }
+            other => panic!("expected IllegalDevTableEntry, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_translate_iova_offset_preserved() {
+        let mut dev = create_test_device_for_translation();
+        let devtab_gpa = 0x1_0000;
+        setup_iommu_with_devtab(&mut dev, devtab_gpa, 256);
+
+        // 1-level page table mapping IOVA page 0 → GPA 0xB_0000.
+        let l1_gpa = 0x5_0000u64;
+        let target_gpa = 0xB_0000u64;
+
+        write_pte(
+            &dev,
+            l1_gpa,
+            0,
+            &IommuPte::new()
+                .with_pr(true)
+                .with_next_level(0)
+                .with_address(target_gpa >> 12)
+                .with_ir(true)
+                .with_iw(true),
+        );
+
+        let dte = make_dte_with_translation(l1_gpa, 1, true, true, 1);
+        write_dte(&dev, devtab_gpa, 0x10, &dte);
+
+        // Various offsets within the 4KB page should be preserved.
+        for offset in [0u64, 1, 0x100, 0x7FF, 0xFFF] {
+            let gpa = dev.translate(0x10, offset, false).unwrap();
+            assert_eq!(
+                gpa,
+                target_gpa | offset,
+                "offset 0x{:x} not preserved",
+                offset
+            );
+        }
+    }
+
+    #[test]
+    fn test_translate_fault_to_event() {
+        // Test that IommuFault::to_event_entry produces correct event entries.
+        let fault = IommuFault::IoPageFault {
+            device_id: 0x0100,
+            domain_id: 0x0042,
+            address: 0xDEAD_0000,
+            is_write: true,
+        };
+        let event = fault.to_event_entry();
+        assert_eq!(event.event_code(), EventCode::IO_PAGE_FAULT);
+        assert_eq!(event.device_id(), 0x0100);
+
+        let fault = IommuFault::IllegalDevTableEntry {
+            device_id: 0x0200,
+            address: 0x1000,
+            is_interrupt: false,
+            is_write: true,
+        };
+        let event = fault.to_event_entry();
+        assert_eq!(event.event_code(), EventCode::ILLEGAL_DEV_TABLE_ENTRY);
+        assert_eq!(event.device_id(), 0x0200);
+
+        let fault = IommuFault::DevTabHardwareError {
+            device_id: 0x0300,
+            address: 0x2000,
+        };
+        let event = fault.to_event_entry();
+        assert_eq!(event.event_code(), EventCode::DEV_TAB_HARDWARE_ERROR);
+        assert_eq!(event.device_id(), 0x0300);
+
+        let fault = IommuFault::PageTabHardwareError {
+            device_id: 0x0400,
+            address: 0x3000,
+        };
+        let event = fault.to_event_entry();
+        assert_eq!(event.event_code(), EventCode::PAGE_TAB_HARDWARE_ERROR);
+        assert_eq!(event.device_id(), 0x0400);
+    }
+
+    // =========================================================================
+    // Interrupt Remapping Tests (1F)
+    // =========================================================================
+
+    /// Build a DTE with interrupt remapping configured.
+    fn make_dte_with_interrupt_remap(irt_base_gpa: u64, int_tab_len: u8, int_ctl: u8) -> Dte {
+        use spec::dte::*;
+        Dte {
+            dw0: DteDw0::new().with_v(true).with_tv(false),
+            dw1: DteDw1::new().with_domain_id(1),
+            dw2: DteDw2::new()
+                .with_iv(true)
+                .with_int_tab_len(int_tab_len)
+                .with_int_tab_root_ptr(irt_base_gpa >> 6)
+                .with_int_ctl(int_ctl),
+            dw3: 0,
+        }
+    }
+
+    /// Write an IRTE into guest memory.
+    fn write_irte(dev: &AmdIommuDevice, irt_base_gpa: u64, index: u32, irte: &Irte) {
+        let irte_gpa = irt_base_gpa + (index as u64) * (IRTE_SIZE as u64);
+        dev.shared
+            .guest_memory
+            .write_plain(irte_gpa, irte)
+            .expect("write IRTE");
+    }
+
+    #[test]
+    fn test_irte_lookup_valid() {
+        let mut dev = create_test_device_for_translation();
+        let devtab_gpa = 0x1_0000;
+        setup_iommu_with_devtab(&mut dev, devtab_gpa, 256);
+
+        // IRT at 0xA_0000, 128-byte aligned (required by spec).
+        let irt_gpa = 0xA_0000u64;
+        let irte = Irte::new()
+            .with_remap_en(true)
+            .with_int_type(0) // Fixed
+            .with_dm(false) // Physical destination
+            .with_destination(3)
+            .with_vector(0x40);
+        write_irte(&dev, irt_gpa, 0, &irte);
+
+        // DTE with IntCtl=Remap, IntTabLen=4 (16 entries), IV=1.
+        let dte = make_dte_with_interrupt_remap(irt_gpa, 4, IntCtl::REMAP.0);
+        write_dte(&dev, devtab_gpa, 0x10, &dte);
+
+        // MSI data index = 0 → look up IRTE at index 0.
+        let result = dev.lookup_irte(0x10, &dte, 0);
+        let irte_out = result.unwrap();
+        assert_eq!(irte_out.vector, 0x40);
+        assert_eq!(irte_out.destination, 3);
+        assert!(!irte_out.dm);
+    }
+
+    #[test]
+    fn test_irte_lookup_invalid_remap_disabled() {
+        let mut dev = create_test_device_for_translation();
+        let devtab_gpa = 0x1_0000;
+        setup_iommu_with_devtab(&mut dev, devtab_gpa, 256);
+
+        let irt_gpa = 0xA_0000u64;
+        // IRTE with RemapEn=0.
+        let irte = Irte::new().with_remap_en(false).with_vector(0x40);
+        write_irte(&dev, irt_gpa, 0, &irte);
+
+        let dte = make_dte_with_interrupt_remap(irt_gpa, 4, IntCtl::REMAP.0);
+        write_dte(&dev, devtab_gpa, 0x10, &dte);
+
+        let result = dev.lookup_irte(0x10, &dte, 0);
+        assert!(result.is_err());
+        match result.unwrap_err() {
+            IommuFault::IoPageFault { device_id, .. } => {
+                assert_eq!(device_id, 0x10);
+            }
+            other => panic!("expected IoPageFault, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_irte_lookup_index_out_of_range() {
+        let mut dev = create_test_device_for_translation();
+        let devtab_gpa = 0x1_0000;
+        setup_iommu_with_devtab(&mut dev, devtab_gpa, 256);
+
+        let irt_gpa = 0xA_0000u64;
+        // IntTabLen=2 → 4 entries (2^2). Index 5 is out of range.
+        let dte = make_dte_with_interrupt_remap(irt_gpa, 2, IntCtl::REMAP.0);
+        write_dte(&dev, devtab_gpa, 0x10, &dte);
+
+        let result = dev.lookup_irte(0x10, &dte, 5);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_irte_lookup_iv_not_set() {
+        let mut dev = create_test_device_for_translation();
+        let devtab_gpa = 0x1_0000;
+        setup_iommu_with_devtab(&mut dev, devtab_gpa, 256);
+
+        // DTE with IV=0 (interrupt map not valid).
+        use spec::dte::*;
+        let dte = Dte {
+            dw0: DteDw0::new().with_v(true).with_tv(false),
+            dw1: DteDw1::new(),
+            dw2: DteDw2::new().with_iv(false).with_int_ctl(IntCtl::REMAP.0),
+            dw3: 0,
+        };
+        write_dte(&dev, devtab_gpa, 0x10, &dte);
+
+        let result = dev.lookup_irte(0x10, &dte, 0);
+        assert!(result.is_err());
+        match result.unwrap_err() {
+            IommuFault::IllegalDevTableEntry {
+                device_id,
+                is_interrupt,
+                ..
+            } => {
+                assert_eq!(device_id, 0x10);
+                assert!(is_interrupt);
+            }
+            other => panic!("expected IllegalDevTableEntry, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_remap_msi_basic() {
+        let mut dev = create_test_device_for_translation();
+        let devtab_gpa = 0x1_0000;
+        setup_iommu_with_devtab(&mut dev, devtab_gpa, 256);
+
+        let irt_gpa = 0xA_0000u64;
+        // Set up IRTE at index 0x30: remap to vector 0x40, destination 3, fixed.
+        let irte = Irte::new()
+            .with_remap_en(true)
+            .with_int_type(0) // Fixed
+            .with_dm(false) // Physical
+            .with_destination(3)
+            .with_vector(0x40);
+        write_irte(&dev, irt_gpa, 0x30, &irte);
+
+        let dte = make_dte_with_interrupt_remap(irt_gpa, 8, IntCtl::REMAP.0);
+        write_dte(&dev, devtab_gpa, 0x10, &dte);
+
+        // Original MSI: vector 0x30, destination 0, fixed.
+        let orig_addr = 0xFEE0_0000u64;
+        let orig_data = 0x30u32; // data[10:0] = 0x30 = IRTE index
+
+        let (new_addr, new_data) = dev.remap_msi(0x10, orig_addr, orig_data).unwrap();
+
+        // Remapped: vector 0x40, destination 3, physical.
+        assert_eq!(new_addr, 0xFEE0_0000 | (3u64 << 12)); // dest=3
+        assert_eq!(new_data & 0xFF, 0x40); // vector
+        assert_eq!((new_data >> 8) & 0x7, 0); // delivery mode = Fixed
+    }
+
+    #[test]
+    fn test_remap_msi_logical_destination() {
+        let mut dev = create_test_device_for_translation();
+        let devtab_gpa = 0x1_0000;
+        setup_iommu_with_devtab(&mut dev, devtab_gpa, 256);
+
+        let irt_gpa = 0xA_0000u64;
+        let irte = Irte::new()
+            .with_remap_en(true)
+            .with_int_type(0) // Fixed
+            .with_dm(true) // Logical destination
+            .with_destination(0xFF)
+            .with_vector(0x50);
+        write_irte(&dev, irt_gpa, 0, &irte);
+
+        let dte = make_dte_with_interrupt_remap(irt_gpa, 4, IntCtl::REMAP.0);
+        write_dte(&dev, devtab_gpa, 0x10, &dte);
+
+        let (new_addr, new_data) = dev.remap_msi(0x10, 0xFEE0_0000, 0).unwrap();
+
+        // Logical destination mode set in bit 2.
+        assert_eq!(new_addr & (1 << 2), 1 << 2);
+        // Destination 0xFF in bits [19:12].
+        assert_eq!((new_addr >> 12) & 0xFF, 0xFF);
+        assert_eq!(new_data & 0xFF, 0x50);
+    }
+
+    #[test]
+    fn test_remap_msi_passthrough() {
+        let mut dev = create_test_device_for_translation();
+        let devtab_gpa = 0x1_0000;
+        setup_iommu_with_devtab(&mut dev, devtab_gpa, 256);
+
+        // IntCtl = PASS_THROUGH (01b) → return original address/data.
+        let dte = make_dte_with_interrupt_remap(0, 0, IntCtl::PASS_THROUGH.0);
+        write_dte(&dev, devtab_gpa, 0x10, &dte);
+
+        let orig_addr = 0xFEE0_5000u64;
+        let orig_data = 0x30u32;
+
+        let (new_addr, new_data) = dev.remap_msi(0x10, orig_addr, orig_data).unwrap();
+        assert_eq!(new_addr, orig_addr);
+        assert_eq!(new_data, orig_data);
+    }
+
+    #[test]
+    fn test_remap_msi_abort() {
+        let mut dev = create_test_device_for_translation();
+        let devtab_gpa = 0x1_0000;
+        setup_iommu_with_devtab(&mut dev, devtab_gpa, 256);
+
+        // IntCtl = ABORT (00b) → fault.
+        let dte = make_dte_with_interrupt_remap(0, 0, IntCtl::ABORT.0);
+        write_dte(&dev, devtab_gpa, 0x10, &dte);
+
+        let result = dev.remap_msi(0x10, 0xFEE0_0000, 0x30);
+        assert!(result.is_err());
+        match result.unwrap_err() {
+            IommuFault::IllegalDevTableEntry {
+                device_id,
+                is_interrupt,
+                ..
+            } => {
+                assert_eq!(device_id, 0x10);
+                assert!(is_interrupt);
+            }
+            other => panic!("expected IllegalDevTableEntry, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_remap_msi_reserved_int_ctl() {
+        let mut dev = create_test_device_for_translation();
+        let devtab_gpa = 0x1_0000;
+        setup_iommu_with_devtab(&mut dev, devtab_gpa, 256);
+
+        // IntCtl = 11b (reserved) → fault.
+        let dte = make_dte_with_interrupt_remap(0, 0, 0b11);
+        write_dte(&dev, devtab_gpa, 0x10, &dte);
+
+        let result = dev.remap_msi(0x10, 0xFEE0_0000, 0x30);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_remap_msi_ga_mode_128bit_irte() {
+        // This test exercises the GA (Guest APIC) IRTE path that Linux uses
+        // when GASup=1 in the EFR. The driver sets GA_EN in the control
+        // register and uses 128-bit GA-format IRTEs (irte_128_ops).
+        let mut dev = create_test_device_for_translation();
+        let devtab_gpa = 0x1_0000;
+
+        // Set up IOMMU with GA_EN=1.
+        let size = (256u64 * DTE_SIZE as u64 / 4096).saturating_sub(1) as u16;
+        let dtb = DevTabBase::new()
+            .with_base_addr(devtab_gpa >> 12)
+            .with_size(size);
+        mmio_write64(
+            &mut dev,
+            MmioRegister::DEV_TAB_BASE.0 as u64,
+            dtb.into_bits(),
+        );
+
+        let cmd_base = CmdBufBase::new()
+            .with_base_addr(0x8_0000 >> 12)
+            .with_length(8);
+        mmio_write64(
+            &mut dev,
+            MmioRegister::CMD_BUF_BASE.0 as u64,
+            cmd_base.into_bits(),
+        );
+
+        let evt_base = EvtLogBase::new()
+            .with_base_addr(0x9_0000 >> 12)
+            .with_length(8);
+        mmio_write64(
+            &mut dev,
+            MmioRegister::EVT_LOG_BASE.0 as u64,
+            evt_base.into_bits(),
+        );
+
+        let ctrl = IommuCtrl::new()
+            .with_iommu_en(true)
+            .with_cmd_buf_en(true)
+            .with_evt_log_en(true)
+            .with_ga_en(true); // Enable GA mode → 128-bit IRTEs
+        mmio_write64(
+            &mut dev,
+            MmioRegister::IOMMU_CTRL.0 as u64,
+            ctrl.into_bits(),
+        );
+
+        // Verify GA_EN is set.
+        let readback =
+            IommuCtrl::from_bits(mmio_read64(&mut dev, MmioRegister::IOMMU_CTRL.0 as u64));
+        assert!(readback.ga_en(), "GA_EN should be set");
+
+        // IRT with 128-bit GA entries at 0xA_0000 (128-byte aligned).
+        let irt_gpa = 0xA_0000u64;
+        let irte_index = 5u32;
+
+        // Build a 128-bit GA IRTE: vector=0x80, destination=7, physical mode.
+        use spec::irte::{IRTE_GA_SIZE, IrteGa, IrteGaHi, IrteGaLo};
+        let ga_irte = IrteGa {
+            lo: IrteGaLo::new()
+                .with_remap_en(true)
+                .with_int_type(0) // Fixed
+                .with_dm(false) // Physical
+                .with_destination(7), // Low 24 bits of destination
+            hi: IrteGaHi::new().with_vector(0x80).with_destination_hi(0), // High 8 bits of destination
+        };
+
+        // Write the 128-bit IRTE at the correct offset.
+        let irte_gpa = irt_gpa + (irte_index as u64) * (IRTE_GA_SIZE as u64);
+        dev.shared
+            .guest_memory
+            .write_plain(irte_gpa, &ga_irte)
+            .unwrap();
+
+        // DTE with interrupt remapping, pointing to our IRT.
+        let dte = make_dte_with_interrupt_remap(irt_gpa, 8, IntCtl::REMAP.0);
+        write_dte(&dev, devtab_gpa, 0x10, &dte);
+
+        // Remap MSI with data=irte_index → should read 128-bit GA IRTE.
+        let (new_addr, new_data) = dev.remap_msi(0x10, 0xFEE0_0000, irte_index).unwrap();
+
+        // Verify remapped values.
+        assert_eq!(new_data & 0xFF, 0x80, "vector should be 0x80");
+        assert_eq!((new_data >> 8) & 0x7, 0, "delivery mode should be Fixed");
+        assert_eq!((new_addr >> 12) & 0xFF, 7, "destination should be 7");
+        assert_eq!(new_addr & (1 << 2), 0, "DM should be physical (0)");
+    }
+
+    /// Verify that the 128-bit GA-format IRTE walker correctly assembles a
+    /// full 32-bit x2APIC destination from `destination_lo` (24 bits in the
+    /// low qword) and `destination_hi` (8 bits in the high qword), per spec
+    /// §2.2.5.2.
+    #[test]
+    fn test_remap_msi_ga_mode_x2apic_destination() {
+        let mut dev = create_test_device_for_translation();
+        let devtab_gpa = 0x1_0000;
+        setup_iommu_with_devtab(&mut dev, devtab_gpa, 256);
+
+        // Enable GA mode so the walker uses the 128-bit IRTE format.
+        let ctrl = IommuCtrl::from_bits(mmio_read64(&mut dev, MmioRegister::IOMMU_CTRL.0 as u64))
+            .with_ga_en(true);
+        mmio_write64(
+            &mut dev,
+            MmioRegister::IOMMU_CTRL.0 as u64,
+            ctrl.into_bits(),
+        );
+
+        // Build a GA IRTE with a 32-bit X2APIC destination 0x0A12_3456:
+        // destination_lo = 0x12_3456 (24 bits), destination_hi = 0x0A (8 bits).
+        let irt_gpa = 0xA_0000u64;
+        let irte_index = 3u32;
+        use spec::irte::{IRTE_GA_SIZE, IrteGa, IrteGaHi, IrteGaLo};
+        let ga_irte = IrteGa {
+            lo: IrteGaLo::new()
+                .with_remap_en(true)
+                .with_int_type(0)
+                .with_dm(false)
+                .with_destination(0x12_3456),
+            hi: IrteGaHi::new().with_vector(0x42).with_destination_hi(0x0A),
+        };
+        let irte_gpa = irt_gpa + (irte_index as u64) * (IRTE_GA_SIZE as u64);
+        dev.shared
+            .guest_memory
+            .write_plain(irte_gpa, &ga_irte)
+            .unwrap();
+
+        let dte = make_dte_with_interrupt_remap(irt_gpa, 4, IntCtl::REMAP.0);
+        write_dte(&dev, devtab_gpa, 0x10, &dte);
+
+        // Use the IRTE walker directly so we observe the full 32-bit
+        // destination, independent of how the legacy MSI-address encoder
+        // packs the result.
+        let ri = dev.lookup_irte(0x10, &dte, irte_index).unwrap();
+        assert_eq!(
+            ri.destination, 0x0A12_3456,
+            "32-bit X2APIC destination should combine destination_lo and destination_hi"
+        );
+        assert_eq!(ri.vector, 0x42);
+        assert!(!ri.dm, "physical destination mode");
+    }
+
+    /// Verify that `ADVERTISED_EXT_FEAT` advertises `XTSup` (bit 2), `IASup`
+    /// (bit 6), and `GASup` (bit 7) when read via MMIO.
+    #[test]
+    fn test_ext_feat_advertises_xtsup_iasup_gasup() {
+        let mut dev = create_test_device();
+        let efr = mmio_read64(&mut dev, MmioRegister::EXT_FEAT.0 as u64);
+        let ef = ExtFeat::from_bits(efr);
+        assert!(ef.xt_sup(), "XTSup (bit 2) must be advertised");
+        assert!(ef.ia_sup(), "IASup (bit 6) must be advertised");
+        assert!(ef.ga_sup(), "GASup (bit 7) must be advertised");
+    }
+
+    /// Verify that the `XTEn` and `IntCapXTEn` bits round-trip through the
+    /// IOMMU control register. When `EFR[XTSup]=1`, both bits are valid
+    /// software-settable bits in `IOMMU_CTRL` (§3.4.8).
+    #[test]
+    fn test_iommu_ctrl_xten_intcapxten_roundtrip() {
+        let mut dev = create_test_device();
+        let ctrl = IommuCtrl::new()
+            .with_iommu_en(true)
+            .with_xt_en(true)
+            .with_int_cap_xt_en(true);
+        mmio_write64(
+            &mut dev,
+            MmioRegister::IOMMU_CTRL.0 as u64,
+            ctrl.into_bits(),
+        );
+
+        let readback =
+            IommuCtrl::from_bits(mmio_read64(&mut dev, MmioRegister::IOMMU_CTRL.0 as u64));
+        assert!(readback.iommu_en());
+        assert!(readback.xt_en(), "XTEn must round-trip");
+        assert!(readback.int_cap_xt_en(), "IntCapXTEn must round-trip");
+    }
+
+    /// Verify that the General and PPR XT Interrupt Control registers
+    /// round-trip arbitrary 64-bit values via MMIO. When `EFR[XTSup]=1`,
+    /// these registers (§3.4.13) hold the IOMMU's own MSI destination in
+    /// x2APIC format and must not fall through to the "unknown register"
+    /// warn-and-discard path.
+    #[test]
+    fn test_xt_interrupt_control_registers_roundtrip() {
+        use spec::registers::XtIntCtrl;
+
+        let mut dev = create_test_device();
+
+        // Compose an XT control value with non-zero high destination bits so
+        // both `xt_int_dest_low` (24 bits) and `xt_int_dest_high` (8 bits) are
+        // exercised through the round-trip.
+        let value = XtIntCtrl::new()
+            .with_xt_int_dest_mode(false)
+            .with_xt_int_dest_low(0x12_3456)
+            .with_xt_int_vector(0x80)
+            .with_xt_int_dm(false)
+            .with_xt_int_dest_high(0x0A)
+            .into_bits();
+
+        mmio_write64(&mut dev, MmioRegister::GEN_XT_INT_CTRL.0 as u64, value);
+        mmio_write64(
+            &mut dev,
+            MmioRegister::PPR_XT_INT_CTRL.0 as u64,
+            value.wrapping_add(1),
+        );
+
+        let gen_readback = mmio_read64(&mut dev, MmioRegister::GEN_XT_INT_CTRL.0 as u64);
+        let ppr_readback = mmio_read64(&mut dev, MmioRegister::PPR_XT_INT_CTRL.0 as u64);
+        assert_eq!(gen_readback, value);
+        assert_eq!(ppr_readback, value.wrapping_add(1));
+
+        // Sanity-check that the bitfield decodes the round-tripped value.
+        let decoded = XtIntCtrl::from_bits(gen_readback);
+        assert_eq!(decoded.xt_int_dest_low(), 0x12_3456);
+        assert_eq!(decoded.xt_int_dest_high(), 0x0A);
+        assert_eq!(decoded.xt_int_vector(), 0x80);
+    }
+
+    #[test]
+    fn test_remap_msi_iommu_disabled() {
+        let guest_memory = GuestMemory::allocate(0x10_0000);
+        let msi_conn =
+            pci_core::msi::MsiConnection::new(pci_core::bus_range::AssignedBusRange::new(), 0);
+        let dev = AmdIommuDevice::new(guest_memory, test_config(), msi_conn.target());
+
+        // IOMMU not enabled — MSI should pass through unchanged.
+        let (new_addr, new_data) = dev.remap_msi(0x10, 0xFEE0_0000, 0x30).unwrap();
+        assert_eq!(new_addr, 0xFEE0_0000);
+        assert_eq!(new_data, 0x30);
+    }
+
+    #[test]
+    fn test_remap_msi_index_out_of_range() {
+        let mut dev = create_test_device_for_translation();
+        let devtab_gpa = 0x1_0000;
+        setup_iommu_with_devtab(&mut dev, devtab_gpa, 256);
+
+        let irt_gpa = 0xA_0000u64;
+        // IntTabLen=1 → 2 entries (2^1). MSI data index = 5 is out of range.
+        let dte = make_dte_with_interrupt_remap(irt_gpa, 1, IntCtl::REMAP.0);
+        write_dte(&dev, devtab_gpa, 0x10, &dte);
+
+        let result = dev.remap_msi(0x10, 0xFEE0_0000, 5);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_remap_msi_arbitrated_delivery() {
+        let mut dev = create_test_device_for_translation();
+        let devtab_gpa = 0x1_0000;
+        setup_iommu_with_devtab(&mut dev, devtab_gpa, 256);
+
+        let irt_gpa = 0xA_0000u64;
+        let irte = Irte::new()
+            .with_remap_en(true)
+            .with_int_type(1) // Arbitrated (lowest priority)
+            .with_dm(false)
+            .with_destination(7)
+            .with_vector(0x80);
+        write_irte(&dev, irt_gpa, 0, &irte);
+
+        let dte = make_dte_with_interrupt_remap(irt_gpa, 4, IntCtl::REMAP.0);
+        write_dte(&dev, devtab_gpa, 0x10, &dte);
+
+        let (new_addr, new_data) = dev.remap_msi(0x10, 0xFEE0_0000, 0).unwrap();
+        assert_eq!((new_addr >> 12) & 0xFF, 7); // destination
+        assert_eq!(new_data & 0xFF, 0x80); // vector
+        assert_eq!((new_data >> 8) & 0x7, 1); // delivery mode = Arbitrated
+    }
+
+    #[test]
+    fn test_irte_lookup_multiple_indices() {
+        let mut dev = create_test_device_for_translation();
+        let devtab_gpa = 0x1_0000;
+        setup_iommu_with_devtab(&mut dev, devtab_gpa, 256);
+
+        let irt_gpa = 0xA_0000u64;
+        // Set up multiple IRTEs.
+        for i in 0..4u32 {
+            let irte = Irte::new()
+                .with_remap_en(true)
+                .with_vector((0x40 + i) as u8)
+                .with_destination(i as u8);
+            write_irte(&dev, irt_gpa, i, &irte);
+        }
+
+        let dte = make_dte_with_interrupt_remap(irt_gpa, 4, IntCtl::REMAP.0);
+        write_dte(&dev, devtab_gpa, 0x10, &dte);
+
+        // Verify each index returns the correct IRTE.
+        for i in 0..4u32 {
+            let irte = dev.lookup_irte(0x10, &dte, i).unwrap();
+            assert_eq!(irte.vector, (0x40 + i) as u8);
+            assert_eq!(irte.destination, i);
+        }
+    }
+
+    // =========================================================================
+    // Shared State and Per-Device Wrapper Tests (1G)
+    // =========================================================================
+
+    /// A mock `SignalMsi` implementation that records the last MSI signaled.
+    struct MockSignalMsi {
+        last_msi: parking_lot::Mutex<Option<(Option<u32>, u64, u32)>>,
+    }
+
+    impl MockSignalMsi {
+        fn new() -> Arc<Self> {
+            Arc::new(Self {
+                last_msi: parking_lot::Mutex::new(None),
+            })
+        }
+
+        fn last(&self) -> Option<(Option<u32>, u64, u32)> {
+            *self.last_msi.lock()
+        }
+    }
+
+    impl SignalMsi for MockSignalMsi {
+        fn signal_msi(&self, devid: Option<u32>, address: u64, data: u32) {
+            *self.last_msi.lock() = Some((devid, address, data));
+        }
+    }
+
+    const WRAPPER_BUS: u8 = 1;
+    const WRAPPER_DEVICE_ID: u16 = (WRAPPER_BUS as u16) << 8;
+
+    fn bus_range_for_device_id(device_id: u16) -> pci_core::bus_range::AssignedBusRange {
+        assert_eq!(device_id & 0xFF, 0, "test DeviceID must be dev 0 fn 0");
+        let bus = (device_id >> 8) as u8;
+        let bus_range = pci_core::bus_range::AssignedBusRange::new();
+        bus_range.set_bus_range(bus, bus);
+        bus_range
+    }
+
+    fn wrapper_bus_range() -> pci_core::bus_range::AssignedBusRange {
+        bus_range_for_device_id(WRAPPER_DEVICE_ID)
+    }
+
+    /// Set up a device with IOMMU enabled, device table, page tables, and IRT
+    /// for testing per-device wrappers. Returns the device and shared state.
+    fn setup_iommu_for_wrappers() -> AmdIommuDevice {
+        let guest_memory = GuestMemory::allocate(0x10_0000); // 1MB
+        let msi_conn =
+            pci_core::msi::MsiConnection::new(pci_core::bus_range::AssignedBusRange::new(), 0);
+        let mut dev = AmdIommuDevice::new(guest_memory, test_config(), msi_conn.target());
+
+        let devtab_gpa = 0x1_0000;
+        setup_iommu_with_devtab(&mut dev, devtab_gpa, 512);
+
+        // Set up a 1-level page table mapping IOVA 0 → GPA 0xA_0000.
+        let l1_gpa = 0x5_0000u64;
+        let target_gpa = 0xA_0000u64;
+
+        write_pte(
+            &dev,
+            l1_gpa,
+            0,
+            &IommuPte::new()
+                .with_pr(true)
+                .with_next_level(0)
+                .with_address(target_gpa >> 12)
+                .with_ir(true)
+                .with_iw(true),
+        );
+
+        // DTE for the default BDF on the assigned wrapper test bus:
+        // 1-level page table, IRT with remapping.
+        let irt_gpa = 0xC_0000u64;
+        let dte = {
+            use spec::dte::*;
+            Dte {
+                dw0: DteDw0::new()
+                    .with_v(true)
+                    .with_tv(true)
+                    .with_mode(1)
+                    .with_host_pt_root_ptr(l1_gpa >> 12)
+                    .with_ir(true)
+                    .with_iw(true),
+                dw1: DteDw1::new().with_domain_id(1),
+                dw2: DteDw2::new()
+                    .with_iv(true)
+                    .with_int_tab_len(4) // 16 entries
+                    .with_int_tab_root_ptr(irt_gpa >> 6)
+                    .with_int_ctl(IntCtl::REMAP.0),
+                dw3: 0,
+            }
+        };
+        write_dte(&dev, devtab_gpa, WRAPPER_DEVICE_ID, &dte);
+
+        // Set up IRTE at index 0: remap to vector 0x40, destination 3.
+        let irte = Irte::new()
+            .with_remap_en(true)
+            .with_int_type(0)
+            .with_dm(false)
+            .with_destination(3)
+            .with_vector(0x40);
+        write_irte(&dev, irt_gpa, 0, &irte);
+
+        dev
+    }
+
+    #[test]
+    fn test_translating_memory_basic_read() {
+        let dev = setup_iommu_for_wrappers();
+        let shared = dev.shared_state().clone();
+        let mock_msi = MockSignalMsi::new();
+
+        let (iommu_gm, _msi) =
+            shared.create_device_context(wrapper_bus_range(), &dev.shared.guest_memory, mock_msi);
+
+        // Write data at GPA 0xA_0000 (the target page).
+        dev.shared
+            .guest_memory
+            .write_at(0xA_0000, &[0xDE, 0xAD, 0xBE, 0xEF])
+            .unwrap();
+
+        // Read via IOVA 0x0 through the translating memory.
+        let mut buf = [0u8; 4];
+        iommu_gm.read_at(0x0, &mut buf).unwrap();
+        assert_eq!(buf, [0xDE, 0xAD, 0xBE, 0xEF]);
+    }
+
+    #[test]
+    fn test_translating_memory_basic_write() {
+        let dev = setup_iommu_for_wrappers();
+        let shared = dev.shared_state().clone();
+        let mock_msi = MockSignalMsi::new();
+
+        let (iommu_gm, _msi) =
+            shared.create_device_context(wrapper_bus_range(), &dev.shared.guest_memory, mock_msi);
+
+        // Write via IOVA 0x100 through the translating memory.
+        iommu_gm.write_at(0x100, &[0xCA, 0xFE]).unwrap();
+
+        // Read raw from GPA 0xA_0100.
+        let mut buf = [0u8; 2];
+        dev.shared.guest_memory.read_at(0xA_0100, &mut buf).unwrap();
+        assert_eq!(buf, [0xCA, 0xFE]);
+    }
+
+    #[test]
+    fn test_translating_memory_passthrough() {
+        let guest_memory = GuestMemory::allocate(0x10_0000);
+        let msi_conn =
+            pci_core::msi::MsiConnection::new(pci_core::bus_range::AssignedBusRange::new(), 0);
+        let mut dev = AmdIommuDevice::new(guest_memory, test_config(), msi_conn.target());
+
+        let devtab_gpa = 0x1_0000;
+        setup_iommu_with_devtab(&mut dev, devtab_gpa, 512);
+
+        // DTE with V=1, TV=1, Mode=0 (pass-through).
+        let dte = make_dte_with_translation(0, 0, true, true, 1);
+        write_dte(&dev, devtab_gpa, WRAPPER_DEVICE_ID, &dte);
+
+        let shared = dev.shared_state().clone();
+        let mock_msi = MockSignalMsi::new();
+        let (iommu_gm, _msi) =
+            shared.create_device_context(wrapper_bus_range(), &dev.shared.guest_memory, mock_msi);
+
+        // Write data at GPA 0x2000.
+        dev.shared.guest_memory.write_at(0x2000, &[0x42]).unwrap();
+
+        // Read via IOVA 0x2000 — should pass through.
+        let mut buf = [0u8; 1];
+        iommu_gm.read_at(0x2000, &mut buf).unwrap();
+        assert_eq!(buf, [0x42]);
+    }
+
+    #[test]
+    fn test_translating_memory_fault() {
+        let dev = setup_iommu_for_wrappers();
+        let shared = dev.shared_state().clone();
+        let mock_msi = MockSignalMsi::new();
+
+        let (iommu_gm, _msi) =
+            shared.create_device_context(wrapper_bus_range(), &dev.shared.guest_memory, mock_msi);
+
+        // Read from unmapped IOVA (page index 1 is not mapped in the L1 table).
+        let mut buf = [0u8; 4];
+        let result = iommu_gm.read_at(0x1000, &mut buf);
+        assert!(result.is_err(), "unmapped IOVA should fault");
+    }
+
+    #[test]
+    fn test_translating_memory_disabled_bypass() {
+        let guest_memory = GuestMemory::allocate(0x10_0000);
+        let msi_conn =
+            pci_core::msi::MsiConnection::new(pci_core::bus_range::AssignedBusRange::new(), 0);
+        let dev = AmdIommuDevice::new(guest_memory, test_config(), msi_conn.target());
+        // IOMMU not enabled — all accesses should pass through.
+
+        let shared = dev.shared_state().clone();
+        let mock_msi = MockSignalMsi::new();
+        let (iommu_gm, _msi) =
+            shared.create_device_context(wrapper_bus_range(), &dev.shared.guest_memory, mock_msi);
+
+        dev.shared.guest_memory.write_at(0x5000, &[0xAA]).unwrap();
+
+        let mut buf = [0u8; 1];
+        iommu_gm.read_at(0x5000, &mut buf).unwrap();
+        assert_eq!(buf, [0xAA]);
+    }
+
+    #[test]
+    fn test_signal_msi_remapped() {
+        let dev = setup_iommu_for_wrappers();
+        let shared = dev.shared_state().clone();
+        let mock_msi = MockSignalMsi::new();
+
+        let (_gm, iommu_msi) = shared.create_device_context(
+            wrapper_bus_range(),
+            &dev.shared.guest_memory,
+            mock_msi.clone(),
+        );
+
+        // Signal MSI with data=0 (IRTE index 0), requester ID = wrapper device.
+        // Should remap to vector 0x40, dest 3.
+        iommu_msi.signal_msi(Some(WRAPPER_DEVICE_ID as u32), 0xFEE0_0000, 0);
+
+        let (devid, addr, data) = mock_msi.last().expect("MSI should have been delivered");
+        assert_eq!(devid, Some(WRAPPER_DEVICE_ID as u32));
+        assert_eq!(addr, 0xFEE0_0000 | (3u64 << 12)); // destination 3
+        assert_eq!(data & 0xFF, 0x40); // vector 0x40
+    }
+
+    #[test]
+    fn test_signal_msi_iommu_disabled() {
+        let guest_memory = GuestMemory::allocate(0x10_0000);
+        let msi_conn =
+            pci_core::msi::MsiConnection::new(pci_core::bus_range::AssignedBusRange::new(), 0);
+        let dev = AmdIommuDevice::new(guest_memory, test_config(), msi_conn.target());
+
+        let shared = dev.shared_state().clone();
+        let mock_msi = MockSignalMsi::new();
+        let (_gm, iommu_msi) = shared.create_device_context(
+            wrapper_bus_range(),
+            &dev.shared.guest_memory,
+            mock_msi.clone(),
+        );
+
+        // IOMMU disabled — MSI should pass through unchanged.
+        iommu_msi.signal_msi(Some(5), 0xFEE0_5000, 0x30);
+
+        let (devid, addr, data) = mock_msi.last().expect("MSI should pass through");
+        assert_eq!(devid, Some(5));
+        assert_eq!(addr, 0xFEE0_5000);
+        assert_eq!(data, 0x30);
+    }
+
+    #[test]
+    fn test_signal_msi_fault_drops_interrupt() {
+        let dev = setup_iommu_for_wrappers();
+        let devtab_gpa = 0x1_0000;
+
+        // Set up a DTE with IntCtl=ABORT for device 0x20.
+        let dte = make_dte_with_interrupt_remap(0, 0, IntCtl::ABORT.0);
+        write_dte(&dev, devtab_gpa, 0x20, &dte);
+
+        let shared = dev.shared_state().clone();
+        let mock_msi = MockSignalMsi::new();
+        let (_gm, iommu_msi) = shared.create_device_context(
+            wrapper_bus_range(),
+            &dev.shared.guest_memory,
+            mock_msi.clone(),
+        );
+
+        // Signal MSI with requester ID — should be dropped (IntCtl=ABORT).
+        iommu_msi.signal_msi(Some(0x20), 0xFEE0_0000, 0x30);
+
+        assert!(
+            mock_msi.last().is_none(),
+            "MSI should be dropped on abort fault"
+        );
+    }
+
+    #[test]
+    fn test_create_device_context() {
+        let dev = setup_iommu_for_wrappers();
+        let shared = dev.shared_state().clone();
+        let mock_msi = MockSignalMsi::new();
+
+        let (gm, msi) =
+            shared.create_device_context(wrapper_bus_range(), &dev.shared.guest_memory, mock_msi);
+
+        // Verify the returned GuestMemory works.
+        dev.shared.guest_memory.write_at(0xA_0000, &[0x55]).unwrap();
+        let mut buf = [0u8; 1];
+        gm.read_at(0x0, &mut buf).unwrap();
+        assert_eq!(buf, [0x55]);
+
+        // Verify the MSI wrapper works.
+        msi.signal_msi(None, 0xFEE0_0000, 0);
+        // (IRTE 0 remaps to vector 0x40, dest 3 — verified in other tests)
+    }
+
+    // =========================================================================
+    // End-to-End Test (1J.1)
+    // =========================================================================
+
+    /// End-to-end test exercising the full IOMMU stack: device discovery via
+    /// PCI capability, MMIO register programming (mimicking a guest IOMMU
+    /// driver init sequence), device table + page table + IRT setup in guest
+    /// memory, command buffer processing, DMA translation through
+    /// `IommuTranslatingMemory`, and MSI remapping through `IommuSignalMsi`.
+    ///
+    /// This test follows the exact sequence a guest IOMMU driver would use:
+    ///
+    /// 1. Read PCI capability, find MMIO base.
+    /// 2. Read ExtFeat register, verify features.
+    /// 3. Write DevTabBase (point to device table in guest memory).
+    /// 4. Write CmdBufBase (point to command buffer).
+    /// 5. Write EvtLogBase (point to event log).
+    /// 6. Write IommuCtrl: enable CmdBufEn, EvtLogEn, IommuEn.
+    /// 7. Configure DTE for a device with page table and IRT.
+    /// 8. Build a 4-level page table mapping IOVA 0x0 → GPA 0x10_0000.
+    /// 9. Set up IRTE: RemapEn=1, Vector=0x40, Destination=0, IntType=FIXED.
+    /// 10. Issue INVALIDATE_DEVTAB_ENTRY + COMPLETION_WAIT via command buffer.
+    /// 11. Write data to GPA via raw guest memory.
+    /// 12. Read via IommuTranslatingMemory at IOVA, verify data.
+    /// 13. Write via IommuTranslatingMemory at IOVA, read from GPA, verify.
+    /// 14. Read from unmapped IOVA, verify error + event log entry.
+    /// 15. Fire MSI via IommuSignalMsi, verify remapped vector/destination.
+    #[test]
+    fn test_end_to_end_full_stack() {
+        // =====================================================================
+        // Memory layout (2MB guest memory):
+        //   0x00_0000 – 0x00_7FFF  Device Table (1024 entries × 32 bytes = 32KB)
+        //   0x00_8000 – 0x00_8FFF  Command Buffer (256 entries × 16 = 4KB)
+        //   0x00_9000 – 0x00_9FFF  Event Log (256 entries × 16 = 4KB)
+        //   0x00_A000 – 0x00_AFFF  L4 Page Table
+        //   0x00_B000 – 0x00_BFFF  L3 Page Table
+        //   0x00_C000 – 0x00_CFFF  L2 Page Table
+        //   0x00_D000 – 0x00_DFFF  L1 Page Table
+        //   0x00_E000 – 0x00_E3FF  Interrupt Remapping Table (256 IRTEs × 4)
+        //   0x00_F000 – 0x00_F007  COMPLETION_WAIT store target
+        //   0x10_0000 – 0x10_0FFF  DMA target page (GPA for IOVA 0x0)
+        // =====================================================================
+
+        let guest_memory = GuestMemory::allocate(0x20_0000); // 2MB
+        let msi_conn =
+            pci_core::msi::MsiConnection::new(pci_core::bus_range::AssignedBusRange::new(), 0);
+        let mut dev = AmdIommuDevice::new(guest_memory, test_config(), msi_conn.target());
+
+        let devtab_gpa: u64 = 0x00_0000;
+        let cmdbuf_gpa: u64 = 0x00_8000;
+        let evtlog_gpa: u64 = 0x00_9000;
+        let l4_gpa: u64 = 0x00_A000;
+        let l3_gpa: u64 = 0x00_B000;
+        let l2_gpa: u64 = 0x00_C000;
+        let l1_gpa: u64 = 0x00_D000;
+        let irt_gpa: u64 = 0x00_E000;
+        let store_gpa: u64 = 0x00_F000;
+        let dma_target_gpa: u64 = 0x10_0000;
+        let device_id: u16 = WRAPPER_DEVICE_ID;
+
+        // -----------------------------------------------------------------
+        // Step 1: Read PCI capability, find MMIO base.
+        // -----------------------------------------------------------------
+        let cap_header_raw = pci_read(&mut dev, PCI_CAP_OFFSET);
+        let cap_id = cap_header_raw & 0xFF;
+        assert_eq!(cap_id, 0x0F, "CapID should be AMD IOMMU");
+
+        let base_low_raw = pci_read(&mut dev, PCI_CAP_OFFSET + 4);
+        let base_high_raw = pci_read(&mut dev, PCI_CAP_OFFSET + 8);
+        let base_low = BaseAddrLow::from_bits(base_low_raw);
+        let base_high = BaseAddrHigh::from_bits(base_high_raw);
+        assert!(base_low.enable(), "IOMMU MMIO should be enabled");
+        let mmio_base_from_cap =
+            ((base_low.base_addr() as u64) << 14) | ((base_high.base_addr() as u64) << 32);
+        assert_eq!(mmio_base_from_cap, TEST_MMIO_BASE);
+
+        // Read device range from capability.
+        let range_raw = pci_read(&mut dev, PCI_CAP_OFFSET + 12);
+        let range = Range::from_bits(range_raw);
+        assert!(range.rng_valid(), "range should be valid");
+        assert_eq!(range.first_device(), 0x00);
+        assert_eq!(range.last_device(), 0xFF);
+
+        // -----------------------------------------------------------------
+        // Step 2: Read ExtFeat register, verify features.
+        // -----------------------------------------------------------------
+        let ext_feat = mmio_read64(&mut dev, MmioRegister::EXT_FEAT.0 as u64);
+        let ef = ExtFeat::from_bits(ext_feat);
+        assert!(ef.ia_sup(), "INVALIDATE_IOMMU_ALL should be supported");
+        assert_eq!(ef.hats(), 0b00, "HATS should be 4-level");
+
+        // -----------------------------------------------------------------
+        // Step 3: Write DevTabBase.
+        // -----------------------------------------------------------------
+        // 1024 entries: size = (1024 * 32 / 4096) - 1 = 7
+        let dtb = DevTabBase::new()
+            .with_base_addr(devtab_gpa >> 12)
+            .with_size(7);
+        mmio_write64(
+            &mut dev,
+            MmioRegister::DEV_TAB_BASE.0 as u64,
+            dtb.into_bits(),
+        );
+        assert_eq!(
+            mmio_read64(&mut dev, MmioRegister::DEV_TAB_BASE.0 as u64),
+            dtb.into_bits()
+        );
+
+        // -----------------------------------------------------------------
+        // Step 4: Write CmdBufBase.
+        // -----------------------------------------------------------------
+        let cmd_base = CmdBufBase::new()
+            .with_base_addr(cmdbuf_gpa >> 12)
+            .with_length(8); // 256 entries
+        mmio_write64(
+            &mut dev,
+            MmioRegister::CMD_BUF_BASE.0 as u64,
+            cmd_base.into_bits(),
+        );
+
+        // -----------------------------------------------------------------
+        // Step 5: Write EvtLogBase.
+        // -----------------------------------------------------------------
+        let evt_base = EvtLogBase::new()
+            .with_base_addr(evtlog_gpa >> 12)
+            .with_length(8); // 256 entries
+        mmio_write64(
+            &mut dev,
+            MmioRegister::EVT_LOG_BASE.0 as u64,
+            evt_base.into_bits(),
+        );
+
+        // -----------------------------------------------------------------
+        // Step 6: Enable IOMMU.
+        // -----------------------------------------------------------------
+        let ctrl = IommuCtrl::new()
+            .with_iommu_en(true)
+            .with_cmd_buf_en(true)
+            .with_evt_log_en(true)
+            .with_evt_int_en(true)
+            .with_com_wait_int_en(true);
+        mmio_write64(
+            &mut dev,
+            MmioRegister::IOMMU_CTRL.0 as u64,
+            ctrl.into_bits(),
+        );
+
+        // Verify status reflects running state.
+        let status =
+            IommuStatus::from_bits(mmio_read64(&mut dev, MmioRegister::IOMMU_STATUS.0 as u64));
+        assert!(status.cmd_buf_run(), "CmdBufRun should be set");
+        assert!(status.evt_log_run(), "EvtLogRun should be set");
+
+        // -----------------------------------------------------------------
+        // Step 7: Configure DTE for the test device.
+        // -----------------------------------------------------------------
+        // 4-level page table, interrupt remapping enabled.
+        use spec::dte::*;
+        let dte = Dte {
+            dw0: DteDw0::new()
+                .with_v(true)
+                .with_tv(true)
+                .with_mode(4) // 4-level page table
+                .with_host_pt_root_ptr(l4_gpa >> 12)
+                .with_ir(true)
+                .with_iw(true),
+            dw1: DteDw1::new().with_domain_id(1),
+            dw2: DteDw2::new()
+                .with_iv(true)
+                .with_int_tab_len(8) // 2^8 = 256 IRT entries
+                .with_int_tab_root_ptr(irt_gpa >> 6)
+                .with_int_ctl(IntCtl::REMAP.0),
+            dw3: 0,
+        };
+        write_dte(&dev, devtab_gpa, device_id, &dte);
+
+        // -----------------------------------------------------------------
+        // Step 8: Build 4-level page table: IOVA 0x0 → GPA 0x10_0000.
+        // -----------------------------------------------------------------
+        // L4[0] → L3
+        write_pte(
+            &dev,
+            l4_gpa,
+            0,
+            &IommuPte::new()
+                .with_pr(true)
+                .with_next_level(3)
+                .with_address(l3_gpa >> 12)
+                .with_ir(true)
+                .with_iw(true),
+        );
+        // L3[0] → L2
+        write_pte(
+            &dev,
+            l3_gpa,
+            0,
+            &IommuPte::new()
+                .with_pr(true)
+                .with_next_level(2)
+                .with_address(l2_gpa >> 12)
+                .with_ir(true)
+                .with_iw(true),
+        );
+        // L2[0] → L1
+        write_pte(
+            &dev,
+            l2_gpa,
+            0,
+            &IommuPte::new()
+                .with_pr(true)
+                .with_next_level(1)
+                .with_address(l1_gpa >> 12)
+                .with_ir(true)
+                .with_iw(true),
+        );
+        // L1[0] → target page at GPA 0x10_0000
+        write_pte(
+            &dev,
+            l1_gpa,
+            0,
+            &IommuPte::new()
+                .with_pr(true)
+                .with_next_level(0) // leaf
+                .with_address(dma_target_gpa >> 12)
+                .with_ir(true)
+                .with_iw(true),
+        );
+
+        // -----------------------------------------------------------------
+        // Step 9: Set up IRTE at index 0x30.
+        // -----------------------------------------------------------------
+        let irte = Irte::new()
+            .with_remap_en(true)
+            .with_int_type(0) // Fixed
+            .with_dm(false) // Physical destination
+            .with_destination(0) // CPU 0
+            .with_vector(0x40); // Remapped vector
+        write_irte(&dev, irt_gpa, 0x30, &irte);
+
+        // -----------------------------------------------------------------
+        // Step 10: Issue INVALIDATE_DEVTAB_ENTRY + COMPLETION_WAIT.
+        // -----------------------------------------------------------------
+        // Write commands to the command buffer.
+        let cmd0 = invalidate_devtab_entry(device_id);
+        // Build COMPLETION_WAIT with both S (store) and I (interrupt) flags.
+        let cw_store_data: u64 = 0xDEAD_BEEF_CAFE_1234;
+        let cmd1 = {
+            let dw0 = 0x03u32 // s=1 (bit 0), i=1 (bit 1)
+                | ((store_gpa >> 3) as u32 & 0x1FFF_FFFF) << 3;
+            let dw1 = (CommandOpcode::COMPLETION_WAIT.0 as u32) << 28
+                | ((store_gpa >> 32) as u32 & 0x000F_FFFF);
+            CommandEntry {
+                dw0,
+                dw1,
+                dw2: cw_store_data as u32,
+                dw3: (cw_store_data >> 32) as u32,
+            }
+        };
+        dev.shared
+            .guest_memory
+            .write_plain(cmdbuf_gpa, &cmd0)
+            .unwrap();
+        dev.shared
+            .guest_memory
+            .write_plain(cmdbuf_gpa + 16, &cmd1)
+            .unwrap();
+
+        // Poke CmdBufTail to process both commands.
+        let tail = CmdBufTail::new().with_tail_ptr(2);
+        mmio_write64(
+            &mut dev,
+            MmioRegister::CMD_BUF_TAIL.0 as u64,
+            tail.into_bits(),
+        );
+
+        // Verify CmdBufHead advanced to 2.
+        let head =
+            CmdBufHead::from_bits(mmio_read64(&mut dev, MmioRegister::CMD_BUF_HEAD.0 as u64));
+        assert_eq!(head.head_ptr(), 2, "CmdBufHead should advance to 2");
+
+        // Verify COMPLETION_WAIT store data written.
+        let store_readback: u64 = dev
+            .shared
+            .guest_memory
+            .read_plain(store_gpa)
+            .expect("read store data");
+        assert_eq!(store_readback, cw_store_data);
+
+        // Verify ComWaitInt is set.
+        let status =
+            IommuStatus::from_bits(mmio_read64(&mut dev, MmioRegister::IOMMU_STATUS.0 as u64));
+        assert!(status.com_wait_int(), "ComWaitInt should be set");
+
+        // Clear ComWaitInt (RW1C).
+        let clear_status = IommuStatus::new().with_com_wait_int(true);
+        mmio_write64(
+            &mut dev,
+            MmioRegister::IOMMU_STATUS.0 as u64,
+            clear_status.into_bits(),
+        );
+        let status =
+            IommuStatus::from_bits(mmio_read64(&mut dev, MmioRegister::IOMMU_STATUS.0 as u64));
+        assert!(
+            !status.com_wait_int(),
+            "ComWaitInt should be cleared after RW1C"
+        );
+
+        // -----------------------------------------------------------------
+        // Create per-device wrappers.
+        // -----------------------------------------------------------------
+        let shared = dev.shared_state().clone();
+        let mock_msi = MockSignalMsi::new();
+        let (iommu_gm, iommu_msi) = shared.create_device_context(
+            bus_range_for_device_id(device_id),
+            &dev.shared.guest_memory,
+            mock_msi.clone(),
+        );
+
+        // -----------------------------------------------------------------
+        // Step 11: Write test data to GPA via raw guest memory.
+        // -----------------------------------------------------------------
+        let test_data = [0xDE, 0xAD, 0xBE, 0xEF, 0xCA, 0xFE, 0xBA, 0xBE];
+        dev.shared
+            .guest_memory
+            .write_at(dma_target_gpa, &test_data)
+            .unwrap();
+
+        // -----------------------------------------------------------------
+        // Step 12: Read via IommuTranslatingMemory at IOVA 0x0.
+        // -----------------------------------------------------------------
+        let mut buf = [0u8; 8];
+        iommu_gm
+            .read_at(0x0, &mut buf)
+            .expect("DMA read should succeed through IOMMU translation");
+        assert_eq!(buf, test_data, "DMA read data should match");
+
+        // -----------------------------------------------------------------
+        // Step 13: Write via IommuTranslatingMemory, read from GPA.
+        // -----------------------------------------------------------------
+        let write_data = [0x01, 0x02, 0x03, 0x04];
+        iommu_gm
+            .write_at(0x100, &write_data)
+            .expect("DMA write should succeed");
+
+        let mut verify_buf = [0u8; 4];
+        dev.shared
+            .guest_memory
+            .read_at(dma_target_gpa + 0x100, &mut verify_buf)
+            .unwrap();
+        assert_eq!(
+            verify_buf, write_data,
+            "DMA write data should appear at GPA"
+        );
+
+        // -----------------------------------------------------------------
+        // Step 14: Read from unmapped IOVA, verify error + event log entry.
+        // -----------------------------------------------------------------
+        // IOVA 0x1000 is page index 1, which has no L1 PTE (PR=0).
+        let mut fail_buf = [0u8; 4];
+        let result = iommu_gm.read_at(0x1000, &mut fail_buf);
+        assert!(
+            result.is_err(),
+            "read from unmapped IOVA should return error"
+        );
+
+        // Verify event log has an IO_PAGE_FAULT entry.
+        let evt_tail =
+            EvtLogTail::from_bits(mmio_read64(&mut dev, MmioRegister::EVT_LOG_TAIL.0 as u64));
+        assert!(
+            evt_tail.tail_ptr() > 0,
+            "event log should have at least one entry"
+        );
+        let event: EventEntry = dev
+            .shared
+            .guest_memory
+            .read_plain(evtlog_gpa)
+            .expect("read event log entry");
+        assert_eq!(
+            event.event_code(),
+            EventCode::IO_PAGE_FAULT,
+            "event should be IO_PAGE_FAULT"
+        );
+        assert_eq!(event.device_id(), device_id, "fault device_id should match");
+
+        // -----------------------------------------------------------------
+        // Step 15: Fire MSI via IommuSignalMsi, verify remapped output.
+        // -----------------------------------------------------------------
+        // Original MSI data = 0x30 → IRTE index 0x30, which we set up above
+        // to remap to vector 0x40, destination 0, physical.
+        iommu_msi.signal_msi(Some(device_id as u32), 0xFEE0_0000, 0x30);
+
+        let (devid, new_addr, new_data) =
+            mock_msi.last().expect("remapped MSI should be delivered");
+        assert_eq!(devid, Some(device_id as u32));
+        // Destination 0 → address = 0xFEE0_0000 | (0 << 12) = 0xFEE0_0000
+        assert_eq!(
+            new_addr, 0xFEE0_0000,
+            "remapped MSI address should have destination 0"
+        );
+        // Vector 0x40, delivery mode Fixed (0)
+        assert_eq!(new_data & 0xFF, 0x40, "remapped vector should be 0x40");
+        assert_eq!(
+            (new_data >> 8) & 0x7,
+            0,
+            "delivery mode should be Fixed (0)"
+        );
+    }
+
+    // =========================================================================
+    // Multi-page and cross-page DMA translation tests
+    // =========================================================================
+
+    /// Set up an IOMMU with two consecutive IOVA pages mapped to
+    /// non-contiguous GPAs, for testing cross-page and large DMA accesses.
+    ///
+    /// Memory layout (2MB guest memory):
+    ///   0x01_0000  Device table (256 entries)
+    ///   0x05_0000  L1 page table (512 entries, only [0] and [1] populated)
+    ///   0x08_0000  Command buffer
+    ///   0x09_0000  Event log
+    ///   0x0A_0000  Target page 0: IOVA 0x0000–0x0FFF → GPA 0x0A_0000
+    ///   0x0C_0000  Target page 1: IOVA 0x1000–0x1FFF → GPA 0x0C_0000
+    ///              (deliberately non-contiguous GPAs)
+    fn setup_iommu_two_pages() -> AmdIommuDevice {
+        let guest_memory = GuestMemory::allocate(0x20_0000); // 2MB
+        let msi_conn =
+            pci_core::msi::MsiConnection::new(pci_core::bus_range::AssignedBusRange::new(), 0);
+        let mut dev = AmdIommuDevice::new(guest_memory, test_config(), msi_conn.target());
+
+        let devtab_gpa = 0x1_0000;
+        setup_iommu_with_devtab(&mut dev, devtab_gpa, 512);
+
+        let l1_gpa = 0x5_0000u64;
+        let target_page0 = 0xA_0000u64;
+        let target_page1 = 0xC_0000u64;
+
+        // L1[0] → GPA 0xA_0000
+        write_pte(
+            &dev,
+            l1_gpa,
+            0,
+            &IommuPte::new()
+                .with_pr(true)
+                .with_next_level(0)
+                .with_address(target_page0 >> 12)
+                .with_ir(true)
+                .with_iw(true),
+        );
+        // L1[1] → GPA 0xC_0000
+        write_pte(
+            &dev,
+            l1_gpa,
+            1,
+            &IommuPte::new()
+                .with_pr(true)
+                .with_next_level(0)
+                .with_address(target_page1 >> 12)
+                .with_ir(true)
+                .with_iw(true),
+        );
+
+        let dte = make_dte_with_translation(l1_gpa, 1, true, true, 1);
+        write_dte(&dev, devtab_gpa, WRAPPER_DEVICE_ID, &dte);
+
+        dev
+    }
+
+    fn setup_iommu_multi_region_target() -> AmdIommuDevice {
+        let guest_memory = GuestMemory::new_multi_region(
+            "iommu-multi-region-test",
+            0x10_0000,
+            vec![
+                Some(guestmem::AlignedHeapMemory::new(0x20_000)),
+                Some(guestmem::AlignedHeapMemory::new(0x20_000)),
+            ],
+        )
+        .unwrap();
+        let msi_conn =
+            pci_core::msi::MsiConnection::new(pci_core::bus_range::AssignedBusRange::new(), 0);
+        let mut dev = AmdIommuDevice::new(guest_memory, test_config(), msi_conn.target());
+
+        let devtab_gpa = 0x1000;
+        setup_iommu_with_devtab(&mut dev, devtab_gpa, 512);
+
+        let l1_gpa = 0x5000u64;
+        let target_page0 = 0x10_0000u64;
+        let target_page1 = 0x10_1000u64;
+
+        write_pte(
+            &dev,
+            l1_gpa,
+            0,
+            &IommuPte::new()
+                .with_pr(true)
+                .with_next_level(0)
+                .with_address(target_page0 >> 12)
+                .with_ir(true)
+                .with_iw(true),
+        );
+        write_pte(
+            &dev,
+            l1_gpa,
+            1,
+            &IommuPte::new()
+                .with_pr(true)
+                .with_next_level(0)
+                .with_address(target_page1 >> 12)
+                .with_ir(true)
+                .with_iw(true),
+        );
+
+        let dte = make_dte_with_translation(l1_gpa, 1, true, true, 1);
+        write_dte(&dev, devtab_gpa, WRAPPER_DEVICE_ID, &dte);
+
+        dev
+    }
+
+    #[test]
+    fn test_translating_memory_write_plain_u32() {
+        let dev = setup_iommu_for_wrappers();
+        let shared = dev.shared_state().clone();
+        let mock_msi = MockSignalMsi::new();
+        let (iommu_gm, _msi) =
+            shared.create_device_context(wrapper_bus_range(), &dev.shared.guest_memory, mock_msi);
+
+        // write_plain<u32> at IOVA offset 0x100.
+        iommu_gm.write_plain::<u32>(0x100, &0xDEAD_BEEFu32).unwrap();
+
+        let val: u32 = dev.shared.guest_memory.read_plain(0xA_0100).unwrap();
+        assert_eq!(val, 0xDEAD_BEEF);
+    }
+
+    #[test]
+    fn test_translating_memory_read_plain_u32() {
+        let dev = setup_iommu_for_wrappers();
+        let shared = dev.shared_state().clone();
+        let mock_msi = MockSignalMsi::new();
+        let (iommu_gm, _msi) =
+            shared.create_device_context(wrapper_bus_range(), &dev.shared.guest_memory, mock_msi);
+
+        dev.shared
+            .guest_memory
+            .write_plain::<u32>(0xA_0200, &0xCAFE_BABEu32)
+            .unwrap();
+
+        let val: u32 = iommu_gm.read_plain(0x200).unwrap();
+        assert_eq!(val, 0xCAFE_BABE);
+    }
+
+    #[test]
+    fn test_translating_memory_fill() {
+        let dev = setup_iommu_for_wrappers();
+        let shared = dev.shared_state().clone();
+        let mock_msi = MockSignalMsi::new();
+        let (iommu_gm, _msi) =
+            shared.create_device_context(wrapper_bus_range(), &dev.shared.guest_memory, mock_msi);
+
+        // Fill 64 bytes at IOVA 0x300 with 0xAB.
+        iommu_gm.fill_at(0x300, 0xAB, 64).unwrap();
+
+        let mut buf = [0u8; 64];
+        dev.shared.guest_memory.read_at(0xA_0300, &mut buf).unwrap();
+        assert!(buf.iter().all(|&b| b == 0xAB));
+    }
+
+    #[test]
+    fn test_translating_memory_large_intra_page() {
+        let dev = setup_iommu_for_wrappers();
+        let shared = dev.shared_state().clone();
+        let mock_msi = MockSignalMsi::new();
+        let (iommu_gm, _msi) =
+            shared.create_device_context(wrapper_bus_range(), &dev.shared.guest_memory, mock_msi);
+
+        // Write a full 4KB page via IOMMU-translated memory.
+        let data: Vec<u8> = (0..4096u32).map(|i| (i & 0xFF) as u8).collect();
+        iommu_gm.write_at(0x0, &data).unwrap();
+
+        let mut readback = vec![0u8; 4096];
+        dev.shared
+            .guest_memory
+            .read_at(0xA_0000, &mut readback)
+            .unwrap();
+        assert_eq!(readback, data);
+
+        // Read it back through the IOMMU too.
+        let mut via_iommu = vec![0u8; 4096];
+        iommu_gm.read_at(0x0, &mut via_iommu).unwrap();
+        assert_eq!(via_iommu, data);
+    }
+
+    #[test]
+    fn test_translating_memory_cross_page_read() {
+        let dev = setup_iommu_two_pages();
+        let shared = dev.shared_state().clone();
+        let mock_msi = MockSignalMsi::new();
+        let (iommu_gm, _msi) =
+            shared.create_device_context(wrapper_bus_range(), &dev.shared.guest_memory, mock_msi);
+
+        // Write known patterns at the end of page 0 and start of page 1
+        // in the raw guest memory (non-contiguous GPAs).
+        dev.shared
+            .guest_memory
+            .write_at(0xA_0FF0, &[0x11; 16])
+            .unwrap();
+        dev.shared
+            .guest_memory
+            .write_at(0xC_0000, &[0x22; 16])
+            .unwrap();
+
+        // Read 32 bytes spanning IOVA 0x0FF0–0x100F (crosses page boundary).
+        let mut buf = [0u8; 32];
+        iommu_gm.read_at(0x0FF0, &mut buf).unwrap();
+
+        assert_eq!(&buf[..16], &[0x11; 16], "first half from page 0");
+        assert_eq!(&buf[16..], &[0x22; 16], "second half from page 1");
+    }
+
+    #[test]
+    fn test_translating_memory_cross_page_write() {
+        let dev = setup_iommu_two_pages();
+        let shared = dev.shared_state().clone();
+        let mock_msi = MockSignalMsi::new();
+        let (iommu_gm, _msi) =
+            shared.create_device_context(wrapper_bus_range(), &dev.shared.guest_memory, mock_msi);
+
+        // Write 32 bytes spanning IOVA 0x0FF0–0x100F.
+        let data: Vec<u8> = (0..32u8).collect();
+        iommu_gm.write_at(0x0FF0, &data).unwrap();
+
+        // Verify first 16 bytes landed at GPA 0xA_0FF0.
+        let mut buf0 = [0u8; 16];
+        dev.shared
+            .guest_memory
+            .read_at(0xA_0FF0, &mut buf0)
+            .unwrap();
+        assert_eq!(&buf0, &data[..16]);
+
+        // Verify last 16 bytes landed at GPA 0xC_0000.
+        let mut buf1 = [0u8; 16];
+        dev.shared
+            .guest_memory
+            .read_at(0xC_0000, &mut buf1)
+            .unwrap();
+        assert_eq!(&buf1, &data[16..]);
+    }
+
+    #[test]
+    fn test_translating_memory_cross_page_fill() {
+        let dev = setup_iommu_two_pages();
+        let shared = dev.shared_state().clone();
+        let mock_msi = MockSignalMsi::new();
+        let (iommu_gm, _msi) =
+            shared.create_device_context(wrapper_bus_range(), &dev.shared.guest_memory, mock_msi);
+
+        // Fill 256 bytes spanning the page boundary at IOVA 0x0F80–0x107F.
+        iommu_gm.fill_at(0x0F80, 0xCC, 256).unwrap();
+
+        // First 128 bytes at GPA 0xA_0F80.
+        let mut buf0 = [0u8; 128];
+        dev.shared
+            .guest_memory
+            .read_at(0xA_0F80, &mut buf0)
+            .unwrap();
+        assert!(buf0.iter().all(|&b| b == 0xCC));
+
+        // Next 128 bytes at GPA 0xC_0000.
+        let mut buf1 = [0u8; 128];
+        dev.shared
+            .guest_memory
+            .read_at(0xC_0000, &mut buf1)
+            .unwrap();
+        assert!(buf1.iter().all(|&b| b == 0xCC));
+    }
+
+    #[test]
+    fn test_translating_memory_subrange_cross_page_write() {
+        let dev = setup_iommu_two_pages();
+        let shared = dev.shared_state().clone();
+        let mock_msi = MockSignalMsi::new();
+        let (iommu_gm, _msi) =
+            shared.create_device_context(wrapper_bus_range(), &dev.shared.guest_memory, mock_msi);
+
+        let subrange = iommu_gm.subrange(0x0FF0, 0x20, true).unwrap();
+        let data: Vec<u8> = (0..32u8).map(|n| n.wrapping_add(0x40)).collect();
+        subrange.write_at(0, &data).unwrap();
+
+        let mut buf0 = [0u8; 16];
+        dev.shared
+            .guest_memory
+            .read_at(0xA_0FF0, &mut buf0)
+            .unwrap();
+        assert_eq!(&buf0, &data[..16]);
+
+        let mut buf1 = [0u8; 16];
+        dev.shared
+            .guest_memory
+            .read_at(0xC_0000, &mut buf1)
+            .unwrap();
+        assert_eq!(&buf1, &data[16..]);
+    }
+
+    #[test]
+    fn test_translating_memory_paged_range_write() {
+        let dev = setup_iommu_two_pages();
+        let shared = dev.shared_state().clone();
+        let mock_msi = MockSignalMsi::new();
+        let (iommu_gm, _msi) =
+            shared.create_device_context(wrapper_bus_range(), &dev.shared.guest_memory, mock_msi);
+
+        let iova_gpns = [0, 1];
+        let range = guestmem::ranges::PagedRange::new(0x0FF0, 0x20, &iova_gpns).unwrap();
+        let data: Vec<u8> = (0..32u8).map(|n| n.wrapping_add(0x80)).collect();
+        iommu_gm.write_range(&range, &data).unwrap();
+
+        let mut buf0 = [0u8; 16];
+        dev.shared
+            .guest_memory
+            .read_at(0xA_0FF0, &mut buf0)
+            .unwrap();
+        assert_eq!(&buf0, &data[..16]);
+
+        let mut buf1 = [0u8; 16];
+        dev.shared
+            .guest_memory
+            .read_at(0xC_0000, &mut buf1)
+            .unwrap();
+        assert_eq!(&buf1, &data[16..]);
+    }
+
+    #[test]
+    fn test_translating_memory_compare_exchange_and_probe() {
+        let dev = setup_iommu_two_pages();
+        let shared = dev.shared_state().clone();
+        let mock_msi = MockSignalMsi::new();
+        let (iommu_gm, _msi) =
+            shared.create_device_context(wrapper_bus_range(), &dev.shared.guest_memory, mock_msi);
+
+        dev.shared
+            .guest_memory
+            .write_plain(0xA_0000, &0x1122_3344u32)
+            .unwrap();
+
+        let result = iommu_gm
+            .compare_exchange(0, 0x1122_3344u32, 0x5566_7788u32)
+            .unwrap();
+        assert_eq!(result, Ok(0x5566_7788));
+        assert_eq!(
+            dev.shared.guest_memory.read_plain::<u32>(0xA_0000).unwrap(),
+            0x5566_7788
+        );
+
+        let result = iommu_gm
+            .compare_exchange(0, 0x1122_3344u32, 0x99AA_BBCCu32)
+            .unwrap();
+        assert_eq!(result, Err(0x5566_7788));
+        assert_eq!(
+            dev.shared.guest_memory.read_plain::<u32>(0xA_0000).unwrap(),
+            0x5566_7788
+        );
+
+        dev.shared.guest_memory.write_at(0xC_0008, &[0xAB]).unwrap();
+        iommu_gm.probe_gpa_writable(0x1008).unwrap();
+        let mut byte = [0];
+        dev.shared
+            .guest_memory
+            .read_at(0xC_0008, &mut byte)
+            .unwrap();
+        assert_eq!(byte, [0xAB]);
+    }
+
+    #[test]
+    fn test_translating_memory_multi_region_target() {
+        let dev = setup_iommu_multi_region_target();
+        let shared = dev.shared_state().clone();
+        let mock_msi = MockSignalMsi::new();
+        let (iommu_gm, _msi) =
+            shared.create_device_context(wrapper_bus_range(), &dev.shared.guest_memory, mock_msi);
+
+        let data: Vec<u8> = (0..32u8).map(|n| n.wrapping_add(0x20)).collect();
+        iommu_gm.write_at(0x0FF0, &data).unwrap();
+
+        let mut buf0 = [0u8; 16];
+        dev.shared
+            .guest_memory
+            .read_at(0x10_0FF0, &mut buf0)
+            .unwrap();
+        assert_eq!(&buf0, &data[..16]);
+
+        let mut buf1 = [0u8; 16];
+        dev.shared
+            .guest_memory
+            .read_at(0x10_1000, &mut buf1)
+            .unwrap();
+        assert_eq!(&buf1, &data[16..]);
+    }
+
+    #[test]
+    fn test_translating_memory_cross_page_single_byte() {
+        let dev = setup_iommu_two_pages();
+        let shared = dev.shared_state().clone();
+        let mock_msi = MockSignalMsi::new();
+        let (iommu_gm, _msi) =
+            shared.create_device_context(wrapper_bus_range(), &dev.shared.guest_memory, mock_msi);
+
+        // Write single bytes at the last byte of page 0 and first byte of page 1.
+        iommu_gm.write_at(0x0FFF, &[0xAA]).unwrap();
+        iommu_gm.write_at(0x1000, &[0xBB]).unwrap();
+
+        let mut b0 = [0u8; 1];
+        dev.shared.guest_memory.read_at(0xA_0FFF, &mut b0).unwrap();
+        assert_eq!(b0, [0xAA]);
+
+        let mut b1 = [0u8; 1];
+        dev.shared.guest_memory.read_at(0xC_0000, &mut b1).unwrap();
+        assert_eq!(b1, [0xBB]);
+    }
+
+    #[test]
+    fn test_translating_memory_cross_page_fault_second_page() {
+        // Map only page 0, leave page 1 unmapped. A cross-page access
+        // should fault when it reaches the unmapped second page.
+        let dev = setup_iommu_for_wrappers(); // only IOVA page 0 mapped
+        let shared = dev.shared_state().clone();
+        let mock_msi = MockSignalMsi::new();
+        let (iommu_gm, _msi) =
+            shared.create_device_context(wrapper_bus_range(), &dev.shared.guest_memory, mock_msi);
+
+        // Read 32 bytes starting at IOVA 0x0FF0 — last 16 bytes cross into
+        // unmapped page 1.
+        let mut buf = [0u8; 32];
+        let result = iommu_gm.read_at(0x0FF0, &mut buf);
+        assert!(
+            result.is_err(),
+            "cross-page read into unmapped page should fault"
+        );
+    }
+
+    /// Test 3-level page table translation with high IOVAs (like Linux's
+    /// reverse IOVA allocator uses: 0xFFFFF000, 0xFFFFE000, etc.).
+    ///
+    /// This mimics the real page table layout a Linux 6.1 guest creates
+    /// for an AMD IOMMU with mode=3 (3-level, 39-bit VA space).
+    #[test]
+    fn test_translating_memory_3level_high_iova() {
+        let guest_memory = GuestMemory::allocate(0x20_0000); // 2MB
+        let msi_conn =
+            pci_core::msi::MsiConnection::new(pci_core::bus_range::AssignedBusRange::new(), 0);
+        let mut dev = AmdIommuDevice::new(guest_memory, test_config(), msi_conn.target());
+
+        let devtab_gpa = 0x1_0000;
+        setup_iommu_with_devtab(&mut dev, devtab_gpa, 512);
+
+        // Build 3-level page tables mapping:
+        //   IOVA 0xFFFFF000 → GPA 0x15_0000
+        //   IOVA 0xFFFFE000 → GPA 0x15_1000
+        //
+        // With mode=3 (39-bit VA space):
+        //   L3 index = (iova >> 30) & 0x1FF
+        //   L2 index = (iova >> 21) & 0x1FF
+        //   L1 index = (iova >> 12) & 0x1FF
+        //
+        // For IOVA 0xFFFFF000:
+        //   L3 index = (0xFFFFF000 >> 30) & 0x1FF = 3
+        //   L2 index = (0xFFFFF000 >> 21) & 0x1FF = 511
+        //   L1 index = (0xFFFFF000 >> 12) & 0x1FF = 511
+        //
+        // For IOVA 0xFFFFE000:
+        //   L3 index = 3, L2 index = 511, L1 index = 510
+
+        let l3_gpa = 0x5_0000u64;
+        let l2_gpa = 0x6_0000u64;
+        let l1_gpa = 0x7_0000u64;
+        let target0_gpa = 0x15_0000u64;
+        let target1_gpa = 0x15_1000u64;
+
+        // L3[3] → L2
+        write_pte(
+            &dev,
+            l3_gpa,
+            3,
+            &IommuPte::new()
+                .with_pr(true)
+                .with_next_level(2)
+                .with_address(l2_gpa >> 12)
+                .with_ir(true)
+                .with_iw(true),
+        );
+        // L2[511] → L1
+        write_pte(
+            &dev,
+            l2_gpa,
+            511,
+            &IommuPte::new()
+                .with_pr(true)
+                .with_next_level(1)
+                .with_address(l1_gpa >> 12)
+                .with_ir(true)
+                .with_iw(true),
+        );
+        // L1[511] → target0 (IOVA 0xFFFFF000)
+        write_pte(
+            &dev,
+            l1_gpa,
+            511,
+            &IommuPte::new()
+                .with_pr(true)
+                .with_next_level(0)
+                .with_address(target0_gpa >> 12)
+                .with_ir(true)
+                .with_iw(true),
+        );
+        // L1[510] → target1 (IOVA 0xFFFFE000)
+        write_pte(
+            &dev,
+            l1_gpa,
+            510,
+            &IommuPte::new()
+                .with_pr(true)
+                .with_next_level(0)
+                .with_address(target1_gpa >> 12)
+                .with_ir(true)
+                .with_iw(true),
+        );
+
+        // DTE for the assigned wrapper test bus: 3-level page table.
+        let dte = make_dte_with_translation(l3_gpa, 3, true, true, 1);
+        write_dte(&dev, devtab_gpa, WRAPPER_DEVICE_ID, &dte);
+
+        let shared = dev.shared_state().clone();
+        let mock_msi = MockSignalMsi::new();
+        let (iommu_gm, _msi) =
+            shared.create_device_context(wrapper_bus_range(), &dev.shared.guest_memory, mock_msi);
+
+        // Write test pattern at GPA 0x15_0000 (target for IOVA 0xFFFFF000).
+        dev.shared
+            .guest_memory
+            .write_at(target0_gpa, &[0xDE, 0xAD, 0xBE, 0xEF])
+            .unwrap();
+
+        // Read via IOVA 0xFFFFF000 through IOMMU translation.
+        let mut buf = [0u8; 4];
+        iommu_gm.read_at(0xFFFFF000, &mut buf).unwrap();
+        assert_eq!(buf, [0xDE, 0xAD, 0xBE, 0xEF]);
+
+        // Write via IOVA 0xFFFFF100.
+        iommu_gm.write_at(0xFFFFF100, &[0xCA, 0xFE]).unwrap();
+        let mut buf2 = [0u8; 2];
+        dev.shared
+            .guest_memory
+            .read_at(target0_gpa + 0x100, &mut buf2)
+            .unwrap();
+        assert_eq!(buf2, [0xCA, 0xFE]);
+
+        // Write via IOVA 0xFFFFE000 (second mapped page).
+        iommu_gm
+            .write_at(0xFFFFE000, &[0x42, 0x43, 0x44, 0x45])
+            .unwrap();
+        let mut buf3 = [0u8; 4];
+        dev.shared
+            .guest_memory
+            .read_at(target1_gpa, &mut buf3)
+            .unwrap();
+        assert_eq!(buf3, [0x42, 0x43, 0x44, 0x45]);
+
+        // write_plain<u32> via IOVA (the NVMe shadow doorbell path).
+        iommu_gm
+            .write_plain::<u32>(0xFFFFF200, &0xDEAD_BEEFu32)
+            .unwrap();
+        let val: u32 = dev
+            .shared
+            .guest_memory
+            .read_plain(target0_gpa + 0x200)
+            .unwrap();
+        assert_eq!(val, 0xDEAD_BEEF);
+
+        // Verify subrange works (the virtio path).
+        let sub = iommu_gm.subrange(0xFFFFF000, 0x1000, false).unwrap();
+        sub.write_at(0x300, &[0xAA, 0xBB]).unwrap();
+        let mut buf4 = [0u8; 2];
+        dev.shared
+            .guest_memory
+            .read_at(target0_gpa + 0x300, &mut buf4)
+            .unwrap();
+        assert_eq!(buf4, [0xAA, 0xBB]);
+
+        // Cross-page read spanning IOVA 0xFFFFEFFF–0xFFFFF000.
+        dev.shared
+            .guest_memory
+            .write_at(target1_gpa + 0xFFC, &[0x11, 0x22, 0x33, 0x44])
+            .unwrap();
+        dev.shared
+            .guest_memory
+            .write_at(target0_gpa, &[0x55, 0x66, 0x77, 0x88])
+            .unwrap();
+        let mut buf5 = [0u8; 8];
+        iommu_gm.read_at(0xFFFFEFFC, &mut buf5).unwrap();
+        assert_eq!(buf5, [0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88]);
+    }
+
+    // =========================================================================
+    // Regression tests for pointer/overflow hardening
+    // =========================================================================
+
+    /// §3.4.15: If software sets the command buffer tail pointer to an offset
+    /// beyond the buffer length, IOMMU behavior is undefined. The emulator
+    /// masks to the buffer size to prevent an infinite spin.
+    #[test]
+    fn test_cmdbuf_out_of_range_tail_no_spin() {
+        let mut dev = create_test_device_with_memory();
+        setup_iommu_enabled(&mut dev);
+
+        // Command buffer is 256 entries (log2=8), so valid tail range is 0..255.
+        // 300 % 256 = 44, so after masking we need valid commands at entries 0..43.
+        for i in 0..44 {
+            write_cmd(&dev, i, &invalidate_devtab_entry(0x01));
+        }
+
+        // Set tail pointer well beyond the buffer size (entry index 300).
+        // Without masking, head would never equal tail and spin forever.
+        let out_of_range_tail = CmdBufTail::new().with_tail_ptr(300);
+        mmio_write64(
+            &mut dev,
+            MmioRegister::CMD_BUF_TAIL.0 as u64,
+            out_of_range_tail.into_bits(),
+        );
+
+        // The test completing without hanging proves the fix works.
+        // Head should have advanced to the masked tail position: 300 % 256 = 44.
+        let head =
+            CmdBufHead::from_bits(mmio_read64(&mut dev, MmioRegister::CMD_BUF_HEAD.0 as u64));
+        assert_eq!(
+            head.head_ptr(),
+            300 % 256,
+            "head should stop at tail masked to buffer size"
+        );
+    }
+
+    /// §3.4.15: If software sets the event log head pointer to an offset
+    /// beyond the buffer length, IOMMU behavior is undefined. The emulator
+    /// masks to the buffer size so the overflow check stays within the ring.
+    #[test]
+    fn test_evtlog_out_of_range_head_masked() {
+        let mut dev = create_test_device_with_memory();
+        setup_iommu_enabled(&mut dev);
+
+        // Set event log head to an out-of-range value (entry index 300).
+        let out_of_range_head = EvtLogHead::new().with_head_ptr(300);
+        mmio_write64(
+            &mut dev,
+            MmioRegister::EVT_LOG_HEAD.0 as u64,
+            out_of_range_head.into_bits(),
+        );
+
+        // Write an event — should not write outside the ring or panic.
+        let event = EventEntry::io_page_fault(0xBEEF, 0x0001, false, false, 0x0);
+        dev.write_event(event);
+
+        // Tail should have advanced (event was written successfully).
+        let tail =
+            EvtLogTail::from_bits(mmio_read64(&mut dev, MmioRegister::EVT_LOG_TAIL.0 as u64));
+        assert!(tail.tail_ptr() > 0, "event should have been logged");
+    }
+
+    /// A 2-byte DMA read at IOVA u64::MAX must hit the `checked_add`
+    /// overflow guard after the first 1-byte chunk succeeds.
+    ///
+    /// Setup: 1-level page table with L1[511] mapped to a backed GPA.
+    /// IOVA u64::MAX has L1 index 511 and page offset 0xFFF, so the
+    /// first chunk is 1 byte and translates successfully. Advancing
+    /// the IOVA for the second chunk requires u64::MAX + 1, which
+    /// overflows and returns an error.
+    #[test]
+    fn test_translating_memory_iova_overflow() {
+        let guest_memory = GuestMemory::allocate(0x10_0000);
+        let msi_conn =
+            pci_core::msi::MsiConnection::new(pci_core::bus_range::AssignedBusRange::new(), 0);
+        let mut dev = AmdIommuDevice::new(guest_memory, test_config(), msi_conn.target());
+
+        let devtab_gpa = 0x1_0000;
+        setup_iommu_with_devtab(&mut dev, devtab_gpa, 512);
+
+        // 1-level page table: L1[511] → GPA 0xA_0000 (backed memory).
+        // IOVA u64::MAX has L1 index 511, page offset 0xFFF.
+        let l1_gpa = 0x5_0000u64;
+        let target_gpa = 0xA_0000u64;
+        write_pte(
+            &dev,
+            l1_gpa,
+            511,
+            &IommuPte::new()
+                .with_pr(true)
+                .with_next_level(0)
+                .with_address(target_gpa >> 12)
+                .with_ir(true)
+                .with_iw(true),
+        );
+
+        let dte = make_dte_with_translation(l1_gpa, 1, true, true, 1);
+        write_dte(&dev, devtab_gpa, WRAPPER_DEVICE_ID, &dte);
+
+        let shared = dev.shared_state().clone();
+        let mock_msi = MockSignalMsi::new();
+        let (iommu_gm, _msi) =
+            shared.create_device_context(wrapper_bus_range(), &dev.shared.guest_memory, mock_msi);
+
+        // Write a known byte at the target GPA + 0xFFF so the first
+        // chunk's read succeeds with real data.
+        dev.shared
+            .guest_memory
+            .write_at(target_gpa + 0xFFF, &[0x42])
+            .unwrap();
+
+        // 2-byte read at IOVA u64::MAX:
+        //   chunk 1: 1 byte at page offset 0xFFF → translates to
+        //            target_gpa + 0xFFF → succeeds
+        //   advance: u64::MAX + 1 → checked_add overflow → error
+        let mut buf = [0u8; 2];
+        let result = iommu_gm.read_at(u64::MAX, &mut buf);
+        assert!(result.is_err(), "should fail on IOVA overflow, not wrap");
+    }
+}

--- a/vm/devices/iommu/amd_iommu/src/spec/commands.rs
+++ b/vm/devices/iommu/amd_iommu/src/spec/commands.rs
@@ -1,0 +1,332 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Command buffer entry types for the AMD IOMMU.
+//!
+//! All commands are 128 bits (16 bytes). Based on AMD IOMMU Specification
+//! Rev 3.11, §2.4.
+
+use bitfield_struct::bitfield;
+use inspect::Inspect;
+use open_enum::open_enum;
+use zerocopy::FromBytes;
+use zerocopy::Immutable;
+use zerocopy::IntoBytes;
+use zerocopy::KnownLayout;
+
+/// A raw 128-bit command buffer entry (16 bytes).
+#[derive(Debug, Copy, Clone, FromBytes, IntoBytes, Immutable, KnownLayout)]
+#[repr(C)]
+pub struct CommandEntry {
+    /// First dword: operand-dependent fields.
+    pub dw0: u32,
+    /// Second dword: bits 31:28 = opcode, bits 27:0 = operand-dependent.
+    pub dw1: u32,
+    /// Third dword: second operand low.
+    pub dw2: u32,
+    /// Fourth dword: second operand high.
+    pub dw3: u32,
+}
+
+impl CommandEntry {
+    /// Extract the 4-bit opcode from bits 31:28 of dw1.
+    pub fn opcode(&self) -> CommandOpcode {
+        CommandOpcode((self.dw1 >> 28) as u8)
+    }
+}
+
+open_enum! {
+    /// AMD IOMMU command opcodes (§2.4).
+    #[derive(Inspect)]
+    #[inspect(debug)]
+    pub enum CommandOpcode: u8 {
+        /// §2.4.1 — Write completion stamp and/or signal interrupt.
+        COMPLETION_WAIT             = 0x01,
+        /// §2.4.2 — Invalidate a device table entry.
+        INVALIDATE_DEVTAB_ENTRY     = 0x02,
+        /// §2.4.3 — Invalidate IOMMU TLB pages.
+        INVALIDATE_IOMMU_PAGES      = 0x03,
+        /// §2.4.4 — Invalidate IOTLB pages (requires IotlbSup).
+        INVALIDATE_IOTLB_PAGES      = 0x04,
+        /// §2.4.5 — Invalidate interrupt table entry.
+        INVALIDATE_INTERRUPT_TABLE  = 0x05,
+        /// §2.4.6 — Prefetch IOMMU pages (requires PreFSup).
+        PREFETCH_IOMMU_PAGES        = 0x06,
+        /// §2.4.8 — Invalidate all IOMMU state.
+        INVALIDATE_IOMMU_ALL        = 0x08,
+    }
+}
+
+/// COMPLETION_WAIT command fields (opcode 0x01, §2.4.1).
+///
+/// ```text
+/// +00: [31:3]=StoreAddress[31:3], [2]=f (flush), [1]=i (interrupt), [0]=s (store)
+/// +04: [31:28]=01h, [19:0]=StoreAddress[51:32]
+/// +08: [31:0]=StoreData[31:0]
+/// +12: [31:0]=StoreData[63:32]
+/// ```
+#[bitfield(u64)]
+#[derive(Inspect)]
+#[rustfmt::skip]
+pub struct CompletionWaitDw0Dw1 {
+    /// Store flag — if set, write StoreData to StoreAddress.
+    pub s: bool,
+    /// Interrupt flag — if set, signal completion interrupt.
+    pub i: bool,
+    /// Flush flag — if set, flush internal write buffers. No-op for emulator.
+    pub f: bool,
+    /// Store address bits [31:3].
+    #[bits(29)]
+    pub store_addr_lo: u32,
+    /// Store address bits [51:32].
+    #[bits(20)]
+    pub store_addr_hi: u32,
+    #[bits(8)]
+    _reserved: u64,
+    /// Opcode (must be 0x01). Bits [31:28] of dw1.
+    #[bits(4)]
+    _opcode: u8,
+}
+
+impl CompletionWaitDw0Dw1 {
+    /// Reconstruct the full 52-bit store address (bits 51:3 shifted left by 3).
+    pub fn store_address(&self) -> u64 {
+        let lo = self.store_addr_lo() as u64;
+        let hi = self.store_addr_hi() as u64;
+        (hi << 29 | lo) << 3
+    }
+}
+
+/// Parse a `CommandEntry` as COMPLETION_WAIT fields.
+impl From<&CommandEntry> for CompletionWaitDw0Dw1 {
+    fn from(entry: &CommandEntry) -> Self {
+        let raw = (entry.dw0 as u64) | ((entry.dw1 as u64) << 32);
+        CompletionWaitDw0Dw1::from(raw)
+    }
+}
+
+/// Extract the 64-bit StoreData from a COMPLETION_WAIT command.
+pub fn completion_wait_store_data(entry: &CommandEntry) -> u64 {
+    (entry.dw2 as u64) | ((entry.dw3 as u64) << 32)
+}
+
+/// INVALIDATE_DEVTAB_ENTRY command (opcode 0x02, §2.4.2).
+///
+/// ```text
+/// +00: [15:0]=DeviceID
+/// ```
+#[bitfield(u32)]
+#[derive(Inspect)]
+#[rustfmt::skip]
+pub struct InvalidateDevTabEntry {
+    /// Device ID (BDF) to invalidate.
+    pub device_id: u16,
+    _reserved: u16,
+}
+
+impl From<&CommandEntry> for InvalidateDevTabEntry {
+    fn from(entry: &CommandEntry) -> Self {
+        InvalidateDevTabEntry::from(entry.dw0)
+    }
+}
+
+/// INVALIDATE_IOMMU_PAGES command (opcode 0x03, §2.4.3).
+///
+/// ```text
+/// +00: [19:0]=PASID
+/// +04: [31:28]=03h, [15:0]=DomainID
+/// +08: [31:12]=Address[31:12], [2]=GN, [1]=PDE, [0]=S
+/// +12: [31:0]=Address[63:32]
+/// ```
+#[bitfield(u32)]
+#[derive(Inspect)]
+#[rustfmt::skip]
+pub struct InvalidateIommuPagesDw0 {
+    /// PASID (process address space ID, not used in our emulator).
+    #[bits(20)]
+    pub pasid: u32,
+    #[bits(12)]
+    _reserved: u32,
+}
+
+impl From<&CommandEntry> for InvalidateIommuPagesDw0 {
+    fn from(entry: &CommandEntry) -> Self {
+        InvalidateIommuPagesDw0::from(entry.dw0)
+    }
+}
+
+/// DomainID from dw1 of INVALIDATE_IOMMU_PAGES.
+pub fn invalidate_iommu_pages_domain_id(entry: &CommandEntry) -> u16 {
+    entry.dw1 as u16
+}
+
+/// Address and control bits from dw2/dw3 of INVALIDATE_IOMMU_PAGES.
+#[bitfield(u64)]
+#[derive(Inspect)]
+#[rustfmt::skip]
+pub struct InvalidateIommuPagesDw2Dw3 {
+    /// Size bit — 1 = invalidate all pages in domain.
+    pub s: bool,
+    /// PDE bit — 1 = also invalidate page directory entries.
+    pub pde: bool,
+    /// Guest/Nested bit.
+    pub gn: bool,
+    #[bits(9)]
+    _reserved: u64,
+    /// Address bits [31:12].
+    #[bits(20)]
+    pub addr_lo: u32,
+    /// Address bits [63:32].
+    pub addr_hi: u32,
+}
+
+impl From<&CommandEntry> for InvalidateIommuPagesDw2Dw3 {
+    fn from(entry: &CommandEntry) -> Self {
+        let raw = (entry.dw2 as u64) | ((entry.dw3 as u64) << 32);
+        InvalidateIommuPagesDw2Dw3::from(raw)
+    }
+}
+
+/// INVALIDATE_INTERRUPT_TABLE command (opcode 0x05, §2.4.5).
+///
+/// ```text
+/// +00: [15:0]=DeviceID
+/// ```
+#[bitfield(u32)]
+#[derive(Inspect)]
+#[rustfmt::skip]
+pub struct InvalidateInterruptTable {
+    /// Device ID (BDF) whose interrupt table to invalidate.
+    pub device_id: u16,
+    _reserved: u16,
+}
+
+impl From<&CommandEntry> for InvalidateInterruptTable {
+    fn from(entry: &CommandEntry) -> Self {
+        InvalidateInterruptTable::from(entry.dw0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_command_entry_opcode() {
+        let entry = CommandEntry {
+            dw0: 0,
+            dw1: 0x1000_0000, // opcode 1 = COMPLETION_WAIT
+            dw2: 0,
+            dw3: 0,
+        };
+        assert_eq!(entry.opcode(), CommandOpcode::COMPLETION_WAIT);
+    }
+
+    #[test]
+    fn test_command_opcodes() {
+        assert_eq!(CommandOpcode::COMPLETION_WAIT.0, 0x01);
+        assert_eq!(CommandOpcode::INVALIDATE_DEVTAB_ENTRY.0, 0x02);
+        assert_eq!(CommandOpcode::INVALIDATE_IOMMU_PAGES.0, 0x03);
+        assert_eq!(CommandOpcode::INVALIDATE_IOTLB_PAGES.0, 0x04);
+        assert_eq!(CommandOpcode::INVALIDATE_INTERRUPT_TABLE.0, 0x05);
+        assert_eq!(CommandOpcode::PREFETCH_IOMMU_PAGES.0, 0x06);
+        assert_eq!(CommandOpcode::INVALIDATE_IOMMU_ALL.0, 0x08);
+    }
+
+    #[test]
+    fn test_completion_wait_fields() {
+        // Build a COMPLETION_WAIT command: s=1, i=1, f=0,
+        // StoreAddress = 0x1000 (bits [31:3] = 0x200, bits [51:32] = 0)
+        let entry = CommandEntry {
+            dw0: 0x0000_1003, // addr[31:3]=0x200, s=1, i=1
+            dw1: 0x1000_0000, // opcode=1, addr[51:32]=0
+            dw2: 0xDEAD_BEEF, // StoreData low
+            dw3: 0xCAFE_BABE, // StoreData high
+        };
+        assert_eq!(entry.opcode(), CommandOpcode::COMPLETION_WAIT);
+
+        let cw = CompletionWaitDw0Dw1::from(&entry);
+        assert!(cw.s());
+        assert!(cw.i());
+        assert!(!cw.f());
+        assert_eq!(cw.store_address(), 0x1000);
+
+        let data = completion_wait_store_data(&entry);
+        assert_eq!(data, 0xCAFE_BABE_DEAD_BEEF);
+    }
+
+    #[test]
+    fn test_completion_wait_store_address_high() {
+        // Test with a store address that uses the high bits.
+        // StoreAddress = 0x1_0000_0000 (above 4GB)
+        // bits [31:3] = 0, bits [51:32] = 0x1_0000_0000 >> 32 = 1
+        // But StoreAddr is bits [51:3], so 0x1_0000_0000 >> 3 = 0x2000_0000
+        // store_addr_lo (bits [31:3]) = 0, store_addr_hi (bits [51:32]) = 0x1
+        let entry = CommandEntry {
+            dw0: 0x0000_0001, // s=1, addr_lo=0
+            dw1: 0x1000_0001, // opcode=1, addr_hi[19:0] = 1
+            dw2: 0,
+            dw3: 0,
+        };
+        let cw = CompletionWaitDw0Dw1::from(&entry);
+        assert!(cw.s());
+        assert_eq!(cw.store_address(), 1u64 << 32);
+    }
+
+    #[test]
+    fn test_invalidate_devtab_entry() {
+        let entry = CommandEntry {
+            dw0: 0x0000_00FF, // DeviceID = 0xFF
+            dw1: 0x2000_0000, // opcode=2
+            dw2: 0,
+            dw3: 0,
+        };
+        assert_eq!(entry.opcode(), CommandOpcode::INVALIDATE_DEVTAB_ENTRY);
+        let inv = InvalidateDevTabEntry::from(&entry);
+        assert_eq!(inv.device_id(), 0xFF);
+    }
+
+    #[test]
+    fn test_invalidate_iommu_pages() {
+        let entry = CommandEntry {
+            dw0: 0x0000_0000,
+            dw1: 0x3000_1234, // opcode=3, DomainID=0x1234
+            dw2: 0x1234_5001, // addr[31:12]=0x12345, S=1
+            dw3: 0x0000_0000,
+        };
+        assert_eq!(entry.opcode(), CommandOpcode::INVALIDATE_IOMMU_PAGES);
+        assert_eq!(invalidate_iommu_pages_domain_id(&entry), 0x1234);
+        let dw2dw3 = InvalidateIommuPagesDw2Dw3::from(&entry);
+        assert!(dw2dw3.s());
+        assert!(!dw2dw3.pde());
+    }
+
+    #[test]
+    fn test_invalidate_interrupt_table() {
+        let entry = CommandEntry {
+            dw0: 0x0000_ABCD,
+            dw1: 0x5000_0000, // opcode=5
+            dw2: 0,
+            dw3: 0,
+        };
+        assert_eq!(entry.opcode(), CommandOpcode::INVALIDATE_INTERRUPT_TABLE);
+        let inv = InvalidateInterruptTable::from(&entry);
+        assert_eq!(inv.device_id(), 0xABCD);
+    }
+
+    #[test]
+    fn test_invalidate_iommu_all() {
+        let entry = CommandEntry {
+            dw0: 0,
+            dw1: 0x8000_0000, // opcode=8
+            dw2: 0,
+            dw3: 0,
+        };
+        assert_eq!(entry.opcode(), CommandOpcode::INVALIDATE_IOMMU_ALL);
+    }
+
+    #[test]
+    fn test_command_entry_size() {
+        assert_eq!(size_of::<CommandEntry>(), 16);
+    }
+}

--- a/vm/devices/iommu/amd_iommu/src/spec/dte.rs
+++ b/vm/devices/iommu/amd_iommu/src/spec/dte.rs
@@ -1,0 +1,365 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Device Table Entry (DTE) for the AMD IOMMU.
+//!
+//! Each DTE is 256 bits (32 bytes), stored as `[u64; 4]`. Based on AMD IOMMU
+//! Specification Rev 3.11, §2.2.2, Figure 7, Table 7.
+
+use bitfield_struct::bitfield;
+use inspect::Inspect;
+use open_enum::open_enum;
+use zerocopy::FromBytes;
+use zerocopy::Immutable;
+use zerocopy::IntoBytes;
+use zerocopy::KnownLayout;
+
+/// A raw 256-bit (32-byte) Device Table Entry.
+#[derive(Debug, Copy, Clone, FromBytes, IntoBytes, Immutable, KnownLayout)]
+#[repr(C)]
+pub struct Dte {
+    /// DW0 (bits 63:0) — Address translation fields.
+    pub dw0: DteDw0,
+    /// DW1 (bits 127:64) — DomainID, GCR3, IoCtl.
+    pub dw1: DteDw1,
+    /// DW2 (bits 191:128) — Interrupt remapping fields.
+    pub dw2: DteDw2,
+    /// DW3 (bits 255:192) — Reserved for guest/vIOMMU features.
+    pub dw3: u64,
+}
+
+/// DTE size in bytes.
+pub const DTE_SIZE: usize = 32;
+
+/// DTE DW0 (bits 63:0) — Address Translation.
+///
+/// Key fields: V (valid), TV (translation valid), Mode (paging levels),
+/// HostPTRootPtr (page table root), IR/IW (read/write permission).
+#[bitfield(u64)]
+#[derive(IntoBytes, Immutable, KnownLayout, FromBytes, Inspect)]
+#[rustfmt::skip]
+pub struct DteDw0 {
+    /// Valid — 1 = this DTE is valid.
+    pub v: bool,
+    /// Translation Valid — 1 = address translation active.
+    pub tv: bool,
+    #[bits(5)]
+    _reserved1: u64,
+    /// Host Access/Dirty bit 1 (HAD[1]).
+    pub had1: bool,
+    #[bits(1)]
+    _reserved2: u64,
+    /// Paging mode / number of translation levels.
+    /// 0 = disabled/pass-through, 1–6 = N-level page table, 7 = reserved.
+    #[bits(3)]
+    pub mode: u8,
+    /// Host page table root pointer, bits [51:12]. 4KB-aligned.
+    #[bits(40)]
+    pub host_pt_root_ptr: u64,
+    /// PPR enable (not used in our emulator).
+    pub ppr: bool,
+    /// Guest RPT (not used).
+    pub gprp: bool,
+    /// Guest I/O valid (not used).
+    pub giov: bool,
+    /// Guest valid (not used).
+    pub gv: bool,
+    /// Guest CR3 root table level (GLX).
+    #[bits(2)]
+    pub glx: u8,
+    /// GCR3 table root pointer bits [14:12].
+    #[bits(3)]
+    pub gcr3_trp_14_12: u8,
+    /// IOMMU Read permission — 1 = reads allowed.
+    pub ir: bool,
+    /// IOMMU Write permission — 1 = writes allowed.
+    pub iw: bool,
+    #[bits(1)]
+    _reserved3: u64,
+}
+
+impl DteDw0 {
+    /// Get the paging mode as a typed enum.
+    pub fn paging_mode(&self) -> PagingMode {
+        PagingMode(self.mode())
+    }
+
+    /// Get the full host page table root pointer address (bits 51:12 shifted left by 12).
+    pub fn page_table_root_address(&self) -> u64 {
+        self.host_pt_root_ptr() << 12
+    }
+}
+
+/// DTE DW1 (bits 127:64) — DomainID, GCR3, IoCtl.
+#[bitfield(u64)]
+#[derive(IntoBytes, Immutable, KnownLayout, FromBytes, Inspect)]
+#[rustfmt::skip]
+pub struct DteDw1 {
+    /// Domain ID for TLB invalidation matching (16-bit).
+    #[bits(16)]
+    pub domain_id: u16,
+    /// GCR3 table root pointer bits [30:15].
+    #[bits(16)]
+    pub gcr3_trp_30_15: u16,
+    /// Suppress all events.
+    pub se: bool,
+    /// Suppress all page faults.
+    pub sa: bool,
+    /// Port I/O control.
+    #[bits(2)]
+    pub io_ctl: u8,
+    /// Cache disable.
+    pub sd: bool,
+    /// Exclusion range.
+    pub ex: bool,
+    /// SysMgt.
+    #[bits(2)]
+    pub sys_mgt: u8,
+    /// SATS.
+    pub sats: bool,
+    /// GCR3 table root pointer bits [51:31].
+    #[bits(21)]
+    pub gcr3_trp_51_31: u32,
+    #[bits(2)]
+    _reserved: u64,
+}
+
+/// DTE DW2 (bits 191:128) — Interrupt Remapping.
+#[bitfield(u64)]
+#[derive(IntoBytes, Immutable, KnownLayout, FromBytes, Inspect)]
+#[rustfmt::skip]
+pub struct DteDw2 {
+    /// Interrupt map valid — 1 = interrupt remapping is active.
+    pub iv: bool,
+    /// Log2 of interrupt remapping table size.
+    /// 0 = 1 entry, 1 = 2, ..., 10 = 1024 entries.
+    #[bits(4)]
+    pub int_tab_len: u8,
+    /// Ignore unmapped interrupt faults.
+    pub ig: bool,
+    /// Interrupt Remapping Table root pointer, bits [51:6].
+    /// Address = value << 6 (128-byte aligned).
+    #[bits(46)]
+    pub int_tab_root_ptr: u64,
+    #[bits(2)]
+    _reserved1: u64,
+    /// Guest paging mode (not used).
+    #[bits(2)]
+    pub guest_paging_mode: u8,
+    /// Pass INIT interrupts.
+    pub init_pass: bool,
+    /// Pass ExtInt interrupts.
+    pub eint_pass: bool,
+    /// Pass NMI interrupts.
+    pub nmi_pass: bool,
+    /// Host page table mode (not used).
+    pub hpt_mode: bool,
+    /// Interrupt control mode.
+    /// 00 = abort, 01 = pass-through unmapped, 10 = remap, 11 = reserved.
+    #[bits(2)]
+    pub int_ctl: u8,
+    /// Pass LINT0.
+    pub lint0_pass: bool,
+    /// Pass LINT1.
+    pub lint1_pass: bool,
+}
+
+impl DteDw2 {
+    /// Get the interrupt control mode as a typed enum.
+    pub fn int_ctl_mode(&self) -> IntCtl {
+        IntCtl(self.int_ctl())
+    }
+
+    /// Get the full interrupt remapping table base address.
+    /// Address = IntTabRootPtr << 6.
+    pub fn int_tab_address(&self) -> u64 {
+        self.int_tab_root_ptr() << 6
+    }
+
+    /// Get the maximum number of IRT entries: 2^IntTabLen.
+    pub fn int_tab_entries(&self) -> u32 {
+        1u32 << self.int_tab_len()
+    }
+}
+
+open_enum! {
+    /// DTE paging mode (bits 11:9 of DW0).
+    #[derive(Inspect)]
+    #[inspect(debug)]
+    pub enum PagingMode: u8 {
+        /// Translation disabled / pass-through.
+        DISABLED    = 0,
+        /// 1-level page table.
+        ONE_LEVEL   = 1,
+        /// 2-level page table.
+        TWO_LEVEL   = 2,
+        /// 3-level page table.
+        THREE_LEVEL = 3,
+        /// 4-level page table.
+        FOUR_LEVEL  = 4,
+        /// 5-level page table.
+        FIVE_LEVEL  = 5,
+        /// 6-level page table.
+        SIX_LEVEL   = 6,
+    }
+}
+
+/// Reserved paging mode value (7).
+pub const PAGING_MODE_RESERVED: u8 = 7;
+
+open_enum! {
+    /// DTE interrupt control mode (IntCtl field in DW2, bits 189:188).
+    #[derive(Inspect)]
+    #[inspect(debug)]
+    pub enum IntCtl: u8 {
+        /// Abort — target abort on interrupt.
+        ABORT           = 0b00,
+        /// Pass-through — forward unmapped interrupts unchanged.
+        PASS_THROUGH    = 0b01,
+        /// Remap — remap interrupts via the IRT.
+        REMAP           = 0b10,
+    }
+}
+
+/// Reserved IntCtl value.
+pub const INT_CTL_RESERVED: u8 = 0b11;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_dte_size() {
+        assert_eq!(size_of::<Dte>(), DTE_SIZE);
+        assert_eq!(DTE_SIZE, 32);
+    }
+
+    #[test]
+    fn test_dte_dw0_valid_and_mode() {
+        let dw0 = DteDw0::new().with_v(true).with_tv(true).with_mode(4);
+        assert!(dw0.v());
+        assert!(dw0.tv());
+        assert_eq!(dw0.paging_mode(), PagingMode::FOUR_LEVEL);
+    }
+
+    #[test]
+    fn test_dte_dw0_page_table_root() {
+        // Set page table root to physical address 0x1_0000_0000 (4GB).
+        // bits [51:12] = 0x1_0000_0000 >> 12 = 0x10_0000
+        let dw0 = DteDw0::new().with_host_pt_root_ptr(0x10_0000);
+        assert_eq!(dw0.page_table_root_address(), 0x1_0000_0000);
+    }
+
+    #[test]
+    fn test_dte_dw0_permissions() {
+        let dw0 = DteDw0::new().with_ir(true).with_iw(true);
+        assert!(dw0.ir());
+        assert!(dw0.iw());
+
+        let dw0_ro = DteDw0::new().with_ir(true).with_iw(false);
+        assert!(dw0_ro.ir());
+        assert!(!dw0_ro.iw());
+    }
+
+    #[test]
+    fn test_dte_dw1_domain_id() {
+        let dw1 = DteDw1::new().with_domain_id(0x1234);
+        assert_eq!(dw1.domain_id(), 0x1234);
+    }
+
+    #[test]
+    fn test_dte_dw2_interrupt_remapping() {
+        let dw2 = DteDw2::new()
+            .with_iv(true)
+            .with_int_tab_len(8) // 2^8 = 256 entries
+            .with_int_ctl(IntCtl::REMAP.0)
+            .with_int_tab_root_ptr(0x1000); // address = 0x1000 << 6 = 0x40000
+        assert!(dw2.iv());
+        assert_eq!(dw2.int_ctl_mode(), IntCtl::REMAP);
+        assert_eq!(dw2.int_tab_entries(), 256);
+        assert_eq!(dw2.int_tab_address(), 0x40000);
+    }
+
+    #[test]
+    fn test_dte_dw2_int_ctl_modes() {
+        assert_eq!(IntCtl::ABORT.0, 0b00);
+        assert_eq!(IntCtl::PASS_THROUGH.0, 0b01);
+        assert_eq!(IntCtl::REMAP.0, 0b10);
+    }
+
+    #[test]
+    fn test_dte_dw2_passthrough_interrupts() {
+        let dw2 = DteDw2::new()
+            .with_init_pass(true)
+            .with_eint_pass(true)
+            .with_nmi_pass(true)
+            .with_lint0_pass(true)
+            .with_lint1_pass(true);
+        assert!(dw2.init_pass());
+        assert!(dw2.eint_pass());
+        assert!(dw2.nmi_pass());
+        assert!(dw2.lint0_pass());
+        assert!(dw2.lint1_pass());
+    }
+
+    #[test]
+    fn test_paging_modes() {
+        assert_eq!(PagingMode::DISABLED.0, 0);
+        assert_eq!(PagingMode::ONE_LEVEL.0, 1);
+        assert_eq!(PagingMode::TWO_LEVEL.0, 2);
+        assert_eq!(PagingMode::THREE_LEVEL.0, 3);
+        assert_eq!(PagingMode::FOUR_LEVEL.0, 4);
+        assert_eq!(PagingMode::FIVE_LEVEL.0, 5);
+        assert_eq!(PagingMode::SIX_LEVEL.0, 6);
+    }
+
+    #[test]
+    fn test_dte_passthrough_config() {
+        // DTE configured for pass-through: V=1, TV=0
+        let dte = Dte {
+            dw0: DteDw0::new()
+                .with_v(true)
+                .with_tv(false)
+                .with_ir(true)
+                .with_iw(true),
+            dw1: DteDw1::new(),
+            dw2: DteDw2::new(),
+            dw3: 0,
+        };
+        assert!(dte.dw0.v());
+        assert!(!dte.dw0.tv());
+        assert_eq!(dte.dw0.paging_mode(), PagingMode::DISABLED);
+    }
+
+    #[test]
+    fn test_dte_full_translation_config() {
+        // DTE configured for 4-level translation with interrupt remapping.
+        let dte = Dte {
+            dw0: DteDw0::new()
+                .with_v(true)
+                .with_tv(true)
+                .with_mode(PagingMode::FOUR_LEVEL.0)
+                .with_host_pt_root_ptr(0x100) // root at 0x100000
+                .with_ir(true)
+                .with_iw(true),
+            dw1: DteDw1::new().with_domain_id(42),
+            dw2: DteDw2::new()
+                .with_iv(true)
+                .with_int_tab_len(8)
+                .with_int_ctl(IntCtl::REMAP.0)
+                .with_int_tab_root_ptr(0x200),
+            dw3: 0,
+        };
+        assert!(dte.dw0.v());
+        assert!(dte.dw0.tv());
+        assert_eq!(dte.dw0.paging_mode(), PagingMode::FOUR_LEVEL);
+        assert_eq!(dte.dw0.page_table_root_address(), 0x100000);
+        assert!(dte.dw0.ir());
+        assert!(dte.dw0.iw());
+        assert_eq!(dte.dw1.domain_id(), 42);
+        assert!(dte.dw2.iv());
+        assert_eq!(dte.dw2.int_ctl_mode(), IntCtl::REMAP);
+        assert_eq!(dte.dw2.int_tab_entries(), 256);
+        assert_eq!(dte.dw2.int_tab_address(), 0x200 << 6);
+    }
+}

--- a/vm/devices/iommu/amd_iommu/src/spec/events.rs
+++ b/vm/devices/iommu/amd_iommu/src/spec/events.rs
@@ -1,0 +1,235 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Event log entry types for the AMD IOMMU.
+//!
+//! All events are 128 bits (16 bytes). Based on AMD IOMMU Specification
+//! Rev 3.11, §2.5.
+
+use inspect::Inspect;
+use open_enum::open_enum;
+use zerocopy::FromBytes;
+use zerocopy::Immutable;
+use zerocopy::IntoBytes;
+use zerocopy::KnownLayout;
+
+/// A raw 128-bit event log entry (16 bytes).
+#[derive(Debug, Copy, Clone, FromBytes, IntoBytes, Immutable, KnownLayout)]
+#[repr(C)]
+pub struct EventEntry {
+    /// First dword: bits 31:16 = DeviceID (for most events), bits 15:0 = event-specific.
+    pub dw0: u32,
+    /// Second dword: bits 31:28 = EventCode, bits 27:0 = event-specific.
+    pub dw1: u32,
+    /// Third dword: address low or operand-dependent.
+    pub dw2: u32,
+    /// Fourth dword: address high or operand-dependent.
+    pub dw3: u32,
+}
+
+impl EventEntry {
+    /// Extract the 4-bit event code from bits 31:28 of dw1.
+    pub fn event_code(&self) -> EventCode {
+        EventCode((self.dw1 >> 28) as u8)
+    }
+
+    /// Extract the DeviceID from bits 31:16 of dw0.
+    pub fn device_id(&self) -> u16 {
+        (self.dw0 >> 16) as u16
+    }
+}
+
+open_enum! {
+    /// AMD IOMMU event codes (§2.5).
+    #[derive(Inspect)]
+    #[inspect(debug)]
+    pub enum EventCode: u8 {
+        /// §2.5.2 — Illegal device table entry.
+        ILLEGAL_DEV_TABLE_ENTRY = 0x01,
+        /// §2.5.3 — I/O page fault.
+        IO_PAGE_FAULT           = 0x02,
+        /// §2.5.4 — Device table hardware error.
+        DEV_TAB_HARDWARE_ERROR  = 0x03,
+        /// §2.5.5 — Page table hardware error.
+        PAGE_TAB_HARDWARE_ERROR = 0x04,
+        /// §2.5.6 — Illegal command error.
+        ILLEGAL_COMMAND_ERROR   = 0x05,
+        /// §2.5.7 — Command hardware error.
+        COMMAND_HARDWARE_ERROR  = 0x06,
+        /// §2.5.8 — IOTLB invalidation timeout error.
+        IOTLB_INV_TIMEOUT       = 0x07,
+        /// §2.5.9 — Invalid device request.
+        INVALID_DEVICE_REQUEST  = 0x08,
+    }
+}
+
+// =============================================================================
+// Event construction helpers
+// =============================================================================
+
+impl EventEntry {
+    /// Create an ILLEGAL_DEV_TABLE_ENTRY event (code 1, §2.5.2).
+    ///
+    /// - `device_id`: the device that caused the fault.
+    /// - `is_interrupt`: true if this was an interrupt request, false for DMA.
+    /// - `is_write`: true if write, false if read.
+    /// - `address`: the faulting address.
+    pub fn illegal_dev_table_entry(
+        device_id: u16,
+        is_interrupt: bool,
+        is_write: bool,
+        address: u64,
+    ) -> Self {
+        let flags = (is_write as u32) << 2 | (is_interrupt as u32) << 3;
+        Self {
+            dw0: (device_id as u32) << 16 | flags,
+            dw1: (EventCode::ILLEGAL_DEV_TABLE_ENTRY.0 as u32) << 28,
+            dw2: address as u32,
+            dw3: (address >> 32) as u32,
+        }
+    }
+
+    /// Create an IO_PAGE_FAULT event (code 2, §2.5.3).
+    ///
+    /// - `device_id`: the device that caused the fault.
+    /// - `domain_id`: domain ID from the DTE.
+    /// - `is_interrupt`: true if this was an interrupt request.
+    /// - `is_write`: true if write access.
+    /// - `address`: the faulting IOVA.
+    pub fn io_page_fault(
+        device_id: u16,
+        domain_id: u16,
+        is_interrupt: bool,
+        is_write: bool,
+        address: u64,
+    ) -> Self {
+        let flags = is_interrupt as u32;
+        Self {
+            dw0: (device_id as u32) << 16 | flags,
+            dw1: (EventCode::IO_PAGE_FAULT.0 as u32) << 28 | (domain_id as u32),
+            dw2: address as u32,
+            dw3: ((is_write as u32) << 31) | ((address >> 32) as u32 & 0x7FFF_FFFF),
+        }
+    }
+
+    /// Create an ILLEGAL_COMMAND_ERROR event (code 5, §2.5.6).
+    ///
+    /// - `cmd_address`: physical address of the illegal command in the command buffer.
+    pub fn illegal_command_error(cmd_address: u64) -> Self {
+        Self {
+            dw0: 0,
+            dw1: (EventCode::ILLEGAL_COMMAND_ERROR.0 as u32) << 28,
+            dw2: cmd_address as u32,
+            dw3: (cmd_address >> 32) as u32,
+        }
+    }
+
+    /// Create a DEV_TAB_HARDWARE_ERROR event (code 3, §2.5.4).
+    ///
+    /// - `device_id`: the device whose DTE access failed.
+    /// - `address`: the physical address that failed to read.
+    pub fn dev_tab_hardware_error(device_id: u16, address: u64) -> Self {
+        Self {
+            dw0: (device_id as u32) << 16,
+            dw1: (EventCode::DEV_TAB_HARDWARE_ERROR.0 as u32) << 28,
+            dw2: address as u32,
+            dw3: (address >> 32) as u32,
+        }
+    }
+
+    /// Create a PAGE_TAB_HARDWARE_ERROR event (code 4, §2.5.5).
+    ///
+    /// - `device_id`: the device whose page table access failed.
+    /// - `address`: the physical address that failed to read.
+    pub fn page_tab_hardware_error(device_id: u16, address: u64) -> Self {
+        Self {
+            dw0: (device_id as u32) << 16,
+            dw1: (EventCode::PAGE_TAB_HARDWARE_ERROR.0 as u32) << 28,
+            dw2: address as u32,
+            dw3: (address >> 32) as u32,
+        }
+    }
+
+    /// Create an INVALID_DEVICE_REQUEST event (code 8, §2.5.9).
+    ///
+    /// - `device_id`: the device that caused the request.
+    /// - `request_type`: sub-type of the invalid request.
+    /// - `address`: the faulting address.
+    pub fn invalid_device_request(device_id: u16, request_type: u8, address: u64) -> Self {
+        Self {
+            dw0: (device_id as u32) << 16 | (request_type as u32 & 0xF),
+            dw1: (EventCode::INVALID_DEVICE_REQUEST.0 as u32) << 28,
+            dw2: address as u32,
+            dw3: (address >> 32) as u32,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_event_entry_size() {
+        assert_eq!(size_of::<EventEntry>(), 16);
+    }
+
+    #[test]
+    fn test_event_codes() {
+        assert_eq!(EventCode::ILLEGAL_DEV_TABLE_ENTRY.0, 0x01);
+        assert_eq!(EventCode::IO_PAGE_FAULT.0, 0x02);
+        assert_eq!(EventCode::DEV_TAB_HARDWARE_ERROR.0, 0x03);
+        assert_eq!(EventCode::PAGE_TAB_HARDWARE_ERROR.0, 0x04);
+        assert_eq!(EventCode::ILLEGAL_COMMAND_ERROR.0, 0x05);
+        assert_eq!(EventCode::COMMAND_HARDWARE_ERROR.0, 0x06);
+        assert_eq!(EventCode::IOTLB_INV_TIMEOUT.0, 0x07);
+        assert_eq!(EventCode::INVALID_DEVICE_REQUEST.0, 0x08);
+    }
+
+    #[test]
+    fn test_illegal_dev_table_entry_event() {
+        let event = EventEntry::illegal_dev_table_entry(0x1234, false, true, 0xDEAD_BEEF_0000);
+        assert_eq!(event.event_code(), EventCode::ILLEGAL_DEV_TABLE_ENTRY);
+        assert_eq!(event.device_id(), 0x1234);
+        // RW bit is bit 2 of dw0
+        assert_eq!(event.dw0 & 0x04, 0x04);
+        // I bit is bit 3 of dw0
+        assert_eq!(event.dw0 & 0x08, 0x00);
+        // Address
+        assert_eq!(event.dw2, 0xBEEF_0000);
+        assert_eq!(event.dw3, 0x0000_DEAD);
+    }
+
+    #[test]
+    fn test_io_page_fault_event() {
+        let event = EventEntry::io_page_fault(0xABCD, 0x0042, true, true, 0x1_0000_0000);
+        assert_eq!(event.event_code(), EventCode::IO_PAGE_FAULT);
+        assert_eq!(event.device_id(), 0xABCD);
+        // I bit (interrupt) is bit 0 of dw0
+        assert_eq!(event.dw0 & 0x01, 0x01);
+        // DomainID in dw1[15:0]
+        assert_eq!(event.dw1 & 0xFFFF, 0x0042);
+        // RW bit in dw3[31]
+        assert_eq!(event.dw3 & 0x8000_0000, 0x8000_0000);
+        // Address
+        assert_eq!(event.dw2, 0x0000_0000);
+        assert_eq!(event.dw3 & 0x7FFF_FFFF, 0x0000_0001);
+    }
+
+    #[test]
+    fn test_illegal_command_error_event() {
+        let event = EventEntry::illegal_command_error(0xFEDC_BA98_7654_3210);
+        assert_eq!(event.event_code(), EventCode::ILLEGAL_COMMAND_ERROR);
+        assert_eq!(event.dw0, 0); // No DeviceID
+        assert_eq!(event.dw2, 0x7654_3210);
+        assert_eq!(event.dw3, 0xFEDC_BA98);
+    }
+
+    #[test]
+    fn test_invalid_device_request_event() {
+        let event = EventEntry::invalid_device_request(0x00FF, 0x03, 0xAAAA_BBBB_CCCC);
+        assert_eq!(event.event_code(), EventCode::INVALID_DEVICE_REQUEST);
+        assert_eq!(event.device_id(), 0x00FF);
+        assert_eq!(event.dw0 & 0x0F, 0x03); // request type
+    }
+}

--- a/vm/devices/iommu/amd_iommu/src/spec/irte.rs
+++ b/vm/devices/iommu/amd_iommu/src/spec/irte.rs
@@ -1,0 +1,200 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Interrupt Remapping Table Entry (IRTE) for the AMD IOMMU.
+//!
+//! Basic 32-bit format (GASup=0). Based on AMD IOMMU Specification Rev 3.11,
+//! §2.2.5.1, Figure 15, Table 20.
+
+use bitfield_struct::bitfield;
+use inspect::Inspect;
+use open_enum::open_enum;
+use zerocopy::FromBytes;
+use zerocopy::Immutable;
+use zerocopy::IntoBytes;
+use zerocopy::KnownLayout;
+
+/// A 32-bit basic Interrupt Remapping Table Entry.
+///
+/// Used when GASup=0 (guest APIC not supported). Each IRTE specifies the
+/// remapped interrupt vector, destination, and delivery mode.
+#[bitfield(u32)]
+#[derive(IntoBytes, Immutable, KnownLayout, FromBytes, Inspect)]
+#[rustfmt::skip]
+pub struct Irte {
+    /// Remap enable — 1 = remap this interrupt, 0 = target abort.
+    pub remap_en: bool,
+    /// Suppress IO_PAGE_FAULT event logging for this interrupt.
+    pub sup_iopf: bool,
+    /// Interrupt type (delivery mode).
+    #[bits(3)]
+    pub int_type: u8,
+    /// Request EOI.
+    pub rq_eoi: bool,
+    /// Destination mode — 0 = physical, 1 = logical.
+    pub dm: bool,
+    /// Guest mode — must be 0 for basic format.
+    pub guest_mode: bool,
+    /// APIC destination ID.
+    #[bits(8)]
+    pub destination: u8,
+    /// Interrupt vector.
+    #[bits(8)]
+    pub vector: u8,
+    #[bits(8)]
+    _reserved: u32,
+}
+
+/// IRTE size in bytes (basic 32-bit format).
+pub const IRTE_SIZE: usize = 4;
+
+/// IRTE size in bytes (128-bit GA format, used when GASup=1 and GA_EN=1).
+pub const IRTE_GA_SIZE: usize = 16;
+
+/// A 128-bit Guest APIC Interrupt Remapping Table Entry (GA-format).
+///
+/// Used when GASup=1 and CONTROL\[GAEn\]=1. The low 64 bits contain remapping
+/// fields with a wider (24-bit) destination. The high 64 bits hold the vector
+/// and extended destination bits.
+///
+/// §2.2.5.2, Table 21.
+#[repr(C)]
+#[derive(Copy, Clone, Debug, IntoBytes, Immutable, KnownLayout, FromBytes)]
+pub struct IrteGa {
+    /// Low 64 bits.
+    pub lo: IrteGaLo,
+    /// High 64 bits.
+    pub hi: IrteGaHi,
+}
+
+/// GA-format IRTE low 64 bits.
+#[bitfield(u64)]
+#[derive(IntoBytes, Immutable, KnownLayout, FromBytes, Inspect)]
+#[rustfmt::skip]
+pub struct IrteGaLo {
+    /// Remap enable — 1 = remap this interrupt.
+    pub remap_en: bool,
+    /// Suppress IO_PAGE_FAULT event logging.
+    pub sup_iopf: bool,
+    /// Interrupt type (delivery mode).
+    #[bits(3)]
+    pub int_type: u8,
+    /// Request EOI.
+    pub rq_eoi: bool,
+    /// Destination mode — 0 = physical, 1 = logical.
+    pub dm: bool,
+    /// Guest mode — 1 = guest VAPIC mode.
+    pub guest_mode: bool,
+    /// Destination APIC ID (low 24 bits).
+    #[bits(24)]
+    pub destination: u32,
+    #[bits(32)]
+    _reserved: u64,
+}
+
+/// GA-format IRTE high 64 bits.
+#[bitfield(u64)]
+#[derive(IntoBytes, Immutable, KnownLayout, FromBytes, Inspect)]
+#[rustfmt::skip]
+pub struct IrteGaHi {
+    /// Interrupt vector.
+    #[bits(8)]
+    pub vector: u8,
+    #[bits(48)]
+    _reserved: u64,
+    /// Destination APIC ID high bits [31:24].
+    #[bits(8)]
+    pub destination_hi: u8,
+}
+
+impl Irte {
+    /// Get the interrupt type as a typed enum.
+    pub fn interrupt_type(&self) -> IntType {
+        IntType(self.int_type())
+    }
+}
+
+open_enum! {
+    /// Interrupt delivery type for the IRTE.
+    #[derive(Inspect)]
+    #[inspect(debug)]
+    pub enum IntType: u8 {
+        /// Fixed delivery mode.
+        FIXED       = 0b000,
+        /// Arbitrated (lowest priority) delivery mode.
+        ARBITRATED  = 0b001,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_irte_size() {
+        assert_eq!(size_of::<Irte>(), IRTE_SIZE);
+        assert_eq!(IRTE_SIZE, 4);
+    }
+
+    #[test]
+    fn test_irte_basic_roundtrip() {
+        let irte = Irte::new()
+            .with_remap_en(true)
+            .with_int_type(IntType::FIXED.0)
+            .with_dm(false) // physical destination
+            .with_destination(3)
+            .with_vector(0x40);
+        assert!(irte.remap_en());
+        assert_eq!(irte.interrupt_type(), IntType::FIXED);
+        assert!(!irte.dm());
+        assert_eq!(irte.destination(), 3);
+        assert_eq!(irte.vector(), 0x40);
+        assert!(!irte.guest_mode());
+    }
+
+    #[test]
+    fn test_irte_disabled() {
+        let irte = Irte::new().with_remap_en(false);
+        assert!(!irte.remap_en());
+    }
+
+    #[test]
+    fn test_irte_logical_destination() {
+        let irte = Irte::new()
+            .with_remap_en(true)
+            .with_dm(true) // logical destination
+            .with_destination(0xFF)
+            .with_vector(0x30);
+        assert!(irte.dm());
+        assert_eq!(irte.destination(), 0xFF);
+        assert_eq!(irte.vector(), 0x30);
+    }
+
+    #[test]
+    fn test_irte_suppress_iopf() {
+        let irte = Irte::new().with_remap_en(true).with_sup_iopf(true);
+        assert!(irte.sup_iopf());
+    }
+
+    #[test]
+    fn test_int_types() {
+        assert_eq!(IntType::FIXED.0, 0);
+        assert_eq!(IntType::ARBITRATED.0, 1);
+    }
+
+    #[test]
+    fn test_irte_from_raw_u32() {
+        // Construct a raw u32 representing an IRTE:
+        // RemapEn=1, IntType=0 (Fixed), DM=0 (physical),
+        // Destination=5, Vector=0x80
+        let raw: u32 = 1       // RemapEn
+            | (5 << 8)         // Destination = 5
+            | (0x80 << 16); // Vector = 0x80
+        let irte = Irte::from(raw);
+        assert!(irte.remap_en());
+        assert_eq!(irte.interrupt_type(), IntType::FIXED);
+        assert!(!irte.dm());
+        assert_eq!(irte.destination(), 5);
+        assert_eq!(irte.vector(), 0x80);
+    }
+}

--- a/vm/devices/iommu/amd_iommu/src/spec/mod.rs
+++ b/vm/devices/iommu/amd_iommu/src/spec/mod.rs
@@ -1,0 +1,15 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! AMD IOMMU specification-derived types.
+//!
+//! Register layouts, device table entries, page table entries, command/event
+//! formats, and interrupt remapping table entries. All definitions are based on
+//! the AMD I/O Virtualization Technology (IOMMU) Specification, Rev 3.11.
+
+pub mod commands;
+pub mod dte;
+pub mod events;
+pub mod irte;
+pub mod pte;
+pub mod registers;

--- a/vm/devices/iommu/amd_iommu/src/spec/pte.rs
+++ b/vm/devices/iommu/amd_iommu/src/spec/pte.rs
@@ -1,0 +1,400 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! I/O Page Table Entry (PTE/PDE) for the AMD IOMMU.
+//!
+//! 64-bit entries used in the IOMMU I/O page tables. Based on AMD IOMMU
+//! Specification Rev 3.11, §2.2.3, Figures 8–10, Tables 15–18.
+//!
+//! The AMD IOMMU I/O page table uses a structure similar to x86-64 page tables
+//! (9 bits per level, 8 bytes per entry) but differs in field semantics:
+//! - `IR` (bit 61) and `IW` (bit 62) replace x86-64 R/W and NX bits.
+//! - `NextLevel` (bits 11:9) indicates the next page table level or marks
+//!   a leaf entry (NextLevel = 0 or 7).
+//! - Permissions are AND-accumulated across all levels including the DTE.
+//! - Level skipping is supported when `PDE.NextLevel < (current_level - 1)`.
+
+use bitfield_struct::bitfield;
+use inspect::Inspect;
+use zerocopy::FromBytes;
+use zerocopy::Immutable;
+use zerocopy::IntoBytes;
+use zerocopy::KnownLayout;
+
+/// A 64-bit I/O Page Table Entry (PTE or PDE).
+#[bitfield(u64)]
+#[derive(IntoBytes, Immutable, KnownLayout, FromBytes, Inspect)]
+#[rustfmt::skip]
+pub struct IommuPte {
+    /// Present — 1 = this entry is valid.
+    pub pr: bool,
+    #[bits(4)]
+    _ignored1: u64,
+    /// Accessed — set by hardware if HD support enabled (not used in emulator).
+    pub a: bool,
+    /// Dirty — set by hardware if HD support enabled (not used in emulator).
+    pub d: bool,
+    #[bits(2)]
+    _ignored2: u64,
+    /// Next level indicator (bits 11:9).
+    /// - For PDE (non-leaf): 1–6 = target level.
+    /// - For PTE (leaf): 0 or 7 = leaf marker.
+    #[bits(3)]
+    pub next_level: u8,
+    /// Address bits [51:12].
+    /// - For PDE: next-level table base address.
+    /// - For PTE: physical page frame number.
+    #[bits(40)]
+    pub address: u64,
+    #[bits(5)]
+    _reserved: u64,
+    /// Page migration state (reserved for our emulator).
+    #[bits(2)]
+    pub pms: u8,
+    /// User bit (ATS attribute, not used).
+    pub u: bool,
+    /// Force coherent.
+    pub fc: bool,
+    /// IOMMU Read permission — 1 = reads allowed.
+    pub ir: bool,
+    /// IOMMU Write permission — 1 = writes allowed.
+    pub iw: bool,
+    #[bits(1)]
+    _ignored3: u64,
+}
+
+/// PTE size in bytes.
+pub const PTE_SIZE: usize = 8;
+
+/// Number of entries per page table page (4KB / 8 bytes = 512).
+pub const ENTRIES_PER_TABLE: usize = 512;
+
+/// Bits per page table level index (log2 of 512 = 9).
+pub const BITS_PER_LEVEL: u32 = 9;
+
+/// Page size at level 1 (4KB).
+pub const PAGE_SIZE_4K: u64 = 4096;
+
+impl IommuPte {
+    /// Check if this entry is present (PR=1).
+    pub fn is_present(&self) -> bool {
+        self.pr()
+    }
+
+    /// Check if this is a leaf entry (PTE, not PDE).
+    ///
+    /// A leaf entry has NextLevel = 0 or NextLevel = 7.
+    pub fn is_leaf(&self) -> bool {
+        let nl = self.next_level();
+        nl == 0 || nl == 7
+    }
+
+    /// Check if this entry has read permission.
+    pub fn has_read(&self) -> bool {
+        self.ir()
+    }
+
+    /// Check if this entry has write permission.
+    pub fn has_write(&self) -> bool {
+        self.iw()
+    }
+
+    /// Get the full physical address from the address field (bits 51:12 shifted left by 12).
+    pub fn phys_address(&self) -> u64 {
+        self.address() << 12
+    }
+
+    /// Compute the page table entry index for a given VA and level.
+    ///
+    /// Extracts the 9-bit index from `va` at the bit range for `level`:
+    /// `(va >> shift) & 0x1FF`, where `shift = 12 + (level - 1) * 9`.
+    ///
+    /// Level 1: bits 20:12 (shift=12)
+    /// Level 2: bits 29:21 (shift=21)
+    /// Level 3: bits 38:30 (shift=30)
+    /// Level 4: bits 47:39 (shift=39)
+    /// Level 5: bits 56:48 (shift=48)
+    /// Level 6: bits 63:57 — only 7 bits at this level
+    pub fn va_index(va: u64, level: u8) -> usize {
+        let shift = 12 + (level as u32 - 1) * BITS_PER_LEVEL;
+        ((va >> shift) & 0x1FF) as usize
+    }
+
+    /// Compute the page size for a large page at the given level.
+    ///
+    /// Level 1: 4KB, Level 2: 2MB, Level 3: 1GB, Level 4: 512GB, etc.
+    pub fn page_size_at_level(level: u8) -> u64 {
+        1u64 << (12 + (level as u32 - 1) * BITS_PER_LEVEL)
+    }
+
+    /// Compute the offset mask for a page at the given level.
+    ///
+    /// This mask extracts the page-offset bits from a VA for a page mapped
+    /// at the given level.
+    pub fn page_offset_mask(level: u8) -> u64 {
+        Self::page_size_at_level(level) - 1
+    }
+
+    /// Decode the page size of a mode-7 (NextLevel = 7) large-page leaf PTE.
+    ///
+    /// AMD IOMMU §2.2.3 ("Default page size" / "level skipping") allows a leaf
+    /// PTE to describe a page of arbitrary power-of-two size, encoded inline
+    /// in the address field. The trailing 1-bits below the first cleared bit
+    /// of the address field indicate the page size:
+    ///
+    /// ```text
+    ///   page_size = 1 << (1 + ffz(raw_pte | 0xFFF))
+    /// ```
+    ///
+    /// where `ffz` finds the index of the first zero bit. (The `| 0xFFF`
+    /// forces the non-address low bits to 1 so that `ffz` sees only the
+    /// address field's encoded bits.)
+    ///
+    /// This matches Linux's `PTE_PAGE_SIZE` macro in
+    /// `drivers/iommu/amd/amd_iommu_types.h`.
+    ///
+    /// Returns `None` if the encoding is invalid (no zero bit found in the
+    /// address field, or a page size outside the supported range).
+    pub fn mode7_page_size(raw_pte: u64) -> Option<u64> {
+        // First zero bit, starting from bit 0 (forced to bit 12 or higher
+        // by the `| 0xFFF`).
+        let first_zero = (raw_pte | 0xFFF).trailing_ones();
+        // Hardware addresses are 52-bit (PM_ADDR_MASK covers bits 51:12), so
+        // the highest meaningful page-size bit is 51. That yields a max
+        // page size of 1 << 52. Anything beyond is malformed.
+        if first_zero >= 52 {
+            return None;
+        }
+        Some(1u64 << (first_zero + 1))
+    }
+
+    /// Recover the physical page base from a mode-7 leaf PTE.
+    ///
+    /// `mode7_page_size` decodes the page size from the address field; the
+    /// remaining (size-aligned) high bits of the address field form the page
+    /// base.
+    pub fn mode7_page_base(raw_pte: u64, page_size: u64) -> u64 {
+        // `phys_address()` is the 40-bit address field shifted left by 12.
+        // Clear the size-encoding low bits to recover the actual base.
+        let pte = IommuPte::from_bits(raw_pte);
+        pte.phys_address() & !(page_size - 1)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_pte_size() {
+        assert_eq!(size_of::<IommuPte>(), PTE_SIZE);
+        assert_eq!(PTE_SIZE, 8);
+    }
+
+    #[test]
+    fn test_pte_leaf_detection() {
+        // NextLevel = 0 → leaf
+        let pte = IommuPte::new().with_pr(true).with_next_level(0);
+        assert!(pte.is_leaf());
+
+        // NextLevel = 7 → leaf
+        let pte = IommuPte::new().with_pr(true).with_next_level(7);
+        assert!(pte.is_leaf());
+
+        // NextLevel = 3 → non-leaf (PDE)
+        let pde = IommuPte::new().with_pr(true).with_next_level(3);
+        assert!(!pde.is_leaf());
+    }
+
+    #[test]
+    fn test_pte_present() {
+        let pte = IommuPte::new().with_pr(true);
+        assert!(pte.is_present());
+
+        let pte = IommuPte::new().with_pr(false);
+        assert!(!pte.is_present());
+    }
+
+    #[test]
+    fn test_pte_permissions() {
+        let pte = IommuPte::new().with_ir(true).with_iw(false);
+        assert!(pte.has_read());
+        assert!(!pte.has_write());
+
+        let pte = IommuPte::new().with_ir(true).with_iw(true);
+        assert!(pte.has_read());
+        assert!(pte.has_write());
+    }
+
+    #[test]
+    fn test_pte_address() {
+        // Address field = 0x12345 → physical address = 0x12345 << 12 = 0x12345000
+        let pte = IommuPte::new().with_address(0x12345);
+        assert_eq!(pte.phys_address(), 0x12345000);
+    }
+
+    #[test]
+    fn test_va_index_level1() {
+        // VA = 0x12345678, level 1: bits [20:12] = 0x45678 >> 12 = 0x45 → index = 0x45
+        let idx = IommuPte::va_index(0x12345678, 1);
+        assert_eq!(idx, (0x12345678u64 >> 12) as usize & 0x1FF);
+    }
+
+    #[test]
+    fn test_va_index_level4() {
+        // VA = 0x0000_7F80_0000_0000, level 4: bits [47:39]
+        let va = 0x0000_7F80_0000_0000u64;
+        let idx = IommuPte::va_index(va, 4);
+        assert_eq!(idx, ((va >> 39) & 0x1FF) as usize);
+        assert_eq!(idx, 0xFF);
+    }
+
+    #[test]
+    fn test_page_size_at_level() {
+        assert_eq!(IommuPte::page_size_at_level(1), 4096); // 4KB
+        assert_eq!(IommuPte::page_size_at_level(2), 2 * 1024 * 1024); // 2MB
+        assert_eq!(IommuPte::page_size_at_level(3), 1024 * 1024 * 1024); // 1GB
+        assert_eq!(IommuPte::page_size_at_level(4), 512 * 1024 * 1024 * 1024); // 512GB
+    }
+
+    #[test]
+    fn test_page_offset_mask() {
+        assert_eq!(IommuPte::page_offset_mask(1), 0xFFF); // 4KB - 1
+        assert_eq!(IommuPte::page_offset_mask(2), 0x1F_FFFF); // 2MB - 1
+        assert_eq!(IommuPte::page_offset_mask(3), 0x3FFF_FFFF); // 1GB - 1
+    }
+
+    #[test]
+    fn test_pte_roundtrip() {
+        let pte = IommuPte::new()
+            .with_pr(true)
+            .with_next_level(0) // leaf
+            .with_address(0x00_DEAD_BEEF) // 40-bit address field
+            .with_ir(true)
+            .with_iw(true)
+            .with_fc(true);
+        assert!(pte.is_present());
+        assert!(pte.is_leaf());
+        assert!(pte.has_read());
+        assert!(pte.has_write());
+        assert!(pte.fc());
+        assert_eq!(pte.address(), 0x00_DEAD_BEEF);
+    }
+
+    #[test]
+    fn test_pde_roundtrip() {
+        // PDE pointing to level 2, next-table at 0x100000
+        let pde = IommuPte::new()
+            .with_pr(true)
+            .with_next_level(2)
+            .with_address(0x100) // 0x100 << 12 = 0x100000
+            .with_ir(true)
+            .with_iw(true);
+        assert!(pde.is_present());
+        assert!(!pde.is_leaf());
+        assert_eq!(pde.next_level(), 2);
+        assert_eq!(pde.phys_address(), 0x100000);
+    }
+
+    #[test]
+    fn test_entries_per_table() {
+        assert_eq!(ENTRIES_PER_TABLE, 512);
+        assert_eq!(ENTRIES_PER_TABLE * PTE_SIZE, 4096); // one 4KB page
+    }
+
+    /// Mirror Linux's `PAGE_SIZE_PTE` macro from `amd_iommu_types.h`:
+    ///
+    /// ```c
+    /// #define PAGE_SIZE_PTE(address, pagesize) \
+    ///         (((address) | ((pagesize) - 1)) & (~((pagesize) >> 1)) & PM_ADDR_MASK)
+    /// ```
+    fn encode_mode7_address_field(paddr: u64, pgsize: u64) -> u64 {
+        const PM_ADDR_MASK: u64 = 0x000F_FFFF_FFFF_F000;
+        ((paddr | (pgsize - 1)) & !(pgsize >> 1)) & PM_ADDR_MASK
+    }
+
+    #[test]
+    fn test_mode7_page_size_roundtrip_small() {
+        // 8 KiB page at paddr 0x80000.
+        let pgsize = 0x2000u64;
+        let paddr = 0x80000u64;
+        let addr_field = encode_mode7_address_field(paddr, pgsize);
+        let raw = IommuPte::new()
+            .with_pr(true)
+            .with_next_level(7)
+            .with_address(addr_field >> 12)
+            .with_ir(true)
+            .with_iw(true)
+            .into_bits();
+
+        assert_eq!(IommuPte::mode7_page_size(raw), Some(pgsize));
+        assert_eq!(IommuPte::mode7_page_base(raw, pgsize), paddr);
+    }
+
+    #[test]
+    fn test_mode7_page_size_roundtrip_16k() {
+        // 16 KiB page at paddr 0x80000.
+        let pgsize = 0x4000u64;
+        let paddr = 0x80000u64;
+        let addr_field = encode_mode7_address_field(paddr, pgsize);
+        let raw = IommuPte::new()
+            .with_pr(true)
+            .with_next_level(7)
+            .with_address(addr_field >> 12)
+            .into_bits();
+
+        assert_eq!(IommuPte::mode7_page_size(raw), Some(pgsize));
+        assert_eq!(IommuPte::mode7_page_base(raw, pgsize), paddr);
+    }
+
+    #[test]
+    fn test_mode7_page_size_roundtrip_64k() {
+        // 64 KiB page at paddr 0x1_0000.
+        let pgsize = 0x10000u64;
+        let paddr = 0x10000u64;
+        let addr_field = encode_mode7_address_field(paddr, pgsize);
+        let raw = IommuPte::new()
+            .with_pr(true)
+            .with_next_level(7)
+            .with_address(addr_field >> 12)
+            .into_bits();
+
+        assert_eq!(IommuPte::mode7_page_size(raw), Some(pgsize));
+        assert_eq!(IommuPte::mode7_page_base(raw, pgsize), paddr);
+    }
+
+    #[test]
+    fn test_mode7_page_size_roundtrip_4m() {
+        // 4 MiB page at paddr 0x40_0000.
+        let pgsize = 0x40_0000u64;
+        let paddr = 0x40_0000u64;
+        let addr_field = encode_mode7_address_field(paddr, pgsize);
+        let raw = IommuPte::new()
+            .with_pr(true)
+            .with_next_level(7)
+            .with_address(addr_field >> 12)
+            .into_bits();
+
+        assert_eq!(IommuPte::mode7_page_size(raw), Some(pgsize));
+        assert_eq!(IommuPte::mode7_page_base(raw, pgsize), paddr);
+    }
+
+    #[test]
+    fn test_mode7_page_size_with_flag_bits() {
+        // Verify flag bits (PR, IR, IW, FC) don't affect size decoding.
+        let pgsize = 0x10000u64;
+        let paddr = 0x20_0000u64;
+        let addr_field = encode_mode7_address_field(paddr, pgsize);
+        let raw = IommuPte::new()
+            .with_pr(true)
+            .with_next_level(7)
+            .with_address(addr_field >> 12)
+            .with_ir(true)
+            .with_iw(true)
+            .with_fc(true)
+            .into_bits();
+
+        assert_eq!(IommuPte::mode7_page_size(raw), Some(pgsize));
+        assert_eq!(IommuPte::mode7_page_base(raw, pgsize), paddr);
+    }
+}

--- a/vm/devices/iommu/amd_iommu/src/spec/registers.rs
+++ b/vm/devices/iommu/amd_iommu/src/spec/registers.rs
@@ -1,0 +1,811 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! MMIO register definitions and PCI capability block types for the AMD IOMMU.
+//!
+//! Based on AMD IOMMU Specification Rev 3.11, §3.2 (PCI Capability Block) and
+//! §3.4 (MMIO Register Map).
+
+use bitfield_struct::bitfield;
+use inspect::Inspect;
+use open_enum::open_enum;
+
+// =============================================================================
+// MMIO Register Offsets (§3.4)
+// =============================================================================
+
+open_enum! {
+    /// MMIO register offsets for the AMD IOMMU.
+    #[derive(Inspect)]
+    #[inspect(debug)]
+    pub enum MmioRegister: u16 {
+        /// Device Table Base Address Register (64-bit).
+        DEV_TAB_BASE        = 0x0000,
+        /// Command Buffer Base Address Register (64-bit).
+        CMD_BUF_BASE        = 0x0008,
+        /// Event Log Base Address Register (64-bit).
+        EVT_LOG_BASE        = 0x0010,
+        /// IOMMU Control Register (64-bit).
+        IOMMU_CTRL          = 0x0018,
+        /// Exclusion Base Register (64-bit).
+        EXCL_BASE           = 0x0020,
+        /// Exclusion Range Limit Register (64-bit).
+        EXCL_LIMIT          = 0x0028,
+        /// Extended Feature Register (64-bit, RO).
+        EXT_FEAT            = 0x0030,
+        /// General XT Interrupt Control Register (64-bit). §3.4.8.
+        ///
+        /// IOMMU's own MSI destination in X2APIC (XT) format. Used when
+        /// `IntCapXTEn=1` for the event log / IOMMU general interrupt,
+        /// replacing the legacy MSI capability registers at 0x158..0x164.
+        GEN_XT_INT_CTRL     = 0x0170,
+        /// PPR XT Interrupt Control Register (64-bit). §3.4.8.
+        ///
+        /// IOMMU's own MSI destination in X2APIC (XT) format for the PPR
+        /// log interrupt. Used when `IntCapXTEn=1`.
+        PPR_XT_INT_CTRL     = 0x0178,
+        /// Command Buffer Head Pointer (64-bit).
+        CMD_BUF_HEAD        = 0x2000,
+        /// Command Buffer Tail Pointer (64-bit).
+        CMD_BUF_TAIL        = 0x2008,
+        /// Event Log Head Pointer (64-bit).
+        EVT_LOG_HEAD        = 0x2010,
+        /// Event Log Tail Pointer (64-bit).
+        EVT_LOG_TAIL        = 0x2018,
+        /// IOMMU Status Register (64-bit).
+        IOMMU_STATUS        = 0x2020,
+        /// Extended Feature Register 2 (MMIO offset 0x01A0, RO).
+        EXT_FEAT2           = 0x01A0,
+    }
+}
+
+// =============================================================================
+// MMIO Register Bitfield Definitions
+// =============================================================================
+
+/// Device Table Base Address Register (MMIO offset 0x0000, 64-bit).
+///
+/// §3.4.1. Holds the base address and size of the device table.
+#[bitfield(u64)]
+#[derive(Inspect)]
+#[rustfmt::skip]
+pub struct DevTabBase {
+    /// Table size: number of entries = (size + 1) * 4096 / 32.
+    /// Max value 0x1FF = 2MB = 65536 entries.
+    #[bits(9)]
+    pub size: u16,
+    #[bits(3)]
+    _reserved1: u64,
+    /// Device table base address, bits [51:12]. 4KB-aligned.
+    #[bits(40)]
+    pub base_addr: u64,
+    #[bits(12)]
+    _reserved2: u64,
+}
+
+/// Command Buffer Base Address Register (MMIO offset 0x0008, 64-bit).
+///
+/// §3.4.2. Holds the base address and size of the command buffer.
+#[bitfield(u64)]
+#[derive(Inspect)]
+#[rustfmt::skip]
+pub struct CmdBufBase {
+    #[bits(12)]
+    _reserved1: u64,
+    /// Command buffer base address, bits [51:12]. 4KB-aligned.
+    #[bits(40)]
+    pub base_addr: u64,
+    #[bits(4)]
+    _reserved2: u64,
+    /// Log2 of buffer length in entries. Min 0b1000 (256 entries).
+    #[bits(4)]
+    pub length: u8,
+    #[bits(4)]
+    _reserved3: u64,
+}
+
+/// Event Log Base Address Register (MMIO offset 0x0010, 64-bit).
+///
+/// §3.4.3. Holds the base address and size of the event log.
+#[bitfield(u64)]
+#[derive(Inspect)]
+#[rustfmt::skip]
+pub struct EvtLogBase {
+    #[bits(12)]
+    _reserved1: u64,
+    /// Event log base address, bits [51:12]. 4KB-aligned.
+    #[bits(40)]
+    pub base_addr: u64,
+    #[bits(4)]
+    _reserved2: u64,
+    /// Log2 of event log length in entries. Min 0b1000 (256 entries).
+    #[bits(4)]
+    pub length: u8,
+    #[bits(4)]
+    _reserved3: u64,
+}
+
+/// IOMMU Control Register (MMIO offset 0x0018, 64-bit).
+///
+/// §3.4.4. Master control register for the IOMMU.
+#[bitfield(u64)]
+#[derive(Inspect)]
+#[rustfmt::skip]
+pub struct IommuCtrl {
+    /// Master enable for all IOMMU translation.
+    pub iommu_en: bool,
+    /// HyperTransport tunnel enable (stored, no effect in emulator).
+    pub ht_tun_en: bool,
+    /// Event logging enable.
+    pub evt_log_en: bool,
+    /// Event log interrupt enable.
+    pub evt_int_en: bool,
+    /// Completion wait interrupt enable.
+    pub com_wait_int_en: bool,
+    /// Invalidation timeout (stored, no effect in emulator).
+    #[bits(3)]
+    pub inv_timeout: u8,
+    /// Pass posted writes (HT attribute, stored).
+    pub pass_pw: bool,
+    /// Response pass posted writes (HT attribute, stored).
+    pub res_pass_pw: bool,
+    /// Coherent (HT attribute, stored).
+    pub coherent: bool,
+    /// Isochronous (HT attribute, stored).
+    pub isoc: bool,
+    /// Command buffer enable.
+    pub cmd_buf_en: bool,
+    /// PPR log enable (stored, no effect).
+    pub ppr_log_en: bool,
+    /// PPR interrupt enable (stored, no effect).
+    pub ppr_int_en: bool,
+    /// PPR enable (stored, no effect).
+    pub ppr_en: bool,
+    /// Guest translation enable (stored, no effect).
+    pub gt_en: bool,
+    /// Guest virtual APIC enable (stored, no effect).
+    pub ga_en: bool,
+    #[bits(4)]
+    _reserved1: u64,
+    /// SMI filter enable (stored, no effect).
+    pub smif_en: bool,
+    /// Self-writeback dirty enable (stored, no effect).
+    pub slf_wb_dis: bool,
+    /// SMI filter log enable (stored, no effect).
+    pub smif_log_en: bool,
+    #[bits(3)]
+    _reserved2: u64,
+    /// GA log enable (stored, no effect). Bit 28.
+    pub ga_log_en: bool,
+    /// GA interrupt enable (stored, no effect). Bit 29.
+    pub ga_int_en: bool,
+    /// Dual PPR log enable (stored, no effect). Bits 31:30.
+    #[bits(2)]
+    pub dual_ppr_log_en: u8,
+    /// Dual event log enable (stored, no effect). Bits 33:32.
+    #[bits(2)]
+    pub dual_evt_log_en: u8,
+    /// Device table segmentation enable (stored, no effect). Bits 36:34.
+    #[bits(3)]
+    pub dev_tbl_seg_en: u8,
+    /// Privilege abort enable (stored, no effect). Bits 38:37.
+    #[bits(2)]
+    pub priv_abrt_en: u8,
+    /// PPR auto-response enable (stored, no effect). Bit 39.
+    pub ppr_auto_rsp_en: bool,
+    /// Memory access routing and control enable (stored, no effect). Bit 40.
+    pub marc_en: bool,
+    /// Block stop marker enable (stored, no effect). Bit 41.
+    pub blk_stop_mrk_en: bool,
+    /// PPR auto response always-on (stored, no effect). Bit 42.
+    pub ppr_auto_rsp_aon: bool,
+    /// Interrupt remapping mode: number of interrupts per function.
+    /// 00b = 512 interrupts/function. Bits 44:43.
+    #[bits(2)]
+    pub num_int_remap_mode: u8,
+    /// Enhanced PPR handling enable (stored, no effect). Bit 45.
+    pub eph_en: bool,
+    /// Host access/dirty update mode (stored, no effect). Bits 47:46.
+    #[bits(2)]
+    pub had_update: u8,
+    /// Guest dirty update disable (stored, no effect). Bit 48.
+    pub gd_update_dis: bool,
+    #[bits(1)]
+    _reserved3: u64,
+    /// x2APIC enable (stored, no effect). Bit 50.
+    pub xt_en: bool,
+    /// IOMMU x2APIC interrupt generation enable (stored, no effect). Bit 51.
+    pub int_cap_xt_en: bool,
+    /// Virtualized command buffer enable (stored, no effect). Bit 52.
+    pub vcmd_en: bool,
+    /// Virtualized IOMMU enable (stored, no effect). Bit 53.
+    pub viommu_en: bool,
+    /// GA update disable (stored, no effect). Bit 54.
+    pub ga_update_dis: bool,
+    /// Guest APIC physical processor interrupt enable (stored, no effect). Bit 55.
+    pub gappi_en: bool,
+    /// Tiered memory page migration enable (stored, no effect). Bit 56.
+    pub tmpm_en: bool,
+    #[bits(1)]
+    _reserved4: u64,
+    /// GCR3 table root pointer mode (stored, no effect). Bit 58.
+    pub gcr3_trp_mode: bool,
+    /// IRT cache disable (stored, no effect). Bit 59.
+    pub irt_cache_dis: bool,
+    /// Guest buffer TRP mode (stored, no effect). Bit 60.
+    pub gst_buffer_trp_mode: bool,
+    /// SNP AVIC enable (stored, no effect). Bits 63:61.
+    #[bits(3)]
+    pub snp_avic_en: u8,
+}
+
+/// Exclusion Base Register (MMIO offset 0x0020, 64-bit).
+///
+/// §3.4.5. Exclusion range base address.
+#[bitfield(u64)]
+#[derive(Inspect)]
+#[rustfmt::skip]
+pub struct ExclBase {
+    /// Exclusion range enable.
+    pub ex_en: bool,
+    /// Allow all devices in exclusion range.
+    pub allow: bool,
+    #[bits(10)]
+    _reserved1: u64,
+    /// Exclusion base address, bits [51:12].
+    #[bits(40)]
+    pub base_addr: u64,
+    #[bits(12)]
+    _reserved2: u64,
+}
+
+/// Exclusion Range Limit Register (MMIO offset 0x0028, 64-bit).
+///
+/// §3.4.6. Exclusion range upper limit.
+#[bitfield(u64)]
+#[derive(Inspect)]
+#[rustfmt::skip]
+pub struct ExclLimit {
+    #[bits(12)]
+    _reserved1: u64,
+    /// Exclusion limit address, bits [51:12].
+    #[bits(40)]
+    pub limit_addr: u64,
+    #[bits(12)]
+    _reserved2: u64,
+}
+
+/// Extended Feature Register (MMIO offset 0x0030, 64-bit, RO).
+///
+/// §3.4.7. Reports IOMMU hardware capabilities.
+#[bitfield(u64)]
+#[derive(Inspect)]
+#[rustfmt::skip]
+pub struct ExtFeat {
+    /// Prefetch support.
+    pub pref_sup: bool,
+    /// PPR support.
+    pub ppr_sup: bool,
+    /// x2APIC support.
+    pub xt_sup: bool,
+    /// NX (no-execute) bit support.
+    pub nx_sup: bool,
+    /// Guest translation support.
+    pub gt_sup: bool,
+    /// Guest APIC physical interrupt support.
+    pub gappi_sup: bool,
+    /// INVALIDATE_IOMMU_ALL support.
+    pub ia_sup: bool,
+    /// Guest virtual APIC support.
+    pub ga_sup: bool,
+    /// Hardware error register support.
+    pub he_sup: bool,
+    /// Performance counter support.
+    pub pc_sup: bool,
+    /// Host Address Translation Size (00 = 4-level, 01 = 5-level, 10 = 6-level).
+    #[bits(2)]
+    pub hats: u8,
+    /// Guest Address Translation Size.
+    #[bits(2)]
+    pub gats: u8,
+    /// Guest CR3 root pointer table level support.
+    #[bits(2)]
+    pub glx_sup: u8,
+    /// SMI filter register support.
+    #[bits(2)]
+    pub smif_sup: u8,
+    /// SMI filter register count.
+    #[bits(3)]
+    pub smif_rc: u8,
+    /// Guest APIC mode support.
+    #[bits(3)]
+    pub gam_sup: u8,
+    /// Dual PPR log support.
+    #[bits(2)]
+    pub dual_ppr_log_sup: u8,
+    #[bits(2)]
+    _reserved1: u64,
+    /// Dual event log support.
+    #[bits(2)]
+    pub dual_evt_log_sup: u8,
+    #[bits(2)]
+    _reserved2: u64,
+    /// SATS (secure ATS) support.
+    pub sats_sup: bool,
+    /// PAS max.
+    #[bits(5)]
+    pub pas_max: u8,
+    /// User/supervisor support.
+    pub us_sup: bool,
+    /// Device table segmentation support.
+    #[bits(2)]
+    pub dev_tbl_seg_sup: u8,
+    /// PPR overflow early warning.
+    pub ppr_ovrflw_early: bool,
+    /// PPR auto-response support.
+    pub ppr_auto_rsp_sup: bool,
+    /// MARC (memory access routing and control) support.
+    #[bits(2)]
+    pub marc_sup: u8,
+    /// Block stop marker support.
+    pub blk_stop_mrk_sup: bool,
+    /// Performance optimization support.
+    pub perf_opt_sup: bool,
+    /// MSI capability MMIO access support.
+    pub msi_cap_mmio_sup: bool,
+    /// Snoop attribute support.
+    pub snoop_attr_sup: bool,
+    /// Guest I/O protection support.
+    pub gio_sup: bool,
+    /// Host access/dirty support.
+    pub ha_sup: bool,
+    /// Enhanced PPR handling support.
+    pub eph_sup: bool,
+    /// Attribute forward support.
+    pub attr_fw_sup: bool,
+    /// HD (host dirty) support.
+    pub hd_sup: bool,
+    /// v2 HD (host dirty) disable support.
+    pub v2_hd_dis_sup: bool,
+    /// Invalidate IOTLB type support.
+    pub inv_iotlb_type_sup: bool,
+    /// vIOMMU support.
+    pub viommu_sup: bool,
+    /// VM guard I/O support.
+    pub vm_guard_io_sup: bool,
+    #[bits(4)]
+    _reserved3: u64,
+    /// Force physical destination mode support.
+    pub force_phy_dest: bool,
+    /// SNP support.
+    pub snp_sup: bool,
+}
+
+/// XT Interrupt Control Register (MMIO offsets 0x0170, 0x0178, 64-bit).
+///
+/// §3.4.13. Specifies the IOMMU's own MSI destination in x2APIC format,
+/// used when `CONTROL[IntCapXTEn]=1`. Implemented when `EFR[XTSup]=1`. There
+/// are two instances with the same layout: `GEN_XT_INT_CTRL` (0x0170) for
+/// the event log / general interrupt and `PPR_XT_INT_CTRL` (0x0178) for the
+/// PPR log interrupt.
+///
+/// The emulator stores writes to these registers verbatim but does not source
+/// MSIs from them, because IOMMU-internal interrupts are not delivered to the
+/// guest (events are surfaced through `IOMMU_STATUS` only).
+#[bitfield(u64)]
+#[derive(Inspect)]
+#[rustfmt::skip]
+pub struct XtIntCtrl {
+    #[bits(2)]
+    _reserved1: u64,
+    /// Interrupt destination mode (0 = physical, 1 = logical).
+    pub xt_int_dest_mode: bool,
+    #[bits(5)]
+    _reserved2: u64,
+    /// Destination APIC ID, low 24 bits.
+    #[bits(24)]
+    pub xt_int_dest_low: u32,
+    /// Interrupt vector.
+    #[bits(8)]
+    pub xt_int_vector: u8,
+    /// Delivery mode (0 = fixed, etc.; AMD reuses APIC encoding).
+    pub xt_int_dm: bool,
+    #[bits(15)]
+    _reserved3: u64,
+    /// Destination APIC ID, high 8 bits.
+    #[bits(8)]
+    pub xt_int_dest_high: u8,
+}
+
+/// Command Buffer Head Pointer Register (MMIO offset 0x2000, 64-bit).
+///
+/// §3.4.9. Read by software to determine which commands have been consumed.
+/// Updated by the IOMMU as commands are processed.
+#[bitfield(u64)]
+#[derive(Inspect)]
+#[rustfmt::skip]
+pub struct CmdBufHead {
+    #[bits(4)]
+    _reserved1: u64,
+    /// Head pointer offset, 16-byte aligned (bits [18:4]).
+    #[bits(15)]
+    pub head_ptr: u32,
+    #[bits(45)]
+    _reserved2: u64,
+}
+
+/// Command Buffer Tail Pointer Register (MMIO offset 0x2008, 64-bit).
+///
+/// §3.4.10. Written by software to indicate new commands have been added.
+#[bitfield(u64)]
+#[derive(Inspect)]
+#[rustfmt::skip]
+pub struct CmdBufTail {
+    #[bits(4)]
+    _reserved1: u64,
+    /// Tail pointer offset, 16-byte aligned (bits [18:4]).
+    #[bits(15)]
+    pub tail_ptr: u32,
+    #[bits(45)]
+    _reserved2: u64,
+}
+
+/// Event Log Head Pointer Register (MMIO offset 0x2010, 64-bit).
+///
+/// §3.4.11. Written by software after consuming event log entries.
+#[bitfield(u64)]
+#[derive(Inspect)]
+#[rustfmt::skip]
+pub struct EvtLogHead {
+    #[bits(4)]
+    _reserved1: u64,
+    /// Head pointer offset, 16-byte aligned (bits [18:4]).
+    #[bits(15)]
+    pub head_ptr: u32,
+    #[bits(45)]
+    _reserved2: u64,
+}
+
+/// Event Log Tail Pointer Register (MMIO offset 0x2018, 64-bit).
+///
+/// §3.4.12. Updated by the IOMMU after writing event log entries.
+#[bitfield(u64)]
+#[derive(Inspect)]
+#[rustfmt::skip]
+pub struct EvtLogTail {
+    #[bits(4)]
+    _reserved1: u64,
+    /// Tail pointer offset, 16-byte aligned (bits [18:4]).
+    #[bits(15)]
+    pub tail_ptr: u32,
+    #[bits(45)]
+    _reserved2: u64,
+}
+
+/// IOMMU Status Register (MMIO offset 0x2020, 64-bit).
+///
+/// §3.4.13. Bits 0–2 are RW1C (write-1-to-clear), bits 3–4 are RO.
+#[bitfield(u64)]
+#[derive(Inspect)]
+#[rustfmt::skip]
+pub struct IommuStatus {
+    /// Event log overflow (RW1C). Set when the event log is full.
+    pub evt_overflow: bool,
+    /// Event log interrupt (RW1C). Set when an event is written to the log.
+    pub evt_log_int: bool,
+    /// Completion wait interrupt (RW1C). Set by COMPLETION_WAIT with i=1.
+    pub com_wait_int: bool,
+    /// Event log running (RO). 1 = the IOMMU is logging events.
+    pub evt_log_run: bool,
+    /// Command buffer running (RO). 1 = the IOMMU is fetching commands.
+    pub cmd_buf_run: bool,
+    #[bits(5)]
+    _reserved1: u64,
+    /// PPR overflow (RW1C, not implemented).
+    pub ppr_overflow: bool,
+    /// PPR interrupt (RW1C, not implemented).
+    pub ppr_int: bool,
+    /// PPR log running (RO, not implemented).
+    pub ppr_log_run: bool,
+    /// Guest log running (RO, not implemented).
+    pub ga_log_run: bool,
+    /// Guest log overflow (RW1C, not implemented).
+    pub ga_log_overflow: bool,
+    /// Guest log interrupt (RW1C, not implemented).
+    pub ga_log_int: bool,
+    #[bits(48)]
+    _reserved2: u64,
+}
+
+// =============================================================================
+// PCI Capability Block Types (§3.2)
+// =============================================================================
+
+open_enum! {
+    /// PCI Capability offset within the AMD IOMMU capability block.
+    #[derive(Inspect)]
+    #[inspect(debug)]
+    pub enum CapabilityOffset: u8 {
+        /// Capability header (32-bit).
+        HEADER      = 0x00,
+        /// Base address low (32-bit).
+        BASE_LOW    = 0x04,
+        /// Base address high (32-bit).
+        BASE_HIGH   = 0x08,
+        /// Range register (32-bit).
+        RANGE       = 0x0C,
+        /// Miscellaneous information 0 (32-bit).
+        MISC_INFO_0 = 0x10,
+    }
+}
+
+/// AMD IOMMU Capability ID in PCI config space.
+pub const CAP_ID: u8 = 0x0F;
+
+/// AMD IOMMU PCI Capability Header (offset 00h, 32-bit).
+///
+/// §3.2.1.
+#[bitfield(u32)]
+#[derive(Inspect)]
+#[rustfmt::skip]
+pub struct CapHeader {
+    /// Capability ID (0x0F for IOMMU).
+    #[bits(8)]
+    pub cap_id: u8,
+    /// Next capability pointer.
+    #[bits(8)]
+    pub cap_ptr: u8,
+    /// Capability type (011b for IOMMU).
+    #[bits(3)]
+    pub cap_type: u8,
+    /// Capability revision (00001b).
+    #[bits(5)]
+    pub cap_rev: u8,
+    /// IOTLB support.
+    pub iotlb_sup: bool,
+    /// HyperTransport tunnel.
+    pub ht_tunnel: bool,
+    /// NpCache (not-present cache).
+    pub np_cache: bool,
+    /// Extended Feature Register support.
+    pub efr_sup: bool,
+    /// Capability extension (MiscInfo1 present).
+    pub cap_ext: bool,
+    #[bits(3)]
+    _reserved: u32,
+}
+
+/// AMD IOMMU Base Address Low (capability offset 04h, 32-bit).
+///
+/// §3.2.2.
+#[bitfield(u32)]
+#[derive(Inspect)]
+#[rustfmt::skip]
+pub struct BaseAddrLow {
+    /// Enable bit (RW1S — locks all cap regs when set to 1).
+    pub enable: bool,
+    #[bits(13)]
+    _reserved: u32,
+    /// Base address bits [31:14]. MMIO base is 16KB-aligned.
+    #[bits(18)]
+    pub base_addr: u32,
+}
+
+/// AMD IOMMU Base Address High (capability offset 08h, 32-bit).
+///
+/// §3.2.3.
+#[bitfield(u32)]
+#[derive(Inspect)]
+#[rustfmt::skip]
+pub struct BaseAddrHigh {
+    /// Base address bits [63:32].
+    #[bits(32)]
+    pub base_addr: u32,
+}
+
+/// AMD IOMMU Range Register (capability offset 0Ch, 32-bit).
+///
+/// §3.2.4.
+#[bitfield(u32)]
+#[derive(Inspect)]
+#[rustfmt::skip]
+pub struct Range {
+    /// Unit ID (deprecated, set to 0).
+    #[bits(5)]
+    pub unit_id: u8,
+    #[bits(2)]
+    _reserved: u32,
+    /// Range valid — 1 = FirstDevice/LastDevice/BusNumber fields are valid.
+    pub rng_valid: bool,
+    /// Bus number for the IOMMU's upstream bus.
+    #[bits(8)]
+    pub bus_number: u8,
+    /// First device (BDF bits [7:0]) managed by this IOMMU.
+    #[bits(8)]
+    pub first_device: u8,
+    /// Last device (BDF bits [7:0]) managed by this IOMMU.
+    #[bits(8)]
+    pub last_device: u8,
+}
+
+/// AMD IOMMU Miscellaneous Information Register 0 (capability offset 10h, 32-bit).
+///
+/// §3.2.5.
+#[bitfield(u32)]
+#[derive(Inspect)]
+#[rustfmt::skip]
+pub struct MiscInfo0 {
+    /// MSI message number (interrupt vector index for event log + completion wait).
+    #[bits(5)]
+    pub msi_num: u8,
+    /// Guest VA size (0 = not supported).
+    #[bits(3)]
+    pub gva_size: u8,
+    /// Physical address size in bits.
+    #[bits(7)]
+    pub pa_size: u8,
+    /// Virtual address size in bits.
+    #[bits(7)]
+    pub va_size: u8,
+    /// HT ATS reserved bit.
+    pub ht_ats_resv: bool,
+    #[bits(4)]
+    _reserved: u32,
+    /// MSI message number for PPR log.
+    #[bits(5)]
+    pub msi_num_ppr: u8,
+}
+
+/// AMD IOMMU PCI Vendor ID.
+pub const PCI_VENDOR_ID: u16 = 0x1022;
+
+/// AMD IOMMU PCI Device ID (family 17h / Zen IOMMU).
+pub const PCI_DEVICE_ID: u16 = 0x1451;
+
+/// PCI class code base: System Peripheral.
+pub const PCI_CLASS_BASE: u8 = 0x08;
+
+/// PCI class code sub: IOMMU.
+pub const PCI_CLASS_SUB: u8 = 0x06;
+
+/// PCI class code programming interface.
+pub const PCI_CLASS_PROG_IF: u8 = 0x00;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_register_offsets() {
+        assert_eq!(MmioRegister::DEV_TAB_BASE.0, 0x0000);
+        assert_eq!(MmioRegister::CMD_BUF_BASE.0, 0x0008);
+        assert_eq!(MmioRegister::EVT_LOG_BASE.0, 0x0010);
+        assert_eq!(MmioRegister::IOMMU_CTRL.0, 0x0018);
+        assert_eq!(MmioRegister::EXCL_BASE.0, 0x0020);
+        assert_eq!(MmioRegister::EXCL_LIMIT.0, 0x0028);
+        assert_eq!(MmioRegister::EXT_FEAT.0, 0x0030);
+        assert_eq!(MmioRegister::GEN_XT_INT_CTRL.0, 0x0170);
+        assert_eq!(MmioRegister::PPR_XT_INT_CTRL.0, 0x0178);
+        assert_eq!(MmioRegister::CMD_BUF_HEAD.0, 0x2000);
+        assert_eq!(MmioRegister::CMD_BUF_TAIL.0, 0x2008);
+        assert_eq!(MmioRegister::EVT_LOG_HEAD.0, 0x2010);
+        assert_eq!(MmioRegister::EVT_LOG_TAIL.0, 0x2018);
+        assert_eq!(MmioRegister::IOMMU_STATUS.0, 0x2020);
+    }
+
+    #[test]
+    fn test_dev_tab_base_roundtrip() {
+        let reg = DevTabBase::new()
+            .with_size(0x1FF)
+            .with_base_addr(0x0001_2345_6789);
+        assert_eq!(reg.size(), 0x1FF);
+        assert_eq!(reg.base_addr(), 0x0001_2345_6789);
+    }
+
+    #[test]
+    fn test_cmd_buf_base_roundtrip() {
+        let reg = CmdBufBase::new()
+            .with_length(0x09)
+            .with_base_addr(0x000A_BCD0_0000);
+        assert_eq!(reg.length(), 0x09);
+        assert_eq!(reg.base_addr(), 0x000A_BCD0_0000);
+    }
+
+    #[test]
+    fn test_evt_log_base_roundtrip() {
+        let reg = EvtLogBase::new()
+            .with_length(0x08)
+            .with_base_addr(0x000F_EDC0_0000);
+        assert_eq!(reg.length(), 0x08);
+        assert_eq!(reg.base_addr(), 0x000F_EDC0_0000);
+    }
+
+    #[test]
+    fn test_iommu_ctrl_roundtrip() {
+        let ctrl = IommuCtrl::new()
+            .with_iommu_en(true)
+            .with_evt_log_en(true)
+            .with_cmd_buf_en(true)
+            .with_com_wait_int_en(true)
+            .with_evt_int_en(true)
+            .with_coherent(true);
+        assert!(ctrl.iommu_en());
+        assert!(ctrl.evt_log_en());
+        assert!(ctrl.cmd_buf_en());
+        assert!(ctrl.com_wait_int_en());
+        assert!(ctrl.evt_int_en());
+        assert!(ctrl.coherent());
+        assert!(!ctrl.ht_tun_en());
+    }
+
+    #[test]
+    fn test_iommu_ctrl_int_remap_mode() {
+        let ctrl = IommuCtrl::new().with_num_int_remap_mode(0b10);
+        assert_eq!(ctrl.num_int_remap_mode(), 0b10);
+    }
+
+    #[test]
+    fn test_cmd_buf_head_roundtrip() {
+        let reg = CmdBufHead::new().with_head_ptr(0x100);
+        assert_eq!(reg.head_ptr(), 0x100);
+    }
+
+    #[test]
+    fn test_iommu_status_roundtrip() {
+        let status = IommuStatus::new()
+            .with_evt_overflow(true)
+            .with_com_wait_int(true)
+            .with_cmd_buf_run(true);
+        assert!(status.evt_overflow());
+        assert!(status.com_wait_int());
+        assert!(status.cmd_buf_run());
+        assert!(!status.evt_log_int());
+        assert!(!status.evt_log_run());
+    }
+
+    #[test]
+    fn test_cap_header_roundtrip() {
+        let hdr = CapHeader::new()
+            .with_cap_id(CAP_ID)
+            .with_cap_type(0b011)
+            .with_cap_rev(0b00001)
+            .with_efr_sup(true);
+        assert_eq!(hdr.cap_id(), CAP_ID);
+        assert_eq!(hdr.cap_type(), 0b011);
+        assert_eq!(hdr.cap_rev(), 0b00001);
+        assert!(hdr.efr_sup());
+        assert!(!hdr.iotlb_sup());
+    }
+
+    #[test]
+    fn test_base_addr_low_roundtrip() {
+        let reg = BaseAddrLow::new().with_enable(true).with_base_addr(0x3F400); // 0xFD000000 >> 14
+        assert!(reg.enable());
+        assert_eq!(reg.base_addr(), 0x3F400);
+    }
+
+    #[test]
+    fn test_range_roundtrip() {
+        let reg = Range::new()
+            .with_rng_valid(true)
+            .with_bus_number(0)
+            .with_first_device(0x00)
+            .with_last_device(0xFF);
+        assert!(reg.rng_valid());
+        assert_eq!(reg.bus_number(), 0);
+        assert_eq!(reg.first_device(), 0x00);
+        assert_eq!(reg.last_device(), 0xFF);
+    }
+
+    #[test]
+    fn test_misc_info0_roundtrip() {
+        let reg = MiscInfo0::new()
+            .with_pa_size(48)
+            .with_va_size(48)
+            .with_msi_num(0);
+        assert_eq!(reg.pa_size(), 48);
+        assert_eq!(reg.va_size(), 48);
+        assert_eq!(reg.msi_num(), 0);
+        assert_eq!(reg.gva_size(), 0);
+    }
+}

--- a/vmm_core/src/acpi_builder.rs
+++ b/vmm_core/src/acpi_builder.rs
@@ -72,6 +72,38 @@ pub struct AcpiTablesBuilder<'a, T: AcpiTopology> {
     pub arch: AcpiArchConfig,
 }
 
+/// Configuration for AMD IOMMU ACPI table (IVRS) generation.
+#[derive(Clone, Debug)]
+pub struct AmdIommuAcpiConfig {
+    /// PCI DeviceID (BDF) of the IOMMU, encoded as `(bus << 8) | (dev << 3) | fn`.
+    pub device_id: u16,
+    /// Offset of the AMD IOMMU capability block in PCI config space.
+    pub capability_offset: u16,
+    /// MMIO base address of the IOMMU register region.
+    pub mmio_base: u64,
+    /// PCI segment group number (typically 0).
+    pub pci_segment: u16,
+    /// IOMMU feature reporting for the IVHD (should match MMIO ExtFeat register).
+    pub ivhd_features: u64,
+    /// Lowest bus number covered by this IOMMU.
+    pub start_bus: u8,
+    /// Highest bus number covered by this IOMMU.
+    pub end_bus: u8,
+}
+
+/// IVRS-level configuration for AMD IOMMU ACPI table generation.
+///
+/// Groups the IVRS header fields (PA/VA sizes) with the per-IOMMU configs.
+#[derive(Clone, Debug)]
+pub struct AmdIommuIvrsConfig {
+    /// Physical address size in bits (e.g. 48). Written to the IVRS IVinfo header.
+    pub pa_size: u8,
+    /// Virtual address size in bits (e.g. 48). Written to the IVRS IVinfo header.
+    pub va_size: u8,
+    /// Per-IOMMU configurations, one per root complex with an AMD IOMMU.
+    pub iommus: Vec<AmdIommuAcpiConfig>,
+}
+
 /// Architecture-specific ACPI configuration carried by [`AcpiTablesBuilder`].
 pub enum AcpiArchConfig {
     /// x86-specific settings (IOAPIC, PIC, PIT, PSP, PM base, SCI IRQ).
@@ -88,6 +120,9 @@ pub enum AcpiArchConfig {
         pm_base: u16,
         /// ACPI IRQ number.
         acpi_irq: u32,
+        /// AMD IOMMU IVRS table configuration. If `Some`, an IVRS table is
+        /// generated with one IVHD block per IOMMU instance.
+        amd_iommu: Option<AmdIommuIvrsConfig>,
     },
     /// ARM64-specific settings (HW_REDUCED_ACPI FADT).
     Aarch64 {
@@ -608,6 +643,57 @@ impl<T: AcpiTopology> AcpiTablesBuilder<'_, T> {
         T::needs_iort(self.processor_topology) && !self.pcie_host_bridges.is_empty()
     }
 
+    fn with_ivrs<F, R>(&self, ivrs_config: &AmdIommuIvrsConfig, f: F) -> R
+    where
+        F: FnOnce(&acpi::builder::Table<'_>) -> R,
+    {
+        use acpi_spec::ivrs;
+
+        let mut ivrs_extra: Vec<u8> = Vec::new();
+
+        for config in &ivrs_config.iommus {
+            // Use a device range entry to cover the bus range owned by this
+            // root complex's IOMMU (IVHD_DEV_RANGE_START + IVHD_DEV_RANGE_END).
+            // This correctly supports multiple IOMMUs within a single PCI
+            // segment, each covering its own bus range.
+            let dev_entries_size = 2 * size_of::<ivrs::IvhdDeviceEntry4>();
+            let ivhd_total = size_of::<ivrs::IvhdType40>() + dev_entries_size;
+
+            // Type 40h is the "mixed format" IVHD (§5.2.2.3) — same layout
+            // as type 11h but supports both BDF and ACPI HID device entries.
+            // We use it as the superset format; our entries are all BDF-based.
+            let ivhd = ivrs::IvhdType40::new(
+                config.device_id,
+                config.capability_offset,
+                config.mmio_base,
+                config.pci_segment,
+                config.ivhd_features,
+            )
+            .with_length(ivhd_total as u16)
+            .with_flags(0); // no HT tunnel, coherent, etc.
+
+            ivrs_extra.extend_from_slice(ivhd.as_bytes());
+
+            let start_bdf = (config.start_bus as u16) << 8;
+            let end_bdf = ((config.end_bus as u16) << 8) | 0xFF;
+            ivrs_extra
+                .extend_from_slice(ivrs::IvhdDeviceEntry4::range_start(start_bdf, 0).as_bytes());
+            ivrs_extra.extend_from_slice(ivrs::IvhdDeviceEntry4::range_end(end_bdf).as_bytes());
+        }
+
+        let iv_info = ivrs::IvInfo::new()
+            .with_efr_sup(true)
+            .with_pa_size(ivrs_config.pa_size)
+            .with_va_size(ivrs_config.va_size);
+
+        (f)(&acpi::builder::Table::new_dyn(
+            ivrs::IVRS_REVISION,
+            None,
+            &ivrs::Ivrs::new(u32::from(iv_info)),
+            &[ivrs_extra.as_slice()],
+        ))
+    }
+
     fn with_pptt<F, R>(&self, f: F) -> R
     where
         F: FnOnce(&acpi::builder::Table<'_>) -> R,
@@ -958,6 +1044,14 @@ impl<T: AcpiTopology> AcpiTablesBuilder<'_, T> {
             self.with_pptt(|t| b.append(t));
         }
 
+        if let AcpiArchConfig::X86 {
+            amd_iommu: Some(ivrs_config),
+            ..
+        } = &self.arch
+        {
+            self.with_ivrs(ivrs_config, |t| b.append(t));
+        }
+
         if matches!(self.arch, AcpiArchConfig::Aarch64 { .. }) {
             self.with_gtdt(|t| b.append(t));
         }
@@ -990,6 +1084,19 @@ impl<T: AcpiTopology> AcpiTablesBuilder<'_, T> {
     pub fn build_iort(&self) -> Option<Vec<u8>> {
         self.should_build_iort()
             .then(|| self.with_iort(|t| t.to_vec(&OEM_INFO)))
+    }
+
+    /// Helper method to construct an IVRS without constructing the rest of the
+    /// ACPI tables. Returns `None` if AMD IOMMU is not configured.
+    pub fn build_ivrs(&self) -> Option<Vec<u8>> {
+        if let AcpiArchConfig::X86 {
+            amd_iommu: Some(ivrs_config),
+            ..
+        } = &self.arch
+        {
+            return Some(self.with_ivrs(ivrs_config, |t| t.to_vec(&OEM_INFO)));
+        }
+        None
     }
 
     /// Helper method to construct a PPTT without constructing the rest of the
@@ -1067,6 +1174,7 @@ mod test {
                 with_psp: false,
                 pm_base: 1234,
                 acpi_irq: 2,
+                amd_iommu: None,
             },
         }
     }
@@ -1613,5 +1721,232 @@ mod test {
         assert_eq!(u32_at(&data, smmu_node + 48), 0); // pri_gsiv
         assert_eq!(u32_at(&data, smmu_node + 52), 36); // gerr_gsiv
         assert_eq!(u32_at(&data, smmu_node + 56), 0); // sync_gsiv
+    }
+
+    fn set_amd_iommu(
+        builder: &mut AcpiTablesBuilder<'_, X86Topology>,
+        configs: Vec<AmdIommuAcpiConfig>,
+    ) {
+        if let AcpiArchConfig::X86 { amd_iommu, .. } = &mut builder.arch {
+            *amd_iommu = Some(AmdIommuIvrsConfig {
+                pa_size: 48,
+                va_size: 48,
+                iommus: configs,
+            });
+        } else {
+            panic!("expected X86 arch config");
+        }
+    }
+
+    #[test]
+    fn test_ivrs_basic() {
+        let mem = new_mem();
+        let topology = TopologyBuilder::new_x86().build(4).unwrap();
+        let pcie = vec![];
+        let mut builder = new_builder(&mem, &topology, &pcie);
+        set_amd_iommu(
+            &mut builder,
+            vec![AmdIommuAcpiConfig {
+                device_id: 0x0000, // bus 0, dev 0, fn 0
+                capability_offset: 0x40,
+                mmio_base: 0xFD00_0000,
+                pci_segment: 0,
+                ivhd_features: 0xC0,
+                start_bus: 0,
+                end_bus: 255,
+            }],
+        );
+
+        let ivrs = builder.build_ivrs().unwrap();
+
+        // Verify IVRS signature in the first 4 bytes of the table
+        assert_eq!(&ivrs[0..4], b"IVRS");
+        // Verify checksum
+        assert_eq!(checksum(&ivrs), 0);
+
+        // After the 36-byte ACPI header and 12-byte IVRS header (offset 48),
+        // the IVHD type 40h block starts.
+        let ivhd_offset = 48;
+        assert_eq!(ivrs[ivhd_offset], 0x40); // IVHD type 40h
+
+        // IOMMU DeviceID at offset +4 (u16)
+        let dev_id = u16::from_ne_bytes(ivrs[ivhd_offset + 4..ivhd_offset + 6].try_into().unwrap());
+        assert_eq!(dev_id, 0x0000);
+
+        // Capability offset at offset +6 (u16)
+        let cap_offset =
+            u16::from_ne_bytes(ivrs[ivhd_offset + 6..ivhd_offset + 8].try_into().unwrap());
+        assert_eq!(cap_offset, 0x40);
+
+        // MMIO base at offset +8 (u64)
+        let mmio_base =
+            u64::from_ne_bytes(ivrs[ivhd_offset + 8..ivhd_offset + 16].try_into().unwrap());
+        assert_eq!(mmio_base, 0xFD00_0000);
+
+        // EFR at offset +24 (u64) in the type 40h extended fields
+        let efr = u64::from_ne_bytes(ivrs[ivhd_offset + 24..ivhd_offset + 32].try_into().unwrap());
+        assert_eq!(efr, 0xC0); // IASup + GASup
+
+        // Device entries follow the IVHD type 40h header (40 bytes).
+        // We emit a range_start + range_end pair.
+        let dev_entry_offset = ivhd_offset + 40;
+        assert_eq!(ivrs[dev_entry_offset], 0x03); // range_start entry
+        assert_eq!(ivrs[dev_entry_offset + 4], 0x04); // range_end entry
+    }
+
+    #[test]
+    fn test_ivrs_not_generated_when_disabled() {
+        let mem = new_mem();
+        let topology = TopologyBuilder::new_x86().build(4).unwrap();
+        let pcie = vec![];
+        let builder = new_builder(&mem, &topology, &pcie);
+
+        // amd_iommu is empty by default
+        assert!(builder.build_ivrs().is_none());
+
+        let tables = builder.build_acpi_tables(0x100000, |_| {});
+        assert!(!contains_signature(&tables.tables, b"IVRS"));
+    }
+
+    #[test]
+    fn test_ivrs_in_acpi_tables() {
+        let mem = new_mem();
+        let topology = TopologyBuilder::new_x86().build(4).unwrap();
+        let pcie = vec![];
+        let mut builder = new_builder(&mem, &topology, &pcie);
+        set_amd_iommu(
+            &mut builder,
+            vec![AmdIommuAcpiConfig {
+                device_id: 0x0000,
+                capability_offset: 0x40,
+                mmio_base: 0xFD00_0000,
+                pci_segment: 0,
+                ivhd_features: 0xC0,
+                start_bus: 0,
+                end_bus: 255,
+            }],
+        );
+
+        let tables = builder.build_acpi_tables(0x100000, |_| {});
+        assert!(contains_signature(&tables.tables, b"IVRS"));
+    }
+
+    #[test]
+    fn test_ivrs_iommu_fields() {
+        let mem = new_mem();
+        let topology = TopologyBuilder::new_x86().build(4).unwrap();
+        let pcie = vec![];
+        let mut builder = new_builder(&mem, &topology, &pcie);
+        set_amd_iommu(
+            &mut builder,
+            vec![AmdIommuAcpiConfig {
+                device_id: 0x1234,
+                capability_offset: 0x80,
+                mmio_base: 0xFE00_0000,
+                pci_segment: 1,
+                ivhd_features: 0xC0,
+                start_bus: 0,
+                end_bus: 255,
+            }],
+        );
+
+        let ivrs = builder.build_ivrs().unwrap();
+
+        let ivhd_offset = 48;
+        // DeviceID
+        let dev_id = u16::from_ne_bytes(ivrs[ivhd_offset + 4..ivhd_offset + 6].try_into().unwrap());
+        assert_eq!(dev_id, 0x1234);
+
+        // Capability offset
+        let cap_offset =
+            u16::from_ne_bytes(ivrs[ivhd_offset + 6..ivhd_offset + 8].try_into().unwrap());
+        assert_eq!(cap_offset, 0x80);
+
+        // MMIO base
+        let mmio_base =
+            u64::from_ne_bytes(ivrs[ivhd_offset + 8..ivhd_offset + 16].try_into().unwrap());
+        assert_eq!(mmio_base, 0xFE00_0000);
+
+        // PCI segment at offset +16 (u16)
+        let pci_seg =
+            u16::from_ne_bytes(ivrs[ivhd_offset + 16..ivhd_offset + 18].try_into().unwrap());
+        assert_eq!(pci_seg, 1);
+    }
+
+    #[test]
+    fn test_ivrs_multiple_iommus() {
+        let mem = new_mem();
+        let topology = TopologyBuilder::new_x86().build(4).unwrap();
+        let pcie = vec![];
+        let mut builder = new_builder(&mem, &topology, &pcie);
+        set_amd_iommu(
+            &mut builder,
+            vec![
+                AmdIommuAcpiConfig {
+                    device_id: 0x0000,
+                    capability_offset: 0x40,
+                    mmio_base: 0xFD00_0000,
+                    pci_segment: 0,
+                    ivhd_features: 0xC0,
+                    start_bus: 0,
+                    end_bus: 127,
+                },
+                AmdIommuAcpiConfig {
+                    device_id: 0x0000,
+                    capability_offset: 0x40,
+                    mmio_base: 0xFD00_4000,
+                    pci_segment: 1,
+                    ivhd_features: 0xC0,
+                    start_bus: 0,
+                    end_bus: 255,
+                },
+            ],
+        );
+
+        let ivrs = builder.build_ivrs().unwrap();
+
+        // Verify IVRS signature
+        assert_eq!(&ivrs[0..4], b"IVRS");
+        assert_eq!(checksum(&ivrs), 0);
+
+        // First IVHD block at offset 48 (after 36-byte ACPI header + 12-byte IVRS header)
+        let ivhd0_offset = 48;
+        assert_eq!(ivrs[ivhd0_offset], 0x40); // IVHD type 40h
+
+        // Read first IVHD length to find second IVHD
+        let ivhd0_len =
+            u16::from_ne_bytes(ivrs[ivhd0_offset + 2..ivhd0_offset + 4].try_into().unwrap());
+
+        // First IOMMU: segment 0, MMIO 0xFD00_0000
+        let mmio0 = u64::from_ne_bytes(
+            ivrs[ivhd0_offset + 8..ivhd0_offset + 16]
+                .try_into()
+                .unwrap(),
+        );
+        assert_eq!(mmio0, 0xFD00_0000);
+        let seg0 = u16::from_ne_bytes(
+            ivrs[ivhd0_offset + 16..ivhd0_offset + 18]
+                .try_into()
+                .unwrap(),
+        );
+        assert_eq!(seg0, 0);
+
+        // Second IVHD block follows the first
+        let ivhd1_offset = ivhd0_offset + ivhd0_len as usize;
+        assert_eq!(ivrs[ivhd1_offset], 0x40); // IVHD type 40h
+
+        // Second IOMMU: segment 1, MMIO 0xFD00_4000
+        let mmio1 = u64::from_ne_bytes(
+            ivrs[ivhd1_offset + 8..ivhd1_offset + 16]
+                .try_into()
+                .unwrap(),
+        );
+        assert_eq!(mmio1, 0xFD00_4000);
+        let seg1 = u16::from_ne_bytes(
+            ivrs[ivhd1_offset + 16..ivhd1_offset + 18]
+                .try_into()
+                .unwrap(),
+        );
+        assert_eq!(seg1, 1);
     }
 }

--- a/vmm_tests/vmm_test_macros/src/lib.rs
+++ b/vmm_tests/vmm_test_macros/src/lib.rs
@@ -37,12 +37,23 @@ struct ResolvedConfig {
     extra_deps: Vec<Path>,
     unstable: bool,
     requires_vpci: bool,
+    requires_host_vendor: Option<HostVendor>,
 }
 
 #[derive(Clone, Copy, PartialEq, Eq)]
 enum Vmm {
     OpenVmm,
     HyperV,
+}
+
+/// Host CPU vendor that a test can be restricted to via macro overrides.
+///
+/// When set, the test is marked ignored at runtime on hosts whose vendor
+/// does not match (e.g. an `amd`-gated test is skipped on Intel hosts).
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum HostVendor {
+    Amd,
+    Intel,
 }
 
 enum Firmware {
@@ -93,6 +104,7 @@ struct ArgsWithOverrides {
     unstable: bool,
     with_vtl0_pipette: bool,
     requires_vpci: bool,
+    requires_host_vendor: Option<HostVendor>,
 }
 
 struct ResolvedArgs {
@@ -259,6 +271,7 @@ impl Parse for ArgsWithOverrides {
         let mut with_vtl0_pipette = None;
         let mut vmm = None;
         let mut requires_vpci = None;
+        let mut requires_host_vendor = None;
 
         let word = input.parse::<Ident>()?;
         let conflict_err = || Err::<Self, Error>(Error::new(word.span(), "conflicting override"));
@@ -281,6 +294,18 @@ impl Parse for ArgsWithOverrides {
                         return conflict_err();
                     }
                     requires_vpci = Some(true);
+                }
+                "amd" => {
+                    if requires_host_vendor.is_some() {
+                        return conflict_err();
+                    }
+                    requires_host_vendor = Some(HostVendor::Amd);
+                }
+                "intel" => {
+                    if requires_host_vendor.is_some() {
+                        return conflict_err();
+                    }
+                    requires_host_vendor = Some(HostVendor::Intel);
                 }
                 "hyperv" => {
                     if vmm.is_some() {
@@ -312,6 +337,7 @@ impl Parse for ArgsWithOverrides {
             with_vtl0_pipette,
             unstable,
             requires_vpci,
+            requires_host_vendor,
         })
     }
 }
@@ -324,6 +350,7 @@ impl ArgsWithOverrides {
             unstable,
             with_vtl0_pipette,
             requires_vpci,
+            requires_host_vendor,
         } = self;
 
         let mut resolved_configs = Vec::new();
@@ -345,6 +372,7 @@ impl ArgsWithOverrides {
                 extra_deps: config.extra_deps,
                 unstable: config.unstable || unstable,
                 requires_vpci,
+                requires_host_vendor,
             });
         }
 
@@ -752,6 +780,7 @@ pub fn vmm_test(
         unstable: false,
         with_vtl0_pipette: true,
         requires_vpci: false,
+        requires_host_vendor: None,
     };
     let item = parse_macro_input!(item as ItemFn);
     make_vmm_test(args, item)
@@ -763,6 +792,10 @@ pub fn vmm_test(
 /// to all tests, separated by underscores:
 /// - unstable: all variants of this test are unstable
 /// - noagent: don't use pipette in vtl0 for this test
+/// - vpci: this test requires a hypervisor backend that supports VPCI
+///   (virtual PCI) device emulation
+/// - amd: this test only runs on AMD-vendor hosts (skipped otherwise)
+/// - intel: this test only runs on Intel-vendor hosts (skipped otherwise)
 /// - hyperv: use hyperv as the vmm
 /// - openvmm: use openvmm as the vmm
 ///
@@ -792,6 +825,7 @@ pub fn openvmm_test(
         unstable: false,
         with_vtl0_pipette: true,
         requires_vpci: false,
+        requires_host_vendor: None,
     };
     let item = parse_macro_input!(item as ItemFn);
     make_vmm_test(args, item)
@@ -812,6 +846,7 @@ pub fn openvmm_test_no_agent(
         unstable: false,
         with_vtl0_pipette: false,
         requires_vpci: false,
+        requires_host_vendor: None,
     };
     let item = parse_macro_input!(item as ItemFn);
     make_vmm_test(args, item)
@@ -843,7 +878,12 @@ fn make_vmm_test(args: ArgsWithOverrides, item: ItemFn) -> syn::Result<TokenStre
         let name = format!("{}_{original_name}", config.name_prefix());
 
         // Build requirements based on the configuration and resolved VMM
-        let requirements = build_requirements(&config.firmware, config.vmm, config.requires_vpci);
+        let requirements = build_requirements(
+            &config.firmware,
+            config.vmm,
+            config.requires_vpci,
+            config.requires_host_vendor,
+        );
 
         // Now move the values for the FirmwareAndArch and extra_deps
         let extra_deps = config.extra_deps;
@@ -908,7 +948,12 @@ fn make_vmm_test(args: ArgsWithOverrides, item: ItemFn) -> syn::Result<TokenStre
 }
 
 // Helper to build requirements TokenStream for firmware and resolved VMM
-fn build_requirements(firmware: &Firmware, resolved_vmm: Vmm, requires_vpci: bool) -> TokenStream {
+fn build_requirements(
+    firmware: &Firmware,
+    resolved_vmm: Vmm,
+    requires_vpci: bool,
+    requires_host_vendor: Option<HostVendor>,
+) -> TokenStream {
     let mut requirement_expr: TokenStream = quote!(::petri::requirements::TestRequirement::Any);
     let mut is_vbs = false;
     // Add isolation requirement if specified
@@ -950,6 +995,16 @@ fn build_requirements(firmware: &Firmware, resolved_vmm: Vmm, requires_vpci: boo
     if requires_vpci {
         requirement_expr =
             quote!(#requirement_expr.and(::petri::requirements::TestRequirement::VpciSupport));
+    }
+
+    if let Some(vendor) = requires_host_vendor {
+        let vendor_tokens = match vendor {
+            HostVendor::Amd => quote!(::petri::requirements::Vendor::Amd),
+            HostVendor::Intel => quote!(::petri::requirements::Vendor::Intel),
+        };
+        requirement_expr = quote!(#requirement_expr.and(
+            ::petri::requirements::TestRequirement::Vendor(#vendor_tokens)
+        ));
     }
 
     quote!(

--- a/vmm_tests/vmm_tests/tests/tests/multiarch/pcie.rs
+++ b/vmm_tests/vmm_tests/tests/tests/multiarch/pcie.rs
@@ -17,6 +17,7 @@ use pipette_client::PipetteClient;
 use std::fmt;
 use std::time::Duration;
 use vmm_test_macros::openvmm_test;
+use vmm_test_macros::vmm_test_with;
 
 /// List of MAC addresses for tests to use.
 const PCIE_NIC_MAC_ADDRESSES: [MacAddress; 2] = [
@@ -553,71 +554,93 @@ async fn smmu_mixed_topology(config: PetriVmBuilder<OpenVmmPetriBackend>) -> any
     );
 
     // 3. Verify IOMMU groups exist (devices behind the SMMU RC)
-    let iommu_groups = cmd!(sh, "ls /sys/kernel/iommu_groups/")
-        .read()
-        .await
-        .unwrap_or_default();
+    let iommu_groups = cmd!(sh, "ls /sys/kernel/iommu_groups/").read().await?;
     tracing::info!(%iommu_groups, "IOMMU groups");
     assert!(
         !iommu_groups.trim().is_empty(),
         "IOMMU groups should exist for devices behind the SMMU"
     );
 
-    // 4. Verify all NVMe devices enumerate and have block devices
-    let block_devs = cmd!(sh, "ls /sys/block/").read().await?;
-    let nvme_count = block_devs
-        .split_whitespace()
-        .filter(|d| d.starts_with("nvme"))
-        .count();
-    assert_eq!(
-        nvme_count, 2,
-        "both NVMe controllers should create block devices: {block_devs}"
-    );
+    // 4. Verify all NVMe devices enumerate, have block devices, and DMA
+    //    works through the SMMU (segment 0 / PCI domain 0000).
+    verify_nvme_dma_on_segment(&sh, 2, "0000").await?;
 
-    // 5. Verify NVMe behind SMMU works: write and read back data.
-    //    Resolve each NVMe block device's PCI domain from sysfs to find the
-    //    one on segment 0 (the SMMU-covered root complex). This ensures we
-    //    exercise DMA through the SMMU, not the non-SMMU path.
-    let nvme_devs: Vec<&str> = block_devs
-        .split_whitespace()
-        .filter(|d| d.starts_with("nvme"))
-        .collect();
-    let mut smmu_nvme = None;
-    for dev in &nvme_devs {
-        let pci_path = cmd!(sh, "readlink -f /sys/block/{dev}/device")
-            .read()
-            .await?;
-        // PCI path looks like .../pci0000:00/0000:00:00.0/0000:01:00.0/nvme/nvme0
-        // Search all path segments for a BDF in PCI domain 0000.
-        if pci_path.split('/').any(|seg| seg.starts_with("0000:")) {
-            smmu_nvme = Some(*dev);
-            break;
-        }
-    }
-    let smmu_nvme =
-        smmu_nvme.expect("should find an NVMe on PCI domain 0000 (SMMU-covered segment)");
-    tracing::info!(smmu_nvme, "exercising DMA through SMMU");
-    cmd!(
-        sh,
-        "dd if=/dev/urandom of=/dev/{smmu_nvme} bs=4096 count=16 oflag=direct"
-    )
-    .read()
-    .await?;
-    cmd!(
-        sh,
-        "dd if=/dev/{smmu_nvme} of=/dev/null bs=4096 count=16 iflag=direct"
-    )
-    .read()
-    .await?;
+    // 5. Verify virtio-net interfaces exist on both RCs
+    verify_net_interface_count(&sh, 2).await?;
 
-    // 6. Verify virtio-net interfaces exist on both RCs
-    let net_devs = cmd!(sh, "ls /sys/class/net/").read().await?;
-    let net_count = net_devs.split_whitespace().filter(|d| *d != "lo").count();
-    tracing::info!(%net_devs, net_count, "network devices");
+    agent.power_off().await?;
+    vm.wait_for_clean_teardown().await?;
+    Ok(())
+}
+
+/// Test AMD IOMMU emulation with a mixed topology:
+///
+/// - Root complex s0rc0 (segment 0): IOMMU enabled, virtio-net + NVMe behind it
+/// - Root complex s1rc0 (segment 1): no IOMMU, virtio-net behind it
+///
+/// Verifies:
+/// 1. Linux discovers the AMD IOMMU (dmesg shows AMD-Vi init)
+/// 2. IVRS ACPI table is present
+/// 3. Devices behind the IOMMU RC are in IOMMU groups
+/// 4. Devices on both RCs enumerate and function (block I/O, network interface)
+/// 5. DMA through the IOMMU works (NVMe I/O behind the IOMMU)
+///
+/// Restricted to AMD-vendor hosts: the AMD IOMMU emulator's IVHD entries
+/// surface a host-cpuid-derived AMD-Vi family/model that Linux's IOMMU
+/// driver only accepts when the boot CPU also reports as AMD.
+#[vmm_test_with(openvmm_amd(linux_direct_x64))]
+async fn amd_iommu_mixed_topology(
+    config: PetriVmBuilder<OpenVmmPetriBackend>,
+) -> anyhow::Result<()> {
+    let (vm, agent) = config
+        .modify_backend(|b| {
+            b.with_pcie_root_topology(2, 1, 4) // 2 segments, 1 RC each, 4 ports each
+                .with_amd_iommu(&["s0rc0"]) // IOMMU only on segment 0's RC
+                .with_pcie_nvme("s0rc0rp0", PCIE_NVME_SUBSYSTEM_IDS[0])
+                .with_virtio_nic("s0rc0rp1")
+                .with_pcie_nvme("s1rc0rp0", PCIE_NVME_SUBSYSTEM_IDS[1])
+                .with_virtio_nic("s1rc0rp1")
+        })
+        .run()
+        .await?;
+
+    let sh = agent.unix_shell();
+
+    // 1. Verify IOMMU is discovered by Linux
+    let dmesg = cmd!(sh, "dmesg").read().await?;
+    tracing::info!(dmesg_len = dmesg.len(), "dmesg captured");
+
     assert!(
-        net_count >= 2,
-        "at least 2 network interfaces should exist (got {net_count}): {net_devs}"
+        dmesg.contains("AMD-Vi") || dmesg.contains("AMD IOMMUv2") || dmesg.contains("AMD IOMMU"),
+        "Linux should discover the AMD IOMMU in dmesg. dmesg excerpt:\n{}",
+        dmesg
+            .lines()
+            .filter(|l| l.contains("IOMMU") || l.contains("iommu") || l.contains("AMD-Vi"))
+            .collect::<Vec<_>>()
+            .join("\n")
     );
+
+    // 2. Verify IVRS ACPI table is present
+    let acpi_tables = cmd!(sh, "ls /sys/firmware/acpi/tables/").read().await?;
+    assert!(
+        acpi_tables.contains("IVRS"),
+        "IVRS ACPI table should be present. Tables: {acpi_tables}"
+    );
+
+    // 3. Verify IOMMU groups exist (devices behind the IOMMU RC)
+    let iommu_groups = cmd!(sh, "ls /sys/kernel/iommu_groups/").read().await?;
+    tracing::info!(%iommu_groups, "IOMMU groups");
+    assert!(
+        !iommu_groups.trim().is_empty(),
+        "IOMMU groups should exist for devices behind the IOMMU"
+    );
+
+    // 4. Verify all NVMe devices enumerate, have block devices, and DMA
+    //    works through the IOMMU (segment 0 / PCI domain 0000).
+    verify_nvme_dma_on_segment(&sh, 2, "0000").await?;
+
+    // 5. Verify virtio-net interfaces exist
+    verify_net_interface_count(&sh, 2).await?;
 
     agent.power_off().await?;
     vm.wait_for_clean_teardown().await?;
@@ -644,5 +667,75 @@ async fn _boot_no_vmbus_pcie_nvme(
 
     agent.power_off().await?;
     vm.wait_for_clean_teardown().await?;
+    Ok(())
+}
+
+/// Verify that NVMe block devices are visible in the guest and exercise DMA
+/// on the device whose PCI path falls in the given domain (segment).
+async fn verify_nvme_dma_on_segment(
+    sh: &pipette_client::shell::UnixShell<'_>,
+    expected_count: usize,
+    pci_domain: &str,
+) -> anyhow::Result<()> {
+    let block_devs = cmd!(sh, "ls /sys/block/").read().await?;
+    let nvme_devs: Vec<&str> = block_devs
+        .split_whitespace()
+        .filter(|d| d.starts_with("nvme"))
+        .collect();
+    assert_eq!(
+        nvme_devs.len(),
+        expected_count,
+        "expected {expected_count} NVMe block devices, found {}: {block_devs}",
+        nvme_devs.len(),
+    );
+
+    // Find the NVMe device on the target PCI domain and exercise DMA.
+    let domain_prefix = format!("{pci_domain}:");
+    let mut target = None;
+    for dev in &nvme_devs {
+        let pci_path = cmd!(sh, "readlink -f /sys/block/{dev}/device")
+            .read()
+            .await?;
+        if pci_path
+            .split('/')
+            .any(|seg| seg.starts_with(&domain_prefix))
+        {
+            target = Some(*dev);
+            break;
+        }
+    }
+    let target =
+        target.unwrap_or_else(|| panic!("no NVMe device found on PCI domain {pci_domain}"));
+
+    tracing::info!(target, pci_domain, "exercising DMA on NVMe device");
+    cmd!(
+        sh,
+        "dd if=/dev/urandom of=/dev/{target} bs=4096 count=16 oflag=direct"
+    )
+    .read()
+    .await?;
+    cmd!(
+        sh,
+        "dd if=/dev/{target} of=/dev/null bs=4096 count=16 iflag=direct"
+    )
+    .read()
+    .await?;
+
+    Ok(())
+}
+
+/// Assert that the guest has at least `min_count` non-loopback network
+/// interfaces.
+async fn verify_net_interface_count(
+    sh: &pipette_client::shell::UnixShell<'_>,
+    min_count: usize,
+) -> anyhow::Result<()> {
+    let net_devs = cmd!(sh, "ls /sys/class/net/").read().await?;
+    let net_count = net_devs.split_whitespace().filter(|d| *d != "lo").count();
+    tracing::info!(%net_devs, net_count, "network devices");
+    assert!(
+        net_count >= min_count,
+        "expected at least {min_count} network interfaces, got {net_count}: {net_devs}"
+    );
     Ok(())
 }


### PR DESCRIPTION
Add an emulated AMD IOMMU that can be attached to PCIe root complexes, giving guests DMA address translation and interrupt remapping for emulated PCI devices. The guest discovers the IOMMU through standard PCI enumeration (CapID 0x0F) and ACPI IVRS tables, then programs it through the MMIO command/event-log interface — the same flow as on real hardware.

The emulator implements the guest-visible surface needed for a virtual environment: device table entry lookup, multi-level IOMMU page table walking for IOVA-to-GPA translation, interrupt remapping via IRTE tables, and MMIO command buffer processing (`COMPLETION_WAIT`, `INVALIDATE_DEVTAB_ENTRY`, `INVALIDATE_IOMMU_PAGES`, `INVALIDATE_INTERRUPT_TABLE`). The device presents as a Root Complex Integrated Endpoint (RCiEP) at device 0 on each enabled root complex.

The IOMMU is configured per-root-complex via `--amd-iommu <rc-name>`, so a VM can mix IOMMU-covered and pass-through root complexes. Per-device DMA and MSI wrappers intercept device traffic and route it through the IOMMU's translation logic transparently — device emulators don't need changes. ACPI IVRS tables are generated automatically for each IOMMU instance, and the wiring module (`amd_iommu_wiring`) handles IOMMU instantiation, IVRS config, and port-to-IOMMU mapping.

The test macro infrastructure gains `#[vmm_test_with(openvmm_amd(...))]` to gate tests to AMD-vendor hosts, since the IVHD entries carry host-CPUID-derived family/model data that Linux's IOMMU driver validates against the boot CPU. An end-to-end test (`amd_iommu_mixed_topology`) exercises a two-segment topology with IOMMU on one RC, validating device enumeration, IOMMU group assignment, DMA through the IOMMU, and network interface visibility. The test shares device-validation helpers with the existing SMMU mixed-topology test.