### PR TITLE
vnc: read only the dirty columns, not whole scanlines

### DIFF
--- a/Guide/src/reference/devices/vnc/architecture.md
+++ b/Guide/src/reference/devices/vnc/architecture.md
@@ -94,7 +94,7 @@ collect_dirty()
     |
     +-- Choose update mode:
     |   (a) force_full: read entire VRAM, mark all tiles dirty
-    |   (b) got_device_dirty: O(1) swap prev_fb/cur_fb, read only dirty scanlines
+    |   (b) got_device_dirty: O(1) swap prev_fb/cur_fb, read only dirty-rect pixels
     |   (c) device_dirty_seen but empty channel: nothing changed, skip entirely
     |   (d) no device support: read entire VRAM, tile-diff against prev_fb
     |
@@ -140,8 +140,9 @@ Supported drivers:
 - Linux `hyperv_drm`: full support (sends `SYNTHVID_DIRT` messages)
 - Linux `hyperv_fb` (older): does NOT send dirty rects
 
-When device dirty rects arrive, the server reads only the affected scanlines
-from VRAM — an idle 1080p desktop reads 0 bytes instead of 8MB per cycle.
+When device dirty rects arrive, the server reads only those rectangles from
+VRAM (the dirty columns of the dirty rows), not whole scanlines. An idle 1080p
+desktop reads 0 bytes per cycle instead of 8MB.
 
 **2. Tile diff fallback (old guests)**
 
@@ -306,7 +307,7 @@ non-ASCII characters, and client compatibility notes.
 |----------------------------|---------------|--------------------------------|
 | Idle desktop, device dirty | 0 bytes/cycle | Channel drain only             |
 | Idle desktop, tile diff    | 8MB/cycle     | memcmp 8160 tiles              |
-| Small update, device dirty | ~1KB/cycle    | Partial scanline read + encode |
+| Small update, device dirty | ~1KB/cycle    | Read dirty columns + encode    |
 | Full screen, zlib          | 8MB/cycle     | Full read + zlib compress      |
 | Full screen, raw           | 8MB/cycle     | Full read + memcpy             |
 

--- a/vm/devices/framebuffer/src/lib.rs
+++ b/vm/devices/framebuffer/src/lib.rs
@@ -159,12 +159,28 @@ pub struct View {
 impl View {
     /// Reads a line within the framebuffer.
     pub fn read_line(&mut self, line: u16, data: &mut [u8]) {
+        self.read_line_at(line, 0, data);
+    }
+
+    /// Reads part of a line, starting at pixel column `x`, into `data`, filling
+    /// it in full. The caller must pass an in-bounds span: `x` plus
+    /// `data.len() / 4` pixels must not exceed the line width. Use this to read
+    /// only a dirty horizontal span instead of the whole line.
+    pub fn read_line_at(&mut self, line: u16, x: u16, data: &mut [u8]) {
         if let Some(format) = &self.format {
             if let Some(offset) = (line as usize)
                 .checked_mul(format.bytes_per_line)
-                .and_then(|x| x.checked_add(format.offset))
+                .and_then(|v| v.checked_add(format.offset))
+                .and_then(|v| v.checked_add(x as usize * 4))
             {
-                let len = std::cmp::min(data.len(), format.width * 4);
+                let avail = format.width.saturating_sub(x as usize) * 4;
+                debug_assert!(
+                    data.len() <= avail,
+                    "read_line_at span runs past end of line (data.len()={}, avail={})",
+                    data.len(),
+                    avail,
+                );
+                let len = std::cmp::min(data.len(), avail);
                 let _ = self.mapping.read_at(offset, &mut data[..len]);
                 return;
             }

--- a/workers/vnc_worker/src/lib.rs
+++ b/workers/vnc_worker/src/lib.rs
@@ -456,8 +456,8 @@ impl vnc::Input for SharedInput {
 struct SharedView(Arc<Mutex<ViewWrapper>>);
 
 impl vnc::Framebuffer for SharedView {
-    fn read_line(&mut self, line: u16, data: &mut [u8]) {
-        self.0.lock().0.read_line(line, data)
+    fn read_line(&mut self, line: u16, x: u16, data: &mut [u8]) {
+        self.0.lock().0.read_line_at(line, x, data)
     }
 
     fn resolution(&mut self) -> (u16, u16) {

--- a/workers/vnc_worker/vnc/examples/vncserver.rs
+++ b/workers/vnc_worker/vnc/examples/vncserver.rs
@@ -23,9 +23,9 @@ impl vnc::Framebuffer for Framebuffer {
         (WIDTH as u16, HEIGHT as u16)
     }
 
-    fn read_line(&mut self, line: u16, data: &mut [u8]) {
-        let start = (line as usize) * WIDTH;
-        data.copy_from_slice(&self.0.as_bytes()[start..start + WIDTH * 4]);
+    fn read_line(&mut self, line: u16, x: u16, data: &mut [u8]) {
+        let start = (line as usize) * WIDTH + x as usize;
+        data.copy_from_slice(&self.0.as_bytes()[start * 4..start * 4 + data.len()]);
     }
 }
 

--- a/workers/vnc_worker/vnc/src/server.rs
+++ b/workers/vnc_worker/vnc/src/server.rs
@@ -871,10 +871,10 @@ mod tests {
             (self.width, self.height)
         }
 
-        fn read_line(&mut self, line: u16, data: &mut [u8]) {
-            let start = line as usize * self.width as usize;
-            let end = start + self.width as usize;
-            data.copy_from_slice(self.pixels[start..end].as_bytes());
+        fn read_line(&mut self, line: u16, x: u16, data: &mut [u8]) {
+            let start = line as usize * self.width as usize + x as usize;
+            let pixels = data.len() / 4;
+            data.copy_from_slice(self.pixels[start..start + pixels].as_bytes());
         }
     }
 
@@ -931,8 +931,8 @@ mod tests {
             self.0.lock().resolution()
         }
 
-        fn read_line(&mut self, line: u16, data: &mut [u8]) {
-            self.0.lock().read_line(line, data)
+        fn read_line(&mut self, line: u16, x: u16, data: &mut [u8]) {
+            self.0.lock().read_line(line, x, data)
         }
     }
 

--- a/workers/vnc_worker/vnc/src/traits.rs
+++ b/workers/vnc_worker/vnc/src/traits.rs
@@ -9,10 +9,11 @@ pub trait Framebuffer: Send + Sync {
     /// pixels. Called once per update cycle so the server can react to
     /// guest-driven resolution changes.
     fn resolution(&mut self) -> (u16, u16);
-    /// Reads the pixel data for one scanline (`line`, 0-based) into `data`.
-    /// `data` is sized by the caller for one full scanline at the current
-    /// resolution in the internal `0x00RRGGBB` format.
-    fn read_line(&mut self, line: u16, data: &mut [u8]);
+    /// Reads pixel data for one scanline (`line`, 0-based) starting at pixel
+    /// column `x` into `data`. `data` is sized by the caller for the span being
+    /// read (a full scanline with `x = 0`, or just the dirty columns) in the
+    /// internal `0x00RRGGBB` format.
+    fn read_line(&mut self, line: u16, x: u16, data: &mut [u8]);
 }
 
 pub(crate) const HID_MOUSE_MAX_ABS_VALUE: u32 = 0x7FFF;

--- a/workers/vnc_worker/vnc/src/update_state.rs
+++ b/workers/vnc_worker/vnc/src/update_state.rs
@@ -147,11 +147,14 @@ impl UpdateState {
             std::mem::swap(&mut self.cur_fb, &mut self.prev_fb);
             for r in &self.merged_rects {
                 for y in r.y..r.y + r.h {
-                    let offset = y as usize * width as usize;
-                    fb.read_line(
-                        y,
-                        self.cur_fb[offset..offset + width as usize].as_mut_bytes(),
-                    );
+                    // Read only the dirty columns of this row. The non-dirty
+                    // columns are already correct from the cur_fb/prev_fb swap
+                    // (they did not change), so reading the full width would be
+                    // wasted VRAM traffic.
+                    let row = y as usize * width as usize;
+                    let start = row + r.x as usize;
+                    let end = start + r.w as usize;
+                    fb.read_line(y, r.x, self.cur_fb[start..end].as_mut_bytes());
                 }
             }
             DirtySource::Device
@@ -184,6 +187,7 @@ impl UpdateState {
             let offset = y as usize * self.width as usize;
             fb.read_line(
                 y,
+                0,
                 self.cur_fb[offset..offset + self.width as usize].as_mut_bytes(),
             );
         }
@@ -264,10 +268,10 @@ mod tests {
             (self.width, self.height)
         }
 
-        fn read_line(&mut self, line: u16, data: &mut [u8]) {
-            let start = line as usize * self.width as usize;
-            let end = start + self.width as usize;
-            data.copy_from_slice(self.pixels[start..end].as_bytes());
+        fn read_line(&mut self, line: u16, x: u16, data: &mut [u8]) {
+            let start = line as usize * self.width as usize + x as usize;
+            let pixels = data.len() / 4;
+            data.copy_from_slice(self.pixels[start..start + pixels].as_bytes());
         }
     }
 
@@ -354,6 +358,41 @@ mod tests {
         assert_eq!(result.source, DirtySource::Device);
         assert!(!result.rects.is_empty());
         state.commit();
+    }
+
+    #[test]
+    fn update_state_device_dirty_reads_only_dirty_columns() {
+        let mut fb = MockFramebuffer::new(64, 32, 0);
+        let mut state = UpdateState::new();
+        state.set_resolution(64, 32);
+
+        // First frame establishes prev_fb (all zero).
+        let _ = state.collect_dirty(&mut fb, &mut None, true, &None);
+        state.commit();
+
+        // Device reports only the tile at columns [32, 48) of rows [0, 16).
+        let (tx, rx) = async_channel::bounded(4);
+        let _ = tx.try_send(Arc::new(vec![video_core::DirtyRect {
+            left: 32,
+            top: 0,
+            right: 48,
+            bottom: 16,
+        }]));
+        let mut dirty_recv: Option<DirtyRectReceiver> = Some(rx);
+
+        // Change one pixel inside the dirty region and one outside it on the
+        // same row. Only the inside one should be read.
+        fb.set(40, 5, 0x00aabbcc); // inside [32, 48)
+        fb.set(5, 5, 0x00112233); // outside the dirty rect
+
+        let result = state.collect_dirty(&mut fb, &mut dirty_recv, false, &None);
+        assert_eq!(result.source, DirtySource::Device);
+
+        // The inside pixel was read from VRAM.
+        assert_eq!(state.cur_fb[5 * 64 + 40], 0x00aabbcc);
+        // The outside pixel was not read (we only read the dirty columns), so
+        // it keeps the previous frame's value from the cur_fb/prev_fb swap.
+        assert_eq!(state.cur_fb[5 * 64 + 5], 0);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

When forwarding device dirty rectangles, the VNC server read only the dirty
rows but the full screen width of each, ignoring the rectangle's horizontal
extent. For a tall, narrow update (a dragged scrollbar, a text caret column,
a vertical widget) that reads far more VRAM than needed, up to roughly screen
width over rectangle width, which can approach a full-frame read for a tiny
change. Full-width updates were already optimal.

This reads only the dirty columns. The non-dirty columns of a dirty row are
already correct from the cur_fb/prev_fb swap (they did not change), and the
encoder only emits the merged rectangles, so the output is identical, just
with less VRAM traffic.

## What changed

- `framebuffer`: add `View::read_line_at(line, x, data)`; `read_line(line,
  data)` now delegates to it with `x = 0`.
- The vnc `Framebuffer::read_line` gains a start column `x`. The device-dirty
  loop reads `[r.x, r.x + r.w)` into the matching slice of `cur_fb`; the
  full-frame read and the tile-diff fallback pass `x = 0`.
- Update the `vncserver` example for the new signature. This also fixes a
  latent byte-offset bug in its `read_line`: it indexed the byte view of the
  `Vec<u32>` framebuffer with a pixel offset, so every line after the first
  read the wrong region. Example only, no effect on shipping code or tests.

## On the API shape

The shared `framebuffer` crate keeps `read_line` and adds `read_line_at`, so
existing callers (for example the screenshot capture in petri) do not change.
The vnc `Framebuffer` trait is internal to the vnc crate, so it takes the
start column directly rather than carrying two methods. There is an inline
comment on `View::read_line` noting this.

The byte arithmetic in `read_line_at`, including the 4-bytes-per-pixel factor
for the 32bpp framebuffer, is carried over unchanged from the previous
`read_line` (which only read whole lines). The one addition is the
start-column offset that `read_line` did not allow.

## Testing

- New unit test asserts only the dirty columns are read: a pixel changed
  outside the dirty rectangle on a dirty row is not picked up.
- Existing vnc and framebuffer tests pass; `cargo fmt --all -- --check`,
  `cargo clippy --workspace --all-targets`, and `cargo doc --workspace
  --no-deps` are clean.
- Ran a Windows guest over VNC with a video workload; the screen renders
  correctly with the column-limited reads, no stale or torn columns around
  updated regions.

## Docs

Corrected the architecture guide, which described this partial read as if it
were already implemented.
