### PR TITLE
openvmm_entry: add explicit controller and relay CLI for storage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5550,6 +5550,7 @@ dependencies = [
  "serial_16550_resources",
  "serial_core",
  "serial_socket",
+ "sha2",
  "shell-words",
  "socket2",
  "sparse_mmap",

--- a/Guide/src/dev_guide/contrib/style_guide.md
+++ b/Guide/src/dev_guide/contrib/style_guide.md
@@ -82,7 +82,7 @@ in context:
 - **`path/to/...` style** — for file paths where the structure is obvious.
   This is the predominant style in the existing guide.
   ```bash
-  cargo run -- --uefi --vmbus-scsi id=scsi0 --disk memdiff:file:path/to/disk.vhdx,controller=scsi0
+  cargo run -- --uefi --vmbus-scsi id=scsi0 --disk memdiff:file:path/to/disk.vhdx,on=scsi0
   ```
 
 - **`<SCREAMING_SNAKE_CASE>` style** — for values that need extra emphasis or
@@ -94,7 +94,7 @@ in context:
 Bad (hardcoded path that won't work for the reader):
 
 ~~~bash
-cargo run -- --uefi --vmbus-scsi id=scsi0 --disk memdiff:file:/home/alice/disks/myvm.vhdx,controller=scsi0
+cargo run -- --uefi --vmbus-scsi id=scsi0 --disk memdiff:file:/home/alice/disks/myvm.vhdx,on=scsi0
 ~~~
 
 ### File paths in code examples
@@ -104,17 +104,17 @@ even when the path refers to a Windows filesystem location accessed via WSL:
 
 ```bash
 # Good — forward slashes in bash
-cargo run -- --vmbus-scsi id=scsi0 --disk memdiff:file:path/to/disk.vhdx,controller=scsi0
+cargo run -- --vmbus-scsi id=scsi0 --disk memdiff:file:path/to/disk.vhdx,on=scsi0
 
 # Good — wslpath output uses backslashes, but that's a Windows path
-cargo run -- --vmbus-scsi id=scsi0 --disk "memdiff:file:$(wslpath -w /mnt/c/vhds/disk.vhdx),controller=scsi0"
+cargo run -- --vmbus-scsi id=scsi0 --disk "memdiff:file:$(wslpath -w /mnt/c/vhds/disk.vhdx),on=scsi0"
 ```
 
 Use **backslashes** for paths in `powershell` code blocks:
 
 ```powershell
 # Good — backslashes in PowerShell
-cargo run -- --vmbus-scsi id=scsi0 --disk memdiff:file:C:\vhds\disk.vhdx,controller=scsi0
+cargo run -- --vmbus-scsi id=scsi0 --disk memdiff:file:C:\vhds\disk.vhdx,on=scsi0
 ```
 
 ### Length

--- a/Guide/src/dev_guide/contrib/style_guide.md
+++ b/Guide/src/dev_guide/contrib/style_guide.md
@@ -82,7 +82,7 @@ in context:
 - **`path/to/...` style** — for file paths where the structure is obvious.
   This is the predominant style in the existing guide.
   ```bash
-  cargo run -- --uefi --disk memdiff:file:path/to/disk.vhdx
+  cargo run -- --uefi --vmbus-scsi id=scsi0 --disk memdiff:file:path/to/disk.vhdx,controller=scsi0
   ```
 
 - **`<SCREAMING_SNAKE_CASE>` style** — for values that need extra emphasis or
@@ -94,7 +94,7 @@ in context:
 Bad (hardcoded path that won't work for the reader):
 
 ~~~bash
-cargo run -- --uefi --disk memdiff:file:/home/alice/disks/myvm.vhdx
+cargo run -- --uefi --vmbus-scsi id=scsi0 --disk memdiff:file:/home/alice/disks/myvm.vhdx,controller=scsi0
 ~~~
 
 ### File paths in code examples
@@ -104,17 +104,17 @@ even when the path refers to a Windows filesystem location accessed via WSL:
 
 ```bash
 # Good — forward slashes in bash
-cargo run -- --disk memdiff:file:path/to/disk.vhdx
+cargo run -- --vmbus-scsi id=scsi0 --disk memdiff:file:path/to/disk.vhdx,controller=scsi0
 
 # Good — wslpath output uses backslashes, but that's a Windows path
-cargo run -- --disk "memdiff:file:$(wslpath -w /mnt/c/vhds/disk.vhdx)"
+cargo run -- --vmbus-scsi id=scsi0 --disk "memdiff:file:$(wslpath -w /mnt/c/vhds/disk.vhdx),controller=scsi0"
 ```
 
 Use **backslashes** for paths in `powershell` code blocks:
 
 ```powershell
 # Good — backslashes in PowerShell
-cargo run -- --disk memdiff:file:C:\vhds\disk.vhdx
+cargo run -- --vmbus-scsi id=scsi0 --disk memdiff:file:C:\vhds\disk.vhdx,controller=scsi0
 ```
 
 ### Length

--- a/Guide/src/dev_guide/dev_tools/guest_test_uefi.md
+++ b/Guide/src/dev_guide/dev_tools/guest_test_uefi.md
@@ -29,7 +29,9 @@ cargo build -p guest_test_uefi --target x86_64-unknown-uefi
 # create the disk image
 cargo xtask guest-test uefi --bootx64 ./target/x86_64-unknown-uefi/debug/guest_test_uefi.efi
 # test in OpenVMM
-cargo run -- --uefi --gfx --hv --processors 1 --disk memdiff:./target/x86_64-unknown-uefi/debug/guest_test_uefi.img
+cargo run -- --uefi --gfx --hv --processors 1 \
+  --vmbus-scsi id=scsi0 \
+  --disk memdiff:./target/x86_64-unknown-uefi/debug/guest_test_uefi.img,controller=scsi0
 ```
 
 Protip: this is a generic UEFI binary, and can be run outside of the OpenVMM

--- a/Guide/src/dev_guide/dev_tools/guest_test_uefi.md
+++ b/Guide/src/dev_guide/dev_tools/guest_test_uefi.md
@@ -31,7 +31,7 @@ cargo xtask guest-test uefi --bootx64 ./target/x86_64-unknown-uefi/debug/guest_t
 # test in OpenVMM
 cargo run -- --uefi --gfx --hv --processors 1 \
   --vmbus-scsi id=scsi0 \
-  --disk memdiff:./target/x86_64-unknown-uefi/debug/guest_test_uefi.img,controller=scsi0
+  --disk memdiff:./target/x86_64-unknown-uefi/debug/guest_test_uefi.img,on=scsi0
 ```
 
 Protip: this is a generic UEFI binary, and can be run outside of the OpenVMM

--- a/Guide/src/dev_guide/getting_started/cross_compile.md
+++ b/Guide/src/dev_guide/getting_started/cross_compile.md
@@ -176,7 +176,7 @@ if [[ $1 == "build" || $1 == "run" ]]; then
         
 
         if [[ $4 == "uefi" ]]; then
-            args+=" --uefi --uefi-firmware $uefi_firmware --vmbus-scsi id=scsi0 --disk memdiff:$disk_path,controller=scsi0"
+            args+=" --uefi --uefi-firmware $uefi_firmware --vmbus-scsi id=scsi0 --disk memdiff:$disk_path,on=scsi0"
         elif [[ $4 == "linux" ]]; then
             args+=""
         else
@@ -189,7 +189,7 @@ if [[ $1 == "build" || $1 == "run" ]]; then
 
         if [[ $4 == "uefi" ]]; then
             recipe="$short_arch"
-            args+=" --vmbus-scsi id=scsi0 --disk memdiff:$disk_path,controller=scsi0 --gfx --vmbus-com1-serial term --uefi-console-mode com1 --uefi"
+            args+=" --vmbus-scsi id=scsi0 --disk memdiff:$disk_path,on=scsi0 --gfx --vmbus-com1-serial term --uefi-console-mode com1 --uefi"
         elif [[ $4 == "linux" ]]; then
             recipe="$short_arch-test-linux-direct"
             args+=" --vmbus-com1-serial term --vmbus-com2-serial term"
@@ -320,7 +320,7 @@ Here is a full working example that launches OpenVMM with a VHDX disk:
 ```bash
 cargo run --target x86_64-pc-windows-msvc -- \
   --vmbus-scsi id=scsi0 \
-  --disk "memdiff:file:$(wslpath -w /mnt/c/vhds/server25.vhdx),controller=scsi0" \
+  --disk "memdiff:file:$(wslpath -w /mnt/c/vhds/server25.vhdx),on=scsi0" \
   --uefi \
   --uefi-firmware "$(wslpath -w .packages/hyperv.uefi.mscoreuefi.x64.RELEASE/MsvmX64/RELEASE_VS2022/FV/MSVM.fd)" \
   --gfx -p 6 -m 8GB
@@ -336,7 +336,7 @@ Windows path:
 export WSLENV=$WSLENV:X86_64_OPENVMM_UEFI_FIRMWARE/p
 cargo run --target x86_64-pc-windows-msvc -- \
   --vmbus-scsi id=scsi0 \
-  --disk "memdiff:file:$(wslpath -w /mnt/c/vhds/server25.vhdx),controller=scsi0" \
+  --disk "memdiff:file:$(wslpath -w /mnt/c/vhds/server25.vhdx),on=scsi0" \
   --uefi --gfx -p 6 -m 8GB
 ```
 ~~~

--- a/Guide/src/dev_guide/getting_started/cross_compile.md
+++ b/Guide/src/dev_guide/getting_started/cross_compile.md
@@ -176,7 +176,7 @@ if [[ $1 == "build" || $1 == "run" ]]; then
         
 
         if [[ $4 == "uefi" ]]; then
-            args+=" --uefi --uefi-firmware $uefi_firmware --disk memdiff:$disk_path"
+            args+=" --uefi --uefi-firmware $uefi_firmware --vmbus-scsi id=scsi0 --disk memdiff:$disk_path,controller=scsi0"
         elif [[ $4 == "linux" ]]; then
             args+=""
         else
@@ -189,7 +189,7 @@ if [[ $1 == "build" || $1 == "run" ]]; then
 
         if [[ $4 == "uefi" ]]; then
             recipe="$short_arch"
-            args+=" --disk memdiff:$disk_path --gfx --vmbus-com1-serial term --uefi-console-mode com1 --uefi"
+            args+=" --vmbus-scsi id=scsi0 --disk memdiff:$disk_path,controller=scsi0 --gfx --vmbus-com1-serial term --uefi-console-mode com1 --uefi"
         elif [[ $4 == "linux" ]]; then
             recipe="$short_arch-test-linux-direct"
             args+=" --vmbus-com1-serial term --vmbus-com2-serial term"
@@ -319,7 +319,8 @@ Here is a full working example that launches OpenVMM with a VHDX disk:
 
 ```bash
 cargo run --target x86_64-pc-windows-msvc -- \
-  --disk "memdiff:file:$(wslpath -w /mnt/c/vhds/server25.vhdx)" \
+  --vmbus-scsi id=scsi0 \
+  --disk "memdiff:file:$(wslpath -w /mnt/c/vhds/server25.vhdx),controller=scsi0" \
   --uefi \
   --uefi-firmware "$(wslpath -w .packages/hyperv.uefi.mscoreuefi.x64.RELEASE/MsvmX64/RELEASE_VS2022/FV/MSVM.fd)" \
   --gfx -p 6 -m 8GB
@@ -334,7 +335,8 @@ Windows path:
 ```bash
 export WSLENV=$WSLENV:X86_64_OPENVMM_UEFI_FIRMWARE/p
 cargo run --target x86_64-pc-windows-msvc -- \
-  --disk "memdiff:file:$(wslpath -w /mnt/c/vhds/server25.vhdx)" \
+  --vmbus-scsi id=scsi0 \
+  --disk "memdiff:file:$(wslpath -w /mnt/c/vhds/server25.vhdx),controller=scsi0" \
   --uefi --gfx -p 6 -m 8GB
 ```
 ~~~

--- a/Guide/src/reference/architecture/devices/storage.md
+++ b/Guide/src/reference/architecture/devices/storage.md
@@ -154,7 +154,7 @@ The resource resolver connects configuration (CLI flags, VTL2 settings) to concr
 
 The storage resolver chain is recursive. An NVMe controller resolves each namespace's disk, which may be a layered disk, which resolves each layer in parallel, which may itself be a disk that needs resolving.
 
-**Example:** `--disk memdiff:file:path/to/disk.vhdx`
+**Example:** `--vmbus-scsi id=scsi0 --disk memdiff:file:path/to/disk.vhdx,controller=scsi0`
 
 1. CLI parses this into a `LayeredDiskHandle` with two layers:
    - Layer 0: `RamDiskLayerHandle { len: None, sector_size: None }` (RAM diff, inherits size and sector size from backing disk)
@@ -229,7 +229,7 @@ Two eject paths exist:
 
 ### CLI
 
-- `--disk file:my.iso,dvd` → SCSI optical drive.
+- `--disk file:my.iso,dvd,controller=scsi0` → SCSI optical drive.
 - `--ide file:my.iso,dvd` → IDE optical drive (ATAPI).
 
 The `dvd` flag implicitly sets `read_only = true`.

--- a/Guide/src/reference/architecture/devices/storage.md
+++ b/Guide/src/reference/architecture/devices/storage.md
@@ -154,7 +154,7 @@ The resource resolver connects configuration (CLI flags, VTL2 settings) to concr
 
 The storage resolver chain is recursive. An NVMe controller resolves each namespace's disk, which may be a layered disk, which resolves each layer in parallel, which may itself be a disk that needs resolving.
 
-**Example:** `--vmbus-scsi id=scsi0 --disk memdiff:file:path/to/disk.vhdx,controller=scsi0`
+**Example:** `--vmbus-scsi id=scsi0 --disk memdiff:file:path/to/disk.vhdx,on=scsi0`
 
 1. CLI parses this into a `LayeredDiskHandle` with two layers:
    - Layer 0: `RamDiskLayerHandle { len: None, sector_size: None }` (RAM diff, inherits size and sector size from backing disk)
@@ -229,7 +229,7 @@ Two eject paths exist:
 
 ### CLI
 
-- `--disk file:my.iso,dvd,controller=scsi0` → SCSI optical drive.
+- `--disk file:my.iso,dvd,on=scsi0` → SCSI optical drive.
 - `--ide file:my.iso,dvd` → IDE optical drive (ATAPI).
 
 The `dvd` flag implicitly sets `read_only = true`.

--- a/Guide/src/reference/architecture/openhcl/storage_configuration.md
+++ b/Guide/src/reference/architecture/openhcl/storage_configuration.md
@@ -199,10 +199,10 @@ These rules are useful when debugging configuration failures because they tell y
 
 The [Running OpenHCL with OpenVMM](../../../user_guide/openhcl/run/openvmm.md) page shows where OpenVMM consumes this model. In code, `openvmm_entry::storage_builder` makes the two-axis split visible:
 
-1. `add_underhill()` chooses a **source** backing device family and a **target** guest-visible controller family separately.
+1. `add_relay()` chooses a **source** backing device family and a **target** guest-visible controller family separately.
 2. It derives `sub_device_path` from the source child it created in VTL2.
 3. It emits `Lun` objects whose `physical_devices` point back to that source.
-4. `build_underhill()` groups those `Lun`s under guest-visible `StorageController`s for SCSI or NVMe.
+4. `build_openhcl_settings()` groups those `Lun`s under guest-visible `StorageController`s for SCSI or NVMe.
 
 Read the configuration model as a description of the guest-visible tree plus a separate description of the backing tree under each child.
 

--- a/Guide/src/reference/architecture/openhcl/storage_translation.md
+++ b/Guide/src/reference/architecture/openhcl/storage_translation.md
@@ -116,10 +116,20 @@ cargo run -- \
   --hv --vtl2 \
   --igvm path/to/openhcl.igvm \
   --vmbus-redirect \
-  --disk mem:1G,uh-nvme
+  --nvme-pci id=nvme0,vpci,vtl2 \
+  --openhcl-controller id=relay0,type=scsi \
+  --disk mem:1G,controller=nvme0,relay=relay0
 ```
 
-This command offers NVMe into VTL2 and lets OpenHCL expose guest-visible storage through its own controller model.
+This command creates a named NVMe controller (`nvme0`) offered to VTL2 via VPCI,
+an OpenHCL relay target (`relay0`) that presents a SCSI controller to VTL0, and
+attaches a 1 GB memory-backed disk to `nvme0` relayed through `relay0`.
+
+```admonish note
+Older examples use `--disk mem:1G,uh-nvme` as a shorthand. That syntax is
+deprecated; use `--nvme-pci`, `--openhcl-controller`, and
+`--disk controller=...,relay=...` instead.
+```
 
 The guest-visible and backing sides remain distinct in the VTL2 settings model:
 
@@ -170,7 +180,7 @@ If the guest-visible disk is striped, the backing side changes shape while the g
 ```
 
 ```admonish note
-The [NVMe Emulator](../../emulated/NVMe/overview.md) guide notes that the OpenVMM NVMe emulator can serve I/O workloads, but pragmatically is only used by OpenVMM for test scenarios today. Keep that test-oriented context in mind when using `uh-nvme` examples from the OpenVMM flow.
+The [NVMe Emulator](../../emulated/NVMe/overview.md) guide notes that the OpenVMM NVMe emulator can serve I/O workloads, but pragmatically is only used by OpenVMM for test scenarios today. Keep that test-oriented context in mind when reading the NVMe relay examples.
 ```
 
 ## Concrete example: vSCSI backing to SCSI guest target
@@ -182,10 +192,22 @@ cargo run -- \
   --hv --vtl2 \
   --igvm path/to/openhcl.igvm \
   --vmbus-redirect \
-  --disk file:ubuntu.img,uh
+  --vmbus-scsi id=scsi0,vtl2 \
+  --openhcl-controller id=relay0,type=scsi \
+  --disk file:ubuntu.img,controller=scsi0,relay=relay0
 ```
 
-The guest-visible controller family (SCSI) happens to match the backing family (also SCSI via storvsp), but the controller instances are different. The Root owns the backing SCSI controller. OpenHCL owns the guest-visible SCSI controller. The `sub_device_path` in the VTL2 settings maps a host LUN on the backing controller to a guest LUN on the guest-visible controller.
+The guest-visible controller family (SCSI) happens to match the backing family
+(also SCSI via storvsp), but the controller instances are different. The Root
+owns the backing SCSI controller (`scsi0`). OpenHCL owns the guest-visible SCSI
+controller (`relay0`). The `sub_device_path` in the VTL2 settings maps a host
+LUN on the backing controller to a guest LUN on the guest-visible controller.
+
+```admonish note
+Older examples use `--disk file:ubuntu.img,uh` as a shorthand. That syntax is
+deprecated; use `--vmbus-scsi`, `--openhcl-controller`, and
+`--disk controller=...,relay=...` instead.
+```
 
 In the VTL2 settings model, this path looks like:
 
@@ -222,7 +244,7 @@ This is also the path used in the [Hyper-V storage relay tutorial](../../../user
 
 | Component | Why read it | Source |
 |-----------|-------------|---------------------|
-| OpenVMM Underhill storage builder | Separates the backing device family from the guest-visible target and groups resulting children under guest-visible controllers | [`add_underhill()` and `build_underhill()`](https://github.com/microsoft/openvmm/blob/main/openvmm/openvmm_entry/src/storage_builder.rs#L249-L483) |
+| OpenVMM storage builder | Separates the backing device family from the guest-visible target and groups resulting children under guest-visible controllers | [`add_relay()` and `build_openhcl_settings()`](https://github.com/microsoft/openvmm/blob/main/openvmm/openvmm_entry/src/storage_builder.rs) |
 | Petri VTL2 settings helpers | Shows the builder-side model for backing devices, LUNs, and storage controllers | [`Vtl2StorageBackingDeviceBuilder`, `Vtl2LunBuilder`, and `Vtl2StorageControllerBuilder`](https://github.com/microsoft/openvmm/blob/main/petri/src/vm/vtl2_settings.rs#L19-L253) |
 | Underhill configuration model | Defines `PhysicalDevice`, `PhysicalDevices`, and the runtime controller and child types | [`PhysicalDevice`, `PhysicalDevices`, and controller structs`](https://github.com/microsoft/openvmm/blob/main/vm/devices/get/underhill_config/src/lib.rs#L27-L207) |
 | Underhill configuration schema | Shows how `Lun` objects are parsed into `Single`, `Striped`, and protocol-specific child types | [`impl ParseSchema<crate::PhysicalDevices> for Lun`](https://github.com/microsoft/openvmm/blob/main/vm/devices/get/underhill_config/src/schema/v1.rs#L233-L375) |

--- a/Guide/src/reference/architecture/openhcl/storage_translation.md
+++ b/Guide/src/reference/architecture/openhcl/storage_translation.md
@@ -118,7 +118,7 @@ cargo run -- \
   --vmbus-redirect \
   --nvme-pci id=nvme0,vpci,vtl2 \
   --openhcl-controller id=relay0,type=scsi \
-  --disk mem:1G,controller=nvme0,relay=relay0
+  --disk mem:1G,on=nvme0,relay=relay0
 ```
 
 This command creates a named NVMe controller (`nvme0`) offered to VTL2 via VPCI,
@@ -128,7 +128,7 @@ attaches a 1 GB memory-backed disk to `nvme0` relayed through `relay0`.
 ```admonish note
 Older examples use `--disk mem:1G,uh-nvme` as a shorthand. That syntax is
 deprecated; use `--nvme-pci`, `--openhcl-controller`, and
-`--disk controller=...,relay=...` instead.
+`--disk on=...,relay=...` instead.
 ```
 
 The guest-visible and backing sides remain distinct in the VTL2 settings model:
@@ -194,7 +194,7 @@ cargo run -- \
   --vmbus-redirect \
   --vmbus-scsi id=scsi0,vtl2 \
   --openhcl-controller id=relay0,type=scsi \
-  --disk file:ubuntu.img,controller=scsi0,relay=relay0
+  --disk file:ubuntu.img,on=scsi0,relay=relay0
 ```
 
 The guest-visible controller family (SCSI) happens to match the backing family
@@ -206,7 +206,7 @@ LUN on the backing controller to a guest LUN on the guest-visible controller.
 ```admonish note
 Older examples use `--disk file:ubuntu.img,uh` as a shorthand. That syntax is
 deprecated; use `--vmbus-scsi`, `--openhcl-controller`, and
-`--disk controller=...,relay=...` instead.
+`--disk on=...,relay=...` instead.
 ```
 
 In the VTL2 settings model, this path looks like:

--- a/Guide/src/reference/architecture/openhcl/vmbus.md
+++ b/Guide/src/reference/architecture/openhcl/vmbus.md
@@ -96,14 +96,19 @@ The [Running OpenHCL with OpenVMM](../../../user_guide/openhcl/run/openvmm.md) p
 --net uh:consomme --vmbus-redirect
 
 # Offer NVMe into VTL2 and expose storvsp-backed SCSI to VTL0
---disk mem:1G,uh-nvme --vmbus-redirect
+--nvme-pci id=nvme0,vpci,vtl2 \
+  --openhcl-controller id=relay0,type=scsi \
+  --disk mem:1G,controller=nvme0,relay=relay0 --vmbus-redirect
 ```
 
 These examples show three separate decisions:
 
 1. `--vmbus-redirect` enables the host-offer relay substrate.
-2. `uh:*` or `uh-nvme` determines what the Root offers into VTL2.
-3. The resulting guest-visible device family is still chosen by VTL2-owned device logic, not by the existence of relay alone.
+2. Named controllers (`--vmbus-scsi`, `--nvme-pci`,
+   `--openhcl-controller`) determine what the Root offers into VTL2
+   and what OpenHCL exposes to VTL0.
+3. The resulting guest-visible device family is still chosen by VTL2-owned
+   device logic, not by the existence of relay alone.
 
 ```admonish note title="How VPCI relay differs from the general VMBus relay path"
 VPCI-capable devices still arrive as VMBus offers, which is why VPCI relay depends on VMBus relay being active at all. But once OpenHCL identifies those offers, it does not hand them to the generic `HostVmbusTransport` path. Instead, it routes them into `VpciRelay`, which handles the extra PCI-visible semantics such as allowed-device filtering and MMIO space. In other words, VPCI relay starts from VMBus offers but does different work after that handoff point.

--- a/Guide/src/reference/architecture/openhcl/vmbus.md
+++ b/Guide/src/reference/architecture/openhcl/vmbus.md
@@ -98,7 +98,7 @@ The [Running OpenHCL with OpenVMM](../../../user_guide/openhcl/run/openvmm.md) p
 # Offer NVMe into VTL2 and expose storvsp-backed SCSI to VTL0
 --nvme-pci id=nvme0,vpci,vtl2 \
   --openhcl-controller id=relay0,type=scsi \
-  --disk mem:1G,controller=nvme0,relay=relay0 --vmbus-redirect
+  --disk mem:1G,on=nvme0,relay=relay0 --vmbus-redirect
 ```
 
 These examples show three separate decisions:

--- a/Guide/src/reference/dev_feats/kdnet.md
+++ b/Guide/src/reference/dev_feats/kdnet.md
@@ -22,10 +22,15 @@ for the network transport:
 
 ```bash
 # Without OpenHCL
-cargo run -- --uefi --hv --net consomme --disk memdiff:file:path/to/windows.vhdx
+cargo run -- --uefi --hv --net consomme \
+  --vmbus-scsi id=scsi0 \
+  --disk memdiff:file:path/to/windows.vhdx,controller=scsi0
 
 # With OpenHCL
-cargo run -- --uefi --hv --vtl2 --net consomme --igvm path/to/openhcl.igvm --disk memdiff:file:path/to/windows.vhdx
+cargo run -- --uefi --hv --vtl2 --net consomme \
+  --igvm path/to/openhcl.igvm \
+  --vmbus-scsi id=scsi0 \
+  --disk memdiff:file:path/to/windows.vhdx,controller=scsi0
 ```
 
 ### Known Issues

--- a/Guide/src/reference/dev_feats/kdnet.md
+++ b/Guide/src/reference/dev_feats/kdnet.md
@@ -24,13 +24,13 @@ for the network transport:
 # Without OpenHCL
 cargo run -- --uefi --hv --net consomme \
   --vmbus-scsi id=scsi0 \
-  --disk memdiff:file:path/to/windows.vhdx,controller=scsi0
+  --disk memdiff:file:path/to/windows.vhdx,on=scsi0
 
 # With OpenHCL
 cargo run -- --uefi --hv --vtl2 --net consomme \
   --igvm path/to/openhcl.igvm \
   --vmbus-scsi id=scsi0 \
-  --disk memdiff:file:path/to/windows.vhdx,controller=scsi0
+  --disk memdiff:file:path/to/windows.vhdx,on=scsi0
 ```
 
 ### Known Issues

--- a/Guide/src/reference/devices/vmbus/storvsp_channels.md
+++ b/Guide/src/reference/devices/vmbus/storvsp_channels.md
@@ -325,11 +325,11 @@ controllers.
 ```bash
 # Default: no subchannels (all I/O on primary channel)
 openvmm --vmbus-scsi id=scsi0 \
-  --disk memdiff:file:disk.vhd,controller=scsi0
+  --disk memdiff:file:disk.vhd,on=scsi0
 
 # 4 subchannels (5 total channels: 1 primary + 4 sub)
 openvmm --vmbus-scsi id=scsi0,sub_channels=4 \
-  --disk memdiff:file:disk.vhd,controller=scsi0
+  --disk memdiff:file:disk.vhd,on=scsi0
 ```
 
 The enforced maximum is 1023 (one less than `MAX_PROCESSOR_COUNT`).

--- a/Guide/src/reference/devices/vmbus/storvsp_channels.md
+++ b/Guide/src/reference/devices/vmbus/storvsp_channels.md
@@ -324,10 +324,12 @@ controllers.
 
 ```bash
 # Default: no subchannels (all I/O on primary channel)
-openvmm --disk memdiff:file:disk.vhd
+openvmm --vmbus-scsi id=scsi0 \
+  --disk memdiff:file:disk.vhd,controller=scsi0
 
 # 4 subchannels (5 total channels: 1 primary + 4 sub)
-openvmm --scsi-sub-channels 4 --disk memdiff:file:disk.vhd
+openvmm --vmbus-scsi id=scsi0,sub_channels=4 \
+  --disk memdiff:file:disk.vhd,controller=scsi0
 ```
 
 The enforced maximum is 1023 (one less than `MAX_PROCESSOR_COUNT`).

--- a/Guide/src/reference/openvmm/management/cli.md
+++ b/Guide/src/reference/openvmm/management/cli.md
@@ -76,9 +76,9 @@ as well as the generated CLI help (via `cargo run -- --help`).
 * `--uefi-firmware <FILE>`: Path to the UEFI firmware file (`MSVM.fd`). When `--uefi` is specified, this option is required only if you do not set the environment variable `OPENVMM_UEFI_FIRMWARE` (or the architecture-specific variants `X86_64_OPENVMM_UEFI_FIRMWARE`, or `AARCH64_OPENVMM_UEFI_FIRMWARE`). If omitted, the default is read from `OPENVMM_UEFI_FIRMWARE` first, then falls back to the architecture-specific variables.
 * `--pcat`: Boot using the Microsoft Hyper-V PCAT BIOS
 * `--vmbus-scsi id=<name>[,sub_channels=<N>][,vtl2]`: Creates a
-  named VMBus SCSI controller. Use with `--disk ...,controller=<name>` to
+  named VMBus SCSI controller. Use with `--disk ...,on=<name>` to
   attach disks.
-* `--disk file:<DISK>,controller=<name>`: Attaches a disk to the named
+* `--disk file:<DISK>,on=<name>`: Attaches a disk to the named
   controller. The `DISK` argument can be:
   * A flat binary disk image
   * A VHD file with an extension of .vhd (Windows host only)
@@ -86,7 +86,7 @@ as well as the generated CLI help (via `cargo run -- --help`).
 
   On Linux, raw files and block devices use the `disk_blockdevice` backend
   (io_uring-based async I/O) by default. Append `;direct` to the path to
-  bypass the OS page cache, e.g. `--disk file:/dev/sdb;direct,controller=scsi0`.
+  bypass the OS page cache, e.g. `--disk file:/dev/sdb;direct,on=scsi0`.
 * `--private-memory`, `--prefetch`, `--thp`, and
   `--memory-backing-file <PATH>`: Deprecated aliases for `--memory`
   parameters. Prefer `shared=off`, `prefetch=on`, `thp=on`, and
@@ -227,7 +227,7 @@ PCIe root port. The syntax varies slightly between device types:
 
 ```sh
 --virtio-blk file:/path/to/disk.raw,pcie_port=rp0
---nvme-pci id=nvme0,pcie_port=rp0 --disk file:/path/to/disk.raw,controller=nvme0
+--nvme-pci id=nvme0,pcie_port=rp0 --disk file:/path/to/disk.raw,on=nvme0
 ```
 
 **CXL test endpoint** (comma-separated option): `--cxl-test`

--- a/Guide/src/reference/openvmm/management/cli.md
+++ b/Guide/src/reference/openvmm/management/cli.md
@@ -75,16 +75,18 @@ as well as the generated CLI help (via `cargo run -- --help`).
 * `--uefi`: Boot using `mu_msvm` UEFI
 * `--uefi-firmware <FILE>`: Path to the UEFI firmware file (`MSVM.fd`). When `--uefi` is specified, this option is required only if you do not set the environment variable `OPENVMM_UEFI_FIRMWARE` (or the architecture-specific variants `X86_64_OPENVMM_UEFI_FIRMWARE`, or `AARCH64_OPENVMM_UEFI_FIRMWARE`). If omitted, the default is read from `OPENVMM_UEFI_FIRMWARE` first, then falls back to the architecture-specific variables.
 * `--pcat`: Boot using the Microsoft Hyper-V PCAT BIOS
-* `--disk file:<DISK>`: Exposes a single disk over VMBus SCSI. You must also
-  pass `--hv`. Incompatible with `--no-vmbus`; use `--nvme` for PCIe-attached
-  storage instead. The `DISK` argument can be:
+* `--vmbus-scsi id=<name>[,sub_channels=<N>][,vtl2]`: Creates a
+  named VMBus SCSI controller. Use with `--disk ...,controller=<name>` to
+  attach disks.
+* `--disk file:<DISK>,controller=<name>`: Attaches a disk to the named
+  controller. The `DISK` argument can be:
   * A flat binary disk image
   * A VHD file with an extension of .vhd (Windows host only)
   * A VHDX file with an extension of .vhdx (Windows host only)
 
   On Linux, raw files and block devices use the `disk_blockdevice` backend
   (io_uring-based async I/O) by default. Append `;direct` to the path to
-  bypass the OS page cache, e.g. `--disk file:/dev/sdb;direct`.
+  bypass the OS page cache, e.g. `--disk file:/dev/sdb;direct,controller=scsi0`.
 * `--private-memory`, `--prefetch`, `--thp`, and
   `--memory-backing-file <PATH>`: Deprecated aliases for `--memory`
   parameters. Prefer `shared=off`, `prefetch=on`, `thp=on`, and
@@ -221,12 +223,11 @@ name:
 Several device types support the `pcie_port=<name>` option to attach to a
 PCIe root port. The syntax varies slightly between device types:
 
-**Disks** (comma-separated option): `--disk`, `--nvme`, `--virtio-blk`
+**Disks** (comma-separated option): `--nvme-pci` + `--disk`, `--virtio-blk`
 
 ```sh
 --virtio-blk file:/path/to/disk.raw,pcie_port=rp0
---nvme file:/path/to/disk.raw,pcie_port=rp0
---disk file:/path/to/disk.raw,pcie_port=rp0
+--nvme-pci id=nvme0,pcie_port=rp0 --disk file:/path/to/disk.raw,controller=nvme0
 ```
 
 **CXL test endpoint** (comma-separated option): `--cxl-test`

--- a/Guide/src/user_guide/openhcl/run/openvmm.md
+++ b/Guide/src/user_guide/openhcl/run/openvmm.md
@@ -94,7 +94,7 @@ You can assign a SCSI disk to VTL2 and have OpenHCL reassign it to VTL0:
 ```bash
 --vmbus-scsi id=scsi0,vtl2 \
   --openhcl-controller id=relay0,type=scsi \
-  --disk file:ubuntu.img,controller=scsi0,relay=relay0 --vmbus-redirect
+  --disk file:ubuntu.img,on=scsi0,relay=relay0 --vmbus-redirect
 ```
 
 ### Assigning NVME devices to VTL2
@@ -105,5 +105,5 @@ VMBus scsi device (see [Storage Translation](../../../reference/architecture/ope
 ```bash
 --nvme-pci id=nvme0,vpci,vtl2 \
   --openhcl-controller id=relay0,type=scsi \
-  --disk mem:1G,controller=nvme0,relay=relay0 --vmbus-redirect
+  --disk mem:1G,on=nvme0,relay=relay0 --vmbus-redirect
 ```

--- a/Guide/src/user_guide/openhcl/run/openvmm.md
+++ b/Guide/src/user_guide/openhcl/run/openvmm.md
@@ -92,7 +92,9 @@ guest in VTL0. Expose it by adding the following:
 You can assign a SCSI disk to VTL2 and have OpenHCL reassign it to VTL0:
 
 ```bash
---disk file:ubuntu.img,uh --vmbus-redirect
+--vmbus-scsi id=scsi0,vtl2 \
+  --openhcl-controller id=relay0,type=scsi \
+  --disk file:ubuntu.img,controller=scsi0,relay=relay0 --vmbus-redirect
 ```
 
 ### Assigning NVME devices to VTL2
@@ -101,5 +103,7 @@ You can assign an NVME disk to VTL2 and have OpenHCL relay it to VTL0 as a
 VMBus scsi device (see [Storage Translation](../../../reference/architecture/openhcl/storage_translation.md)):
 
 ```bash
---disk mem:1G,uh-nvme --vmbus-redirect
+--nvme-pci id=nvme0,vpci,vtl2 \
+  --openhcl-controller id=relay0,type=scsi \
+  --disk mem:1G,controller=nvme0,relay=relay0 --vmbus-redirect
 ```

--- a/Guide/src/user_guide/openvmm/run.md
+++ b/Guide/src/user_guide/openvmm/run.md
@@ -52,7 +52,7 @@ To fix this, **explicitly pass the firmware** using `--uefi-firmware`:
 ```shell
 openvmm --uefi --uefi-firmware path/to/MSVM.fd \
   --vmbus-scsi id=scsi0 \
-  --disk memdiff:path/to/disk.vhdx,controller=scsi0
+  --disk memdiff:path/to/disk.vhdx,on=scsi0
 ```
 
 If you ran `cargo xflowey restore-packages`, the firmware is at:
@@ -128,7 +128,7 @@ xflowey restore-packages`.
 ```shell
 cargo run -- --uefi \
   --vmbus-scsi id=scsi0 \
-  --disk memdiff:path/to/windows.vhdx,controller=scsi0 \
+  --disk memdiff:path/to/windows.vhdx,on=scsi0 \
   --gfx
 ```
 

--- a/Guide/src/user_guide/openvmm/run.md
+++ b/Guide/src/user_guide/openvmm/run.md
@@ -50,7 +50,9 @@ When running the `openvmm` binary directly, these environment variables are
 To fix this, **explicitly pass the firmware** using `--uefi-firmware`:
 
 ```shell
-openvmm --uefi --uefi-firmware path/to/MSVM.fd --disk memdiff:path/to/disk.vhdx
+openvmm --uefi --uefi-firmware path/to/MSVM.fd \
+  --vmbus-scsi id=scsi0 \
+  --disk memdiff:path/to/disk.vhdx,controller=scsi0
 ```
 
 If you ran `cargo xflowey restore-packages`, the firmware is at:
@@ -124,7 +126,10 @@ A copy of the `mu_msvm` UEFI firmware is automatically downloaded via `cargo
 xflowey restore-packages`.
 
 ```shell
-cargo run -- --uefi --disk memdiff:path/to/windows.vhdx --gfx
+cargo run -- --uefi \
+  --vmbus-scsi id=scsi0 \
+  --disk memdiff:path/to/windows.vhdx,controller=scsi0 \
+  --gfx
 ```
 
 For more info on `--gfx`, and how to actually interact with the VM using a

--- a/Guide/src/user_guide/openvmm/snapshots.md
+++ b/Guide/src/user_guide/openvmm/snapshots.md
@@ -41,7 +41,7 @@ Start a VM with file-backed memory:
 cargo run -- \
   --uefi \
   --vmbus-scsi id=scsi0 \
-  --disk memdiff:file:path/to/disk.vhdx,controller=scsi0 \
+  --disk memdiff:file:path/to/disk.vhdx,on=scsi0 \
   --memory size=4096M,file=path/to/memory.bin
 ```
 
@@ -69,7 +69,7 @@ To restore, pass the snapshot directory with `--restore-snapshot`:
 cargo run -- \
   --uefi \
   --vmbus-scsi id=scsi0 \
-  --disk memdiff:file:path/to/disk.vhdx,controller=scsi0 \
+  --disk memdiff:file:path/to/disk.vhdx,on=scsi0 \
   --memory size=4096M \
   --processors 4 \
   --restore-snapshot path/to/snapshot-dir

--- a/Guide/src/user_guide/openvmm/snapshots.md
+++ b/Guide/src/user_guide/openvmm/snapshots.md
@@ -40,7 +40,8 @@ Start a VM with file-backed memory:
 ```bash
 cargo run -- \
   --uefi \
-  --disk memdiff:file:path/to/disk.vhdx \
+  --vmbus-scsi id=scsi0 \
+  --disk memdiff:file:path/to/disk.vhdx,controller=scsi0 \
   --memory size=4096M,file=path/to/memory.bin
 ```
 
@@ -67,7 +68,8 @@ To restore, pass the snapshot directory with `--restore-snapshot`:
 ```bash
 cargo run -- \
   --uefi \
-  --disk memdiff:file:path/to/disk.vhdx \
+  --vmbus-scsi id=scsi0 \
+  --disk memdiff:file:path/to/disk.vhdx,controller=scsi0 \
   --memory size=4096M \
   --processors 4 \
   --restore-snapshot path/to/snapshot-dir

--- a/Guide/src/user_guide/openvmm/vm_configurations.md
+++ b/Guide/src/user_guide/openvmm/vm_configurations.md
@@ -27,7 +27,7 @@ Windows and Linux guests.
 cargo run -- \
   --uefi \
   --vmbus-scsi id=scsi0 \
-  --disk memdiff:file:path/to/disk.vhdx,controller=scsi0 \
+  --disk memdiff:file:path/to/disk.vhdx,on=scsi0 \
   -p 4 -m 4GB \
   --gfx
 ```
@@ -36,7 +36,7 @@ Key flags:
 - `--uefi` — boot using `mu_msvm` UEFI firmware (implicitly enables Hyper-V
   enlightenments and VMBus, so `--hv` is not needed separately)
 - `--vmbus-scsi` — creates a named SCSI controller
-- `--disk ...,controller=scsi0` — attaches a disk to that controller
+- `--disk ...,on=scsi0` — attaches a disk to that controller
 
 ## Gen1-equivalent (PCAT BIOS boot)
 
@@ -76,7 +76,7 @@ cargo run -- \
   --hv --vtl2 \
   --igvm path/to/openhcl.igvm \
   --vmbus-scsi id=scsi0 \
-  --disk memdiff:file:path/to/disk.vhdx,controller=scsi0 \
+  --disk memdiff:file:path/to/disk.vhdx,on=scsi0 \
   -p 4 -m 4GB
 ```
 
@@ -94,9 +94,9 @@ for full setup instructions.
 
 | Scenario | Flags | Notes |
 |----------|-------|-------|
-| Modern Windows/Linux guest | `--uefi --vmbus-scsi id=scsi0 --disk memdiff:file:disk.vhdx,controller=scsi0` | Most common |
+| Modern Windows/Linux guest | `--uefi --vmbus-scsi id=scsi0 --disk memdiff:file:disk.vhdx,on=scsi0` | Most common |
 | With graphical console | add `--gfx` | VNC-based, see [Graphical Console](../../reference/openvmm/graphical_console.md) |
 | With networking | add `--nic` | Consomme user-mode NAT |
-| With OpenHCL | `--hv --vtl2 --igvm path/to/openhcl.igvm --vmbus-scsi id=scsi0 --disk memdiff:file:disk.vhdx,controller=scsi0` | IGVM carries the paravisor; no `--uefi`/`--pcat` needed |
+| With OpenHCL | `--hv --vtl2 --igvm path/to/openhcl.igvm --vmbus-scsi id=scsi0 --disk memdiff:file:disk.vhdx,on=scsi0` | IGVM carries the paravisor; no `--uefi`/`--pcat` needed |
 | Legacy OS (DOS, old Windows) | `--pcat --ide memdiff:file:disk.vhd --gfx` | IDE storage, BIOS boot |
 | Linux direct boot (no firmware) | `--kernel vmlinux --initrd initrd` | Skips UEFI/PCAT entirely |

--- a/Guide/src/user_guide/openvmm/vm_configurations.md
+++ b/Guide/src/user_guide/openvmm/vm_configurations.md
@@ -26,7 +26,8 @@ Windows and Linux guests.
 ```bash
 cargo run -- \
   --uefi \
-  --disk memdiff:file:path/to/disk.vhdx \
+  --vmbus-scsi id=scsi0 \
+  --disk memdiff:file:path/to/disk.vhdx,controller=scsi0 \
   -p 4 -m 4GB \
   --gfx
 ```
@@ -34,7 +35,8 @@ cargo run -- \
 Key flags:
 - `--uefi` — boot using `mu_msvm` UEFI firmware (implicitly enables Hyper-V
   enlightenments and VMBus, so `--hv` is not needed separately)
-- `--disk` — exposes a disk over VMBus (SCSI-equivalent)
+- `--vmbus-scsi` — creates a named SCSI controller
+- `--disk ...,controller=scsi0` — attaches a disk to that controller
 
 ## Gen1-equivalent (PCAT BIOS boot)
 
@@ -73,7 +75,8 @@ even though other flags like `--uefi` imply it internally.
 cargo run -- \
   --hv --vtl2 \
   --igvm path/to/openhcl.igvm \
-  --disk memdiff:file:path/to/disk.vhdx \
+  --vmbus-scsi id=scsi0 \
+  --disk memdiff:file:path/to/disk.vhdx,controller=scsi0 \
   -p 4 -m 4GB
 ```
 
@@ -91,9 +94,9 @@ for full setup instructions.
 
 | Scenario | Flags | Notes |
 |----------|-------|-------|
-| Modern Windows/Linux guest | `--uefi --disk memdiff:file:disk.vhdx` | Most common |
+| Modern Windows/Linux guest | `--uefi --vmbus-scsi id=scsi0 --disk memdiff:file:disk.vhdx,controller=scsi0` | Most common |
 | With graphical console | add `--gfx` | VNC-based, see [Graphical Console](../../reference/openvmm/graphical_console.md) |
 | With networking | add `--nic` | Consomme user-mode NAT |
-| With OpenHCL | `--hv --vtl2 --igvm path/to/openhcl.igvm --disk memdiff:file:disk.vhdx` | IGVM carries the paravisor; no `--uefi`/`--pcat` needed |
+| With OpenHCL | `--hv --vtl2 --igvm path/to/openhcl.igvm --vmbus-scsi id=scsi0 --disk memdiff:file:disk.vhdx,controller=scsi0` | IGVM carries the paravisor; no `--uefi`/`--pcat` needed |
 | Legacy OS (DOS, old Windows) | `--pcat --ide memdiff:file:disk.vhd --gfx` | IDE storage, BIOS boot |
 | Linux direct boot (no firmware) | `--kernel vmlinux --initrd initrd` | Skips UEFI/PCAT entirely |

--- a/openvmm/openvmm_entry/Cargo.toml
+++ b/openvmm/openvmm_entry/Cargo.toml
@@ -73,7 +73,6 @@ inspect_proto.workspace = true
 mesh.workspace = true
 mesh_rpc.workspace = true
 mesh_process.workspace = true
-sha2.workspace = true
 mesh_worker.workspace = true
 pal.workspace = true
 unix_socket.workspace = true
@@ -92,6 +91,7 @@ futures-concurrency.workspace = true
 getrandom.workspace = true
 prost.workspace = true
 rustyline = { workspace = true, features = ["derive"] }
+sha2.workspace = true
 shell-words.workspace = true
 socket2 = { workspace = true, features = ["all"] }
 tempfile.workspace = true

--- a/openvmm/openvmm_entry/Cargo.toml
+++ b/openvmm/openvmm_entry/Cargo.toml
@@ -73,6 +73,7 @@ inspect_proto.workspace = true
 mesh.workspace = true
 mesh_rpc.workspace = true
 mesh_process.workspace = true
+sha2.workspace = true
 mesh_worker.workspace = true
 pal.workspace = true
 unix_socket.workspace = true

--- a/openvmm/openvmm_entry/src/cli_args.rs
+++ b/openvmm/openvmm_entry/src/cli_args.rs
@@ -22,6 +22,7 @@ use anyhow::Context;
 use clap::Parser;
 use clap::ValueEnum;
 use cxl_spec::spec::CfmwsWindowRestrictions;
+use guid::Guid;
 use openvmm_defs::config::DEFAULT_PCAT_BOOT_ORDER;
 use openvmm_defs::config::DeviceVtl;
 use openvmm_defs::config::PcatBootDevice;
@@ -252,11 +253,17 @@ flags:
 
 options:
     `pcie_port=<name>`             present the disk using pcie under the specified port, incompatible with `dvd`, `vtl2`, `uh`, and `uh-nvme`
+    `controller=<name>`            attach to a named controller (NVMe or SCSI), incompatible with `pcie_port`
+    `nsid=<N>`                     NVMe namespace ID (1-based), requires `controller`; auto-assigned if omitted
+    `lun=<N>`                      SCSI LUN (0-based), requires `controller`; auto-assigned if omitted
+    `relay=<ctrl>[:<loc>]`         relay through OpenHCL to the named OpenHCL controller, with optional location (LUN or NSID)
 "#)]
     #[clap(long, value_name = "FILE")]
     pub disk: Vec<DiskCli>,
 
-    /// attach a disk via an NVMe controller
+    /// \[deprecated\] attach a disk via an NVMe controller
+    ///
+    /// Use --nvme-controller and --disk controller=\<name\> instead.
     #[clap(long_help = r#"
 e.g: --nvme memdiff:file:/path/to/disk.vhd
 
@@ -290,6 +297,71 @@ options:
 "#)]
     #[clap(long)]
     pub nvme: Vec<DiskCli>,
+
+    /// create a named NVMe controller
+    #[clap(long_help = r#"
+Create a named NVMe controller with an explicit transport.
+
+syntax: id=<name>,pcie_port=<port> | id=<name>,vpci[=<guid>]
+
+The controller name can be referenced by `--disk` with the `controller=<name>`
+option to attach namespaces to this controller.
+
+options:
+    `id=<name>`                    controller name (required)
+    `pcie_port=<port>`             present on PCIe under the specified port
+    `vpci[=<guid>]`                present via VPCI; optional instance GUID
+    `vtl2`                         assign to VTL2 (default VTL0)
+
+Exactly one of `pcie_port` or `vpci` must be specified.
+
+Examples:
+    --nvme-controller id=nvme0,pcie_port=p0
+    --nvme-controller id=nvme1,vpci
+    --nvme-controller id=nvme2,vpci=008091f6-9688-497d-9091-af347dc9173c
+"#)]
+    #[clap(long = "nvme-controller")]
+    pub nvme_controller: Vec<NvmeControllerCli>,
+
+    /// create a named VMBus SCSI controller
+    #[clap(long_help = r#"
+Create a named VMBus SCSI controller.
+
+syntax: id=<name>[,sub_channels=<N>][,vtl2]
+
+The controller name can be referenced by `--disk` with the `controller=<name>`
+option to attach disks to this controller.
+
+options:
+    `id=<name>`                    controller name (required)
+    `sub_channels=<N>`             number of sub-channels (default 0)
+    `vtl2`                         assign to VTL2 (default VTL0)
+
+Examples:
+    --vmbus-scsi-controller id=scsi0
+    --vmbus-scsi-controller id=scsi1,sub_channels=4
+"#)]
+    #[clap(long = "vmbus-scsi-controller")]
+    pub vmbus_scsi_controller: Vec<ScsiControllerCli>,
+
+    /// register an OpenHCL-managed storage controller (relay target)
+    #[clap(long_help = r#"
+Register an OpenHCL-managed storage controller that can be used as a
+relay target with `--disk ... relay=<name>`.
+
+syntax: id=<name>,type=scsi|nvme[,guid=<guid>]
+
+options:
+    `id=<name>`                    controller name (required)
+    `type=scsi|nvme`               controller protocol (required)
+    `guid=<guid>`                  instance GUID (auto-derived from name if omitted)
+
+Examples:
+    --openhcl-controller id=vtl0-scsi,type=scsi
+    --openhcl-controller id=vtl0-nvme,type=nvme,guid=09a59b81-...
+"#)]
+    #[clap(long = "openhcl-controller")]
+    pub openhcl_controller: Vec<OpenhclControllerCli>,
 
     /// attach a CXL Type-3 test endpoint on a PCIe root port
     #[clap(long = "cxl-test", value_name = "mem:<len>,pcie_port=<name>")]
@@ -1603,6 +1675,10 @@ pub struct DiskCli {
     pub is_dvd: bool,
     pub underhill: Option<UnderhillDiskSource>,
     pub pcie_port: Option<String>,
+    pub controller: Option<String>,
+    pub nsid: Option<u32>,
+    pub lun: Option<u8>,
+    pub relay: Option<(String, Option<u32>)>,
 }
 
 #[derive(Copy, Clone)]
@@ -1623,6 +1699,10 @@ impl FromStr for DiskCli {
         let mut underhill = None;
         let mut vtl = DeviceVtl::Vtl0;
         let mut pcie_port = None;
+        let mut controller = None;
+        let mut nsid = None;
+        let mut lun = None;
+        let mut relay = None;
         for opt in opts {
             let mut s = opt.split('=');
             let opt = s.next().unwrap();
@@ -1644,6 +1724,35 @@ impl FromStr for DiskCli {
                     }
                     pcie_port = Some(String::from(port.unwrap()));
                 }
+                "controller" => {
+                    let name = s.next();
+                    if name.is_none_or(|n| n.is_empty()) {
+                        anyhow::bail!("`controller` requires a controller name");
+                    }
+                    controller = Some(String::from(name.unwrap()));
+                }
+                "nsid" => {
+                    let val = s.next().context("`nsid` requires a value")?;
+                    nsid = Some(val.parse::<u32>().context("invalid `nsid` value")?);
+                }
+                "lun" => {
+                    let val = s.next().context("`lun` requires a value")?;
+                    lun = Some(val.parse::<u8>().context("invalid `lun` value")?);
+                }
+                "relay" => {
+                    let val = s.next();
+                    if val.is_none_or(|v| v.is_empty()) {
+                        anyhow::bail!("`relay` requires a target controller name");
+                    }
+                    let val = val.unwrap();
+                    // Parse "name" or "name:location"
+                    if let Some((name, loc)) = val.split_once(':') {
+                        let loc = loc.parse::<u32>().context("invalid relay location")?;
+                        relay = Some((name.to_string(), Some(loc)));
+                    } else {
+                        relay = Some((val.to_string(), None));
+                    }
+                }
                 opt => anyhow::bail!("unknown option: '{opt}'"),
             }
         }
@@ -1656,6 +1765,30 @@ impl FromStr for DiskCli {
             anyhow::bail!("`pcie_port` is incompatible with `uh`, `uh-nvme`, `vtl2`, and `dvd`");
         }
 
+        if controller.is_some() && pcie_port.is_some() {
+            anyhow::bail!("`controller` is incompatible with `pcie_port`");
+        }
+
+        if nsid.is_some() && controller.is_none() {
+            anyhow::bail!("`nsid` requires `controller`");
+        }
+
+        if lun.is_some() && controller.is_none() {
+            anyhow::bail!("`lun` requires `controller`");
+        }
+
+        if nsid.is_some() && lun.is_some() {
+            anyhow::bail!("`nsid` and `lun` are mutually exclusive");
+        }
+
+        if relay.is_some() && controller.is_none() {
+            anyhow::bail!("`relay` requires `controller`");
+        }
+
+        if relay.is_some() && underhill.is_some() {
+            anyhow::bail!("`relay` is incompatible with `uh` and `uh-nvme`");
+        }
+
         Ok(DiskCli {
             vtl,
             kind,
@@ -1663,6 +1796,205 @@ impl FromStr for DiskCli {
             is_dvd,
             underhill,
             pcie_port,
+            controller,
+            nsid,
+            lun,
+            relay,
+        })
+    }
+}
+
+/// The transport for a named NVMe controller.
+#[derive(Clone, Debug, PartialEq)]
+pub enum NvmeControllerTransport {
+    /// Present via PCIe on the specified root port.
+    Pcie(String),
+    /// Present via VPCI with an optional instance GUID.
+    Vpci(Option<Guid>),
+}
+
+/// CLI arguments for a named NVMe controller.
+#[derive(Clone, Debug)]
+pub struct NvmeControllerCli {
+    /// Controller name, referenced by `--disk controller=<name>`.
+    pub id: String,
+    /// Transport configuration.
+    pub transport: NvmeControllerTransport,
+    /// VTL assignment (default VTL0).
+    pub vtl: DeviceVtl,
+}
+
+impl FromStr for NvmeControllerCli {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> anyhow::Result<Self> {
+        let mut id = None;
+        let mut pcie_port = None;
+        let mut vpci = None;
+        let mut vpci_set = false;
+        let mut vtl = DeviceVtl::Vtl0;
+
+        for part in s.split(',') {
+            let mut kv = part.split('=');
+            let key = kv.next().unwrap();
+            match key {
+                "id" => {
+                    let val = kv.next();
+                    if val.is_none_or(|v| v.is_empty()) {
+                        anyhow::bail!("`id` requires a name");
+                    }
+                    id = Some(val.unwrap().to_string());
+                }
+                "pcie_port" => {
+                    let val = kv.next();
+                    if val.is_none_or(|v| v.is_empty()) {
+                        anyhow::bail!("`pcie_port` requires a port name");
+                    }
+                    pcie_port = Some(val.unwrap().to_string());
+                }
+                "vpci" => {
+                    vpci_set = true;
+                    if let Some(val) = kv.next() {
+                        if !val.is_empty() {
+                            vpci = Some(val.parse::<Guid>().context("invalid GUID for `vpci`")?);
+                        }
+                    }
+                }
+                "vtl2" => {
+                    vtl = DeviceVtl::Vtl2;
+                }
+                other => anyhow::bail!("unknown option: '{other}'"),
+            }
+        }
+
+        let id = id.context("`id` is required")?;
+
+        let transport = match (pcie_port, vpci_set) {
+            (Some(port), false) => NvmeControllerTransport::Pcie(port),
+            (None, true) => NvmeControllerTransport::Vpci(vpci),
+            (Some(_), true) => {
+                anyhow::bail!("`pcie_port` and `vpci` are mutually exclusive")
+            }
+            (None, false) => {
+                anyhow::bail!("one of `pcie_port` or `vpci` is required")
+            }
+        };
+
+        Ok(NvmeControllerCli { id, transport, vtl })
+    }
+}
+
+/// CLI arguments for a named VMBus SCSI controller.
+#[derive(Clone, Debug)]
+pub struct ScsiControllerCli {
+    /// Controller name, referenced by `--disk controller=<name>`.
+    pub id: String,
+    /// Number of sub-channels.
+    pub sub_channels: u16,
+    /// VTL assignment (default VTL0).
+    pub vtl: DeviceVtl,
+}
+
+impl FromStr for ScsiControllerCli {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> anyhow::Result<Self> {
+        let mut id = None;
+        let mut sub_channels = 0u16;
+        let mut vtl = DeviceVtl::Vtl0;
+
+        for part in s.split(',') {
+            let mut kv = part.split('=');
+            let key = kv.next().unwrap();
+            match key {
+                "id" => {
+                    let val = kv.next();
+                    if val.is_none_or(|v| v.is_empty()) {
+                        anyhow::bail!("`id` requires a name");
+                    }
+                    id = Some(val.unwrap().to_string());
+                }
+                "sub_channels" => {
+                    let val = kv.next().context("`sub_channels` requires a value")?;
+                    sub_channels = val.parse().context("invalid `sub_channels` value")?;
+                }
+                "vtl2" => {
+                    vtl = DeviceVtl::Vtl2;
+                }
+                other => anyhow::bail!("unknown option: '{other}'"),
+            }
+        }
+
+        let id = id.context("`id` is required")?;
+
+        Ok(ScsiControllerCli {
+            id,
+            sub_channels,
+            vtl,
+        })
+    }
+}
+
+/// Protocol type for an OpenHCL-managed controller.
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub enum OpenhclControllerType {
+    Scsi,
+    Nvme,
+}
+
+/// CLI arguments for an OpenHCL-managed storage controller (relay target).
+#[derive(Clone, Debug)]
+pub struct OpenhclControllerCli {
+    /// Controller name, referenced by `--disk ... relay=<name>`.
+    pub id: String,
+    /// Controller protocol.
+    pub controller_type: OpenhclControllerType,
+    /// Instance GUID (auto-derived from name if omitted).
+    pub guid: Option<Guid>,
+}
+
+impl FromStr for OpenhclControllerCli {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> anyhow::Result<Self> {
+        let mut id = None;
+        let mut controller_type = None;
+        let mut guid = None;
+
+        for part in s.split(',') {
+            let mut kv = part.split('=');
+            let key = kv.next().unwrap();
+            match key {
+                "id" => {
+                    let val = kv.next();
+                    if val.is_none_or(|v| v.is_empty()) {
+                        anyhow::bail!("`id` requires a name");
+                    }
+                    id = Some(val.unwrap().to_string());
+                }
+                "type" => {
+                    let val = kv.next().context("`type` requires a value")?;
+                    controller_type = Some(match val {
+                        "scsi" => OpenhclControllerType::Scsi,
+                        "nvme" => OpenhclControllerType::Nvme,
+                        other => anyhow::bail!("unknown controller type: '{other}'"),
+                    });
+                }
+                "guid" => {
+                    let val = kv.next().context("`guid` requires a value")?;
+                    guid = Some(val.parse::<Guid>().context("invalid GUID")?);
+                }
+                other => anyhow::bail!("unknown option: '{other}'"),
+            }
+        }
+
+        let id = id.context("`id` is required")?;
+        let controller_type = controller_type.context("`type` is required")?;
+
+        Ok(OpenhclControllerCli {
+            id,
+            controller_type,
+            guid,
         })
     }
 }
@@ -4211,5 +4543,180 @@ mod tests {
 
         // Empty id.
         assert!(IommuCli::from_str("id=").is_err());
+    }
+
+    #[test]
+    fn test_nvme_controller_cli_pcie() {
+        let c = NvmeControllerCli::from_str("id=nvme0,pcie_port=p0").unwrap();
+        assert_eq!(c.id, "nvme0");
+        assert_eq!(c.transport, NvmeControllerTransport::Pcie("p0".into()));
+    }
+
+    #[test]
+    fn test_nvme_controller_cli_vpci_no_guid() {
+        let c = NvmeControllerCli::from_str("id=nvme1,vpci").unwrap();
+        assert_eq!(c.id, "nvme1");
+        assert!(matches!(c.transport, NvmeControllerTransport::Vpci(None)));
+    }
+
+    #[test]
+    fn test_nvme_controller_cli_vpci_with_guid() {
+        let c = NvmeControllerCli::from_str("id=nvme2,vpci=008091f6-9688-497d-9091-af347dc9173c")
+            .unwrap();
+        assert_eq!(c.id, "nvme2");
+        assert!(matches!(
+            c.transport,
+            NvmeControllerTransport::Vpci(Some(_))
+        ));
+    }
+
+    #[test]
+    fn test_nvme_controller_cli_errors() {
+        // Missing id.
+        assert!(NvmeControllerCli::from_str("pcie_port=p0").is_err());
+        // Missing transport.
+        assert!(NvmeControllerCli::from_str("id=nvme0").is_err());
+        // Both transports.
+        assert!(NvmeControllerCli::from_str("id=nvme0,pcie_port=p0,vpci").is_err());
+        // Unknown option.
+        assert!(NvmeControllerCli::from_str("id=nvme0,pcie_port=p0,foo=bar").is_err());
+        // Empty id.
+        assert!(NvmeControllerCli::from_str("id=,pcie_port=p0").is_err());
+        // Empty pcie_port.
+        assert!(NvmeControllerCli::from_str("id=nvme0,pcie_port=").is_err());
+        // Invalid GUID.
+        assert!(NvmeControllerCli::from_str("id=nvme0,vpci=not-a-guid").is_err());
+    }
+
+    #[test]
+    fn test_disk_cli_controller() {
+        let d = DiskCli::from_str("file:disk.vhd,controller=nvme0").unwrap();
+        assert_eq!(d.controller.as_deref(), Some("nvme0"));
+        assert_eq!(d.nsid, None);
+    }
+
+    #[test]
+    fn test_disk_cli_controller_with_nsid() {
+        let d = DiskCli::from_str("file:disk.vhd,controller=nvme0,nsid=3").unwrap();
+        assert_eq!(d.controller.as_deref(), Some("nvme0"));
+        assert_eq!(d.nsid, Some(3));
+    }
+
+    #[test]
+    fn test_disk_cli_controller_errors() {
+        // nsid without controller.
+        assert!(DiskCli::from_str("file:disk.vhd,nsid=1").is_err());
+        // lun without controller.
+        assert!(DiskCli::from_str("file:disk.vhd,lun=0").is_err());
+        // controller with pcie_port.
+        assert!(DiskCli::from_str("file:disk.vhd,controller=nvme0,pcie_port=p0").is_err());
+        // Empty controller name.
+        assert!(DiskCli::from_str("file:disk.vhd,controller=").is_err());
+        // Invalid nsid.
+        assert!(DiskCli::from_str("file:disk.vhd,controller=nvme0,nsid=abc").is_err());
+        // nsid and lun together.
+        assert!(DiskCli::from_str("file:disk.vhd,controller=c,nsid=1,lun=0").is_err());
+    }
+
+    #[test]
+    fn test_disk_cli_controller_with_lun() {
+        let d = DiskCli::from_str("file:disk.vhd,controller=scsi0,lun=3").unwrap();
+        assert_eq!(d.controller.as_deref(), Some("scsi0"));
+        assert_eq!(d.lun, Some(3));
+        assert_eq!(d.nsid, None);
+    }
+
+    #[test]
+    fn test_scsi_controller_cli() {
+        let c = ScsiControllerCli::from_str("id=scsi0").unwrap();
+        assert_eq!(c.id, "scsi0");
+        assert_eq!(c.sub_channels, 0);
+    }
+
+    #[test]
+    fn test_scsi_controller_cli_with_sub_channels() {
+        let c = ScsiControllerCli::from_str("id=scsi1,sub_channels=4").unwrap();
+        assert_eq!(c.id, "scsi1");
+        assert_eq!(c.sub_channels, 4);
+    }
+
+    #[test]
+    fn test_scsi_controller_cli_errors() {
+        // Missing id.
+        assert!(ScsiControllerCli::from_str("sub_channels=4").is_err());
+        // Empty id.
+        assert!(ScsiControllerCli::from_str("id=").is_err());
+        // Unknown option.
+        assert!(ScsiControllerCli::from_str("id=scsi0,foo=bar").is_err());
+        // Invalid sub_channels.
+        assert!(ScsiControllerCli::from_str("id=scsi0,sub_channels=abc").is_err());
+    }
+
+    #[test]
+    fn test_disk_cli_relay() {
+        let d = DiskCli::from_str("file:disk.vhd,controller=src,relay=tgt").unwrap();
+        assert_eq!(d.relay.as_ref().unwrap().0, "tgt");
+        assert_eq!(d.relay.as_ref().unwrap().1, None);
+    }
+
+    #[test]
+    fn test_disk_cli_relay_with_location() {
+        let d = DiskCli::from_str("file:disk.vhd,controller=src,relay=tgt:3").unwrap();
+        assert_eq!(d.relay.as_ref().unwrap().0, "tgt");
+        assert_eq!(d.relay.as_ref().unwrap().1, Some(3));
+    }
+
+    #[test]
+    fn test_disk_cli_relay_errors() {
+        // relay without controller.
+        assert!(DiskCli::from_str("file:disk.vhd,relay=tgt").is_err());
+        // relay with uh.
+        assert!(DiskCli::from_str("file:disk.vhd,controller=src,relay=tgt,uh").is_err());
+        // relay with invalid location.
+        assert!(DiskCli::from_str("file:disk.vhd,controller=src,relay=tgt:abc").is_err());
+        // empty relay.
+        assert!(DiskCli::from_str("file:disk.vhd,controller=src,relay=").is_err());
+    }
+
+    #[test]
+    fn test_nvme_controller_cli_vtl2() {
+        let c = NvmeControllerCli::from_str("id=nvme0,vpci,vtl2").unwrap();
+        assert_eq!(c.vtl, DeviceVtl::Vtl2);
+    }
+
+    #[test]
+    fn test_scsi_controller_cli_vtl2() {
+        let c = ScsiControllerCli::from_str("id=scsi0,vtl2").unwrap();
+        assert_eq!(c.vtl, DeviceVtl::Vtl2);
+    }
+
+    #[test]
+    fn test_openhcl_controller_cli() {
+        let c = OpenhclControllerCli::from_str("id=vtl0-scsi,type=scsi").unwrap();
+        assert_eq!(c.id, "vtl0-scsi");
+        assert_eq!(c.controller_type, OpenhclControllerType::Scsi);
+        assert_eq!(c.guid, None);
+    }
+
+    #[test]
+    fn test_openhcl_controller_cli_nvme_with_guid() {
+        let c = OpenhclControllerCli::from_str(
+            "id=vtl0-nvme,type=nvme,guid=09a59b81-2bf6-4164-81d7-3a0dc977ba65",
+        )
+        .unwrap();
+        assert_eq!(c.controller_type, OpenhclControllerType::Nvme);
+        assert!(c.guid.is_some());
+    }
+
+    #[test]
+    fn test_openhcl_controller_cli_errors() {
+        // Missing id.
+        assert!(OpenhclControllerCli::from_str("type=scsi").is_err());
+        // Missing type.
+        assert!(OpenhclControllerCli::from_str("id=foo").is_err());
+        // Invalid type.
+        assert!(OpenhclControllerCli::from_str("id=foo,type=ide").is_err());
+        // Invalid guid.
+        assert!(OpenhclControllerCli::from_str("id=foo,type=scsi,guid=bad").is_err());
     }
 }

--- a/openvmm/openvmm_entry/src/cli_args.rs
+++ b/openvmm/openvmm_entry/src/cli_args.rs
@@ -253,9 +253,9 @@ flags:
 
 options:
     `pcie_port=<name>`             present the disk using pcie under the specified port, incompatible with `dvd`, `vtl2`, `uh`, and `uh-nvme`
-    `controller=<name>`            attach to a named controller (NVMe or SCSI), incompatible with `pcie_port`
-    `nsid=<N>`                     NVMe namespace ID (1-based), requires `controller`; auto-assigned if omitted
-    `lun=<N>`                      SCSI LUN (0-based), requires `controller`; auto-assigned if omitted
+    `on=<name>`                    attach to a named controller (NVMe or SCSI), incompatible with `pcie_port`
+    `nsid=<N>`                     NVMe namespace ID (1-based), requires `on`; auto-assigned if omitted
+    `lun=<N>`                      SCSI LUN (0-based), requires `on`; auto-assigned if omitted
     `relay=<ctrl>[:<loc>]`         relay through OpenHCL to the named OpenHCL controller, with optional location (LUN or NSID)
 "#)]
     #[clap(long, value_name = "FILE")]
@@ -263,7 +263,7 @@ options:
 
     /// \[deprecated\] attach a disk via an NVMe controller
     ///
-    /// Use --nvme-controller and --disk controller=\<name\> instead.
+    /// Use --nvme-pci and --disk on=\<name\> instead.
     #[clap(long_help = r#"
 e.g: --nvme memdiff:file:/path/to/disk.vhd
 
@@ -304,7 +304,7 @@ Create a named NVMe controller with an explicit transport.
 
 syntax: id=<name>,pcie_port=<port> | id=<name>,vpci[=<guid>]
 
-The controller name can be referenced by `--disk` with the `controller=<name>`
+The controller name can be referenced by `--disk` with the `on=<name>`
 option to attach namespaces to this controller.
 
 options:
@@ -316,12 +316,12 @@ options:
 Exactly one of `pcie_port` or `vpci` must be specified.
 
 Examples:
-    --nvme-controller id=nvme0,pcie_port=p0
-    --nvme-controller id=nvme1,vpci
-    --nvme-controller id=nvme2,vpci=008091f6-9688-497d-9091-af347dc9173c
+    --nvme-pci id=nvme0,pcie_port=p0
+    --nvme-pci id=nvme1,vpci
+    --nvme-pci id=nvme2,vpci=008091f6-9688-497d-9091-af347dc9173c
 "#)]
-    #[clap(long = "nvme-controller")]
-    pub nvme_controller: Vec<NvmeControllerCli>,
+    #[clap(long = "nvme-pci")]
+    pub nvme_pci: Vec<NvmeControllerCli>,
 
     /// create a named VMBus SCSI controller
     #[clap(long_help = r#"
@@ -329,7 +329,7 @@ Create a named VMBus SCSI controller.
 
 syntax: id=<name>[,sub_channels=<N>][,vtl2]
 
-The controller name can be referenced by `--disk` with the `controller=<name>`
+The controller name can be referenced by `--disk` with the `on=<name>`
 option to attach disks to this controller.
 
 options:
@@ -338,11 +338,11 @@ options:
     `vtl2`                         assign to VTL2 (default VTL0)
 
 Examples:
-    --vmbus-scsi-controller id=scsi0
-    --vmbus-scsi-controller id=scsi1,sub_channels=4
+    --vmbus-scsi id=scsi0
+    --vmbus-scsi id=scsi1,sub_channels=4
 "#)]
-    #[clap(long = "vmbus-scsi-controller")]
-    pub vmbus_scsi_controller: Vec<ScsiControllerCli>,
+    #[clap(long = "vmbus-scsi")]
+    pub vmbus_scsi: Vec<ScsiControllerCli>,
 
     /// register an OpenHCL-managed storage controller (relay target)
     #[clap(long_help = r#"
@@ -1724,10 +1724,10 @@ impl FromStr for DiskCli {
                     }
                     pcie_port = Some(String::from(port.unwrap()));
                 }
-                "controller" => {
+                "on" => {
                     let name = s.next();
                     if name.is_none_or(|n| n.is_empty()) {
-                        anyhow::bail!("`controller` requires a controller name");
+                        anyhow::bail!("`on` requires a controller name");
                     }
                     controller = Some(String::from(name.unwrap()));
                 }
@@ -1766,15 +1766,15 @@ impl FromStr for DiskCli {
         }
 
         if controller.is_some() && pcie_port.is_some() {
-            anyhow::bail!("`controller` is incompatible with `pcie_port`");
+            anyhow::bail!("`on` is incompatible with `pcie_port`");
         }
 
         if nsid.is_some() && controller.is_none() {
-            anyhow::bail!("`nsid` requires `controller`");
+            anyhow::bail!("`nsid` requires `on`");
         }
 
         if lun.is_some() && controller.is_none() {
-            anyhow::bail!("`lun` requires `controller`");
+            anyhow::bail!("`lun` requires `on`");
         }
 
         if nsid.is_some() && lun.is_some() {
@@ -1782,7 +1782,7 @@ impl FromStr for DiskCli {
         }
 
         if relay.is_some() && controller.is_none() {
-            anyhow::bail!("`relay` requires `controller`");
+            anyhow::bail!("`relay` requires `on`");
         }
 
         if relay.is_some() && underhill.is_some() {
@@ -1816,7 +1816,7 @@ pub enum NvmeControllerTransport {
 /// CLI arguments for a named NVMe controller.
 #[derive(Clone, Debug)]
 pub struct NvmeControllerCli {
-    /// Controller name, referenced by `--disk controller=<name>`.
+    /// Controller name, referenced by `--disk on=<name>`.
     pub id: String,
     /// Transport configuration.
     pub transport: NvmeControllerTransport,
@@ -1887,7 +1887,7 @@ impl FromStr for NvmeControllerCli {
 /// CLI arguments for a named VMBus SCSI controller.
 #[derive(Clone, Debug)]
 pub struct ScsiControllerCli {
-    /// Controller name, referenced by `--disk controller=<name>`.
+    /// Controller name, referenced by `--disk on=<name>`.
     pub id: String,
     /// Number of sub-channels.
     pub sub_channels: u16,
@@ -4590,37 +4590,37 @@ mod tests {
 
     #[test]
     fn test_disk_cli_controller() {
-        let d = DiskCli::from_str("file:disk.vhd,controller=nvme0").unwrap();
+        let d = DiskCli::from_str("file:disk.vhd,on=nvme0").unwrap();
         assert_eq!(d.controller.as_deref(), Some("nvme0"));
         assert_eq!(d.nsid, None);
     }
 
     #[test]
     fn test_disk_cli_controller_with_nsid() {
-        let d = DiskCli::from_str("file:disk.vhd,controller=nvme0,nsid=3").unwrap();
+        let d = DiskCli::from_str("file:disk.vhd,on=nvme0,nsid=3").unwrap();
         assert_eq!(d.controller.as_deref(), Some("nvme0"));
         assert_eq!(d.nsid, Some(3));
     }
 
     #[test]
     fn test_disk_cli_controller_errors() {
-        // nsid without controller.
+        // nsid without on.
         assert!(DiskCli::from_str("file:disk.vhd,nsid=1").is_err());
-        // lun without controller.
+        // lun without on.
         assert!(DiskCli::from_str("file:disk.vhd,lun=0").is_err());
-        // controller with pcie_port.
-        assert!(DiskCli::from_str("file:disk.vhd,controller=nvme0,pcie_port=p0").is_err());
+        // on with pcie_port.
+        assert!(DiskCli::from_str("file:disk.vhd,on=nvme0,pcie_port=p0").is_err());
         // Empty controller name.
-        assert!(DiskCli::from_str("file:disk.vhd,controller=").is_err());
+        assert!(DiskCli::from_str("file:disk.vhd,on=").is_err());
         // Invalid nsid.
-        assert!(DiskCli::from_str("file:disk.vhd,controller=nvme0,nsid=abc").is_err());
+        assert!(DiskCli::from_str("file:disk.vhd,on=nvme0,nsid=abc").is_err());
         // nsid and lun together.
-        assert!(DiskCli::from_str("file:disk.vhd,controller=c,nsid=1,lun=0").is_err());
+        assert!(DiskCli::from_str("file:disk.vhd,on=c,nsid=1,lun=0").is_err());
     }
 
     #[test]
     fn test_disk_cli_controller_with_lun() {
-        let d = DiskCli::from_str("file:disk.vhd,controller=scsi0,lun=3").unwrap();
+        let d = DiskCli::from_str("file:disk.vhd,on=scsi0,lun=3").unwrap();
         assert_eq!(d.controller.as_deref(), Some("scsi0"));
         assert_eq!(d.lun, Some(3));
         assert_eq!(d.nsid, None);
@@ -4654,28 +4654,28 @@ mod tests {
 
     #[test]
     fn test_disk_cli_relay() {
-        let d = DiskCli::from_str("file:disk.vhd,controller=src,relay=tgt").unwrap();
+        let d = DiskCli::from_str("file:disk.vhd,on=src,relay=tgt").unwrap();
         assert_eq!(d.relay.as_ref().unwrap().0, "tgt");
         assert_eq!(d.relay.as_ref().unwrap().1, None);
     }
 
     #[test]
     fn test_disk_cli_relay_with_location() {
-        let d = DiskCli::from_str("file:disk.vhd,controller=src,relay=tgt:3").unwrap();
+        let d = DiskCli::from_str("file:disk.vhd,on=src,relay=tgt:3").unwrap();
         assert_eq!(d.relay.as_ref().unwrap().0, "tgt");
         assert_eq!(d.relay.as_ref().unwrap().1, Some(3));
     }
 
     #[test]
     fn test_disk_cli_relay_errors() {
-        // relay without controller.
+        // relay without on.
         assert!(DiskCli::from_str("file:disk.vhd,relay=tgt").is_err());
         // relay with uh.
-        assert!(DiskCli::from_str("file:disk.vhd,controller=src,relay=tgt,uh").is_err());
+        assert!(DiskCli::from_str("file:disk.vhd,on=src,relay=tgt,uh").is_err());
         // relay with invalid location.
-        assert!(DiskCli::from_str("file:disk.vhd,controller=src,relay=tgt:abc").is_err());
+        assert!(DiskCli::from_str("file:disk.vhd,on=src,relay=tgt:abc").is_err());
         // empty relay.
-        assert!(DiskCli::from_str("file:disk.vhd,controller=src,relay=").is_err());
+        assert!(DiskCli::from_str("file:disk.vhd,on=src,relay=").is_err());
     }
 
     #[test]

--- a/openvmm/openvmm_entry/src/cli_args.rs
+++ b/openvmm/openvmm_entry/src/cli_args.rs
@@ -253,7 +253,7 @@ flags:
 
 options:
     `pcie_port=<name>`             present the disk using pcie under the specified port, incompatible with `dvd`, `vtl2`, `uh`, and `uh-nvme`
-    `on=<name>`                    attach to a named controller (NVMe or SCSI), incompatible with `pcie_port`
+    `on=<name>`                    attach to a named controller (NVMe or SCSI), incompatible with `pcie_port` and `vtl2`
     `nsid=<N>`                     NVMe namespace ID (1-based), requires `on`; auto-assigned if omitted
     `lun=<N>`                      SCSI LUN (0-based), requires `on`; auto-assigned if omitted
     `relay=<ctrl>[:<loc>]`         relay through OpenHCL to the named OpenHCL controller, with optional location (LUN or NSID)
@@ -1767,6 +1767,16 @@ impl FromStr for DiskCli {
 
         if controller.is_some() && pcie_port.is_some() {
             anyhow::bail!("`on` is incompatible with `pcie_port`");
+        }
+
+        if controller.is_some() && vtl != DeviceVtl::Vtl0 {
+            anyhow::bail!(
+                "`vtl2` is incompatible with `on`; the controller's VTL determines placement"
+            );
+        }
+
+        if controller.is_some() && underhill.is_some() {
+            anyhow::bail!("`on` is incompatible with `uh` and `uh-nvme`; use `relay` instead");
         }
 
         if nsid.is_some() && controller.is_none() {

--- a/openvmm/openvmm_entry/src/lib.rs
+++ b/openvmm/openvmm_entry/src/lib.rs
@@ -454,9 +454,9 @@ async fn vm_config_from_command_line(
 
     let mut storage = storage_builder::StorageBuilder::new(with_get.then_some(openhcl_vtl));
 
-    // Register named controllers first, so that --disk controller=<name>
+    // Register named controllers first, so that --disk on=<name>
     // references can be resolved.
-    for ctrl in &opt.nvme_controller {
+    for ctrl in &opt.nvme_pci {
         let transport = match &ctrl.transport {
             cli_args::NvmeControllerTransport::Pcie(port) => {
                 storage_builder::NvmeControllerTransport::Pcie(port.clone())
@@ -469,7 +469,7 @@ async fn vm_config_from_command_line(
         storage.add_nvme_controller(ctrl.id.clone(), ctrl.vtl, transport, None)?;
     }
 
-    for ctrl in &opt.vmbus_scsi_controller {
+    for ctrl in &opt.vmbus_scsi {
         let instance_id = storage_builder::deterministic_guid(&ctrl.id);
         storage.add_scsi_controller(ctrl.id.clone(), ctrl.vtl, instance_id, ctrl.sub_channels)?;
     }
@@ -500,8 +500,8 @@ async fn vm_config_from_command_line(
     {
         if controller.is_none() && underhill.is_none() && relay.is_none() {
             tracing::warn!(
-                "--disk without `controller` is deprecated; \
-                 use --vmbus-scsi-controller and --disk controller=<name> instead"
+                "--disk without `on` is deprecated; \
+                 use --vmbus-scsi and --disk on=<name> instead"
             );
         }
 
@@ -514,7 +514,7 @@ async fn vm_config_from_command_line(
 
         let target = if let Some(name) = controller {
             if pcie_port.is_some() {
-                anyhow::bail!("`controller` is incompatible with `pcie_port` on `--disk`");
+                anyhow::bail!("`on` is incompatible with `pcie_port` on `--disk`");
             }
             storage_builder::DiskLocation::Named {
                 controller: name.clone(),
@@ -562,9 +562,7 @@ async fn vm_config_from_command_line(
     }
 
     if !opt.nvme.is_empty() {
-        tracing::warn!(
-            "--nvme is deprecated; use --nvme-controller and --disk controller=<name> instead"
-        );
+        tracing::warn!("--nvme is deprecated; use --nvme-pci and --disk on=<name> instead");
 
         // Pre-register implicit PCIe controllers for unique port names.
         let mut registered_ports = std::collections::BTreeSet::new();
@@ -576,7 +574,10 @@ async fn vm_config_from_command_line(
                         DeviceVtl::Vtl0,
                         storage_builder::NvmeControllerTransport::Pcie(port.clone()),
                         None,
-                    )?;
+                    ).with_context(|| format!(
+                        "legacy --nvme flag conflicts with an explicit controller named '{port}'; \
+                         use --nvme-pci and --disk on=<name> instead"
+                    ))?;
                 }
             }
         }
@@ -1298,6 +1299,7 @@ async fn vm_config_from_command_line(
     });
 
     if with_get && with_hv {
+        let has_vtl0_nvme = storage.has_vtl0_nvme();
         let vtl2_settings = vtl2_settings_proto::Vtl2Settings {
             version: vtl2_settings_proto::vtl2_settings_base::Version::V1.into(),
             fixed: Some(Default::default()),
@@ -1348,7 +1350,7 @@ async fn vm_config_from_command_line(
                         use get_resources::ged::UefiConsoleMode;
 
                         get_resources::ged::GuestFirmwareConfig::Uefi {
-                            enable_vpci_boot: storage.has_vtl0_nvme(),
+                            enable_vpci_boot: has_vtl0_nvme,
                             firmware_debug: opt.uefi_debug,
                             disable_frontpage: opt.disable_frontpage,
                             console_mode: match opt.uefi_console_mode.unwrap_or(UefiConsoleModeCli::Default) {

--- a/openvmm/openvmm_entry/src/lib.rs
+++ b/openvmm/openvmm_entry/src/lib.rs
@@ -453,6 +453,38 @@ async fn vm_config_from_command_line(
     let with_get = opt.get || (opt.vtl2 && !opt.no_get);
 
     let mut storage = storage_builder::StorageBuilder::new(with_get.then_some(openhcl_vtl));
+
+    // Register named controllers first, so that --disk controller=<name>
+    // references can be resolved.
+    for ctrl in &opt.nvme_controller {
+        let transport = match &ctrl.transport {
+            cli_args::NvmeControllerTransport::Pcie(port) => {
+                storage_builder::NvmeControllerTransport::Pcie(port.clone())
+            }
+            cli_args::NvmeControllerTransport::Vpci(guid) => {
+                let guid = guid.unwrap_or_else(|| storage_builder::deterministic_guid(&ctrl.id));
+                storage_builder::NvmeControllerTransport::Vpci(guid)
+            }
+        };
+        storage.add_nvme_controller(ctrl.id.clone(), ctrl.vtl, transport, None)?;
+    }
+
+    for ctrl in &opt.vmbus_scsi_controller {
+        let instance_id = storage_builder::deterministic_guid(&ctrl.id);
+        storage.add_scsi_controller(ctrl.id.clone(), ctrl.vtl, instance_id, ctrl.sub_channels)?;
+    }
+
+    for ctrl in &opt.openhcl_controller {
+        let controller_type = match ctrl.controller_type {
+            cli_args::OpenhclControllerType::Scsi => storage_builder::OpenhclControllerType::Scsi,
+            cli_args::OpenhclControllerType::Nvme => storage_builder::OpenhclControllerType::Nvme,
+        };
+        let instance_id = ctrl
+            .guid
+            .unwrap_or_else(|| storage_builder::deterministic_guid(&ctrl.id));
+        storage.add_openhcl_controller(ctrl.id.clone(), controller_type, instance_id)?;
+    }
+
     for &cli_args::DiskCli {
         vtl,
         ref kind,
@@ -460,17 +492,47 @@ async fn vm_config_from_command_line(
         is_dvd,
         underhill,
         ref pcie_port,
+        ref controller,
+        nsid,
+        lun,
+        ref relay,
     } in &opt.disk
     {
-        if pcie_port.is_some() {
-            anyhow::bail!("`--disk` is incompatible with PCIe");
+        if controller.is_none() && underhill.is_none() && relay.is_none() {
+            tracing::warn!(
+                "--disk without `controller` is deprecated; \
+                 use --vmbus-scsi-controller and --disk controller=<name> instead"
+            );
         }
+
+        let relay_target = relay
+            .as_ref()
+            .map(|(name, loc)| storage_builder::RelayTarget {
+                controller: name.clone(),
+                location: *loc,
+            });
+
+        let target = if let Some(name) = controller {
+            if pcie_port.is_some() {
+                anyhow::bail!("`controller` is incompatible with `pcie_port` on `--disk`");
+            }
+            storage_builder::DiskLocation::Named {
+                controller: name.clone(),
+                nsid,
+                lun,
+            }
+        } else if pcie_port.is_some() {
+            anyhow::bail!("`--disk` is incompatible with `pcie_port` without `controller`");
+        } else {
+            storage_builder::DiskLocation::Scsi(None)
+        };
 
         storage
             .add(
                 vtl,
                 underhill,
-                storage_builder::DiskLocation::Scsi(None),
+                relay_target,
+                target,
                 kind,
                 is_dvd,
                 read_only,
@@ -490,12 +552,34 @@ async fn vm_config_from_command_line(
             .add(
                 DeviceVtl::Vtl0,
                 None,
+                None,
                 storage_builder::DiskLocation::Ide(channel, device),
                 kind,
                 is_dvd,
                 read_only,
             )
             .await?;
+    }
+
+    if !opt.nvme.is_empty() {
+        tracing::warn!(
+            "--nvme is deprecated; use --nvme-controller and --disk controller=<name> instead"
+        );
+
+        // Pre-register implicit PCIe controllers for unique port names.
+        let mut registered_ports = std::collections::BTreeSet::new();
+        for disk in &opt.nvme {
+            if let Some(port) = &disk.pcie_port {
+                if registered_ports.insert(port.clone()) {
+                    storage.add_nvme_controller(
+                        port.clone(),
+                        DeviceVtl::Vtl0,
+                        storage_builder::NvmeControllerTransport::Pcie(port.clone()),
+                        None,
+                    )?;
+                }
+            }
+        }
     }
 
     for &cli_args::DiskCli {
@@ -505,17 +589,23 @@ async fn vm_config_from_command_line(
         is_dvd,
         underhill,
         ref pcie_port,
+        controller: _,
+        nsid: _,
+        lun: _,
+        relay: _,
     } in &opt.nvme
     {
+        let target = if let Some(port) = pcie_port {
+            storage_builder::DiskLocation::Named {
+                controller: port.clone(),
+                nsid: None,
+                lun: None,
+            }
+        } else {
+            storage_builder::DiskLocation::Nvme(None)
+        };
         storage
-            .add(
-                vtl,
-                underhill,
-                storage_builder::DiskLocation::Nvme(None, pcie_port.clone()),
-                kind,
-                is_dvd,
-                read_only,
-            )
+            .add(vtl, underhill, None, target, kind, is_dvd, read_only)
             .await?;
     }
 
@@ -526,6 +616,10 @@ async fn vm_config_from_command_line(
         is_dvd,
         ref underhill,
         ref pcie_port,
+        controller: _,
+        nsid: _,
+        lun: _,
+        relay: _,
     } in &opt.virtio_blk
     {
         if underhill.is_some() {
@@ -534,6 +628,7 @@ async fn vm_config_from_command_line(
         storage
             .add(
                 vtl,
+                None,
                 None,
                 storage_builder::DiskLocation::VirtioBlk(pcie_port.clone()),
                 kind,
@@ -1207,7 +1302,7 @@ async fn vm_config_from_command_line(
             version: vtl2_settings_proto::vtl2_settings_base::Version::V1.into(),
             fixed: Some(Default::default()),
             dynamic: Some(vtl2_settings_proto::Vtl2SettingsDynamic {
-                storage_controllers: storage.build_underhill(opt.vmbus_redirect),
+                storage_controllers: storage.build_openhcl_settings(opt.vmbus_redirect),
                 nic_devices: underhill_nics,
             }),
             namespace_settings: Vec::default(),

--- a/openvmm/openvmm_entry/src/storage_builder.rs
+++ b/openvmm/openvmm_entry/src/storage_builder.rs
@@ -433,6 +433,11 @@ impl StorageBuilder {
                         anyhow::bail!("dvd not supported with nvme");
                     }
                     let nsid = nsid.unwrap_or(nvme.namespaces.len() as u32 + 1);
+                    if nvme.namespaces.iter().any(|ns| ns.nsid == nsid) {
+                        anyhow::bail!(
+                            "duplicate namespace ID {nsid} on NVMe controller '{controller}'"
+                        );
+                    }
                     nvme.namespaces.push(NamespaceDefinition {
                         nsid,
                         disk,
@@ -459,6 +464,9 @@ impl StorageBuilder {
                         .into_resource()
                     };
                     let lun = lun.unwrap_or(scsi.devices.len() as u8);
+                    if scsi.devices.iter().any(|d| d.path.lun == lun) {
+                        anyhow::bail!("duplicate LUN {lun} on SCSI controller '{controller}'");
+                    }
                     scsi.devices.push(ScsiDeviceAndPath {
                         path: ScsiPath {
                             path: 0,
@@ -532,6 +540,17 @@ impl StorageBuilder {
                 anyhow::bail!("`relay` requires a named source controller");
             }
         };
+
+        // The relay model requires the source controller to be offered into
+        // the OpenHCL VTL so that OpenHCL can intercept and re-expose it.
+        let openhcl_vtl = self.openhcl_vtl.context("OpenHCL not configured")?;
+        if source_vtl != openhcl_vtl {
+            anyhow::bail!(
+                "relay source controller must be assigned to {openhcl_vtl:?}, \
+                 but it is assigned to {source_vtl:?}; add the `vtl2` option \
+                 to the source controller"
+            );
+        }
 
         let sub_device_path = self
             .add_inner(source_vtl, target, kind, is_dvd, read_only)

--- a/openvmm/openvmm_entry/src/storage_builder.rs
+++ b/openvmm/openvmm_entry/src/storage_builder.rs
@@ -90,6 +90,12 @@ struct ScsiControllerEntry {
     devices: Vec<ScsiDeviceAndPath>,
 }
 
+/// A named controller entry (NVMe or SCSI).
+enum ControllerEntry {
+    Nvme(NvmeControllerEntry),
+    Scsi(ScsiControllerEntry),
+}
+
 /// Protocol type for an OpenHCL-managed controller.
 #[derive(Copy, Clone, PartialEq)]
 pub enum OpenhclControllerType {
@@ -119,8 +125,7 @@ pub(super) struct StorageBuilder {
     vtl2_scsi_devices: Vec<ScsiDeviceAndPath>,
     vtl0_nvme_namespaces: Vec<NamespaceDefinition>,
     vtl2_nvme_namespaces: Vec<NamespaceDefinition>,
-    nvme_controllers: BTreeMap<String, NvmeControllerEntry>,
-    scsi_controllers: BTreeMap<String, ScsiControllerEntry>,
+    controllers: BTreeMap<String, ControllerEntry>,
     openhcl_controllers: BTreeMap<String, OpenhclControllerEntry>,
     pcie_virtio_blk_disks: Vec<(String, VirtioBlkDisk)>,
     underhill_scsi_luns: Vec<Lun>,
@@ -184,8 +189,7 @@ impl StorageBuilder {
             vtl2_scsi_devices: Vec::new(),
             vtl0_nvme_namespaces: Vec::new(),
             vtl2_nvme_namespaces: Vec::new(),
-            nvme_controllers: BTreeMap::new(),
-            scsi_controllers: BTreeMap::new(),
+            controllers: BTreeMap::new(),
             openhcl_controllers: BTreeMap::new(),
             pcie_virtio_blk_disks: Vec::new(),
             underhill_scsi_luns: Vec::new(),
@@ -207,17 +211,23 @@ impl StorageBuilder {
         transport: NvmeControllerTransport,
         requests: Option<mesh::Receiver<NvmeControllerRequest>>,
     ) -> anyhow::Result<()> {
-        if self.nvme_controllers.contains_key(&name) {
-            anyhow::bail!("duplicate NVMe controller name: '{name}'");
+        if let Some(existing) = self.controllers.get(&name) {
+            let kind = match existing {
+                ControllerEntry::Nvme(_) => "NVMe",
+                ControllerEntry::Scsi(_) => "SCSI",
+            };
+            anyhow::bail!(
+                "cannot add NVMe controller '{name}': name already used by a {kind} controller"
+            );
         }
-        self.nvme_controllers.insert(
+        self.controllers.insert(
             name,
-            NvmeControllerEntry {
+            ControllerEntry::Nvme(NvmeControllerEntry {
                 vtl,
                 transport,
                 namespaces: Vec::new(),
                 requests,
-            },
+            }),
         );
         Ok(())
     }
@@ -230,17 +240,23 @@ impl StorageBuilder {
         instance_id: Guid,
         sub_channels: u16,
     ) -> anyhow::Result<()> {
-        if self.scsi_controllers.contains_key(&name) {
-            anyhow::bail!("duplicate SCSI controller name: '{name}'");
+        if let Some(existing) = self.controllers.get(&name) {
+            let kind = match existing {
+                ControllerEntry::Nvme(_) => "NVMe",
+                ControllerEntry::Scsi(_) => "SCSI",
+            };
+            anyhow::bail!(
+                "cannot add SCSI controller '{name}': name already used by a {kind} controller"
+            );
         }
-        self.scsi_controllers.insert(
+        self.controllers.insert(
             name,
-            ScsiControllerEntry {
+            ControllerEntry::Scsi(ScsiControllerEntry {
                 vtl,
                 instance_id,
                 sub_channels,
                 devices: Vec::new(),
-            },
+            }),
         );
         Ok(())
     }
@@ -398,8 +414,8 @@ impl StorageBuilder {
                 controller,
                 nsid,
                 lun,
-            } => {
-                if let Some(nvme) = self.nvme_controllers.get_mut(&controller) {
+            } => match self.controllers.get_mut(&controller) {
+                Some(ControllerEntry::Nvme(nvme)) => {
                     if lun.is_some() {
                         anyhow::bail!("`lun` is not valid for NVMe controller '{controller}'");
                     }
@@ -413,7 +429,8 @@ impl StorageBuilder {
                         read_only,
                     });
                     Some(nsid)
-                } else if let Some(scsi) = self.scsi_controllers.get_mut(&controller) {
+                }
+                Some(ControllerEntry::Scsi(scsi)) => {
                     if nsid.is_some() {
                         anyhow::bail!("`nsid` is not valid for SCSI controller '{controller}'");
                     }
@@ -441,10 +458,11 @@ impl StorageBuilder {
                         device,
                     });
                     Some(lun.into())
-                } else {
+                }
+                None => {
                     anyhow::bail!("unknown controller: '{controller}'");
                 }
-            }
+            },
             DiskLocation::VirtioBlk(pcie_port) => {
                 if vtl != DeviceVtl::Vtl0 {
                     anyhow::bail!("virtio-blk only supported for VTL0");
@@ -477,8 +495,8 @@ impl StorageBuilder {
     ) -> anyhow::Result<()> {
         // Look up the source controller to determine VTL and instance ID.
         let (source_vtl, device_type, device_path) = match &target {
-            DiskLocation::Named { controller, .. } => {
-                if let Some(nvme) = self.nvme_controllers.get(controller) {
+            DiskLocation::Named { controller, .. } => match self.controllers.get(controller) {
+                Some(ControllerEntry::Nvme(nvme)) => {
                     let instance_id = match &nvme.transport {
                         NvmeControllerTransport::Vpci(guid) => *guid,
                         NvmeControllerTransport::Pcie(_) => {
@@ -490,16 +508,16 @@ impl StorageBuilder {
                         vtl2_settings_proto::physical_device::DeviceType::Nvme,
                         instance_id,
                     )
-                } else if let Some(scsi) = self.scsi_controllers.get(controller) {
-                    (
-                        scsi.vtl,
-                        vtl2_settings_proto::physical_device::DeviceType::Vscsi,
-                        scsi.instance_id,
-                    )
-                } else {
+                }
+                Some(ControllerEntry::Scsi(scsi)) => (
+                    scsi.vtl,
+                    vtl2_settings_proto::physical_device::DeviceType::Vscsi,
+                    scsi.instance_id,
+                ),
+                None => {
                     anyhow::bail!("unknown source controller: '{controller}'");
                 }
-            }
+            },
             _ => {
                 anyhow::bail!("`relay` requires a named source controller");
             }
@@ -516,7 +534,15 @@ impl StorageBuilder {
             .get_mut(&relay.controller)
             .with_context(|| format!("unknown OpenHCL controller: '{}'", relay.controller))?;
 
-        let location = relay.location.unwrap_or(openhcl.luns.len() as u32);
+        // NVMe namespace IDs are 1-based (0 is invalid per spec),
+        // while SCSI LUNs are 0-based.
+        let location = relay.location.unwrap_or_else(|| {
+            let base = openhcl.luns.len() as u32;
+            match openhcl.controller_type {
+                OpenhclControllerType::Nvme => base + 1,
+                OpenhclControllerType::Scsi => base,
+            }
+        });
 
         openhcl.luns.push(Lun {
             location,
@@ -675,20 +701,69 @@ impl StorageBuilder {
             ));
         }
 
-        // Emit named SCSI controllers.
-        for (_name, ctrl) in std::mem::take(&mut self.scsi_controllers) {
-            config.vmbus_devices.push((
-                ctrl.vtl,
-                ScsiControllerHandle {
-                    instance_id: ctrl.instance_id,
-                    max_sub_channel_count: ctrl.sub_channels,
-                    devices: ctrl.devices,
-                    io_queue_depth: None,
-                    requests: None,
-                    poll_mode_queue_depth: None,
+        // Emit named controllers.
+        for (name, entry) in std::mem::take(&mut self.controllers) {
+            match entry {
+                ControllerEntry::Scsi(ctrl) => {
+                    config.vmbus_devices.push((
+                        ctrl.vtl,
+                        ScsiControllerHandle {
+                            instance_id: ctrl.instance_id,
+                            max_sub_channel_count: ctrl.sub_channels,
+                            devices: ctrl.devices,
+                            io_queue_depth: None,
+                            requests: None,
+                            poll_mode_queue_depth: None,
+                        }
+                        .into_resource(),
+                    ));
                 }
-                .into_resource(),
-            ));
+                ControllerEntry::Nvme(ctrl) => {
+                    if ctrl.namespaces.is_empty() && ctrl.requests.is_none() {
+                        tracing::warn!(name, "named NVMe controller has no namespaces");
+                    }
+                    let subsystem_id = deterministic_guid(&name);
+                    match ctrl.transport {
+                        NvmeControllerTransport::Pcie(port_name) => {
+                            config.pcie_devices.push(PcieDeviceConfig {
+                                port_name,
+                                resource: NvmeControllerHandle {
+                                    subsystem_id,
+                                    namespaces: ctrl.namespaces,
+                                    max_io_queues: 64,
+                                    msix_count: 64,
+                                    requests: ctrl.requests,
+                                }
+                                .into_resource(),
+                            });
+                        }
+                        NvmeControllerTransport::Vpci(instance_id) => {
+                            config.vpci_devices.push(VpciDeviceConfig {
+                                vtl: ctrl.vtl,
+                                instance_id,
+                                resource: NvmeControllerHandle {
+                                    subsystem_id,
+                                    namespaces: ctrl.namespaces,
+                                    max_io_queues: 64,
+                                    msix_count: 64,
+                                    requests: ctrl.requests,
+                                }
+                                .into_resource(),
+                            });
+
+                            // Tell UEFI to try to enumerate VPCI devices since there
+                            // might be an NVMe namespace to boot from.
+                            if let LoadMode::Uefi {
+                                enable_vpci_boot: vpci_boot,
+                                ..
+                            } = &mut config.load_mode
+                            {
+                                *vpci_boot = true;
+                            }
+                        }
+                    }
+                }
+            }
         }
 
         if !self.vtl0_nvme_namespaces.is_empty() {
@@ -742,53 +817,6 @@ impl StorageBuilder {
                 .into_resource(),
             });
             resources.nvme_vtl2_rpc = Some(send);
-        }
-
-        // Emit named NVMe controllers.
-        for (name, ctrl) in std::mem::take(&mut self.nvme_controllers) {
-            if ctrl.namespaces.is_empty() && ctrl.requests.is_none() {
-                tracing::warn!(name, "named NVMe controller has no namespaces");
-            }
-            let subsystem_id = deterministic_guid(&name);
-            match ctrl.transport {
-                NvmeControllerTransport::Pcie(port_name) => {
-                    config.pcie_devices.push(PcieDeviceConfig {
-                        port_name,
-                        resource: NvmeControllerHandle {
-                            subsystem_id,
-                            namespaces: ctrl.namespaces,
-                            max_io_queues: 64,
-                            msix_count: 64,
-                            requests: ctrl.requests,
-                        }
-                        .into_resource(),
-                    });
-                }
-                NvmeControllerTransport::Vpci(instance_id) => {
-                    config.vpci_devices.push(VpciDeviceConfig {
-                        vtl: ctrl.vtl,
-                        instance_id,
-                        resource: NvmeControllerHandle {
-                            subsystem_id,
-                            namespaces: ctrl.namespaces,
-                            max_io_queues: 64,
-                            msix_count: 64,
-                            requests: ctrl.requests,
-                        }
-                        .into_resource(),
-                    });
-
-                    // Tell UEFI to try to enumerate VPCI devices since there
-                    // might be an NVMe namespace to boot from.
-                    if let LoadMode::Uefi {
-                        enable_vpci_boot: vpci_boot,
-                        ..
-                    } = &mut config.load_mode
-                    {
-                        *vpci_boot = true;
-                    }
-                }
-            }
         }
 
         for (i, vblk) in std::mem::take(&mut self.vtl0_virtio_blk_disks)

--- a/openvmm/openvmm_entry/src/storage_builder.rs
+++ b/openvmm/openvmm_entry/src/storage_builder.rs
@@ -200,7 +200,17 @@ impl StorageBuilder {
     }
 
     pub fn has_vtl0_nvme(&self) -> bool {
-        !self.vtl0_nvme_namespaces.is_empty() || !self.underhill_nvme_luns.is_empty()
+        !self.vtl0_nvme_namespaces.is_empty()
+            || !self.underhill_nvme_luns.is_empty()
+            || self.controllers.values().any(|entry| {
+                matches!(
+                    entry,
+                    ControllerEntry::Nvme(nvme)
+                        if nvme.vtl == DeviceVtl::Vtl0
+                            && matches!(nvme.transport, NvmeControllerTransport::Vpci(_))
+                            && !nvme.namespaces.is_empty()
+                )
+            })
     }
 
     /// Register a named NVMe controller.
@@ -719,9 +729,6 @@ impl StorageBuilder {
                     ));
                 }
                 ControllerEntry::Nvme(ctrl) => {
-                    if ctrl.namespaces.is_empty() && ctrl.requests.is_none() {
-                        tracing::warn!(name, "named NVMe controller has no namespaces");
-                    }
                     let subsystem_id = deterministic_guid(&name);
                     match ctrl.transport {
                         NvmeControllerTransport::Pcie(port_name) => {

--- a/openvmm/openvmm_entry/src/storage_builder.rs
+++ b/openvmm/openvmm_entry/src/storage_builder.rs
@@ -14,6 +14,7 @@ use ide_resources::IdeDeviceConfig;
 use ide_resources::IdePath;
 use nvme_resources::NamespaceDefinition;
 use nvme_resources::NvmeControllerHandle;
+use nvme_resources::NvmeControllerRequest;
 use openvmm_defs::config::Config;
 use openvmm_defs::config::DeviceVtl;
 use openvmm_defs::config::LoadMode;
@@ -34,13 +35,93 @@ use vtl2_settings_proto::Lun;
 use vtl2_settings_proto::StorageController;
 use vtl2_settings_proto::storage_controller;
 
+/// Namespace GUID for deriving deterministic GUIDs from controller names.
+/// This is hashed together with the name via SHA-256 to produce a UUIDv8.
+const OPENVMM_CONTROLLER_NS: Guid = guid::guid!("a3f1e2d4-5b6c-4a8d-9e0f-1234567890ab");
+
+/// Derive a deterministic GUID from a name string using UUIDv8 (RFC 9562
+/// §5.8) with SHA-256. The result is stable across Rust versions and
+/// process restarts for the same input name.
+pub(super) fn deterministic_guid(name: &str) -> Guid {
+    use sha2::Digest;
+    let mut hasher = sha2::Sha256::new();
+    hasher.update(OPENVMM_CONTROLLER_NS.data1.to_le_bytes());
+    hasher.update(OPENVMM_CONTROLLER_NS.data2.to_le_bytes());
+    hasher.update(OPENVMM_CONTROLLER_NS.data3.to_le_bytes());
+    hasher.update(OPENVMM_CONTROLLER_NS.data4);
+    hasher.update(name.as_bytes());
+    let hash = hasher.finalize();
+    let b = &hash[..16];
+    Guid {
+        data1: u32::from_le_bytes([b[0], b[1], b[2], b[3]]),
+        data2: u16::from_le_bytes([b[4], b[5]]),
+        // Version 8
+        data3: u16::from_le_bytes([b[6], b[7]]) & 0x0fff | 0x8000,
+        data4: {
+            let mut d = [b[8], b[9], b[10], b[11], b[12], b[13], b[14], b[15]];
+            // Variant 10
+            d[0] = (d[0] & 0x3f) | 0x80;
+            d
+        },
+    }
+}
+
+/// Transport for a named NVMe controller.
+#[derive(Clone, PartialEq)]
+pub enum NvmeControllerTransport {
+    /// PCIe under a specific root port name.
+    Pcie(String),
+    /// VPCI with a specific instance GUID.
+    Vpci(Guid),
+}
+
+struct NvmeControllerEntry {
+    vtl: DeviceVtl,
+    transport: NvmeControllerTransport,
+    namespaces: Vec<NamespaceDefinition>,
+    /// Optional pre-created channel for runtime namespace add/remove.
+    requests: Option<mesh::Receiver<NvmeControllerRequest>>,
+}
+
+struct ScsiControllerEntry {
+    vtl: DeviceVtl,
+    instance_id: Guid,
+    sub_channels: u16,
+    devices: Vec<ScsiDeviceAndPath>,
+}
+
+/// Protocol type for an OpenHCL-managed controller.
+#[derive(Copy, Clone, PartialEq)]
+pub enum OpenhclControllerType {
+    Scsi,
+    Nvme,
+}
+
+struct OpenhclControllerEntry {
+    controller_type: OpenhclControllerType,
+    instance_id: Guid,
+    luns: Vec<Lun>,
+}
+
+/// Relay target for a disk routed through OpenHCL.
+#[derive(Clone)]
+pub struct RelayTarget {
+    /// Name of the OpenHCL controller to expose the disk on.
+    pub controller: String,
+    /// Location on the target controller (LUN for SCSI, NSID for NVMe).
+    /// Auto-assigned if `None`.
+    pub location: Option<u32>,
+}
+
 pub(super) struct StorageBuilder {
     vtl0_ide_disks: Vec<IdeDeviceConfig>,
     vtl0_scsi_devices: Vec<ScsiDeviceAndPath>,
     vtl2_scsi_devices: Vec<ScsiDeviceAndPath>,
     vtl0_nvme_namespaces: Vec<NamespaceDefinition>,
     vtl2_nvme_namespaces: Vec<NamespaceDefinition>,
-    pcie_nvme_controllers: BTreeMap<String, Vec<NamespaceDefinition>>,
+    nvme_controllers: BTreeMap<String, NvmeControllerEntry>,
+    scsi_controllers: BTreeMap<String, ScsiControllerEntry>,
+    openhcl_controllers: BTreeMap<String, OpenhclControllerEntry>,
     pcie_virtio_blk_disks: Vec<(String, VirtioBlkDisk)>,
     underhill_scsi_luns: Vec<Lun>,
     underhill_nvme_luns: Vec<Lun>,
@@ -56,8 +137,16 @@ struct VirtioBlkDisk {
 #[derive(Clone)]
 pub enum DiskLocation {
     Ide(Option<u8>, Option<u8>),
+    /// Implicit VTL0/VTL2 SCSI controller.
     Scsi(Option<u8>),
-    Nvme(Option<u32>, Option<String>),
+    /// Implicit VTL0/VTL2 VPCI NVMe controller.
+    Nvme(Option<u32>),
+    /// Named controller (NVMe or SCSI, resolved by name at add time).
+    Named {
+        controller: String,
+        nsid: Option<u32>,
+        lun: Option<u8>,
+    },
     VirtioBlk(Option<String>),
 }
 
@@ -65,7 +154,7 @@ impl From<UnderhillDiskSource> for DiskLocation {
     fn from(value: UnderhillDiskSource) -> Self {
         match value {
             UnderhillDiskSource::Scsi => Self::Scsi(None),
-            UnderhillDiskSource::Nvme => Self::Nvme(None, None),
+            UnderhillDiskSource::Nvme => Self::Nvme(None),
         }
     }
 }
@@ -82,29 +171,6 @@ pub const SCSI_VTL2_INSTANCE_ID: Guid = guid::guid!("73d3aa59-b82b-4fe7-9e15-e2b
 pub const UNDERHILL_VTL0_SCSI_INSTANCE: Guid = guid::guid!("e1c5bd94-d0d6-41d4-a2b0-88095a16ded7");
 const UNDERHILL_VTL0_NVME_INSTANCE: Guid = guid::guid!("09a59b81-2bf6-4164-81d7-3a0dc977ba65");
 
-// PCIe controllers don't have VMBUS channel instance IDs the way VPCI
-// enumerated controllers do but we still need to present different
-// subsystem IDs to the guest and we want those to be somewhat reliable.
-// Just hardcode a bunch for now.
-const PCIE_NVME_SUBSYSTEM_IDS: [Guid; 16] = [
-    guid::guid!("55bfb22d-3f6c-4d5a-8ed8-d779dbdae6b8"),
-    guid::guid!("6e4fbff0-eefc-4982-9e09-faf2f185701e"),
-    guid::guid!("5f429e81-06e4-4a5f-8763-1f589ce51f9d"),
-    guid::guid!("9732c737-d78a-4c29-bc8c-72664b8fe970"),
-    guid::guid!("8b561a94-6e13-4449-8b69-f37995b66a51"),
-    guid::guid!("a17a3e14-9f12-426b-b48a-49c397cc0e5e"),
-    guid::guid!("6e26115c-df74-432b-82a2-ced14fa80fa3"),
-    guid::guid!("00335fd5-0967-45bf-abd0-1d2f46ab6f92"),
-    guid::guid!("aeb1f8a9-f9e1-4177-84e2-3a31a73b57da"),
-    guid::guid!("1a95b8bd-353e-41ff-8420-32c4173ef296"),
-    guid::guid!("02613c53-23d1-4c0a-b3ab-90e8dc1bcec2"),
-    guid::guid!("c95d1f3f-a89f-4727-bc16-6be1cbeed1ec"),
-    guid::guid!("b2ded1f0-7a13-4c2a-83bd-d0156e3867a9"),
-    guid::guid!("7f3ac17d-667f-470c-a441-6adcea9164a1"),
-    guid::guid!("ca7d41a4-0337-47ee-990e-23140e652f47"),
-    guid::guid!("5864e1e4-bb70-40d2-900c-2128034960d2"),
-];
-
 /// Template GUID for virtio-blk VPCI instance IDs. `data1` is set to the
 /// disk index to produce a unique ID per device. The remaining fields are
 /// an arbitrarily generated fixed value.
@@ -118,7 +184,9 @@ impl StorageBuilder {
             vtl2_scsi_devices: Vec::new(),
             vtl0_nvme_namespaces: Vec::new(),
             vtl2_nvme_namespaces: Vec::new(),
-            pcie_nvme_controllers: BTreeMap::new(),
+            nvme_controllers: BTreeMap::new(),
+            scsi_controllers: BTreeMap::new(),
+            openhcl_controllers: BTreeMap::new(),
             pcie_virtio_blk_disks: Vec::new(),
             underhill_scsi_luns: Vec::new(),
             underhill_nvme_luns: Vec::new(),
@@ -131,10 +199,78 @@ impl StorageBuilder {
         !self.vtl0_nvme_namespaces.is_empty() || !self.underhill_nvme_luns.is_empty()
     }
 
+    /// Register a named NVMe controller.
+    pub fn add_nvme_controller(
+        &mut self,
+        name: String,
+        vtl: DeviceVtl,
+        transport: NvmeControllerTransport,
+        requests: Option<mesh::Receiver<NvmeControllerRequest>>,
+    ) -> anyhow::Result<()> {
+        if self.nvme_controllers.contains_key(&name) {
+            anyhow::bail!("duplicate NVMe controller name: '{name}'");
+        }
+        self.nvme_controllers.insert(
+            name,
+            NvmeControllerEntry {
+                vtl,
+                transport,
+                namespaces: Vec::new(),
+                requests,
+            },
+        );
+        Ok(())
+    }
+
+    /// Register a named SCSI controller.
+    pub fn add_scsi_controller(
+        &mut self,
+        name: String,
+        vtl: DeviceVtl,
+        instance_id: Guid,
+        sub_channels: u16,
+    ) -> anyhow::Result<()> {
+        if self.scsi_controllers.contains_key(&name) {
+            anyhow::bail!("duplicate SCSI controller name: '{name}'");
+        }
+        self.scsi_controllers.insert(
+            name,
+            ScsiControllerEntry {
+                vtl,
+                instance_id,
+                sub_channels,
+                devices: Vec::new(),
+            },
+        );
+        Ok(())
+    }
+
+    /// Register an OpenHCL-managed controller (relay target).
+    pub fn add_openhcl_controller(
+        &mut self,
+        name: String,
+        controller_type: OpenhclControllerType,
+        instance_id: Guid,
+    ) -> anyhow::Result<()> {
+        if self.openhcl_controllers.contains_key(&name) {
+            anyhow::bail!("duplicate OpenHCL controller name: '{name}'");
+        }
+        self.openhcl_controllers.insert(
+            name,
+            OpenhclControllerEntry {
+                controller_type,
+                instance_id,
+                luns: Vec::new(),
+            },
+        );
+        Ok(())
+    }
+
     pub async fn add(
         &mut self,
         vtl: DeviceVtl,
         underhill: Option<UnderhillDiskSource>,
+        relay: Option<RelayTarget>,
         target: DiskLocation,
         kind: &DiskCliKind,
         is_dvd: bool,
@@ -142,9 +278,12 @@ impl StorageBuilder {
     ) -> anyhow::Result<()> {
         if let Some(source) = underhill {
             if vtl != DeviceVtl::Vtl0 {
-                anyhow::bail!("underhill can only offer devices to vtl0");
+                anyhow::bail!("OpenHCL relay can only offer devices to VTL0");
             }
             self.add_underhill(source.into(), target, kind, is_dvd, read_only)
+                .await?;
+        } else if let Some(relay) = relay {
+            self.add_relay(relay, target, kind, is_dvd, read_only)
                 .await?;
         } else {
             self.add_inner(vtl, target, kind, is_dvd, read_only).await?;
@@ -238,18 +377,11 @@ impl StorageBuilder {
                 });
                 Some(lun.into())
             }
-            DiskLocation::Nvme(nsid, pcie_port) => {
-                let namespaces = match (vtl, pcie_port) {
-                    // VPCI
-                    (DeviceVtl::Vtl0, None) => &mut self.vtl0_nvme_namespaces,
-                    (DeviceVtl::Vtl1, None) => anyhow::bail!("vtl1 vpci unsupported"),
-                    (DeviceVtl::Vtl2, None) => &mut self.vtl2_nvme_namespaces,
-                    // PCIe
-                    (DeviceVtl::Vtl0, Some(port)) => {
-                        self.pcie_nvme_controllers.entry(port).or_default()
-                    }
-                    (DeviceVtl::Vtl1, Some(_)) => anyhow::bail!("vtl1 pcie unsupported"),
-                    (DeviceVtl::Vtl2, Some(_)) => anyhow::bail!("vtl2 pcie unsupported"),
+            DiskLocation::Nvme(nsid) => {
+                let namespaces = match vtl {
+                    DeviceVtl::Vtl0 => &mut self.vtl0_nvme_namespaces,
+                    DeviceVtl::Vtl1 => anyhow::bail!("vtl1 vpci unsupported"),
+                    DeviceVtl::Vtl2 => &mut self.vtl2_nvme_namespaces,
                 };
                 if is_dvd {
                     anyhow::bail!("dvd not supported with nvme");
@@ -261,6 +393,57 @@ impl StorageBuilder {
                     read_only,
                 });
                 Some(nsid)
+            }
+            DiskLocation::Named {
+                controller,
+                nsid,
+                lun,
+            } => {
+                if let Some(nvme) = self.nvme_controllers.get_mut(&controller) {
+                    if lun.is_some() {
+                        anyhow::bail!("`lun` is not valid for NVMe controller '{controller}'");
+                    }
+                    if is_dvd {
+                        anyhow::bail!("dvd not supported with nvme");
+                    }
+                    let nsid = nsid.unwrap_or(nvme.namespaces.len() as u32 + 1);
+                    nvme.namespaces.push(NamespaceDefinition {
+                        nsid,
+                        disk,
+                        read_only,
+                    });
+                    Some(nsid)
+                } else if let Some(scsi) = self.scsi_controllers.get_mut(&controller) {
+                    if nsid.is_some() {
+                        anyhow::bail!("`nsid` is not valid for SCSI controller '{controller}'");
+                    }
+                    let device = if is_dvd {
+                        SimpleScsiDvdHandle {
+                            media: Some(disk),
+                            requests: None,
+                        }
+                        .into_resource()
+                    } else {
+                        SimpleScsiDiskHandle {
+                            disk,
+                            read_only,
+                            parameters: Default::default(),
+                        }
+                        .into_resource()
+                    };
+                    let lun = lun.unwrap_or(scsi.devices.len() as u8);
+                    scsi.devices.push(ScsiDeviceAndPath {
+                        path: ScsiPath {
+                            path: 0,
+                            target: 0,
+                            lun,
+                        },
+                        device,
+                    });
+                    Some(lun.into())
+                } else {
+                    anyhow::bail!("unknown controller: '{controller}'");
+                }
             }
             DiskLocation::VirtioBlk(pcie_port) => {
                 if vtl != DeviceVtl::Vtl0 {
@@ -281,6 +464,84 @@ impl StorageBuilder {
         Ok(location)
     }
 
+    /// Add a disk relayed through OpenHCL. The disk is added to the source
+    /// controller (identified by `target`) and an OpenHCL LUN entry is
+    /// created on the relay target controller.
+    async fn add_relay(
+        &mut self,
+        relay: RelayTarget,
+        target: DiskLocation,
+        kind: &DiskCliKind,
+        is_dvd: bool,
+        read_only: bool,
+    ) -> anyhow::Result<()> {
+        // Look up the source controller to determine VTL and instance ID.
+        let (source_vtl, device_type, device_path) = match &target {
+            DiskLocation::Named { controller, .. } => {
+                if let Some(nvme) = self.nvme_controllers.get(controller) {
+                    let instance_id = match &nvme.transport {
+                        NvmeControllerTransport::Vpci(guid) => *guid,
+                        NvmeControllerTransport::Pcie(_) => {
+                            anyhow::bail!("OpenHCL relay does not support PCIe source controllers");
+                        }
+                    };
+                    (
+                        nvme.vtl,
+                        vtl2_settings_proto::physical_device::DeviceType::Nvme,
+                        instance_id,
+                    )
+                } else if let Some(scsi) = self.scsi_controllers.get(controller) {
+                    (
+                        scsi.vtl,
+                        vtl2_settings_proto::physical_device::DeviceType::Vscsi,
+                        scsi.instance_id,
+                    )
+                } else {
+                    anyhow::bail!("unknown source controller: '{controller}'");
+                }
+            }
+            _ => {
+                anyhow::bail!("`relay` requires a named source controller");
+            }
+        };
+
+        let sub_device_path = self
+            .add_inner(source_vtl, target, kind, is_dvd, read_only)
+            .await?
+            .context("source device not supported by relay")?;
+
+        // Look up the OpenHCL target controller and add the LUN.
+        let openhcl = self
+            .openhcl_controllers
+            .get_mut(&relay.controller)
+            .with_context(|| format!("unknown OpenHCL controller: '{}'", relay.controller))?;
+
+        let location = relay.location.unwrap_or(openhcl.luns.len() as u32);
+
+        openhcl.luns.push(Lun {
+            location,
+            device_id: Guid::new_random().to_string(),
+            vendor_id: "OpenVMM".to_string(),
+            product_id: "Disk".to_string(),
+            product_revision_level: "1.0".to_string(),
+            serial_number: "0".to_string(),
+            model_number: "1".to_string(),
+            physical_devices: Some(vtl2_settings_proto::PhysicalDevices {
+                r#type: vtl2_settings_proto::physical_devices::BackingType::Single.into(),
+                device: Some(vtl2_settings_proto::PhysicalDevice {
+                    device_type: device_type.into(),
+                    device_path: device_path.to_string(),
+                    sub_device_path,
+                }),
+                devices: Vec::new(),
+            }),
+            is_dvd,
+            ..Default::default()
+        });
+
+        Ok(())
+    }
+
     async fn add_underhill(
         &mut self,
         source: DiskLocation,
@@ -289,14 +550,14 @@ impl StorageBuilder {
         is_dvd: bool,
         read_only: bool,
     ) -> anyhow::Result<()> {
-        let vtl = self.openhcl_vtl.context("openhcl not configured")?;
+        let vtl = self.openhcl_vtl.context("OpenHCL not configured")?;
         let sub_device_path = self
             .add_inner(vtl, source.clone(), kind, is_dvd, read_only)
             .await?
-            .context("source device not supported by underhill")?;
+            .context("source device not supported by OpenHCL")?;
 
         let (device_type, device_path) = match source {
-            DiskLocation::Ide(_, _) => anyhow::bail!("ide source not supported for Underhill"),
+            DiskLocation::Ide(_, _) => anyhow::bail!("ide source not supported for OpenHCL"),
             DiskLocation::Scsi(_) => (
                 vtl2_settings_proto::physical_device::DeviceType::Vscsi,
                 if vtl == DeviceVtl::Vtl2 {
@@ -305,10 +566,7 @@ impl StorageBuilder {
                     SCSI_VTL0_INSTANCE_ID
                 },
             ),
-            DiskLocation::Nvme(_, Some(_)) => {
-                anyhow::bail!("underhill does not support consuming pcie")
-            }
-            DiskLocation::Nvme(_, None) => (
+            DiskLocation::Nvme(_) => (
                 vtl2_settings_proto::physical_device::DeviceType::Nvme,
                 if vtl == DeviceVtl::Vtl2 {
                     NVME_VTL2_INSTANCE_ID
@@ -317,28 +575,30 @@ impl StorageBuilder {
                 },
             ),
             DiskLocation::VirtioBlk(_) => {
-                anyhow::bail!("underhill not supported with virtio-blk")
+                anyhow::bail!("OpenHCL relay not supported with virtio-blk")
+            }
+            DiskLocation::Named { .. } => {
+                anyhow::bail!("use `relay` instead of `uh` with named controllers")
             }
         };
 
         let (luns, location) = match target {
-            // TODO: once openvmm supports VTL2 with PCAT VTL0, remove this restriction.
             DiskLocation::Ide(_, _) => {
-                anyhow::bail!("ide target currently not supported for Underhill (no PCAT support)")
+                anyhow::bail!("ide target currently not supported for OpenHCL (no PCAT support)")
             }
             DiskLocation::Scsi(lun) => {
                 let lun = lun.unwrap_or(self.underhill_scsi_luns.len() as u8);
                 (&mut self.underhill_scsi_luns, lun.into())
             }
-            DiskLocation::Nvme(_, Some(_)) => {
-                anyhow::bail!("underhill does not support targeting pcie")
-            }
-            DiskLocation::Nvme(nsid, None) => {
+            DiskLocation::Nvme(nsid) => {
                 let nsid = nsid.unwrap_or(self.underhill_nvme_luns.len() as u32 + 1);
                 (&mut self.underhill_nvme_luns, nsid)
             }
             DiskLocation::VirtioBlk(_) => {
-                anyhow::bail!("underhill not supported with virtio-blk")
+                anyhow::bail!("OpenHCL relay not supported with virtio-blk")
+            }
+            DiskLocation::Named { .. } => {
+                anyhow::bail!("use `relay` instead of `uh` with named controllers")
             }
         };
 
@@ -415,6 +675,22 @@ impl StorageBuilder {
             ));
         }
 
+        // Emit named SCSI controllers.
+        for (_name, ctrl) in std::mem::take(&mut self.scsi_controllers) {
+            config.vmbus_devices.push((
+                ctrl.vtl,
+                ScsiControllerHandle {
+                    instance_id: ctrl.instance_id,
+                    max_sub_channel_count: ctrl.sub_channels,
+                    devices: ctrl.devices,
+                    io_queue_depth: None,
+                    requests: None,
+                    poll_mode_queue_depth: None,
+                }
+                .into_resource(),
+            ));
+        }
+
         if !self.vtl0_nvme_namespaces.is_empty() {
             config.vpci_devices.push(VpciDeviceConfig {
                 vtl: DeviceVtl::Vtl0,
@@ -468,28 +744,51 @@ impl StorageBuilder {
             resources.nvme_vtl2_rpc = Some(send);
         }
 
-        let owned_pcie_controllers = std::mem::take(&mut self.pcie_nvme_controllers);
-        if owned_pcie_controllers.len() > PCIE_NVME_SUBSYSTEM_IDS.len() {
-            anyhow::bail!(
-                "too many PCIe nvme controllers, max supported: {}",
-                PCIE_NVME_SUBSYSTEM_IDS.len()
-            );
-        }
-        for ((port_name, namespaces), subsystem_id) in owned_pcie_controllers
-            .into_iter()
-            .zip(PCIE_NVME_SUBSYSTEM_IDS)
-        {
-            config.pcie_devices.push(PcieDeviceConfig {
-                port_name,
-                resource: NvmeControllerHandle {
-                    subsystem_id,
-                    namespaces,
-                    max_io_queues: 64,
-                    msix_count: 64,
-                    requests: None,
+        // Emit named NVMe controllers.
+        for (name, ctrl) in std::mem::take(&mut self.nvme_controllers) {
+            if ctrl.namespaces.is_empty() && ctrl.requests.is_none() {
+                tracing::warn!(name, "named NVMe controller has no namespaces");
+            }
+            let subsystem_id = deterministic_guid(&name);
+            match ctrl.transport {
+                NvmeControllerTransport::Pcie(port_name) => {
+                    config.pcie_devices.push(PcieDeviceConfig {
+                        port_name,
+                        resource: NvmeControllerHandle {
+                            subsystem_id,
+                            namespaces: ctrl.namespaces,
+                            max_io_queues: 64,
+                            msix_count: 64,
+                            requests: ctrl.requests,
+                        }
+                        .into_resource(),
+                    });
                 }
-                .into_resource(),
-            });
+                NvmeControllerTransport::Vpci(instance_id) => {
+                    config.vpci_devices.push(VpciDeviceConfig {
+                        vtl: ctrl.vtl,
+                        instance_id,
+                        resource: NvmeControllerHandle {
+                            subsystem_id,
+                            namespaces: ctrl.namespaces,
+                            max_io_queues: 64,
+                            msix_count: 64,
+                            requests: ctrl.requests,
+                        }
+                        .into_resource(),
+                    });
+
+                    // Tell UEFI to try to enumerate VPCI devices since there
+                    // might be an NVMe namespace to boot from.
+                    if let LoadMode::Uefi {
+                        enable_vpci_boot: vpci_boot,
+                        ..
+                    } = &mut config.load_mode
+                    {
+                        *vpci_boot = true;
+                    }
+                }
+            }
         }
 
         for (i, vblk) in std::mem::take(&mut self.vtl0_virtio_blk_disks)
@@ -531,28 +830,40 @@ impl StorageBuilder {
 
     /// Generate VTL2 settings for storage devices offered to the guest via
     /// OpenHCL.
-    pub fn build_underhill(&self, vmbus_redirect: bool) -> Vec<StorageController> {
+    pub fn build_openhcl_settings(&mut self, vmbus_redirect: bool) -> Vec<StorageController> {
         let mut storage_controllers = Vec::new();
-        // Only create a SCSI controller if there are LUNs configured, or if
-        // vmbus redirection is enabled (to allow hot-plugging at runtime).
+
+        // Legacy implicit controllers.
         if !self.underhill_scsi_luns.is_empty() || vmbus_redirect {
-            let controller = StorageController {
+            storage_controllers.push(StorageController {
                 instance_id: UNDERHILL_VTL0_SCSI_INSTANCE.to_string(),
                 protocol: storage_controller::StorageProtocol::Scsi.into(),
-                luns: self.underhill_scsi_luns.clone(),
+                luns: std::mem::take(&mut self.underhill_scsi_luns),
                 io_queue_depth: None,
-            };
-            storage_controllers.push(controller);
+            });
         }
 
         if !self.underhill_nvme_luns.is_empty() {
-            let controller = StorageController {
+            storage_controllers.push(StorageController {
                 instance_id: UNDERHILL_VTL0_NVME_INSTANCE.to_string(),
                 protocol: storage_controller::StorageProtocol::Nvme.into(),
-                luns: self.underhill_nvme_luns.clone(),
+                luns: std::mem::take(&mut self.underhill_nvme_luns),
                 io_queue_depth: None,
+            });
+        }
+
+        // Named OpenHCL controllers.
+        for (_name, ctrl) in std::mem::take(&mut self.openhcl_controllers) {
+            let protocol = match ctrl.controller_type {
+                OpenhclControllerType::Scsi => storage_controller::StorageProtocol::Scsi,
+                OpenhclControllerType::Nvme => storage_controller::StorageProtocol::Nvme,
             };
-            storage_controllers.push(controller);
+            storage_controllers.push(StorageController {
+                instance_id: ctrl.instance_id.to_string(),
+                protocol: protocol.into(),
+                luns: ctrl.luns,
+                io_queue_depth: None,
+            });
         }
 
         storage_controllers


### PR DESCRIPTION
The existing `--disk` and `--nvme` flags use implicit, unnamed controllers whose identity and VTL are determined by convention. This makes it impossible to precisely control controller placement, and the OpenHCL relay path (`uh`/`uh-nvme`) is tightly coupled to hardcoded instance IDs.

This PR introduces explicit, named controller management:

- `--nvme-pci id=<name>,pcie_port=<port>|vpci[=<guid>][,vtl2]` creates a named NVMe controller with an explicit transport and VTL. Accepts an optional pre-created mesh channel for runtime hot-plug.

- `--vmbus-scsi id=<name>[,sub_channels=<N>][,vtl2]` creates a named VMBus SCSI controller.

- `--openhcl-controller id=<name>,type=scsi|nvme[,guid=<guid>]` registers an OpenHCL-managed controller as a relay target.

- `--disk` gains `on=<name>`, `nsid=<N>`, `lun=<N>`, and `relay=<ctrl>[:<loc>]` options. `on=` attaches the disk to a named controller (NVMe or SCSI, resolved by type at add time). `relay=` routes the disk through OpenHCL to the named target controller, replacing the `uh`/`uh-nvme` mechanism for new usage.

The storage builder is refactored to support these named controllers alongside the existing implicit paths.

`--disk` without `on=`, `--nvme`, and `uh`/`uh-nvme` are deprecated with warnings pointing to the new flags. `build_underhill` is renamed to `build_openhcl_settings`.

Guide documentation is updated throughout to use the new CLI syntax in examples.