### PR TITLE
openvmm_entry: crash-safe pidfile with mutual exclusion

### DIFF
--- a/openvmm/openvmm_entry/Cargo.toml
+++ b/openvmm/openvmm_entry/Cargo.toml
@@ -114,6 +114,7 @@ win_etw_tracing.workspace = true
 workspace = true
 features = [
   "Win32_Foundation",
+  "Win32_Storage_FileSystem",
 ]
 
 [build-dependencies]

--- a/openvmm/openvmm_entry/src/lib.rs
+++ b/openvmm/openvmm_entry/src/lib.rs
@@ -11,6 +11,7 @@ mod cli_args;
 mod crash_dump;
 mod kvp;
 mod meshworker;
+mod pidfile;
 mod repl;
 mod serial_io;
 mod storage_builder;
@@ -142,26 +143,14 @@ use vmgs_resources::VmgsResource;
 use vmotherboard::ChipsetDeviceHandle;
 use vnc_worker_defs::VncParameters;
 
-/// RAII guard that removes the pidfile when dropped. Ensures the pidfile is
-/// cleaned up even if [`do_main`] panics.
-struct PidfileGuard(Option<PathBuf>);
-
-impl Drop for PidfileGuard {
-    fn drop(&mut self) {
-        if let Some(path) = &self.0 {
-            let _ = fs_err::remove_file(path);
-        }
-    }
-}
-
 pub fn openvmm_main() {
     // Save the current state of the terminal so we can restore it back to
     // normal before exiting.
     #[cfg(unix)]
     let orig_termios = io::stderr().is_terminal().then(term::get_termios);
 
-    let mut pidfile_guard = PidfileGuard(None);
-    let exit_code = match do_main(&mut pidfile_guard.0) {
+    let mut pidfile_guard: Option<pidfile::Pidfile> = None;
+    let exit_code = match do_main(&mut pidfile_guard) {
         Ok(_) => 0,
         Err(err) => {
             eprintln!("fatal error: {:?}", err);
@@ -175,8 +164,8 @@ pub fn openvmm_main() {
         term::set_termios(orig_termios);
     }
 
-    // Clean up the pidfile before terminating, since pal::process::terminate
-    // skips destructors.
+    // Clean up the pidfile before terminating, since
+    // pal::process::terminate skips destructors.
     drop(pidfile_guard);
 
     // Terminate the process immediately without graceful shutdown of DLLs or
@@ -2223,7 +2212,7 @@ fn prepare_snapshot_restore(
     Ok((shared_memory_fd, state_msg))
 }
 
-fn do_main(pidfile_path: &mut Option<PathBuf>) -> anyhow::Result<()> {
+fn do_main(pidfile_guard: &mut Option<pidfile::Pidfile>) -> anyhow::Result<()> {
     #[cfg(windows)]
     pal::windows::disable_hard_error_dialog();
 
@@ -2243,9 +2232,7 @@ fn do_main(pidfile_path: &mut Option<PathBuf>) -> anyhow::Result<()> {
     }
 
     if let Some(ref path) = opt.pidfile {
-        std::fs::write(path, format!("{}\n", std::process::id()))
-            .context("failed to write pidfile")?;
-        *pidfile_path = Some(path.clone());
+        *pidfile_guard = Some(pidfile::Pidfile::new(path).context("failed to create pidfile")?);
     }
 
     if let Some(path) = opt.relay_console_path {

--- a/openvmm/openvmm_entry/src/pidfile.rs
+++ b/openvmm/openvmm_entry/src/pidfile.rs
@@ -93,7 +93,7 @@ impl Pidfile {
         (|| {
             file.set_len(0)?;
             (&file).seek(io::SeekFrom::Start(0))?;
-            write!(&file, "{pid}\n")?;
+            writeln!(&file, "{pid}")?;
             Ok(())
         })()
         .map_err(|e| PidfileError::Io {
@@ -145,11 +145,11 @@ impl Pidfile {
         };
 
         use std::io::Write;
-        write!(&file, "{pid}\n").map_err(|e| PidfileError::Io {
+        writeln!(&file, "{pid}").map_err(|e| PidfileError::Io {
             file: path.to_owned(),
             error: e,
         })?;
-        Ok(Self { _file: file.into() })
+        Ok(Self { _file: file })
     }
 }
 

--- a/openvmm/openvmm_entry/src/pidfile.rs
+++ b/openvmm/openvmm_entry/src/pidfile.rs
@@ -1,0 +1,209 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Pidfile management with crash-safe cleanup.
+//!
+//! On Unix, the pidfile is held open with an exclusive `flock` lock for
+//! the lifetime of the [`Pidfile`] guard. If the process crashes, the
+//! kernel releases the lock, and the stale file can be detected by
+//! attempting to acquire the lock. The file is deleted on [`Drop`].
+//!
+//! On Windows, the pidfile is opened with `FILE_FLAG_DELETE_ON_CLOSE` and
+//! shared read access (but not write or delete), so the OS removes it
+//! when the handle closes — even after a crash.
+
+use std::io;
+use std::path::Path;
+use std::path::PathBuf;
+
+/// Error returned by [`Pidfile::new`].
+#[derive(Debug, thiserror::Error)]
+pub enum PidfileError {
+    /// The pidfile is already locked by another process.
+    #[error("pidfile is locked by another process (pid {existing_pid:?})")]
+    Locked {
+        /// The PID read from the existing pidfile, if available.
+        existing_pid: Option<u32>,
+    },
+    /// An I/O error occurred.
+    #[error("I/O error occurred while handling pidfile: {}", file.display())]
+    Io {
+        file: PathBuf,
+        #[source]
+        error: io::Error,
+    },
+}
+
+/// An open pidfile that holds a lock (Unix) or delete-on-close handle
+/// (Windows) for the lifetime of the guard.
+#[derive(Debug)]
+pub struct Pidfile {
+    #[cfg(unix)]
+    path: PathBuf,
+    _file: std::fs::File,
+}
+
+impl Pidfile {
+    /// Create a new pidfile at `path` containing the current process ID.
+    ///
+    /// Returns [`PidfileError::Locked`] if another process already holds
+    /// the pidfile.
+    pub fn new(path: &Path) -> Result<Self, PidfileError> {
+        let pid = std::process::id();
+        Self::create(path, pid)
+    }
+
+    #[cfg(unix)]
+    fn create(path: &Path, pid: u32) -> Result<Self, PidfileError> {
+        use std::io::Seek;
+        use std::io::Write;
+
+        // Open (or create) without truncating — we need to lock first so
+        // we don't destroy a live process's pidfile.
+        let file = std::fs::OpenOptions::new()
+            .write(true)
+            .read(true)
+            .create(true)
+            .truncate(false)
+            .open(path)
+            .map_err(|e| PidfileError::Io {
+                file: path.to_owned(),
+                error: e,
+            })?;
+        // Acquire an exclusive lock. If another instance holds the lock,
+        // this returns an error immediately.
+        match file.try_lock() {
+            Ok(()) => {}
+            Err(std::fs::TryLockError::WouldBlock) => {
+                use std::io::Read;
+                let mut contents = String::new();
+                let _ = (&file).read_to_string(&mut contents);
+                return Err(PidfileError::Locked {
+                    existing_pid: contents.trim().parse().ok(),
+                });
+            }
+            Err(std::fs::TryLockError::Error(e)) => {
+                return Err(PidfileError::Io {
+                    file: path.to_owned(),
+                    error: e,
+                });
+            }
+        }
+        // Now that we hold the lock, truncate and write the new PID.
+        (|| {
+            file.set_len(0)?;
+            (&file).seek(io::SeekFrom::Start(0))?;
+            write!(&file, "{pid}\n")?;
+            Ok(())
+        })()
+        .map_err(|e| PidfileError::Io {
+            file: path.to_owned(),
+            error: e,
+        })?;
+        Ok(Self {
+            path: path.to_owned(),
+            _file: file,
+        })
+    }
+
+    #[cfg(windows)]
+    fn create(path: &Path, pid: u32) -> Result<Self, PidfileError> {
+        use std::os::windows::fs::OpenOptionsExt;
+        use windows_sys::Win32::Storage::FileSystem::FILE_FLAG_DELETE_ON_CLOSE;
+        use windows_sys::Win32::Storage::FileSystem::FILE_SHARE_READ;
+
+        // Open with FILE_SHARE_READ (but not WRITE or DELETE) and
+        // FILE_FLAG_DELETE_ON_CLOSE so the OS removes it on handle close.
+        // The lack of FILE_SHARE_WRITE means a second create will fail
+        // with ERROR_SHARING_VIOLATION, providing mutual exclusion.
+        let file = match std::fs::OpenOptions::new()
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .share_mode(FILE_SHARE_READ)
+            .custom_flags(FILE_FLAG_DELETE_ON_CLOSE)
+            .open(path)
+        {
+            Ok(f) => f,
+            Err(e)
+                if e.raw_os_error()
+                    == Some(windows_sys::Win32::Foundation::ERROR_SHARING_VIOLATION as i32) =>
+            {
+                // Another process has the file open. Try to read the existing
+                // PID for the error message.
+                let existing_pid = std::fs::read_to_string(path)
+                    .ok()
+                    .and_then(|s| s.trim().parse().ok());
+                return Err(PidfileError::Locked { existing_pid });
+            }
+            Err(e) => {
+                return Err(PidfileError::Io {
+                    file: path.to_owned(),
+                    error: e,
+                });
+            }
+        };
+
+        use std::io::Write;
+        write!(&file, "{pid}\n").map_err(|e| PidfileError::Io {
+            file: path.to_owned(),
+            error: e,
+        })?;
+        Ok(Self { _file: file.into() })
+    }
+}
+
+#[cfg(unix)]
+impl Drop for Pidfile {
+    fn drop(&mut self) {
+        // Best-effort removal. The flock is released automatically when
+        // the file is closed (which happens when `_file` is dropped after
+        // this).
+        let _ = std::fs::remove_file(&self.path);
+    }
+}
+
+// On Windows, FILE_FLAG_DELETE_ON_CLOSE handles removal — no Drop needed.
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn pidfile_contains_pid() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("test.pid");
+        let _pf = Pidfile::new(&path).unwrap();
+
+        let content = std::fs::read_to_string(&path).unwrap();
+        assert_eq!(content, format!("{}\n", std::process::id()));
+    }
+
+    #[test]
+    fn pidfile_removed_on_drop() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("test.pid");
+        {
+            let _pf = Pidfile::new(&path).unwrap();
+            assert!(path.exists());
+        }
+        assert!(!path.exists());
+    }
+
+    #[test]
+    fn double_lock_fails() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("test.pid");
+        let _pf = Pidfile::new(&path).unwrap();
+
+        // A second pidfile at the same path should fail because the lock
+        // is held.
+        let err = Pidfile::new(&path).unwrap_err();
+        match err {
+            PidfileError::Locked { existing_pid } => {
+                assert_eq!(existing_pid, Some(std::process::id()));
+            }
+            other => panic!("expected PidfileError::Locked, got: {other}"),
+        }
+    }
+}


### PR DESCRIPTION
The existing pidfile implementation does a plain file write with no locking. Two openvmm instances pointed at the same pidfile will silently overwrite each other, and if the process crashes, the stale file is left behind with no way to distinguish it from a live one.

Replace the inline PidfileGuard with a new pidfile module that uses OS-level mechanisms for both mutual exclusion and crash safety. On Unix, the pidfile is held with an exclusive flock lock for the process lifetime -- a second instance gets a clear error with the existing PID. If the process crashes, the kernel releases the lock, so the next instance can reclaim the stale file. On Windows, the file is opened with FILE_FLAG_DELETE_ON_CLOSE and without FILE_SHARE_WRITE, so the OS enforces exclusion via sharing violations and removes the file automatically when the handle closes, even after a crash.