### PR TITLE
Bump openssl to 0.10.80 to fix CVE-2026-45784

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5273,9 +5273,9 @@ dependencies = [
 
 [[package]]
 name = "openssl"
-version = "0.10.79"
+version = "0.10.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf0b434746ee2832f4f0baf10137e1cabb18cbe6912c69e2e33263c45250f542"
+checksum = "a45fa2aa886c42762255da344f0a0d313e254066c46aad76f300c3d3da62d967"
 dependencies = [
  "bitflags 2.9.3",
  "cfg-if",
@@ -5313,9 +5313,9 @@ dependencies = [
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.115"
+version = "0.9.116"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "158fe5b292746440aa6e7a7e690e55aeb72d41505e2804c23c6973ad0e9c9781"
+checksum = "f28a22dc7140cda5f096e5e7724a6962ca81a7f8bfd2979f9b18c11af56318c4"
 dependencies = [
  "cc",
  "libc",


### PR DESCRIPTION
Updates `openssl` 0.10.79 → 0.10.80 (and `openssl-sys` 0.9.115 → 0.9.116) in `Cargo.lock` to address [GHSA-phqj-4mhp-q6mq](https://github.com/rust-openssl/rust-openssl/security/advisories/GHSA-phqj-4mhp-q6mq) / CVE-2026-45784.

This is a potential out-of-bounds write in `CipherCtxRef::cipher_update_inplace` for AES-KW-PAD ciphers (`EVP_aes_{128,192,256}_wrap_pad`). The advisory's first patched version is 0.10.80.

Resolves Dependabot alert #35. Lockfile-only change; `cargo xtask fmt --fix` passes.