### PR TITLE
crypto: Add native windows and mac backends for x509

### DIFF
--- a/support/crypto/Cargo.toml
+++ b/support/crypto/Cargo.toml
@@ -79,11 +79,14 @@ windows = { workspace = true, features = [
 windows-result.workspace = true
 zerocopy.workspace = true
 
-# Used by the native Security.framework RSA backend to parse/encode PKCS#8 / PKCS#1.
+# Used by the native RSA / X.509 backend to parse/encode PKCS#8 / PKCS#1
+# and X.509 certificates.
 [target.'cfg(target_os = "macos")'.dependencies]
 der.workspace = true
 pkcs1.workspace = true
 pkcs8 = { workspace = true, features = ["alloc"] }
+signature = { workspace = true, features = ["alloc"] }
+x509-cert.workspace = true
 
 # Default to OpenSSL on Linux since there is no native backend available
 [target.'cfg(target_os = "linux")'.dependencies]

--- a/support/crypto/src/hashes.rs
+++ b/support/crypto/src/hashes.rs
@@ -155,7 +155,7 @@ impl HashAlgorithm {
     }
 }
 
-#[cfg(any(symcrypt, rust))]
+#[cfg(any(symcrypt, rust, all(native, target_os = "macos")))]
 impl TryFrom<der::asn1::ObjectIdentifier> for HashAlgorithm {
     type Error = der::Error;
 

--- a/support/crypto/src/rsa/mac.rs
+++ b/support/crypto/src/rsa/mac.rs
@@ -167,10 +167,10 @@ fn import_public(pkcs1_der: &[u8]) -> Result<CfHandle, RsaError> {
 }
 
 #[repr(transparent)]
-pub struct RsaKeyPairInner(CfHandle);
+pub(crate) struct RsaKeyPairInner(CfHandle);
 
 #[repr(transparent)]
-pub struct RsaPublicKeyInner(CfHandle);
+pub(crate) struct RsaPublicKeyInner(CfHandle);
 
 impl RsaKeyPairInner {
     pub fn generate(bits: u32) -> Result<Self, RsaError> {

--- a/support/crypto/src/rsa/mod.rs
+++ b/support/crypto/src/rsa/mod.rs
@@ -19,15 +19,15 @@ use ossl as sys;
 #[cfg(rust)]
 pub(crate) mod rust;
 #[cfg(rust)]
-pub(crate) use rust as sys;
+use rust as sys;
 
 #[cfg(symcrypt)]
 pub(crate) mod symcrypt;
 #[cfg(symcrypt)]
-pub(crate) use symcrypt as sys;
+use symcrypt as sys;
 
 #[cfg(all(native, windows))]
-mod win;
+pub(crate) mod win;
 #[cfg(all(native, windows))]
 use win as sys;
 

--- a/support/crypto/src/rsa/win.rs
+++ b/support/crypto/src/rsa/win.rs
@@ -50,10 +50,10 @@ fn err(err: windows_result::Error, op: &'static str) -> RsaError {
 }
 
 #[repr(transparent)]
-pub struct RsaKeyPairInner(KeyHandle);
+pub(crate) struct RsaKeyPairInner(pub(crate) KeyHandle);
 
 #[repr(transparent)]
-pub struct RsaPublicKeyInner(KeyHandle);
+pub(crate) struct RsaPublicKeyInner(pub(crate) KeyHandle);
 
 /// Parse a BCRYPT_RSAFULLPRIVATE_BLOB or BCRYPT_RSAPUBLIC_BLOB into its
 /// big-endian component byte ranges.

--- a/support/crypto/src/x509/builder.rs
+++ b/support/crypto/src/x509/builder.rs
@@ -1,0 +1,150 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Shared helpers for constructing self-signed test certificates with the
+//! `x509-cert` builder.
+
+#![cfg(any(test, feature = "test_helpers"))]
+
+use core::str::FromStr;
+use der::Encode;
+use x509_cert::builder::CertificateBuilder;
+use x509_cert::name::Name;
+
+/// `BuilderProfile` that produces a self-signed certificate with no
+/// extensions and the same distinguished name for the issuer and subject.
+pub(super) struct SelfSignedProfile {
+    subject: Name,
+}
+
+impl x509_cert::builder::profile::BuilderProfile for SelfSignedProfile {
+    fn get_issuer(&self, _subject: &Name) -> Name {
+        self.subject.clone()
+    }
+
+    fn get_subject(&self) -> Name {
+        self.subject.clone()
+    }
+
+    fn build_extensions(
+        &self,
+        _spk: x509_cert::spki::SubjectPublicKeyInfoRef<'_>,
+        _issuer_spk: x509_cert::spki::SubjectPublicKeyInfoRef<'_>,
+        _tbs: &x509_cert::TbsCertificate,
+    ) -> x509_cert::builder::Result<Vec<x509_cert::ext::Extension>> {
+        Ok(Vec::new())
+    }
+}
+
+/// Set up a `CertificateBuilder` for a self-signed RSA certificate with the
+/// given distinguished name components, serial number 1, and a validity
+/// range covering all of representable time. The caller invokes `.build()`
+/// with a backend-specific signer to produce the final `Certificate`.
+///
+/// Returns the builder along with the PKCS#1 `RSAPublicKey` DER encoding
+/// of the supplied key, which several backends need to hand to their
+/// signer adapter.
+pub(super) fn self_signed_builder(
+    key: &crate::rsa::RsaKeyPair,
+    country: &str,
+    state: &str,
+    locality: &str,
+    organization: &str,
+    common_name: &str,
+) -> anyhow::Result<(CertificateBuilder<SelfSignedProfile>, Vec<u8>)> {
+    let name = Name::from_str(&format!(
+        "CN={common_name},O={organization},L={locality},ST={state},C={country}"
+    ))?;
+
+    let modulus = key.modulus();
+    let exponent = key.public_exponent();
+    let pkcs1_pub = pkcs1::RsaPublicKey {
+        modulus: der::asn1::UintRef::new(&modulus)?,
+        public_exponent: der::asn1::UintRef::new(&exponent)?,
+    };
+    let pkcs1_der = pkcs1_pub.to_der()?;
+    let spki = x509_cert::spki::SubjectPublicKeyInfoOwned {
+        algorithm: x509_cert::spki::AlgorithmIdentifierOwned {
+            oid: pkcs1::ALGORITHM_OID,
+            parameters: Some(der::Any::null()),
+        },
+        subject_public_key: der::asn1::BitString::from_bytes(&pkcs1_der)?,
+    };
+
+    let serial_number = x509_cert::serial_number::SerialNumber::from(1u32);
+    let validity = x509_cert::time::Validity::new(
+        der::asn1::GeneralizedTime::from_unix_duration(std::time::Duration::from_secs(0))?.into(),
+        x509_cert::time::Time::INFINITY,
+    );
+
+    let profile = SelfSignedProfile { subject: name };
+    let builder = CertificateBuilder::new(profile, serial_number, validity, spki)?;
+    Ok((builder, pkcs1_der))
+}
+
+/// Adapter that implements the `signature` and `spki` traits required by
+/// [`x509_cert::builder::CertificateBuilder::build`] on top of a
+/// [`crate::rsa::RsaKeyPair`] using its `pkcs1_sign` primitive with SHA-256.
+#[cfg(any(all(native, target_os = "macos"), symcrypt))]
+pub(super) mod rsa_keypair_signer {
+    use der::Encode;
+
+    pub struct RsaKeyPairSigner<'a> {
+        pub key: &'a crate::rsa::RsaKeyPair,
+        pub pkcs1_der: Vec<u8>,
+    }
+
+    #[derive(Clone)]
+    pub struct RsaKeyPairVerifyingKey(Vec<u8>);
+
+    pub struct RsaKeyPairSignature(Vec<u8>);
+
+    impl signature::Keypair for RsaKeyPairSigner<'_> {
+        type VerifyingKey = RsaKeyPairVerifyingKey;
+
+        fn verifying_key(&self) -> Self::VerifyingKey {
+            RsaKeyPairVerifyingKey(self.pkcs1_der.clone())
+        }
+    }
+
+    impl x509_cert::spki::DynSignatureAlgorithmIdentifier for RsaKeyPairSigner<'_> {
+        fn signature_algorithm_identifier(
+            &self,
+        ) -> x509_cert::spki::Result<x509_cert::spki::AlgorithmIdentifierOwned> {
+            Ok(x509_cert::spki::AlgorithmIdentifierOwned {
+                oid: der::oid::db::rfc5912::SHA_256_WITH_RSA_ENCRYPTION,
+                parameters: Some(der::Any::null()),
+            })
+        }
+    }
+
+    impl signature::Signer<RsaKeyPairSignature> for RsaKeyPairSigner<'_> {
+        fn try_sign(&self, msg: &[u8]) -> Result<RsaKeyPairSignature, signature::Error> {
+            self.key
+                .pkcs1_sign(msg, crate::HashAlgorithm::Sha256)
+                .map(RsaKeyPairSignature)
+                .map_err(signature::Error::from_source)
+        }
+    }
+
+    impl x509_cert::spki::EncodePublicKey for RsaKeyPairVerifyingKey {
+        fn to_public_key_der(&self) -> x509_cert::spki::Result<der::Document> {
+            // Wrap the PKCS#1 RSAPublicKey DER in a SubjectPublicKeyInfo and
+            // encode the result as a DER document.
+            let spki = x509_cert::spki::SubjectPublicKeyInfoOwned {
+                algorithm: x509_cert::spki::AlgorithmIdentifierOwned {
+                    oid: pkcs1::ALGORITHM_OID,
+                    parameters: Some(der::Any::null()),
+                },
+                subject_public_key: der::asn1::BitString::from_bytes(&self.0)?,
+            };
+            Ok(der::Document::try_from(spki.to_der()?)?)
+        }
+    }
+
+    impl x509_cert::spki::SignatureBitStringEncoding for RsaKeyPairSignature {
+        fn to_bitstring(&self) -> der::Result<der::asn1::BitString> {
+            der::asn1::BitString::from_bytes(&self.0)
+        }
+    }
+}

--- a/support/crypto/src/x509/mac.rs
+++ b/support/crypto/src/x509/mac.rs
@@ -1,0 +1,263 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! X.509 certificate parsing and verification on macOS.
+//!
+//! The certificate's ASN.1 structure is decoded and re-encoded with the
+//! `x509-cert` and `der` crates. Public-key extraction, distinguished-name
+//! normalization, and common-name lookup are delegated to
+//! Security.framework via the `SecCertificate` API.
+
+// UNSAFETY: calling Security.framework and CoreFoundation C APIs via FFI.
+#![expect(unsafe_code)]
+
+use super::X509Error;
+use crate::mac::*;
+use der::Decode;
+use der::Encode;
+use std::ptr;
+use x509_cert::Certificate;
+
+type SecCertificateRef = CFTypeRef;
+
+#[link(name = "Security", kind = "framework")]
+unsafe extern "C" {
+    fn SecCertificateCreateWithData(
+        allocator: CFAllocatorRef,
+        data: CFDataRef,
+    ) -> SecCertificateRef;
+    fn SecCertificateCopyKey(cert: SecCertificateRef) -> SecKeyRef;
+    fn SecCertificateCopyCommonName(
+        cert: SecCertificateRef,
+        common_name: *mut CFStringRef,
+    ) -> OsStatusCode;
+    fn SecCertificateCopyNormalizedSubjectSequence(cert: SecCertificateRef) -> CFDataRef;
+    fn SecCertificateCopyNormalizedIssuerSequence(cert: SecCertificateRef) -> CFDataRef;
+
+    fn SecKeyCopyExternalRepresentation(key: SecKeyRef, error: *mut CFErrorRef) -> CFDataRef;
+}
+
+fn err(e: crate::BackendError) -> X509Error {
+    X509Error(e)
+}
+
+fn rsa_err(e: crate::BackendError) -> crate::rsa::RsaError {
+    crate::rsa::RsaError(e)
+}
+
+fn der_err(e: der::Error, op: &'static str) -> X509Error {
+    X509Error(crate::BackendError::Der(e, op))
+}
+
+fn rsa_der_err(e: der::Error, op: &'static str) -> crate::rsa::RsaError {
+    crate::rsa::RsaError(crate::BackendError::Der(e, op))
+}
+
+fn null_err(op: &'static str) -> X509Error {
+    X509Error(crate::BackendError::Null(op))
+}
+
+fn rsa_null_err(op: &'static str) -> crate::rsa::RsaError {
+    crate::rsa::RsaError(crate::BackendError::Null(op))
+}
+
+/// A SecCertificate paired with the parsed ASN.1 view of the same DER
+/// bytes. The Security.framework handle is used for public-key extraction
+/// and DN normalization; the parsed view is used for everything else.
+pub struct X509CertificateInner {
+    cert: CfHandle,
+    parsed: Certificate,
+}
+
+impl X509CertificateInner {
+    pub fn from_der(data: &[u8]) -> Result<Self, X509Error> {
+        let parsed =
+            Certificate::from_der(data).map_err(|e| der_err(e, "parsing DER certificate"))?;
+        let cf = cf_data(data, "CFDataCreate for certificate").map_err(err)?;
+        // SAFETY: cf.0 is a valid CFDataRef.
+        let cert = unsafe { SecCertificateCreateWithData(kCFAllocatorDefault, cf.0) };
+        if cert.is_null() {
+            return Err(null_err("SecCertificateCreateWithData"));
+        }
+        Ok(Self {
+            cert: CfHandle(cert),
+            parsed,
+        })
+    }
+
+    pub fn public_key(&self) -> Result<crate::rsa::RsaPublicKey, crate::rsa::RsaError> {
+        // SAFETY: self.cert.0 is a valid SecCertificateRef.
+        let key = unsafe { SecCertificateCopyKey(self.cert.0) };
+        if key.is_null() {
+            return Err(rsa_null_err("SecCertificateCopyKey"));
+        }
+        let key = CfHandle(key);
+        let mut error: CFErrorRef = ptr::null();
+        // SAFETY: key.0 is a valid SecKeyRef.
+        let data = unsafe { SecKeyCopyExternalRepresentation(key.0, &mut error) };
+        if data.is_null() {
+            // SAFETY: error is null or a valid CFErrorRef.
+            return Err(rsa_err(unsafe {
+                sec_err(error, "SecKeyCopyExternalRepresentation")
+            }));
+        }
+        let data = CfHandle(data);
+        // SAFETY: data.0 is a valid CFDataRef.
+        let pkcs1_der = unsafe { cf_data_to_vec(data.0) };
+        let pk = pkcs1::RsaPublicKey::from_der(&pkcs1_der)
+            .map_err(|e| rsa_der_err(e, "parsing PKCS#1 RSA public key"))?;
+        crate::rsa::RsaPublicKey::from_components(
+            pk.modulus.as_bytes(),
+            pk.public_exponent.as_bytes(),
+        )
+    }
+
+    pub fn verify(
+        &self,
+        issuer_public_key: &crate::rsa::RsaPublicKey,
+    ) -> Result<bool, crate::rsa::RsaError> {
+        let oid = self.parsed.signature_algorithm().oid;
+        let hash = crate::HashAlgorithm::try_from(oid)
+            .map_err(|e| rsa_der_err(e, "unrecognized signature algorithm OID"))?;
+
+        let tbs_der = self
+            .parsed
+            .tbs_certificate()
+            .to_der()
+            .map_err(|e| rsa_der_err(e, "encoding TBS certificate"))?;
+        let signature = self.parsed.signature().raw_bytes();
+        issuer_public_key.pkcs1_verify(&tbs_der, signature, hash)
+    }
+
+    pub fn issued(&self, subject: &X509CertificateInner) -> Result<bool, X509Error> {
+        use x509_cert::ext::pkix::AuthorityKeyIdentifier;
+        use x509_cert::ext::pkix::KeyUsage;
+        use x509_cert::ext::pkix::SubjectKeyIdentifier;
+        use x509_cert::ext::pkix::name::GeneralName;
+
+        // Compare DNs via Security.framework's normalized form so equivalent
+        // encodings still match.
+        let issuer_subject = copy_normalized(self.cert.0, /*subject=*/ true)?;
+        let subject_issuer = copy_normalized(subject.cert.0, /*subject=*/ false)?;
+        if issuer_subject != subject_issuer {
+            return Ok(false);
+        }
+
+        let issuer_tbs = self.parsed.tbs_certificate();
+        let subject_tbs = subject.parsed.tbs_certificate();
+
+        if let Some((_crit, ku)) = issuer_tbs
+            .get_extension::<KeyUsage>()
+            .map_err(|e| der_err(e, "parsing KeyUsage extension"))?
+            && !ku.key_cert_sign()
+        {
+            return Ok(false);
+        }
+
+        if let Some((_crit, akid)) = subject_tbs
+            .get_extension::<AuthorityKeyIdentifier>()
+            .map_err(|e| der_err(e, "parsing AuthorityKeyIdentifier extension"))?
+        {
+            if let Some(akid_key_id) = &akid.key_identifier {
+                let skid = issuer_tbs
+                    .get_extension::<SubjectKeyIdentifier>()
+                    .map_err(|e| der_err(e, "parsing SubjectKeyIdentifier extension"))?;
+                match skid {
+                    Some((_crit, ski)) => {
+                        if akid_key_id != &ski.0 {
+                            return Ok(false);
+                        }
+                    }
+                    None => return Ok(false),
+                }
+            }
+            if let Some(akid_serial) = &akid.authority_cert_serial_number {
+                if akid_serial != issuer_tbs.serial_number() {
+                    return Ok(false);
+                }
+            }
+            if let Some(gens) = &akid.authority_cert_issuer {
+                let mut has_dn = false;
+                let has_matching_dn = gens.iter().any(|g| match g {
+                    GeneralName::DirectoryName(dn) => {
+                        has_dn = true;
+                        dn == issuer_tbs.subject()
+                    }
+                    _ => false,
+                });
+                if has_dn && !has_matching_dn {
+                    return Ok(false);
+                }
+            }
+        }
+
+        Ok(true)
+    }
+
+    pub fn to_der(&self) -> Result<Vec<u8>, X509Error> {
+        self.parsed
+            .to_der()
+            .map_err(|e| der_err(e, "encoding certificate as DER"))
+    }
+
+    pub fn subject_common_name(&self) -> Result<Option<String>, X509Error> {
+        let mut cn: CFStringRef = ptr::null();
+        // SAFETY: self.cert.0 is a valid SecCertificateRef.
+        let status = unsafe { SecCertificateCopyCommonName(self.cert.0, &mut cn) };
+        if status.0 != 0 {
+            return Err(err(crate::BackendError::OsStatus(
+                status,
+                "SecCertificateCopyCommonName",
+            )));
+        }
+        if cn.is_null() {
+            return Ok(None);
+        }
+        // SAFETY: cn is a valid owned CFStringRef.
+        Ok(Some(unsafe { cf_string_to_string(cn) }))
+    }
+
+    #[cfg(any(test, feature = "test_helpers"))]
+    pub fn build_self_signed(
+        key: &crate::rsa::RsaKeyPair,
+        country: &str,
+        state: &str,
+        locality: &str,
+        organization: &str,
+        common_name: &str,
+    ) -> anyhow::Result<Self> {
+        use super::builder::rsa_keypair_signer::RsaKeyPairSigner;
+        use x509_cert::builder::Builder;
+
+        let (builder, pkcs1_der) = super::builder::self_signed_builder(
+            key,
+            country,
+            state,
+            locality,
+            organization,
+            common_name,
+        )?;
+        let cert = builder.build(&RsaKeyPairSigner { key, pkcs1_der })?;
+        Ok(Self::from_der(&cert.to_der()?)?)
+    }
+}
+
+/// Copy the normalized subject or issuer DN bytes from a certificate.
+fn copy_normalized(cert: SecCertificateRef, subject: bool) -> Result<Vec<u8>, X509Error> {
+    // SAFETY: cert is a valid SecCertificateRef.
+    let data = unsafe {
+        if subject {
+            SecCertificateCopyNormalizedSubjectSequence(cert)
+        } else {
+            SecCertificateCopyNormalizedIssuerSequence(cert)
+        }
+    };
+    if data.is_null() {
+        return Err(null_err(
+            "SecCertificateCopyNormalized{Subject,Issuer}Sequence",
+        ));
+    }
+    let data = CfHandle(data);
+    // SAFETY: data.0 is a valid CFDataRef.
+    Ok(unsafe { cf_data_to_vec(data.0) })
+}

--- a/support/crypto/src/x509/mod.rs
+++ b/support/crypto/src/x509/mod.rs
@@ -3,7 +3,16 @@
 
 //! X.509 certificate operations.
 
-#![cfg(any(openssl, rust, symcrypt))]
+#![cfg(any(
+    openssl,
+    rust,
+    symcrypt,
+    all(native, windows),
+    all(native, target_os = "macos")
+))]
+
+#[cfg(any(rust, symcrypt, all(native, target_os = "macos"),))]
+mod builder;
 
 #[cfg(openssl)]
 mod ossl;
@@ -15,17 +24,27 @@ mod symcrypt_rust;
 #[cfg(any(rust, symcrypt))]
 use symcrypt_rust as sys;
 
+#[cfg(all(native, windows))]
+mod win;
+#[cfg(all(native, windows))]
+use win as sys;
+
+#[cfg(all(native, target_os = "macos"))]
+mod mac;
+#[cfg(all(native, target_os = "macos"))]
+use mac as sys;
+
 use thiserror::Error;
 
 /// An error for X.509 operations.
 #[cfg(not(rust))]
-#[derive(Debug, Error)]
+#[derive(Clone, Debug, Error)]
 #[error("X.509 error")]
 pub struct X509Error(#[source] pub(crate) super::BackendError);
 
 /// An error for X.509 operations.
 #[cfg(rust)]
-#[derive(Debug, Error)]
+#[derive(Clone, Debug, Error)]
 #[error("X.509 error during {1}")]
 pub struct X509Error(#[source] pub(crate) der::Error, pub(crate) &'static str);
 
@@ -122,8 +141,7 @@ mod tests {
     fn self_signed_cert_verifies() {
         let key = crate::rsa::RsaKeyPair::generate(2048).unwrap();
         let cert = build_test_cert(&key);
-        let pubkey = cert.public_key().unwrap();
-        assert!(cert.verify(&pubkey).unwrap());
+        assert!(cert.verify(&key).unwrap());
         assert!(cert.issued(&cert).unwrap());
     }
 

--- a/support/crypto/src/x509/symcrypt_rust.rs
+++ b/support/crypto/src/x509/symcrypt_rust.rs
@@ -155,67 +155,22 @@ impl X509CertificateInner {
         organization: &str,
         common_name: &str,
     ) -> anyhow::Result<Self> {
-        use core::str::FromStr;
         use x509_cert::builder::Builder;
-        use x509_cert::name::Name;
 
-        // Profile that produces a basic self-signed certificate with no
-        // extensions and the same `Name` for both the subject and issuer.
-        struct SelfSignedProfile {
-            subject: Name,
-        }
-
-        impl x509_cert::builder::profile::BuilderProfile for SelfSignedProfile {
-            fn get_issuer(&self, _subject: &Name) -> Name {
-                self.subject.clone()
-            }
-
-            fn get_subject(&self) -> Name {
-                self.subject.clone()
-            }
-
-            fn build_extensions(
-                &self,
-                _spk: x509_cert::spki::SubjectPublicKeyInfoRef<'_>,
-                _issuer_spk: x509_cert::spki::SubjectPublicKeyInfoRef<'_>,
-                _tbs: &x509_cert::TbsCertificate,
-            ) -> x509_cert::builder::Result<Vec<x509_cert::ext::Extension>> {
-                Ok(Vec::new())
-            }
-        }
-
-        let name = Name::from_str(&format!(
-            "CN={common_name},O={organization},L={locality},ST={state},C={country}"
-        ))?;
-
-        let modulus = key.modulus();
-        let exponent = key.public_exponent();
-        let pkcs1_pub = pkcs1::RsaPublicKey {
-            modulus: der::asn1::UintRef::new(&modulus)?,
-            public_exponent: der::asn1::UintRef::new(&exponent)?,
-        };
-        let pkcs1_der = pkcs1_pub.to_der()?;
-        let spki = x509_cert::spki::SubjectPublicKeyInfoOwned {
-            algorithm: x509_cert::spki::AlgorithmIdentifierOwned {
-                oid: pkcs1::ALGORITHM_OID,
-                parameters: Some(der::Any::null()),
-            },
-            subject_public_key: der::asn1::BitString::from_bytes(&pkcs1_der)?,
-        };
-
-        let serial_number = x509_cert::serial_number::SerialNumber::from(1u32);
-        let validity = x509_cert::time::Validity::new(
-            der::asn1::GeneralizedTime::from_unix_duration(std::time::Duration::from_secs(0))?
-                .into(),
-            x509_cert::time::Time::INFINITY,
-        );
-
-        let profile = SelfSignedProfile { subject: name };
-        let builder =
-            x509_cert::builder::CertificateBuilder::new(profile, serial_number, validity, spki)?;
+        let (builder, _pkcs1_der) = super::builder::self_signed_builder(
+            key,
+            country,
+            state,
+            locality,
+            organization,
+            common_name,
+        )?;
 
         #[cfg(symcrypt)]
-        let cert = builder.build(&symcrypt_signer::SymCryptRsaSigner { key, pkcs1_der })?;
+        let cert = builder.build(&super::builder::rsa_keypair_signer::RsaKeyPairSigner {
+            key,
+            pkcs1_der: _pkcs1_der,
+        })?;
         #[cfg(rust)]
         let cert = builder.build(&rsa::pkcs1v15::SigningKey::<sha2::Sha256>::new(
             key.0.0.clone(),
@@ -231,72 +186,5 @@ impl X509CertificateInner {
             .common_name()
             .map_err(|e| der_err(e, "getting common_name"))?
             .map(|s| s.value().into_owned()))
-    }
-}
-
-/// Adapters that implement the `signature` and `spki` traits required by
-/// `x509_cert::builder::CertificateBuilder::build` on top of SymCrypt's
-/// PKCS#1 v1.5 signing primitive.
-#[cfg(all(symcrypt, any(test, feature = "test_helpers")))]
-mod symcrypt_signer {
-    use der::Encode;
-
-    pub struct SymCryptRsaSigner<'a> {
-        pub key: &'a crate::rsa::RsaKeyPair,
-        pub pkcs1_der: Vec<u8>,
-    }
-
-    #[derive(Clone)]
-    pub struct SymCryptRsaVerifyingKey(Vec<u8>);
-
-    pub struct SymCryptRsaSignature(Vec<u8>);
-
-    impl signature::Keypair for SymCryptRsaSigner<'_> {
-        type VerifyingKey = SymCryptRsaVerifyingKey;
-
-        fn verifying_key(&self) -> Self::VerifyingKey {
-            SymCryptRsaVerifyingKey(self.pkcs1_der.clone())
-        }
-    }
-
-    impl x509_cert::spki::DynSignatureAlgorithmIdentifier for SymCryptRsaSigner<'_> {
-        fn signature_algorithm_identifier(
-            &self,
-        ) -> x509_cert::spki::Result<x509_cert::spki::AlgorithmIdentifierOwned> {
-            Ok(x509_cert::spki::AlgorithmIdentifierOwned {
-                oid: der::oid::db::rfc5912::SHA_256_WITH_RSA_ENCRYPTION,
-                parameters: Some(der::Any::null()),
-            })
-        }
-    }
-
-    impl signature::Signer<SymCryptRsaSignature> for SymCryptRsaSigner<'_> {
-        fn try_sign(&self, msg: &[u8]) -> Result<SymCryptRsaSignature, signature::Error> {
-            self.key
-                .pkcs1_sign(msg, crate::HashAlgorithm::Sha256)
-                .map(SymCryptRsaSignature)
-                .map_err(signature::Error::from_source)
-        }
-    }
-
-    impl x509_cert::spki::EncodePublicKey for SymCryptRsaVerifyingKey {
-        fn to_public_key_der(&self) -> x509_cert::spki::Result<der::Document> {
-            // Wrap the PKCS#1 RSAPublicKey DER in a SubjectPublicKeyInfo and
-            // encode the result as a DER document.
-            let spki = x509_cert::spki::SubjectPublicKeyInfoOwned {
-                algorithm: x509_cert::spki::AlgorithmIdentifierOwned {
-                    oid: pkcs1::ALGORITHM_OID,
-                    parameters: Some(der::Any::null()),
-                },
-                subject_public_key: der::asn1::BitString::from_bytes(&self.0)?,
-            };
-            Ok(der::Document::try_from(spki.to_der()?)?)
-        }
-    }
-
-    impl x509_cert::spki::SignatureBitStringEncoding for SymCryptRsaSignature {
-        fn to_bitstring(&self) -> der::Result<der::asn1::BitString> {
-            der::asn1::BitString::from_bytes(&self.0)
-        }
     }
 }

--- a/support/crypto/src/x509/win.rs
+++ b/support/crypto/src/x509/win.rs
@@ -194,19 +194,15 @@ impl X509CertificateInner {
             }
         };
 
-        // SAFETY: ToBeSigned describes a valid byte range within cert_der.
-        let tbs = unsafe {
-            std::slice::from_raw_parts(
-                signed.value.ToBeSigned.pbData,
-                signed.value.ToBeSigned.cbData as usize,
-            )
-        };
-        // SAFETY: Signature.pbData describes a valid byte range within cert_der.
-        let sig = unsafe {
-            std::slice::from_raw_parts(
-                signed.value.Signature.pbData,
-                signed.value.Signature.cbData as usize,
-            )
+        let tbs = blob_as_slice(&signed.value.ToBeSigned);
+        // Signature is a CRYPT_BIT_BLOB; reject empty/null defensively.
+        let sig_bits = &signed.value.Signature;
+        let sig = if sig_bits.cbData == 0 || sig_bits.pbData.is_null() {
+            &[][..]
+        } else {
+            // SAFETY: pbData is non-null and describes cbData bytes owned
+            // by the decoded CERT_SIGNED_CONTENT_INFO allocation.
+            unsafe { std::slice::from_raw_parts(sig_bits.pbData, sig_bits.cbData as usize) }
         };
 
         issuer_public_key.pkcs1_verify(tbs, sig, hash)
@@ -483,18 +479,25 @@ impl X509CertificateInner {
     }
 }
 
+/// Safely view a `CRYPT_INTEGER_BLOB` as a byte slice, returning an empty
+/// slice when the blob is empty or its pointer is null. `from_raw_parts`
+/// requires a non-null pointer even for zero-length slices, so blob fields
+/// originating from CryptoAPI-decoded structures (driven by potentially
+/// untrusted certificate data) must be checked before use.
+fn blob_as_slice(blob: &CRYPT_INTEGER_BLOB) -> &[u8] {
+    if blob.cbData == 0 || blob.pbData.is_null() {
+        return &[];
+    }
+    // SAFETY: pbData is non-null and describes cbData bytes owned by the
+    // containing CryptoAPI allocation.
+    unsafe { std::slice::from_raw_parts(blob.pbData, blob.cbData as usize) }
+}
+
 fn blob_eq(a: &CRYPT_INTEGER_BLOB, b: &CRYPT_INTEGER_BLOB) -> bool {
     if a.cbData != b.cbData {
         return false;
     }
-    if a.cbData == 0 {
-        return true;
-    }
-    // SAFETY: blobs describe valid byte ranges.
-    let sa = unsafe { std::slice::from_raw_parts(a.pbData, a.cbData as usize) };
-    // SAFETY: blobs describe valid byte ranges.
-    let sb = unsafe { std::slice::from_raw_parts(b.pbData, b.cbData as usize) };
-    sa == sb
+    blob_as_slice(a) == blob_as_slice(b)
 }
 
 /// Find an extension by OID in a CERT_INFO. Returns `None` if not present.
@@ -542,8 +545,16 @@ fn decode_object<T: Copy>(
 ) -> Result<Decoded<T>, X509Error> {
     use windows::Win32::Security::Cryptography::CRYPT_DECODE_ALLOC_FLAG;
 
-    // SAFETY: blob describes a valid byte range owned by the cert context.
-    let encoded = unsafe { std::slice::from_raw_parts(blob.pbData, blob.cbData as usize) };
+    // Reject malformed inputs (non-zero length with a null pointer) before
+    // calling into CryptoAPI; `from_raw_parts` with a null pointer would
+    // be immediate UB even if the API would have tolerated it.
+    if blob.cbData != 0 && blob.pbData.is_null() {
+        return Err(err(
+            windows_result::Error::from_hresult(windows::core::HRESULT(-1)),
+            "CryptDecodeObjectEx: input blob has null pbData with non-zero cbData",
+        ));
+    }
+    let encoded = blob_as_slice(blob);
     let mut raw: *mut c_void = std::ptr::null_mut();
     let mut size: u32 = 0;
     // SAFETY: We pass CRYPT_DECODE_ALLOC_FLAG so the API allocates the
@@ -566,8 +577,24 @@ fn decode_object<T: Copy>(
             "CryptDecodeObjectEx returned null",
         ));
     }
-    // SAFETY: raw points to a `T` written by CryptoAPI. We copy it out so
-    // that `value` lives at a stable address.
+    // Validate the API actually wrote a `T`-sized header before reading
+    // it. A short buffer here would mean `read_unaligned` reads past the
+    // allocation.
+    if (size as usize) < size_of::<T>() {
+        // SAFETY: raw was allocated by CryptoAPI via CRYPT_DECODE_ALLOC_FLAG.
+        unsafe {
+            let _ = windows::Win32::Foundation::LocalFree(Some(
+                windows::Win32::Foundation::HLOCAL(raw),
+            ));
+        }
+        return Err(err(
+            windows_result::Error::from_hresult(windows::core::HRESULT(-1)),
+            "CryptDecodeObjectEx returned buffer smaller than expected struct",
+        ));
+    }
+    // SAFETY: raw points to a `T` written by CryptoAPI (validated above to
+    // be at least size_of::<T>() bytes). We copy it out so that `value`
+    // lives at a stable address.
     let value = unsafe { std::ptr::read_unaligned(raw.cast::<T>()) };
     Ok(Decoded {
         raw,
@@ -611,7 +638,8 @@ fn encode_object(
     Ok(out)
 }
 
-/// Build a single-RDN-per-component DN as `C=…, ST=…, L=…, O=…, CN=…`.
+/// Convert a Unix timestamp (seconds since 1970-01-01) to a Windows
+/// `FILETIME` (100-ns intervals since 1601-01-01).
 #[cfg(any(test, feature = "test_helpers"))]
 fn unix_to_filetime(unix_secs: i64) -> windows::Win32::Foundation::FILETIME {
     // FILETIME counts 100-ns intervals since 1601-01-01; Unix epoch is
@@ -623,6 +651,7 @@ fn unix_to_filetime(unix_secs: i64) -> windows::Win32::Foundation::FILETIME {
     }
 }
 
+/// Build a single-RDN-per-component DN as `C=…, ST=…, L=…, O=…, CN=…`.
 #[cfg(any(test, feature = "test_helpers"))]
 fn encode_x500_name(
     country: &str,

--- a/support/crypto/src/x509/win.rs
+++ b/support/crypto/src/x509/win.rs
@@ -194,9 +194,21 @@ impl X509CertificateInner {
             }
         };
 
-        let tbs = blob_as_slice(&signed.value.ToBeSigned);
+        let tbs = blob_as_slice(&signed.value.ToBeSigned).ok_or_else(|| {
+            rsa_err(
+                windows_result::Error::from_hresult(windows::core::HRESULT(-1)),
+                "malformed ToBeSigned blob",
+            )
+        })?;
         // Signature is a CRYPT_BIT_BLOB; reject empty/null defensively.
         let sig_bits = &signed.value.Signature;
+        // For X.509 RSA signatures the BIT STRING must be byte-aligned;
+        // a non-zero cUnusedBits means the encoding is malformed for this
+        // algorithm. Treat as an invalid signature rather than verifying
+        // bytes that don't reflect the encoded value.
+        if sig_bits.cUnusedBits != 0 {
+            return Ok(false);
+        }
         let sig = if sig_bits.cbData == 0 || sig_bits.pbData.is_null() {
             &[][..]
         } else {
@@ -262,7 +274,9 @@ impl X509CertificateInner {
                             windows::Win32::Security::Cryptography::X509_OCTET_STRING,
                             &ext.Value,
                         )?;
-                        if !blob_eq(&akid.value.KeyId, &skid.value) {
+                        let a = blob_as_slice(&akid.value.KeyId);
+                        let b = blob_as_slice(&skid.value);
+                        if a.is_none() || b.is_none() || a != b {
                             return Ok(false);
                         }
                     }
@@ -270,13 +284,12 @@ impl X509CertificateInner {
                 }
             }
 
-            if akid.value.AuthorityCertSerialNumber.cbData != 0
-                && !blob_eq(
-                    &akid.value.AuthorityCertSerialNumber,
-                    &issuer_info.SerialNumber,
-                )
-            {
-                return Ok(false);
+            if akid.value.AuthorityCertSerialNumber.cbData != 0 {
+                let a = blob_as_slice(&akid.value.AuthorityCertSerialNumber);
+                let b = blob_as_slice(&issuer_info.SerialNumber);
+                if a.is_none() || b.is_none() || a != b {
+                    return Ok(false);
+                }
             }
 
             // AuthorityCertIssuer (a CERT_ALT_NAME_INFO): if any
@@ -479,25 +492,20 @@ impl X509CertificateInner {
     }
 }
 
-/// Safely view a `CRYPT_INTEGER_BLOB` as a byte slice, returning an empty
-/// slice when the blob is empty or its pointer is null. `from_raw_parts`
-/// requires a non-null pointer even for zero-length slices, so blob fields
-/// originating from CryptoAPI-decoded structures (driven by potentially
-/// untrusted certificate data) must be checked before use.
-fn blob_as_slice(blob: &CRYPT_INTEGER_BLOB) -> &[u8] {
-    if blob.cbData == 0 || blob.pbData.is_null() {
-        return &[];
+/// View a `CRYPT_INTEGER_BLOB` as a byte slice. Returns `None` if the blob
+/// is malformed (non-zero `cbData` with a null `pbData`), since
+/// `from_raw_parts` would be immediate UB in that case. An empty blob
+/// returns `Some(&[])`.
+fn blob_as_slice(blob: &CRYPT_INTEGER_BLOB) -> Option<&[u8]> {
+    if blob.cbData == 0 {
+        return Some(&[]);
+    }
+    if blob.pbData.is_null() {
+        return None;
     }
     // SAFETY: pbData is non-null and describes cbData bytes owned by the
     // containing CryptoAPI allocation.
-    unsafe { std::slice::from_raw_parts(blob.pbData, blob.cbData as usize) }
-}
-
-fn blob_eq(a: &CRYPT_INTEGER_BLOB, b: &CRYPT_INTEGER_BLOB) -> bool {
-    if a.cbData != b.cbData {
-        return false;
-    }
-    blob_as_slice(a) == blob_as_slice(b)
+    Some(unsafe { std::slice::from_raw_parts(blob.pbData, blob.cbData as usize) })
 }
 
 /// Find an extension by OID in a CERT_INFO. Returns `None` if not present.
@@ -545,16 +553,12 @@ fn decode_object<T: Copy>(
 ) -> Result<Decoded<T>, X509Error> {
     use windows::Win32::Security::Cryptography::CRYPT_DECODE_ALLOC_FLAG;
 
-    // Reject malformed inputs (non-zero length with a null pointer) before
-    // calling into CryptoAPI; `from_raw_parts` with a null pointer would
-    // be immediate UB even if the API would have tolerated it.
-    if blob.cbData != 0 && blob.pbData.is_null() {
-        return Err(err(
+    let encoded = blob_as_slice(blob).ok_or_else(|| {
+        err(
             windows_result::Error::from_hresult(windows::core::HRESULT(-1)),
             "CryptDecodeObjectEx: input blob has null pbData with non-zero cbData",
-        ));
-    }
-    let encoded = blob_as_slice(blob);
+        )
+    })?;
     let mut raw: *mut c_void = std::ptr::null_mut();
     let mut size: u32 = 0;
     // SAFETY: We pass CRYPT_DECODE_ALLOC_FLAG so the API allocates the

--- a/support/crypto/src/x509/win.rs
+++ b/support/crypto/src/x509/win.rs
@@ -37,11 +37,11 @@ use windows::Win32::Security::Cryptography::szOID_SUBJECT_KEY_IDENTIFIER;
 use windows::core::PCSTR;
 
 fn err(err: windows_result::Error, op: &'static str) -> X509Error {
-    X509Error(crate::BackendError::Bcrypt(err, op))
+    X509Error(crate::BackendError(err, op))
 }
 
 fn rsa_err(err: windows_result::Error, op: &'static str) -> crate::rsa::RsaError {
-    crate::rsa::RsaError(crate::BackendError::Bcrypt(err, op))
+    crate::rsa::RsaError(crate::BackendError(err, op))
 }
 
 fn last_err(op: &'static str) -> X509Error {

--- a/support/crypto/src/x509/win.rs
+++ b/support/crypto/src/x509/win.rs
@@ -1,0 +1,736 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! X.509 certificate parsing and verification using the Windows CryptoAPI
+//! (crypt32.dll). This backend is fully native — it does not depend on the
+//! `der` or `x509-cert` RustCrypto crates.
+
+use super::X509Error;
+use crate::win::KeyHandle;
+use std::ffi::c_void;
+use windows::Win32::Security::Cryptography::BCRYPT_KEY_HANDLE;
+use windows::Win32::Security::Cryptography::CERT_AUTHORITY_KEY_ID2_INFO;
+use windows::Win32::Security::Cryptography::CERT_CONTEXT;
+use windows::Win32::Security::Cryptography::CERT_EXTENSION;
+use windows::Win32::Security::Cryptography::CERT_INFO;
+use windows::Win32::Security::Cryptography::CERT_KEY_CERT_SIGN_KEY_USAGE;
+use windows::Win32::Security::Cryptography::CERT_NAME_ATTR_TYPE;
+#[cfg(any(test, feature = "test_helpers"))]
+use windows::Win32::Security::Cryptography::CERT_PUBLIC_KEY_INFO;
+#[cfg(any(test, feature = "test_helpers"))]
+use windows::Win32::Security::Cryptography::CRYPT_ALGORITHM_IDENTIFIER;
+use windows::Win32::Security::Cryptography::CRYPT_BIT_BLOB;
+#[cfg(any(test, feature = "test_helpers"))]
+use windows::Win32::Security::Cryptography::CRYPT_ENCODE_OBJECT_FLAGS;
+use windows::Win32::Security::Cryptography::CRYPT_IMPORT_PUBLIC_KEY_FLAGS;
+use windows::Win32::Security::Cryptography::CRYPT_INTEGER_BLOB;
+use windows::Win32::Security::Cryptography::X509_ASN_ENCODING;
+use windows::Win32::Security::Cryptography::X509_AUTHORITY_KEY_ID2;
+use windows::Win32::Security::Cryptography::X509_CERT;
+use windows::Win32::Security::Cryptography::X509_KEY_USAGE;
+use windows::Win32::Security::Cryptography::szOID_AUTHORITY_KEY_IDENTIFIER2;
+use windows::Win32::Security::Cryptography::szOID_COMMON_NAME;
+use windows::Win32::Security::Cryptography::szOID_KEY_USAGE;
+use windows::Win32::Security::Cryptography::szOID_RSA_RSA;
+use windows::Win32::Security::Cryptography::szOID_RSA_SHA256RSA;
+use windows::Win32::Security::Cryptography::szOID_SUBJECT_KEY_IDENTIFIER;
+use windows::core::PCSTR;
+
+fn err(err: windows_result::Error, op: &'static str) -> X509Error {
+    X509Error(crate::BackendError::Bcrypt(err, op))
+}
+
+fn rsa_err(err: windows_result::Error, op: &'static str) -> crate::rsa::RsaError {
+    crate::rsa::RsaError(crate::BackendError::Bcrypt(err, op))
+}
+
+fn last_err(op: &'static str) -> X509Error {
+    err(windows_result::Error::from_thread(), op)
+}
+
+/// RAII wrapper around `PCCERT_CONTEXT`.
+struct CertContext(*const CERT_CONTEXT);
+
+// SAFETY: cert context can be sent across threads.
+unsafe impl Send for CertContext {}
+// SAFETY: cert context is read-only after creation and safe to share.
+unsafe impl Sync for CertContext {}
+
+impl Drop for CertContext {
+    fn drop(&mut self) {
+        // SAFETY: handle is valid; CertFreeCertificateContext tolerates
+        // the call exactly once per CertCreateCertificateContext.
+        let _ = unsafe {
+            windows::Win32::Security::Cryptography::CertFreeCertificateContext(Some(self.0))
+        };
+    }
+}
+
+impl CertContext {
+    fn cert_context(&self) -> &CERT_CONTEXT {
+        // SAFETY: self.0 is a valid PCCERT_CONTEXT owned by `self`, and the
+        // pointed-to CERT_CONTEXT is immutable for the lifetime of `self`.
+        unsafe { &*self.0 }
+    }
+
+    fn cert_info(&self) -> &CERT_INFO {
+        // SAFETY: pCertInfo is a valid pointer owned by the cert context
+        // and the pointed-to CERT_INFO is immutable for the lifetime of
+        // `self`.
+        unsafe { &*self.cert_context().pCertInfo }
+    }
+}
+
+pub struct X509CertificateInner(CertContext);
+
+impl X509CertificateInner {
+    pub fn from_der(data: &[u8]) -> Result<Self, X509Error> {
+        // SAFETY: `data` is a valid byte slice for its declared length.
+        let p = unsafe {
+            windows::Win32::Security::Cryptography::CertCreateCertificateContext(
+                X509_ASN_ENCODING,
+                data,
+            )
+        };
+        if p.is_null() {
+            return Err(last_err("CertCreateCertificateContext"));
+        }
+        Ok(Self(CertContext(p)))
+    }
+
+    pub fn public_key(&self) -> Result<crate::rsa::RsaPublicKey, crate::rsa::RsaError> {
+        let info = &self.0.cert_info().SubjectPublicKeyInfo;
+
+        // Reject non-RSA keys. The OID is a PSTR (null-terminated ASCII).
+
+        let oid = info.Algorithm.pszObjId;
+        // SAFETY: info points to a valid CERT_PUBLIC_KEY_INFO owned by
+        // the cert context; the OID strings produced by crypt32 and the
+        // szOID_* constants are null-terminated ASCII.
+        let is_rsa = !oid.is_null() && unsafe { oid.as_bytes() == szOID_RSA_RSA.as_bytes() };
+        if !is_rsa {
+            return Err(rsa_err(
+                windows_result::Error::from_hresult(windows::core::HRESULT(
+                    windows::Win32::Foundation::E_NOTIMPL.0,
+                )),
+                "non-RSA public key in certificate",
+            ));
+        }
+
+        // Import the SubjectPublicKeyInfo into a BCrypt key handle
+        let mut h = BCRYPT_KEY_HANDLE::default();
+        // SAFETY: info points to a valid CERT_PUBLIC_KEY_INFO owned by
+        // the cert context.
+        unsafe {
+            windows::Win32::Security::Cryptography::CryptImportPublicKeyInfoEx2(
+                X509_ASN_ENCODING,
+                info,
+                CRYPT_IMPORT_PUBLIC_KEY_FLAGS(0),
+                None,
+                &mut h,
+            )
+        }
+        .map_err(|e| rsa_err(e, "CryptImportPublicKeyInfoEx2"))?;
+        let key = KeyHandle(h);
+        Ok(crate::rsa::RsaPublicKey(
+            crate::rsa::win::RsaPublicKeyInner(key),
+        ))
+    }
+
+    pub fn verify(
+        &self,
+        issuer_public_key: &crate::rsa::RsaPublicKey,
+    ) -> Result<bool, crate::rsa::RsaError> {
+        // Decode the cert into CERT_SIGNED_CONTENT_INFO to extract the
+        // TBS bytes, signature algorithm OID, and signature bits, then
+        // delegate to the RsaPublicKey::pkcs1_verify path.
+        // This avoids constructing a CERT_PUBLIC_KEY_INFO from scratch,
+        // which CryptVerifyCertificateSignatureEx is finicky about.
+        let ctx = self.0.cert_context();
+        let signed =
+            decode_object::<windows::Win32::Security::Cryptography::CERT_SIGNED_CONTENT_INFO>(
+                X509_CERT,
+                &CRYPT_INTEGER_BLOB {
+                    cbData: ctx.cbCertEncoded,
+                    pbData: ctx.pbCertEncoded,
+                },
+            )
+            .map_err(|X509Error(e)| crate::rsa::RsaError(e))?;
+
+        // Hash algorithm from the signature algorithm OID.
+        let oid = signed.value.SignatureAlgorithm.pszObjId;
+        if oid.is_null() {
+            return Err(rsa_err(
+                windows_result::Error::from_hresult(windows::core::HRESULT(
+                    windows::Win32::Foundation::E_NOTIMPL.0,
+                )),
+                "missing signature algorithm OID",
+            ));
+        }
+        // SAFETY: ASN.1-decoded OID strings from crypt32 are null-terminated,
+        // as are the szOID_* constants.
+        let hash = unsafe {
+            let oid_bytes = oid.as_bytes();
+            if oid_bytes == szOID_RSA_SHA256RSA.as_bytes() {
+                crate::HashAlgorithm::Sha256
+            } else if oid_bytes
+                == windows::Win32::Security::Cryptography::szOID_RSA_SHA384RSA.as_bytes()
+            {
+                crate::HashAlgorithm::Sha384
+            } else if oid_bytes
+                == windows::Win32::Security::Cryptography::szOID_RSA_SHA1RSA.as_bytes()
+            {
+                #[expect(deprecated)]
+                {
+                    crate::HashAlgorithm::Sha1
+                }
+            } else {
+                return Err(rsa_err(
+                    windows_result::Error::from_hresult(windows::core::HRESULT(
+                        windows::Win32::Foundation::E_NOTIMPL.0,
+                    )),
+                    "unsupported signature algorithm OID",
+                ));
+            }
+        };
+
+        // SAFETY: ToBeSigned describes a valid byte range within cert_der.
+        let tbs = unsafe {
+            std::slice::from_raw_parts(
+                signed.value.ToBeSigned.pbData,
+                signed.value.ToBeSigned.cbData as usize,
+            )
+        };
+        // SAFETY: Signature.pbData describes a valid byte range within cert_der.
+        let sig = unsafe {
+            std::slice::from_raw_parts(
+                signed.value.Signature.pbData,
+                signed.value.Signature.cbData as usize,
+            )
+        };
+
+        issuer_public_key.pkcs1_verify(tbs, sig, hash)
+    }
+
+    pub fn issued(&self, subject: &X509CertificateInner) -> Result<bool, X509Error> {
+        let issuer_info = self.0.cert_info();
+        let subject_info = subject.0.cert_info();
+
+        // Compare issuer DN of subject with subject DN of issuer.
+        // SAFETY: blobs come from valid CERT_INFOs.
+        let names_match = unsafe {
+            windows::Win32::Security::Cryptography::CertCompareCertificateName(
+                X509_ASN_ENCODING,
+                &issuer_info.Subject,
+                &subject_info.Issuer,
+            )
+        };
+        if !names_match.as_bool() {
+            return Ok(false);
+        }
+
+        // KeyUsage on issuer must permit cert signing if present.
+        if let Some(ku_ext) = find_extension(issuer_info, szOID_KEY_USAGE) {
+            let bits = decode_object::<CRYPT_BIT_BLOB>(X509_KEY_USAGE, &ku_ext.Value)?;
+            let mut u32_usage: u32 = 0;
+            // SAFETY: bits.pbData points to at least bits.cbData bytes if
+            // non-null. Copy up to 4 bytes; default to 0 otherwise.
+            unsafe {
+                let n = bits.value.cbData.min(4) as usize;
+                if !bits.value.pbData.is_null() {
+                    std::ptr::copy_nonoverlapping(
+                        bits.value.pbData,
+                        std::ptr::from_mut(&mut u32_usage).cast::<u8>(),
+                        n,
+                    );
+                }
+            }
+            if u32_usage & CERT_KEY_CERT_SIGN_KEY_USAGE == 0 {
+                return Ok(false);
+            }
+        }
+
+        // AKID validation on subject (if present), against issuer.
+        if let Some(akid_ext) = find_extension(subject_info, szOID_AUTHORITY_KEY_IDENTIFIER2) {
+            let akid = decode_object::<CERT_AUTHORITY_KEY_ID2_INFO>(
+                X509_AUTHORITY_KEY_ID2,
+                &akid_ext.Value,
+            )?;
+
+            if akid.value.KeyId.cbData != 0 {
+                let skid_ext = find_extension(issuer_info, szOID_SUBJECT_KEY_IDENTIFIER);
+                match skid_ext {
+                    Some(ext) => {
+                        // X509_OCTET_STRING decodes to CRYPT_INTEGER_BLOB
+                        let skid = decode_object::<CRYPT_INTEGER_BLOB>(
+                            windows::Win32::Security::Cryptography::X509_OCTET_STRING,
+                            &ext.Value,
+                        )?;
+                        if !blob_eq(&akid.value.KeyId, &skid.value) {
+                            return Ok(false);
+                        }
+                    }
+                    None => return Ok(false),
+                }
+            }
+
+            if akid.value.AuthorityCertSerialNumber.cbData != 0
+                && !blob_eq(
+                    &akid.value.AuthorityCertSerialNumber,
+                    &issuer_info.SerialNumber,
+                )
+            {
+                return Ok(false);
+            }
+
+            // AuthorityCertIssuer (a CERT_ALT_NAME_INFO): if any
+            // DirectoryName entry is present, at least one must equal the
+            // issuer's subject DN.
+            if akid.value.AuthorityCertIssuer.cAltEntry != 0 {
+                // SAFETY: rgAltEntry/cAltEntry describe a valid array
+                // owned by the decoded structure.
+                let entries = unsafe {
+                    std::slice::from_raw_parts(
+                        akid.value.AuthorityCertIssuer.rgAltEntry,
+                        akid.value.AuthorityCertIssuer.cAltEntry as usize,
+                    )
+                };
+                let mut has_dn = false;
+                let mut has_match = false;
+                for e in entries {
+                    // CERT_ALT_NAME_DIRECTORYNAME = 5
+                    if e.dwAltNameChoice == 5 {
+                        has_dn = true;
+                        // SAFETY: union: DirectoryName is the active field.
+                        let dn = unsafe { e.Anonymous.DirectoryName };
+                        // SAFETY: comparing two cert name blobs.
+                        let m = unsafe {
+                            windows::Win32::Security::Cryptography::CertCompareCertificateName(
+                                X509_ASN_ENCODING,
+                                &dn,
+                                &issuer_info.Subject,
+                            )
+                        };
+                        if m.as_bool() {
+                            has_match = true;
+                            break;
+                        }
+                    }
+                }
+                if has_dn && !has_match {
+                    return Ok(false);
+                }
+            }
+        }
+
+        Ok(true)
+    }
+
+    pub fn to_der(&self) -> Result<Vec<u8>, X509Error> {
+        let ctx = self.0.cert_context();
+        // SAFETY: pbCertEncoded/cbCertEncoded describe a valid byte slice.
+        let s =
+            unsafe { std::slice::from_raw_parts(ctx.pbCertEncoded, ctx.cbCertEncoded as usize) };
+        Ok(s.to_vec())
+    }
+
+    pub fn subject_common_name(&self) -> Result<Option<String>, X509Error> {
+        let oid = szOID_COMMON_NAME.0.cast::<c_void>();
+        // SAFETY: ctx is valid; passing None for psznamestring queries the
+        // required size.
+        let needed = unsafe {
+            windows::Win32::Security::Cryptography::CertGetNameStringW(
+                self.0.0,
+                CERT_NAME_ATTR_TYPE,
+                0,
+                Some(oid),
+                None,
+            )
+        };
+        // 0 from the size query indicates a CryptoAPI failure; 1 (just the
+        // NUL terminator) indicates the attribute is absent.
+        if needed == 0 {
+            return Err(last_err("CertGetNameStringW (size query)"));
+        }
+        if needed == 1 {
+            return Ok(None);
+        }
+        let mut buf = vec![0u16; needed as usize];
+        // SAFETY: buf is sized per the previous query.
+        let written = unsafe {
+            windows::Win32::Security::Cryptography::CertGetNameStringW(
+                self.0.0,
+                CERT_NAME_ATTR_TYPE,
+                0,
+                Some(oid),
+                Some(&mut buf),
+            )
+        };
+        if written == 0 {
+            return Err(last_err("CertGetNameStringW"));
+        }
+        // Strip trailing NUL.
+        let len = buf.iter().position(|&c| c == 0).unwrap_or(buf.len());
+        Ok(Some(String::from_utf16_lossy(&buf[..len])))
+    }
+
+    #[cfg(any(test, feature = "test_helpers"))]
+    pub fn build_self_signed(
+        key: &crate::rsa::RsaKeyPair,
+        country: &str,
+        state: &str,
+        locality: &str,
+        organization: &str,
+        common_name: &str,
+    ) -> anyhow::Result<Self> {
+        use anyhow::Context;
+        use windows::Win32::Security::Cryptography::CERT_V3;
+        use windows::Win32::Security::Cryptography::X509_CERT_TO_BE_SIGNED;
+
+        // 1. Encode the subject (== issuer for self-signed) DN.
+        let name_der = encode_x500_name(country, state, locality, organization, common_name)
+            .context("encoding X.500 name")?;
+
+        // 2. Build the SubjectPublicKeyInfo DER.
+        let n = key.modulus();
+        let e = key.public_exponent();
+        let pkcs1_pub = encode_pkcs1_rsa_pubkey(&n, &e).context("encoding RSA public key")?;
+
+        // 3. Build CERT_INFO and encode TBS.
+        let mut serial_bytes: [u8; 1] = [1];
+        let mut name_buf = name_der.clone();
+        let mut pk_buf = pkcs1_pub.clone();
+        let mut null_params = [0x05u8, 0x00];
+
+        let cert_info = CERT_INFO {
+            dwVersion: CERT_V3,
+            SerialNumber: CRYPT_INTEGER_BLOB {
+                cbData: serial_bytes.len() as u32,
+                pbData: serial_bytes.as_mut_ptr(),
+            },
+            SignatureAlgorithm: CRYPT_ALGORITHM_IDENTIFIER {
+                pszObjId: windows::core::PSTR(szOID_RSA_SHA256RSA.0.cast_mut()),
+                Parameters: CRYPT_INTEGER_BLOB {
+                    cbData: null_params.len() as u32,
+                    pbData: null_params.as_mut_ptr(),
+                },
+            },
+            Issuer: CRYPT_INTEGER_BLOB {
+                cbData: name_buf.len() as u32,
+                pbData: name_buf.as_mut_ptr(),
+            },
+            NotBefore: unix_to_filetime(0),
+            NotAfter: unix_to_filetime(i32::MAX as i64),
+            Subject: CRYPT_INTEGER_BLOB {
+                cbData: name_buf.len() as u32,
+                pbData: name_buf.as_mut_ptr(),
+            },
+            SubjectPublicKeyInfo: CERT_PUBLIC_KEY_INFO {
+                Algorithm: CRYPT_ALGORITHM_IDENTIFIER {
+                    pszObjId: windows::core::PSTR(szOID_RSA_RSA.0.cast_mut()),
+                    Parameters: CRYPT_INTEGER_BLOB {
+                        cbData: null_params.len() as u32,
+                        pbData: null_params.as_mut_ptr(),
+                    },
+                },
+                PublicKey: CRYPT_BIT_BLOB {
+                    cbData: pk_buf.len() as u32,
+                    pbData: pk_buf.as_mut_ptr(),
+                    cUnusedBits: 0,
+                },
+            },
+            IssuerUniqueId: CRYPT_BIT_BLOB::default(),
+            SubjectUniqueId: CRYPT_BIT_BLOB::default(),
+            cExtension: 0,
+            rgExtension: std::ptr::null_mut(),
+        };
+
+        let tbs = encode_object(
+            X509_CERT_TO_BE_SIGNED,
+            std::ptr::from_ref(&cert_info).cast(),
+        )
+        .context("encoding TBS certificate")?;
+
+        // 4. Sign the TBS.
+        let signature = key.pkcs1_sign(&tbs, crate::HashAlgorithm::Sha256)?;
+
+        // 5. Build CERT_SIGNED_CONTENT_INFO and encode the whole cert.
+        let mut tbs_buf = tbs.clone();
+        let mut sig_buf = signature.clone();
+        let mut null_params2 = [0x05u8, 0x00];
+        let signed = windows::Win32::Security::Cryptography::CERT_SIGNED_CONTENT_INFO {
+            ToBeSigned: CRYPT_INTEGER_BLOB {
+                cbData: tbs_buf.len() as u32,
+                pbData: tbs_buf.as_mut_ptr(),
+            },
+            SignatureAlgorithm: CRYPT_ALGORITHM_IDENTIFIER {
+                pszObjId: windows::core::PSTR(szOID_RSA_SHA256RSA.0.cast_mut()),
+                Parameters: CRYPT_INTEGER_BLOB {
+                    cbData: null_params2.len() as u32,
+                    pbData: null_params2.as_mut_ptr(),
+                },
+            },
+            Signature: CRYPT_BIT_BLOB {
+                cbData: sig_buf.len() as u32,
+                pbData: sig_buf.as_mut_ptr(),
+                cUnusedBits: 0,
+            },
+        };
+        let cert_der = encode_object(X509_CERT, std::ptr::from_ref(&signed).cast())
+            .context("encoding X.509 certificate")?;
+
+        Ok(Self::from_der(&cert_der)?)
+    }
+}
+
+fn blob_eq(a: &CRYPT_INTEGER_BLOB, b: &CRYPT_INTEGER_BLOB) -> bool {
+    if a.cbData != b.cbData {
+        return false;
+    }
+    if a.cbData == 0 {
+        return true;
+    }
+    // SAFETY: blobs describe valid byte ranges.
+    let sa = unsafe { std::slice::from_raw_parts(a.pbData, a.cbData as usize) };
+    // SAFETY: blobs describe valid byte ranges.
+    let sb = unsafe { std::slice::from_raw_parts(b.pbData, b.cbData as usize) };
+    sa == sb
+}
+
+/// Find an extension by OID in a CERT_INFO. Returns `None` if not present.
+fn find_extension(info: &CERT_INFO, oid: PCSTR) -> Option<&CERT_EXTENSION> {
+    if info.cExtension == 0 || info.rgExtension.is_null() {
+        return None;
+    }
+    // SAFETY: rgExtension/cExtension describe a valid array.
+    let exts = unsafe { std::slice::from_raw_parts(info.rgExtension, info.cExtension as usize) };
+    // SAFETY: CertFindExtension is a deterministic comparison over the slice.
+    let p = unsafe { windows::Win32::Security::Cryptography::CertFindExtension(oid, exts) };
+    if p.is_null() {
+        None
+    } else {
+        // SAFETY: p points into the same array, owned by the CERT_INFO.
+        Some(unsafe { &*p })
+    }
+}
+
+/// RAII wrapper for a CryptoAPI-allocated decoded structure. Frees with
+/// `LocalFree` when dropped.
+struct Decoded<T> {
+    raw: *mut c_void,
+    /// Layout-compatible reference to the decoded structure inside `raw`.
+    value: T,
+    _phantom: std::marker::PhantomData<*const T>,
+}
+
+impl<T> Drop for Decoded<T> {
+    fn drop(&mut self) {
+        // SAFETY: raw was allocated by CryptoAPI via CRYPT_DECODE_ALLOC_FLAG.
+        unsafe {
+            let _ = windows::Win32::Foundation::LocalFree(Some(
+                windows::Win32::Foundation::HLOCAL(self.raw),
+            ));
+        }
+    }
+}
+
+/// Decode a CryptoAPI-defined object using `CryptDecodeObjectEx` with the
+/// alloc flag. The returned `Decoded<T>` owns the buffer.
+fn decode_object<T: Copy>(
+    struct_type: PCSTR,
+    blob: &CRYPT_INTEGER_BLOB,
+) -> Result<Decoded<T>, X509Error> {
+    use windows::Win32::Security::Cryptography::CRYPT_DECODE_ALLOC_FLAG;
+
+    // SAFETY: blob describes a valid byte range owned by the cert context.
+    let encoded = unsafe { std::slice::from_raw_parts(blob.pbData, blob.cbData as usize) };
+    let mut raw: *mut c_void = std::ptr::null_mut();
+    let mut size: u32 = 0;
+    // SAFETY: We pass CRYPT_DECODE_ALLOC_FLAG so the API allocates the
+    // output buffer. `&mut raw` is the documented form when alloc flag is set.
+    unsafe {
+        windows::Win32::Security::Cryptography::CryptDecodeObjectEx(
+            X509_ASN_ENCODING,
+            struct_type,
+            encoded,
+            CRYPT_DECODE_ALLOC_FLAG,
+            None,
+            Some(std::ptr::from_mut(&mut raw).cast::<c_void>()),
+            &mut size,
+        )
+    }
+    .map_err(|e| err(e, "CryptDecodeObjectEx"))?;
+    if raw.is_null() {
+        return Err(err(
+            windows_result::Error::from_hresult(windows::core::HRESULT(-1)),
+            "CryptDecodeObjectEx returned null",
+        ));
+    }
+    // SAFETY: raw points to a `T` written by CryptoAPI. We copy it out so
+    // that `value` lives at a stable address.
+    let value = unsafe { std::ptr::read_unaligned(raw.cast::<T>()) };
+    Ok(Decoded {
+        raw,
+        value,
+        _phantom: std::marker::PhantomData,
+    })
+}
+
+#[cfg(any(test, feature = "test_helpers"))]
+fn encode_object(
+    struct_type: PCSTR,
+    value: *const c_void,
+) -> Result<Vec<u8>, windows_result::Error> {
+    let mut size: u32 = 0;
+    // SAFETY: first call queries size.
+    unsafe {
+        windows::Win32::Security::Cryptography::CryptEncodeObjectEx(
+            X509_ASN_ENCODING,
+            struct_type,
+            value,
+            CRYPT_ENCODE_OBJECT_FLAGS(0),
+            None,
+            None,
+            &mut size,
+        )
+    }?;
+    let mut out = vec![0u8; size as usize];
+    // SAFETY: out sized per query.
+    unsafe {
+        windows::Win32::Security::Cryptography::CryptEncodeObjectEx(
+            X509_ASN_ENCODING,
+            struct_type,
+            value,
+            CRYPT_ENCODE_OBJECT_FLAGS(0),
+            None,
+            Some(out.as_mut_ptr().cast::<c_void>()),
+            &mut size,
+        )
+    }?;
+    out.truncate(size as usize);
+    Ok(out)
+}
+
+/// Build a single-RDN-per-component DN as `C=…, ST=…, L=…, O=…, CN=…`.
+#[cfg(any(test, feature = "test_helpers"))]
+fn unix_to_filetime(unix_secs: i64) -> windows::Win32::Foundation::FILETIME {
+    // FILETIME counts 100-ns intervals since 1601-01-01; Unix epoch is
+    // 1970-01-01 which is 11_644_473_600 seconds later.
+    let ticks = ((unix_secs + 11_644_473_600) as u64) * 10_000_000;
+    windows::Win32::Foundation::FILETIME {
+        dwLowDateTime: ticks as u32,
+        dwHighDateTime: (ticks >> 32) as u32,
+    }
+}
+
+#[cfg(any(test, feature = "test_helpers"))]
+fn encode_x500_name(
+    country: &str,
+    state: &str,
+    locality: &str,
+    organization: &str,
+    common_name: &str,
+) -> Result<Vec<u8>, windows_result::Error> {
+    use windows::Win32::Security::Cryptography::CERT_NAME_INFO;
+    use windows::Win32::Security::Cryptography::CERT_RDN;
+    use windows::Win32::Security::Cryptography::CERT_RDN_ATTR;
+    use windows::Win32::Security::Cryptography::CERT_RDN_PRINTABLE_STRING;
+
+    let mut rdn_entries: Vec<(PCSTR, Vec<u8>)> = vec![
+        (
+            windows::Win32::Security::Cryptography::szOID_COUNTRY_NAME,
+            country.as_bytes().to_vec(),
+        ),
+        (
+            windows::Win32::Security::Cryptography::szOID_STATE_OR_PROVINCE_NAME,
+            state.as_bytes().to_vec(),
+        ),
+        (
+            windows::Win32::Security::Cryptography::szOID_LOCALITY_NAME,
+            locality.as_bytes().to_vec(),
+        ),
+        (
+            windows::Win32::Security::Cryptography::szOID_ORGANIZATION_NAME,
+            organization.as_bytes().to_vec(),
+        ),
+        (szOID_COMMON_NAME, common_name.as_bytes().to_vec()),
+    ];
+
+    // Build CERT_RDN_ATTR list and one CERT_RDN per attribute (each in its
+    // own RDN so the resulting DN is fully ordered).
+    let mut attrs: Vec<CERT_RDN_ATTR> = Vec::with_capacity(rdn_entries.len());
+    for (oid, bytes) in &mut rdn_entries {
+        attrs.push(CERT_RDN_ATTR {
+            pszObjId: windows::core::PSTR(oid.0.cast_mut()),
+            dwValueType: CERT_RDN_PRINTABLE_STRING.0 as u32,
+            Value: CRYPT_INTEGER_BLOB {
+                cbData: bytes.len() as u32,
+                pbData: bytes.as_mut_ptr(),
+            },
+        });
+    }
+    let mut rdns: Vec<CERT_RDN> = attrs
+        .iter_mut()
+        .map(|a| CERT_RDN {
+            cRDNAttr: 1,
+            rgRDNAttr: std::ptr::from_mut(a),
+        })
+        .collect();
+    let name_info = CERT_NAME_INFO {
+        cRDN: rdns.len() as u32,
+        rgRDN: rdns.as_mut_ptr(),
+    };
+    let out = encode_object(
+        windows::Win32::Security::Cryptography::X509_NAME,
+        std::ptr::from_ref(&name_info).cast(),
+    )?;
+    drop(rdns);
+    drop(attrs);
+    drop(rdn_entries);
+    Ok(out)
+}
+
+/// Encode a PKCS#1 RSAPublicKey (`SEQUENCE { INTEGER n, INTEGER e }`) by
+/// asking CryptoAPI to encode a `BCRYPT_RSAKEY_BLOB` via the
+/// `CNG_RSA_PUBLIC_KEY_BLOB` struct type.
+#[cfg(any(test, feature = "test_helpers"))]
+fn encode_pkcs1_rsa_pubkey(n: &[u8], e: &[u8]) -> Result<Vec<u8>, windows_result::Error> {
+    use windows::Win32::Security::Cryptography::BCRYPT_RSAKEY_BLOB;
+    use windows::Win32::Security::Cryptography::BCRYPT_RSAPUBLIC_MAGIC;
+    use windows::Win32::Security::Cryptography::CNG_RSA_PUBLIC_KEY_BLOB;
+
+    // Compute bit length of the modulus (big-endian, ignoring leading zeros).
+    let bit_length = {
+        let mut bits = 0u32;
+        for (i, &b) in n.iter().enumerate() {
+            if b != 0 {
+                bits = ((n.len() - i) as u32) * 8 - b.leading_zeros();
+                break;
+            }
+        }
+        bits
+    };
+
+    let header = BCRYPT_RSAKEY_BLOB {
+        Magic: BCRYPT_RSAPUBLIC_MAGIC,
+        BitLength: bit_length,
+        cbPublicExp: e.len() as u32,
+        cbModulus: n.len() as u32,
+        cbPrime1: 0,
+        cbPrime2: 0,
+    };
+
+    let mut blob = Vec::with_capacity(size_of::<BCRYPT_RSAKEY_BLOB>() + e.len() + n.len());
+    // SAFETY: BCRYPT_RSAKEY_BLOB is #[repr(C)] with all-integer fields, so
+    // any byte pattern is a valid representation.
+    blob.extend_from_slice(unsafe {
+        std::slice::from_raw_parts(
+            std::ptr::from_ref(&header).cast::<u8>(),
+            size_of::<BCRYPT_RSAKEY_BLOB>(),
+        )
+    });
+    blob.extend_from_slice(e);
+    blob.extend_from_slice(n);
+
+    encode_object(CNG_RSA_PUBLIC_KEY_BLOB, blob.as_ptr().cast())
+}


### PR DESCRIPTION
These will be used with the upcoming generic PKCS7 code.