### PR TITLE
kernel upgrade: arm64/hyperv - Add Device Tree Support

### DIFF
--- a/flowey/flowey_lib_hvlite/src/_jobs/cfg_versions.rs
+++ b/flowey/flowey_lib_hvlite/src/_jobs/cfg_versions.rs
@@ -30,8 +30,8 @@ pub const NODEJS: &str = "24.x";
 // N.B. Kernel version numbers for dev and stable branches are not directly
 //      comparable. They originate from separate branches, and the fourth digit
 //      increases with each release from the respective branch.
-pub const OPENHCL_KERNEL_DEV_VERSION: &str = "6.18.0.3";
-pub const OPENHCL_KERNEL_STABLE_VERSION: &str = "6.18.0.3";
+pub const OPENHCL_KERNEL_DEV_VERSION: &str = "6.18.0.4";
+pub const OPENHCL_KERNEL_STABLE_VERSION: &str = "6.18.0.4";
 pub const OPENVMM_DEPS: &str = "0.3.0-40";
 pub const PROTOC: &str = "27.1";
 

--- a/nix/openhcl_kernel.nix
+++ b/nix/openhcl_kernel.nix
@@ -1,7 +1,7 @@
 { system, stdenv, fetchzip, targetArch ? null, is_dev ? false, is_cvm ? false }:
 
 let
-  version = if is_dev then "6.18.0.3" else "6.18.0.3";
+  version = if is_dev then "6.18.0.4" else "6.18.0.4";
   # Allow explicit override of architecture, otherwise derive from host system
   # Note: targetArch uses "x86_64"/"aarch64", but URLs use "x64"/"arm64"
   arch = if targetArch == "x86_64" then "x64"
@@ -18,21 +18,21 @@ let
   hashes = {
     hcl-main = {
       std = {
-        x64 = "sha256-bE7exmjCaR+g0pFKmQCpFgMS/7eqLCmWj4UN04qlCwQ=";
-        arm64 = "sha256-FFC4826tOleHvRouF+KwquFPHQKT3hanUfXbWtWFO50=";
+        x64 = "sha256-YqmF+1CY2vvRhktPMZM2PtFGzhXRBVvYt7+CYOAQH/E=";
+        arm64 = "sha256-4Ntvl9WSZ3u+MDy6iQC4lEoRTWfFAbt6N+4l8kGySek=";
       };
       cvm = {
-        x64 = "sha256-WtTHIHec4rmQPFCKfPzAdMDJkN0/WimV/l77ZX49KdU=";
+        x64 = "sha256-VumSnRGNNee0Xx34y/sVo4vWTcnHAtIsnBQ7loZqMJw=";
         arm64 = throw "openhcl-kernel: cvm arm64 variant not available";
       };
     };
     hcl-dev = {
       std = {
-        x64 = "sha256-l41pBU22R2NjdRpLT1JSwEj3ROf8Stqp6N5Rw/mi90E=";
-        arm64 = "sha256-taGhLFIiYwmqeTk5zOUDkHafdyW7Nc7w95EMIuJaEy8=";
+        x64 = "sha256-hAIJc1aKEVu7+pLpIfdS9S47ajVQhYuVnSAfF4anIK8=";
+        arm64 = "sha256-7d16HiNDxWB9TD5bbqhtdltj0/nOmw3PjG380w+kNSE=";
       };
       cvm = {
-        x64 = "sha256-Ohjbjz1wjKjyKL9vCBejClNGYCS/0Ir7XtijKRJtvc0=";
+        x64 = "sha256-wmegRN+QO3J7ksDLXVe7j4qmIMlR8Wyv46+hnKa91h8=";
         arm64 = throw "openhcl-kernel: dev cvm arm64 variant not available";
       };
     };


### PR DESCRIPTION
Enable arm vm boot with DeviceTree along with ACPI and SMCCC.

Kernel change: https://github.com/microsoft/OHCL-Linux-Kernel/commit/46ee03c717ad05039e6f19249840b52b22e8c8de

This change fixes the v6.18 kernel arm vm boot failure: https://microsoft.visualstudio.com/OS/_workitems/edit/62182660/


Signed-off-by: Hardik Garg <hargar@microsoft.com>