### PR TITLE
smmu: fix spec deviations found by IHI 0070H.a audit

### DIFF
--- a/vm/devices/iommu/smmu/src/emulator.rs
+++ b/vm/devices/iommu/smmu/src/emulator.rs
@@ -346,8 +346,12 @@ impl SmmuDevice {
                 self.process_cmdq();
             }
             registers::CMDQ_CONS => {
-                // CMDQ_CONS is writable by the SMMU only (for error reporting).
-                // Guest writes are ignored per spec.
+                // Per IHI 0070H.a §6.3.28, CMDQ_CONS is RW when CMDQEN==0
+                // (software initializes it before enabling the queue) and
+                // RO when CMDQEN==1.
+                if !self.cr0.cmdqen() {
+                    self.cmdq_cons = registers::CmdqCons::from(value);
+                }
             }
 
             registers::GERROR_IRQ_CFG1 => self.gerror_msi.data = value,
@@ -565,7 +569,9 @@ impl SmmuDevice {
 
                 // Synchronization command.
                 CmdOpcode::CMD_SYNC => {
-                    self.handle_cmd_sync(&entry);
+                    if !self.handle_cmd_sync(&entry) {
+                        break;
+                    }
                 }
 
                 // Unknown opcode — set CMDQ error.
@@ -589,7 +595,9 @@ impl SmmuDevice {
     /// With IDR0.MSI=0, Linux uses CS=SIG_SEV and polls CMDQ_CONS for
     /// completion. The MSIWrite path is kept for spec compliance but won't
     /// be exercised by Linux when MSI is not advertised.
-    fn handle_cmd_sync(&mut self, entry: &CmdEntry) {
+    /// Returns `true` on success, `false` if a CMDQ error was raised
+    /// (caller must stop consuming).
+    fn handle_cmd_sync(&mut self, entry: &CmdEntry) -> bool {
         let cmd = CmdSync::from(entry.qw0);
         let cs = SyncCs(cmd.cs());
 
@@ -616,9 +624,12 @@ impl SmmuDevice {
                 }
             }
             _ => {
-                tracelimit::warn_ratelimited!(cs = cs.0, "smmu: unknown CMD_SYNC CS value");
+                // CS=0b11 is reserved and causes CERROR_ILL per §4.7.3.
+                self.set_cmdq_error(registers::CmdqError::CERROR_ILL);
+                return false;
             }
         }
+        true
     }
 
     /// Set a command queue error, toggling GERROR.CMDQ_ERR and storing the
@@ -2588,6 +2599,113 @@ mod tests {
         assert!(
             !dev.shared_state.cmdq_err_active(),
             "error must be cleared after acknowledge"
+        );
+    }
+
+    /// Per IHI 0070H.a §6.3.28, CMDQ_CONS is RW when CMDQEN==0 and
+    /// CR0ACK.CMDQEN==0, allowing software to initialize it before
+    /// enabling the queue. It becomes RO when CMDQEN==1.
+    #[test]
+    fn test_cmdq_cons_writable_when_disabled() {
+        let gm = GuestMemory::allocate(0x40_0000);
+        let mut dev = SmmuDevice::new(
+            TEST_MMIO_BASE,
+            gm.clone(),
+            &SmmuConfig::default(),
+            None,
+            None,
+        );
+
+        // CMDQEN is 0 at reset — CMDQ_CONS should be writable.
+        assert!(!Cr0::from(read32(&mut dev, CR0)).cmdqen());
+
+        // Write a non-zero value to CMDQ_CONS.
+        write32(&mut dev, CMDQ_CONS, 0x05);
+        let cons = CmdqCons::from(read32(&mut dev, CMDQ_CONS));
+        assert_eq!(
+            cons.rd(),
+            0x05,
+            "CMDQ_CONS.RD must accept writes when CMDQEN==0"
+        );
+
+        // Now enable CMDQEN — CMDQ_CONS should become read-only.
+        let cmdq_base = QueueBase::new()
+            .with_log2size(5)
+            .with_addr_bits(0x20_0000u64 >> 5);
+        write64(&mut dev, CMDQ_BASE, cmdq_base.into());
+        // Re-init CONS to 0 before enabling (required by spec).
+        write32(&mut dev, CMDQ_CONS, 0);
+        write32(&mut dev, CMDQ_PROD, 0);
+        write32(&mut dev, CR0, Cr0::new().with_cmdqen(true).into());
+        assert!(Cr0::from(read32(&mut dev, CR0ACK)).cmdqen());
+
+        // Writes to CMDQ_CONS while CMDQEN==1 must be ignored.
+        write32(&mut dev, CMDQ_CONS, 0x10);
+        let cons = CmdqCons::from(read32(&mut dev, CMDQ_CONS));
+        assert_eq!(cons.rd(), 0, "CMDQ_CONS must be read-only when CMDQEN==1");
+    }
+
+    /// Per IHI 0070H.a §4.7.3, CMD_SYNC with CS=0b11 is reserved and
+    /// must cause CERROR_ILL. The SMMU should stop consuming commands
+    /// and toggle GERROR.CMDQ_ERR.
+    #[test]
+    fn test_cmd_sync_reserved_cs_causes_cerror_ill() {
+        use crate::spec::commands::CmdEntry;
+        use crate::spec::commands::CmdOpcode;
+        use crate::spec::commands::CmdSync;
+
+        let gm = GuestMemory::allocate(0x40_0000);
+        let mut dev = SmmuDevice::new(
+            TEST_MMIO_BASE,
+            gm.clone(),
+            &SmmuConfig::default(),
+            None,
+            None,
+        );
+
+        const CMDQ_GPA: u64 = 0x20_0000;
+
+        // Set up CMDQ.
+        let cmdq_base = QueueBase::new()
+            .with_log2size(5)
+            .with_addr_bits(CMDQ_GPA >> 5);
+        write64(&mut dev, CMDQ_BASE, cmdq_base.into());
+        write32(&mut dev, CMDQ_PROD, 0);
+        write32(&mut dev, CMDQ_CONS, 0);
+
+        // Enable CMDQ.
+        write32(&mut dev, CR0, Cr0::new().with_cmdqen(true).into());
+        assert!(Cr0::from(read32(&mut dev, CR0ACK)).cmdqen());
+
+        // Write a CMD_SYNC with CS=0b11 (reserved).
+        let bad_sync = CmdEntry {
+            qw0: CmdSync::new()
+                .with_opcode(CmdOpcode::CMD_SYNC.0)
+                .with_cs(0b11) // Reserved — must cause CERROR_ILL
+                .into(),
+            qw1: 0,
+        };
+        let cmd_addr = CMDQ_GPA;
+        gm.write_plain(cmd_addr, &bad_sync).expect("write cmd");
+
+        // Advance PROD to trigger processing.
+        write32(&mut dev, CMDQ_PROD, 1);
+
+        // GERROR.CMDQ_ERR should now be active (toggled != GERRORN).
+        let gerror = Gerror::from(read32(&mut dev, GERROR));
+        let gerrorn = Gerror::from(read32(&mut dev, GERRORN));
+        assert_ne!(
+            gerror.cmdq_err(),
+            gerrorn.cmdq_err(),
+            "GERROR.CMDQ_ERR must be active after CS=0b11"
+        );
+
+        // CMDQ_CONS.ERR must be CERROR_ILL (1).
+        let cons = CmdqCons::from(read32(&mut dev, CMDQ_CONS));
+        assert_eq!(
+            cons.err(),
+            CmdqError::CERROR_ILL.0,
+            "CMDQ_CONS.ERR must be CERROR_ILL"
         );
     }
 }

--- a/vm/devices/iommu/smmu/src/spec/cd.rs
+++ b/vm/devices/iommu/smmu/src/spec/cd.rs
@@ -295,31 +295,6 @@ mod tests {
         assert!(cd.valid());
     }
 
-    #[test]
-    fn test_cd_dw0_fields() {
-        let dw0 = CdDw0::new()
-            .with_t0sz(16)
-            .with_tg0(Tg0::GRAN_4K.0)
-            .with_ir0(0b01) // WB
-            .with_or0(0b01)
-            .with_sh0(0b11) // ISH
-            .with_v(true)
-            .with_ips(Ips::IPS_40.0)
-            .with_aa64(true)
-            .with_asid(42);
-
-        assert_eq!(dw0.t0sz(), 16);
-        assert_eq!(dw0.tg0(), Tg0::GRAN_4K.0);
-        assert_eq!(dw0.ir0(), 0b01);
-        assert_eq!(dw0.or0(), 0b01);
-        assert_eq!(dw0.sh0(), 0b11);
-        assert!(dw0.v());
-        assert_eq!(dw0.ips(), Ips::IPS_40.0);
-        assert!(dw0.aa64());
-        assert_eq!(dw0.asid(), 42);
-        assert!(!dw0.epd0());
-    }
-
     fn new_cd() -> Cd {
         Cd {
             qw0: CdDw0::new(),
@@ -349,35 +324,6 @@ mod tests {
             ..new_cd()
         };
         assert_eq!(cd.ttb0(), ttb0_addr);
-    }
-
-    #[test]
-    fn test_cd_full_roundtrip() {
-        let ttb0_addr: u64 = 0x8000_0000;
-        let cd = Cd {
-            qw0: CdDw0::new()
-                .with_t0sz(32)
-                .with_tg0(Tg0::GRAN_4K.0)
-                .with_ir0(0b01)
-                .with_or0(0b01)
-                .with_sh0(0b11)
-                .with_v(true)
-                .with_ips(Ips::IPS_40.0)
-                .with_aa64(true)
-                .with_asid(100),
-            qw1: CdDw1::new().with_ttb0(ttb0_addr >> 4),
-            mair0: 0xFF44_0C04_00BB_FF00,
-            ..new_cd()
-        };
-
-        assert!(cd.valid());
-        assert_eq!(cd.t0sz(), 32);
-        assert_eq!(cd.tg0(), Tg0::GRAN_4K);
-        assert_eq!(cd.ips(), Ips::IPS_40);
-        assert!(cd.aa64());
-        assert_eq!(cd.asid(), 100);
-        assert_eq!(cd.ttb0(), ttb0_addr);
-        assert_eq!(cd.mair0, 0xFF44_0C04_00BB_FF00);
     }
 
     #[test]
@@ -412,12 +358,6 @@ mod tests {
         assert_eq!(Ips::IPS_48.bits(), Some(48));
         assert_eq!(Ips::IPS_52.bits(), Some(52));
         assert_eq!(Ips(0b111).bits(), None);
-    }
-
-    #[test]
-    fn test_cd_invalid() {
-        let cd = new_cd();
-        assert!(!cd.valid());
     }
 
     #[test]

--- a/vm/devices/iommu/smmu/src/spec/commands.rs
+++ b/vm/devices/iommu/smmu/src/spec/commands.rs
@@ -248,26 +248,6 @@ mod tests {
     }
 
     #[test]
-    fn test_cmd_cfgi_ste_sid() {
-        let cmd = CmdCfgiSte::new()
-            .with_opcode(CmdOpcode::CFGI_STE.0)
-            .with_sid(42);
-        assert_eq!(cmd.opcode(), CmdOpcode::CFGI_STE.0);
-        assert_eq!(cmd.sid(), 42);
-    }
-
-    #[test]
-    fn test_cmd_sync_fields() {
-        let cmd = CmdSync::new()
-            .with_opcode(CmdOpcode::CMD_SYNC.0)
-            .with_cs(SyncCs::SIG_IRQ.0)
-            .with_msi_data(0xDEAD_BEEF);
-        assert_eq!(cmd.opcode(), CmdOpcode::CMD_SYNC.0);
-        assert_eq!(cmd.cs(), SyncCs::SIG_IRQ.0);
-        assert_eq!(cmd.msi_data(), 0xDEAD_BEEF);
-    }
-
-    #[test]
     fn test_cmd_sync_msi_addr() {
         // MSI address = 0x1234_5678
         // Stored in qw1 bits [55:2] as (addr >> 2) << 2

--- a/vm/devices/iommu/smmu/src/spec/events.rs
+++ b/vm/devices/iommu/smmu/src/spec/events.rs
@@ -246,20 +246,4 @@ mod tests {
         assert_eq!(evt.sid, 5);
         assert_eq!(evt.input_addr, 0xDEAD_BEEF_0000);
     }
-
-    #[test]
-    fn test_evt_entry_roundtrip() {
-        let evt = EvtEntry {
-            header: EvtHeader::new().with_event_id(EventId::F_ADDR_SIZE.0),
-            sid: 0xABCD,
-            flags: EvtFlags::new().with_rnw(true),
-            input_addr: 0x1234_5678_9ABC_DEF0,
-            ..EvtEntry::new()
-        };
-
-        assert_eq!(evt.event_id(), EventId::F_ADDR_SIZE);
-        assert_eq!(evt.sid, 0xABCD);
-        assert_eq!(evt.input_addr, 0x1234_5678_9ABC_DEF0);
-        assert!(evt.flags.rnw());
-    }
 }

--- a/vm/devices/iommu/smmu/src/spec/registers.rs
+++ b/vm/devices/iommu/smmu/src/spec/registers.rs
@@ -504,143 +504,6 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_idr0_bitfield_roundtrip() {
-        let idr0 = Idr0::new()
-            .with_s1p(true)
-            .with_ttf(0b10)
-            .with_cohacc(true)
-            .with_asid16(true)
-            .with_msi(true)
-            .with_ttendian(0b10)
-            .with_stall_model(0b01)
-            .with_term_model(true);
-        assert!(idr0.s1p());
-        assert_eq!(idr0.ttf(), 0b10);
-        assert!(idr0.cohacc());
-        assert!(idr0.asid16());
-        assert!(idr0.msi());
-        assert_eq!(idr0.ttendian(), 0b10);
-        assert!(!idr0.s2p());
-        assert!(!idr0.ats());
-        assert!(!idr0.pri());
-    }
-
-    #[test]
-    fn test_idr0_recommended_value() {
-        // The recommended IDR0 value from the spec reference:
-        // S1P=1, TTF=0b10, COHACC=1, ASID16=1, MSI=1,
-        // TTENDIAN=0b10 (LE), STALL_MODEL=0b01, TERM_MODEL=1
-        // = 0x0E40_301E
-        let idr0 = Idr0::new()
-            .with_s1p(true)
-            .with_ttf(0b10)
-            .with_cohacc(true)
-            .with_asid16(true)
-            .with_msi(true)
-            .with_ttendian(0b10)
-            .with_stall_model(0b01)
-            .with_term_model(true);
-
-        // Verify individual bits
-        assert!(idr0.s1p());
-        assert!(idr0.msi());
-        assert!(idr0.cohacc());
-        assert!(idr0.term_model());
-    }
-
-    #[test]
-    fn test_idr1_bitfield_roundtrip() {
-        let idr1 = Idr1::new().with_sidsize(8).with_cmdqs(8).with_eventqs(8);
-        assert_eq!(idr1.sidsize(), 8);
-        assert_eq!(idr1.cmdqs(), 8);
-        assert_eq!(idr1.eventqs(), 8);
-        assert_eq!(idr1.ssidsize(), 0);
-        assert!(!idr1.tables_preset());
-        assert!(!idr1.queues_preset());
-    }
-
-    #[test]
-    fn test_idr5_bitfield_roundtrip() {
-        let idr5 = Idr5::new()
-            .with_oas(0b010)
-            .with_gran4k(true)
-            .with_gran64k(true);
-        assert_eq!(idr5.oas(), 0b010);
-        assert!(idr5.gran4k());
-        assert!(idr5.gran64k());
-        assert!(!idr5.gran16k());
-    }
-
-    #[test]
-    fn test_cr0_bitfield_roundtrip() {
-        let cr0 = Cr0::new()
-            .with_smmuen(true)
-            .with_cmdqen(true)
-            .with_eventqen(true);
-        assert!(cr0.smmuen());
-        assert!(cr0.cmdqen());
-        assert!(cr0.eventqen());
-        assert!(!cr0.priqen());
-    }
-
-    #[test]
-    fn test_cr0_enable_sequence() {
-        // Linux enables features one at a time:
-        // 1. CMDQEN
-        let cr0 = Cr0::new().with_cmdqen(true);
-        assert!(cr0.cmdqen());
-        assert!(!cr0.eventqen());
-        assert!(!cr0.smmuen());
-
-        // 2. CMDQEN + EVENTQEN
-        let cr0 = cr0.with_eventqen(true);
-        assert!(cr0.cmdqen());
-        assert!(cr0.eventqen());
-        assert!(!cr0.smmuen());
-
-        // 3. CMDQEN + EVENTQEN + SMMUEN
-        let cr0 = cr0.with_smmuen(true);
-        assert!(cr0.cmdqen());
-        assert!(cr0.eventqen());
-        assert!(cr0.smmuen());
-    }
-
-    #[test]
-    fn test_gbpa_update_bit() {
-        let gbpa = Gbpa::new().with_update(true).with_abort(true);
-        assert!(gbpa.update());
-        assert!(gbpa.abort());
-
-        // Simulate SMMU clearing the update bit
-        let gbpa = gbpa.with_update(false);
-        assert!(!gbpa.update());
-        assert!(gbpa.abort());
-    }
-
-    #[test]
-    fn test_irq_ctrl_roundtrip() {
-        let irq_ctrl = IrqCtrl::new()
-            .with_gerror_irqen(true)
-            .with_eventq_irqen(true);
-        assert!(irq_ctrl.gerror_irqen());
-        assert!(irq_ctrl.eventq_irqen());
-        assert!(!irq_ctrl.priq_irqen());
-    }
-
-    #[test]
-    fn test_gerror_toggle_protocol() {
-        let gerror = Gerror::new().with_cmdq_err(true);
-        let gerrorn = Gerror::new();
-
-        // Error is active when bits differ
-        assert_ne!(gerror.cmdq_err(), gerrorn.cmdq_err(),);
-
-        // Software acknowledges by matching
-        let gerrorn = gerrorn.with_cmdq_err(true);
-        assert_eq!(gerror.cmdq_err(), gerrorn.cmdq_err(),);
-    }
-
-    #[test]
     fn test_strtab_base_address() {
         // Address must be 64-byte aligned (bottom 6 bits zero)
         let base = StrtabBase::new().with_addr_bits(0x1000_0000_u64 >> 6);
@@ -651,30 +514,12 @@ mod tests {
     }
 
     #[test]
-    fn test_strtab_base_cfg_roundtrip() {
-        let cfg = StrtabBaseCfg::new()
-            .with_fmt(StrtabFmt::LINEAR.0)
-            .with_log2size(8);
-        assert_eq!(cfg.fmt(), StrtabFmt::LINEAR.0);
-        assert_eq!(cfg.log2size(), 8);
-    }
-
-    #[test]
     fn test_queue_base_address() {
         let base = QueueBase::new()
             .with_addr_bits(0x2000_0000_u64 >> 5)
             .with_log2size(8);
         assert_eq!(base.addr(), 0x2000_0000);
         assert_eq!(base.log2size(), 8);
-    }
-
-    #[test]
-    fn test_cmdq_cons_error() {
-        let cons = CmdqCons::new()
-            .with_rd(42)
-            .with_err(CmdqError::CERROR_ILL.0);
-        assert_eq!(cons.rd(), 42);
-        assert_eq!(cons.err(), CmdqError::CERROR_ILL.0);
     }
 
     #[test]

--- a/vm/devices/iommu/smmu/src/spec/ste.rs
+++ b/vm/devices/iommu/smmu/src/spec/ste.rs
@@ -83,69 +83,78 @@ pub struct SteDw0 {
     pub s1_cd_max: u8,
 }
 
-/// STE QW1 (bits `[127:64]`): Stage 1 attributes, stream world, etc.
+/// STE QW1 (bits `[127:64]`): Stage 1 attributes, stream world, overrides.
 #[bitfield(u64)]
 #[derive(IntoBytes, Immutable, KnownLayout, FromBytes)]
 pub struct SteDw1 {
-    /// S1 default substream behavior.
+    /// S1 default substream behavior (bits `[65:64]`).
     #[bits(2)]
     pub s1_dss: u8,
-    /// CD pointer inner cacheability.
+    /// CD pointer inner cacheability (bits `[67:66]`).
     #[bits(2)]
     pub s1_cir: u8,
-    /// CD pointer outer cacheability.
+    /// CD pointer outer cacheability (bits `[69:68]`).
     #[bits(2)]
     pub s1_cor: u8,
-    /// CD pointer shareability.
+    /// CD pointer shareability (bits `[71:70]`).
     #[bits(2)]
     pub s1_csh: u8,
+    /// S2HWU59-62 (bits `[75:72]`, RES0 for S1-only emulator).
     #[bits(4)]
-    _reserved0: u64,
-    /// DRE (DPCM/stall related).
+    _s2hwu: u64,
+    /// Destructive Read Enable (bit `[76]`).
     pub dre: bool,
-    /// Contiguous hint.
-    pub cont: bool,
-    #[bits(2)]
-    _reserved1: u64,
-    /// Memory type config / MemAttr / MEV.
-    #[bits(5)]
-    pub mem_attr_and_mev: u8,
-    #[bits(3)]
-    _reserved2: u64,
-    /// Allocation configuration.
+    /// Contiguous hint — 4-bit span (bits `[80:77]`).
     #[bits(4)]
-    pub alloccfg: u8,
-    /// Shareability override.
-    #[bits(2)]
-    pub shcfg: u8,
-    /// NS configuration.
-    #[bits(2)]
-    pub nscfg: u8,
-    #[bits(3)]
-    _reserved3: u64,
-    /// Stream world.
-    #[bits(2)]
-    pub strw: u8,
-    /// Memory type config override.
-    pub mtcfg: bool,
-    /// Memory attribute (for bypass).
-    #[bits(4)]
-    pub mem_attr: u8,
-    /// Instruction/data override.
-    #[bits(2)]
-    pub instcfg: u8,
-    /// Privilege override.
-    #[bits(2)]
-    pub privcfg: u8,
-    /// Software reserved fields.
+    pub cont: u8,
+    /// Directed Cache Prefetch (bit `[81]`).
+    pub dcp: bool,
+    /// PPAR (bit `[82]`).
+    pub ppar: bool,
+    /// MEV — merge events (bit `[83]`).
+    pub mev: bool,
+    /// Software reserved (bits `[87:84]`).
     #[bits(4)]
     pub sw_reserved: u8,
-    /// EATS (ATS behavior).
-    #[bits(3)]
+    /// S1PIE (bit `[88]`).
+    pub s1pie: bool,
+    /// S2FWB (bit `[89]`).
+    pub s2fwb: bool,
+    /// S1MPAM (bit `[90]`).
+    pub s1mpam: bool,
+    /// S1STALLD — stage 1 stall disable (bit `[91]`).
+    pub s1stalld: bool,
+    /// EATS — ATS behavior (bits `[93:92]`).
+    #[bits(2)]
     pub eats: u8,
-    /// S2 VMID (ignored for S2 bypass).
-    #[bits(11)]
-    pub s2_vmid: u16,
+    /// Stream world (bits `[95:94]`).
+    #[bits(2)]
+    pub strw: u8,
+    /// Memory attribute for bypass (bits `[99:96]`).
+    #[bits(4)]
+    pub mem_attr: u8,
+    /// Memory type config override (bit `[100]`).
+    pub mtcfg: bool,
+    /// Allocation hints override (bits `[104:101]`).
+    #[bits(4)]
+    pub alloccfg: u8,
+    #[bits(3)]
+    _reserved0: u64,
+    /// Shareability override (bits `[109:108]`).
+    #[bits(2)]
+    pub shcfg: u8,
+    /// NS configuration (bits `[111:110]`).
+    #[bits(2)]
+    pub nscfg: u8,
+    /// Privilege override (bits `[113:112]`).
+    #[bits(2)]
+    pub privcfg: u8,
+    /// Instruction/data override (bits `[115:114]`).
+    #[bits(2)]
+    pub instcfg: u8,
+    /// Implementation defined (bits `[127:116]`).
+    #[bits(12)]
+    _impl_def: u64,
 }
 
 open_enum! {
@@ -223,36 +232,6 @@ mod tests {
     }
 
     #[test]
-    fn test_ste_dw0_fields() {
-        let dw0 = SteDw0::new()
-            .with_v(true)
-            .with_config(SteConfig::S1_TRANS.0)
-            .with_s1_fmt(S1Fmt::LINEAR.0)
-            .with_s1_context_ptr(0x1000_0000_u64 >> 6)
-            .with_s1_cd_max(0);
-
-        assert!(dw0.v());
-        assert_eq!(dw0.config(), SteConfig::S1_TRANS.0);
-        assert_eq!(dw0.s1_fmt(), S1Fmt::LINEAR.0);
-        assert_eq!(dw0.s1_context_ptr() << 6, 0x1000_0000);
-        assert_eq!(dw0.s1_cd_max(), 0);
-    }
-
-    #[test]
-    fn test_ste_dw1_fields() {
-        let dw1 = SteDw1::new()
-            .with_s1_cir(0b01) // WB
-            .with_s1_cor(0b01) // WB
-            .with_s1_csh(0b11) // ISH
-            .with_strw(Strw::NS_EL1.0);
-
-        assert_eq!(dw1.s1_cir(), 0b01);
-        assert_eq!(dw1.s1_cor(), 0b01);
-        assert_eq!(dw1.s1_csh(), 0b11);
-        assert_eq!(dw1.strw(), Strw::NS_EL1.0);
-    }
-
-    #[test]
     fn test_ste_bypass() {
         let ste = Ste {
             qw0: SteDw0::new().with_v(true).with_config(SteConfig::BYPASS.0),
@@ -287,23 +266,5 @@ mod tests {
         assert_eq!(ste.s1_context_ptr(), cd_addr);
         assert_eq!(ste.s1_cd_max(), 0);
         assert_eq!(ste.s1_fmt(), S1Fmt::LINEAR.0);
-    }
-
-    #[test]
-    fn test_ste_invalid_returns_fault() {
-        let ste = Ste {
-            qw0: SteDw0::new(),
-            qw1: SteDw1::new(),
-            _qw2_7: [0; 6],
-        };
-        assert!(!ste.valid());
-    }
-
-    #[test]
-    fn test_ste_context_ptr_alignment() {
-        // Context pointer is 64-byte aligned (bits [55:6])
-        let dw0 = SteDw0::new().with_s1_context_ptr(0xABCD_EF00_u64 >> 6);
-        // Reconstructed address should be 64-byte aligned
-        assert_eq!((dw0.s1_context_ptr() << 6) & 0x3F, 0);
     }
 }


### PR DESCRIPTION
Audited the SMMUv3 emulator against the Arm SMMUv3 architecture specification (IHI 0070H.a) and fixed three deviations:

STE DW1 bitfield layout (spec §5.2): The SteDw1 bitfield had incorrect field positions from bit 77 onward due to following an incorrect distilled reference. Fields like CONT, EATS, STRW, MemAttr, MTCFG, ALLOCCFG, SHCFG, NSCFG, PRIVCFG, and INSTCFG were all at wrong bit offsets, and S2VMID was incorrectly placed in DW1 instead of DW2. No functional impact yet since the translation path only reads DW0 fields, but would have caused incorrect behavior once DW1 fields are consumed.

CMDQ_CONS writability (spec §6.3.28): CMDQ_CONS was unconditionally ignoring guest writes, but the spec says it is RW when CMDQEN==0 so that software can initialize the consumer index before enabling the command queue. Now accepts writes when CMDQEN is clear.

CMD_SYNC CS=0b11 (spec §4.7.3): A CMD_SYNC with the reserved completion signal value 0b11 was silently ignored. The spec requires this to raise CERROR_ILL, stopping command processing and toggling GERROR.CMDQ_ERR. Now correctly raises the error and halts the queue.