### PR TITLE
crypto: Rework backend selection to be more strict, take 2

### DIFF
--- a/.github/workflows/openvmm-ci.yaml
+++ b/.github/workflows/openvmm-ci.yaml
@@ -1765,7 +1765,7 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 14 flowey_lib_common::git_checkout 0
-        flowey v 14 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar10
+        flowey v 14 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar9
         flowey v 14 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
@@ -1773,7 +1773,7 @@ jobs:
       with:
         fetch-depth: '1'
         path: repo0
-        persist-credentials: ${{ env.floweyvar10 }}
+        persist-credentials: ${{ env.floweyvar9 }}
       name: checkout repo openvmm
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
@@ -1793,14 +1793,14 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 14 flowey_lib_common::cache 4
-        flowey v 14 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
-        flowey v 14 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
+        flowey v 14 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar7
+        flowey v 14 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar8
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
       with:
-        key: ${{ env.floweyvar8 }}
-        path: ${{ env.floweyvar9 }}
+        key: ${{ env.floweyvar7 }}
+        path: ${{ env.floweyvar8 }}
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
@@ -1844,17 +1844,14 @@ jobs:
       run: flowey e 14 flowey_lib_common::run_cargo_clippy 0
       shell: bash
     - name: cargo clippy
-      run: flowey e 14 flowey_lib_common::run_cargo_clippy 2
-      shell: bash
-    - name: cargo clippy
-      run: flowey e 14 flowey_lib_common::run_cargo_clippy 4
+      run: flowey e 14 flowey_lib_common::run_cargo_clippy 1
       shell: bash
     - name: cargo clippy
       run: flowey e 14 flowey_lib_common::run_cargo_clippy 3
       shell: bash
     - name: cargo clippy
       run: |-
-        flowey e 14 flowey_lib_common::run_cargo_clippy 1
+        flowey e 14 flowey_lib_common::run_cargo_clippy 2
         flowey e 14 flowey_lib_hvlite::init_cross_build 4
       shell: bash
     - name: cargo build xtask
@@ -1872,13 +1869,13 @@ jobs:
       run: flowey e 14 flowey_lib_hvlite::_jobs::check_clippy 0
       shell: bash
     - name: cargo clippy
+      run: flowey e 14 flowey_lib_common::run_cargo_clippy 4
+      shell: bash
+    - name: cargo clippy
       run: flowey e 14 flowey_lib_common::run_cargo_clippy 5
       shell: bash
     - name: cargo clippy
       run: flowey e 14 flowey_lib_common::run_cargo_clippy 6
-      shell: bash
-    - name: cargo clippy
-      run: flowey e 14 flowey_lib_common::run_cargo_clippy 7
       shell: bash
     - name: create cargo-nextest cache dir
       run: |-
@@ -1890,14 +1887,14 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 14 flowey_lib_common::cache 0
-        flowey v 14 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
-        flowey v 14 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
+        flowey v 14 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar5
+        flowey v 14 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar6
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
       with:
-        key: ${{ env.floweyvar6 }}
-        path: ${{ env.floweyvar7 }}
+        key: ${{ env.floweyvar5 }}
+        path: ${{ env.floweyvar6 }}
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
@@ -1917,13 +1914,13 @@ jobs:
         flowey e 14 flowey_lib_hvlite::run_cargo_nextest_run 0
       shell: bash
     - name: generate nextest command
-      run: flowey e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 1
+      run: flowey e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 2
       shell: bash
-    - name: run 'unit-tests crypto (native)' nextest tests
+    - name: run 'unit-tests crypto (rust)' nextest tests
       run: |-
-        flowey e 14 flowey_lib_common::run_cargo_nextest_run 2
-        flowey e 14 flowey_lib_common::run_cargo_nextest_run 3
-        flowey e 14 flowey_lib_hvlite::build_nextest_unit_tests 2
+        flowey e 14 flowey_lib_common::run_cargo_nextest_run 4
+        flowey e 14 flowey_lib_common::run_cargo_nextest_run 5
+        flowey e 14 flowey_lib_hvlite::build_nextest_unit_tests 3
         flowey e 14 flowey_lib_common::publish_test_results 5
         flowey e 14 flowey_lib_common::publish_test_results 6
         flowey e 14 flowey_lib_common::publish_test_results 4
@@ -1933,18 +1930,18 @@ jobs:
     - id: flowey_lib_common__publish_test_results__7
       uses: actions/upload-artifact@v7
       with:
-        name: x64-linux-unit-tests-unit-tests crypto (native)-junit-xml
+        name: x64-linux-unit-tests-unit-tests crypto (rust)-junit-xml
         path: ${{ env.floweyvar2 }}
-      name: 'publish test results: x64-linux-unit-tests-unit-tests crypto (native) (JUnit XML)'
+      name: 'publish test results: x64-linux-unit-tests-unit-tests crypto (rust) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 3
+      run: flowey e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 1
       shell: bash
-    - name: run 'unit-tests crypto (rust)' nextest tests
+    - name: run 'unit-tests crypto (openssl)' nextest tests
       run: |-
-        flowey e 14 flowey_lib_common::run_cargo_nextest_run 6
-        flowey e 14 flowey_lib_common::run_cargo_nextest_run 7
-        flowey e 14 flowey_lib_hvlite::build_nextest_unit_tests 3
+        flowey e 14 flowey_lib_common::run_cargo_nextest_run 2
+        flowey e 14 flowey_lib_common::run_cargo_nextest_run 3
+        flowey e 14 flowey_lib_hvlite::build_nextest_unit_tests 4
         flowey e 14 flowey_lib_common::publish_test_results 8
         flowey e 14 flowey_lib_common::publish_test_results 9
         flowey e 14 flowey_lib_common::publish_test_results 10
@@ -1954,51 +1951,9 @@ jobs:
     - id: flowey_lib_common__publish_test_results__11
       uses: actions/upload-artifact@v7
       with:
-        name: x64-linux-unit-tests-unit-tests crypto (rust)-junit-xml
-        path: ${{ env.floweyvar3 }}
-      name: 'publish test results: x64-linux-unit-tests-unit-tests crypto (rust) (JUnit XML)'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: generate nextest command
-      run: flowey e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 2
-      shell: bash
-    - name: run 'unit-tests crypto (openssl)' nextest tests
-      run: |-
-        flowey e 14 flowey_lib_common::run_cargo_nextest_run 4
-        flowey e 14 flowey_lib_common::run_cargo_nextest_run 5
-        flowey e 14 flowey_lib_hvlite::build_nextest_unit_tests 4
-        flowey e 14 flowey_lib_common::publish_test_results 12
-        flowey e 14 flowey_lib_common::publish_test_results 13
-        flowey e 14 flowey_lib_common::publish_test_results 14
-        flowey v 14 'flowey_lib_common::publish_test_results:25:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar4
-        flowey v 14 'flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__publish_test_results__15
-      uses: actions/upload-artifact@v7
-      with:
         name: x64-linux-unit-tests-unit-tests crypto (openssl)-junit-xml
-        path: ${{ env.floweyvar4 }}
+        path: ${{ env.floweyvar3 }}
       name: 'publish test results: x64-linux-unit-tests-unit-tests crypto (openssl) (JUnit XML)'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: generate nextest command
-      run: flowey e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 0
-      shell: bash
-    - name: run 'unit-tests crypto (all)' nextest tests
-      run: |-
-        flowey e 14 flowey_lib_common::run_cargo_nextest_run 0
-        flowey e 14 flowey_lib_common::run_cargo_nextest_run 1
-        flowey e 14 flowey_lib_hvlite::build_nextest_unit_tests 5
-        flowey e 14 flowey_lib_common::publish_test_results 16
-        flowey e 14 flowey_lib_common::publish_test_results 17
-        flowey e 14 flowey_lib_common::publish_test_results 18
-        flowey v 14 'flowey_lib_common::publish_test_results:32:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:28:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar5
-        flowey v 14 'flowey_lib_common::publish_test_results:28:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__publish_test_results__19
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-linux-unit-tests-unit-tests crypto (all)-junit-xml
-        path: ${{ env.floweyvar5 }}
-      name: 'publish test results: x64-linux-unit-tests-unit-tests crypto (all) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: cargo build xtask
       run: |-
@@ -2016,13 +1971,34 @@ jobs:
       run: flowey e 14 flowey_lib_hvlite::build_nextest_unit_tests 0
       shell: bash
     - name: generate nextest command
-      run: flowey e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 4
+      run: flowey e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 3
       shell: bash
     - name: run 'unit-tests' nextest tests
       run: |-
-        flowey e 14 flowey_lib_common::run_cargo_nextest_run 8
-        flowey e 14 flowey_lib_common::run_cargo_nextest_run 9
+        flowey e 14 flowey_lib_common::run_cargo_nextest_run 6
+        flowey e 14 flowey_lib_common::run_cargo_nextest_run 7
         flowey e 14 flowey_lib_hvlite::build_nextest_unit_tests 1
+        flowey e 14 flowey_lib_common::publish_test_results 12
+        flowey e 14 flowey_lib_common::publish_test_results 13
+        flowey e 14 flowey_lib_common::publish_test_results 14
+        flowey v 14 'flowey_lib_common::publish_test_results:25:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar4
+        flowey v 14 'flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__publish_test_results__15
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-linux-unit-tests-unit-tests-junit-xml
+        path: ${{ env.floweyvar4 }}
+      name: 'publish test results: x64-linux-unit-tests-unit-tests (JUnit XML)'
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: generate nextest command
+      run: flowey e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      shell: bash
+    - name: run 'unit-tests crypto (native)' nextest tests
+      run: |-
+        flowey e 14 flowey_lib_common::run_cargo_nextest_run 0
+        flowey e 14 flowey_lib_common::run_cargo_nextest_run 1
+        flowey e 14 flowey_lib_hvlite::build_nextest_unit_tests 2
         flowey e 14 flowey_lib_common::publish_test_results 0
         flowey e 14 flowey_lib_common::publish_test_results 1
         flowey e 14 flowey_lib_common::publish_test_results 2
@@ -2032,13 +2008,13 @@ jobs:
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v7
       with:
-        name: x64-linux-unit-tests-unit-tests-junit-xml
+        name: x64-linux-unit-tests-unit-tests crypto (native)-junit-xml
         path: ${{ env.floweyvar1 }}
-      name: 'publish test results: x64-linux-unit-tests-unit-tests (JUnit XML)'
+      name: 'publish test results: x64-linux-unit-tests-unit-tests crypto (native) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
       run: |-
-        flowey e 14 flowey_lib_hvlite::build_nextest_unit_tests 6
+        flowey e 14 flowey_lib_hvlite::build_nextest_unit_tests 5
         flowey e 14 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
       shell: bash
     - name: run doctests for x86_64-unknown-linux-gnu
@@ -2143,7 +2119,7 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 15 flowey_lib_common::git_checkout 0
-        flowey v 15 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar11
+        flowey v 15 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar10
         flowey v 15 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
@@ -2151,7 +2127,7 @@ jobs:
       with:
         fetch-depth: '1'
         path: repo0
-        persist-credentials: ${{ env.floweyvar11 }}
+        persist-credentials: ${{ env.floweyvar10 }}
       name: checkout repo openvmm
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
@@ -2169,14 +2145,14 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 15 flowey_lib_common::cache 4
-        flowey v 15 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar9
-        flowey v 15 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar10
+        flowey v 15 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
+        flowey v 15 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
       with:
-        key: ${{ env.floweyvar9 }}
-        path: ${{ env.floweyvar10 }}
+        key: ${{ env.floweyvar8 }}
+        path: ${{ env.floweyvar9 }}
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
@@ -2210,20 +2186,17 @@ jobs:
         flowey e 15 flowey_lib_hvlite::init_cross_build 2
       shell: bash
     - name: cargo clippy
-      run: flowey e 15 flowey_lib_common::run_cargo_clippy 3
+      run: flowey e 15 flowey_lib_common::run_cargo_clippy 2
       shell: bash
     - name: cargo clippy
-      run: flowey e 15 flowey_lib_common::run_cargo_clippy 5
+      run: flowey e 15 flowey_lib_common::run_cargo_clippy 4
       shell: bash
     - name: cargo clippy
-      run: flowey e 15 flowey_lib_common::run_cargo_clippy 1
-      shell: bash
-    - name: cargo clippy
-      run: flowey e 15 flowey_lib_common::run_cargo_clippy 7
+      run: flowey e 15 flowey_lib_common::run_cargo_clippy 6
       shell: bash
     - name: cargo clippy
       run: |-
-        flowey e 15 flowey_lib_common::run_cargo_clippy 6
+        flowey e 15 flowey_lib_common::run_cargo_clippy 5
         flowey e 15 flowey_lib_hvlite::init_cross_build 0
       shell: bash
     - name: cargo build xtask
@@ -2244,10 +2217,10 @@ jobs:
       run: flowey e 15 flowey_lib_common::run_cargo_clippy 0
       shell: bash
     - name: cargo clippy
-      run: flowey e 15 flowey_lib_common::run_cargo_clippy 2
+      run: flowey e 15 flowey_lib_common::run_cargo_clippy 1
       shell: bash
     - name: cargo clippy
-      run: flowey e 15 flowey_lib_common::run_cargo_clippy 4
+      run: flowey e 15 flowey_lib_common::run_cargo_clippy 3
       shell: bash
     - name: create cargo-nextest cache dir
       run: |-
@@ -2259,14 +2232,14 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 15 flowey_lib_common::cache 0
-        flowey v 15 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar7
-        flowey v 15 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar8
+        flowey v 15 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
+        flowey v 15 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
       with:
-        key: ${{ env.floweyvar7 }}
-        path: ${{ env.floweyvar8 }}
+        key: ${{ env.floweyvar6 }}
+        path: ${{ env.floweyvar7 }}
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
@@ -2286,12 +2259,12 @@ jobs:
         flowey e 15 flowey_lib_hvlite::run_cargo_nextest_run 0
       shell: bash
     - name: generate nextest command
-      run: flowey e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 1
+      run: flowey e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 0
       shell: bash
     - name: run 'unit-tests crypto (native)' nextest tests
       run: |-
-        flowey e 15 flowey_lib_common::run_cargo_nextest_run 2
-        flowey e 15 flowey_lib_common::run_cargo_nextest_run 3
+        flowey e 15 flowey_lib_common::run_cargo_nextest_run 0
+        flowey e 15 flowey_lib_common::run_cargo_nextest_run 1
         flowey e 15 flowey_lib_hvlite::build_nextest_unit_tests 2
         flowey e 15 flowey_lib_common::publish_test_results 5
         flowey e 15 flowey_lib_common::publish_test_results 6
@@ -2307,12 +2280,12 @@ jobs:
       name: 'publish test results: x64-linux-musl-unit-tests-unit-tests crypto (native) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 3
+      run: flowey e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 2
       shell: bash
     - name: run 'unit-tests crypto (rust)' nextest tests
       run: |-
-        flowey e 15 flowey_lib_common::run_cargo_nextest_run 6
-        flowey e 15 flowey_lib_common::run_cargo_nextest_run 7
+        flowey e 15 flowey_lib_common::run_cargo_nextest_run 4
+        flowey e 15 flowey_lib_common::run_cargo_nextest_run 5
         flowey e 15 flowey_lib_hvlite::build_nextest_unit_tests 3
         flowey e 15 flowey_lib_common::publish_test_results 8
         flowey e 15 flowey_lib_common::publish_test_results 9
@@ -2328,12 +2301,12 @@ jobs:
       name: 'publish test results: x64-linux-musl-unit-tests-unit-tests crypto (rust) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 2
+      run: flowey e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 1
       shell: bash
     - name: run 'unit-tests crypto (openssl)' nextest tests
       run: |-
-        flowey e 15 flowey_lib_common::run_cargo_nextest_run 4
-        flowey e 15 flowey_lib_common::run_cargo_nextest_run 5
+        flowey e 15 flowey_lib_common::run_cargo_nextest_run 2
+        flowey e 15 flowey_lib_common::run_cargo_nextest_run 3
         flowey e 15 flowey_lib_hvlite::build_nextest_unit_tests 4
         flowey e 15 flowey_lib_common::publish_test_results 12
         flowey e 15 flowey_lib_common::publish_test_results 13
@@ -2349,12 +2322,12 @@ jobs:
       name: 'publish test results: x64-linux-musl-unit-tests-unit-tests crypto (openssl) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 4
+      run: flowey e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 3
       shell: bash
     - name: run 'unit-tests crypto (symcrypt)' nextest tests
       run: |-
-        flowey e 15 flowey_lib_common::run_cargo_nextest_run 8
-        flowey e 15 flowey_lib_common::run_cargo_nextest_run 9
+        flowey e 15 flowey_lib_common::run_cargo_nextest_run 6
+        flowey e 15 flowey_lib_common::run_cargo_nextest_run 7
         flowey e 15 flowey_lib_hvlite::build_nextest_unit_tests 5
         flowey e 15 flowey_lib_common::publish_test_results 16
         flowey e 15 flowey_lib_common::publish_test_results 17
@@ -2368,27 +2341,6 @@ jobs:
         name: x64-linux-musl-unit-tests-unit-tests crypto (symcrypt)-junit-xml
         path: ${{ env.floweyvar5 }}
       name: 'publish test results: x64-linux-musl-unit-tests-unit-tests crypto (symcrypt) (JUnit XML)'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: generate nextest command
-      run: flowey e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 0
-      shell: bash
-    - name: run 'unit-tests crypto (all)' nextest tests
-      run: |-
-        flowey e 15 flowey_lib_common::run_cargo_nextest_run 0
-        flowey e 15 flowey_lib_common::run_cargo_nextest_run 1
-        flowey e 15 flowey_lib_hvlite::build_nextest_unit_tests 6
-        flowey e 15 flowey_lib_common::publish_test_results 20
-        flowey e 15 flowey_lib_common::publish_test_results 21
-        flowey e 15 flowey_lib_common::publish_test_results 22
-        flowey v 15 'flowey_lib_common::publish_test_results:39:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:35:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar6
-        flowey v 15 'flowey_lib_common::publish_test_results:35:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__publish_test_results__23
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-linux-musl-unit-tests-unit-tests crypto (all)-junit-xml
-        path: ${{ env.floweyvar6 }}
-      name: 'publish test results: x64-linux-musl-unit-tests-unit-tests crypto (all) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: cargo build xtask
       run: |-
@@ -2406,12 +2358,12 @@ jobs:
       run: flowey e 15 flowey_lib_hvlite::build_nextest_unit_tests 0
       shell: bash
     - name: generate nextest command
-      run: flowey e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 5
+      run: flowey e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 4
       shell: bash
     - name: run 'unit-tests' nextest tests
       run: |-
-        flowey e 15 flowey_lib_common::run_cargo_nextest_run 10
-        flowey e 15 flowey_lib_common::run_cargo_nextest_run 11
+        flowey e 15 flowey_lib_common::run_cargo_nextest_run 8
+        flowey e 15 flowey_lib_common::run_cargo_nextest_run 9
         flowey e 15 flowey_lib_hvlite::build_nextest_unit_tests 1
         flowey e 15 flowey_lib_common::publish_test_results 0
         flowey e 15 flowey_lib_common::publish_test_results 1
@@ -2428,7 +2380,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
       run: |-
-        flowey e 15 flowey_lib_hvlite::build_nextest_unit_tests 7
+        flowey e 15 flowey_lib_hvlite::build_nextest_unit_tests 6
         flowey e 15 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
       shell: bash
     - name: run doctests for x86_64-unknown-linux-musl
@@ -2829,7 +2781,7 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 17 flowey_lib_common::git_checkout 0
-        flowey v 17 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar10
+        flowey v 17 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar9
         flowey v 17 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
@@ -2837,7 +2789,7 @@ jobs:
       with:
         fetch-depth: '1'
         path: repo0
-        persist-credentials: ${{ env.floweyvar10 }}
+        persist-credentials: ${{ env.floweyvar9 }}
       name: checkout repo openvmm
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
@@ -2857,14 +2809,14 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 17 flowey_lib_common::cache 4
-        flowey v 17 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
-        flowey v 17 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
+        flowey v 17 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar7
+        flowey v 17 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar8
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
       with:
-        key: ${{ env.floweyvar8 }}
-        path: ${{ env.floweyvar9 }}
+        key: ${{ env.floweyvar7 }}
+        path: ${{ env.floweyvar8 }}
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
@@ -2883,10 +2835,6 @@ jobs:
       run: |-
         flowey e 17 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
         flowey e 17 flowey_lib_hvlite::init_cross_build 0
-      shell: bash
-    - name: cargo clippy
-      run: |-
-        flowey e 17 flowey_lib_common::run_cargo_clippy 1
         flowey e 17 flowey_lib_hvlite::init_cross_build 2
       shell: bash
     - name: cargo build xtask
@@ -2907,13 +2855,13 @@ jobs:
       run: flowey e 17 flowey_lib_common::run_cargo_clippy 0
       shell: bash
     - name: cargo clippy
-      run: flowey e 17 flowey_lib_common::run_cargo_clippy 2
-      shell: bash
-    - name: cargo clippy
-      run: flowey e 17 flowey_lib_common::run_cargo_clippy 4
+      run: flowey e 17 flowey_lib_common::run_cargo_clippy 1
       shell: bash
     - name: cargo clippy
       run: flowey e 17 flowey_lib_common::run_cargo_clippy 3
+      shell: bash
+    - name: cargo clippy
+      run: flowey e 17 flowey_lib_common::run_cargo_clippy 2
       shell: bash
     - name: create cargo-nextest cache dir
       run: |-
@@ -2925,14 +2873,14 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 17 flowey_lib_common::cache 0
-        flowey v 17 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
-        flowey v 17 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
+        flowey v 17 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar5
+        flowey v 17 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar6
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
       with:
-        key: ${{ env.floweyvar6 }}
-        path: ${{ env.floweyvar7 }}
+        key: ${{ env.floweyvar5 }}
+        path: ${{ env.floweyvar6 }}
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
@@ -2952,13 +2900,13 @@ jobs:
         flowey e 17 flowey_lib_hvlite::run_cargo_nextest_run 0
       shell: bash
     - name: generate nextest command
-      run: flowey e 17 flowey_lib_common::gen_cargo_nextest_run_cmd 1
+      run: flowey e 17 flowey_lib_common::gen_cargo_nextest_run_cmd 2
       shell: bash
-    - name: run 'unit-tests crypto (native)' nextest tests
+    - name: run 'unit-tests crypto (rust)' nextest tests
       run: |-
-        flowey e 17 flowey_lib_common::run_cargo_nextest_run 2
-        flowey e 17 flowey_lib_common::run_cargo_nextest_run 3
-        flowey e 17 flowey_lib_hvlite::build_nextest_unit_tests 2
+        flowey e 17 flowey_lib_common::run_cargo_nextest_run 4
+        flowey e 17 flowey_lib_common::run_cargo_nextest_run 5
+        flowey e 17 flowey_lib_hvlite::build_nextest_unit_tests 3
         flowey e 17 flowey_lib_common::publish_test_results 5
         flowey e 17 flowey_lib_common::publish_test_results 6
         flowey e 17 flowey_lib_common::publish_test_results 4
@@ -2968,18 +2916,18 @@ jobs:
     - id: flowey_lib_common__publish_test_results__7
       uses: actions/upload-artifact@v7
       with:
-        name: aarch64-linux-unit-tests-unit-tests crypto (native)-junit-xml
+        name: aarch64-linux-unit-tests-unit-tests crypto (rust)-junit-xml
         path: ${{ env.floweyvar2 }}
-      name: 'publish test results: aarch64-linux-unit-tests-unit-tests crypto (native) (JUnit XML)'
+      name: 'publish test results: aarch64-linux-unit-tests-unit-tests crypto (rust) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey e 17 flowey_lib_common::gen_cargo_nextest_run_cmd 3
+      run: flowey e 17 flowey_lib_common::gen_cargo_nextest_run_cmd 1
       shell: bash
-    - name: run 'unit-tests crypto (rust)' nextest tests
+    - name: run 'unit-tests crypto (openssl)' nextest tests
       run: |-
-        flowey e 17 flowey_lib_common::run_cargo_nextest_run 6
-        flowey e 17 flowey_lib_common::run_cargo_nextest_run 7
-        flowey e 17 flowey_lib_hvlite::build_nextest_unit_tests 3
+        flowey e 17 flowey_lib_common::run_cargo_nextest_run 2
+        flowey e 17 flowey_lib_common::run_cargo_nextest_run 3
+        flowey e 17 flowey_lib_hvlite::build_nextest_unit_tests 4
         flowey e 17 flowey_lib_common::publish_test_results 8
         flowey e 17 flowey_lib_common::publish_test_results 9
         flowey e 17 flowey_lib_common::publish_test_results 10
@@ -2989,51 +2937,9 @@ jobs:
     - id: flowey_lib_common__publish_test_results__11
       uses: actions/upload-artifact@v7
       with:
-        name: aarch64-linux-unit-tests-unit-tests crypto (rust)-junit-xml
-        path: ${{ env.floweyvar3 }}
-      name: 'publish test results: aarch64-linux-unit-tests-unit-tests crypto (rust) (JUnit XML)'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: generate nextest command
-      run: flowey e 17 flowey_lib_common::gen_cargo_nextest_run_cmd 2
-      shell: bash
-    - name: run 'unit-tests crypto (openssl)' nextest tests
-      run: |-
-        flowey e 17 flowey_lib_common::run_cargo_nextest_run 4
-        flowey e 17 flowey_lib_common::run_cargo_nextest_run 5
-        flowey e 17 flowey_lib_hvlite::build_nextest_unit_tests 4
-        flowey e 17 flowey_lib_common::publish_test_results 12
-        flowey e 17 flowey_lib_common::publish_test_results 13
-        flowey e 17 flowey_lib_common::publish_test_results 14
-        flowey v 17 'flowey_lib_common::publish_test_results:25:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar4
-        flowey v 17 'flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__publish_test_results__15
-      uses: actions/upload-artifact@v7
-      with:
         name: aarch64-linux-unit-tests-unit-tests crypto (openssl)-junit-xml
-        path: ${{ env.floweyvar4 }}
+        path: ${{ env.floweyvar3 }}
       name: 'publish test results: aarch64-linux-unit-tests-unit-tests crypto (openssl) (JUnit XML)'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: generate nextest command
-      run: flowey e 17 flowey_lib_common::gen_cargo_nextest_run_cmd 0
-      shell: bash
-    - name: run 'unit-tests crypto (all)' nextest tests
-      run: |-
-        flowey e 17 flowey_lib_common::run_cargo_nextest_run 0
-        flowey e 17 flowey_lib_common::run_cargo_nextest_run 1
-        flowey e 17 flowey_lib_hvlite::build_nextest_unit_tests 5
-        flowey e 17 flowey_lib_common::publish_test_results 16
-        flowey e 17 flowey_lib_common::publish_test_results 17
-        flowey e 17 flowey_lib_common::publish_test_results 18
-        flowey v 17 'flowey_lib_common::publish_test_results:32:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:28:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar5
-        flowey v 17 'flowey_lib_common::publish_test_results:28:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__publish_test_results__19
-      uses: actions/upload-artifact@v7
-      with:
-        name: aarch64-linux-unit-tests-unit-tests crypto (all)-junit-xml
-        path: ${{ env.floweyvar5 }}
-      name: 'publish test results: aarch64-linux-unit-tests-unit-tests crypto (all) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: cargo build xtask
       run: |-
@@ -3051,13 +2957,34 @@ jobs:
       run: flowey e 17 flowey_lib_hvlite::build_nextest_unit_tests 0
       shell: bash
     - name: generate nextest command
-      run: flowey e 17 flowey_lib_common::gen_cargo_nextest_run_cmd 4
+      run: flowey e 17 flowey_lib_common::gen_cargo_nextest_run_cmd 3
       shell: bash
     - name: run 'unit-tests' nextest tests
       run: |-
-        flowey e 17 flowey_lib_common::run_cargo_nextest_run 8
-        flowey e 17 flowey_lib_common::run_cargo_nextest_run 9
+        flowey e 17 flowey_lib_common::run_cargo_nextest_run 6
+        flowey e 17 flowey_lib_common::run_cargo_nextest_run 7
         flowey e 17 flowey_lib_hvlite::build_nextest_unit_tests 1
+        flowey e 17 flowey_lib_common::publish_test_results 12
+        flowey e 17 flowey_lib_common::publish_test_results 13
+        flowey e 17 flowey_lib_common::publish_test_results 14
+        flowey v 17 'flowey_lib_common::publish_test_results:25:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar4
+        flowey v 17 'flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__publish_test_results__15
+      uses: actions/upload-artifact@v7
+      with:
+        name: aarch64-linux-unit-tests-unit-tests-junit-xml
+        path: ${{ env.floweyvar4 }}
+      name: 'publish test results: aarch64-linux-unit-tests-unit-tests (JUnit XML)'
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: generate nextest command
+      run: flowey e 17 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      shell: bash
+    - name: run 'unit-tests crypto (native)' nextest tests
+      run: |-
+        flowey e 17 flowey_lib_common::run_cargo_nextest_run 0
+        flowey e 17 flowey_lib_common::run_cargo_nextest_run 1
+        flowey e 17 flowey_lib_hvlite::build_nextest_unit_tests 2
         flowey e 17 flowey_lib_common::publish_test_results 0
         flowey e 17 flowey_lib_common::publish_test_results 1
         flowey e 17 flowey_lib_common::publish_test_results 2
@@ -3067,13 +2994,13 @@ jobs:
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v7
       with:
-        name: aarch64-linux-unit-tests-unit-tests-junit-xml
+        name: aarch64-linux-unit-tests-unit-tests crypto (native)-junit-xml
         path: ${{ env.floweyvar1 }}
-      name: 'publish test results: aarch64-linux-unit-tests-unit-tests (JUnit XML)'
+      name: 'publish test results: aarch64-linux-unit-tests-unit-tests crypto (native) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
       run: |-
-        flowey e 17 flowey_lib_hvlite::build_nextest_unit_tests 6
+        flowey e 17 flowey_lib_hvlite::build_nextest_unit_tests 5
         flowey e 17 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
       shell: bash
     - name: run doctests for aarch64-unknown-linux-gnu
@@ -3178,7 +3105,7 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 18 flowey_lib_common::git_checkout 0
-        flowey v 18 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar11
+        flowey v 18 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar10
         flowey v 18 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
@@ -3186,7 +3113,7 @@ jobs:
       with:
         fetch-depth: '1'
         path: repo0
-        persist-credentials: ${{ env.floweyvar11 }}
+        persist-credentials: ${{ env.floweyvar10 }}
       name: checkout repo openvmm
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
@@ -3204,14 +3131,14 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 18 flowey_lib_common::cache 4
-        flowey v 18 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar9
-        flowey v 18 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar10
+        flowey v 18 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
+        flowey v 18 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
       with:
-        key: ${{ env.floweyvar9 }}
-        path: ${{ env.floweyvar10 }}
+        key: ${{ env.floweyvar8 }}
+        path: ${{ env.floweyvar9 }}
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
@@ -3245,20 +3172,17 @@ jobs:
         flowey e 18 flowey_lib_hvlite::init_cross_build 2
       shell: bash
     - name: cargo clippy
-      run: flowey e 18 flowey_lib_common::run_cargo_clippy 3
+      run: flowey e 18 flowey_lib_common::run_cargo_clippy 2
       shell: bash
     - name: cargo clippy
-      run: flowey e 18 flowey_lib_common::run_cargo_clippy 5
+      run: flowey e 18 flowey_lib_common::run_cargo_clippy 4
       shell: bash
     - name: cargo clippy
-      run: flowey e 18 flowey_lib_common::run_cargo_clippy 1
-      shell: bash
-    - name: cargo clippy
-      run: flowey e 18 flowey_lib_common::run_cargo_clippy 7
+      run: flowey e 18 flowey_lib_common::run_cargo_clippy 6
       shell: bash
     - name: cargo clippy
       run: |-
-        flowey e 18 flowey_lib_common::run_cargo_clippy 6
+        flowey e 18 flowey_lib_common::run_cargo_clippy 5
         flowey e 18 flowey_lib_hvlite::init_cross_build 0
       shell: bash
     - name: cargo build xtask
@@ -3279,10 +3203,10 @@ jobs:
       run: flowey e 18 flowey_lib_common::run_cargo_clippy 0
       shell: bash
     - name: cargo clippy
-      run: flowey e 18 flowey_lib_common::run_cargo_clippy 2
+      run: flowey e 18 flowey_lib_common::run_cargo_clippy 1
       shell: bash
     - name: cargo clippy
-      run: flowey e 18 flowey_lib_common::run_cargo_clippy 4
+      run: flowey e 18 flowey_lib_common::run_cargo_clippy 3
       shell: bash
     - name: create cargo-nextest cache dir
       run: |-
@@ -3294,14 +3218,14 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 18 flowey_lib_common::cache 0
-        flowey v 18 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar7
-        flowey v 18 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar8
+        flowey v 18 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
+        flowey v 18 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
       with:
-        key: ${{ env.floweyvar7 }}
-        path: ${{ env.floweyvar8 }}
+        key: ${{ env.floweyvar6 }}
+        path: ${{ env.floweyvar7 }}
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
@@ -3321,12 +3245,12 @@ jobs:
         flowey e 18 flowey_lib_hvlite::run_cargo_nextest_run 0
       shell: bash
     - name: generate nextest command
-      run: flowey e 18 flowey_lib_common::gen_cargo_nextest_run_cmd 1
+      run: flowey e 18 flowey_lib_common::gen_cargo_nextest_run_cmd 0
       shell: bash
     - name: run 'unit-tests crypto (native)' nextest tests
       run: |-
-        flowey e 18 flowey_lib_common::run_cargo_nextest_run 2
-        flowey e 18 flowey_lib_common::run_cargo_nextest_run 3
+        flowey e 18 flowey_lib_common::run_cargo_nextest_run 0
+        flowey e 18 flowey_lib_common::run_cargo_nextest_run 1
         flowey e 18 flowey_lib_hvlite::build_nextest_unit_tests 2
         flowey e 18 flowey_lib_common::publish_test_results 5
         flowey e 18 flowey_lib_common::publish_test_results 6
@@ -3342,12 +3266,12 @@ jobs:
       name: 'publish test results: aarch64-linux-musl-unit-tests-unit-tests crypto (native) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey e 18 flowey_lib_common::gen_cargo_nextest_run_cmd 3
+      run: flowey e 18 flowey_lib_common::gen_cargo_nextest_run_cmd 2
       shell: bash
     - name: run 'unit-tests crypto (rust)' nextest tests
       run: |-
-        flowey e 18 flowey_lib_common::run_cargo_nextest_run 6
-        flowey e 18 flowey_lib_common::run_cargo_nextest_run 7
+        flowey e 18 flowey_lib_common::run_cargo_nextest_run 4
+        flowey e 18 flowey_lib_common::run_cargo_nextest_run 5
         flowey e 18 flowey_lib_hvlite::build_nextest_unit_tests 3
         flowey e 18 flowey_lib_common::publish_test_results 8
         flowey e 18 flowey_lib_common::publish_test_results 9
@@ -3363,12 +3287,12 @@ jobs:
       name: 'publish test results: aarch64-linux-musl-unit-tests-unit-tests crypto (rust) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey e 18 flowey_lib_common::gen_cargo_nextest_run_cmd 2
+      run: flowey e 18 flowey_lib_common::gen_cargo_nextest_run_cmd 1
       shell: bash
     - name: run 'unit-tests crypto (openssl)' nextest tests
       run: |-
-        flowey e 18 flowey_lib_common::run_cargo_nextest_run 4
-        flowey e 18 flowey_lib_common::run_cargo_nextest_run 5
+        flowey e 18 flowey_lib_common::run_cargo_nextest_run 2
+        flowey e 18 flowey_lib_common::run_cargo_nextest_run 3
         flowey e 18 flowey_lib_hvlite::build_nextest_unit_tests 4
         flowey e 18 flowey_lib_common::publish_test_results 12
         flowey e 18 flowey_lib_common::publish_test_results 13
@@ -3384,12 +3308,12 @@ jobs:
       name: 'publish test results: aarch64-linux-musl-unit-tests-unit-tests crypto (openssl) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey e 18 flowey_lib_common::gen_cargo_nextest_run_cmd 4
+      run: flowey e 18 flowey_lib_common::gen_cargo_nextest_run_cmd 3
       shell: bash
     - name: run 'unit-tests crypto (symcrypt)' nextest tests
       run: |-
-        flowey e 18 flowey_lib_common::run_cargo_nextest_run 8
-        flowey e 18 flowey_lib_common::run_cargo_nextest_run 9
+        flowey e 18 flowey_lib_common::run_cargo_nextest_run 6
+        flowey e 18 flowey_lib_common::run_cargo_nextest_run 7
         flowey e 18 flowey_lib_hvlite::build_nextest_unit_tests 5
         flowey e 18 flowey_lib_common::publish_test_results 16
         flowey e 18 flowey_lib_common::publish_test_results 17
@@ -3403,27 +3327,6 @@ jobs:
         name: aarch64-linux-musl-unit-tests-unit-tests crypto (symcrypt)-junit-xml
         path: ${{ env.floweyvar5 }}
       name: 'publish test results: aarch64-linux-musl-unit-tests-unit-tests crypto (symcrypt) (JUnit XML)'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: generate nextest command
-      run: flowey e 18 flowey_lib_common::gen_cargo_nextest_run_cmd 0
-      shell: bash
-    - name: run 'unit-tests crypto (all)' nextest tests
-      run: |-
-        flowey e 18 flowey_lib_common::run_cargo_nextest_run 0
-        flowey e 18 flowey_lib_common::run_cargo_nextest_run 1
-        flowey e 18 flowey_lib_hvlite::build_nextest_unit_tests 6
-        flowey e 18 flowey_lib_common::publish_test_results 20
-        flowey e 18 flowey_lib_common::publish_test_results 21
-        flowey e 18 flowey_lib_common::publish_test_results 22
-        flowey v 18 'flowey_lib_common::publish_test_results:39:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:35:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar6
-        flowey v 18 'flowey_lib_common::publish_test_results:35:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__publish_test_results__23
-      uses: actions/upload-artifact@v7
-      with:
-        name: aarch64-linux-musl-unit-tests-unit-tests crypto (all)-junit-xml
-        path: ${{ env.floweyvar6 }}
-      name: 'publish test results: aarch64-linux-musl-unit-tests-unit-tests crypto (all) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: cargo build xtask
       run: |-
@@ -3441,12 +3344,12 @@ jobs:
       run: flowey e 18 flowey_lib_hvlite::build_nextest_unit_tests 0
       shell: bash
     - name: generate nextest command
-      run: flowey e 18 flowey_lib_common::gen_cargo_nextest_run_cmd 5
+      run: flowey e 18 flowey_lib_common::gen_cargo_nextest_run_cmd 4
       shell: bash
     - name: run 'unit-tests' nextest tests
       run: |-
-        flowey e 18 flowey_lib_common::run_cargo_nextest_run 10
-        flowey e 18 flowey_lib_common::run_cargo_nextest_run 11
+        flowey e 18 flowey_lib_common::run_cargo_nextest_run 8
+        flowey e 18 flowey_lib_common::run_cargo_nextest_run 9
         flowey e 18 flowey_lib_hvlite::build_nextest_unit_tests 1
         flowey e 18 flowey_lib_common::publish_test_results 0
         flowey e 18 flowey_lib_common::publish_test_results 1
@@ -3463,7 +3366,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
       run: |-
-        flowey e 18 flowey_lib_hvlite::build_nextest_unit_tests 7
+        flowey e 18 flowey_lib_hvlite::build_nextest_unit_tests 6
         flowey e 18 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
       shell: bash
     - name: run doctests for aarch64-unknown-linux-musl

--- a/.github/workflows/openvmm-ci.yaml
+++ b/.github/workflows/openvmm-ci.yaml
@@ -1639,7 +1639,7 @@ jobs:
     - name: generate nextest command
       run: flowey.exe e 13 flowey_lib_common::gen_cargo_nextest_run_cmd 0
       shell: bash
-    - name: run 'unit-tests crypto (none)' nextest tests
+    - name: run 'unit-tests crypto (native)' nextest tests
       run: |-
         flowey.exe e 13 flowey_lib_common::run_cargo_nextest_run 0
         flowey.exe e 13 flowey_lib_common::run_cargo_nextest_run 1
@@ -1653,9 +1653,9 @@ jobs:
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v7
       with:
-        name: x64-windows-unit-tests-unit-tests crypto (none)-junit-xml
+        name: x64-windows-unit-tests-unit-tests crypto (native)-junit-xml
         path: ${{ env.floweyvar1 }}
-      name: 'publish test results: x64-windows-unit-tests-unit-tests crypto (none) (JUnit XML)'
+      name: 'publish test results: x64-windows-unit-tests-unit-tests crypto (native) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
       run: |-
@@ -1919,7 +1919,7 @@ jobs:
     - name: generate nextest command
       run: flowey e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 1
       shell: bash
-    - name: run 'unit-tests crypto (none)' nextest tests
+    - name: run 'unit-tests crypto (native)' nextest tests
       run: |-
         flowey e 14 flowey_lib_common::run_cargo_nextest_run 2
         flowey e 14 flowey_lib_common::run_cargo_nextest_run 3
@@ -1933,9 +1933,9 @@ jobs:
     - id: flowey_lib_common__publish_test_results__7
       uses: actions/upload-artifact@v7
       with:
-        name: x64-linux-unit-tests-unit-tests crypto (none)-junit-xml
+        name: x64-linux-unit-tests-unit-tests crypto (native)-junit-xml
         path: ${{ env.floweyvar2 }}
-      name: 'publish test results: x64-linux-unit-tests-unit-tests crypto (none) (JUnit XML)'
+      name: 'publish test results: x64-linux-unit-tests-unit-tests crypto (native) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
       run: flowey e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 3
@@ -2288,7 +2288,7 @@ jobs:
     - name: generate nextest command
       run: flowey e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 1
       shell: bash
-    - name: run 'unit-tests crypto (none)' nextest tests
+    - name: run 'unit-tests crypto (native)' nextest tests
       run: |-
         flowey e 15 flowey_lib_common::run_cargo_nextest_run 2
         flowey e 15 flowey_lib_common::run_cargo_nextest_run 3
@@ -2302,9 +2302,9 @@ jobs:
     - id: flowey_lib_common__publish_test_results__7
       uses: actions/upload-artifact@v7
       with:
-        name: x64-linux-musl-unit-tests-unit-tests crypto (none)-junit-xml
+        name: x64-linux-musl-unit-tests-unit-tests crypto (native)-junit-xml
         path: ${{ env.floweyvar2 }}
-      name: 'publish test results: x64-linux-musl-unit-tests-unit-tests crypto (none) (JUnit XML)'
+      name: 'publish test results: x64-linux-musl-unit-tests-unit-tests crypto (native) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
       run: flowey e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 3
@@ -2698,7 +2698,7 @@ jobs:
     - name: generate nextest command
       run: flowey.exe e 16 flowey_lib_common::gen_cargo_nextest_run_cmd 0
       shell: bash
-    - name: run 'unit-tests crypto (none)' nextest tests
+    - name: run 'unit-tests crypto (native)' nextest tests
       run: |-
         flowey.exe e 16 flowey_lib_common::run_cargo_nextest_run 0
         flowey.exe e 16 flowey_lib_common::run_cargo_nextest_run 1
@@ -2712,9 +2712,9 @@ jobs:
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v7
       with:
-        name: aarch64-windows-unit-tests-unit-tests crypto (none)-junit-xml
+        name: aarch64-windows-unit-tests-unit-tests crypto (native)-junit-xml
         path: ${{ env.floweyvar1 }}
-      name: 'publish test results: aarch64-windows-unit-tests-unit-tests crypto (none) (JUnit XML)'
+      name: 'publish test results: aarch64-windows-unit-tests-unit-tests crypto (native) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
       run: |-
@@ -2954,7 +2954,7 @@ jobs:
     - name: generate nextest command
       run: flowey e 17 flowey_lib_common::gen_cargo_nextest_run_cmd 1
       shell: bash
-    - name: run 'unit-tests crypto (none)' nextest tests
+    - name: run 'unit-tests crypto (native)' nextest tests
       run: |-
         flowey e 17 flowey_lib_common::run_cargo_nextest_run 2
         flowey e 17 flowey_lib_common::run_cargo_nextest_run 3
@@ -2968,9 +2968,9 @@ jobs:
     - id: flowey_lib_common__publish_test_results__7
       uses: actions/upload-artifact@v7
       with:
-        name: aarch64-linux-unit-tests-unit-tests crypto (none)-junit-xml
+        name: aarch64-linux-unit-tests-unit-tests crypto (native)-junit-xml
         path: ${{ env.floweyvar2 }}
-      name: 'publish test results: aarch64-linux-unit-tests-unit-tests crypto (none) (JUnit XML)'
+      name: 'publish test results: aarch64-linux-unit-tests-unit-tests crypto (native) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
       run: flowey e 17 flowey_lib_common::gen_cargo_nextest_run_cmd 3
@@ -3323,7 +3323,7 @@ jobs:
     - name: generate nextest command
       run: flowey e 18 flowey_lib_common::gen_cargo_nextest_run_cmd 1
       shell: bash
-    - name: run 'unit-tests crypto (none)' nextest tests
+    - name: run 'unit-tests crypto (native)' nextest tests
       run: |-
         flowey e 18 flowey_lib_common::run_cargo_nextest_run 2
         flowey e 18 flowey_lib_common::run_cargo_nextest_run 3
@@ -3337,9 +3337,9 @@ jobs:
     - id: flowey_lib_common__publish_test_results__7
       uses: actions/upload-artifact@v7
       with:
-        name: aarch64-linux-musl-unit-tests-unit-tests crypto (none)-junit-xml
+        name: aarch64-linux-musl-unit-tests-unit-tests crypto (native)-junit-xml
         path: ${{ env.floweyvar2 }}
-      name: 'publish test results: aarch64-linux-musl-unit-tests-unit-tests crypto (none) (JUnit XML)'
+      name: 'publish test results: aarch64-linux-musl-unit-tests-unit-tests crypto (native) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
       run: flowey e 18 flowey_lib_common::gen_cargo_nextest_run_cmd 3

--- a/.github/workflows/openvmm-ci.yaml
+++ b/.github/workflows/openvmm-ci.yaml
@@ -1765,7 +1765,7 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 14 flowey_lib_common::git_checkout 0
-        flowey v 14 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar9
+        flowey v 14 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar10
         flowey v 14 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
@@ -1773,7 +1773,7 @@ jobs:
       with:
         fetch-depth: '1'
         path: repo0
-        persist-credentials: ${{ env.floweyvar9 }}
+        persist-credentials: ${{ env.floweyvar10 }}
       name: checkout repo openvmm
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
@@ -1793,14 +1793,14 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 14 flowey_lib_common::cache 4
-        flowey v 14 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar7
-        flowey v 14 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar8
+        flowey v 14 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
+        flowey v 14 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
       with:
-        key: ${{ env.floweyvar7 }}
-        path: ${{ env.floweyvar8 }}
+        key: ${{ env.floweyvar8 }}
+        path: ${{ env.floweyvar9 }}
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
@@ -1844,14 +1844,17 @@ jobs:
       run: flowey e 14 flowey_lib_common::run_cargo_clippy 0
       shell: bash
     - name: cargo clippy
-      run: flowey e 14 flowey_lib_common::run_cargo_clippy 1
+      run: flowey e 14 flowey_lib_common::run_cargo_clippy 2
+      shell: bash
+    - name: cargo clippy
+      run: flowey e 14 flowey_lib_common::run_cargo_clippy 4
       shell: bash
     - name: cargo clippy
       run: flowey e 14 flowey_lib_common::run_cargo_clippy 3
       shell: bash
     - name: cargo clippy
       run: |-
-        flowey e 14 flowey_lib_common::run_cargo_clippy 2
+        flowey e 14 flowey_lib_common::run_cargo_clippy 1
         flowey e 14 flowey_lib_hvlite::init_cross_build 4
       shell: bash
     - name: cargo build xtask
@@ -1869,13 +1872,13 @@ jobs:
       run: flowey e 14 flowey_lib_hvlite::_jobs::check_clippy 0
       shell: bash
     - name: cargo clippy
-      run: flowey e 14 flowey_lib_common::run_cargo_clippy 4
-      shell: bash
-    - name: cargo clippy
       run: flowey e 14 flowey_lib_common::run_cargo_clippy 5
       shell: bash
     - name: cargo clippy
       run: flowey e 14 flowey_lib_common::run_cargo_clippy 6
+      shell: bash
+    - name: cargo clippy
+      run: flowey e 14 flowey_lib_common::run_cargo_clippy 7
       shell: bash
     - name: create cargo-nextest cache dir
       run: |-
@@ -1887,14 +1890,14 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 14 flowey_lib_common::cache 0
-        flowey v 14 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar5
-        flowey v 14 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar6
+        flowey v 14 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
+        flowey v 14 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
       with:
-        key: ${{ env.floweyvar5 }}
-        path: ${{ env.floweyvar6 }}
+        key: ${{ env.floweyvar6 }}
+        path: ${{ env.floweyvar7 }}
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
@@ -1914,13 +1917,13 @@ jobs:
         flowey e 14 flowey_lib_hvlite::run_cargo_nextest_run 0
       shell: bash
     - name: generate nextest command
-      run: flowey e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 2
+      run: flowey e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 1
       shell: bash
-    - name: run 'unit-tests crypto (rust)' nextest tests
+    - name: run 'unit-tests crypto (native)' nextest tests
       run: |-
-        flowey e 14 flowey_lib_common::run_cargo_nextest_run 4
-        flowey e 14 flowey_lib_common::run_cargo_nextest_run 5
-        flowey e 14 flowey_lib_hvlite::build_nextest_unit_tests 3
+        flowey e 14 flowey_lib_common::run_cargo_nextest_run 2
+        flowey e 14 flowey_lib_common::run_cargo_nextest_run 3
+        flowey e 14 flowey_lib_hvlite::build_nextest_unit_tests 2
         flowey e 14 flowey_lib_common::publish_test_results 5
         flowey e 14 flowey_lib_common::publish_test_results 6
         flowey e 14 flowey_lib_common::publish_test_results 4
@@ -1930,18 +1933,18 @@ jobs:
     - id: flowey_lib_common__publish_test_results__7
       uses: actions/upload-artifact@v7
       with:
-        name: x64-linux-unit-tests-unit-tests crypto (rust)-junit-xml
+        name: x64-linux-unit-tests-unit-tests crypto (native)-junit-xml
         path: ${{ env.floweyvar2 }}
-      name: 'publish test results: x64-linux-unit-tests-unit-tests crypto (rust) (JUnit XML)'
+      name: 'publish test results: x64-linux-unit-tests-unit-tests crypto (native) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 1
+      run: flowey e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 3
       shell: bash
-    - name: run 'unit-tests crypto (openssl)' nextest tests
+    - name: run 'unit-tests crypto (rust)' nextest tests
       run: |-
-        flowey e 14 flowey_lib_common::run_cargo_nextest_run 2
-        flowey e 14 flowey_lib_common::run_cargo_nextest_run 3
-        flowey e 14 flowey_lib_hvlite::build_nextest_unit_tests 4
+        flowey e 14 flowey_lib_common::run_cargo_nextest_run 6
+        flowey e 14 flowey_lib_common::run_cargo_nextest_run 7
+        flowey e 14 flowey_lib_hvlite::build_nextest_unit_tests 3
         flowey e 14 flowey_lib_common::publish_test_results 8
         flowey e 14 flowey_lib_common::publish_test_results 9
         flowey e 14 flowey_lib_common::publish_test_results 10
@@ -1951,9 +1954,51 @@ jobs:
     - id: flowey_lib_common__publish_test_results__11
       uses: actions/upload-artifact@v7
       with:
-        name: x64-linux-unit-tests-unit-tests crypto (openssl)-junit-xml
+        name: x64-linux-unit-tests-unit-tests crypto (rust)-junit-xml
         path: ${{ env.floweyvar3 }}
+      name: 'publish test results: x64-linux-unit-tests-unit-tests crypto (rust) (JUnit XML)'
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: generate nextest command
+      run: flowey e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 2
+      shell: bash
+    - name: run 'unit-tests crypto (openssl)' nextest tests
+      run: |-
+        flowey e 14 flowey_lib_common::run_cargo_nextest_run 4
+        flowey e 14 flowey_lib_common::run_cargo_nextest_run 5
+        flowey e 14 flowey_lib_hvlite::build_nextest_unit_tests 4
+        flowey e 14 flowey_lib_common::publish_test_results 12
+        flowey e 14 flowey_lib_common::publish_test_results 13
+        flowey e 14 flowey_lib_common::publish_test_results 14
+        flowey v 14 'flowey_lib_common::publish_test_results:25:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar4
+        flowey v 14 'flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__publish_test_results__15
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-linux-unit-tests-unit-tests crypto (openssl)-junit-xml
+        path: ${{ env.floweyvar4 }}
       name: 'publish test results: x64-linux-unit-tests-unit-tests crypto (openssl) (JUnit XML)'
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: generate nextest command
+      run: flowey e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      shell: bash
+    - name: run 'unit-tests crypto (all)' nextest tests
+      run: |-
+        flowey e 14 flowey_lib_common::run_cargo_nextest_run 0
+        flowey e 14 flowey_lib_common::run_cargo_nextest_run 1
+        flowey e 14 flowey_lib_hvlite::build_nextest_unit_tests 5
+        flowey e 14 flowey_lib_common::publish_test_results 16
+        flowey e 14 flowey_lib_common::publish_test_results 17
+        flowey e 14 flowey_lib_common::publish_test_results 18
+        flowey v 14 'flowey_lib_common::publish_test_results:32:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:28:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar5
+        flowey v 14 'flowey_lib_common::publish_test_results:28:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__publish_test_results__19
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-linux-unit-tests-unit-tests crypto (all)-junit-xml
+        path: ${{ env.floweyvar5 }}
+      name: 'publish test results: x64-linux-unit-tests-unit-tests crypto (all) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: cargo build xtask
       run: |-
@@ -1971,34 +2016,13 @@ jobs:
       run: flowey e 14 flowey_lib_hvlite::build_nextest_unit_tests 0
       shell: bash
     - name: generate nextest command
-      run: flowey e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 3
+      run: flowey e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 4
       shell: bash
     - name: run 'unit-tests' nextest tests
       run: |-
-        flowey e 14 flowey_lib_common::run_cargo_nextest_run 6
-        flowey e 14 flowey_lib_common::run_cargo_nextest_run 7
+        flowey e 14 flowey_lib_common::run_cargo_nextest_run 8
+        flowey e 14 flowey_lib_common::run_cargo_nextest_run 9
         flowey e 14 flowey_lib_hvlite::build_nextest_unit_tests 1
-        flowey e 14 flowey_lib_common::publish_test_results 12
-        flowey e 14 flowey_lib_common::publish_test_results 13
-        flowey e 14 flowey_lib_common::publish_test_results 14
-        flowey v 14 'flowey_lib_common::publish_test_results:25:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar4
-        flowey v 14 'flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__publish_test_results__15
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-linux-unit-tests-unit-tests-junit-xml
-        path: ${{ env.floweyvar4 }}
-      name: 'publish test results: x64-linux-unit-tests-unit-tests (JUnit XML)'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: generate nextest command
-      run: flowey e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 0
-      shell: bash
-    - name: run 'unit-tests crypto (native)' nextest tests
-      run: |-
-        flowey e 14 flowey_lib_common::run_cargo_nextest_run 0
-        flowey e 14 flowey_lib_common::run_cargo_nextest_run 1
-        flowey e 14 flowey_lib_hvlite::build_nextest_unit_tests 2
         flowey e 14 flowey_lib_common::publish_test_results 0
         flowey e 14 flowey_lib_common::publish_test_results 1
         flowey e 14 flowey_lib_common::publish_test_results 2
@@ -2008,13 +2032,13 @@ jobs:
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v7
       with:
-        name: x64-linux-unit-tests-unit-tests crypto (native)-junit-xml
+        name: x64-linux-unit-tests-unit-tests-junit-xml
         path: ${{ env.floweyvar1 }}
-      name: 'publish test results: x64-linux-unit-tests-unit-tests crypto (native) (JUnit XML)'
+      name: 'publish test results: x64-linux-unit-tests-unit-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
       run: |-
-        flowey e 14 flowey_lib_hvlite::build_nextest_unit_tests 5
+        flowey e 14 flowey_lib_hvlite::build_nextest_unit_tests 6
         flowey e 14 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
       shell: bash
     - name: run doctests for x86_64-unknown-linux-gnu
@@ -2119,7 +2143,7 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 15 flowey_lib_common::git_checkout 0
-        flowey v 15 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar10
+        flowey v 15 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar11
         flowey v 15 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
@@ -2127,7 +2151,7 @@ jobs:
       with:
         fetch-depth: '1'
         path: repo0
-        persist-credentials: ${{ env.floweyvar10 }}
+        persist-credentials: ${{ env.floweyvar11 }}
       name: checkout repo openvmm
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
@@ -2145,14 +2169,14 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 15 flowey_lib_common::cache 4
-        flowey v 15 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
-        flowey v 15 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
+        flowey v 15 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar9
+        flowey v 15 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar10
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
       with:
-        key: ${{ env.floweyvar8 }}
-        path: ${{ env.floweyvar9 }}
+        key: ${{ env.floweyvar9 }}
+        path: ${{ env.floweyvar10 }}
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
@@ -2186,17 +2210,20 @@ jobs:
         flowey e 15 flowey_lib_hvlite::init_cross_build 2
       shell: bash
     - name: cargo clippy
-      run: flowey e 15 flowey_lib_common::run_cargo_clippy 2
+      run: flowey e 15 flowey_lib_common::run_cargo_clippy 3
       shell: bash
     - name: cargo clippy
-      run: flowey e 15 flowey_lib_common::run_cargo_clippy 4
+      run: flowey e 15 flowey_lib_common::run_cargo_clippy 5
       shell: bash
     - name: cargo clippy
-      run: flowey e 15 flowey_lib_common::run_cargo_clippy 6
+      run: flowey e 15 flowey_lib_common::run_cargo_clippy 1
+      shell: bash
+    - name: cargo clippy
+      run: flowey e 15 flowey_lib_common::run_cargo_clippy 7
       shell: bash
     - name: cargo clippy
       run: |-
-        flowey e 15 flowey_lib_common::run_cargo_clippy 5
+        flowey e 15 flowey_lib_common::run_cargo_clippy 6
         flowey e 15 flowey_lib_hvlite::init_cross_build 0
       shell: bash
     - name: cargo build xtask
@@ -2217,10 +2244,10 @@ jobs:
       run: flowey e 15 flowey_lib_common::run_cargo_clippy 0
       shell: bash
     - name: cargo clippy
-      run: flowey e 15 flowey_lib_common::run_cargo_clippy 1
+      run: flowey e 15 flowey_lib_common::run_cargo_clippy 2
       shell: bash
     - name: cargo clippy
-      run: flowey e 15 flowey_lib_common::run_cargo_clippy 3
+      run: flowey e 15 flowey_lib_common::run_cargo_clippy 4
       shell: bash
     - name: create cargo-nextest cache dir
       run: |-
@@ -2232,14 +2259,14 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 15 flowey_lib_common::cache 0
-        flowey v 15 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
-        flowey v 15 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
+        flowey v 15 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar7
+        flowey v 15 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar8
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
       with:
-        key: ${{ env.floweyvar6 }}
-        path: ${{ env.floweyvar7 }}
+        key: ${{ env.floweyvar7 }}
+        path: ${{ env.floweyvar8 }}
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
@@ -2259,12 +2286,12 @@ jobs:
         flowey e 15 flowey_lib_hvlite::run_cargo_nextest_run 0
       shell: bash
     - name: generate nextest command
-      run: flowey e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      run: flowey e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 1
       shell: bash
     - name: run 'unit-tests crypto (native)' nextest tests
       run: |-
-        flowey e 15 flowey_lib_common::run_cargo_nextest_run 0
-        flowey e 15 flowey_lib_common::run_cargo_nextest_run 1
+        flowey e 15 flowey_lib_common::run_cargo_nextest_run 2
+        flowey e 15 flowey_lib_common::run_cargo_nextest_run 3
         flowey e 15 flowey_lib_hvlite::build_nextest_unit_tests 2
         flowey e 15 flowey_lib_common::publish_test_results 5
         flowey e 15 flowey_lib_common::publish_test_results 6
@@ -2280,12 +2307,12 @@ jobs:
       name: 'publish test results: x64-linux-musl-unit-tests-unit-tests crypto (native) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 2
+      run: flowey e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 3
       shell: bash
     - name: run 'unit-tests crypto (rust)' nextest tests
       run: |-
-        flowey e 15 flowey_lib_common::run_cargo_nextest_run 4
-        flowey e 15 flowey_lib_common::run_cargo_nextest_run 5
+        flowey e 15 flowey_lib_common::run_cargo_nextest_run 6
+        flowey e 15 flowey_lib_common::run_cargo_nextest_run 7
         flowey e 15 flowey_lib_hvlite::build_nextest_unit_tests 3
         flowey e 15 flowey_lib_common::publish_test_results 8
         flowey e 15 flowey_lib_common::publish_test_results 9
@@ -2301,12 +2328,12 @@ jobs:
       name: 'publish test results: x64-linux-musl-unit-tests-unit-tests crypto (rust) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 1
+      run: flowey e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 2
       shell: bash
     - name: run 'unit-tests crypto (openssl)' nextest tests
       run: |-
-        flowey e 15 flowey_lib_common::run_cargo_nextest_run 2
-        flowey e 15 flowey_lib_common::run_cargo_nextest_run 3
+        flowey e 15 flowey_lib_common::run_cargo_nextest_run 4
+        flowey e 15 flowey_lib_common::run_cargo_nextest_run 5
         flowey e 15 flowey_lib_hvlite::build_nextest_unit_tests 4
         flowey e 15 flowey_lib_common::publish_test_results 12
         flowey e 15 flowey_lib_common::publish_test_results 13
@@ -2322,12 +2349,12 @@ jobs:
       name: 'publish test results: x64-linux-musl-unit-tests-unit-tests crypto (openssl) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 3
+      run: flowey e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 4
       shell: bash
     - name: run 'unit-tests crypto (symcrypt)' nextest tests
       run: |-
-        flowey e 15 flowey_lib_common::run_cargo_nextest_run 6
-        flowey e 15 flowey_lib_common::run_cargo_nextest_run 7
+        flowey e 15 flowey_lib_common::run_cargo_nextest_run 8
+        flowey e 15 flowey_lib_common::run_cargo_nextest_run 9
         flowey e 15 flowey_lib_hvlite::build_nextest_unit_tests 5
         flowey e 15 flowey_lib_common::publish_test_results 16
         flowey e 15 flowey_lib_common::publish_test_results 17
@@ -2341,6 +2368,27 @@ jobs:
         name: x64-linux-musl-unit-tests-unit-tests crypto (symcrypt)-junit-xml
         path: ${{ env.floweyvar5 }}
       name: 'publish test results: x64-linux-musl-unit-tests-unit-tests crypto (symcrypt) (JUnit XML)'
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: generate nextest command
+      run: flowey e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      shell: bash
+    - name: run 'unit-tests crypto (all)' nextest tests
+      run: |-
+        flowey e 15 flowey_lib_common::run_cargo_nextest_run 0
+        flowey e 15 flowey_lib_common::run_cargo_nextest_run 1
+        flowey e 15 flowey_lib_hvlite::build_nextest_unit_tests 6
+        flowey e 15 flowey_lib_common::publish_test_results 20
+        flowey e 15 flowey_lib_common::publish_test_results 21
+        flowey e 15 flowey_lib_common::publish_test_results 22
+        flowey v 15 'flowey_lib_common::publish_test_results:39:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:35:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar6
+        flowey v 15 'flowey_lib_common::publish_test_results:35:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__publish_test_results__23
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-linux-musl-unit-tests-unit-tests crypto (all)-junit-xml
+        path: ${{ env.floweyvar6 }}
+      name: 'publish test results: x64-linux-musl-unit-tests-unit-tests crypto (all) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: cargo build xtask
       run: |-
@@ -2358,12 +2406,12 @@ jobs:
       run: flowey e 15 flowey_lib_hvlite::build_nextest_unit_tests 0
       shell: bash
     - name: generate nextest command
-      run: flowey e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 4
+      run: flowey e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 5
       shell: bash
     - name: run 'unit-tests' nextest tests
       run: |-
-        flowey e 15 flowey_lib_common::run_cargo_nextest_run 8
-        flowey e 15 flowey_lib_common::run_cargo_nextest_run 9
+        flowey e 15 flowey_lib_common::run_cargo_nextest_run 10
+        flowey e 15 flowey_lib_common::run_cargo_nextest_run 11
         flowey e 15 flowey_lib_hvlite::build_nextest_unit_tests 1
         flowey e 15 flowey_lib_common::publish_test_results 0
         flowey e 15 flowey_lib_common::publish_test_results 1
@@ -2380,7 +2428,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
       run: |-
-        flowey e 15 flowey_lib_hvlite::build_nextest_unit_tests 6
+        flowey e 15 flowey_lib_hvlite::build_nextest_unit_tests 7
         flowey e 15 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
       shell: bash
     - name: run doctests for x86_64-unknown-linux-musl
@@ -2781,7 +2829,7 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 17 flowey_lib_common::git_checkout 0
-        flowey v 17 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar9
+        flowey v 17 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar10
         flowey v 17 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
@@ -2789,7 +2837,7 @@ jobs:
       with:
         fetch-depth: '1'
         path: repo0
-        persist-credentials: ${{ env.floweyvar9 }}
+        persist-credentials: ${{ env.floweyvar10 }}
       name: checkout repo openvmm
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
@@ -2809,14 +2857,14 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 17 flowey_lib_common::cache 4
-        flowey v 17 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar7
-        flowey v 17 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar8
+        flowey v 17 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
+        flowey v 17 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
       with:
-        key: ${{ env.floweyvar7 }}
-        path: ${{ env.floweyvar8 }}
+        key: ${{ env.floweyvar8 }}
+        path: ${{ env.floweyvar9 }}
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
@@ -2835,6 +2883,10 @@ jobs:
       run: |-
         flowey e 17 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
         flowey e 17 flowey_lib_hvlite::init_cross_build 0
+      shell: bash
+    - name: cargo clippy
+      run: |-
+        flowey e 17 flowey_lib_common::run_cargo_clippy 1
         flowey e 17 flowey_lib_hvlite::init_cross_build 2
       shell: bash
     - name: cargo build xtask
@@ -2855,13 +2907,13 @@ jobs:
       run: flowey e 17 flowey_lib_common::run_cargo_clippy 0
       shell: bash
     - name: cargo clippy
-      run: flowey e 17 flowey_lib_common::run_cargo_clippy 1
+      run: flowey e 17 flowey_lib_common::run_cargo_clippy 2
+      shell: bash
+    - name: cargo clippy
+      run: flowey e 17 flowey_lib_common::run_cargo_clippy 4
       shell: bash
     - name: cargo clippy
       run: flowey e 17 flowey_lib_common::run_cargo_clippy 3
-      shell: bash
-    - name: cargo clippy
-      run: flowey e 17 flowey_lib_common::run_cargo_clippy 2
       shell: bash
     - name: create cargo-nextest cache dir
       run: |-
@@ -2873,14 +2925,14 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 17 flowey_lib_common::cache 0
-        flowey v 17 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar5
-        flowey v 17 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar6
+        flowey v 17 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
+        flowey v 17 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
       with:
-        key: ${{ env.floweyvar5 }}
-        path: ${{ env.floweyvar6 }}
+        key: ${{ env.floweyvar6 }}
+        path: ${{ env.floweyvar7 }}
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
@@ -2900,13 +2952,13 @@ jobs:
         flowey e 17 flowey_lib_hvlite::run_cargo_nextest_run 0
       shell: bash
     - name: generate nextest command
-      run: flowey e 17 flowey_lib_common::gen_cargo_nextest_run_cmd 2
+      run: flowey e 17 flowey_lib_common::gen_cargo_nextest_run_cmd 1
       shell: bash
-    - name: run 'unit-tests crypto (rust)' nextest tests
+    - name: run 'unit-tests crypto (native)' nextest tests
       run: |-
-        flowey e 17 flowey_lib_common::run_cargo_nextest_run 4
-        flowey e 17 flowey_lib_common::run_cargo_nextest_run 5
-        flowey e 17 flowey_lib_hvlite::build_nextest_unit_tests 3
+        flowey e 17 flowey_lib_common::run_cargo_nextest_run 2
+        flowey e 17 flowey_lib_common::run_cargo_nextest_run 3
+        flowey e 17 flowey_lib_hvlite::build_nextest_unit_tests 2
         flowey e 17 flowey_lib_common::publish_test_results 5
         flowey e 17 flowey_lib_common::publish_test_results 6
         flowey e 17 flowey_lib_common::publish_test_results 4
@@ -2916,18 +2968,18 @@ jobs:
     - id: flowey_lib_common__publish_test_results__7
       uses: actions/upload-artifact@v7
       with:
-        name: aarch64-linux-unit-tests-unit-tests crypto (rust)-junit-xml
+        name: aarch64-linux-unit-tests-unit-tests crypto (native)-junit-xml
         path: ${{ env.floweyvar2 }}
-      name: 'publish test results: aarch64-linux-unit-tests-unit-tests crypto (rust) (JUnit XML)'
+      name: 'publish test results: aarch64-linux-unit-tests-unit-tests crypto (native) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey e 17 flowey_lib_common::gen_cargo_nextest_run_cmd 1
+      run: flowey e 17 flowey_lib_common::gen_cargo_nextest_run_cmd 3
       shell: bash
-    - name: run 'unit-tests crypto (openssl)' nextest tests
+    - name: run 'unit-tests crypto (rust)' nextest tests
       run: |-
-        flowey e 17 flowey_lib_common::run_cargo_nextest_run 2
-        flowey e 17 flowey_lib_common::run_cargo_nextest_run 3
-        flowey e 17 flowey_lib_hvlite::build_nextest_unit_tests 4
+        flowey e 17 flowey_lib_common::run_cargo_nextest_run 6
+        flowey e 17 flowey_lib_common::run_cargo_nextest_run 7
+        flowey e 17 flowey_lib_hvlite::build_nextest_unit_tests 3
         flowey e 17 flowey_lib_common::publish_test_results 8
         flowey e 17 flowey_lib_common::publish_test_results 9
         flowey e 17 flowey_lib_common::publish_test_results 10
@@ -2937,9 +2989,51 @@ jobs:
     - id: flowey_lib_common__publish_test_results__11
       uses: actions/upload-artifact@v7
       with:
-        name: aarch64-linux-unit-tests-unit-tests crypto (openssl)-junit-xml
+        name: aarch64-linux-unit-tests-unit-tests crypto (rust)-junit-xml
         path: ${{ env.floweyvar3 }}
+      name: 'publish test results: aarch64-linux-unit-tests-unit-tests crypto (rust) (JUnit XML)'
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: generate nextest command
+      run: flowey e 17 flowey_lib_common::gen_cargo_nextest_run_cmd 2
+      shell: bash
+    - name: run 'unit-tests crypto (openssl)' nextest tests
+      run: |-
+        flowey e 17 flowey_lib_common::run_cargo_nextest_run 4
+        flowey e 17 flowey_lib_common::run_cargo_nextest_run 5
+        flowey e 17 flowey_lib_hvlite::build_nextest_unit_tests 4
+        flowey e 17 flowey_lib_common::publish_test_results 12
+        flowey e 17 flowey_lib_common::publish_test_results 13
+        flowey e 17 flowey_lib_common::publish_test_results 14
+        flowey v 17 'flowey_lib_common::publish_test_results:25:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar4
+        flowey v 17 'flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__publish_test_results__15
+      uses: actions/upload-artifact@v7
+      with:
+        name: aarch64-linux-unit-tests-unit-tests crypto (openssl)-junit-xml
+        path: ${{ env.floweyvar4 }}
       name: 'publish test results: aarch64-linux-unit-tests-unit-tests crypto (openssl) (JUnit XML)'
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: generate nextest command
+      run: flowey e 17 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      shell: bash
+    - name: run 'unit-tests crypto (all)' nextest tests
+      run: |-
+        flowey e 17 flowey_lib_common::run_cargo_nextest_run 0
+        flowey e 17 flowey_lib_common::run_cargo_nextest_run 1
+        flowey e 17 flowey_lib_hvlite::build_nextest_unit_tests 5
+        flowey e 17 flowey_lib_common::publish_test_results 16
+        flowey e 17 flowey_lib_common::publish_test_results 17
+        flowey e 17 flowey_lib_common::publish_test_results 18
+        flowey v 17 'flowey_lib_common::publish_test_results:32:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:28:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar5
+        flowey v 17 'flowey_lib_common::publish_test_results:28:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__publish_test_results__19
+      uses: actions/upload-artifact@v7
+      with:
+        name: aarch64-linux-unit-tests-unit-tests crypto (all)-junit-xml
+        path: ${{ env.floweyvar5 }}
+      name: 'publish test results: aarch64-linux-unit-tests-unit-tests crypto (all) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: cargo build xtask
       run: |-
@@ -2957,34 +3051,13 @@ jobs:
       run: flowey e 17 flowey_lib_hvlite::build_nextest_unit_tests 0
       shell: bash
     - name: generate nextest command
-      run: flowey e 17 flowey_lib_common::gen_cargo_nextest_run_cmd 3
+      run: flowey e 17 flowey_lib_common::gen_cargo_nextest_run_cmd 4
       shell: bash
     - name: run 'unit-tests' nextest tests
       run: |-
-        flowey e 17 flowey_lib_common::run_cargo_nextest_run 6
-        flowey e 17 flowey_lib_common::run_cargo_nextest_run 7
+        flowey e 17 flowey_lib_common::run_cargo_nextest_run 8
+        flowey e 17 flowey_lib_common::run_cargo_nextest_run 9
         flowey e 17 flowey_lib_hvlite::build_nextest_unit_tests 1
-        flowey e 17 flowey_lib_common::publish_test_results 12
-        flowey e 17 flowey_lib_common::publish_test_results 13
-        flowey e 17 flowey_lib_common::publish_test_results 14
-        flowey v 17 'flowey_lib_common::publish_test_results:25:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar4
-        flowey v 17 'flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__publish_test_results__15
-      uses: actions/upload-artifact@v7
-      with:
-        name: aarch64-linux-unit-tests-unit-tests-junit-xml
-        path: ${{ env.floweyvar4 }}
-      name: 'publish test results: aarch64-linux-unit-tests-unit-tests (JUnit XML)'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: generate nextest command
-      run: flowey e 17 flowey_lib_common::gen_cargo_nextest_run_cmd 0
-      shell: bash
-    - name: run 'unit-tests crypto (native)' nextest tests
-      run: |-
-        flowey e 17 flowey_lib_common::run_cargo_nextest_run 0
-        flowey e 17 flowey_lib_common::run_cargo_nextest_run 1
-        flowey e 17 flowey_lib_hvlite::build_nextest_unit_tests 2
         flowey e 17 flowey_lib_common::publish_test_results 0
         flowey e 17 flowey_lib_common::publish_test_results 1
         flowey e 17 flowey_lib_common::publish_test_results 2
@@ -2994,13 +3067,13 @@ jobs:
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v7
       with:
-        name: aarch64-linux-unit-tests-unit-tests crypto (native)-junit-xml
+        name: aarch64-linux-unit-tests-unit-tests-junit-xml
         path: ${{ env.floweyvar1 }}
-      name: 'publish test results: aarch64-linux-unit-tests-unit-tests crypto (native) (JUnit XML)'
+      name: 'publish test results: aarch64-linux-unit-tests-unit-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
       run: |-
-        flowey e 17 flowey_lib_hvlite::build_nextest_unit_tests 5
+        flowey e 17 flowey_lib_hvlite::build_nextest_unit_tests 6
         flowey e 17 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
       shell: bash
     - name: run doctests for aarch64-unknown-linux-gnu
@@ -3105,7 +3178,7 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 18 flowey_lib_common::git_checkout 0
-        flowey v 18 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar10
+        flowey v 18 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar11
         flowey v 18 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
@@ -3113,7 +3186,7 @@ jobs:
       with:
         fetch-depth: '1'
         path: repo0
-        persist-credentials: ${{ env.floweyvar10 }}
+        persist-credentials: ${{ env.floweyvar11 }}
       name: checkout repo openvmm
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
@@ -3131,14 +3204,14 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 18 flowey_lib_common::cache 4
-        flowey v 18 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
-        flowey v 18 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
+        flowey v 18 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar9
+        flowey v 18 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar10
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
       with:
-        key: ${{ env.floweyvar8 }}
-        path: ${{ env.floweyvar9 }}
+        key: ${{ env.floweyvar9 }}
+        path: ${{ env.floweyvar10 }}
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
@@ -3172,17 +3245,20 @@ jobs:
         flowey e 18 flowey_lib_hvlite::init_cross_build 2
       shell: bash
     - name: cargo clippy
-      run: flowey e 18 flowey_lib_common::run_cargo_clippy 2
+      run: flowey e 18 flowey_lib_common::run_cargo_clippy 3
       shell: bash
     - name: cargo clippy
-      run: flowey e 18 flowey_lib_common::run_cargo_clippy 4
+      run: flowey e 18 flowey_lib_common::run_cargo_clippy 5
       shell: bash
     - name: cargo clippy
-      run: flowey e 18 flowey_lib_common::run_cargo_clippy 6
+      run: flowey e 18 flowey_lib_common::run_cargo_clippy 1
+      shell: bash
+    - name: cargo clippy
+      run: flowey e 18 flowey_lib_common::run_cargo_clippy 7
       shell: bash
     - name: cargo clippy
       run: |-
-        flowey e 18 flowey_lib_common::run_cargo_clippy 5
+        flowey e 18 flowey_lib_common::run_cargo_clippy 6
         flowey e 18 flowey_lib_hvlite::init_cross_build 0
       shell: bash
     - name: cargo build xtask
@@ -3203,10 +3279,10 @@ jobs:
       run: flowey e 18 flowey_lib_common::run_cargo_clippy 0
       shell: bash
     - name: cargo clippy
-      run: flowey e 18 flowey_lib_common::run_cargo_clippy 1
+      run: flowey e 18 flowey_lib_common::run_cargo_clippy 2
       shell: bash
     - name: cargo clippy
-      run: flowey e 18 flowey_lib_common::run_cargo_clippy 3
+      run: flowey e 18 flowey_lib_common::run_cargo_clippy 4
       shell: bash
     - name: create cargo-nextest cache dir
       run: |-
@@ -3218,14 +3294,14 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 18 flowey_lib_common::cache 0
-        flowey v 18 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
-        flowey v 18 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
+        flowey v 18 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar7
+        flowey v 18 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar8
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
       with:
-        key: ${{ env.floweyvar6 }}
-        path: ${{ env.floweyvar7 }}
+        key: ${{ env.floweyvar7 }}
+        path: ${{ env.floweyvar8 }}
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
@@ -3245,12 +3321,12 @@ jobs:
         flowey e 18 flowey_lib_hvlite::run_cargo_nextest_run 0
       shell: bash
     - name: generate nextest command
-      run: flowey e 18 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      run: flowey e 18 flowey_lib_common::gen_cargo_nextest_run_cmd 1
       shell: bash
     - name: run 'unit-tests crypto (native)' nextest tests
       run: |-
-        flowey e 18 flowey_lib_common::run_cargo_nextest_run 0
-        flowey e 18 flowey_lib_common::run_cargo_nextest_run 1
+        flowey e 18 flowey_lib_common::run_cargo_nextest_run 2
+        flowey e 18 flowey_lib_common::run_cargo_nextest_run 3
         flowey e 18 flowey_lib_hvlite::build_nextest_unit_tests 2
         flowey e 18 flowey_lib_common::publish_test_results 5
         flowey e 18 flowey_lib_common::publish_test_results 6
@@ -3266,12 +3342,12 @@ jobs:
       name: 'publish test results: aarch64-linux-musl-unit-tests-unit-tests crypto (native) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey e 18 flowey_lib_common::gen_cargo_nextest_run_cmd 2
+      run: flowey e 18 flowey_lib_common::gen_cargo_nextest_run_cmd 3
       shell: bash
     - name: run 'unit-tests crypto (rust)' nextest tests
       run: |-
-        flowey e 18 flowey_lib_common::run_cargo_nextest_run 4
-        flowey e 18 flowey_lib_common::run_cargo_nextest_run 5
+        flowey e 18 flowey_lib_common::run_cargo_nextest_run 6
+        flowey e 18 flowey_lib_common::run_cargo_nextest_run 7
         flowey e 18 flowey_lib_hvlite::build_nextest_unit_tests 3
         flowey e 18 flowey_lib_common::publish_test_results 8
         flowey e 18 flowey_lib_common::publish_test_results 9
@@ -3287,12 +3363,12 @@ jobs:
       name: 'publish test results: aarch64-linux-musl-unit-tests-unit-tests crypto (rust) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey e 18 flowey_lib_common::gen_cargo_nextest_run_cmd 1
+      run: flowey e 18 flowey_lib_common::gen_cargo_nextest_run_cmd 2
       shell: bash
     - name: run 'unit-tests crypto (openssl)' nextest tests
       run: |-
-        flowey e 18 flowey_lib_common::run_cargo_nextest_run 2
-        flowey e 18 flowey_lib_common::run_cargo_nextest_run 3
+        flowey e 18 flowey_lib_common::run_cargo_nextest_run 4
+        flowey e 18 flowey_lib_common::run_cargo_nextest_run 5
         flowey e 18 flowey_lib_hvlite::build_nextest_unit_tests 4
         flowey e 18 flowey_lib_common::publish_test_results 12
         flowey e 18 flowey_lib_common::publish_test_results 13
@@ -3308,12 +3384,12 @@ jobs:
       name: 'publish test results: aarch64-linux-musl-unit-tests-unit-tests crypto (openssl) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey e 18 flowey_lib_common::gen_cargo_nextest_run_cmd 3
+      run: flowey e 18 flowey_lib_common::gen_cargo_nextest_run_cmd 4
       shell: bash
     - name: run 'unit-tests crypto (symcrypt)' nextest tests
       run: |-
-        flowey e 18 flowey_lib_common::run_cargo_nextest_run 6
-        flowey e 18 flowey_lib_common::run_cargo_nextest_run 7
+        flowey e 18 flowey_lib_common::run_cargo_nextest_run 8
+        flowey e 18 flowey_lib_common::run_cargo_nextest_run 9
         flowey e 18 flowey_lib_hvlite::build_nextest_unit_tests 5
         flowey e 18 flowey_lib_common::publish_test_results 16
         flowey e 18 flowey_lib_common::publish_test_results 17
@@ -3327,6 +3403,27 @@ jobs:
         name: aarch64-linux-musl-unit-tests-unit-tests crypto (symcrypt)-junit-xml
         path: ${{ env.floweyvar5 }}
       name: 'publish test results: aarch64-linux-musl-unit-tests-unit-tests crypto (symcrypt) (JUnit XML)'
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: generate nextest command
+      run: flowey e 18 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      shell: bash
+    - name: run 'unit-tests crypto (all)' nextest tests
+      run: |-
+        flowey e 18 flowey_lib_common::run_cargo_nextest_run 0
+        flowey e 18 flowey_lib_common::run_cargo_nextest_run 1
+        flowey e 18 flowey_lib_hvlite::build_nextest_unit_tests 6
+        flowey e 18 flowey_lib_common::publish_test_results 20
+        flowey e 18 flowey_lib_common::publish_test_results 21
+        flowey e 18 flowey_lib_common::publish_test_results 22
+        flowey v 18 'flowey_lib_common::publish_test_results:39:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:35:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar6
+        flowey v 18 'flowey_lib_common::publish_test_results:35:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__publish_test_results__23
+      uses: actions/upload-artifact@v7
+      with:
+        name: aarch64-linux-musl-unit-tests-unit-tests crypto (all)-junit-xml
+        path: ${{ env.floweyvar6 }}
+      name: 'publish test results: aarch64-linux-musl-unit-tests-unit-tests crypto (all) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: cargo build xtask
       run: |-
@@ -3344,12 +3441,12 @@ jobs:
       run: flowey e 18 flowey_lib_hvlite::build_nextest_unit_tests 0
       shell: bash
     - name: generate nextest command
-      run: flowey e 18 flowey_lib_common::gen_cargo_nextest_run_cmd 4
+      run: flowey e 18 flowey_lib_common::gen_cargo_nextest_run_cmd 5
       shell: bash
     - name: run 'unit-tests' nextest tests
       run: |-
-        flowey e 18 flowey_lib_common::run_cargo_nextest_run 8
-        flowey e 18 flowey_lib_common::run_cargo_nextest_run 9
+        flowey e 18 flowey_lib_common::run_cargo_nextest_run 10
+        flowey e 18 flowey_lib_common::run_cargo_nextest_run 11
         flowey e 18 flowey_lib_hvlite::build_nextest_unit_tests 1
         flowey e 18 flowey_lib_common::publish_test_results 0
         flowey e 18 flowey_lib_common::publish_test_results 1
@@ -3366,7 +3463,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
       run: |-
-        flowey e 18 flowey_lib_hvlite::build_nextest_unit_tests 6
+        flowey e 18 flowey_lib_hvlite::build_nextest_unit_tests 7
         flowey e 18 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
       shell: bash
     - name: run doctests for aarch64-unknown-linux-musl

--- a/.github/workflows/openvmm-pr-release.yaml
+++ b/.github/workflows/openvmm-pr-release.yaml
@@ -194,10 +194,6 @@ jobs:
       run: |-
         flowey e 0 flowey_lib_hvlite::_jobs::check_xtask_fmt 0
         flowey e 0 flowey_lib_hvlite::init_cross_build 0
-      shell: bash
-    - name: cargo clippy
-      run: |-
-        flowey e 0 flowey_lib_common::run_cargo_clippy 1
         flowey e 0 flowey_lib_hvlite::init_cross_build 1
       shell: bash
     - name: cargo build xtask
@@ -218,13 +214,13 @@ jobs:
       run: flowey e 0 flowey_lib_common::run_cargo_clippy 0
       shell: bash
     - name: cargo clippy
-      run: flowey e 0 flowey_lib_common::run_cargo_clippy 2
-      shell: bash
-    - name: cargo clippy
-      run: flowey e 0 flowey_lib_common::run_cargo_clippy 4
+      run: flowey e 0 flowey_lib_common::run_cargo_clippy 1
       shell: bash
     - name: cargo clippy
       run: flowey e 0 flowey_lib_common::run_cargo_clippy 3
+      shell: bash
+    - name: cargo clippy
+      run: flowey e 0 flowey_lib_common::run_cargo_clippy 2
       shell: bash
     - name: 'validate cache entry: gh-release-download'
       run: flowey e 0 flowey_lib_common::cache 3
@@ -1607,7 +1603,7 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 14 flowey_lib_common::git_checkout 0
-        flowey v 14 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar10
+        flowey v 14 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar9
         flowey v 14 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
@@ -1615,7 +1611,7 @@ jobs:
       with:
         fetch-depth: '1'
         path: repo0
-        persist-credentials: ${{ env.floweyvar10 }}
+        persist-credentials: ${{ env.floweyvar9 }}
       name: checkout repo openvmm
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
@@ -1635,14 +1631,14 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 14 flowey_lib_common::cache 4
-        flowey v 14 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
-        flowey v 14 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
+        flowey v 14 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar7
+        flowey v 14 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar8
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
       with:
-        key: ${{ env.floweyvar8 }}
-        path: ${{ env.floweyvar9 }}
+        key: ${{ env.floweyvar7 }}
+        path: ${{ env.floweyvar8 }}
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
@@ -1695,14 +1691,14 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 14 flowey_lib_common::cache 0
-        flowey v 14 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
-        flowey v 14 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
+        flowey v 14 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar5
+        flowey v 14 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar6
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
       with:
-        key: ${{ env.floweyvar6 }}
-        path: ${{ env.floweyvar7 }}
+        key: ${{ env.floweyvar5 }}
+        path: ${{ env.floweyvar6 }}
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
@@ -1722,13 +1718,13 @@ jobs:
         flowey e 14 flowey_lib_hvlite::run_cargo_nextest_run 0
       shell: bash
     - name: generate nextest command
-      run: flowey e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 1
+      run: flowey e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 2
       shell: bash
-    - name: run 'unit-tests crypto (native)' nextest tests
+    - name: run 'unit-tests crypto (rust)' nextest tests
       run: |-
-        flowey e 14 flowey_lib_common::run_cargo_nextest_run 2
-        flowey e 14 flowey_lib_common::run_cargo_nextest_run 3
-        flowey e 14 flowey_lib_hvlite::build_nextest_unit_tests 2
+        flowey e 14 flowey_lib_common::run_cargo_nextest_run 4
+        flowey e 14 flowey_lib_common::run_cargo_nextest_run 5
+        flowey e 14 flowey_lib_hvlite::build_nextest_unit_tests 3
         flowey e 14 flowey_lib_common::publish_test_results 5
         flowey e 14 flowey_lib_common::publish_test_results 6
         flowey e 14 flowey_lib_common::publish_test_results 4
@@ -1738,18 +1734,18 @@ jobs:
     - id: flowey_lib_common__publish_test_results__7
       uses: actions/upload-artifact@v7
       with:
-        name: x64-linux-unit-tests-unit-tests crypto (native)-junit-xml
+        name: x64-linux-unit-tests-unit-tests crypto (rust)-junit-xml
         path: ${{ env.floweyvar2 }}
-      name: 'publish test results: x64-linux-unit-tests-unit-tests crypto (native) (JUnit XML)'
+      name: 'publish test results: x64-linux-unit-tests-unit-tests crypto (rust) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 3
+      run: flowey e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 1
       shell: bash
-    - name: run 'unit-tests crypto (rust)' nextest tests
+    - name: run 'unit-tests crypto (openssl)' nextest tests
       run: |-
-        flowey e 14 flowey_lib_common::run_cargo_nextest_run 6
-        flowey e 14 flowey_lib_common::run_cargo_nextest_run 7
-        flowey e 14 flowey_lib_hvlite::build_nextest_unit_tests 3
+        flowey e 14 flowey_lib_common::run_cargo_nextest_run 2
+        flowey e 14 flowey_lib_common::run_cargo_nextest_run 3
+        flowey e 14 flowey_lib_hvlite::build_nextest_unit_tests 4
         flowey e 14 flowey_lib_common::publish_test_results 8
         flowey e 14 flowey_lib_common::publish_test_results 9
         flowey e 14 flowey_lib_common::publish_test_results 10
@@ -1759,51 +1755,9 @@ jobs:
     - id: flowey_lib_common__publish_test_results__11
       uses: actions/upload-artifact@v7
       with:
-        name: x64-linux-unit-tests-unit-tests crypto (rust)-junit-xml
-        path: ${{ env.floweyvar3 }}
-      name: 'publish test results: x64-linux-unit-tests-unit-tests crypto (rust) (JUnit XML)'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: generate nextest command
-      run: flowey e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 2
-      shell: bash
-    - name: run 'unit-tests crypto (openssl)' nextest tests
-      run: |-
-        flowey e 14 flowey_lib_common::run_cargo_nextest_run 4
-        flowey e 14 flowey_lib_common::run_cargo_nextest_run 5
-        flowey e 14 flowey_lib_hvlite::build_nextest_unit_tests 4
-        flowey e 14 flowey_lib_common::publish_test_results 12
-        flowey e 14 flowey_lib_common::publish_test_results 13
-        flowey e 14 flowey_lib_common::publish_test_results 14
-        flowey v 14 'flowey_lib_common::publish_test_results:25:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar4
-        flowey v 14 'flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__publish_test_results__15
-      uses: actions/upload-artifact@v7
-      with:
         name: x64-linux-unit-tests-unit-tests crypto (openssl)-junit-xml
-        path: ${{ env.floweyvar4 }}
+        path: ${{ env.floweyvar3 }}
       name: 'publish test results: x64-linux-unit-tests-unit-tests crypto (openssl) (JUnit XML)'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: generate nextest command
-      run: flowey e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 0
-      shell: bash
-    - name: run 'unit-tests crypto (all)' nextest tests
-      run: |-
-        flowey e 14 flowey_lib_common::run_cargo_nextest_run 0
-        flowey e 14 flowey_lib_common::run_cargo_nextest_run 1
-        flowey e 14 flowey_lib_hvlite::build_nextest_unit_tests 5
-        flowey e 14 flowey_lib_common::publish_test_results 16
-        flowey e 14 flowey_lib_common::publish_test_results 17
-        flowey e 14 flowey_lib_common::publish_test_results 18
-        flowey v 14 'flowey_lib_common::publish_test_results:32:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:28:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar5
-        flowey v 14 'flowey_lib_common::publish_test_results:28:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__publish_test_results__19
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-linux-unit-tests-unit-tests crypto (all)-junit-xml
-        path: ${{ env.floweyvar5 }}
-      name: 'publish test results: x64-linux-unit-tests-unit-tests crypto (all) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: cargo build xtask
       run: |-
@@ -1821,13 +1775,34 @@ jobs:
       run: flowey e 14 flowey_lib_hvlite::build_nextest_unit_tests 0
       shell: bash
     - name: generate nextest command
-      run: flowey e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 4
+      run: flowey e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 3
       shell: bash
     - name: run 'unit-tests' nextest tests
       run: |-
-        flowey e 14 flowey_lib_common::run_cargo_nextest_run 8
-        flowey e 14 flowey_lib_common::run_cargo_nextest_run 9
+        flowey e 14 flowey_lib_common::run_cargo_nextest_run 6
+        flowey e 14 flowey_lib_common::run_cargo_nextest_run 7
         flowey e 14 flowey_lib_hvlite::build_nextest_unit_tests 1
+        flowey e 14 flowey_lib_common::publish_test_results 12
+        flowey e 14 flowey_lib_common::publish_test_results 13
+        flowey e 14 flowey_lib_common::publish_test_results 14
+        flowey v 14 'flowey_lib_common::publish_test_results:25:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar4
+        flowey v 14 'flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__publish_test_results__15
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-linux-unit-tests-unit-tests-junit-xml
+        path: ${{ env.floweyvar4 }}
+      name: 'publish test results: x64-linux-unit-tests-unit-tests (JUnit XML)'
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: generate nextest command
+      run: flowey e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      shell: bash
+    - name: run 'unit-tests crypto (native)' nextest tests
+      run: |-
+        flowey e 14 flowey_lib_common::run_cargo_nextest_run 0
+        flowey e 14 flowey_lib_common::run_cargo_nextest_run 1
+        flowey e 14 flowey_lib_hvlite::build_nextest_unit_tests 2
         flowey e 14 flowey_lib_common::publish_test_results 0
         flowey e 14 flowey_lib_common::publish_test_results 1
         flowey e 14 flowey_lib_common::publish_test_results 2
@@ -1837,13 +1812,13 @@ jobs:
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v7
       with:
-        name: x64-linux-unit-tests-unit-tests-junit-xml
+        name: x64-linux-unit-tests-unit-tests crypto (native)-junit-xml
         path: ${{ env.floweyvar1 }}
-      name: 'publish test results: x64-linux-unit-tests-unit-tests (JUnit XML)'
+      name: 'publish test results: x64-linux-unit-tests-unit-tests crypto (native) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
       run: |-
-        flowey e 14 flowey_lib_hvlite::build_nextest_unit_tests 6
+        flowey e 14 flowey_lib_hvlite::build_nextest_unit_tests 5
         flowey e 14 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
       shell: bash
     - name: run doctests for x86_64-unknown-linux-gnu
@@ -1906,7 +1881,7 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 15 flowey_lib_common::git_checkout 0
-        flowey v 15 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar11
+        flowey v 15 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar10
         flowey v 15 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
@@ -1914,7 +1889,7 @@ jobs:
       with:
         fetch-depth: '1'
         path: repo0
-        persist-credentials: ${{ env.floweyvar11 }}
+        persist-credentials: ${{ env.floweyvar10 }}
       name: checkout repo openvmm
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
@@ -1932,14 +1907,14 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 15 flowey_lib_common::cache 4
-        flowey v 15 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar9
-        flowey v 15 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar10
+        flowey v 15 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
+        flowey v 15 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
       with:
-        key: ${{ env.floweyvar9 }}
-        path: ${{ env.floweyvar10 }}
+        key: ${{ env.floweyvar8 }}
+        path: ${{ env.floweyvar9 }}
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
@@ -1973,20 +1948,17 @@ jobs:
         flowey e 15 flowey_lib_hvlite::init_cross_build 2
       shell: bash
     - name: cargo clippy
-      run: flowey e 15 flowey_lib_common::run_cargo_clippy 3
+      run: flowey e 15 flowey_lib_common::run_cargo_clippy 2
       shell: bash
     - name: cargo clippy
-      run: flowey e 15 flowey_lib_common::run_cargo_clippy 5
+      run: flowey e 15 flowey_lib_common::run_cargo_clippy 4
       shell: bash
     - name: cargo clippy
-      run: flowey e 15 flowey_lib_common::run_cargo_clippy 1
-      shell: bash
-    - name: cargo clippy
-      run: flowey e 15 flowey_lib_common::run_cargo_clippy 7
+      run: flowey e 15 flowey_lib_common::run_cargo_clippy 6
       shell: bash
     - name: cargo clippy
       run: |-
-        flowey e 15 flowey_lib_common::run_cargo_clippy 6
+        flowey e 15 flowey_lib_common::run_cargo_clippy 5
         flowey e 15 flowey_lib_hvlite::init_cross_build 0
       shell: bash
     - name: cargo build xtask
@@ -2007,10 +1979,10 @@ jobs:
       run: flowey e 15 flowey_lib_common::run_cargo_clippy 0
       shell: bash
     - name: cargo clippy
-      run: flowey e 15 flowey_lib_common::run_cargo_clippy 2
+      run: flowey e 15 flowey_lib_common::run_cargo_clippy 1
       shell: bash
     - name: cargo clippy
-      run: flowey e 15 flowey_lib_common::run_cargo_clippy 4
+      run: flowey e 15 flowey_lib_common::run_cargo_clippy 3
       shell: bash
     - name: create cargo-nextest cache dir
       run: |-
@@ -2022,14 +1994,14 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 15 flowey_lib_common::cache 0
-        flowey v 15 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar7
-        flowey v 15 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar8
+        flowey v 15 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
+        flowey v 15 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
       with:
-        key: ${{ env.floweyvar7 }}
-        path: ${{ env.floweyvar8 }}
+        key: ${{ env.floweyvar6 }}
+        path: ${{ env.floweyvar7 }}
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
@@ -2049,12 +2021,12 @@ jobs:
         flowey e 15 flowey_lib_hvlite::run_cargo_nextest_run 0
       shell: bash
     - name: generate nextest command
-      run: flowey e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 1
+      run: flowey e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 0
       shell: bash
     - name: run 'unit-tests crypto (native)' nextest tests
       run: |-
-        flowey e 15 flowey_lib_common::run_cargo_nextest_run 2
-        flowey e 15 flowey_lib_common::run_cargo_nextest_run 3
+        flowey e 15 flowey_lib_common::run_cargo_nextest_run 0
+        flowey e 15 flowey_lib_common::run_cargo_nextest_run 1
         flowey e 15 flowey_lib_hvlite::build_nextest_unit_tests 2
         flowey e 15 flowey_lib_common::publish_test_results 5
         flowey e 15 flowey_lib_common::publish_test_results 6
@@ -2070,12 +2042,12 @@ jobs:
       name: 'publish test results: x64-linux-musl-unit-tests-unit-tests crypto (native) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 3
+      run: flowey e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 2
       shell: bash
     - name: run 'unit-tests crypto (rust)' nextest tests
       run: |-
-        flowey e 15 flowey_lib_common::run_cargo_nextest_run 6
-        flowey e 15 flowey_lib_common::run_cargo_nextest_run 7
+        flowey e 15 flowey_lib_common::run_cargo_nextest_run 4
+        flowey e 15 flowey_lib_common::run_cargo_nextest_run 5
         flowey e 15 flowey_lib_hvlite::build_nextest_unit_tests 3
         flowey e 15 flowey_lib_common::publish_test_results 8
         flowey e 15 flowey_lib_common::publish_test_results 9
@@ -2091,12 +2063,12 @@ jobs:
       name: 'publish test results: x64-linux-musl-unit-tests-unit-tests crypto (rust) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 2
+      run: flowey e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 1
       shell: bash
     - name: run 'unit-tests crypto (openssl)' nextest tests
       run: |-
-        flowey e 15 flowey_lib_common::run_cargo_nextest_run 4
-        flowey e 15 flowey_lib_common::run_cargo_nextest_run 5
+        flowey e 15 flowey_lib_common::run_cargo_nextest_run 2
+        flowey e 15 flowey_lib_common::run_cargo_nextest_run 3
         flowey e 15 flowey_lib_hvlite::build_nextest_unit_tests 4
         flowey e 15 flowey_lib_common::publish_test_results 12
         flowey e 15 flowey_lib_common::publish_test_results 13
@@ -2112,12 +2084,12 @@ jobs:
       name: 'publish test results: x64-linux-musl-unit-tests-unit-tests crypto (openssl) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 4
+      run: flowey e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 3
       shell: bash
     - name: run 'unit-tests crypto (symcrypt)' nextest tests
       run: |-
-        flowey e 15 flowey_lib_common::run_cargo_nextest_run 8
-        flowey e 15 flowey_lib_common::run_cargo_nextest_run 9
+        flowey e 15 flowey_lib_common::run_cargo_nextest_run 6
+        flowey e 15 flowey_lib_common::run_cargo_nextest_run 7
         flowey e 15 flowey_lib_hvlite::build_nextest_unit_tests 5
         flowey e 15 flowey_lib_common::publish_test_results 16
         flowey e 15 flowey_lib_common::publish_test_results 17
@@ -2131,27 +2103,6 @@ jobs:
         name: x64-linux-musl-unit-tests-unit-tests crypto (symcrypt)-junit-xml
         path: ${{ env.floweyvar5 }}
       name: 'publish test results: x64-linux-musl-unit-tests-unit-tests crypto (symcrypt) (JUnit XML)'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: generate nextest command
-      run: flowey e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 0
-      shell: bash
-    - name: run 'unit-tests crypto (all)' nextest tests
-      run: |-
-        flowey e 15 flowey_lib_common::run_cargo_nextest_run 0
-        flowey e 15 flowey_lib_common::run_cargo_nextest_run 1
-        flowey e 15 flowey_lib_hvlite::build_nextest_unit_tests 6
-        flowey e 15 flowey_lib_common::publish_test_results 20
-        flowey e 15 flowey_lib_common::publish_test_results 21
-        flowey e 15 flowey_lib_common::publish_test_results 22
-        flowey v 15 'flowey_lib_common::publish_test_results:39:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:35:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar6
-        flowey v 15 'flowey_lib_common::publish_test_results:35:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__publish_test_results__23
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-linux-musl-unit-tests-unit-tests crypto (all)-junit-xml
-        path: ${{ env.floweyvar6 }}
-      name: 'publish test results: x64-linux-musl-unit-tests-unit-tests crypto (all) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: cargo build xtask
       run: |-
@@ -2169,12 +2120,12 @@ jobs:
       run: flowey e 15 flowey_lib_hvlite::build_nextest_unit_tests 0
       shell: bash
     - name: generate nextest command
-      run: flowey e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 5
+      run: flowey e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 4
       shell: bash
     - name: run 'unit-tests' nextest tests
       run: |-
-        flowey e 15 flowey_lib_common::run_cargo_nextest_run 10
-        flowey e 15 flowey_lib_common::run_cargo_nextest_run 11
+        flowey e 15 flowey_lib_common::run_cargo_nextest_run 8
+        flowey e 15 flowey_lib_common::run_cargo_nextest_run 9
         flowey e 15 flowey_lib_hvlite::build_nextest_unit_tests 1
         flowey e 15 flowey_lib_common::publish_test_results 0
         flowey e 15 flowey_lib_common::publish_test_results 1
@@ -2191,7 +2142,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
       run: |-
-        flowey e 15 flowey_lib_hvlite::build_nextest_unit_tests 7
+        flowey e 15 flowey_lib_hvlite::build_nextest_unit_tests 6
         flowey e 15 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
       shell: bash
     - name: run doctests for x86_64-unknown-linux-musl
@@ -2596,7 +2547,7 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 17 flowey_lib_common::git_checkout 0
-        flowey v 17 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar10
+        flowey v 17 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar9
         flowey v 17 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
@@ -2604,7 +2555,7 @@ jobs:
       with:
         fetch-depth: '1'
         path: repo0
-        persist-credentials: ${{ env.floweyvar10 }}
+        persist-credentials: ${{ env.floweyvar9 }}
       name: checkout repo openvmm
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
@@ -2624,14 +2575,14 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 17 flowey_lib_common::cache 4
-        flowey v 17 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
-        flowey v 17 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
+        flowey v 17 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar7
+        flowey v 17 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar8
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
       with:
-        key: ${{ env.floweyvar8 }}
-        path: ${{ env.floweyvar9 }}
+        key: ${{ env.floweyvar7 }}
+        path: ${{ env.floweyvar8 }}
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
@@ -2650,10 +2601,6 @@ jobs:
       run: |-
         flowey e 17 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
         flowey e 17 flowey_lib_hvlite::init_cross_build 0
-      shell: bash
-    - name: cargo clippy
-      run: |-
-        flowey e 17 flowey_lib_common::run_cargo_clippy 1
         flowey e 17 flowey_lib_hvlite::init_cross_build 2
       shell: bash
     - name: cargo build xtask
@@ -2674,13 +2621,13 @@ jobs:
       run: flowey e 17 flowey_lib_common::run_cargo_clippy 0
       shell: bash
     - name: cargo clippy
-      run: flowey e 17 flowey_lib_common::run_cargo_clippy 2
-      shell: bash
-    - name: cargo clippy
-      run: flowey e 17 flowey_lib_common::run_cargo_clippy 4
+      run: flowey e 17 flowey_lib_common::run_cargo_clippy 1
       shell: bash
     - name: cargo clippy
       run: flowey e 17 flowey_lib_common::run_cargo_clippy 3
+      shell: bash
+    - name: cargo clippy
+      run: flowey e 17 flowey_lib_common::run_cargo_clippy 2
       shell: bash
     - name: create cargo-nextest cache dir
       run: |-
@@ -2692,14 +2639,14 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 17 flowey_lib_common::cache 0
-        flowey v 17 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
-        flowey v 17 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
+        flowey v 17 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar5
+        flowey v 17 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar6
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
       with:
-        key: ${{ env.floweyvar6 }}
-        path: ${{ env.floweyvar7 }}
+        key: ${{ env.floweyvar5 }}
+        path: ${{ env.floweyvar6 }}
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
@@ -2719,13 +2666,13 @@ jobs:
         flowey e 17 flowey_lib_hvlite::run_cargo_nextest_run 0
       shell: bash
     - name: generate nextest command
-      run: flowey e 17 flowey_lib_common::gen_cargo_nextest_run_cmd 1
+      run: flowey e 17 flowey_lib_common::gen_cargo_nextest_run_cmd 2
       shell: bash
-    - name: run 'unit-tests crypto (native)' nextest tests
+    - name: run 'unit-tests crypto (rust)' nextest tests
       run: |-
-        flowey e 17 flowey_lib_common::run_cargo_nextest_run 2
-        flowey e 17 flowey_lib_common::run_cargo_nextest_run 3
-        flowey e 17 flowey_lib_hvlite::build_nextest_unit_tests 2
+        flowey e 17 flowey_lib_common::run_cargo_nextest_run 4
+        flowey e 17 flowey_lib_common::run_cargo_nextest_run 5
+        flowey e 17 flowey_lib_hvlite::build_nextest_unit_tests 3
         flowey e 17 flowey_lib_common::publish_test_results 5
         flowey e 17 flowey_lib_common::publish_test_results 6
         flowey e 17 flowey_lib_common::publish_test_results 4
@@ -2735,18 +2682,18 @@ jobs:
     - id: flowey_lib_common__publish_test_results__7
       uses: actions/upload-artifact@v7
       with:
-        name: aarch64-linux-unit-tests-unit-tests crypto (native)-junit-xml
+        name: aarch64-linux-unit-tests-unit-tests crypto (rust)-junit-xml
         path: ${{ env.floweyvar2 }}
-      name: 'publish test results: aarch64-linux-unit-tests-unit-tests crypto (native) (JUnit XML)'
+      name: 'publish test results: aarch64-linux-unit-tests-unit-tests crypto (rust) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey e 17 flowey_lib_common::gen_cargo_nextest_run_cmd 3
+      run: flowey e 17 flowey_lib_common::gen_cargo_nextest_run_cmd 1
       shell: bash
-    - name: run 'unit-tests crypto (rust)' nextest tests
+    - name: run 'unit-tests crypto (openssl)' nextest tests
       run: |-
-        flowey e 17 flowey_lib_common::run_cargo_nextest_run 6
-        flowey e 17 flowey_lib_common::run_cargo_nextest_run 7
-        flowey e 17 flowey_lib_hvlite::build_nextest_unit_tests 3
+        flowey e 17 flowey_lib_common::run_cargo_nextest_run 2
+        flowey e 17 flowey_lib_common::run_cargo_nextest_run 3
+        flowey e 17 flowey_lib_hvlite::build_nextest_unit_tests 4
         flowey e 17 flowey_lib_common::publish_test_results 8
         flowey e 17 flowey_lib_common::publish_test_results 9
         flowey e 17 flowey_lib_common::publish_test_results 10
@@ -2756,51 +2703,9 @@ jobs:
     - id: flowey_lib_common__publish_test_results__11
       uses: actions/upload-artifact@v7
       with:
-        name: aarch64-linux-unit-tests-unit-tests crypto (rust)-junit-xml
-        path: ${{ env.floweyvar3 }}
-      name: 'publish test results: aarch64-linux-unit-tests-unit-tests crypto (rust) (JUnit XML)'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: generate nextest command
-      run: flowey e 17 flowey_lib_common::gen_cargo_nextest_run_cmd 2
-      shell: bash
-    - name: run 'unit-tests crypto (openssl)' nextest tests
-      run: |-
-        flowey e 17 flowey_lib_common::run_cargo_nextest_run 4
-        flowey e 17 flowey_lib_common::run_cargo_nextest_run 5
-        flowey e 17 flowey_lib_hvlite::build_nextest_unit_tests 4
-        flowey e 17 flowey_lib_common::publish_test_results 12
-        flowey e 17 flowey_lib_common::publish_test_results 13
-        flowey e 17 flowey_lib_common::publish_test_results 14
-        flowey v 17 'flowey_lib_common::publish_test_results:25:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar4
-        flowey v 17 'flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__publish_test_results__15
-      uses: actions/upload-artifact@v7
-      with:
         name: aarch64-linux-unit-tests-unit-tests crypto (openssl)-junit-xml
-        path: ${{ env.floweyvar4 }}
+        path: ${{ env.floweyvar3 }}
       name: 'publish test results: aarch64-linux-unit-tests-unit-tests crypto (openssl) (JUnit XML)'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: generate nextest command
-      run: flowey e 17 flowey_lib_common::gen_cargo_nextest_run_cmd 0
-      shell: bash
-    - name: run 'unit-tests crypto (all)' nextest tests
-      run: |-
-        flowey e 17 flowey_lib_common::run_cargo_nextest_run 0
-        flowey e 17 flowey_lib_common::run_cargo_nextest_run 1
-        flowey e 17 flowey_lib_hvlite::build_nextest_unit_tests 5
-        flowey e 17 flowey_lib_common::publish_test_results 16
-        flowey e 17 flowey_lib_common::publish_test_results 17
-        flowey e 17 flowey_lib_common::publish_test_results 18
-        flowey v 17 'flowey_lib_common::publish_test_results:32:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:28:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar5
-        flowey v 17 'flowey_lib_common::publish_test_results:28:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__publish_test_results__19
-      uses: actions/upload-artifact@v7
-      with:
-        name: aarch64-linux-unit-tests-unit-tests crypto (all)-junit-xml
-        path: ${{ env.floweyvar5 }}
-      name: 'publish test results: aarch64-linux-unit-tests-unit-tests crypto (all) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: cargo build xtask
       run: |-
@@ -2818,13 +2723,34 @@ jobs:
       run: flowey e 17 flowey_lib_hvlite::build_nextest_unit_tests 0
       shell: bash
     - name: generate nextest command
-      run: flowey e 17 flowey_lib_common::gen_cargo_nextest_run_cmd 4
+      run: flowey e 17 flowey_lib_common::gen_cargo_nextest_run_cmd 3
       shell: bash
     - name: run 'unit-tests' nextest tests
       run: |-
-        flowey e 17 flowey_lib_common::run_cargo_nextest_run 8
-        flowey e 17 flowey_lib_common::run_cargo_nextest_run 9
+        flowey e 17 flowey_lib_common::run_cargo_nextest_run 6
+        flowey e 17 flowey_lib_common::run_cargo_nextest_run 7
         flowey e 17 flowey_lib_hvlite::build_nextest_unit_tests 1
+        flowey e 17 flowey_lib_common::publish_test_results 12
+        flowey e 17 flowey_lib_common::publish_test_results 13
+        flowey e 17 flowey_lib_common::publish_test_results 14
+        flowey v 17 'flowey_lib_common::publish_test_results:25:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar4
+        flowey v 17 'flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__publish_test_results__15
+      uses: actions/upload-artifact@v7
+      with:
+        name: aarch64-linux-unit-tests-unit-tests-junit-xml
+        path: ${{ env.floweyvar4 }}
+      name: 'publish test results: aarch64-linux-unit-tests-unit-tests (JUnit XML)'
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: generate nextest command
+      run: flowey e 17 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      shell: bash
+    - name: run 'unit-tests crypto (native)' nextest tests
+      run: |-
+        flowey e 17 flowey_lib_common::run_cargo_nextest_run 0
+        flowey e 17 flowey_lib_common::run_cargo_nextest_run 1
+        flowey e 17 flowey_lib_hvlite::build_nextest_unit_tests 2
         flowey e 17 flowey_lib_common::publish_test_results 0
         flowey e 17 flowey_lib_common::publish_test_results 1
         flowey e 17 flowey_lib_common::publish_test_results 2
@@ -2834,13 +2760,13 @@ jobs:
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v7
       with:
-        name: aarch64-linux-unit-tests-unit-tests-junit-xml
+        name: aarch64-linux-unit-tests-unit-tests crypto (native)-junit-xml
         path: ${{ env.floweyvar1 }}
-      name: 'publish test results: aarch64-linux-unit-tests-unit-tests (JUnit XML)'
+      name: 'publish test results: aarch64-linux-unit-tests-unit-tests crypto (native) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
       run: |-
-        flowey e 17 flowey_lib_hvlite::build_nextest_unit_tests 6
+        flowey e 17 flowey_lib_hvlite::build_nextest_unit_tests 5
         flowey e 17 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
       shell: bash
     - name: run doctests for aarch64-unknown-linux-gnu
@@ -2947,7 +2873,7 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 18 flowey_lib_common::git_checkout 0
-        flowey v 18 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar11
+        flowey v 18 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar10
         flowey v 18 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
@@ -2955,7 +2881,7 @@ jobs:
       with:
         fetch-depth: '1'
         path: repo0
-        persist-credentials: ${{ env.floweyvar11 }}
+        persist-credentials: ${{ env.floweyvar10 }}
       name: checkout repo openvmm
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
@@ -2973,14 +2899,14 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 18 flowey_lib_common::cache 4
-        flowey v 18 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar9
-        flowey v 18 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar10
+        flowey v 18 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
+        flowey v 18 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
       with:
-        key: ${{ env.floweyvar9 }}
-        path: ${{ env.floweyvar10 }}
+        key: ${{ env.floweyvar8 }}
+        path: ${{ env.floweyvar9 }}
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
@@ -3014,20 +2940,17 @@ jobs:
         flowey e 18 flowey_lib_hvlite::init_cross_build 2
       shell: bash
     - name: cargo clippy
-      run: flowey e 18 flowey_lib_common::run_cargo_clippy 3
+      run: flowey e 18 flowey_lib_common::run_cargo_clippy 2
       shell: bash
     - name: cargo clippy
-      run: flowey e 18 flowey_lib_common::run_cargo_clippy 5
+      run: flowey e 18 flowey_lib_common::run_cargo_clippy 4
       shell: bash
     - name: cargo clippy
-      run: flowey e 18 flowey_lib_common::run_cargo_clippy 1
-      shell: bash
-    - name: cargo clippy
-      run: flowey e 18 flowey_lib_common::run_cargo_clippy 7
+      run: flowey e 18 flowey_lib_common::run_cargo_clippy 6
       shell: bash
     - name: cargo clippy
       run: |-
-        flowey e 18 flowey_lib_common::run_cargo_clippy 6
+        flowey e 18 flowey_lib_common::run_cargo_clippy 5
         flowey e 18 flowey_lib_hvlite::init_cross_build 0
       shell: bash
     - name: cargo build xtask
@@ -3048,10 +2971,10 @@ jobs:
       run: flowey e 18 flowey_lib_common::run_cargo_clippy 0
       shell: bash
     - name: cargo clippy
-      run: flowey e 18 flowey_lib_common::run_cargo_clippy 2
+      run: flowey e 18 flowey_lib_common::run_cargo_clippy 1
       shell: bash
     - name: cargo clippy
-      run: flowey e 18 flowey_lib_common::run_cargo_clippy 4
+      run: flowey e 18 flowey_lib_common::run_cargo_clippy 3
       shell: bash
     - name: create cargo-nextest cache dir
       run: |-
@@ -3063,14 +2986,14 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 18 flowey_lib_common::cache 0
-        flowey v 18 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar7
-        flowey v 18 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar8
+        flowey v 18 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
+        flowey v 18 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
       with:
-        key: ${{ env.floweyvar7 }}
-        path: ${{ env.floweyvar8 }}
+        key: ${{ env.floweyvar6 }}
+        path: ${{ env.floweyvar7 }}
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
@@ -3090,12 +3013,12 @@ jobs:
         flowey e 18 flowey_lib_hvlite::run_cargo_nextest_run 0
       shell: bash
     - name: generate nextest command
-      run: flowey e 18 flowey_lib_common::gen_cargo_nextest_run_cmd 1
+      run: flowey e 18 flowey_lib_common::gen_cargo_nextest_run_cmd 0
       shell: bash
     - name: run 'unit-tests crypto (native)' nextest tests
       run: |-
-        flowey e 18 flowey_lib_common::run_cargo_nextest_run 2
-        flowey e 18 flowey_lib_common::run_cargo_nextest_run 3
+        flowey e 18 flowey_lib_common::run_cargo_nextest_run 0
+        flowey e 18 flowey_lib_common::run_cargo_nextest_run 1
         flowey e 18 flowey_lib_hvlite::build_nextest_unit_tests 2
         flowey e 18 flowey_lib_common::publish_test_results 5
         flowey e 18 flowey_lib_common::publish_test_results 6
@@ -3111,12 +3034,12 @@ jobs:
       name: 'publish test results: aarch64-linux-musl-unit-tests-unit-tests crypto (native) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey e 18 flowey_lib_common::gen_cargo_nextest_run_cmd 3
+      run: flowey e 18 flowey_lib_common::gen_cargo_nextest_run_cmd 2
       shell: bash
     - name: run 'unit-tests crypto (rust)' nextest tests
       run: |-
-        flowey e 18 flowey_lib_common::run_cargo_nextest_run 6
-        flowey e 18 flowey_lib_common::run_cargo_nextest_run 7
+        flowey e 18 flowey_lib_common::run_cargo_nextest_run 4
+        flowey e 18 flowey_lib_common::run_cargo_nextest_run 5
         flowey e 18 flowey_lib_hvlite::build_nextest_unit_tests 3
         flowey e 18 flowey_lib_common::publish_test_results 8
         flowey e 18 flowey_lib_common::publish_test_results 9
@@ -3132,12 +3055,12 @@ jobs:
       name: 'publish test results: aarch64-linux-musl-unit-tests-unit-tests crypto (rust) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey e 18 flowey_lib_common::gen_cargo_nextest_run_cmd 2
+      run: flowey e 18 flowey_lib_common::gen_cargo_nextest_run_cmd 1
       shell: bash
     - name: run 'unit-tests crypto (openssl)' nextest tests
       run: |-
-        flowey e 18 flowey_lib_common::run_cargo_nextest_run 4
-        flowey e 18 flowey_lib_common::run_cargo_nextest_run 5
+        flowey e 18 flowey_lib_common::run_cargo_nextest_run 2
+        flowey e 18 flowey_lib_common::run_cargo_nextest_run 3
         flowey e 18 flowey_lib_hvlite::build_nextest_unit_tests 4
         flowey e 18 flowey_lib_common::publish_test_results 12
         flowey e 18 flowey_lib_common::publish_test_results 13
@@ -3153,12 +3076,12 @@ jobs:
       name: 'publish test results: aarch64-linux-musl-unit-tests-unit-tests crypto (openssl) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey e 18 flowey_lib_common::gen_cargo_nextest_run_cmd 4
+      run: flowey e 18 flowey_lib_common::gen_cargo_nextest_run_cmd 3
       shell: bash
     - name: run 'unit-tests crypto (symcrypt)' nextest tests
       run: |-
-        flowey e 18 flowey_lib_common::run_cargo_nextest_run 8
-        flowey e 18 flowey_lib_common::run_cargo_nextest_run 9
+        flowey e 18 flowey_lib_common::run_cargo_nextest_run 6
+        flowey e 18 flowey_lib_common::run_cargo_nextest_run 7
         flowey e 18 flowey_lib_hvlite::build_nextest_unit_tests 5
         flowey e 18 flowey_lib_common::publish_test_results 16
         flowey e 18 flowey_lib_common::publish_test_results 17
@@ -3172,27 +3095,6 @@ jobs:
         name: aarch64-linux-musl-unit-tests-unit-tests crypto (symcrypt)-junit-xml
         path: ${{ env.floweyvar5 }}
       name: 'publish test results: aarch64-linux-musl-unit-tests-unit-tests crypto (symcrypt) (JUnit XML)'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: generate nextest command
-      run: flowey e 18 flowey_lib_common::gen_cargo_nextest_run_cmd 0
-      shell: bash
-    - name: run 'unit-tests crypto (all)' nextest tests
-      run: |-
-        flowey e 18 flowey_lib_common::run_cargo_nextest_run 0
-        flowey e 18 flowey_lib_common::run_cargo_nextest_run 1
-        flowey e 18 flowey_lib_hvlite::build_nextest_unit_tests 6
-        flowey e 18 flowey_lib_common::publish_test_results 20
-        flowey e 18 flowey_lib_common::publish_test_results 21
-        flowey e 18 flowey_lib_common::publish_test_results 22
-        flowey v 18 'flowey_lib_common::publish_test_results:39:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:35:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar6
-        flowey v 18 'flowey_lib_common::publish_test_results:35:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__publish_test_results__23
-      uses: actions/upload-artifact@v7
-      with:
-        name: aarch64-linux-musl-unit-tests-unit-tests crypto (all)-junit-xml
-        path: ${{ env.floweyvar6 }}
-      name: 'publish test results: aarch64-linux-musl-unit-tests-unit-tests crypto (all) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: cargo build xtask
       run: |-
@@ -3210,12 +3112,12 @@ jobs:
       run: flowey e 18 flowey_lib_hvlite::build_nextest_unit_tests 0
       shell: bash
     - name: generate nextest command
-      run: flowey e 18 flowey_lib_common::gen_cargo_nextest_run_cmd 5
+      run: flowey e 18 flowey_lib_common::gen_cargo_nextest_run_cmd 4
       shell: bash
     - name: run 'unit-tests' nextest tests
       run: |-
-        flowey e 18 flowey_lib_common::run_cargo_nextest_run 10
-        flowey e 18 flowey_lib_common::run_cargo_nextest_run 11
+        flowey e 18 flowey_lib_common::run_cargo_nextest_run 8
+        flowey e 18 flowey_lib_common::run_cargo_nextest_run 9
         flowey e 18 flowey_lib_hvlite::build_nextest_unit_tests 1
         flowey e 18 flowey_lib_common::publish_test_results 0
         flowey e 18 flowey_lib_common::publish_test_results 1
@@ -3232,7 +3134,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
       run: |-
-        flowey e 18 flowey_lib_hvlite::build_nextest_unit_tests 7
+        flowey e 18 flowey_lib_hvlite::build_nextest_unit_tests 6
         flowey e 18 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
       shell: bash
     - name: run doctests for aarch64-unknown-linux-musl

--- a/.github/workflows/openvmm-pr-release.yaml
+++ b/.github/workflows/openvmm-pr-release.yaml
@@ -194,6 +194,10 @@ jobs:
       run: |-
         flowey e 0 flowey_lib_hvlite::_jobs::check_xtask_fmt 0
         flowey e 0 flowey_lib_hvlite::init_cross_build 0
+      shell: bash
+    - name: cargo clippy
+      run: |-
+        flowey e 0 flowey_lib_common::run_cargo_clippy 1
         flowey e 0 flowey_lib_hvlite::init_cross_build 1
       shell: bash
     - name: cargo build xtask
@@ -214,13 +218,13 @@ jobs:
       run: flowey e 0 flowey_lib_common::run_cargo_clippy 0
       shell: bash
     - name: cargo clippy
-      run: flowey e 0 flowey_lib_common::run_cargo_clippy 1
+      run: flowey e 0 flowey_lib_common::run_cargo_clippy 2
+      shell: bash
+    - name: cargo clippy
+      run: flowey e 0 flowey_lib_common::run_cargo_clippy 4
       shell: bash
     - name: cargo clippy
       run: flowey e 0 flowey_lib_common::run_cargo_clippy 3
-      shell: bash
-    - name: cargo clippy
-      run: flowey e 0 flowey_lib_common::run_cargo_clippy 2
       shell: bash
     - name: 'validate cache entry: gh-release-download'
       run: flowey e 0 flowey_lib_common::cache 3
@@ -1603,7 +1607,7 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 14 flowey_lib_common::git_checkout 0
-        flowey v 14 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar9
+        flowey v 14 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar10
         flowey v 14 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
@@ -1611,7 +1615,7 @@ jobs:
       with:
         fetch-depth: '1'
         path: repo0
-        persist-credentials: ${{ env.floweyvar9 }}
+        persist-credentials: ${{ env.floweyvar10 }}
       name: checkout repo openvmm
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
@@ -1631,14 +1635,14 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 14 flowey_lib_common::cache 4
-        flowey v 14 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar7
-        flowey v 14 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar8
+        flowey v 14 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
+        flowey v 14 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
       with:
-        key: ${{ env.floweyvar7 }}
-        path: ${{ env.floweyvar8 }}
+        key: ${{ env.floweyvar8 }}
+        path: ${{ env.floweyvar9 }}
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
@@ -1691,14 +1695,14 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 14 flowey_lib_common::cache 0
-        flowey v 14 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar5
-        flowey v 14 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar6
+        flowey v 14 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
+        flowey v 14 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
       with:
-        key: ${{ env.floweyvar5 }}
-        path: ${{ env.floweyvar6 }}
+        key: ${{ env.floweyvar6 }}
+        path: ${{ env.floweyvar7 }}
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
@@ -1718,13 +1722,13 @@ jobs:
         flowey e 14 flowey_lib_hvlite::run_cargo_nextest_run 0
       shell: bash
     - name: generate nextest command
-      run: flowey e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 2
+      run: flowey e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 1
       shell: bash
-    - name: run 'unit-tests crypto (rust)' nextest tests
+    - name: run 'unit-tests crypto (native)' nextest tests
       run: |-
-        flowey e 14 flowey_lib_common::run_cargo_nextest_run 4
-        flowey e 14 flowey_lib_common::run_cargo_nextest_run 5
-        flowey e 14 flowey_lib_hvlite::build_nextest_unit_tests 3
+        flowey e 14 flowey_lib_common::run_cargo_nextest_run 2
+        flowey e 14 flowey_lib_common::run_cargo_nextest_run 3
+        flowey e 14 flowey_lib_hvlite::build_nextest_unit_tests 2
         flowey e 14 flowey_lib_common::publish_test_results 5
         flowey e 14 flowey_lib_common::publish_test_results 6
         flowey e 14 flowey_lib_common::publish_test_results 4
@@ -1734,18 +1738,18 @@ jobs:
     - id: flowey_lib_common__publish_test_results__7
       uses: actions/upload-artifact@v7
       with:
-        name: x64-linux-unit-tests-unit-tests crypto (rust)-junit-xml
+        name: x64-linux-unit-tests-unit-tests crypto (native)-junit-xml
         path: ${{ env.floweyvar2 }}
-      name: 'publish test results: x64-linux-unit-tests-unit-tests crypto (rust) (JUnit XML)'
+      name: 'publish test results: x64-linux-unit-tests-unit-tests crypto (native) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 1
+      run: flowey e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 3
       shell: bash
-    - name: run 'unit-tests crypto (openssl)' nextest tests
+    - name: run 'unit-tests crypto (rust)' nextest tests
       run: |-
-        flowey e 14 flowey_lib_common::run_cargo_nextest_run 2
-        flowey e 14 flowey_lib_common::run_cargo_nextest_run 3
-        flowey e 14 flowey_lib_hvlite::build_nextest_unit_tests 4
+        flowey e 14 flowey_lib_common::run_cargo_nextest_run 6
+        flowey e 14 flowey_lib_common::run_cargo_nextest_run 7
+        flowey e 14 flowey_lib_hvlite::build_nextest_unit_tests 3
         flowey e 14 flowey_lib_common::publish_test_results 8
         flowey e 14 flowey_lib_common::publish_test_results 9
         flowey e 14 flowey_lib_common::publish_test_results 10
@@ -1755,9 +1759,51 @@ jobs:
     - id: flowey_lib_common__publish_test_results__11
       uses: actions/upload-artifact@v7
       with:
-        name: x64-linux-unit-tests-unit-tests crypto (openssl)-junit-xml
+        name: x64-linux-unit-tests-unit-tests crypto (rust)-junit-xml
         path: ${{ env.floweyvar3 }}
+      name: 'publish test results: x64-linux-unit-tests-unit-tests crypto (rust) (JUnit XML)'
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: generate nextest command
+      run: flowey e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 2
+      shell: bash
+    - name: run 'unit-tests crypto (openssl)' nextest tests
+      run: |-
+        flowey e 14 flowey_lib_common::run_cargo_nextest_run 4
+        flowey e 14 flowey_lib_common::run_cargo_nextest_run 5
+        flowey e 14 flowey_lib_hvlite::build_nextest_unit_tests 4
+        flowey e 14 flowey_lib_common::publish_test_results 12
+        flowey e 14 flowey_lib_common::publish_test_results 13
+        flowey e 14 flowey_lib_common::publish_test_results 14
+        flowey v 14 'flowey_lib_common::publish_test_results:25:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar4
+        flowey v 14 'flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__publish_test_results__15
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-linux-unit-tests-unit-tests crypto (openssl)-junit-xml
+        path: ${{ env.floweyvar4 }}
       name: 'publish test results: x64-linux-unit-tests-unit-tests crypto (openssl) (JUnit XML)'
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: generate nextest command
+      run: flowey e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      shell: bash
+    - name: run 'unit-tests crypto (all)' nextest tests
+      run: |-
+        flowey e 14 flowey_lib_common::run_cargo_nextest_run 0
+        flowey e 14 flowey_lib_common::run_cargo_nextest_run 1
+        flowey e 14 flowey_lib_hvlite::build_nextest_unit_tests 5
+        flowey e 14 flowey_lib_common::publish_test_results 16
+        flowey e 14 flowey_lib_common::publish_test_results 17
+        flowey e 14 flowey_lib_common::publish_test_results 18
+        flowey v 14 'flowey_lib_common::publish_test_results:32:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:28:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar5
+        flowey v 14 'flowey_lib_common::publish_test_results:28:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__publish_test_results__19
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-linux-unit-tests-unit-tests crypto (all)-junit-xml
+        path: ${{ env.floweyvar5 }}
+      name: 'publish test results: x64-linux-unit-tests-unit-tests crypto (all) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: cargo build xtask
       run: |-
@@ -1775,34 +1821,13 @@ jobs:
       run: flowey e 14 flowey_lib_hvlite::build_nextest_unit_tests 0
       shell: bash
     - name: generate nextest command
-      run: flowey e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 3
+      run: flowey e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 4
       shell: bash
     - name: run 'unit-tests' nextest tests
       run: |-
-        flowey e 14 flowey_lib_common::run_cargo_nextest_run 6
-        flowey e 14 flowey_lib_common::run_cargo_nextest_run 7
+        flowey e 14 flowey_lib_common::run_cargo_nextest_run 8
+        flowey e 14 flowey_lib_common::run_cargo_nextest_run 9
         flowey e 14 flowey_lib_hvlite::build_nextest_unit_tests 1
-        flowey e 14 flowey_lib_common::publish_test_results 12
-        flowey e 14 flowey_lib_common::publish_test_results 13
-        flowey e 14 flowey_lib_common::publish_test_results 14
-        flowey v 14 'flowey_lib_common::publish_test_results:25:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar4
-        flowey v 14 'flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__publish_test_results__15
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-linux-unit-tests-unit-tests-junit-xml
-        path: ${{ env.floweyvar4 }}
-      name: 'publish test results: x64-linux-unit-tests-unit-tests (JUnit XML)'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: generate nextest command
-      run: flowey e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 0
-      shell: bash
-    - name: run 'unit-tests crypto (native)' nextest tests
-      run: |-
-        flowey e 14 flowey_lib_common::run_cargo_nextest_run 0
-        flowey e 14 flowey_lib_common::run_cargo_nextest_run 1
-        flowey e 14 flowey_lib_hvlite::build_nextest_unit_tests 2
         flowey e 14 flowey_lib_common::publish_test_results 0
         flowey e 14 flowey_lib_common::publish_test_results 1
         flowey e 14 flowey_lib_common::publish_test_results 2
@@ -1812,13 +1837,13 @@ jobs:
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v7
       with:
-        name: x64-linux-unit-tests-unit-tests crypto (native)-junit-xml
+        name: x64-linux-unit-tests-unit-tests-junit-xml
         path: ${{ env.floweyvar1 }}
-      name: 'publish test results: x64-linux-unit-tests-unit-tests crypto (native) (JUnit XML)'
+      name: 'publish test results: x64-linux-unit-tests-unit-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
       run: |-
-        flowey e 14 flowey_lib_hvlite::build_nextest_unit_tests 5
+        flowey e 14 flowey_lib_hvlite::build_nextest_unit_tests 6
         flowey e 14 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
       shell: bash
     - name: run doctests for x86_64-unknown-linux-gnu
@@ -1881,7 +1906,7 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 15 flowey_lib_common::git_checkout 0
-        flowey v 15 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar10
+        flowey v 15 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar11
         flowey v 15 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
@@ -1889,7 +1914,7 @@ jobs:
       with:
         fetch-depth: '1'
         path: repo0
-        persist-credentials: ${{ env.floweyvar10 }}
+        persist-credentials: ${{ env.floweyvar11 }}
       name: checkout repo openvmm
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
@@ -1907,14 +1932,14 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 15 flowey_lib_common::cache 4
-        flowey v 15 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
-        flowey v 15 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
+        flowey v 15 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar9
+        flowey v 15 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar10
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
       with:
-        key: ${{ env.floweyvar8 }}
-        path: ${{ env.floweyvar9 }}
+        key: ${{ env.floweyvar9 }}
+        path: ${{ env.floweyvar10 }}
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
@@ -1948,17 +1973,20 @@ jobs:
         flowey e 15 flowey_lib_hvlite::init_cross_build 2
       shell: bash
     - name: cargo clippy
-      run: flowey e 15 flowey_lib_common::run_cargo_clippy 2
+      run: flowey e 15 flowey_lib_common::run_cargo_clippy 3
       shell: bash
     - name: cargo clippy
-      run: flowey e 15 flowey_lib_common::run_cargo_clippy 4
+      run: flowey e 15 flowey_lib_common::run_cargo_clippy 5
       shell: bash
     - name: cargo clippy
-      run: flowey e 15 flowey_lib_common::run_cargo_clippy 6
+      run: flowey e 15 flowey_lib_common::run_cargo_clippy 1
+      shell: bash
+    - name: cargo clippy
+      run: flowey e 15 flowey_lib_common::run_cargo_clippy 7
       shell: bash
     - name: cargo clippy
       run: |-
-        flowey e 15 flowey_lib_common::run_cargo_clippy 5
+        flowey e 15 flowey_lib_common::run_cargo_clippy 6
         flowey e 15 flowey_lib_hvlite::init_cross_build 0
       shell: bash
     - name: cargo build xtask
@@ -1979,10 +2007,10 @@ jobs:
       run: flowey e 15 flowey_lib_common::run_cargo_clippy 0
       shell: bash
     - name: cargo clippy
-      run: flowey e 15 flowey_lib_common::run_cargo_clippy 1
+      run: flowey e 15 flowey_lib_common::run_cargo_clippy 2
       shell: bash
     - name: cargo clippy
-      run: flowey e 15 flowey_lib_common::run_cargo_clippy 3
+      run: flowey e 15 flowey_lib_common::run_cargo_clippy 4
       shell: bash
     - name: create cargo-nextest cache dir
       run: |-
@@ -1994,14 +2022,14 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 15 flowey_lib_common::cache 0
-        flowey v 15 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
-        flowey v 15 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
+        flowey v 15 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar7
+        flowey v 15 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar8
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
       with:
-        key: ${{ env.floweyvar6 }}
-        path: ${{ env.floweyvar7 }}
+        key: ${{ env.floweyvar7 }}
+        path: ${{ env.floweyvar8 }}
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
@@ -2021,12 +2049,12 @@ jobs:
         flowey e 15 flowey_lib_hvlite::run_cargo_nextest_run 0
       shell: bash
     - name: generate nextest command
-      run: flowey e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      run: flowey e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 1
       shell: bash
     - name: run 'unit-tests crypto (native)' nextest tests
       run: |-
-        flowey e 15 flowey_lib_common::run_cargo_nextest_run 0
-        flowey e 15 flowey_lib_common::run_cargo_nextest_run 1
+        flowey e 15 flowey_lib_common::run_cargo_nextest_run 2
+        flowey e 15 flowey_lib_common::run_cargo_nextest_run 3
         flowey e 15 flowey_lib_hvlite::build_nextest_unit_tests 2
         flowey e 15 flowey_lib_common::publish_test_results 5
         flowey e 15 flowey_lib_common::publish_test_results 6
@@ -2042,12 +2070,12 @@ jobs:
       name: 'publish test results: x64-linux-musl-unit-tests-unit-tests crypto (native) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 2
+      run: flowey e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 3
       shell: bash
     - name: run 'unit-tests crypto (rust)' nextest tests
       run: |-
-        flowey e 15 flowey_lib_common::run_cargo_nextest_run 4
-        flowey e 15 flowey_lib_common::run_cargo_nextest_run 5
+        flowey e 15 flowey_lib_common::run_cargo_nextest_run 6
+        flowey e 15 flowey_lib_common::run_cargo_nextest_run 7
         flowey e 15 flowey_lib_hvlite::build_nextest_unit_tests 3
         flowey e 15 flowey_lib_common::publish_test_results 8
         flowey e 15 flowey_lib_common::publish_test_results 9
@@ -2063,12 +2091,12 @@ jobs:
       name: 'publish test results: x64-linux-musl-unit-tests-unit-tests crypto (rust) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 1
+      run: flowey e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 2
       shell: bash
     - name: run 'unit-tests crypto (openssl)' nextest tests
       run: |-
-        flowey e 15 flowey_lib_common::run_cargo_nextest_run 2
-        flowey e 15 flowey_lib_common::run_cargo_nextest_run 3
+        flowey e 15 flowey_lib_common::run_cargo_nextest_run 4
+        flowey e 15 flowey_lib_common::run_cargo_nextest_run 5
         flowey e 15 flowey_lib_hvlite::build_nextest_unit_tests 4
         flowey e 15 flowey_lib_common::publish_test_results 12
         flowey e 15 flowey_lib_common::publish_test_results 13
@@ -2084,12 +2112,12 @@ jobs:
       name: 'publish test results: x64-linux-musl-unit-tests-unit-tests crypto (openssl) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 3
+      run: flowey e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 4
       shell: bash
     - name: run 'unit-tests crypto (symcrypt)' nextest tests
       run: |-
-        flowey e 15 flowey_lib_common::run_cargo_nextest_run 6
-        flowey e 15 flowey_lib_common::run_cargo_nextest_run 7
+        flowey e 15 flowey_lib_common::run_cargo_nextest_run 8
+        flowey e 15 flowey_lib_common::run_cargo_nextest_run 9
         flowey e 15 flowey_lib_hvlite::build_nextest_unit_tests 5
         flowey e 15 flowey_lib_common::publish_test_results 16
         flowey e 15 flowey_lib_common::publish_test_results 17
@@ -2103,6 +2131,27 @@ jobs:
         name: x64-linux-musl-unit-tests-unit-tests crypto (symcrypt)-junit-xml
         path: ${{ env.floweyvar5 }}
       name: 'publish test results: x64-linux-musl-unit-tests-unit-tests crypto (symcrypt) (JUnit XML)'
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: generate nextest command
+      run: flowey e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      shell: bash
+    - name: run 'unit-tests crypto (all)' nextest tests
+      run: |-
+        flowey e 15 flowey_lib_common::run_cargo_nextest_run 0
+        flowey e 15 flowey_lib_common::run_cargo_nextest_run 1
+        flowey e 15 flowey_lib_hvlite::build_nextest_unit_tests 6
+        flowey e 15 flowey_lib_common::publish_test_results 20
+        flowey e 15 flowey_lib_common::publish_test_results 21
+        flowey e 15 flowey_lib_common::publish_test_results 22
+        flowey v 15 'flowey_lib_common::publish_test_results:39:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:35:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar6
+        flowey v 15 'flowey_lib_common::publish_test_results:35:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__publish_test_results__23
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-linux-musl-unit-tests-unit-tests crypto (all)-junit-xml
+        path: ${{ env.floweyvar6 }}
+      name: 'publish test results: x64-linux-musl-unit-tests-unit-tests crypto (all) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: cargo build xtask
       run: |-
@@ -2120,12 +2169,12 @@ jobs:
       run: flowey e 15 flowey_lib_hvlite::build_nextest_unit_tests 0
       shell: bash
     - name: generate nextest command
-      run: flowey e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 4
+      run: flowey e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 5
       shell: bash
     - name: run 'unit-tests' nextest tests
       run: |-
-        flowey e 15 flowey_lib_common::run_cargo_nextest_run 8
-        flowey e 15 flowey_lib_common::run_cargo_nextest_run 9
+        flowey e 15 flowey_lib_common::run_cargo_nextest_run 10
+        flowey e 15 flowey_lib_common::run_cargo_nextest_run 11
         flowey e 15 flowey_lib_hvlite::build_nextest_unit_tests 1
         flowey e 15 flowey_lib_common::publish_test_results 0
         flowey e 15 flowey_lib_common::publish_test_results 1
@@ -2142,7 +2191,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
       run: |-
-        flowey e 15 flowey_lib_hvlite::build_nextest_unit_tests 6
+        flowey e 15 flowey_lib_hvlite::build_nextest_unit_tests 7
         flowey e 15 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
       shell: bash
     - name: run doctests for x86_64-unknown-linux-musl
@@ -2547,7 +2596,7 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 17 flowey_lib_common::git_checkout 0
-        flowey v 17 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar9
+        flowey v 17 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar10
         flowey v 17 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
@@ -2555,7 +2604,7 @@ jobs:
       with:
         fetch-depth: '1'
         path: repo0
-        persist-credentials: ${{ env.floweyvar9 }}
+        persist-credentials: ${{ env.floweyvar10 }}
       name: checkout repo openvmm
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
@@ -2575,14 +2624,14 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 17 flowey_lib_common::cache 4
-        flowey v 17 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar7
-        flowey v 17 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar8
+        flowey v 17 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
+        flowey v 17 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
       with:
-        key: ${{ env.floweyvar7 }}
-        path: ${{ env.floweyvar8 }}
+        key: ${{ env.floweyvar8 }}
+        path: ${{ env.floweyvar9 }}
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
@@ -2601,6 +2650,10 @@ jobs:
       run: |-
         flowey e 17 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
         flowey e 17 flowey_lib_hvlite::init_cross_build 0
+      shell: bash
+    - name: cargo clippy
+      run: |-
+        flowey e 17 flowey_lib_common::run_cargo_clippy 1
         flowey e 17 flowey_lib_hvlite::init_cross_build 2
       shell: bash
     - name: cargo build xtask
@@ -2621,13 +2674,13 @@ jobs:
       run: flowey e 17 flowey_lib_common::run_cargo_clippy 0
       shell: bash
     - name: cargo clippy
-      run: flowey e 17 flowey_lib_common::run_cargo_clippy 1
+      run: flowey e 17 flowey_lib_common::run_cargo_clippy 2
+      shell: bash
+    - name: cargo clippy
+      run: flowey e 17 flowey_lib_common::run_cargo_clippy 4
       shell: bash
     - name: cargo clippy
       run: flowey e 17 flowey_lib_common::run_cargo_clippy 3
-      shell: bash
-    - name: cargo clippy
-      run: flowey e 17 flowey_lib_common::run_cargo_clippy 2
       shell: bash
     - name: create cargo-nextest cache dir
       run: |-
@@ -2639,14 +2692,14 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 17 flowey_lib_common::cache 0
-        flowey v 17 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar5
-        flowey v 17 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar6
+        flowey v 17 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
+        flowey v 17 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
       with:
-        key: ${{ env.floweyvar5 }}
-        path: ${{ env.floweyvar6 }}
+        key: ${{ env.floweyvar6 }}
+        path: ${{ env.floweyvar7 }}
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
@@ -2666,13 +2719,13 @@ jobs:
         flowey e 17 flowey_lib_hvlite::run_cargo_nextest_run 0
       shell: bash
     - name: generate nextest command
-      run: flowey e 17 flowey_lib_common::gen_cargo_nextest_run_cmd 2
+      run: flowey e 17 flowey_lib_common::gen_cargo_nextest_run_cmd 1
       shell: bash
-    - name: run 'unit-tests crypto (rust)' nextest tests
+    - name: run 'unit-tests crypto (native)' nextest tests
       run: |-
-        flowey e 17 flowey_lib_common::run_cargo_nextest_run 4
-        flowey e 17 flowey_lib_common::run_cargo_nextest_run 5
-        flowey e 17 flowey_lib_hvlite::build_nextest_unit_tests 3
+        flowey e 17 flowey_lib_common::run_cargo_nextest_run 2
+        flowey e 17 flowey_lib_common::run_cargo_nextest_run 3
+        flowey e 17 flowey_lib_hvlite::build_nextest_unit_tests 2
         flowey e 17 flowey_lib_common::publish_test_results 5
         flowey e 17 flowey_lib_common::publish_test_results 6
         flowey e 17 flowey_lib_common::publish_test_results 4
@@ -2682,18 +2735,18 @@ jobs:
     - id: flowey_lib_common__publish_test_results__7
       uses: actions/upload-artifact@v7
       with:
-        name: aarch64-linux-unit-tests-unit-tests crypto (rust)-junit-xml
+        name: aarch64-linux-unit-tests-unit-tests crypto (native)-junit-xml
         path: ${{ env.floweyvar2 }}
-      name: 'publish test results: aarch64-linux-unit-tests-unit-tests crypto (rust) (JUnit XML)'
+      name: 'publish test results: aarch64-linux-unit-tests-unit-tests crypto (native) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey e 17 flowey_lib_common::gen_cargo_nextest_run_cmd 1
+      run: flowey e 17 flowey_lib_common::gen_cargo_nextest_run_cmd 3
       shell: bash
-    - name: run 'unit-tests crypto (openssl)' nextest tests
+    - name: run 'unit-tests crypto (rust)' nextest tests
       run: |-
-        flowey e 17 flowey_lib_common::run_cargo_nextest_run 2
-        flowey e 17 flowey_lib_common::run_cargo_nextest_run 3
-        flowey e 17 flowey_lib_hvlite::build_nextest_unit_tests 4
+        flowey e 17 flowey_lib_common::run_cargo_nextest_run 6
+        flowey e 17 flowey_lib_common::run_cargo_nextest_run 7
+        flowey e 17 flowey_lib_hvlite::build_nextest_unit_tests 3
         flowey e 17 flowey_lib_common::publish_test_results 8
         flowey e 17 flowey_lib_common::publish_test_results 9
         flowey e 17 flowey_lib_common::publish_test_results 10
@@ -2703,9 +2756,51 @@ jobs:
     - id: flowey_lib_common__publish_test_results__11
       uses: actions/upload-artifact@v7
       with:
-        name: aarch64-linux-unit-tests-unit-tests crypto (openssl)-junit-xml
+        name: aarch64-linux-unit-tests-unit-tests crypto (rust)-junit-xml
         path: ${{ env.floweyvar3 }}
+      name: 'publish test results: aarch64-linux-unit-tests-unit-tests crypto (rust) (JUnit XML)'
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: generate nextest command
+      run: flowey e 17 flowey_lib_common::gen_cargo_nextest_run_cmd 2
+      shell: bash
+    - name: run 'unit-tests crypto (openssl)' nextest tests
+      run: |-
+        flowey e 17 flowey_lib_common::run_cargo_nextest_run 4
+        flowey e 17 flowey_lib_common::run_cargo_nextest_run 5
+        flowey e 17 flowey_lib_hvlite::build_nextest_unit_tests 4
+        flowey e 17 flowey_lib_common::publish_test_results 12
+        flowey e 17 flowey_lib_common::publish_test_results 13
+        flowey e 17 flowey_lib_common::publish_test_results 14
+        flowey v 17 'flowey_lib_common::publish_test_results:25:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar4
+        flowey v 17 'flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__publish_test_results__15
+      uses: actions/upload-artifact@v7
+      with:
+        name: aarch64-linux-unit-tests-unit-tests crypto (openssl)-junit-xml
+        path: ${{ env.floweyvar4 }}
       name: 'publish test results: aarch64-linux-unit-tests-unit-tests crypto (openssl) (JUnit XML)'
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: generate nextest command
+      run: flowey e 17 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      shell: bash
+    - name: run 'unit-tests crypto (all)' nextest tests
+      run: |-
+        flowey e 17 flowey_lib_common::run_cargo_nextest_run 0
+        flowey e 17 flowey_lib_common::run_cargo_nextest_run 1
+        flowey e 17 flowey_lib_hvlite::build_nextest_unit_tests 5
+        flowey e 17 flowey_lib_common::publish_test_results 16
+        flowey e 17 flowey_lib_common::publish_test_results 17
+        flowey e 17 flowey_lib_common::publish_test_results 18
+        flowey v 17 'flowey_lib_common::publish_test_results:32:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:28:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar5
+        flowey v 17 'flowey_lib_common::publish_test_results:28:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__publish_test_results__19
+      uses: actions/upload-artifact@v7
+      with:
+        name: aarch64-linux-unit-tests-unit-tests crypto (all)-junit-xml
+        path: ${{ env.floweyvar5 }}
+      name: 'publish test results: aarch64-linux-unit-tests-unit-tests crypto (all) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: cargo build xtask
       run: |-
@@ -2723,34 +2818,13 @@ jobs:
       run: flowey e 17 flowey_lib_hvlite::build_nextest_unit_tests 0
       shell: bash
     - name: generate nextest command
-      run: flowey e 17 flowey_lib_common::gen_cargo_nextest_run_cmd 3
+      run: flowey e 17 flowey_lib_common::gen_cargo_nextest_run_cmd 4
       shell: bash
     - name: run 'unit-tests' nextest tests
       run: |-
-        flowey e 17 flowey_lib_common::run_cargo_nextest_run 6
-        flowey e 17 flowey_lib_common::run_cargo_nextest_run 7
+        flowey e 17 flowey_lib_common::run_cargo_nextest_run 8
+        flowey e 17 flowey_lib_common::run_cargo_nextest_run 9
         flowey e 17 flowey_lib_hvlite::build_nextest_unit_tests 1
-        flowey e 17 flowey_lib_common::publish_test_results 12
-        flowey e 17 flowey_lib_common::publish_test_results 13
-        flowey e 17 flowey_lib_common::publish_test_results 14
-        flowey v 17 'flowey_lib_common::publish_test_results:25:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar4
-        flowey v 17 'flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__publish_test_results__15
-      uses: actions/upload-artifact@v7
-      with:
-        name: aarch64-linux-unit-tests-unit-tests-junit-xml
-        path: ${{ env.floweyvar4 }}
-      name: 'publish test results: aarch64-linux-unit-tests-unit-tests (JUnit XML)'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: generate nextest command
-      run: flowey e 17 flowey_lib_common::gen_cargo_nextest_run_cmd 0
-      shell: bash
-    - name: run 'unit-tests crypto (native)' nextest tests
-      run: |-
-        flowey e 17 flowey_lib_common::run_cargo_nextest_run 0
-        flowey e 17 flowey_lib_common::run_cargo_nextest_run 1
-        flowey e 17 flowey_lib_hvlite::build_nextest_unit_tests 2
         flowey e 17 flowey_lib_common::publish_test_results 0
         flowey e 17 flowey_lib_common::publish_test_results 1
         flowey e 17 flowey_lib_common::publish_test_results 2
@@ -2760,13 +2834,13 @@ jobs:
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v7
       with:
-        name: aarch64-linux-unit-tests-unit-tests crypto (native)-junit-xml
+        name: aarch64-linux-unit-tests-unit-tests-junit-xml
         path: ${{ env.floweyvar1 }}
-      name: 'publish test results: aarch64-linux-unit-tests-unit-tests crypto (native) (JUnit XML)'
+      name: 'publish test results: aarch64-linux-unit-tests-unit-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
       run: |-
-        flowey e 17 flowey_lib_hvlite::build_nextest_unit_tests 5
+        flowey e 17 flowey_lib_hvlite::build_nextest_unit_tests 6
         flowey e 17 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
       shell: bash
     - name: run doctests for aarch64-unknown-linux-gnu
@@ -2873,7 +2947,7 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 18 flowey_lib_common::git_checkout 0
-        flowey v 18 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar10
+        flowey v 18 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar11
         flowey v 18 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
@@ -2881,7 +2955,7 @@ jobs:
       with:
         fetch-depth: '1'
         path: repo0
-        persist-credentials: ${{ env.floweyvar10 }}
+        persist-credentials: ${{ env.floweyvar11 }}
       name: checkout repo openvmm
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
@@ -2899,14 +2973,14 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 18 flowey_lib_common::cache 4
-        flowey v 18 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
-        flowey v 18 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
+        flowey v 18 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar9
+        flowey v 18 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar10
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
       with:
-        key: ${{ env.floweyvar8 }}
-        path: ${{ env.floweyvar9 }}
+        key: ${{ env.floweyvar9 }}
+        path: ${{ env.floweyvar10 }}
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
@@ -2940,17 +3014,20 @@ jobs:
         flowey e 18 flowey_lib_hvlite::init_cross_build 2
       shell: bash
     - name: cargo clippy
-      run: flowey e 18 flowey_lib_common::run_cargo_clippy 2
+      run: flowey e 18 flowey_lib_common::run_cargo_clippy 3
       shell: bash
     - name: cargo clippy
-      run: flowey e 18 flowey_lib_common::run_cargo_clippy 4
+      run: flowey e 18 flowey_lib_common::run_cargo_clippy 5
       shell: bash
     - name: cargo clippy
-      run: flowey e 18 flowey_lib_common::run_cargo_clippy 6
+      run: flowey e 18 flowey_lib_common::run_cargo_clippy 1
+      shell: bash
+    - name: cargo clippy
+      run: flowey e 18 flowey_lib_common::run_cargo_clippy 7
       shell: bash
     - name: cargo clippy
       run: |-
-        flowey e 18 flowey_lib_common::run_cargo_clippy 5
+        flowey e 18 flowey_lib_common::run_cargo_clippy 6
         flowey e 18 flowey_lib_hvlite::init_cross_build 0
       shell: bash
     - name: cargo build xtask
@@ -2971,10 +3048,10 @@ jobs:
       run: flowey e 18 flowey_lib_common::run_cargo_clippy 0
       shell: bash
     - name: cargo clippy
-      run: flowey e 18 flowey_lib_common::run_cargo_clippy 1
+      run: flowey e 18 flowey_lib_common::run_cargo_clippy 2
       shell: bash
     - name: cargo clippy
-      run: flowey e 18 flowey_lib_common::run_cargo_clippy 3
+      run: flowey e 18 flowey_lib_common::run_cargo_clippy 4
       shell: bash
     - name: create cargo-nextest cache dir
       run: |-
@@ -2986,14 +3063,14 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 18 flowey_lib_common::cache 0
-        flowey v 18 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
-        flowey v 18 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
+        flowey v 18 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar7
+        flowey v 18 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar8
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
       with:
-        key: ${{ env.floweyvar6 }}
-        path: ${{ env.floweyvar7 }}
+        key: ${{ env.floweyvar7 }}
+        path: ${{ env.floweyvar8 }}
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
@@ -3013,12 +3090,12 @@ jobs:
         flowey e 18 flowey_lib_hvlite::run_cargo_nextest_run 0
       shell: bash
     - name: generate nextest command
-      run: flowey e 18 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      run: flowey e 18 flowey_lib_common::gen_cargo_nextest_run_cmd 1
       shell: bash
     - name: run 'unit-tests crypto (native)' nextest tests
       run: |-
-        flowey e 18 flowey_lib_common::run_cargo_nextest_run 0
-        flowey e 18 flowey_lib_common::run_cargo_nextest_run 1
+        flowey e 18 flowey_lib_common::run_cargo_nextest_run 2
+        flowey e 18 flowey_lib_common::run_cargo_nextest_run 3
         flowey e 18 flowey_lib_hvlite::build_nextest_unit_tests 2
         flowey e 18 flowey_lib_common::publish_test_results 5
         flowey e 18 flowey_lib_common::publish_test_results 6
@@ -3034,12 +3111,12 @@ jobs:
       name: 'publish test results: aarch64-linux-musl-unit-tests-unit-tests crypto (native) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey e 18 flowey_lib_common::gen_cargo_nextest_run_cmd 2
+      run: flowey e 18 flowey_lib_common::gen_cargo_nextest_run_cmd 3
       shell: bash
     - name: run 'unit-tests crypto (rust)' nextest tests
       run: |-
-        flowey e 18 flowey_lib_common::run_cargo_nextest_run 4
-        flowey e 18 flowey_lib_common::run_cargo_nextest_run 5
+        flowey e 18 flowey_lib_common::run_cargo_nextest_run 6
+        flowey e 18 flowey_lib_common::run_cargo_nextest_run 7
         flowey e 18 flowey_lib_hvlite::build_nextest_unit_tests 3
         flowey e 18 flowey_lib_common::publish_test_results 8
         flowey e 18 flowey_lib_common::publish_test_results 9
@@ -3055,12 +3132,12 @@ jobs:
       name: 'publish test results: aarch64-linux-musl-unit-tests-unit-tests crypto (rust) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey e 18 flowey_lib_common::gen_cargo_nextest_run_cmd 1
+      run: flowey e 18 flowey_lib_common::gen_cargo_nextest_run_cmd 2
       shell: bash
     - name: run 'unit-tests crypto (openssl)' nextest tests
       run: |-
-        flowey e 18 flowey_lib_common::run_cargo_nextest_run 2
-        flowey e 18 flowey_lib_common::run_cargo_nextest_run 3
+        flowey e 18 flowey_lib_common::run_cargo_nextest_run 4
+        flowey e 18 flowey_lib_common::run_cargo_nextest_run 5
         flowey e 18 flowey_lib_hvlite::build_nextest_unit_tests 4
         flowey e 18 flowey_lib_common::publish_test_results 12
         flowey e 18 flowey_lib_common::publish_test_results 13
@@ -3076,12 +3153,12 @@ jobs:
       name: 'publish test results: aarch64-linux-musl-unit-tests-unit-tests crypto (openssl) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey e 18 flowey_lib_common::gen_cargo_nextest_run_cmd 3
+      run: flowey e 18 flowey_lib_common::gen_cargo_nextest_run_cmd 4
       shell: bash
     - name: run 'unit-tests crypto (symcrypt)' nextest tests
       run: |-
-        flowey e 18 flowey_lib_common::run_cargo_nextest_run 6
-        flowey e 18 flowey_lib_common::run_cargo_nextest_run 7
+        flowey e 18 flowey_lib_common::run_cargo_nextest_run 8
+        flowey e 18 flowey_lib_common::run_cargo_nextest_run 9
         flowey e 18 flowey_lib_hvlite::build_nextest_unit_tests 5
         flowey e 18 flowey_lib_common::publish_test_results 16
         flowey e 18 flowey_lib_common::publish_test_results 17
@@ -3095,6 +3172,27 @@ jobs:
         name: aarch64-linux-musl-unit-tests-unit-tests crypto (symcrypt)-junit-xml
         path: ${{ env.floweyvar5 }}
       name: 'publish test results: aarch64-linux-musl-unit-tests-unit-tests crypto (symcrypt) (JUnit XML)'
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: generate nextest command
+      run: flowey e 18 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      shell: bash
+    - name: run 'unit-tests crypto (all)' nextest tests
+      run: |-
+        flowey e 18 flowey_lib_common::run_cargo_nextest_run 0
+        flowey e 18 flowey_lib_common::run_cargo_nextest_run 1
+        flowey e 18 flowey_lib_hvlite::build_nextest_unit_tests 6
+        flowey e 18 flowey_lib_common::publish_test_results 20
+        flowey e 18 flowey_lib_common::publish_test_results 21
+        flowey e 18 flowey_lib_common::publish_test_results 22
+        flowey v 18 'flowey_lib_common::publish_test_results:39:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:35:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar6
+        flowey v 18 'flowey_lib_common::publish_test_results:35:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__publish_test_results__23
+      uses: actions/upload-artifact@v7
+      with:
+        name: aarch64-linux-musl-unit-tests-unit-tests crypto (all)-junit-xml
+        path: ${{ env.floweyvar6 }}
+      name: 'publish test results: aarch64-linux-musl-unit-tests-unit-tests crypto (all) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: cargo build xtask
       run: |-
@@ -3112,12 +3210,12 @@ jobs:
       run: flowey e 18 flowey_lib_hvlite::build_nextest_unit_tests 0
       shell: bash
     - name: generate nextest command
-      run: flowey e 18 flowey_lib_common::gen_cargo_nextest_run_cmd 4
+      run: flowey e 18 flowey_lib_common::gen_cargo_nextest_run_cmd 5
       shell: bash
     - name: run 'unit-tests' nextest tests
       run: |-
-        flowey e 18 flowey_lib_common::run_cargo_nextest_run 8
-        flowey e 18 flowey_lib_common::run_cargo_nextest_run 9
+        flowey e 18 flowey_lib_common::run_cargo_nextest_run 10
+        flowey e 18 flowey_lib_common::run_cargo_nextest_run 11
         flowey e 18 flowey_lib_hvlite::build_nextest_unit_tests 1
         flowey e 18 flowey_lib_common::publish_test_results 0
         flowey e 18 flowey_lib_common::publish_test_results 1
@@ -3134,7 +3232,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
       run: |-
-        flowey e 18 flowey_lib_hvlite::build_nextest_unit_tests 6
+        flowey e 18 flowey_lib_hvlite::build_nextest_unit_tests 7
         flowey e 18 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
       shell: bash
     - name: run doctests for aarch64-unknown-linux-musl

--- a/.github/workflows/openvmm-pr-release.yaml
+++ b/.github/workflows/openvmm-pr-release.yaml
@@ -1518,7 +1518,7 @@ jobs:
     - name: generate nextest command
       run: flowey.exe e 13 flowey_lib_common::gen_cargo_nextest_run_cmd 0
       shell: bash
-    - name: run 'unit-tests crypto (none)' nextest tests
+    - name: run 'unit-tests crypto (native)' nextest tests
       run: |-
         flowey.exe e 13 flowey_lib_common::run_cargo_nextest_run 0
         flowey.exe e 13 flowey_lib_common::run_cargo_nextest_run 1
@@ -1532,9 +1532,9 @@ jobs:
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v7
       with:
-        name: x64-windows-unit-tests-unit-tests crypto (none)-junit-xml
+        name: x64-windows-unit-tests-unit-tests crypto (native)-junit-xml
         path: ${{ env.floweyvar1 }}
-      name: 'publish test results: x64-windows-unit-tests-unit-tests crypto (none) (JUnit XML)'
+      name: 'publish test results: x64-windows-unit-tests-unit-tests crypto (native) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
       run: |-
@@ -1724,7 +1724,7 @@ jobs:
     - name: generate nextest command
       run: flowey e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 1
       shell: bash
-    - name: run 'unit-tests crypto (none)' nextest tests
+    - name: run 'unit-tests crypto (native)' nextest tests
       run: |-
         flowey e 14 flowey_lib_common::run_cargo_nextest_run 2
         flowey e 14 flowey_lib_common::run_cargo_nextest_run 3
@@ -1738,9 +1738,9 @@ jobs:
     - id: flowey_lib_common__publish_test_results__7
       uses: actions/upload-artifact@v7
       with:
-        name: x64-linux-unit-tests-unit-tests crypto (none)-junit-xml
+        name: x64-linux-unit-tests-unit-tests crypto (native)-junit-xml
         path: ${{ env.floweyvar2 }}
-      name: 'publish test results: x64-linux-unit-tests-unit-tests crypto (none) (JUnit XML)'
+      name: 'publish test results: x64-linux-unit-tests-unit-tests crypto (native) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
       run: flowey e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 3
@@ -2051,7 +2051,7 @@ jobs:
     - name: generate nextest command
       run: flowey e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 1
       shell: bash
-    - name: run 'unit-tests crypto (none)' nextest tests
+    - name: run 'unit-tests crypto (native)' nextest tests
       run: |-
         flowey e 15 flowey_lib_common::run_cargo_nextest_run 2
         flowey e 15 flowey_lib_common::run_cargo_nextest_run 3
@@ -2065,9 +2065,9 @@ jobs:
     - id: flowey_lib_common__publish_test_results__7
       uses: actions/upload-artifact@v7
       with:
-        name: x64-linux-musl-unit-tests-unit-tests crypto (none)-junit-xml
+        name: x64-linux-musl-unit-tests-unit-tests crypto (native)-junit-xml
         path: ${{ env.floweyvar2 }}
-      name: 'publish test results: x64-linux-musl-unit-tests-unit-tests crypto (none) (JUnit XML)'
+      name: 'publish test results: x64-linux-musl-unit-tests-unit-tests crypto (native) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
       run: flowey e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 3
@@ -2463,7 +2463,7 @@ jobs:
     - name: generate nextest command
       run: flowey.exe e 16 flowey_lib_common::gen_cargo_nextest_run_cmd 0
       shell: bash
-    - name: run 'unit-tests crypto (none)' nextest tests
+    - name: run 'unit-tests crypto (native)' nextest tests
       run: |-
         flowey.exe e 16 flowey_lib_common::run_cargo_nextest_run 0
         flowey.exe e 16 flowey_lib_common::run_cargo_nextest_run 1
@@ -2477,9 +2477,9 @@ jobs:
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v7
       with:
-        name: aarch64-windows-unit-tests-unit-tests crypto (none)-junit-xml
+        name: aarch64-windows-unit-tests-unit-tests crypto (native)-junit-xml
         path: ${{ env.floweyvar1 }}
-      name: 'publish test results: aarch64-windows-unit-tests-unit-tests crypto (none) (JUnit XML)'
+      name: 'publish test results: aarch64-windows-unit-tests-unit-tests crypto (native) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
       run: |-
@@ -2721,7 +2721,7 @@ jobs:
     - name: generate nextest command
       run: flowey e 17 flowey_lib_common::gen_cargo_nextest_run_cmd 1
       shell: bash
-    - name: run 'unit-tests crypto (none)' nextest tests
+    - name: run 'unit-tests crypto (native)' nextest tests
       run: |-
         flowey e 17 flowey_lib_common::run_cargo_nextest_run 2
         flowey e 17 flowey_lib_common::run_cargo_nextest_run 3
@@ -2735,9 +2735,9 @@ jobs:
     - id: flowey_lib_common__publish_test_results__7
       uses: actions/upload-artifact@v7
       with:
-        name: aarch64-linux-unit-tests-unit-tests crypto (none)-junit-xml
+        name: aarch64-linux-unit-tests-unit-tests crypto (native)-junit-xml
         path: ${{ env.floweyvar2 }}
-      name: 'publish test results: aarch64-linux-unit-tests-unit-tests crypto (none) (JUnit XML)'
+      name: 'publish test results: aarch64-linux-unit-tests-unit-tests crypto (native) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
       run: flowey e 17 flowey_lib_common::gen_cargo_nextest_run_cmd 3
@@ -3092,7 +3092,7 @@ jobs:
     - name: generate nextest command
       run: flowey e 18 flowey_lib_common::gen_cargo_nextest_run_cmd 1
       shell: bash
-    - name: run 'unit-tests crypto (none)' nextest tests
+    - name: run 'unit-tests crypto (native)' nextest tests
       run: |-
         flowey e 18 flowey_lib_common::run_cargo_nextest_run 2
         flowey e 18 flowey_lib_common::run_cargo_nextest_run 3
@@ -3106,9 +3106,9 @@ jobs:
     - id: flowey_lib_common__publish_test_results__7
       uses: actions/upload-artifact@v7
       with:
-        name: aarch64-linux-musl-unit-tests-unit-tests crypto (none)-junit-xml
+        name: aarch64-linux-musl-unit-tests-unit-tests crypto (native)-junit-xml
         path: ${{ env.floweyvar2 }}
-      name: 'publish test results: aarch64-linux-musl-unit-tests-unit-tests crypto (none) (JUnit XML)'
+      name: 'publish test results: aarch64-linux-musl-unit-tests-unit-tests crypto (native) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
       run: flowey e 18 flowey_lib_common::gen_cargo_nextest_run_cmd 3

--- a/.github/workflows/openvmm-pr.yaml
+++ b/.github/workflows/openvmm-pr.yaml
@@ -193,6 +193,10 @@ jobs:
       run: |-
         flowey e 0 flowey_lib_hvlite::_jobs::check_xtask_fmt 0
         flowey e 0 flowey_lib_hvlite::init_cross_build 0
+      shell: bash
+    - name: cargo clippy
+      run: |-
+        flowey e 0 flowey_lib_common::run_cargo_clippy 1
         flowey e 0 flowey_lib_hvlite::init_cross_build 1
       shell: bash
     - name: cargo build xtask
@@ -213,13 +217,13 @@ jobs:
       run: flowey e 0 flowey_lib_common::run_cargo_clippy 0
       shell: bash
     - name: cargo clippy
-      run: flowey e 0 flowey_lib_common::run_cargo_clippy 1
+      run: flowey e 0 flowey_lib_common::run_cargo_clippy 2
+      shell: bash
+    - name: cargo clippy
+      run: flowey e 0 flowey_lib_common::run_cargo_clippy 4
       shell: bash
     - name: cargo clippy
       run: flowey e 0 flowey_lib_common::run_cargo_clippy 3
-      shell: bash
-    - name: cargo clippy
-      run: flowey e 0 flowey_lib_common::run_cargo_clippy 2
       shell: bash
     - name: 'validate cache entry: gh-release-download'
       run: flowey e 0 flowey_lib_common::cache 3
@@ -1994,7 +1998,7 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 16 flowey_lib_common::git_checkout 0
-        flowey v 16 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar9
+        flowey v 16 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar10
         flowey v 16 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
@@ -2002,7 +2006,7 @@ jobs:
       with:
         fetch-depth: '1'
         path: repo0
-        persist-credentials: ${{ env.floweyvar9 }}
+        persist-credentials: ${{ env.floweyvar10 }}
       name: checkout repo openvmm
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
@@ -2022,14 +2026,14 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 16 flowey_lib_common::cache 4
-        flowey v 16 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar7
-        flowey v 16 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar8
+        flowey v 16 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
+        flowey v 16 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
       with:
-        key: ${{ env.floweyvar7 }}
-        path: ${{ env.floweyvar8 }}
+        key: ${{ env.floweyvar8 }}
+        path: ${{ env.floweyvar9 }}
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
@@ -2082,14 +2086,14 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 16 flowey_lib_common::cache 0
-        flowey v 16 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar5
-        flowey v 16 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar6
+        flowey v 16 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
+        flowey v 16 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
       with:
-        key: ${{ env.floweyvar5 }}
-        path: ${{ env.floweyvar6 }}
+        key: ${{ env.floweyvar6 }}
+        path: ${{ env.floweyvar7 }}
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
@@ -2109,13 +2113,13 @@ jobs:
         flowey e 16 flowey_lib_hvlite::run_cargo_nextest_run 0
       shell: bash
     - name: generate nextest command
-      run: flowey e 16 flowey_lib_common::gen_cargo_nextest_run_cmd 2
+      run: flowey e 16 flowey_lib_common::gen_cargo_nextest_run_cmd 1
       shell: bash
-    - name: run 'unit-tests crypto (rust)' nextest tests
+    - name: run 'unit-tests crypto (native)' nextest tests
       run: |-
-        flowey e 16 flowey_lib_common::run_cargo_nextest_run 4
-        flowey e 16 flowey_lib_common::run_cargo_nextest_run 5
-        flowey e 16 flowey_lib_hvlite::build_nextest_unit_tests 3
+        flowey e 16 flowey_lib_common::run_cargo_nextest_run 2
+        flowey e 16 flowey_lib_common::run_cargo_nextest_run 3
+        flowey e 16 flowey_lib_hvlite::build_nextest_unit_tests 2
         flowey e 16 flowey_lib_common::publish_test_results 5
         flowey e 16 flowey_lib_common::publish_test_results 6
         flowey e 16 flowey_lib_common::publish_test_results 4
@@ -2125,18 +2129,18 @@ jobs:
     - id: flowey_lib_common__publish_test_results__7
       uses: actions/upload-artifact@v7
       with:
-        name: x64-linux-unit-tests-unit-tests crypto (rust)-junit-xml
+        name: x64-linux-unit-tests-unit-tests crypto (native)-junit-xml
         path: ${{ env.floweyvar2 }}
-      name: 'publish test results: x64-linux-unit-tests-unit-tests crypto (rust) (JUnit XML)'
+      name: 'publish test results: x64-linux-unit-tests-unit-tests crypto (native) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey e 16 flowey_lib_common::gen_cargo_nextest_run_cmd 1
+      run: flowey e 16 flowey_lib_common::gen_cargo_nextest_run_cmd 3
       shell: bash
-    - name: run 'unit-tests crypto (openssl)' nextest tests
+    - name: run 'unit-tests crypto (rust)' nextest tests
       run: |-
-        flowey e 16 flowey_lib_common::run_cargo_nextest_run 2
-        flowey e 16 flowey_lib_common::run_cargo_nextest_run 3
-        flowey e 16 flowey_lib_hvlite::build_nextest_unit_tests 4
+        flowey e 16 flowey_lib_common::run_cargo_nextest_run 6
+        flowey e 16 flowey_lib_common::run_cargo_nextest_run 7
+        flowey e 16 flowey_lib_hvlite::build_nextest_unit_tests 3
         flowey e 16 flowey_lib_common::publish_test_results 8
         flowey e 16 flowey_lib_common::publish_test_results 9
         flowey e 16 flowey_lib_common::publish_test_results 10
@@ -2146,9 +2150,51 @@ jobs:
     - id: flowey_lib_common__publish_test_results__11
       uses: actions/upload-artifact@v7
       with:
-        name: x64-linux-unit-tests-unit-tests crypto (openssl)-junit-xml
+        name: x64-linux-unit-tests-unit-tests crypto (rust)-junit-xml
         path: ${{ env.floweyvar3 }}
+      name: 'publish test results: x64-linux-unit-tests-unit-tests crypto (rust) (JUnit XML)'
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: generate nextest command
+      run: flowey e 16 flowey_lib_common::gen_cargo_nextest_run_cmd 2
+      shell: bash
+    - name: run 'unit-tests crypto (openssl)' nextest tests
+      run: |-
+        flowey e 16 flowey_lib_common::run_cargo_nextest_run 4
+        flowey e 16 flowey_lib_common::run_cargo_nextest_run 5
+        flowey e 16 flowey_lib_hvlite::build_nextest_unit_tests 4
+        flowey e 16 flowey_lib_common::publish_test_results 12
+        flowey e 16 flowey_lib_common::publish_test_results 13
+        flowey e 16 flowey_lib_common::publish_test_results 14
+        flowey v 16 'flowey_lib_common::publish_test_results:25:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar4
+        flowey v 16 'flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__publish_test_results__15
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-linux-unit-tests-unit-tests crypto (openssl)-junit-xml
+        path: ${{ env.floweyvar4 }}
       name: 'publish test results: x64-linux-unit-tests-unit-tests crypto (openssl) (JUnit XML)'
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: generate nextest command
+      run: flowey e 16 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      shell: bash
+    - name: run 'unit-tests crypto (all)' nextest tests
+      run: |-
+        flowey e 16 flowey_lib_common::run_cargo_nextest_run 0
+        flowey e 16 flowey_lib_common::run_cargo_nextest_run 1
+        flowey e 16 flowey_lib_hvlite::build_nextest_unit_tests 5
+        flowey e 16 flowey_lib_common::publish_test_results 16
+        flowey e 16 flowey_lib_common::publish_test_results 17
+        flowey e 16 flowey_lib_common::publish_test_results 18
+        flowey v 16 'flowey_lib_common::publish_test_results:32:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:28:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar5
+        flowey v 16 'flowey_lib_common::publish_test_results:28:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__publish_test_results__19
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-linux-unit-tests-unit-tests crypto (all)-junit-xml
+        path: ${{ env.floweyvar5 }}
+      name: 'publish test results: x64-linux-unit-tests-unit-tests crypto (all) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: cargo build xtask
       run: |-
@@ -2166,34 +2212,13 @@ jobs:
       run: flowey e 16 flowey_lib_hvlite::build_nextest_unit_tests 0
       shell: bash
     - name: generate nextest command
-      run: flowey e 16 flowey_lib_common::gen_cargo_nextest_run_cmd 3
+      run: flowey e 16 flowey_lib_common::gen_cargo_nextest_run_cmd 4
       shell: bash
     - name: run 'unit-tests' nextest tests
       run: |-
-        flowey e 16 flowey_lib_common::run_cargo_nextest_run 6
-        flowey e 16 flowey_lib_common::run_cargo_nextest_run 7
+        flowey e 16 flowey_lib_common::run_cargo_nextest_run 8
+        flowey e 16 flowey_lib_common::run_cargo_nextest_run 9
         flowey e 16 flowey_lib_hvlite::build_nextest_unit_tests 1
-        flowey e 16 flowey_lib_common::publish_test_results 12
-        flowey e 16 flowey_lib_common::publish_test_results 13
-        flowey e 16 flowey_lib_common::publish_test_results 14
-        flowey v 16 'flowey_lib_common::publish_test_results:25:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar4
-        flowey v 16 'flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__publish_test_results__15
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-linux-unit-tests-unit-tests-junit-xml
-        path: ${{ env.floweyvar4 }}
-      name: 'publish test results: x64-linux-unit-tests-unit-tests (JUnit XML)'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: generate nextest command
-      run: flowey e 16 flowey_lib_common::gen_cargo_nextest_run_cmd 0
-      shell: bash
-    - name: run 'unit-tests crypto (native)' nextest tests
-      run: |-
-        flowey e 16 flowey_lib_common::run_cargo_nextest_run 0
-        flowey e 16 flowey_lib_common::run_cargo_nextest_run 1
-        flowey e 16 flowey_lib_hvlite::build_nextest_unit_tests 2
         flowey e 16 flowey_lib_common::publish_test_results 0
         flowey e 16 flowey_lib_common::publish_test_results 1
         flowey e 16 flowey_lib_common::publish_test_results 2
@@ -2203,13 +2228,13 @@ jobs:
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v7
       with:
-        name: x64-linux-unit-tests-unit-tests crypto (native)-junit-xml
+        name: x64-linux-unit-tests-unit-tests-junit-xml
         path: ${{ env.floweyvar1 }}
-      name: 'publish test results: x64-linux-unit-tests-unit-tests crypto (native) (JUnit XML)'
+      name: 'publish test results: x64-linux-unit-tests-unit-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
       run: |-
-        flowey e 16 flowey_lib_hvlite::build_nextest_unit_tests 5
+        flowey e 16 flowey_lib_hvlite::build_nextest_unit_tests 6
         flowey e 16 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
       shell: bash
     - name: run doctests for x86_64-unknown-linux-gnu
@@ -2272,7 +2297,7 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 17 flowey_lib_common::git_checkout 0
-        flowey v 17 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar10
+        flowey v 17 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar11
         flowey v 17 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
@@ -2280,7 +2305,7 @@ jobs:
       with:
         fetch-depth: '1'
         path: repo0
-        persist-credentials: ${{ env.floweyvar10 }}
+        persist-credentials: ${{ env.floweyvar11 }}
       name: checkout repo openvmm
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
@@ -2298,14 +2323,14 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 17 flowey_lib_common::cache 4
-        flowey v 17 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
-        flowey v 17 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
+        flowey v 17 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar9
+        flowey v 17 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar10
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
       with:
-        key: ${{ env.floweyvar8 }}
-        path: ${{ env.floweyvar9 }}
+        key: ${{ env.floweyvar9 }}
+        path: ${{ env.floweyvar10 }}
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
@@ -2339,17 +2364,20 @@ jobs:
         flowey e 17 flowey_lib_hvlite::init_cross_build 2
       shell: bash
     - name: cargo clippy
-      run: flowey e 17 flowey_lib_common::run_cargo_clippy 2
+      run: flowey e 17 flowey_lib_common::run_cargo_clippy 3
       shell: bash
     - name: cargo clippy
-      run: flowey e 17 flowey_lib_common::run_cargo_clippy 4
+      run: flowey e 17 flowey_lib_common::run_cargo_clippy 5
       shell: bash
     - name: cargo clippy
-      run: flowey e 17 flowey_lib_common::run_cargo_clippy 6
+      run: flowey e 17 flowey_lib_common::run_cargo_clippy 1
+      shell: bash
+    - name: cargo clippy
+      run: flowey e 17 flowey_lib_common::run_cargo_clippy 7
       shell: bash
     - name: cargo clippy
       run: |-
-        flowey e 17 flowey_lib_common::run_cargo_clippy 5
+        flowey e 17 flowey_lib_common::run_cargo_clippy 6
         flowey e 17 flowey_lib_hvlite::init_cross_build 0
       shell: bash
     - name: cargo build xtask
@@ -2370,10 +2398,10 @@ jobs:
       run: flowey e 17 flowey_lib_common::run_cargo_clippy 0
       shell: bash
     - name: cargo clippy
-      run: flowey e 17 flowey_lib_common::run_cargo_clippy 1
+      run: flowey e 17 flowey_lib_common::run_cargo_clippy 2
       shell: bash
     - name: cargo clippy
-      run: flowey e 17 flowey_lib_common::run_cargo_clippy 3
+      run: flowey e 17 flowey_lib_common::run_cargo_clippy 4
       shell: bash
     - name: create cargo-nextest cache dir
       run: |-
@@ -2385,14 +2413,14 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 17 flowey_lib_common::cache 0
-        flowey v 17 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
-        flowey v 17 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
+        flowey v 17 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar7
+        flowey v 17 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar8
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
       with:
-        key: ${{ env.floweyvar6 }}
-        path: ${{ env.floweyvar7 }}
+        key: ${{ env.floweyvar7 }}
+        path: ${{ env.floweyvar8 }}
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
@@ -2412,12 +2440,12 @@ jobs:
         flowey e 17 flowey_lib_hvlite::run_cargo_nextest_run 0
       shell: bash
     - name: generate nextest command
-      run: flowey e 17 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      run: flowey e 17 flowey_lib_common::gen_cargo_nextest_run_cmd 1
       shell: bash
     - name: run 'unit-tests crypto (native)' nextest tests
       run: |-
-        flowey e 17 flowey_lib_common::run_cargo_nextest_run 0
-        flowey e 17 flowey_lib_common::run_cargo_nextest_run 1
+        flowey e 17 flowey_lib_common::run_cargo_nextest_run 2
+        flowey e 17 flowey_lib_common::run_cargo_nextest_run 3
         flowey e 17 flowey_lib_hvlite::build_nextest_unit_tests 2
         flowey e 17 flowey_lib_common::publish_test_results 5
         flowey e 17 flowey_lib_common::publish_test_results 6
@@ -2433,12 +2461,12 @@ jobs:
       name: 'publish test results: x64-linux-musl-unit-tests-unit-tests crypto (native) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey e 17 flowey_lib_common::gen_cargo_nextest_run_cmd 2
+      run: flowey e 17 flowey_lib_common::gen_cargo_nextest_run_cmd 3
       shell: bash
     - name: run 'unit-tests crypto (rust)' nextest tests
       run: |-
-        flowey e 17 flowey_lib_common::run_cargo_nextest_run 4
-        flowey e 17 flowey_lib_common::run_cargo_nextest_run 5
+        flowey e 17 flowey_lib_common::run_cargo_nextest_run 6
+        flowey e 17 flowey_lib_common::run_cargo_nextest_run 7
         flowey e 17 flowey_lib_hvlite::build_nextest_unit_tests 3
         flowey e 17 flowey_lib_common::publish_test_results 8
         flowey e 17 flowey_lib_common::publish_test_results 9
@@ -2454,12 +2482,12 @@ jobs:
       name: 'publish test results: x64-linux-musl-unit-tests-unit-tests crypto (rust) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey e 17 flowey_lib_common::gen_cargo_nextest_run_cmd 1
+      run: flowey e 17 flowey_lib_common::gen_cargo_nextest_run_cmd 2
       shell: bash
     - name: run 'unit-tests crypto (openssl)' nextest tests
       run: |-
-        flowey e 17 flowey_lib_common::run_cargo_nextest_run 2
-        flowey e 17 flowey_lib_common::run_cargo_nextest_run 3
+        flowey e 17 flowey_lib_common::run_cargo_nextest_run 4
+        flowey e 17 flowey_lib_common::run_cargo_nextest_run 5
         flowey e 17 flowey_lib_hvlite::build_nextest_unit_tests 4
         flowey e 17 flowey_lib_common::publish_test_results 12
         flowey e 17 flowey_lib_common::publish_test_results 13
@@ -2475,12 +2503,12 @@ jobs:
       name: 'publish test results: x64-linux-musl-unit-tests-unit-tests crypto (openssl) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey e 17 flowey_lib_common::gen_cargo_nextest_run_cmd 3
+      run: flowey e 17 flowey_lib_common::gen_cargo_nextest_run_cmd 4
       shell: bash
     - name: run 'unit-tests crypto (symcrypt)' nextest tests
       run: |-
-        flowey e 17 flowey_lib_common::run_cargo_nextest_run 6
-        flowey e 17 flowey_lib_common::run_cargo_nextest_run 7
+        flowey e 17 flowey_lib_common::run_cargo_nextest_run 8
+        flowey e 17 flowey_lib_common::run_cargo_nextest_run 9
         flowey e 17 flowey_lib_hvlite::build_nextest_unit_tests 5
         flowey e 17 flowey_lib_common::publish_test_results 16
         flowey e 17 flowey_lib_common::publish_test_results 17
@@ -2494,6 +2522,27 @@ jobs:
         name: x64-linux-musl-unit-tests-unit-tests crypto (symcrypt)-junit-xml
         path: ${{ env.floweyvar5 }}
       name: 'publish test results: x64-linux-musl-unit-tests-unit-tests crypto (symcrypt) (JUnit XML)'
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: generate nextest command
+      run: flowey e 17 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      shell: bash
+    - name: run 'unit-tests crypto (all)' nextest tests
+      run: |-
+        flowey e 17 flowey_lib_common::run_cargo_nextest_run 0
+        flowey e 17 flowey_lib_common::run_cargo_nextest_run 1
+        flowey e 17 flowey_lib_hvlite::build_nextest_unit_tests 6
+        flowey e 17 flowey_lib_common::publish_test_results 20
+        flowey e 17 flowey_lib_common::publish_test_results 21
+        flowey e 17 flowey_lib_common::publish_test_results 22
+        flowey v 17 'flowey_lib_common::publish_test_results:39:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:35:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar6
+        flowey v 17 'flowey_lib_common::publish_test_results:35:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__publish_test_results__23
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-linux-musl-unit-tests-unit-tests crypto (all)-junit-xml
+        path: ${{ env.floweyvar6 }}
+      name: 'publish test results: x64-linux-musl-unit-tests-unit-tests crypto (all) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: cargo build xtask
       run: |-
@@ -2511,12 +2560,12 @@ jobs:
       run: flowey e 17 flowey_lib_hvlite::build_nextest_unit_tests 0
       shell: bash
     - name: generate nextest command
-      run: flowey e 17 flowey_lib_common::gen_cargo_nextest_run_cmd 4
+      run: flowey e 17 flowey_lib_common::gen_cargo_nextest_run_cmd 5
       shell: bash
     - name: run 'unit-tests' nextest tests
       run: |-
-        flowey e 17 flowey_lib_common::run_cargo_nextest_run 8
-        flowey e 17 flowey_lib_common::run_cargo_nextest_run 9
+        flowey e 17 flowey_lib_common::run_cargo_nextest_run 10
+        flowey e 17 flowey_lib_common::run_cargo_nextest_run 11
         flowey e 17 flowey_lib_hvlite::build_nextest_unit_tests 1
         flowey e 17 flowey_lib_common::publish_test_results 0
         flowey e 17 flowey_lib_common::publish_test_results 1
@@ -2533,7 +2582,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
       run: |-
-        flowey e 17 flowey_lib_hvlite::build_nextest_unit_tests 6
+        flowey e 17 flowey_lib_hvlite::build_nextest_unit_tests 7
         flowey e 17 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
       shell: bash
     - name: run doctests for x86_64-unknown-linux-musl
@@ -2938,7 +2987,7 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 19 flowey_lib_common::git_checkout 0
-        flowey v 19 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar9
+        flowey v 19 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar10
         flowey v 19 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
@@ -2946,7 +2995,7 @@ jobs:
       with:
         fetch-depth: '1'
         path: repo0
-        persist-credentials: ${{ env.floweyvar9 }}
+        persist-credentials: ${{ env.floweyvar10 }}
       name: checkout repo openvmm
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
@@ -2966,14 +3015,14 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 19 flowey_lib_common::cache 4
-        flowey v 19 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar7
-        flowey v 19 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar8
+        flowey v 19 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
+        flowey v 19 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
       with:
-        key: ${{ env.floweyvar7 }}
-        path: ${{ env.floweyvar8 }}
+        key: ${{ env.floweyvar8 }}
+        path: ${{ env.floweyvar9 }}
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
@@ -2992,6 +3041,10 @@ jobs:
       run: |-
         flowey e 19 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
         flowey e 19 flowey_lib_hvlite::init_cross_build 0
+      shell: bash
+    - name: cargo clippy
+      run: |-
+        flowey e 19 flowey_lib_common::run_cargo_clippy 1
         flowey e 19 flowey_lib_hvlite::init_cross_build 2
       shell: bash
     - name: cargo build xtask
@@ -3012,13 +3065,13 @@ jobs:
       run: flowey e 19 flowey_lib_common::run_cargo_clippy 0
       shell: bash
     - name: cargo clippy
-      run: flowey e 19 flowey_lib_common::run_cargo_clippy 1
+      run: flowey e 19 flowey_lib_common::run_cargo_clippy 2
+      shell: bash
+    - name: cargo clippy
+      run: flowey e 19 flowey_lib_common::run_cargo_clippy 4
       shell: bash
     - name: cargo clippy
       run: flowey e 19 flowey_lib_common::run_cargo_clippy 3
-      shell: bash
-    - name: cargo clippy
-      run: flowey e 19 flowey_lib_common::run_cargo_clippy 2
       shell: bash
     - name: create cargo-nextest cache dir
       run: |-
@@ -3030,14 +3083,14 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 19 flowey_lib_common::cache 0
-        flowey v 19 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar5
-        flowey v 19 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar6
+        flowey v 19 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
+        flowey v 19 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
       with:
-        key: ${{ env.floweyvar5 }}
-        path: ${{ env.floweyvar6 }}
+        key: ${{ env.floweyvar6 }}
+        path: ${{ env.floweyvar7 }}
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
@@ -3057,13 +3110,13 @@ jobs:
         flowey e 19 flowey_lib_hvlite::run_cargo_nextest_run 0
       shell: bash
     - name: generate nextest command
-      run: flowey e 19 flowey_lib_common::gen_cargo_nextest_run_cmd 2
+      run: flowey e 19 flowey_lib_common::gen_cargo_nextest_run_cmd 1
       shell: bash
-    - name: run 'unit-tests crypto (rust)' nextest tests
+    - name: run 'unit-tests crypto (native)' nextest tests
       run: |-
-        flowey e 19 flowey_lib_common::run_cargo_nextest_run 4
-        flowey e 19 flowey_lib_common::run_cargo_nextest_run 5
-        flowey e 19 flowey_lib_hvlite::build_nextest_unit_tests 3
+        flowey e 19 flowey_lib_common::run_cargo_nextest_run 2
+        flowey e 19 flowey_lib_common::run_cargo_nextest_run 3
+        flowey e 19 flowey_lib_hvlite::build_nextest_unit_tests 2
         flowey e 19 flowey_lib_common::publish_test_results 5
         flowey e 19 flowey_lib_common::publish_test_results 6
         flowey e 19 flowey_lib_common::publish_test_results 4
@@ -3073,18 +3126,18 @@ jobs:
     - id: flowey_lib_common__publish_test_results__7
       uses: actions/upload-artifact@v7
       with:
-        name: aarch64-linux-unit-tests-unit-tests crypto (rust)-junit-xml
+        name: aarch64-linux-unit-tests-unit-tests crypto (native)-junit-xml
         path: ${{ env.floweyvar2 }}
-      name: 'publish test results: aarch64-linux-unit-tests-unit-tests crypto (rust) (JUnit XML)'
+      name: 'publish test results: aarch64-linux-unit-tests-unit-tests crypto (native) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey e 19 flowey_lib_common::gen_cargo_nextest_run_cmd 1
+      run: flowey e 19 flowey_lib_common::gen_cargo_nextest_run_cmd 3
       shell: bash
-    - name: run 'unit-tests crypto (openssl)' nextest tests
+    - name: run 'unit-tests crypto (rust)' nextest tests
       run: |-
-        flowey e 19 flowey_lib_common::run_cargo_nextest_run 2
-        flowey e 19 flowey_lib_common::run_cargo_nextest_run 3
-        flowey e 19 flowey_lib_hvlite::build_nextest_unit_tests 4
+        flowey e 19 flowey_lib_common::run_cargo_nextest_run 6
+        flowey e 19 flowey_lib_common::run_cargo_nextest_run 7
+        flowey e 19 flowey_lib_hvlite::build_nextest_unit_tests 3
         flowey e 19 flowey_lib_common::publish_test_results 8
         flowey e 19 flowey_lib_common::publish_test_results 9
         flowey e 19 flowey_lib_common::publish_test_results 10
@@ -3094,9 +3147,51 @@ jobs:
     - id: flowey_lib_common__publish_test_results__11
       uses: actions/upload-artifact@v7
       with:
-        name: aarch64-linux-unit-tests-unit-tests crypto (openssl)-junit-xml
+        name: aarch64-linux-unit-tests-unit-tests crypto (rust)-junit-xml
         path: ${{ env.floweyvar3 }}
+      name: 'publish test results: aarch64-linux-unit-tests-unit-tests crypto (rust) (JUnit XML)'
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: generate nextest command
+      run: flowey e 19 flowey_lib_common::gen_cargo_nextest_run_cmd 2
+      shell: bash
+    - name: run 'unit-tests crypto (openssl)' nextest tests
+      run: |-
+        flowey e 19 flowey_lib_common::run_cargo_nextest_run 4
+        flowey e 19 flowey_lib_common::run_cargo_nextest_run 5
+        flowey e 19 flowey_lib_hvlite::build_nextest_unit_tests 4
+        flowey e 19 flowey_lib_common::publish_test_results 12
+        flowey e 19 flowey_lib_common::publish_test_results 13
+        flowey e 19 flowey_lib_common::publish_test_results 14
+        flowey v 19 'flowey_lib_common::publish_test_results:25:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar4
+        flowey v 19 'flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__publish_test_results__15
+      uses: actions/upload-artifact@v7
+      with:
+        name: aarch64-linux-unit-tests-unit-tests crypto (openssl)-junit-xml
+        path: ${{ env.floweyvar4 }}
       name: 'publish test results: aarch64-linux-unit-tests-unit-tests crypto (openssl) (JUnit XML)'
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: generate nextest command
+      run: flowey e 19 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      shell: bash
+    - name: run 'unit-tests crypto (all)' nextest tests
+      run: |-
+        flowey e 19 flowey_lib_common::run_cargo_nextest_run 0
+        flowey e 19 flowey_lib_common::run_cargo_nextest_run 1
+        flowey e 19 flowey_lib_hvlite::build_nextest_unit_tests 5
+        flowey e 19 flowey_lib_common::publish_test_results 16
+        flowey e 19 flowey_lib_common::publish_test_results 17
+        flowey e 19 flowey_lib_common::publish_test_results 18
+        flowey v 19 'flowey_lib_common::publish_test_results:32:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:28:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar5
+        flowey v 19 'flowey_lib_common::publish_test_results:28:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__publish_test_results__19
+      uses: actions/upload-artifact@v7
+      with:
+        name: aarch64-linux-unit-tests-unit-tests crypto (all)-junit-xml
+        path: ${{ env.floweyvar5 }}
+      name: 'publish test results: aarch64-linux-unit-tests-unit-tests crypto (all) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: cargo build xtask
       run: |-
@@ -3114,34 +3209,13 @@ jobs:
       run: flowey e 19 flowey_lib_hvlite::build_nextest_unit_tests 0
       shell: bash
     - name: generate nextest command
-      run: flowey e 19 flowey_lib_common::gen_cargo_nextest_run_cmd 3
+      run: flowey e 19 flowey_lib_common::gen_cargo_nextest_run_cmd 4
       shell: bash
     - name: run 'unit-tests' nextest tests
       run: |-
-        flowey e 19 flowey_lib_common::run_cargo_nextest_run 6
-        flowey e 19 flowey_lib_common::run_cargo_nextest_run 7
+        flowey e 19 flowey_lib_common::run_cargo_nextest_run 8
+        flowey e 19 flowey_lib_common::run_cargo_nextest_run 9
         flowey e 19 flowey_lib_hvlite::build_nextest_unit_tests 1
-        flowey e 19 flowey_lib_common::publish_test_results 12
-        flowey e 19 flowey_lib_common::publish_test_results 13
-        flowey e 19 flowey_lib_common::publish_test_results 14
-        flowey v 19 'flowey_lib_common::publish_test_results:25:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar4
-        flowey v 19 'flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__publish_test_results__15
-      uses: actions/upload-artifact@v7
-      with:
-        name: aarch64-linux-unit-tests-unit-tests-junit-xml
-        path: ${{ env.floweyvar4 }}
-      name: 'publish test results: aarch64-linux-unit-tests-unit-tests (JUnit XML)'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: generate nextest command
-      run: flowey e 19 flowey_lib_common::gen_cargo_nextest_run_cmd 0
-      shell: bash
-    - name: run 'unit-tests crypto (native)' nextest tests
-      run: |-
-        flowey e 19 flowey_lib_common::run_cargo_nextest_run 0
-        flowey e 19 flowey_lib_common::run_cargo_nextest_run 1
-        flowey e 19 flowey_lib_hvlite::build_nextest_unit_tests 2
         flowey e 19 flowey_lib_common::publish_test_results 0
         flowey e 19 flowey_lib_common::publish_test_results 1
         flowey e 19 flowey_lib_common::publish_test_results 2
@@ -3151,13 +3225,13 @@ jobs:
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v7
       with:
-        name: aarch64-linux-unit-tests-unit-tests crypto (native)-junit-xml
+        name: aarch64-linux-unit-tests-unit-tests-junit-xml
         path: ${{ env.floweyvar1 }}
-      name: 'publish test results: aarch64-linux-unit-tests-unit-tests crypto (native) (JUnit XML)'
+      name: 'publish test results: aarch64-linux-unit-tests-unit-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
       run: |-
-        flowey e 19 flowey_lib_hvlite::build_nextest_unit_tests 5
+        flowey e 19 flowey_lib_hvlite::build_nextest_unit_tests 6
         flowey e 19 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
       shell: bash
     - name: run doctests for aarch64-unknown-linux-gnu
@@ -3448,7 +3522,7 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 20 flowey_lib_common::git_checkout 0
-        flowey v 20 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar10
+        flowey v 20 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar11
         flowey v 20 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
@@ -3456,7 +3530,7 @@ jobs:
       with:
         fetch-depth: '1'
         path: repo0
-        persist-credentials: ${{ env.floweyvar10 }}
+        persist-credentials: ${{ env.floweyvar11 }}
       name: checkout repo openvmm
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
@@ -3474,14 +3548,14 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 20 flowey_lib_common::cache 4
-        flowey v 20 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
-        flowey v 20 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
+        flowey v 20 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar9
+        flowey v 20 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar10
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
       with:
-        key: ${{ env.floweyvar8 }}
-        path: ${{ env.floweyvar9 }}
+        key: ${{ env.floweyvar9 }}
+        path: ${{ env.floweyvar10 }}
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
@@ -3515,17 +3589,20 @@ jobs:
         flowey e 20 flowey_lib_hvlite::init_cross_build 2
       shell: bash
     - name: cargo clippy
-      run: flowey e 20 flowey_lib_common::run_cargo_clippy 2
+      run: flowey e 20 flowey_lib_common::run_cargo_clippy 3
       shell: bash
     - name: cargo clippy
-      run: flowey e 20 flowey_lib_common::run_cargo_clippy 4
+      run: flowey e 20 flowey_lib_common::run_cargo_clippy 5
       shell: bash
     - name: cargo clippy
-      run: flowey e 20 flowey_lib_common::run_cargo_clippy 6
+      run: flowey e 20 flowey_lib_common::run_cargo_clippy 1
+      shell: bash
+    - name: cargo clippy
+      run: flowey e 20 flowey_lib_common::run_cargo_clippy 7
       shell: bash
     - name: cargo clippy
       run: |-
-        flowey e 20 flowey_lib_common::run_cargo_clippy 5
+        flowey e 20 flowey_lib_common::run_cargo_clippy 6
         flowey e 20 flowey_lib_hvlite::init_cross_build 0
       shell: bash
     - name: cargo build xtask
@@ -3546,10 +3623,10 @@ jobs:
       run: flowey e 20 flowey_lib_common::run_cargo_clippy 0
       shell: bash
     - name: cargo clippy
-      run: flowey e 20 flowey_lib_common::run_cargo_clippy 1
+      run: flowey e 20 flowey_lib_common::run_cargo_clippy 2
       shell: bash
     - name: cargo clippy
-      run: flowey e 20 flowey_lib_common::run_cargo_clippy 3
+      run: flowey e 20 flowey_lib_common::run_cargo_clippy 4
       shell: bash
     - name: create cargo-nextest cache dir
       run: |-
@@ -3561,14 +3638,14 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 20 flowey_lib_common::cache 0
-        flowey v 20 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
-        flowey v 20 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
+        flowey v 20 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar7
+        flowey v 20 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar8
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
       with:
-        key: ${{ env.floweyvar6 }}
-        path: ${{ env.floweyvar7 }}
+        key: ${{ env.floweyvar7 }}
+        path: ${{ env.floweyvar8 }}
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
@@ -3588,12 +3665,12 @@ jobs:
         flowey e 20 flowey_lib_hvlite::run_cargo_nextest_run 0
       shell: bash
     - name: generate nextest command
-      run: flowey e 20 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      run: flowey e 20 flowey_lib_common::gen_cargo_nextest_run_cmd 1
       shell: bash
     - name: run 'unit-tests crypto (native)' nextest tests
       run: |-
-        flowey e 20 flowey_lib_common::run_cargo_nextest_run 0
-        flowey e 20 flowey_lib_common::run_cargo_nextest_run 1
+        flowey e 20 flowey_lib_common::run_cargo_nextest_run 2
+        flowey e 20 flowey_lib_common::run_cargo_nextest_run 3
         flowey e 20 flowey_lib_hvlite::build_nextest_unit_tests 2
         flowey e 20 flowey_lib_common::publish_test_results 5
         flowey e 20 flowey_lib_common::publish_test_results 6
@@ -3609,12 +3686,12 @@ jobs:
       name: 'publish test results: aarch64-linux-musl-unit-tests-unit-tests crypto (native) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey e 20 flowey_lib_common::gen_cargo_nextest_run_cmd 2
+      run: flowey e 20 flowey_lib_common::gen_cargo_nextest_run_cmd 3
       shell: bash
     - name: run 'unit-tests crypto (rust)' nextest tests
       run: |-
-        flowey e 20 flowey_lib_common::run_cargo_nextest_run 4
-        flowey e 20 flowey_lib_common::run_cargo_nextest_run 5
+        flowey e 20 flowey_lib_common::run_cargo_nextest_run 6
+        flowey e 20 flowey_lib_common::run_cargo_nextest_run 7
         flowey e 20 flowey_lib_hvlite::build_nextest_unit_tests 3
         flowey e 20 flowey_lib_common::publish_test_results 8
         flowey e 20 flowey_lib_common::publish_test_results 9
@@ -3630,12 +3707,12 @@ jobs:
       name: 'publish test results: aarch64-linux-musl-unit-tests-unit-tests crypto (rust) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey e 20 flowey_lib_common::gen_cargo_nextest_run_cmd 1
+      run: flowey e 20 flowey_lib_common::gen_cargo_nextest_run_cmd 2
       shell: bash
     - name: run 'unit-tests crypto (openssl)' nextest tests
       run: |-
-        flowey e 20 flowey_lib_common::run_cargo_nextest_run 2
-        flowey e 20 flowey_lib_common::run_cargo_nextest_run 3
+        flowey e 20 flowey_lib_common::run_cargo_nextest_run 4
+        flowey e 20 flowey_lib_common::run_cargo_nextest_run 5
         flowey e 20 flowey_lib_hvlite::build_nextest_unit_tests 4
         flowey e 20 flowey_lib_common::publish_test_results 12
         flowey e 20 flowey_lib_common::publish_test_results 13
@@ -3651,12 +3728,12 @@ jobs:
       name: 'publish test results: aarch64-linux-musl-unit-tests-unit-tests crypto (openssl) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey e 20 flowey_lib_common::gen_cargo_nextest_run_cmd 3
+      run: flowey e 20 flowey_lib_common::gen_cargo_nextest_run_cmd 4
       shell: bash
     - name: run 'unit-tests crypto (symcrypt)' nextest tests
       run: |-
-        flowey e 20 flowey_lib_common::run_cargo_nextest_run 6
-        flowey e 20 flowey_lib_common::run_cargo_nextest_run 7
+        flowey e 20 flowey_lib_common::run_cargo_nextest_run 8
+        flowey e 20 flowey_lib_common::run_cargo_nextest_run 9
         flowey e 20 flowey_lib_hvlite::build_nextest_unit_tests 5
         flowey e 20 flowey_lib_common::publish_test_results 16
         flowey e 20 flowey_lib_common::publish_test_results 17
@@ -3670,6 +3747,27 @@ jobs:
         name: aarch64-linux-musl-unit-tests-unit-tests crypto (symcrypt)-junit-xml
         path: ${{ env.floweyvar5 }}
       name: 'publish test results: aarch64-linux-musl-unit-tests-unit-tests crypto (symcrypt) (JUnit XML)'
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: generate nextest command
+      run: flowey e 20 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      shell: bash
+    - name: run 'unit-tests crypto (all)' nextest tests
+      run: |-
+        flowey e 20 flowey_lib_common::run_cargo_nextest_run 0
+        flowey e 20 flowey_lib_common::run_cargo_nextest_run 1
+        flowey e 20 flowey_lib_hvlite::build_nextest_unit_tests 6
+        flowey e 20 flowey_lib_common::publish_test_results 20
+        flowey e 20 flowey_lib_common::publish_test_results 21
+        flowey e 20 flowey_lib_common::publish_test_results 22
+        flowey v 20 'flowey_lib_common::publish_test_results:39:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:35:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar6
+        flowey v 20 'flowey_lib_common::publish_test_results:35:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__publish_test_results__23
+      uses: actions/upload-artifact@v7
+      with:
+        name: aarch64-linux-musl-unit-tests-unit-tests crypto (all)-junit-xml
+        path: ${{ env.floweyvar6 }}
+      name: 'publish test results: aarch64-linux-musl-unit-tests-unit-tests crypto (all) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: cargo build xtask
       run: |-
@@ -3687,12 +3785,12 @@ jobs:
       run: flowey e 20 flowey_lib_hvlite::build_nextest_unit_tests 0
       shell: bash
     - name: generate nextest command
-      run: flowey e 20 flowey_lib_common::gen_cargo_nextest_run_cmd 4
+      run: flowey e 20 flowey_lib_common::gen_cargo_nextest_run_cmd 5
       shell: bash
     - name: run 'unit-tests' nextest tests
       run: |-
-        flowey e 20 flowey_lib_common::run_cargo_nextest_run 8
-        flowey e 20 flowey_lib_common::run_cargo_nextest_run 9
+        flowey e 20 flowey_lib_common::run_cargo_nextest_run 10
+        flowey e 20 flowey_lib_common::run_cargo_nextest_run 11
         flowey e 20 flowey_lib_hvlite::build_nextest_unit_tests 1
         flowey e 20 flowey_lib_common::publish_test_results 0
         flowey e 20 flowey_lib_common::publish_test_results 1
@@ -3709,7 +3807,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
       run: |-
-        flowey e 20 flowey_lib_hvlite::build_nextest_unit_tests 6
+        flowey e 20 flowey_lib_hvlite::build_nextest_unit_tests 7
         flowey e 20 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
       shell: bash
     - name: run doctests for aarch64-unknown-linux-musl

--- a/.github/workflows/openvmm-pr.yaml
+++ b/.github/workflows/openvmm-pr.yaml
@@ -1909,7 +1909,7 @@ jobs:
     - name: generate nextest command
       run: flowey.exe e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 0
       shell: bash
-    - name: run 'unit-tests crypto (none)' nextest tests
+    - name: run 'unit-tests crypto (native)' nextest tests
       run: |-
         flowey.exe e 15 flowey_lib_common::run_cargo_nextest_run 0
         flowey.exe e 15 flowey_lib_common::run_cargo_nextest_run 1
@@ -1923,9 +1923,9 @@ jobs:
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v7
       with:
-        name: x64-windows-unit-tests-unit-tests crypto (none)-junit-xml
+        name: x64-windows-unit-tests-unit-tests crypto (native)-junit-xml
         path: ${{ env.floweyvar1 }}
-      name: 'publish test results: x64-windows-unit-tests-unit-tests crypto (none) (JUnit XML)'
+      name: 'publish test results: x64-windows-unit-tests-unit-tests crypto (native) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
       run: |-
@@ -2115,7 +2115,7 @@ jobs:
     - name: generate nextest command
       run: flowey e 16 flowey_lib_common::gen_cargo_nextest_run_cmd 1
       shell: bash
-    - name: run 'unit-tests crypto (none)' nextest tests
+    - name: run 'unit-tests crypto (native)' nextest tests
       run: |-
         flowey e 16 flowey_lib_common::run_cargo_nextest_run 2
         flowey e 16 flowey_lib_common::run_cargo_nextest_run 3
@@ -2129,9 +2129,9 @@ jobs:
     - id: flowey_lib_common__publish_test_results__7
       uses: actions/upload-artifact@v7
       with:
-        name: x64-linux-unit-tests-unit-tests crypto (none)-junit-xml
+        name: x64-linux-unit-tests-unit-tests crypto (native)-junit-xml
         path: ${{ env.floweyvar2 }}
-      name: 'publish test results: x64-linux-unit-tests-unit-tests crypto (none) (JUnit XML)'
+      name: 'publish test results: x64-linux-unit-tests-unit-tests crypto (native) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
       run: flowey e 16 flowey_lib_common::gen_cargo_nextest_run_cmd 3
@@ -2442,7 +2442,7 @@ jobs:
     - name: generate nextest command
       run: flowey e 17 flowey_lib_common::gen_cargo_nextest_run_cmd 1
       shell: bash
-    - name: run 'unit-tests crypto (none)' nextest tests
+    - name: run 'unit-tests crypto (native)' nextest tests
       run: |-
         flowey e 17 flowey_lib_common::run_cargo_nextest_run 2
         flowey e 17 flowey_lib_common::run_cargo_nextest_run 3
@@ -2456,9 +2456,9 @@ jobs:
     - id: flowey_lib_common__publish_test_results__7
       uses: actions/upload-artifact@v7
       with:
-        name: x64-linux-musl-unit-tests-unit-tests crypto (none)-junit-xml
+        name: x64-linux-musl-unit-tests-unit-tests crypto (native)-junit-xml
         path: ${{ env.floweyvar2 }}
-      name: 'publish test results: x64-linux-musl-unit-tests-unit-tests crypto (none) (JUnit XML)'
+      name: 'publish test results: x64-linux-musl-unit-tests-unit-tests crypto (native) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
       run: flowey e 17 flowey_lib_common::gen_cargo_nextest_run_cmd 3
@@ -2854,7 +2854,7 @@ jobs:
     - name: generate nextest command
       run: flowey.exe e 18 flowey_lib_common::gen_cargo_nextest_run_cmd 0
       shell: bash
-    - name: run 'unit-tests crypto (none)' nextest tests
+    - name: run 'unit-tests crypto (native)' nextest tests
       run: |-
         flowey.exe e 18 flowey_lib_common::run_cargo_nextest_run 0
         flowey.exe e 18 flowey_lib_common::run_cargo_nextest_run 1
@@ -2868,9 +2868,9 @@ jobs:
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v7
       with:
-        name: aarch64-windows-unit-tests-unit-tests crypto (none)-junit-xml
+        name: aarch64-windows-unit-tests-unit-tests crypto (native)-junit-xml
         path: ${{ env.floweyvar1 }}
-      name: 'publish test results: aarch64-windows-unit-tests-unit-tests crypto (none) (JUnit XML)'
+      name: 'publish test results: aarch64-windows-unit-tests-unit-tests crypto (native) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
       run: |-
@@ -3112,7 +3112,7 @@ jobs:
     - name: generate nextest command
       run: flowey e 19 flowey_lib_common::gen_cargo_nextest_run_cmd 1
       shell: bash
-    - name: run 'unit-tests crypto (none)' nextest tests
+    - name: run 'unit-tests crypto (native)' nextest tests
       run: |-
         flowey e 19 flowey_lib_common::run_cargo_nextest_run 2
         flowey e 19 flowey_lib_common::run_cargo_nextest_run 3
@@ -3126,9 +3126,9 @@ jobs:
     - id: flowey_lib_common__publish_test_results__7
       uses: actions/upload-artifact@v7
       with:
-        name: aarch64-linux-unit-tests-unit-tests crypto (none)-junit-xml
+        name: aarch64-linux-unit-tests-unit-tests crypto (native)-junit-xml
         path: ${{ env.floweyvar2 }}
-      name: 'publish test results: aarch64-linux-unit-tests-unit-tests crypto (none) (JUnit XML)'
+      name: 'publish test results: aarch64-linux-unit-tests-unit-tests crypto (native) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
       run: flowey e 19 flowey_lib_common::gen_cargo_nextest_run_cmd 3
@@ -3667,7 +3667,7 @@ jobs:
     - name: generate nextest command
       run: flowey e 20 flowey_lib_common::gen_cargo_nextest_run_cmd 1
       shell: bash
-    - name: run 'unit-tests crypto (none)' nextest tests
+    - name: run 'unit-tests crypto (native)' nextest tests
       run: |-
         flowey e 20 flowey_lib_common::run_cargo_nextest_run 2
         flowey e 20 flowey_lib_common::run_cargo_nextest_run 3
@@ -3681,9 +3681,9 @@ jobs:
     - id: flowey_lib_common__publish_test_results__7
       uses: actions/upload-artifact@v7
       with:
-        name: aarch64-linux-musl-unit-tests-unit-tests crypto (none)-junit-xml
+        name: aarch64-linux-musl-unit-tests-unit-tests crypto (native)-junit-xml
         path: ${{ env.floweyvar2 }}
-      name: 'publish test results: aarch64-linux-musl-unit-tests-unit-tests crypto (none) (JUnit XML)'
+      name: 'publish test results: aarch64-linux-musl-unit-tests-unit-tests crypto (native) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
       run: flowey e 20 flowey_lib_common::gen_cargo_nextest_run_cmd 3

--- a/.github/workflows/openvmm-pr.yaml
+++ b/.github/workflows/openvmm-pr.yaml
@@ -193,10 +193,6 @@ jobs:
       run: |-
         flowey e 0 flowey_lib_hvlite::_jobs::check_xtask_fmt 0
         flowey e 0 flowey_lib_hvlite::init_cross_build 0
-      shell: bash
-    - name: cargo clippy
-      run: |-
-        flowey e 0 flowey_lib_common::run_cargo_clippy 1
         flowey e 0 flowey_lib_hvlite::init_cross_build 1
       shell: bash
     - name: cargo build xtask
@@ -217,13 +213,13 @@ jobs:
       run: flowey e 0 flowey_lib_common::run_cargo_clippy 0
       shell: bash
     - name: cargo clippy
-      run: flowey e 0 flowey_lib_common::run_cargo_clippy 2
-      shell: bash
-    - name: cargo clippy
-      run: flowey e 0 flowey_lib_common::run_cargo_clippy 4
+      run: flowey e 0 flowey_lib_common::run_cargo_clippy 1
       shell: bash
     - name: cargo clippy
       run: flowey e 0 flowey_lib_common::run_cargo_clippy 3
+      shell: bash
+    - name: cargo clippy
+      run: flowey e 0 flowey_lib_common::run_cargo_clippy 2
       shell: bash
     - name: 'validate cache entry: gh-release-download'
       run: flowey e 0 flowey_lib_common::cache 3
@@ -1998,7 +1994,7 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 16 flowey_lib_common::git_checkout 0
-        flowey v 16 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar10
+        flowey v 16 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar9
         flowey v 16 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
@@ -2006,7 +2002,7 @@ jobs:
       with:
         fetch-depth: '1'
         path: repo0
-        persist-credentials: ${{ env.floweyvar10 }}
+        persist-credentials: ${{ env.floweyvar9 }}
       name: checkout repo openvmm
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
@@ -2026,14 +2022,14 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 16 flowey_lib_common::cache 4
-        flowey v 16 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
-        flowey v 16 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
+        flowey v 16 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar7
+        flowey v 16 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar8
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
       with:
-        key: ${{ env.floweyvar8 }}
-        path: ${{ env.floweyvar9 }}
+        key: ${{ env.floweyvar7 }}
+        path: ${{ env.floweyvar8 }}
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
@@ -2086,14 +2082,14 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 16 flowey_lib_common::cache 0
-        flowey v 16 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
-        flowey v 16 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
+        flowey v 16 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar5
+        flowey v 16 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar6
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
       with:
-        key: ${{ env.floweyvar6 }}
-        path: ${{ env.floweyvar7 }}
+        key: ${{ env.floweyvar5 }}
+        path: ${{ env.floweyvar6 }}
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
@@ -2113,13 +2109,13 @@ jobs:
         flowey e 16 flowey_lib_hvlite::run_cargo_nextest_run 0
       shell: bash
     - name: generate nextest command
-      run: flowey e 16 flowey_lib_common::gen_cargo_nextest_run_cmd 1
+      run: flowey e 16 flowey_lib_common::gen_cargo_nextest_run_cmd 2
       shell: bash
-    - name: run 'unit-tests crypto (native)' nextest tests
+    - name: run 'unit-tests crypto (rust)' nextest tests
       run: |-
-        flowey e 16 flowey_lib_common::run_cargo_nextest_run 2
-        flowey e 16 flowey_lib_common::run_cargo_nextest_run 3
-        flowey e 16 flowey_lib_hvlite::build_nextest_unit_tests 2
+        flowey e 16 flowey_lib_common::run_cargo_nextest_run 4
+        flowey e 16 flowey_lib_common::run_cargo_nextest_run 5
+        flowey e 16 flowey_lib_hvlite::build_nextest_unit_tests 3
         flowey e 16 flowey_lib_common::publish_test_results 5
         flowey e 16 flowey_lib_common::publish_test_results 6
         flowey e 16 flowey_lib_common::publish_test_results 4
@@ -2129,18 +2125,18 @@ jobs:
     - id: flowey_lib_common__publish_test_results__7
       uses: actions/upload-artifact@v7
       with:
-        name: x64-linux-unit-tests-unit-tests crypto (native)-junit-xml
+        name: x64-linux-unit-tests-unit-tests crypto (rust)-junit-xml
         path: ${{ env.floweyvar2 }}
-      name: 'publish test results: x64-linux-unit-tests-unit-tests crypto (native) (JUnit XML)'
+      name: 'publish test results: x64-linux-unit-tests-unit-tests crypto (rust) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey e 16 flowey_lib_common::gen_cargo_nextest_run_cmd 3
+      run: flowey e 16 flowey_lib_common::gen_cargo_nextest_run_cmd 1
       shell: bash
-    - name: run 'unit-tests crypto (rust)' nextest tests
+    - name: run 'unit-tests crypto (openssl)' nextest tests
       run: |-
-        flowey e 16 flowey_lib_common::run_cargo_nextest_run 6
-        flowey e 16 flowey_lib_common::run_cargo_nextest_run 7
-        flowey e 16 flowey_lib_hvlite::build_nextest_unit_tests 3
+        flowey e 16 flowey_lib_common::run_cargo_nextest_run 2
+        flowey e 16 flowey_lib_common::run_cargo_nextest_run 3
+        flowey e 16 flowey_lib_hvlite::build_nextest_unit_tests 4
         flowey e 16 flowey_lib_common::publish_test_results 8
         flowey e 16 flowey_lib_common::publish_test_results 9
         flowey e 16 flowey_lib_common::publish_test_results 10
@@ -2150,51 +2146,9 @@ jobs:
     - id: flowey_lib_common__publish_test_results__11
       uses: actions/upload-artifact@v7
       with:
-        name: x64-linux-unit-tests-unit-tests crypto (rust)-junit-xml
-        path: ${{ env.floweyvar3 }}
-      name: 'publish test results: x64-linux-unit-tests-unit-tests crypto (rust) (JUnit XML)'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: generate nextest command
-      run: flowey e 16 flowey_lib_common::gen_cargo_nextest_run_cmd 2
-      shell: bash
-    - name: run 'unit-tests crypto (openssl)' nextest tests
-      run: |-
-        flowey e 16 flowey_lib_common::run_cargo_nextest_run 4
-        flowey e 16 flowey_lib_common::run_cargo_nextest_run 5
-        flowey e 16 flowey_lib_hvlite::build_nextest_unit_tests 4
-        flowey e 16 flowey_lib_common::publish_test_results 12
-        flowey e 16 flowey_lib_common::publish_test_results 13
-        flowey e 16 flowey_lib_common::publish_test_results 14
-        flowey v 16 'flowey_lib_common::publish_test_results:25:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar4
-        flowey v 16 'flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__publish_test_results__15
-      uses: actions/upload-artifact@v7
-      with:
         name: x64-linux-unit-tests-unit-tests crypto (openssl)-junit-xml
-        path: ${{ env.floweyvar4 }}
+        path: ${{ env.floweyvar3 }}
       name: 'publish test results: x64-linux-unit-tests-unit-tests crypto (openssl) (JUnit XML)'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: generate nextest command
-      run: flowey e 16 flowey_lib_common::gen_cargo_nextest_run_cmd 0
-      shell: bash
-    - name: run 'unit-tests crypto (all)' nextest tests
-      run: |-
-        flowey e 16 flowey_lib_common::run_cargo_nextest_run 0
-        flowey e 16 flowey_lib_common::run_cargo_nextest_run 1
-        flowey e 16 flowey_lib_hvlite::build_nextest_unit_tests 5
-        flowey e 16 flowey_lib_common::publish_test_results 16
-        flowey e 16 flowey_lib_common::publish_test_results 17
-        flowey e 16 flowey_lib_common::publish_test_results 18
-        flowey v 16 'flowey_lib_common::publish_test_results:32:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:28:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar5
-        flowey v 16 'flowey_lib_common::publish_test_results:28:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__publish_test_results__19
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-linux-unit-tests-unit-tests crypto (all)-junit-xml
-        path: ${{ env.floweyvar5 }}
-      name: 'publish test results: x64-linux-unit-tests-unit-tests crypto (all) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: cargo build xtask
       run: |-
@@ -2212,13 +2166,34 @@ jobs:
       run: flowey e 16 flowey_lib_hvlite::build_nextest_unit_tests 0
       shell: bash
     - name: generate nextest command
-      run: flowey e 16 flowey_lib_common::gen_cargo_nextest_run_cmd 4
+      run: flowey e 16 flowey_lib_common::gen_cargo_nextest_run_cmd 3
       shell: bash
     - name: run 'unit-tests' nextest tests
       run: |-
-        flowey e 16 flowey_lib_common::run_cargo_nextest_run 8
-        flowey e 16 flowey_lib_common::run_cargo_nextest_run 9
+        flowey e 16 flowey_lib_common::run_cargo_nextest_run 6
+        flowey e 16 flowey_lib_common::run_cargo_nextest_run 7
         flowey e 16 flowey_lib_hvlite::build_nextest_unit_tests 1
+        flowey e 16 flowey_lib_common::publish_test_results 12
+        flowey e 16 flowey_lib_common::publish_test_results 13
+        flowey e 16 flowey_lib_common::publish_test_results 14
+        flowey v 16 'flowey_lib_common::publish_test_results:25:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar4
+        flowey v 16 'flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__publish_test_results__15
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-linux-unit-tests-unit-tests-junit-xml
+        path: ${{ env.floweyvar4 }}
+      name: 'publish test results: x64-linux-unit-tests-unit-tests (JUnit XML)'
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: generate nextest command
+      run: flowey e 16 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      shell: bash
+    - name: run 'unit-tests crypto (native)' nextest tests
+      run: |-
+        flowey e 16 flowey_lib_common::run_cargo_nextest_run 0
+        flowey e 16 flowey_lib_common::run_cargo_nextest_run 1
+        flowey e 16 flowey_lib_hvlite::build_nextest_unit_tests 2
         flowey e 16 flowey_lib_common::publish_test_results 0
         flowey e 16 flowey_lib_common::publish_test_results 1
         flowey e 16 flowey_lib_common::publish_test_results 2
@@ -2228,13 +2203,13 @@ jobs:
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v7
       with:
-        name: x64-linux-unit-tests-unit-tests-junit-xml
+        name: x64-linux-unit-tests-unit-tests crypto (native)-junit-xml
         path: ${{ env.floweyvar1 }}
-      name: 'publish test results: x64-linux-unit-tests-unit-tests (JUnit XML)'
+      name: 'publish test results: x64-linux-unit-tests-unit-tests crypto (native) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
       run: |-
-        flowey e 16 flowey_lib_hvlite::build_nextest_unit_tests 6
+        flowey e 16 flowey_lib_hvlite::build_nextest_unit_tests 5
         flowey e 16 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
       shell: bash
     - name: run doctests for x86_64-unknown-linux-gnu
@@ -2297,7 +2272,7 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 17 flowey_lib_common::git_checkout 0
-        flowey v 17 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar11
+        flowey v 17 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar10
         flowey v 17 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
@@ -2305,7 +2280,7 @@ jobs:
       with:
         fetch-depth: '1'
         path: repo0
-        persist-credentials: ${{ env.floweyvar11 }}
+        persist-credentials: ${{ env.floweyvar10 }}
       name: checkout repo openvmm
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
@@ -2323,14 +2298,14 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 17 flowey_lib_common::cache 4
-        flowey v 17 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar9
-        flowey v 17 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar10
+        flowey v 17 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
+        flowey v 17 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
       with:
-        key: ${{ env.floweyvar9 }}
-        path: ${{ env.floweyvar10 }}
+        key: ${{ env.floweyvar8 }}
+        path: ${{ env.floweyvar9 }}
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
@@ -2364,20 +2339,17 @@ jobs:
         flowey e 17 flowey_lib_hvlite::init_cross_build 2
       shell: bash
     - name: cargo clippy
-      run: flowey e 17 flowey_lib_common::run_cargo_clippy 3
+      run: flowey e 17 flowey_lib_common::run_cargo_clippy 2
       shell: bash
     - name: cargo clippy
-      run: flowey e 17 flowey_lib_common::run_cargo_clippy 5
+      run: flowey e 17 flowey_lib_common::run_cargo_clippy 4
       shell: bash
     - name: cargo clippy
-      run: flowey e 17 flowey_lib_common::run_cargo_clippy 1
-      shell: bash
-    - name: cargo clippy
-      run: flowey e 17 flowey_lib_common::run_cargo_clippy 7
+      run: flowey e 17 flowey_lib_common::run_cargo_clippy 6
       shell: bash
     - name: cargo clippy
       run: |-
-        flowey e 17 flowey_lib_common::run_cargo_clippy 6
+        flowey e 17 flowey_lib_common::run_cargo_clippy 5
         flowey e 17 flowey_lib_hvlite::init_cross_build 0
       shell: bash
     - name: cargo build xtask
@@ -2398,10 +2370,10 @@ jobs:
       run: flowey e 17 flowey_lib_common::run_cargo_clippy 0
       shell: bash
     - name: cargo clippy
-      run: flowey e 17 flowey_lib_common::run_cargo_clippy 2
+      run: flowey e 17 flowey_lib_common::run_cargo_clippy 1
       shell: bash
     - name: cargo clippy
-      run: flowey e 17 flowey_lib_common::run_cargo_clippy 4
+      run: flowey e 17 flowey_lib_common::run_cargo_clippy 3
       shell: bash
     - name: create cargo-nextest cache dir
       run: |-
@@ -2413,14 +2385,14 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 17 flowey_lib_common::cache 0
-        flowey v 17 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar7
-        flowey v 17 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar8
+        flowey v 17 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
+        flowey v 17 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
       with:
-        key: ${{ env.floweyvar7 }}
-        path: ${{ env.floweyvar8 }}
+        key: ${{ env.floweyvar6 }}
+        path: ${{ env.floweyvar7 }}
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
@@ -2440,12 +2412,12 @@ jobs:
         flowey e 17 flowey_lib_hvlite::run_cargo_nextest_run 0
       shell: bash
     - name: generate nextest command
-      run: flowey e 17 flowey_lib_common::gen_cargo_nextest_run_cmd 1
+      run: flowey e 17 flowey_lib_common::gen_cargo_nextest_run_cmd 0
       shell: bash
     - name: run 'unit-tests crypto (native)' nextest tests
       run: |-
-        flowey e 17 flowey_lib_common::run_cargo_nextest_run 2
-        flowey e 17 flowey_lib_common::run_cargo_nextest_run 3
+        flowey e 17 flowey_lib_common::run_cargo_nextest_run 0
+        flowey e 17 flowey_lib_common::run_cargo_nextest_run 1
         flowey e 17 flowey_lib_hvlite::build_nextest_unit_tests 2
         flowey e 17 flowey_lib_common::publish_test_results 5
         flowey e 17 flowey_lib_common::publish_test_results 6
@@ -2461,12 +2433,12 @@ jobs:
       name: 'publish test results: x64-linux-musl-unit-tests-unit-tests crypto (native) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey e 17 flowey_lib_common::gen_cargo_nextest_run_cmd 3
+      run: flowey e 17 flowey_lib_common::gen_cargo_nextest_run_cmd 2
       shell: bash
     - name: run 'unit-tests crypto (rust)' nextest tests
       run: |-
-        flowey e 17 flowey_lib_common::run_cargo_nextest_run 6
-        flowey e 17 flowey_lib_common::run_cargo_nextest_run 7
+        flowey e 17 flowey_lib_common::run_cargo_nextest_run 4
+        flowey e 17 flowey_lib_common::run_cargo_nextest_run 5
         flowey e 17 flowey_lib_hvlite::build_nextest_unit_tests 3
         flowey e 17 flowey_lib_common::publish_test_results 8
         flowey e 17 flowey_lib_common::publish_test_results 9
@@ -2482,12 +2454,12 @@ jobs:
       name: 'publish test results: x64-linux-musl-unit-tests-unit-tests crypto (rust) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey e 17 flowey_lib_common::gen_cargo_nextest_run_cmd 2
+      run: flowey e 17 flowey_lib_common::gen_cargo_nextest_run_cmd 1
       shell: bash
     - name: run 'unit-tests crypto (openssl)' nextest tests
       run: |-
-        flowey e 17 flowey_lib_common::run_cargo_nextest_run 4
-        flowey e 17 flowey_lib_common::run_cargo_nextest_run 5
+        flowey e 17 flowey_lib_common::run_cargo_nextest_run 2
+        flowey e 17 flowey_lib_common::run_cargo_nextest_run 3
         flowey e 17 flowey_lib_hvlite::build_nextest_unit_tests 4
         flowey e 17 flowey_lib_common::publish_test_results 12
         flowey e 17 flowey_lib_common::publish_test_results 13
@@ -2503,12 +2475,12 @@ jobs:
       name: 'publish test results: x64-linux-musl-unit-tests-unit-tests crypto (openssl) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey e 17 flowey_lib_common::gen_cargo_nextest_run_cmd 4
+      run: flowey e 17 flowey_lib_common::gen_cargo_nextest_run_cmd 3
       shell: bash
     - name: run 'unit-tests crypto (symcrypt)' nextest tests
       run: |-
-        flowey e 17 flowey_lib_common::run_cargo_nextest_run 8
-        flowey e 17 flowey_lib_common::run_cargo_nextest_run 9
+        flowey e 17 flowey_lib_common::run_cargo_nextest_run 6
+        flowey e 17 flowey_lib_common::run_cargo_nextest_run 7
         flowey e 17 flowey_lib_hvlite::build_nextest_unit_tests 5
         flowey e 17 flowey_lib_common::publish_test_results 16
         flowey e 17 flowey_lib_common::publish_test_results 17
@@ -2522,27 +2494,6 @@ jobs:
         name: x64-linux-musl-unit-tests-unit-tests crypto (symcrypt)-junit-xml
         path: ${{ env.floweyvar5 }}
       name: 'publish test results: x64-linux-musl-unit-tests-unit-tests crypto (symcrypt) (JUnit XML)'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: generate nextest command
-      run: flowey e 17 flowey_lib_common::gen_cargo_nextest_run_cmd 0
-      shell: bash
-    - name: run 'unit-tests crypto (all)' nextest tests
-      run: |-
-        flowey e 17 flowey_lib_common::run_cargo_nextest_run 0
-        flowey e 17 flowey_lib_common::run_cargo_nextest_run 1
-        flowey e 17 flowey_lib_hvlite::build_nextest_unit_tests 6
-        flowey e 17 flowey_lib_common::publish_test_results 20
-        flowey e 17 flowey_lib_common::publish_test_results 21
-        flowey e 17 flowey_lib_common::publish_test_results 22
-        flowey v 17 'flowey_lib_common::publish_test_results:39:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:35:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar6
-        flowey v 17 'flowey_lib_common::publish_test_results:35:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__publish_test_results__23
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-linux-musl-unit-tests-unit-tests crypto (all)-junit-xml
-        path: ${{ env.floweyvar6 }}
-      name: 'publish test results: x64-linux-musl-unit-tests-unit-tests crypto (all) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: cargo build xtask
       run: |-
@@ -2560,12 +2511,12 @@ jobs:
       run: flowey e 17 flowey_lib_hvlite::build_nextest_unit_tests 0
       shell: bash
     - name: generate nextest command
-      run: flowey e 17 flowey_lib_common::gen_cargo_nextest_run_cmd 5
+      run: flowey e 17 flowey_lib_common::gen_cargo_nextest_run_cmd 4
       shell: bash
     - name: run 'unit-tests' nextest tests
       run: |-
-        flowey e 17 flowey_lib_common::run_cargo_nextest_run 10
-        flowey e 17 flowey_lib_common::run_cargo_nextest_run 11
+        flowey e 17 flowey_lib_common::run_cargo_nextest_run 8
+        flowey e 17 flowey_lib_common::run_cargo_nextest_run 9
         flowey e 17 flowey_lib_hvlite::build_nextest_unit_tests 1
         flowey e 17 flowey_lib_common::publish_test_results 0
         flowey e 17 flowey_lib_common::publish_test_results 1
@@ -2582,7 +2533,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
       run: |-
-        flowey e 17 flowey_lib_hvlite::build_nextest_unit_tests 7
+        flowey e 17 flowey_lib_hvlite::build_nextest_unit_tests 6
         flowey e 17 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
       shell: bash
     - name: run doctests for x86_64-unknown-linux-musl
@@ -2987,7 +2938,7 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 19 flowey_lib_common::git_checkout 0
-        flowey v 19 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar10
+        flowey v 19 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar9
         flowey v 19 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
@@ -2995,7 +2946,7 @@ jobs:
       with:
         fetch-depth: '1'
         path: repo0
-        persist-credentials: ${{ env.floweyvar10 }}
+        persist-credentials: ${{ env.floweyvar9 }}
       name: checkout repo openvmm
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
@@ -3015,14 +2966,14 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 19 flowey_lib_common::cache 4
-        flowey v 19 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
-        flowey v 19 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
+        flowey v 19 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar7
+        flowey v 19 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar8
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
       with:
-        key: ${{ env.floweyvar8 }}
-        path: ${{ env.floweyvar9 }}
+        key: ${{ env.floweyvar7 }}
+        path: ${{ env.floweyvar8 }}
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
@@ -3041,10 +2992,6 @@ jobs:
       run: |-
         flowey e 19 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
         flowey e 19 flowey_lib_hvlite::init_cross_build 0
-      shell: bash
-    - name: cargo clippy
-      run: |-
-        flowey e 19 flowey_lib_common::run_cargo_clippy 1
         flowey e 19 flowey_lib_hvlite::init_cross_build 2
       shell: bash
     - name: cargo build xtask
@@ -3065,13 +3012,13 @@ jobs:
       run: flowey e 19 flowey_lib_common::run_cargo_clippy 0
       shell: bash
     - name: cargo clippy
-      run: flowey e 19 flowey_lib_common::run_cargo_clippy 2
-      shell: bash
-    - name: cargo clippy
-      run: flowey e 19 flowey_lib_common::run_cargo_clippy 4
+      run: flowey e 19 flowey_lib_common::run_cargo_clippy 1
       shell: bash
     - name: cargo clippy
       run: flowey e 19 flowey_lib_common::run_cargo_clippy 3
+      shell: bash
+    - name: cargo clippy
+      run: flowey e 19 flowey_lib_common::run_cargo_clippy 2
       shell: bash
     - name: create cargo-nextest cache dir
       run: |-
@@ -3083,14 +3030,14 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 19 flowey_lib_common::cache 0
-        flowey v 19 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
-        flowey v 19 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
+        flowey v 19 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar5
+        flowey v 19 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar6
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
       with:
-        key: ${{ env.floweyvar6 }}
-        path: ${{ env.floweyvar7 }}
+        key: ${{ env.floweyvar5 }}
+        path: ${{ env.floweyvar6 }}
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
@@ -3110,13 +3057,13 @@ jobs:
         flowey e 19 flowey_lib_hvlite::run_cargo_nextest_run 0
       shell: bash
     - name: generate nextest command
-      run: flowey e 19 flowey_lib_common::gen_cargo_nextest_run_cmd 1
+      run: flowey e 19 flowey_lib_common::gen_cargo_nextest_run_cmd 2
       shell: bash
-    - name: run 'unit-tests crypto (native)' nextest tests
+    - name: run 'unit-tests crypto (rust)' nextest tests
       run: |-
-        flowey e 19 flowey_lib_common::run_cargo_nextest_run 2
-        flowey e 19 flowey_lib_common::run_cargo_nextest_run 3
-        flowey e 19 flowey_lib_hvlite::build_nextest_unit_tests 2
+        flowey e 19 flowey_lib_common::run_cargo_nextest_run 4
+        flowey e 19 flowey_lib_common::run_cargo_nextest_run 5
+        flowey e 19 flowey_lib_hvlite::build_nextest_unit_tests 3
         flowey e 19 flowey_lib_common::publish_test_results 5
         flowey e 19 flowey_lib_common::publish_test_results 6
         flowey e 19 flowey_lib_common::publish_test_results 4
@@ -3126,18 +3073,18 @@ jobs:
     - id: flowey_lib_common__publish_test_results__7
       uses: actions/upload-artifact@v7
       with:
-        name: aarch64-linux-unit-tests-unit-tests crypto (native)-junit-xml
+        name: aarch64-linux-unit-tests-unit-tests crypto (rust)-junit-xml
         path: ${{ env.floweyvar2 }}
-      name: 'publish test results: aarch64-linux-unit-tests-unit-tests crypto (native) (JUnit XML)'
+      name: 'publish test results: aarch64-linux-unit-tests-unit-tests crypto (rust) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey e 19 flowey_lib_common::gen_cargo_nextest_run_cmd 3
+      run: flowey e 19 flowey_lib_common::gen_cargo_nextest_run_cmd 1
       shell: bash
-    - name: run 'unit-tests crypto (rust)' nextest tests
+    - name: run 'unit-tests crypto (openssl)' nextest tests
       run: |-
-        flowey e 19 flowey_lib_common::run_cargo_nextest_run 6
-        flowey e 19 flowey_lib_common::run_cargo_nextest_run 7
-        flowey e 19 flowey_lib_hvlite::build_nextest_unit_tests 3
+        flowey e 19 flowey_lib_common::run_cargo_nextest_run 2
+        flowey e 19 flowey_lib_common::run_cargo_nextest_run 3
+        flowey e 19 flowey_lib_hvlite::build_nextest_unit_tests 4
         flowey e 19 flowey_lib_common::publish_test_results 8
         flowey e 19 flowey_lib_common::publish_test_results 9
         flowey e 19 flowey_lib_common::publish_test_results 10
@@ -3147,51 +3094,9 @@ jobs:
     - id: flowey_lib_common__publish_test_results__11
       uses: actions/upload-artifact@v7
       with:
-        name: aarch64-linux-unit-tests-unit-tests crypto (rust)-junit-xml
-        path: ${{ env.floweyvar3 }}
-      name: 'publish test results: aarch64-linux-unit-tests-unit-tests crypto (rust) (JUnit XML)'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: generate nextest command
-      run: flowey e 19 flowey_lib_common::gen_cargo_nextest_run_cmd 2
-      shell: bash
-    - name: run 'unit-tests crypto (openssl)' nextest tests
-      run: |-
-        flowey e 19 flowey_lib_common::run_cargo_nextest_run 4
-        flowey e 19 flowey_lib_common::run_cargo_nextest_run 5
-        flowey e 19 flowey_lib_hvlite::build_nextest_unit_tests 4
-        flowey e 19 flowey_lib_common::publish_test_results 12
-        flowey e 19 flowey_lib_common::publish_test_results 13
-        flowey e 19 flowey_lib_common::publish_test_results 14
-        flowey v 19 'flowey_lib_common::publish_test_results:25:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar4
-        flowey v 19 'flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__publish_test_results__15
-      uses: actions/upload-artifact@v7
-      with:
         name: aarch64-linux-unit-tests-unit-tests crypto (openssl)-junit-xml
-        path: ${{ env.floweyvar4 }}
+        path: ${{ env.floweyvar3 }}
       name: 'publish test results: aarch64-linux-unit-tests-unit-tests crypto (openssl) (JUnit XML)'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: generate nextest command
-      run: flowey e 19 flowey_lib_common::gen_cargo_nextest_run_cmd 0
-      shell: bash
-    - name: run 'unit-tests crypto (all)' nextest tests
-      run: |-
-        flowey e 19 flowey_lib_common::run_cargo_nextest_run 0
-        flowey e 19 flowey_lib_common::run_cargo_nextest_run 1
-        flowey e 19 flowey_lib_hvlite::build_nextest_unit_tests 5
-        flowey e 19 flowey_lib_common::publish_test_results 16
-        flowey e 19 flowey_lib_common::publish_test_results 17
-        flowey e 19 flowey_lib_common::publish_test_results 18
-        flowey v 19 'flowey_lib_common::publish_test_results:32:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:28:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar5
-        flowey v 19 'flowey_lib_common::publish_test_results:28:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__publish_test_results__19
-      uses: actions/upload-artifact@v7
-      with:
-        name: aarch64-linux-unit-tests-unit-tests crypto (all)-junit-xml
-        path: ${{ env.floweyvar5 }}
-      name: 'publish test results: aarch64-linux-unit-tests-unit-tests crypto (all) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: cargo build xtask
       run: |-
@@ -3209,13 +3114,34 @@ jobs:
       run: flowey e 19 flowey_lib_hvlite::build_nextest_unit_tests 0
       shell: bash
     - name: generate nextest command
-      run: flowey e 19 flowey_lib_common::gen_cargo_nextest_run_cmd 4
+      run: flowey e 19 flowey_lib_common::gen_cargo_nextest_run_cmd 3
       shell: bash
     - name: run 'unit-tests' nextest tests
       run: |-
-        flowey e 19 flowey_lib_common::run_cargo_nextest_run 8
-        flowey e 19 flowey_lib_common::run_cargo_nextest_run 9
+        flowey e 19 flowey_lib_common::run_cargo_nextest_run 6
+        flowey e 19 flowey_lib_common::run_cargo_nextest_run 7
         flowey e 19 flowey_lib_hvlite::build_nextest_unit_tests 1
+        flowey e 19 flowey_lib_common::publish_test_results 12
+        flowey e 19 flowey_lib_common::publish_test_results 13
+        flowey e 19 flowey_lib_common::publish_test_results 14
+        flowey v 19 'flowey_lib_common::publish_test_results:25:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar4
+        flowey v 19 'flowey_lib_common::publish_test_results:21:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__publish_test_results__15
+      uses: actions/upload-artifact@v7
+      with:
+        name: aarch64-linux-unit-tests-unit-tests-junit-xml
+        path: ${{ env.floweyvar4 }}
+      name: 'publish test results: aarch64-linux-unit-tests-unit-tests (JUnit XML)'
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: generate nextest command
+      run: flowey e 19 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      shell: bash
+    - name: run 'unit-tests crypto (native)' nextest tests
+      run: |-
+        flowey e 19 flowey_lib_common::run_cargo_nextest_run 0
+        flowey e 19 flowey_lib_common::run_cargo_nextest_run 1
+        flowey e 19 flowey_lib_hvlite::build_nextest_unit_tests 2
         flowey e 19 flowey_lib_common::publish_test_results 0
         flowey e 19 flowey_lib_common::publish_test_results 1
         flowey e 19 flowey_lib_common::publish_test_results 2
@@ -3225,13 +3151,13 @@ jobs:
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v7
       with:
-        name: aarch64-linux-unit-tests-unit-tests-junit-xml
+        name: aarch64-linux-unit-tests-unit-tests crypto (native)-junit-xml
         path: ${{ env.floweyvar1 }}
-      name: 'publish test results: aarch64-linux-unit-tests-unit-tests (JUnit XML)'
+      name: 'publish test results: aarch64-linux-unit-tests-unit-tests crypto (native) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
       run: |-
-        flowey e 19 flowey_lib_hvlite::build_nextest_unit_tests 6
+        flowey e 19 flowey_lib_hvlite::build_nextest_unit_tests 5
         flowey e 19 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
       shell: bash
     - name: run doctests for aarch64-unknown-linux-gnu
@@ -3522,7 +3448,7 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 20 flowey_lib_common::git_checkout 0
-        flowey v 20 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar11
+        flowey v 20 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar10
         flowey v 20 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
@@ -3530,7 +3456,7 @@ jobs:
       with:
         fetch-depth: '1'
         path: repo0
-        persist-credentials: ${{ env.floweyvar11 }}
+        persist-credentials: ${{ env.floweyvar10 }}
       name: checkout repo openvmm
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
@@ -3548,14 +3474,14 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 20 flowey_lib_common::cache 4
-        flowey v 20 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar9
-        flowey v 20 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar10
+        flowey v 20 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
+        flowey v 20 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
       with:
-        key: ${{ env.floweyvar9 }}
-        path: ${{ env.floweyvar10 }}
+        key: ${{ env.floweyvar8 }}
+        path: ${{ env.floweyvar9 }}
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
@@ -3589,20 +3515,17 @@ jobs:
         flowey e 20 flowey_lib_hvlite::init_cross_build 2
       shell: bash
     - name: cargo clippy
-      run: flowey e 20 flowey_lib_common::run_cargo_clippy 3
+      run: flowey e 20 flowey_lib_common::run_cargo_clippy 2
       shell: bash
     - name: cargo clippy
-      run: flowey e 20 flowey_lib_common::run_cargo_clippy 5
+      run: flowey e 20 flowey_lib_common::run_cargo_clippy 4
       shell: bash
     - name: cargo clippy
-      run: flowey e 20 flowey_lib_common::run_cargo_clippy 1
-      shell: bash
-    - name: cargo clippy
-      run: flowey e 20 flowey_lib_common::run_cargo_clippy 7
+      run: flowey e 20 flowey_lib_common::run_cargo_clippy 6
       shell: bash
     - name: cargo clippy
       run: |-
-        flowey e 20 flowey_lib_common::run_cargo_clippy 6
+        flowey e 20 flowey_lib_common::run_cargo_clippy 5
         flowey e 20 flowey_lib_hvlite::init_cross_build 0
       shell: bash
     - name: cargo build xtask
@@ -3623,10 +3546,10 @@ jobs:
       run: flowey e 20 flowey_lib_common::run_cargo_clippy 0
       shell: bash
     - name: cargo clippy
-      run: flowey e 20 flowey_lib_common::run_cargo_clippy 2
+      run: flowey e 20 flowey_lib_common::run_cargo_clippy 1
       shell: bash
     - name: cargo clippy
-      run: flowey e 20 flowey_lib_common::run_cargo_clippy 4
+      run: flowey e 20 flowey_lib_common::run_cargo_clippy 3
       shell: bash
     - name: create cargo-nextest cache dir
       run: |-
@@ -3638,14 +3561,14 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 20 flowey_lib_common::cache 0
-        flowey v 20 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar7
-        flowey v 20 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar8
+        flowey v 20 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
+        flowey v 20 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
       with:
-        key: ${{ env.floweyvar7 }}
-        path: ${{ env.floweyvar8 }}
+        key: ${{ env.floweyvar6 }}
+        path: ${{ env.floweyvar7 }}
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
@@ -3665,12 +3588,12 @@ jobs:
         flowey e 20 flowey_lib_hvlite::run_cargo_nextest_run 0
       shell: bash
     - name: generate nextest command
-      run: flowey e 20 flowey_lib_common::gen_cargo_nextest_run_cmd 1
+      run: flowey e 20 flowey_lib_common::gen_cargo_nextest_run_cmd 0
       shell: bash
     - name: run 'unit-tests crypto (native)' nextest tests
       run: |-
-        flowey e 20 flowey_lib_common::run_cargo_nextest_run 2
-        flowey e 20 flowey_lib_common::run_cargo_nextest_run 3
+        flowey e 20 flowey_lib_common::run_cargo_nextest_run 0
+        flowey e 20 flowey_lib_common::run_cargo_nextest_run 1
         flowey e 20 flowey_lib_hvlite::build_nextest_unit_tests 2
         flowey e 20 flowey_lib_common::publish_test_results 5
         flowey e 20 flowey_lib_common::publish_test_results 6
@@ -3686,12 +3609,12 @@ jobs:
       name: 'publish test results: aarch64-linux-musl-unit-tests-unit-tests crypto (native) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey e 20 flowey_lib_common::gen_cargo_nextest_run_cmd 3
+      run: flowey e 20 flowey_lib_common::gen_cargo_nextest_run_cmd 2
       shell: bash
     - name: run 'unit-tests crypto (rust)' nextest tests
       run: |-
-        flowey e 20 flowey_lib_common::run_cargo_nextest_run 6
-        flowey e 20 flowey_lib_common::run_cargo_nextest_run 7
+        flowey e 20 flowey_lib_common::run_cargo_nextest_run 4
+        flowey e 20 flowey_lib_common::run_cargo_nextest_run 5
         flowey e 20 flowey_lib_hvlite::build_nextest_unit_tests 3
         flowey e 20 flowey_lib_common::publish_test_results 8
         flowey e 20 flowey_lib_common::publish_test_results 9
@@ -3707,12 +3630,12 @@ jobs:
       name: 'publish test results: aarch64-linux-musl-unit-tests-unit-tests crypto (rust) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey e 20 flowey_lib_common::gen_cargo_nextest_run_cmd 2
+      run: flowey e 20 flowey_lib_common::gen_cargo_nextest_run_cmd 1
       shell: bash
     - name: run 'unit-tests crypto (openssl)' nextest tests
       run: |-
-        flowey e 20 flowey_lib_common::run_cargo_nextest_run 4
-        flowey e 20 flowey_lib_common::run_cargo_nextest_run 5
+        flowey e 20 flowey_lib_common::run_cargo_nextest_run 2
+        flowey e 20 flowey_lib_common::run_cargo_nextest_run 3
         flowey e 20 flowey_lib_hvlite::build_nextest_unit_tests 4
         flowey e 20 flowey_lib_common::publish_test_results 12
         flowey e 20 flowey_lib_common::publish_test_results 13
@@ -3728,12 +3651,12 @@ jobs:
       name: 'publish test results: aarch64-linux-musl-unit-tests-unit-tests crypto (openssl) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey e 20 flowey_lib_common::gen_cargo_nextest_run_cmd 4
+      run: flowey e 20 flowey_lib_common::gen_cargo_nextest_run_cmd 3
       shell: bash
     - name: run 'unit-tests crypto (symcrypt)' nextest tests
       run: |-
-        flowey e 20 flowey_lib_common::run_cargo_nextest_run 8
-        flowey e 20 flowey_lib_common::run_cargo_nextest_run 9
+        flowey e 20 flowey_lib_common::run_cargo_nextest_run 6
+        flowey e 20 flowey_lib_common::run_cargo_nextest_run 7
         flowey e 20 flowey_lib_hvlite::build_nextest_unit_tests 5
         flowey e 20 flowey_lib_common::publish_test_results 16
         flowey e 20 flowey_lib_common::publish_test_results 17
@@ -3747,27 +3670,6 @@ jobs:
         name: aarch64-linux-musl-unit-tests-unit-tests crypto (symcrypt)-junit-xml
         path: ${{ env.floweyvar5 }}
       name: 'publish test results: aarch64-linux-musl-unit-tests-unit-tests crypto (symcrypt) (JUnit XML)'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: generate nextest command
-      run: flowey e 20 flowey_lib_common::gen_cargo_nextest_run_cmd 0
-      shell: bash
-    - name: run 'unit-tests crypto (all)' nextest tests
-      run: |-
-        flowey e 20 flowey_lib_common::run_cargo_nextest_run 0
-        flowey e 20 flowey_lib_common::run_cargo_nextest_run 1
-        flowey e 20 flowey_lib_hvlite::build_nextest_unit_tests 6
-        flowey e 20 flowey_lib_common::publish_test_results 20
-        flowey e 20 flowey_lib_common::publish_test_results 21
-        flowey e 20 flowey_lib_common::publish_test_results 22
-        flowey v 20 'flowey_lib_common::publish_test_results:39:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:35:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar6
-        flowey v 20 'flowey_lib_common::publish_test_results:35:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__publish_test_results__23
-      uses: actions/upload-artifact@v7
-      with:
-        name: aarch64-linux-musl-unit-tests-unit-tests crypto (all)-junit-xml
-        path: ${{ env.floweyvar6 }}
-      name: 'publish test results: aarch64-linux-musl-unit-tests-unit-tests crypto (all) (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: cargo build xtask
       run: |-
@@ -3785,12 +3687,12 @@ jobs:
       run: flowey e 20 flowey_lib_hvlite::build_nextest_unit_tests 0
       shell: bash
     - name: generate nextest command
-      run: flowey e 20 flowey_lib_common::gen_cargo_nextest_run_cmd 5
+      run: flowey e 20 flowey_lib_common::gen_cargo_nextest_run_cmd 4
       shell: bash
     - name: run 'unit-tests' nextest tests
       run: |-
-        flowey e 20 flowey_lib_common::run_cargo_nextest_run 10
-        flowey e 20 flowey_lib_common::run_cargo_nextest_run 11
+        flowey e 20 flowey_lib_common::run_cargo_nextest_run 8
+        flowey e 20 flowey_lib_common::run_cargo_nextest_run 9
         flowey e 20 flowey_lib_hvlite::build_nextest_unit_tests 1
         flowey e 20 flowey_lib_common::publish_test_results 0
         flowey e 20 flowey_lib_common::publish_test_results 1
@@ -3807,7 +3709,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
       run: |-
-        flowey e 20 flowey_lib_hvlite::build_nextest_unit_tests 7
+        flowey e 20 flowey_lib_hvlite::build_nextest_unit_tests 6
         flowey e 20 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
       shell: bash
     - name: run doctests for aarch64-unknown-linux-musl

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5364,6 +5364,7 @@ dependencies = [
 name = "openvmm"
 version = "0.0.0"
 dependencies = [
+ "crypto",
  "embed-resource",
  "openvmm_entry",
  "openvmm_hypervisors",
@@ -5504,7 +5505,6 @@ dependencies = [
  "clap",
  "clap_dyn_complete",
  "console_relay",
- "crypto",
  "cxl_spec",
  "debug_worker_defs",
  "diag_client",
@@ -5592,6 +5592,8 @@ dependencies = [
 name = "openvmm_hcl"
 version = "0.0.0"
 dependencies = [
+ "crypto",
+ "openssl_crypto_only",
  "openvmm_hcl_resources",
  "tracing",
  "underhill_entry",
@@ -8540,7 +8542,6 @@ dependencies = [
  "chipset_legacy",
  "chipset_resources",
  "closeable_mutex",
- "crypto",
  "cvm_tracing",
  "debug_ptr",
  "debug_worker_defs",
@@ -8719,7 +8720,6 @@ dependencies = [
  "dhat",
  "fast_memcpy",
  "mimalloc",
- "openssl_crypto_only",
  "underhill_core",
  "underhill_crash",
  "underhill_dump",

--- a/Guide/src/SUMMARY.md
+++ b/Guide/src/SUMMARY.md
@@ -66,6 +66,7 @@
   - [Code Review Process](./dev_guide/contrib/code_review.md)
   - [Guide Updates](./dev_guide/contrib/guide.md)
   - [Style Guide](./dev_guide/contrib/style_guide.md)
+  - [Crypto Backends](./dev_guide/contrib/crypto_backends.md)
 
 # Reference
 

--- a/Guide/src/dev_guide/contrib/crypto_backends.md
+++ b/Guide/src/dev_guide/contrib/crypto_backends.md
@@ -15,29 +15,39 @@ Selection happens in [`support/crypto/build.rs`](https://github.com/microsoft/op
 which emits a `cfg` (`openssl`, `symcrypt`, `rust`, or `native`) based on
 the enabled features.
 
-## The "multiple backends enabled" error
+## The "wrong number of backends" error
 
 Because Cargo unifies features across a workspace, building two binaries
 in the same `cargo` invocation that ask for *different* `crypto` backends
 will result in the `crypto` crate being compiled with *all* of those
-features enabled at once. There is no sensible single backend to pick in
-that case.
+features enabled at once. Conversely, building a library crate that
+transitively depends on `crypto` without itself selecting a backend
+(e.g. running its unit tests) results in `crypto` being compiled with
+*zero* backends enabled. In either case there is no sensible single
+backend to pick.
 
-To keep workspace-wide `cargo check` usable, the build script does not
-panic in this situation. Instead it emits a `multi_backend` cfg, and
-`crypto`'s `lib.rs` references an undefined extern symbol under that cfg.
+To keep workspace-wide `cargo check` and `cargo test` usable, the build
+script does not panic in this situation — it picks a placeholder backend
+so the crate still compiles. To still guarantee that a *shipping binary*
+has linked exactly one backend, each binary opts into a link-time check
+by invoking the `crypto::ensure_single_backend!()` macro (typically gated
+on `#[cfg(test)]`). The macro emits a `#[used]` reference to a symbol
+that is only defined by `crypto` when exactly one backend is selected.
 The result:
 
 - `cargo check --workspace` — succeeds. No linking happens.
-- `cargo build --workspace` (or any actual link step) — fails with:
+- `cargo test -p <unrelated_crate>` — succeeds, even when that crate
+  transitively depends on `crypto` without selecting a backend.
+- `cargo test -p <binary>` for a binary that invokes the macro — fails
+  at link time if zero or multiple backends end up enabled, with:
 
   ```text
   rust-lld: error: undefined symbol:
-    __openvmm_crypto_multiple_backends_enabled__enable_exactly_one__see_support_crypto
+    __openvmm_crypto_ensure_single_backend__enable_exactly_one__see_support_crypto
   ```
 
-The symbol name *is* the diagnostic: the offending binary has multiple
-`crypto` backend features enabled simultaneously and needs to pick one.
+The symbol name *is* the diagnostic: the offending binary has the wrong
+number of `crypto` backend features enabled and needs to pick exactly one.
 
 ### Fixing it
 

--- a/Guide/src/dev_guide/contrib/crypto_backends.md
+++ b/Guide/src/dev_guide/contrib/crypto_backends.md
@@ -31,14 +31,14 @@ script does not panic in this situation — it picks a placeholder backend
 so the crate still compiles. To still guarantee that a *shipping binary*
 has linked exactly one backend, each binary opts into a link-time check
 by invoking the `crypto::ensure_single_backend!()` macro (typically gated
-on `#[cfg(test)]`). The macro emits a `#[used]` reference to a symbol
+on `#[cfg(not(test))]`). The macro emits a `#[used]` reference to a symbol
 that is only defined by `crypto` when exactly one backend is selected.
 The result:
 
 - `cargo check --workspace` — succeeds. No linking happens.
 - `cargo test -p <unrelated_crate>` — succeeds, even when that crate
   transitively depends on `crypto` without selecting a backend.
-- `cargo test -p <binary>` for a binary that invokes the macro — fails
+- `cargo build -p <binary>` for a binary that invokes the macro — fails
   at link time if zero or multiple backends end up enabled, with:
 
   ```text

--- a/Guide/src/dev_guide/contrib/crypto_backends.md
+++ b/Guide/src/dev_guide/contrib/crypto_backends.md
@@ -1,0 +1,53 @@
+# Crypto Backends
+
+The `crypto` crate (`support/crypto`) abstracts over several backend
+implementations of the cryptographic primitives OpenVMM and OpenHCL need.
+Exactly one backend must be selected per binary, chosen via Cargo features:
+
+| Feature    | Backend                                                                          |
+| ---------- | -------------------------------------------------------------------------------- |
+| `openssl`  | OpenSSL (typical for Linux / OpenHCL).                                           |
+| `symcrypt` | [SymCrypt](https://github.com/microsoft/SymCrypt).                               |
+| `rust`     | Pure-Rust implementations from [RustCrypto](https://github.com/RustCrypto).      |
+| `native`   | Platform default — OpenSSL on Linux, BCrypt/CNG on Windows, Security.framework on macOS. |
+
+Selection happens in [`support/crypto/build.rs`](https://github.com/microsoft/openvmm/blob/main/support/crypto/build.rs),
+which emits a `cfg` (`openssl`, `symcrypt`, `rust`, or `native`) based on
+the enabled features.
+
+## The "multiple backends enabled" error
+
+Because Cargo unifies features across a workspace, building two binaries
+in the same `cargo` invocation that ask for *different* `crypto` backends
+will result in the `crypto` crate being compiled with *all* of those
+features enabled at once. There is no sensible single backend to pick in
+that case.
+
+To keep workspace-wide `cargo check` usable, the build script does not
+panic in this situation. Instead it emits a `multi_backend` cfg, and
+`crypto`'s `lib.rs` references an undefined extern symbol under that cfg.
+The result:
+
+- `cargo check --workspace` — succeeds. No linking happens.
+- `cargo build --workspace` (or any actual link step) — fails with:
+
+  ```text
+  rust-lld: error: undefined symbol:
+    __openvmm_crypto_multiple_backends_enabled__enable_exactly_one__see_support_crypto
+  ```
+
+The symbol name *is* the diagnostic: the offending binary has multiple
+`crypto` backend features enabled simultaneously and needs to pick one.
+
+### Fixing it
+
+1. Identify which binary you are building and which `crypto` features it
+   (transitively) enables. `cargo tree -e features -p <binary> -i crypto`
+   is usually the fastest way.
+2. Either narrow your `cargo build` invocation (e.g. `-p <binary>`
+   instead of `--workspace`), or adjust the offending crate's
+   `Cargo.toml` so it stops enabling a backend it shouldn't.
+3. Remember that adding `features = ["native"]` (or any other backend)
+   to a *library* crate's dependency on `crypto` will force that
+   backend on every binary that links the library. Backends should
+   normally be selected by binary crates only.

--- a/ci-flowey/openvmm-pr.yaml
+++ b/ci-flowey/openvmm-pr.yaml
@@ -514,13 +514,13 @@ jobs:
       $(FLOWEY_BIN) e 15 flowey_lib_common::publish_test_results 2
       $FLOWEY_BIN v 15 'flowey_lib_common::ado_task_publish_test_results:4:flowey_lib_common/src/ado_task_publish_test_results.rs:57:45' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env ado floweyvar3
       $FLOWEY_BIN v 15 'flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env ado FLOWEY_CONDITION
-    displayName: run 'unit-tests crypto (none)' nextest tests
+    displayName: run 'unit-tests crypto (native)' nextest tests
   - task: PublishTestResults@2
     inputs:
       testResultsFormat: JUnit
       testResultsFiles: $(floweyvar3)
-      testRunTitle: x64-linux-musl-unit-tests-unit-tests crypto (none)
-    displayName: 'publish test results: x64-linux-musl-unit-tests-unit-tests crypto (none) (JUnit XML)'
+      testRunTitle: x64-linux-musl-unit-tests-unit-tests crypto (native)
+    displayName: 'publish test results: x64-linux-musl-unit-tests-unit-tests crypto (native) (JUnit XML)'
     condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
   - bash: |-
       set -e
@@ -796,13 +796,13 @@ jobs:
       $(FLOWEY_BIN) e 14 flowey_lib_common::publish_test_results 2
       $FLOWEY_BIN v 14 'flowey_lib_common::ado_task_publish_test_results:4:flowey_lib_common/src/ado_task_publish_test_results.rs:57:45' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env ado floweyvar3
       $FLOWEY_BIN v 14 'flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env ado FLOWEY_CONDITION
-    displayName: run 'unit-tests crypto (none)' nextest tests
+    displayName: run 'unit-tests crypto (native)' nextest tests
   - task: PublishTestResults@2
     inputs:
       testResultsFormat: JUnit
       testResultsFiles: $(floweyvar3)
-      testRunTitle: x64-linux-unit-tests-unit-tests crypto (none)
-    displayName: 'publish test results: x64-linux-unit-tests-unit-tests crypto (none) (JUnit XML)'
+      testRunTitle: x64-linux-unit-tests-unit-tests crypto (native)
+    displayName: 'publish test results: x64-linux-unit-tests-unit-tests crypto (native) (JUnit XML)'
     condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
   - bash: |-
       set -e
@@ -1052,13 +1052,13 @@ jobs:
       $(FLOWEY_BIN) e 13 flowey_lib_common::publish_test_results 0
       $FLOWEY_BIN v 13 'flowey_lib_common::ado_task_publish_test_results:2:flowey_lib_common/src/ado_task_publish_test_results.rs:57:45' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env ado floweyvar2
       $FLOWEY_BIN v 13 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env ado FLOWEY_CONDITION
-    displayName: run 'unit-tests crypto (none)' nextest tests
+    displayName: run 'unit-tests crypto (native)' nextest tests
   - task: PublishTestResults@2
     inputs:
       testResultsFormat: JUnit
       testResultsFiles: $(floweyvar2)
-      testRunTitle: x64-windows-unit-tests-unit-tests crypto (none)
-    displayName: 'publish test results: x64-windows-unit-tests-unit-tests crypto (none) (JUnit XML)'
+      testRunTitle: x64-windows-unit-tests-unit-tests crypto (native)
+    displayName: 'publish test results: x64-windows-unit-tests-unit-tests crypto (native) (JUnit XML)'
     condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
   - bash: $(FLOWEY_BIN) e 13 flowey_lib_common::gen_cargo_nextest_run_cmd 1
     displayName: generate nextest command

--- a/ci-flowey/openvmm-pr.yaml
+++ b/ci-flowey/openvmm-pr.yaml
@@ -182,12 +182,8 @@ jobs:
       set -e
       $(FLOWEY_BIN) e 0 flowey_lib_hvlite::_jobs::check_xtask_fmt 0
       $(FLOWEY_BIN) e 0 flowey_lib_hvlite::init_cross_build 0
-    displayName: run xtask fmt
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 0 flowey_lib_common::run_cargo_clippy 1
       $(FLOWEY_BIN) e 0 flowey_lib_hvlite::init_cross_build 1
-    displayName: cargo clippy
+    displayName: run xtask fmt
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 0 flowey_lib_common::run_cargo_build 0
@@ -203,11 +199,11 @@ jobs:
     displayName: determine clippy exclusions
   - bash: $(FLOWEY_BIN) e 0 flowey_lib_common::run_cargo_clippy 0
     displayName: cargo clippy
-  - bash: $(FLOWEY_BIN) e 0 flowey_lib_common::run_cargo_clippy 2
-    displayName: cargo clippy
-  - bash: $(FLOWEY_BIN) e 0 flowey_lib_common::run_cargo_clippy 4
+  - bash: $(FLOWEY_BIN) e 0 flowey_lib_common::run_cargo_clippy 1
     displayName: cargo clippy
   - bash: $(FLOWEY_BIN) e 0 flowey_lib_common::run_cargo_clippy 3
+    displayName: cargo clippy
+  - bash: $(FLOWEY_BIN) e 0 flowey_lib_common::run_cargo_clippy 2
     displayName: cargo clippy
   - bash: $(FLOWEY_BIN) e 0 flowey_lib_common::cache 3
     displayName: 'validate cache entry: gh-release-download'
@@ -263,14 +259,14 @@ jobs:
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 15 flowey_lib_common::git_checkout 0
-      $FLOWEY_BIN v 15 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:319:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46 write-to-env ado floweyvar11
+      $FLOWEY_BIN v 15 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:319:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46 write-to-env ado floweyvar10
       $FLOWEY_BIN v 15 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46' write-to-env ado FLOWEY_CONDITION
     displayName: check if openvmm needs to be cloned
   - checkout: self
     path: repo0
     fetchTags: false
     fetchDepth: 1
-    persistCredentials: $(floweyvar11)
+    persistCredentials: $(floweyvar10)
     submodules: recursive
     displayName: checkout repo openvmm
     condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
@@ -285,13 +281,13 @@ jobs:
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 15 flowey_lib_common::cache 4
-      $FLOWEY_BIN v 15 'flowey_lib_common::cache:8:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar9
-      $FLOWEY_BIN v 15 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar10
+      $FLOWEY_BIN v 15 'flowey_lib_common::cache:8:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar8
+      $FLOWEY_BIN v 15 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar9
     displayName: Pre-processing cache vars
   - task: Cache@2
     inputs:
-      key: $(floweyvar10)
-      path: $(floweyvar9)
+      key: $(floweyvar9)
+      path: $(floweyvar8)
       cacheHitVar: FLOWEY_CACHE_HITVAR
     displayName: 'Restore cache: gh-release-download'
   - bash: |-
@@ -320,17 +316,15 @@ jobs:
       $(FLOWEY_BIN) e 15 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
       $(FLOWEY_BIN) e 15 flowey_lib_hvlite::init_cross_build 2
     displayName: symlink protoc
-  - bash: $(FLOWEY_BIN) e 15 flowey_lib_common::run_cargo_clippy 3
+  - bash: $(FLOWEY_BIN) e 15 flowey_lib_common::run_cargo_clippy 2
     displayName: cargo clippy
-  - bash: $(FLOWEY_BIN) e 15 flowey_lib_common::run_cargo_clippy 5
+  - bash: $(FLOWEY_BIN) e 15 flowey_lib_common::run_cargo_clippy 4
     displayName: cargo clippy
-  - bash: $(FLOWEY_BIN) e 15 flowey_lib_common::run_cargo_clippy 1
-    displayName: cargo clippy
-  - bash: $(FLOWEY_BIN) e 15 flowey_lib_common::run_cargo_clippy 7
+  - bash: $(FLOWEY_BIN) e 15 flowey_lib_common::run_cargo_clippy 6
     displayName: cargo clippy
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 15 flowey_lib_common::run_cargo_clippy 6
+      $(FLOWEY_BIN) e 15 flowey_lib_common::run_cargo_clippy 5
       $(FLOWEY_BIN) e 15 flowey_lib_hvlite::init_cross_build 0
     displayName: cargo clippy
   - bash: |-
@@ -348,9 +342,9 @@ jobs:
     displayName: determine clippy exclusions
   - bash: $(FLOWEY_BIN) e 15 flowey_lib_common::run_cargo_clippy 0
     displayName: cargo clippy
-  - bash: $(FLOWEY_BIN) e 15 flowey_lib_common::run_cargo_clippy 2
+  - bash: $(FLOWEY_BIN) e 15 flowey_lib_common::run_cargo_clippy 1
     displayName: cargo clippy
-  - bash: $(FLOWEY_BIN) e 15 flowey_lib_common::run_cargo_clippy 4
+  - bash: $(FLOWEY_BIN) e 15 flowey_lib_common::run_cargo_clippy 3
     displayName: cargo clippy
   - bash: |-
       set -e
@@ -362,13 +356,13 @@ jobs:
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 15 flowey_lib_common::cache 0
-      $FLOWEY_BIN v 15 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar7
-      $FLOWEY_BIN v 15 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar8
+      $FLOWEY_BIN v 15 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar6
+      $FLOWEY_BIN v 15 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar7
     displayName: Pre-processing cache vars
   - task: Cache@2
     inputs:
-      key: $(floweyvar8)
-      path: $(floweyvar7)
+      key: $(floweyvar7)
+      path: $(floweyvar6)
       cacheHitVar: FLOWEY_CACHE_HITVAR
     displayName: 'Restore cache: cargo-nextest'
   - bash: |-
@@ -388,85 +382,65 @@ jobs:
       $(FLOWEY_BIN) e 15 flowey_lib_hvlite::init_cross_build 3
       $(FLOWEY_BIN) e 15 flowey_lib_hvlite::run_cargo_nextest_run 0
     displayName: installing cargo-nextest
-  - bash: $(FLOWEY_BIN) e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 3
-    displayName: generate nextest command
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 15 flowey_lib_common::run_cargo_nextest_run 6
-      $(FLOWEY_BIN) e 15 flowey_lib_common::run_cargo_nextest_run 7
-      $(FLOWEY_BIN) e 15 flowey_lib_hvlite::build_nextest_unit_tests 3
-      $(FLOWEY_BIN) e 15 flowey_lib_common::publish_test_results 5
-      $(FLOWEY_BIN) e 15 flowey_lib_common::ado_task_publish_test_results 8
-      $(FLOWEY_BIN) e 15 flowey_lib_common::publish_test_results 4
-      $FLOWEY_BIN v 15 'flowey_lib_common::ado_task_publish_test_results:8:flowey_lib_common/src/ado_task_publish_test_results.rs:57:45' --is-raw-string --condvar flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env ado floweyvar5
-      $FLOWEY_BIN v 15 'flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env ado FLOWEY_CONDITION
-    displayName: run 'unit-tests crypto (rust)' nextest tests
-  - task: PublishTestResults@2
-    inputs:
-      testResultsFormat: JUnit
-      testResultsFiles: $(floweyvar5)
-      testRunTitle: x64-linux-musl-unit-tests-unit-tests crypto (rust)
-    displayName: 'publish test results: x64-linux-musl-unit-tests-unit-tests crypto (rust) (JUnit XML)'
-    condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
   - bash: $(FLOWEY_BIN) e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 2
     displayName: generate nextest command
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 15 flowey_lib_common::run_cargo_nextest_run 4
       $(FLOWEY_BIN) e 15 flowey_lib_common::run_cargo_nextest_run 5
+      $(FLOWEY_BIN) e 15 flowey_lib_hvlite::build_nextest_unit_tests 3
+      $(FLOWEY_BIN) e 15 flowey_lib_common::publish_test_results 5
+      $(FLOWEY_BIN) e 15 flowey_lib_common::ado_task_publish_test_results 6
+      $(FLOWEY_BIN) e 15 flowey_lib_common::publish_test_results 4
+      $FLOWEY_BIN v 15 'flowey_lib_common::ado_task_publish_test_results:6:flowey_lib_common/src/ado_task_publish_test_results.rs:57:45' --is-raw-string --condvar flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env ado floweyvar4
+      $FLOWEY_BIN v 15 'flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env ado FLOWEY_CONDITION
+    displayName: run 'unit-tests crypto (rust)' nextest tests
+  - task: PublishTestResults@2
+    inputs:
+      testResultsFormat: JUnit
+      testResultsFiles: $(floweyvar4)
+      testRunTitle: x64-linux-musl-unit-tests-unit-tests crypto (rust)
+    displayName: 'publish test results: x64-linux-musl-unit-tests-unit-tests crypto (rust) (JUnit XML)'
+    condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
+  - bash: $(FLOWEY_BIN) e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 1
+    displayName: generate nextest command
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 15 flowey_lib_common::run_cargo_nextest_run 2
+      $(FLOWEY_BIN) e 15 flowey_lib_common::run_cargo_nextest_run 3
       $(FLOWEY_BIN) e 15 flowey_lib_hvlite::build_nextest_unit_tests 4
       $(FLOWEY_BIN) e 15 flowey_lib_common::publish_test_results 7
-      $(FLOWEY_BIN) e 15 flowey_lib_common::ado_task_publish_test_results 6
+      $(FLOWEY_BIN) e 15 flowey_lib_common::ado_task_publish_test_results 4
       $(FLOWEY_BIN) e 15 flowey_lib_common::publish_test_results 6
-      $FLOWEY_BIN v 15 'flowey_lib_common::ado_task_publish_test_results:6:flowey_lib_common/src/ado_task_publish_test_results.rs:57:45' --is-raw-string --condvar flowey_lib_common::publish_test_results:15:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env ado floweyvar4
+      $FLOWEY_BIN v 15 'flowey_lib_common::ado_task_publish_test_results:4:flowey_lib_common/src/ado_task_publish_test_results.rs:57:45' --is-raw-string --condvar flowey_lib_common::publish_test_results:15:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env ado floweyvar3
       $FLOWEY_BIN v 15 'flowey_lib_common::publish_test_results:15:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env ado FLOWEY_CONDITION
     displayName: run 'unit-tests crypto (openssl)' nextest tests
   - task: PublishTestResults@2
     inputs:
       testResultsFormat: JUnit
-      testResultsFiles: $(floweyvar4)
+      testResultsFiles: $(floweyvar3)
       testRunTitle: x64-linux-musl-unit-tests-unit-tests crypto (openssl)
     displayName: 'publish test results: x64-linux-musl-unit-tests-unit-tests crypto (openssl) (JUnit XML)'
     condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
-  - bash: $(FLOWEY_BIN) e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 4
+  - bash: $(FLOWEY_BIN) e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 3
     displayName: generate nextest command
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 15 flowey_lib_common::run_cargo_nextest_run 8
-      $(FLOWEY_BIN) e 15 flowey_lib_common::run_cargo_nextest_run 9
+      $(FLOWEY_BIN) e 15 flowey_lib_common::run_cargo_nextest_run 6
+      $(FLOWEY_BIN) e 15 flowey_lib_common::run_cargo_nextest_run 7
       $(FLOWEY_BIN) e 15 flowey_lib_hvlite::build_nextest_unit_tests 5
       $(FLOWEY_BIN) e 15 flowey_lib_common::publish_test_results 9
-      $(FLOWEY_BIN) e 15 flowey_lib_common::ado_task_publish_test_results 10
+      $(FLOWEY_BIN) e 15 flowey_lib_common::ado_task_publish_test_results 8
       $(FLOWEY_BIN) e 15 flowey_lib_common::publish_test_results 8
-      $FLOWEY_BIN v 15 'flowey_lib_common::ado_task_publish_test_results:10:flowey_lib_common/src/ado_task_publish_test_results.rs:57:45' --is-raw-string --condvar flowey_lib_common::publish_test_results:20:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env ado floweyvar6
+      $FLOWEY_BIN v 15 'flowey_lib_common::ado_task_publish_test_results:8:flowey_lib_common/src/ado_task_publish_test_results.rs:57:45' --is-raw-string --condvar flowey_lib_common::publish_test_results:20:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env ado floweyvar5
       $FLOWEY_BIN v 15 'flowey_lib_common::publish_test_results:20:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env ado FLOWEY_CONDITION
     displayName: run 'unit-tests crypto (symcrypt)' nextest tests
   - task: PublishTestResults@2
     inputs:
       testResultsFormat: JUnit
-      testResultsFiles: $(floweyvar6)
+      testResultsFiles: $(floweyvar5)
       testRunTitle: x64-linux-musl-unit-tests-unit-tests crypto (symcrypt)
     displayName: 'publish test results: x64-linux-musl-unit-tests-unit-tests crypto (symcrypt) (JUnit XML)'
-    condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
-  - bash: $(FLOWEY_BIN) e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 0
-    displayName: generate nextest command
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 15 flowey_lib_common::run_cargo_nextest_run 0
-      $(FLOWEY_BIN) e 15 flowey_lib_common::run_cargo_nextest_run 1
-      $(FLOWEY_BIN) e 15 flowey_lib_hvlite::build_nextest_unit_tests 6
-      $(FLOWEY_BIN) e 15 flowey_lib_common::publish_test_results 11
-      $(FLOWEY_BIN) e 15 flowey_lib_common::ado_task_publish_test_results 2
-      $(FLOWEY_BIN) e 15 flowey_lib_common::publish_test_results 10
-      $FLOWEY_BIN v 15 'flowey_lib_common::ado_task_publish_test_results:2:flowey_lib_common/src/ado_task_publish_test_results.rs:57:45' --is-raw-string --condvar flowey_lib_common::publish_test_results:25:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env ado floweyvar2
-      $FLOWEY_BIN v 15 'flowey_lib_common::publish_test_results:25:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env ado FLOWEY_CONDITION
-    displayName: run 'unit-tests crypto (all)' nextest tests
-  - task: PublishTestResults@2
-    inputs:
-      testResultsFormat: JUnit
-      testResultsFiles: $(floweyvar2)
-      testRunTitle: x64-linux-musl-unit-tests-unit-tests crypto (all)
-    displayName: 'publish test results: x64-linux-musl-unit-tests-unit-tests crypto (all) (JUnit XML)'
     condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
   - bash: |-
       set -e
@@ -482,12 +456,12 @@ jobs:
     displayName: split debug symbols
   - bash: $(FLOWEY_BIN) e 15 flowey_lib_hvlite::build_nextest_unit_tests 0
     displayName: determine unit test exclusions
-  - bash: $(FLOWEY_BIN) e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 5
+  - bash: $(FLOWEY_BIN) e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 4
     displayName: generate nextest command
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 15 flowey_lib_common::run_cargo_nextest_run 10
-      $(FLOWEY_BIN) e 15 flowey_lib_common::run_cargo_nextest_run 11
+      $(FLOWEY_BIN) e 15 flowey_lib_common::run_cargo_nextest_run 8
+      $(FLOWEY_BIN) e 15 flowey_lib_common::run_cargo_nextest_run 9
       $(FLOWEY_BIN) e 15 flowey_lib_hvlite::build_nextest_unit_tests 1
       $(FLOWEY_BIN) e 15 flowey_lib_common::publish_test_results 1
       $(FLOWEY_BIN) e 15 flowey_lib_common::ado_task_publish_test_results 0
@@ -502,29 +476,29 @@ jobs:
       testRunTitle: x64-linux-musl-unit-tests-unit-tests
     displayName: 'publish test results: x64-linux-musl-unit-tests-unit-tests (JUnit XML)'
     condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
-  - bash: $(FLOWEY_BIN) e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 1
+  - bash: $(FLOWEY_BIN) e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 0
     displayName: generate nextest command
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 15 flowey_lib_common::run_cargo_nextest_run 2
-      $(FLOWEY_BIN) e 15 flowey_lib_common::run_cargo_nextest_run 3
+      $(FLOWEY_BIN) e 15 flowey_lib_common::run_cargo_nextest_run 0
+      $(FLOWEY_BIN) e 15 flowey_lib_common::run_cargo_nextest_run 1
       $(FLOWEY_BIN) e 15 flowey_lib_hvlite::build_nextest_unit_tests 2
       $(FLOWEY_BIN) e 15 flowey_lib_common::publish_test_results 3
-      $(FLOWEY_BIN) e 15 flowey_lib_common::ado_task_publish_test_results 4
+      $(FLOWEY_BIN) e 15 flowey_lib_common::ado_task_publish_test_results 2
       $(FLOWEY_BIN) e 15 flowey_lib_common::publish_test_results 2
-      $FLOWEY_BIN v 15 'flowey_lib_common::ado_task_publish_test_results:4:flowey_lib_common/src/ado_task_publish_test_results.rs:57:45' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env ado floweyvar3
+      $FLOWEY_BIN v 15 'flowey_lib_common::ado_task_publish_test_results:2:flowey_lib_common/src/ado_task_publish_test_results.rs:57:45' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env ado floweyvar2
       $FLOWEY_BIN v 15 'flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env ado FLOWEY_CONDITION
     displayName: run 'unit-tests crypto (native)' nextest tests
   - task: PublishTestResults@2
     inputs:
       testResultsFormat: JUnit
-      testResultsFiles: $(floweyvar3)
+      testResultsFiles: $(floweyvar2)
       testRunTitle: x64-linux-musl-unit-tests-unit-tests crypto (native)
     displayName: 'publish test results: x64-linux-musl-unit-tests-unit-tests crypto (native) (JUnit XML)'
     condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 15 flowey_lib_hvlite::build_nextest_unit_tests 7
+      $(FLOWEY_BIN) e 15 flowey_lib_hvlite::build_nextest_unit_tests 6
       $(FLOWEY_BIN) e 15 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
     displayName: report test results to overall pipeline status
   - bash: $(FLOWEY_BIN) e 15 flowey_lib_hvlite::_jobs::build_and_run_doc_tests 0
@@ -584,14 +558,14 @@ jobs:
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 14 flowey_lib_common::git_checkout 0
-      $FLOWEY_BIN v 14 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:319:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46 write-to-env ado floweyvar10
+      $FLOWEY_BIN v 14 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:319:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46 write-to-env ado floweyvar9
       $FLOWEY_BIN v 14 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46' write-to-env ado FLOWEY_CONDITION
     displayName: check if openvmm needs to be cloned
   - checkout: self
     path: repo0
     fetchTags: false
     fetchDepth: 1
-    persistCredentials: $(floweyvar10)
+    persistCredentials: $(floweyvar9)
     submodules: recursive
     displayName: checkout repo openvmm
     condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
@@ -607,13 +581,13 @@ jobs:
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 14 flowey_lib_common::cache 4
-      $FLOWEY_BIN v 14 'flowey_lib_common::cache:8:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar8
-      $FLOWEY_BIN v 14 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar9
+      $FLOWEY_BIN v 14 'flowey_lib_common::cache:8:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar7
+      $FLOWEY_BIN v 14 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar8
     displayName: Pre-processing cache vars
   - task: Cache@2
     inputs:
-      key: $(floweyvar9)
-      path: $(floweyvar8)
+      key: $(floweyvar8)
+      path: $(floweyvar7)
       cacheHitVar: FLOWEY_CACHE_HITVAR
     displayName: 'Restore cache: gh-release-download'
   - bash: |-
@@ -664,13 +638,13 @@ jobs:
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 14 flowey_lib_common::cache 0
-      $FLOWEY_BIN v 14 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar6
-      $FLOWEY_BIN v 14 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar7
+      $FLOWEY_BIN v 14 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar5
+      $FLOWEY_BIN v 14 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar6
     displayName: Pre-processing cache vars
   - task: Cache@2
     inputs:
-      key: $(floweyvar7)
-      path: $(floweyvar6)
+      key: $(floweyvar6)
+      path: $(floweyvar5)
       cacheHitVar: FLOWEY_CACHE_HITVAR
     displayName: 'Restore cache: cargo-nextest'
   - bash: |-
@@ -690,65 +664,25 @@ jobs:
       $(FLOWEY_BIN) e 14 flowey_lib_hvlite::init_cross_build 0
       $(FLOWEY_BIN) e 14 flowey_lib_hvlite::run_cargo_nextest_run 0
     displayName: installing cargo-nextest
-  - bash: $(FLOWEY_BIN) e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 3
+  - bash: $(FLOWEY_BIN) e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 1
     displayName: generate nextest command
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 14 flowey_lib_common::run_cargo_nextest_run 6
-      $(FLOWEY_BIN) e 14 flowey_lib_common::run_cargo_nextest_run 7
-      $(FLOWEY_BIN) e 14 flowey_lib_hvlite::build_nextest_unit_tests 3
-      $(FLOWEY_BIN) e 14 flowey_lib_common::publish_test_results 5
-      $(FLOWEY_BIN) e 14 flowey_lib_common::ado_task_publish_test_results 8
-      $(FLOWEY_BIN) e 14 flowey_lib_common::publish_test_results 4
-      $FLOWEY_BIN v 14 'flowey_lib_common::ado_task_publish_test_results:8:flowey_lib_common/src/ado_task_publish_test_results.rs:57:45' --is-raw-string --condvar flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env ado floweyvar5
-      $FLOWEY_BIN v 14 'flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env ado FLOWEY_CONDITION
-    displayName: run 'unit-tests crypto (rust)' nextest tests
-  - task: PublishTestResults@2
-    inputs:
-      testResultsFormat: JUnit
-      testResultsFiles: $(floweyvar5)
-      testRunTitle: x64-linux-unit-tests-unit-tests crypto (rust)
-    displayName: 'publish test results: x64-linux-unit-tests-unit-tests crypto (rust) (JUnit XML)'
-    condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
-  - bash: $(FLOWEY_BIN) e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 2
-    displayName: generate nextest command
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 14 flowey_lib_common::run_cargo_nextest_run 4
-      $(FLOWEY_BIN) e 14 flowey_lib_common::run_cargo_nextest_run 5
+      $(FLOWEY_BIN) e 14 flowey_lib_common::run_cargo_nextest_run 2
+      $(FLOWEY_BIN) e 14 flowey_lib_common::run_cargo_nextest_run 3
       $(FLOWEY_BIN) e 14 flowey_lib_hvlite::build_nextest_unit_tests 4
-      $(FLOWEY_BIN) e 14 flowey_lib_common::publish_test_results 7
-      $(FLOWEY_BIN) e 14 flowey_lib_common::ado_task_publish_test_results 6
-      $(FLOWEY_BIN) e 14 flowey_lib_common::publish_test_results 6
-      $FLOWEY_BIN v 14 'flowey_lib_common::ado_task_publish_test_results:6:flowey_lib_common/src/ado_task_publish_test_results.rs:57:45' --is-raw-string --condvar flowey_lib_common::publish_test_results:15:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env ado floweyvar4
-      $FLOWEY_BIN v 14 'flowey_lib_common::publish_test_results:15:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env ado FLOWEY_CONDITION
+      $(FLOWEY_BIN) e 14 flowey_lib_common::publish_test_results 5
+      $(FLOWEY_BIN) e 14 flowey_lib_common::ado_task_publish_test_results 4
+      $(FLOWEY_BIN) e 14 flowey_lib_common::publish_test_results 4
+      $FLOWEY_BIN v 14 'flowey_lib_common::ado_task_publish_test_results:4:flowey_lib_common/src/ado_task_publish_test_results.rs:57:45' --is-raw-string --condvar flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env ado floweyvar3
+      $FLOWEY_BIN v 14 'flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env ado FLOWEY_CONDITION
     displayName: run 'unit-tests crypto (openssl)' nextest tests
   - task: PublishTestResults@2
     inputs:
       testResultsFormat: JUnit
-      testResultsFiles: $(floweyvar4)
+      testResultsFiles: $(floweyvar3)
       testRunTitle: x64-linux-unit-tests-unit-tests crypto (openssl)
     displayName: 'publish test results: x64-linux-unit-tests-unit-tests crypto (openssl) (JUnit XML)'
-    condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
-  - bash: $(FLOWEY_BIN) e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 0
-    displayName: generate nextest command
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 14 flowey_lib_common::run_cargo_nextest_run 0
-      $(FLOWEY_BIN) e 14 flowey_lib_common::run_cargo_nextest_run 1
-      $(FLOWEY_BIN) e 14 flowey_lib_hvlite::build_nextest_unit_tests 5
-      $(FLOWEY_BIN) e 14 flowey_lib_common::publish_test_results 9
-      $(FLOWEY_BIN) e 14 flowey_lib_common::ado_task_publish_test_results 2
-      $(FLOWEY_BIN) e 14 flowey_lib_common::publish_test_results 8
-      $FLOWEY_BIN v 14 'flowey_lib_common::ado_task_publish_test_results:2:flowey_lib_common/src/ado_task_publish_test_results.rs:57:45' --is-raw-string --condvar flowey_lib_common::publish_test_results:20:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env ado floweyvar2
-      $FLOWEY_BIN v 14 'flowey_lib_common::publish_test_results:20:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env ado FLOWEY_CONDITION
-    displayName: run 'unit-tests crypto (all)' nextest tests
-  - task: PublishTestResults@2
-    inputs:
-      testResultsFormat: JUnit
-      testResultsFiles: $(floweyvar2)
-      testRunTitle: x64-linux-unit-tests-unit-tests crypto (all)
-    displayName: 'publish test results: x64-linux-unit-tests-unit-tests crypto (all) (JUnit XML)'
     condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
   - bash: |-
       set -e
@@ -764,18 +698,18 @@ jobs:
     displayName: split debug symbols
   - bash: $(FLOWEY_BIN) e 14 flowey_lib_hvlite::build_nextest_unit_tests 0
     displayName: determine unit test exclusions
-  - bash: $(FLOWEY_BIN) e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 4
+  - bash: $(FLOWEY_BIN) e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 3
     displayName: generate nextest command
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 14 flowey_lib_common::run_cargo_nextest_run 8
-      $(FLOWEY_BIN) e 14 flowey_lib_common::run_cargo_nextest_run 9
+      $(FLOWEY_BIN) e 14 flowey_lib_common::run_cargo_nextest_run 6
+      $(FLOWEY_BIN) e 14 flowey_lib_common::run_cargo_nextest_run 7
       $(FLOWEY_BIN) e 14 flowey_lib_hvlite::build_nextest_unit_tests 1
-      $(FLOWEY_BIN) e 14 flowey_lib_common::publish_test_results 1
+      $(FLOWEY_BIN) e 14 flowey_lib_common::publish_test_results 7
       $(FLOWEY_BIN) e 14 flowey_lib_common::ado_task_publish_test_results 0
-      $(FLOWEY_BIN) e 14 flowey_lib_common::publish_test_results 0
-      $FLOWEY_BIN v 14 'flowey_lib_common::ado_task_publish_test_results:0:flowey_lib_common/src/ado_task_publish_test_results.rs:57:45' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env ado floweyvar1
-      $FLOWEY_BIN v 14 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env ado FLOWEY_CONDITION
+      $(FLOWEY_BIN) e 14 flowey_lib_common::publish_test_results 6
+      $FLOWEY_BIN v 14 'flowey_lib_common::ado_task_publish_test_results:0:flowey_lib_common/src/ado_task_publish_test_results.rs:57:45' --is-raw-string --condvar flowey_lib_common::publish_test_results:15:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env ado floweyvar1
+      $FLOWEY_BIN v 14 'flowey_lib_common::publish_test_results:15:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env ado FLOWEY_CONDITION
     displayName: run 'unit-tests' nextest tests
   - task: PublishTestResults@2
     inputs:
@@ -784,29 +718,49 @@ jobs:
       testRunTitle: x64-linux-unit-tests-unit-tests
     displayName: 'publish test results: x64-linux-unit-tests-unit-tests (JUnit XML)'
     condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
-  - bash: $(FLOWEY_BIN) e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 1
+  - bash: $(FLOWEY_BIN) e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 0
     displayName: generate nextest command
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 14 flowey_lib_common::run_cargo_nextest_run 2
-      $(FLOWEY_BIN) e 14 flowey_lib_common::run_cargo_nextest_run 3
+      $(FLOWEY_BIN) e 14 flowey_lib_common::run_cargo_nextest_run 0
+      $(FLOWEY_BIN) e 14 flowey_lib_common::run_cargo_nextest_run 1
       $(FLOWEY_BIN) e 14 flowey_lib_hvlite::build_nextest_unit_tests 2
-      $(FLOWEY_BIN) e 14 flowey_lib_common::publish_test_results 3
-      $(FLOWEY_BIN) e 14 flowey_lib_common::ado_task_publish_test_results 4
-      $(FLOWEY_BIN) e 14 flowey_lib_common::publish_test_results 2
-      $FLOWEY_BIN v 14 'flowey_lib_common::ado_task_publish_test_results:4:flowey_lib_common/src/ado_task_publish_test_results.rs:57:45' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env ado floweyvar3
-      $FLOWEY_BIN v 14 'flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env ado FLOWEY_CONDITION
+      $(FLOWEY_BIN) e 14 flowey_lib_common::publish_test_results 1
+      $(FLOWEY_BIN) e 14 flowey_lib_common::ado_task_publish_test_results 2
+      $(FLOWEY_BIN) e 14 flowey_lib_common::publish_test_results 0
+      $FLOWEY_BIN v 14 'flowey_lib_common::ado_task_publish_test_results:2:flowey_lib_common/src/ado_task_publish_test_results.rs:57:45' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env ado floweyvar2
+      $FLOWEY_BIN v 14 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env ado FLOWEY_CONDITION
     displayName: run 'unit-tests crypto (native)' nextest tests
   - task: PublishTestResults@2
     inputs:
       testResultsFormat: JUnit
-      testResultsFiles: $(floweyvar3)
+      testResultsFiles: $(floweyvar2)
       testRunTitle: x64-linux-unit-tests-unit-tests crypto (native)
     displayName: 'publish test results: x64-linux-unit-tests-unit-tests crypto (native) (JUnit XML)'
     condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
+  - bash: $(FLOWEY_BIN) e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 2
+    displayName: generate nextest command
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 14 flowey_lib_hvlite::build_nextest_unit_tests 6
+      $(FLOWEY_BIN) e 14 flowey_lib_common::run_cargo_nextest_run 4
+      $(FLOWEY_BIN) e 14 flowey_lib_common::run_cargo_nextest_run 5
+      $(FLOWEY_BIN) e 14 flowey_lib_hvlite::build_nextest_unit_tests 3
+      $(FLOWEY_BIN) e 14 flowey_lib_common::publish_test_results 3
+      $(FLOWEY_BIN) e 14 flowey_lib_common::ado_task_publish_test_results 6
+      $(FLOWEY_BIN) e 14 flowey_lib_common::publish_test_results 2
+      $FLOWEY_BIN v 14 'flowey_lib_common::ado_task_publish_test_results:6:flowey_lib_common/src/ado_task_publish_test_results.rs:57:45' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env ado floweyvar4
+      $FLOWEY_BIN v 14 'flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env ado FLOWEY_CONDITION
+    displayName: run 'unit-tests crypto (rust)' nextest tests
+  - task: PublishTestResults@2
+    inputs:
+      testResultsFormat: JUnit
+      testResultsFiles: $(floweyvar4)
+      testRunTitle: x64-linux-unit-tests-unit-tests crypto (rust)
+    displayName: 'publish test results: x64-linux-unit-tests-unit-tests crypto (rust) (JUnit XML)'
+    condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 14 flowey_lib_hvlite::build_nextest_unit_tests 5
       $(FLOWEY_BIN) e 14 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
     displayName: report test results to overall pipeline status
   - bash: $(FLOWEY_BIN) e 14 flowey_lib_hvlite::_jobs::build_and_run_doc_tests 0

--- a/ci-flowey/openvmm-pr.yaml
+++ b/ci-flowey/openvmm-pr.yaml
@@ -182,8 +182,12 @@ jobs:
       set -e
       $(FLOWEY_BIN) e 0 flowey_lib_hvlite::_jobs::check_xtask_fmt 0
       $(FLOWEY_BIN) e 0 flowey_lib_hvlite::init_cross_build 0
-      $(FLOWEY_BIN) e 0 flowey_lib_hvlite::init_cross_build 1
     displayName: run xtask fmt
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 0 flowey_lib_common::run_cargo_clippy 1
+      $(FLOWEY_BIN) e 0 flowey_lib_hvlite::init_cross_build 1
+    displayName: cargo clippy
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 0 flowey_lib_common::run_cargo_build 0
@@ -199,11 +203,11 @@ jobs:
     displayName: determine clippy exclusions
   - bash: $(FLOWEY_BIN) e 0 flowey_lib_common::run_cargo_clippy 0
     displayName: cargo clippy
-  - bash: $(FLOWEY_BIN) e 0 flowey_lib_common::run_cargo_clippy 1
+  - bash: $(FLOWEY_BIN) e 0 flowey_lib_common::run_cargo_clippy 2
+    displayName: cargo clippy
+  - bash: $(FLOWEY_BIN) e 0 flowey_lib_common::run_cargo_clippy 4
     displayName: cargo clippy
   - bash: $(FLOWEY_BIN) e 0 flowey_lib_common::run_cargo_clippy 3
-    displayName: cargo clippy
-  - bash: $(FLOWEY_BIN) e 0 flowey_lib_common::run_cargo_clippy 2
     displayName: cargo clippy
   - bash: $(FLOWEY_BIN) e 0 flowey_lib_common::cache 3
     displayName: 'validate cache entry: gh-release-download'
@@ -259,14 +263,14 @@ jobs:
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 15 flowey_lib_common::git_checkout 0
-      $FLOWEY_BIN v 15 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:319:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46 write-to-env ado floweyvar10
+      $FLOWEY_BIN v 15 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:319:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46 write-to-env ado floweyvar11
       $FLOWEY_BIN v 15 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46' write-to-env ado FLOWEY_CONDITION
     displayName: check if openvmm needs to be cloned
   - checkout: self
     path: repo0
     fetchTags: false
     fetchDepth: 1
-    persistCredentials: $(floweyvar10)
+    persistCredentials: $(floweyvar11)
     submodules: recursive
     displayName: checkout repo openvmm
     condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
@@ -281,13 +285,13 @@ jobs:
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 15 flowey_lib_common::cache 4
-      $FLOWEY_BIN v 15 'flowey_lib_common::cache:8:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar8
-      $FLOWEY_BIN v 15 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar9
+      $FLOWEY_BIN v 15 'flowey_lib_common::cache:8:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar9
+      $FLOWEY_BIN v 15 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar10
     displayName: Pre-processing cache vars
   - task: Cache@2
     inputs:
-      key: $(floweyvar9)
-      path: $(floweyvar8)
+      key: $(floweyvar10)
+      path: $(floweyvar9)
       cacheHitVar: FLOWEY_CACHE_HITVAR
     displayName: 'Restore cache: gh-release-download'
   - bash: |-
@@ -316,15 +320,17 @@ jobs:
       $(FLOWEY_BIN) e 15 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
       $(FLOWEY_BIN) e 15 flowey_lib_hvlite::init_cross_build 2
     displayName: symlink protoc
-  - bash: $(FLOWEY_BIN) e 15 flowey_lib_common::run_cargo_clippy 2
+  - bash: $(FLOWEY_BIN) e 15 flowey_lib_common::run_cargo_clippy 3
     displayName: cargo clippy
-  - bash: $(FLOWEY_BIN) e 15 flowey_lib_common::run_cargo_clippy 4
+  - bash: $(FLOWEY_BIN) e 15 flowey_lib_common::run_cargo_clippy 5
     displayName: cargo clippy
-  - bash: $(FLOWEY_BIN) e 15 flowey_lib_common::run_cargo_clippy 6
+  - bash: $(FLOWEY_BIN) e 15 flowey_lib_common::run_cargo_clippy 1
+    displayName: cargo clippy
+  - bash: $(FLOWEY_BIN) e 15 flowey_lib_common::run_cargo_clippy 7
     displayName: cargo clippy
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 15 flowey_lib_common::run_cargo_clippy 5
+      $(FLOWEY_BIN) e 15 flowey_lib_common::run_cargo_clippy 6
       $(FLOWEY_BIN) e 15 flowey_lib_hvlite::init_cross_build 0
     displayName: cargo clippy
   - bash: |-
@@ -342,9 +348,9 @@ jobs:
     displayName: determine clippy exclusions
   - bash: $(FLOWEY_BIN) e 15 flowey_lib_common::run_cargo_clippy 0
     displayName: cargo clippy
-  - bash: $(FLOWEY_BIN) e 15 flowey_lib_common::run_cargo_clippy 1
+  - bash: $(FLOWEY_BIN) e 15 flowey_lib_common::run_cargo_clippy 2
     displayName: cargo clippy
-  - bash: $(FLOWEY_BIN) e 15 flowey_lib_common::run_cargo_clippy 3
+  - bash: $(FLOWEY_BIN) e 15 flowey_lib_common::run_cargo_clippy 4
     displayName: cargo clippy
   - bash: |-
       set -e
@@ -356,13 +362,13 @@ jobs:
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 15 flowey_lib_common::cache 0
-      $FLOWEY_BIN v 15 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar6
-      $FLOWEY_BIN v 15 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar7
+      $FLOWEY_BIN v 15 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar7
+      $FLOWEY_BIN v 15 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar8
     displayName: Pre-processing cache vars
   - task: Cache@2
     inputs:
-      key: $(floweyvar7)
-      path: $(floweyvar6)
+      key: $(floweyvar8)
+      path: $(floweyvar7)
       cacheHitVar: FLOWEY_CACHE_HITVAR
     displayName: 'Restore cache: cargo-nextest'
   - bash: |-
@@ -382,65 +388,85 @@ jobs:
       $(FLOWEY_BIN) e 15 flowey_lib_hvlite::init_cross_build 3
       $(FLOWEY_BIN) e 15 flowey_lib_hvlite::run_cargo_nextest_run 0
     displayName: installing cargo-nextest
-  - bash: $(FLOWEY_BIN) e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 2
-    displayName: generate nextest command
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 15 flowey_lib_common::run_cargo_nextest_run 4
-      $(FLOWEY_BIN) e 15 flowey_lib_common::run_cargo_nextest_run 5
-      $(FLOWEY_BIN) e 15 flowey_lib_hvlite::build_nextest_unit_tests 3
-      $(FLOWEY_BIN) e 15 flowey_lib_common::publish_test_results 5
-      $(FLOWEY_BIN) e 15 flowey_lib_common::ado_task_publish_test_results 6
-      $(FLOWEY_BIN) e 15 flowey_lib_common::publish_test_results 4
-      $FLOWEY_BIN v 15 'flowey_lib_common::ado_task_publish_test_results:6:flowey_lib_common/src/ado_task_publish_test_results.rs:57:45' --is-raw-string --condvar flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env ado floweyvar4
-      $FLOWEY_BIN v 15 'flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env ado FLOWEY_CONDITION
-    displayName: run 'unit-tests crypto (rust)' nextest tests
-  - task: PublishTestResults@2
-    inputs:
-      testResultsFormat: JUnit
-      testResultsFiles: $(floweyvar4)
-      testRunTitle: x64-linux-musl-unit-tests-unit-tests crypto (rust)
-    displayName: 'publish test results: x64-linux-musl-unit-tests-unit-tests crypto (rust) (JUnit XML)'
-    condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
-  - bash: $(FLOWEY_BIN) e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 1
-    displayName: generate nextest command
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 15 flowey_lib_common::run_cargo_nextest_run 2
-      $(FLOWEY_BIN) e 15 flowey_lib_common::run_cargo_nextest_run 3
-      $(FLOWEY_BIN) e 15 flowey_lib_hvlite::build_nextest_unit_tests 4
-      $(FLOWEY_BIN) e 15 flowey_lib_common::publish_test_results 7
-      $(FLOWEY_BIN) e 15 flowey_lib_common::ado_task_publish_test_results 4
-      $(FLOWEY_BIN) e 15 flowey_lib_common::publish_test_results 6
-      $FLOWEY_BIN v 15 'flowey_lib_common::ado_task_publish_test_results:4:flowey_lib_common/src/ado_task_publish_test_results.rs:57:45' --is-raw-string --condvar flowey_lib_common::publish_test_results:15:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env ado floweyvar3
-      $FLOWEY_BIN v 15 'flowey_lib_common::publish_test_results:15:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env ado FLOWEY_CONDITION
-    displayName: run 'unit-tests crypto (openssl)' nextest tests
-  - task: PublishTestResults@2
-    inputs:
-      testResultsFormat: JUnit
-      testResultsFiles: $(floweyvar3)
-      testRunTitle: x64-linux-musl-unit-tests-unit-tests crypto (openssl)
-    displayName: 'publish test results: x64-linux-musl-unit-tests-unit-tests crypto (openssl) (JUnit XML)'
-    condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
   - bash: $(FLOWEY_BIN) e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 3
     displayName: generate nextest command
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 15 flowey_lib_common::run_cargo_nextest_run 6
       $(FLOWEY_BIN) e 15 flowey_lib_common::run_cargo_nextest_run 7
+      $(FLOWEY_BIN) e 15 flowey_lib_hvlite::build_nextest_unit_tests 3
+      $(FLOWEY_BIN) e 15 flowey_lib_common::publish_test_results 5
+      $(FLOWEY_BIN) e 15 flowey_lib_common::ado_task_publish_test_results 8
+      $(FLOWEY_BIN) e 15 flowey_lib_common::publish_test_results 4
+      $FLOWEY_BIN v 15 'flowey_lib_common::ado_task_publish_test_results:8:flowey_lib_common/src/ado_task_publish_test_results.rs:57:45' --is-raw-string --condvar flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env ado floweyvar5
+      $FLOWEY_BIN v 15 'flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env ado FLOWEY_CONDITION
+    displayName: run 'unit-tests crypto (rust)' nextest tests
+  - task: PublishTestResults@2
+    inputs:
+      testResultsFormat: JUnit
+      testResultsFiles: $(floweyvar5)
+      testRunTitle: x64-linux-musl-unit-tests-unit-tests crypto (rust)
+    displayName: 'publish test results: x64-linux-musl-unit-tests-unit-tests crypto (rust) (JUnit XML)'
+    condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
+  - bash: $(FLOWEY_BIN) e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 2
+    displayName: generate nextest command
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 15 flowey_lib_common::run_cargo_nextest_run 4
+      $(FLOWEY_BIN) e 15 flowey_lib_common::run_cargo_nextest_run 5
+      $(FLOWEY_BIN) e 15 flowey_lib_hvlite::build_nextest_unit_tests 4
+      $(FLOWEY_BIN) e 15 flowey_lib_common::publish_test_results 7
+      $(FLOWEY_BIN) e 15 flowey_lib_common::ado_task_publish_test_results 6
+      $(FLOWEY_BIN) e 15 flowey_lib_common::publish_test_results 6
+      $FLOWEY_BIN v 15 'flowey_lib_common::ado_task_publish_test_results:6:flowey_lib_common/src/ado_task_publish_test_results.rs:57:45' --is-raw-string --condvar flowey_lib_common::publish_test_results:15:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env ado floweyvar4
+      $FLOWEY_BIN v 15 'flowey_lib_common::publish_test_results:15:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env ado FLOWEY_CONDITION
+    displayName: run 'unit-tests crypto (openssl)' nextest tests
+  - task: PublishTestResults@2
+    inputs:
+      testResultsFormat: JUnit
+      testResultsFiles: $(floweyvar4)
+      testRunTitle: x64-linux-musl-unit-tests-unit-tests crypto (openssl)
+    displayName: 'publish test results: x64-linux-musl-unit-tests-unit-tests crypto (openssl) (JUnit XML)'
+    condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
+  - bash: $(FLOWEY_BIN) e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 4
+    displayName: generate nextest command
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 15 flowey_lib_common::run_cargo_nextest_run 8
+      $(FLOWEY_BIN) e 15 flowey_lib_common::run_cargo_nextest_run 9
       $(FLOWEY_BIN) e 15 flowey_lib_hvlite::build_nextest_unit_tests 5
       $(FLOWEY_BIN) e 15 flowey_lib_common::publish_test_results 9
-      $(FLOWEY_BIN) e 15 flowey_lib_common::ado_task_publish_test_results 8
+      $(FLOWEY_BIN) e 15 flowey_lib_common::ado_task_publish_test_results 10
       $(FLOWEY_BIN) e 15 flowey_lib_common::publish_test_results 8
-      $FLOWEY_BIN v 15 'flowey_lib_common::ado_task_publish_test_results:8:flowey_lib_common/src/ado_task_publish_test_results.rs:57:45' --is-raw-string --condvar flowey_lib_common::publish_test_results:20:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env ado floweyvar5
+      $FLOWEY_BIN v 15 'flowey_lib_common::ado_task_publish_test_results:10:flowey_lib_common/src/ado_task_publish_test_results.rs:57:45' --is-raw-string --condvar flowey_lib_common::publish_test_results:20:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env ado floweyvar6
       $FLOWEY_BIN v 15 'flowey_lib_common::publish_test_results:20:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env ado FLOWEY_CONDITION
     displayName: run 'unit-tests crypto (symcrypt)' nextest tests
   - task: PublishTestResults@2
     inputs:
       testResultsFormat: JUnit
-      testResultsFiles: $(floweyvar5)
+      testResultsFiles: $(floweyvar6)
       testRunTitle: x64-linux-musl-unit-tests-unit-tests crypto (symcrypt)
     displayName: 'publish test results: x64-linux-musl-unit-tests-unit-tests crypto (symcrypt) (JUnit XML)'
+    condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
+  - bash: $(FLOWEY_BIN) e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+    displayName: generate nextest command
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 15 flowey_lib_common::run_cargo_nextest_run 0
+      $(FLOWEY_BIN) e 15 flowey_lib_common::run_cargo_nextest_run 1
+      $(FLOWEY_BIN) e 15 flowey_lib_hvlite::build_nextest_unit_tests 6
+      $(FLOWEY_BIN) e 15 flowey_lib_common::publish_test_results 11
+      $(FLOWEY_BIN) e 15 flowey_lib_common::ado_task_publish_test_results 2
+      $(FLOWEY_BIN) e 15 flowey_lib_common::publish_test_results 10
+      $FLOWEY_BIN v 15 'flowey_lib_common::ado_task_publish_test_results:2:flowey_lib_common/src/ado_task_publish_test_results.rs:57:45' --is-raw-string --condvar flowey_lib_common::publish_test_results:25:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env ado floweyvar2
+      $FLOWEY_BIN v 15 'flowey_lib_common::publish_test_results:25:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env ado FLOWEY_CONDITION
+    displayName: run 'unit-tests crypto (all)' nextest tests
+  - task: PublishTestResults@2
+    inputs:
+      testResultsFormat: JUnit
+      testResultsFiles: $(floweyvar2)
+      testRunTitle: x64-linux-musl-unit-tests-unit-tests crypto (all)
+    displayName: 'publish test results: x64-linux-musl-unit-tests-unit-tests crypto (all) (JUnit XML)'
     condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
   - bash: |-
       set -e
@@ -456,12 +482,12 @@ jobs:
     displayName: split debug symbols
   - bash: $(FLOWEY_BIN) e 15 flowey_lib_hvlite::build_nextest_unit_tests 0
     displayName: determine unit test exclusions
-  - bash: $(FLOWEY_BIN) e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 4
+  - bash: $(FLOWEY_BIN) e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 5
     displayName: generate nextest command
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 15 flowey_lib_common::run_cargo_nextest_run 8
-      $(FLOWEY_BIN) e 15 flowey_lib_common::run_cargo_nextest_run 9
+      $(FLOWEY_BIN) e 15 flowey_lib_common::run_cargo_nextest_run 10
+      $(FLOWEY_BIN) e 15 flowey_lib_common::run_cargo_nextest_run 11
       $(FLOWEY_BIN) e 15 flowey_lib_hvlite::build_nextest_unit_tests 1
       $(FLOWEY_BIN) e 15 flowey_lib_common::publish_test_results 1
       $(FLOWEY_BIN) e 15 flowey_lib_common::ado_task_publish_test_results 0
@@ -476,29 +502,29 @@ jobs:
       testRunTitle: x64-linux-musl-unit-tests-unit-tests
     displayName: 'publish test results: x64-linux-musl-unit-tests-unit-tests (JUnit XML)'
     condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
-  - bash: $(FLOWEY_BIN) e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+  - bash: $(FLOWEY_BIN) e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 1
     displayName: generate nextest command
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 15 flowey_lib_common::run_cargo_nextest_run 0
-      $(FLOWEY_BIN) e 15 flowey_lib_common::run_cargo_nextest_run 1
+      $(FLOWEY_BIN) e 15 flowey_lib_common::run_cargo_nextest_run 2
+      $(FLOWEY_BIN) e 15 flowey_lib_common::run_cargo_nextest_run 3
       $(FLOWEY_BIN) e 15 flowey_lib_hvlite::build_nextest_unit_tests 2
       $(FLOWEY_BIN) e 15 flowey_lib_common::publish_test_results 3
-      $(FLOWEY_BIN) e 15 flowey_lib_common::ado_task_publish_test_results 2
+      $(FLOWEY_BIN) e 15 flowey_lib_common::ado_task_publish_test_results 4
       $(FLOWEY_BIN) e 15 flowey_lib_common::publish_test_results 2
-      $FLOWEY_BIN v 15 'flowey_lib_common::ado_task_publish_test_results:2:flowey_lib_common/src/ado_task_publish_test_results.rs:57:45' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env ado floweyvar2
+      $FLOWEY_BIN v 15 'flowey_lib_common::ado_task_publish_test_results:4:flowey_lib_common/src/ado_task_publish_test_results.rs:57:45' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env ado floweyvar3
       $FLOWEY_BIN v 15 'flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env ado FLOWEY_CONDITION
     displayName: run 'unit-tests crypto (native)' nextest tests
   - task: PublishTestResults@2
     inputs:
       testResultsFormat: JUnit
-      testResultsFiles: $(floweyvar2)
+      testResultsFiles: $(floweyvar3)
       testRunTitle: x64-linux-musl-unit-tests-unit-tests crypto (native)
     displayName: 'publish test results: x64-linux-musl-unit-tests-unit-tests crypto (native) (JUnit XML)'
     condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 15 flowey_lib_hvlite::build_nextest_unit_tests 6
+      $(FLOWEY_BIN) e 15 flowey_lib_hvlite::build_nextest_unit_tests 7
       $(FLOWEY_BIN) e 15 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
     displayName: report test results to overall pipeline status
   - bash: $(FLOWEY_BIN) e 15 flowey_lib_hvlite::_jobs::build_and_run_doc_tests 0
@@ -558,14 +584,14 @@ jobs:
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 14 flowey_lib_common::git_checkout 0
-      $FLOWEY_BIN v 14 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:319:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46 write-to-env ado floweyvar9
+      $FLOWEY_BIN v 14 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:319:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46 write-to-env ado floweyvar10
       $FLOWEY_BIN v 14 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46' write-to-env ado FLOWEY_CONDITION
     displayName: check if openvmm needs to be cloned
   - checkout: self
     path: repo0
     fetchTags: false
     fetchDepth: 1
-    persistCredentials: $(floweyvar9)
+    persistCredentials: $(floweyvar10)
     submodules: recursive
     displayName: checkout repo openvmm
     condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
@@ -581,13 +607,13 @@ jobs:
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 14 flowey_lib_common::cache 4
-      $FLOWEY_BIN v 14 'flowey_lib_common::cache:8:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar7
-      $FLOWEY_BIN v 14 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar8
+      $FLOWEY_BIN v 14 'flowey_lib_common::cache:8:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar8
+      $FLOWEY_BIN v 14 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar9
     displayName: Pre-processing cache vars
   - task: Cache@2
     inputs:
-      key: $(floweyvar8)
-      path: $(floweyvar7)
+      key: $(floweyvar9)
+      path: $(floweyvar8)
       cacheHitVar: FLOWEY_CACHE_HITVAR
     displayName: 'Restore cache: gh-release-download'
   - bash: |-
@@ -638,13 +664,13 @@ jobs:
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 14 flowey_lib_common::cache 0
-      $FLOWEY_BIN v 14 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar5
-      $FLOWEY_BIN v 14 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar6
+      $FLOWEY_BIN v 14 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar6
+      $FLOWEY_BIN v 14 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar7
     displayName: Pre-processing cache vars
   - task: Cache@2
     inputs:
-      key: $(floweyvar6)
-      path: $(floweyvar5)
+      key: $(floweyvar7)
+      path: $(floweyvar6)
       cacheHitVar: FLOWEY_CACHE_HITVAR
     displayName: 'Restore cache: cargo-nextest'
   - bash: |-
@@ -664,25 +690,65 @@ jobs:
       $(FLOWEY_BIN) e 14 flowey_lib_hvlite::init_cross_build 0
       $(FLOWEY_BIN) e 14 flowey_lib_hvlite::run_cargo_nextest_run 0
     displayName: installing cargo-nextest
-  - bash: $(FLOWEY_BIN) e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 1
+  - bash: $(FLOWEY_BIN) e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 3
     displayName: generate nextest command
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 14 flowey_lib_common::run_cargo_nextest_run 2
-      $(FLOWEY_BIN) e 14 flowey_lib_common::run_cargo_nextest_run 3
-      $(FLOWEY_BIN) e 14 flowey_lib_hvlite::build_nextest_unit_tests 4
+      $(FLOWEY_BIN) e 14 flowey_lib_common::run_cargo_nextest_run 6
+      $(FLOWEY_BIN) e 14 flowey_lib_common::run_cargo_nextest_run 7
+      $(FLOWEY_BIN) e 14 flowey_lib_hvlite::build_nextest_unit_tests 3
       $(FLOWEY_BIN) e 14 flowey_lib_common::publish_test_results 5
-      $(FLOWEY_BIN) e 14 flowey_lib_common::ado_task_publish_test_results 4
+      $(FLOWEY_BIN) e 14 flowey_lib_common::ado_task_publish_test_results 8
       $(FLOWEY_BIN) e 14 flowey_lib_common::publish_test_results 4
-      $FLOWEY_BIN v 14 'flowey_lib_common::ado_task_publish_test_results:4:flowey_lib_common/src/ado_task_publish_test_results.rs:57:45' --is-raw-string --condvar flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env ado floweyvar3
+      $FLOWEY_BIN v 14 'flowey_lib_common::ado_task_publish_test_results:8:flowey_lib_common/src/ado_task_publish_test_results.rs:57:45' --is-raw-string --condvar flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env ado floweyvar5
       $FLOWEY_BIN v 14 'flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env ado FLOWEY_CONDITION
+    displayName: run 'unit-tests crypto (rust)' nextest tests
+  - task: PublishTestResults@2
+    inputs:
+      testResultsFormat: JUnit
+      testResultsFiles: $(floweyvar5)
+      testRunTitle: x64-linux-unit-tests-unit-tests crypto (rust)
+    displayName: 'publish test results: x64-linux-unit-tests-unit-tests crypto (rust) (JUnit XML)'
+    condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
+  - bash: $(FLOWEY_BIN) e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 2
+    displayName: generate nextest command
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 14 flowey_lib_common::run_cargo_nextest_run 4
+      $(FLOWEY_BIN) e 14 flowey_lib_common::run_cargo_nextest_run 5
+      $(FLOWEY_BIN) e 14 flowey_lib_hvlite::build_nextest_unit_tests 4
+      $(FLOWEY_BIN) e 14 flowey_lib_common::publish_test_results 7
+      $(FLOWEY_BIN) e 14 flowey_lib_common::ado_task_publish_test_results 6
+      $(FLOWEY_BIN) e 14 flowey_lib_common::publish_test_results 6
+      $FLOWEY_BIN v 14 'flowey_lib_common::ado_task_publish_test_results:6:flowey_lib_common/src/ado_task_publish_test_results.rs:57:45' --is-raw-string --condvar flowey_lib_common::publish_test_results:15:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env ado floweyvar4
+      $FLOWEY_BIN v 14 'flowey_lib_common::publish_test_results:15:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env ado FLOWEY_CONDITION
     displayName: run 'unit-tests crypto (openssl)' nextest tests
   - task: PublishTestResults@2
     inputs:
       testResultsFormat: JUnit
-      testResultsFiles: $(floweyvar3)
+      testResultsFiles: $(floweyvar4)
       testRunTitle: x64-linux-unit-tests-unit-tests crypto (openssl)
     displayName: 'publish test results: x64-linux-unit-tests-unit-tests crypto (openssl) (JUnit XML)'
+    condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
+  - bash: $(FLOWEY_BIN) e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+    displayName: generate nextest command
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 14 flowey_lib_common::run_cargo_nextest_run 0
+      $(FLOWEY_BIN) e 14 flowey_lib_common::run_cargo_nextest_run 1
+      $(FLOWEY_BIN) e 14 flowey_lib_hvlite::build_nextest_unit_tests 5
+      $(FLOWEY_BIN) e 14 flowey_lib_common::publish_test_results 9
+      $(FLOWEY_BIN) e 14 flowey_lib_common::ado_task_publish_test_results 2
+      $(FLOWEY_BIN) e 14 flowey_lib_common::publish_test_results 8
+      $FLOWEY_BIN v 14 'flowey_lib_common::ado_task_publish_test_results:2:flowey_lib_common/src/ado_task_publish_test_results.rs:57:45' --is-raw-string --condvar flowey_lib_common::publish_test_results:20:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env ado floweyvar2
+      $FLOWEY_BIN v 14 'flowey_lib_common::publish_test_results:20:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env ado FLOWEY_CONDITION
+    displayName: run 'unit-tests crypto (all)' nextest tests
+  - task: PublishTestResults@2
+    inputs:
+      testResultsFormat: JUnit
+      testResultsFiles: $(floweyvar2)
+      testRunTitle: x64-linux-unit-tests-unit-tests crypto (all)
+    displayName: 'publish test results: x64-linux-unit-tests-unit-tests crypto (all) (JUnit XML)'
     condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
   - bash: |-
       set -e
@@ -698,18 +764,18 @@ jobs:
     displayName: split debug symbols
   - bash: $(FLOWEY_BIN) e 14 flowey_lib_hvlite::build_nextest_unit_tests 0
     displayName: determine unit test exclusions
-  - bash: $(FLOWEY_BIN) e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 3
+  - bash: $(FLOWEY_BIN) e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 4
     displayName: generate nextest command
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 14 flowey_lib_common::run_cargo_nextest_run 6
-      $(FLOWEY_BIN) e 14 flowey_lib_common::run_cargo_nextest_run 7
+      $(FLOWEY_BIN) e 14 flowey_lib_common::run_cargo_nextest_run 8
+      $(FLOWEY_BIN) e 14 flowey_lib_common::run_cargo_nextest_run 9
       $(FLOWEY_BIN) e 14 flowey_lib_hvlite::build_nextest_unit_tests 1
-      $(FLOWEY_BIN) e 14 flowey_lib_common::publish_test_results 7
+      $(FLOWEY_BIN) e 14 flowey_lib_common::publish_test_results 1
       $(FLOWEY_BIN) e 14 flowey_lib_common::ado_task_publish_test_results 0
-      $(FLOWEY_BIN) e 14 flowey_lib_common::publish_test_results 6
-      $FLOWEY_BIN v 14 'flowey_lib_common::ado_task_publish_test_results:0:flowey_lib_common/src/ado_task_publish_test_results.rs:57:45' --is-raw-string --condvar flowey_lib_common::publish_test_results:15:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env ado floweyvar1
-      $FLOWEY_BIN v 14 'flowey_lib_common::publish_test_results:15:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env ado FLOWEY_CONDITION
+      $(FLOWEY_BIN) e 14 flowey_lib_common::publish_test_results 0
+      $FLOWEY_BIN v 14 'flowey_lib_common::ado_task_publish_test_results:0:flowey_lib_common/src/ado_task_publish_test_results.rs:57:45' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env ado floweyvar1
+      $FLOWEY_BIN v 14 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env ado FLOWEY_CONDITION
     displayName: run 'unit-tests' nextest tests
   - task: PublishTestResults@2
     inputs:
@@ -718,49 +784,29 @@ jobs:
       testRunTitle: x64-linux-unit-tests-unit-tests
     displayName: 'publish test results: x64-linux-unit-tests-unit-tests (JUnit XML)'
     condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
-  - bash: $(FLOWEY_BIN) e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+  - bash: $(FLOWEY_BIN) e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 1
     displayName: generate nextest command
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 14 flowey_lib_common::run_cargo_nextest_run 0
-      $(FLOWEY_BIN) e 14 flowey_lib_common::run_cargo_nextest_run 1
+      $(FLOWEY_BIN) e 14 flowey_lib_common::run_cargo_nextest_run 2
+      $(FLOWEY_BIN) e 14 flowey_lib_common::run_cargo_nextest_run 3
       $(FLOWEY_BIN) e 14 flowey_lib_hvlite::build_nextest_unit_tests 2
-      $(FLOWEY_BIN) e 14 flowey_lib_common::publish_test_results 1
-      $(FLOWEY_BIN) e 14 flowey_lib_common::ado_task_publish_test_results 2
-      $(FLOWEY_BIN) e 14 flowey_lib_common::publish_test_results 0
-      $FLOWEY_BIN v 14 'flowey_lib_common::ado_task_publish_test_results:2:flowey_lib_common/src/ado_task_publish_test_results.rs:57:45' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env ado floweyvar2
-      $FLOWEY_BIN v 14 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env ado FLOWEY_CONDITION
+      $(FLOWEY_BIN) e 14 flowey_lib_common::publish_test_results 3
+      $(FLOWEY_BIN) e 14 flowey_lib_common::ado_task_publish_test_results 4
+      $(FLOWEY_BIN) e 14 flowey_lib_common::publish_test_results 2
+      $FLOWEY_BIN v 14 'flowey_lib_common::ado_task_publish_test_results:4:flowey_lib_common/src/ado_task_publish_test_results.rs:57:45' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env ado floweyvar3
+      $FLOWEY_BIN v 14 'flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env ado FLOWEY_CONDITION
     displayName: run 'unit-tests crypto (native)' nextest tests
   - task: PublishTestResults@2
     inputs:
       testResultsFormat: JUnit
-      testResultsFiles: $(floweyvar2)
+      testResultsFiles: $(floweyvar3)
       testRunTitle: x64-linux-unit-tests-unit-tests crypto (native)
     displayName: 'publish test results: x64-linux-unit-tests-unit-tests crypto (native) (JUnit XML)'
     condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
-  - bash: $(FLOWEY_BIN) e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 2
-    displayName: generate nextest command
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 14 flowey_lib_common::run_cargo_nextest_run 4
-      $(FLOWEY_BIN) e 14 flowey_lib_common::run_cargo_nextest_run 5
-      $(FLOWEY_BIN) e 14 flowey_lib_hvlite::build_nextest_unit_tests 3
-      $(FLOWEY_BIN) e 14 flowey_lib_common::publish_test_results 3
-      $(FLOWEY_BIN) e 14 flowey_lib_common::ado_task_publish_test_results 6
-      $(FLOWEY_BIN) e 14 flowey_lib_common::publish_test_results 2
-      $FLOWEY_BIN v 14 'flowey_lib_common::ado_task_publish_test_results:6:flowey_lib_common/src/ado_task_publish_test_results.rs:57:45' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env ado floweyvar4
-      $FLOWEY_BIN v 14 'flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env ado FLOWEY_CONDITION
-    displayName: run 'unit-tests crypto (rust)' nextest tests
-  - task: PublishTestResults@2
-    inputs:
-      testResultsFormat: JUnit
-      testResultsFiles: $(floweyvar4)
-      testRunTitle: x64-linux-unit-tests-unit-tests crypto (rust)
-    displayName: 'publish test results: x64-linux-unit-tests-unit-tests crypto (rust) (JUnit XML)'
-    condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 14 flowey_lib_hvlite::build_nextest_unit_tests 5
+      $(FLOWEY_BIN) e 14 flowey_lib_hvlite::build_nextest_unit_tests 6
       $(FLOWEY_BIN) e 14 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
     displayName: report test results to overall pipeline status
   - bash: $(FLOWEY_BIN) e 14 flowey_lib_hvlite::_jobs::build_and_run_doc_tests 0

--- a/flowey/flowey_lib_hvlite/src/_jobs/check_clippy.rs
+++ b/flowey/flowey_lib_hvlite/src/_jobs/check_clippy.rs
@@ -142,8 +142,7 @@ impl SimpleFlowNode for Node {
                 let repo_path = rt.read(repo_path);
 
                 // guest_test_uefi is uefi-only, and is handled separately below
-                // crypto is handled separately in order to deal with its non-additive features
-                let mut exclude = vec!["guest_test_uefi".into(), "crypto".into()];
+                let mut exclude = vec!["guest_test_uefi".into()];
 
                 // packages depending on libfuzzer-sys are currently x86 only
                 if !(matches!(target.architecture, target_lexicon::Architecture::X86_64)
@@ -205,12 +204,12 @@ impl SimpleFlowNode for Node {
         })];
 
         // crypto has non-additive features, we need to ensure full coverage of different backends.
-        // Always test the 'native' no-feature backends.
+        // Always test the 'native' backends.
         reqs.push(ctx.reqv(|v| flowey_lib_common::run_cargo_clippy::Request {
             in_folder: openvmm_repo_path.clone(),
             package: CargoPackage::Crate("crypto".into()),
             profile: profile.clone(),
-            features: CargoFeatureSet::None,
+            features: CargoFeatureSet::Specific(vec!["native".into()]),
             target: target.clone(),
             extra_env: None,
             exclude: ReadVar::from_static(None),

--- a/flowey/flowey_lib_hvlite/src/_jobs/check_clippy.rs
+++ b/flowey/flowey_lib_hvlite/src/_jobs/check_clippy.rs
@@ -269,6 +269,19 @@ impl SimpleFlowNode for Node {
                     done: v,
                 }));
             }
+            reqs.push(ctx.reqv(|v| flowey_lib_common::run_cargo_clippy::Request {
+                in_folder: openvmm_repo_path.clone(),
+                package: CargoPackage::Crate("crypto".into()),
+                profile: profile.clone(),
+                features: CargoFeatureSet::All,
+                target: target.clone(),
+                extra_env: None,
+                exclude: ReadVar::from_static(None),
+                keep_going: true,
+                all_targets: true,
+                pre_build_deps: pre_build_deps.clone(),
+                done: v,
+            }));
         }
 
         if also_check_misc_nostd_crates {

--- a/flowey/flowey_lib_hvlite/src/_jobs/check_clippy.rs
+++ b/flowey/flowey_lib_hvlite/src/_jobs/check_clippy.rs
@@ -269,19 +269,6 @@ impl SimpleFlowNode for Node {
                     done: v,
                 }));
             }
-            reqs.push(ctx.reqv(|v| flowey_lib_common::run_cargo_clippy::Request {
-                in_folder: openvmm_repo_path.clone(),
-                package: CargoPackage::Crate("crypto".into()),
-                profile: profile.clone(),
-                features: CargoFeatureSet::All,
-                target: target.clone(),
-                extra_env: None,
-                exclude: ReadVar::from_static(None),
-                keep_going: true,
-                all_targets: true,
-                pre_build_deps: pre_build_deps.clone(),
-                done: v,
-            }));
         }
 
         if also_check_misc_nostd_crates {

--- a/flowey/flowey_lib_hvlite/src/build_nextest_unit_tests.rs
+++ b/flowey/flowey_lib_hvlite/src/build_nextest_unit_tests.rs
@@ -203,7 +203,7 @@ impl FlowNode for Node {
             // crypto has non-additive features, so it gets its own runs to
             // ensure full coverage of different backends. Always test the
             // native and pure-rust backends. On linux additionally test
-            // the openssl & symcrypt backends.
+            // the openssl & symcrypt backends and --all-features fallback.
             // We could test openssl on non-linux targets too, but setting up
             // builds for them is a pain. We could test Symcrypt on non-musl
             // linux targets too, but we don't currently have a prebuilt
@@ -225,6 +225,7 @@ impl FlowNode for Node {
                         CargoFeatureSet::Specific(vec!["symcrypt".into()]),
                     ));
                 }
+                crypto_feature_sets.push(("all", CargoFeatureSet::All));
             }
             for (name, features) in crypto_feature_sets {
                 runs.push((

--- a/flowey/flowey_lib_hvlite/src/build_nextest_unit_tests.rs
+++ b/flowey/flowey_lib_hvlite/src/build_nextest_unit_tests.rs
@@ -105,8 +105,6 @@ impl FlowNode for Node {
                     "vmm_tests",
                     // Skip guest_test_uefi, as it's a no_std UEFI crate
                     "guest_test_uefi",
-                    // Skip crypto, handle it separately due to its non-additive features
-                    "crypto",
                     // Exclude various proc_macro crates, since they don't compile successfully
                     // under --test with panic=abort targets.
                     // https://github.com/rust-lang/cargo/issues/4336 is tracking this.
@@ -198,20 +196,20 @@ impl FlowNode for Node {
                 extra_env: injected_env,
             };
 
-            // The first run is the main workspace run with --all-features.
+            // The first run is the main workspace run with the base features.
             let mut runs: Vec<(String, NextestBuildParams)> =
                 vec![("unit-tests".into(), base_build_params.clone())];
 
             // crypto has non-additive features, so it gets its own runs to
             // ensure full coverage of different backends. Always test the
-            // 'native' no-feature and pure-rust backends. On linux additionally
-            // test the openssl & symcrypt backends and --all-features fallback.
+            // native and pure-rust backends. On linux additionally test
+            // the openssl & symcrypt backends and --all-features fallback.
             // We could test openssl on non-linux targets too, but setting up
             // builds for them is a pain. We could test Symcrypt on non-musl
             // linux targets too, but we don't currently have a prebuilt
             // library for them.
             let mut crypto_feature_sets = vec![
-                ("none", CargoFeatureSet::None),
+                ("native", CargoFeatureSet::Specific(vec!["native".into()])),
                 ("rust", CargoFeatureSet::Specific(vec!["rust".into()])),
             ];
             if matches!(

--- a/flowey/flowey_lib_hvlite/src/build_nextest_unit_tests.rs
+++ b/flowey/flowey_lib_hvlite/src/build_nextest_unit_tests.rs
@@ -203,7 +203,7 @@ impl FlowNode for Node {
             // crypto has non-additive features, so it gets its own runs to
             // ensure full coverage of different backends. Always test the
             // native and pure-rust backends. On linux additionally test
-            // the openssl & symcrypt backends and --all-features fallback.
+            // the openssl & symcrypt backends.
             // We could test openssl on non-linux targets too, but setting up
             // builds for them is a pain. We could test Symcrypt on non-musl
             // linux targets too, but we don't currently have a prebuilt
@@ -225,7 +225,6 @@ impl FlowNode for Node {
                         CargoFeatureSet::Specific(vec!["symcrypt".into()]),
                     ));
                 }
-                crypto_feature_sets.push(("all", CargoFeatureSet::All));
             }
             for (name, features) in crypto_feature_sets {
                 runs.push((

--- a/openhcl/openvmm_hcl/Cargo.toml
+++ b/openhcl/openvmm_hcl/Cargo.toml
@@ -34,6 +34,10 @@ dev_snp_ohcl_tio_support = ["underhill_entry/dev_snp_ohcl_tio_support"]
 underhill_entry.workspace = true
 openvmm_hcl_resources.workspace = true
 tracing.workspace = true
+crypto = { workspace = true, features = ["openssl"] }
+# OpenVMM-HCL only needs libcrypto from openssl, not libssl; see the
+# `openssl_crypto_only!()` invocation in `src/main.rs`.
+openssl_crypto_only.workspace = true
 
 [package.metadata.xtask.unused-deps]
 ignored = ["tracing"] # Present to specify features from flowey

--- a/openhcl/openvmm_hcl/Cargo.toml
+++ b/openhcl/openvmm_hcl/Cargo.toml
@@ -35,8 +35,7 @@ underhill_entry.workspace = true
 openvmm_hcl_resources.workspace = true
 tracing.workspace = true
 crypto = { workspace = true, features = ["openssl"] }
-# OpenVMM-HCL only needs libcrypto from openssl, not libssl; see the
-# `openssl_crypto_only!()` invocation in `src/main.rs`.
+# OpenVMM-HCL only needs libcrypto from openssl
 openssl_crypto_only.workspace = true
 
 [package.metadata.xtask.unused-deps]

--- a/openhcl/openvmm_hcl/src/main.rs
+++ b/openhcl/openvmm_hcl/src/main.rs
@@ -9,6 +9,13 @@
 #[cfg(target_os = "linux")]
 use openvmm_hcl_resources as _;
 
+// OpenVMM-HCL only needs libcrypto from openssl, not libssl.
+#[cfg(target_os = "linux")]
+openssl_crypto_only::openssl_crypto_only!();
+
+#[cfg(all(not(test), target_os = "linux"))]
+crypto::ensure_single_backend!();
+
 #[cfg(not(target_os = "linux"))]
 fn main() {
     unimplemented!("openvmm_hcl only runs on Linux");

--- a/openhcl/underhill_core/Cargo.toml
+++ b/openhcl/underhill_core/Cargo.toml
@@ -142,7 +142,6 @@ x86defs.workspace = true
 safe_intrinsics.workspace = true
 debug_ptr.workspace = true
 guid.workspace = true
-crypto = { workspace = true, features = ["openssl"] }
 inspect.workspace = true
 kmsg.workspace = true
 local_clock.workspace = true
@@ -198,7 +197,3 @@ build_rs_guest_arch.workspace = true
 
 [lints]
 workspace = true
-
-[package.metadata.xtask.unused-deps]
-# keep the crypto dep so we can specify the vendored and openssl features
-ignored = ["crypto"]

--- a/openhcl/underhill_entry/Cargo.toml
+++ b/openhcl/underhill_entry/Cargo.toml
@@ -34,8 +34,6 @@ underhill_init.workspace = true
 underhill_crash.workspace = true
 underhill_dump.workspace = true
 
-openssl_crypto_only.workspace = true
-
 anyhow.workspace = true
 fast_memcpy = { workspace = true, features = ["replace_system_memcpy"] }
 mimalloc.workspace = true

--- a/openhcl/underhill_entry/src/lib.rs
+++ b/openhcl/underhill_entry/src/lib.rs
@@ -22,10 +22,6 @@ static GLOBAL: dhat::Alloc = dhat::Alloc;
 #[cfg(target_arch = "x86_64")]
 use fast_memcpy as _;
 
-// OpenVMM-HCL only needs libcrypto from openssl, not libssl.
-#[cfg(target_os = "linux")]
-openssl_crypto_only::openssl_crypto_only!();
-
 /// Entry point into the underhill multi-binary, dispatching between various
 /// entrypoints based on argv0.
 pub fn underhill_main() -> anyhow::Result<()> {

--- a/openvmm/openvmm/Cargo.toml
+++ b/openvmm/openvmm/Cargo.toml
@@ -21,7 +21,7 @@ default = [
 
 # see the `openvmm_entry` crate for more info on these features
 gdb = ["openvmm_resources/gdb"]
-vendored_crypto = ["openvmm_entry/vendored_crypto"]
+vendored_crypto = ["crypto/vendored"]
 tpm = ["openvmm_resources/tpm"]
 virt_hvf = ["openvmm_resources/virt_hvf", "openvmm_hypervisors/virt_hvf"]
 virt_kvm = ["openvmm_resources/virt_kvm", "openvmm_hypervisors/virt_kvm"]
@@ -39,6 +39,7 @@ disklayer_sqlite = ["openvmm_resources/disklayer_sqlite"]
 openvmm_entry.workspace = true
 openvmm_hypervisors.workspace = true
 openvmm_resources.workspace = true
+crypto = { workspace = true, features = ["native"] }
 
 [build-dependencies]
 embed-resource.workspace = true

--- a/openvmm/openvmm/src/main.rs
+++ b/openvmm/openvmm/src/main.rs
@@ -9,6 +9,9 @@
 extern crate openvmm_hypervisors as _;
 extern crate openvmm_resources as _;
 
+#[cfg(not(test))]
+crypto::ensure_single_backend!();
+
 fn main() {
     openvmm_entry::openvmm_main()
 }

--- a/openvmm/openvmm_entry/Cargo.toml
+++ b/openvmm/openvmm_entry/Cargo.toml
@@ -9,8 +9,6 @@ rust-version.workspace = true
 [features]
 default = ["ttrpc", "grpc"]
 
-vendored_crypto = ["crypto/vendored"]
-
 grpc = ["mesh_rpc/grpc"]
 ttrpc = []
 
@@ -66,7 +64,6 @@ pcie_remote_resources.workspace = true
 
 clap_dyn_complete.workspace = true
 console_relay.workspace = true
-crypto = { workspace = true, features = ["native"] }
 guid.workspace = true
 inspect.workspace = true
 inspect_proto.workspace = true
@@ -121,7 +118,3 @@ build_rs_guest_arch.workspace = true
 
 [lints]
 workspace = true
-
-[package.metadata.xtask.unused-deps]
-# keep the crypto dep so we can specify the vendored and backend features
-ignored = ["crypto"]

--- a/openvmm/openvmm_entry/Cargo.toml
+++ b/openvmm/openvmm_entry/Cargo.toml
@@ -66,7 +66,7 @@ pcie_remote_resources.workspace = true
 
 clap_dyn_complete.workspace = true
 console_relay.workspace = true
-crypto = { workspace = true, optional = true }
+crypto = { workspace = true, features = ["native"] }
 guid.workspace = true
 inspect.workspace = true
 inspect_proto.workspace = true
@@ -123,5 +123,5 @@ build_rs_guest_arch.workspace = true
 workspace = true
 
 [package.metadata.xtask.unused-deps]
-# keep the crypto dep so we can specify the vendored feature
+# keep the crypto dep so we can specify the vendored and backend features
 ignored = ["crypto"]

--- a/support/crypto/Cargo.toml
+++ b/support/crypto/Cargo.toml
@@ -15,12 +15,17 @@ test_helpers = ["x509-cert?/builder"]
 # If the chosen backend is not natively available and can't be vendored, this will trigger a compile error.
 vendored = ["openssl?/vendored"]
 
-# Use OpenSSL instead of any native backend.
+# Use the native crypto backend (OpenSSL on Linux).
+# TODO: It'd be nice if the dependencies needed for the native backends didn't get built unconditionally,
+# but Cargo doesn't provide a way to conditionally include dependencies for specific targets based on features.
+native = []
+
+# Use OpenSSL.
 openssl = ["dep:openssl", "dep:openssl_kdf"]
 
-# Use Symcrypt instead of any native backend.
+# Use Symcrypt.
 # Note that the symcrypt backend does not support vendoring, enabling both
-# `symcrypt` and `vendored` will trigger a compile error
+# `symcrypt` and `vendored` will trigger a compile error.
 symcrypt = [
     "dep:symcrypt",
     "symcrypt/sha1",
@@ -33,7 +38,7 @@ symcrypt = [
     "dep:x509-cert",
 ]
 
-# Use RustCrypto crates instead of any native backend.
+# Use RustCrypto crates.
 # Note that some of these crates have known security issues.
 # This backend should not be used in production scenarios.
 rust = [

--- a/support/crypto/build.rs
+++ b/support/crypto/build.rs
@@ -57,6 +57,9 @@ fn main() {
         } else {
             println!("cargo::rustc-cfg=native");
         }
+        println!(
+            "cargo::warning=Multiple crypto backends enabled. This will cause a link-time error."
+        );
         println!("cargo::rustc-cfg=multi_backend");
     }
 }

--- a/support/crypto/build.rs
+++ b/support/crypto/build.rs
@@ -4,6 +4,7 @@
 #![expect(missing_docs)]
 
 fn main() {
+    println!("cargo::rerun-if-env-changed=CARGO_FEATURE_NATIVE");
     println!("cargo::rerun-if-env-changed=CARGO_FEATURE_OPENSSL");
     println!("cargo::rerun-if-env-changed=CARGO_FEATURE_RUST");
     println!("cargo::rerun-if-env-changed=CARGO_FEATURE_SYMCRYPT");
@@ -14,42 +15,48 @@ fn main() {
     println!("cargo::rustc-check-cfg=cfg(openssl)");
     println!("cargo::rustc-check-cfg=cfg(rust)");
     println!("cargo::rustc-check-cfg=cfg(symcrypt)");
+    println!("cargo::rustc-check-cfg=cfg(multi_backend)");
 
+    let linux = std::env::var("CARGO_CFG_TARGET_OS").unwrap() == "linux";
+
+    let native = std::env::var_os("CARGO_FEATURE_NATIVE").is_some();
     let openssl = std::env::var_os("CARGO_FEATURE_OPENSSL").is_some();
     let rust = std::env::var_os("CARGO_FEATURE_RUST").is_some();
     let symcrypt = std::env::var_os("CARGO_FEATURE_SYMCRYPT").is_some();
     let vendored = std::env::var_os("CARGO_FEATURE_VENDORED").is_some();
-    let linux = std::env::var("CARGO_CFG_TARGET_OS").unwrap() == "linux";
 
-    let all_features = openssl && rust && symcrypt && vendored;
-    let backend_count = openssl as u8 + rust as u8 + symcrypt as u8;
+    let backend_count = openssl as u8 + rust as u8 + symcrypt as u8 + native as u8;
 
-    // If we see multiple backends enabled that's an error. However if we see every
-    // backend, and vendoring, enabled, it's likely we're in an --all-features session.
-    // Since this is a common rust-analyzer configuration, allow it and fall back to
-    // platform defaults.
-    if backend_count > 1 && !all_features {
-        panic!("Multiple crypto backends enabled, but only one can be selected");
-    } else if backend_count == 0 || all_features {
-        // Default to openssl on linux, the dependencies are also marked
-        // non-optional and there is no native backend available
+    // If no backends are enabled, abort. Binaries must choose a backend.
+    if backend_count == 0 {
+        panic!("No crypto backend enabled. Enable one in your binary's dependencies.");
+    }
+    // If exactly one backend is enabled, use it.
+    else if backend_count == 1 {
+        if openssl {
+            println!("cargo::rustc-cfg=openssl");
+        } else if symcrypt {
+            if vendored {
+                panic!("The symcrypt backend does not support vendoring");
+            }
+            println!("cargo::rustc-cfg=symcrypt");
+        } else if rust {
+            println!("cargo::rustc-cfg=rust");
+        } else if native && linux {
+            println!("cargo::rustc-cfg=openssl");
+        } else if native && !linux {
+            println!("cargo::rustc-cfg=native");
+        }
+    }
+    // If multiple backends are enabled, fall back to the native backend so that
+    // operations like `cargo check --workspace` can succeed, but emit a warning
+    // and a cfg that will cause our link-time check to fail.
+    else {
         if linux {
             println!("cargo::rustc-cfg=openssl");
         } else {
             println!("cargo::rustc-cfg=native");
         }
-    }
-    // Symcrypt does not support vendoring, so fail early if the user tries to
-    // enable both the symcrypt backend and the vendored feature.
-    else if vendored && symcrypt {
-        panic!("The symcrypt backend does not support vendoring");
-    }
-    // Output a single config flag to indicate which backend should be used.
-    else if openssl {
-        println!("cargo::rustc-cfg=openssl");
-    } else if symcrypt {
-        println!("cargo::rustc-cfg=symcrypt");
-    } else if rust {
-        println!("cargo::rustc-cfg=rust");
+        println!("cargo::rustc-cfg=multi_backend");
     }
 }

--- a/support/crypto/build.rs
+++ b/support/crypto/build.rs
@@ -15,7 +15,7 @@ fn main() {
     println!("cargo::rustc-check-cfg=cfg(openssl)");
     println!("cargo::rustc-check-cfg=cfg(rust)");
     println!("cargo::rustc-check-cfg=cfg(symcrypt)");
-    println!("cargo::rustc-check-cfg=cfg(multi_backend)");
+    println!("cargo::rustc-check-cfg=cfg(single_backend)");
 
     let linux = std::env::var("CARGO_CFG_TARGET_OS").unwrap() == "linux";
 
@@ -27,11 +27,21 @@ fn main() {
 
     let backend_count = openssl as u8 + rust as u8 + symcrypt as u8 + native as u8;
 
-    // If no backends are enabled, abort. Binaries must choose a backend.
-    if backend_count == 0 {
-        panic!("No crypto backend enabled. Enable one in your binary's dependencies.");
+    // If no or multiple backends are enabled, fall back to the native backend
+    // so that operations like `cargo check` and `cargo test` can succeed, but
+    // emit a warning.
+    if backend_count != 1 {
+        if linux {
+            println!("cargo::rustc-cfg=openssl");
+        } else {
+            println!("cargo::rustc-cfg=native");
+        }
+        println!(
+            "cargo::warning=No or multiple crypto backends enabled. This may cause a link-time error."
+        );
     }
-    // If exactly one backend is enabled, use it.
+    // If exactly one backend is enabled, use it and emit the `single_backend`
+    // cfg for link-time checking.
     else if backend_count == 1 {
         if openssl {
             println!("cargo::rustc-cfg=openssl");
@@ -47,19 +57,6 @@ fn main() {
         } else if native && !linux {
             println!("cargo::rustc-cfg=native");
         }
-    }
-    // If multiple backends are enabled, fall back to the native backend so that
-    // operations like `cargo check --workspace` can succeed, but emit a warning
-    // and a cfg that will cause our link-time check to fail.
-    else {
-        if linux {
-            println!("cargo::rustc-cfg=openssl");
-        } else {
-            println!("cargo::rustc-cfg=native");
-        }
-        println!(
-            "cargo::warning=Multiple crypto backends enabled. This will cause a link-time error."
-        );
-        println!("cargo::rustc-cfg=multi_backend");
+        println!("cargo::rustc-cfg=single_backend");
     }
 }

--- a/support/crypto/src/lib.rs
+++ b/support/crypto/src/lib.rs
@@ -10,25 +10,50 @@
 //! It is explicitly specialized for the needs of the OpenVMM project and is
 //! not suitable for general-purpose use.
 
-// UNSAFETY: calling BCrypt APIs on Windows, Security.framework APIs on macOS.
+// UNSAFETY: calling BCrypt APIs on Windows, Security.framework APIs on macOS,
+// and defining/referencing an extern symbol for the backend-selection
+// link-time check.
 #![allow(unsafe_code)]
 
-// When multiple crypto backends are enabled at once (typically via Cargo
-// feature unification across the workspace), `cargo check` is allowed to
-// succeed so that workspace-wide checks aren't blocked, but linking must
-// fail with a clear message. We achieve this by referencing an undefined
-// extern symbol from a `#[used]` static, which `cargo check` ignores
-// (it doesn't link) but `cargo build` resolves and fails on with an
-// unresolved-symbol error naming the symbol below.
-#[cfg(multi_backend)]
-const _: () = {
-    unsafe extern "C" {
-        fn __openvmm_crypto_multiple_backends_enabled__enable_exactly_one__see_support_crypto();
-    }
-    #[used]
-    static _FORCE_LINK_ERROR: unsafe extern "C" fn() =
-        __openvmm_crypto_multiple_backends_enabled__enable_exactly_one__see_support_crypto;
-};
+// Backend-selection link-time check.
+//
+// The build script lets compilation of this crate succeed even when the
+// crate's features add up to zero or multiple backends (which will
+// easily happen as a side effect of feature unification across a workspace
+// or when testing a crate that transitively depends on `crypto` without
+// itself picking a backend). To still guarantee that a *shipping binary*
+// has linked exactly one backend, we expose a check that each binary opts
+// into via the [`ensure_single_backend`] macro.
+//
+// The check works by having the binary place a `#[used]` reference to an
+// extern symbol whose definition lives in this crate, and is only emitted
+// when exactly one backend is selected. If zero or multiple backends are
+// selected the symbol is undefined and linking the binary fails with a
+// clear, named symbol.
+
+#[cfg(single_backend)]
+#[unsafe(no_mangle)]
+extern "C" fn __openvmm_crypto_ensure_single_backend__enable_exactly_one__see_support_crypto() {}
+
+/// Emit a `#[used]` reference to a symbol that is only defined when the
+/// `crypto` crate was built with exactly one backend selected. Place a call
+/// to this macro in each binary that depends on `crypto` (typically gated on
+/// `#[cfg(not(test))]`) so that workspace-wide `cargo test` still succeeds,
+/// while a misconfigured binary fails at link time with an unresolved-symbol
+/// error pointing at the missing/conflicting backend.
+#[macro_export]
+macro_rules! ensure_single_backend {
+    () => {
+        const _: () = {
+            unsafe extern "C" {
+                fn __openvmm_crypto_ensure_single_backend__enable_exactly_one__see_support_crypto();
+            }
+            #[used]
+            static _CRYPTO_BACKEND_LINK_CHECK: unsafe extern "C" fn() =
+                __openvmm_crypto_ensure_single_backend__enable_exactly_one__see_support_crypto;
+        };
+    };
+}
 
 pub mod aes_256_cbc;
 pub mod aes_256_gcm;

--- a/support/crypto/src/lib.rs
+++ b/support/crypto/src/lib.rs
@@ -13,6 +13,23 @@
 // UNSAFETY: calling BCrypt APIs on Windows, Security.framework APIs on macOS.
 #![allow(unsafe_code)]
 
+// When multiple crypto backends are enabled at once (typically via Cargo
+// feature unification across the workspace), `cargo check` is allowed to
+// succeed so that workspace-wide checks aren't blocked, but linking must
+// fail with a clear message. We achieve this by referencing an undefined
+// extern symbol from a `#[used]` static, which `cargo check` ignores
+// (it doesn't link) but `cargo build` resolves and fails on with an
+// unresolved-symbol error naming the symbol below.
+#[cfg(multi_backend)]
+const _: () = {
+    unsafe extern "C" {
+        fn __openvmm_crypto_multiple_backends_enabled__enable_exactly_one__see_support_crypto();
+    }
+    #[used]
+    static _FORCE_LINK_ERROR: unsafe extern "C" fn() =
+        __openvmm_crypto_multiple_backends_enabled__enable_exactly_one__see_support_crypto;
+};
+
 pub mod aes_256_cbc;
 pub mod aes_256_gcm;
 pub mod aes_kwp;

--- a/vm/devices/firmware/firmware_uefi/fuzz/Cargo.toml
+++ b/vm/devices/firmware/firmware_uefi/fuzz/Cargo.toml
@@ -9,7 +9,7 @@ rust-version.workspace = true
 
 [target.'cfg(all(target_os = "linux", target_env = "gnu"))'.dependencies]
 arbitrary = { workspace = true, features = ["derive"] }
-crypto = { workspace = true, features = ["test_helpers", "vendored"] }
+crypto = { workspace = true, features = ["test_helpers", "rust"] }
 firmware_uefi = { workspace = true, features = ["fuzzing"] }
 firmware_uefi_resources.workspace = true
 guid.workspace = true

--- a/vm/vmgs/vmgs_lib/Cargo.toml
+++ b/vm/vmgs/vmgs_lib/Cargo.toml
@@ -19,7 +19,3 @@ vmgs = { workspace = true, features = ["encryption"] }
 
 [lints]
 workspace = true
-
-[package.metadata.xtask.unused-deps]
-# keep the crypto dep so we can specify the vendored feature
-ignored = ["crypto"]

--- a/vm/vmgs/vmgs_lib/Cargo.toml
+++ b/vm/vmgs/vmgs_lib/Cargo.toml
@@ -10,7 +10,7 @@ rust-version.workspace = true
 crate-type = ["cdylib"]
 
 [dependencies]
-crypto = { workspace = true, features = ["vendored"] }
+crypto = { workspace = true, features = ["native", "vendored"] }
 disk_backend.workspace = true
 disk_vhd1.workspace = true
 futures.workspace = true

--- a/vm/vmgs/vmgs_lib/src/lib.rs
+++ b/vm/vmgs/vmgs_lib/src/lib.rs
@@ -8,6 +8,9 @@
 #![expect(unsafe_code)]
 #![expect(missing_docs)]
 
+#[cfg(not(test))]
+crypto::ensure_single_backend!();
+
 use core::slice;
 use disk_backend::Disk;
 use disk_vhd1::Vhd1Disk;

--- a/vm/vmgs/vmgstool/Cargo.toml
+++ b/vm/vmgs/vmgstool/Cargo.toml
@@ -49,7 +49,3 @@ tempfile.workspace = true
 
 [lints]
 workspace = true
-
-[package.metadata.xtask.unused-deps]
-# keep the crypto dep so we can specify the vendored feature
-ignored = ["crypto"]

--- a/vm/vmgs/vmgstool/Cargo.toml
+++ b/vm/vmgs/vmgstool/Cargo.toml
@@ -10,7 +10,7 @@ rust-version.workspace = true
 [features]
 default = []
 
-encryption = ["vmgs/encryption", "crypto/vendored"]
+encryption = ["vmgs/encryption", "crypto/native", "crypto/vendored"]
 
 test_helpers = ["vmgs/test_helpers", "getrandom", "dep:resource_dll_parser"]
 

--- a/vm/vmgs/vmgstool/src/main.rs
+++ b/vm/vmgs/vmgstool/src/main.rs
@@ -4,6 +4,9 @@
 #![forbid(unsafe_code)]
 #![expect(missing_docs)]
 
+#[cfg(all(not(test), feature = "encryption"))]
+crypto::ensure_single_backend!();
+
 // The version in this crate's Cargo.toml file should be updated using the
 // semver standard when changes are made, which triggers CI to automatically
 // publish a new version.

--- a/xtask/src/tasks/fuzz/html_coverage.rs
+++ b/xtask/src/tasks/fuzz/html_coverage.rs
@@ -89,7 +89,6 @@ pub(super) fn generate_html_coverage_report(
             .arg("-object")
             .arg(&coverage_bin)
             .args(["--ignore-filename-regex", "rustc"])
-            .args(["--ignore-filename-regex", "openssl-sys"])
             .stdout(std::process::Stdio::from(lcov_output))
             .spawn()?;
         if !cmd.wait()?.success() {


### PR DESCRIPTION
With this PR I'm trying to thread the needle between two slightly contradictory goals:

- A shipping binary should have a strong guarantee that it has linked in the crypto backend it expects
- Developers should have minimal friction when performing workspace-wide operations, despite binaries asking for disparate crypto backends

To accomplish this I've come up with the following protocol:

- crypto's build script will enforce that either a single backend is chosen, or linking will fail. This allows `cargo check` to always succeed, but `cargo build` in a multi-backend situation will fail.

I'm hoping that this flow will allow all common developer commands to continue working, while ensuring that we don't accidentally produce an insecure binary. As the new linking error is not the greatest user experience, a guide page has also been added to help clarify it.