### PR TITLE
ci: bump node version to 24

### DIFF
--- a/flowey/flowey_lib_hvlite/src/_jobs/cfg_versions.rs
+++ b/flowey/flowey_lib_hvlite/src/_jobs/cfg_versions.rs
@@ -24,7 +24,7 @@ pub const MDBOOK_MERMAID: &str = "0.14.0";
 pub const RUSTUP_TOOLCHAIN: &str = "1.90.0";
 pub const MU_MSVM: &str = "25.1.11";
 pub const NEXTEST: &str = "0.9.101";
-pub const NODEJS: &str = "18.x";
+pub const NODEJS: &str = "24.x";
 // N.B. Kernel version numbers for dev and stable branches are not directly
 //      comparable. They originate from separate branches, and the fourth digit
 //      increases with each release from the respective branch.


### PR DESCRIPTION
Needed for addressing internal security vulnerabilities.