### PR TITLE
pci_resource_assignment: size, assign, and program VF BARs

### DIFF
--- a/vm/devices/pci/pci_core/src/spec.rs
+++ b/vm/devices/pci/pci_core/src/spec.rs
@@ -1228,4 +1228,39 @@ pub mod caps {
             pub dvsec_id: u16,
         }
     }
+
+    /// SR-IOV Extended Capability
+    ///
+    /// Source: PCI Express Base Specification, "Single Root I/O Virtualization"
+    #[expect(missing_docs)] // primarily enums/structs with self-explanatory variants
+    pub mod sriov {
+        open_enum::open_enum! {
+            /// Offsets into the SR-IOV Extended Capability structure.
+            ///
+            /// | Offset    | Bits 31-16              | Bits 15-0               |
+            /// |-----------|-------------------------|-------------------------|
+            /// | Ext + 0x0 | Next Cap Ptr + Version  | Extended Capability ID  |
+            /// | Ext + 0x4 | SR-IOV Control          | SR-IOV Capabilities     |
+            /// | Ext + 0x8 | Total VFs               | Initial VFs             |
+            /// | Ext + 0xC | Num VFs                 | Function Dep Link       |
+            /// | Ext + 0x10| First VF Offset         | VF Stride               |
+            /// | Ext + 0x14| VF Device ID            | Reserved                |
+            /// | Ext + 0x18| Supported Page Sizes                              |
+            /// | Ext + 0x1C| System Page Size                                  |
+            /// | Ext + 0x20| VF BAR0                                           |
+            /// | Ext + 0x24| VF BAR1                                           |
+            /// | Ext + 0x28| VF BAR2                                           |
+            /// | Ext + 0x2C| VF BAR3                                           |
+            /// | Ext + 0x30| VF BAR4                                           |
+            /// | Ext + 0x34| VF BAR5                                           |
+            /// | Ext + 0x38| VF Migration State Array Offset                   |
+            pub enum SriovExtendedCapabilityHeader: u16 {
+                HEADER = 0x00,
+                CAPS_CONTROL = 0x04,
+                INITIAL_TOTAL_VFS = 0x0C,
+                VF_OFFSET_STRIDE = 0x14,
+                VF_BAR0 = 0x24,
+            }
+        }
+    }
 }

--- a/vm/devices/pci/pci_resource_assignment/src/assign.rs
+++ b/vm/devices/pci/pci_resource_assignment/src/assign.rs
@@ -304,7 +304,10 @@ fn assign_subtree(
         /// addresses via the SR-IOV capability registers, so no explicit BAR
         /// assignment is made, but the space must be accounted for in the
         /// bridge window.
-        SriovVfBars,
+        SriovVfBars {
+            /// Per-VF BAR size (alignment requirement).
+            alignment: u64,
+        },
     }
 
     let mut demands: Vec<(u64, Demand)> = Vec::new();
@@ -328,7 +331,12 @@ fn assign_subtree(
             for bar in &sriov.vf_bars {
                 if is_mem64_bar(bar) == alloc_64bit {
                     let total_size = bar.size * sriov.total_vfs as u64;
-                    demands.push((total_size, Demand::SriovVfBars));
+                    demands.push((
+                        total_size,
+                        Demand::SriovVfBars {
+                            alignment: bar.size,
+                        },
+                    ));
                 }
             }
         }
@@ -358,7 +366,8 @@ fn assign_subtree(
     // produce consistent results.
     demands.sort_by_key(|d| {
         let alignment = match &d.1 {
-            Demand::Bar { .. } | Demand::SriovVfBars => d.0,
+            Demand::Bar { .. } => d.0,
+            Demand::SriovVfBars { alignment, .. } => *alignment,
             Demand::BridgeSubtree { alignment, .. } => *alignment,
         };
         std::cmp::Reverse(alignment)
@@ -371,7 +380,8 @@ fn assign_subtree(
         // Bridge subtrees are aligned to the max of bridge window
         // granularity and the largest internal alignment requirement.
         let alignment = match demand {
-            Demand::Bar { .. } | Demand::SriovVfBars => *size,
+            Demand::Bar { .. } => *size,
+            Demand::SriovVfBars { alignment, .. } => *alignment,
             Demand::BridgeSubtree { alignment, .. } => *alignment,
         };
         offset = align_up(offset, alignment);
@@ -411,7 +421,7 @@ fn assign_subtree(
                 // Recurse into children with this bridge's carved-out range.
                 assign_subtree(&dev.children, alloc_64bit, offset, entries);
             }
-            Demand::SriovVfBars => {
+            Demand::SriovVfBars { .. } => {
                 // VF BAR space is reserved but not explicitly assigned.
                 // The guest programs VF BAR addresses through the SR-IOV
                 // capability registers.

--- a/vm/devices/pci/pci_resource_assignment/src/assign.rs
+++ b/vm/devices/pci/pci_resource_assignment/src/assign.rs
@@ -57,6 +57,68 @@ pub(crate) struct SubtreeRequirement {
     align32: u64,
     /// Required alignment for the mem64 pool.
     align64: u64,
+    /// Sorted demands for this level's devices, used by the assignment
+    /// pass to avoid recomputing them.
+    demands: Vec<Demand>,
+}
+
+/// A single resource demand at one level of the PCI tree.
+///
+/// Shared between the sizing pass (which sums sizes) and the assignment
+/// pass (which bump-allocates addresses).
+#[derive(Debug, Clone)]
+enum Demand {
+    /// An endpoint BAR.
+    Bar {
+        dev_idx: usize,
+        bar_index: u8,
+        size: u64,
+        is_64bit: bool,
+        is_mem64: bool,
+    },
+    /// A bridge's child subtree window.
+    BridgeSubtree {
+        dev_idx: usize,
+        /// Aligned size of the bridge window.
+        size: u64,
+        alignment: u64,
+        is_mem64: bool,
+    },
+    /// VF BAR space — reserved for SR-IOV VFs.
+    SriovVfBars {
+        /// Total size (per-VF BAR size * total_vfs).
+        size: u64,
+        /// Per-VF BAR size (alignment requirement).
+        alignment: u64,
+        is_mem64: bool,
+    },
+}
+
+impl Demand {
+    fn size(&self) -> u64 {
+        match self {
+            Demand::Bar { size, .. }
+            | Demand::BridgeSubtree { size, .. }
+            | Demand::SriovVfBars { size, .. } => *size,
+        }
+    }
+
+    fn alignment(&self) -> u64 {
+        match self {
+            Demand::Bar { size, .. } => *size, // BARs are naturally aligned
+            Demand::BridgeSubtree { alignment, .. } | Demand::SriovVfBars { alignment, .. } => {
+                *alignment
+            }
+        }
+    }
+
+    fn is_mem64(&self) -> bool {
+        match self {
+            Demand::Bar { is_mem64, .. }
+            | Demand::BridgeSubtree { is_mem64, .. }
+            | Demand::SriovVfBars { is_mem64, .. } => *is_mem64,
+        }
+    }
 }
 
 /// Assign addresses to all discovered devices.
@@ -118,7 +180,7 @@ pub fn assign_addresses(
             });
         }
 
-        assign_subtree(devices, false, base, &mut entries);
+        assign_subtree(devices, &root_req.demands, false, base, &mut entries);
 
         mem32_end = Some(base + root_req.mem32);
     }
@@ -152,7 +214,7 @@ pub fn assign_addresses(
             });
         }
 
-        assign_subtree(devices, true, base, &mut entries);
+        assign_subtree(devices, &root_req.demands, true, base, &mut entries);
     }
 
     let result = AssignmentResult { entries };
@@ -191,32 +253,19 @@ fn is_mem64_bar(bar: &crate::enumerate::DiscoveredBar) -> bool {
 
 /// Bottom-up: compute the total aligned resource requirement for a list
 /// of devices (which may be the root level or children behind a bridge).
+///
+/// Also builds and stores the sorted demand list so that `assign_subtree`
+/// can reuse it without recomputing.
 fn compute_subtree_requirement(devices: &mut [DiscoveredDevice]) -> SubtreeRequirement {
-    let mut mem32: u64 = 0;
-    let mut mem64: u64 = 0;
-
-    // Track the required alignment for each pool. This is the maximum of
-    // BRIDGE_WINDOW_ALIGN and the largest BAR (or nested bridge alignment)
-    // in the subtree — the parent must place this subtree at an address
-    // aligned to this value so that internal bump allocation matches the
-    // sizing computed here (which starts from zero, where all alignments
-    // are trivially satisfied).
-    let mut align32: u64 = BRIDGE_WINDOW_ALIGN;
-    let mut align64: u64 = BRIDGE_WINDOW_ALIGN;
-
-    struct Demand {
-        size: u64,
-        alignment: u64,
-        is_mem64: bool,
-    }
-
     let mut demands: Vec<Demand> = Vec::new();
 
-    for dev in devices {
+    for (i, dev) in devices.iter_mut().enumerate() {
         for bar in &dev.bars {
-            demands.push(Demand {
+            demands.push(Demand::Bar {
+                dev_idx: i,
+                bar_index: bar.index,
                 size: bar.size,
-                alignment: bar.size, // BARs are naturally aligned
+                is_64bit: bar.is_64bit,
                 is_mem64: is_mem64_bar(bar),
             });
         }
@@ -225,7 +274,7 @@ fn compute_subtree_requirement(devices: &mut [DiscoveredDevice]) -> SubtreeRequi
         if let Some(sriov) = &dev.sriov {
             for bar in &sriov.vf_bars {
                 let total_size = bar.size.saturating_mul(sriov.total_vfs as u64);
-                demands.push(Demand {
+                demands.push(Demand::SriovVfBars {
                     size: total_size,
                     // VF BAR region base must be aligned to per-VF BAR size
                     // (each VF's BAR is at base + n * bar_size).
@@ -239,7 +288,8 @@ fn compute_subtree_requirement(devices: &mut [DiscoveredDevice]) -> SubtreeRequi
             let child_req = compute_subtree_requirement(&mut dev.children);
             if child_req.mem32 > 0 {
                 let size = align_up(child_req.mem32, BRIDGE_WINDOW_ALIGN);
-                demands.push(Demand {
+                demands.push(Demand::BridgeSubtree {
+                    dev_idx: i,
                     size,
                     alignment: child_req.align32,
                     is_mem64: false,
@@ -247,7 +297,8 @@ fn compute_subtree_requirement(devices: &mut [DiscoveredDevice]) -> SubtreeRequi
             }
             if child_req.mem64 > 0 {
                 let size = align_up(child_req.mem64, BRIDGE_WINDOW_ALIGN);
-                demands.push(Demand {
+                demands.push(Demand::BridgeSubtree {
+                    dev_idx: i,
                     size,
                     alignment: child_req.align64,
                     is_mem64: true,
@@ -257,23 +308,25 @@ fn compute_subtree_requirement(devices: &mut [DiscoveredDevice]) -> SubtreeRequi
         }
     }
 
-    // Sum with proper alignment, largest-alignment-first within each pool.
-    // Placing the most alignment-demanding items first minimizes padding
-    // waste, since the offset is most likely well-aligned at the start.
-    let mut demands_32: Vec<&Demand> = demands.iter().filter(|d| !d.is_mem64).collect();
-    let mut demands_64: Vec<&Demand> = demands.iter().filter(|d| d.is_mem64).collect();
-    demands_32.sort_by_key(|d| std::cmp::Reverse(d.alignment));
-    demands_64.sort_by_key(|d| std::cmp::Reverse(d.alignment));
+    // Sum with proper alignment, largest-alignment-first. Placing the most
+    // alignment-demanding items first minimizes padding waste.
+    demands.sort_by_key(|d| std::cmp::Reverse(d.alignment()));
 
-    for d in &demands_32 {
-        mem32 = align_up(mem32, d.alignment);
-        mem32 += d.size;
-        align32 = align32.max(d.alignment);
-    }
-    for d in &demands_64 {
-        mem64 = align_up(mem64, d.alignment);
-        mem64 += d.size;
-        align64 = align64.max(d.alignment);
+    let mut mem32: u64 = 0;
+    let mut mem64: u64 = 0;
+    let mut align32 = BRIDGE_WINDOW_ALIGN;
+    let mut align64 = BRIDGE_WINDOW_ALIGN;
+
+    for d in &demands {
+        if d.is_mem64() {
+            mem64 = align_up(mem64, d.alignment());
+            mem64 += d.size();
+            align64 = align64.max(d.alignment());
+        } else {
+            mem32 = align_up(mem32, d.alignment());
+            mem32 += d.size();
+            align32 = align32.max(d.alignment());
+        }
     }
 
     SubtreeRequirement {
@@ -281,124 +334,40 @@ fn compute_subtree_requirement(devices: &mut [DiscoveredDevice]) -> SubtreeRequi
         mem64,
         align32,
         align64,
+        demands,
     }
 }
 
 /// Top-down: assign addresses to devices within a subtree, carving from
 /// the given base address. `alloc_64bit` selects which pool (mem32 or
 /// mem64) we are assigning.
+///
+/// `demands` is the pre-sorted demand list built by `compute_subtree_requirement`.
 fn assign_subtree(
     devices: &mut [DiscoveredDevice],
+    demands: &[Demand],
     alloc_64bit: bool,
     base: u64,
     entries: &mut Vec<AssignmentEntry>,
 ) {
-    // Collect all demands at this level as (size, device_index, kind).
-    // Kind distinguishes endpoint BARs from bridge subtree requirements.
-    enum Demand {
-        Bar {
-            dev_idx: usize,
-            bar_index: u8,
-            is_64bit: bool,
-        },
-        BridgeSubtree {
-            dev_idx: usize,
-            alignment: u64,
-        },
-        /// VF BAR space — reserved for SR-IOV VFs. The guest programs VF BAR
-        /// addresses via the SR-IOV capability registers, so no explicit BAR
-        /// assignment is made, but the space must be accounted for in the
-        /// bridge window.
-        SriovVfBars {
-            /// Per-VF BAR size (alignment requirement).
-            alignment: u64,
-        },
-    }
-
-    let mut demands: Vec<(u64, Demand)> = Vec::new();
-
-    for (i, dev) in devices.iter().enumerate() {
-        for bar in &dev.bars {
-            if is_mem64_bar(bar) == alloc_64bit {
-                demands.push((
-                    bar.size,
-                    Demand::Bar {
-                        dev_idx: i,
-                        bar_index: bar.index,
-                        is_64bit: bar.is_64bit,
-                    },
-                ));
-            }
-        }
-
-        // SR-IOV VF BARs: reserve total space in the bridge window.
-        if let Some(sriov) = &dev.sriov {
-            for bar in &sriov.vf_bars {
-                if is_mem64_bar(bar) == alloc_64bit {
-                    let total_size = bar.size.saturating_mul(sriov.total_vfs as u64);
-                    demands.push((
-                        total_size,
-                        Demand::SriovVfBars {
-                            alignment: bar.size,
-                        },
-                    ));
-                }
-            }
-        }
-
-        if dev.is_bridge {
-            let child_req = dev
-                .subtree_req
-                .as_ref()
-                .expect("subtree_req must be populated by compute_subtree_requirement");
-            let (size, alignment) = if alloc_64bit {
-                (child_req.mem64, child_req.align64)
-            } else {
-                (child_req.mem32, child_req.align32)
-            };
-            if size > 0 {
-                let aligned = align_up(size, BRIDGE_WINDOW_ALIGN);
-                demands.push((
-                    aligned,
-                    Demand::BridgeSubtree {
-                        dev_idx: i,
-                        alignment,
-                    },
-                ));
-            }
-        }
-    }
-
-    // Sort by alignment descending. This must match the order used in
-    // compute_subtree_requirement so that the sizing and assignment
-    // produce consistent results.
-    demands.sort_by_key(|d| {
-        let alignment = match &d.1 {
-            Demand::Bar { .. } => d.0,
-            Demand::SriovVfBars { alignment, .. } => *alignment,
-            Demand::BridgeSubtree { alignment, .. } => *alignment,
-        };
-        std::cmp::Reverse(alignment)
-    });
-
-    // Bump-allocate.
+    // Bump-allocate from the pre-sorted demands, skipping demands that
+    // belong to the other pool.
     let mut offset = base;
-    for &(size, ref demand) in &demands {
-        // BARs are naturally aligned to their size (always a power of two).
-        // Bridge subtrees are aligned to the max of bridge window
-        // granularity and the largest internal alignment requirement.
-        let alignment = match *demand {
-            Demand::Bar { .. } => size,
-            Demand::SriovVfBars { alignment, .. } => alignment,
-            Demand::BridgeSubtree { alignment, .. } => alignment,
-        };
-        offset = align_up(offset, alignment);
+    for demand in demands {
+        if demand.is_mem64() != alloc_64bit {
+            continue;
+        }
+
+        let size = demand.size();
+        offset = align_up(offset, demand.alignment());
 
         match *demand {
             Demand::Bar {
                 dev_idx,
                 bar_index,
+                size,
                 is_64bit,
+                ..
             } => {
                 let dev = &devices[dev_idx];
                 let entry = find_or_create_entry(entries, dev.bus, dev.device, dev.function);
@@ -409,7 +378,7 @@ fn assign_subtree(
                     is_64bit,
                 });
             }
-            Demand::BridgeSubtree { dev_idx, .. } => {
+            Demand::BridgeSubtree { dev_idx, size, .. } => {
                 let dev = &mut devices[dev_idx];
                 let entry = find_or_create_entry(entries, dev.bus, dev.device, dev.function);
                 entry.secondary_bus = dev.secondary_bus;
@@ -427,7 +396,18 @@ fn assign_subtree(
                 }
 
                 // Recurse into children with this bridge's carved-out range.
-                assign_subtree(&mut dev.children, alloc_64bit, offset, entries);
+                let child_demands = &dev
+                    .subtree_req
+                    .as_ref()
+                    .expect("subtree_req must be populated by compute_subtree_requirement")
+                    .demands;
+                assign_subtree(
+                    &mut dev.children,
+                    child_demands,
+                    alloc_64bit,
+                    offset,
+                    entries,
+                );
             }
             Demand::SriovVfBars { .. } => {
                 // VF BAR space is reserved but not explicitly assigned.
@@ -441,7 +421,7 @@ fn assign_subtree(
 
     // Ensure bridge entries exist even if they have no BARs in this pool
     // (needed for bridges that only have resources in the other pool).
-    for dev in devices {
+    for dev in &*devices {
         if dev.is_bridge {
             let entry = find_or_create_entry(entries, dev.bus, dev.device, dev.function);
             entry.secondary_bus = dev.secondary_bus;

--- a/vm/devices/pci/pci_resource_assignment/src/assign.rs
+++ b/vm/devices/pci/pci_resource_assignment/src/assign.rs
@@ -220,7 +220,7 @@ fn compute_subtree_requirement(devices: &[DiscoveredDevice]) -> SubtreeRequireme
         // SR-IOV PF: account for VF BAR space (TotalVFs * per-VF BAR size).
         if let Some(sriov) = &dev.sriov {
             for bar in &sriov.vf_bars {
-                let total_size = bar.size * sriov.total_vfs as u64;
+                let total_size = bar.size.saturating_mul(sriov.total_vfs as u64);
                 demands.push(Demand {
                     size: total_size,
                     // VF BAR region base must be aligned to per-VF BAR size

--- a/vm/devices/pci/pci_resource_assignment/src/assign.rs
+++ b/vm/devices/pci/pci_resource_assignment/src/assign.rs
@@ -217,6 +217,20 @@ fn compute_subtree_requirement(devices: &[DiscoveredDevice]) -> SubtreeRequireme
             });
         }
 
+        // SR-IOV PF: account for VF BAR space (TotalVFs * per-VF BAR size).
+        if let Some(sriov) = &dev.sriov {
+            for bar in &sriov.vf_bars {
+                let total_size = bar.size * sriov.total_vfs as u64;
+                demands.push(Demand {
+                    size: total_size,
+                    // VF BAR region base must be aligned to per-VF BAR size
+                    // (each VF's BAR is at base + n * bar_size).
+                    alignment: bar.size,
+                    is_mem64: is_mem64_bar(bar),
+                });
+            }
+        }
+
         if dev.is_bridge {
             let child_req = compute_subtree_requirement(&dev.children);
             if child_req.mem32 > 0 {
@@ -286,6 +300,11 @@ fn assign_subtree(
             dev_idx: usize,
             alignment: u64,
         },
+        /// VF BAR space — reserved for SR-IOV VFs. The guest programs VF BAR
+        /// addresses via the SR-IOV capability registers, so no explicit BAR
+        /// assignment is made, but the space must be accounted for in the
+        /// bridge window.
+        SriovVfBars,
     }
 
     let mut demands: Vec<(u64, Demand)> = Vec::new();
@@ -301,6 +320,16 @@ fn assign_subtree(
                         is_64bit: bar.is_64bit,
                     },
                 ));
+            }
+        }
+
+        // SR-IOV VF BARs: reserve total space in the bridge window.
+        if let Some(sriov) = &dev.sriov {
+            for bar in &sriov.vf_bars {
+                if is_mem64_bar(bar) == alloc_64bit {
+                    let total_size = bar.size * sriov.total_vfs as u64;
+                    demands.push((total_size, Demand::SriovVfBars));
+                }
             }
         }
 
@@ -329,7 +358,7 @@ fn assign_subtree(
     // produce consistent results.
     demands.sort_by_key(|d| {
         let alignment = match &d.1 {
-            Demand::Bar { .. } => d.0,
+            Demand::Bar { .. } | Demand::SriovVfBars => d.0,
             Demand::BridgeSubtree { alignment, .. } => *alignment,
         };
         std::cmp::Reverse(alignment)
@@ -342,7 +371,7 @@ fn assign_subtree(
         // Bridge subtrees are aligned to the max of bridge window
         // granularity and the largest internal alignment requirement.
         let alignment = match demand {
-            Demand::Bar { .. } => *size,
+            Demand::Bar { .. } | Demand::SriovVfBars => *size,
             Demand::BridgeSubtree { alignment, .. } => *alignment,
         };
         offset = align_up(offset, alignment);
@@ -381,6 +410,11 @@ fn assign_subtree(
 
                 // Recurse into children with this bridge's carved-out range.
                 assign_subtree(&dev.children, alloc_64bit, offset, entries);
+            }
+            Demand::SriovVfBars => {
+                // VF BAR space is reserved but not explicitly assigned.
+                // The guest programs VF BAR addresses through the SR-IOV
+                // capability registers.
             }
         }
 

--- a/vm/devices/pci/pci_resource_assignment/src/assign.rs
+++ b/vm/devices/pci/pci_resource_assignment/src/assign.rs
@@ -330,7 +330,7 @@ fn assign_subtree(
         if let Some(sriov) = &dev.sriov {
             for bar in &sriov.vf_bars {
                 if is_mem64_bar(bar) == alloc_64bit {
-                    let total_size = bar.size * sriov.total_vfs as u64;
+                    let total_size = bar.size.saturating_mul(sriov.total_vfs as u64);
                     demands.push((
                         total_size,
                         Demand::SriovVfBars {

--- a/vm/devices/pci/pci_resource_assignment/src/assign.rs
+++ b/vm/devices/pci/pci_resource_assignment/src/assign.rs
@@ -3,11 +3,8 @@
 
 //! Phase 2: Bottom-up aperture computation and top-down address assignment.
 
-use crate::AssignmentEntry;
 use crate::AssignmentError;
 use crate::AssignmentParams;
-use crate::AssignmentResult;
-use crate::BarAssignment;
 use crate::PciConfigAccess;
 use crate::enumerate::DiscoveredDevice;
 use pci_core::spec::cfg_space::HeaderType00;
@@ -16,34 +13,6 @@ use pci_core::spec::cfg_space::MEMORY_BASE_LIMIT_ADDRESS_MASK;
 
 /// Bridge memory window granularity: 1 MB.
 const BRIDGE_WINDOW_ALIGN: u64 = 1 << 20;
-
-fn find_or_create_entry(
-    entries: &mut Vec<AssignmentEntry>,
-    bus: u8,
-    device: u8,
-    function: u8,
-) -> &mut AssignmentEntry {
-    let pos = entries
-        .iter()
-        .position(|e| e.bus == bus && e.device == device && e.function == function);
-    if let Some(idx) = pos {
-        &mut entries[idx]
-    } else {
-        entries.push(AssignmentEntry {
-            bus,
-            device,
-            function,
-            bars: Vec::new(),
-            secondary_bus: None,
-            subordinate_bus: None,
-            memory_base: None,
-            memory_limit: None,
-            prefetchable_base: None,
-            prefetchable_limit: None,
-        });
-        entries.last_mut().unwrap()
-    }
-}
 
 /// Resource requirement for a subtree (bridge or root).
 #[derive(Debug, Clone)]
@@ -73,7 +42,6 @@ enum Demand {
         dev_idx: usize,
         bar_index: u8,
         size: u64,
-        is_64bit: bool,
         is_mem64: bool,
     },
     /// A bridge's child subtree window.
@@ -143,9 +111,7 @@ impl Demand {
 pub fn assign_addresses(
     devices: &mut [DiscoveredDevice],
     params: &AssignmentParams,
-) -> Result<AssignmentResult, AssignmentError> {
-    let mut entries = Vec::new();
-
+) -> Result<(), AssignmentError> {
     // Step 1: Bottom-up — compute total resource requirements.
     // This also stores per-bridge requirements on the DiscoveredDevice
     // nodes so that the assignment pass can read them without recomputing.
@@ -180,7 +146,7 @@ pub fn assign_addresses(
             });
         }
 
-        assign_subtree(devices, &root_req.demands, false, base, &mut entries);
+        assign_subtree(devices, &root_req.demands, false, base);
 
         mem32_end = Some(base + root_req.mem32);
     }
@@ -214,37 +180,39 @@ pub fn assign_addresses(
             });
         }
 
-        assign_subtree(devices, &root_req.demands, true, base, &mut entries);
+        assign_subtree(devices, &root_req.demands, true, base);
     }
 
-    let result = AssignmentResult { entries };
-    validate_assignments(&result, params);
-    Ok(result)
+    validate_assignments(devices, params);
+    Ok(())
 }
 
 /// Verify that all assigned BAR addresses fall within the provided apertures.
-fn validate_assignments(result: &AssignmentResult, params: &AssignmentParams) {
-    for entry in &result.entries {
-        for bar in &entry.bars {
-            let bar_end = bar.address + bar.size;
-            let in_low = params
-                .low_mmio
-                .is_some_and(|a| bar.address >= a.base && bar_end <= a.base + a.len);
-            let in_high = params
-                .high_mmio
-                .is_some_and(|a| bar.address >= a.base && bar_end <= a.base + a.len);
-            assert!(
-                in_low || in_high,
-                "BAR {bus:02x}:{dev:02x}.{func} index {idx} at {addr:#x}..{end:#x} \
-                 is outside all MMIO apertures",
-                bus = entry.bus,
-                dev = entry.device,
-                func = entry.function,
-                idx = bar.index,
-                addr = bar.address,
-                end = bar_end,
-            );
+fn validate_assignments(devices: &[DiscoveredDevice], params: &AssignmentParams) {
+    for dev in devices {
+        for bar in &dev.bars {
+            if let Some(address) = bar.address {
+                let bar_end = address + bar.size;
+                let in_low = params
+                    .low_mmio
+                    .is_some_and(|a| address >= a.base && bar_end <= a.base + a.len);
+                let in_high = params
+                    .high_mmio
+                    .is_some_and(|a| address >= a.base && bar_end <= a.base + a.len);
+                assert!(
+                    in_low || in_high,
+                    "BAR {bus:02x}:{device:02x}.{func} index {idx} at {addr:#x}..{end:#x} \
+                     is outside all MMIO apertures",
+                    bus = dev.bus,
+                    device = dev.device,
+                    func = dev.function,
+                    idx = bar.index,
+                    addr = address,
+                    end = bar_end,
+                );
+            }
         }
+        validate_assignments(&dev.children, params);
     }
 }
 fn is_mem64_bar(bar: &crate::enumerate::DiscoveredBar) -> bool {
@@ -265,7 +233,6 @@ fn compute_subtree_requirement(devices: &mut [DiscoveredDevice]) -> SubtreeRequi
                 dev_idx: i,
                 bar_index: bar.index,
                 size: bar.size,
-                is_64bit: bar.is_64bit,
                 is_mem64: is_mem64_bar(bar),
             });
         }
@@ -337,7 +304,6 @@ fn compute_subtree_requirement(devices: &mut [DiscoveredDevice]) -> SubtreeRequi
         demands,
     }
 }
-
 /// Top-down: assign addresses to devices within a subtree, carving from
 /// the given base address. `alloc_64bit` selects which pool (mem32 or
 /// mem64) we are assigning.
@@ -348,7 +314,6 @@ fn assign_subtree(
     demands: &[Demand],
     alloc_64bit: bool,
     base: u64,
-    entries: &mut Vec<AssignmentEntry>,
 ) {
     // Bump-allocate from the pre-sorted demands, skipping demands that
     // belong to the other pool.
@@ -365,34 +330,27 @@ fn assign_subtree(
             Demand::Bar {
                 dev_idx,
                 bar_index,
-                size,
-                is_64bit,
                 ..
             } => {
-                let dev = &devices[dev_idx];
-                let entry = find_or_create_entry(entries, dev.bus, dev.device, dev.function);
-                entry.bars.push(BarAssignment {
-                    index: bar_index,
-                    address: offset,
-                    size,
-                    is_64bit,
-                });
+                let bar = devices[dev_idx]
+                    .bars
+                    .iter_mut()
+                    .find(|b| b.index == bar_index)
+                    .expect("demand references a BAR that exists");
+                bar.address = Some(offset);
             }
             Demand::BridgeSubtree { dev_idx, size, .. } => {
                 let dev = &mut devices[dev_idx];
-                let entry = find_or_create_entry(entries, dev.bus, dev.device, dev.function);
-                entry.secondary_bus = dev.secondary_bus;
-                entry.subordinate_bus = dev.subordinate_bus;
 
                 // Set the bridge window to the carved-out range.
                 let window_base = offset;
                 let window_limit = offset + size - 1;
                 if alloc_64bit {
-                    entry.prefetchable_base = Some(window_base);
-                    entry.prefetchable_limit = Some(window_limit);
+                    dev.prefetchable_base = Some(window_base);
+                    dev.prefetchable_limit = Some(window_limit);
                 } else {
-                    entry.memory_base = Some(window_base);
-                    entry.memory_limit = Some(window_limit);
+                    dev.memory_base = Some(window_base);
+                    dev.memory_limit = Some(window_limit);
                 }
 
                 // Recurse into children with this bridge's carved-out range.
@@ -401,13 +359,7 @@ fn assign_subtree(
                     .as_ref()
                     .expect("subtree_req must be populated by compute_subtree_requirement")
                     .demands;
-                assign_subtree(
-                    &mut dev.children,
-                    child_demands,
-                    alloc_64bit,
-                    offset,
-                    entries,
-                );
+                assign_subtree(&mut dev.children, child_demands, alloc_64bit, offset);
             }
             Demand::SriovVfBars { .. } => {
                 // VF BAR space is reserved but not explicitly assigned.
@@ -418,66 +370,65 @@ fn assign_subtree(
 
         offset += size;
     }
-
-    // Ensure bridge entries exist even if they have no BARs in this pool
-    // (needed for bridges that only have resources in the other pool).
-    for dev in devices {
-        if dev.is_bridge {
-            let entry = find_or_create_entry(entries, dev.bus, dev.device, dev.function);
-            entry.secondary_bus = dev.secondary_bus;
-            entry.subordinate_bus = dev.subordinate_bus;
-        }
-    }
 }
 
 /// Program all assignments into config space.
 ///
-/// Writes BAR addresses and bridge memory windows for every entry in
-/// `result`. This function assumes MMIO decode (MSE) has already been
+/// Writes BAR addresses and bridge memory windows for every device in
+/// the tree. This function assumes MMIO decode (MSE) has already been
 /// cleared by the enumeration phase and does not modify the command
 /// register.
-pub async fn program_assignments(cfg: &mut impl PciConfigAccess, result: &AssignmentResult) {
-    for entry in &result.entries {
-        // Program BAR addresses.
-        for bar in &entry.bars {
-            let offset = HeaderType00::BAR0.0 + (bar.index as u16) * 4;
-            entry.write_cfg(cfg, offset, bar.address as u32).await;
+pub async fn program_assignments(
+    cfg: &mut impl PciConfigAccess,
+    devices: &[DiscoveredDevice],
+) {
+    for dev in devices {
+        let devfn = crate::devfn(dev.device, dev.function);
 
-            if bar.is_64bit {
-                let upper_offset = HeaderType00::BAR0.0 + ((bar.index + 1) as u16) * 4;
-                entry
-                    .write_cfg(cfg, upper_offset, (bar.address >> 32) as u32)
-                    .await;
+        // Program BAR addresses.
+        for bar in &dev.bars {
+            if let Some(address) = bar.address {
+                let offset = HeaderType00::BAR0.0 + (bar.index as u16) * 4;
+                cfg.write_u32(dev.bus, devfn, offset, address as u32).await;
+
+                if bar.is_64bit {
+                    let upper_offset = HeaderType00::BAR0.0 + ((bar.index + 1) as u16) * 4;
+                    cfg.write_u32(dev.bus, devfn, upper_offset, (address >> 32) as u32)
+                        .await;
+                }
             }
         }
 
         // Program bridge windows. For bridges, explicitly disable any unused
         // window by writing base > limit so that the guest OS's probe
         // (write-readback) doesn't mistake zeroed registers for a valid window.
-        if entry.secondary_bus.is_some() {
+        if dev.is_bridge {
             // I/O window — we don't assign I/O BARs, so always disable.
             // Write zeros to the upper 16 bits (Secondary Status) since
             // those bits are W1C — writing back a read value would clear them.
-            entry
-                .write_cfg(cfg, HeaderType01::SEC_STATUS_IO_RANGE.0, 0x0000_00F0)
-                .await;
+            cfg.write_u32(
+                dev.bus,
+                devfn,
+                HeaderType01::SEC_STATUS_IO_RANGE.0,
+                0x0000_00F0,
+            )
+            .await;
 
             // Non-prefetchable memory window (32-bit only).
-            let value = if let (Some(base), Some(limit)) = (entry.memory_base, entry.memory_limit) {
+            let value = if let (Some(base), Some(limit)) = (dev.memory_base, dev.memory_limit) {
                 let mem_base_reg = ((base >> 16) as u16 & MEMORY_BASE_LIMIT_ADDRESS_MASK) as u32;
                 let mem_limit_reg = ((limit >> 16) as u16 & MEMORY_BASE_LIMIT_ADDRESS_MASK) as u32;
                 mem_base_reg | (mem_limit_reg << 16)
             } else {
                 0x0000_fff0
             };
-            entry
-                .write_cfg(cfg, HeaderType01::MEMORY_RANGE.0, value)
+            cfg.write_u32(dev.bus, devfn, HeaderType01::MEMORY_RANGE.0, value)
                 .await;
 
             // Prefetchable memory window (64-bit capable).
             // Use base > limit to disable when no window is assigned.
             let (pf_range, pf_base_upper, pf_limit_upper) = if let (Some(base), Some(limit)) =
-                (entry.prefetchable_base, entry.prefetchable_limit)
+                (dev.prefetchable_base, dev.prefetchable_limit)
             {
                 let pf_base_reg =
                     ((base >> 16) as u16 & MEMORY_BASE_LIMIT_ADDRESS_MASK) as u32 | 0x1;
@@ -491,44 +442,57 @@ pub async fn program_assignments(cfg: &mut impl PciConfigAccess, result: &Assign
             } else {
                 (0x0000_fff0, 0xFFFF_FFFF, 0)
             };
-            entry
-                .write_cfg(cfg, HeaderType01::PREFETCH_LIMIT_UPPER.0, pf_limit_upper)
+            cfg.write_u32(
+                dev.bus,
+                devfn,
+                HeaderType01::PREFETCH_LIMIT_UPPER.0,
+                pf_limit_upper,
+            )
+            .await;
+            cfg.write_u32(dev.bus, devfn, HeaderType01::PREFETCH_RANGE.0, pf_range)
                 .await;
-            entry
-                .write_cfg(cfg, HeaderType01::PREFETCH_RANGE.0, pf_range)
-                .await;
-            entry
-                .write_cfg(cfg, HeaderType01::PREFETCH_BASE_UPPER.0, pf_base_upper)
-                .await;
+            cfg.write_u32(
+                dev.bus,
+                devfn,
+                HeaderType01::PREFETCH_BASE_UPPER.0,
+                pf_base_upper,
+            )
+            .await;
         }
 
-        if entry.bars.is_empty() {
+        let has_assigned_bars = dev.bars.iter().any(|b| b.address.is_some());
+        if !has_assigned_bars && dev.is_bridge {
             tracing::debug!(
-                bus = entry.bus,
-                device = entry.device,
-                function = entry.function,
-                ?entry.secondary_bus,
-                ?entry.subordinate_bus,
-                ?entry.memory_base,
-                ?entry.memory_limit,
-                ?entry.prefetchable_base,
-                ?entry.prefetchable_limit,
+                bus = dev.bus,
+                device = dev.device,
+                function = dev.function,
+                ?dev.secondary_bus,
+                ?dev.subordinate_bus,
+                ?dev.memory_base,
+                ?dev.memory_limit,
+                ?dev.prefetchable_base,
+                ?dev.prefetchable_limit,
                 "bridge programmed"
             );
         } else {
-            for bar in &entry.bars {
-                tracing::debug!(
-                    bus = entry.bus,
-                    device = entry.device,
-                    function = entry.function,
-                    bar_index = bar.index,
-                    address = format_args!("{:#x}", bar.address),
-                    size = format_args!("{:#x}", bar.size),
-                    is_64bit = bar.is_64bit,
-                    "BAR programmed"
-                );
+            for bar in &dev.bars {
+                if let Some(address) = bar.address {
+                    tracing::debug!(
+                        bus = dev.bus,
+                        device = dev.device,
+                        function = dev.function,
+                        bar_index = bar.index,
+                        address = format_args!("{:#x}", address),
+                        size = format_args!("{:#x}", bar.size),
+                        is_64bit = bar.is_64bit,
+                        "BAR programmed"
+                    );
+                }
             }
         }
+
+        // Recurse into children.
+        Box::pin(program_assignments(cfg, &dev.children)).await;
     }
 }
 

--- a/vm/devices/pci/pci_resource_assignment/src/assign.rs
+++ b/vm/devices/pci/pci_resource_assignment/src/assign.rs
@@ -46,7 +46,8 @@ fn find_or_create_entry(
 }
 
 /// Resource requirement for a subtree (bridge or root).
-struct SubtreeRequirement {
+#[derive(Debug, Clone)]
+pub(crate) struct SubtreeRequirement {
     /// Total aligned size needed in the mem32 (non-prefetchable) pool.
     mem32: u64,
     /// Total aligned size needed in the mem64 (prefetchable) pool.
@@ -78,12 +79,14 @@ struct SubtreeRequirement {
 ///
 /// Returns an error if any BAR cannot be placed.
 pub fn assign_addresses(
-    devices: &[DiscoveredDevice],
+    devices: &mut [DiscoveredDevice],
     params: &AssignmentParams,
 ) -> Result<AssignmentResult, AssignmentError> {
     let mut entries = Vec::new();
 
     // Step 1: Bottom-up — compute total resource requirements.
+    // This also stores per-bridge requirements on the DiscoveredDevice
+    // nodes so that the assignment pass can read them without recomputing.
     let root_req = compute_subtree_requirement(devices);
 
     // Step 2: Top-down — allocate from apertures and assign addresses.
@@ -116,6 +119,7 @@ pub fn assign_addresses(
         }
 
         assign_subtree(devices, false, base, &mut entries);
+
         mem32_end = Some(base + root_req.mem32);
     }
 
@@ -187,7 +191,7 @@ fn is_mem64_bar(bar: &crate::enumerate::DiscoveredBar) -> bool {
 
 /// Bottom-up: compute the total aligned resource requirement for a list
 /// of devices (which may be the root level or children behind a bridge).
-fn compute_subtree_requirement(devices: &[DiscoveredDevice]) -> SubtreeRequirement {
+fn compute_subtree_requirement(devices: &mut [DiscoveredDevice]) -> SubtreeRequirement {
     let mut mem32: u64 = 0;
     let mut mem64: u64 = 0;
 
@@ -232,7 +236,7 @@ fn compute_subtree_requirement(devices: &[DiscoveredDevice]) -> SubtreeRequireme
         }
 
         if dev.is_bridge {
-            let child_req = compute_subtree_requirement(&dev.children);
+            let child_req = compute_subtree_requirement(&mut dev.children);
             if child_req.mem32 > 0 {
                 let size = align_up(child_req.mem32, BRIDGE_WINDOW_ALIGN);
                 demands.push(Demand {
@@ -249,6 +253,7 @@ fn compute_subtree_requirement(devices: &[DiscoveredDevice]) -> SubtreeRequireme
                     is_mem64: true,
                 });
             }
+            dev.subtree_req = Some(child_req);
         }
     }
 
@@ -283,7 +288,7 @@ fn compute_subtree_requirement(devices: &[DiscoveredDevice]) -> SubtreeRequireme
 /// the given base address. `alloc_64bit` selects which pool (mem32 or
 /// mem64) we are assigning.
 fn assign_subtree(
-    devices: &[DiscoveredDevice],
+    devices: &mut [DiscoveredDevice],
     alloc_64bit: bool,
     base: u64,
     entries: &mut Vec<AssignmentEntry>,
@@ -342,7 +347,10 @@ fn assign_subtree(
         }
 
         if dev.is_bridge {
-            let child_req = compute_subtree_requirement(&dev.children);
+            let child_req = dev
+                .subtree_req
+                .as_ref()
+                .expect("subtree_req must be populated by compute_subtree_requirement");
             let (size, alignment) = if alloc_64bit {
                 (child_req.mem64, child_req.align64)
             } else {
@@ -375,34 +383,34 @@ fn assign_subtree(
 
     // Bump-allocate.
     let mut offset = base;
-    for (size, demand) in &demands {
+    for &(size, ref demand) in &demands {
         // BARs are naturally aligned to their size (always a power of two).
         // Bridge subtrees are aligned to the max of bridge window
         // granularity and the largest internal alignment requirement.
-        let alignment = match demand {
-            Demand::Bar { .. } => *size,
-            Demand::SriovVfBars { alignment, .. } => *alignment,
-            Demand::BridgeSubtree { alignment, .. } => *alignment,
+        let alignment = match *demand {
+            Demand::Bar { .. } => size,
+            Demand::SriovVfBars { alignment, .. } => alignment,
+            Demand::BridgeSubtree { alignment, .. } => alignment,
         };
         offset = align_up(offset, alignment);
 
-        match demand {
+        match *demand {
             Demand::Bar {
                 dev_idx,
                 bar_index,
                 is_64bit,
             } => {
-                let dev = &devices[*dev_idx];
+                let dev = &devices[dev_idx];
                 let entry = find_or_create_entry(entries, dev.bus, dev.device, dev.function);
                 entry.bars.push(BarAssignment {
-                    index: *bar_index,
+                    index: bar_index,
                     address: offset,
-                    size: *size,
-                    is_64bit: *is_64bit,
+                    size,
+                    is_64bit,
                 });
             }
             Demand::BridgeSubtree { dev_idx, .. } => {
-                let dev = &devices[*dev_idx];
+                let dev = &mut devices[dev_idx];
                 let entry = find_or_create_entry(entries, dev.bus, dev.device, dev.function);
                 entry.secondary_bus = dev.secondary_bus;
                 entry.subordinate_bus = dev.subordinate_bus;
@@ -419,7 +427,7 @@ fn assign_subtree(
                 }
 
                 // Recurse into children with this bridge's carved-out range.
-                assign_subtree(&dev.children, alloc_64bit, offset, entries);
+                assign_subtree(&mut dev.children, alloc_64bit, offset, entries);
             }
             Demand::SriovVfBars { .. } => {
                 // VF BAR space is reserved but not explicitly assigned.

--- a/vm/devices/pci/pci_resource_assignment/src/assign.rs
+++ b/vm/devices/pci/pci_resource_assignment/src/assign.rs
@@ -29,6 +29,10 @@ pub(crate) struct SubtreeRequirement {
     /// Sorted demands for this level's devices, used by the assignment
     /// pass to avoid recomputing them.
     demands: Vec<Demand>,
+    /// Assigned non-prefetchable bridge window (base, limit). Set by assign_subtree.
+    pub(crate) memory_window: Option<(u64, u64)>,
+    /// Assigned prefetchable bridge window (base, limit). Set by assign_subtree.
+    pub(crate) prefetchable_window: Option<(u64, u64)>,
 }
 
 /// A single resource demand at one level of the PCI tree.
@@ -302,6 +306,8 @@ fn compute_subtree_requirement(devices: &mut [DiscoveredDevice]) -> SubtreeRequi
         align32,
         align64,
         demands,
+        memory_window: None,
+        prefetchable_window: None,
     }
 }
 /// Top-down: assign addresses to devices within a subtree, carving from
@@ -345,12 +351,11 @@ fn assign_subtree(
                 // Set the bridge window to the carved-out range.
                 let window_base = offset;
                 let window_limit = offset + size - 1;
+                let req = dev.subtree_req.as_mut().unwrap();
                 if alloc_64bit {
-                    dev.prefetchable_base = Some(window_base);
-                    dev.prefetchable_limit = Some(window_limit);
+                    req.prefetchable_window = Some((window_base, window_limit));
                 } else {
-                    dev.memory_base = Some(window_base);
-                    dev.memory_limit = Some(window_limit);
+                    req.memory_window = Some((window_base, window_limit));
                 }
 
                 // Recurse into children with this bridge's carved-out range.
@@ -403,6 +408,12 @@ pub async fn program_assignments(
         // window by writing base > limit so that the guest OS's probe
         // (write-readback) doesn't mistake zeroed registers for a valid window.
         if dev.is_bridge {
+            let (memory_window, prefetchable_window) = dev
+                .subtree_req
+                .as_ref()
+                .map(|r| (r.memory_window, r.prefetchable_window))
+                .unwrap_or((None, None));
+
             // I/O window — we don't assign I/O BARs, so always disable.
             // Write zeros to the upper 16 bits (Secondary Status) since
             // those bits are W1C — writing back a read value would clear them.
@@ -415,7 +426,7 @@ pub async fn program_assignments(
             .await;
 
             // Non-prefetchable memory window (32-bit only).
-            let value = if let (Some(base), Some(limit)) = (dev.memory_base, dev.memory_limit) {
+            let value = if let Some((base, limit)) = memory_window {
                 let mem_base_reg = ((base >> 16) as u16 & MEMORY_BASE_LIMIT_ADDRESS_MASK) as u32;
                 let mem_limit_reg = ((limit >> 16) as u16 & MEMORY_BASE_LIMIT_ADDRESS_MASK) as u32;
                 mem_base_reg | (mem_limit_reg << 16)
@@ -427,8 +438,8 @@ pub async fn program_assignments(
 
             // Prefetchable memory window (64-bit capable).
             // Use base > limit to disable when no window is assigned.
-            let (pf_range, pf_base_upper, pf_limit_upper) = if let (Some(base), Some(limit)) =
-                (dev.prefetchable_base, dev.prefetchable_limit)
+            let (pf_range, pf_base_upper, pf_limit_upper) = if let Some((base, limit)) =
+                prefetchable_window
             {
                 let pf_base_reg =
                     ((base >> 16) as u16 & MEMORY_BASE_LIMIT_ADDRESS_MASK) as u32 | 0x1;
@@ -462,16 +473,16 @@ pub async fn program_assignments(
 
         let has_assigned_bars = dev.bars.iter().any(|b| b.address.is_some());
         if !has_assigned_bars && dev.is_bridge {
+            let memory_window = dev.subtree_req.as_ref().and_then(|r| r.memory_window);
+            let prefetchable_window = dev.subtree_req.as_ref().and_then(|r| r.prefetchable_window);
             tracing::debug!(
                 bus = dev.bus,
                 device = dev.device,
                 function = dev.function,
                 ?dev.secondary_bus,
                 ?dev.subordinate_bus,
-                ?dev.memory_base,
-                ?dev.memory_limit,
-                ?dev.prefetchable_base,
-                ?dev.prefetchable_limit,
+                ?memory_window,
+                ?prefetchable_window,
                 "bridge programmed"
             );
         } else {

--- a/vm/devices/pci/pci_resource_assignment/src/assign.rs
+++ b/vm/devices/pci/pci_resource_assignment/src/assign.rs
@@ -16,7 +16,7 @@ const BRIDGE_WINDOW_ALIGN: u64 = 1 << 20;
 
 /// Resource requirement for a subtree (bridge or root).
 #[derive(Debug, Clone)]
-pub(crate) struct SubtreeRequirement {
+pub(crate) struct SubtreeState {
     /// Total aligned size needed in the mem32 (non-prefetchable) pool.
     mem32: u64,
     /// Total aligned size needed in the mem64 (prefetchable) pool.
@@ -30,9 +30,9 @@ pub(crate) struct SubtreeRequirement {
     /// pass to avoid recomputing them.
     demands: Vec<Demand>,
     /// Assigned non-prefetchable bridge window (base, limit). Set by assign_subtree.
-    pub(crate) memory_window: Option<(u64, u64)>,
+    memory_window: Option<(u64, u64)>,
     /// Assigned prefetchable bridge window (base, limit). Set by assign_subtree.
-    pub(crate) prefetchable_window: Option<(u64, u64)>,
+    prefetchable_window: Option<(u64, u64)>,
 }
 
 /// A single resource demand at one level of the PCI tree.
@@ -119,7 +119,7 @@ pub fn assign_addresses(
     // Step 1: Bottom-up — compute total resource requirements.
     // This also stores per-bridge requirements on the DiscoveredDevice
     // nodes so that the assignment pass can read them without recomputing.
-    let root_req = compute_subtree_requirement(devices);
+    let root_req = compute_subtree_state(devices);
 
     // Step 2: Top-down — allocate from apertures and assign addresses.
     // Align the effective base to the root's alignment requirement so that
@@ -228,7 +228,7 @@ fn is_mem64_bar(bar: &crate::enumerate::DiscoveredBar) -> bool {
 ///
 /// Also builds and stores the sorted demand list so that `assign_subtree`
 /// can reuse it without recomputing.
-fn compute_subtree_requirement(devices: &mut [DiscoveredDevice]) -> SubtreeRequirement {
+fn compute_subtree_state(devices: &mut [DiscoveredDevice]) -> SubtreeState {
     let mut demands: Vec<Demand> = Vec::new();
 
     for (i, dev) in devices.iter_mut().enumerate() {
@@ -256,7 +256,7 @@ fn compute_subtree_requirement(devices: &mut [DiscoveredDevice]) -> SubtreeRequi
         }
 
         if dev.is_bridge {
-            let child_req = compute_subtree_requirement(&mut dev.children);
+            let child_req = compute_subtree_state(&mut dev.children);
             if child_req.mem32 > 0 {
                 let size = align_up(child_req.mem32, BRIDGE_WINDOW_ALIGN);
                 demands.push(Demand::BridgeSubtree {
@@ -300,7 +300,7 @@ fn compute_subtree_requirement(devices: &mut [DiscoveredDevice]) -> SubtreeRequi
         }
     }
 
-    SubtreeRequirement {
+    SubtreeState {
         mem32,
         mem64,
         align32,
@@ -334,9 +334,7 @@ fn assign_subtree(
 
         match *demand {
             Demand::Bar {
-                dev_idx,
-                bar_index,
-                ..
+                dev_idx, bar_index, ..
             } => {
                 let bar = devices[dev_idx]
                     .bars
@@ -383,10 +381,7 @@ fn assign_subtree(
 /// the tree. This function assumes MMIO decode (MSE) has already been
 /// cleared by the enumeration phase and does not modify the command
 /// register.
-pub async fn program_assignments(
-    cfg: &mut impl PciConfigAccess,
-    devices: &[DiscoveredDevice],
-) {
+pub async fn program_assignments(cfg: &mut impl PciConfigAccess, devices: &[DiscoveredDevice]) {
     for dev in devices {
         let devfn = crate::devfn(dev.device, dev.function);
 
@@ -438,21 +433,20 @@ pub async fn program_assignments(
 
             // Prefetchable memory window (64-bit capable).
             // Use base > limit to disable when no window is assigned.
-            let (pf_range, pf_base_upper, pf_limit_upper) = if let Some((base, limit)) =
-                prefetchable_window
-            {
-                let pf_base_reg =
-                    ((base >> 16) as u16 & MEMORY_BASE_LIMIT_ADDRESS_MASK) as u32 | 0x1;
-                let pf_limit_reg =
-                    ((limit >> 16) as u16 & MEMORY_BASE_LIMIT_ADDRESS_MASK) as u32 | 0x1;
-                (
-                    pf_base_reg | (pf_limit_reg << 16),
-                    (base >> 32) as u32,
-                    (limit >> 32) as u32,
-                )
-            } else {
-                (0x0000_fff0, 0xFFFF_FFFF, 0)
-            };
+            let (pf_range, pf_base_upper, pf_limit_upper) =
+                if let Some((base, limit)) = prefetchable_window {
+                    let pf_base_reg =
+                        ((base >> 16) as u16 & MEMORY_BASE_LIMIT_ADDRESS_MASK) as u32 | 0x1;
+                    let pf_limit_reg =
+                        ((limit >> 16) as u16 & MEMORY_BASE_LIMIT_ADDRESS_MASK) as u32 | 0x1;
+                    (
+                        pf_base_reg | (pf_limit_reg << 16),
+                        (base >> 32) as u32,
+                        (limit >> 32) as u32,
+                    )
+                } else {
+                    (0x0000_fff0, 0xFFFF_FFFF, 0)
+                };
             cfg.write_u32(
                 dev.bus,
                 devfn,

--- a/vm/devices/pci/pci_resource_assignment/src/assign.rs
+++ b/vm/devices/pci/pci_resource_assignment/src/assign.rs
@@ -421,7 +421,7 @@ fn assign_subtree(
 
     // Ensure bridge entries exist even if they have no BARs in this pool
     // (needed for bridges that only have resources in the other pool).
-    for dev in &*devices {
+    for dev in devices {
         if dev.is_bridge {
             let entry = find_or_create_entry(entries, dev.bus, dev.device, dev.function);
             entry.secondary_bus = dev.secondary_bus;

--- a/vm/devices/pci/pci_resource_assignment/src/assign.rs
+++ b/vm/devices/pci/pci_resource_assignment/src/assign.rs
@@ -7,6 +7,7 @@ use crate::AssignmentError;
 use crate::AssignmentParams;
 use crate::PciConfigAccess;
 use crate::enumerate::DiscoveredDevice;
+use pci_core::spec::caps::sriov::SriovExtendedCapabilityHeader;
 use pci_core::spec::cfg_space::HeaderType00;
 use pci_core::spec::cfg_space::HeaderType01;
 use pci_core::spec::cfg_space::MEMORY_BASE_LIMIT_ADDRESS_MASK;
@@ -58,6 +59,10 @@ enum Demand {
     },
     /// VF BAR space — reserved for SR-IOV VFs.
     SriovVfBars {
+        /// Index of the device in the parent's device list.
+        dev_idx: usize,
+        /// VF BAR register index within the SR-IOV capability.
+        bar_index: u8,
         /// Total size (per-VF BAR size * total_vfs).
         size: u64,
         /// Per-VF BAR size (alignment requirement).
@@ -195,29 +200,45 @@ pub fn assign_addresses(
 fn validate_assignments(devices: &[DiscoveredDevice], params: &AssignmentParams) {
     for dev in devices {
         for bar in &dev.bars {
-            if let Some(address) = bar.address {
-                let bar_end = address + bar.size;
-                let in_low = params
-                    .low_mmio
-                    .is_some_and(|a| address >= a.base && bar_end <= a.base + a.len);
-                let in_high = params
-                    .high_mmio
-                    .is_some_and(|a| address >= a.base && bar_end <= a.base + a.len);
-                assert!(
-                    in_low || in_high,
-                    "BAR {bus:02x}:{device:02x}.{func} index {idx} at {addr:#x}..{end:#x} \
-                     is outside all MMIO apertures",
-                    bus = dev.bus,
-                    device = dev.device,
-                    func = dev.function,
-                    idx = bar.index,
-                    addr = address,
-                    end = bar_end,
-                );
+            let address = bar.address.unwrap();
+            assert_bar_in_aperture(address, bar.size, dev, bar.index, params);
+        }
+        if let Some(sriov) = &dev.sriov {
+            for bar in &sriov.vf_bars {
+                let address = bar.address.unwrap();
+                let total_size = bar.size * sriov.total_vfs as u64;
+                assert_bar_in_aperture(address, total_size, dev, bar.index, params);
             }
         }
         validate_assignments(&dev.children, params);
     }
+}
+
+fn assert_bar_in_aperture(
+    address: u64,
+    size: u64,
+    dev: &DiscoveredDevice,
+    index: u8,
+    params: &AssignmentParams,
+) {
+    let bar_end = address + size;
+    let in_low = params
+        .low_mmio
+        .is_some_and(|a| address >= a.base && bar_end <= a.base + a.len);
+    let in_high = params
+        .high_mmio
+        .is_some_and(|a| address >= a.base && bar_end <= a.base + a.len);
+    assert!(
+        in_low || in_high,
+        "BAR {bus:02x}:{device:02x}.{func} index {idx} at {addr:#x}..{end:#x} \
+         is outside all MMIO apertures",
+        bus = dev.bus,
+        device = dev.device,
+        func = dev.function,
+        idx = index,
+        addr = address,
+        end = bar_end,
+    );
 }
 fn is_mem64_bar(bar: &crate::enumerate::DiscoveredBar) -> bool {
     bar.is_64bit && bar.is_prefetchable
@@ -246,6 +267,8 @@ fn compute_subtree_state(devices: &mut [DiscoveredDevice]) -> SubtreeState {
             for bar in &sriov.vf_bars {
                 let total_size = bar.size.saturating_mul(sriov.total_vfs as u64);
                 demands.push(Demand::SriovVfBars {
+                    dev_idx: i,
+                    bar_index: bar.index,
                     size: total_size,
                     // VF BAR region base must be aligned to per-VF BAR size
                     // (each VF's BAR is at base + n * bar_size).
@@ -364,10 +387,20 @@ fn assign_subtree(
                     .demands;
                 assign_subtree(&mut dev.children, child_demands, alloc_64bit, offset);
             }
-            Demand::SriovVfBars { .. } => {
-                // VF BAR space is reserved but not explicitly assigned.
-                // The guest programs VF BAR addresses through the SR-IOV
-                // capability registers.
+            Demand::SriovVfBars {
+                dev_idx, bar_index, ..
+            } => {
+                // Record the assigned base address on the VF BAR.
+                let sriov = devices[dev_idx]
+                    .sriov
+                    .as_mut()
+                    .expect("SriovVfBars demand implies sriov is present");
+                let vf_bar = sriov
+                    .vf_bars
+                    .iter_mut()
+                    .find(|b| b.index == bar_index)
+                    .expect("demand references a VF BAR that exists");
+                vf_bar.address = Some(offset);
             }
         }
 
@@ -387,12 +420,28 @@ pub async fn program_assignments(cfg: &mut impl PciConfigAccess, devices: &[Disc
 
         // Program BAR addresses.
         for bar in &dev.bars {
-            if let Some(address) = bar.address {
-                let offset = HeaderType00::BAR0.0 + (bar.index as u16) * 4;
+            let address = bar.address.unwrap();
+            let offset = HeaderType00::BAR0.0 + (bar.index as u16) * 4;
+            cfg.write_u32(dev.bus, devfn, offset, address as u32).await;
+
+            if bar.is_64bit {
+                let upper_offset = HeaderType00::BAR0.0 + ((bar.index + 1) as u16) * 4;
+                cfg.write_u32(dev.bus, devfn, upper_offset, (address >> 32) as u32)
+                    .await;
+            }
+        }
+
+        // Program VF BAR addresses into the SR-IOV capability registers.
+        if let Some(sriov) = &dev.sriov {
+            for bar in &sriov.vf_bars {
+                let address = bar.address.unwrap();
+                let offset = sriov.cap_offset
+                    + SriovExtendedCapabilityHeader::VF_BAR0.0
+                    + (bar.index as u16) * 4;
                 cfg.write_u32(dev.bus, devfn, offset, address as u32).await;
 
                 if bar.is_64bit {
-                    let upper_offset = HeaderType00::BAR0.0 + ((bar.index + 1) as u16) * 4;
+                    let upper_offset = offset + 4;
                     cfg.write_u32(dev.bus, devfn, upper_offset, (address >> 32) as u32)
                         .await;
                 }
@@ -465,8 +514,7 @@ pub async fn program_assignments(cfg: &mut impl PciConfigAccess, devices: &[Disc
             .await;
         }
 
-        let has_assigned_bars = dev.bars.iter().any(|b| b.address.is_some());
-        if !has_assigned_bars && dev.is_bridge {
+        if dev.bars.is_empty() && dev.is_bridge {
             let memory_window = dev.subtree_req.as_ref().and_then(|r| r.memory_window);
             let prefetchable_window = dev.subtree_req.as_ref().and_then(|r| r.prefetchable_window);
             tracing::debug!(
@@ -481,18 +529,32 @@ pub async fn program_assignments(cfg: &mut impl PciConfigAccess, devices: &[Disc
             );
         } else {
             for bar in &dev.bars {
-                if let Some(address) = bar.address {
-                    tracing::debug!(
-                        bus = dev.bus,
-                        device = dev.device,
-                        function = dev.function,
-                        bar_index = bar.index,
-                        address = format_args!("{:#x}", address),
-                        size = format_args!("{:#x}", bar.size),
-                        is_64bit = bar.is_64bit,
-                        "BAR programmed"
-                    );
-                }
+                tracing::debug!(
+                    bus = dev.bus,
+                    device = dev.device,
+                    function = dev.function,
+                    bar_index = bar.index,
+                    address = format_args!("{:#x}", bar.address.unwrap()),
+                    size = format_args!("{:#x}", bar.size),
+                    is_64bit = bar.is_64bit,
+                    "BAR programmed"
+                );
+            }
+        }
+
+        if let Some(sriov) = &dev.sriov {
+            for bar in &sriov.vf_bars {
+                tracing::debug!(
+                    bus = dev.bus,
+                    device = dev.device,
+                    function = dev.function,
+                    vf_bar_index = bar.index,
+                    address = format_args!("{:#x}", bar.address.unwrap()),
+                    size = format_args!("{:#x}", bar.size),
+                    total_vfs = sriov.total_vfs,
+                    is_64bit = bar.is_64bit,
+                    "VF BAR programmed"
+                );
             }
         }
 

--- a/vm/devices/pci/pci_resource_assignment/src/enumerate.rs
+++ b/vm/devices/pci/pci_resource_assignment/src/enumerate.rs
@@ -344,9 +344,14 @@ async fn probe_sriov(
                 return None;
             }
 
-            // Compute the BDF of the last VF.
-            let pf_rid = (bus as u32) << 8 | devfn as u32;
-            let last_vf_rid = pf_rid + vf_offset as u32 + (total_vfs - 1) as u32 * vf_stride as u32;
+            // Compute the BDF of the last VF. Use checked arithmetic
+            // since these values come from hardware and could overflow.
+            // A routing ID is 16 bits (bus:8 | devfn:8).
+            let pf_rid = (bus as u16) << 8 | devfn as u16;
+            let last_vf_rid = (total_vfs - 1)
+                .checked_mul(vf_stride)?
+                .checked_add(vf_offset)?
+                .checked_add(pf_rid)?;
             let max_vf_bus = (last_vf_rid >> 8) as u16;
 
             // Probe VF BAR sizes (same write-all-ones/readback technique).

--- a/vm/devices/pci/pci_resource_assignment/src/enumerate.rs
+++ b/vm/devices/pci/pci_resource_assignment/src/enumerate.rs
@@ -247,7 +247,6 @@ async fn probe_bars(
     is_bridge: bool,
 ) -> Vec<DiscoveredBar> {
     let max_bars: u8 = if is_bridge { 2 } else { 6 };
-    let mut bars = Vec::new();
 
     // Disable MMIO decode so that writing all-ones to BARs during
     // probing does not cause the device to decode a bogus address range.
@@ -268,69 +267,20 @@ async fn probe_bars(
         .await;
     }
 
-    let mut i = 0u8;
-    while i < max_bars {
-        let offset = HeaderType00::BAR0.0 + (i as u16) * 4;
+    probe_bar_range(cfg, bus, devfn, HeaderType00::BAR0.0, max_bars).await
+}
 
-        // Write all-ones to probe size.
-        cfg.write_u32(bus, devfn, offset, !0u32).await;
-        let readback = cfg.read_u32(bus, devfn, offset).await;
-
-        if readback == 0 {
-            // BAR not implemented.
-            i += 1;
-            continue;
-        }
-
-        let is_io = BarEncodingBits::from(readback).use_pio();
-        if is_io {
-            // Skip I/O BARs for now.
-            i += 1;
-            continue;
-        }
-
-        let encoding = BarEncodingBits::from(readback);
-        let is_64bit = encoding.type_64_bit();
-        let is_prefetchable = encoding.prefetchable();
-
-        let size = if is_64bit && (i + 1) < max_bars {
-            // Probe upper 32 bits.
-            let upper_offset = HeaderType00::BAR0.0 + ((i + 1) as u16) * 4;
-            cfg.write_u32(bus, devfn, upper_offset, !0u32).await;
-            let upper_readback = cfg.read_u32(bus, devfn, upper_offset).await;
-
-            let mask = ((upper_readback as u64) << 32) | (readback as u64 & !0xF);
-            if mask == 0 {
-                i += 2;
-                continue;
-            }
-            (!mask).wrapping_add(1)
-        } else {
-            let mask = readback & !0xF;
-            if mask == 0 {
-                i += 1;
-                continue;
-            }
-            (!(mask as u64 | (!0u64 << 32))).wrapping_add(1)
-        };
-
-        if size > 0 {
-            bars.push(DiscoveredBar {
-                index: i,
-                size,
-                is_64bit,
-                is_prefetchable,
-            });
-        }
-
-        if is_64bit {
-            i += 2;
-        } else {
-            i += 1;
-        }
-    }
-
-    bars
+/// Probe VF BAR sizes from the SR-IOV capability's VF BAR registers.
+///
+/// VF BARs are at offsets 0x24–0x38 within the SR-IOV capability, and
+/// use the same write-all-ones/readback protocol as regular BARs.
+async fn probe_vf_bars(
+    cfg: &mut impl PciConfigAccess,
+    bus: u8,
+    devfn: u8,
+    sriov_offset: u16,
+) -> Vec<DiscoveredBar> {
+    probe_bar_range(cfg, bus, devfn, sriov_offset + sriov::VF_BAR0, 6).await
 }
 
 /// SR-IOV capability register offsets (relative to capability start).
@@ -417,38 +367,36 @@ async fn probe_sriov(
     None
 }
 
-/// Probe VF BAR sizes from the SR-IOV capability's VF BAR registers.
+/// Probe BAR sizes for a range of BAR registers starting at `base_offset`.
 ///
-/// VF BARs are at offsets 0x24–0x38 within the SR-IOV capability, and
-/// use the same write-all-ones/readback protocol as regular BARs.
-async fn probe_vf_bars(
+/// Writes all-ones to each BAR and reads back to determine size. BAR
+/// registers are left in an undefined state after probing.
+async fn probe_bar_range(
     cfg: &mut impl PciConfigAccess,
     bus: u8,
     devfn: u8,
-    sriov_offset: u16,
+    base_offset: u16,
+    max_bars: u8,
 ) -> Vec<DiscoveredBar> {
     let mut bars = Vec::new();
-    let mut i = 0u8;
-    while i < 6 {
-        let bar_offset = sriov_offset + sriov::VF_BAR0 + (i as u16) * 4;
 
-        // Save original value.
-        let original = cfg.read_u32(bus, devfn, bar_offset).await;
+    let mut i = 0u8;
+    while i < max_bars {
+        let offset = base_offset + (i as u16) * 4;
 
         // Write all-ones to probe size.
-        cfg.write_u32(bus, devfn, bar_offset, !0u32).await;
-        let readback = cfg.read_u32(bus, devfn, bar_offset).await;
-
-        // Restore original value.
-        cfg.write_u32(bus, devfn, bar_offset, original).await;
+        cfg.write_u32(bus, devfn, offset, !0u32).await;
+        let readback = cfg.read_u32(bus, devfn, offset).await;
 
         if readback == 0 {
+            // BAR not implemented.
             i += 1;
             continue;
         }
 
         let is_io = BarEncodingBits::from(readback).use_pio();
         if is_io {
+            // Skip I/O BARs.
             i += 1;
             continue;
         }
@@ -457,13 +405,11 @@ async fn probe_vf_bars(
         let is_64bit = encoding.type_64_bit();
         let is_prefetchable = encoding.prefetchable();
 
-        let size = if is_64bit && (i + 1) < 6 {
-            let upper_offset = sriov_offset + sriov::VF_BAR0 + ((i + 1) as u16) * 4;
-            let upper_original = cfg.read_u32(bus, devfn, upper_offset).await;
+        let size = if is_64bit && (i + 1) < max_bars {
+            // Probe upper 32 bits.
+            let upper_offset = base_offset + ((i + 1) as u16) * 4;
             cfg.write_u32(bus, devfn, upper_offset, !0u32).await;
             let upper_readback = cfg.read_u32(bus, devfn, upper_offset).await;
-            cfg.write_u32(bus, devfn, upper_offset, upper_original)
-                .await;
 
             let mask = ((upper_readback as u64) << 32) | (readback as u64 & !0xF);
             if mask == 0 {

--- a/vm/devices/pci/pci_resource_assignment/src/enumerate.rs
+++ b/vm/devices/pci/pci_resource_assignment/src/enumerate.rs
@@ -33,6 +33,8 @@ pub struct DiscoveredDevice {
     pub secondary_bus: Option<u8>,
     /// For bridges: the subordinate bus number assigned during enumeration.
     pub subordinate_bus: Option<u8>,
+    /// For SR-IOV PFs: total VFs and per-VF BAR sizes.
+    pub(crate) sriov: Option<DiscoveredSriov>,
 }
 
 /// A discovered BAR with its size.
@@ -42,6 +44,15 @@ pub struct DiscoveredBar {
     pub size: u64,
     pub is_64bit: bool,
     pub is_prefetchable: bool,
+}
+
+/// SR-IOV information for a PF.
+#[derive(Debug, Clone)]
+pub(crate) struct DiscoveredSriov {
+    /// Total number of VFs.
+    pub total_vfs: u16,
+    /// Per-VF BAR sizes.
+    pub vf_bars: Vec<DiscoveredBar>,
 }
 
 /// Enumerate all devices starting from the host bridge's start bus,
@@ -129,6 +140,7 @@ async fn scan_bus(
                 children: Vec::new(),
                 secondary_bus: None,
                 subordinate_bus: None,
+                sriov: None,
             };
 
             if is_bridge {
@@ -172,8 +184,9 @@ async fn scan_bus(
                     "bridge enumerated"
                 );
             } else {
-                // Reserve bus numbers for SR-IOV VFs on this endpoint.
-                if let Some(max_vf_bus) = probe_sriov_bus_requirement(cfg, bus, devfn).await {
+                // Probe SR-IOV capability for bus reservation and VF BAR sizes.
+                if let Some(sriov_result) = probe_sriov(cfg, bus, devfn).await {
+                    let max_vf_bus = sriov_result.max_vf_bus;
                     if max_vf_bus > end_bus as u16 {
                         return Err(AssignmentError::BusExhaustion {
                             bus,
@@ -198,6 +211,11 @@ async fn scan_bus(
                         }
                         *next_bus = max_vf_bus + 1;
                     }
+
+                    dev.sriov = Some(DiscoveredSriov {
+                        total_vfs: sriov_result.total_vfs,
+                        vf_bars: sriov_result.vf_bars,
+                    });
                 }
 
                 tracing::debug!(
@@ -321,16 +339,27 @@ mod sriov {
     pub const INITIAL_TOTAL_VFS: u16 = 0x0C;
     /// Offset of the DWORD containing VF Offset (low u16) and VF Stride (high u16).
     pub const VF_OFFSET_STRIDE: u16 = 0x14;
+    /// Offset of VF BAR0 (6 consecutive DWORDs for VF BAR0–5).
+    pub const VF_BAR0: u16 = 0x24;
 }
 
-/// Probe SR-IOV capability to determine how many extra bus numbers
-/// this device's VFs will need. Returns the highest bus number a VF
-/// could land on, or `None` if the device has no SR-IOV capability.
-async fn probe_sriov_bus_requirement(
+/// Result of probing an SR-IOV capability.
+pub(crate) struct SriovProbeResult {
+    /// Highest bus number a VF could land on.
+    pub max_vf_bus: u16,
+    /// Total number of VFs.
+    pub total_vfs: u16,
+    /// VF BAR sizes discovered by probing (same format as device BARs).
+    pub vf_bars: Vec<DiscoveredBar>,
+}
+
+/// Probe SR-IOV capability to determine bus requirements and VF BAR sizes.
+/// Returns `None` if the device has no SR-IOV capability or has no VFs.
+async fn probe_sriov(
     cfg: &mut impl PciConfigAccess,
     bus: u8,
     devfn: u8,
-) -> Option<u16> {
+) -> Option<SriovProbeResult> {
     // Walk extended capabilities starting at 0x100.
     let mut offset = EXT_CAP_START;
     loop {
@@ -365,13 +394,19 @@ async fn probe_sriov_bus_requirement(
                 return None;
             }
 
-            // Compute the BDF of the last VF in u32 to detect overflow.
-            // First VF routing ID = (bus << 8 | devfn) + vf_offset
-            // Last VF routing ID = first + (total_vfs - 1) * vf_stride
+            // Compute the BDF of the last VF.
             let pf_rid = (bus as u32) << 8 | devfn as u32;
             let last_vf_rid = pf_rid + vf_offset as u32 + (total_vfs - 1) as u32 * vf_stride as u32;
-            let max_bus = (last_vf_rid >> 8) as u16;
-            return Some(max_bus);
+            let max_vf_bus = (last_vf_rid >> 8) as u16;
+
+            // Probe VF BAR sizes (same write-all-ones/readback technique).
+            let vf_bars = probe_vf_bars(cfg, bus, devfn, offset).await;
+
+            return Some(SriovProbeResult {
+                max_vf_bus,
+                total_vfs,
+                vf_bars,
+            });
         }
 
         if next == 0 || next <= offset {
@@ -380,4 +415,86 @@ async fn probe_sriov_bus_requirement(
         offset = next;
     }
     None
+}
+
+/// Probe VF BAR sizes from the SR-IOV capability's VF BAR registers.
+///
+/// VF BARs are at offsets 0x24–0x38 within the SR-IOV capability, and
+/// use the same write-all-ones/readback protocol as regular BARs.
+async fn probe_vf_bars(
+    cfg: &mut impl PciConfigAccess,
+    bus: u8,
+    devfn: u8,
+    sriov_offset: u16,
+) -> Vec<DiscoveredBar> {
+    let mut bars = Vec::new();
+    let mut i = 0u8;
+    while i < 6 {
+        let bar_offset = sriov_offset + sriov::VF_BAR0 + (i as u16) * 4;
+
+        // Save original value.
+        let original = cfg.read_u32(bus, devfn, bar_offset).await;
+
+        // Write all-ones to probe size.
+        cfg.write_u32(bus, devfn, bar_offset, !0u32).await;
+        let readback = cfg.read_u32(bus, devfn, bar_offset).await;
+
+        // Restore original value.
+        cfg.write_u32(bus, devfn, bar_offset, original).await;
+
+        if readback == 0 {
+            i += 1;
+            continue;
+        }
+
+        let is_io = BarEncodingBits::from(readback).use_pio();
+        if is_io {
+            i += 1;
+            continue;
+        }
+
+        let encoding = BarEncodingBits::from(readback);
+        let is_64bit = encoding.type_64_bit();
+        let is_prefetchable = encoding.prefetchable();
+
+        let size = if is_64bit && (i + 1) < 6 {
+            let upper_offset = sriov_offset + sriov::VF_BAR0 + ((i + 1) as u16) * 4;
+            let upper_original = cfg.read_u32(bus, devfn, upper_offset).await;
+            cfg.write_u32(bus, devfn, upper_offset, !0u32).await;
+            let upper_readback = cfg.read_u32(bus, devfn, upper_offset).await;
+            cfg.write_u32(bus, devfn, upper_offset, upper_original)
+                .await;
+
+            let mask = ((upper_readback as u64) << 32) | (readback as u64 & !0xF);
+            if mask == 0 {
+                i += 2;
+                continue;
+            }
+            (!mask).wrapping_add(1)
+        } else {
+            let mask = readback & !0xF;
+            if mask == 0 {
+                i += 1;
+                continue;
+            }
+            (!(mask as u64 | (!0u64 << 32))).wrapping_add(1)
+        };
+
+        if size > 0 {
+            bars.push(DiscoveredBar {
+                index: i,
+                size,
+                is_64bit,
+                is_prefetchable,
+            });
+        }
+
+        if is_64bit {
+            i += 2;
+        } else {
+            i += 1;
+        }
+    }
+
+    bars
 }

--- a/vm/devices/pci/pci_resource_assignment/src/enumerate.rs
+++ b/vm/devices/pci/pci_resource_assignment/src/enumerate.rs
@@ -38,7 +38,7 @@ pub struct DiscoveredDevice {
     /// Computed during the sizing pass for bridges: the total resource
     /// requirement of this bridge's children. Avoids recomputation during
     /// address assignment.
-    pub(crate) subtree_req: Option<crate::assign::SubtreeRequirement>,
+    pub(crate) subtree_req: Option<crate::assign::SubtreeState>,
 }
 
 /// A discovered BAR with its size.

--- a/vm/devices/pci/pci_resource_assignment/src/enumerate.rs
+++ b/vm/devices/pci/pci_resource_assignment/src/enumerate.rs
@@ -39,6 +39,15 @@ pub struct DiscoveredDevice {
     /// requirement of this bridge's children. Avoids recomputation during
     /// address assignment.
     pub(crate) subtree_req: Option<crate::assign::SubtreeRequirement>,
+    /// For bridges: the non-prefetchable memory window base (32-bit only).
+    /// Populated by the assignment pass.
+    pub(crate) memory_base: Option<u64>,
+    /// For bridges: the non-prefetchable memory window limit (32-bit only).
+    pub(crate) memory_limit: Option<u64>,
+    /// For bridges: the prefetchable memory window base (64-bit capable).
+    pub(crate) prefetchable_base: Option<u64>,
+    /// For bridges: the prefetchable memory window limit (64-bit capable).
+    pub(crate) prefetchable_limit: Option<u64>,
 }
 
 /// A discovered BAR with its size.
@@ -48,6 +57,8 @@ pub struct DiscoveredBar {
     pub size: u64,
     pub is_64bit: bool,
     pub is_prefetchable: bool,
+    /// Assigned base address (populated by the assignment pass).
+    pub(crate) address: Option<u64>,
 }
 
 /// SR-IOV information for a PF.
@@ -146,6 +157,10 @@ async fn scan_bus(
                 subordinate_bus: None,
                 sriov: None,
                 subtree_req: None,
+                memory_base: None,
+                memory_limit: None,
+                prefetchable_base: None,
+                prefetchable_limit: None,
             };
 
             if is_bridge {
@@ -442,6 +457,7 @@ async fn probe_bar_range(
                 size,
                 is_64bit,
                 is_prefetchable,
+                address: None,
             });
         }
 

--- a/vm/devices/pci/pci_resource_assignment/src/enumerate.rs
+++ b/vm/devices/pci/pci_resource_assignment/src/enumerate.rs
@@ -39,15 +39,6 @@ pub struct DiscoveredDevice {
     /// requirement of this bridge's children. Avoids recomputation during
     /// address assignment.
     pub(crate) subtree_req: Option<crate::assign::SubtreeRequirement>,
-    /// For bridges: the non-prefetchable memory window base (32-bit only).
-    /// Populated by the assignment pass.
-    pub(crate) memory_base: Option<u64>,
-    /// For bridges: the non-prefetchable memory window limit (32-bit only).
-    pub(crate) memory_limit: Option<u64>,
-    /// For bridges: the prefetchable memory window base (64-bit capable).
-    pub(crate) prefetchable_base: Option<u64>,
-    /// For bridges: the prefetchable memory window limit (64-bit capable).
-    pub(crate) prefetchable_limit: Option<u64>,
 }
 
 /// A discovered BAR with its size.
@@ -157,10 +148,6 @@ async fn scan_bus(
                 subordinate_bus: None,
                 sriov: None,
                 subtree_req: None,
-                memory_base: None,
-                memory_limit: None,
-                prefetchable_base: None,
-                prefetchable_limit: None,
             };
 
             if is_bridge {

--- a/vm/devices/pci/pci_resource_assignment/src/enumerate.rs
+++ b/vm/devices/pci/pci_resource_assignment/src/enumerate.rs
@@ -35,6 +35,10 @@ pub struct DiscoveredDevice {
     pub subordinate_bus: Option<u8>,
     /// For SR-IOV PFs: total VFs and per-VF BAR sizes.
     pub(crate) sriov: Option<DiscoveredSriov>,
+    /// Computed during the sizing pass for bridges: the total resource
+    /// requirement of this bridge's children. Avoids recomputation during
+    /// address assignment.
+    pub(crate) subtree_req: Option<crate::assign::SubtreeRequirement>,
 }
 
 /// A discovered BAR with its size.
@@ -141,6 +145,7 @@ async fn scan_bus(
                 secondary_bus: None,
                 subordinate_bus: None,
                 sriov: None,
+                subtree_req: None,
             };
 
             if is_bridge {

--- a/vm/devices/pci/pci_resource_assignment/src/enumerate.rs
+++ b/vm/devices/pci/pci_resource_assignment/src/enumerate.rs
@@ -8,6 +8,7 @@ use crate::AssignmentParams;
 use crate::PciConfigAccess;
 use pci_core::spec::caps::EXT_CAP_START;
 use pci_core::spec::caps::ExtendedCapabilityId;
+use pci_core::spec::caps::sriov::SriovExtendedCapabilityHeader;
 use pci_core::spec::cfg_space::BarEncodingBits;
 use pci_core::spec::cfg_space::BistHeader;
 use pci_core::spec::cfg_space::Command;
@@ -287,17 +288,14 @@ async fn probe_vf_bars(
     devfn: u8,
     sriov_offset: u16,
 ) -> Vec<DiscoveredBar> {
-    probe_bar_range(cfg, bus, devfn, sriov_offset + sriov::VF_BAR0, 6).await
-}
-
-/// SR-IOV capability register offsets (relative to capability start).
-mod sriov {
-    /// Offset of the DWORD containing InitialVFs (low u16) and TotalVFs (high u16).
-    pub const INITIAL_TOTAL_VFS: u16 = 0x0C;
-    /// Offset of the DWORD containing VF Offset (low u16) and VF Stride (high u16).
-    pub const VF_OFFSET_STRIDE: u16 = 0x14;
-    /// Offset of VF BAR0 (6 consecutive DWORDs for VF BAR0–5).
-    pub const VF_BAR0: u16 = 0x24;
+    probe_bar_range(
+        cfg,
+        bus,
+        devfn,
+        sriov_offset + SriovExtendedCapabilityHeader::VF_BAR0.0,
+        6,
+    )
+    .await
 }
 
 /// Result of probing an SR-IOV capability.
@@ -333,7 +331,11 @@ async fn probe_sriov(
         if cap_id == ExtendedCapabilityId::SRIOV.0 {
             // Read TotalVFs.
             let vfs_dword = cfg
-                .read_u32(bus, devfn, offset + sriov::INITIAL_TOTAL_VFS)
+                .read_u32(
+                    bus,
+                    devfn,
+                    offset + SriovExtendedCapabilityHeader::INITIAL_TOTAL_VFS.0,
+                )
                 .await;
             let total_vfs = (vfs_dword >> 16) as u16;
             if total_vfs == 0 {
@@ -342,7 +344,11 @@ async fn probe_sriov(
 
             // Read VF Offset and VF Stride.
             let offset_stride = cfg
-                .read_u32(bus, devfn, offset + sriov::VF_OFFSET_STRIDE)
+                .read_u32(
+                    bus,
+                    devfn,
+                    offset + SriovExtendedCapabilityHeader::VF_OFFSET_STRIDE.0,
+                )
                 .await;
             let vf_offset = offset_stride as u16;
             let vf_stride = (offset_stride >> 16) as u16;

--- a/vm/devices/pci/pci_resource_assignment/src/enumerate.rs
+++ b/vm/devices/pci/pci_resource_assignment/src/enumerate.rs
@@ -56,6 +56,8 @@ pub struct DiscoveredBar {
 /// SR-IOV information for a PF.
 #[derive(Debug, Clone)]
 pub(crate) struct DiscoveredSriov {
+    /// Config space offset of the SR-IOV extended capability.
+    pub cap_offset: u16,
     /// Total number of VFs.
     pub total_vfs: u16,
     /// Per-VF BAR sizes.
@@ -221,6 +223,7 @@ async fn scan_bus(
                     }
 
                     dev.sriov = Some(DiscoveredSriov {
+                        cap_offset: sriov_result.cap_offset,
                         total_vfs: sriov_result.total_vfs,
                         vf_bars: sriov_result.vf_bars,
                     });
@@ -300,6 +303,8 @@ async fn probe_vf_bars(
 
 /// Result of probing an SR-IOV capability.
 pub(crate) struct SriovProbeResult {
+    /// Config space offset of the SR-IOV extended capability.
+    pub cap_offset: u16,
     /// Highest bus number a VF could land on.
     pub max_vf_bus: u16,
     /// Total number of VFs.
@@ -371,6 +376,7 @@ async fn probe_sriov(
             let vf_bars = probe_vf_bars(cfg, bus, devfn, offset).await;
 
             return Some(SriovProbeResult {
+                cap_offset: offset,
                 max_vf_bus,
                 total_vfs,
                 vf_bars,

--- a/vm/devices/pci/pci_resource_assignment/src/lib.rs
+++ b/vm/devices/pci/pci_resource_assignment/src/lib.rs
@@ -88,8 +88,8 @@ pub(crate) async fn assign_pci_resources_inner(
     cfg: &mut impl PciConfigAccess,
     params: &AssignmentParams,
 ) -> Result<AssignmentResult, AssignmentError> {
-    let devices = enumerate::enumerate_and_probe(cfg, params).await?;
-    let assignments = assign::assign_addresses(&devices, params)?;
+    let mut devices = enumerate::enumerate_and_probe(cfg, params).await?;
+    let assignments = assign::assign_addresses(&mut devices, params)?;
     assign::program_assignments(cfg, &assignments).await;
     Ok(assignments)
 }

--- a/vm/devices/pci/pci_resource_assignment/src/lib.rs
+++ b/vm/devices/pci/pci_resource_assignment/src/lib.rs
@@ -82,71 +82,16 @@ pub async fn assign_pci_resources(
     Ok(())
 }
 
-/// Inner implementation that returns the assignment result for internal use
-/// (e.g., tests).
+/// Inner implementation that returns the device tree with assignments
+/// populated, for internal use (e.g., tests).
 pub(crate) async fn assign_pci_resources_inner(
     cfg: &mut impl PciConfigAccess,
     params: &AssignmentParams,
-) -> Result<AssignmentResult, AssignmentError> {
+) -> Result<Vec<enumerate::DiscoveredDevice>, AssignmentError> {
     let mut devices = enumerate::enumerate_and_probe(cfg, params).await?;
-    let assignments = assign::assign_addresses(&mut devices, params)?;
-    assign::program_assignments(cfg, &assignments).await;
-    Ok(assignments)
-}
-
-/// Result of a successful resource assignment.
-#[derive(Debug, Clone)]
-struct AssignmentResult {
-    /// All device and bridge assignments made.
-    entries: Vec<AssignmentEntry>,
-}
-
-/// A single device or bridge assignment.
-#[derive(Debug, Clone)]
-struct AssignmentEntry {
-    /// Bus number.
-    bus: u8,
-    /// Device number.
-    device: u8,
-    /// Function number.
-    function: u8,
-    /// BAR assignments (index → address). Only populated BARs are included.
-    bars: Vec<BarAssignment>,
-    /// For bridges: the secondary bus number assigned.
-    secondary_bus: Option<u8>,
-    /// For bridges: the subordinate bus number assigned.
-    subordinate_bus: Option<u8>,
-    /// For bridges: the non-prefetchable memory window base (32-bit only).
-    memory_base: Option<u64>,
-    /// For bridges: the non-prefetchable memory window limit (32-bit only).
-    memory_limit: Option<u64>,
-    /// For bridges: the prefetchable memory window base (64-bit capable).
-    prefetchable_base: Option<u64>,
-    /// For bridges: the prefetchable memory window limit (64-bit capable).
-    prefetchable_limit: Option<u64>,
-}
-
-impl AssignmentEntry {
-    fn devfn(&self) -> u8 {
-        devfn(self.device, self.function)
-    }
-
-    async fn write_cfg(&self, cfg: &mut impl PciConfigAccess, offset: u16, value: u32) {
-        cfg.write_u32(self.bus, self.devfn(), offset, value).await
-    }
-}
-
-/// A BAR address assignment.
-#[derive(Debug, Clone)]
-struct BarAssignment {
-    /// BAR index (0–5 for endpoints, 0–1 for bridges).
-    index: u8,
-    /// Assigned base address.
-    address: u64,
-    /// Size in bytes.
-    size: u64,
-    /// Whether the BAR register is 64-bit (occupies two config space DWORDs).
-    is_64bit: bool,
+    assign::assign_addresses(&mut devices, params)?;
+    assign::program_assignments(cfg, &devices).await;
+    Ok(devices)
 }
 
 /// Errors during resource assignment.

--- a/vm/devices/pci/pci_resource_assignment/src/lib.rs
+++ b/vm/devices/pci/pci_resource_assignment/src/lib.rs
@@ -78,20 +78,10 @@ pub async fn assign_pci_resources(
     cfg: &mut impl PciConfigAccess,
     params: &AssignmentParams,
 ) -> Result<(), AssignmentError> {
-    assign_pci_resources_inner(cfg, params).await?;
-    Ok(())
-}
-
-/// Inner implementation that returns the device tree with assignments
-/// populated, for internal use (e.g., tests).
-pub(crate) async fn assign_pci_resources_inner(
-    cfg: &mut impl PciConfigAccess,
-    params: &AssignmentParams,
-) -> Result<Vec<enumerate::DiscoveredDevice>, AssignmentError> {
     let mut devices = enumerate::enumerate_and_probe(cfg, params).await?;
     assign::assign_addresses(&mut devices, params)?;
     assign::program_assignments(cfg, &devices).await;
-    Ok(devices)
+    Ok(())
 }
 
 /// Errors during resource assignment.

--- a/vm/devices/pci/pci_resource_assignment/src/tests.rs
+++ b/vm/devices/pci/pci_resource_assignment/src/tests.rs
@@ -6,8 +6,7 @@
 use crate::AssignmentParams;
 use crate::MmioAperture;
 use crate::PciConfigAccess;
-use crate::assign_pci_resources_inner;
-use crate::enumerate::DiscoveredDevice;
+use crate::assign_pci_resources;
 use parking_lot::Mutex;
 use std::collections::BTreeMap;
 use std::sync::Arc;
@@ -224,32 +223,66 @@ impl PciConfigAccess for MockConfigSpace {
 
 use pal_async::async_test;
 
-// ---- Tests ----
+// ---- Config space reading helpers ----
 
-/// Flatten a device tree into a list for test assertions.
-fn flatten_devices(devices: &[DiscoveredDevice]) -> Vec<&DiscoveredDevice> {
-    let mut out = Vec::new();
-    for dev in devices {
-        out.push(dev);
-        out.extend(flatten_devices(&dev.children));
+/// Read a 32-bit BAR address from mock config space.
+fn read_bar32(mock: &MockConfigSpace, bus: u8, dev: u8, func: u8, bar_idx: u8) -> u32 {
+    mock.read_reg(bus, dev, func, 0x10 + bar_idx as u16 * 4)
+}
+
+/// Read a 64-bit BAR address from mock config space (two consecutive DWORDs).
+fn read_bar64(mock: &MockConfigSpace, bus: u8, dev: u8, func: u8, bar_idx: u8) -> u64 {
+    let lo = mock.read_reg(bus, dev, func, 0x10 + bar_idx as u16 * 4) as u64;
+    let hi = mock.read_reg(bus, dev, func, 0x10 + (bar_idx + 1) as u16 * 4) as u64;
+    lo | (hi << 32)
+}
+
+/// Read bus numbers (primary, secondary, subordinate) from a bridge.
+fn read_bus_numbers(mock: &MockConfigSpace, bus: u8, dev: u8, func: u8) -> (u8, u8, u8) {
+    let reg = mock.read_reg(bus, dev, func, 0x18);
+    (reg as u8, (reg >> 8) as u8, (reg >> 16) as u8)
+}
+
+/// Read the non-prefetchable memory window from a bridge.
+/// Returns None if disabled (base > limit).
+fn read_memory_window(mock: &MockConfigSpace, bus: u8, dev: u8, func: u8) -> Option<(u64, u64)> {
+    let reg = mock.read_reg(bus, dev, func, 0x20);
+    let base = ((reg as u64) & 0xFFF0) << 16;
+    let limit = (((reg >> 16) as u64) & 0xFFF0) << 16 | 0xF_FFFF;
+    if base <= limit {
+        Some((base, limit))
+    } else {
+        None
     }
-    out
 }
 
-/// Get the bridge memory window from a device's subtree requirement.
-fn memory_window(dev: &DiscoveredDevice) -> Option<(u64, u64)> {
-    dev.subtree_req.as_ref().and_then(|r| r.memory_window)
+/// Read the prefetchable memory window from a bridge.
+/// Returns None if disabled (base > limit).
+fn read_prefetchable_window(
+    mock: &MockConfigSpace,
+    bus: u8,
+    dev: u8,
+    func: u8,
+) -> Option<(u64, u64)> {
+    let reg = mock.read_reg(bus, dev, func, 0x24);
+    let base_lo = ((reg as u64) & 0xFFF0) << 16;
+    let limit_lo = (((reg >> 16) as u64) & 0xFFF0) << 16 | 0xF_FFFF;
+    let base_hi = mock.read_reg(bus, dev, func, 0x28) as u64;
+    let limit_hi = mock.read_reg(bus, dev, func, 0x2C) as u64;
+    let base = base_lo | (base_hi << 32);
+    let limit = limit_lo | (limit_hi << 32);
+    if base <= limit {
+        Some((base, limit))
+    } else {
+        None
+    }
 }
 
-/// Get the bridge prefetchable window from a device's subtree requirement.
-fn prefetchable_window(dev: &DiscoveredDevice) -> Option<(u64, u64)> {
-    dev.subtree_req.as_ref().and_then(|r| r.prefetchable_window)
-}
+// ---- Tests ----
 
 #[async_test]
 async fn single_endpoint_32bit_bar() {
     let mock = MockConfigSpace::new();
-    // Device on bus 0, device 0, function 0 with a 64KB 32-bit non-pref BAR at index 0.
     mock.add_endpoint(0, 0, 0, &[(0, 0x10000, false, false)]);
 
     let params = AssignmentParams {
@@ -263,28 +296,15 @@ async fn single_endpoint_32bit_bar() {
     };
 
     let mut cfg = mock.clone();
-    let result = assign_pci_resources_inner(&mut cfg, &params).await.unwrap();
+    assign_pci_resources(&mut cfg, &params).await.unwrap();
 
-    let flat = flatten_devices(&result);
-    assert_eq!(flat.len(), 1);
-    let entry = flat[0];
-    assert_eq!(entry.bus, 0);
-    assert_eq!(entry.device, 0);
-    assert_eq!(entry.function, 0);
-    assert_eq!(entry.bars.len(), 1);
-    assert_eq!(entry.bars[0].address.unwrap(), 0x1000_0000);
-    assert_eq!(entry.bars[0].size, 0x10000);
-    assert!(!entry.bars[0].is_64bit);
-
-    // Verify BAR was programmed in config space.
-    let bar_val = mock.read_reg(0, 0, 0, 0x10);
-    assert_eq!(bar_val, 0x1000_0000);
+    // BAR0 should be assigned at the aperture base.
+    assert_eq!(read_bar32(&mock, 0, 0, 0, 0), 0x1000_0000);
 }
 
 #[async_test]
 async fn single_endpoint_64bit_bar() {
     let mock = MockConfigSpace::new();
-    // 1 MB 64-bit prefetchable BAR at index 0.
     mock.add_endpoint(0, 1, 0, &[(0, 0x100000, true, true)]);
 
     let params = AssignmentParams {
@@ -298,30 +318,16 @@ async fn single_endpoint_64bit_bar() {
     };
 
     let mut cfg = mock.clone();
-    let result = assign_pci_resources_inner(&mut cfg, &params).await.unwrap();
+    assign_pci_resources(&mut cfg, &params).await.unwrap();
 
-    let flat = flatten_devices(&result);
-    assert_eq!(flat.len(), 1);
-    let bar = &flat[0].bars[0];
-    assert_eq!(bar.address.unwrap(), 0x1_0000_0000);
-    assert_eq!(bar.size, 0x100000);
-    assert!(bar.is_64bit);
-
-    // Verify both BAR registers were programmed.
-    let bar_lo = mock.read_reg(0, 1, 0, 0x10);
-    let bar_hi = mock.read_reg(0, 1, 0, 0x14);
-    assert_eq!(bar_lo, 0x0000_0000);
-    assert_eq!(bar_hi, 0x0000_0001);
+    assert_eq!(read_bar64(&mock, 0, 1, 0, 0), 0x1_0000_0000);
 }
 
 #[async_test]
 async fn bridge_with_endpoint() {
     let mock = MockConfigSpace::new();
 
-    // Bridge at bus 0, device 0, function 0.
     mock.add_bridge(0, 0, 0);
-    // Endpoint behind bridge at bus 1, device 0, function 0.
-    // 64KB non-prefetchable BAR.
     mock.add_endpoint(1, 0, 0, &[(0, 0x10000, false, false)]);
 
     let params = AssignmentParams {
@@ -335,41 +341,25 @@ async fn bridge_with_endpoint() {
     };
 
     let mut cfg = mock.clone();
-    let result = assign_pci_resources_inner(&mut cfg, &params).await.unwrap();
+    assign_pci_resources(&mut cfg, &params).await.unwrap();
 
-    // Should have 2 entries: bridge + endpoint.
-    let flat = flatten_devices(&result);
-    assert_eq!(flat.len(), 2);
+    // Bridge bus numbers.
+    let (_, secondary, subordinate) = read_bus_numbers(&mock, 0, 0, 0);
+    assert_eq!(secondary, 1);
+    assert_eq!(subordinate, 1);
 
-    // Find the bridge entry.
-    let bridge = flat
-        .iter()
-        .find(|e| e.bus == 0 && e.device == 0)
-        .unwrap();
-    assert_eq!(bridge.secondary_bus, Some(1));
-    assert_eq!(bridge.subordinate_bus, Some(1));
-    assert!(memory_window(bridge).is_some());
+    // Bridge should have a non-prefetchable memory window.
+    assert!(read_memory_window(&mock, 0, 0, 0).is_some());
 
-    // Find the endpoint entry.
-    let endpoint = flat
-        .iter()
-        .find(|e| e.bus == 1 && e.device == 0)
-        .unwrap();
-    assert_eq!(endpoint.bars.len(), 1);
-    assert_eq!(endpoint.bars[0].size, 0x10000);
-
-    // Verify bus numbers were programmed on the bridge.
-    let bus_reg = mock.read_reg(0, 0, 0, 0x18);
-    assert_eq!(bus_reg & 0xFF, 0, "primary bus");
-    assert_eq!((bus_reg >> 8) & 0xFF, 1, "secondary bus");
-    assert_eq!((bus_reg >> 16) & 0xFF, 1, "subordinate bus");
+    // Endpoint BAR should be programmed.
+    let bar = read_bar32(&mock, 1, 0, 0, 0);
+    assert!(bar >= 0x1000_0000);
 }
 
 #[async_test]
 async fn multiple_endpoints_sorted_by_size() {
     let mock = MockConfigSpace::new();
 
-    // Two devices with different BAR sizes.
     // Device 0: 4KB BAR.
     mock.add_endpoint(0, 0, 0, &[(0, 0x1000, false, false)]);
     // Device 1: 1MB BAR.
@@ -386,32 +376,20 @@ async fn multiple_endpoints_sorted_by_size() {
     };
 
     let mut cfg = mock.clone();
-    let result = assign_pci_resources_inner(&mut cfg, &params).await.unwrap();
+    assign_pci_resources(&mut cfg, &params).await.unwrap();
 
-    let flat = flatten_devices(&result);
-    assert_eq!(flat.len(), 2);
-
-    // The 1MB BAR should be allocated first (sorted by size desc) and
-    // aligned to 1MB.
-    let dev1 = flat.iter().find(|e| e.device == 1).unwrap();
-    assert_eq!(dev1.bars[0].address.unwrap(), 0x1000_0000);
-    assert_eq!(dev1.bars[0].size, 0x100000);
-
-    // The 4KB BAR should follow.
-    let dev0 = flat.iter().find(|e| e.device == 0).unwrap();
-    assert_eq!(dev0.bars[0].address.unwrap(), 0x1010_0000);
-    assert_eq!(dev0.bars[0].size, 0x1000);
+    // 1 MB BAR (dev 1) should be first, at the aperture base.
+    assert_eq!(read_bar32(&mock, 0, 1, 0, 0), 0x1000_0000);
+    // 4 KB BAR (dev 0) should follow.
+    assert_eq!(read_bar32(&mock, 0, 0, 0, 0), 0x1010_0000);
 }
 
 #[async_test]
 async fn multi_function_device() {
     let mock = MockConfigSpace::new();
 
-    // Function 0: 4KB BAR.
     mock.add_endpoint(0, 0, 0, &[(0, 0x1000, false, false)]);
-    // Function 1: 4KB BAR.
     mock.add_endpoint(0, 0, 1, &[(0, 0x1000, false, false)]);
-    // Mark as multi-function.
     mock.set_multi_function(0, 0);
 
     let params = AssignmentParams {
@@ -425,14 +403,11 @@ async fn multi_function_device() {
     };
 
     let mut cfg = mock.clone();
-    let result = assign_pci_resources_inner(&mut cfg, &params).await.unwrap();
+    assign_pci_resources(&mut cfg, &params).await.unwrap();
 
-    // Should find both functions.
-    let flat = flatten_devices(&result);
-    assert_eq!(flat.len(), 2);
-    let f0 = flat.iter().find(|e| e.function == 0).unwrap();
-    let f1 = flat.iter().find(|e| e.function == 1).unwrap();
-    assert_ne!(f0.bars[0].address.unwrap(), f1.bars[0].address.unwrap());
+    let f0_bar = read_bar32(&mock, 0, 0, 0, 0);
+    let f1_bar = read_bar32(&mock, 0, 0, 1, 0);
+    assert_ne!(f0_bar, f1_bar);
 }
 
 #[async_test]
@@ -466,50 +441,32 @@ async fn switch_with_multiple_endpoints() {
     };
 
     let mut cfg = mock.clone();
-    let result = assign_pci_resources_inner(&mut cfg, &params).await.unwrap();
+    assign_pci_resources(&mut cfg, &params).await.unwrap();
 
-    // Should have entries for: upstream bridge, 2 downstream bridges, 2 endpoints.
-    let flat = flatten_devices(&result);
-    assert!(flat.len() >= 4);
+    // Upstream bridge.
+    let (_, secondary, _) = read_bus_numbers(&mock, 0, 0, 0);
+    assert_eq!(secondary, 1);
 
-    // Verify bus numbers were assigned correctly.
-    let upstream = flat
-        .iter()
-        .find(|e| e.bus == 0 && e.device == 0)
-        .unwrap();
-    assert_eq!(upstream.secondary_bus, Some(1));
-
-    // Both endpoints should have BAR addresses assigned.
-    let ep1 = flat.iter().find(|e| e.bus == 2).unwrap();
-    let ep2 = flat.iter().find(|e| e.bus == 3).unwrap();
-    assert_eq!(ep1.bars.len(), 1);
-    assert_eq!(ep2.bars.len(), 1);
     // 32-bit BAR on bus 2 should be in low MMIO.
-    assert!(ep1.bars[0].address.unwrap() >= 0x1000_0000);
-    assert!(ep1.bars[0].address.unwrap() < 0x2000_0000);
-    // 64-bit BAR on bus 3 should be in high MMIO.
-    assert!(ep2.bars[0].address.unwrap() >= 0x1_0000_0000);
+    let ep1_bar = read_bar32(&mock, 2, 0, 0, 0) as u64;
+    assert!(ep1_bar >= 0x1000_0000);
+    assert!(ep1_bar < 0x2000_0000);
 
-    // The downstream bridge for the 64-bit endpoint should have a
-    // prefetchable window covering high MMIO.
-    let ds_bridge_64 = flat
-        .iter()
-        .find(|e| e.bus == 1 && e.device == 1)
-        .unwrap();
+    // 64-bit BAR on bus 3 should be in high MMIO.
+    let ep2_bar = read_bar64(&mock, 3, 0, 0, 0);
+    assert!(ep2_bar >= 0x1_0000_0000);
+
+    // Bridge for 64-bit endpoint should have prefetchable window.
+    let pref = read_prefetchable_window(&mock, 1, 1, 0);
     assert!(
-        prefetchable_window(ds_bridge_64).is_some(),
+        pref.is_some(),
         "bridge behind 64-bit endpoint should have prefetchable window"
     );
-    assert!(prefetchable_window(ds_bridge_64).unwrap().0 >= 0x1_0000_0000);
+    assert!(pref.unwrap().0 >= 0x1_0000_0000);
 
-    // The downstream bridge for the 32-bit endpoint should have a
-    // non-prefetchable window in low MMIO, and no prefetchable window.
-    let ds_bridge_32 = flat
-        .iter()
-        .find(|e| e.bus == 1 && e.device == 0)
-        .unwrap();
-    assert!(memory_window(ds_bridge_32).is_some());
-    assert!(prefetchable_window(ds_bridge_32).is_none());
+    // Bridge for 32-bit endpoint should have non-pref window but no pref window.
+    assert!(read_memory_window(&mock, 1, 0, 0).is_some());
+    assert!(read_prefetchable_window(&mock, 1, 0, 0).is_none());
 }
 
 #[async_test]
@@ -525,7 +482,7 @@ async fn bus_exhaustion_error() {
     };
 
     let mut cfg = mock;
-    let result = assign_pci_resources_inner(&mut cfg, &params).await;
+    let result = assign_pci_resources(&mut cfg, &params).await;
     assert!(result.is_err());
     assert!(
         matches!(
@@ -551,8 +508,8 @@ async fn no_devices_is_ok() {
     };
 
     let mut cfg = mock;
-    let result = assign_pci_resources_inner(&mut cfg, &params).await.unwrap();
-    assert!(result.is_empty());
+    assign_pci_resources(&mut cfg, &params).await.unwrap();
+    // Success is the assertion — no devices means nothing to program.
 }
 
 #[async_test]
@@ -574,7 +531,7 @@ async fn mmio_exhaustion_error() {
     };
 
     let mut cfg = mock;
-    let result = assign_pci_resources_inner(&mut cfg, &params).await;
+    let result = assign_pci_resources(&mut cfg, &params).await;
     assert!(result.is_err());
     assert!(
         matches!(
@@ -600,7 +557,7 @@ async fn no_aperture_error() {
     };
 
     let mut cfg = mock;
-    let result = assign_pci_resources_inner(&mut cfg, &params).await;
+    let result = assign_pci_resources(&mut cfg, &params).await;
     assert!(result.is_err());
     assert!(
         matches!(
@@ -615,12 +572,9 @@ async fn no_aperture_error() {
 async fn sriov_reserves_bus_numbers() {
     let mock = MockConfigSpace::new();
 
-    // Bridge on bus 0.
     mock.add_bridge(0, 0, 0);
 
     // Endpoint on bus 1 with SR-IOV: 256 VFs, offset=1, stride=1.
-    // PF routing ID = (1 << 8) | (0 << 3) | 0 = 0x100
-    // Last VF routing ID = 0x100 + 1 + 255*1 = 0x200 → bus 2
     mock.add_endpoint(1, 0, 0, &[(0, 0x1000, false, false)]);
     mock.add_sriov(1, 0, 0, 256, 1, 1);
 
@@ -635,31 +589,28 @@ async fn sriov_reserves_bus_numbers() {
     };
 
     let mut cfg = mock.clone();
-    let result = assign_pci_resources_inner(&mut cfg, &params).await.unwrap();
+    assign_pci_resources(&mut cfg, &params).await.unwrap();
 
-    // Bridge should have subordinate >= 2 to cover VF buses.
-    let bridge = flatten_devices(&result)
-        .into_iter()
-        .find(|e| e.bus == 0 && e.device == 0)
-        .unwrap();
-    assert_eq!(bridge.secondary_bus, Some(1));
+    let (_, secondary, subordinate) = read_bus_numbers(&mock, 0, 0, 0);
+    assert_eq!(secondary, 1);
     assert!(
-        bridge.subordinate_bus.unwrap() >= 2,
-        "subordinate bus {} should be >= 2 to cover SR-IOV VFs",
-        bridge.subordinate_bus.unwrap()
+        subordinate >= 2,
+        "subordinate bus {subordinate} should be >= 2 to cover SR-IOV VFs"
     );
 
-    // Verify bus numbers programmed on the bridge.
+    // Also verify from config space.
     let bus_reg = mock.read_reg(0, 0, 0, 0x18);
-    let subordinate = (bus_reg >> 16) & 0xFF;
-    assert!(subordinate >= 2, "subordinate {subordinate} should be >= 2");
+    let sub_from_reg = (bus_reg >> 16) & 0xFF;
+    assert!(
+        sub_from_reg >= 2,
+        "subordinate {sub_from_reg} should be >= 2"
+    );
 }
 
 #[async_test]
 async fn sriov_no_vfs_no_reservation() {
     let mock = MockConfigSpace::new();
 
-    // Bridge on bus 0.
     mock.add_bridge(0, 0, 0);
 
     // Endpoint on bus 1 with SR-IOV but 0 VFs.
@@ -677,21 +628,16 @@ async fn sriov_no_vfs_no_reservation() {
     };
 
     let mut cfg = mock.clone();
-    let result = assign_pci_resources_inner(&mut cfg, &params).await.unwrap();
+    assign_pci_resources(&mut cfg, &params).await.unwrap();
 
-    // No extra buses reserved — subordinate should be 1.
-    let bridge = flatten_devices(&result)
-        .into_iter()
-        .find(|e| e.bus == 0 && e.device == 0)
-        .unwrap();
-    assert_eq!(bridge.subordinate_bus, Some(1));
+    let (_, _, subordinate) = read_bus_numbers(&mock, 0, 0, 0);
+    assert_eq!(subordinate, 1);
 }
 
 #[async_test]
 async fn bridge_prefetchable_window_programmed() {
     let mock = MockConfigSpace::new();
 
-    // Bridge on bus 0 with a 64-bit endpoint behind it.
     mock.add_bridge(0, 0, 0);
     mock.add_endpoint(1, 0, 0, &[(0, 0x100000, true, true)]); // 1 MB 64-bit pref
 
@@ -706,25 +652,20 @@ async fn bridge_prefetchable_window_programmed() {
     };
 
     let mut cfg = mock.clone();
-    let result = assign_pci_resources_inner(&mut cfg, &params).await.unwrap();
+    assign_pci_resources(&mut cfg, &params).await.unwrap();
 
-    // The bridge should have a prefetchable window, not a non-prefetchable one.
-    let bridge = flatten_devices(&result)
-        .into_iter()
-        .find(|e| e.bus == 0 && e.device == 0)
-        .unwrap();
+    // No non-prefetchable window.
     assert!(
-        memory_window(bridge).is_none(),
+        read_memory_window(&mock, 0, 0, 0).is_none(),
         "no non-prefetchable window expected"
     );
-    assert!(
-        prefetchable_window(bridge).is_some(),
-        "prefetchable window expected"
-    );
-    assert!(prefetchable_window(bridge).unwrap().0 >= 0x1_0000_0000);
+
+    // Prefetchable window should exist.
+    let pref = read_prefetchable_window(&mock, 0, 0, 0);
+    assert!(pref.is_some(), "prefetchable window expected");
+    assert!(pref.unwrap().0 >= 0x1_0000_0000);
 
     // Verify the prefetchable window registers were programmed.
-    // Offset 0x24: prefetchable base/limit (lower 16 bits each, with 64-bit flag).
     let pf_range = mock.read_reg(0, 0, 0, 0x24);
     assert_ne!(
         pf_range, 0,
@@ -778,29 +719,18 @@ async fn sibling_bridge_windows_must_not_overlap() {
     };
 
     let mut cfg = mock.clone();
-    let result = assign_pci_resources_inner(&mut cfg, &params).await.unwrap();
+    assign_pci_resources(&mut cfg, &params).await.unwrap();
 
-    // Find bridge windows for the two downstream bridges.
-    let flat = flatten_devices(&result);
-    let bridge_a = flat
-        .iter()
-        .find(|e| e.bus == 1 && e.device == 0)
-        .unwrap();
-    let bridge_b = flat
-        .iter()
-        .find(|e| e.bus == 1 && e.device == 1)
-        .unwrap();
+    let a_window = read_memory_window(&mock, 1, 0, 0).expect("bridge A should have memory window");
+    let b_window = read_memory_window(&mock, 1, 1, 0).expect("bridge B should have memory window");
 
-    let (a_base, a_limit) = memory_window(bridge_a)
-        .expect("bridge A should have memory window");
-    let (b_base, b_limit) = memory_window(bridge_b)
-        .expect("bridge B should have memory window");
-
-    // Sibling bridge windows must not overlap — if they do, both bridges
-    // will claim the same addresses on the upstream bus.
     assert!(
-        a_limit < b_base || b_limit < a_base,
-        "bridge windows overlap: A=[{a_base:#x}..={a_limit:#x}], B=[{b_base:#x}..={b_limit:#x}]"
+        a_window.1 < b_window.0 || b_window.1 < a_window.0,
+        "bridge windows overlap: A=[{:#x}..={:#x}], B=[{:#x}..={:#x}]",
+        a_window.0,
+        a_window.1,
+        b_window.0,
+        b_window.1
     );
 }
 
@@ -808,7 +738,6 @@ async fn sibling_bridge_windows_must_not_overlap() {
 async fn large_bar_alignment_fits_in_bridge_window() {
     let mock = MockConfigSpace::new();
 
-    // Bridge on bus 0.
     mock.add_bridge(0, 0, 0);
 
     // Endpoint behind bridge with a 1 GB BAR (needs 1 GB natural alignment).
@@ -825,33 +754,25 @@ async fn large_bar_alignment_fits_in_bridge_window() {
     };
 
     let mut cfg = mock.clone();
-    let result = assign_pci_resources_inner(&mut cfg, &params).await.unwrap();
+    assign_pci_resources(&mut cfg, &params).await.unwrap();
 
-    let flat = flatten_devices(&result);
-    let bridge = flat
-        .iter()
-        .find(|e| e.bus == 0 && e.device == 0)
-        .unwrap();
-    let ep = flat
-        .iter()
-        .find(|e| e.bus == 1 && e.device == 0)
-        .unwrap();
+    let window = read_memory_window(&mock, 0, 0, 0).expect("bridge should have memory window");
+    let bar_addr = read_bar32(&mock, 1, 0, 0, 0) as u64;
 
-    let (window_base, window_limit) = memory_window(bridge)
-        .expect("bridge should have memory window");
-    let bar_addr = ep.bars[0].address.unwrap();    let bar_end = bar_addr + ep.bars[0].size - 1;
-
-    // The BAR must be naturally aligned.
+    // BAR must be naturally aligned.
     assert_eq!(
         bar_addr % 0x4000_0000,
         0,
         "1 GB BAR at {bar_addr:#x} is not 1 GB aligned"
     );
 
-    // The BAR must fit within the bridge window.
+    // BAR must fit within bridge window.
+    let bar_end = bar_addr + 0x4000_0000 - 1;
     assert!(
-        bar_addr >= window_base && bar_end <= window_limit,
-        "BAR [{bar_addr:#x}..={bar_end:#x}] overflows bridge window [{window_base:#x}..={window_limit:#x}]"
+        bar_addr >= window.0 && bar_end <= window.1,
+        "BAR [{bar_addr:#x}..={bar_end:#x}] overflows bridge window [{:#x}..={:#x}]",
+        window.0,
+        window.1
     );
 }
 
@@ -869,11 +790,6 @@ async fn alignment_first_sort_avoids_wasted_padding() {
     mock.add_bridge(0, 1, 0);
     mock.add_endpoint(2, 0, 0, &[(0, 0x200000, false, false)]);
 
-    // 5 MB aperture. With alignment-first ordering (B then A), total is
-    // exactly 5 MB: B at 0 (2 MB aligned, uses 2 MB), A at 2 MB (1 MB
-    // aligned, uses 3 MB). With size-first ordering (A then B), A uses
-    // 3 MB, then B needs 2 MB alignment → next 2 MB boundary is 4 MB,
-    // total = 6 MB, which overflows.
     let params = AssignmentParams {
         start_bus: 0,
         end_bus: 255,
@@ -885,11 +801,11 @@ async fn alignment_first_sort_avoids_wasted_padding() {
     };
 
     let mut cfg = mock.clone();
-    let result = assign_pci_resources_inner(&mut cfg, &params).await;
+    let result = assign_pci_resources(&mut cfg, &params).await;
 
     assert!(
         result.is_ok(),
-        "5 MB aperture should be sufficient for 3 MB + 2 MB: {}",
+        "5 MB aperture should be sufficient: {}",
         result.unwrap_err()
     );
 }
@@ -898,14 +814,8 @@ async fn alignment_first_sort_avoids_wasted_padding() {
 async fn misaligned_aperture_does_not_overflow() {
     let mock = MockConfigSpace::new();
 
-    // Single endpoint with a 4 MB BAR (needs 4 MB natural alignment).
     mock.add_endpoint(0, 0, 0, &[(0, 0x400000, false, false)]);
 
-    // Aperture base is only 2 MB aligned, not 4 MB aligned.
-    // The allocator must align up to the next 4 MB boundary, losing 2 MB,
-    // so it needs at least 6 MB of aperture. Give it exactly 4 MB — this
-    // should fail because the BAR won't fit after alignment, but must not
-    // silently place the BAR past the end of the aperture.
     let params = AssignmentParams {
         start_bus: 0,
         end_bus: 255,
@@ -917,9 +827,8 @@ async fn misaligned_aperture_does_not_overflow() {
     };
 
     let mut cfg = mock.clone();
-    let result = assign_pci_resources_inner(&mut cfg, &params).await;
+    let result = assign_pci_resources(&mut cfg, &params).await;
 
-    // The aperture is too small after alignment padding — this must fail.
     assert!(
         matches!(result, Err(crate::AssignmentError::MmioExhaustion { .. })),
         "expected MmioExhaustion for misaligned aperture, got {result:?}"
@@ -930,12 +839,8 @@ async fn misaligned_aperture_does_not_overflow() {
 async fn alignment_exceeds_aperture_returns_error() {
     let mock = MockConfigSpace::new();
 
-    // Single endpoint with a 16 MB BAR (needs 16 MB alignment).
     mock.add_endpoint(0, 0, 0, &[(0, 0x1000000, false, false)]);
 
-    // Aperture is only 2 MB total. Alignment pushes base past the end,
-    // which must produce MmioExhaustion rather than wrapping the
-    // available-space calculation.
     let params = AssignmentParams {
         start_bus: 0,
         end_bus: 255,
@@ -947,7 +852,7 @@ async fn alignment_exceeds_aperture_returns_error() {
     };
 
     let mut cfg = mock.clone();
-    let result = assign_pci_resources_inner(&mut cfg, &params).await;
+    let result = assign_pci_resources(&mut cfg, &params).await;
 
     assert!(
         matches!(result, Err(crate::AssignmentError::MmioExhaustion { .. })),
@@ -959,13 +864,8 @@ async fn alignment_exceeds_aperture_returns_error() {
 async fn sriov_bus_reservation_exceeding_end_bus_returns_error() {
     let mock = MockConfigSpace::new();
 
-    // Bridge on bus 0.
     mock.add_bridge(0, 0, 0);
 
-    // Endpoint on bus 1 with SR-IOV: 256 VFs, offset=1, stride=1.
-    // PF routing ID = (1 << 8) | (0 << 3) | 0 = 0x100
-    // Last VF routing ID = 0x100 + 1 + 255*1 = 0x200 → bus 2
-    // But end_bus is 1, so VF bus 2 is out of range.
     mock.add_endpoint(1, 0, 0, &[(0, 0x1000, false, false)]);
     mock.add_sriov(1, 0, 0, 256, 1, 1);
 
@@ -980,26 +880,19 @@ async fn sriov_bus_reservation_exceeding_end_bus_returns_error() {
     };
 
     let mut cfg = mock;
-    let result = assign_pci_resources_inner(&mut cfg, &params).await;
+    let result = assign_pci_resources(&mut cfg, &params).await;
 
-    // SR-IOV VFs need bus 2, but end_bus is 1. The code returns
-    // BusExhaustion because the VF bus range exceeds the allowed range.
     assert!(
         matches!(result, Err(crate::AssignmentError::BusExhaustion { .. })),
         "expected BusExhaustion when SR-IOV reservation exceeds end_bus, got {result:?}"
     );
 }
 
-/// Bug B: When low_mmio is None, 32-bit (non-prefetchable) BARs fall back
-/// to high_mmio via `.or(params.high_mmio)`. If high_mmio is above 4 GB,
-/// the BAR address is truncated by `bar.address as u32` and bridge memory
-/// base/limit registers (inherently 32-bit) silently lose upper bits.
 /// 32-bit BARs must never be placed above 4 GB.
 #[async_test]
 async fn mem32_bar_must_not_be_placed_above_4gb() {
     let mock = MockConfigSpace::new();
 
-    // 32-bit non-prefetchable BAR.
     mock.add_endpoint(0, 0, 0, &[(0, 0x10000, false, false)]);
 
     let params = AssignmentParams {
@@ -1013,38 +906,25 @@ async fn mem32_bar_must_not_be_placed_above_4gb() {
     };
 
     let mut cfg = mock;
-    let result = assign_pci_resources_inner(&mut cfg, &params).await;
+    let result = assign_pci_resources(&mut cfg, &params).await;
 
-    // No sub-4GB aperture exists, so 32-bit BARs cannot be placed.
-    // Must fail rather than silently placing them above 4 GB.
     assert!(
         result.is_err(),
-        "expected error when only aperture is above 4 GB, but got assignments: {:#?}",
-        result.unwrap()
+        "expected error when only aperture is above 4 GB"
     );
 }
 
-/// Bug C: When both mem32 and mem64 pools share the same aperture (only
-/// one of low_mmio/high_mmio is provided), the mem64 base is computed
-/// from `aperture.base + root_req.mem32` instead of from the actual
-/// aligned mem32 end address. If aperture.base needs alignment for mem32,
-/// mem64 can start inside the mem32 region, causing overlapping
-/// assignments.
+/// When both mem32 and mem64 pools share the same aperture, BAR regions
+/// must not overlap.
 #[async_test]
 async fn shared_aperture_mem32_mem64_must_not_overlap() {
     let mock = MockConfigSpace::new();
 
-    // Device 0: 4 MB 32-bit non-prefetchable BAR (needs 4 MB alignment).
+    // Device 0: 4 MB 32-bit non-prefetchable BAR.
     mock.add_endpoint(0, 0, 0, &[(0, 0x40_0000, false, false)]);
     // Device 1: 1 MB 64-bit prefetchable BAR.
     mock.add_endpoint(0, 1, 0, &[(0, 0x10_0000, true, true)]);
 
-    // Single aperture, misaligned so that mem32 alignment pushes its base
-    // forward, creating a gap between aperture.base and mem32 start.
-    // aperture.base = 0x1020_0000 (2 MB past a 4 MB boundary)
-    // mem32 aligns up to 0x1040_0000, occupies [0x1040_0000, 0x1080_0000)
-    // Bug: mem64 base = align_up(0x1020_0000 + 0x40_0000, 1MB)
-    //                  = 0x1060_0000, which is INSIDE the mem32 region.
     let params = AssignmentParams {
         start_bus: 0,
         end_bus: 255,
@@ -1055,68 +935,34 @@ async fn shared_aperture_mem32_mem64_must_not_overlap() {
         high_mmio: None,
     };
 
-    let mut cfg = mock;
-    let result = assign_pci_resources_inner(&mut cfg, &params).await.unwrap();
+    let mut cfg = mock.clone();
+    assign_pci_resources(&mut cfg, &params).await.unwrap();
 
-    // Collect all BAR regions and verify no overlaps.
-    let mut regions: Vec<(u64, u64, String)> = Vec::new();
-    let flat = flatten_devices(&result);
-    for entry in &flat {
-        for bar in &entry.bars {
-            regions.push((
-                bar.address.unwrap(),
-                bar.address.unwrap() + bar.size,
-                format!(
-                    "{:02x}:{:02x}.{} BAR{}",
-                    entry.bus, entry.device, entry.function, bar.index
-                ),
-            ));
-        }
-    }
+    // Device 0: 4 MB 32-bit BAR.
+    let bar0_addr = read_bar32(&mock, 0, 0, 0, 0) as u64;
+    let bar0_end = bar0_addr + 0x40_0000;
 
-    for i in 0..regions.len() {
-        for j in (i + 1)..regions.len() {
-            let (a_start, a_end, a_name) = &regions[i];
-            let (b_start, b_end, b_name) = &regions[j];
-            assert!(
-                a_end <= b_start || b_end <= a_start,
-                "BAR regions overlap: {a_name} [{a_start:#x}..{a_end:#x}) vs \
-                 {b_name} [{b_start:#x}..{b_end:#x})"
-            );
-        }
-    }
+    // Device 1: 1 MB 64-bit BAR (in low MMIO, so hi is 0).
+    let bar1_addr = read_bar64(&mock, 0, 1, 0, 0);
+    let bar1_end = bar1_addr + 0x10_0000;
+
+    assert!(
+        bar0_end <= bar1_addr || bar1_end <= bar0_addr,
+        "BAR regions overlap: [{bar0_addr:#x}..{bar0_end:#x}) vs [{bar1_addr:#x}..{bar1_end:#x})"
+    );
 }
 
-/// Bug A: When bus 255 is consumed (by a bridge secondary or SR-IOV VF
-/// range), `wrapping_add(1)` wraps `*next_bus` to 0. The subsequent
-/// `*next_bus > end_bus` guard (0 > 255) is false, so the next bridge
-/// gets secondary bus 0, colliding with the host bridge. Should return
-/// BusExhaustion instead.
+/// When bus 255 is consumed, next_bus must not wrap to 0.
 #[async_test]
 async fn bus_wrap_to_zero_must_return_exhaustion() {
     let mock = MockConfigSpace::new();
 
-    // Bridge 0 on bus 0 → secondary = 1.
     mock.add_bridge(0, 0, 0);
 
-    // Endpoint on bus 1 with SR-IOV: 256 VFs, offset = 0x100, stride = 1.
-    // PF routing ID = (1 << 8) | 0 = 0x100
-    // Last VF routing ID = 0x100 + 0x100 + 255*1 = 0x2FF → bus 2
-    // But we'll craft it so max_vf_bus = 255:
-    // PF on bus 1, devfn 0. vf_offset = 0x700, stride = 1, total_vfs = 1.
-    // First VF RID = 0x100 + 0x700 = 0x800 → bus 8? No...
-    // We want last VF on bus 255. RID of last VF = 0xFF00..0xFFFF → bus 255.
-    // PF RID = (1 << 8) | 0 = 0x100.
-    // last_vf_rid = 0x100 + vf_offset + (total_vfs - 1) * vf_stride = 0xFF00
-    // With total_vfs=1, stride=1: last_vf_rid = 0x100 + vf_offset = 0xFF00
-    // → vf_offset = 0xFE00
     mock.add_endpoint(1, 0, 0, &[(0, 0x1000, false, false)]);
     mock.add_sriov(1, 0, 0, 1, 0xFE00, 1);
 
-    // Second bridge on bus 0 → needs secondary bus, but next_bus wrapped to 0.
     mock.add_bridge(0, 1, 0);
-    // Empty device behind it (bus 256 which doesn't exist).
-    // The bridge just needs to exist to trigger the next bus allocation.
 
     let params = AssignmentParams {
         start_bus: 0,
@@ -1129,10 +975,8 @@ async fn bus_wrap_to_zero_must_return_exhaustion() {
     };
 
     let mut cfg = mock;
-    let result = assign_pci_resources_inner(&mut cfg, &params).await;
+    let result = assign_pci_resources(&mut cfg, &params).await;
 
-    // The SR-IOV reservation consumes up through bus 255. The next bridge
-    // should fail with BusExhaustion, not silently wrap to bus 0.
     assert!(
         matches!(result, Err(crate::AssignmentError::BusExhaustion { .. })),
         "expected BusExhaustion when next_bus wraps past 255, got {result:?}"
@@ -1140,18 +984,12 @@ async fn bus_wrap_to_zero_must_return_exhaustion() {
 }
 
 /// VF BARs from SR-IOV capability must be included in bridge window sizing.
-/// Without this, the bridge window is too small for VF BAR space and VF
-/// MMIO accesses fault.
 #[async_test]
 async fn sriov_vf_bars_included_in_bridge_window() {
     let mock = MockConfigSpace::new();
 
-    // Bridge on bus 0.
     mock.add_bridge(0, 0, 0);
 
-    // PF on bus 1 with a 4 KB device BAR and SR-IOV with 4 VFs, each
-    // needing a 4 KB non-prefetchable VF BAR0.
-    // Total VF BAR space: 4 * 4 KB = 16 KB.
     mock.add_endpoint(1, 0, 0, &[(0, 0x1000, false, false)]);
     mock.set_multi_function(1, 0);
     mock.add_sriov_with_bars(
@@ -1174,38 +1012,26 @@ async fn sriov_vf_bars_included_in_bridge_window() {
         high_mmio: None,
     };
 
-    let mut cfg = mock;
-    let result = assign_pci_resources_inner(&mut cfg, &params).await.unwrap();
+    let mut cfg = mock.clone();
+    assign_pci_resources(&mut cfg, &params).await.unwrap();
 
-    // Find the bridge entry and check that its memory window is large
-    // enough for both the PF BAR (4 KB) and VF BARs (4 * 4 KB = 16 KB).
-    let bridge = flatten_devices(&result)
-        .into_iter()
-        .find(|e| e.bus == 0 && e.device == 0)
-        .unwrap();
-    let (window_base, window_limit) = memory_window(bridge)
-        .expect("bridge should have memory window");
-    let window_size = window_limit - window_base + 1;
+    let window = read_memory_window(&mock, 0, 0, 0).expect("bridge should have memory window");
+    let window_size = window.1 - window.0 + 1;
 
     // PF BAR = 0x1000, VF BARs = 4 * 0x1000 = 0x4000, total = 0x5000.
-    // Bridge window is rounded up to 1 MB granularity.
     assert!(
         window_size >= 0x5000,
-        "bridge window {window_size:#x} must be >= 0x5000 (PF BAR + 4 VF BARs)"
+        "bridge window {window_size:#x} must be >= 0x5000"
     );
 }
 
-/// Non-power-of-two VF counts must not panic. The total VF BAR space
-/// (total_vfs * per-VF BAR size) is not a power of two in this case,
-/// so alignment must use the per-VF BAR size, not the total size.
+/// Non-power-of-two VF counts must not panic.
 #[async_test]
 async fn sriov_non_power_of_two_vf_count() {
     let mock = MockConfigSpace::new();
 
     mock.add_bridge(0, 0, 0);
 
-    // PF with 3 VFs (not a power of two), each with a 4 KB VF BAR.
-    // Total VF BAR space: 3 * 4 KB = 12 KB (not a power of two).
     mock.add_endpoint(1, 0, 0, &[(0, 0x1000, false, false)]);
     mock.set_multi_function(1, 0);
     mock.add_sriov_with_bars(
@@ -1228,34 +1054,25 @@ async fn sriov_non_power_of_two_vf_count() {
         high_mmio: None,
     };
 
-    let mut cfg = mock;
-    let result = assign_pci_resources_inner(&mut cfg, &params).await.unwrap();
+    let mut cfg = mock.clone();
+    assign_pci_resources(&mut cfg, &params).await.unwrap();
 
-    let bridge = flatten_devices(&result)
-        .into_iter()
-        .find(|e| e.bus == 0 && e.device == 0)
-        .unwrap();
-    let (window_base, window_limit) = memory_window(bridge)
-        .expect("bridge should have memory window");
-    let window_size = window_limit - window_base + 1;
+    let window = read_memory_window(&mock, 0, 0, 0).expect("bridge should have memory window");
+    let window_size = window.1 - window.0 + 1;
 
-    // PF BAR = 0x1000, VF BARs = 3 * 0x1000 = 0x3000, total = 0x4000.
     assert!(
         window_size >= 0x4000,
-        "bridge window {window_size:#x} must be >= 0x4000 (PF BAR + 3 VF BARs)"
+        "bridge window {window_size:#x} must be >= 0x4000"
     );
 }
 
-/// 64-bit prefetchable VF BARs should be placed in the high MMIO aperture
-/// via the prefetchable bridge window, not the non-prefetchable window.
+/// 64-bit prefetchable VF BARs should be placed in the high MMIO aperture.
 #[async_test]
 async fn sriov_vf_bars_64bit_prefetchable() {
     let mock = MockConfigSpace::new();
 
     mock.add_bridge(0, 0, 0);
 
-    // PF with a 32-bit non-pref device BAR and SR-IOV with 4 VFs,
-    // each needing a 64-bit prefetchable VF BAR (1 MB each).
     mock.add_endpoint(1, 0, 0, &[(0, 0x1000, false, false)]);
     mock.set_multi_function(1, 0);
     mock.add_sriov_with_bars(
@@ -1281,36 +1098,28 @@ async fn sriov_vf_bars_64bit_prefetchable() {
         }),
     };
 
-    let mut cfg = mock;
-    let result = assign_pci_resources_inner(&mut cfg, &params).await.unwrap();
+    let mut cfg = mock.clone();
+    assign_pci_resources(&mut cfg, &params).await.unwrap();
 
-    let bridge = flatten_devices(&result)
-        .into_iter()
-        .find(|e| e.bus == 0 && e.device == 0)
-        .unwrap();
-
-    // Non-prefetchable window should exist for the PF's 32-bit BAR.
-    let (mem_base, mem_limit) = memory_window(bridge)
-        .expect("bridge should have non-pref memory window");
-    let mem_size = mem_limit - mem_base + 1;
+    // Non-pref window for PF's 32-bit BAR.
+    let mem = read_memory_window(&mock, 0, 0, 0).expect("bridge should have non-pref window");
+    let mem_size = mem.1 - mem.0 + 1;
     assert!(
         mem_size >= 0x1000,
         "non-pref window {mem_size:#x} must fit PF BAR (0x1000)"
     );
 
-    // Prefetchable window should exist for VF BARs (4 * 1 MB = 4 MB).
-    let (pref_base, pref_limit) = prefetchable_window(bridge)
-        .expect("bridge should have prefetchable window");
-    let pref_size = pref_limit - pref_base + 1;
+    // Pref window for VF BARs (4 * 1 MB).
+    let pref = read_prefetchable_window(&mock, 0, 0, 0).expect("bridge should have pref window");
+    let pref_size = pref.1 - pref.0 + 1;
     assert!(
         pref_size >= 0x40_0000,
-        "prefetchable window {pref_size:#x} must be >= 0x400000 (4 * 1 MB VF BARs)"
+        "pref window {pref_size:#x} must be >= 0x400000"
     );
-
-    // Prefetchable window should be in high MMIO.
     assert!(
-        pref_base >= 0x1_0000_0000,
-        "prefetchable window base {pref_base:#x} should be in high MMIO"
+        pref.0 >= 0x1_0000_0000,
+        "pref window base {:#x} should be in high MMIO",
+        pref.0
     );
 }
 
@@ -1322,10 +1131,6 @@ async fn sriov_mixed_vf_bar_types() {
 
     mock.add_bridge(0, 0, 0);
 
-    // PF with no device BARs, but two VF BARs:
-    //   VF BAR0: 4 KB non-prefetchable 32-bit
-    //   VF BAR2: 64 KB 64-bit prefetchable
-    // 2 VFs.
     mock.add_endpoint(1, 0, 0, &[]);
     mock.set_multi_function(1, 0);
     mock.add_sriov_with_bars(
@@ -1354,41 +1159,29 @@ async fn sriov_mixed_vf_bar_types() {
         }),
     };
 
-    let mut cfg = mock;
-    let result = assign_pci_resources_inner(&mut cfg, &params).await.unwrap();
+    let mut cfg = mock.clone();
+    assign_pci_resources(&mut cfg, &params).await.unwrap();
 
-    let bridge = flatten_devices(&result)
-        .into_iter()
-        .find(|e| e.bus == 0 && e.device == 0)
-        .unwrap();
-
-    // Non-pref window for VF BAR0: 2 * 4 KB = 8 KB.
-    let (mem_base, mem_limit) = memory_window(bridge)
-        .expect("bridge should have non-pref window for VF BAR0");
-    let mem_size = mem_limit - mem_base + 1;
+    let mem = read_memory_window(&mock, 0, 0, 0).expect("bridge should have non-pref window");
+    let mem_size = mem.1 - mem.0 + 1;
     assert!(
         mem_size >= 0x2000,
-        "non-pref window {mem_size:#x} must be >= 0x2000 (2 * 4 KB VF BAR0)"
+        "non-pref window {mem_size:#x} must be >= 0x2000"
     );
 
-    // Pref window for VF BAR2: 2 * 64 KB = 128 KB.
-    let (pref_base, pref_limit) = prefetchable_window(bridge)
-        .expect("bridge should have pref window for VF BAR2");
-    let pref_size = pref_limit - pref_base + 1;
+    let pref = read_prefetchable_window(&mock, 0, 0, 0).expect("bridge should have pref window");
+    let pref_size = pref.1 - pref.0 + 1;
     assert!(
         pref_size >= 0x2_0000,
-        "pref window {pref_size:#x} must be >= 0x20000 (2 * 64 KB VF BAR2)"
+        "pref window {pref_size:#x} must be >= 0x20000"
     );
 }
 
-/// Top-level PF (no bridge) with VF BARs: VF BAR space must be accounted
-/// for in the root aperture, and the PF's own BARs must be assigned without
-/// overlapping the reserved VF BAR region.
+/// Top-level PF (no bridge) with VF BARs.
 #[async_test]
 async fn sriov_top_level_pf_no_bridge() {
     let mock = MockConfigSpace::new();
 
-    // PF on bus 0 with a 64 KB device BAR and 4 VFs each with 64 KB VF BAR.
     mock.add_endpoint(0, 0, 0, &[(0, 0x1_0000, false, false)]);
     mock.set_multi_function(0, 0);
     mock.add_sriov_with_bars(
@@ -1411,27 +1204,20 @@ async fn sriov_top_level_pf_no_bridge() {
         high_mmio: None,
     };
 
-    let mut cfg = mock;
-    let result = assign_pci_resources_inner(&mut cfg, &params).await.unwrap();
+    let mut cfg = mock.clone();
+    assign_pci_resources(&mut cfg, &params).await.unwrap();
 
-    // The PF should have its own BAR assigned.
-    let pf = flatten_devices(&result)
-        .into_iter()
-        .find(|e| e.bus == 0 && e.device == 0)
-        .unwrap();
-    assert_eq!(pf.bars.len(), 1);
-    assert_eq!(pf.bars[0].size, 0x1_0000);
-
-    // The PF BAR should be within the aperture.
-    let bar_end = pf.bars[0].address.unwrap() + pf.bars[0].size;
+    // PF BAR should be programmed.
+    let bar = read_bar32(&mock, 0, 0, 0, 0);
+    assert!(bar > 0, "PF BAR should be assigned");
+    let bar_end = bar as u64 + 0x1_0000;
     assert!(
         bar_end <= 0x2000_0000,
         "PF BAR must fit in low_mmio aperture"
     );
 }
 
-/// Two PFs behind the same bridge, each with VF BARs. The bridge window
-/// must be large enough for both PFs' device BARs plus both VF BAR regions.
+/// Two PFs behind the same bridge, each with VF BARs.
 #[async_test]
 async fn sriov_multiple_pfs_behind_bridge() {
     let mock = MockConfigSpace::new();
@@ -1458,57 +1244,38 @@ async fn sriov_multiple_pfs_behind_bridge() {
         high_mmio: None,
     };
 
-    let mut cfg = mock;
-    let result = assign_pci_resources_inner(&mut cfg, &params).await.unwrap();
+    let mut cfg = mock.clone();
+    assign_pci_resources(&mut cfg, &params).await.unwrap();
 
-    let flat = flatten_devices(&result);
-    let bridge = flat
-        .iter()
-        .find(|e| e.bus == 0 && e.device == 0)
-        .unwrap();
-    let (window_base, window_limit) = memory_window(bridge)
-        .expect("bridge should have memory window");
-    let window_size = window_limit - window_base + 1;
+    let window = read_memory_window(&mock, 0, 0, 0).expect("bridge should have memory window");
+    let window_size = window.1 - window.0 + 1;
 
     // PF1: BAR=0x1000 + VF=2*0x1000=0x2000
     // PF2: BAR=0x2000 + VF=3*0x2000=0x6000
     // Total = 0x1000 + 0x2000 + 0x2000 + 0x6000 = 0xB000
     assert!(
         window_size >= 0xB000,
-        "bridge window {window_size:#x} must be >= 0xB000 (two PFs with VF BARs)"
+        "bridge window {window_size:#x} must be >= 0xB000"
     );
 
-    // Both PFs should have their device BARs assigned.
-    let pf1 = flat
-        .iter()
-        .find(|e| e.bus == 1 && e.device == 0)
-        .unwrap();
-    let pf2 = flat
-        .iter()
-        .find(|e| e.bus == 1 && e.device == 1)
-        .unwrap();
-    assert_eq!(pf1.bars.len(), 1);
-    assert_eq!(pf2.bars.len(), 1);
-
-    // PF BARs must not overlap each other.
-    let pf1_end = pf1.bars[0].address.unwrap() + pf1.bars[0].size;
-    let pf2_end = pf2.bars[0].address.unwrap() + pf2.bars[0].size;
+    // Both PF BARs should be programmed and not overlap.
+    let pf1_bar = read_bar32(&mock, 1, 0, 0, 0) as u64;
+    let pf2_bar = read_bar32(&mock, 1, 1, 0, 0) as u64;
+    let pf1_size: u64 = 0x1000;
+    let pf2_size: u64 = 0x2000;
     assert!(
-        pf1_end <= pf2.bars[0].address.unwrap() || pf2_end <= pf1.bars[0].address.unwrap(),
+        pf1_bar + pf1_size <= pf2_bar || pf2_bar + pf2_size <= pf1_bar,
         "PF BARs must not overlap"
     );
 }
 
-/// VF BAR space contributing to MMIO exhaustion should produce an error,
-/// not a panic or silent misallocation.
+/// VF BAR space contributing to MMIO exhaustion should produce an error.
 #[async_test]
 async fn sriov_vf_bars_cause_mmio_exhaustion() {
     let mock = MockConfigSpace::new();
 
     mock.add_bridge(0, 0, 0);
 
-    // PF with 16 VFs, each needing 1 MB VF BAR = 16 MB total.
-    // The aperture is only 2 MB.
     mock.add_endpoint(1, 0, 0, &[(0, 0x1000, false, false)]);
     mock.set_multi_function(1, 0);
     mock.add_sriov_with_bars(
@@ -1532,7 +1299,7 @@ async fn sriov_vf_bars_cause_mmio_exhaustion() {
     };
 
     let mut cfg = mock;
-    let result = assign_pci_resources_inner(&mut cfg, &params).await;
+    let result = assign_pci_resources(&mut cfg, &params).await;
     assert!(
         result.is_err(),
         "should fail with MMIO exhaustion, got {result:?}"

--- a/vm/devices/pci/pci_resource_assignment/src/tests.rs
+++ b/vm/devices/pci/pci_resource_assignment/src/tests.rs
@@ -1251,3 +1251,321 @@ async fn sriov_non_power_of_two_vf_count() {
         "bridge window {window_size:#x} must be >= 0x4000 (PF BAR + 3 VF BARs)"
     );
 }
+
+/// 64-bit prefetchable VF BARs should be placed in the high MMIO aperture
+/// via the prefetchable bridge window, not the non-prefetchable window.
+#[async_test]
+async fn sriov_vf_bars_64bit_prefetchable() {
+    let mock = MockConfigSpace::new();
+
+    mock.add_bridge(0, 0, 0);
+
+    // PF with a 32-bit non-pref device BAR and SR-IOV with 4 VFs,
+    // each needing a 64-bit prefetchable VF BAR (1 MB each).
+    mock.add_endpoint(1, 0, 0, &[(0, 0x1000, false, false)]);
+    mock.set_multi_function(1, 0);
+    mock.add_sriov_with_bars(
+        1,
+        0,
+        0,
+        4,
+        1,
+        1,
+        &[(0, 0x10_0000, true, true)], // VF BAR0: 1 MB, 64-bit prefetchable
+    );
+
+    let params = AssignmentParams {
+        start_bus: 0,
+        end_bus: 255,
+        low_mmio: Some(MmioAperture {
+            base: 0x1000_0000,
+            len: 0x1000_0000,
+        }),
+        high_mmio: Some(MmioAperture {
+            base: 0x1_0000_0000,
+            len: 0x1_0000_0000,
+        }),
+    };
+
+    let mut cfg = mock;
+    let result = assign_pci_resources_inner(&mut cfg, &params).await.unwrap();
+
+    let bridge = result
+        .entries
+        .iter()
+        .find(|e| e.bus == 0 && e.device == 0)
+        .unwrap();
+
+    // Non-prefetchable window should exist for the PF's 32-bit BAR.
+    let mem_base = bridge
+        .memory_base
+        .expect("bridge should have non-pref memory window");
+    let mem_limit = bridge
+        .memory_limit
+        .expect("bridge should have non-pref memory limit");
+    let mem_size = mem_limit - mem_base + 1;
+    assert!(
+        mem_size >= 0x1000,
+        "non-pref window {mem_size:#x} must fit PF BAR (0x1000)"
+    );
+
+    // Prefetchable window should exist for VF BARs (4 * 1 MB = 4 MB).
+    let pref_base = bridge
+        .prefetchable_base
+        .expect("bridge should have prefetchable window");
+    let pref_limit = bridge
+        .prefetchable_limit
+        .expect("bridge should have prefetchable limit");
+    let pref_size = pref_limit - pref_base + 1;
+    assert!(
+        pref_size >= 0x40_0000,
+        "prefetchable window {pref_size:#x} must be >= 0x400000 (4 * 1 MB VF BARs)"
+    );
+
+    // Prefetchable window should be in high MMIO.
+    assert!(
+        pref_base >= 0x1_0000_0000,
+        "prefetchable window base {pref_base:#x} should be in high MMIO"
+    );
+}
+
+/// A PF with both 32-bit non-pref and 64-bit prefetchable VF BARs should
+/// have space reserved in both bridge windows.
+#[async_test]
+async fn sriov_mixed_vf_bar_types() {
+    let mock = MockConfigSpace::new();
+
+    mock.add_bridge(0, 0, 0);
+
+    // PF with no device BARs, but two VF BARs:
+    //   VF BAR0: 4 KB non-prefetchable 32-bit
+    //   VF BAR2: 64 KB 64-bit prefetchable
+    // 2 VFs.
+    mock.add_endpoint(1, 0, 0, &[]);
+    mock.set_multi_function(1, 0);
+    mock.add_sriov_with_bars(
+        1,
+        0,
+        0,
+        2,
+        1,
+        1,
+        &[
+            (0, 0x1000, false, false), // VF BAR0: 4 KB non-pref
+            (2, 0x1_0000, true, true), // VF BAR2: 64 KB 64-bit pref
+        ],
+    );
+
+    let params = AssignmentParams {
+        start_bus: 0,
+        end_bus: 255,
+        low_mmio: Some(MmioAperture {
+            base: 0x1000_0000,
+            len: 0x1000_0000,
+        }),
+        high_mmio: Some(MmioAperture {
+            base: 0x1_0000_0000,
+            len: 0x1_0000_0000,
+        }),
+    };
+
+    let mut cfg = mock;
+    let result = assign_pci_resources_inner(&mut cfg, &params).await.unwrap();
+
+    let bridge = result
+        .entries
+        .iter()
+        .find(|e| e.bus == 0 && e.device == 0)
+        .unwrap();
+
+    // Non-pref window for VF BAR0: 2 * 4 KB = 8 KB.
+    let mem_base = bridge
+        .memory_base
+        .expect("bridge should have non-pref window for VF BAR0");
+    let mem_limit = bridge
+        .memory_limit
+        .expect("bridge should have non-pref limit");
+    let mem_size = mem_limit - mem_base + 1;
+    assert!(
+        mem_size >= 0x2000,
+        "non-pref window {mem_size:#x} must be >= 0x2000 (2 * 4 KB VF BAR0)"
+    );
+
+    // Pref window for VF BAR2: 2 * 64 KB = 128 KB.
+    let pref_base = bridge
+        .prefetchable_base
+        .expect("bridge should have pref window for VF BAR2");
+    let pref_limit = bridge
+        .prefetchable_limit
+        .expect("bridge should have pref limit");
+    let pref_size = pref_limit - pref_base + 1;
+    assert!(
+        pref_size >= 0x2_0000,
+        "pref window {pref_size:#x} must be >= 0x20000 (2 * 64 KB VF BAR2)"
+    );
+}
+
+/// Top-level PF (no bridge) with VF BARs: VF BAR space must be accounted
+/// for in the root aperture, and the PF's own BARs must be assigned without
+/// overlapping the reserved VF BAR region.
+#[async_test]
+async fn sriov_top_level_pf_no_bridge() {
+    let mock = MockConfigSpace::new();
+
+    // PF on bus 0 with a 64 KB device BAR and 4 VFs each with 64 KB VF BAR.
+    mock.add_endpoint(0, 0, 0, &[(0, 0x1_0000, false, false)]);
+    mock.set_multi_function(0, 0);
+    mock.add_sriov_with_bars(
+        0,
+        0,
+        0,
+        4,
+        1,
+        1,
+        &[(0, 0x1_0000, false, false)], // VF BAR0: 64 KB non-pref
+    );
+
+    let params = AssignmentParams {
+        start_bus: 0,
+        end_bus: 255,
+        low_mmio: Some(MmioAperture {
+            base: 0x1000_0000,
+            len: 0x1000_0000,
+        }),
+        high_mmio: None,
+    };
+
+    let mut cfg = mock;
+    let result = assign_pci_resources_inner(&mut cfg, &params).await.unwrap();
+
+    // The PF should have its own BAR assigned.
+    let pf = result
+        .entries
+        .iter()
+        .find(|e| e.bus == 0 && e.device == 0)
+        .unwrap();
+    assert_eq!(pf.bars.len(), 1);
+    assert_eq!(pf.bars[0].size, 0x1_0000);
+
+    // The PF BAR should be within the aperture.
+    let bar_end = pf.bars[0].address + pf.bars[0].size;
+    assert!(
+        bar_end <= 0x2000_0000,
+        "PF BAR must fit in low_mmio aperture"
+    );
+}
+
+/// Two PFs behind the same bridge, each with VF BARs. The bridge window
+/// must be large enough for both PFs' device BARs plus both VF BAR regions.
+#[async_test]
+async fn sriov_multiple_pfs_behind_bridge() {
+    let mock = MockConfigSpace::new();
+
+    mock.add_bridge(0, 0, 0);
+
+    // PF1 on bus 1, device 0: 4 KB device BAR, 2 VFs with 4 KB VF BAR.
+    mock.add_endpoint(1, 0, 0, &[(0, 0x1000, false, false)]);
+    mock.set_multi_function(1, 0);
+    mock.add_sriov_with_bars(1, 0, 0, 2, 1, 1, &[(0, 0x1000, false, false)]);
+
+    // PF2 on bus 1, device 1: 8 KB device BAR, 3 VFs with 8 KB VF BAR.
+    mock.add_endpoint(1, 1, 0, &[(0, 0x2000, false, false)]);
+    mock.set_multi_function(1, 1);
+    mock.add_sriov_with_bars(1, 1, 0, 3, 1, 1, &[(0, 0x2000, false, false)]);
+
+    let params = AssignmentParams {
+        start_bus: 0,
+        end_bus: 255,
+        low_mmio: Some(MmioAperture {
+            base: 0x1000_0000,
+            len: 0x1000_0000,
+        }),
+        high_mmio: None,
+    };
+
+    let mut cfg = mock;
+    let result = assign_pci_resources_inner(&mut cfg, &params).await.unwrap();
+
+    let bridge = result
+        .entries
+        .iter()
+        .find(|e| e.bus == 0 && e.device == 0)
+        .unwrap();
+    let window_base = bridge
+        .memory_base
+        .expect("bridge should have memory window");
+    let window_limit = bridge
+        .memory_limit
+        .expect("bridge should have memory limit");
+    let window_size = window_limit - window_base + 1;
+
+    // PF1: BAR=0x1000 + VF=2*0x1000=0x2000
+    // PF2: BAR=0x2000 + VF=3*0x2000=0x6000
+    // Total = 0x1000 + 0x2000 + 0x2000 + 0x6000 = 0xB000
+    assert!(
+        window_size >= 0xB000,
+        "bridge window {window_size:#x} must be >= 0xB000 (two PFs with VF BARs)"
+    );
+
+    // Both PFs should have their device BARs assigned.
+    let pf1 = result
+        .entries
+        .iter()
+        .find(|e| e.bus == 1 && e.device == 0)
+        .unwrap();
+    let pf2 = result
+        .entries
+        .iter()
+        .find(|e| e.bus == 1 && e.device == 1)
+        .unwrap();
+    assert_eq!(pf1.bars.len(), 1);
+    assert_eq!(pf2.bars.len(), 1);
+
+    // PF BARs must not overlap each other.
+    let pf1_end = pf1.bars[0].address + pf1.bars[0].size;
+    let pf2_end = pf2.bars[0].address + pf2.bars[0].size;
+    assert!(
+        pf1_end <= pf2.bars[0].address || pf2_end <= pf1.bars[0].address,
+        "PF BARs must not overlap"
+    );
+}
+
+/// VF BAR space contributing to MMIO exhaustion should produce an error,
+/// not a panic or silent misallocation.
+#[async_test]
+async fn sriov_vf_bars_cause_mmio_exhaustion() {
+    let mock = MockConfigSpace::new();
+
+    mock.add_bridge(0, 0, 0);
+
+    // PF with 16 VFs, each needing 1 MB VF BAR = 16 MB total.
+    // The aperture is only 2 MB.
+    mock.add_endpoint(1, 0, 0, &[(0, 0x1000, false, false)]);
+    mock.set_multi_function(1, 0);
+    mock.add_sriov_with_bars(
+        1,
+        0,
+        0,
+        16,
+        1,
+        1,
+        &[(0, 0x10_0000, false, false)], // VF BAR0: 1 MB each
+    );
+
+    let params = AssignmentParams {
+        start_bus: 0,
+        end_bus: 255,
+        low_mmio: Some(MmioAperture {
+            base: 0x1000_0000,
+            len: 0x20_0000, // Only 2 MB — not enough for 16 MB of VF BARs
+        }),
+        high_mmio: None,
+    };
+
+    let mut cfg = mock;
+    let result = assign_pci_resources_inner(&mut cfg, &params).await;
+    assert!(
+        result.is_err(),
+        "should fail with MMIO exhaustion, got {result:?}"
+    );
+}

--- a/vm/devices/pci/pci_resource_assignment/src/tests.rs
+++ b/vm/devices/pci/pci_resource_assignment/src/tests.rs
@@ -7,6 +7,7 @@ use crate::AssignmentParams;
 use crate::MmioAperture;
 use crate::PciConfigAccess;
 use crate::assign_pci_resources_inner;
+use crate::enumerate::DiscoveredDevice;
 use parking_lot::Mutex;
 use std::collections::BTreeMap;
 use std::sync::Arc;
@@ -225,6 +226,16 @@ use pal_async::async_test;
 
 // ---- Tests ----
 
+/// Flatten a device tree into a list for test assertions.
+fn flatten_devices(devices: &[DiscoveredDevice]) -> Vec<&DiscoveredDevice> {
+    let mut out = Vec::new();
+    for dev in devices {
+        out.push(dev);
+        out.extend(flatten_devices(&dev.children));
+    }
+    out
+}
+
 #[async_test]
 async fn single_endpoint_32bit_bar() {
     let mock = MockConfigSpace::new();
@@ -244,13 +255,14 @@ async fn single_endpoint_32bit_bar() {
     let mut cfg = mock.clone();
     let result = assign_pci_resources_inner(&mut cfg, &params).await.unwrap();
 
-    assert_eq!(result.entries.len(), 1);
-    let entry = &result.entries[0];
+    let flat = flatten_devices(&result);
+    assert_eq!(flat.len(), 1);
+    let entry = flat[0];
     assert_eq!(entry.bus, 0);
     assert_eq!(entry.device, 0);
     assert_eq!(entry.function, 0);
     assert_eq!(entry.bars.len(), 1);
-    assert_eq!(entry.bars[0].address, 0x1000_0000);
+    assert_eq!(entry.bars[0].address.unwrap(), 0x1000_0000);
     assert_eq!(entry.bars[0].size, 0x10000);
     assert!(!entry.bars[0].is_64bit);
 
@@ -278,9 +290,10 @@ async fn single_endpoint_64bit_bar() {
     let mut cfg = mock.clone();
     let result = assign_pci_resources_inner(&mut cfg, &params).await.unwrap();
 
-    assert_eq!(result.entries.len(), 1);
-    let bar = &result.entries[0].bars[0];
-    assert_eq!(bar.address, 0x1_0000_0000);
+    let flat = flatten_devices(&result);
+    assert_eq!(flat.len(), 1);
+    let bar = &flat[0].bars[0];
+    assert_eq!(bar.address.unwrap(), 0x1_0000_0000);
     assert_eq!(bar.size, 0x100000);
     assert!(bar.is_64bit);
 
@@ -315,11 +328,11 @@ async fn bridge_with_endpoint() {
     let result = assign_pci_resources_inner(&mut cfg, &params).await.unwrap();
 
     // Should have 2 entries: bridge + endpoint.
-    assert_eq!(result.entries.len(), 2);
+    let flat = flatten_devices(&result);
+    assert_eq!(flat.len(), 2);
 
     // Find the bridge entry.
-    let bridge = result
-        .entries
+    let bridge = flat
         .iter()
         .find(|e| e.bus == 0 && e.device == 0)
         .unwrap();
@@ -329,8 +342,7 @@ async fn bridge_with_endpoint() {
     assert!(bridge.memory_limit.is_some());
 
     // Find the endpoint entry.
-    let endpoint = result
-        .entries
+    let endpoint = flat
         .iter()
         .find(|e| e.bus == 1 && e.device == 0)
         .unwrap();
@@ -367,17 +379,18 @@ async fn multiple_endpoints_sorted_by_size() {
     let mut cfg = mock.clone();
     let result = assign_pci_resources_inner(&mut cfg, &params).await.unwrap();
 
-    assert_eq!(result.entries.len(), 2);
+    let flat = flatten_devices(&result);
+    assert_eq!(flat.len(), 2);
 
     // The 1MB BAR should be allocated first (sorted by size desc) and
     // aligned to 1MB.
-    let dev1 = result.entries.iter().find(|e| e.device == 1).unwrap();
-    assert_eq!(dev1.bars[0].address, 0x1000_0000);
+    let dev1 = flat.iter().find(|e| e.device == 1).unwrap();
+    assert_eq!(dev1.bars[0].address.unwrap(), 0x1000_0000);
     assert_eq!(dev1.bars[0].size, 0x100000);
 
     // The 4KB BAR should follow.
-    let dev0 = result.entries.iter().find(|e| e.device == 0).unwrap();
-    assert_eq!(dev0.bars[0].address, 0x1010_0000);
+    let dev0 = flat.iter().find(|e| e.device == 0).unwrap();
+    assert_eq!(dev0.bars[0].address.unwrap(), 0x1010_0000);
     assert_eq!(dev0.bars[0].size, 0x1000);
 }
 
@@ -406,10 +419,11 @@ async fn multi_function_device() {
     let result = assign_pci_resources_inner(&mut cfg, &params).await.unwrap();
 
     // Should find both functions.
-    assert_eq!(result.entries.len(), 2);
-    let f0 = result.entries.iter().find(|e| e.function == 0).unwrap();
-    let f1 = result.entries.iter().find(|e| e.function == 1).unwrap();
-    assert_ne!(f0.bars[0].address, f1.bars[0].address);
+    let flat = flatten_devices(&result);
+    assert_eq!(flat.len(), 2);
+    let f0 = flat.iter().find(|e| e.function == 0).unwrap();
+    let f1 = flat.iter().find(|e| e.function == 1).unwrap();
+    assert_ne!(f0.bars[0].address.unwrap(), f1.bars[0].address.unwrap());
 }
 
 #[async_test]
@@ -446,31 +460,30 @@ async fn switch_with_multiple_endpoints() {
     let result = assign_pci_resources_inner(&mut cfg, &params).await.unwrap();
 
     // Should have entries for: upstream bridge, 2 downstream bridges, 2 endpoints.
-    assert!(result.entries.len() >= 4);
+    let flat = flatten_devices(&result);
+    assert!(flat.len() >= 4);
 
     // Verify bus numbers were assigned correctly.
-    let upstream = result
-        .entries
+    let upstream = flat
         .iter()
         .find(|e| e.bus == 0 && e.device == 0)
         .unwrap();
     assert_eq!(upstream.secondary_bus, Some(1));
 
     // Both endpoints should have BAR addresses assigned.
-    let ep1 = result.entries.iter().find(|e| e.bus == 2).unwrap();
-    let ep2 = result.entries.iter().find(|e| e.bus == 3).unwrap();
+    let ep1 = flat.iter().find(|e| e.bus == 2).unwrap();
+    let ep2 = flat.iter().find(|e| e.bus == 3).unwrap();
     assert_eq!(ep1.bars.len(), 1);
     assert_eq!(ep2.bars.len(), 1);
     // 32-bit BAR on bus 2 should be in low MMIO.
-    assert!(ep1.bars[0].address >= 0x1000_0000);
-    assert!(ep1.bars[0].address < 0x2000_0000);
+    assert!(ep1.bars[0].address.unwrap() >= 0x1000_0000);
+    assert!(ep1.bars[0].address.unwrap() < 0x2000_0000);
     // 64-bit BAR on bus 3 should be in high MMIO.
-    assert!(ep2.bars[0].address >= 0x1_0000_0000);
+    assert!(ep2.bars[0].address.unwrap() >= 0x1_0000_0000);
 
     // The downstream bridge for the 64-bit endpoint should have a
     // prefetchable window covering high MMIO.
-    let ds_bridge_64 = result
-        .entries
+    let ds_bridge_64 = flat
         .iter()
         .find(|e| e.bus == 1 && e.device == 1)
         .unwrap();
@@ -482,8 +495,7 @@ async fn switch_with_multiple_endpoints() {
 
     // The downstream bridge for the 32-bit endpoint should have a
     // non-prefetchable window in low MMIO, and no prefetchable window.
-    let ds_bridge_32 = result
-        .entries
+    let ds_bridge_32 = flat
         .iter()
         .find(|e| e.bus == 1 && e.device == 0)
         .unwrap();
@@ -531,7 +543,7 @@ async fn no_devices_is_ok() {
 
     let mut cfg = mock;
     let result = assign_pci_resources_inner(&mut cfg, &params).await.unwrap();
-    assert!(result.entries.is_empty());
+    assert!(result.is_empty());
 }
 
 #[async_test]
@@ -617,9 +629,8 @@ async fn sriov_reserves_bus_numbers() {
     let result = assign_pci_resources_inner(&mut cfg, &params).await.unwrap();
 
     // Bridge should have subordinate >= 2 to cover VF buses.
-    let bridge = result
-        .entries
-        .iter()
+    let bridge = flatten_devices(&result)
+        .into_iter()
         .find(|e| e.bus == 0 && e.device == 0)
         .unwrap();
     assert_eq!(bridge.secondary_bus, Some(1));
@@ -660,9 +671,8 @@ async fn sriov_no_vfs_no_reservation() {
     let result = assign_pci_resources_inner(&mut cfg, &params).await.unwrap();
 
     // No extra buses reserved — subordinate should be 1.
-    let bridge = result
-        .entries
-        .iter()
+    let bridge = flatten_devices(&result)
+        .into_iter()
         .find(|e| e.bus == 0 && e.device == 0)
         .unwrap();
     assert_eq!(bridge.subordinate_bus, Some(1));
@@ -690,9 +700,8 @@ async fn bridge_prefetchable_window_programmed() {
     let result = assign_pci_resources_inner(&mut cfg, &params).await.unwrap();
 
     // The bridge should have a prefetchable window, not a non-prefetchable one.
-    let bridge = result
-        .entries
-        .iter()
+    let bridge = flatten_devices(&result)
+        .into_iter()
         .find(|e| e.bus == 0 && e.device == 0)
         .unwrap();
     assert!(
@@ -763,13 +772,12 @@ async fn sibling_bridge_windows_must_not_overlap() {
     let result = assign_pci_resources_inner(&mut cfg, &params).await.unwrap();
 
     // Find bridge windows for the two downstream bridges.
-    let bridge_a = result
-        .entries
+    let flat = flatten_devices(&result);
+    let bridge_a = flat
         .iter()
         .find(|e| e.bus == 1 && e.device == 0)
         .unwrap();
-    let bridge_b = result
-        .entries
+    let bridge_b = flat
         .iter()
         .find(|e| e.bus == 1 && e.device == 1)
         .unwrap();
@@ -818,13 +826,12 @@ async fn large_bar_alignment_fits_in_bridge_window() {
     let mut cfg = mock.clone();
     let result = assign_pci_resources_inner(&mut cfg, &params).await.unwrap();
 
-    let bridge = result
-        .entries
+    let flat = flatten_devices(&result);
+    let bridge = flat
         .iter()
         .find(|e| e.bus == 0 && e.device == 0)
         .unwrap();
-    let ep = result
-        .entries
+    let ep = flat
         .iter()
         .find(|e| e.bus == 1 && e.device == 0)
         .unwrap();
@@ -835,7 +842,7 @@ async fn large_bar_alignment_fits_in_bridge_window() {
     let window_limit = bridge
         .memory_limit
         .expect("bridge should have memory window");
-    let bar_addr = ep.bars[0].address;
+    let bar_addr = ep.bars[0].address.unwrap();
     let bar_end = bar_addr + ep.bars[0].size - 1;
 
     // The BAR must be naturally aligned.
@@ -1017,7 +1024,7 @@ async fn mem32_bar_must_not_be_placed_above_4gb() {
     assert!(
         result.is_err(),
         "expected error when only aperture is above 4 GB, but got assignments: {:#?}",
-        result.unwrap().entries
+        result.unwrap()
     );
 }
 
@@ -1057,11 +1064,12 @@ async fn shared_aperture_mem32_mem64_must_not_overlap() {
 
     // Collect all BAR regions and verify no overlaps.
     let mut regions: Vec<(u64, u64, String)> = Vec::new();
-    for entry in &result.entries {
+    let flat = flatten_devices(&result);
+    for entry in &flat {
         for bar in &entry.bars {
             regions.push((
-                bar.address,
-                bar.address + bar.size,
+                bar.address.unwrap(),
+                bar.address.unwrap() + bar.size,
                 format!(
                     "{:02x}:{:02x}.{} BAR{}",
                     entry.bus, entry.device, entry.function, bar.index
@@ -1175,9 +1183,8 @@ async fn sriov_vf_bars_included_in_bridge_window() {
 
     // Find the bridge entry and check that its memory window is large
     // enough for both the PF BAR (4 KB) and VF BARs (4 * 4 KB = 16 KB).
-    let bridge = result
-        .entries
-        .iter()
+    let bridge = flatten_devices(&result)
+        .into_iter()
         .find(|e| e.bus == 0 && e.device == 0)
         .unwrap();
     let window_base = bridge
@@ -1232,9 +1239,8 @@ async fn sriov_non_power_of_two_vf_count() {
     let mut cfg = mock;
     let result = assign_pci_resources_inner(&mut cfg, &params).await.unwrap();
 
-    let bridge = result
-        .entries
-        .iter()
+    let bridge = flatten_devices(&result)
+        .into_iter()
         .find(|e| e.bus == 0 && e.device == 0)
         .unwrap();
     let window_base = bridge
@@ -1290,9 +1296,8 @@ async fn sriov_vf_bars_64bit_prefetchable() {
     let mut cfg = mock;
     let result = assign_pci_resources_inner(&mut cfg, &params).await.unwrap();
 
-    let bridge = result
-        .entries
-        .iter()
+    let bridge = flatten_devices(&result)
+        .into_iter()
         .find(|e| e.bus == 0 && e.device == 0)
         .unwrap();
 
@@ -1372,9 +1377,8 @@ async fn sriov_mixed_vf_bar_types() {
     let mut cfg = mock;
     let result = assign_pci_resources_inner(&mut cfg, &params).await.unwrap();
 
-    let bridge = result
-        .entries
-        .iter()
+    let bridge = flatten_devices(&result)
+        .into_iter()
         .find(|e| e.bus == 0 && e.device == 0)
         .unwrap();
 
@@ -1439,16 +1443,15 @@ async fn sriov_top_level_pf_no_bridge() {
     let result = assign_pci_resources_inner(&mut cfg, &params).await.unwrap();
 
     // The PF should have its own BAR assigned.
-    let pf = result
-        .entries
-        .iter()
+    let pf = flatten_devices(&result)
+        .into_iter()
         .find(|e| e.bus == 0 && e.device == 0)
         .unwrap();
     assert_eq!(pf.bars.len(), 1);
     assert_eq!(pf.bars[0].size, 0x1_0000);
 
     // The PF BAR should be within the aperture.
-    let bar_end = pf.bars[0].address + pf.bars[0].size;
+    let bar_end = pf.bars[0].address.unwrap() + pf.bars[0].size;
     assert!(
         bar_end <= 0x2000_0000,
         "PF BAR must fit in low_mmio aperture"
@@ -1486,8 +1489,8 @@ async fn sriov_multiple_pfs_behind_bridge() {
     let mut cfg = mock;
     let result = assign_pci_resources_inner(&mut cfg, &params).await.unwrap();
 
-    let bridge = result
-        .entries
+    let flat = flatten_devices(&result);
+    let bridge = flat
         .iter()
         .find(|e| e.bus == 0 && e.device == 0)
         .unwrap();
@@ -1508,13 +1511,11 @@ async fn sriov_multiple_pfs_behind_bridge() {
     );
 
     // Both PFs should have their device BARs assigned.
-    let pf1 = result
-        .entries
+    let pf1 = flat
         .iter()
         .find(|e| e.bus == 1 && e.device == 0)
         .unwrap();
-    let pf2 = result
-        .entries
+    let pf2 = flat
         .iter()
         .find(|e| e.bus == 1 && e.device == 1)
         .unwrap();
@@ -1522,10 +1523,10 @@ async fn sriov_multiple_pfs_behind_bridge() {
     assert_eq!(pf2.bars.len(), 1);
 
     // PF BARs must not overlap each other.
-    let pf1_end = pf1.bars[0].address + pf1.bars[0].size;
-    let pf2_end = pf2.bars[0].address + pf2.bars[0].size;
+    let pf1_end = pf1.bars[0].address.unwrap() + pf1.bars[0].size;
+    let pf2_end = pf2.bars[0].address.unwrap() + pf2.bars[0].size;
     assert!(
-        pf1_end <= pf2.bars[0].address || pf2_end <= pf1.bars[0].address,
+        pf1_end <= pf2.bars[0].address.unwrap() || pf2_end <= pf1.bars[0].address.unwrap(),
         "PF BARs must not overlap"
     );
 }

--- a/vm/devices/pci/pci_resource_assignment/src/tests.rs
+++ b/vm/devices/pci/pci_resource_assignment/src/tests.rs
@@ -116,6 +116,7 @@ impl MockConfigSpace {
     /// Add an SR-IOV extended capability to a device.
     /// `total_vfs`: max VFs supported, `vf_offset`: routing ID offset to first VF,
     /// `vf_stride`: routing ID increment per VF.
+    /// `vf_bars`: VF BAR definitions as (bar_index, size, is_64bit, prefetchable).
     fn add_sriov(
         &self,
         bus: u8,
@@ -124,6 +125,19 @@ impl MockConfigSpace {
         total_vfs: u16,
         vf_offset: u16,
         vf_stride: u16,
+    ) {
+        self.add_sriov_with_bars(bus, device, function, total_vfs, vf_offset, vf_stride, &[]);
+    }
+
+    fn add_sriov_with_bars(
+        &self,
+        bus: u8,
+        device: u8,
+        function: u8,
+        total_vfs: u16,
+        vf_offset: u16,
+        vf_stride: u16,
+        vf_bars: &[(u8, u64, bool, bool)],
     ) {
         let mut inner = self.inner.lock();
         let key = |off: u16| (bus, device, function, off);
@@ -143,6 +157,28 @@ impl MockConfigSpace {
             key(0x100 + 0x14),
             (vf_stride as u32) << 16 | vf_offset as u32,
         );
+
+        // VF BARs at cap + 0x24..0x38.
+        for &(bar_idx, size, is_64bit, prefetchable) in vf_bars {
+            let offset = 0x100 + 0x24 + (bar_idx as u16) * 4;
+            let mut encoding: u32 = 0;
+            if is_64bit {
+                encoding |= 0x04;
+            }
+            if prefetchable {
+                encoding |= 0x08;
+            }
+            inner.regs.insert(key(offset), encoding);
+            let mask = (!(size - 1)) as u32;
+            inner.bar_masks.insert(key(offset), mask | encoding);
+
+            if is_64bit {
+                let upper_offset = offset + 4;
+                let upper_mask = ((!(size - 1)) >> 32) as u32;
+                inner.regs.insert(key(upper_offset), 0);
+                inner.bar_masks.insert(key(upper_offset), upper_mask);
+            }
+        }
     }
 
     fn read_reg(&self, bus: u8, device: u8, function: u8, offset: u16) -> u32 {
@@ -161,9 +197,8 @@ impl MockConfigSpace {
         let mut inner = self.inner.lock();
         let key = (bus, device, function, offset);
 
-        // Check if this is a BAR offset being probed.
-        let is_bar_offset = (0x10..=0x24).contains(&offset) && (offset & 0x3) == 0;
-        if is_bar_offset && inner.bar_masks.contains_key(&key) {
+        // Check if this offset has a BAR mask (device BAR or VF BAR).
+        if inner.bar_masks.contains_key(&key) {
             if value == !0u32 {
                 inner.bar_probing.insert(key, true);
                 return;
@@ -1097,5 +1132,66 @@ async fn bus_wrap_to_zero_must_return_exhaustion() {
     assert!(
         matches!(result, Err(crate::AssignmentError::BusExhaustion { .. })),
         "expected BusExhaustion when next_bus wraps past 255, got {result:?}"
+    );
+}
+
+/// VF BARs from SR-IOV capability must be included in bridge window sizing.
+/// Without this, the bridge window is too small for VF BAR space and VF
+/// MMIO accesses fault.
+#[async_test]
+async fn sriov_vf_bars_included_in_bridge_window() {
+    let mock = MockConfigSpace::new();
+
+    // Bridge on bus 0.
+    mock.add_bridge(0, 0, 0);
+
+    // PF on bus 1 with a 4 KB device BAR and SR-IOV with 4 VFs, each
+    // needing a 4 KB non-prefetchable VF BAR0.
+    // Total VF BAR space: 4 * 4 KB = 16 KB.
+    mock.add_endpoint(1, 0, 0, &[(0, 0x1000, false, false)]);
+    mock.set_multi_function(1, 0);
+    mock.add_sriov_with_bars(
+        1,
+        0,
+        0,
+        4,
+        1,
+        1,
+        &[(0, 0x1000, false, false)], // VF BAR0: 4 KB non-pref
+    );
+
+    let params = AssignmentParams {
+        start_bus: 0,
+        end_bus: 255,
+        low_mmio: Some(MmioAperture {
+            base: 0x1000_0000,
+            len: 0x1000_0000,
+        }),
+        high_mmio: None,
+    };
+
+    let mut cfg = mock;
+    let result = assign_pci_resources_inner(&mut cfg, &params).await.unwrap();
+
+    // Find the bridge entry and check that its memory window is large
+    // enough for both the PF BAR (4 KB) and VF BARs (4 * 4 KB = 16 KB).
+    let bridge = result
+        .entries
+        .iter()
+        .find(|e| e.bus == 0 && e.device == 0)
+        .unwrap();
+    let window_base = bridge
+        .memory_base
+        .expect("bridge should have memory window");
+    let window_limit = bridge
+        .memory_limit
+        .expect("bridge should have memory limit");
+    let window_size = window_limit - window_base + 1;
+
+    // PF BAR = 0x1000, VF BARs = 4 * 0x1000 = 0x4000, total = 0x5000.
+    // Bridge window is rounded up to 1 MB granularity.
+    assert!(
+        window_size >= 0x5000,
+        "bridge window {window_size:#x} must be >= 0x5000 (PF BAR + 4 VF BARs)"
     );
 }

--- a/vm/devices/pci/pci_resource_assignment/src/tests.rs
+++ b/vm/devices/pci/pci_resource_assignment/src/tests.rs
@@ -1195,3 +1195,59 @@ async fn sriov_vf_bars_included_in_bridge_window() {
         "bridge window {window_size:#x} must be >= 0x5000 (PF BAR + 4 VF BARs)"
     );
 }
+
+/// Non-power-of-two VF counts must not panic. The total VF BAR space
+/// (total_vfs * per-VF BAR size) is not a power of two in this case,
+/// so alignment must use the per-VF BAR size, not the total size.
+#[async_test]
+async fn sriov_non_power_of_two_vf_count() {
+    let mock = MockConfigSpace::new();
+
+    mock.add_bridge(0, 0, 0);
+
+    // PF with 3 VFs (not a power of two), each with a 4 KB VF BAR.
+    // Total VF BAR space: 3 * 4 KB = 12 KB (not a power of two).
+    mock.add_endpoint(1, 0, 0, &[(0, 0x1000, false, false)]);
+    mock.set_multi_function(1, 0);
+    mock.add_sriov_with_bars(
+        1,
+        0,
+        0,
+        3, // 3 VFs
+        1,
+        1,
+        &[(0, 0x1000, false, false)],
+    );
+
+    let params = AssignmentParams {
+        start_bus: 0,
+        end_bus: 255,
+        low_mmio: Some(MmioAperture {
+            base: 0x1000_0000,
+            len: 0x1000_0000,
+        }),
+        high_mmio: None,
+    };
+
+    let mut cfg = mock;
+    let result = assign_pci_resources_inner(&mut cfg, &params).await.unwrap();
+
+    let bridge = result
+        .entries
+        .iter()
+        .find(|e| e.bus == 0 && e.device == 0)
+        .unwrap();
+    let window_base = bridge
+        .memory_base
+        .expect("bridge should have memory window");
+    let window_limit = bridge
+        .memory_limit
+        .expect("bridge should have memory limit");
+    let window_size = window_limit - window_base + 1;
+
+    // PF BAR = 0x1000, VF BARs = 3 * 0x1000 = 0x3000, total = 0x4000.
+    assert!(
+        window_size >= 0x4000,
+        "bridge window {window_size:#x} must be >= 0x4000 (PF BAR + 3 VF BARs)"
+    );
+}

--- a/vm/devices/pci/pci_resource_assignment/src/tests.rs
+++ b/vm/devices/pci/pci_resource_assignment/src/tests.rs
@@ -236,6 +236,16 @@ fn flatten_devices(devices: &[DiscoveredDevice]) -> Vec<&DiscoveredDevice> {
     out
 }
 
+/// Get the bridge memory window from a device's subtree requirement.
+fn memory_window(dev: &DiscoveredDevice) -> Option<(u64, u64)> {
+    dev.subtree_req.as_ref().and_then(|r| r.memory_window)
+}
+
+/// Get the bridge prefetchable window from a device's subtree requirement.
+fn prefetchable_window(dev: &DiscoveredDevice) -> Option<(u64, u64)> {
+    dev.subtree_req.as_ref().and_then(|r| r.prefetchable_window)
+}
+
 #[async_test]
 async fn single_endpoint_32bit_bar() {
     let mock = MockConfigSpace::new();
@@ -338,8 +348,7 @@ async fn bridge_with_endpoint() {
         .unwrap();
     assert_eq!(bridge.secondary_bus, Some(1));
     assert_eq!(bridge.subordinate_bus, Some(1));
-    assert!(bridge.memory_base.is_some());
-    assert!(bridge.memory_limit.is_some());
+    assert!(memory_window(bridge).is_some());
 
     // Find the endpoint entry.
     let endpoint = flat
@@ -488,10 +497,10 @@ async fn switch_with_multiple_endpoints() {
         .find(|e| e.bus == 1 && e.device == 1)
         .unwrap();
     assert!(
-        ds_bridge_64.prefetchable_base.is_some(),
+        prefetchable_window(ds_bridge_64).is_some(),
         "bridge behind 64-bit endpoint should have prefetchable window"
     );
-    assert!(ds_bridge_64.prefetchable_base.unwrap() >= 0x1_0000_0000);
+    assert!(prefetchable_window(ds_bridge_64).unwrap().0 >= 0x1_0000_0000);
 
     // The downstream bridge for the 32-bit endpoint should have a
     // non-prefetchable window in low MMIO, and no prefetchable window.
@@ -499,8 +508,8 @@ async fn switch_with_multiple_endpoints() {
         .iter()
         .find(|e| e.bus == 1 && e.device == 0)
         .unwrap();
-    assert!(ds_bridge_32.memory_base.is_some());
-    assert!(ds_bridge_32.prefetchable_base.is_none());
+    assert!(memory_window(ds_bridge_32).is_some());
+    assert!(prefetchable_window(ds_bridge_32).is_none());
 }
 
 #[async_test]
@@ -705,14 +714,14 @@ async fn bridge_prefetchable_window_programmed() {
         .find(|e| e.bus == 0 && e.device == 0)
         .unwrap();
     assert!(
-        bridge.memory_base.is_none(),
+        memory_window(bridge).is_none(),
         "no non-prefetchable window expected"
     );
     assert!(
-        bridge.prefetchable_base.is_some(),
+        prefetchable_window(bridge).is_some(),
         "prefetchable window expected"
     );
-    assert!(bridge.prefetchable_base.unwrap() >= 0x1_0000_0000);
+    assert!(prefetchable_window(bridge).unwrap().0 >= 0x1_0000_0000);
 
     // Verify the prefetchable window registers were programmed.
     // Offset 0x24: prefetchable base/limit (lower 16 bits each, with 64-bit flag).
@@ -782,17 +791,9 @@ async fn sibling_bridge_windows_must_not_overlap() {
         .find(|e| e.bus == 1 && e.device == 1)
         .unwrap();
 
-    let a_base = bridge_a
-        .memory_base
+    let (a_base, a_limit) = memory_window(bridge_a)
         .expect("bridge A should have memory window");
-    let a_limit = bridge_a
-        .memory_limit
-        .expect("bridge A should have memory window");
-    let b_base = bridge_b
-        .memory_base
-        .expect("bridge B should have memory window");
-    let b_limit = bridge_b
-        .memory_limit
+    let (b_base, b_limit) = memory_window(bridge_b)
         .expect("bridge B should have memory window");
 
     // Sibling bridge windows must not overlap — if they do, both bridges
@@ -836,14 +837,9 @@ async fn large_bar_alignment_fits_in_bridge_window() {
         .find(|e| e.bus == 1 && e.device == 0)
         .unwrap();
 
-    let window_base = bridge
-        .memory_base
+    let (window_base, window_limit) = memory_window(bridge)
         .expect("bridge should have memory window");
-    let window_limit = bridge
-        .memory_limit
-        .expect("bridge should have memory window");
-    let bar_addr = ep.bars[0].address.unwrap();
-    let bar_end = bar_addr + ep.bars[0].size - 1;
+    let bar_addr = ep.bars[0].address.unwrap();    let bar_end = bar_addr + ep.bars[0].size - 1;
 
     // The BAR must be naturally aligned.
     assert_eq!(
@@ -1187,12 +1183,8 @@ async fn sriov_vf_bars_included_in_bridge_window() {
         .into_iter()
         .find(|e| e.bus == 0 && e.device == 0)
         .unwrap();
-    let window_base = bridge
-        .memory_base
+    let (window_base, window_limit) = memory_window(bridge)
         .expect("bridge should have memory window");
-    let window_limit = bridge
-        .memory_limit
-        .expect("bridge should have memory limit");
     let window_size = window_limit - window_base + 1;
 
     // PF BAR = 0x1000, VF BARs = 4 * 0x1000 = 0x4000, total = 0x5000.
@@ -1243,12 +1235,8 @@ async fn sriov_non_power_of_two_vf_count() {
         .into_iter()
         .find(|e| e.bus == 0 && e.device == 0)
         .unwrap();
-    let window_base = bridge
-        .memory_base
+    let (window_base, window_limit) = memory_window(bridge)
         .expect("bridge should have memory window");
-    let window_limit = bridge
-        .memory_limit
-        .expect("bridge should have memory limit");
     let window_size = window_limit - window_base + 1;
 
     // PF BAR = 0x1000, VF BARs = 3 * 0x1000 = 0x3000, total = 0x4000.
@@ -1302,12 +1290,8 @@ async fn sriov_vf_bars_64bit_prefetchable() {
         .unwrap();
 
     // Non-prefetchable window should exist for the PF's 32-bit BAR.
-    let mem_base = bridge
-        .memory_base
+    let (mem_base, mem_limit) = memory_window(bridge)
         .expect("bridge should have non-pref memory window");
-    let mem_limit = bridge
-        .memory_limit
-        .expect("bridge should have non-pref memory limit");
     let mem_size = mem_limit - mem_base + 1;
     assert!(
         mem_size >= 0x1000,
@@ -1315,12 +1299,8 @@ async fn sriov_vf_bars_64bit_prefetchable() {
     );
 
     // Prefetchable window should exist for VF BARs (4 * 1 MB = 4 MB).
-    let pref_base = bridge
-        .prefetchable_base
+    let (pref_base, pref_limit) = prefetchable_window(bridge)
         .expect("bridge should have prefetchable window");
-    let pref_limit = bridge
-        .prefetchable_limit
-        .expect("bridge should have prefetchable limit");
     let pref_size = pref_limit - pref_base + 1;
     assert!(
         pref_size >= 0x40_0000,
@@ -1383,12 +1363,8 @@ async fn sriov_mixed_vf_bar_types() {
         .unwrap();
 
     // Non-pref window for VF BAR0: 2 * 4 KB = 8 KB.
-    let mem_base = bridge
-        .memory_base
+    let (mem_base, mem_limit) = memory_window(bridge)
         .expect("bridge should have non-pref window for VF BAR0");
-    let mem_limit = bridge
-        .memory_limit
-        .expect("bridge should have non-pref limit");
     let mem_size = mem_limit - mem_base + 1;
     assert!(
         mem_size >= 0x2000,
@@ -1396,12 +1372,8 @@ async fn sriov_mixed_vf_bar_types() {
     );
 
     // Pref window for VF BAR2: 2 * 64 KB = 128 KB.
-    let pref_base = bridge
-        .prefetchable_base
+    let (pref_base, pref_limit) = prefetchable_window(bridge)
         .expect("bridge should have pref window for VF BAR2");
-    let pref_limit = bridge
-        .prefetchable_limit
-        .expect("bridge should have pref limit");
     let pref_size = pref_limit - pref_base + 1;
     assert!(
         pref_size >= 0x2_0000,
@@ -1494,12 +1466,8 @@ async fn sriov_multiple_pfs_behind_bridge() {
         .iter()
         .find(|e| e.bus == 0 && e.device == 0)
         .unwrap();
-    let window_base = bridge
-        .memory_base
+    let (window_base, window_limit) = memory_window(bridge)
         .expect("bridge should have memory window");
-    let window_limit = bridge
-        .memory_limit
-        .expect("bridge should have memory limit");
     let window_size = window_limit - window_base + 1;
 
     // PF1: BAR=0x1000 + VF=2*0x1000=0x2000

--- a/vm/devices/pci/pci_resource_assignment/src/tests.rs
+++ b/vm/devices/pci/pci_resource_assignment/src/tests.rs
@@ -278,6 +278,21 @@ fn read_prefetchable_window(
     }
 }
 
+/// Read a 32-bit VF BAR address from the SR-IOV capability in mock config space.
+/// SR-IOV cap is at 0x100, VF BAR0 starts at cap + 0x24.
+/// Masks off the low 4 encoding bits.
+fn read_vf_bar32(mock: &MockConfigSpace, bus: u8, dev: u8, func: u8, bar_idx: u8) -> u32 {
+    mock.read_reg(bus, dev, func, 0x100 + 0x24 + bar_idx as u16 * 4) & !0xF
+}
+
+/// Read a 64-bit VF BAR address from the SR-IOV capability in mock config space.
+/// Masks off the low 4 encoding bits from the lower DWORD.
+fn read_vf_bar64(mock: &MockConfigSpace, bus: u8, dev: u8, func: u8, bar_idx: u8) -> u64 {
+    let lo = (mock.read_reg(bus, dev, func, 0x100 + 0x24 + bar_idx as u16 * 4) & !0xF) as u64;
+    let hi = mock.read_reg(bus, dev, func, 0x100 + 0x24 + (bar_idx + 1) as u16 * 4) as u64;
+    lo | (hi << 32)
+}
+
 // ---- Tests ----
 
 #[async_test]
@@ -1106,6 +1121,23 @@ async fn sriov_vf_bars_included_in_bridge_window() {
         window_size >= 0x5000,
         "bridge window {window_size:#x} must be >= 0x5000"
     );
+
+    // VF BAR0 should be programmed into the SR-IOV capability registers.
+    let vf_bar = read_vf_bar32(&mock, 1, 0, 0, 0) as u64;
+    assert!(vf_bar > 0, "VF BAR should be assigned, got {vf_bar:#x}");
+    assert!(
+        vf_bar >= window.0 && vf_bar + 0x4000 <= window.1 + 1,
+        "VF BAR region {vf_bar:#x}..{:#x} must be within bridge window {:#x}..{:#x}",
+        vf_bar + 0x4000,
+        window.0,
+        window.1 + 1,
+    );
+    // VF BAR region must not overlap PF BAR.
+    let pf_bar = read_bar32(&mock, 1, 0, 0, 0) as u64;
+    assert!(
+        vf_bar + 0x4000 <= pf_bar || pf_bar + 0x1000 <= vf_bar,
+        "VF BAR region must not overlap PF BAR"
+    );
 }
 
 /// Non-power-of-two VF counts must not panic.
@@ -1204,6 +1236,20 @@ async fn sriov_vf_bars_64bit_prefetchable() {
         "pref window base {:#x} should be in high MMIO",
         pref.0
     );
+
+    // VF BAR0 should be programmed as a 64-bit address in the high MMIO aperture.
+    let vf_bar = read_vf_bar64(&mock, 1, 0, 0, 0);
+    assert!(
+        (0x1_0000_0000..0x2_0000_0000).contains(&vf_bar),
+        "VF BAR {vf_bar:#x} should be in high MMIO"
+    );
+    assert!(
+        vf_bar >= pref.0 && vf_bar + 0x40_0000 <= pref.1 + 1,
+        "VF BAR region {vf_bar:#x}..{:#x} must be within pref window {:#x}..{:#x}",
+        vf_bar + 0x40_0000,
+        pref.0,
+        pref.1 + 1,
+    );
 }
 
 /// A PF with both 32-bit non-pref and 64-bit prefetchable VF BARs should
@@ -1258,6 +1304,20 @@ async fn sriov_mixed_vf_bar_types() {
         pref_size >= 0x2_0000,
         "pref window {pref_size:#x} must be >= 0x20000"
     );
+
+    // VF BAR0 (non-pref) should be in the non-pref window.
+    let vf_bar0 = read_vf_bar32(&mock, 1, 0, 0, 0) as u64;
+    assert!(vf_bar0 > 0, "VF BAR0 should be assigned");
+    assert!(
+        vf_bar0 >= mem.0 && vf_bar0 + 0x2000 <= mem.1 + 1,
+        "VF BAR0 region must be within non-pref window"
+    );
+    // VF BAR2 (64-bit pref) should be in the pref window.
+    let vf_bar2 = read_vf_bar64(&mock, 1, 0, 0, 2);
+    assert!(
+        vf_bar2 >= pref.0 && vf_bar2 + 0x2_0000 <= pref.1 + 1,
+        "VF BAR2 region must be within pref window"
+    );
 }
 
 /// Top-level PF (no bridge) with VF BARs.
@@ -1297,6 +1357,18 @@ async fn sriov_top_level_pf_no_bridge() {
     assert!(
         bar_end <= 0x2000_0000,
         "PF BAR must fit in low_mmio aperture"
+    );
+
+    // VF BAR0 should be programmed and not overlap the PF BAR.
+    let vf_bar = read_vf_bar32(&mock, 0, 0, 0, 0) as u64;
+    assert!(vf_bar > 0, "VF BAR should be assigned, got {vf_bar:#x}");
+    assert!(
+        vf_bar + 0x4_0000 <= 0x2000_0000,
+        "VF BARs must fit in low_mmio aperture"
+    );
+    assert!(
+        vf_bar + 0x4_0000 <= bar as u64 || bar_end <= vf_bar,
+        "VF BAR region must not overlap PF BAR"
     );
 }
 
@@ -1349,6 +1421,28 @@ async fn sriov_multiple_pfs_behind_bridge() {
     assert!(
         pf1_bar + pf1_size <= pf2_bar || pf2_bar + pf2_size <= pf1_bar,
         "PF BARs must not overlap"
+    );
+
+    // VF BARs should be programmed for both PFs.
+    let vf1_bar = read_vf_bar32(&mock, 1, 0, 0, 0) as u64;
+    let vf2_bar = read_vf_bar32(&mock, 1, 1, 0, 0) as u64;
+    let vf1_size: u64 = 2 * 0x1000;
+    let vf2_size: u64 = 3 * 0x2000;
+    assert!(vf1_bar > 0, "PF1 VF BAR should be assigned");
+    assert!(vf2_bar > 0, "PF2 VF BAR should be assigned");
+    // VF BAR regions must not overlap each other.
+    assert!(
+        vf1_bar + vf1_size <= vf2_bar || vf2_bar + vf2_size <= vf1_bar,
+        "VF BAR regions must not overlap each other"
+    );
+    // VF BAR regions must not overlap PF BARs.
+    assert!(
+        vf1_bar + vf1_size <= pf1_bar || pf1_bar + pf1_size <= vf1_bar,
+        "PF1 VF BARs must not overlap PF1 BAR"
+    );
+    assert!(
+        vf2_bar + vf2_size <= pf2_bar || pf2_bar + pf2_size <= vf2_bar,
+        "PF2 VF BARs must not overlap PF2 BAR"
     );
 }
 

--- a/vm/devices/pci/pci_resource_assignment/src/tests.rs
+++ b/vm/devices/pci/pci_resource_assignment/src/tests.rs
@@ -283,6 +283,7 @@ fn read_prefetchable_window(
 #[async_test]
 async fn single_endpoint_32bit_bar() {
     let mock = MockConfigSpace::new();
+    // Device on bus 0, device 0, function 0 with a 64KB 32-bit non-pref BAR at index 0.
     mock.add_endpoint(0, 0, 0, &[(0, 0x10000, false, false)]);
 
     let params = AssignmentParams {
@@ -305,6 +306,7 @@ async fn single_endpoint_32bit_bar() {
 #[async_test]
 async fn single_endpoint_64bit_bar() {
     let mock = MockConfigSpace::new();
+    // 1 MB 64-bit prefetchable BAR at index 0.
     mock.add_endpoint(0, 1, 0, &[(0, 0x100000, true, true)]);
 
     let params = AssignmentParams {
@@ -320,6 +322,7 @@ async fn single_endpoint_64bit_bar() {
     let mut cfg = mock.clone();
     assign_pci_resources(&mut cfg, &params).await.unwrap();
 
+    // Verify both BAR registers were programmed.
     assert_eq!(read_bar64(&mock, 0, 1, 0, 0), 0x1_0000_0000);
 }
 
@@ -327,7 +330,10 @@ async fn single_endpoint_64bit_bar() {
 async fn bridge_with_endpoint() {
     let mock = MockConfigSpace::new();
 
+    // Bridge at bus 0, device 0, function 0.
     mock.add_bridge(0, 0, 0);
+    // Endpoint behind bridge at bus 1, device 0, function 0.
+    // 64KB non-prefetchable BAR.
     mock.add_endpoint(1, 0, 0, &[(0, 0x10000, false, false)]);
 
     let params = AssignmentParams {
@@ -360,6 +366,7 @@ async fn bridge_with_endpoint() {
 async fn multiple_endpoints_sorted_by_size() {
     let mock = MockConfigSpace::new();
 
+    // Two devices with different BAR sizes.
     // Device 0: 4KB BAR.
     mock.add_endpoint(0, 0, 0, &[(0, 0x1000, false, false)]);
     // Device 1: 1MB BAR.
@@ -378,9 +385,10 @@ async fn multiple_endpoints_sorted_by_size() {
     let mut cfg = mock.clone();
     assign_pci_resources(&mut cfg, &params).await.unwrap();
 
-    // 1 MB BAR (dev 1) should be first, at the aperture base.
+    // The 1MB BAR should be allocated first (sorted by size desc) and
+    // aligned to 1MB.
     assert_eq!(read_bar32(&mock, 0, 1, 0, 0), 0x1000_0000);
-    // 4 KB BAR (dev 0) should follow.
+    // The 4KB BAR should follow.
     assert_eq!(read_bar32(&mock, 0, 0, 0, 0), 0x1010_0000);
 }
 
@@ -388,8 +396,11 @@ async fn multiple_endpoints_sorted_by_size() {
 async fn multi_function_device() {
     let mock = MockConfigSpace::new();
 
+    // Function 0: 4KB BAR.
     mock.add_endpoint(0, 0, 0, &[(0, 0x1000, false, false)]);
+    // Function 1: 4KB BAR.
     mock.add_endpoint(0, 0, 1, &[(0, 0x1000, false, false)]);
+    // Mark as multi-function.
     mock.set_multi_function(0, 0);
 
     let params = AssignmentParams {
@@ -405,6 +416,7 @@ async fn multi_function_device() {
     let mut cfg = mock.clone();
     assign_pci_resources(&mut cfg, &params).await.unwrap();
 
+    // Should find both functions.
     let f0_bar = read_bar32(&mock, 0, 0, 0, 0);
     let f1_bar = read_bar32(&mock, 0, 0, 1, 0);
     assert_ne!(f0_bar, f1_bar);
@@ -443,10 +455,11 @@ async fn switch_with_multiple_endpoints() {
     let mut cfg = mock.clone();
     assign_pci_resources(&mut cfg, &params).await.unwrap();
 
-    // Upstream bridge.
+    // Verify bus numbers were assigned correctly.
     let (_, secondary, _) = read_bus_numbers(&mock, 0, 0, 0);
     assert_eq!(secondary, 1);
 
+    // Both endpoints should have BAR addresses assigned.
     // 32-bit BAR on bus 2 should be in low MMIO.
     let ep1_bar = read_bar32(&mock, 2, 0, 0, 0) as u64;
     assert!(ep1_bar >= 0x1000_0000);
@@ -456,7 +469,8 @@ async fn switch_with_multiple_endpoints() {
     let ep2_bar = read_bar64(&mock, 3, 0, 0, 0);
     assert!(ep2_bar >= 0x1_0000_0000);
 
-    // Bridge for 64-bit endpoint should have prefetchable window.
+    // The downstream bridge for the 64-bit endpoint should have a
+    // prefetchable window covering high MMIO.
     let pref = read_prefetchable_window(&mock, 1, 1, 0);
     assert!(
         pref.is_some(),
@@ -464,7 +478,8 @@ async fn switch_with_multiple_endpoints() {
     );
     assert!(pref.unwrap().0 >= 0x1_0000_0000);
 
-    // Bridge for 32-bit endpoint should have non-pref window but no pref window.
+    // The downstream bridge for the 32-bit endpoint should have a
+    // non-prefetchable window in low MMIO, and no prefetchable window.
     assert!(read_memory_window(&mock, 1, 0, 0).is_some());
     assert!(read_prefetchable_window(&mock, 1, 0, 0).is_none());
 }
@@ -572,9 +587,12 @@ async fn no_aperture_error() {
 async fn sriov_reserves_bus_numbers() {
     let mock = MockConfigSpace::new();
 
+    // Bridge on bus 0.
     mock.add_bridge(0, 0, 0);
 
     // Endpoint on bus 1 with SR-IOV: 256 VFs, offset=1, stride=1.
+    // PF routing ID = (1 << 8) | (0 << 3) | 0 = 0x100
+    // Last VF routing ID = 0x100 + 1 + 255*1 = 0x200 → bus 2
     mock.add_endpoint(1, 0, 0, &[(0, 0x1000, false, false)]);
     mock.add_sriov(1, 0, 0, 256, 1, 1);
 
@@ -591,6 +609,7 @@ async fn sriov_reserves_bus_numbers() {
     let mut cfg = mock.clone();
     assign_pci_resources(&mut cfg, &params).await.unwrap();
 
+    // Bridge should have subordinate >= 2 to cover VF buses.
     let (_, secondary, subordinate) = read_bus_numbers(&mock, 0, 0, 0);
     assert_eq!(secondary, 1);
     assert!(
@@ -611,6 +630,7 @@ async fn sriov_reserves_bus_numbers() {
 async fn sriov_no_vfs_no_reservation() {
     let mock = MockConfigSpace::new();
 
+    // Bridge on bus 0.
     mock.add_bridge(0, 0, 0);
 
     // Endpoint on bus 1 with SR-IOV but 0 VFs.
@@ -630,6 +650,7 @@ async fn sriov_no_vfs_no_reservation() {
     let mut cfg = mock.clone();
     assign_pci_resources(&mut cfg, &params).await.unwrap();
 
+    // No extra buses reserved — subordinate should be 1.
     let (_, _, subordinate) = read_bus_numbers(&mock, 0, 0, 0);
     assert_eq!(subordinate, 1);
 }
@@ -638,6 +659,7 @@ async fn sriov_no_vfs_no_reservation() {
 async fn bridge_prefetchable_window_programmed() {
     let mock = MockConfigSpace::new();
 
+    // Bridge on bus 0 with a 64-bit endpoint behind it.
     mock.add_bridge(0, 0, 0);
     mock.add_endpoint(1, 0, 0, &[(0, 0x100000, true, true)]); // 1 MB 64-bit pref
 
@@ -654,7 +676,7 @@ async fn bridge_prefetchable_window_programmed() {
     let mut cfg = mock.clone();
     assign_pci_resources(&mut cfg, &params).await.unwrap();
 
-    // No non-prefetchable window.
+    // The bridge should have a prefetchable window, not a non-prefetchable one.
     assert!(
         read_memory_window(&mock, 0, 0, 0).is_none(),
         "no non-prefetchable window expected"
@@ -666,6 +688,7 @@ async fn bridge_prefetchable_window_programmed() {
     assert!(pref.unwrap().0 >= 0x1_0000_0000);
 
     // Verify the prefetchable window registers were programmed.
+    // Offset 0x24: prefetchable base/limit (lower 16 bits each, with 64-bit flag).
     let pf_range = mock.read_reg(0, 0, 0, 0x24);
     assert_ne!(
         pf_range, 0,
@@ -721,9 +744,12 @@ async fn sibling_bridge_windows_must_not_overlap() {
     let mut cfg = mock.clone();
     assign_pci_resources(&mut cfg, &params).await.unwrap();
 
+    // Find bridge windows for the two downstream bridges.
     let a_window = read_memory_window(&mock, 1, 0, 0).expect("bridge A should have memory window");
     let b_window = read_memory_window(&mock, 1, 1, 0).expect("bridge B should have memory window");
 
+    // Sibling bridge windows must not overlap — if they do, both bridges
+    // will claim the same addresses on the upstream bus.
     assert!(
         a_window.1 < b_window.0 || b_window.1 < a_window.0,
         "bridge windows overlap: A=[{:#x}..={:#x}], B=[{:#x}..={:#x}]",
@@ -738,6 +764,7 @@ async fn sibling_bridge_windows_must_not_overlap() {
 async fn large_bar_alignment_fits_in_bridge_window() {
     let mock = MockConfigSpace::new();
 
+    // Bridge on bus 0.
     mock.add_bridge(0, 0, 0);
 
     // Endpoint behind bridge with a 1 GB BAR (needs 1 GB natural alignment).
@@ -759,14 +786,14 @@ async fn large_bar_alignment_fits_in_bridge_window() {
     let window = read_memory_window(&mock, 0, 0, 0).expect("bridge should have memory window");
     let bar_addr = read_bar32(&mock, 1, 0, 0, 0) as u64;
 
-    // BAR must be naturally aligned.
+    // The BAR must be naturally aligned.
     assert_eq!(
         bar_addr % 0x4000_0000,
         0,
         "1 GB BAR at {bar_addr:#x} is not 1 GB aligned"
     );
 
-    // BAR must fit within bridge window.
+    // The BAR must fit within the bridge window.
     let bar_end = bar_addr + 0x4000_0000 - 1;
     assert!(
         bar_addr >= window.0 && bar_end <= window.1,
@@ -803,6 +830,11 @@ async fn alignment_first_sort_avoids_wasted_padding() {
     let mut cfg = mock.clone();
     let result = assign_pci_resources(&mut cfg, &params).await;
 
+    // 5 MB aperture. With alignment-first ordering (B then A), total is
+    // exactly 5 MB: B at 0 (2 MB aligned, uses 2 MB), A at 2 MB (1 MB
+    // aligned, uses 3 MB). With size-first ordering (A then B), A uses
+    // 3 MB, then B needs 2 MB alignment → next 2 MB boundary is 4 MB,
+    // total = 6 MB, which overflows.
     assert!(
         result.is_ok(),
         "5 MB aperture should be sufficient: {}",
@@ -814,8 +846,14 @@ async fn alignment_first_sort_avoids_wasted_padding() {
 async fn misaligned_aperture_does_not_overflow() {
     let mock = MockConfigSpace::new();
 
+    // Single endpoint with a 4 MB BAR (needs 4 MB natural alignment).
     mock.add_endpoint(0, 0, 0, &[(0, 0x400000, false, false)]);
 
+    // Aperture base is only 2 MB aligned, not 4 MB aligned.
+    // The allocator must align up to the next 4 MB boundary, losing 2 MB,
+    // so it needs at least 6 MB of aperture. Give it exactly 4 MB — this
+    // should fail because the BAR won't fit after alignment, but must not
+    // silently place the BAR past the end of the aperture.
     let params = AssignmentParams {
         start_bus: 0,
         end_bus: 255,
@@ -829,6 +867,7 @@ async fn misaligned_aperture_does_not_overflow() {
     let mut cfg = mock.clone();
     let result = assign_pci_resources(&mut cfg, &params).await;
 
+    // The aperture is too small after alignment padding — this must fail.
     assert!(
         matches!(result, Err(crate::AssignmentError::MmioExhaustion { .. })),
         "expected MmioExhaustion for misaligned aperture, got {result:?}"
@@ -839,8 +878,12 @@ async fn misaligned_aperture_does_not_overflow() {
 async fn alignment_exceeds_aperture_returns_error() {
     let mock = MockConfigSpace::new();
 
+    // Single endpoint with a 16 MB BAR (needs 16 MB alignment).
     mock.add_endpoint(0, 0, 0, &[(0, 0x1000000, false, false)]);
 
+    // Aperture is only 2 MB total. Alignment pushes base past the end,
+    // which must produce MmioExhaustion rather than wrapping the
+    // available-space calculation.
     let params = AssignmentParams {
         start_bus: 0,
         end_bus: 255,
@@ -864,8 +907,13 @@ async fn alignment_exceeds_aperture_returns_error() {
 async fn sriov_bus_reservation_exceeding_end_bus_returns_error() {
     let mock = MockConfigSpace::new();
 
+    // Bridge on bus 0.
     mock.add_bridge(0, 0, 0);
 
+    // Endpoint on bus 1 with SR-IOV: 256 VFs, offset=1, stride=1.
+    // PF routing ID = (1 << 8) | (0 << 3) | 0 = 0x100
+    // Last VF routing ID = 0x100 + 1 + 255*1 = 0x200 → bus 2
+    // But end_bus is 1, so VF bus 2 is out of range.
     mock.add_endpoint(1, 0, 0, &[(0, 0x1000, false, false)]);
     mock.add_sriov(1, 0, 0, 256, 1, 1);
 
@@ -882,17 +930,24 @@ async fn sriov_bus_reservation_exceeding_end_bus_returns_error() {
     let mut cfg = mock;
     let result = assign_pci_resources(&mut cfg, &params).await;
 
+    // SR-IOV VFs need bus 2, but end_bus is 1. The code returns
+    // BusExhaustion because the VF bus range exceeds the allowed range.
     assert!(
         matches!(result, Err(crate::AssignmentError::BusExhaustion { .. })),
         "expected BusExhaustion when SR-IOV reservation exceeds end_bus, got {result:?}"
     );
 }
 
+/// When low_mmio is None, 32-bit (non-prefetchable) BARs fall back
+/// to high_mmio via `.or(params.high_mmio)`. If high_mmio is above 4 GB,
+/// the BAR address is truncated by `bar.address as u32` and bridge memory
+/// base/limit registers (inherently 32-bit) silently lose upper bits.
 /// 32-bit BARs must never be placed above 4 GB.
 #[async_test]
 async fn mem32_bar_must_not_be_placed_above_4gb() {
     let mock = MockConfigSpace::new();
 
+    // 32-bit non-prefetchable BAR.
     mock.add_endpoint(0, 0, 0, &[(0, 0x10000, false, false)]);
 
     let params = AssignmentParams {
@@ -908,23 +963,35 @@ async fn mem32_bar_must_not_be_placed_above_4gb() {
     let mut cfg = mock;
     let result = assign_pci_resources(&mut cfg, &params).await;
 
+    // No sub-4GB aperture exists, so 32-bit BARs cannot be placed.
+    // Must fail rather than silently placing them above 4 GB.
     assert!(
         result.is_err(),
         "expected error when only aperture is above 4 GB"
     );
 }
 
-/// When both mem32 and mem64 pools share the same aperture, BAR regions
-/// must not overlap.
+/// When both mem32 and mem64 pools share the same aperture (only
+/// one of low_mmio/high_mmio is provided), the mem64 base is computed
+/// from `aperture.base + root_req.mem32` instead of from the actual
+/// aligned mem32 end address. If aperture.base needs alignment for mem32,
+/// mem64 can start inside the mem32 region, causing overlapping
+/// assignments. BAR regions must not overlap.
 #[async_test]
 async fn shared_aperture_mem32_mem64_must_not_overlap() {
     let mock = MockConfigSpace::new();
 
-    // Device 0: 4 MB 32-bit non-prefetchable BAR.
+    // Device 0: 4 MB 32-bit non-prefetchable BAR (needs 4 MB alignment).
     mock.add_endpoint(0, 0, 0, &[(0, 0x40_0000, false, false)]);
     // Device 1: 1 MB 64-bit prefetchable BAR.
     mock.add_endpoint(0, 1, 0, &[(0, 0x10_0000, true, true)]);
 
+    // Single aperture, misaligned so that mem32 alignment pushes its base
+    // forward, creating a gap between aperture.base and mem32 start.
+    // aperture.base = 0x1020_0000 (2 MB past a 4 MB boundary)
+    // mem32 aligns up to 0x1040_0000, occupies [0x1040_0000, 0x1080_0000)
+    // Bug: mem64 base = align_up(0x1020_0000 + 0x40_0000, 1MB)
+    //                  = 0x1060_0000, which is INSIDE the mem32 region.
     let params = AssignmentParams {
         start_bus: 0,
         end_bus: 255,
@@ -938,6 +1005,7 @@ async fn shared_aperture_mem32_mem64_must_not_overlap() {
     let mut cfg = mock.clone();
     assign_pci_resources(&mut cfg, &params).await.unwrap();
 
+    // Collect all BAR regions and verify no overlaps.
     // Device 0: 4 MB 32-bit BAR.
     let bar0_addr = read_bar32(&mock, 0, 0, 0, 0) as u64;
     let bar0_end = bar0_addr + 0x40_0000;
@@ -952,16 +1020,29 @@ async fn shared_aperture_mem32_mem64_must_not_overlap() {
     );
 }
 
-/// When bus 255 is consumed, next_bus must not wrap to 0.
+/// When bus 255 is consumed (by a bridge secondary or SR-IOV VF
+/// range), `wrapping_add(1)` wraps `*next_bus` to 0. The subsequent
+/// `*next_bus > end_bus` guard (0 > 255) is false, so the next bridge
+/// gets secondary bus 0, colliding with the host bridge. Should return
+/// BusExhaustion instead.
 #[async_test]
 async fn bus_wrap_to_zero_must_return_exhaustion() {
     let mock = MockConfigSpace::new();
 
+    // Bridge 0 on bus 0 → secondary = 1.
     mock.add_bridge(0, 0, 0);
 
+    // Endpoint on bus 1 with SR-IOV: 256 VFs, offset = 0x100, stride = 1.
+    // PF routing ID = (1 << 8) | 0 = 0x100.
+    // We want last VF on bus 255. RID of last VF = 0xFF00..0xFFFF → bus 255.
+    // last_vf_rid = 0x100 + vf_offset + (total_vfs - 1) * vf_stride = 0xFF00
+    // With total_vfs=1, stride=1: last_vf_rid = 0x100 + vf_offset = 0xFF00
+    // → vf_offset = 0xFE00
     mock.add_endpoint(1, 0, 0, &[(0, 0x1000, false, false)]);
     mock.add_sriov(1, 0, 0, 1, 0xFE00, 1);
 
+    // Second bridge on bus 0 → needs secondary bus, but next_bus wrapped to 0.
+    // The bridge just needs to exist to trigger the next bus allocation.
     mock.add_bridge(0, 1, 0);
 
     let params = AssignmentParams {
@@ -977,6 +1058,8 @@ async fn bus_wrap_to_zero_must_return_exhaustion() {
     let mut cfg = mock;
     let result = assign_pci_resources(&mut cfg, &params).await;
 
+    // The SR-IOV reservation consumes up through bus 255. The next bridge
+    // should fail with BusExhaustion, not silently wrap to bus 0.
     assert!(
         matches!(result, Err(crate::AssignmentError::BusExhaustion { .. })),
         "expected BusExhaustion when next_bus wraps past 255, got {result:?}"


### PR DESCRIPTION
Bridge windows are sized by summing the BAR requirements of all devices behind the bridge. However, VF BARs (declared in the PF's SR-IOV extended capability) were not included in this calculation, causing the bridge window to be too small when an SR-IOV PF is present.

Fix this by including VF BAR space in the bottom-up sizing pass. Additionally, assign VF BAR addresses during the top-down allocation pass and program them into the SR-IOV capability registers, so the host has correct VF BAR base addresses before enabling VFs. Refactor the assignment code to reduce duplication.