### PR TITLE
vnc: diagnostics for client negotiation and the dirty-rect channel

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10415,6 +10415,7 @@ dependencies = [
  "parking_lot",
  "socket2",
  "sparse_mmap",
+ "tracelimit",
  "tracing",
  "tracing_helpers",
  "unicycle",

--- a/workers/vnc_worker/Cargo.toml
+++ b/workers/vnc_worker/Cargo.toml
@@ -18,6 +18,7 @@ inspect.workspace = true
 mesh.workspace = true
 mesh_worker.workspace = true
 pal_async.workspace = true
+tracelimit.workspace = true
 tracing_helpers.workspace = true
 vmsocket.workspace = true
 

--- a/workers/vnc_worker/src/lib.rs
+++ b/workers/vnc_worker/src/lib.rs
@@ -202,10 +202,17 @@ impl<T: Listener> MultiClientServer<T> {
         enum Event<A> {
             Accepted(A),
             ClientDone(u64),
-            DirtyRects(Vec<video_core::DirtyRect>),
+            // A drained batch of device messages: one Vec per message that was
+            // queued on the (unbounded) mesh channel when we serviced it. The
+            // batch length is the channel backlog at that instant.
+            DirtyRects(Vec<Vec<video_core::DirtyRect>>),
         }
 
         let mut device_dirty_seen = false;
+        // High-water mark of the dirty-rect channel backlog, to confirm the
+        // unbounded mesh queue is not growing (stays at 1 when the consumer
+        // keeps up) and to surface it if it ever does.
+        let mut dirty_backlog_max = 0usize;
 
         loop {
             let listener = &mut self.listener;
@@ -213,9 +220,18 @@ impl<T: Listener> MultiClientServer<T> {
             let dirty_recv = &mut self.dirty_recv;
 
             // Optional future for dirty rect reception (pending if no video device).
+            // Block for the first message, then drain everything else already
+            // queued via try_recv. The drained count is the channel backlog,
+            // our measure of the unbounded mesh queue depth.
             let dirty_fut = async {
                 match dirty_recv {
-                    Some(recv) => recv.recv().await,
+                    Some(recv) => recv.recv().await.map(|first| {
+                        let mut batch = vec![first];
+                        while let Ok(rects) = recv.try_recv() {
+                            batch.push(rects);
+                        }
+                        batch
+                    }),
                     None => std::future::pending().await,
                 }
             };
@@ -237,12 +253,15 @@ impl<T: Listener> MultiClientServer<T> {
                 }
                 id = client_done.fuse() => Event::ClientDone(id),
                 msg = dirty_fut.fuse() => match msg {
-                    Ok(rects) => Event::DirtyRects(rects),
+                    Ok(batch) => Event::DirtyRects(batch),
                     Err(_) => {
                         // Upstream dirty channel closed (video device reset
                         // or teardown). Drop it so clients fall back to tile
                         // diff instead of freezing with device_dirty_seen.
-                        tracing::warn!("device dirty channel closed, falling back to tile diff");
+                        tracing::warn!(
+                            backlog_max = dirty_backlog_max,
+                            "device dirty channel closed, falling back to tile diff"
+                        );
                         self.dirty_recv = None;
                         // Close all per-client dirty senders so clients
                         // detect the closure and reset device_dirty_seen.
@@ -304,28 +323,49 @@ impl<T: Listener> MultiClientServer<T> {
                     self.dirty_senders.retain(|s| s.id != id);
                     tracing::info!(id, count = self.clients.len(), "VNC client disconnected");
                 }
-                Event::DirtyRects(rects) => {
+                Event::DirtyRects(batch) => {
                     if !device_dirty_seen {
                         device_dirty_seen = true;
                         tracing::info!("device dirty rects active, preferring over tile diff");
                     }
-                    // Broadcast to all connected clients. Arc avoids cloning
-                    // the rect Vec for each client (only ref-count bump).
-                    let rects = Arc::new(rects);
-                    for s in &mut self.dirty_senders {
-                        if s.sender.try_send(Arc::clone(&rects)).is_err() {
-                            s.missed_dirty.store(true, Ordering::Relaxed);
-                            tracing::debug!(
-                                id = s.id,
-                                "client dirty channel full, flagged for full refresh"
-                            );
-                        }
+                    // Backlog = how many messages were queued when we got to
+                    // service the channel. 1 means the consumer is keeping up
+                    // and the unbounded mesh queue is not growing; >1 means the
+                    // device is briefly outpacing us.
+                    let backlog = batch.len();
+                    if backlog > dirty_backlog_max {
+                        dirty_backlog_max = backlog;
                     }
-                    tracing::trace!(
-                        rect_count = rects.len(),
-                        clients = self.dirty_senders.len(),
-                        "broadcast device dirty rects"
-                    );
+                    if backlog > 1 {
+                        tracing::debug!(
+                            backlog,
+                            rects_total = batch.iter().map(|r| r.len()).sum::<usize>(),
+                            backlog_max = dirty_backlog_max,
+                            "device dirty channel backlog above 1 (producer outpacing consumer)"
+                        );
+                    } else {
+                        tracing::trace!(backlog, "device dirty channel drained");
+                    }
+                    // Broadcast each drained message individually so behavior is
+                    // identical to receiving them one at a time. Arc avoids
+                    // cloning the rect Vec per client (only a ref-count bump).
+                    for rects in batch {
+                        let rects = Arc::new(rects);
+                        for s in &mut self.dirty_senders {
+                            if s.sender.try_send(Arc::clone(&rects)).is_err() {
+                                s.missed_dirty.store(true, Ordering::Relaxed);
+                                tracing::debug!(
+                                    id = s.id,
+                                    "client dirty channel full, flagged for full refresh"
+                                );
+                            }
+                        }
+                        tracing::trace!(
+                            rect_count = rects.len(),
+                            clients = self.dirty_senders.len(),
+                            "broadcast device dirty rects"
+                        );
+                    }
                 }
             }
         }

--- a/workers/vnc_worker/src/lib.rs
+++ b/workers/vnc_worker/src/lib.rs
@@ -213,6 +213,11 @@ impl<T: Listener> MultiClientServer<T> {
         // unbounded mesh queue is not growing (stays at 1 when the consumer
         // keeps up) and to surface it if it ever does.
         let mut dirty_backlog_max = 0usize;
+        // Ceiling for the rate-limited alarm in the dirty-rect handler below.
+        // The drain empties the whole channel each wakeup, so the live depth
+        // stays in single digits; crossing this means the consumer is
+        // catastrophically starved, not under normal load.
+        const MAX_DIRTY_BACKLOG: usize = 1000;
 
         loop {
             let listener = &mut self.listener;
@@ -336,7 +341,19 @@ impl<T: Listener> MultiClientServer<T> {
                     if backlog > dirty_backlog_max {
                         dirty_backlog_max = backlog;
                     }
-                    if backlog > 1 {
+                    if backlog > MAX_DIRTY_BACKLOG {
+                        // Should be unreachable: the drain reads the whole queue
+                        // each wakeup, so the depth only grows if the consumer is
+                        // wedged and the unbounded mesh queue is climbing without
+                        // bound. Surface it loudly, rate-limited so a sustained
+                        // stall cannot flood the log.
+                        tracelimit::error_ratelimited!(
+                            backlog,
+                            backlog_max = dirty_backlog_max,
+                            limit = MAX_DIRTY_BACKLOG,
+                            "device dirty channel backlog exceeded limit (consumer wedged, mesh queue growing unbounded)"
+                        );
+                    } else if backlog > 1 {
                         tracing::debug!(
                             backlog,
                             rects_total = batch.iter().map(|r| r.len()).sum::<usize>(),

--- a/workers/vnc_worker/vnc/src/rfb.rs
+++ b/workers/vnc_worker/vnc/src/rfb.rs
@@ -4,6 +4,7 @@
 #![expect(dead_code)]
 
 use self::packed_nums::*;
+use std::borrow::Cow;
 use zerocopy::FromBytes;
 use zerocopy::Immutable;
 use zerocopy::IntoBytes;
@@ -129,6 +130,96 @@ pub const ENCODING_TYPE_CURSOR: u32 = -239i32 as u32;
 pub const ENCODING_TYPE_DESKTOP_SIZE: u32 = -223i32 as u32;
 pub const ENCODING_TYPE_QEMU_EXTENDED_KEY_EVENT: u32 = -258i32 as u32;
 
+/// Human-readable name for an RFB encoding number, for diagnostics logging.
+///
+/// Covers the registered RFB encoding and pseudo-encoding numbers (see the IANA
+/// RFB registry), the Tight option ranges (compression level, JPEG quality,
+/// fine-grained quality, subsampling), and the vendor blocks (VMware, Apple,
+/// RealVNC, UltraVNC, LibVNCServer, extended clipboard). Names follow common
+/// libvncserver usage where the registry only assigns a coarse range. Anything
+/// unrecognized falls back to its signed-decimal and hex form, so nothing a
+/// client advertises is dropped from the report.
+///
+/// Source: IANA Remote Framebuffer (RFB) registry,
+/// <https://www.iana.org/assignments/rfb/rfb.xhtml>.
+pub fn encoding_name(enc: i32) -> Cow<'static, str> {
+    let raw = enc as u32;
+    // Vendor blocks reserved as hex ranges, outside the contiguous
+    // signed-number space handled by the match below.
+    if (0x574d5600..=0x574d56ff).contains(&raw) {
+        return Cow::Owned(format!("VMware({raw:#010x})"));
+    }
+    if (0xc0a1e5ce..=0xc0a1e5cf).contains(&raw) {
+        return Cow::Borrowed("ExtendedClipboard");
+    }
+    if (0xfffe0000..=0xfffe00ff).contains(&raw) {
+        return Cow::Owned(format!("LibVNCServer({raw:#010x})"));
+    }
+    if (0xffff0000..=0xffff8003).contains(&raw) {
+        return Cow::Owned(format!("UltraVNC({raw:#010x})"));
+    }
+    let name = match enc {
+        // Standard framebuffer encodings.
+        0 => "Raw",
+        1 => "CopyRect",
+        2 => "RRE",
+        4 => "CoRRE",
+        5 => "Hextile",
+        6 => "zlib",
+        7 => "Tight",
+        8 => "zlibhex",
+        15 => "TRLE",
+        16 => "ZRLE",
+        17 => "ZYWRLE",
+        20 => "H.264",
+        21 => "JPEG",
+        22 => "JRLE",
+        23 => "VA-H.264",
+        24 => "ZRLE2",
+        50 => "OpenH.264",
+        // Pseudo-encodings.
+        -223 => "DesktopSize",
+        -224 => "LastRect",
+        -232 => "PointerPos",
+        -239 => "Cursor",
+        -240 => "XCursor",
+        -257 => "QEMUPointerMotionChange",
+        -258 => "QEMUExtendedKeyEvent",
+        -259 => "QEMUAudio",
+        -260 => "TightPNG",
+        -261 => "LedState",
+        -305 => "gii",
+        -306 => "popa",
+        -307 => "DesktopName",
+        -308 => "ExtendedDesktopSize",
+        -309 => "xvp",
+        -310 => "OliveCallControl",
+        -311 => "ClientRedirect",
+        -312 => "Fence",
+        -313 => "ContinuousUpdates",
+        -314 => "CursorWithAlpha",
+        -315 => "ColorMap",
+        -316 => "ExtendedMouseButtons",
+        -317 => "TightNoZlib",
+        // Range and vendor-block arms come after the single-value arms so a
+        // future named encoding takes precedence. These ranges are disjoint
+        // from each other and from the single values above (per the IANA RFB
+        // registry), so the order among them does not matter; an overlapping
+        // literal added later would be an unreachable_pattern compile error
+        // under -D warnings rather than a silent shadow.
+        -32..=-23 => return Cow::Owned(format!("TightJpegQuality({})", enc + 32)),
+        -256..=-247 => return Cow::Owned(format!("TightCompressionLevel({})", enc + 256)),
+        -304..=-273 => return Cow::Owned(format!("VMware({enc})")),
+        -512..=-412 => return Cow::Owned(format!("TightFineQuality({})", enc + 512)),
+        -528..=-523 => return Cow::Owned(format!("CarConnectivity({enc})")),
+        -768..=-763 => return Cow::Owned(format!("TightSubsampling({})", enc + 768)),
+        1024..=1099 => return Cow::Owned(format!("RealVNC({enc})")),
+        1000..=1002 | 1011 | 1100..=1109 => return Cow::Owned(format!("Apple({enc})")),
+        _ => return Cow::Owned(format!("Unknown({enc}/{raw:#010x})")),
+    };
+    Cow::Borrowed(name)
+}
+
 #[repr(C)]
 #[derive(Copy, Clone, Debug, IntoBytes, Immutable, KnownLayout, FromBytes)]
 pub struct FramebufferUpdateRequest {
@@ -244,4 +335,73 @@ pub struct QemuExtendedKeyEvent {
     pub down_flag: u16_be,
     pub keysym: u32_be,
     pub keycode: u32_be,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn encoding_name_known_and_pseudo() {
+        assert_eq!(encoding_name(0), "Raw");
+        assert_eq!(encoding_name(6), "zlib");
+        assert_eq!(encoding_name(15), "TRLE");
+        assert_eq!(encoding_name(16), "ZRLE");
+        assert_eq!(encoding_name(20), "H.264");
+        assert_eq!(encoding_name(24), "ZRLE2");
+        assert_eq!(encoding_name(50), "OpenH.264");
+        assert_eq!(encoding_name(-239), "Cursor");
+        assert_eq!(encoding_name(-240), "XCursor");
+        assert_eq!(encoding_name(-223), "DesktopSize");
+        assert_eq!(encoding_name(-313), "ContinuousUpdates");
+        assert_eq!(encoding_name(-316), "ExtendedMouseButtons");
+        assert_eq!(encoding_name(-317), "TightNoZlib");
+    }
+
+    #[test]
+    fn encoding_name_vendor_blocks() {
+        // VMware reserves 0x574d56xx; report the block with its sub-code.
+        assert_eq!(encoding_name(0x574d5664u32 as i32), "VMware(0x574d5664)");
+        assert_eq!(encoding_name(0x574d56ffu32 as i32), "VMware(0x574d56ff)");
+        // VMware also reserves a negative pseudo-encoding block.
+        assert_eq!(encoding_name(-273), "VMware(-273)");
+        // Extended clipboard pseudo-encoding.
+        assert_eq!(encoding_name(0xc0a1e5ceu32 as i32), "ExtendedClipboard");
+        assert_eq!(
+            encoding_name(0xfffe0000u32 as i32),
+            "LibVNCServer(0xfffe0000)"
+        );
+        assert_eq!(encoding_name(0xffff0000u32 as i32), "UltraVNC(0xffff0000)");
+        // RealVNC owns 1024-1099; Apple owns 1000-1002, 1011, 1100-1109. The
+        // two must not overlap, and the gaps between Apple's sub-blocks are
+        // unassigned (not Apple).
+        assert_eq!(encoding_name(1050), "RealVNC(1050)");
+        assert_eq!(encoding_name(1024), "RealVNC(1024)");
+        assert_eq!(encoding_name(1000), "Apple(1000)");
+        assert_eq!(encoding_name(1011), "Apple(1011)");
+        assert_eq!(encoding_name(1100), "Apple(1100)");
+        assert_eq!(encoding_name(1015), "Unknown(1015/0x000003f7)");
+    }
+
+    #[test]
+    fn encoding_name_ranges() {
+        // Tight compression levels 0..=9 map to -256..=-247.
+        assert_eq!(encoding_name(-256), "TightCompressionLevel(0)");
+        assert_eq!(encoding_name(-247), "TightCompressionLevel(9)");
+        // JPEG quality levels 0..=9 map to -32..=-23.
+        assert_eq!(encoding_name(-32), "TightJpegQuality(0)");
+        assert_eq!(encoding_name(-23), "TightJpegQuality(9)");
+        // Fine-grained quality 0..=100 map to -512..=-412.
+        assert_eq!(encoding_name(-512), "TightFineQuality(0)");
+        assert_eq!(encoding_name(-412), "TightFineQuality(100)");
+        // Subsampling 0..=5 map to -768..=-763.
+        assert_eq!(encoding_name(-768), "TightSubsampling(0)");
+        assert_eq!(encoding_name(-763), "TightSubsampling(5)");
+    }
+
+    #[test]
+    fn encoding_name_unknown_keeps_value() {
+        assert_eq!(encoding_name(3), "Unknown(3/0x00000003)");
+        assert_eq!(encoding_name(-5), "Unknown(-5/0xfffffffb)");
+    }
 }

--- a/workers/vnc_worker/vnc/src/rfb.rs
+++ b/workers/vnc_worker/vnc/src/rfb.rs
@@ -144,19 +144,15 @@ pub const ENCODING_TYPE_QEMU_EXTENDED_KEY_EVENT: u32 = -258i32 as u32;
 /// <https://www.iana.org/assignments/rfb/rfb.xhtml>.
 pub fn encoding_name(enc: i32) -> Cow<'static, str> {
     let raw = enc as u32;
-    // Vendor blocks reserved as hex ranges, outside the contiguous
-    // signed-number space handled by the match below.
-    if (0x574d5600..=0x574d56ff).contains(&raw) {
-        return Cow::Owned(format!("VMware({raw:#010x})"));
-    }
-    if (0xc0a1e5ce..=0xc0a1e5cf).contains(&raw) {
-        return Cow::Borrowed("ExtendedClipboard");
-    }
-    if (0xfffe0000..=0xfffe00ff).contains(&raw) {
-        return Cow::Owned(format!("LibVNCServer({raw:#010x})"));
-    }
-    if (0xffff0000..=0xffff8003).contains(&raw) {
-        return Cow::Owned(format!("UltraVNC({raw:#010x})"));
+    // Vendor blocks live in high u32 hex ranges, outside the contiguous
+    // signed-number space the `enc` match below covers, so match them on the
+    // raw value where the hex reads naturally.
+    match raw {
+        0x574d5600..=0x574d56ff => return Cow::Owned(format!("VMware({raw:#010x})")),
+        0xc0a1e5ce..=0xc0a1e5cf => return Cow::Borrowed("ExtendedClipboard"),
+        0xfffe0000..=0xfffe00ff => return Cow::Owned(format!("LibVNCServer({raw:#010x})")),
+        0xffff0000..=0xffff8003 => return Cow::Owned(format!("UltraVNC({raw:#010x})")),
+        _ => {}
     }
     let name = match enc {
         // Standard framebuffer encodings.

--- a/workers/vnc_worker/vnc/src/rfb.rs
+++ b/workers/vnc_worker/vnc/src/rfb.rs
@@ -342,23 +342,6 @@ mod tests {
     use super::*;
 
     #[test]
-    fn encoding_name_known_and_pseudo() {
-        assert_eq!(encoding_name(0), "Raw");
-        assert_eq!(encoding_name(6), "zlib");
-        assert_eq!(encoding_name(15), "TRLE");
-        assert_eq!(encoding_name(16), "ZRLE");
-        assert_eq!(encoding_name(20), "H.264");
-        assert_eq!(encoding_name(24), "ZRLE2");
-        assert_eq!(encoding_name(50), "OpenH.264");
-        assert_eq!(encoding_name(-239), "Cursor");
-        assert_eq!(encoding_name(-240), "XCursor");
-        assert_eq!(encoding_name(-223), "DesktopSize");
-        assert_eq!(encoding_name(-313), "ContinuousUpdates");
-        assert_eq!(encoding_name(-316), "ExtendedMouseButtons");
-        assert_eq!(encoding_name(-317), "TightNoZlib");
-    }
-
-    #[test]
     fn encoding_name_vendor_blocks() {
         // VMware reserves 0x574d56xx; report the block with its sub-code.
         assert_eq!(encoding_name(0x574d5664u32 as i32), "VMware(0x574d5664)");

--- a/workers/vnc_worker/vnc/src/server.rs
+++ b/workers/vnc_worker/vnc/src/server.rs
@@ -184,6 +184,7 @@ impl<F: Framebuffer, I: Input> Server<F, I> {
 
                 let mut chosen_type = 0u8;
                 socket.read_exact(chosen_type.as_mut_bytes()).await?;
+                tracing::debug!(security_type = chosen_type, "client selected security type");
 
                 if chosen_type != rfb::SECURITY_TYPE_NONE {
                     if version.0 == rfb::PROTOCOL_VERSION_38 {
@@ -387,6 +388,24 @@ impl<F: Framebuffer, I: Input> Server<F, I> {
                     blue_shift = cs.fmt.blue_shift,
                     "client pixel format changed"
                 );
+                // Full requested format plus what the server actually does with
+                // it: no_convert = the client's layout matches our internal
+                // 0x00RRGGBB so pixels go out as-is (the memcpy fast path);
+                // otherwise every pixel is converted on the way out.
+                tracing::debug!(
+                    bpp = cs.fmt.bits_per_pixel,
+                    depth = cs.fmt.depth,
+                    true_color = cs.fmt.true_color_flag != 0,
+                    big_endian = cs.fmt.big_endian_flag != 0,
+                    red_max = cs.fmt.red_max.get(),
+                    green_max = cs.fmt.green_max.get(),
+                    blue_max = cs.fmt.blue_max.get(),
+                    red_shift = cs.fmt.red_shift,
+                    green_shift = cs.fmt.green_shift,
+                    blue_shift = cs.fmt.blue_shift,
+                    no_convert = cs.pixel_conv.no_convert,
+                    "pixel format negotiated"
+                );
                 cs.force_full_update = true;
             }
             rfb::CS_MESSAGE_SET_ENCODINGS => {
@@ -418,6 +437,8 @@ impl<F: Framebuffer, I: Input> Server<F, I> {
                 cs.supports_zlib = encodings.contains(&rfb::ENCODING_TYPE_ZLIB.into());
                 let had_cursor = cs.supports_cursor;
                 cs.supports_cursor = encodings.contains(&rfb::ENCODING_TYPE_CURSOR.into());
+                let supports_qemu_ext_key =
+                    encodings.contains(&rfb::ENCODING_TYPE_QEMU_EXTENDED_KEY_EVENT.into());
                 tracing::info!(
                     zlib = cs.supports_zlib,
                     desktop_resize = cs.supports_desktop_resize,
@@ -425,11 +446,32 @@ impl<F: Framebuffer, I: Input> Server<F, I> {
                     encoding_count = encodings.len(),
                     "client encodings"
                 );
+                // Full offered set, every entry decoded to a name. The
+                // collect runs only when debug is enabled (tracing does not
+                // evaluate field expressions for a disabled level), and this
+                // is the once-per-connection negotiation path, not per frame.
+                tracing::debug!(
+                    offered = ?encodings
+                        .iter()
+                        .map(|e| rfb::encoding_name(e.get() as i32))
+                        .collect::<Vec<_>>(),
+                    "client offered encodings"
+                );
+                // What the server will actually use given that offer: zlib if
+                // the client advertised it, else raw; plus the capabilities we
+                // honor. This is the "finally agreed" half of the report.
+                tracing::debug!(
+                    wire_encoding = if cs.supports_zlib { "zlib" } else { "raw" },
+                    cursor = cs.supports_cursor,
+                    desktop_resize = cs.supports_desktop_resize,
+                    qemu_extended_key = supports_qemu_ext_key,
+                    "encodings negotiated"
+                );
                 if cs.supports_cursor && !had_cursor {
                     cs.send_cursor = true;
                 }
 
-                if encodings.contains(&rfb::ENCODING_TYPE_QEMU_EXTENDED_KEY_EVENT.into()) {
+                if supports_qemu_ext_key {
                     let mut msg = rfb::FramebufferUpdate {
                         message_type: rfb::SC_MESSAGE_TYPE_FRAMEBUFFER_UPDATE,
                         padding: 0,


### PR DESCRIPTION
Two diagnostics for the VNC server, both off by default and gated on `OPENVMM_LOG`. They answer two questions you currently cannot answer without a debugger: what did a connecting viewer actually negotiate, and does the device-to-worker dirty-rect channel ever back up?

## Client negotiation report (`vnc`)

Right now the server logs three booleans about client encodings (zlib, desktop_resize, cursor) and a partial pixel format line. That does not tell you what the viewer offered or what the server picked.

This adds `encoding_name`, which decodes RFB encoding numbers: the standard encodings, the Tight compression and JPEG quality ranges, the common pseudo-encodings, and the VMware and extended-clipboard vendor blocks. Anything it does not recognize falls back to its number and hex, so nothing a client sends is lost. With that, the server logs once per connection, at debug:

- the full offered encoding list, by name
- the selected security type
- the full requested pixel format
- what the server will actually use: the wire encoding (zlib or raw), whether the host-native no-convert fast path applies, and which capabilities are honored

The existing info-level lines stay; the detail is at debug.

## Dirty-rect channel backlog metric (`vnc_worker`)

The device-to-worker dirty-rect channel is an unbounded `mesh` channel, and there was no way to know whether its queue grows. The coordinator now drains it on each wakeup (receive one, then `try_recv` the rest) and records how many were waiting, which is the backlog at that moment. It keeps a session high-water mark, logs a backlog above one at debug, a backlog of one at trace, and the high-water on channel close.

Behavior does not change: each drained message is still broadcast to clients individually, exactly as if they had arrived one at a time. The only difference is the receive shape, one-at-a-time becomes drain-all.

In practice the queue sits at 1 under normal load, and only grew (to a few hundred) when the worker was CPU-starved during boot. I also ran it with 16 simultaneous clients, 8 negotiating zlib and 8 falling back to raw, and the shared queue barely moved:

| Backlog depth | Count over 90s (16 clients) |
| ------------- | --------------------------- |
| 2             | 441                         |
| 3             | 115                         |
| 4             | 21                          |
| 5             | 1                           |
| 7             | 1                           |

It sat at 2 almost the whole time and peaked at 7. The single consumer's fan-out to the per-client channels is non-blocking, so adding clients does not grow the shared queue. That is the relevant data point for the broadcast-ring discussion.

## Cost when off

The negotiation report runs once per connection, and the field expressions live inside the `tracing` macros, so they are not evaluated when the level is off. The backlog count reuses values already computed and only formats inside the macros. Nothing measurable when the levels are off.

## Enabling

```
OPENVMM_LOG=info,vnc=debug,vnc_worker=debug
```

Add `vnc_worker=trace` to see each drain confirm a backlog of 1.

## Testing

- Unit tests for `encoding_name`: known encodings, the ranges, the vendor blocks, and the unknown fallback.
- The existing `vnc` and `vnc_worker` tests pass, including the dirty-channel-close path that the drain change touches.
- Ran live against a Windows guest with RealVNC and TigerVNC. RealVNC negotiated zlib; TigerVNC fell back to raw because it does not offer zlib(6). The backlog metric matched what is described above.
- The 16-client run (8 zlib, 8 raw) above confirmed client count does not grow the shared queue.
