### PR TITLE
vmm_tests: re-enable boot_no_vmbus_pcie_nvme test

### DIFF
--- a/petri/src/vm/mod.rs
+++ b/petri/src/vm/mod.rs
@@ -398,7 +398,6 @@ pub struct PetriVm<T: PetriVmmBackend> {
     guest_quirks: GuestQuirksInner,
     vmm_quirks: VmmQuirks,
     expected_boot_event: Option<FirmwareEvent>,
-    uses_pipette_as_init: bool,
 
     config: PetriVmRuntimeConfig,
 }
@@ -1024,7 +1023,6 @@ impl<T: PetriVmmBackend> PetriVmBuilder<T> {
 
         let arch = self.config.arch;
         let expect_reset = self.expect_reset();
-        let uses_pipette_as_init = self.uses_pipette_as_init();
         let properties = self.properties();
 
         let (mut runtime, config) = self
@@ -1050,7 +1048,6 @@ impl<T: PetriVmmBackend> PetriVmBuilder<T> {
             guest_quirks: self.guest_quirks,
             vmm_quirks: self.vmm_quirks,
             expected_boot_event: self.expected_boot_event,
-            uses_pipette_as_init,
 
             config,
         };
@@ -1785,11 +1782,9 @@ impl<T: PetriVmmBackend> PetriVm<T> {
         // TODO: remove this once the bug is fixed, since it shouldn't be
         // necessary and a guest could in theory support pipette and not the IC
         //
-        // Skip when pipette runs as PID 1 init — the shutdown IC may not
-        // be present (e.g., minimal mode).
-        if !self.uses_pipette_as_init {
-            self.runtime.wait_for_enlightened_shutdown_ready().await?;
-        }
+        // This is a no-op when the shutdown IC is not configured (e.g.,
+        // no VMBus or minimal mode).
+        self.runtime.wait_for_enlightened_shutdown_ready().await?;
         self.runtime.wait_for_agent(false).await
     }
 

--- a/petri/src/vm/openvmm/construct.rs
+++ b/petri/src/vm/openvmm/construct.rs
@@ -343,15 +343,9 @@ impl PetriVmConfigOpenVmm {
                 hyperv_ic_resources::timesync::TimesyncIcHandle.into_resource(),
             ));
 
-            (shutdown_ic_send, kvp_ic_send)
+            (Some(shutdown_ic_send), Some(kvp_ic_send))
         } else {
-            // Minimal mode: no ICs. Create dummy senders so the fields
-            // are populated (calls to send_enlightened_shutdown will fail
-            // with a channel error, which is fine — minimal VMs shut down
-            // via reboot(2) directly).
-            let (shutdown_ic_send, _) = mesh::channel();
-            let (kvp_ic_send, _) = mesh::channel();
-            (shutdown_ic_send, kvp_ic_send)
+            (None, None)
         };
 
         // Make a vmbus or virtio vsock path for pipette connections

--- a/petri/src/vm/openvmm/construct.rs
+++ b/petri/src/vm/openvmm/construct.rs
@@ -233,7 +233,7 @@ impl PetriVmConfigOpenVmm {
             pcie_devices.push(PcieDeviceConfig {
                 port_name,
                 resource: NvmeControllerHandle {
-                    subsystem_id: guid::guid!("a1b2c3d4-e5f6-7890-abcd-ef0123456789"),
+                    subsystem_id: Guid::new_random(),
                     max_io_queues: 64,
                     msix_count: 64,
                     namespaces: vec![NamespaceDefinition {

--- a/petri/src/vm/openvmm/mod.rs
+++ b/petri/src/vm/openvmm/mod.rs
@@ -183,8 +183,8 @@ pub struct PetriVmConfigOpenVmm {
 struct PetriVmResourcesOpenVmm {
     log_stream_tasks: Vec<Task<anyhow::Result<()>>>,
     firmware_event_recv: Receiver<FirmwareEvent>,
-    shutdown_ic_send: Sender<ShutdownRpc>,
-    kvp_ic_send: Sender<hyperv_ic_resources::kvp::KvpConnectRpc>,
+    shutdown_ic_send: Option<Sender<ShutdownRpc>>,
+    kvp_ic_send: Option<Sender<hyperv_ic_resources::kvp::KvpConnectRpc>>,
     ged_send: Option<Sender<get_resources::ged::GuestEmulationRequest>>,
     pipette_listener: PolledSocket<UnixListener>,
     vtl2_pipette_listener: Option<PolledSocket<UnixListener>>,

--- a/petri/src/vm/openvmm/runtime.rs
+++ b/petri/src/vm/openvmm/runtime.rs
@@ -257,8 +257,9 @@ impl PetriVmOpenVmm {
     );
     petri_vm_fn!(
         /// Waits for the Hyper-V shutdown IC to be ready, returning a receiver
-        /// that will be closed when it is no longer ready.
-        pub async fn wait_for_enlightened_shutdown_ready(&mut self) -> anyhow::Result<mesh::OneshotReceiver<()>>
+        /// that will be closed when it is no longer ready. Returns `None` if
+        /// the shutdown IC is not configured.
+        pub async fn wait_for_enlightened_shutdown_ready(&mut self) -> anyhow::Result<Option<mesh::OneshotReceiver<()>>>
     );
     petri_vm_fn!(
         /// Instruct the guest to shutdown via the Hyper-V shutdown IC.
@@ -422,20 +423,24 @@ impl PetriVmInner {
 
     async fn wait_for_enlightened_shutdown_ready(
         &mut self,
-    ) -> anyhow::Result<mesh::OneshotReceiver<()>> {
-        let recv = self
-            .resources
-            .shutdown_ic_send
+    ) -> anyhow::Result<Option<mesh::OneshotReceiver<()>>> {
+        let Some(send) = self.resources.shutdown_ic_send.as_ref() else {
+            return Ok(None);
+        };
+        let recv = send
             .call(ShutdownRpc::WaitReady, ())
-            .await?;
-
-        Ok(recv)
+            .await
+            .context("waiting for shutdown IC to be ready")?;
+        Ok(Some(recv))
     }
 
     async fn send_enlightened_shutdown(&mut self, kind: ShutdownKind) -> anyhow::Result<()> {
-        let shutdown_result = self
+        let send = self
             .resources
             .shutdown_ic_send
+            .as_ref()
+            .context("shutdown IC not configured")?;
+        let shutdown_result = send
             .call(
                 ShutdownRpc::Shutdown,
                 hyperv_ic_resources::shutdown::ShutdownParams {
@@ -463,9 +468,12 @@ impl PetriVmInner {
         &mut self,
     ) -> anyhow::Result<mesh::Sender<hyperv_ic_resources::kvp::KvpRpc>> {
         tracing::info!("Waiting for KVP IC");
-        let (send, _) = self
+        let send = self
             .resources
             .kvp_ic_send
+            .as_ref()
+            .context("KVP IC not configured")?;
+        let (send, _) = send
             .call_failable(hyperv_ic_resources::kvp::KvpConnectRpc::WaitForGuest, ())
             .await
             .context("failed to connect to KVP IC")?;

--- a/vmm_tests/vmm_tests/tests/tests/multiarch/openhcl_servicing.rs
+++ b/vmm_tests/vmm_tests/tests/tests/multiarch/openhcl_servicing.rs
@@ -439,7 +439,11 @@ async fn servicing_shutdown_ic(
     // Make sure the disk showed up.
     cmd!(sh, "ls /dev/sda").run().await?;
 
-    let shutdown_ic = vm.backend().wait_for_enlightened_shutdown_ready().await?;
+    let shutdown_ic = vm
+        .backend()
+        .wait_for_enlightened_shutdown_ready()
+        .await?
+        .expect("shutdown IC should be configured");
     vm.restart_openhcl(igvm_file, flags).await?;
     // VTL2 will disconnect and then reconnect the shutdown IC across a servicing event.
     tracing::info!("waiting for shutdown IC to close");

--- a/vmm_tests/vmm_tests/tests/tests/multiarch/pcie.rs
+++ b/vmm_tests/vmm_tests/tests/tests/multiarch/pcie.rs
@@ -652,9 +652,8 @@ async fn amd_iommu_mixed_topology(
 /// Uses PCIe NVMe for the boot disk, virtio-vsock for pipette communication,
 /// and a second PCIe NVMe controller for the cidata agent disk. Validates
 /// that the guest boots and pipette is reachable without any VMBus devices.
-// Disabled until the in-tree UEFI is updated to support this.
-//#[openvmm_test(uefi_x64(vhd(alpine_3_23_x64)))]
-async fn _boot_no_vmbus_pcie_nvme(
+#[openvmm_test(uefi_x64(vhd(alpine_3_23_x64)))]
+async fn boot_no_vmbus_pcie_nvme(
     config: PetriVmBuilder<OpenVmmPetriBackend>,
 ) -> anyhow::Result<()> {
     let (vm, agent) = config


### PR DESCRIPTION
Re-enable the no-VMBus UEFI boot test that was disabled pending a UEFI firmware update. The test was also blocked by a petri issue: when VMBus is disabled, wait_for_agent() tried to wait for the shutdown IC to come online, which failed with "channel closed" because petri was creating dummy mesh channels with immediately-dropped receivers.

Fix this by making shutdown_ic_send and kvp_ic_send into Option, so the absence of these VMBus ICs is explicit rather than hidden behind dead channels. wait_for_enlightened_shutdown_ready becomes a no-op when the shutdown IC isn't configured.