### PR TITLE
openhcl SNP: shrink minimum release memory size to 64 MB

### DIFF
--- a/vm/loader/manifests/openhcl-x64-cvm-release.json
+++ b/vm/loader/manifests/openhcl-x64-cvm-release.json
@@ -16,7 +16,7 @@
             "image": {
                 "openhcl": {
                     "command_line": "",
-                    "memory_page_count": 163840,
+                    "memory_page_count": 16384,
                     "memory_page_base": 32768,
                     "uefi": true
                 }
@@ -51,7 +51,7 @@
             "image": {
                 "openhcl": {
                     "command_line": "",
-                    "memory_page_count": 32768,
+                    "memory_page_count": 16384,
                     "memory_page_base": 32768,
                     "uefi": true
                 }


### PR DESCRIPTION
Shrink the minimum memory required to 64 MB for SNP and VBS, which matches
TDX builds.

Issue was fixed for TDX a year ago here: https://github.com/microsoft/openvmm/commit/3d597d84dec64938ce518ffc64dc7493f56458fd