### PR TITLE
crypto: Small cleanups

### DIFF
--- a/openhcl/underhill_attestation/src/secure_key_release.rs
+++ b/openhcl/underhill_attestation/src/secure_key_release.rs
@@ -141,14 +141,13 @@ pub async fn request_vmgs_encryption_keys(
         )
     })?;
 
-    let exponent = transfer_key.public_exponent();
-    let modulus = transfer_key.modulus();
+    let components = transfer_key.to_components();
     let host_time = get.host_time().await.to_jiff().timestamp().as_second();
 
     let mut igvm_attest_request_helper = IgvmAttestRequestHelper::prepare_key_release_request(
         tee_call.tee_type(),
-        &exponent,
-        &modulus,
+        &components.public_exponent,
+        &components.modulus,
         host_time,
         attestation_vm_config,
     );

--- a/support/crypto/build.rs
+++ b/support/crypto/build.rs
@@ -41,22 +41,33 @@ fn main() {
         );
     }
     // If exactly one backend is enabled, use it and emit the `single_backend`
-    // cfg for link-time checking.
+    // cfg for link-time checking. Don't emit the cfg for the rust backend,
+    // as it's known to be insecure and should be used for testing purposes only.
     else if backend_count == 1 {
+        let secure;
         if openssl {
             println!("cargo::rustc-cfg=openssl");
+            secure = true;
         } else if symcrypt {
             if vendored {
                 panic!("The symcrypt backend does not support vendoring");
             }
             println!("cargo::rustc-cfg=symcrypt");
+            secure = true;
         } else if rust {
             println!("cargo::rustc-cfg=rust");
+            secure = false;
         } else if native && linux {
             println!("cargo::rustc-cfg=openssl");
+            secure = true;
         } else if native && !linux {
             println!("cargo::rustc-cfg=native");
+            secure = true;
+        } else {
+            unreachable!();
         }
-        println!("cargo::rustc-cfg=single_backend");
+        if secure {
+            println!("cargo::rustc-cfg=single_backend");
+        }
     }
 }

--- a/support/crypto/src/rsa/mac.rs
+++ b/support/crypto/src/rsa/mac.rs
@@ -397,12 +397,20 @@ impl RsaPublicKeyInner {
         unsafe { SecKeyGetBlockSize(self.0.0) }
     }
 
-    pub fn modulus(&self) -> Vec<u8> {
-        self.export_components().map(|(n, _)| n).unwrap_or_default()
-    }
-
-    pub fn public_exponent(&self) -> Vec<u8> {
-        self.export_components().map(|(_, e)| e).unwrap_or_default()
+    pub fn to_components(&self) -> super::RsaPublicKeyComponents {
+        let pub_key = self.public_key_handle().unwrap();
+        let mut error: CFErrorRef = ptr::null();
+        // SAFETY: pub_key.0 is valid.
+        let data = unsafe { SecKeyCopyExternalRepresentation(pub_key.0, &mut error) };
+        assert!(!data.is_null(), "SecKeyCopyExternalRepresentation failed");
+        let data = CfHandle(data);
+        // SAFETY: data.0 is valid.
+        let der_bytes = unsafe { cf_data_to_vec(data.0) };
+        let (modulus, public_exponent) = parse_pkcs1_pub(&der_bytes).unwrap();
+        super::RsaPublicKeyComponents {
+            modulus,
+            public_exponent,
+        }
     }
 
     /// Get a SecKeyRef for the public half of this key. For a key already
@@ -414,22 +422,5 @@ impl RsaPublicKeyInner {
             return Err(null_err("SecKeyCopyPublicKey"));
         }
         Ok(CfHandle(pk))
-    }
-
-    /// Export and parse the PKCS#1 RSAPublicKey representation, returning
-    /// `(modulus, public_exponent)`.
-    fn export_components(&self) -> Result<(Vec<u8>, Vec<u8>), RsaError> {
-        let pub_key = self.public_key_handle()?;
-        let mut error: CFErrorRef = ptr::null();
-        // SAFETY: pub_key.0 is valid.
-        let data = unsafe { SecKeyCopyExternalRepresentation(pub_key.0, &mut error) };
-        if data.is_null() {
-            // SAFETY: error is null or valid.
-            return Err(unsafe { rsa_sec_err(error, "export RSA public key") });
-        }
-        let data = CfHandle(data);
-        // SAFETY: data.0 is valid.
-        let der_bytes = unsafe { cf_data_to_vec(data.0) };
-        parse_pkcs1_pub(&der_bytes)
     }
 }

--- a/support/crypto/src/rsa/mod.rs
+++ b/support/crypto/src/rsa/mod.rs
@@ -116,6 +116,15 @@ impl RsaKeyPair {
 #[repr(transparent)] // Needed for the transmute in deref.
 pub struct RsaPublicKey(pub(crate) sys::RsaPublicKeyInner);
 
+/// The public components of an RSA key.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RsaPublicKeyComponents {
+    /// The RSA modulus as a big-endian byte vector.
+    pub modulus: Vec<u8>,
+    /// The RSA public exponent as a big-endian byte vector.
+    pub public_exponent: Vec<u8>,
+}
+
 impl RsaPublicKey {
     /// Construct an RSA public key from a big-endian modulus `n` and
     /// big-endian public exponent `e`.
@@ -164,14 +173,9 @@ impl RsaPublicKey {
         self.0.modulus_size()
     }
 
-    /// Returns the RSA modulus as a big-endian byte vector.
-    pub fn modulus(&self) -> Vec<u8> {
-        self.0.modulus()
-    }
-
-    /// Returns the RSA public exponent as a big-endian byte vector.
-    pub fn public_exponent(&self) -> Vec<u8> {
-        self.0.public_exponent()
+    /// Returns the RSA public components as big-endian byte vectors.
+    pub fn to_components(&self) -> RsaPublicKeyComponents {
+        self.0.to_components()
     }
 }
 
@@ -242,8 +246,7 @@ mod tests {
         let key = RsaKeyPair::generate(2048).unwrap();
         let der = key.to_pkcs8_der().unwrap();
         let imported = RsaKeyPair::from_pkcs8_der(&der).unwrap();
-        assert_eq!(key.modulus(), imported.modulus());
-        assert_eq!(key.public_exponent(), imported.public_exponent());
+        assert_eq!(key.to_components(), imported.to_components());
 
         // Sign with the original and verify with the imported, to confirm
         // the private-key components survived the round-trip.

--- a/support/crypto/src/rsa/ossl.rs
+++ b/support/crypto/src/rsa/ossl.rs
@@ -4,6 +4,7 @@
 //! RSA implementation using OpenSSL.
 
 use super::RsaError;
+use super::RsaPublicKeyComponents;
 use crate::HashAlgorithm;
 
 fn err(err: openssl::error::ErrorStack, op: &'static str) -> RsaError {
@@ -176,13 +177,12 @@ impl RsaPublicKeyInner {
         self.0.rsa().unwrap().size() as usize
     }
 
-    pub fn modulus(&self) -> Vec<u8> {
+    pub fn to_components(&self) -> RsaPublicKeyComponents {
         // TODO: This should use EVP_PKEY_get_params but the openssl crate doesn't expose it
-        self.0.rsa().unwrap().n().to_vec()
-    }
-
-    pub fn public_exponent(&self) -> Vec<u8> {
-        // TODO: This should use EVP_PKEY_get_params but the openssl crate doesn't expose it
-        self.0.rsa().unwrap().e().to_vec()
+        let rsa = self.0.rsa().unwrap();
+        RsaPublicKeyComponents {
+            modulus: rsa.n().to_vec(),
+            public_exponent: rsa.e().to_vec(),
+        }
     }
 }

--- a/support/crypto/src/rsa/rust.rs
+++ b/support/crypto/src/rsa/rust.rs
@@ -6,6 +6,7 @@
 #![expect(deprecated)]
 
 use super::RsaError;
+use super::RsaPublicKeyComponents;
 use crate::HashAlgorithm;
 use getrandom::SysRng;
 use pkcs8::DecodePrivateKey;
@@ -218,11 +219,10 @@ impl RsaPublicKeyInner {
         self.0.size()
     }
 
-    pub fn modulus(&self) -> Vec<u8> {
-        self.0.n().to_be_bytes_trimmed_vartime().to_vec()
-    }
-
-    pub fn public_exponent(&self) -> Vec<u8> {
-        self.0.e().to_be_bytes_trimmed_vartime().to_vec()
+    pub fn to_components(&self) -> RsaPublicKeyComponents {
+        RsaPublicKeyComponents {
+            modulus: self.0.n().to_be_bytes_trimmed_vartime().to_vec(),
+            public_exponent: self.0.e().to_be_bytes_trimmed_vartime().to_vec(),
+        }
     }
 }

--- a/support/crypto/src/rsa/symcrypt.rs
+++ b/support/crypto/src/rsa/symcrypt.rs
@@ -4,6 +4,7 @@
 //! RSA implementation using SymCrypt.
 
 use super::RsaError;
+use super::RsaPublicKeyComponents;
 use der::Decode;
 use symcrypt::rsa::RsaKey;
 use symcrypt::rsa::RsaKeyUsage;
@@ -221,13 +222,11 @@ impl RsaPublicKeyInner {
         self.0.get_size_of_modulus() as usize
     }
 
-    pub fn modulus(&self) -> Vec<u8> {
-        // TODO: Maybe cache the pub blob?
-        self.0.export_public_key_blob().unwrap().modulus
-    }
-
-    pub fn public_exponent(&self) -> Vec<u8> {
-        // TODO: Maybe cache the pub blob?
-        self.0.export_public_key_blob().unwrap().pub_exp
+    pub fn to_components(&self) -> RsaPublicKeyComponents {
+        let blob = self.0.export_public_key_blob().unwrap();
+        RsaPublicKeyComponents {
+            modulus: blob.modulus,
+            public_exponent: blob.pub_exp,
+        }
     }
 }

--- a/support/crypto/src/rsa/win.rs
+++ b/support/crypto/src/rsa/win.rs
@@ -4,6 +4,7 @@
 //! RSA implementation using Windows BCrypt APIs.
 
 use super::RsaError;
+use super::RsaPublicKeyComponents;
 use crate::HashAlgorithm;
 use crate::win::CryptAlloc;
 use crate::win::KeyHandle;
@@ -613,16 +614,15 @@ impl RsaPublicKeyInner {
     }
 
     pub fn modulus_size(&self) -> usize {
-        self.modulus().len()
+        self.to_components().modulus.len()
     }
 
-    pub fn modulus(&self) -> Vec<u8> {
+    pub fn to_components(&self) -> RsaPublicKeyComponents {
         let blob = export_key(&self.0, BCRYPT_RSAPUBLIC_BLOB).unwrap();
-        parse_public_components(&blob).modulus.to_vec()
-    }
-
-    pub fn public_exponent(&self) -> Vec<u8> {
-        let blob = export_key(&self.0, BCRYPT_RSAPUBLIC_BLOB).unwrap();
-        parse_public_components(&blob).public_exponent.to_vec()
+        let components = parse_public_components(&blob);
+        RsaPublicKeyComponents {
+            modulus: components.modulus.to_vec(),
+            public_exponent: components.public_exponent.to_vec(),
+        }
     }
 }

--- a/support/crypto/src/x509/builder.rs
+++ b/support/crypto/src/x509/builder.rs
@@ -56,11 +56,10 @@ pub(super) fn self_signed_builder(
         "CN={common_name},O={organization},L={locality},ST={state},C={country}"
     ))?;
 
-    let modulus = key.modulus();
-    let exponent = key.public_exponent();
+    let components = key.to_components();
     let pkcs1_pub = pkcs1::RsaPublicKey {
-        modulus: der::asn1::UintRef::new(&modulus)?,
-        public_exponent: der::asn1::UintRef::new(&exponent)?,
+        modulus: der::asn1::UintRef::new(&components.modulus)?,
+        public_exponent: der::asn1::UintRef::new(&components.public_exponent)?,
     };
     let pkcs1_der = pkcs1_pub.to_der()?;
     let spki = x509_cert::spki::SubjectPublicKeyInfoOwned {

--- a/support/crypto/src/x509/win.rs
+++ b/support/crypto/src/x509/win.rs
@@ -401,9 +401,9 @@ impl X509CertificateInner {
             .context("encoding X.500 name")?;
 
         // 2. Build the SubjectPublicKeyInfo DER.
-        let n = key.modulus();
-        let e = key.public_exponent();
-        let pkcs1_pub = encode_pkcs1_rsa_pubkey(&n, &e).context("encoding RSA public key")?;
+        let components = key.to_components();
+        let pkcs1_pub = encode_pkcs1_rsa_pubkey(&components.modulus, &components.public_exponent)
+            .context("encoding RSA public key")?;
 
         // 3. Build CERT_INFO and encode TBS.
         let mut serial_bytes: [u8; 1] = [1];

--- a/vm/devices/firmware/firmware_uefi/src/service/nvram/spec_services/auth_var_crypto.rs
+++ b/vm/devices/firmware/firmware_uefi/src/service/nvram/spec_services/auth_var_crypto.rs
@@ -143,12 +143,8 @@ mod pkcs7_details {
     ///     [0] EXPLICIT ANY DEFINED BY contentType OPTIONAL }
     /// ```
     pub fn encapsulate_in_content_info(content: &[u8]) -> der::Result<Vec<u8>> {
-        // constant pulled from https://datatracker.ietf.org/doc/html/rfc2315#section-14
-        const PKCS_7_SIGNED_DATA_OID: ObjectIdentifier =
-            ObjectIdentifier::new_unwrap("1.2.840.113549.1.7.2");
-
         let content_info = ContentInfo {
-            content_type: PKCS_7_SIGNED_DATA_OID,
+            content_type: der::oid::db::rfc5911::ID_SIGNED_DATA,
             content: ContextSpecific {
                 tag_number: TagNumber(0),
                 value: AnyRef::try_from(content)?,

--- a/vm/devices/firmware/firmware_uefi/src/service/nvram/spec_services/auth_var_crypto.rs
+++ b/vm/devices/firmware/firmware_uefi/src/service/nvram/spec_services/auth_var_crypto.rs
@@ -143,8 +143,12 @@ mod pkcs7_details {
     ///     [0] EXPLICIT ANY DEFINED BY contentType OPTIONAL }
     /// ```
     pub fn encapsulate_in_content_info(content: &[u8]) -> der::Result<Vec<u8>> {
+        // constant pulled from https://datatracker.ietf.org/doc/html/rfc2315#section-14
+        const PKCS_7_SIGNED_DATA_OID: ObjectIdentifier =
+            ObjectIdentifier::new_unwrap("1.2.840.113549.1.7.2");
+
         let content_info = ContentInfo {
-            content_type: der::oid::db::rfc5911::ID_SIGNED_DATA,
+            content_type: PKCS_7_SIGNED_DATA_OID,
             content: ContextSpecific {
                 tag_number: TagNumber(0),
                 value: AnyRef::try_from(content)?,


### PR DESCRIPTION
2 small tweaks. Change RsaPublicKey's two exporters to just be one combined one instead, since most backends function that ways and in practice we always need both anyways. Change the build script to not allow the single-backend linker check when the rust backend is the only selected backend, since it's known to be insecure.