### PR TITLE
net_consomme: support dynamic host ports

### DIFF
--- a/openvmm/openvmm_entry/src/lib.rs
+++ b/openvmm/openvmm_entry/src/lib.rs
@@ -1872,7 +1872,7 @@ fn parse_endpoint(
                         host_address: fwd
                             .host_address
                             .map(net_backend_resources::consomme::HostIpAddress::from),
-                        host_port: fwd.host_port,
+                        host_port: net_backend_resources::consomme::HostPort::Fixed(fwd.host_port),
                         guest_port: fwd.guest_port,
                     }
                 })

--- a/vm/devices/net/net_backend_resources/src/lib.rs
+++ b/vm/devices/net/net_backend_resources/src/lib.rs
@@ -67,15 +67,25 @@ pub mod consomme {
         }
     }
 
+    /// The host port to listen on for a port forward.
+    #[derive(Debug, MeshPayload)]
+    pub enum HostPort {
+        /// A fixed host port.
+        Fixed(u16),
+        /// Let the OS assign a port. The assigned port is sent back via the
+        /// oneshot sender.
+        Dynamic(mesh::OneshotSender<u16>),
+    }
+
     /// Configuration for forwarding a host port into the guest.
-    #[derive(Clone, Debug, MeshPayload)]
+    #[derive(Debug, MeshPayload)]
     pub struct HostPortConfig {
         /// The protocol to forward.
         pub protocol: HostPortProtocol,
         /// The host IP address to bind to, or `None` to bind to all interfaces.
         pub host_address: Option<HostIpAddress>,
         /// The host port to listen on.
-        pub host_port: u16,
+        pub host_port: HostPort,
         /// The guest port to forward to.
         pub guest_port: u16,
     }

--- a/vm/devices/net/net_consomme/src/resolver.rs
+++ b/vm/devices/net/net_consomme/src/resolver.rs
@@ -9,6 +9,7 @@ use consomme::ConsommeParams;
 use net_backend::resolve::ResolveEndpointParams;
 use net_backend::resolve::ResolvedEndpoint;
 use net_backend_resources::consomme::ConsommeHandle;
+use net_backend_resources::consomme::HostPort;
 use net_backend_resources::consomme::HostPortProtocol;
 use thiserror::Error;
 use vm_resource::ResolveResource;
@@ -61,7 +62,11 @@ impl ResolveResource<NetEndpointHandleKind, ConsommeHandle> for ConsommeResolver
                     HostPortProtocol::Udp => IpProtocol::Udp,
                 };
                 let ip_addr = p.host_address.map(std::net::IpAddr::from);
-                let socket = create_bound_socket(&protocol, ip_addr, p.host_port).map_err(|e| {
+                let (bind_port, dynamic_sender) = match p.host_port {
+                    HostPort::Fixed(port) => (port, None),
+                    HostPort::Dynamic(sender) => (0, Some(sender)),
+                };
+                let socket = create_bound_socket(&protocol, ip_addr, bind_port).map_err(|e| {
                     ResolveConsommeError::SocketCreation {
                         source: e,
                         details: format!(
@@ -70,7 +75,7 @@ impl ResolveResource<NetEndpointHandleKind, ConsommeHandle> for ConsommeResolver
                             ip_addr
                                 .map(|a| a.to_string())
                                 .unwrap_or_else(|| "*".to_string()),
-                            p.host_port,
+                            bind_port,
                         ),
                     }
                 })?;
@@ -81,6 +86,9 @@ impl ResolveResource<NetEndpointHandleKind, ConsommeHandle> for ConsommeResolver
                     guest_port = %p.guest_port,
                     "port forward socket created"
                 );
+                if let Some(sender) = dynamic_sender {
+                    sender.send(host_addr.expect("just bound an IP socket").port());
+                }
                 Ok(PortForwardConfig {
                     protocol,
                     socket,


### PR DESCRIPTION
Consomme port forwarding needs a way to bind a host listener without requiring the caller to choose an available port ahead of time. This lets callers ask the OS for an ephemeral host port while still using the same forwarding resource path.

Extend the host port configuration to distinguish fixed ports from dynamically assigned ports, and report the assigned port back to the caller after the socket is bound.

This will be used in petri in the future.