### PR TITLE
vnc: stop guest screen/pointer reporting when no client is connected

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10451,6 +10451,7 @@ dependencies = [
  "parking_lot",
  "socket2",
  "sparse_mmap",
+ "tracelimit",
  "tracing",
  "tracing_helpers",
  "unicycle",

--- a/Guide/src/reference/devices/vnc/architecture.md
+++ b/Guide/src/reference/devices/vnc/architecture.md
@@ -68,8 +68,9 @@ The multi-client orchestrator. Manages connections and broadcasts dirty rects.
 ### `vnc_worker_defs` crate
 
 `VncParameters<T>` — the mesh-serializable config passed from `openvmm_entry`
-to the worker. Contains listener, framebuffer access, input sender, and dirty
-rect receiver.
+to the worker. Contains listener, framebuffer access, input sender, the dirty
+rect receiver, and the "updates needed" sender that tells the video device
+when a client is connected.
 
 ### `video_core` crate
 
@@ -175,6 +176,33 @@ Key operations:
 Once device dirty rects have been received at least once (`device_dirty_seen`),
 subsequent empty cycles skip the VRAM read entirely. This reduces an idle
 1080p desktop from 8MB/frame/client to 0 bytes.
+
+### Suppressing Guest Reporting When No Client Is Connected
+
+The optimization above still lets the guest generate and send dirty
+rectangles even when nobody is connected. To avoid that, the VNC worker
+tells the synthetic video device whether any client is connected: a `bool`
+sent over a `mesh` channel (paired with the dirty-rect channel), `true` on
+the first connect and `false` when the last client leaves. When updates are
+not needed, the device sends a synthvid `FeatureChange` with `is_dirt_needed`
+and the pointer flags cleared, so a cooperating guest stops reporting
+altogether. It re-enables on the next connect.
+
+Situation (resolution) updates stay enabled the whole time, so a mode change
+while idle is still tracked and the next client renders at the right size.
+The device also drops any dirt that arrives while reporting is disabled, and
+logs a rate-limited warning if a guest keeps sending it, which indicates the
+guest is not honoring the request.
+
+The device side defaults to the guest's enabled state and only disables when
+the coordinator signals "no client". This keeps a connected client working
+across a guest reboot or video-driver reload: those re-open the synthvid
+channel and reset the device's per-connection state, but the coordinator does
+not re-signal (the client never left), so the guest keeps reporting. The flip
+side is that a reopen while no client is connected leaves the guest reporting
+to nobody. The coordinator corrects this on its own: if it receives device
+dirt while it has zero clients, it re-sends "no client", which settles in one
+cycle (the device then drops further dirt at the gate).
 
 ## Multi-Client Architecture
 

--- a/Guide/src/reference/devices/vnc/architecture.md
+++ b/Guide/src/reference/devices/vnc/architecture.md
@@ -68,9 +68,12 @@ The multi-client orchestrator. Manages connections and broadcasts dirty rects.
 ### `vnc_worker_defs` crate
 
 `VncParameters<T>` — the mesh-serializable config passed from `openvmm_entry`
-to the worker. Contains listener, framebuffer access, input sender, the dirty
-rect receiver, and the "updates needed" sender that tells the video device
-when a client is connected.
+to the worker. Contains listener, framebuffer access, input sender, and
+`synth_video: Option<SynthVideoChannels>`, which bundles the dirty-rect
+receiver and the "updates needed" sender (the latter tells the video device
+when a client is connected). The two are present together or not at all, so the
+mismatched state cannot be constructed. The device end mirrors this with
+`SynthVideoHandle.channels: Option<SynthVideoDeviceChannels>`.
 
 ### `video_core` crate
 
@@ -133,8 +136,9 @@ every 30ms.
 
 The synthetic video device (Hyper-V SYNTHVID protocol) receives `DirtMessage`
 from the guest video driver with pixel-coordinate rectangles of changed
-regions. These are forwarded via a `mesh::channel` from the video device
-through `SynthVideoHandle.dirt_send` to the VNC worker's `dirty_recv`.
+regions. These are forwarded via a `mesh::channel` from the video device's
+dirt sender (`SynthVideoHandle.channels`) to the VNC worker's dirty-rect
+receiver (`VncParameters.synth_video`).
 
 Supported drivers:
 - Windows: full support (DWM reports dirty regions)

--- a/Guide/src/reference/devices/vnc/what-we-are-proud-of.md
+++ b/Guide/src/reference/devices/vnc/what-we-are-proud-of.md
@@ -44,6 +44,12 @@ reads **0 bytes from VRAM per cycle** instead of scanning for changes.
 For guests without device dirty support (older `hyperv_fb` driver), we
 fall back to tile-based diffing automatically.
 
+Because our dirty source is a cooperating guest driver, we can also turn it
+off: when no client is connected, the worker asks the device to tell the
+guest to stop reporting dirty rectangles (via the synthvid FeatureChange).
+A VM with no viewer attached does no console dirty-tracking work until
+someone connects.
+
 ### Non-ASCII Clipboard Paste Without Guest Agent
 
 QEMU supports bidirectional VNC clipboard (since 6.1) but requires a

--- a/openhcl/underhill_core/src/lib.rs
+++ b/openhcl/underhill_core/src/lib.rs
@@ -79,13 +79,21 @@ use vmsocket::VmAddress;
 use vmsocket::VmListener;
 use vnc_worker_defs::VncParameters;
 
+/// Result of [`new_underhill_remote_console_cfg`]: the remote console config
+/// plus the framebuffer access and the two ends of the dirty/updates channels
+/// that the VNC worker needs.
+struct RemoteConsoleSetup {
+    cfg: UnderhillRemoteConsoleCfg,
+    framebuffer_access: Option<FramebufferAccess>,
+    /// Receives dirty rectangles from the video device for the VNC worker.
+    dirty_recv: Option<mesh::Receiver<Vec<video_core::DirtyRect>>>,
+    /// Sends "updates needed" from the VNC worker to the video device.
+    updates_needed_send: Option<mesh::Sender<bool>>,
+}
+
 fn new_underhill_remote_console_cfg(
     framebuffer_gpa_base: Option<u64>,
-) -> anyhow::Result<(
-    UnderhillRemoteConsoleCfg,
-    Option<FramebufferAccess>,
-    Option<mesh::Receiver<Vec<video_core::DirtyRect>>>,
-)> {
+) -> anyhow::Result<RemoteConsoleSetup> {
     if let Some(framebuffer_gpa_base) = framebuffer_gpa_base {
         // Underhill accesses the framebuffer by using /dev/mshv_vtl_low to read
         // from a second mapping placed after the end of RAM at a static
@@ -108,32 +116,37 @@ fn new_underhill_remote_console_cfg(
         tracing::debug!("framebuffer_gpa_base: {:#x}", framebuffer_gpa_base);
 
         let (dirt_send, dirt_recv) = mesh::channel();
+        let (updates_needed_send, updates_needed_recv) = mesh::channel();
 
-        Ok((
-            UnderhillRemoteConsoleCfg {
+        Ok(RemoteConsoleSetup {
+            cfg: UnderhillRemoteConsoleCfg {
                 synth_keyboard: true,
                 synth_mouse: true,
                 synth_video: true,
                 input: mesh::Receiver::new(),
                 framebuffer: Some(fb),
                 dirt_send: Some(dirt_send),
+                updates_needed_recv: Some(updates_needed_recv),
             },
-            Some(fba),
-            Some(dirt_recv),
-        ))
+            framebuffer_access: Some(fba),
+            dirty_recv: Some(dirt_recv),
+            updates_needed_send: Some(updates_needed_send),
+        })
     } else {
-        Ok((
-            UnderhillRemoteConsoleCfg {
+        Ok(RemoteConsoleSetup {
+            cfg: UnderhillRemoteConsoleCfg {
                 synth_keyboard: false,
                 synth_mouse: false,
                 synth_video: false,
                 input: mesh::Receiver::new(),
                 framebuffer: None,
                 dirt_send: None,
+                updates_needed_recv: None,
             },
-            None,
-            None,
-        ))
+            framebuffer_access: None,
+            dirty_recv: None,
+            updates_needed_send: None,
+        })
     }
 }
 
@@ -358,8 +371,12 @@ async fn launch_workers(
         servicing_timeout_dump_collection_in_ms: opt.servicing_timeout_dump_collection_in_ms,
     };
 
-    let (mut remote_console_cfg, framebuffer_access, dirty_rect_recv) =
-        new_underhill_remote_console_cfg(opt.framebuffer_gpa_base)?;
+    let RemoteConsoleSetup {
+        cfg: mut remote_console_cfg,
+        framebuffer_access,
+        dirty_recv: dirty_rect_recv,
+        updates_needed_send,
+    } = new_underhill_remote_console_cfg(opt.framebuffer_gpa_base)?;
 
     let mut vnc_worker = None;
     if let Some(framebuffer) = framebuffer_access {
@@ -383,6 +400,7 @@ async fn launch_workers(
                         dirty_recv: dirty_rect_recv,
                         max_clients: 16,
                         evict_oldest: false,
+                        updates_needed_send,
                     },
                 )
                 .await?,

--- a/openhcl/underhill_core/src/lib.rs
+++ b/openhcl/underhill_core/src/lib.rs
@@ -397,10 +397,17 @@ async fn launch_workers(
                         listener,
                         framebuffer,
                         input_send,
-                        dirty_recv: dirty_rect_recv,
+                        synth_video: match (dirty_rect_recv, updates_needed_send) {
+                            (Some(dirty_recv), Some(updates_needed_send)) => {
+                                Some(vnc_worker_defs::SynthVideoChannels {
+                                    dirty_recv,
+                                    updates_needed_send,
+                                })
+                            }
+                            _ => None,
+                        },
                         max_clients: 16,
                         evict_oldest: false,
-                        updates_needed_send,
                     },
                 )
                 .await?,

--- a/openhcl/underhill_core/src/lib.rs
+++ b/openhcl/underhill_core/src/lib.rs
@@ -115,7 +115,7 @@ fn new_underhill_remote_console_cfg(
             .context("allocating framebuffer")?;
         tracing::debug!("framebuffer_gpa_base: {:#x}", framebuffer_gpa_base);
 
-        let (dirt_send, dirt_recv) = mesh::channel();
+        let (dirty_send, dirty_recv) = mesh::channel();
         let (updates_needed_send, updates_needed_recv) = mesh::channel();
 
         Ok(RemoteConsoleSetup {
@@ -125,11 +125,11 @@ fn new_underhill_remote_console_cfg(
                 synth_video: true,
                 input: mesh::Receiver::new(),
                 framebuffer: Some(fb),
-                dirt_send: Some(dirt_send),
+                dirty_send: Some(dirty_send),
                 updates_needed_recv: Some(updates_needed_recv),
             },
             framebuffer_access: Some(fba),
-            dirty_recv: Some(dirt_recv),
+            dirty_recv: Some(dirty_recv),
             updates_needed_send: Some(updates_needed_send),
         })
     } else {
@@ -140,7 +140,7 @@ fn new_underhill_remote_console_cfg(
                 synth_video: false,
                 input: mesh::Receiver::new(),
                 framebuffer: None,
-                dirt_send: None,
+                dirty_send: None,
                 updates_needed_recv: None,
             },
             framebuffer_access: None,

--- a/openhcl/underhill_core/src/worker.rs
+++ b/openhcl/underhill_core/src/worker.rs
@@ -341,6 +341,11 @@ pub struct UnderhillRemoteConsoleCfg {
     /// device is in play; the VNC worker then relies on whole-framebuffer
     /// tile-diff scanning.
     pub dirt_send: Option<mesh::Sender<Vec<video_core::DirtyRect>>>,
+    /// Receiver side of the reverse channel by which the VNC worker tells the
+    /// synth video device whether any client is connected, so the guest stops
+    /// reporting screen/pointer updates while idle. `None` when no synth video
+    /// device is in play.
+    pub updates_needed_recv: Option<mesh::Receiver<bool>>,
 }
 
 #[derive(Debug, MeshPayload)]
@@ -450,6 +455,7 @@ impl Worker for UnderhillVmWorker {
                     input: mesh::Receiver::new(),
                     framebuffer: None,
                     dirt_send: None,
+                    updates_needed_recv: None,
                 },
                 debugger_rpc: None,
                 vm_rpc: state.vm_rpc,
@@ -3454,6 +3460,7 @@ async fn new_underhill_vm(
             uidevices_resources::SynthVideoHandle {
                 framebuffer: video_core::SharedFramebufferHandle.into_resource(),
                 dirt_send: remote_console_cfg.dirt_send,
+                updates_needed_recv: remote_console_cfg.updates_needed_recv,
             }
             .into_resource(),
         );

--- a/openhcl/underhill_core/src/worker.rs
+++ b/openhcl/underhill_core/src/worker.rs
@@ -340,7 +340,7 @@ pub struct UnderhillRemoteConsoleCfg {
     /// the synth video device to the VNC worker. `None` when no synth video
     /// device is in play; the VNC worker then relies on whole-framebuffer
     /// tile-diff scanning.
-    pub dirt_send: Option<mesh::Sender<Vec<video_core::DirtyRect>>>,
+    pub dirty_send: Option<mesh::Sender<Vec<video_core::DirtyRect>>>,
     /// Receiver side of the reverse channel by which the VNC worker tells the
     /// synth video device whether any client is connected, so the guest stops
     /// reporting screen/pointer updates while idle. `None` when no synth video
@@ -454,7 +454,7 @@ impl Worker for UnderhillVmWorker {
                     synth_video: false,
                     input: mesh::Receiver::new(),
                     framebuffer: None,
-                    dirt_send: None,
+                    dirty_send: None,
                     updates_needed_recv: None,
                 },
                 debugger_rpc: None,
@@ -3460,12 +3460,12 @@ async fn new_underhill_vm(
             uidevices_resources::SynthVideoHandle {
                 framebuffer: video_core::SharedFramebufferHandle.into_resource(),
                 channels: match (
-                    remote_console_cfg.dirt_send,
+                    remote_console_cfg.dirty_send,
                     remote_console_cfg.updates_needed_recv,
                 ) {
-                    (Some(dirt_send), Some(updates_needed_recv)) => {
+                    (Some(dirty_send), Some(updates_needed_recv)) => {
                         Some(uidevices_resources::SynthVideoDeviceChannels {
-                            dirt_send,
+                            dirty_send,
                             updates_needed_recv,
                         })
                     }

--- a/openhcl/underhill_core/src/worker.rs
+++ b/openhcl/underhill_core/src/worker.rs
@@ -3459,8 +3459,18 @@ async fn new_underhill_vm(
         vmbus_device_handles.push(
             uidevices_resources::SynthVideoHandle {
                 framebuffer: video_core::SharedFramebufferHandle.into_resource(),
-                dirt_send: remote_console_cfg.dirt_send,
-                updates_needed_recv: remote_console_cfg.updates_needed_recv,
+                channels: match (
+                    remote_console_cfg.dirt_send,
+                    remote_console_cfg.updates_needed_recv,
+                ) {
+                    (Some(dirt_send), Some(updates_needed_recv)) => {
+                        Some(uidevices_resources::SynthVideoDeviceChannels {
+                            dirt_send,
+                            updates_needed_recv,
+                        })
+                    }
+                    _ => None,
+                },
             }
             .into_resource(),
         );

--- a/openvmm/openvmm_entry/src/lib.rs
+++ b/openvmm/openvmm_entry/src/lib.rs
@@ -200,6 +200,9 @@ struct VmResources {
     vtl2_settings: Option<vtl2_settings_proto::Vtl2Settings>,
     /// Receives dirty rectangles from the synthetic video device for the VNC worker.
     dirty_rect_recv: Option<mesh::Receiver<Vec<video_core::DirtyRect>>>,
+    /// Sends "are updates needed" from the VNC worker to the synthetic video
+    /// device, so the guest stops reporting while no client is connected.
+    updates_needed_send: Option<mesh::Sender<bool>>,
     #[cfg(windows)]
     switch_ports: Vec<vmswitch::kernel::SwitchPort>,
 }
@@ -1357,12 +1360,18 @@ async fn vm_config_from_command_line(
         let (dirt_send, dirt_recv) = mesh::channel();
         resources.dirty_rect_recv = Some(dirt_recv);
 
+        // Reverse channel: the VNC worker tells the video device whether any
+        // client is connected, so the guest can stop reporting updates while idle.
+        let (updates_needed_send, updates_needed_recv) = mesh::channel();
+        resources.updates_needed_send = Some(updates_needed_send);
+
         vmbus_devices.extend([
             (
                 DeviceVtl::Vtl0,
                 SynthVideoHandle {
                     framebuffer: SharedFramebufferHandle.into_resource(),
                     dirt_send: Some(dirt_send),
+                    updates_needed_recv: Some(updates_needed_recv),
                 }
                 .into_resource(),
             ),
@@ -2387,6 +2396,7 @@ async fn run_control_inner(
                         dirty_recv: resources.dirty_rect_recv.take(),
                         max_clients: opt.vnc.vnc_max_clients,
                         evict_oldest: opt.vnc.vnc_evict_oldest,
+                        updates_needed_send: resources.updates_needed_send.take(),
                     },
                 )
                 .await?,

--- a/openvmm/openvmm_entry/src/lib.rs
+++ b/openvmm/openvmm_entry/src/lib.rs
@@ -1369,7 +1369,7 @@ async fn vm_config_from_command_line(
                 DeviceVtl::Vtl0,
                 SynthVideoHandle {
                     framebuffer: SharedFramebufferHandle.into_resource(),
-                    channels: Some(uidevices_resources::SynthVideoChannels {
+                    channels: Some(uidevices_resources::SynthVideoDeviceChannels {
                         dirt_send,
                         updates_needed_recv,
                     }),

--- a/openvmm/openvmm_entry/src/lib.rs
+++ b/openvmm/openvmm_entry/src/lib.rs
@@ -1355,12 +1355,12 @@ async fn vm_config_from_command_line(
 
     if opt.gfx {
         // Channel for the video device to report dirty rectangles to the VNC worker.
-        let (dirt_send, dirt_recv) = mesh::channel();
+        let (dirty_send, dirty_recv) = mesh::channel();
         // Reverse channel: the VNC worker tells the video device whether any
         // client is connected, so the guest can stop reporting updates while idle.
         let (updates_needed_send, updates_needed_recv) = mesh::channel();
         resources.synth_video = Some(vnc_worker_defs::SynthVideoChannels {
-            dirty_recv: dirt_recv,
+            dirty_recv,
             updates_needed_send,
         });
 
@@ -1370,7 +1370,7 @@ async fn vm_config_from_command_line(
                 SynthVideoHandle {
                     framebuffer: SharedFramebufferHandle.into_resource(),
                     channels: Some(uidevices_resources::SynthVideoDeviceChannels {
-                        dirt_send,
+                        dirty_send,
                         updates_needed_recv,
                     }),
                 }

--- a/openvmm/openvmm_entry/src/lib.rs
+++ b/openvmm/openvmm_entry/src/lib.rs
@@ -1369,8 +1369,10 @@ async fn vm_config_from_command_line(
                 DeviceVtl::Vtl0,
                 SynthVideoHandle {
                     framebuffer: SharedFramebufferHandle.into_resource(),
-                    dirt_send: Some(dirt_send),
-                    updates_needed_recv: Some(updates_needed_recv),
+                    channels: Some(uidevices_resources::SynthVideoChannels {
+                        dirt_send,
+                        updates_needed_recv,
+                    }),
                 }
                 .into_resource(),
             ),

--- a/openvmm/openvmm_entry/src/lib.rs
+++ b/openvmm/openvmm_entry/src/lib.rs
@@ -198,11 +198,9 @@ struct VmResources {
     nvme_vtl2_rpc: Option<mesh::Sender<NvmeControllerRequest>>,
     ged_rpc: Option<mesh::Sender<get_resources::ged::GuestEmulationRequest>>,
     vtl2_settings: Option<vtl2_settings_proto::Vtl2Settings>,
-    /// Receives dirty rectangles from the synthetic video device for the VNC worker.
-    dirty_rect_recv: Option<mesh::Receiver<Vec<video_core::DirtyRect>>>,
-    /// Sends "are updates needed" from the VNC worker to the synthetic video
-    /// device, so the guest stops reporting while no client is connected.
-    updates_needed_send: Option<mesh::Sender<bool>>,
+    /// Channels linking the VNC worker to the synthetic video device, present
+    /// only when a graphics console is configured (`--gfx`).
+    synth_video: Option<vnc_worker_defs::SynthVideoChannels>,
     #[cfg(windows)]
     switch_ports: Vec<vmswitch::kernel::SwitchPort>,
 }
@@ -1358,12 +1356,13 @@ async fn vm_config_from_command_line(
     if opt.gfx {
         // Channel for the video device to report dirty rectangles to the VNC worker.
         let (dirt_send, dirt_recv) = mesh::channel();
-        resources.dirty_rect_recv = Some(dirt_recv);
-
         // Reverse channel: the VNC worker tells the video device whether any
         // client is connected, so the guest can stop reporting updates while idle.
         let (updates_needed_send, updates_needed_recv) = mesh::channel();
-        resources.updates_needed_send = Some(updates_needed_send);
+        resources.synth_video = Some(vnc_worker_defs::SynthVideoChannels {
+            dirty_recv: dirt_recv,
+            updates_needed_send,
+        });
 
         vmbus_devices.extend([
             (
@@ -2393,10 +2392,9 @@ async fn run_control_inner(
                         listener,
                         framebuffer,
                         input_send,
-                        dirty_recv: resources.dirty_rect_recv.take(),
+                        synth_video: resources.synth_video.take(),
                         max_clients: opt.vnc.vnc_max_clients,
                         evict_oldest: opt.vnc.vnc_evict_oldest,
-                        updates_needed_send: resources.updates_needed_send.take(),
                     },
                 )
                 .await?,

--- a/petri/src/vm/openvmm/construct.rs
+++ b/petri/src/vm/openvmm/construct.rs
@@ -1100,6 +1100,7 @@ impl PetriVmConfigSetupCore<'_> {
                 SynthVideoHandle {
                     framebuffer: SharedFramebufferHandle.into_resource(),
                     dirt_send: None,
+                    updates_needed_recv: None,
                 }
                 .into_resource(),
             )),

--- a/petri/src/vm/openvmm/construct.rs
+++ b/petri/src/vm/openvmm/construct.rs
@@ -1099,8 +1099,7 @@ impl PetriVmConfigSetupCore<'_> {
                 DeviceVtl::Vtl0,
                 SynthVideoHandle {
                     framebuffer: SharedFramebufferHandle.into_resource(),
-                    dirt_send: None,
-                    updates_needed_recv: None,
+                    channels: None,
                 }
                 .into_resource(),
             )),

--- a/vm/devices/uidevices/src/resolver.rs
+++ b/vm/devices/uidevices/src/resolver.rs
@@ -58,7 +58,12 @@ impl AsyncResolveResource<VmbusDeviceHandleKind, SynthVideoHandle> for VmbusUiRe
             .map_err(VideoError::Framebuffer)?;
         let device = SimpleDeviceWrapper::new(
             input.driver_source.simple(),
-            Video::new(framebuffer.0, resource.dirt_send).map_err(VideoError::Video)?,
+            Video::new(
+                framebuffer.0,
+                resource.dirt_send,
+                resource.updates_needed_recv,
+            )
+            .map_err(VideoError::Video)?,
         );
         Ok(device.into())
     }

--- a/vm/devices/uidevices/src/resolver.rs
+++ b/vm/devices/uidevices/src/resolver.rs
@@ -56,13 +56,17 @@ impl AsyncResolveResource<VmbusDeviceHandleKind, SynthVideoHandle> for VmbusUiRe
             .resolve(resource.framebuffer, ())
             .await
             .map_err(VideoError::Framebuffer)?;
-        let (dirt_send, updates_needed_recv) = match resource.channels {
-            Some(channels) => (Some(channels.dirt_send), Some(channels.updates_needed_recv)),
+        let (dirty_send, updates_needed_recv) = match resource.channels {
+            Some(channels) => (
+                Some(channels.dirty_send),
+                Some(channels.updates_needed_recv),
+            ),
             None => (None, None),
         };
         let device = SimpleDeviceWrapper::new(
             input.driver_source.simple(),
-            Video::new(framebuffer.0, dirt_send, updates_needed_recv).map_err(VideoError::Video)?,
+            Video::new(framebuffer.0, dirty_send, updates_needed_recv)
+                .map_err(VideoError::Video)?,
         );
         Ok(device.into())
     }

--- a/vm/devices/uidevices/src/resolver.rs
+++ b/vm/devices/uidevices/src/resolver.rs
@@ -56,14 +56,13 @@ impl AsyncResolveResource<VmbusDeviceHandleKind, SynthVideoHandle> for VmbusUiRe
             .resolve(resource.framebuffer, ())
             .await
             .map_err(VideoError::Framebuffer)?;
+        let (dirt_send, updates_needed_recv) = match resource.channels {
+            Some(channels) => (Some(channels.dirt_send), Some(channels.updates_needed_recv)),
+            None => (None, None),
+        };
         let device = SimpleDeviceWrapper::new(
             input.driver_source.simple(),
-            Video::new(
-                framebuffer.0,
-                resource.dirt_send,
-                resource.updates_needed_recv,
-            )
-            .map_err(VideoError::Video)?,
+            Video::new(framebuffer.0, dirt_send, updates_needed_recv).map_err(VideoError::Video)?,
         );
         Ok(device.into())
     }

--- a/vm/devices/uidevices/src/video/mod.rs
+++ b/vm/devices/uidevices/src/video/mod.rs
@@ -6,6 +6,7 @@
 mod protocol;
 
 use async_trait::async_trait;
+use futures::FutureExt;
 use guestmem::AccessError;
 use guid::Guid;
 use mesh::payload::Protobuf;
@@ -155,6 +156,12 @@ pub struct Video {
     control: Box<dyn FramebufferControl>,
     /// Channel to forward dirty rectangles from the guest to the VNC worker.
     dirt_send: Option<mesh::Sender<Vec<DirtyRect>>>,
+    /// Receives whether any consumer currently needs the guest's
+    /// screen/pointer updates. When present, the device relays the latest
+    /// value to the guest via a synthvid `FeatureChange`, so the guest stops
+    /// generating dirty rectangles and pointer reports while no client is
+    /// watching. `None` leaves the guest at its default (everything enabled).
+    updates_needed_recv: Option<mesh::Receiver<bool>>,
 }
 
 impl Video {
@@ -162,8 +169,13 @@ impl Video {
     pub fn new(
         control: Box<dyn FramebufferControl>,
         dirt_send: Option<mesh::Sender<Vec<DirtyRect>>>,
+        updates_needed_recv: Option<mesh::Receiver<bool>>,
     ) -> anyhow::Result<Self> {
-        Ok(Self { control, dirt_send })
+        Ok(Self {
+            control,
+            dirt_send,
+            updates_needed_recv,
+        })
     }
 }
 
@@ -343,7 +355,14 @@ impl SimpleVmbusDevice for Video {
         channel: &mut VideoChannel,
     ) -> Result<(), task_control::Cancelled> {
         stop.until_stopped(async {
-            match channel.process(&mut self.control, &self.dirt_send).await {
+            match channel
+                .process(
+                    &mut self.control,
+                    &self.dirt_send,
+                    &mut self.updates_needed_recv,
+                )
+                .await
+            {
                 Ok(()) => {}
                 Err(err) => tracing::error!(error = &err as &dyn std::error::Error, "video error"),
             }
@@ -408,6 +427,7 @@ impl VideoChannel {
         &mut self,
         framebuffer: &mut Box<dyn FramebufferControl>,
         dirt_send: &Option<mesh::Sender<Vec<DirtyRect>>>,
+        updates_needed_recv: &mut Option<mesh::Receiver<bool>>,
     ) -> Result<(), Error> {
         process_channel(
             &mut self.channel,
@@ -415,9 +435,64 @@ impl VideoChannel {
             &mut self.packet_buf,
             framebuffer,
             dirt_send,
+            updates_needed_recv,
         )
         .await
     }
+}
+
+/// Tells the guest whether it should report screen and pointer updates, by
+/// sending a synthvid `FeatureChange`.
+///
+/// The message is a full snapshot of all four feature toggles, not a delta, so
+/// every send must specify all of them. Dirty rectangles and the two
+/// hardware-pointer features follow `updates_needed` (the device forwards dirt
+/// only to a connected VNC client and ignores pointer reports entirely, so all
+/// three are pure waste while nobody is watching).
+/// `is_video_situation_updates_needed` always stays set: situation updates are
+/// rare (resolution changes) and the device relies on them to keep the
+/// framebuffer format current, so a client that connects later renders at the
+/// right size even if the resolution changed while idle.
+/// After this many screen/pointer updates are received while we have told the
+/// guest they are disabled, warn that the guest is not honoring the synthvid
+/// `FeatureChange`. Sized comfortably above the normal in-flight burst that
+/// arrives during the round-trip after we disable updates, so a compliant
+/// guest never trips it but a non-compliant one does.
+const UPDATES_IGNORED_WARN_THRESHOLD: u32 = 64;
+
+/// Records that the guest sent a screen/pointer update while updates were
+/// disabled, and increments `count`. A handful right after disabling are
+/// expected (in flight during the FeatureChange round-trip) and stay at
+/// `trace`; a sustained stream means the guest is ignoring the squelch, which
+/// warrants a rate-limited warning.
+fn note_update_while_disabled(count: &mut u32, kind: &str) {
+    *count = count.saturating_add(1);
+    if *count >= UPDATES_IGNORED_WARN_THRESHOLD {
+        tracelimit::warn_ratelimited!(
+            count = *count,
+            kind,
+            "guest still sending updates after they were disabled; not honoring FeatureChange"
+        );
+    } else {
+        tracing::trace!(kind, "dropping guest update while disabled");
+    }
+}
+
+async fn send_feature_change(
+    channel: &mut (impl AsyncSend + Unpin),
+    updates_needed: bool,
+) -> Result<(), Error> {
+    VideoChannel::send_packet(
+        channel,
+        protocol::MESSAGE_FEATURE_CHANGE,
+        &protocol::FeatureChangeMessage {
+            is_dirt_needed: updates_needed as u8,
+            is_pointer_position_updates_needed: updates_needed as u8,
+            is_pointer_shape_updates_needed: updates_needed as u8,
+            is_video_situation_updates_needed: 1,
+        },
+    )
+    .await
 }
 
 async fn process_channel(
@@ -426,7 +501,26 @@ async fn process_channel(
     packet_buf: &mut PacketBuffer,
     framebuffer: &mut Box<dyn FramebufferControl>,
     dirt_send: &Option<mesh::Sender<Vec<DirtyRect>>>,
+    updates_needed_recv: &mut Option<mesh::Receiver<bool>>,
 ) -> Result<(), Error> {
+    // Whether the guest should currently report screen/pointer updates. The
+    // guest enables everything by default after the handshake, so we start
+    // from `true` and only send a FeatureChange once a consumer's demand
+    // diverges from that. Starting enabled is what makes a guest channel
+    // reopen or a device save/restore safe: if a client is still connected
+    // (and the coordinator therefore never re-signals), we leave the guest
+    // reporting rather than wrongly disabling it and freezing that client.
+    // The coordinator drives `false` only when no client is watching. With no
+    // demand channel wired up this stays `true` and no FeatureChange is ever
+    // sent, matching the original behavior.
+    let mut updates_needed = true;
+    // What the guest currently believes, used to avoid redundant
+    // FeatureChanges. The post-handshake guest default is everything-enabled,
+    // hence `Some(true)`.
+    let mut synced_updates: Option<bool> = Some(true);
+    // Count of updates received from the guest while disabled, to detect a
+    // guest that ignores the FeatureChange. Reset whenever updates are enabled.
+    let mut updates_while_disabled: u32 = 0;
     loop {
         match state {
             ChannelState::ReadVersion => {
@@ -474,7 +568,62 @@ async fn process_channel(
                 substate,
             } => match *substate {
                 ActiveState::ReadRequest => {
-                    let packet = packet_buf.recv_packet(channel).await?;
+                    // Bring the guest's update-reporting state in line with the
+                    // latest consumer demand before waiting for the next event.
+                    if let Some(recv) = updates_needed_recv.as_mut() {
+                        loop {
+                            match recv.try_recv() {
+                                Ok(v) => updates_needed = v,
+                                Err(mesh::TryRecvError::Empty) => break,
+                                // Sender dropped; stop managing the feature and
+                                // leave the guest at its last known state.
+                                Err(_) => {
+                                    *updates_needed_recv = None;
+                                    break;
+                                }
+                            }
+                        }
+                        if updates_needed_recv.is_some() && synced_updates != Some(updates_needed) {
+                            send_feature_change(channel, updates_needed).await?;
+                            synced_updates = Some(updates_needed);
+                            tracing::debug!(updates_needed, "sent synthvid FeatureChange to guest");
+                        }
+                    }
+                    if updates_needed {
+                        updates_while_disabled = 0;
+                    }
+
+                    // Wait for the next guest packet, or for a demand change
+                    // that should re-sync the update features on the next pass.
+                    let mut demand_closed = false;
+                    let packet = if let Some(recv) = updates_needed_recv.as_mut() {
+                        let recv_packet = std::pin::pin!(packet_buf.recv_packet(channel));
+                        let demand = std::pin::pin!(recv.recv());
+                        futures::select! {
+                            p = recv_packet.fuse() => Some(p?),
+                            d = demand.fuse() => {
+                                match d {
+                                    Ok(v) => {
+                                        updates_needed = v;
+                                        None
+                                    }
+                                    Err(_) => {
+                                        demand_closed = true;
+                                        None
+                                    }
+                                }
+                            }
+                        }
+                    } else {
+                        Some(packet_buf.recv_packet(channel).await?)
+                    };
+                    if demand_closed {
+                        *updates_needed_recv = None;
+                    }
+                    // Demand changed (no packet): loop back to re-sync and wait.
+                    let Some(packet) = packet else {
+                        continue;
+                    };
                     match packet {
                         Request::VramLocation {
                             user_context,
@@ -503,20 +652,41 @@ async fn process_channel(
                         }
                         Request::PointerPosition { is_visible, x, y } => {
                             let _ = (is_visible, x, y);
+                            if !updates_needed {
+                                note_update_while_disabled(
+                                    &mut updates_while_disabled,
+                                    "pointer-position",
+                                );
+                            }
                         }
-                        Request::PointerShape => {}
+                        Request::PointerShape => {
+                            if !updates_needed {
+                                note_update_while_disabled(
+                                    &mut updates_while_disabled,
+                                    "pointer-shape",
+                                );
+                            }
+                        }
                         Request::Dirt(rects) => {
-                            if let Some(send) = dirt_send {
-                                let dirty: Vec<DirtyRect> = rects
-                                    .iter()
-                                    .map(|r| DirtyRect {
-                                        left: r.left.into(),
-                                        top: r.top.into(),
-                                        right: r.right.into(),
-                                        bottom: r.bottom.into(),
-                                    })
-                                    .collect();
-                                send.send(dirty);
+                            // Skip forwarding while no consumer is watching.
+                            // Compliant guests stop sending these once told via
+                            // FeatureChange; this also drops any that a
+                            // non-compliant guest keeps sending.
+                            if updates_needed {
+                                if let Some(send) = dirt_send {
+                                    let dirty: Vec<DirtyRect> = rects
+                                        .iter()
+                                        .map(|r| DirtyRect {
+                                            left: r.left.into(),
+                                            top: r.top.into(),
+                                            right: r.right.into(),
+                                            bottom: r.bottom.into(),
+                                        })
+                                        .collect();
+                                    send.send(dirty);
+                                }
+                            } else {
+                                note_update_while_disabled(&mut updates_while_disabled, "dirt");
                             }
                         }
                         Request::BiosInfo => {
@@ -755,21 +925,35 @@ mod tests {
         (*header, rest)
     }
 
+    async fn recv_feature_change(
+        reader: &mut (impl AsyncRecv + Unpin + Send),
+    ) -> protocol::FeatureChangeMessage {
+        let packet = recv_bytes(reader).await;
+        let (header, rest) = parse_header(&packet);
+        assert_eq!(header.typ.to_ne(), protocol::MESSAGE_FEATURE_CHANGE);
+        *protocol::FeatureChangeMessage::ref_from_prefix(rest)
+            .unwrap()
+            .0
+    }
+
     fn start_worker<T: RingMem + 'static + Unpin + Send + Sync>(
         driver: &DefaultDriver,
         mut control: Box<dyn FramebufferControl>,
         dirt_send: Option<mesh::Sender<Vec<DirtyRect>>>,
+        updates_needed_recv: Option<mesh::Receiver<bool>>,
         mut channel: MessagePipe<T>,
     ) -> Task<Result<(), Error>> {
         driver.spawn("video worker", async move {
             let mut state = ChannelState::ReadVersion;
             let mut packet_buf = PacketBuffer::new();
+            let mut updates_needed_recv = updates_needed_recv;
             process_channel(
                 &mut channel,
                 &mut state,
                 &mut packet_buf,
                 &mut control,
                 &dirt_send,
+                &mut updates_needed_recv,
             )
             .await
             .or_else(|e| match e {
@@ -784,7 +968,7 @@ mod tests {
         let (host, mut guest) = connected_message_pipes(16384);
         let (_device, control, mut view) = framebuffer_fixture();
         let (dirt_send, mut dirt_recv) = mesh::channel();
-        let worker = start_worker(&driver, control, Some(dirt_send), host);
+        let worker = start_worker(&driver, control, Some(dirt_send), None, host);
 
         let version = protocol::Version::new(protocol::VERSION_MAJOR, protocol::VERSION_MINOR_BLUE);
         send_packet(
@@ -886,10 +1070,129 @@ mod tests {
     }
 
     #[async_test]
+    async fn test_feature_change_gates_dirt_on_consumer_presence(driver: DefaultDriver) {
+        let (host, mut guest) = connected_message_pipes(16384);
+        let (_device, control, _view) = framebuffer_fixture();
+        let (dirt_send, mut dirt_recv) = mesh::channel();
+        let (updates_needed_send, updates_needed_recv) = mesh::channel();
+        let worker = start_worker(
+            &driver,
+            control,
+            Some(dirt_send),
+            Some(updates_needed_recv),
+            host,
+        );
+
+        // The coordinator signals "no client" at startup, which is what drives
+        // the device to disable reporting (the device itself defaults to the
+        // guest's enabled state).
+        updates_needed_send.send(false);
+
+        // Complete the version handshake.
+        send_packet(
+            &mut guest,
+            protocol::MESSAGE_VERSION_REQUEST,
+            &protocol::VersionRequestMessage {
+                version: protocol::Version::new(
+                    protocol::VERSION_MAJOR,
+                    protocol::VERSION_MINOR_BLUE,
+                ),
+            },
+        )
+        .await;
+        let packet = recv_bytes(&mut guest).await;
+        assert_eq!(
+            parse_header(&packet).0.typ.to_ne(),
+            protocol::MESSAGE_VERSION_RESPONSE
+        );
+
+        // With a demand channel present and no client yet, the device should
+        // immediately tell the guest to stop reporting updates.
+        let fc = recv_feature_change(&mut guest).await;
+        assert_eq!(fc.is_dirt_needed, 0);
+        assert_eq!(fc.is_pointer_position_updates_needed, 0);
+        assert_eq!(fc.is_pointer_shape_updates_needed, 0);
+        // Situation updates always stay on so resolution changes keep working.
+        assert_eq!(fc.is_video_situation_updates_needed, 1);
+
+        // Dirt sent while no consumer is watching must be dropped. Follow it
+        // with a situation update and wait for its ack: vmbus packets are
+        // processed in order, so the ack proves the dirt was already handled
+        // (and dropped) while updates were still disabled.
+        send_dirt_packet(
+            &mut guest,
+            &[protocol::Rectangle {
+                left: 0.into(),
+                top: 0.into(),
+                right: 10.into(),
+                bottom: 10.into(),
+            }],
+        )
+        .await;
+        send_packet(
+            &mut guest,
+            protocol::MESSAGE_SITUATION_UPDATE,
+            &protocol::SituationUpdateMessage {
+                user_context: 0x1u64.into(),
+                video_output_count: 1,
+                video_output: protocol::VideoOutputSituation {
+                    active: 1,
+                    primary_surface_vram_offset: 0.into(),
+                    depth_bits: 32,
+                    width_pixels: 640u32.into(),
+                    height_pixels: 480u32.into(),
+                    pitch_bytes: (640u32 * 4).into(),
+                },
+            },
+        )
+        .await;
+        let packet = recv_bytes(&mut guest).await;
+        assert_eq!(
+            parse_header(&packet).0.typ.to_ne(),
+            protocol::MESSAGE_SITUATION_UPDATE_ACK
+        );
+
+        // A client connects: the device re-enables reporting.
+        updates_needed_send.send(true);
+        let fc = recv_feature_change(&mut guest).await;
+        assert_eq!(fc.is_dirt_needed, 1);
+        assert_eq!(fc.is_pointer_position_updates_needed, 1);
+        assert_eq!(fc.is_pointer_shape_updates_needed, 1);
+        assert_eq!(fc.is_video_situation_updates_needed, 1);
+
+        // Dirt is now forwarded. Since the earlier rect was dropped, this is
+        // the first rect the consumer sees.
+        send_dirt_packet(
+            &mut guest,
+            &[protocol::Rectangle {
+                left: 5.into(),
+                top: 6.into(),
+                right: 7.into(),
+                bottom: 8.into(),
+            }],
+        )
+        .await;
+        let dirt = dirt_recv.recv().await.unwrap();
+        assert_eq!(dirt.len(), 1);
+        assert_eq!(
+            (dirt[0].left, dirt[0].top, dirt[0].right, dirt[0].bottom),
+            (5, 6, 7, 8)
+        );
+
+        // The client disconnects: reporting is disabled again.
+        updates_needed_send.send(false);
+        let fc = recv_feature_change(&mut guest).await;
+        assert_eq!(fc.is_dirt_needed, 0);
+
+        drop(guest);
+        worker.await.unwrap();
+    }
+
+    #[async_test]
     async fn test_channel_reports_bios_resolutions_and_capability(driver: DefaultDriver) {
         let (host, mut guest) = connected_message_pipes(16384);
         let (_device, control, _view) = framebuffer_fixture();
-        let worker = start_worker(&driver, control, None, host);
+        let worker = start_worker(&driver, control, None, None, host);
 
         send_packet(
             &mut guest,
@@ -968,7 +1271,7 @@ mod tests {
     async fn test_channel_rejects_out_of_order_request(driver: DefaultDriver) {
         let (host, mut guest) = connected_message_pipes(16384);
         let (_device, control, _view) = framebuffer_fixture();
-        let worker = start_worker(&driver, control, None, host);
+        let worker = start_worker(&driver, control, None, None, host);
 
         send_packet(
             &mut guest,

--- a/vm/devices/uidevices/src/video/mod.rs
+++ b/vm/devices/uidevices/src/video/mod.rs
@@ -595,6 +595,14 @@ async fn process_channel(
 
                     // Wait for the next guest packet, or for a demand change
                     // that should re-sync the update features on the next pass.
+                    // We must select on both: a client can disconnect while the
+                    // guest is idle (sending no packets), and we still need to
+                    // disable reporting. Cancelling `recv_packet` when the demand
+                    // branch wins is safe: message-mode `MessagePipe::recv`
+                    // commits the ring read offset only on the poll that returns
+                    // a complete packet, so a pending-then-dropped read leaves the
+                    // stream untouched and the next call re-reads from the same
+                    // offset.
                     let mut demand_closed = false;
                     let packet = if let Some(recv) = updates_needed_recv.as_mut() {
                         let recv_packet = std::pin::pin!(packet_buf.recv_packet(channel));

--- a/vm/devices/uidevices/src/video/mod.rs
+++ b/vm/devices/uidevices/src/video/mod.rs
@@ -155,7 +155,7 @@ fn parse_packet(buf: &[u8]) -> Result<Request, Error> {
 pub struct Video {
     control: Box<dyn FramebufferControl>,
     /// Channel to forward dirty rectangles from the guest to the VNC worker.
-    dirt_send: Option<mesh::Sender<Vec<DirtyRect>>>,
+    dirty_send: Option<mesh::Sender<Vec<DirtyRect>>>,
     /// Receives whether any consumer currently needs the guest's
     /// screen/pointer updates. When present, the device relays the latest
     /// value to the guest via a synthvid `FeatureChange`, so the guest stops
@@ -168,12 +168,12 @@ impl Video {
     /// Creates a new video device.
     pub fn new(
         control: Box<dyn FramebufferControl>,
-        dirt_send: Option<mesh::Sender<Vec<DirtyRect>>>,
+        dirty_send: Option<mesh::Sender<Vec<DirtyRect>>>,
         updates_needed_recv: Option<mesh::Receiver<bool>>,
     ) -> anyhow::Result<Self> {
         Ok(Self {
             control,
-            dirt_send,
+            dirty_send,
             updates_needed_recv,
         })
     }
@@ -358,7 +358,7 @@ impl SimpleVmbusDevice for Video {
             match channel
                 .process(
                     &mut self.control,
-                    &self.dirt_send,
+                    &self.dirty_send,
                     &mut self.updates_needed_recv,
                 )
                 .await
@@ -426,7 +426,7 @@ impl VideoChannel {
     async fn process(
         &mut self,
         framebuffer: &mut Box<dyn FramebufferControl>,
-        dirt_send: &Option<mesh::Sender<Vec<DirtyRect>>>,
+        dirty_send: &Option<mesh::Sender<Vec<DirtyRect>>>,
         updates_needed_recv: &mut Option<mesh::Receiver<bool>>,
     ) -> Result<(), Error> {
         process_channel(
@@ -434,7 +434,7 @@ impl VideoChannel {
             &mut self.state,
             &mut self.packet_buf,
             framebuffer,
-            dirt_send,
+            dirty_send,
             updates_needed_recv,
         )
         .await
@@ -500,7 +500,7 @@ async fn process_channel(
     state: &mut ChannelState,
     packet_buf: &mut PacketBuffer,
     framebuffer: &mut Box<dyn FramebufferControl>,
-    dirt_send: &Option<mesh::Sender<Vec<DirtyRect>>>,
+    dirty_send: &Option<mesh::Sender<Vec<DirtyRect>>>,
     updates_needed_recv: &mut Option<mesh::Receiver<bool>>,
 ) -> Result<(), Error> {
     // Whether the guest should currently report screen/pointer updates. The
@@ -681,7 +681,7 @@ async fn process_channel(
                             // FeatureChange; this also drops any that a
                             // non-compliant guest keeps sending.
                             if updates_needed {
-                                if let Some(send) = dirt_send {
+                                if let Some(send) = dirty_send {
                                     let dirty: Vec<DirtyRect> = rects
                                         .iter()
                                         .map(|r| DirtyRect {
@@ -947,7 +947,7 @@ mod tests {
     fn start_worker<T: RingMem + 'static + Unpin + Send + Sync>(
         driver: &DefaultDriver,
         mut control: Box<dyn FramebufferControl>,
-        dirt_send: Option<mesh::Sender<Vec<DirtyRect>>>,
+        dirty_send: Option<mesh::Sender<Vec<DirtyRect>>>,
         updates_needed_recv: Option<mesh::Receiver<bool>>,
         mut channel: MessagePipe<T>,
     ) -> Task<Result<(), Error>> {
@@ -960,7 +960,7 @@ mod tests {
                 &mut state,
                 &mut packet_buf,
                 &mut control,
-                &dirt_send,
+                &dirty_send,
                 &mut updates_needed_recv,
             )
             .await
@@ -975,8 +975,8 @@ mod tests {
     async fn test_channel_updates_framebuffer_and_forwards_dirt(driver: DefaultDriver) {
         let (host, mut guest) = connected_message_pipes(16384);
         let (_device, control, mut view) = framebuffer_fixture();
-        let (dirt_send, mut dirt_recv) = mesh::channel();
-        let worker = start_worker(&driver, control, Some(dirt_send), None, host);
+        let (dirty_send, mut dirty_recv) = mesh::channel();
+        let worker = start_worker(&driver, control, Some(dirty_send), None, host);
 
         let version = protocol::Version::new(protocol::VERSION_MAJOR, protocol::VERSION_MINOR_BLUE);
         send_packet(
@@ -1062,7 +1062,7 @@ mod tests {
         ];
         send_dirt_packet(&mut guest, &rects).await;
 
-        let dirt = dirt_recv.recv().await.unwrap();
+        let dirt = dirty_recv.recv().await.unwrap();
         assert_eq!(dirt.len(), 2);
         assert_eq!(dirt[0].left, 1);
         assert_eq!(dirt[0].top, 2);
@@ -1081,12 +1081,12 @@ mod tests {
     async fn test_feature_change_gates_dirt_on_consumer_presence(driver: DefaultDriver) {
         let (host, mut guest) = connected_message_pipes(16384);
         let (_device, control, _view) = framebuffer_fixture();
-        let (dirt_send, mut dirt_recv) = mesh::channel();
+        let (dirty_send, mut dirty_recv) = mesh::channel();
         let (updates_needed_send, updates_needed_recv) = mesh::channel();
         let worker = start_worker(
             &driver,
             control,
-            Some(dirt_send),
+            Some(dirty_send),
             Some(updates_needed_recv),
             host,
         );
@@ -1180,7 +1180,7 @@ mod tests {
             }],
         )
         .await;
-        let dirt = dirt_recv.recv().await.unwrap();
+        let dirt = dirty_recv.recv().await.unwrap();
         assert_eq!(dirt.len(), 1);
         assert_eq!(
             (dirt[0].left, dirt[0].top, dirt[0].right, dirt[0].bottom),

--- a/vm/devices/uidevices_resources/src/lib.rs
+++ b/vm/devices/uidevices_resources/src/lib.rs
@@ -44,6 +44,15 @@ pub struct SynthVideoHandle {
     /// to a consumer (typically the VNC worker). `None` when no consumer is
     /// wired up — the device still runs, it just doesn't publish hints.
     pub dirt_send: Option<mesh::Sender<Vec<video_core::DirtyRect>>>,
+    /// Channel by which a consumer tells the device whether the guest's
+    /// screen/pointer updates are currently needed: `true` when at least one
+    /// consumer (e.g. a connected VNC client) is watching, `false` when none
+    /// are. The device relays this to the guest via a synthvid `FeatureChange`
+    /// (dirty rectangles and hardware-pointer reporting), so the guest stops
+    /// generating them while nobody is watching. `None` when no consumer is
+    /// wired up, in which case the device leaves the guest at its default
+    /// (everything enabled) and never sends a `FeatureChange`.
+    pub updates_needed_recv: Option<mesh::Receiver<bool>>,
 }
 
 impl ResourceId<VmbusDeviceHandleKind> for SynthVideoHandle {

--- a/vm/devices/uidevices_resources/src/lib.rs
+++ b/vm/devices/uidevices_resources/src/lib.rs
@@ -35,24 +35,32 @@ impl ResourceId<VmbusDeviceHandleKind> for SynthMouseHandle {
     const ID: &'static str = "mouse";
 }
 
+/// The pair of channels linking the synth video device to its consumer (the
+/// VNC worker). They are wired together or not at all, so bundling them in one
+/// `Option` makes the mismatched state unrepresentable.
+#[derive(MeshPayload)]
+pub struct SynthVideoChannels {
+    /// Channel for the device to forward dirty-rectangle hints to the consumer.
+    pub dirt_send: mesh::Sender<Vec<video_core::DirtyRect>>,
+    /// Channel by which the consumer tells the device whether the guest's
+    /// screen/pointer updates are currently needed: `true` when at least one
+    /// consumer (e.g. a connected VNC client) is watching, `false` when none
+    /// are. The device relays this to the guest via a synthvid `FeatureChange`
+    /// (dirty rectangles and hardware-pointer reporting), so the guest stops
+    /// generating them while nobody is watching.
+    pub updates_needed_recv: mesh::Receiver<bool>,
+}
+
 /// Handle for a synthetic video device.
 #[derive(MeshPayload)]
 pub struct SynthVideoHandle {
     /// The framebuffer memory to map into the guest for rendering.
     pub framebuffer: Resource<FramebufferHandleKind>,
-    /// Channel for the synth video device to forward dirty-rectangle hints
-    /// to a consumer (typically the VNC worker). `None` when no consumer is
-    /// wired up — the device still runs, it just doesn't publish hints.
-    pub dirt_send: Option<mesh::Sender<Vec<video_core::DirtyRect>>>,
-    /// Channel by which a consumer tells the device whether the guest's
-    /// screen/pointer updates are currently needed: `true` when at least one
-    /// consumer (e.g. a connected VNC client) is watching, `false` when none
-    /// are. The device relays this to the guest via a synthvid `FeatureChange`
-    /// (dirty rectangles and hardware-pointer reporting), so the guest stops
-    /// generating them while nobody is watching. `None` when no consumer is
-    /// wired up, in which case the device leaves the guest at its default
-    /// (everything enabled) and never sends a `FeatureChange`.
-    pub updates_needed_recv: Option<mesh::Receiver<bool>>,
+    /// Channels to the consumer (the VNC worker), or `None` when no consumer is
+    /// wired up; the device still runs, it just doesn't publish hints and leaves
+    /// the guest at its default (everything enabled), never sending a
+    /// `FeatureChange`.
+    pub channels: Option<SynthVideoChannels>,
 }
 
 impl ResourceId<VmbusDeviceHandleKind> for SynthVideoHandle {

--- a/vm/devices/uidevices_resources/src/lib.rs
+++ b/vm/devices/uidevices_resources/src/lib.rs
@@ -41,7 +41,7 @@ impl ResourceId<VmbusDeviceHandleKind> for SynthMouseHandle {
 #[derive(MeshPayload)]
 pub struct SynthVideoDeviceChannels {
     /// Channel for the device to forward dirty-rectangle hints to the consumer.
-    pub dirt_send: mesh::Sender<Vec<video_core::DirtyRect>>,
+    pub dirty_send: mesh::Sender<Vec<video_core::DirtyRect>>,
     /// Channel by which the consumer tells the device whether the guest's
     /// screen/pointer updates are currently needed: `true` when at least one
     /// consumer (e.g. a connected VNC client) is watching, `false` when none

--- a/vm/devices/uidevices_resources/src/lib.rs
+++ b/vm/devices/uidevices_resources/src/lib.rs
@@ -39,7 +39,7 @@ impl ResourceId<VmbusDeviceHandleKind> for SynthMouseHandle {
 /// VNC worker). They are wired together or not at all, so bundling them in one
 /// `Option` makes the mismatched state unrepresentable.
 #[derive(MeshPayload)]
-pub struct SynthVideoChannels {
+pub struct SynthVideoDeviceChannels {
     /// Channel for the device to forward dirty-rectangle hints to the consumer.
     pub dirt_send: mesh::Sender<Vec<video_core::DirtyRect>>,
     /// Channel by which the consumer tells the device whether the guest's
@@ -60,7 +60,7 @@ pub struct SynthVideoHandle {
     /// wired up; the device still runs, it just doesn't publish hints and leaves
     /// the guest at its default (everything enabled), never sending a
     /// `FeatureChange`.
-    pub channels: Option<SynthVideoChannels>,
+    pub channels: Option<SynthVideoDeviceChannels>,
 }
 
 impl ResourceId<VmbusDeviceHandleKind> for SynthVideoHandle {

--- a/workers/vnc_worker/Cargo.toml
+++ b/workers/vnc_worker/Cargo.toml
@@ -18,6 +18,7 @@ inspect.workspace = true
 mesh.workspace = true
 mesh_worker.workspace = true
 pal_async.workspace = true
+tracelimit.workspace = true
 tracing_helpers.workspace = true
 vmsocket.workspace = true
 

--- a/workers/vnc_worker/src/lib.rs
+++ b/workers/vnc_worker/src/lib.rs
@@ -691,6 +691,7 @@ mod tests {
         format_send: mesh::Sender<FramebufferFormat>,
         input_recv: mesh::Receiver<InputData>,
         dirty_send: Option<mesh::Sender<Vec<DirtyRect>>>,
+        updates_needed_recv: mesh::Receiver<bool>,
         stop_send: Option<mesh::OneshotSender<()>>,
         join: Option<JoinHandle<anyhow::Result<()>>>,
     }
@@ -758,6 +759,7 @@ mod tests {
             (None, None)
         };
         let (stop_send, stop_recv) = mesh::oneshot();
+        let (updates_needed_send, updates_needed_recv) = mesh::channel();
 
         let join = thread::spawn(move || {
             block_with_io(async |driver| -> anyhow::Result<()> {
@@ -772,7 +774,7 @@ mod tests {
                     next_client_id: 0,
                     max_clients,
                     evict_oldest,
-                    updates_needed_send: None,
+                    updates_needed_send: Some(updates_needed_send),
                 };
 
                 futures::select! {
@@ -788,6 +790,7 @@ mod tests {
             format_send,
             input_recv,
             dirty_send,
+            updates_needed_recv,
             stop_send: Some(stop_send),
             join: Some(join),
         }
@@ -801,6 +804,51 @@ mod tests {
             thread::sleep(Duration::from_millis(10));
         }
         panic!("timed out waiting for input");
+    }
+
+    fn wait_for_signal(recv: &mut mesh::Receiver<bool>) -> bool {
+        for _ in 0..200 {
+            if let Ok(v) = recv.try_recv() {
+                return v;
+            }
+            thread::sleep(Duration::from_millis(10));
+        }
+        panic!("timed out waiting for updates-needed signal");
+    }
+
+    #[test]
+    fn e2e_signals_updates_needed_on_presence_and_idle_dirt() {
+        let mut server = start_server(32, 32, true);
+
+        // Startup with no clients signals "not needed".
+        assert!(!wait_for_signal(&mut server.updates_needed_recv));
+
+        // First client connect signals "needed".
+        let client = Client::connect(server.addr);
+        assert!(wait_for_signal(&mut server.updates_needed_recv));
+
+        // Last client disconnect signals "not needed". (The disconnect signal
+        // is sent after the client is removed from the active set, so by the
+        // time we observe it the coordinator has no clients.)
+        drop(client);
+        assert!(!wait_for_signal(&mut server.updates_needed_recv));
+
+        // Dirt arriving while idle re-asserts "not needed": this is the
+        // self-heal for a device that re-handshaked and returned to its
+        // enabled default while a client is not connected.
+        server
+            .dirty_send
+            .as_ref()
+            .unwrap()
+            .send(vec![DirtyRect {
+                left: 0,
+                top: 0,
+                right: 16,
+                bottom: 16,
+            }]);
+        assert!(!wait_for_signal(&mut server.updates_needed_recv));
+
+        server.stop();
     }
 
     #[test]

--- a/workers/vnc_worker/src/lib.rs
+++ b/workers/vnc_worker/src/lib.rs
@@ -40,6 +40,7 @@ pub struct VncWorker<T: Listener> {
     dirty_recv: Option<mesh::Receiver<Vec<video_core::DirtyRect>>>,
     max_clients: usize,
     evict_oldest: bool,
+    updates_needed_send: Option<mesh::Sender<bool>>,
 }
 
 impl Worker for VncWorker<TcpListener> {
@@ -93,6 +94,7 @@ impl<T: 'static + Listener + MeshField + Send> VncWorker<T> {
             dirty_recv: params.dirty_recv,
             max_clients: params.max_clients,
             evict_oldest: params.evict_oldest,
+            updates_needed_send: params.updates_needed_send,
         })
     }
 
@@ -118,6 +120,7 @@ impl<T: 'static + Listener + MeshField + Send> VncWorker<T> {
                 next_client_id: 0,
                 max_clients: self.max_clients,
                 evict_oldest: self.evict_oldest,
+                updates_needed_send: self.updates_needed_send,
             };
 
             let rpc = loop {
@@ -147,6 +150,7 @@ impl<T: 'static + Listener + MeshField + Send> VncWorker<T> {
                     dirty_recv: server.dirty_recv,
                     max_clients: server.max_clients,
                     evict_oldest: server.evict_oldest,
+                    updates_needed_send: server.updates_needed_send,
                 };
                 rpc.complete(Ok(state));
             }
@@ -193,9 +197,23 @@ struct MultiClientServer<T: Listener> {
     max_clients: usize,
     /// When true, evict the oldest client instead of rejecting new ones.
     evict_oldest: bool,
+    /// Tells the synth video device whether any client is connected, so the
+    /// guest can stop generating screen/pointer updates while idle. `true` is
+    /// sent when the client count goes from 0 to 1, `false` when it returns to
+    /// 0. `None` when no synth video device is wired up.
+    updates_needed_send: Option<mesh::Sender<bool>>,
 }
 
 impl<T: Listener> MultiClientServer<T> {
+    /// Tells the synth video device whether the guest's screen/pointer updates
+    /// are needed. No-op when no device is wired up.
+    fn signal_updates_needed(&self, needed: bool) {
+        if let Some(send) = &self.updates_needed_send {
+            send.send(needed);
+            tracing::debug!(needed, "signaled updates-needed to video device");
+        }
+    }
+
     /// Main loop: accept new clients, reap finished ones, and broadcast
     /// device dirty rects to per-client channels.
     async fn process(&mut self, driver: &LocalDriver) -> anyhow::Result<()> {
@@ -206,6 +224,10 @@ impl<T: Listener> MultiClientServer<T> {
         }
 
         let mut device_dirty_seen = false;
+
+        // Force the device to a known state on (re)start: no clients yet, so
+        // the guest should not be reporting updates.
+        self.signal_updates_needed(false);
 
         loop {
             let listener = &mut self.listener;
@@ -289,8 +311,16 @@ impl<T: Listener> MultiClientServer<T> {
                     }
                     let sock: socket2::Socket = socket.into();
                     let _ = sock.set_tcp_nodelay(true);
+                    let was_idle = self.abort_senders.is_empty();
                     match PolledSocket::new(driver, sock) {
-                        Ok(socket) => self.spawn_client(driver, socket, remote_addr),
+                        Ok(socket) => {
+                            self.spawn_client(driver, socket, remote_addr);
+                            // First client connected: ask the guest to start
+                            // reporting screen/pointer updates again.
+                            if was_idle {
+                                self.signal_updates_needed(true);
+                            }
+                        }
                         Err(e) => {
                             tracing::error!(
                                 error = %e,
@@ -303,8 +333,24 @@ impl<T: Listener> MultiClientServer<T> {
                     self.abort_senders.retain(|(cid, _)| *cid != id);
                     self.dirty_senders.retain(|s| s.id != id);
                     tracing::info!(id, count = self.clients.len(), "VNC client disconnected");
+                    // Last client gone: tell the guest it can stop reporting
+                    // screen/pointer updates.
+                    if self.abort_senders.is_empty() {
+                        self.signal_updates_needed(false);
+                    }
                 }
                 Event::DirtyRects(rects) => {
+                    if self.abort_senders.is_empty() {
+                        // Receiving dirt with no clients means the device is
+                        // reporting to nobody, which happens if its synthvid
+                        // channel re-handshaked while idle (guest reboot or
+                        // video-driver reload) and reset to the guest's
+                        // enabled default. Re-assert that updates are not
+                        // needed; the device dedupes, so this settles in one
+                        // cycle and the guest stops reporting again.
+                        self.signal_updates_needed(false);
+                        continue;
+                    }
                     if !device_dirty_seen {
                         device_dirty_seen = true;
                         tracing::info!("device dirty rects active, preferring over tile diff");
@@ -726,6 +772,7 @@ mod tests {
                     next_client_id: 0,
                     max_clients,
                     evict_oldest,
+                    updates_needed_send: None,
                 };
 
                 futures::select! {

--- a/workers/vnc_worker/src/lib.rs
+++ b/workers/vnc_worker/src/lib.rs
@@ -200,8 +200,8 @@ impl<T: Listener> MultiClientServer<T> {
     /// Tells the synth video device whether the guest's screen/pointer updates
     /// are needed. No-op when no device is wired up.
     fn signal_updates_needed(&self, needed: bool) {
-        if let Some(v) = &self.synth_video {
-            v.updates_needed_send.send(needed);
+        if let Some(channels) = &self.synth_video {
+            channels.updates_needed_send.send(needed);
             tracing::debug!(needed, "signaled updates-needed to video device");
         }
     }
@@ -229,7 +229,7 @@ impl<T: Listener> MultiClientServer<T> {
             // Optional future for dirty rect reception (pending if no video device).
             let dirty_fut = async {
                 match synth_video {
-                    Some(v) => v.dirty_recv.recv().await,
+                    Some(channels) => channels.dirty_recv.recv().await,
                     None => std::future::pending().await,
                 }
             };

--- a/workers/vnc_worker/src/lib.rs
+++ b/workers/vnc_worker/src/lib.rs
@@ -202,7 +202,14 @@ impl<T: Listener> MultiClientServer<T> {
     fn signal_updates_needed(&self, needed: bool) {
         if let Some(channels) = &self.synth_video {
             channels.updates_needed_send.send(needed);
-            tracing::debug!(needed, "signaled updates-needed to video device");
+            // Rate-limited: the idle self-heal re-asserts `false` on every dirty
+            // event a re-handshaked (or non-compliant) guest sends while no
+            // client is connected, which would otherwise spam this log.
+            tracelimit::event_ratelimited!(
+                tracing::Level::DEBUG,
+                needed,
+                "signaled updates-needed to video device"
+            );
         }
     }
 

--- a/workers/vnc_worker/src/lib.rs
+++ b/workers/vnc_worker/src/lib.rs
@@ -795,24 +795,16 @@ mod tests {
         }
     }
 
+    // Block until the message arrives instead of rolling our own deadline: a
+    // hand-rolled timeout only adds flakiness, and nextest fails a wedged test
+    // on its own slow-test timeout. A closed channel is a real failure, so let
+    // the unwrap surface it.
     fn wait_for_input(recv: &mut mesh::Receiver<InputData>) -> InputData {
-        for _ in 0..100 {
-            if let Ok(data) = recv.try_recv() {
-                return data;
-            }
-            thread::sleep(Duration::from_millis(10));
-        }
-        panic!("timed out waiting for input");
+        pal_async::local::block_on(recv.recv()).expect("input channel closed")
     }
 
     fn wait_for_signal(recv: &mut mesh::Receiver<bool>) -> bool {
-        for _ in 0..200 {
-            if let Ok(v) = recv.try_recv() {
-                return v;
-            }
-            thread::sleep(Duration::from_millis(10));
-        }
-        panic!("timed out waiting for updates-needed signal");
+        pal_async::local::block_on(recv.recv()).expect("updates-needed channel closed")
     }
 
     #[test]

--- a/workers/vnc_worker/src/lib.rs
+++ b/workers/vnc_worker/src/lib.rs
@@ -30,6 +30,7 @@ use std::sync::atomic::AtomicBool;
 use std::sync::atomic::Ordering;
 use std::time::Duration;
 use tracing_helpers::AnyhowValueExt;
+use vnc_worker_defs::SynthVideoChannels;
 use vnc_worker_defs::VncParameters;
 
 /// A worker for running a VNC server.
@@ -37,10 +38,9 @@ pub struct VncWorker<T: Listener> {
     listener: T,
     view: ViewWrapper,
     input_send: mesh::Sender<InputData>,
-    dirty_recv: Option<mesh::Receiver<Vec<video_core::DirtyRect>>>,
+    synth_video: Option<SynthVideoChannels>,
     max_clients: usize,
     evict_oldest: bool,
-    updates_needed_send: Option<mesh::Sender<bool>>,
 }
 
 impl Worker for VncWorker<TcpListener> {
@@ -91,10 +91,9 @@ impl<T: 'static + Listener + MeshField + Send> VncWorker<T> {
                     .context("failed to map framebuffer")?,
             ),
             input_send: params.input_send,
-            dirty_recv: params.dirty_recv,
+            synth_video: params.synth_video,
             max_clients: params.max_clients,
             evict_oldest: params.evict_oldest,
-            updates_needed_send: params.updates_needed_send,
         })
     }
 
@@ -113,14 +112,13 @@ impl<T: 'static + Listener + MeshField + Send> VncWorker<T> {
                 listener,
                 view: Arc::new(Mutex::new(self.view)),
                 input_send: self.input_send,
-                dirty_recv: self.dirty_recv,
+                synth_video: self.synth_video,
                 dirty_senders: Vec::new(),
                 clients: unicycle::FuturesUnordered::new(),
                 abort_senders: Vec::new(),
                 next_client_id: 0,
                 max_clients: self.max_clients,
                 evict_oldest: self.evict_oldest,
-                updates_needed_send: self.updates_needed_send,
             };
 
             let rpc = loop {
@@ -147,10 +145,9 @@ impl<T: 'static + Listener + MeshField + Send> VncWorker<T> {
                     listener: server.listener.into_inner(),
                     framebuffer: view.0.access(),
                     input_send: server.input_send,
-                    dirty_recv: server.dirty_recv,
+                    synth_video: server.synth_video,
                     max_clients: server.max_clients,
                     evict_oldest: server.evict_oldest,
-                    updates_needed_send: server.updates_needed_send,
                 };
                 rpc.complete(Ok(state));
             }
@@ -177,9 +174,9 @@ struct MultiClientServer<T: Listener> {
     view: Arc<Mutex<ViewWrapper>>,
     /// Cloneable input sender -- each client gets its own clone.
     input_send: mesh::Sender<InputData>,
-    /// Dirty rectangles from the synthetic video device. None if no video
+    /// Channels to the synthetic video device, or `None` if no synth video
     /// device is configured.
-    dirty_recv: Option<mesh::Receiver<Vec<video_core::DirtyRect>>>,
+    synth_video: Option<SynthVideoChannels>,
     /// Per-client dirty rect senders. The coordinator broadcasts device rects
     /// to all clients via these channels. Each client accumulates rects in
     /// its own pending bitmap -- no shared state, no clearing issues.
@@ -197,19 +194,14 @@ struct MultiClientServer<T: Listener> {
     max_clients: usize,
     /// When true, evict the oldest client instead of rejecting new ones.
     evict_oldest: bool,
-    /// Tells the synth video device whether any client is connected, so the
-    /// guest can stop generating screen/pointer updates while idle. `true` is
-    /// sent when the client count goes from 0 to 1, `false` when it returns to
-    /// 0. `None` when no synth video device is wired up.
-    updates_needed_send: Option<mesh::Sender<bool>>,
 }
 
 impl<T: Listener> MultiClientServer<T> {
     /// Tells the synth video device whether the guest's screen/pointer updates
     /// are needed. No-op when no device is wired up.
     fn signal_updates_needed(&self, needed: bool) {
-        if let Some(send) = &self.updates_needed_send {
-            send.send(needed);
+        if let Some(v) = &self.synth_video {
+            v.updates_needed_send.send(needed);
             tracing::debug!(needed, "signaled updates-needed to video device");
         }
     }
@@ -232,12 +224,12 @@ impl<T: Listener> MultiClientServer<T> {
         loop {
             let listener = &mut self.listener;
             let clients = &mut self.clients;
-            let dirty_recv = &mut self.dirty_recv;
+            let synth_video = &mut self.synth_video;
 
             // Optional future for dirty rect reception (pending if no video device).
             let dirty_fut = async {
-                match dirty_recv {
-                    Some(recv) => recv.recv().await,
+                match synth_video {
+                    Some(v) => v.dirty_recv.recv().await,
                     None => std::future::pending().await,
                 }
             };
@@ -262,10 +254,12 @@ impl<T: Listener> MultiClientServer<T> {
                     Ok(rects) => Event::DirtyRects(rects),
                     Err(_) => {
                         // Upstream dirty channel closed (video device reset
-                        // or teardown). Drop it so clients fall back to tile
-                        // diff instead of freezing with device_dirty_seen.
+                        // or teardown). Drop the whole video connection (its
+                        // paired updates-needed sender is dead too) so clients
+                        // fall back to tile diff instead of freezing with
+                        // device_dirty_seen.
                         tracing::warn!("device dirty channel closed, falling back to tile diff");
-                        self.dirty_recv = None;
+                        self.synth_video = None;
                         // Close all per-client dirty senders so clients
                         // detect the closure and reset device_dirty_seen.
                         self.dirty_senders.clear();
@@ -472,7 +466,7 @@ impl<T: Listener> inspect::Inspect for MultiClientServer<T> {
         let mut resp = req.respond();
         resp.display_debug("local_addr", &self.listener.get().local_addr().unwrap());
         resp.field("client_count", self.clients.len());
-        resp.field("has_dirty_recv", self.dirty_recv.is_some());
+        resp.field("has_synth_video", self.synth_video.is_some());
     }
 }
 
@@ -752,14 +746,20 @@ mod tests {
             .unwrap();
 
         let (input_send, input_recv) = mesh::channel();
-        let (dirty_send, dirty_recv) = if with_dirty {
-            let (send, recv) = mesh::channel();
-            (Some(send), Some(recv))
+        let (updates_needed_send, updates_needed_recv) = mesh::channel();
+        let (synth_video, dirty_send) = if with_dirty {
+            let (dirty_send, dirty_recv) = mesh::channel();
+            (
+                Some(SynthVideoChannels {
+                    dirty_recv,
+                    updates_needed_send,
+                }),
+                Some(dirty_send),
+            )
         } else {
             (None, None)
         };
         let (stop_send, stop_recv) = mesh::oneshot();
-        let (updates_needed_send, updates_needed_recv) = mesh::channel();
 
         let join = thread::spawn(move || {
             block_with_io(async |driver| -> anyhow::Result<()> {
@@ -767,14 +767,13 @@ mod tests {
                     listener: PolledSocket::new(&driver, listener)?,
                     view: Arc::new(Mutex::new(ViewWrapper(access.view().unwrap()))),
                     input_send,
-                    dirty_recv,
+                    synth_video,
                     dirty_senders: Vec::new(),
                     clients: unicycle::FuturesUnordered::new(),
                     abort_senders: Vec::new(),
                     next_client_id: 0,
                     max_clients,
                     evict_oldest,
-                    updates_needed_send: Some(updates_needed_send),
                 };
 
                 futures::select! {
@@ -836,16 +835,12 @@ mod tests {
         // Dirt arriving while idle re-asserts "not needed": this is the
         // self-heal for a device that re-handshaked and returned to its
         // enabled default while a client is not connected.
-        server
-            .dirty_send
-            .as_ref()
-            .unwrap()
-            .send(vec![DirtyRect {
-                left: 0,
-                top: 0,
-                right: 16,
-                bottom: 16,
-            }]);
+        server.dirty_send.as_ref().unwrap().send(vec![DirtyRect {
+            left: 0,
+            top: 0,
+            right: 16,
+            bottom: 16,
+        }]);
         assert!(!wait_for_signal(&mut server.updates_needed_recv));
 
         server.stop();

--- a/workers/vnc_worker_defs/src/lib.rs
+++ b/workers/vnc_worker_defs/src/lib.rs
@@ -33,6 +33,14 @@ pub struct VncParameters<T> {
     pub max_clients: usize,
     /// When true, evict the oldest client instead of rejecting new ones.
     pub evict_oldest: bool,
+    /// Channel used to tell the synth video device whether the guest's
+    /// screen/pointer updates are currently needed: `true` is sent when the
+    /// first client connects, `false` when the last one disconnects. The
+    /// device relays this to the guest (via a synthvid `FeatureChange`) so it
+    /// stops generating dirty rectangles and pointer reports while no client
+    /// is watching. `None` when no synth video device is wired up (the paired
+    /// `dirty_recv` is then also `None`).
+    pub updates_needed_send: Option<mesh::Sender<bool>>,
 }
 
 /// Worker ID for the TCP-listening VNC worker. Used by openvmm, where the

--- a/workers/vnc_worker_defs/src/lib.rs
+++ b/workers/vnc_worker_defs/src/lib.rs
@@ -14,6 +14,22 @@ use mesh::MeshPayload;
 use mesh_worker::WorkerId;
 use std::net::TcpListener;
 
+/// The two channels linking the VNC worker to a synth video device. They are
+/// wired together or not at all: present when a synth video device exists and
+/// absent otherwise, so bundling them in one `Option` makes the mismatched
+/// state unrepresentable.
+#[derive(MeshPayload)]
+pub struct SynthVideoChannels {
+    /// Receives dirty-rectangle hints from the synthetic video device.
+    pub dirty_recv: mesh::Receiver<Vec<video_core::DirtyRect>>,
+    /// Tells the device whether the guest's screen/pointer updates are
+    /// currently needed: `true` when the first client connects, `false` when
+    /// the last one disconnects. The device relays this to the guest (via a
+    /// synthvid `FeatureChange`) so it stops generating dirty rectangles and
+    /// pointer reports while no client is watching.
+    pub updates_needed_send: mesh::Sender<bool>,
+}
+
 /// The VNC server's input parameters.
 #[derive(MeshPayload)]
 pub struct VncParameters<T> {
@@ -23,24 +39,16 @@ pub struct VncParameters<T> {
     pub framebuffer: framebuffer::FramebufferAccess,
     /// A channel to send input to.
     pub input_send: mesh::Sender<input_core::InputData>,
-    /// Receives dirty-rectangle hints from the synthetic video device.
-    /// `None` when no synth video device is present (e.g. `--pcat` or any
-    /// guest using a non-synth framebuffer path like VGA BIOS / UEFI GOP);
-    /// the server still has a framebuffer to display and falls back to
-    /// whole-framebuffer tile-diff scanning to detect changes.
-    pub dirty_recv: Option<mesh::Receiver<Vec<video_core::DirtyRect>>>,
+    /// Channels to the synthetic video device, or `None` when no synth video
+    /// device is present (e.g. `--pcat` or any guest using a non-synth
+    /// framebuffer path like VGA BIOS / UEFI GOP); the server still has a
+    /// framebuffer to display and falls back to whole-framebuffer tile-diff
+    /// scanning to detect changes.
+    pub synth_video: Option<SynthVideoChannels>,
     /// Maximum concurrent VNC clients.
     pub max_clients: usize,
     /// When true, evict the oldest client instead of rejecting new ones.
     pub evict_oldest: bool,
-    /// Channel used to tell the synth video device whether the guest's
-    /// screen/pointer updates are currently needed: `true` is sent when the
-    /// first client connects, `false` when the last one disconnects. The
-    /// device relays this to the guest (via a synthvid `FeatureChange`) so it
-    /// stops generating dirty rectangles and pointer reports while no client
-    /// is watching. `None` when no synth video device is wired up (the paired
-    /// `dirty_recv` is then also `None`).
-    pub updates_needed_send: Option<mesh::Sender<bool>>,
 }
 
 /// Worker ID for the TCP-listening VNC worker. Used by openvmm, where the


### PR DESCRIPTION
## Summary

When no VNC client is connected, the guest still generates and sends synthvid
dirty rectangles (and hardware pointer updates) on every screen change. The
synthetic video device parses each message and forwards it to the VNC worker,
which discards it because there are no clients to send to. For a guest with
active screen content and nobody watching, that is wasted guest CPU, vmbus
round-trips, and host allocations that produce nothing.

This change uses the synthvid `FeatureChange` message to tell the guest to stop
reporting while no client is connected, and to resume on the first connect.

## How it works

- The VNC worker tracks the connected-client count and, over a new `mesh`
  channel paired with the existing dirty-rect channel, signals the video device
  when that count crosses 0 to 1 and back.
- The device relays the signal to the guest with a `FeatureChange` that clears
  `is_dirt_needed` and the two hardware-pointer flags (the device ignores those
  pointer reports and the VNC worker is the only dirt consumer).
- `is_video_situation_updates_needed` stays set, so a resolution change while
  idle is still tracked and the next client renders at the correct size.
- As a backstop the device also drops any dirt that arrives while disabled, and
  logs a rate-limited warning if a guest keeps sending updates after being told
  to stop (it is not honoring the `FeatureChange`).

## Design notes

- The device defaults to the guest's post-handshake enabled state and only
  disables when the worker signals "no client". This keeps an already-connected
  client working across a guest reboot or video-driver reload: those re-open the
  synthvid channel and reset the device's per-connection state, but the worker
  and the client connection persist, so the device must not assume "disabled" on
  a fresh handshake.
- If the device re-handshakes while idle and returns to the enabled default, the
  worker self-corrects: receiving dirt with zero connected clients re-sends "no
  client", which settles in one cycle (the device then drops further dirt at the
  gate).
- Disabling reporting never breaks output: any consumer can still read VRAM
  directly, and the `FeatureChange` false-to-true transition makes the guest send
  a fresh full update, which lines up with the VNC server's forced full refresh
  on a client's first frame.

## Testing

New unit test `test_feature_change_gates_dirt_on_consumer_presence` in the video
device: after the handshake, a "no client" demand yields a `FeatureChange` with
`is_dirt_needed = 0`; flipping to "client" yields `is_dirt_needed = 1`; dirt
received while disabled is dropped.

Manual validation on a Linux/KVM host with a Gen2 (UEFI) guest over VNC, watching
the device and worker trace:

| Scenario                            | Result                           |
|-------------------------------------|----------------------------------|
| Boot, no client                     | reporting disabled               |
| Client connects                     | reporting enabled                |
| Client disconnects                  | reporting disabled               |
| Guest reset with a client connected | stays enabled, client not frozen |
| Re-handshake while idle             | worker self-corrects to disabled |

No "guest not honoring FeatureChange" warnings were observed in any scenario.

`cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets`, and
`cargo doc --workspace --no-deps` are clean; touched-crate tests pass.
