### PR TITLE
openvmm: configurable actions for guest power events

### DIFF
--- a/Guide/src/reference/openvmm/management/cli.md
+++ b/Guide/src/reference/openvmm/management/cli.md
@@ -193,6 +193,38 @@ The `BACKEND` argument is the same for all serial devices:
       connections on the given IP address and port. Typically IP will be
       127.0.0.1, to restrict connections to the current host.
 
+## Guest power events
+
+By default OpenVMM keeps running when the guest powers itself off, hibernates,
+or triple-faults: the virtual processors stop, but the VMM process stays up so
+you can inspect the VM or restart it from the
+[interactive console](./interactive_console.md). A guest-requested reset reboots
+the VM in place, as does a guest watchdog timeout when `--guest-watchdog` is
+enabled.
+
+Four flags override what happens on each guest power event, so a supervising
+process can treat the OpenVMM process lifetime as the VM lifetime. Each takes a
+`reset` (reboot in place), `halt` (stop the processors but keep the VMM process,
+as above), or `exit` (exit the VMM process) action. The `exit` action may carry a
+status code as `exit:<code>` (0-255); a bare `exit` uses 0:
+
+* `--guest-reset-action <reset|halt|exit[:<code>]>` (default `reset`): the guest requested
+  a reset.
+* `--guest-shutdown-action <reset|halt|exit[:<code>]>` (default `halt`): the guest powered
+  off or hibernated.
+* `--guest-crash-action <reset|halt|exit[:<code>]>` (default `halt`): the guest
+  triple-faulted. The fault registers are written to the trace log.
+* `--guest-watchdog-action <reset|halt|exit[:<code>]>` (default `reset`): the guest
+  watchdog timer expired without being petted (requires `--guest-watchdog`).
+
+A bare `exit` exits with status 0; `exit:<code>` exits with that code instead, so
+a supervisor can tell the exit reasons apart.
+
+`--disable-frontpage`: when booting UEFI, power the VM off instead of showing the
+firmware frontpage (the menu shown when there is no bootable device). Combined
+with `--guest-shutdown-action exit`, a guest with no boot device exits the VMM.
+Requires `--uefi`.
+
 ## PCIe Device Support
 
 OpenVMM can emulate a PCI Express topology using `--pcie-root-complex` and

--- a/openhcl/underhill_core/src/worker.rs
+++ b/openhcl/underhill_core/src/worker.rs
@@ -3861,7 +3861,10 @@ async fn halt_task(
     while let Ok(reason) = halt_notify_recv.recv().await {
         let halt_request = match reason {
             HaltReason::PowerOff => HaltRequest::PowerOff,
-            HaltReason::Reset => HaltRequest::Reset,
+            // The paravisor's own watchdog raises Reset, so Watchdog never reaches
+            // this arm today; it is folded into Reset to stay exhaustive. Honoring a
+            // configurable paravisor watchdog action would mean raising Watchdog here.
+            HaltReason::Reset | HaltReason::Watchdog => HaltRequest::Reset,
             HaltReason::Hibernate => HaltRequest::Hibernate,
             HaltReason::TripleFault { vp, registers } => {
                 tracing::info!(CVM_ALLOWED, vp, "triple fault");

--- a/openvmm/openvmm_core/src/worker/dispatch.rs
+++ b/openvmm/openvmm_core/src/worker/dispatch.rs
@@ -1605,8 +1605,8 @@ impl InitializedVm {
             // Create the base watchdog platform
             let mut base_watchdog_platform = BaseWatchdogPlatform::new(store).await?;
 
-            // Create callback to reset on watchdog timeout
-            let watchdog_callback = WatchdogTimeoutReset {
+            // Create the callback that raises the watchdog halt reason on timeout
+            let watchdog_callback = WatchdogTimeout {
                 halt_vps: halt_vps.clone(),
                 watchdog_send: None, // This is not the UEFI watchdog, so no need to send
                                      // watchdog notifications
@@ -3829,15 +3829,17 @@ fn add_devices_to_dsdt_arm64(
     }
 }
 
-struct WatchdogTimeoutReset {
+struct WatchdogTimeout {
     halt_vps: Arc<Halt>,
     watchdog_send: Option<mesh::Sender<()>>,
 }
 
 #[async_trait::async_trait]
-impl WatchdogCallback for WatchdogTimeoutReset {
+impl WatchdogCallback for WatchdogTimeout {
     async fn on_timeout(&mut self) {
-        self.halt_vps.halt(HaltReason::Reset);
+        // Report the timeout as its own halt reason; the VMM's guest-watchdog
+        // action decides whether to reset (default), halt, or exit.
+        self.halt_vps.halt(HaltReason::Watchdog);
 
         if let Some(watchdog_send) = &self.watchdog_send {
             watchdog_send.send(());

--- a/openvmm/openvmm_entry/src/cli_args.rs
+++ b/openvmm/openvmm_entry/src/cli_args.rs
@@ -952,9 +952,29 @@ flags:
     #[clap(long)]
     pub openhcl_dump_path: Option<PathBuf>,
 
-    /// halt the VM when the guest requests a reset, instead of resetting it
-    #[clap(long)]
-    pub halt_on_reset: bool,
+    /// what to do when the guest requests a reset: reset it (default), halt the
+    /// VM for inspection, or exit the VMM process (use `exit:<code>` to set the
+    /// exit status)
+    #[clap(long, value_name = "ACTION", default_value = "reset", value_parser = parse_guest_power_action)]
+    pub guest_reset_action: GuestPowerAction,
+
+    /// what to do when the guest powers off or hibernates: halt the VM for
+    /// inspection (default), reset it, or exit the VMM process (use
+    /// `exit:<code>` to set the exit status)
+    #[clap(long, value_name = "ACTION", default_value = "halt", value_parser = parse_guest_power_action)]
+    pub guest_shutdown_action: GuestPowerAction,
+
+    /// what to do when the guest triple-faults: halt the VM for inspection
+    /// (default), reset it, or exit the VMM process (use `exit:<code>` to set
+    /// the exit status)
+    #[clap(long, value_name = "ACTION", default_value = "halt", value_parser = parse_guest_power_action)]
+    pub guest_crash_action: GuestPowerAction,
+
+    /// what to do when the guest watchdog fires (the guest stopped petting it):
+    /// reset the VM (default), halt it for inspection, or exit the VMM process
+    /// (use `exit:<code>` to set the exit status). Requires `--guest-watchdog`.
+    #[clap(long, value_name = "ACTION", default_value = "reset", value_parser = parse_guest_power_action, requires = "guest_watchdog")]
+    pub guest_watchdog_action: GuestPowerAction,
 
     /// write saved state .proto files to the specified path
     #[clap(long)]
@@ -1260,6 +1280,39 @@ impl FromStr for FsArgsWithOptions {
             options,
             pcie_port,
         })
+    }
+}
+
+/// What the VMM does on a guest power event (reset, power-off/hibernate,
+/// triple-fault, or watchdog timeout). Parsed from `reset`, `halt`, `exit`, or
+/// `exit:<code>`; a bare `exit` uses status 0.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum GuestPowerAction {
+    /// Restart the guest.
+    Reset,
+    /// Stop the VM but keep the VMM process, so it can be inspected or
+    /// restarted from the REPL.
+    Halt,
+    /// Exit the VMM process with this status code.
+    Exit(u8),
+}
+
+/// Parse a [`GuestPowerAction`] from `reset`, `halt`, `exit`, or `exit:<code>`.
+/// A bare `exit` exits with status 0; `exit:<code>` exits with `<code>` (0-255).
+fn parse_guest_power_action(s: &str) -> Result<GuestPowerAction, String> {
+    match s {
+        "reset" => Ok(GuestPowerAction::Reset),
+        "halt" => Ok(GuestPowerAction::Halt),
+        "exit" => Ok(GuestPowerAction::Exit(0)),
+        _ => match s.strip_prefix("exit:") {
+            Some(code) => code
+                .parse::<u8>()
+                .map(GuestPowerAction::Exit)
+                .map_err(|err| format!("invalid exit code '{code}' (expected 0-255): {err}")),
+            None => Err(format!(
+                "expected reset, halt, exit, or exit:<code>, got '{s}'"
+            )),
+        },
     }
 }
 
@@ -4719,6 +4772,55 @@ mod tests {
     fn test_pidfile_option_parsed() {
         let opt = Options::try_parse_from(["openvmm", "--pidfile", "/tmp/test.pid"]).unwrap();
         assert_eq!(opt.pidfile, Some(PathBuf::from("/tmp/test.pid")));
+    }
+
+    #[test]
+    fn test_guest_power_action_flags() {
+        // Defaults preserve the historical behavior: reset and watchdog reboot,
+        // power-off and crash keep the stopped VM.
+        let opt = Options::try_parse_from(["openvmm"]).unwrap();
+        assert_eq!(opt.guest_reset_action, GuestPowerAction::Reset);
+        assert_eq!(opt.guest_shutdown_action, GuestPowerAction::Halt);
+        assert_eq!(opt.guest_crash_action, GuestPowerAction::Halt);
+        assert_eq!(opt.guest_watchdog_action, GuestPowerAction::Reset);
+        // The CLI defaults must match the shared GuestPowerActions::default() the
+        // ttrpc server uses, so the two launch paths never drift.
+        assert_eq!(
+            crate::vm_controller::GuestPowerActions {
+                shutdown: opt.guest_shutdown_action,
+                reset: opt.guest_reset_action,
+                crash: opt.guest_crash_action,
+                watchdog: opt.guest_watchdog_action,
+            },
+            crate::vm_controller::GuestPowerActions::default(),
+        );
+
+        let opt = Options::try_parse_from([
+            "openvmm",
+            "--guest-watchdog",
+            "--guest-reset-action",
+            "exit",
+            "--guest-shutdown-action",
+            "exit:5",
+            "--guest-crash-action",
+            "reset",
+            "--guest-watchdog-action",
+            "halt",
+        ])
+        .unwrap();
+        // A bare `exit` is status 0; `exit:5` carries the code through.
+        assert_eq!(opt.guest_reset_action, GuestPowerAction::Exit(0));
+        assert_eq!(opt.guest_shutdown_action, GuestPowerAction::Exit(5));
+        assert_eq!(opt.guest_crash_action, GuestPowerAction::Reset);
+        assert_eq!(opt.guest_watchdog_action, GuestPowerAction::Halt);
+
+        // Malformed and out-of-range exit codes are rejected (status is 0-255).
+        assert!(Options::try_parse_from(["openvmm", "--guest-reset-action", "exit:nope"]).is_err());
+        assert!(Options::try_parse_from(["openvmm", "--guest-reset-action", "exit:300"]).is_err());
+        assert!(Options::try_parse_from(["openvmm", "--guest-reset-action", "exit:-1"]).is_err());
+
+        // --guest-watchdog-action requires the watchdog device (--guest-watchdog).
+        assert!(Options::try_parse_from(["openvmm", "--guest-watchdog-action", "halt"]).is_err());
     }
 
     #[cfg(target_os = "linux")]

--- a/openvmm/openvmm_entry/src/lib.rs
+++ b/openvmm/openvmm_entry/src/lib.rs
@@ -31,6 +31,7 @@ use chipset_resources::battery::HostBatteryUpdate;
 use cli_args::DiskCliKind;
 use cli_args::EfiDiagnosticsLogLevelCli;
 use cli_args::EndpointConfigCli;
+use cli_args::GuestPowerAction;
 use cli_args::NicConfigCli;
 use cli_args::ProvisionVmgs;
 use cli_args::SerialConfigCli;
@@ -154,7 +155,7 @@ pub fn openvmm_main() {
 
     let mut pidfile_guard: Option<pidfile::Pidfile> = None;
     let exit_code = match do_main(&mut pidfile_guard) {
-        Ok(_) => 0,
+        Ok(code) => code,
         Err(err) => {
             eprintln!("fatal error: {:?}", err);
             1
@@ -1937,7 +1938,10 @@ async fn vm_config_from_command_line(
         firmware_event_send: None,
         debugger_rpc: None,
         rtc_delta_milliseconds: 0,
-        automatic_guest_reset: !opt.halt_on_reset,
+        // Only let the partition auto-reset when the reset action is `reset`.
+        // For `halt` or `exit`, the guest reset must surface as a halt event so
+        // the controller can hold the VM or exit instead of rebooting in place.
+        automatic_guest_reset: matches!(opt.guest_reset_action, GuestPowerAction::Reset),
         efi_diagnostics_log_level: {
             match opt.efi_diagnostics_log_level.unwrap_or_default() {
                 EfiDiagnosticsLogLevelCli::Default => EfiDiagnosticsLogLevelType::Default,
@@ -2369,7 +2373,7 @@ fn prepare_snapshot_restore(
     Ok((shared_memory_fd, state_msg))
 }
 
-fn do_main(pidfile_guard: &mut Option<pidfile::Pidfile>) -> anyhow::Result<()> {
+fn do_main(pidfile_guard: &mut Option<pidfile::Pidfile>) -> anyhow::Result<i32> {
     #[cfg(windows)]
     pal::windows::disable_hard_error_dialog();
 
@@ -2385,7 +2389,7 @@ fn do_main(pidfile_guard: &mut Option<pidfile::Pidfile>) -> anyhow::Result<()> {
         mesh::payload::protofile::DescriptorWriter::new(vmcore::save_restore::saved_state_roots())
             .write_to_path(path)
             .context("failed to write protobuf descriptors")?;
-        return Ok(());
+        return Ok(0);
     }
 
     if let Some(ref path) = opt.pidfile {
@@ -2394,7 +2398,7 @@ fn do_main(pidfile_guard: &mut Option<pidfile::Pidfile>) -> anyhow::Result<()> {
 
     if let Some(path) = opt.relay_console_path {
         let console_title = opt.relay_console_title.unwrap_or_default();
-        return console_relay::relay_console(&path, console_title.as_str());
+        return console_relay::relay_console(&path, console_title.as_str()).map(|()| 0);
     }
 
     #[cfg(any(feature = "grpc", feature = "ttrpc"))]
@@ -2425,7 +2429,7 @@ fn do_main(pidfile_guard: &mut Option<pidfile::Pidfile>) -> anyhow::Result<()> {
 
             handle.join().await?;
 
-            Ok(())
+            Ok(0)
         });
     }
 
@@ -2441,7 +2445,7 @@ fn new_hvsock_service_id(port: u32) -> Guid {
     }
 }
 
-async fn run_control(driver: &DefaultDriver, opt: Options) -> anyhow::Result<()> {
+async fn run_control(driver: &DefaultDriver, opt: Options) -> anyhow::Result<i32> {
     let mut mesh = Some(VmmMesh::new(&driver, opt.single_process)?);
     let result = run_control_inner(driver, &mut mesh, opt).await;
     // If setup failed before the mesh was handed to the controller, shut it
@@ -2456,7 +2460,7 @@ async fn run_control_inner(
     driver: &DefaultDriver,
     mesh_slot: &mut Option<VmmMesh>,
     opt: Options,
-) -> anyhow::Result<()> {
+) -> anyhow::Result<i32> {
     let mesh = mesh_slot.as_ref().unwrap();
     let (mut vm_config, mut resources) = vm_config_from_command_line(driver, mesh, &opt).await?;
 
@@ -2660,6 +2664,12 @@ async fn run_control_inner(
         memory: opt.memory_size(),
         processors: opt.processors,
         log_file: opt.log_file.clone(),
+        guest_power_actions: vm_controller::GuestPowerActions {
+            shutdown: opt.guest_shutdown_action,
+            reset: opt.guest_reset_action,
+            crash: opt.guest_crash_action,
+            watchdog: opt.guest_watchdog_action,
+        },
     };
 
     // Spawn the VmController as a task.
@@ -2689,6 +2699,8 @@ async fn run_control_inner(
     // shuts down the mesh).
     controller_task.await;
 
+    // run_repl returns the exit status: the code the guest drove via an opt-in
+    // exit (VmControllerEvent::ExitRequested), or 0 when the VM stopped normally.
     repl_result
 }
 

--- a/openvmm/openvmm_entry/src/repl.rs
+++ b/openvmm/openvmm_entry/src/repl.rs
@@ -403,7 +403,7 @@ pub(crate) struct ReplResources {
 pub(crate) async fn run_repl(
     driver: &DefaultDriver,
     resources: ReplResources,
-) -> anyhow::Result<()> {
+) -> anyhow::Result<i32> {
     let ReplResources {
         vm_rpc,
         vm_controller,
@@ -586,7 +586,10 @@ pub(crate) async fn run_repl(
     let mut inspect_completion_engine_recv =
         inspect_completion_engine_recv.map(Event::InspectRequestFromCompletionEngine);
 
-    loop {
+    // The exit status to return: 0 normally, or the code the controller asks to
+    // exit with on a guest power event the user opted into. The top-level runner
+    // does cleanup and exits with it.
+    let exit_request: i32 = loop {
         let event = {
             let pulse_save_restore = pin!(async {
                 match pulse_save_restore_interval {
@@ -645,7 +648,7 @@ pub(crate) async fn run_repl(
                 res.send(deferred);
                 continue;
             }
-            Event::Quit => break,
+            Event::Quit => break 0,
             Event::PulseSaveRestore => {
                 vm_rpc.call(VmRpc::PulseSaveRestore, ()).await??;
                 continue;
@@ -736,7 +739,8 @@ pub(crate) async fn run_repl(
                         if let Some(err) = &error {
                             tracing::error!(error = err.as_str(), "vm worker stopped");
                         }
-                        break;
+                        // Non-zero exit when the worker stopped with an error.
+                        break i32::from(error.is_some());
                     }
                     VmControllerEvent::VncWorkerStopped { .. } => {
                         // VNC stopped but VM is still running, continue.
@@ -744,6 +748,7 @@ pub(crate) async fn run_repl(
                     VmControllerEvent::GuestHalt(reason) => {
                         tracing::info!(reason = reason.as_str(), "guest halted");
                     }
+                    VmControllerEvent::ExitRequested { code } => break code,
                 }
                 continue;
             }
@@ -1471,9 +1476,9 @@ pub(crate) async fn run_repl(
             }
             InteractiveCommand::Input { .. } | InteractiveCommand::InputMode => unreachable!(),
         }
-    }
+    };
 
-    Ok(())
+    Ok(exit_request)
 }
 
 // -- Rustyline helpers --

--- a/openvmm/openvmm_entry/src/ttrpc/mod.rs
+++ b/openvmm/openvmm_entry/src/ttrpc/mod.rs
@@ -8,6 +8,7 @@
 use crate::meshworker::VmmMesh;
 use crate::serial_io::bind_serial;
 use crate::serial_io::connect_serial;
+use crate::vm_controller::GuestPowerActions;
 use crate::vm_controller::InspectTarget;
 use crate::vm_controller::VmController;
 use crate::vm_controller::VmControllerEvent;
@@ -757,6 +758,10 @@ impl VmService {
             memory,
             processors,
             log_file: None,
+            // The ttrpc/grpc server never exits on a guest power event; it uses
+            // the historical defaults (none of which is Exit), so the
+            // ExitRequested event handled below is unreachable here.
+            guest_power_actions: GuestPowerActions::default(),
         };
 
         // Spawn the controller task.
@@ -808,6 +813,12 @@ impl VmService {
                 if let Some((_, response)) = self.wait_vm_response.take() {
                     response.send(Ok(()));
                 }
+            }
+            VmControllerEvent::ExitRequested { code } => {
+                // The server leaves the guest power actions at their defaults
+                // (none is `exit`), so this should not occur in ttrpc/grpc mode;
+                // log rather than exiting the server out from under its clients.
+                tracing::warn!(code, "unexpected exit request in server mode");
             }
             VmControllerEvent::WorkerStopped { error } => {
                 if let Some(err) = &error {

--- a/openvmm/openvmm_entry/src/vm_controller.rs
+++ b/openvmm/openvmm_entry/src/vm_controller.rs
@@ -5,6 +5,7 @@
 //! DiagInspector, vtl2_settings) and exposes them to the REPL via mesh RPC.
 
 use crate::DiagInspector;
+use crate::cli_args::GuestPowerAction;
 use crate::meshworker::VmmMesh;
 use anyhow::Context;
 use futures::FutureExt;
@@ -23,6 +24,7 @@ use std::path::PathBuf;
 use std::pin::pin;
 use std::sync::Arc;
 use std::time::Instant;
+use vmm_core_defs::HaltReason;
 
 /// Inspection target: host-side workers or the paravisor.
 #[derive(Clone, Copy, mesh::MeshPayload)]
@@ -102,6 +104,9 @@ pub enum VmControllerEvent {
     VncWorkerStopped { error: Option<String> },
     /// The guest halted.
     GuestHalt(String),
+    /// The controller requests that the process exit with this code, because the
+    /// guest drove a power event the user opted into exiting on.
+    ExitRequested { code: i32 },
 }
 
 /// Owns exclusive VM resources and services RPCs from the REPL.
@@ -120,6 +125,45 @@ pub struct VmController {
     pub(crate) memory: u64,
     pub(crate) processors: u32,
     pub(crate) log_file: Option<PathBuf>,
+    pub(crate) guest_power_actions: GuestPowerActions,
+}
+
+/// The action to take for each guest power event.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct GuestPowerActions {
+    /// Guest powered off or hibernated.
+    pub(crate) shutdown: GuestPowerAction,
+    /// Guest requested a reset.
+    pub(crate) reset: GuestPowerAction,
+    /// Guest triple-faulted.
+    pub(crate) crash: GuestPowerAction,
+    /// Guest watchdog timer expired.
+    pub(crate) watchdog: GuestPowerAction,
+}
+
+impl Default for GuestPowerActions {
+    /// The historical behavior: a guest reset and a watchdog timeout reboot in
+    /// place; a power-off or crash keeps the stopped VM.
+    fn default() -> Self {
+        Self {
+            shutdown: GuestPowerAction::Halt,
+            reset: GuestPowerAction::Reset,
+            crash: GuestPowerAction::Halt,
+            watchdog: GuestPowerAction::Reset,
+        }
+    }
+}
+
+/// Decide what to do for a guest halt, given the per-event actions.
+fn action_for(reason: &HaltReason, actions: &GuestPowerActions) -> GuestPowerAction {
+    match reason {
+        HaltReason::PowerOff | HaltReason::Hibernate => actions.shutdown,
+        HaltReason::Reset => actions.reset,
+        HaltReason::TripleFault { .. } => actions.crash,
+        HaltReason::Watchdog => actions.watchdog,
+        // Any other halt reason keeps the stopped VM for inspection.
+        _ => GuestPowerAction::Halt,
+    }
 }
 
 impl VmController {
@@ -129,14 +173,14 @@ impl VmController {
         mut self,
         mut rpc_recv: mesh::Receiver<VmControllerRpc>,
         event_send: mesh::Sender<VmControllerEvent>,
-        mut notify_recv: mesh::Receiver<vmm_core_defs::HaltReason>,
+        mut notify_recv: mesh::Receiver<HaltReason>,
     ) {
         enum Event {
             Rpc(VmControllerRpc),
             RpcClosed,
             Worker(WorkerEvent),
             VncWorker(WorkerEvent),
-            Halt(vmm_core_defs::HaltReason),
+            Halt(HaltReason),
         }
 
         let mut quit = false;
@@ -231,7 +275,37 @@ impl VmController {
                 },
                 Event::Halt(reason) => {
                     tracing::info!(?reason, "guest halted");
-                    event_send.send(VmControllerEvent::GuestHalt(format!("{reason:?}")));
+                    let action = action_for(&reason, &self.guest_power_actions);
+                    match action {
+                        GuestPowerAction::Exit(code) => {
+                            // The VM worker's teardown deadlocks once the guest vCPUs
+                            // are parked, so don't stop it here; signal the runner to
+                            // exit instead.
+                            tracing::info!(exit_code = code, "requesting exit on guest halt");
+                            event_send.send(VmControllerEvent::ExitRequested {
+                                code: i32::from(code),
+                            });
+                            return;
+                        }
+                        GuestPowerAction::Reset => {
+                            // Reboot the VM in place. A guest reset with the default
+                            // action is handled by `automatic_guest_reset` and never
+                            // reaches here; this path covers a reset chosen for a
+                            // power-off or crash.
+                            tracing::info!("resetting VM on guest power event");
+                            if let Err(err) = self.vm_rpc.call_failable(VmRpc::Reset, ()).await {
+                                tracing::error!(
+                                    error = &err as &dyn std::error::Error,
+                                    "failed to reset VM on guest power event; keeping it stopped"
+                                );
+                                event_send
+                                    .send(VmControllerEvent::GuestHalt(format!("{reason:?}")));
+                            }
+                        }
+                        GuestPowerAction::Halt => {
+                            event_send.send(VmControllerEvent::GuestHalt(format!("{reason:?}")));
+                        }
+                    }
                 }
             }
         }

--- a/vmm_core/src/partition_unit/debug.rs
+++ b/vmm_core/src/partition_unit/debug.rs
@@ -55,6 +55,7 @@ impl DebuggerState {
             notify.send(match reason {
                 HaltReason::PowerOff | HaltReason::Hibernate => DebugStopReason::PowerOff,
                 HaltReason::Reset => DebugStopReason::Reset,
+                HaltReason::Watchdog => DebugStopReason::Watchdog,
                 HaltReason::TripleFault { vp, .. } => DebugStopReason::TripleFault { vp: *vp },
                 HaltReason::DebugBreak { .. } => DebugStopReason::Break,
                 HaltReason::SingleStep { vp } => DebugStopReason::SingleStep { vp: *vp },

--- a/vmm_core/vmm_core_defs/src/debug_rpc.rs
+++ b/vmm_core/vmm_core_defs/src/debug_rpc.rs
@@ -108,4 +108,6 @@ pub enum DebugStopReason {
         vp: u32,
         breakpoint: HardwareBreakpoint,
     },
+    /// The guest watchdog timer expired.
+    Watchdog,
 }

--- a/vmm_core/vmm_core_defs/src/lib.rs
+++ b/vmm_core/vmm_core_defs/src/lib.rs
@@ -60,4 +60,6 @@ pub enum HaltReason {
         #[inspect(skip)]
         breakpoint: virt::x86::HardwareBreakpoint,
     },
+    /// The guest watchdog timer expired without being petted.
+    Watchdog,
 }

--- a/workers/debug_worker/src/lib.rs
+++ b/workers/debug_worker/src/lib.rs
@@ -351,6 +351,15 @@ async fn run_state_machine<T: TargetArch>(
                             DebugStopReason::Break => MultiThreadStopReason::Signal(Signal::SIGINT),
                             DebugStopReason::PowerOff => MultiThreadStopReason::Exited(0),
                             DebugStopReason::Reset => MultiThreadStopReason::Exited(1),
+                            // Report as a signal, not Exited, so the debugger stays
+                            // attached for inspection: the watchdog may be configured to
+                            // halt, leaving the VM stopped rather than gone. SIGABRT
+                            // rather than a timer signal like SIGALRM, because GDB's
+                            // default disposition for SIGALRM is nostop/pass, so the
+                            // debugger would not break on the watchdog timeout.
+                            DebugStopReason::Watchdog => {
+                                MultiThreadStopReason::Signal(Signal::SIGABRT)
+                            }
                             DebugStopReason::TripleFault { vp } => {
                                 MultiThreadStopReason::SignalWithThread {
                                     tid: vm_target.vp_to_tid(vp),


### PR DESCRIPTION
## Summary

Four flags that set what OpenVMM does on each guest power event, so an external
process manager can track the VM by the process lifetime:

- `--guest-reset-action <reset|halt|exit[:code]>` (default `reset`)
- `--guest-shutdown-action <reset|halt|exit[:code]>` (default `halt`)
- `--guest-crash-action <reset|halt|exit[:code]>` (default `halt`)
- `--guest-watchdog-action <reset|halt|exit[:code]>` (default `reset`, with `--guest-watchdog`)

`reset` reboots in place, `halt` stops the vCPUs but keeps the process (so the VM
can still be inspected from the console), and `exit` exits the process. The
defaults reproduce today's behavior, so passing nothing changes nothing.

This revision replaces the per-event booleans from the first revision
(`--exit-on-guest-*`) with a single action enum, as requested in review. It also
removes the `--halt-on-reset` flag; `--guest-reset-action halt` is the equivalent.

## Motivation

OpenVMM stays running after the guest powers off, hibernates, or triple-faults:
the vCPUs stop, but the process stays up so the VM can be inspected or restarted
from the interactive console. That is a good default for interactive and test
use, but it means an external supervisor (systemd, a container runtime) can't
tell from the process lifetime when the guest is gone. These flags let it treat
the openvmm process lifetime as the VM lifetime, the way it can with QEMU.

## Behavior and QEMU mapping

- `--guest-shutdown-action exit` gives QEMU's default shutdown behavior; QEMU's
  `-no-shutdown` is the inverse (keep the process up).
- `--guest-reset-action exit` matches QEMU's `-no-reboot`. The `reset` default
  keeps `automatic_guest_reset` on, so a reset reboots in place.
- `--guest-watchdog-action` is the counterpart to QEMU's `-watchdog-action`.
- `--guest-crash-action` covers a triple fault, a distinct halt reason here
  (QEMU folds a triple fault into a reset).

`exit` takes an optional status code (`exit:<code>`, 0-255, default 0), so a
supervisor can give each event a distinct status and tell the reasons apart. A
bare `exit` is 0, matching QEMU under `-no-reboot`.

## Watchdog

The guest watchdog timeout gets its own `HaltReason::Watchdog`, distinct from a
guest-requested reset, so `--guest-watchdog-action` is independent of
`--guest-reset-action`. An attached debugger sees a matching
`DebugStopReason::Watchdog`.

## Implementation note

The exit path routes through the top-level runner rather than calling
`std::process::exit` from the controller. Once the guest vCPUs are parked after a
power event, the graceful worker teardown doesn't complete, so a
controller-driven `vm_worker.stop()` never reports `Stopped`. The runner does
best-effort cleanup (terminal restore, pidfile removal) and then terminates.

## Docs and testing

The flags are documented in the CLI reference. Verified with `cargo fmt` /
`cargo clippy --workspace` / `cargo test -p openvmm_entry` (parse tests for the
actions and `exit:<code>`, plus the event-to-action mapping), and run on
Linux/KVM.
