### PR TITLE
fuzz_uefi: Fix build

### DIFF
--- a/vm/devices/firmware/firmware_uefi/fuzz/Cargo.toml
+++ b/vm/devices/firmware/firmware_uefi/fuzz/Cargo.toml
@@ -9,7 +9,7 @@ rust-version.workspace = true
 
 [target.'cfg(all(target_os = "linux", target_env = "gnu"))'.dependencies]
 arbitrary = { workspace = true, features = ["derive"] }
-crypto = { workspace = true, features = ["test_helpers", "rust"] }
+crypto = { workspace = true, features = ["test_helpers", "rust", "vendored"] }
 firmware_uefi = { workspace = true, features = ["fuzzing"] }
 firmware_uefi_resources.workspace = true
 guid.workspace = true


### PR DESCRIPTION
Unfortunately builds of crypto for linux will always depend on openssl, despite sometimes choosing other backends, due to cargo limitations. Our fuzzers build on a system that doesn't have openssl available, and so need it vendored. Add that feature.