### PR TITLE
crypto: Clean up the windows rsa impl

### DIFF
--- a/support/crypto/Cargo.toml
+++ b/support/crypto/Cargo.toml
@@ -78,10 +78,6 @@ windows = { workspace = true, features = [
 ] }
 windows-result.workspace = true
 zerocopy.workspace = true
-# Used by the native BCrypt RSA backend to parse/encode PKCS#8 / PKCS#1.
-der.workspace = true
-pkcs1.workspace = true
-pkcs8 = { workspace = true, features = ["alloc"] }
 
 # Used by the native Security.framework RSA backend to parse/encode PKCS#8 / PKCS#1.
 [target.'cfg(target_os = "macos")'.dependencies]

--- a/support/crypto/src/aes_256_gcm/win.rs
+++ b/support/crypto/src/aes_256_gcm/win.rs
@@ -42,7 +42,7 @@ static AES_256_GCM: LazyLock<Result<AlgHandle, Aes256GcmError>> = LazyLock::new(
 });
 
 fn err(err: windows_result::Error, op: &'static str) -> Aes256GcmError {
-    Aes256GcmError(crate::BackendError::Bcrypt(err, op))
+    Aes256GcmError(crate::BackendError(err, op))
 }
 
 pub struct Aes256GcmInner {

--- a/support/crypto/src/lib.rs
+++ b/support/crypto/src/lib.rs
@@ -42,17 +42,8 @@ pub(crate) struct BackendError(#[source] openssl::error::ErrorStack, &'static st
 /// operation being performed when the error occurred.
 #[cfg(all(native, windows))]
 #[derive(Clone, Debug, thiserror::Error)]
-pub(crate) enum BackendError {
-    /// An error from a BCrypt / CryptoAPI call.
-    #[error("windows crypto error during {1}")]
-    Bcrypt(#[source] windows_result::Error, &'static str),
-    /// An error from encoding or decoding PKCS#8.
-    #[error("PKCS#8 error during {1}")]
-    Pkcs8(#[source] pkcs8::Error, &'static str),
-    /// An error from DER encoding or decoding.
-    #[error("DER error during {1}")]
-    Der(#[source] der::Error, &'static str),
-}
+#[error("windows crypto error during {1}")]
+pub(crate) struct BackendError(#[source] windows_result::Error, &'static str);
 
 /// An error that occurred in the crypto backend, with a description of the
 /// operation being performed when the error occurred.

--- a/support/crypto/src/pkcs7/win.rs
+++ b/support/crypto/src/pkcs7/win.rs
@@ -10,7 +10,7 @@ use windows::Win32::Foundation::NTE_BAD_SIGNATURE;
 use windows::Win32::Security::Cryptography::*;
 
 fn err(e: windows_result::Error, op: &'static str) -> Pkcs7Error {
-    Pkcs7Error(crate::BackendError::Bcrypt(e, op))
+    Pkcs7Error(crate::BackendError(e, op))
 }
 
 /// RAII wrapper for HCERTSTORE.

--- a/support/crypto/src/rsa/win.rs
+++ b/support/crypto/src/rsa/win.rs
@@ -6,10 +6,11 @@
 use super::RsaError;
 use crate::HashAlgorithm;
 use crate::win::KeyHandle;
-use der::Decode;
-#[cfg(any(test, feature = "test_helpers"))]
-use der::Encode;
+use std::ffi::CStr;
 use std::ffi::c_void;
+use windows::Win32::Foundation::HLOCAL;
+use windows::Win32::Foundation::LocalFree;
+use windows::Win32::Foundation::NTE_BAD_TYPE;
 use windows::Win32::Foundation::STATUS_INVALID_PARAMETER;
 use windows::Win32::Foundation::STATUS_INVALID_SIGNATURE;
 use windows::Win32::Security::Cryptography::BCRYPT_FLAGS;
@@ -22,21 +23,31 @@ use windows::Win32::Security::Cryptography::BCRYPT_PKCS1_PADDING_INFO;
 use windows::Win32::Security::Cryptography::BCRYPT_PSS_PADDING_INFO;
 use windows::Win32::Security::Cryptography::BCRYPT_RSA_ALG_HANDLE;
 use windows::Win32::Security::Cryptography::BCRYPT_RSAFULLPRIVATE_BLOB;
-use windows::Win32::Security::Cryptography::BCRYPT_RSAFULLPRIVATE_MAGIC;
 use windows::Win32::Security::Cryptography::BCRYPT_RSAKEY_BLOB;
+use windows::Win32::Security::Cryptography::BCRYPT_RSAPRIVATE_BLOB;
 use windows::Win32::Security::Cryptography::BCRYPT_RSAPUBLIC_BLOB;
 use windows::Win32::Security::Cryptography::BCRYPT_RSAPUBLIC_MAGIC;
+use windows::Win32::Security::Cryptography::CNG_RSA_PRIVATE_KEY_BLOB;
+#[cfg(any(test, feature = "test_helpers"))]
+use windows::Win32::Security::Cryptography::CRYPT_ALGORITHM_IDENTIFIER;
+use windows::Win32::Security::Cryptography::CRYPT_DECODE_ALLOC_FLAG;
+#[cfg(any(test, feature = "test_helpers"))]
+use windows::Win32::Security::Cryptography::CRYPT_ENCODE_ALLOC_FLAG;
+#[cfg(any(test, feature = "test_helpers"))]
+use windows::Win32::Security::Cryptography::CRYPT_INTEGER_BLOB;
+use windows::Win32::Security::Cryptography::CRYPT_PRIVATE_KEY_INFO;
+use windows::Win32::Security::Cryptography::CryptDecodeObjectEx;
+#[cfg(any(test, feature = "test_helpers"))]
+use windows::Win32::Security::Cryptography::CryptEncodeObjectEx;
+use windows::Win32::Security::Cryptography::PKCS_7_ASN_ENCODING;
+use windows::Win32::Security::Cryptography::PKCS_PRIVATE_KEY_INFO;
+use windows::Win32::Security::Cryptography::X509_ASN_ENCODING;
+use windows::Win32::Security::Cryptography::szOID_RSA_RSA;
+#[cfg(any(test, feature = "test_helpers"))]
+use windows::core::PSTR;
 
 fn err(err: windows_result::Error, op: &'static str) -> RsaError {
-    RsaError(crate::BackendError::Bcrypt(err, op))
-}
-
-fn der_err(e: der::Error, op: &'static str) -> RsaError {
-    RsaError(crate::BackendError::Der(e, op))
-}
-
-fn pkcs8_err(e: pkcs8::Error, op: &'static str) -> RsaError {
-    RsaError(crate::BackendError::Pkcs8(e, op))
+    RsaError(crate::BackendError(err, op))
 }
 
 #[repr(transparent)]
@@ -45,85 +56,17 @@ pub struct RsaKeyPairInner(KeyHandle);
 #[repr(transparent)]
 pub struct RsaPublicKeyInner(KeyHandle);
 
-/// Left-pads `src` with leading zero bytes so the result is `len` bytes long.
-/// Panics if `src.len() > len`.
-fn left_pad(src: &[u8], len: usize) -> Vec<u8> {
-    assert!(src.len() <= len);
-    let mut out = vec![0u8; len];
-    out[len - src.len()..].copy_from_slice(src);
-    out
+/// Owns a buffer allocated by Crypt32 via `CryptDecodeObjectEx` /
+/// `CryptEncodeObjectEx` with the ALLOC flag. Frees with `LocalFree`.
+struct CryptAlloc {
+    ptr: *mut c_void,
+    len: u32,
 }
 
-/// Bit length of a non-negative big-endian integer.
-fn bit_length(bytes: &[u8]) -> u32 {
-    for (i, &b) in bytes.iter().enumerate() {
-        if b != 0 {
-            return ((bytes.len() - i) as u32) * 8 - b.leading_zeros();
-        }
-    }
-    0
-}
-
-/// Build a BCRYPT_RSAFULLPRIVATE_BLOB from PKCS#1 RSA private key components.
-fn build_fullprivate_blob(key: &pkcs1::RsaPrivateKey<'_>) -> Vec<u8> {
-    let n = key.modulus.as_bytes();
-    let e = key.public_exponent.as_bytes();
-    let d = key.private_exponent.as_bytes();
-    let p = key.prime1.as_bytes();
-    let q = key.prime2.as_bytes();
-    let dp = key.exponent1.as_bytes();
-    let dq = key.exponent2.as_bytes();
-    let qinv = key.coefficient.as_bytes();
-
-    let cb_modulus = n.len().max(d.len());
-    let cb_prime1 = p.len().max(dp.len()).max(qinv.len());
-    let cb_prime2 = q.len().max(dq.len());
-    let cb_public_exp = e.len();
-
-    let header = BCRYPT_RSAKEY_BLOB {
-        Magic: BCRYPT_RSAFULLPRIVATE_MAGIC,
-        BitLength: bit_length(n),
-        cbPublicExp: cb_public_exp as u32,
-        cbModulus: cb_modulus as u32,
-        cbPrime1: cb_prime1 as u32,
-        cbPrime2: cb_prime2 as u32,
-    };
-
-    let total = size_of::<BCRYPT_RSAKEY_BLOB>()
-        + cb_public_exp
-        + cb_modulus
-        + cb_prime1 * 3
-        + cb_prime2 * 2
-        + cb_modulus;
-    let mut out = Vec::with_capacity(total);
-    out.extend_from_slice(header.as_bytes());
-    out.extend_from_slice(&left_pad(e, cb_public_exp));
-    out.extend_from_slice(&left_pad(n, cb_modulus));
-    out.extend_from_slice(&left_pad(p, cb_prime1));
-    out.extend_from_slice(&left_pad(q, cb_prime2));
-    out.extend_from_slice(&left_pad(dp, cb_prime1));
-    out.extend_from_slice(&left_pad(dq, cb_prime2));
-    out.extend_from_slice(&left_pad(qinv, cb_prime1));
-    out.extend_from_slice(&left_pad(d, cb_modulus));
-    out
-}
-
-/// SAFETY: zerocopy IntoBytes-compatible because BCRYPT_RSAKEY_BLOB is
-/// `#[repr(C)]` with all-integer fields. We can't derive `IntoBytes` on a
-/// foreign type, so write a small helper.
-trait HeaderBytes {
-    fn as_bytes(&self) -> &[u8];
-}
-impl HeaderBytes for BCRYPT_RSAKEY_BLOB {
-    fn as_bytes(&self) -> &[u8] {
-        // SAFETY: BCRYPT_RSAKEY_BLOB is #[repr(C)] and contains only POD u32
-        // fields, so any byte pattern is valid.
-        unsafe {
-            std::slice::from_raw_parts(
-                std::ptr::from_ref(self).cast::<u8>(),
-                size_of::<BCRYPT_RSAKEY_BLOB>(),
-            )
-        }
+impl Drop for CryptAlloc {
+    fn drop(&mut self) {
+        // SAFETY: ptr was allocated by Crypt32 with LocalAlloc semantics.
+        let _ = unsafe { LocalFree(Some(HLOCAL(self.ptr))) };
     }
 }
 
@@ -132,20 +75,6 @@ impl HeaderBytes for BCRYPT_RSAKEY_BLOB {
 struct PublicComponents<'a> {
     modulus: &'a [u8],
     public_exponent: &'a [u8],
-}
-
-fn parse_public_components(blob: &[u8]) -> PublicComponents<'_> {
-    assert!(blob.len() >= size_of::<BCRYPT_RSAKEY_BLOB>());
-    let header_ptr = blob.as_ptr().cast::<BCRYPT_RSAKEY_BLOB>();
-    // SAFETY: blob is at least header-sized; header is POD.
-    let header = unsafe { std::ptr::read_unaligned(header_ptr) };
-    let off = size_of::<BCRYPT_RSAKEY_BLOB>();
-    let cb_e = header.cbPublicExp as usize;
-    let cb_n = header.cbModulus as usize;
-    PublicComponents {
-        public_exponent: &blob[off..off + cb_e],
-        modulus: &blob[off + cb_e..off + cb_e + cb_n],
-    }
 }
 
 /// Export a BCrypt key as the given blob type.
@@ -226,82 +155,175 @@ impl RsaKeyPairInner {
     }
 
     pub fn from_pkcs8_der(der_bytes: &[u8]) -> Result<Self, RsaError> {
-        let pki = pkcs8::PrivateKeyInfoRef::from_der(der_bytes)
-            .map_err(|e| der_err(e, "parsing PKCS#8 DER"))?;
-        if pki.algorithm.oid != pkcs1::ALGORITHM_OID {
-            return Err(pkcs8_err(
-                pkcs8::Error::KeyMalformed(pkcs8::KeyError::Invalid),
+        // Step 1: parse the PKCS#8 PrivateKeyInfo wrapper to obtain the
+        // algorithm OID and the inner PKCS#1 RSAPrivateKey DER.
+        let pki_buf = {
+            let mut ptr: *mut c_void = std::ptr::null_mut();
+            let mut len: u32 = 0;
+            // SAFETY: With CRYPT_DECODE_ALLOC_FLAG, Crypt32 allocates the
+            // output buffer and writes its pointer into the location
+            // pointed to by pvstructinfo.
+            unsafe {
+                CryptDecodeObjectEx(
+                    X509_ASN_ENCODING | PKCS_7_ASN_ENCODING,
+                    PKCS_PRIVATE_KEY_INFO,
+                    der_bytes,
+                    CRYPT_DECODE_ALLOC_FLAG,
+                    None,
+                    Some(std::ptr::from_mut(&mut ptr).cast::<c_void>()),
+                    &mut len,
+                )
+            }
+            .map_err(|e| err(e, "decoding PKCS#8 PrivateKeyInfo"))?;
+            CryptAlloc { ptr, len }
+        };
+        // SAFETY: pki_buf.ptr points to a CRYPT_PRIVATE_KEY_INFO allocated
+        // by Crypt32, valid for the lifetime of pki_buf.
+        let pki = unsafe { &*pki_buf.ptr.cast::<CRYPT_PRIVATE_KEY_INFO>() };
+        // SAFETY: pszObjId is a NUL-terminated string owned by the same
+        // Crypt32 allocation.
+        let oid = unsafe { CStr::from_ptr(pki.Algorithm.pszObjId.0.cast()) };
+        // SAFETY: szOID_RSA_RSA is a static NUL-terminated string constant.
+        let rsa_oid = unsafe { CStr::from_ptr(szOID_RSA_RSA.0.cast()) };
+        if oid != rsa_oid {
+            return Err(err(
+                windows_result::Error::from_hresult(NTE_BAD_TYPE),
                 "PKCS#8 algorithm is not rsaEncryption",
             ));
         }
-        let key = pkcs1::RsaPrivateKey::from_der(pki.private_key.as_bytes())
-            .map_err(|e| der_err(e, "parsing PKCS#1 RSA private key"))?;
-        if key.other_prime_infos.is_some() {
-            return Err(pkcs8_err(
-                pkcs8::Error::KeyMalformed(pkcs8::KeyError::Invalid),
-                "multiprime RSA keys not supported",
+        // SAFETY: PrivateKey describes a buffer of cbData bytes owned by
+        // the same allocation, containing the PKCS#1 RSAPrivateKey DER.
+        let pkcs1_der = unsafe {
+            std::slice::from_raw_parts(pki.PrivateKey.pbData, pki.PrivateKey.cbData as usize)
+        };
+
+        // Step 2: decode the PKCS#1 RSAPrivateKey DER directly into a
+        // BCRYPT_RSAKEY_BLOB layout suitable for BCryptImportKeyPair.
+        // CNG_RSA_PRIVATE_KEY_BLOB may produce either the BCRYPT_RSAPRIVATE
+        // or BCRYPT_RSAFULLPRIVATE layout depending on which fields are
+        // present in the source DER; the magic word at the start of the
+        // blob distinguishes them.
+        let blob_buf = {
+            let mut ptr: *mut c_void = std::ptr::null_mut();
+            let mut len: u32 = 0;
+            // SAFETY: With CRYPT_DECODE_ALLOC_FLAG, Crypt32 allocates the
+            // output buffer and writes its pointer into the location
+            // pointed to by pvstructinfo.
+            unsafe {
+                CryptDecodeObjectEx(
+                    X509_ASN_ENCODING | PKCS_7_ASN_ENCODING,
+                    CNG_RSA_PRIVATE_KEY_BLOB,
+                    pkcs1_der,
+                    CRYPT_DECODE_ALLOC_FLAG,
+                    None,
+                    Some(std::ptr::from_mut(&mut ptr).cast::<c_void>()),
+                    &mut len,
+                )
+            }
+            .map_err(|e| err(e, "decoding PKCS#1 RSA private key"))?;
+            CryptAlloc { ptr, len }
+        };
+        // SAFETY: blob_buf describes a contiguous buffer of `len` bytes.
+        let blob =
+            unsafe { std::slice::from_raw_parts(blob_buf.ptr.cast::<u8>(), blob_buf.len as usize) };
+        if blob.len() < size_of::<BCRYPT_RSAKEY_BLOB>() {
+            return Err(err(
+                windows_result::Error::from_hresult(NTE_BAD_TYPE),
+                "decoded RSA private blob too small",
             ));
         }
-        let blob = build_fullprivate_blob(&key);
-        let handle = import_key(&blob, BCRYPT_RSAFULLPRIVATE_BLOB)?;
+        // SAFETY: blob is at least header-sized and the header is POD.
+        let magic =
+            unsafe { std::ptr::read_unaligned(blob.as_ptr().cast::<BCRYPT_RSAKEY_BLOB>()) }.Magic;
+        let blob_type =
+            if magic == windows::Win32::Security::Cryptography::BCRYPT_RSAFULLPRIVATE_MAGIC {
+                BCRYPT_RSAFULLPRIVATE_BLOB
+            } else {
+                BCRYPT_RSAPRIVATE_BLOB
+            };
+        let handle = import_key(blob, blob_type)?;
         Ok(Self(handle))
     }
 
     #[cfg(any(test, feature = "test_helpers"))]
     pub fn to_pkcs8_der(&self) -> Result<Vec<u8>, RsaError> {
-        use der::asn1::OctetString;
-        use der::asn1::UintRef;
-        use pkcs8::spki::AlgorithmIdentifierOwned;
-
+        // Step 1: export the key as a BCrypt full-private blob, which
+        // contains every field needed by the PKCS#1 RSAPrivateKey ASN.1
+        // SEQUENCE.
         let blob = export_key(&self.0, BCRYPT_RSAFULLPRIVATE_BLOB)?;
-        let header_ptr = blob.as_ptr().cast::<BCRYPT_RSAKEY_BLOB>();
-        // SAFETY: blob is at least header-sized and header is POD.
-        let header = unsafe { std::ptr::read_unaligned(header_ptr) };
-        let mut off = size_of::<BCRYPT_RSAKEY_BLOB>();
-        let cb_e = header.cbPublicExp as usize;
-        let cb_n = header.cbModulus as usize;
-        let cb_p = header.cbPrime1 as usize;
-        let cb_q = header.cbPrime2 as usize;
-        let take = |off: &mut usize, n: usize| {
-            let s = &blob[*off..*off + n];
-            *off += n;
-            s
-        };
-        let e_bytes = take(&mut off, cb_e);
-        let n_bytes = take(&mut off, cb_n);
-        let p_bytes = take(&mut off, cb_p);
-        let q_bytes = take(&mut off, cb_q);
-        let dp_bytes = take(&mut off, cb_p);
-        let dq_bytes = take(&mut off, cb_q);
-        let qinv_bytes = take(&mut off, cb_p);
-        let d_bytes = take(&mut off, cb_n);
 
-        let pk = pkcs1::RsaPrivateKey {
-            modulus: UintRef::new(n_bytes).map_err(|e| der_err(e, "encoding modulus"))?,
-            public_exponent: UintRef::new(e_bytes).map_err(|e| der_err(e, "encoding e"))?,
-            private_exponent: UintRef::new(d_bytes).map_err(|e| der_err(e, "encoding d"))?,
-            prime1: UintRef::new(p_bytes).map_err(|e| der_err(e, "encoding p"))?,
-            prime2: UintRef::new(q_bytes).map_err(|e| der_err(e, "encoding q"))?,
-            exponent1: UintRef::new(dp_bytes).map_err(|e| der_err(e, "encoding dp"))?,
-            exponent2: UintRef::new(dq_bytes).map_err(|e| der_err(e, "encoding dq"))?,
-            coefficient: UintRef::new(qinv_bytes).map_err(|e| der_err(e, "encoding qinv"))?,
-            other_prime_infos: None,
+        // Step 2: encode the BCrypt blob as PKCS#1 RSAPrivateKey DER.
+        // CryptEncodeObjectEx with CNG_RSA_PRIVATE_KEY_BLOB takes the raw
+        // BCRYPT_RSAKEY_BLOB layout (header + concatenated components) as
+        // its struct input.
+        let pkcs1_buf = {
+            let mut ptr: *mut c_void = std::ptr::null_mut();
+            let mut len: u32 = 0;
+            // SAFETY: With CRYPT_ENCODE_ALLOC_FLAG, Crypt32 allocates the
+            // output buffer and writes its pointer into the location
+            // pointed to by pvencoded.
+            unsafe {
+                CryptEncodeObjectEx(
+                    X509_ASN_ENCODING | PKCS_7_ASN_ENCODING,
+                    CNG_RSA_PRIVATE_KEY_BLOB,
+                    blob.as_ptr().cast::<c_void>(),
+                    CRYPT_ENCODE_ALLOC_FLAG,
+                    None,
+                    Some(std::ptr::from_mut(&mut ptr).cast::<c_void>()),
+                    &mut len,
+                )
+            }
+            .map_err(|e| err(e, "encoding PKCS#1 RSA private key"))?;
+            CryptAlloc { ptr, len }
         };
-        let pkcs1_der = pk
-            .to_der()
-            .map_err(|e| der_err(e, "encoding PKCS#1 RSA private key"))?;
 
-        let pki = pkcs8::PrivateKeyInfoOwned {
-            algorithm: AlgorithmIdentifierOwned {
-                oid: pkcs1::ALGORITHM_OID,
-                parameters: Some(der::Any::null()),
+        // Step 3: wrap the PKCS#1 DER in a PKCS#8 PrivateKeyInfo with the
+        // rsaEncryption algorithm OID and ASN.1 NULL parameters.
+        let mut null_params = [0x05u8, 0x00];
+        let pki = CRYPT_PRIVATE_KEY_INFO {
+            Version: 0,
+            Algorithm: CRYPT_ALGORITHM_IDENTIFIER {
+                // CryptEncodeObjectEx does not mutate pszObjId; the field
+                // is `PSTR` only because the same struct is used by the
+                // decode direction.
+                pszObjId: PSTR(szOID_RSA_RSA.0.cast_mut()),
+                Parameters: CRYPT_INTEGER_BLOB {
+                    cbData: null_params.len() as u32,
+                    pbData: null_params.as_mut_ptr(),
+                },
             },
-            private_key: OctetString::new(pkcs1_der)
-                .map_err(|e| der_err(e, "wrapping PKCS#1 in OCTET STRING"))?,
-            public_key: None,
+            PrivateKey: CRYPT_INTEGER_BLOB {
+                cbData: pkcs1_buf.len,
+                pbData: pkcs1_buf.ptr.cast::<u8>(),
+            },
+            pAttributes: std::ptr::null_mut(),
         };
-        pki.to_der()
-            .map_err(|e| der_err(e, "encoding PKCS#8 PrivateKeyInfo"))
+        let pkcs8_buf = {
+            let mut ptr: *mut c_void = std::ptr::null_mut();
+            let mut len: u32 = 0;
+            // SAFETY: With CRYPT_ENCODE_ALLOC_FLAG, Crypt32 allocates the
+            // output buffer and writes its pointer into the location
+            // pointed to by pvencoded.
+            unsafe {
+                CryptEncodeObjectEx(
+                    X509_ASN_ENCODING | PKCS_7_ASN_ENCODING,
+                    PKCS_PRIVATE_KEY_INFO,
+                    std::ptr::from_ref(&pki).cast::<c_void>(),
+                    CRYPT_ENCODE_ALLOC_FLAG,
+                    None,
+                    Some(std::ptr::from_mut(&mut ptr).cast::<c_void>()),
+                    &mut len,
+                )
+            }
+            .map_err(|e| err(e, "encoding PKCS#8 PrivateKeyInfo"))?;
+            CryptAlloc { ptr, len }
+        };
+        // SAFETY: pkcs8_buf describes a contiguous buffer of `len` bytes.
+        let out = unsafe {
+            std::slice::from_raw_parts(pkcs8_buf.ptr.cast::<u8>(), pkcs8_buf.len as usize)
+        }
+        .to_vec();
+        Ok(out)
     }
 
     pub fn oaep_decrypt(
@@ -459,20 +481,48 @@ fn verify_hash(
     Ok(true)
 }
 
+fn parse_public_components(blob: &[u8]) -> PublicComponents<'_> {
+    assert!(blob.len() >= size_of::<BCRYPT_RSAKEY_BLOB>());
+    let header_ptr = blob.as_ptr().cast::<BCRYPT_RSAKEY_BLOB>();
+    // SAFETY: blob is at least header-sized; header is POD.
+    let header = unsafe { std::ptr::read_unaligned(header_ptr) };
+    let off = size_of::<BCRYPT_RSAKEY_BLOB>();
+    let cb_e = header.cbPublicExp as usize;
+    let cb_n = header.cbModulus as usize;
+    PublicComponents {
+        public_exponent: &blob[off..off + cb_e],
+        modulus: &blob[off + cb_e..off + cb_e + cb_n],
+    }
+}
+
 impl RsaPublicKeyInner {
     pub fn from_components(n: &[u8], e: &[u8]) -> Result<Self, RsaError> {
         let cb_n = n.len();
         let cb_e = e.len();
+        // Bit length of the modulus (a non-negative big-endian integer).
+        let bit_length = n
+            .iter()
+            .enumerate()
+            .find_map(|(i, &b)| (b != 0).then(|| ((n.len() - i) as u32) * 8 - b.leading_zeros()))
+            .unwrap_or(0);
         let header = BCRYPT_RSAKEY_BLOB {
             Magic: BCRYPT_RSAPUBLIC_MAGIC,
-            BitLength: bit_length(n),
+            BitLength: bit_length,
             cbPublicExp: cb_e as u32,
             cbModulus: cb_n as u32,
             cbPrime1: 0,
             cbPrime2: 0,
         };
+        // SAFETY: BCRYPT_RSAKEY_BLOB is #[repr(C)] and contains only POD u32
+        // fields, so any byte pattern is valid.
+        let header_bytes = unsafe {
+            std::slice::from_raw_parts(
+                std::ptr::from_ref(&header).cast::<u8>(),
+                size_of::<BCRYPT_RSAKEY_BLOB>(),
+            )
+        };
         let mut blob = Vec::with_capacity(size_of::<BCRYPT_RSAKEY_BLOB>() + cb_e + cb_n);
-        blob.extend_from_slice(header.as_bytes());
+        blob.extend_from_slice(header_bytes);
         blob.extend_from_slice(e);
         blob.extend_from_slice(n);
         let handle = import_key(&blob, BCRYPT_RSAPUBLIC_BLOB)?;

--- a/support/crypto/src/rsa/win.rs
+++ b/support/crypto/src/rsa/win.rs
@@ -160,7 +160,7 @@ impl RsaKeyPairInner {
                 )
             }
             .map_err(|e| err(e, "decoding PKCS#8 PrivateKeyInfo"))?;
-            CryptAlloc { ptr, len }
+            CryptAlloc::new(ptr, len).map_err(|e| err(e, "decoding PKCS#8 PrivateKeyInfo"))?
         };
         // SAFETY: Crypt32 was asked to decode a PKCS_PRIVATE_KEY_INFO, so
         // the buffer (when non-null and large enough, as validated by
@@ -215,11 +215,9 @@ impl RsaKeyPairInner {
                 )
             }
             .map_err(|e| err(e, "decoding PKCS#1 RSA private key"))?;
-            CryptAlloc { ptr, len }
+            CryptAlloc::new(ptr, len).map_err(|e| err(e, "decoding PKCS#1 RSA private key"))?
         };
-        let blob = blob_buf
-            .as_bytes()
-            .map_err(|e| err(e, "decoding PKCS#1 RSA private key"))?;
+        let blob = blob_buf.as_bytes();
         if blob.len() < size_of::<BCRYPT_RSAKEY_BLOB>() {
             return Err(err(
                 windows_result::Error::from_hresult(NTE_BAD_TYPE),
@@ -229,12 +227,20 @@ impl RsaKeyPairInner {
         // SAFETY: blob is at least header-sized and the header is POD.
         let magic =
             unsafe { std::ptr::read_unaligned(blob.as_ptr().cast::<BCRYPT_RSAKEY_BLOB>()) }.Magic;
-        let blob_type =
-            if magic == windows::Win32::Security::Cryptography::BCRYPT_RSAFULLPRIVATE_MAGIC {
+        let blob_type = match magic {
+            windows::Win32::Security::Cryptography::BCRYPT_RSAFULLPRIVATE_MAGIC => {
                 BCRYPT_RSAFULLPRIVATE_BLOB
-            } else {
+            }
+            windows::Win32::Security::Cryptography::BCRYPT_RSAPRIVATE_MAGIC => {
                 BCRYPT_RSAPRIVATE_BLOB
-            };
+            }
+            _ => {
+                return Err(err(
+                    windows_result::Error::from_hresult(NTE_BAD_TYPE),
+                    "decoded RSA private blob has unexpected magic",
+                ));
+            }
+        };
         let handle = import_key(blob, blob_type)?;
         Ok(Self(handle))
     }
@@ -268,7 +274,7 @@ impl RsaKeyPairInner {
                 )
             }
             .map_err(|e| err(e, "encoding PKCS#1 RSA private key"))?;
-            CryptAlloc { ptr, len }
+            CryptAlloc::new(ptr, len).map_err(|e| err(e, "encoding PKCS#1 RSA private key"))?
         };
 
         // Step 3: wrap the PKCS#1 DER in a PKCS#8 PrivateKeyInfo with the
@@ -286,9 +292,12 @@ impl RsaKeyPairInner {
                     pbData: null_params.as_mut_ptr(),
                 },
             },
-            PrivateKey: CRYPT_INTEGER_BLOB {
-                cbData: pkcs1_buf.len,
-                pbData: pkcs1_buf.ptr.cast::<u8>(),
+            PrivateKey: {
+                let pkcs1 = pkcs1_buf.as_bytes();
+                CRYPT_INTEGER_BLOB {
+                    cbData: pkcs1.len() as u32,
+                    pbData: pkcs1.as_ptr().cast_mut(),
+                }
             },
             pAttributes: std::ptr::null_mut(),
         };
@@ -310,12 +319,9 @@ impl RsaKeyPairInner {
                 )
             }
             .map_err(|e| err(e, "encoding PKCS#8 PrivateKeyInfo"))?;
-            CryptAlloc { ptr, len }
+            CryptAlloc::new(ptr, len).map_err(|e| err(e, "encoding PKCS#8 PrivateKeyInfo"))?
         };
-        Ok(pkcs8_buf
-            .as_bytes()
-            .map_err(|e| err(e, "encoding PKCS#8 PrivateKeyInfo"))?
-            .to_vec())
+        Ok(pkcs8_buf.as_bytes().to_vec())
     }
 
     pub fn oaep_decrypt(

--- a/support/crypto/src/rsa/win.rs
+++ b/support/crypto/src/rsa/win.rs
@@ -5,11 +5,10 @@
 
 use super::RsaError;
 use crate::HashAlgorithm;
+use crate::win::CryptAlloc;
 use crate::win::KeyHandle;
 use std::ffi::CStr;
 use std::ffi::c_void;
-use windows::Win32::Foundation::HLOCAL;
-use windows::Win32::Foundation::LocalFree;
 use windows::Win32::Foundation::NTE_BAD_TYPE;
 use windows::Win32::Foundation::STATUS_INVALID_PARAMETER;
 use windows::Win32::Foundation::STATUS_INVALID_SIGNATURE;
@@ -55,20 +54,6 @@ pub struct RsaKeyPairInner(KeyHandle);
 
 #[repr(transparent)]
 pub struct RsaPublicKeyInner(KeyHandle);
-
-/// Owns a buffer allocated by Crypt32 via `CryptDecodeObjectEx` /
-/// `CryptEncodeObjectEx` with the ALLOC flag. Frees with `LocalFree`.
-struct CryptAlloc {
-    ptr: *mut c_void,
-    len: u32,
-}
-
-impl Drop for CryptAlloc {
-    fn drop(&mut self) {
-        // SAFETY: ptr was allocated by Crypt32 with LocalAlloc semantics.
-        let _ = unsafe { LocalFree(Some(HLOCAL(self.ptr))) };
-    }
-}
 
 /// Parse a BCRYPT_RSAFULLPRIVATE_BLOB or BCRYPT_RSAPUBLIC_BLOB into its
 /// big-endian component byte ranges.
@@ -177,9 +162,11 @@ impl RsaKeyPairInner {
             .map_err(|e| err(e, "decoding PKCS#8 PrivateKeyInfo"))?;
             CryptAlloc { ptr, len }
         };
-        // SAFETY: pki_buf.ptr points to a CRYPT_PRIVATE_KEY_INFO allocated
-        // by Crypt32, valid for the lifetime of pki_buf.
-        let pki = unsafe { &*pki_buf.ptr.cast::<CRYPT_PRIVATE_KEY_INFO>() };
+        // SAFETY: Crypt32 was asked to decode a PKCS_PRIVATE_KEY_INFO, so
+        // the buffer (when non-null and large enough, as validated by
+        // as_struct) holds a CRYPT_PRIVATE_KEY_INFO.
+        let pki = unsafe { pki_buf.as_struct::<CRYPT_PRIVATE_KEY_INFO>() }
+            .map_err(|e| err(e, "decoding PKCS#8 PrivateKeyInfo"))?;
         // SAFETY: pszObjId is a NUL-terminated string owned by the same
         // Crypt32 allocation.
         let oid = unsafe { CStr::from_ptr(pki.Algorithm.pszObjId.0.cast()) };
@@ -191,8 +178,15 @@ impl RsaKeyPairInner {
                 "PKCS#8 algorithm is not rsaEncryption",
             ));
         }
+        if pki.PrivateKey.pbData.is_null() || pki.PrivateKey.cbData == 0 {
+            return Err(err(
+                windows_result::Error::from_hresult(NTE_BAD_TYPE),
+                "PKCS#8 PrivateKey field is empty",
+            ));
+        }
         // SAFETY: PrivateKey describes a buffer of cbData bytes owned by
-        // the same allocation, containing the PKCS#1 RSAPrivateKey DER.
+        // the same allocation, containing the PKCS#1 RSAPrivateKey DER;
+        // validated non-null and non-empty above.
         let pkcs1_der = unsafe {
             std::slice::from_raw_parts(pki.PrivateKey.pbData, pki.PrivateKey.cbData as usize)
         };
@@ -223,9 +217,9 @@ impl RsaKeyPairInner {
             .map_err(|e| err(e, "decoding PKCS#1 RSA private key"))?;
             CryptAlloc { ptr, len }
         };
-        // SAFETY: blob_buf describes a contiguous buffer of `len` bytes.
-        let blob =
-            unsafe { std::slice::from_raw_parts(blob_buf.ptr.cast::<u8>(), blob_buf.len as usize) };
+        let blob = blob_buf
+            .as_bytes()
+            .map_err(|e| err(e, "decoding PKCS#1 RSA private key"))?;
         if blob.len() < size_of::<BCRYPT_RSAKEY_BLOB>() {
             return Err(err(
                 windows_result::Error::from_hresult(NTE_BAD_TYPE),
@@ -318,12 +312,10 @@ impl RsaKeyPairInner {
             .map_err(|e| err(e, "encoding PKCS#8 PrivateKeyInfo"))?;
             CryptAlloc { ptr, len }
         };
-        // SAFETY: pkcs8_buf describes a contiguous buffer of `len` bytes.
-        let out = unsafe {
-            std::slice::from_raw_parts(pkcs8_buf.ptr.cast::<u8>(), pkcs8_buf.len as usize)
-        }
-        .to_vec();
-        Ok(out)
+        Ok(pkcs8_buf
+            .as_bytes()
+            .map_err(|e| err(e, "encoding PKCS#8 PrivateKeyInfo"))?
+            .to_vec())
     }
 
     pub fn oaep_decrypt(

--- a/support/crypto/src/win.rs
+++ b/support/crypto/src/win.rs
@@ -6,6 +6,7 @@
 #![cfg(all(native, windows))]
 
 use std::ffi::c_void;
+use std::ptr::NonNull;
 use windows::Win32::Foundation::HLOCAL;
 use windows::Win32::Foundation::LocalFree;
 use windows::Win32::Foundation::NTE_BAD_TYPE;
@@ -17,36 +18,35 @@ use zerocopy::IntoBytes;
 /// Owns a buffer allocated by Crypt32 via `CryptDecodeObjectEx` /
 /// `CryptEncodeObjectEx` with the ALLOC flag. Frees with `LocalFree`.
 pub struct CryptAlloc {
-    ptr: *mut c_void,
+    ptr: NonNull<c_void>,
     len: u32,
 }
 
 impl Drop for CryptAlloc {
     fn drop(&mut self) {
-        if !self.ptr.is_null() {
-            // SAFETY: ptr was allocated by Crypt32 with LocalAlloc semantics.
-            let _ = unsafe { LocalFree(Some(HLOCAL(self.ptr))) };
-        }
+        // SAFETY: ptr was allocated by Crypt32 with LocalAlloc semantics.
+        let _ = unsafe { LocalFree(Some(HLOCAL(self.ptr.as_ptr()))) };
     }
 }
 
 impl CryptAlloc {
     /// Creates a new `CryptAlloc` from a raw pointer and length.
     pub fn new(ptr: *mut c_void, len: u32) -> Result<Self, windows_result::Error> {
-        if ptr.is_null() {
-            return Err(windows_result::Error::from_hresult(NTE_BAD_TYPE));
-        }
-        Ok(Self { ptr, len })
+        Ok(Self {
+            ptr: NonNull::new(ptr)
+                .ok_or_else(|| windows_result::Error::from_hresult(NTE_BAD_TYPE))?,
+            len,
+        })
     }
 
     /// Returns the allocation as a byte slice.
     pub fn as_bytes(&self) -> &[u8] {
         // SAFETY: ptr is non-null and points to `len` bytes owned by self.
-        unsafe { std::slice::from_raw_parts(self.ptr.cast::<u8>(), self.len as usize) }
+        unsafe { std::slice::from_raw_parts(self.ptr.as_ptr().cast::<u8>(), self.len as usize) }
     }
 
-    /// Reborrows the allocation as a `&T`, validating that the pointer is
-    /// non-null and the buffer is large enough to hold a `T`.
+    /// Reborrows the allocation as a `&T`, validating that the buffer is
+    /// large enough and suitably aligned for a `T`.
     ///
     /// # Safety
     ///
@@ -54,13 +54,12 @@ impl CryptAlloc {
     /// a valid `T` (e.g. by passing the matching struct type to
     /// `CryptDecodeObjectEx`).
     pub unsafe fn as_struct<T>(&self) -> Result<&T, windows_result::Error> {
-        if (self.len as usize) < size_of::<T>() {
+        if (self.len as usize) < size_of::<T>() || !self.ptr.as_ptr().cast::<T>().is_aligned() {
             return Err(windows_result::Error::from_hresult(NTE_BAD_TYPE));
         }
-        // SAFETY: ptr is non-null, aligned (LocalAlloc returns suitably
-        // aligned memory), large enough, and the caller asserts that
-        // Crypt32 populated a valid T.
-        Ok(unsafe { &*self.ptr.cast::<T>() })
+        // SAFETY: ptr is non-null, sized and aligned per the checks above,
+        // and the caller asserts that Crypt32 populated a valid T.
+        Ok(unsafe { &*self.ptr.as_ptr().cast::<T>() })
     }
 }
 

--- a/support/crypto/src/win.rs
+++ b/support/crypto/src/win.rs
@@ -17,8 +17,8 @@ use zerocopy::IntoBytes;
 /// Owns a buffer allocated by Crypt32 via `CryptDecodeObjectEx` /
 /// `CryptEncodeObjectEx` with the ALLOC flag. Frees with `LocalFree`.
 pub struct CryptAlloc {
-    pub ptr: *mut c_void,
-    pub len: u32,
+    ptr: *mut c_void,
+    len: u32,
 }
 
 impl Drop for CryptAlloc {
@@ -31,16 +31,18 @@ impl Drop for CryptAlloc {
 }
 
 impl CryptAlloc {
-    /// Returns the allocation as a byte slice, validating that the
-    /// pointer is non-null. Required before constructing a slice from a
-    /// Crypt32-allocated buffer because `from_raw_parts` requires a
-    /// non-null pointer even when `len == 0`.
-    pub fn as_bytes(&self) -> Result<&[u8], windows_result::Error> {
-        if self.ptr.is_null() {
+    /// Creates a new `CryptAlloc` from a raw pointer and length.
+    pub fn new(ptr: *mut c_void, len: u32) -> Result<Self, windows_result::Error> {
+        if ptr.is_null() {
             return Err(windows_result::Error::from_hresult(NTE_BAD_TYPE));
         }
+        Ok(Self { ptr, len })
+    }
+
+    /// Returns the allocation as a byte slice.
+    pub fn as_bytes(&self) -> &[u8] {
         // SAFETY: ptr is non-null and points to `len` bytes owned by self.
-        Ok(unsafe { std::slice::from_raw_parts(self.ptr.cast::<u8>(), self.len as usize) })
+        unsafe { std::slice::from_raw_parts(self.ptr.cast::<u8>(), self.len as usize) }
     }
 
     /// Reborrows the allocation as a `&T`, validating that the pointer is
@@ -52,7 +54,7 @@ impl CryptAlloc {
     /// a valid `T` (e.g. by passing the matching struct type to
     /// `CryptDecodeObjectEx`).
     pub unsafe fn as_struct<T>(&self) -> Result<&T, windows_result::Error> {
-        if self.ptr.is_null() || (self.len as usize) < size_of::<T>() {
+        if (self.len as usize) < size_of::<T>() {
             return Err(windows_result::Error::from_hresult(NTE_BAD_TYPE));
         }
         // SAFETY: ptr is non-null, aligned (LocalAlloc returns suitably

--- a/support/crypto/src/win.rs
+++ b/support/crypto/src/win.rs
@@ -5,10 +5,62 @@
 
 #![cfg(all(native, windows))]
 
+use std::ffi::c_void;
+use windows::Win32::Foundation::HLOCAL;
+use windows::Win32::Foundation::LocalFree;
+use windows::Win32::Foundation::NTE_BAD_TYPE;
 use windows::Win32::Security::Cryptography::BCRYPT_ALG_HANDLE;
 use windows::Win32::Security::Cryptography::BCRYPT_KEY_HANDLE;
 use zerocopy::Immutable;
 use zerocopy::IntoBytes;
+
+/// Owns a buffer allocated by Crypt32 via `CryptDecodeObjectEx` /
+/// `CryptEncodeObjectEx` with the ALLOC flag. Frees with `LocalFree`.
+pub struct CryptAlloc {
+    pub ptr: *mut c_void,
+    pub len: u32,
+}
+
+impl Drop for CryptAlloc {
+    fn drop(&mut self) {
+        if !self.ptr.is_null() {
+            // SAFETY: ptr was allocated by Crypt32 with LocalAlloc semantics.
+            let _ = unsafe { LocalFree(Some(HLOCAL(self.ptr))) };
+        }
+    }
+}
+
+impl CryptAlloc {
+    /// Returns the allocation as a byte slice, validating that the
+    /// pointer is non-null. Required before constructing a slice from a
+    /// Crypt32-allocated buffer because `from_raw_parts` requires a
+    /// non-null pointer even when `len == 0`.
+    pub fn as_bytes(&self) -> Result<&[u8], windows_result::Error> {
+        if self.ptr.is_null() {
+            return Err(windows_result::Error::from_hresult(NTE_BAD_TYPE));
+        }
+        // SAFETY: ptr is non-null and points to `len` bytes owned by self.
+        Ok(unsafe { std::slice::from_raw_parts(self.ptr.cast::<u8>(), self.len as usize) })
+    }
+
+    /// Reborrows the allocation as a `&T`, validating that the pointer is
+    /// non-null and the buffer is large enough to hold a `T`.
+    ///
+    /// # Safety
+    ///
+    /// Caller must ensure that Crypt32 actually populates the buffer with
+    /// a valid `T` (e.g. by passing the matching struct type to
+    /// `CryptDecodeObjectEx`).
+    pub unsafe fn as_struct<T>(&self) -> Result<&T, windows_result::Error> {
+        if self.ptr.is_null() || (self.len as usize) < size_of::<T>() {
+            return Err(windows_result::Error::from_hresult(NTE_BAD_TYPE));
+        }
+        // SAFETY: ptr is non-null, aligned (LocalAlloc returns suitably
+        // aligned memory), large enough, and the caller asserts that
+        // Crypt32 populated a valid T.
+        Ok(unsafe { &*self.ptr.cast::<T>() })
+    }
+}
 
 pub struct AlgHandle(pub BCRYPT_ALG_HANDLE);
 // SAFETY: the handle can be sent across threads.

--- a/support/crypto/src/xts_aes_256/win.rs
+++ b/support/crypto/src/xts_aes_256/win.rs
@@ -28,7 +28,7 @@ static XTS_AES_256: LazyLock<Result<AlgHandle, XtsAes256Error>> = LazyLock::new(
 });
 
 fn err(err: windows_result::Error, op: &'static str) -> XtsAes256Error {
-    XtsAes256Error(crate::BackendError::Bcrypt(err, op))
+    XtsAes256Error(crate::BackendError(err, op))
 }
 
 pub struct XtsAes256Inner {


### PR DESCRIPTION
Drop the RustCrypto crates for parsing, as windows does indeed provide parsers. Then switch the error type back to a struct instead of an enum. Clean up various small helpers.