### PR TITLE
openvmm_entry: implement CapabilitiesVM and PropertiesVM

### DIFF
--- a/openvmm/openvmm_entry/src/ttrpc/mod.rs
+++ b/openvmm/openvmm_entry/src/ttrpc/mod.rs
@@ -149,6 +149,7 @@ impl Worker for TtrpcWorker {
 
     fn run(self, recv: mesh::Receiver<WorkerRpc<Self::State>>) -> anyhow::Result<()> {
         DefaultPool::run_with(async |driver| {
+            let (paused_send, paused_recv) = mesh::channel();
             let mut service = VmService {
                 driver,
                 vm: None,
@@ -156,7 +157,10 @@ impl Worker for TtrpcWorker {
                 vm_controller_events: None,
                 controller_task: None,
                 wait_vm_response: None,
-                halted: false,
+                halt_reason: None,
+                paused: false,
+                paused_send,
+                paused_recv,
                 rpc_tasks: Vec::new(),
                 transport: self.transport,
             };
@@ -347,9 +351,14 @@ struct VmService {
     vm_controller_events: Option<mesh::Receiver<VmControllerEvent>>,
     controller_task: Option<Task<()>>,
     wait_vm_response: Option<(mesh::CancelContext, mesh::OneshotSender<Result<(), Status>>)>,
-    /// Set when the guest has halted, so that a later `WaitVm` completes
-    /// immediately instead of blocking forever. Cleared on `CreateVm`.
-    halted: bool,
+    /// Reason the guest halted, or `None` if it hasn't.
+    halt_reason: Option<String>,
+    /// Whether the VM is currently paused. Only changed once a Pause/Resume RPC
+    /// confirms (via `paused_recv`), so it never reflects a failed transition.
+    paused: bool,
+    /// Confirmed Pause/Resume results are enqueued here and drained into `paused`.
+    paused_send: mesh::Sender<bool>,
+    paused_recv: mesh::Receiver<bool>,
     rpc_tasks: Vec<Task<()>>,
     transport: ResolvedTransport,
 }
@@ -384,6 +393,12 @@ enum HandleAction {
 
 impl VmService {
     async fn handle(&mut self, ctx: mesh::CancelContext, request: vmservice::Vm) -> HandleAction {
+        // Apply confirmed Pause/Resume results before answering, so a
+        // sequential caller sees fresh state right after a transition completes.
+        // Best-effort for callers that pipeline requests.
+        while let Ok(paused) = self.paused_recv.try_recv() {
+            self.paused = paused;
+        }
         tracing::debug!(?request, "request");
         match request {
             vmservice::Vm::CreateVm(request, response) => {
@@ -408,6 +423,12 @@ impl VmService {
                 response.send(Ok(()));
                 return HandleAction::Quit;
             }
+            vmservice::Vm::CapabilitiesVm((), response) => {
+                response.send(Ok(self.build_capabilities()));
+            }
+            vmservice::Vm::PropertiesVm(_request, response) => {
+                response.send(Ok(self.build_properties()));
+            }
             request => {
                 let vm = match &self.vm {
                     Some(vm) => vm.clone(),
@@ -428,7 +449,7 @@ impl VmService {
                     vmservice::Vm::WaitVm((), response) => {
                         if self.wait_vm_response.is_some() {
                             response.send(Err(grpc_error(anyhow!("wait VM already in flight"))));
-                        } else if self.halted {
+                        } else if self.halt_reason.is_some() {
                             // Guest already halted before WaitVm was called;
                             // complete immediately.
                             response.send(Ok(()));
@@ -465,14 +486,11 @@ impl VmService {
                         );
                     }
 
-                    r @ vmservice::Vm::CapabilitiesVm(_, _)
-                    | r @ vmservice::Vm::PropertiesVm(_, _) => {
-                        r.fail(grpc_error(anyhow!("not supported")))
-                    }
-
                     vmservice::Vm::CreateVm(_, _)
                     | vmservice::Vm::TeardownVm(_, _)
-                    | vmservice::Vm::Quit(_, _) => unreachable!(),
+                    | vmservice::Vm::Quit(_, _)
+                    | vmservice::Vm::CapabilitiesVm(_, _)
+                    | vmservice::Vm::PropertiesVm(_, _) => unreachable!(),
                 };
             }
         }
@@ -544,8 +562,12 @@ impl VmService {
             bail!("VM already created");
         }
 
-        // Reset halt state for the new VM.
-        self.halted = false;
+        // Reset lifecycle state; the VM starts paused. Recreate the pause
+        // channel so a late Pause/Resume task from a prior VM (holding the old
+        // sender) can't apply a stale state to this one.
+        self.halt_reason = None;
+        self.paused = true;
+        (self.paused_send, self.paused_recv) = mesh::channel();
 
         let load_mode = match req_config
             .boot_config
@@ -870,27 +892,93 @@ impl VmService {
         }
         self.vm.take();
         self.vm_controller_events.take();
+        self.halt_reason = None;
+        self.paused = false;
         if let Some((_, response)) = self.wait_vm_response.take() {
             response.send(Err(grpc_error(anyhow!("VM torn down"))));
         }
         Ok(())
     }
 
-    fn pause_vm(&mut self, vm: &Vm) -> impl Future<Output = anyhow::Result<()>> + use<> {
-        let recv = vm.worker_rpc.call(VmRpc::Pause, ());
-        async move { recv.await.map(drop).context("pause failed") }
+    /// Derive the reported lifecycle state. A halt takes precedence over the
+    /// paused/running distinction.
+    fn current_state(&self) -> vmservice::VmState {
+        if self.vm.is_none() {
+            vmservice::VmState::Uninitialized
+        } else if self.halt_reason.is_some() {
+            vmservice::VmState::Halted
+        } else if self.paused {
+            vmservice::VmState::Paused
+        } else {
+            vmservice::VmState::Running
+        }
     }
 
-    fn resume_vm(&mut self, vm: &Vm) -> impl Future<Output = anyhow::Result<()>> + use<> {
+    fn build_properties(&self) -> vmservice::PropertiesVmResponse {
+        // Memory/processor stats require a worker query that isn't wired up
+        // yet; leave them unset rather than reporting fabricated zeros.
+        vmservice::PropertiesVmResponse {
+            memory_stats: None,
+            processor_stats: None,
+            state: self.current_state() as i32,
+            halt_reason: self.halt_reason.clone(),
+        }
+    }
+
+    fn build_capabilities(&self) -> vmservice::CapabilitiesVmResponse {
+        use vmservice::capabilities_vm_response::Resource;
+        use vmservice::capabilities_vm_response::SupportedGuestOs;
+        use vmservice::capabilities_vm_response::SupportedResource;
+
+        // Advertise only what modify_resource() actually accepts.
+        vmservice::CapabilitiesVmResponse {
+            supported_resources: vec![
+                SupportedResource {
+                    resource: Resource::Scsi as i32,
+                    add: true,
+                    remove: true,
+                    update: false,
+                },
+                SupportedResource {
+                    resource: Resource::VmNic as i32,
+                    add: true,
+                    remove: false,
+                    update: false,
+                },
+            ],
+            supported_guest_os: vec![
+                SupportedGuestOs::Windows as i32,
+                SupportedGuestOs::Linux as i32,
+            ],
+        }
+    }
+
+    fn pause_vm(&self, vm: &Vm) -> impl Future<Output = anyhow::Result<()>> + use<> {
+        let recv = vm.worker_rpc.call(VmRpc::Pause, ());
+        let paused = self.paused_send.clone();
+        async move {
+            recv.await.map(drop).context("pause failed")?;
+            // Record the pause only after the worker confirms it.
+            paused.send(true);
+            Ok(())
+        }
+    }
+
+    fn resume_vm(&self, vm: &Vm) -> impl Future<Output = anyhow::Result<()>> + use<> {
         let recv = vm.worker_rpc.call(VmRpc::Resume, ());
-        async move { recv.await.map(drop).context("resume failed") }
+        let paused = self.paused_send.clone();
+        async move {
+            recv.await.map(drop).context("resume failed")?;
+            paused.send(false);
+            Ok(())
+        }
     }
 
     fn handle_controller_event(&mut self, event: VmControllerEvent) {
         match event {
             VmControllerEvent::GuestHalt(reason) => {
                 tracing::info!(%reason, "guest halted (via controller)");
-                self.halted = true;
+                self.halt_reason = Some(reason);
                 if let Some((_, response)) = self.wait_vm_response.take() {
                     response.send(Ok(()));
                 }

--- a/openvmm/openvmm_entry/src/ttrpc/mod.rs
+++ b/openvmm/openvmm_entry/src/ttrpc/mod.rs
@@ -892,10 +892,7 @@ impl VmService {
                     update: true,
                 },
             ],
-            supported_guest_os: vec![
-                SupportedGuestOs::Windows as i32,
-                SupportedGuestOs::Linux as i32,
-            ],
+            supported_guest_os: vec![SupportedGuestOs::Linux as i32],
         }
     }
 

--- a/openvmm/openvmm_entry/src/ttrpc/mod.rs
+++ b/openvmm/openvmm_entry/src/ttrpc/mod.rs
@@ -149,7 +149,6 @@ impl Worker for TtrpcWorker {
 
     fn run(self, recv: mesh::Receiver<WorkerRpc<Self::State>>) -> anyhow::Result<()> {
         DefaultPool::run_with(async |driver| {
-            let (paused_send, paused_recv) = mesh::channel();
             let mut service = VmService {
                 driver,
                 vm: None,
@@ -157,10 +156,7 @@ impl Worker for TtrpcWorker {
                 vm_controller_events: None,
                 controller_task: None,
                 wait_vm_response: None,
-                halt_reason: None,
-                paused: false,
-                paused_send,
-                paused_recv,
+                lifecycle: VmLifecycle::Uninitialized,
                 rpc_tasks: Vec::new(),
                 transport: self.transport,
             };
@@ -344,6 +340,15 @@ struct Vm {
     consomme_rpc: Option<mesh::Sender<ConsommeRequest>>,
 }
 
+/// The VM's lifecycle state, as reported by `PropertiesVm`. The halt reason
+/// travels in the `Halted` variant so it can't disagree with the state.
+enum VmLifecycle {
+    Uninitialized,
+    Running,
+    Paused,
+    Halted(String),
+}
+
 struct VmService {
     driver: DefaultDriver,
     vm: Option<Arc<Vm>>,
@@ -351,14 +356,7 @@ struct VmService {
     vm_controller_events: Option<mesh::Receiver<VmControllerEvent>>,
     controller_task: Option<Task<()>>,
     wait_vm_response: Option<(mesh::CancelContext, mesh::OneshotSender<Result<(), Status>>)>,
-    /// Reason the guest halted, or `None` if it hasn't.
-    halt_reason: Option<String>,
-    /// Whether the VM is currently paused. Only changed once a Pause/Resume RPC
-    /// confirms (via `paused_recv`), so it never reflects a failed transition.
-    paused: bool,
-    /// Confirmed Pause/Resume results are enqueued here and drained into `paused`.
-    paused_send: mesh::Sender<bool>,
-    paused_recv: mesh::Receiver<bool>,
+    lifecycle: VmLifecycle,
     rpc_tasks: Vec<Task<()>>,
     transport: ResolvedTransport,
 }
@@ -393,12 +391,6 @@ enum HandleAction {
 
 impl VmService {
     async fn handle(&mut self, ctx: mesh::CancelContext, request: vmservice::Vm) -> HandleAction {
-        // Apply confirmed Pause/Resume results before answering, so a
-        // sequential caller sees fresh state right after a transition completes.
-        // Best-effort for callers that pipeline requests.
-        while let Ok(paused) = self.paused_recv.try_recv() {
-            self.paused = paused;
-        }
         tracing::debug!(?request, "request");
         match request {
             vmservice::Vm::CreateVm(request, response) => {
@@ -439,17 +431,24 @@ impl VmService {
                 };
                 match request {
                     vmservice::Vm::PauseVm((), response) => {
-                        let r = Ok(self.pause_vm(&vm));
-                        self.start_rpc(response, r);
+                        let r = self.pause_vm(&vm).await;
+                        // A halt takes precedence; don't overwrite it.
+                        if r.is_ok() && !matches!(self.lifecycle, VmLifecycle::Halted(_)) {
+                            self.lifecycle = VmLifecycle::Paused;
+                        }
+                        response.send(map_grpc(r));
                     }
                     vmservice::Vm::ResumeVm((), response) => {
-                        let r = Ok(self.resume_vm(&vm));
-                        self.start_rpc(response, r);
+                        let r = self.resume_vm(&vm).await;
+                        if r.is_ok() && !matches!(self.lifecycle, VmLifecycle::Halted(_)) {
+                            self.lifecycle = VmLifecycle::Running;
+                        }
+                        response.send(map_grpc(r));
                     }
                     vmservice::Vm::WaitVm((), response) => {
                         if self.wait_vm_response.is_some() {
                             response.send(Err(grpc_error(anyhow!("wait VM already in flight"))));
-                        } else if self.halt_reason.is_some() {
+                        } else if matches!(self.lifecycle, VmLifecycle::Halted(_)) {
                             // Guest already halted before WaitVm was called;
                             // complete immediately.
                             response.send(Ok(()));
@@ -561,13 +560,6 @@ impl VmService {
         if self.vm.is_some() {
             bail!("VM already created");
         }
-
-        // Reset lifecycle state; the VM starts paused. Recreate the pause
-        // channel so a late Pause/Resume task from a prior VM (holding the old
-        // sender) can't apply a stale state to this one.
-        self.halt_reason = None;
-        self.paused = true;
-        (self.paused_send, self.paused_recv) = mesh::channel();
 
         let load_mode = match req_config
             .boot_config
@@ -880,6 +872,9 @@ impl VmService {
             consomme_rpc,
             worker_rpc: send,
         }));
+        // Only now that the VM exists does it become observable as paused; if
+        // any step above failed, lifecycle stays Uninitialized.
+        self.lifecycle = VmLifecycle::Paused;
         Ok(())
     }
 
@@ -892,36 +887,35 @@ impl VmService {
         }
         self.vm.take();
         self.vm_controller_events.take();
-        self.halt_reason = None;
-        self.paused = false;
+        self.lifecycle = VmLifecycle::Uninitialized;
         if let Some((_, response)) = self.wait_vm_response.take() {
             response.send(Err(grpc_error(anyhow!("VM torn down"))));
         }
         Ok(())
     }
 
-    /// Derive the reported lifecycle state. A halt takes precedence over the
-    /// paused/running distinction.
+    /// Map the internal lifecycle to the wire `VmState`.
     fn current_state(&self) -> vmservice::VmState {
-        if self.vm.is_none() {
-            vmservice::VmState::Uninitialized
-        } else if self.halt_reason.is_some() {
-            vmservice::VmState::Halted
-        } else if self.paused {
-            vmservice::VmState::Paused
-        } else {
-            vmservice::VmState::Running
+        match &self.lifecycle {
+            VmLifecycle::Uninitialized => vmservice::VmState::Uninitialized,
+            VmLifecycle::Running => vmservice::VmState::Running,
+            VmLifecycle::Paused => vmservice::VmState::Paused,
+            VmLifecycle::Halted(_) => vmservice::VmState::Halted,
         }
     }
 
     fn build_properties(&self) -> vmservice::PropertiesVmResponse {
         // Memory/processor stats require a worker query that isn't wired up
         // yet; leave them unset rather than reporting fabricated zeros.
+        let halt_reason = match &self.lifecycle {
+            VmLifecycle::Halted(reason) => Some(reason.clone()),
+            _ => None,
+        };
         vmservice::PropertiesVmResponse {
             memory_stats: None,
             processor_stats: None,
             state: self.current_state() as i32,
-            halt_reason: self.halt_reason.clone(),
+            halt_reason,
         }
     }
 
@@ -942,8 +936,10 @@ impl VmService {
                 SupportedResource {
                     resource: Resource::VmNic as i32,
                     add: true,
-                    remove: false,
-                    update: false,
+                    // update/remove drive Consomme port bind/unbind in
+                    // modify_resource() (Consomme backend only).
+                    remove: true,
+                    update: true,
                 },
             ],
             supported_guest_os: vec![
@@ -955,30 +951,19 @@ impl VmService {
 
     fn pause_vm(&self, vm: &Vm) -> impl Future<Output = anyhow::Result<()>> + use<> {
         let recv = vm.worker_rpc.call(VmRpc::Pause, ());
-        let paused = self.paused_send.clone();
-        async move {
-            recv.await.map(drop).context("pause failed")?;
-            // Record the pause only after the worker confirms it.
-            paused.send(true);
-            Ok(())
-        }
+        async move { recv.await.map(drop).context("pause failed") }
     }
 
     fn resume_vm(&self, vm: &Vm) -> impl Future<Output = anyhow::Result<()>> + use<> {
         let recv = vm.worker_rpc.call(VmRpc::Resume, ());
-        let paused = self.paused_send.clone();
-        async move {
-            recv.await.map(drop).context("resume failed")?;
-            paused.send(false);
-            Ok(())
-        }
+        async move { recv.await.map(drop).context("resume failed") }
     }
 
     fn handle_controller_event(&mut self, event: VmControllerEvent) {
         match event {
             VmControllerEvent::GuestHalt(reason) => {
                 tracing::info!(%reason, "guest halted (via controller)");
-                self.halt_reason = Some(reason);
+                self.lifecycle = VmLifecycle::Halted(reason);
                 if let Some((_, response)) = self.wait_vm_response.take() {
                     response.send(Ok(()));
                 }
@@ -1007,6 +992,7 @@ impl VmService {
                 // task will be awaited during final cleanup.
                 self.vm.take();
                 self.vm_controller.take();
+                self.lifecycle = VmLifecycle::Uninitialized;
             }
             VmControllerEvent::VncWorkerStopped { error } => {
                 if let Some(err) = &error {

--- a/openvmm/openvmm_entry/src/ttrpc/mod.rs
+++ b/openvmm/openvmm_entry/src/ttrpc/mod.rs
@@ -340,13 +340,22 @@ struct Vm {
     consomme_rpc: Option<mesh::Sender<ConsommeRequest>>,
 }
 
-/// The VM's lifecycle state, as reported by `PropertiesVm`. The halt reason
-/// travels in the `Halted` variant so it can't disagree with the state.
 enum VmLifecycle {
     Uninitialized,
     Running,
     Paused,
     Halted(String),
+}
+
+impl From<&VmLifecycle> for vmservice::VmState {
+    fn from(lifecycle: &VmLifecycle) -> Self {
+        match lifecycle {
+            VmLifecycle::Uninitialized => vmservice::VmState::Uninitialized,
+            VmLifecycle::Running => vmservice::VmState::Running,
+            VmLifecycle::Paused => vmservice::VmState::Paused,
+            VmLifecycle::Halted(_) => vmservice::VmState::Halted,
+        }
+    }
 }
 
 struct VmService {
@@ -421,76 +430,34 @@ impl VmService {
             vmservice::Vm::PropertiesVm(_request, response) => {
                 response.send(Ok(self.build_properties()));
             }
-            request => {
-                let vm = match &self.vm {
-                    Some(vm) => vm.clone(),
-                    None => {
-                        request.fail(grpc_error(anyhow!("VM not created yet")));
-                        return HandleAction::None;
-                    }
-                };
-                match request {
-                    vmservice::Vm::PauseVm((), response) => {
-                        let r = self.pause_vm(&vm).await;
-                        // A halt takes precedence; don't overwrite it.
-                        if r.is_ok() && !matches!(self.lifecycle, VmLifecycle::Halted(_)) {
-                            self.lifecycle = VmLifecycle::Paused;
-                        }
-                        response.send(map_grpc(r));
-                    }
-                    vmservice::Vm::ResumeVm((), response) => {
-                        let r = self.resume_vm(&vm).await;
-                        if r.is_ok() && !matches!(self.lifecycle, VmLifecycle::Halted(_)) {
-                            self.lifecycle = VmLifecycle::Running;
-                        }
-                        response.send(map_grpc(r));
-                    }
-                    vmservice::Vm::WaitVm((), response) => {
-                        if self.wait_vm_response.is_some() {
-                            response.send(Err(grpc_error(anyhow!("wait VM already in flight"))));
-                        } else if matches!(self.lifecycle, VmLifecycle::Halted(_)) {
-                            // Guest already halted before WaitVm was called;
-                            // complete immediately.
-                            response.send(Ok(()));
-                        } else {
-                            self.wait_vm_response = Some((ctx.clone(), response));
-                        }
-                    }
-                    vmservice::Vm::ModifyResource(request, response) => {
-                        let r = self.modify_resource(&vm, request);
-                        self.start_rpc(response, r);
-                    }
-                    vmservice::Vm::AddPcieDevice(request, response) => {
-                        let worker_rpc = vm.worker_rpc.clone();
-                        self.start_rpc(
-                            response,
-                            Ok(async move {
-                                let vmservice::AddPcieDeviceRequest { port_name, device } = request;
-                                let resource =
-                                    build_pcie_device(device.context("missing device")?).await?;
-                                worker_rpc
-                                    .call_failable(VmRpc::AddPcieDevice, (port_name, resource))
-                                    .await
-                                    .map_err(anyhow::Error::from)
-                            }),
-                        );
-                    }
-                    vmservice::Vm::RemovePcieDevice(request, response) => {
-                        let recv = vm
-                            .worker_rpc
-                            .call_failable(VmRpc::RemovePcieDevice, request.port_name);
-                        self.start_rpc(
-                            response,
-                            Ok(async move { recv.await.map_err(anyhow::Error::from) }),
-                        );
-                    }
-
-                    vmservice::Vm::CreateVm(_, _)
-                    | vmservice::Vm::TeardownVm(_, _)
-                    | vmservice::Vm::Quit(_, _)
-                    | vmservice::Vm::CapabilitiesVm(_, _)
-                    | vmservice::Vm::PropertiesVm(_, _) => unreachable!(),
-                };
+            vmservice::Vm::PauseVm((), response) => {
+                response.send(map_grpc(self.pause_vm().await));
+            }
+            vmservice::Vm::ResumeVm((), response) => {
+                response.send(map_grpc(self.resume_vm().await));
+            }
+            vmservice::Vm::WaitVm((), response) => {
+                if self.vm.is_none() {
+                    response.send(Err(grpc_error(anyhow!("VM not created yet"))));
+                } else if self.wait_vm_response.is_some() {
+                    response.send(Err(grpc_error(anyhow!("wait VM already in flight"))));
+                } else if matches!(self.lifecycle, VmLifecycle::Halted(_)) {
+                    response.send(Ok(()));
+                } else {
+                    self.wait_vm_response = Some((ctx.clone(), response));
+                }
+            }
+            vmservice::Vm::ModifyResource(request, response) => {
+                let r = self.modify_resource(request);
+                self.start_rpc(response, r);
+            }
+            vmservice::Vm::AddPcieDevice(request, response) => {
+                let r = self.add_pcie_device(request);
+                self.start_rpc(response, r);
+            }
+            vmservice::Vm::RemovePcieDevice(request, response) => {
+                let r = self.remove_pcie_device(request);
+                self.start_rpc(response, r);
             }
         }
         HandleAction::None
@@ -872,8 +839,6 @@ impl VmService {
             consomme_rpc,
             worker_rpc: send,
         }));
-        // Only now that the VM exists does it become observable as paused; if
-        // any step above failed, lifecycle stays Uninitialized.
         self.lifecycle = VmLifecycle::Paused;
         Ok(())
     }
@@ -894,19 +859,7 @@ impl VmService {
         Ok(())
     }
 
-    /// Map the internal lifecycle to the wire `VmState`.
-    fn current_state(&self) -> vmservice::VmState {
-        match &self.lifecycle {
-            VmLifecycle::Uninitialized => vmservice::VmState::Uninitialized,
-            VmLifecycle::Running => vmservice::VmState::Running,
-            VmLifecycle::Paused => vmservice::VmState::Paused,
-            VmLifecycle::Halted(_) => vmservice::VmState::Halted,
-        }
-    }
-
     fn build_properties(&self) -> vmservice::PropertiesVmResponse {
-        // Memory/processor stats require a worker query that isn't wired up
-        // yet; leave them unset rather than reporting fabricated zeros.
         let halt_reason = match &self.lifecycle {
             VmLifecycle::Halted(reason) => Some(reason.clone()),
             _ => None,
@@ -914,7 +867,7 @@ impl VmService {
         vmservice::PropertiesVmResponse {
             memory_stats: None,
             processor_stats: None,
-            state: self.current_state() as i32,
+            state: vmservice::VmState::from(&self.lifecycle) as i32,
             halt_reason,
         }
     }
@@ -924,7 +877,6 @@ impl VmService {
         use vmservice::capabilities_vm_response::SupportedGuestOs;
         use vmservice::capabilities_vm_response::SupportedResource;
 
-        // Advertise only what modify_resource() actually accepts.
         vmservice::CapabilitiesVmResponse {
             supported_resources: vec![
                 SupportedResource {
@@ -936,8 +888,6 @@ impl VmService {
                 SupportedResource {
                     resource: Resource::VmNic as i32,
                     add: true,
-                    // update/remove drive Consomme port bind/unbind in
-                    // modify_resource() (Consomme backend only).
                     remove: true,
                     update: true,
                 },
@@ -949,14 +899,30 @@ impl VmService {
         }
     }
 
-    fn pause_vm(&self, vm: &Vm) -> impl Future<Output = anyhow::Result<()>> + use<> {
-        let recv = vm.worker_rpc.call(VmRpc::Pause, ());
-        async move { recv.await.map(drop).context("pause failed") }
+    async fn pause_vm(&mut self) -> anyhow::Result<()> {
+        let vm = self.vm.clone().context("VM not created yet")?;
+        vm.worker_rpc
+            .call(VmRpc::Pause, ())
+            .await
+            .map(drop)
+            .context("pause failed")?;
+        if !matches!(self.lifecycle, VmLifecycle::Halted(_)) {
+            self.lifecycle = VmLifecycle::Paused;
+        }
+        Ok(())
     }
 
-    fn resume_vm(&self, vm: &Vm) -> impl Future<Output = anyhow::Result<()>> + use<> {
-        let recv = vm.worker_rpc.call(VmRpc::Resume, ());
-        async move { recv.await.map(drop).context("resume failed") }
+    async fn resume_vm(&mut self) -> anyhow::Result<()> {
+        let vm = self.vm.clone().context("VM not created yet")?;
+        vm.worker_rpc
+            .call(VmRpc::Resume, ())
+            .await
+            .map(drop)
+            .context("resume failed")?;
+        if !matches!(self.lifecycle, VmLifecycle::Halted(_)) {
+            self.lifecycle = VmLifecycle::Running;
+        }
+        Ok(())
     }
 
     fn handle_controller_event(&mut self, event: VmControllerEvent) {
@@ -1002,12 +968,45 @@ impl VmService {
         }
     }
 
+    fn add_pcie_device(
+        &self,
+        request: vmservice::AddPcieDeviceRequest,
+    ) -> anyhow::Result<impl Future<Output = anyhow::Result<()>> + use<>> {
+        let worker_rpc = self
+            .vm
+            .as_ref()
+            .context("VM not created yet")?
+            .worker_rpc
+            .clone();
+        Ok(async move {
+            let vmservice::AddPcieDeviceRequest { port_name, device } = request;
+            let resource = build_pcie_device(device.context("missing device")?).await?;
+            worker_rpc
+                .call_failable(VmRpc::AddPcieDevice, (port_name, resource))
+                .await
+                .map_err(anyhow::Error::from)
+        })
+    }
+
+    fn remove_pcie_device(
+        &self,
+        request: vmservice::RemovePcieDeviceRequest,
+    ) -> anyhow::Result<impl Future<Output = anyhow::Result<()>> + use<>> {
+        let recv = self
+            .vm
+            .as_ref()
+            .context("VM not created yet")?
+            .worker_rpc
+            .call_failable(VmRpc::RemovePcieDevice, request.port_name);
+        Ok(async move { recv.await.map_err(anyhow::Error::from) })
+    }
+
     fn modify_resource(
-        &mut self,
-        vm: &Vm,
+        &self,
         request: vmservice::ModifyResourceRequest,
     ) -> anyhow::Result<impl Future<Output = anyhow::Result<()>> + use<>> {
         use vmservice::modify_resource_request::Resource;
+        let vm = self.vm.as_ref().context("VM not created yet")?;
         match request.resource.context("missing resource")? {
             Resource::ScsiDisk(disk) => {
                 let scsi_path = storvsp_resources::ScsiPath {

--- a/openvmm/openvmm_entry/src/ttrpc/mod.rs
+++ b/openvmm/openvmm_entry/src/ttrpc/mod.rs
@@ -886,6 +886,12 @@ impl VmService {
                     update: false,
                 },
                 SupportedResource {
+                    resource: Resource::Vpci as i32,
+                    add: true,
+                    remove: true,
+                    update: false,
+                },
+                SupportedResource {
                     resource: Resource::VmNic as i32,
                     add: true,
                     remove: true,

--- a/openvmm/openvmm_ttrpc_vmservice/src/vmservice.proto
+++ b/openvmm/openvmm_ttrpc_vmservice/src/vmservice.proto
@@ -509,13 +509,10 @@ enum VmState {
 }
 
 message PropertiesVMResponse {
-    // Not yet populated; these require a worker-side stats source and are
-    // left unset until then.
     MemoryStats memory_stats = 1;
     ProcessorStats processor_stats = 2;
     VmState state = 3;
-    // Present when state is Halted, e.g. "PowerOff" or "TripleFault". Absent
-    // otherwise, so callers can distinguish "no reason" from an empty string.
+    // Set when state is Halted.
     optional string halt_reason = 4;
 }
 

--- a/openvmm/openvmm_ttrpc_vmservice/src/vmservice.proto
+++ b/openvmm/openvmm_ttrpc_vmservice/src/vmservice.proto
@@ -501,9 +501,22 @@ message PropertiesVMRequest {
     repeated PropertiesType types = 1;
 }
 
+enum VmState {
+    Uninitialized = 0;
+    Paused = 1;
+    Running = 2;
+    Halted = 3;
+}
+
 message PropertiesVMResponse {
+    // Not yet populated; these require a worker-side stats source and are
+    // left unset until then.
     MemoryStats memory_stats = 1;
     ProcessorStats processor_stats = 2;
+    VmState state = 3;
+    // Present when state is Halted, e.g. "PowerOff" or "TripleFault". Absent
+    // otherwise, so callers can distinguish "no reason" from an empty string.
+    optional string halt_reason = 4;
 }
 
 message CapabilitiesVMResponse {

--- a/vmm_tests/vmm_tests/tests/tests/ttrpc.rs
+++ b/vmm_tests/vmm_tests/tests/tests/ttrpc.rs
@@ -135,6 +135,14 @@ fn test_ttrpc_interface(
                 && r.add),
             "SCSI add should be advertised as a supported resource"
         );
+        assert!(
+            caps.supported_resources.iter().any(|r| r.resource
+                == vmservice::capabilities_vm_response::Resource::Vpci as i32
+                && r.add
+                && r.remove
+                && !r.update),
+            "vPCI add/remove should be advertised as supported"
+        );
         assert_eq!(
             caps.supported_guest_os,
             vec![vmservice::capabilities_vm_response::SupportedGuestOs::Linux as i32],

--- a/vmm_tests/vmm_tests/tests/tests/ttrpc.rs
+++ b/vmm_tests/vmm_tests/tests/tests/ttrpc.rs
@@ -117,6 +117,38 @@ fn test_ttrpc_interface(
             mesh_rpc::client::UnixDialier::new(driver.clone(), ttrpc_path),
         );
 
+        let query_props = || {
+            client.call().start(
+                vmservice::Vm::PropertiesVm,
+                vmservice::PropertiesVmRequest { types: Vec::new() },
+            )
+        };
+
+        // CapabilitiesVm and PropertiesVm answer without a created VM, so
+        // probe them before creating anything.
+        let caps = client
+            .call()
+            .start(vmservice::Vm::CapabilitiesVm, ())
+            .await
+            .unwrap();
+        assert!(
+            caps.supported_resources.iter().any(|r| r.resource
+                == vmservice::capabilities_vm_response::Resource::Scsi as i32
+                && r.add),
+            "SCSI add should be advertised as a supported resource"
+        );
+        assert!(
+            !caps.supported_guest_os.is_empty(),
+            "expected at least one supported guest OS"
+        );
+
+        let props = query_props().await.unwrap();
+        assert_eq!(
+            props.state,
+            vmservice::VmState::Uninitialized as i32,
+            "no VM created yet, expected UNINITIALIZED"
+        );
+
         // Backing files for the PCIe storage devices created on iteration 0
         // (virtio-blk and an NVMe namespace). They are plain raw disks.
         let nvme_disk_path = tempdir.path().join("nvme.img");
@@ -342,6 +374,18 @@ fn test_ttrpc_interface(
                 .await
                 .unwrap();
 
+            let props = query_props().await.unwrap();
+            assert_eq!(
+                props.state,
+                vmservice::VmState::Paused as i32,
+                "VM should be PAUSED immediately after CreateVm"
+            );
+            // Stats aren't wired up yet; they must be unset, not fabricated zeros.
+            assert!(
+                props.memory_stats.is_none() && props.processor_stats.is_none(),
+                "memory/processor stats should be unset, not zeroed"
+            );
+
             // Exercise the Consomme port-forwarding modify paths. Sending an
             // invalid protocol value drives the request through the
             // `ModifyResource(Update|Remove)` -> `consomme_rpc` wiring and the
@@ -474,6 +518,17 @@ fn test_ttrpc_interface(
                         .unwrap();
 
                     waiter.await.unwrap();
+
+                    let props = query_props().await.unwrap();
+                    assert_eq!(
+                        props.state,
+                        vmservice::VmState::Halted as i32,
+                        "guest powered off, expected HALTED"
+                    );
+                    assert!(
+                        props.halt_reason.as_deref().is_some_and(|r| !r.is_empty()),
+                        "HALTED state should carry a halt_reason"
+                    );
 
                     if i == 0 {
                         client

--- a/vmm_tests/vmm_tests/tests/tests/ttrpc.rs
+++ b/vmm_tests/vmm_tests/tests/tests/ttrpc.rs
@@ -135,9 +135,10 @@ fn test_ttrpc_interface(
                 && r.add),
             "SCSI add should be advertised as a supported resource"
         );
-        assert!(
-            !caps.supported_guest_os.is_empty(),
-            "expected at least one supported guest OS"
+        assert_eq!(
+            caps.supported_guest_os,
+            vec![vmservice::capabilities_vm_response::SupportedGuestOs::Linux as i32],
+            "only Linux direct boot is supported"
         );
 
         let props = query_props().await.unwrap();

--- a/vmm_tests/vmm_tests/tests/tests/ttrpc.rs
+++ b/vmm_tests/vmm_tests/tests/tests/ttrpc.rs
@@ -124,8 +124,6 @@ fn test_ttrpc_interface(
             )
         };
 
-        // CapabilitiesVm and PropertiesVm answer without a created VM, so
-        // probe them before creating anything.
         let caps = client
             .call()
             .start(vmservice::Vm::CapabilitiesVm, ())
@@ -149,9 +147,6 @@ fn test_ttrpc_interface(
             "no VM created yet, expected UNINITIALIZED"
         );
 
-        // A CreateVm that fails partway (here: config present but no
-        // boot_config) must not leave a stale state behind; with no VM
-        // created, the reported state stays UNINITIALIZED.
         client
             .call()
             .start(
@@ -339,6 +334,8 @@ fn test_ttrpc_interface(
                 )
             };
 
+            let guest_command = if i == 1 { "sleep 30" } else { "poweroff -f" };
+
             client
                 .call()
                 .start(
@@ -353,9 +350,9 @@ fn test_ttrpc_interface(
                                 vmservice::DirectBoot {
                                     kernel_path: kernel_path.get().to_string_lossy().to_string(),
                                     initrd_path: initrd_path.get().to_string_lossy().to_string(),
-                                    kernel_cmdline:
-                                        "console=ttyS0 rdinit=/bin/busybox panic=-1 -- poweroff -f"
-                                            .to_string(),
+                                    kernel_cmdline: format!(
+                                        "console=ttyS0 rdinit=/bin/busybox panic=-1 -- {guest_command}"
+                                    ),
                                 },
                             )),
                             serial_config: Some(vmservice::SerialConfig {
@@ -401,19 +398,12 @@ fn test_ttrpc_interface(
                 vmservice::VmState::Paused as i32,
                 "VM should be PAUSED immediately after CreateVm"
             );
-            // Stats aren't wired up yet; they must be unset, not fabricated zeros.
             assert!(
                 props.memory_stats.is_none() && props.processor_stats.is_none(),
                 "memory/processor stats should be unset, not zeroed"
             );
 
-            // Exercise the Consomme port-forwarding modify paths. Sending an
-            // invalid protocol value drives the request through the
-            // `ModifyResource(Update|Remove)` -> `consomme_rpc` wiring and the
-            // protocol validation in `parse_port_config`, returning an error
-            // before touching the device. This guards against regressions in
-            // the bind/unbind routing without depending on guest timing or
-            // host port availability.
+            // Invalid protocols exercise Consomme update/remove without binding a port.
             for modify_type in [vmservice::ModifyType::Update, vmservice::ModifyType::Remove] {
                 let err = client
                     .call()
@@ -432,7 +422,6 @@ fn test_ttrpc_interface(
                                                 ports: vec![vmservice::PortConfig {
                                                     host_port: 8080,
                                                     guest_port: 80,
-                                                    // Deliberately invalid protocol value.
                                                     protocol: 99,
                                                 }],
                                             },
@@ -538,8 +527,6 @@ fn test_ttrpc_interface(
                         .await
                         .unwrap();
 
-                    // Resume is confirmed before the guest has booted far enough
-                    // to power off, so the reported state reflects RUNNING.
                     let props = query_props().await.unwrap();
                     assert_eq!(
                         props.state,
@@ -567,8 +554,6 @@ fn test_ttrpc_interface(
                             .await
                             .unwrap();
 
-                        // Tearing down the VM returns state to UNINITIALIZED and
-                        // clears the halt_reason carried by the prior HALTED state.
                         let props = query_props().await.unwrap();
                         assert_eq!(
                             props.state,
@@ -590,6 +575,32 @@ fn test_ttrpc_interface(
                     }
                 }
                 1 => {
+                    client
+                        .call()
+                        .start(vmservice::Vm::ResumeVm, ())
+                        .await
+                        .unwrap();
+
+                    let props = query_props().await.unwrap();
+                    assert_eq!(
+                        props.state,
+                        vmservice::VmState::Running as i32,
+                        "after ResumeVm, expected RUNNING"
+                    );
+
+                    client
+                        .call()
+                        .start(vmservice::Vm::PauseVm, ())
+                        .await
+                        .unwrap();
+
+                    let props = query_props().await.unwrap();
+                    assert_eq!(
+                        props.state,
+                        vmservice::VmState::Paused as i32,
+                        "after PauseVm, expected PAUSED"
+                    );
+
                     client
                         .call()
                         .start(vmservice::Vm::TeardownVm, ())

--- a/vmm_tests/vmm_tests/tests/tests/ttrpc.rs
+++ b/vmm_tests/vmm_tests/tests/tests/ttrpc.rs
@@ -149,6 +149,27 @@ fn test_ttrpc_interface(
             "no VM created yet, expected UNINITIALIZED"
         );
 
+        // A CreateVm that fails partway (here: config present but no
+        // boot_config) must not leave a stale state behind; with no VM
+        // created, the reported state stays UNINITIALIZED.
+        client
+            .call()
+            .start(
+                vmservice::Vm::CreateVm,
+                vmservice::CreateVmRequest {
+                    config: Some(vmservice::VmConfig::default()),
+                    log_id: String::new(),
+                },
+            )
+            .await
+            .unwrap_err();
+        let props = query_props().await.unwrap();
+        assert_eq!(
+            props.state,
+            vmservice::VmState::Uninitialized as i32,
+            "a failed CreateVm must leave state UNINITIALIZED"
+        );
+
         // Backing files for the PCIe storage devices created on iteration 0
         // (virtio-blk and an NVMe namespace). They are plain raw disks.
         let nvme_disk_path = tempdir.path().join("nvme.img");
@@ -517,6 +538,15 @@ fn test_ttrpc_interface(
                         .await
                         .unwrap();
 
+                    // Resume is confirmed before the guest has booted far enough
+                    // to power off, so the reported state reflects RUNNING.
+                    let props = query_props().await.unwrap();
+                    assert_eq!(
+                        props.state,
+                        vmservice::VmState::Running as i32,
+                        "after ResumeVm, expected RUNNING"
+                    );
+
                     waiter.await.unwrap();
 
                     let props = query_props().await.unwrap();
@@ -536,6 +566,19 @@ fn test_ttrpc_interface(
                             .start(vmservice::Vm::TeardownVm, ())
                             .await
                             .unwrap();
+
+                        // Tearing down the VM returns state to UNINITIALIZED and
+                        // clears the halt_reason carried by the prior HALTED state.
+                        let props = query_props().await.unwrap();
+                        assert_eq!(
+                            props.state,
+                            vmservice::VmState::Uninitialized as i32,
+                            "after TeardownVm, expected UNINITIALIZED"
+                        );
+                        assert!(
+                            props.halt_reason.is_none(),
+                            "after TeardownVm, halt_reason should be cleared"
+                        );
 
                         client
                             .call()


### PR DESCRIPTION
## Summary

`CapabilitiesVM` and `PropertiesVM` are declared in `vmservice.proto` but the
handler returned `"not supported"` for both. This wires them up.

- `PropertiesVM` reports a `VmState` (`Uninitialized`/`Paused`/`Running`/`Halted`)
  and `halt_reason`, tracked from the service's lifecycle events. The
  paused/running value only changes once a `Pause`/`Resume` RPC is confirmed by
  the worker, and halt comes from the `GuestHalt` controller event.
- `CapabilitiesVM` reports the resource kinds and guest OSes that
  `modify_resource()` actually accepts today (SCSI add/remove, VMNic add).

Both answer without a created VM, and both apply to `--ttrpc` and `--grpc`,
which share the handler.

`MemoryStats`/`ProcessorStats` are left unset rather than reported as zeros,
since real values would need a new `VmRpc` to query the worker. That can
follow later.

## Testing

Extended the existing `test_ttrpc_interface` integration test to cover the
capabilities response and the state transitions: `Uninitialized` before
`CreateVm`, `Paused` after (and that stats come back unset, not zeroed), and
`Halted` with a non-empty `halt_reason` once the guest powers off. Passes
against a Linux direct-boot guest. `cargo clippy` and `cargo xtask fmt` are
clean.
