### PR TITLE
virt_kvm: make nested virtualization opt-in

### DIFF
--- a/openvmm/hypervisor_resources/src/lib.rs
+++ b/openvmm/hypervisor_resources/src/lib.rs
@@ -35,6 +35,12 @@ pub struct KvmHandle {
     /// An open `/dev/kvm` file descriptor, open with read and write
     /// permissions.
     pub kvm: std::fs::File,
+    /// Configure the partition for nested virtualization, so that the
+    /// guest can run its own hypervisor (Hyper-V, KVM, etc.).
+    ///
+    /// When false (the default), VMX/SVM CPUID bits and the MS hypervisor
+    /// nested-features leaf are stripped from the guest's view.
+    pub nested_virt: bool,
 }
 
 impl ResourceId<HypervisorKind> for KvmHandle {

--- a/openvmm/openvmm_entry/src/cli_args.rs
+++ b/openvmm/openvmm_entry/src/cli_args.rs
@@ -799,11 +799,18 @@ flags:
     ///                          user_mode_apic=false and host WHP
     ///                          support)
     ///
+    /// KVM parameters (x86_64 guests only):
+    ///   nested_virt          - expose VMX/SVM to the guest so it can run
+    ///                          its own hypervisor (requires host KVM
+    ///                          nested-virt support)
+    ///
     /// Examples:
     ///   --hypervisor whp
     ///   --hypervisor whp:user_mode_apic
     ///   --hypervisor whp:user_mode_apic,no_enlightenments
     ///   --hypervisor whp:nested_virt
+    ///   --hypervisor kvm
+    ///   --hypervisor kvm:nested_virt
     #[clap(long)]
     pub hypervisor: Option<String>,
 

--- a/openvmm/openvmm_hypervisors/src/kvm.rs
+++ b/openvmm/openvmm_hypervisors/src/kvm.rs
@@ -25,15 +25,35 @@ impl hypervisor_resources::HypervisorProbe for KvmProbe {
             Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(None),
             Err(err) => return Err(err.into()),
         };
-        Ok(Some(KvmHandle { kvm: kvm.into() }.into_resource()))
+        Ok(Some(
+            KvmHandle {
+                kvm: kvm.into(),
+                nested_virt: false,
+            }
+            .into_resource(),
+        ))
     }
 
     fn new_resource(&self, params: &[(&str, &str)]) -> anyhow::Result<Resource<HypervisorKind>> {
-        if let Some(&(key, _)) = params.first() {
-            anyhow::bail!("unknown kvm parameter: {key}");
+        let mut nested_virt = false;
+        for &(key, val) in params {
+            match key {
+                "nested_virt" => {
+                    if cfg!(guest_arch = "x86_64") {
+                        nested_virt = parse_bool_param(key, val)?;
+                    } else {
+                        anyhow::bail!("kvm parameter {key} is only supported for x86_64 guests");
+                    }
+                }
+                _ => anyhow::bail!("unknown kvm parameter: {key}"),
+            }
         }
         let kvm = open_kvm().context("KVM is not available")?;
-        Ok(KvmHandle { kvm: kvm.into() }.into_resource())
+        Ok(KvmHandle {
+            kvm: kvm.into(),
+            nested_virt,
+        }
+        .into_resource())
     }
 }
 
@@ -43,3 +63,5 @@ fn open_kvm() -> std::io::Result<fs_err::File> {
         .write(true)
         .open("/dev/kvm")
 }
+
+use crate::parse_bool_param;

--- a/openvmm/openvmm_hypervisors/src/lib.rs
+++ b/openvmm/openvmm_hypervisors/src/lib.rs
@@ -30,3 +30,13 @@ hypervisor_resources::register_hypervisor_probes! {
     #[cfg(all(target_os = "macos", guest_arch = "aarch64", guest_is_native, feature = "virt_hvf"))]
     hvf::HvfProbe,
 }
+
+#[expect(clippy::allow_attributes, reason = "lots of conditions")]
+#[allow(dead_code)]
+pub(crate) fn parse_bool_param(key: &str, val: &str) -> anyhow::Result<bool> {
+    match val {
+        "true" | "1" | "yes" => Ok(true),
+        "false" | "0" | "no" => Ok(false),
+        _ => anyhow::bail!("invalid boolean value for {key}: {val}"),
+    }
+}

--- a/openvmm/openvmm_hypervisors/src/whp.rs
+++ b/openvmm/openvmm_hypervisors/src/whp.rs
@@ -5,6 +5,7 @@
 
 #![cfg(all(target_os = "windows", feature = "virt_whp", guest_is_native))]
 
+use crate::parse_bool_param;
 use hypervisor_resources::HypervisorKind;
 use hypervisor_resources::WhpHandle;
 use vm_resource::Resource;
@@ -51,13 +52,5 @@ impl hypervisor_resources::HypervisorProbe for WhpProbe {
         }
         anyhow::ensure!(virt_whp::is_available()?, "WHP is not available");
         Ok(Resource::new(handle))
-    }
-}
-
-fn parse_bool_param(key: &str, val: &str) -> anyhow::Result<bool> {
-    match val {
-        "true" | "1" | "yes" => Ok(true),
-        "false" | "0" | "no" => Ok(false),
-        _ => anyhow::bail!("invalid boolean value for {key}: {val}"),
     }
 }

--- a/openvmm/openvmm_resources/src/hypervisor_resolvers/kvm.rs
+++ b/openvmm/openvmm_resources/src/hypervisor_resolvers/kvm.rs
@@ -18,6 +18,7 @@ impl vm_resource::ResolveResource<HypervisorKind, KvmHandle> for KvmResolver {
 
     fn resolve(&self, resource: KvmHandle, _input: ()) -> Result<Self::Output, Self::Error> {
         let kvm = resource.kvm;
+        #[cfg_attr(not(guest_arch = "x86_64"), expect(unused_mut))]
         let mut backend = virt_kvm::Kvm::from_kvm(kvm)?;
         #[cfg(guest_arch = "x86_64")]
         {

--- a/openvmm/openvmm_resources/src/hypervisor_resolvers/kvm.rs
+++ b/openvmm/openvmm_resources/src/hypervisor_resolvers/kvm.rs
@@ -18,9 +18,12 @@ impl vm_resource::ResolveResource<HypervisorKind, KvmHandle> for KvmResolver {
 
     fn resolve(&self, resource: KvmHandle, _input: ()) -> Result<Self::Output, Self::Error> {
         let kvm = resource.kvm;
-        Ok(ResolvedHypervisorBackend::new(virt_kvm::Kvm::from_kvm(
-            kvm,
-        )?))
+        let mut backend = virt_kvm::Kvm::from_kvm(kvm)?;
+        #[cfg(guest_arch = "x86_64")]
+        {
+            backend.nested_virt = resource.nested_virt;
+        }
+        Ok(ResolvedHypervisorBackend::new(backend))
     }
 }
 

--- a/vmm_core/virt_kvm/src/arch/x86_64/mod.rs
+++ b/vmm_core/virt_kvm/src/arch/x86_64/mod.rs
@@ -97,6 +97,8 @@ const MYSTERY_MSRS: &[u32] = &[0x88, 0x89, 0x8a, 0x116, 0x118, 0x119, 0x11a, 0x1
 #[derive(Debug)]
 pub struct Kvm {
     kvm: kvm::Kvm,
+    /// Enable nested virtualization (VMX/SVM) for the guest.
+    pub nested_virt: bool,
 }
 
 impl Kvm {
@@ -104,13 +106,17 @@ impl Kvm {
     pub fn new() -> Result<Self, KvmError> {
         Ok(Self {
             kvm: kvm::Kvm::new()?,
+            nested_virt: false,
         })
     }
 
     /// Creates a KVM hypervisor instance from a pre-opened `/dev/kvm` fd.
     pub fn from_kvm(file: std::fs::File) -> Result<Self, KvmError> {
         let kvm = kvm::Kvm::from(file);
-        Ok(Self { kvm })
+        Ok(Self {
+            kvm,
+            nested_virt: false,
+        })
     }
 }
 
@@ -141,9 +147,17 @@ impl virt::Hypervisor for Kvm {
             return Err(KvmError::IsolationNotSupported);
         }
 
-        let mut cpuid_entries = self
-            .kvm
-            .supported_cpuid()?
+        let nested_virt = self.nested_virt;
+        let supported_cpuid = self.kvm.supported_cpuid()?;
+
+        // Determine the CPU vendor from CPUID leaf 0.
+        let vendor = supported_cpuid
+            .iter()
+            .find(|e| e.function == CpuidFunction::VendorAndMaxFunction.0)
+            .map(|e| x86defs::cpuid::Vendor::from_ebx_ecx_edx(e.ebx, e.ecx, e.edx))
+            .unwrap_or(x86defs::cpuid::Vendor([0; 12]));
+
+        let mut cpuid_entries = supported_cpuid
             .into_iter()
             .filter_map(|entry| {
                 // Filter out KVM CPUID entries.
@@ -155,9 +169,33 @@ impl virt::Hypervisor for Kvm {
                 if entry.flags & KVM_CPUID_FLAG_SIGNIFCANT_INDEX != 0 {
                     leaf = leaf.indexed(entry.index);
                 }
+
                 Some(leaf)
             })
             .collect::<Vec<_>>();
+
+        // When nested virt is disabled, strip the virtualization
+        // CPUID bit for the host's vendor.
+        if !nested_virt {
+            let (function, ecx_mask) = if vendor.is_intel_compatible() {
+                (
+                    CpuidFunction::VersionAndFeatures.0,
+                    x86defs::cpuid::VersionAndFeaturesEcx::new()
+                        .with_vmx(true)
+                        .into(),
+                )
+            } else if vendor.is_amd_compatible() {
+                (
+                    CpuidFunction::ExtendedVersionAndFeatures.0,
+                    x86defs::cpuid::ExtendedVersionAndFeaturesEcx::new()
+                        .with_svm(true)
+                        .into(),
+                )
+            } else {
+                (CpuidFunction::VersionAndFeatures.0, 0)
+            };
+            cpuid_entries.push(CpuidLeaf::new(function, [0, 0, 0, 0]).masked([0, 0, ecx_mask, 0]));
+        }
 
         // Add in GB page support based on the host's capabilities. This bit
         // is incorrectly stripped by some versions of KVM (but is important
@@ -223,11 +261,16 @@ impl virt::Hypervisor for Kvm {
                 .with_access_apic_msrs(true);
 
             // Query KVM's supported Hyper-V CPUID leaves to find the
-            // nested virtualization features leaf (0x4000000A).
+            // nested virtualization features leaf (0x4000000A), but only
+            // expose it when nested virtualization is enabled.
             let kvm_hv_cpuid = self.kvm.supported_hv_cpuid()?;
-            let nested_leaf = kvm_hv_cpuid
-                .iter()
-                .find(|e| e.function == HV_CPUID_FUNCTION_MS_HV_NESTED_FEATURES);
+            let nested_leaf = if self.nested_virt {
+                kvm_hv_cpuid
+                    .iter()
+                    .find(|e| e.function == HV_CPUID_FUNCTION_MS_HV_NESTED_FEATURES)
+            } else {
+                None
+            };
 
             let max_function = if nested_leaf.is_some() {
                 HV_CPUID_FUNCTION_MS_HV_NESTED_FEATURES
@@ -283,6 +326,28 @@ impl virt::Hypervisor for Kvm {
 
         let cpuid_entries = CpuidLeafSet::new(cpuid_entries);
 
+        // If nested virt was requested, verify the host actually
+        // supports it (VMX on Intel, SVM on AMD).
+        if nested_virt {
+            let supported = if vendor.is_intel_compatible() {
+                x86defs::cpuid::VersionAndFeaturesEcx::from(
+                    cpuid_entries.result(CpuidFunction::VersionAndFeatures.0, 0, &[0; 4])[2],
+                )
+                .vmx()
+            } else if vendor.is_amd_compatible() {
+                x86defs::cpuid::ExtendedVersionAndFeaturesEcx::from(
+                    cpuid_entries.result(CpuidFunction::ExtendedVersionAndFeatures.0, 0, &[0; 4])
+                        [2],
+                )
+                .svm()
+            } else {
+                false
+            };
+            if !supported {
+                return Err(KvmError::NestedVirtUnsupported);
+            }
+        }
+
         let vm = self.kvm.new_vm()?;
         vm.enable_split_irqchip(virt::irqcon::IRQ_LINES as u32)?;
         vm.enable_x2apic_api()?;
@@ -292,6 +357,7 @@ impl virt::Hypervisor for Kvm {
             vm,
             config,
             cpuid: cpuid_entries,
+            nested_virt: self.nested_virt,
         })
     }
 }
@@ -301,6 +367,7 @@ pub struct KvmProtoPartition<'a> {
     vm: kvm::Partition,
     config: ProtoPartitionConfig<'a>,
     cpuid: CpuidLeafSet,
+    nested_virt: bool,
 }
 
 impl ProtoPartition for KvmProtoPartition<'_> {
@@ -349,6 +416,7 @@ impl ProtoPartition for KvmProtoPartition<'_> {
         .map_err(KvmError::Capabilities)?;
 
         caps.can_freeze_time = false;
+        caps.nested_virt = self.nested_virt;
 
         // Create all VCPUs now so that they are assigned dense, sequential
         // vcpu_idx values (KVM assigns vcpu_idx in creation order).  KVM's

--- a/vmm_core/virt_kvm/src/arch/x86_64/mod.rs
+++ b/vmm_core/virt_kvm/src/arch/x86_64/mod.rs
@@ -157,6 +157,10 @@ impl virt::Hypervisor for Kvm {
             .map(|e| x86defs::cpuid::Vendor::from_ebx_ecx_edx(e.ebx, e.ecx, e.edx))
             .unwrap_or(x86defs::cpuid::Vendor([0; 12]));
 
+        if !vendor.is_intel_compatible() && !vendor.is_amd_compatible() {
+            return Err(KvmError::UnsupportedCpuVendor);
+        }
+
         let mut cpuid_entries = supported_cpuid
             .into_iter()
             .filter_map(|entry| {
@@ -184,15 +188,13 @@ impl virt::Hypervisor for Kvm {
                         .with_vmx(true)
                         .into(),
                 )
-            } else if vendor.is_amd_compatible() {
+            } else {
                 (
                     CpuidFunction::ExtendedVersionAndFeatures.0,
                     x86defs::cpuid::ExtendedVersionAndFeaturesEcx::new()
                         .with_svm(true)
                         .into(),
                 )
-            } else {
-                (CpuidFunction::VersionAndFeatures.0, 0)
             };
             cpuid_entries.push(CpuidLeaf::new(function, [0, 0, 0, 0]).masked([0, 0, ecx_mask, 0]));
         }
@@ -334,14 +336,12 @@ impl virt::Hypervisor for Kvm {
                     cpuid_entries.result(CpuidFunction::VersionAndFeatures.0, 0, &[0; 4])[2],
                 )
                 .vmx()
-            } else if vendor.is_amd_compatible() {
+            } else {
                 x86defs::cpuid::ExtendedVersionAndFeaturesEcx::from(
                     cpuid_entries.result(CpuidFunction::ExtendedVersionAndFeatures.0, 0, &[0; 4])
                         [2],
                 )
                 .svm()
-            } else {
-                false
             };
             if !supported {
                 return Err(KvmError::NestedVirtUnsupported);
@@ -715,23 +715,20 @@ impl virt::BindProcessor for KvmProcessorBinder {
         // this MSR to 0; set the lock bit (as Hyper-V does) so that the
         // MSR reads as locked, and enable VMX outside SMX if the guest
         // has VMX in CPUID.
-        {
-            let cpuid = &self.partition.cpuid;
-            let leaf0 = cpuid.result(CpuidFunction::VendorAndMaxFunction.0, 0, &[0; 4]);
-            let vendor = x86defs::cpuid::Vendor::from_ebx_ecx_edx(leaf0[1], leaf0[2], leaf0[3]);
-            if vendor.is_intel_compatible() {
-                let ecx = x86defs::cpuid::VersionAndFeaturesEcx::from(
-                    cpuid.result(CpuidFunction::VersionAndFeatures.0, 0, &[0; 4])[2],
-                );
-                kvm.set_msrs(&[(
-                    x86defs::X86X_IA32_MSR_FEATURE_CONTROL,
-                    u64::from(
-                        x86defs::vmx::Ia32FeatureControl::new()
-                            .with_locked(true)
-                            .with_vmx_enabled_outside_smx(ecx.vmx()),
-                    ),
-                )])?;
-            }
+        if self.partition.caps.vendor.is_intel_compatible() {
+            let ecx = x86defs::cpuid::VersionAndFeaturesEcx::from(
+                self.partition
+                    .cpuid
+                    .result(CpuidFunction::VersionAndFeatures.0, 0, &[0; 4])[2],
+            );
+            kvm.set_msrs(&[(
+                x86defs::X86X_IA32_MSR_FEATURE_CONTROL,
+                u64::from(
+                    x86defs::vmx::Ia32FeatureControl::new()
+                        .with_locked(true)
+                        .with_vmx_enabled_outside_smx(ecx.vmx()),
+                ),
+            )])?;
         }
 
         // Set per-VP CPUID entries, fixing up APIC ID fields.

--- a/vmm_core/virt_kvm/src/lib.rs
+++ b/vmm_core/virt_kvm/src/lib.rs
@@ -60,6 +60,12 @@ pub enum KvmError {
     #[error("host does not support required cpu capabilities")]
     Capabilities(virt::PartitionCapabilitiesError),
     #[cfg(guest_arch = "x86_64")]
+    #[error("nested virtualization was requested but the host does not support it")]
+    NestedVirtUnsupported,
+    #[cfg(guest_arch = "x86_64")]
+    #[error("unsupported CPU vendor")]
+    UnsupportedCpuVendor,
+    #[cfg(guest_arch = "x86_64")]
     #[error("failed to compute topology cpuid")]
     TopologyCpuid(#[source] virt::x86::topology::UnknownVendor),
 }


### PR DESCRIPTION
The KVM backend unconditionally passed through VMX/SVM CPUID bits and the MS hypervisor nested-features leaf to the guest. This causes problems for Windows guests, which detect nested virt support and attempt to enable the hypervisor for VSM. This hurts performance and breaks boot when using vmbus devices.

Nested virtualization is now disabled by default and must be explicitly requested via `--hypervisor kvm:nested_virt`. When disabled, the backend strips the VMX or SVM CPUID bit (depending on CPU vendor) and suppresses the HV nested-features leaf. When enabled, the backend validates that the host actually supports nested virtualization and fails early if it does not.

Fixes #3646.