### PR TITLE
deps: update mu_msvm UEFI firmware from 26.0.6 to 26.0.9

### DIFF
--- a/flowey/flowey_lib_hvlite/src/_jobs/cfg_versions.rs
+++ b/flowey/flowey_lib_hvlite/src/_jobs/cfg_versions.rs
@@ -24,7 +24,7 @@ pub const GH_CLI: &str = "2.52.0";
 pub const MDBOOK: &str = "0.4.40";
 pub const MDBOOK_ADMONISH: &str = "1.18.0";
 pub const MDBOOK_MERMAID: &str = "0.14.0";
-pub const MU_MSVM: &str = "26.0.6";
+pub const MU_MSVM: &str = "26.0.9";
 pub const NEXTEST: &str = "0.9.133";
 pub const NODEJS: &str = "24.x";
 // N.B. Kernel version numbers for dev and stable branches are not directly


### PR DESCRIPTION
Update to the latest mu_msvm release, which includes support for running UEFI without VMBus, GUIDed HOBs for VMM-provided ACPI tables, and a PciResourcesPreAssigned config flag to skip PCI bus enumeration.