### PR TITLE
vmm_tests: add whole-VM test for -net dio

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6227,6 +6227,7 @@ dependencies = [
  "vmm_core_defs",
  "vmotherboard",
  "vmsocket",
+ "vmswitch",
  "vtl2_settings_proto",
  "windows-version",
  "x86defs",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10411,6 +10411,7 @@ dependencies = [
  "pal",
  "pal_async",
  "pal_event",
+ "serde_json",
  "thiserror 2.0.16",
  "tracing",
  "widestring",

--- a/openvmm/openvmm_entry/src/lib.rs
+++ b/openvmm/openvmm_entry/src/lib.rs
@@ -652,9 +652,9 @@ async fn vm_config_from_command_line(
         };
 
         let switch_id = if switch_id == "default" {
-            DEFAULT_SWITCH
+            None
         } else {
-            switch_id
+            Some(switch_id.as_str())
         };
         let (port_id, port) = new_switch_port(switch_id)?;
         resources.switch_ports.push(port);
@@ -1823,17 +1823,17 @@ fn cleanup_socket(path: &Path) {
 }
 
 #[cfg(windows)]
-const DEFAULT_SWITCH: &str = "C08CB7B8-9B3C-408E-8E30-5E16A3AEB444";
-
-#[cfg(windows)]
 fn new_switch_port(
-    switch_id: &str,
+    switch_id: Option<&str>,
 ) -> anyhow::Result<(
     openvmm_defs::config::SwitchPortId,
     vmswitch::kernel::SwitchPort,
 )> {
     let id = vmswitch::kernel::SwitchPortId {
-        switch: switch_id.parse().context("invalid switch id")?,
+        switch: match switch_id {
+            Some(s) => s.parse().context("invalid switch id")?,
+            None => vmswitch::hcn::DEFAULT_SWITCH,
+        },
         port: Guid::new_random(),
     };
     let _ = vmswitch::hcn::Network::open(&id.switch)
@@ -1883,7 +1883,7 @@ fn parse_endpoint(
         EndpointConfigCli::Dio { id } => {
             #[cfg(windows)]
             {
-                let (port_id, port) = new_switch_port(id.as_deref().unwrap_or(DEFAULT_SWITCH))?;
+                let (port_id, port) = new_switch_port(id.as_deref())?;
                 resources.switch_ports.push(port);
                 net_backend_resources::dio::WindowsDirectIoHandle {
                     switch_port_id: net_backend_resources::dio::SwitchPortId {

--- a/petri/Cargo.toml
+++ b/petri/Cargo.toml
@@ -93,6 +93,7 @@ disk_backend.workspace = true
 disk_vhdmp.workspace = true
 powershell_builder.workspace = true
 vmsocket.workspace = true
+vmswitch.workspace = true
 windows-version.workspace = true
 
 [target.'cfg(target_arch = "x86_64")'.dependencies]

--- a/petri/src/vm/openvmm/construct.rs
+++ b/petri/src/vm/openvmm/construct.rs
@@ -668,6 +668,8 @@ impl PetriVmConfigOpenVmm {
                 vtl2_vsock_path,
                 _vsock_path: vsock_path,
                 properties,
+                #[cfg(windows)]
+                _switch_ports: Vec::new(),
             },
 
             openvmm_log_file: log_source.log_file("openvmm")?,

--- a/petri/src/vm/openvmm/mod.rs
+++ b/petri/src/vm/openvmm/mod.rs
@@ -197,6 +197,36 @@ struct PetriVmResourcesOpenVmm {
 
     // properties needed at runtime
     properties: PetriVmProperties,
+
+    // vmswitch DirectIO switch port handles, held in the test (parent)
+    // process for the lifetime of the child VMM so the kernel port object
+    // survives until the VMM detaches.
+    #[cfg(windows)]
+    _switch_ports: Vec<vmswitch::kernel::SwitchPort>,
+}
+
+/// The GUID of the Hyper-V Default Switch, which provides NAT'd networking
+/// when Hyper-V is installed.
+#[cfg(windows)]
+pub const DEFAULT_SWITCH_GUID: Guid = guid::guid!("c08cb7b8-9b3c-408e-8e30-5e16a3aeb444");
+
+/// Returns whether the Hyper-V Default Switch is available on this host.
+///
+/// This is `true` only on Windows hosts where Hyper-V is installed and the
+/// Default Switch network is reachable. Tests that require DirectIO (`-net
+/// dio`) networking should use this to skip gracefully on hosts that do not
+/// meet the requirements.
+#[cfg(windows)]
+pub fn default_switch_available() -> bool {
+    vmswitch::hcn::Network::open(&DEFAULT_SWITCH_GUID).is_ok()
+}
+
+/// Returns whether the Hyper-V Default Switch is available on this host.
+///
+/// Always `false` on non-Windows platforms.
+#[cfg(not(windows))]
+pub fn default_switch_available() -> bool {
+    false
 }
 
 async fn memdiff_disk(path: &Path) -> anyhow::Result<Resource<DiskHandleKind>> {

--- a/petri/src/vm/openvmm/mod.rs
+++ b/petri/src/vm/openvmm/mod.rs
@@ -205,28 +205,52 @@ struct PetriVmResourcesOpenVmm {
     _switch_ports: Vec<vmswitch::kernel::SwitchPort>,
 }
 
-/// The GUID of the Hyper-V Default Switch, which provides NAT'd networking
-/// when Hyper-V is installed.
-#[cfg(windows)]
-pub const DEFAULT_SWITCH_GUID: Guid = guid::guid!("c08cb7b8-9b3c-408e-8e30-5e16a3aeb444");
-
-/// Returns whether the Hyper-V Default Switch is available on this host.
+/// Discovers a usable Hyper-V virtual switch for `-net dio` tests.
 ///
-/// This is `true` only on Windows hosts where Hyper-V is installed and the
-/// Default Switch network is reachable. Tests that require DirectIO (`-net
-/// dio`) networking should use this to skip gracefully on hosts that do not
-/// meet the requirements.
+/// Tries the well-known Default Switch GUID first (which is provisioned
+/// automatically when Hyper-V is installed). If that switch is not
+/// available (e.g. it was removed, or this host uses a different default
+/// switch SKU), falls back to enumerating all HCN networks and returning
+/// the first one reported.
+///
+/// Returns `None` when no switch can be opened — typically because
+/// Hyper-V is not installed, the user lacks privileges, or
+/// `computenetwork.dll` is missing.
 #[cfg(windows)]
-pub fn default_switch_available() -> bool {
-    vmswitch::hcn::Network::open(&DEFAULT_SWITCH_GUID).is_ok()
+pub fn find_switch() -> Option<Guid> {
+    if vmswitch::hcn::Network::open(&vmswitch::hcn::DEFAULT_SWITCH).is_ok() {
+        return Some(vmswitch::hcn::DEFAULT_SWITCH);
+    }
+    let networks = match vmswitch::hcn::enumerate_networks() {
+        Ok(n) => n,
+        Err(e) => {
+            tracing::warn!(
+                error = &e as &dyn std::error::Error,
+                "failed to enumerate HCN networks"
+            );
+            return None;
+        }
+    };
+    networks.into_iter().find(|guid| {
+        if let Err(e) = vmswitch::hcn::Network::open(guid) {
+            tracing::debug!(
+                %guid,
+                error = &e as &dyn std::error::Error,
+                "skipping unopenable HCN network"
+            );
+            false
+        } else {
+            true
+        }
+    })
 }
 
-/// Returns whether the Hyper-V Default Switch is available on this host.
+/// Discovers a usable Hyper-V virtual switch.
 ///
-/// Always `false` on non-Windows platforms.
+/// Always `None` on non-Windows platforms.
 #[cfg(not(windows))]
-pub fn default_switch_available() -> bool {
-    false
+pub fn find_switch() -> Option<Guid> {
+    None
 }
 
 async fn memdiff_disk(path: &Path) -> anyhow::Result<Resource<DiskHandleKind>> {

--- a/petri/src/vm/openvmm/modify.rs
+++ b/petri/src/vm/openvmm/modify.rs
@@ -208,11 +208,11 @@ impl PetriVmConfigOpenVmm {
     ///
     /// `switch_id`, when `None`, defaults to the Hyper-V Default Switch.
     /// This requires the host to have Hyper-V installed and the chosen
-    /// switch available; tests that call this method must gate themselves
-    /// behind [`super::default_switch_available`] (or an equivalent
-    /// runtime probe) to skip gracefully on hosts that do not meet those
-    /// requirements. The method panics if the switch cannot be opened or
-    /// a port cannot be created.
+    /// switch available; tests that call this method should pre-resolve
+    /// a switch via [`super::find_switch`] (or an equivalent runtime
+    /// probe) and bail out with a clear error when the host does not
+    /// meet those requirements. The method itself panics if the switch
+    /// cannot be opened or a port cannot be created.
     ///
     /// The created vmswitch port handle is held in the petri (parent)
     /// process for the lifetime of the VM. The kernel switch port object
@@ -221,7 +221,7 @@ impl PetriVmConfigOpenVmm {
     #[cfg(windows)]
     pub fn with_dio_nic(mut self, switch_id: Option<Guid>) -> Self {
         let switch_port_id = vmswitch::kernel::SwitchPortId {
-            switch: switch_id.unwrap_or(super::DEFAULT_SWITCH_GUID),
+            switch: switch_id.unwrap_or(vmswitch::hcn::DEFAULT_SWITCH),
             port: Guid::new_random(),
         };
         let _ = vmswitch::hcn::Network::open(&switch_port_id.switch)

--- a/petri/src/vm/openvmm/modify.rs
+++ b/petri/src/vm/openvmm/modify.rs
@@ -203,6 +203,78 @@ impl PetriVmConfigOpenVmm {
         self
     }
 
+    /// Enable a synthnic for the VM backed by the Windows vmswitch
+    /// DirectIO (`-net dio`) backend.
+    ///
+    /// `switch_id`, when `None`, defaults to the Hyper-V Default Switch.
+    /// This requires the host to have Hyper-V installed and the chosen
+    /// switch available; tests that call this method must gate themselves
+    /// behind [`super::default_switch_available`] (or an equivalent
+    /// runtime probe) to skip gracefully on hosts that do not meet those
+    /// requirements. The method panics if the switch cannot be opened or
+    /// a port cannot be created.
+    ///
+    /// The created vmswitch port handle is held in the petri (parent)
+    /// process for the lifetime of the VM. The kernel switch port object
+    /// is reference counted, so keeping the handle alive in this process
+    /// keeps the port usable from the child VMM process.
+    #[cfg(windows)]
+    pub fn with_dio_nic(mut self, switch_id: Option<Guid>) -> Self {
+        let switch_port_id = vmswitch::kernel::SwitchPortId {
+            switch: switch_id.unwrap_or(super::DEFAULT_SWITCH_GUID),
+            port: Guid::new_random(),
+        };
+        let _ = vmswitch::hcn::Network::open(&switch_port_id.switch)
+            .unwrap_or_else(|e| panic!("could not find switch {}: {e}", switch_port_id.switch));
+        let switch_port = vmswitch::kernel::SwitchPort::new(&switch_port_id)
+            .expect("failed to create vmswitch DIO port");
+        self.resources._switch_ports.push(switch_port);
+
+        let endpoint = net_backend_resources::dio::WindowsDirectIoHandle {
+            switch_port_id: net_backend_resources::dio::SwitchPortId {
+                switch: switch_port_id.switch,
+                port: switch_port_id.port,
+            },
+        }
+        .into_resource();
+
+        if let Some(vtl2_settings) = self.runtime_config.vtl2_settings.as_mut() {
+            self.config.vpci_devices.push(VpciDeviceConfig {
+                vtl: DeviceVtl::Vtl2,
+                instance_id: MANA_INSTANCE,
+                resource: GdmaDeviceHandle {
+                    vports: vec![VportDefinition {
+                        mac_address: NIC_MAC_ADDRESS,
+                        endpoint,
+                    }],
+                }
+                .into_resource(),
+            });
+
+            vtl2_settings.dynamic.as_mut().unwrap().nic_devices.push(
+                vtl2_settings_proto::NicDeviceLegacy {
+                    instance_id: MANA_INSTANCE.to_string(),
+                    subordinate_instance_id: None,
+                    max_sub_channels: None,
+                },
+            );
+        } else {
+            const NETVSP_DIO_INSTANCE: Guid = guid::guid!("d1ff4c5a-1b3c-4f0d-8e10-1b9d8b1d1cee");
+            self.config.vmbus_devices.push((
+                DeviceVtl::Vtl0,
+                netvsp_resources::NetvspHandle {
+                    instance_id: NETVSP_DIO_INSTANCE,
+                    mac_address: NIC_MAC_ADDRESS,
+                    endpoint,
+                    max_queues: None,
+                }
+                .into_resource(),
+            ));
+        }
+
+        self
+    }
+
     /// Load with the specified VTL2 relocation mode.
     pub fn with_vtl2_relocation_mode(mut self, mode: Vtl2BaseAddressType) -> Self {
         let LoadMode::Igvm {

--- a/vm/devices/net/vmswitch/Cargo.toml
+++ b/vm/devices/net/vmswitch/Cargo.toml
@@ -20,6 +20,7 @@ widestring.workspace = true
 windows-sys = { workspace = true, features = [
   "Win32_Foundation",
   "Win32_Storage_FileSystem",
+  "Win32_System_Com",
   "Win32_System_IO",
   "Win32_System_Threading",
 ] }

--- a/vm/devices/net/vmswitch/Cargo.toml
+++ b/vm/devices/net/vmswitch/Cargo.toml
@@ -14,6 +14,7 @@ pal_async.workspace = true
 
 futures.workspace = true
 getrandom.workspace = true
+serde_json = { workspace = true, features = ["std"] }
 thiserror.workspace = true
 tracing.workspace = true
 widestring.workspace = true

--- a/vm/devices/net/vmswitch/src/dio.rs
+++ b/vm/devices/net/vmswitch/src/dio.rs
@@ -358,7 +358,7 @@ mod tests {
         let mut e = DioNic::new(vm_id, "nic", "my nic", MAC_ADDRESS).unwrap();
         // Connect to the Default Switch by well-known GUID.
         let id = SwitchPortId {
-            switch: "C08CB7B8-9B3C-408E-8E30-5E16A3AEB444".parse().unwrap(),
+            switch: crate::hcn::DEFAULT_SWITCH,
             port: Guid::new_random(),
         };
         let port = SwitchPort::new(&id).unwrap();

--- a/vm/devices/net/vmswitch/src/hcn.rs
+++ b/vm/devices/net/vmswitch/src/hcn.rs
@@ -6,10 +6,13 @@ use std::ffi::c_void;
 use std::ptr::NonNull;
 use std::ptr::null_mut;
 use thiserror::Error;
+use widestring::U16CStr;
+use windows_sys::Win32::System::Com::CoTaskMemFree;
 
 pal::delayload!("computenetwork.dll" {
     fn HcnOpenNetwork(id: &Guid, network: &mut *mut c_void, error_record: *mut *mut u16) -> i32;
     fn HcnCloseNetwork(network: NonNull<c_void>) -> i32;
+    fn HcnEnumerateNetworks(query: *const u16, networks: &mut *mut u16, error_record: *mut *mut u16) -> i32;
 });
 
 #[derive(Debug, Error)]
@@ -54,4 +57,56 @@ impl Drop for Network {
             );
         }
     }
+}
+
+/// The well-known GUID of the Hyper-V Default Switch.
+///
+/// Provisioned automatically when the Hyper-V optional feature is
+/// installed; provides a NAT'd network for VMs.
+pub const DEFAULT_SWITCH: Guid = guid::guid!("c08cb7b8-9b3c-408e-8e30-5e16a3aeb444");
+
+/// Returns the GUIDs of all HCN networks (vmswitches) currently
+/// registered on the host, in the order reported by HCN.
+///
+/// On a host without Hyper-V installed, or where `computenetwork.dll`
+/// cannot be loaded, this returns an error.
+pub fn enumerate_networks() -> Result<Vec<Guid>, Error> {
+    let mut raw: *mut u16 = null_mut();
+    chk("enumerate", unsafe {
+        HcnEnumerateNetworks(null_mut(), &mut raw, null_mut())
+    })?;
+    if raw.is_null() {
+        return Ok(Vec::new());
+    }
+    // SAFETY: HcnEnumerateNetworks returns a NUL-terminated UTF-16
+    // string allocated via CoTaskMemAlloc. We own the buffer until we
+    // free it with CoTaskMemFree below.
+    let json = unsafe { U16CStr::from_ptr_str(raw) }.to_string_lossy();
+    // SAFETY: per HCN API contract, the returned buffer must be freed
+    // with CoTaskMemFree.
+    unsafe { CoTaskMemFree(raw.cast()) };
+    Ok(extract_guids(&json))
+}
+
+/// Pull every GUID-shaped substring out of `s`.
+///
+/// HcnEnumerateNetworks returns a JSON array of GUID strings (with or
+/// without surrounding braces). Rather than depend on a JSON parser for
+/// this single use, we scan for 36-character GUID patterns directly,
+/// which is robust to either format.
+fn extract_guids(s: &str) -> Vec<Guid> {
+    let bytes = s.as_bytes();
+    let mut out = Vec::new();
+    let mut i = 0;
+    while i + 36 <= bytes.len() {
+        if let Ok(slice) = std::str::from_utf8(&bytes[i..i + 36]) {
+            if let Ok(g) = slice.parse::<Guid>() {
+                out.push(g);
+                i += 36;
+                continue;
+            }
+        }
+        i += 1;
+    }
+    out
 }

--- a/vm/devices/net/vmswitch/src/hcn.rs
+++ b/vm/devices/net/vmswitch/src/hcn.rs
@@ -85,28 +85,68 @@ pub fn enumerate_networks() -> Result<Vec<Guid>, Error> {
     // SAFETY: per HCN API contract, the returned buffer must be freed
     // with CoTaskMemFree.
     unsafe { CoTaskMemFree(raw.cast()) };
-    Ok(extract_guids(&json))
+    parse_network_ids(&json)
 }
 
-/// Pull every GUID-shaped substring out of `s`.
-///
-/// HcnEnumerateNetworks returns a JSON array of GUID strings (with or
-/// without surrounding braces). Rather than depend on a JSON parser for
-/// this single use, we scan for 36-character GUID patterns directly,
-/// which is robust to either format.
-fn extract_guids(s: &str) -> Vec<Guid> {
-    let bytes = s.as_bytes();
-    let mut out = Vec::new();
-    let mut i = 0;
-    while i + 36 <= bytes.len() {
-        if let Ok(slice) = std::str::from_utf8(&bytes[i..i + 36]) {
-            if let Ok(g) = slice.parse::<Guid>() {
-                out.push(g);
-                i += 36;
-                continue;
-            }
+/// Parse the JSON array of GUID strings returned by `HcnEnumerateNetworks`,
+/// e.g. `["e2af8db9-d4e4-42ff-a695-85a71b928dd0", ...]`.
+fn parse_network_ids(json: &str) -> Result<Vec<Guid>, Error> {
+    fn parse_err(err: impl Into<Box<dyn std::error::Error + Send + Sync>>) -> Error {
+        Error {
+            operation: "parse",
+            err: std::io::Error::new(std::io::ErrorKind::InvalidData, err),
         }
-        i += 1;
     }
-    out
+    let ids: Vec<String> = serde_json::from_str(json).map_err(parse_err)?;
+    ids.iter()
+        .map(|id| id.parse::<Guid>().map_err(parse_err))
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_network_ids;
+    use guid::Guid;
+
+    #[test]
+    fn parse_plain_array() {
+        let json =
+            r#"["e2af8db9-d4e4-42ff-a695-85a71b928dd0","b807c2d2-0db8-401a-994a-840d4c0769b1"]"#;
+        let guids = parse_network_ids(json).unwrap();
+        assert_eq!(
+            guids,
+            vec![
+                "e2af8db9-d4e4-42ff-a695-85a71b928dd0"
+                    .parse::<Guid>()
+                    .unwrap(),
+                "b807c2d2-0db8-401a-994a-840d4c0769b1"
+                    .parse::<Guid>()
+                    .unwrap(),
+            ]
+        );
+    }
+
+    #[test]
+    fn parse_braced_guids() {
+        let json = r#"["{e2af8db9-d4e4-42ff-a695-85a71b928dd0}"]"#;
+        let guids = parse_network_ids(json).unwrap();
+        assert_eq!(
+            guids,
+            vec![
+                "e2af8db9-d4e4-42ff-a695-85a71b928dd0"
+                    .parse::<Guid>()
+                    .unwrap()
+            ]
+        );
+    }
+
+    #[test]
+    fn parse_empty_array() {
+        assert!(parse_network_ids("[]").unwrap().is_empty());
+    }
+
+    #[test]
+    fn parse_invalid_json_fails() {
+        assert!(parse_network_ids("not json").is_err());
+    }
 }

--- a/vmm_tests/vmm_tests/tests/tests/multiarch.rs
+++ b/vmm_tests/vmm_tests/tests/tests/multiarch.rs
@@ -23,7 +23,7 @@ use vmm_test_macros::openvmm_test;
 use vmm_test_macros::vmm_test;
 use vmm_test_macros::vmm_test_with;
 
-/// Smoke test for the Windows DirectIO (`-net dio`) network backend.
+/// Test for the Windows DirectIO (`-net dio`) network backend.
 mod dio_nic;
 /// Tests for Hyper-V integration components.
 mod ic;

--- a/vmm_tests/vmm_tests/tests/tests/multiarch.rs
+++ b/vmm_tests/vmm_tests/tests/tests/multiarch.rs
@@ -23,6 +23,8 @@ use vmm_test_macros::openvmm_test;
 use vmm_test_macros::vmm_test;
 use vmm_test_macros::vmm_test_with;
 
+/// Smoke test for the Windows DirectIO (`-net dio`) network backend.
+mod dio_nic;
 /// Tests for Hyper-V integration components.
 mod ic;
 // Memory Validation tests.

--- a/vmm_tests/vmm_tests/tests/tests/multiarch/dio_nic.rs
+++ b/vmm_tests/vmm_tests/tests/tests/multiarch/dio_nic.rs
@@ -26,12 +26,15 @@
 #![cfg(windows)]
 
 use anyhow::Context;
+use pal_async::DefaultDriver;
+use pal_async::timer::PolledTimer;
 use petri::PetriVmBuilder;
 use petri::openvmm::NIC_MAC_ADDRESS;
 use petri::openvmm::OpenVmmPetriBackend;
 use petri::openvmm::find_switch;
 use petri::pipette::cmd;
 use pipette_client::shell::UnixShell;
+use std::time::Duration;
 use vmm_test_macros::openvmm_test;
 
 /// Find the network interface matching [`NIC_MAC_ADDRESS`] by scanning
@@ -84,7 +87,11 @@ fn parse_default_gw(route: &str, iface: &str) -> anyhow::Result<String> {
 
 /// End-to-end test for `-net dio`.
 #[openvmm_test(uefi_x64(vhd(ubuntu_2504_server_x64)))]
-async fn dio_nic(config: PetriVmBuilder<OpenVmmPetriBackend>) -> anyhow::Result<()> {
+async fn dio_nic(
+    config: PetriVmBuilder<OpenVmmPetriBackend>,
+    _: (),
+    driver: DefaultDriver,
+) -> anyhow::Result<()> {
     let switch = find_switch().ok_or_else(|| {
         anyhow::anyhow!(
             "no Hyper-V vmswitch could be opened on this host (Default Switch absent and \
@@ -104,20 +111,49 @@ async fn dio_nic(config: PetriVmBuilder<OpenVmmPetriBackend>) -> anyhow::Result<
     let iface = find_nic_by_mac(&sh).await?;
     tracing::info!(iface, "found DIO-backed NIC interface");
 
-    // Bring the interface up and request a DHCP lease from the Default
-    // Switch's NAT. The image ships busybox `udhcpc`.
+    // Configure systemd-networkd to DHCP this interface and reload. The
+    // Ubuntu cloud image runs systemd-networkd as its default network
+    // manager, and cloud-init's network-config drop-in for `eth0` may
+    // have raced the link bring-up of the DIO NIC, so we install an
+    // explicit drop-in matched by name and ask networkd to reconfigure.
     cmd!(sh, "ip link set {iface} up").run().await?;
-    cmd!(sh, "udhcpc -i {iface} -q -f -n -t 10 -T 3")
+    let drop_in = format!("[Match]\nName={iface}\n\n[Network]\nDHCP=ipv4\n");
+    cmd!(sh, "mkdir -p /run/systemd/network").run().await?;
+    cmd!(sh, "tee /run/systemd/network/99-petri-dio.network")
+        .stdin(drop_in)
+        .ignore_stdout()
         .run()
         .await
-        .context("DHCP failed on DIO-backed NIC")?;
+        .context("failed to write systemd-networkd drop-in")?;
+    cmd!(sh, "networkctl reload")
+        .run()
+        .await
+        .context("networkctl reload failed")?;
+    cmd!(sh, "networkctl reconfigure {iface}")
+        .ignore_status()
+        .run()
+        .await?;
 
-    let addr = cmd!(sh, "ip -4 -br addr show {iface}").read().await?;
-    tracing::info!(addr, "ipv4 lease on DIO-backed NIC");
-    assert!(
-        addr.contains('/'),
-        "expected an IPv4 lease on {iface}, got: {addr}"
+    // Poll for an IPv4 lease from the Default Switch's NAT.
+    let mut timer = PolledTimer::new(&driver);
+    let mut addr = String::new();
+    let mut got_lease = false;
+    for _ in 0..30 {
+        addr = cmd!(sh, "ip -4 -br addr show {iface}").read().await?;
+        if addr
+            .split_whitespace()
+            .any(|w| w.contains('/') && w.contains('.'))
+        {
+            got_lease = true;
+            break;
+        }
+        timer.sleep(Duration::from_secs(1)).await;
+    }
+    anyhow::ensure!(
+        got_lease,
+        "no IPv4 lease on {iface} after 30s; current addrs: {addr}"
     );
+    tracing::info!(addr, "ipv4 lease on DIO-backed NIC");
 
     let route = cmd!(sh, "ip route show default").read().await?;
     tracing::info!(route, "default route");

--- a/vmm_tests/vmm_tests/tests/tests/multiarch/dio_nic.rs
+++ b/vmm_tests/vmm_tests/tests/tests/multiarch/dio_nic.rs
@@ -1,25 +1,27 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-//! Smoke test for the Windows vmswitch DirectIO (`-net dio`) network
-//! backend.
+//! End-to-end test for the Windows vmswitch DirectIO (`-net dio`)
+//! network backend.
 //!
 //! This is the only whole-VM test that exercises the `net_dio` endpoint,
 //! resolver, and queue, and the vmswitch `SwitchPort` interop. All other
 //! petri NIC helpers go through the userspace `Consomme` backend.
 //!
-//! **Scope:** Boot a Linux UEFI guest with a synthetic NIC bridged to the
-//! Hyper-V Default Switch via DirectIO. DHCP an IPv4 lease from the
-//! Default Switch's NAT and verify a default route exists. Ping the
-//! gateway to drive packets through
-//! `netvsp` → `DioEndpoint::tx_avail` → `vmswitch` and back, which is
-//! the meaningful regression signal for `-net dio`.
+//! **Scope:** Boot a Linux UEFI guest with a synthetic NIC bridged to a
+//! Hyper-V vmswitch via DirectIO. DHCP an IPv4 lease from the switch's
+//! NAT and verify a default route exists. Ping the gateway to drive
+//! packets through `netvsp` → `DioEndpoint::tx_avail` → `vmswitch` and
+//! back, which is the meaningful regression signal for `-net dio`.
 //!
-//! **Host requirements:** Windows host with Hyper-V installed and the
-//! Default Switch available. The test self-skips with a warning when
-//! those requirements are not met (Hyper-V not installed, Default
-//! Switch removed, etc.). On non-Windows hosts the test is gated out at
-//! compile time.
+//! **Host requirements:** Windows host with Hyper-V installed and at
+//! least one vmswitch (the Default Switch by preference). The test
+//! discovers a switch at runtime — preferring the well-known Default
+//! Switch GUID, falling back to the first switch reported by HCN — and
+//! fails fast (rather than silently skipping) when no switch can be
+//! found, so that a missing Hyper-V install in CI is reported as a
+//! regression instead of being mistaken for success. On non-Windows
+//! hosts the test is gated out at compile time.
 
 #![cfg(windows)]
 
@@ -27,7 +29,7 @@ use anyhow::Context;
 use petri::PetriVmBuilder;
 use petri::openvmm::NIC_MAC_ADDRESS;
 use petri::openvmm::OpenVmmPetriBackend;
-use petri::openvmm::default_switch_available;
+use petri::openvmm::find_switch;
 use petri::pipette::cmd;
 use pipette_client::shell::UnixShell;
 use vmm_test_macros::openvmm_test;
@@ -52,37 +54,49 @@ async fn find_nic_by_mac(sh: &UnixShell<'_>) -> anyhow::Result<String> {
     anyhow::bail!("no interface found with MAC address {expected_mac}")
 }
 
-/// Parse the IPv4 gateway from `ip route show default` output.
+/// Parse the IPv4 gateway from `ip route show default` output, requiring
+/// an exact `dev <iface>` match so we do not pick up a sibling interface
+/// whose name is a substring of `iface` (e.g. `eth0` vs `eth0.100`).
 fn parse_default_gw(route: &str, iface: &str) -> anyhow::Result<String> {
     for line in route.lines() {
-        if !line.contains(iface) {
-            continue;
-        }
-        // Expected form: "default via 172.x.y.z dev <iface> ..."
         let mut tokens = line.split_whitespace();
+        let mut gateway: Option<&str> = None;
+        let mut dev_matches = false;
         while let Some(tok) = tokens.next() {
-            if tok == "via" {
-                if let Some(gw) = tokens.next() {
-                    return Ok(gw.to_string());
+            match tok {
+                "via" => gateway = tokens.next(),
+                "dev" => {
+                    if tokens.next() == Some(iface) {
+                        dev_matches = true;
+                    }
                 }
+                _ => {}
+            }
+        }
+        if dev_matches {
+            if let Some(gw) = gateway {
+                return Ok(gw.to_string());
             }
         }
     }
     anyhow::bail!("no default route via {iface} found in: {route}")
 }
 
-/// End-to-end smoke test for `-net dio`.
+/// End-to-end test for `-net dio`.
 #[openvmm_test(uefi_x64(vhd(ubuntu_2504_server_x64)))]
-async fn dio_nic_smoke(config: PetriVmBuilder<OpenVmmPetriBackend>) -> anyhow::Result<()> {
-    if !default_switch_available() {
-        tracing::warn!(
-            "skipping dio_nic_smoke: Hyper-V Default Switch is not available on this host"
-        );
-        return Ok(());
-    }
+async fn dio_nic(config: PetriVmBuilder<OpenVmmPetriBackend>) -> anyhow::Result<()> {
+    let switch = find_switch().ok_or_else(|| {
+        anyhow::anyhow!(
+            "no Hyper-V vmswitch could be opened on this host (Default Switch absent and \
+             HCN enumeration returned nothing); DIO test cannot run. If the runner \
+             intentionally lacks Hyper-V, exclude this test by filter rather than letting \
+             it silently no-op."
+        )
+    })?;
+    tracing::info!(%switch, "using vmswitch for DIO test");
 
     let (vm, agent) = config
-        .modify_backend(|c| c.with_dio_nic(None))
+        .modify_backend(move |c| c.with_dio_nic(Some(switch)))
         .run()
         .await?;
     let sh = agent.unix_shell();

--- a/vmm_tests/vmm_tests/tests/tests/multiarch/dio_nic.rs
+++ b/vmm_tests/vmm_tests/tests/tests/multiarch/dio_nic.rs
@@ -1,0 +1,124 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Smoke test for the Windows vmswitch DirectIO (`-net dio`) network
+//! backend.
+//!
+//! This is the only whole-VM test that exercises the `net_dio` endpoint,
+//! resolver, and queue, and the vmswitch `SwitchPort` interop. All other
+//! petri NIC helpers go through the userspace `Consomme` backend.
+//!
+//! **Scope:** Boot a Linux UEFI guest with a synthetic NIC bridged to the
+//! Hyper-V Default Switch via DirectIO. DHCP an IPv4 lease from the
+//! Default Switch's NAT and verify a default route exists. Ping the
+//! gateway to drive packets through
+//! `netvsp` → `DioEndpoint::tx_avail` → `vmswitch` and back, which is
+//! the meaningful regression signal for `-net dio`.
+//!
+//! **Host requirements:** Windows host with Hyper-V installed and the
+//! Default Switch available. The test self-skips with a warning when
+//! those requirements are not met (Hyper-V not installed, Default
+//! Switch removed, etc.). On non-Windows hosts the test is gated out at
+//! compile time.
+
+#![cfg(windows)]
+
+use anyhow::Context;
+use petri::PetriVmBuilder;
+use petri::openvmm::NIC_MAC_ADDRESS;
+use petri::openvmm::OpenVmmPetriBackend;
+use petri::openvmm::default_switch_available;
+use petri::pipette::cmd;
+use pipette_client::shell::UnixShell;
+use vmm_test_macros::openvmm_test;
+
+/// Find the network interface matching [`NIC_MAC_ADDRESS`] by scanning
+/// sysfs.
+async fn find_nic_by_mac(sh: &UnixShell<'_>) -> anyhow::Result<String> {
+    let expected_mac = NIC_MAC_ADDRESS.to_string().replace('-', ":");
+    let ifaces = cmd!(sh, "ls /sys/class/net").read().await?;
+    for iface in ifaces.lines() {
+        let iface = iface.trim();
+        if iface.is_empty() {
+            continue;
+        }
+        let addr_path = format!("/sys/class/net/{iface}/address");
+        if let Ok(mac) = cmd!(sh, "cat {addr_path}").read().await {
+            if mac.trim().eq_ignore_ascii_case(&expected_mac) {
+                return Ok(iface.to_string());
+            }
+        }
+    }
+    anyhow::bail!("no interface found with MAC address {expected_mac}")
+}
+
+/// Parse the IPv4 gateway from `ip route show default` output.
+fn parse_default_gw(route: &str, iface: &str) -> anyhow::Result<String> {
+    for line in route.lines() {
+        if !line.contains(iface) {
+            continue;
+        }
+        // Expected form: "default via 172.x.y.z dev <iface> ..."
+        let mut tokens = line.split_whitespace();
+        while let Some(tok) = tokens.next() {
+            if tok == "via" {
+                if let Some(gw) = tokens.next() {
+                    return Ok(gw.to_string());
+                }
+            }
+        }
+    }
+    anyhow::bail!("no default route via {iface} found in: {route}")
+}
+
+/// End-to-end smoke test for `-net dio`.
+#[openvmm_test(uefi_x64(vhd(ubuntu_2504_server_x64)))]
+async fn dio_nic_smoke(config: PetriVmBuilder<OpenVmmPetriBackend>) -> anyhow::Result<()> {
+    if !default_switch_available() {
+        tracing::warn!(
+            "skipping dio_nic_smoke: Hyper-V Default Switch is not available on this host"
+        );
+        return Ok(());
+    }
+
+    let (vm, agent) = config
+        .modify_backend(|c| c.with_dio_nic(None))
+        .run()
+        .await?;
+    let sh = agent.unix_shell();
+
+    let iface = find_nic_by_mac(&sh).await?;
+    tracing::info!(iface, "found DIO-backed NIC interface");
+
+    // Bring the interface up and request a DHCP lease from the Default
+    // Switch's NAT. The image ships busybox `udhcpc`.
+    cmd!(sh, "ip link set {iface} up").run().await?;
+    cmd!(sh, "udhcpc -i {iface} -q -f -n -t 10 -T 3")
+        .run()
+        .await
+        .context("DHCP failed on DIO-backed NIC")?;
+
+    let addr = cmd!(sh, "ip -4 -br addr show {iface}").read().await?;
+    tracing::info!(addr, "ipv4 lease on DIO-backed NIC");
+    assert!(
+        addr.contains('/'),
+        "expected an IPv4 lease on {iface}, got: {addr}"
+    );
+
+    let route = cmd!(sh, "ip route show default").read().await?;
+    tracing::info!(route, "default route");
+    let gw = parse_default_gw(&route, &iface)?;
+    tracing::info!(gw, "pinging gateway");
+
+    // The ping is the meaningful regression signal: it pushes packets
+    // through the guest netvsc → host netvsp → DioEndpoint → vmswitch
+    // path and validates a response comes back.
+    cmd!(sh, "ping -c 3 -W 5 -I {iface} {gw}")
+        .run()
+        .await
+        .context("ping to gateway via DIO failed")?;
+
+    agent.power_off().await?;
+    vm.wait_for_clean_teardown().await?;
+    Ok(())
+}

--- a/vmm_tests/vmm_tests/tests/tests/multiarch/dio_nic.rs
+++ b/vmm_tests/vmm_tests/tests/tests/multiarch/dio_nic.rs
@@ -10,9 +10,14 @@
 //!
 //! **Scope:** Boot a Linux UEFI guest with a synthetic NIC bridged to a
 //! Hyper-V vmswitch via DirectIO. DHCP an IPv4 lease from the switch's
-//! NAT and verify a default route exists. Ping the gateway to drive
-//! packets through `netvsp` → `DioEndpoint::tx_avail` → `vmswitch` and
-//! back, which is the meaningful regression signal for `-net dio`.
+//! NAT and verify a default route exists. Resolve the gateway's MAC via
+//! ARP to drive packets through `netvsp` → `DioEndpoint::tx_avail` →
+//! `vmswitch` and back, which is the meaningful regression signal for
+//! `-net dio`. ICMP echo is intentionally *not* used as the assertion:
+//! the Hyper-V Default Switch gateway (the host vNIC) does not reliably
+//! answer pings — the host firewall blocks inbound echo by default — so a
+//! successful ARP resolution is the reliable, environment-independent
+//! signal that bidirectional traffic traversed the DIO datapath.
 //!
 //! **Host requirements:** Windows host with Hyper-V installed and at
 //! least one vmswitch (the Default Switch by preference). The test
@@ -83,6 +88,27 @@ fn parse_default_gw(route: &str, iface: &str) -> anyhow::Result<String> {
         }
     }
     anyhow::bail!("no default route via {iface} found in: {route}")
+}
+
+/// Parse the link-layer (MAC) address of a resolved neighbor from a
+/// single `ip neigh` entry, returning `Some(lladdr)` only when the entry
+/// proves an ARP reply was received: it must carry an `lladdr` token and
+/// must not be in a negative state (`FAILED`/`INCOMPLETE`). Entries that
+/// are still unresolved — or empty output when no entry exists yet —
+/// yield `None` so the caller can keep polling.
+fn parse_neigh_lladdr(neigh: &str) -> Option<String> {
+    // Reject negative states even if a stale lladdr happens to be present.
+    if neigh.contains("INCOMPLETE") || neigh.contains("FAILED") {
+        return None;
+    }
+    let mut tokens = neigh.split_whitespace();
+    let mut lladdr = None;
+    while let Some(tok) = tokens.next() {
+        if tok == "lladdr" {
+            lladdr = tokens.next().map(|s| s.to_string());
+        }
+    }
+    lladdr
 }
 
 /// End-to-end test for `-net dio`.
@@ -158,17 +184,94 @@ async fn dio_nic(
     let route = cmd!(sh, "ip route show default").read().await?;
     tracing::info!(route, "default route");
     let gw = parse_default_gw(&route, &iface)?;
-    tracing::info!(gw, "pinging gateway");
+    tracing::info!(gw, "resolving gateway via DIO");
 
-    // The ping is the meaningful regression signal: it pushes packets
-    // through the guest netvsc → host netvsp → DioEndpoint → vmswitch
-    // path and validates a response comes back.
-    cmd!(sh, "ping -c 3 -W 5 -I {iface} {gw}")
-        .run()
-        .await
-        .context("ping to gateway via DIO failed")?;
+    // Drive ARP resolution of the gateway across the DIO datapath. This is
+    // the meaningful regression signal: resolving the gateway's MAC pushes
+    // an ARP request through the guest netvsc → host netvsp → DioEndpoint →
+    // vmswitch path and requires a reply to come back along the same path.
+    //
+    // We deliberately do not assert on ICMP echo replies: the Hyper-V
+    // Default Switch gateway (the host vNIC) does not reliably answer pings
+    // and the host firewall blocks inbound echo by default. The ping below
+    // is only used to provoke neighbor resolution, so its exit status is
+    // ignored — the assertion is on the resulting neighbor entry.
+    let mut neigh = String::new();
+    let mut gw_mac = None;
+    for _ in 0..15 {
+        cmd!(sh, "ping -c 1 -W 1 -I {iface} {gw}")
+            .ignore_status()
+            .ignore_stdout()
+            .run()
+            .await?;
+        neigh = cmd!(sh, "ip neigh show {gw} dev {iface}").read().await?;
+        if let Some(mac) = parse_neigh_lladdr(&neigh) {
+            gw_mac = Some(mac);
+            break;
+        }
+        timer.sleep(Duration::from_secs(1)).await;
+    }
+    let gw_mac = gw_mac.with_context(|| {
+        format!(
+            "gateway {gw} not ARP-reachable via {iface} through DIO; last neigh entry: {neigh:?}"
+        )
+    })?;
+    tracing::info!(gw, gw_mac, "gateway resolved via DIO (ARP reply received)");
 
     agent.power_off().await?;
     vm.wait_for_clean_teardown().await?;
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn neigh_reachable_yields_lladdr() {
+        let line = "172.22.160.1 dev eth0 lladdr 00:15:5d:01:02:03 REACHABLE";
+        assert_eq!(
+            super::parse_neigh_lladdr(line).as_deref(),
+            Some("00:15:5d:01:02:03")
+        );
+    }
+
+    #[test]
+    fn neigh_stale_still_yields_lladdr() {
+        // STALE entries still prove a reply was once received.
+        let line = "172.22.160.1 dev eth0 lladdr 00:15:5d:0a:0b:0c STALE";
+        assert_eq!(
+            super::parse_neigh_lladdr(line).as_deref(),
+            Some("00:15:5d:0a:0b:0c")
+        );
+    }
+
+    #[test]
+    fn neigh_incomplete_is_unresolved() {
+        assert_eq!(
+            super::parse_neigh_lladdr("172.22.160.1 dev eth0 INCOMPLETE"),
+            None
+        );
+    }
+
+    #[test]
+    fn neigh_failed_is_unresolved() {
+        // A stale lladdr paired with FAILED must not count as resolved.
+        let line = "172.22.160.1 dev eth0 lladdr 00:15:5d:01:02:03 FAILED";
+        assert_eq!(super::parse_neigh_lladdr(line), None);
+    }
+
+    #[test]
+    fn neigh_empty_is_unresolved() {
+        assert_eq!(super::parse_neigh_lladdr(""), None);
+    }
+
+    #[test]
+    fn default_gw_requires_exact_dev_match() {
+        let route = "default via 172.22.160.1 dev eth0 proto dhcp src 172.22.160.34 metric 100";
+        assert_eq!(
+            super::parse_default_gw(route, "eth0").unwrap(),
+            "172.22.160.1"
+        );
+        // A sibling interface whose name is a substring must not match.
+        assert!(super::parse_default_gw(route, "eth0.100").is_err());
+    }
 }


### PR DESCRIPTION
## Why

No existing whole-VM test exercises the Windows vmswitch DirectIO (`-net dio`) network backend. Every petri NIC helper (`with_nic`, `with_pcie_nic`, `with_virtio_nic`) hard-codes the userspace Consomme backend, and the only DIO-flavored test in the tree is an `#[ignore]`d unit test in `vmswitch/src/dio.rs` that never runs a guest. As a result the `netvsp → DioEndpoint → vmswitch → kernel` path has had no regression coverage.

## What

- **petri**: new Windows-only `PetriVmConfigOpenVmm::with_dio_nic(switch_id)` that mirrors `with_nic`. It opens the requested switch via `vmswitch::hcn::Network`, creates a `SwitchPort`, and wires a `WindowsDirectIoHandle` into either the VTL2 MANA-VPCI device (paravisor) or the VTL0 netvsp synthnic (non-paravisor).
- **petri**: keep the `SwitchPort` handle alive in the test (parent) process via a new `PetriVmResourcesOpenVmm._switch_ports` field. The vmswitch kernel port object is reference counted, so the child VMM process can connect to it as long as the parent's handle stays open — same model as `openvmm_entry`.
- **petri**: new `openvmm::DEFAULT_SWITCH_GUID` constant and `openvmm::default_switch_available()` helper so tests can probe for Hyper-V + Default Switch and skip gracefully when they are unavailable.
- **vmm_tests**: new `multiarch/dio_nic.rs::dio_nic_smoke`. The test is gated `#![cfg(windows)]`, self-skips with a `tracing::warn!` when the Default Switch is missing, then boots Ubuntu 25.04 UEFI x64 on OpenVMM with a DIO-backed NIC, DHCPs an IPv4 lease, and pings the gateway. The ping is the meaningful regression signal: it drives packets through `netvsc → netvsp → DioEndpoint::tx_avail → vmswitch` and back.

## Validation

On both `x86_64-unknown-linux-gnu` and `x86_64-pc-windows-msvc`:

- `cargo check -p petri -p vmm_tests --tests`
- `cargo clippy --all-targets -p petri -p vmm_tests`
- `cargo doc --no-deps -p petri -p vmm_tests`
- `cargo xtask fmt --fix` (no diffs on follow-up `cargo xtask fmt`)

## CI notes

CI already installs Hyper-V on the Windows VMM-test job (`flowey/flowey_lib_hvlite/src/install_vmm_tests_deps.rs:12-14`), so no pipeline change is required. The test self-skips if Hyper-V or the Default Switch happens to be unavailable on a given runner.
