### PR TITLE
flowey: refresh CCA overlay assets during rootfs update

### DIFF
--- a/flowey/flowey_hvlite/src/pipelines/cca_tests.rs
+++ b/flowey/flowey_hvlite/src/pipelines/cca_tests.rs
@@ -141,6 +141,7 @@ impl IntoPipeline for CcaTestsCli {
                     .dep_on(
                         |ctx| flowey_lib_hvlite::_jobs::local_update_cca_emu::Params {
                             test_root: test_root.clone(),
+                            openvmm_root: crate::repo_root(),
                             sub_cmds: flowey_lib_hvlite::_jobs::local_update_cca_emu::SubCmds {
                                 rebuild_plane0_linux,
                                 rebuild_rootfs,

--- a/flowey/flowey_lib_hvlite/src/_jobs/local_install_cca_emu.rs
+++ b/flowey/flowey_lib_hvlite/src/_jobs/local_install_cca_emu.rs
@@ -117,7 +117,13 @@ pub(crate) fn build_plane0_linux(
     Ok(())
 }
 
-fn sync_shrinkwrap_overlay_assets(
+/// Syncs OpenVMM-owned CCA shrinkwrap overlay assets into the shrinkwrap checkout.
+///
+/// Call this before invoking shrinkwrap builds that reference the CCA overlay
+/// assets. The helper ensures `config/` exists under `shrinkwrap_dir` and copies
+/// the repo versions of the assets there, replacing existing files only when
+/// their contents differ.
+pub(crate) fn sync_shrinkwrap_overlay_assets(
     openvmm_root: &Path,
     shrinkwrap_dir: &Path,
 ) -> anyhow::Result<()> {
@@ -131,6 +137,11 @@ fn sync_shrinkwrap_overlay_assets(
             openvmm_root.join("vmm_tests/vmm_tests/test_data/cca_realm_overlay.yaml"),
             shrinkwrap_dir.join("config/cca_realm_overlay.yaml"),
             "realm overlay config",
+        ),
+        (
+            openvmm_root.join("vmm_tests/vmm_tests/test_data/cca_start_tmk.sh"),
+            shrinkwrap_dir.join("config/cca_start_tmk.sh"),
+            "Plane0 TMK launcher",
         ),
     ];
 

--- a/flowey/flowey_lib_hvlite/src/_jobs/local_update_cca_emu.rs
+++ b/flowey/flowey_lib_hvlite/src/_jobs/local_update_cca_emu.rs
@@ -4,6 +4,7 @@
 //! Update components in CCA emulation environment according to options specified.
 use crate::_jobs::local_install_cca_emu::build_cca_rootfs;
 use crate::_jobs::local_install_cca_emu::build_plane0_linux;
+use crate::_jobs::local_install_cca_emu::sync_shrinkwrap_overlay_assets;
 use flowey::node::prelude::*;
 
 #[derive(Default, Serialize, Deserialize, PartialEq, Eq)]
@@ -18,6 +19,7 @@ pub struct SubCmds {
 flowey_request! {
     pub struct Params {
         pub test_root: PathBuf,
+        pub openvmm_root: PathBuf,
         pub sub_cmds: SubCmds,
         pub done: WriteVar<SideEffect>,
     }
@@ -33,6 +35,7 @@ impl SimpleFlowNode for Node {
     fn process_request(request: Self::Request, ctx: &mut NodeCtx<'_>) -> anyhow::Result<()> {
         let Params {
             test_root,
+            openvmm_root,
             sub_cmds,
             done,
         } = request;
@@ -68,6 +71,7 @@ impl SimpleFlowNode for Node {
                 if rebuild_rootfs {
                     let shrinkwrap_dir = test_root.join("shrinkwrap");
                     let venv_dir = shrinkwrap_dir.join("venv");
+                    sync_shrinkwrap_overlay_assets(&openvmm_root, &shrinkwrap_dir)?;
                     build_cca_rootfs(rt, &test_root, &shrinkwrap_dir, &venv_dir)?;
                 }
 

--- a/vmm_tests/vmm_tests/test_data/cca_realm_overlay.yaml
+++ b/vmm_tests/vmm_tests/test_data/cca_realm_overlay.yaml
@@ -11,7 +11,9 @@ build:
   buildroot:
     prebuild:
       - mkdir -p ${param:builddir}/overlay/usr/local/bin
+      - mkdir -p ${param:builddir}/overlay/root
       - mkdir -p ${param:builddir}/overlay/etc/init.d
+      - cp ${param:configdir}/cca_start_tmk.sh ${param:builddir}/overlay/root/start-tmk.sh
 
       # =========================
       # run_realm_test.sh
@@ -28,6 +30,7 @@ build:
         LKVM="$${CCA_DIR}/lkvm"
         KERNEL="$${KERNEL:-/cca/Image}"
         GUESTROOT="/.lkvm/default"
+        START_TMK="/root/start-tmk.sh"
 
         # Wait for artifacts
         for i in $$(seq 1 30); do
@@ -76,22 +79,12 @@ build:
 
             echo "[realm-launch] installing start-tmk.sh..."
 
-            cat > "$$GUESTROOT/root/start-tmk.sh" <<'EOF'
-        #!/root/busybox sh
-        set -e
+            if [ ! -f "$$START_TMK" ]; then
+                echo "[realm-launch][ERROR] Missing $$START_TMK"
+                return 1
+            fi
 
-        echo "[plane0] start-tmk.sh reached"
-
-        mkdir -p /root/mount
-        mount -t 9p -o trans=virtio cca_mount /root/mount
-
-        cd /root/mount
-        export RUST_BACKTRACE=1
-
-        echo "[plane0] Launching tmk_vmm..."
-        exec ./tmk_vmm --hv cca --tmk ./simple_tmk
-        EOF
-
+            cp "$$START_TMK" "$$GUESTROOT/root/start-tmk.sh"
             chmod 755 "$$GUESTROOT/root/start-tmk.sh"
 
             # Debug to verify correct shebang + interpreter

--- a/vmm_tests/vmm_tests/test_data/cca_start_tmk.sh
+++ b/vmm_tests/vmm_tests/test_data/cca_start_tmk.sh
@@ -1,0 +1,15 @@
+#!/root/busybox sh
+set -e
+
+echo "[plane0] start-tmk.sh reached"
+
+mkdir -p /root/mount
+mount -t 9p -o trans=virtio cca_mount /root/mount
+
+cd /root/mount
+export RUST_BACKTRACE=1
+
+echo "[plane0] Launching tmk_vmm..."
+# Do not exec: keep the shell alive to report PASS after tmk_vmm exits cleanly.
+./tmk_vmm --hv cca --tmk ./simple_tmk
+echo "PASS"


### PR DESCRIPTION
Pass the OpenVMM repo root into the CCA update job so it can refresh the
shrinkwrap overlay assets during --rebuild-rootfs.

Without this sync path, changes to cca_start_tmk.sh after the initial emulator
build would not be copied into the shrinkwrap config directory, so rootfs
rebuilds could keep using a stale launcher unless the user did a full fresh
setup.