### PR TITLE
fix(vmm-tests): re-enable linux direct pcie tests

### DIFF
--- a/flowey/flowey_lib_hvlite/src/_jobs/cfg_versions.rs
+++ b/flowey/flowey_lib_hvlite/src/_jobs/cfg_versions.rs
@@ -32,7 +32,7 @@ pub const NODEJS: &str = "24.x";
 //      increases with each release from the respective branch.
 pub const OPENHCL_KERNEL_DEV_VERSION: &str = "6.18.0.3";
 pub const OPENHCL_KERNEL_STABLE_VERSION: &str = "6.18.0.3";
-pub const OPENVMM_DEPS: &str = "0.3.0-40";
+pub const OPENVMM_DEPS: &str = "0.3.0-43";
 pub const PROTOC: &str = "27.1";
 
 flowey_request! {

--- a/vmm_tests/vmm_tests/tests/tests/multiarch/pcie.rs
+++ b/vmm_tests/vmm_tests/tests/tests/multiarch/pcie.rs
@@ -1,10 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-// All of the PCIe tests on Linux direct have been marked as unstable due to
-// what is presumed to be a bug in the guest kernel currently being used.
-// TODO: remove the unstable designations once the kernel is updated.
-
 use crate::multiarch::OsFlavor;
 use crate::multiarch::cmd;
 use guid::Guid;
@@ -166,7 +162,7 @@ async fn parse_guest_pci_devices(
 /// Test PCIe root complex discovery and root port enumeration by
 /// guest software in a single segment topology.
 #[openvmm_test(
-    unstable_linux_direct_x64,
+    linux_direct_x64,
     uefi_x64(vhd(windows_datacenter_core_2022_x64)),
     uefi_x64(vhd(ubuntu_2404_server_x64)),
     uefi_aarch64(vhd(windows_11_enterprise_aarch64)),
@@ -201,7 +197,7 @@ async fn pcie_root_emulation_single_segment(
 /// ports per root complex to exercise multi-function packing across
 /// multiple PCI device slots.
 #[openvmm_test(
-    unstable_linux_direct_x64,
+    linux_direct_x64,
     uefi_x64(vhd(windows_datacenter_core_2022_x64)),
     uefi_x64(vhd(ubuntu_2404_server_x64)),
     uefi_aarch64(vhd(windows_11_enterprise_aarch64)),
@@ -234,7 +230,7 @@ async fn pcie_root_emulation_multi_segment(
 /// Test PCIe switch enumeration when attached to both root
 /// ports and the downstream switch ports of other switches.
 #[openvmm_test(
-    unstable_linux_direct_x64,
+    linux_direct_x64,
     uefi_x64(vhd(windows_datacenter_core_2022_x64)),
     uefi_x64(vhd(ubuntu_2404_server_x64)),
     uefi_aarch64(vhd(windows_11_enterprise_aarch64)),
@@ -278,7 +274,7 @@ async fn pcie_switches(config: PetriVmBuilder<OpenVmmPetriBackend>) -> anyhow::R
 ///
 /// NOTE: This test relies on device specific software (drivers,
 /// tooling) within the guest OS to perform the validation.
-#[openvmm_test(unstable_linux_direct_x64)]
+#[openvmm_test(linux_direct_x64)]
 async fn pcie_devices(config: PetriVmBuilder<OpenVmmPetriBackend>) -> anyhow::Result<()> {
     let os_flavor = config.os_flavor();
     let (vm, agent) = config
@@ -335,10 +331,7 @@ async fn pcie_devices(config: PetriVmBuilder<OpenVmmPetriBackend>) -> anyhow::Re
 
 /// Test PCIe hotplug: hot-add a device to a hotplug-capable port, verify the
 /// guest sees it, then hot-remove it and verify it's gone.
-#[openvmm_test(
-    unstable_linux_direct_x64,
-    uefi_x64(vhd(windows_datacenter_core_2022_x64))
-)]
+#[openvmm_test(linux_direct_x64, uefi_x64(vhd(windows_datacenter_core_2022_x64)))]
 async fn pcie_hotplug(
     config: PetriVmBuilder<OpenVmmPetriBackend>,
     _: (),
@@ -418,7 +411,7 @@ async fn pcie_hotplug(
 /// 2. Enumerates PCI devices visible to the guest
 /// 3. Pulses save/restore (pause → save → restore → resume)
 /// 4. Re-enumerates PCI devices and verifies they match
-#[openvmm_test(unstable_linux_direct_x64)]
+#[openvmm_test(linux_direct_x64)]
 async fn pcie_save_restore(config: PetriVmBuilder<OpenVmmPetriBackend>) -> anyhow::Result<()> {
     let os_flavor = config.os_flavor();
     let (mut vm, agent) = config


### PR DESCRIPTION
Reverts #3548 which marked linux direct pcie tests as unstable due to a MANA driver crash in kernel 6.18.31.

The root cause was a NULL pointer dereference in `mana_gd_probe()` when probing the second GDMA device behind a PCIe switch downstream port.

This is now fixed by:
- [openvmm-deps#68](https://github.com/microsoft/openvmm-deps/pull/68): kernel bump to 6.18.33
- [#3530](https://github.com/microsoft/openvmm/pull/3530): 6.18 test kernel onboarding

Closes the action item from https://github.com/microsoft/openvmm/pull/3548#issuecomment-4512488483