### PR TITLE
mesh_process: propagate env_vars on Unix process spawn

### DIFF
--- a/support/mesh/mesh_process/src/lib.rs
+++ b/support/mesh/mesh_process/src/lib.rs
@@ -925,6 +925,10 @@ impl MeshInner {
                 .dup_fd(invitation.fd.as_fd(), IPC_FD)
                 .env(INVITATION_ENV_NAME, invitation_env);
 
+            for (key, value) in &config.env_vars {
+                command.env(key, value);
+            }
+
             if !config.skip_worker_arg {
                 command.arg(&name);
             }


### PR DESCRIPTION
The Windows code path already passes config.env_vars to the child process via extend_env, but the Unix code path was missing this, silently dropping any environment variables set through the ProcessConfig::env() API.

This notably breaks petri test logging on Linux, since OPENVMM_LOG is passed to worker processes as an environment variable and was being silently dropped.

Add the corresponding env calls on the Unix path so that environment variables are propagated on both platforms.