### PR TITLE
openvmm_entry: parse CLI args on a thread with a larger stack

### DIFF
--- a/openvmm/openvmm_entry/src/cli_args.rs
+++ b/openvmm/openvmm_entry/src/cli_args.rs
@@ -33,6 +33,37 @@ use std::path::PathBuf;
 use std::str::FromStr;
 use thiserror::Error;
 
+/// Parse CLI options, using a thread with a larger stack on Windows to avoid
+/// stack overflow in debug builds due to clap's deep stack usage.
+/// See <https://github.com/clap-rs/clap/issues/5134>.
+pub(crate) fn parse_options() -> Options {
+    // In non-optimized builds, clap uses an embarrassing amount of stack space
+    // to construct the `Command` instance for `Options`, more than the Windows
+    // default of 1MB. This has been known since 2023:
+    // <https://github.com/clap-rs/clap/issues/5134>, but no one has stepped up
+    // to fix it.
+    //
+    // Work around this by running the code on a thread with lots of stack
+    // space. This is easier and more reliable than configuring the PE binary to
+    // have a larger stack.
+    fn on_big_stack<R: Send>(f: impl Send + FnOnce() -> R) -> R {
+        if cfg!(windows) {
+            std::thread::scope(|s| {
+                std::thread::Builder::new()
+                    .stack_size(0x400000)
+                    .spawn_scoped(s, f)
+                    .unwrap()
+                    .join()
+                    .unwrap()
+            })
+        } else {
+            f()
+        }
+    }
+
+    on_big_stack(Options::parse)
+}
+
 const DEFAULT_MEMORY_SIZE: u64 = 1024 * 1024 * 1024;
 
 /// Guest memory configuration parsed from `--memory`.

--- a/openvmm/openvmm_entry/src/lib.rs
+++ b/openvmm/openvmm_entry/src/lib.rs
@@ -27,7 +27,6 @@ use crate::cli_args::SecureBootTemplateCli;
 use anyhow::Context;
 use anyhow::bail;
 use chipset_resources::battery::HostBatteryUpdate;
-use clap::Parser;
 use cli_args::DiskCliKind;
 use cli_args::EfiDiagnosticsLogLevelCli;
 use cli_args::EndpointConfigCli;
@@ -2234,7 +2233,7 @@ fn do_main(pidfile_path: &mut Option<PathBuf>) -> anyhow::Result<()> {
     // not return). Any worker host setup errors are return and bubbled up.
     meshworker::run_vmm_mesh_host()?;
 
-    let opt = Options::parse();
+    let opt = cli_args::parse_options();
     if let Some(path) = &opt.write_saved_state_proto {
         mesh::payload::protofile::DescriptorWriter::new(vmcore::save_restore::saved_state_roots())
             .write_to_path(path)


### PR DESCRIPTION
In non-optimized builds, clap uses more stack space than the Windows default of 1MB to construct the Command instance for Options. This is a known upstream issue (https://github.com/clap-rs/clap/issues/5134).

Work around this by parsing CLI args on a scoped thread with a 4MB stack on Windows. On other platforms, the function just calls Options::parse() directly since they have sufficient default stack sizes.