### PR TITLE
crypto: Reject empty kbkdf keys for symcrypt

### DIFF
--- a/support/crypto/src/kbkdf/mod.rs
+++ b/support/crypto/src/kbkdf/mod.rs
@@ -82,4 +82,12 @@ mod tests {
 
         assert_eq!(output, expected_result);
     }
+
+    #[test]
+    fn kdf_empty_key_errors() {
+        let key = [];
+        let context = [0u8; 32];
+        let result = kbkdf_hmac_sha256(&key, &context, b"VMGSKEY", 32);
+        assert!(result.is_err(), "expected error for empty key");
+    }
 }

--- a/support/crypto/src/kbkdf/symcrypt.rs
+++ b/support/crypto/src/kbkdf/symcrypt.rs
@@ -13,6 +13,14 @@ pub fn kbkdf_hmac_sha256(
     label: &[u8],
     output_len: usize,
 ) -> Result<Vec<u8>, KbkdfError> {
+    // SymCrypt accepts an empty key, but other backends (e.g. OpenSSL) reject
+    // it. Reject it here for consistent behavior across backends.
+    if key.is_empty() {
+        return Err(KbkdfError(crate::BackendError::SymCrypt(
+            symcrypt::errors::SymCryptError::InvalidArgument,
+            "deriving SP800-108 KBKDF",
+        )));
+    }
     sp800_108_counter_mode(HmacAlgorithm::HmacSha256, key, label, context, output_len)
         .map_err(|e| KbkdfError(crate::BackendError::SymCrypt(e, "deriving SP800-108 KBKDF")))
 }


### PR DESCRIPTION
This fixes an underhill_attestation unit test on top of Symcrypt.