### PR TITLE
vmm_tests: add boot_no_vmbus_windows PCIe test

### DIFF
--- a/.github/workflows/openvmm-ci.yaml
+++ b/.github/workflows/openvmm-ci.yaml
@@ -3693,7 +3693,12 @@ jobs:
       run: flowey.exe e 19 flowey_lib_hvlite::install_vmm_tests_deps 0
       shell: bash
     - name: starting test_igvm_agent_rpc_server
-      run: flowey.exe e 19 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
+      run: |-
+        flowey.exe e 19 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
+        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 7
+      shell: bash
+    - name: running vmm_test prep_steps
+      run: flowey.exe e 19 flowey_lib_hvlite::run_prep_steps 0
       shell: bash
     - name: run 'vmm_tests' nextest tests
       run: |-
@@ -4576,6 +4581,7 @@ jobs:
         flowey.exe e 22 flowey_lib_common::git_checkout 3
         flowey.exe e 22 flowey_lib_hvlite::git_checkout_openvmm_repo 0
         flowey.exe e 22 flowey_lib_hvlite::run_cargo_nextest_run 0
+        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 4
         flowey.exe e 22 flowey_core::pipeline::artifact::resolve 11
         flowey.exe e 22 flowey_core::pipeline::artifact::resolve 10
         flowey.exe e 22 flowey_core::pipeline::artifact::resolve 3
@@ -4586,7 +4592,6 @@ jobs:
         flowey.exe e 22 flowey_core::pipeline::artifact::resolve 0
         flowey.exe e 22 flowey_core::pipeline::artifact::resolve 9
         flowey.exe e 22 flowey_core::pipeline::artifact::resolve 2
-        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 4
       shell: bash
     - name: creating new test content dir
       run: flowey.exe e 22 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
@@ -4691,7 +4696,12 @@ jobs:
       run: flowey.exe e 22 flowey_lib_hvlite::install_vmm_tests_deps 0
       shell: bash
     - name: starting test_igvm_agent_rpc_server
-      run: flowey.exe e 22 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
+      run: |-
+        flowey.exe e 22 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
+        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 7
+      shell: bash
+    - name: running vmm_test prep_steps
+      run: flowey.exe e 22 flowey_lib_hvlite::run_prep_steps 0
       shell: bash
     - name: run 'vmm_tests' nextest tests
       run: |-
@@ -5038,7 +5048,7 @@ jobs:
     - name: 🌼📦 Download artifacts
       uses: actions/download-artifact@v8
       with:
-        pattern: '{_internal-flowey-bootstrap-x86_64-linux-uid-11,x64-guest_test_uefi,x64-linux-musl-pipette,x64-linux-musl-tmk_vmm,x64-linux-openvmm,x64-linux-openvmm_vhost,x64-linux-vmm-tests-archive,x64-tmks,x64-windows-pipette}'
+        pattern: '{_internal-flowey-bootstrap-x86_64-linux-uid-11,x64-guest_test_uefi,x64-linux-musl-pipette,x64-linux-musl-tmk_vmm,x64-linux-openvmm,x64-linux-openvmm_vhost,x64-linux-prep_steps,x64-linux-vmm-tests-archive,x64-tmks,x64-windows-pipette}'
         path: ${{ runner.temp }}/used_artifacts/
     - run: echo "${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-11" >> $GITHUB_PATH
       shell: bash
@@ -5062,6 +5072,7 @@ jobs:
         echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-tmk_vmm" | flowey v 24 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
         echo "$AgentTempDirNormal/used_artifacts/x64-linux-openvmm" | flowey v 24 'artifact_use_from_x64-linux-openvmm' --is-raw-string update
         echo "$AgentTempDirNormal/used_artifacts/x64-linux-openvmm_vhost" | flowey v 24 'artifact_use_from_x64-linux-openvmm_vhost' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-prep_steps" | flowey v 24 'artifact_use_from_x64-linux-prep_steps' --is-raw-string update
         echo "$AgentTempDirNormal/used_artifacts/x64-linux-vmm-tests-archive" | flowey v 24 'artifact_use_from_x64-linux-vmm-tests-archive' --is-raw-string update
         echo "$AgentTempDirNormal/used_artifacts/x64-tmks" | flowey v 24 'artifact_use_from_x64-tmks' --is-raw-string update
         echo "$AgentTempDirNormal/used_artifacts/x64-windows-pipette" | flowey v 24 'artifact_use_from_x64-windows-pipette' --is-raw-string update
@@ -5070,11 +5081,11 @@ jobs:
       run: |-
         flowey e 24 flowey_core::pipeline::artifact::resolve 3
         flowey e 24 flowey_core::pipeline::artifact::resolve 4
-        flowey e 24 flowey_core::pipeline::artifact::resolve 7
+        flowey e 24 flowey_core::pipeline::artifact::resolve 8
         flowey e 24 flowey_core::pipeline::artifact::resolve 1
         flowey e 24 flowey_core::pipeline::artifact::resolve 0
         flowey e 24 flowey_core::pipeline::artifact::resolve 2
-        flowey e 24 flowey_core::pipeline::artifact::resolve 6
+        flowey e 24 flowey_core::pipeline::artifact::resolve 7
         flowey e 24 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
       shell: bash
     - name: checking if packages need to be installed
@@ -5226,14 +5237,19 @@ jobs:
         flowey e 24 flowey_lib_hvlite::run_cargo_nextest_run 0
         flowey e 24 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
         flowey e 24 flowey_lib_hvlite::run_cargo_nextest_run 1
-        flowey e 24 flowey_core::pipeline::artifact::resolve 5
+        flowey e 24 flowey_core::pipeline::artifact::resolve 6
         flowey e 24 flowey_lib_hvlite::test_nextest_vmm_tests_archive 3
       shell: bash
     - name: generate nextest command
       run: flowey e 24 flowey_lib_common::gen_cargo_nextest_run_cmd 0
       shell: bash
     - name: install vmm tests deps (linux)
-      run: flowey e 24 flowey_lib_hvlite::install_vmm_tests_deps 0
+      run: |-
+        flowey e 24 flowey_lib_hvlite::install_vmm_tests_deps 0
+        flowey e 24 flowey_core::pipeline::artifact::resolve 5
+      shell: bash
+    - name: running vmm_test prep_steps
+      run: flowey e 24 flowey_lib_hvlite::run_prep_steps 0
       shell: bash
     - name: run 'vmm_tests' nextest tests
       run: |-
@@ -5338,7 +5354,7 @@ jobs:
     - name: 🌼📦 Download artifacts
       uses: actions/download-artifact@v8
       with:
-        pattern: '{x64-guest_test_uefi,x64-linux-musl-openvmm,x64-linux-musl-openvmm_vhost,x64-linux-musl-pipette,x64-linux-musl-tmk_vmm,x64-linux-musl-vmm-tests-archive,x64-tmks,x64-windows-pipette}'
+        pattern: '{x64-guest_test_uefi,x64-linux-musl-openvmm,x64-linux-musl-openvmm_vhost,x64-linux-musl-pipette,x64-linux-musl-tmk_vmm,x64-linux-musl-vmm-tests-archive,x64-linux-prep_steps,x64-tmks,x64-windows-pipette}'
         path: ${{ runner.temp }}/used_artifacts/
     - run: echo "${{ runner.temp }}/bootstrapped-flowey" >> $GITHUB_PATH
       shell: bash
@@ -5372,6 +5388,7 @@ jobs:
         echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-pipette" | flowey v 25 'artifact_use_from_x64-linux-musl-pipette' --is-raw-string update
         echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-tmk_vmm" | flowey v 25 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
         echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-vmm-tests-archive" | flowey v 25 'artifact_use_from_x64-linux-musl-vmm-tests-archive' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-prep_steps" | flowey v 25 'artifact_use_from_x64-linux-prep_steps' --is-raw-string update
         echo "$AgentTempDirNormal/used_artifacts/x64-tmks" | flowey v 25 'artifact_use_from_x64-tmks' --is-raw-string update
         echo "$AgentTempDirNormal/used_artifacts/x64-windows-pipette" | flowey v 25 'artifact_use_from_x64-windows-pipette' --is-raw-string update
       shell: bash
@@ -5379,11 +5396,11 @@ jobs:
       run: |-
         flowey e 25 flowey_core::pipeline::artifact::resolve 1
         flowey e 25 flowey_core::pipeline::artifact::resolve 2
-        flowey e 25 flowey_core::pipeline::artifact::resolve 7
+        flowey e 25 flowey_core::pipeline::artifact::resolve 8
         flowey e 25 flowey_core::pipeline::artifact::resolve 3
         flowey e 25 flowey_core::pipeline::artifact::resolve 0
         flowey e 25 flowey_core::pipeline::artifact::resolve 4
-        flowey e 25 flowey_core::pipeline::artifact::resolve 6
+        flowey e 25 flowey_core::pipeline::artifact::resolve 7
         flowey e 25 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
       shell: bash
     - name: checking if packages need to be installed
@@ -5538,7 +5555,12 @@ jobs:
       run: flowey e 25 flowey_lib_common::gen_cargo_nextest_run_cmd 0
       shell: bash
     - name: install vmm tests deps (linux)
-      run: flowey e 25 flowey_lib_hvlite::install_vmm_tests_deps 0
+      run: |-
+        flowey e 25 flowey_lib_hvlite::install_vmm_tests_deps 0
+        flowey e 25 flowey_core::pipeline::artifact::resolve 6
+      shell: bash
+    - name: running vmm_test prep_steps
+      run: flowey e 25 flowey_lib_hvlite::run_prep_steps 0
       shell: bash
     - name: run 'vmm_tests' nextest tests
       run: |-
@@ -7664,6 +7686,8 @@ jobs:
         echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-openvmm" | flowey v 8 'artifact_publish_from_aarch64-linux-openvmm' --is-raw-string update
         mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-openvmm_vhost"
         echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-openvmm_vhost" | flowey v 8 'artifact_publish_from_aarch64-linux-openvmm_vhost' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-prep_steps"
+        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-prep_steps" | flowey v 8 'artifact_publish_from_aarch64-linux-prep_steps' --is-raw-string update
         mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-vmgs_lib"
         echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-vmgs_lib" | flowey v 8 'artifact_publish_from_aarch64-linux-vmgs_lib' --is-raw-string update
         mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-vmgstool"
@@ -7768,25 +7792,25 @@ jobs:
         flowey e 8 flowey_lib_hvlite::run_cargo_build 9
         flowey e 8 flowey_lib_hvlite::build_openvmm_vhost 0
         flowey e 8 flowey_core::pipeline::artifact::publish 1
-        flowey e 8 flowey_lib_hvlite::init_cross_build 4
+        flowey e 8 flowey_lib_hvlite::init_cross_build 5
       shell: bash
     - name: cargo build vmgstool
       run: |-
-        flowey e 8 flowey_lib_common::run_cargo_build 7
-        flowey e 8 flowey_lib_hvlite::run_cargo_build 13
+        flowey e 8 flowey_lib_common::run_cargo_build 8
+        flowey e 8 flowey_lib_hvlite::run_cargo_build 15
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 8 flowey_lib_hvlite::run_split_debug_info 6
-        flowey e 8 flowey_lib_hvlite::run_cargo_build 14
+        flowey e 8 flowey_lib_hvlite::run_split_debug_info 7
+        flowey e 8 flowey_lib_hvlite::run_cargo_build 16
         flowey e 8 flowey_lib_hvlite::build_vmgstool 0
         flowey e 8 flowey_core::pipeline::artifact::publish 2
-        flowey e 8 flowey_lib_hvlite::init_cross_build 3
+        flowey e 8 flowey_lib_hvlite::init_cross_build 4
       shell: bash
     - name: cargo build vmgs_lib
       run: |-
-        flowey e 8 flowey_lib_common::run_cargo_build 6
-        flowey e 8 flowey_lib_hvlite::run_cargo_build 12
+        flowey e 8 flowey_lib_common::run_cargo_build 7
+        flowey e 8 flowey_lib_hvlite::run_cargo_build 14
         flowey e 8 flowey_lib_hvlite::build_and_test_vmgs_lib 0
         flowey e 8 flowey_lib_hvlite::build_and_test_vmgs_lib 1
         flowey e 8 flowey_core::pipeline::artifact::publish 3
@@ -7799,11 +7823,11 @@ jobs:
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 8 flowey_lib_hvlite::run_split_debug_info 5
+        flowey e 8 flowey_lib_hvlite::run_split_debug_info 6
         flowey e 8 flowey_lib_hvlite::run_cargo_build 1
         flowey e 8 flowey_lib_hvlite::build_igvmfilegen 0
         flowey e 8 flowey_core::pipeline::artifact::publish 4
-        flowey e 8 flowey_lib_hvlite::init_cross_build 5
+        flowey e 8 flowey_lib_hvlite::init_cross_build 6
       shell: bash
     - name: cargo build ohcldiag-dev
       run: |-
@@ -7823,7 +7847,7 @@ jobs:
     - name: extract Aarch64 sysroot.tar.gz
       run: |-
         flowey e 8 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
-        flowey e 8 flowey_lib_hvlite::init_cross_build 6
+        flowey e 8 flowey_lib_hvlite::init_cross_build 7
       shell: bash
     - name: cargo build openvmm
       run: |-
@@ -7836,7 +7860,7 @@ jobs:
         flowey e 8 flowey_lib_hvlite::run_cargo_build 7
         flowey e 8 flowey_lib_hvlite::build_openvmm 1
         flowey e 8 flowey_core::pipeline::artifact::publish 6
-        flowey e 8 flowey_lib_hvlite::init_cross_build 7
+        flowey e 8 flowey_lib_hvlite::init_cross_build 8
       shell: bash
     - name: cargo build openvmm_vhost
       run: |-
@@ -7849,6 +7873,19 @@ jobs:
         flowey e 8 flowey_lib_hvlite::run_cargo_build 11
         flowey e 8 flowey_lib_hvlite::build_openvmm_vhost 1
         flowey e 8 flowey_core::pipeline::artifact::publish 7
+        flowey e 8 flowey_lib_hvlite::init_cross_build 3
+      shell: bash
+    - name: cargo build prep_steps
+      run: |-
+        flowey e 8 flowey_lib_common::run_cargo_build 6
+        flowey e 8 flowey_lib_hvlite::run_cargo_build 12
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 8 flowey_lib_hvlite::run_split_debug_info 5
+        flowey e 8 flowey_lib_hvlite::run_cargo_build 13
+        flowey e 8 flowey_lib_hvlite::build_prep_steps 0
+        flowey e 8 flowey_core::pipeline::artifact::publish 8
       shell: bash
     - name: 'validate cache entry: gh-release-download'
       run: flowey e 8 flowey_lib_common::cache 3
@@ -7888,6 +7925,12 @@ jobs:
       with:
         name: aarch64-linux-openvmm_vhost
         path: ${{ runner.temp }}/publish_artifacts/aarch64-linux-openvmm_vhost/
+        include-hidden-files: true
+    - name: 🌼📦 Publish aarch64-linux-prep_steps
+      uses: actions/upload-artifact@v7
+      with:
+        name: aarch64-linux-prep_steps
+        path: ${{ runner.temp }}/publish_artifacts/aarch64-linux-prep_steps/
         include-hidden-files: true
     - name: 🌼📦 Publish aarch64-linux-vmgs_lib
       uses: actions/upload-artifact@v7
@@ -7993,6 +8036,8 @@ jobs:
         echo "$AgentTempDirNormal/publish_artifacts/x64-linux-openvmm" | flowey v 9 'artifact_publish_from_x64-linux-openvmm' --is-raw-string update
         mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-openvmm_vhost"
         echo "$AgentTempDirNormal/publish_artifacts/x64-linux-openvmm_vhost" | flowey v 9 'artifact_publish_from_x64-linux-openvmm_vhost' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-prep_steps"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-prep_steps" | flowey v 9 'artifact_publish_from_x64-linux-prep_steps' --is-raw-string update
         mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-vmgs_lib"
         echo "$AgentTempDirNormal/publish_artifacts/x64-linux-vmgs_lib" | flowey v 9 'artifact_publish_from_x64-linux-vmgs_lib' --is-raw-string update
         mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-vmgstool"
@@ -8099,25 +8144,25 @@ jobs:
         flowey e 9 flowey_lib_hvlite::run_cargo_build 9
         flowey e 9 flowey_lib_hvlite::build_openvmm_vhost 0
         flowey e 9 flowey_core::pipeline::artifact::publish 1
-        flowey e 9 flowey_lib_hvlite::init_cross_build 5
+        flowey e 9 flowey_lib_hvlite::init_cross_build 6
       shell: bash
     - name: cargo build vmgstool
       run: |-
-        flowey e 9 flowey_lib_common::run_cargo_build 7
-        flowey e 9 flowey_lib_hvlite::run_cargo_build 13
+        flowey e 9 flowey_lib_common::run_cargo_build 8
+        flowey e 9 flowey_lib_hvlite::run_cargo_build 15
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 9 flowey_lib_hvlite::run_split_debug_info 6
-        flowey e 9 flowey_lib_hvlite::run_cargo_build 14
+        flowey e 9 flowey_lib_hvlite::run_split_debug_info 7
+        flowey e 9 flowey_lib_hvlite::run_cargo_build 16
         flowey e 9 flowey_lib_hvlite::build_vmgstool 0
         flowey e 9 flowey_core::pipeline::artifact::publish 2
-        flowey e 9 flowey_lib_hvlite::init_cross_build 4
+        flowey e 9 flowey_lib_hvlite::init_cross_build 5
       shell: bash
     - name: cargo build vmgs_lib
       run: |-
-        flowey e 9 flowey_lib_common::run_cargo_build 6
-        flowey e 9 flowey_lib_hvlite::run_cargo_build 12
+        flowey e 9 flowey_lib_common::run_cargo_build 7
+        flowey e 9 flowey_lib_hvlite::run_cargo_build 14
         flowey e 9 flowey_lib_hvlite::build_and_test_vmgs_lib 0
       shell: bash
     - name: test vmgs_lib
@@ -8134,11 +8179,11 @@ jobs:
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 9 flowey_lib_hvlite::run_split_debug_info 5
+        flowey e 9 flowey_lib_hvlite::run_split_debug_info 6
         flowey e 9 flowey_lib_hvlite::run_cargo_build 1
         flowey e 9 flowey_lib_hvlite::build_igvmfilegen 0
         flowey e 9 flowey_core::pipeline::artifact::publish 4
-        flowey e 9 flowey_lib_hvlite::init_cross_build 6
+        flowey e 9 flowey_lib_hvlite::init_cross_build 7
       shell: bash
     - name: cargo build ohcldiag-dev
       run: |-
@@ -8158,7 +8203,7 @@ jobs:
     - name: extract X86_64 sysroot.tar.gz
       run: |-
         flowey e 9 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
-        flowey e 9 flowey_lib_hvlite::init_cross_build 8
+        flowey e 9 flowey_lib_hvlite::init_cross_build 9
       shell: bash
     - name: cargo build openvmm
       run: |-
@@ -8171,7 +8216,7 @@ jobs:
         flowey e 9 flowey_lib_hvlite::run_cargo_build 7
         flowey e 9 flowey_lib_hvlite::build_openvmm 1
         flowey e 9 flowey_core::pipeline::artifact::publish 6
-        flowey e 9 flowey_lib_hvlite::init_cross_build 9
+        flowey e 9 flowey_lib_hvlite::init_cross_build 10
       shell: bash
     - name: cargo build openvmm_vhost
       run: |-
@@ -8184,6 +8229,19 @@ jobs:
         flowey e 9 flowey_lib_hvlite::run_cargo_build 11
         flowey e 9 flowey_lib_hvlite::build_openvmm_vhost 1
         flowey e 9 flowey_core::pipeline::artifact::publish 7
+        flowey e 9 flowey_lib_hvlite::init_cross_build 4
+      shell: bash
+    - name: cargo build prep_steps
+      run: |-
+        flowey e 9 flowey_lib_common::run_cargo_build 6
+        flowey e 9 flowey_lib_hvlite::run_cargo_build 12
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 9 flowey_lib_hvlite::run_split_debug_info 5
+        flowey e 9 flowey_lib_hvlite::run_cargo_build 13
+        flowey e 9 flowey_lib_hvlite::build_prep_steps 0
+        flowey e 9 flowey_core::pipeline::artifact::publish 8
       shell: bash
     - name: create cargo-nextest cache dir
       run: |-
@@ -8224,14 +8282,14 @@ jobs:
       run: |-
         flowey e 9 flowey_lib_common::run_cargo_nextest_archive 0
         flowey e 9 flowey_lib_hvlite::build_nextest_vmm_tests 0
-        flowey e 9 flowey_core::pipeline::artifact::publish 8
-        flowey e 9 flowey_lib_hvlite::init_cross_build 7
+        flowey e 9 flowey_core::pipeline::artifact::publish 9
+        flowey e 9 flowey_lib_hvlite::init_cross_build 8
       shell: bash
     - name: build + archive 'vmm_tests' nextests
       run: |-
         flowey e 9 flowey_lib_common::run_cargo_nextest_archive 1
         flowey e 9 flowey_lib_hvlite::build_nextest_vmm_tests 1
-        flowey e 9 flowey_core::pipeline::artifact::publish 9
+        flowey e 9 flowey_core::pipeline::artifact::publish 10
       shell: bash
     - name: 'validate cache entry: cargo-nextest'
       run: flowey e 9 flowey_lib_common::cache 3
@@ -8280,6 +8338,12 @@ jobs:
       with:
         name: x64-linux-openvmm_vhost
         path: ${{ runner.temp }}/publish_artifacts/x64-linux-openvmm_vhost/
+        include-hidden-files: true
+    - name: 🌼📦 Publish x64-linux-prep_steps
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-linux-prep_steps
+        path: ${{ runner.temp }}/publish_artifacts/x64-linux-prep_steps/
         include-hidden-files: true
     - name: 🌼📦 Publish x64-linux-vmgs_lib
       uses: actions/upload-artifact@v7

--- a/.github/workflows/openvmm-ci.yaml
+++ b/.github/workflows/openvmm-ci.yaml
@@ -7792,7 +7792,7 @@ jobs:
         flowey e 8 flowey_lib_hvlite::run_cargo_build 9
         flowey e 8 flowey_lib_hvlite::build_openvmm_vhost 0
         flowey e 8 flowey_core::pipeline::artifact::publish 1
-        flowey e 8 flowey_lib_hvlite::init_cross_build 5
+        flowey e 8 flowey_lib_hvlite::init_cross_build 4
       shell: bash
     - name: cargo build vmgstool
       run: |-
@@ -7805,7 +7805,7 @@ jobs:
         flowey e 8 flowey_lib_hvlite::run_cargo_build 16
         flowey e 8 flowey_lib_hvlite::build_vmgstool 0
         flowey e 8 flowey_core::pipeline::artifact::publish 2
-        flowey e 8 flowey_lib_hvlite::init_cross_build 4
+        flowey e 8 flowey_lib_hvlite::init_cross_build 3
       shell: bash
     - name: cargo build vmgs_lib
       run: |-
@@ -7827,7 +7827,7 @@ jobs:
         flowey e 8 flowey_lib_hvlite::run_cargo_build 1
         flowey e 8 flowey_lib_hvlite::build_igvmfilegen 0
         flowey e 8 flowey_core::pipeline::artifact::publish 4
-        flowey e 8 flowey_lib_hvlite::init_cross_build 6
+        flowey e 8 flowey_lib_hvlite::init_cross_build 5
       shell: bash
     - name: cargo build ohcldiag-dev
       run: |-
@@ -7847,7 +7847,7 @@ jobs:
     - name: extract Aarch64 sysroot.tar.gz
       run: |-
         flowey e 8 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
-        flowey e 8 flowey_lib_hvlite::init_cross_build 7
+        flowey e 8 flowey_lib_hvlite::init_cross_build 6
       shell: bash
     - name: cargo build openvmm
       run: |-
@@ -7860,7 +7860,7 @@ jobs:
         flowey e 8 flowey_lib_hvlite::run_cargo_build 7
         flowey e 8 flowey_lib_hvlite::build_openvmm 1
         flowey e 8 flowey_core::pipeline::artifact::publish 6
-        flowey e 8 flowey_lib_hvlite::init_cross_build 8
+        flowey e 8 flowey_lib_hvlite::init_cross_build 7
       shell: bash
     - name: cargo build openvmm_vhost
       run: |-
@@ -7873,7 +7873,7 @@ jobs:
         flowey e 8 flowey_lib_hvlite::run_cargo_build 11
         flowey e 8 flowey_lib_hvlite::build_openvmm_vhost 1
         flowey e 8 flowey_core::pipeline::artifact::publish 7
-        flowey e 8 flowey_lib_hvlite::init_cross_build 3
+        flowey e 8 flowey_lib_hvlite::init_cross_build 8
       shell: bash
     - name: cargo build prep_steps
       run: |-
@@ -8144,7 +8144,7 @@ jobs:
         flowey e 9 flowey_lib_hvlite::run_cargo_build 9
         flowey e 9 flowey_lib_hvlite::build_openvmm_vhost 0
         flowey e 9 flowey_core::pipeline::artifact::publish 1
-        flowey e 9 flowey_lib_hvlite::init_cross_build 6
+        flowey e 9 flowey_lib_hvlite::init_cross_build 5
       shell: bash
     - name: cargo build vmgstool
       run: |-
@@ -8157,7 +8157,7 @@ jobs:
         flowey e 9 flowey_lib_hvlite::run_cargo_build 16
         flowey e 9 flowey_lib_hvlite::build_vmgstool 0
         flowey e 9 flowey_core::pipeline::artifact::publish 2
-        flowey e 9 flowey_lib_hvlite::init_cross_build 5
+        flowey e 9 flowey_lib_hvlite::init_cross_build 4
       shell: bash
     - name: cargo build vmgs_lib
       run: |-
@@ -8183,7 +8183,7 @@ jobs:
         flowey e 9 flowey_lib_hvlite::run_cargo_build 1
         flowey e 9 flowey_lib_hvlite::build_igvmfilegen 0
         flowey e 9 flowey_core::pipeline::artifact::publish 4
-        flowey e 9 flowey_lib_hvlite::init_cross_build 7
+        flowey e 9 flowey_lib_hvlite::init_cross_build 6
       shell: bash
     - name: cargo build ohcldiag-dev
       run: |-
@@ -8203,7 +8203,7 @@ jobs:
     - name: extract X86_64 sysroot.tar.gz
       run: |-
         flowey e 9 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
-        flowey e 9 flowey_lib_hvlite::init_cross_build 9
+        flowey e 9 flowey_lib_hvlite::init_cross_build 8
       shell: bash
     - name: cargo build openvmm
       run: |-
@@ -8216,7 +8216,7 @@ jobs:
         flowey e 9 flowey_lib_hvlite::run_cargo_build 7
         flowey e 9 flowey_lib_hvlite::build_openvmm 1
         flowey e 9 flowey_core::pipeline::artifact::publish 6
-        flowey e 9 flowey_lib_hvlite::init_cross_build 10
+        flowey e 9 flowey_lib_hvlite::init_cross_build 9
       shell: bash
     - name: cargo build openvmm_vhost
       run: |-
@@ -8229,7 +8229,7 @@ jobs:
         flowey e 9 flowey_lib_hvlite::run_cargo_build 11
         flowey e 9 flowey_lib_hvlite::build_openvmm_vhost 1
         flowey e 9 flowey_core::pipeline::artifact::publish 7
-        flowey e 9 flowey_lib_hvlite::init_cross_build 4
+        flowey e 9 flowey_lib_hvlite::init_cross_build 10
       shell: bash
     - name: cargo build prep_steps
       run: |-
@@ -8283,7 +8283,7 @@ jobs:
         flowey e 9 flowey_lib_common::run_cargo_nextest_archive 0
         flowey e 9 flowey_lib_hvlite::build_nextest_vmm_tests 0
         flowey e 9 flowey_core::pipeline::artifact::publish 9
-        flowey e 9 flowey_lib_hvlite::init_cross_build 8
+        flowey e 9 flowey_lib_hvlite::init_cross_build 7
       shell: bash
     - name: build + archive 'vmm_tests' nextests
       run: |-

--- a/.github/workflows/openvmm-pr-release.yaml
+++ b/.github/workflows/openvmm-pr-release.yaml
@@ -7311,7 +7311,7 @@ jobs:
         flowey e 8 flowey_lib_hvlite::run_cargo_build 9
         flowey e 8 flowey_lib_hvlite::build_openvmm_vhost 0
         flowey e 8 flowey_core::pipeline::artifact::publish 1
-        flowey e 8 flowey_lib_hvlite::init_cross_build 5
+        flowey e 8 flowey_lib_hvlite::init_cross_build 4
       shell: bash
     - name: cargo build vmgstool
       run: |-
@@ -7324,7 +7324,7 @@ jobs:
         flowey e 8 flowey_lib_hvlite::run_cargo_build 16
         flowey e 8 flowey_lib_hvlite::build_vmgstool 0
         flowey e 8 flowey_core::pipeline::artifact::publish 2
-        flowey e 8 flowey_lib_hvlite::init_cross_build 4
+        flowey e 8 flowey_lib_hvlite::init_cross_build 3
       shell: bash
     - name: cargo build vmgs_lib
       run: |-
@@ -7346,7 +7346,7 @@ jobs:
         flowey e 8 flowey_lib_hvlite::run_cargo_build 1
         flowey e 8 flowey_lib_hvlite::build_igvmfilegen 0
         flowey e 8 flowey_core::pipeline::artifact::publish 4
-        flowey e 8 flowey_lib_hvlite::init_cross_build 6
+        flowey e 8 flowey_lib_hvlite::init_cross_build 5
       shell: bash
     - name: cargo build ohcldiag-dev
       run: |-
@@ -7366,7 +7366,7 @@ jobs:
     - name: extract Aarch64 sysroot.tar.gz
       run: |-
         flowey e 8 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
-        flowey e 8 flowey_lib_hvlite::init_cross_build 7
+        flowey e 8 flowey_lib_hvlite::init_cross_build 6
       shell: bash
     - name: cargo build openvmm
       run: |-
@@ -7379,7 +7379,7 @@ jobs:
         flowey e 8 flowey_lib_hvlite::run_cargo_build 7
         flowey e 8 flowey_lib_hvlite::build_openvmm 1
         flowey e 8 flowey_core::pipeline::artifact::publish 6
-        flowey e 8 flowey_lib_hvlite::init_cross_build 8
+        flowey e 8 flowey_lib_hvlite::init_cross_build 7
       shell: bash
     - name: cargo build openvmm_vhost
       run: |-
@@ -7392,7 +7392,7 @@ jobs:
         flowey e 8 flowey_lib_hvlite::run_cargo_build 11
         flowey e 8 flowey_lib_hvlite::build_openvmm_vhost 1
         flowey e 8 flowey_core::pipeline::artifact::publish 7
-        flowey e 8 flowey_lib_hvlite::init_cross_build 3
+        flowey e 8 flowey_lib_hvlite::init_cross_build 8
       shell: bash
     - name: cargo build prep_steps
       run: |-
@@ -7621,7 +7621,7 @@ jobs:
         flowey e 9 flowey_lib_hvlite::run_cargo_build 9
         flowey e 9 flowey_lib_hvlite::build_openvmm_vhost 0
         flowey e 9 flowey_core::pipeline::artifact::publish 1
-        flowey e 9 flowey_lib_hvlite::init_cross_build 6
+        flowey e 9 flowey_lib_hvlite::init_cross_build 5
       shell: bash
     - name: cargo build vmgstool
       run: |-
@@ -7634,7 +7634,7 @@ jobs:
         flowey e 9 flowey_lib_hvlite::run_cargo_build 16
         flowey e 9 flowey_lib_hvlite::build_vmgstool 0
         flowey e 9 flowey_core::pipeline::artifact::publish 2
-        flowey e 9 flowey_lib_hvlite::init_cross_build 5
+        flowey e 9 flowey_lib_hvlite::init_cross_build 4
       shell: bash
     - name: cargo build vmgs_lib
       run: |-
@@ -7660,7 +7660,7 @@ jobs:
         flowey e 9 flowey_lib_hvlite::run_cargo_build 1
         flowey e 9 flowey_lib_hvlite::build_igvmfilegen 0
         flowey e 9 flowey_core::pipeline::artifact::publish 4
-        flowey e 9 flowey_lib_hvlite::init_cross_build 7
+        flowey e 9 flowey_lib_hvlite::init_cross_build 6
       shell: bash
     - name: cargo build ohcldiag-dev
       run: |-
@@ -7680,7 +7680,7 @@ jobs:
     - name: extract X86_64 sysroot.tar.gz
       run: |-
         flowey e 9 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
-        flowey e 9 flowey_lib_hvlite::init_cross_build 9
+        flowey e 9 flowey_lib_hvlite::init_cross_build 8
       shell: bash
     - name: cargo build openvmm
       run: |-
@@ -7693,7 +7693,7 @@ jobs:
         flowey e 9 flowey_lib_hvlite::run_cargo_build 7
         flowey e 9 flowey_lib_hvlite::build_openvmm 1
         flowey e 9 flowey_core::pipeline::artifact::publish 6
-        flowey e 9 flowey_lib_hvlite::init_cross_build 10
+        flowey e 9 flowey_lib_hvlite::init_cross_build 9
       shell: bash
     - name: cargo build openvmm_vhost
       run: |-
@@ -7706,7 +7706,7 @@ jobs:
         flowey e 9 flowey_lib_hvlite::run_cargo_build 11
         flowey e 9 flowey_lib_hvlite::build_openvmm_vhost 1
         flowey e 9 flowey_core::pipeline::artifact::publish 7
-        flowey e 9 flowey_lib_hvlite::init_cross_build 4
+        flowey e 9 flowey_lib_hvlite::init_cross_build 10
       shell: bash
     - name: cargo build prep_steps
       run: |-
@@ -7760,7 +7760,7 @@ jobs:
         flowey e 9 flowey_lib_common::run_cargo_nextest_archive 0
         flowey e 9 flowey_lib_hvlite::build_nextest_vmm_tests 0
         flowey e 9 flowey_core::pipeline::artifact::publish 9
-        flowey e 9 flowey_lib_hvlite::init_cross_build 8
+        flowey e 9 flowey_lib_hvlite::init_cross_build 7
       shell: bash
     - name: build + archive 'vmm_tests' nextests
       run: |-

--- a/.github/workflows/openvmm-pr-release.yaml
+++ b/.github/workflows/openvmm-pr-release.yaml
@@ -3463,7 +3463,12 @@ jobs:
       run: flowey.exe e 19 flowey_lib_hvlite::install_vmm_tests_deps 0
       shell: bash
     - name: starting test_igvm_agent_rpc_server
-      run: flowey.exe e 19 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
+      run: |-
+        flowey.exe e 19 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
+        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 7
+      shell: bash
+    - name: running vmm_test prep_steps
+      run: flowey.exe e 19 flowey_lib_hvlite::run_prep_steps 0
       shell: bash
     - name: run 'vmm_tests' nextest tests
       run: |-
@@ -4351,6 +4356,7 @@ jobs:
         flowey.exe e 22 flowey_lib_common::git_checkout 3
         flowey.exe e 22 flowey_lib_hvlite::git_checkout_openvmm_repo 0
         flowey.exe e 22 flowey_lib_hvlite::run_cargo_nextest_run 0
+        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 4
         flowey.exe e 22 flowey_core::pipeline::artifact::resolve 11
         flowey.exe e 22 flowey_core::pipeline::artifact::resolve 10
         flowey.exe e 22 flowey_core::pipeline::artifact::resolve 3
@@ -4361,7 +4367,6 @@ jobs:
         flowey.exe e 22 flowey_core::pipeline::artifact::resolve 0
         flowey.exe e 22 flowey_core::pipeline::artifact::resolve 9
         flowey.exe e 22 flowey_core::pipeline::artifact::resolve 2
-        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 4
       shell: bash
     - name: creating new test content dir
       run: flowey.exe e 22 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
@@ -4466,7 +4471,12 @@ jobs:
       run: flowey.exe e 22 flowey_lib_hvlite::install_vmm_tests_deps 0
       shell: bash
     - name: starting test_igvm_agent_rpc_server
-      run: flowey.exe e 22 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
+      run: |-
+        flowey.exe e 22 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
+        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 7
+      shell: bash
+    - name: running vmm_test prep_steps
+      run: flowey.exe e 22 flowey_lib_hvlite::run_prep_steps 0
       shell: bash
     - name: run 'vmm_tests' nextest tests
       run: |-
@@ -4815,7 +4825,7 @@ jobs:
     - name: 🌼📦 Download artifacts
       uses: actions/download-artifact@v8
       with:
-        pattern: '{_internal-flowey-bootstrap-x86_64-linux-uid-1,x64-guest_test_uefi,x64-linux-musl-pipette,x64-linux-musl-tmk_vmm,x64-linux-openvmm,x64-linux-openvmm_vhost,x64-linux-vmm-tests-archive,x64-tmks,x64-windows-pipette}'
+        pattern: '{_internal-flowey-bootstrap-x86_64-linux-uid-1,x64-guest_test_uefi,x64-linux-musl-pipette,x64-linux-musl-tmk_vmm,x64-linux-openvmm,x64-linux-openvmm_vhost,x64-linux-prep_steps,x64-linux-vmm-tests-archive,x64-tmks,x64-windows-pipette}'
         path: ${{ runner.temp }}/used_artifacts/
     - run: echo "${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-1" >> $GITHUB_PATH
       shell: bash
@@ -4839,6 +4849,7 @@ jobs:
         echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-tmk_vmm" | flowey v 24 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
         echo "$AgentTempDirNormal/used_artifacts/x64-linux-openvmm" | flowey v 24 'artifact_use_from_x64-linux-openvmm' --is-raw-string update
         echo "$AgentTempDirNormal/used_artifacts/x64-linux-openvmm_vhost" | flowey v 24 'artifact_use_from_x64-linux-openvmm_vhost' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-prep_steps" | flowey v 24 'artifact_use_from_x64-linux-prep_steps' --is-raw-string update
         echo "$AgentTempDirNormal/used_artifacts/x64-linux-vmm-tests-archive" | flowey v 24 'artifact_use_from_x64-linux-vmm-tests-archive' --is-raw-string update
         echo "$AgentTempDirNormal/used_artifacts/x64-tmks" | flowey v 24 'artifact_use_from_x64-tmks' --is-raw-string update
         echo "$AgentTempDirNormal/used_artifacts/x64-windows-pipette" | flowey v 24 'artifact_use_from_x64-windows-pipette' --is-raw-string update
@@ -4847,11 +4858,11 @@ jobs:
       run: |-
         flowey e 24 flowey_core::pipeline::artifact::resolve 3
         flowey e 24 flowey_core::pipeline::artifact::resolve 4
-        flowey e 24 flowey_core::pipeline::artifact::resolve 7
+        flowey e 24 flowey_core::pipeline::artifact::resolve 8
         flowey e 24 flowey_core::pipeline::artifact::resolve 1
         flowey e 24 flowey_core::pipeline::artifact::resolve 0
         flowey e 24 flowey_core::pipeline::artifact::resolve 2
-        flowey e 24 flowey_core::pipeline::artifact::resolve 6
+        flowey e 24 flowey_core::pipeline::artifact::resolve 7
         flowey e 24 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
       shell: bash
     - name: checking if packages need to be installed
@@ -5003,14 +5014,19 @@ jobs:
         flowey e 24 flowey_lib_hvlite::run_cargo_nextest_run 0
         flowey e 24 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
         flowey e 24 flowey_lib_hvlite::run_cargo_nextest_run 1
-        flowey e 24 flowey_core::pipeline::artifact::resolve 5
+        flowey e 24 flowey_core::pipeline::artifact::resolve 6
         flowey e 24 flowey_lib_hvlite::test_nextest_vmm_tests_archive 3
       shell: bash
     - name: generate nextest command
       run: flowey e 24 flowey_lib_common::gen_cargo_nextest_run_cmd 0
       shell: bash
     - name: install vmm tests deps (linux)
-      run: flowey e 24 flowey_lib_hvlite::install_vmm_tests_deps 0
+      run: |-
+        flowey e 24 flowey_lib_hvlite::install_vmm_tests_deps 0
+        flowey e 24 flowey_core::pipeline::artifact::resolve 5
+      shell: bash
+    - name: running vmm_test prep_steps
+      run: flowey e 24 flowey_lib_hvlite::run_prep_steps 0
       shell: bash
     - name: run 'vmm_tests' nextest tests
       run: |-
@@ -5116,7 +5132,7 @@ jobs:
     - name: 🌼📦 Download artifacts
       uses: actions/download-artifact@v8
       with:
-        pattern: '{x64-guest_test_uefi,x64-linux-musl-openvmm,x64-linux-musl-openvmm_vhost,x64-linux-musl-pipette,x64-linux-musl-tmk_vmm,x64-linux-musl-vmm-tests-archive,x64-tmks,x64-windows-pipette}'
+        pattern: '{x64-guest_test_uefi,x64-linux-musl-openvmm,x64-linux-musl-openvmm_vhost,x64-linux-musl-pipette,x64-linux-musl-tmk_vmm,x64-linux-musl-vmm-tests-archive,x64-linux-prep_steps,x64-tmks,x64-windows-pipette}'
         path: ${{ runner.temp }}/used_artifacts/
     - run: echo "${{ runner.temp }}/bootstrapped-flowey" >> $GITHUB_PATH
       shell: bash
@@ -5150,6 +5166,7 @@ jobs:
         echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-pipette" | flowey v 25 'artifact_use_from_x64-linux-musl-pipette' --is-raw-string update
         echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-tmk_vmm" | flowey v 25 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
         echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-vmm-tests-archive" | flowey v 25 'artifact_use_from_x64-linux-musl-vmm-tests-archive' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-prep_steps" | flowey v 25 'artifact_use_from_x64-linux-prep_steps' --is-raw-string update
         echo "$AgentTempDirNormal/used_artifacts/x64-tmks" | flowey v 25 'artifact_use_from_x64-tmks' --is-raw-string update
         echo "$AgentTempDirNormal/used_artifacts/x64-windows-pipette" | flowey v 25 'artifact_use_from_x64-windows-pipette' --is-raw-string update
       shell: bash
@@ -5157,11 +5174,11 @@ jobs:
       run: |-
         flowey e 25 flowey_core::pipeline::artifact::resolve 1
         flowey e 25 flowey_core::pipeline::artifact::resolve 2
-        flowey e 25 flowey_core::pipeline::artifact::resolve 7
+        flowey e 25 flowey_core::pipeline::artifact::resolve 8
         flowey e 25 flowey_core::pipeline::artifact::resolve 3
         flowey e 25 flowey_core::pipeline::artifact::resolve 0
         flowey e 25 flowey_core::pipeline::artifact::resolve 4
-        flowey e 25 flowey_core::pipeline::artifact::resolve 6
+        flowey e 25 flowey_core::pipeline::artifact::resolve 7
         flowey e 25 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
       shell: bash
     - name: checking if packages need to be installed
@@ -5316,7 +5333,12 @@ jobs:
       run: flowey e 25 flowey_lib_common::gen_cargo_nextest_run_cmd 0
       shell: bash
     - name: install vmm tests deps (linux)
-      run: flowey e 25 flowey_lib_hvlite::install_vmm_tests_deps 0
+      run: |-
+        flowey e 25 flowey_lib_hvlite::install_vmm_tests_deps 0
+        flowey e 25 flowey_core::pipeline::artifact::resolve 6
+      shell: bash
+    - name: running vmm_test prep_steps
+      run: flowey e 25 flowey_lib_hvlite::run_prep_steps 0
       shell: bash
     - name: run 'vmm_tests' nextest tests
       run: |-
@@ -7183,6 +7205,8 @@ jobs:
         echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-openvmm" | flowey v 8 'artifact_publish_from_aarch64-linux-openvmm' --is-raw-string update
         mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-openvmm_vhost"
         echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-openvmm_vhost" | flowey v 8 'artifact_publish_from_aarch64-linux-openvmm_vhost' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-prep_steps"
+        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-prep_steps" | flowey v 8 'artifact_publish_from_aarch64-linux-prep_steps' --is-raw-string update
         mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-vmgs_lib"
         echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-vmgs_lib" | flowey v 8 'artifact_publish_from_aarch64-linux-vmgs_lib' --is-raw-string update
         mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-vmgstool"
@@ -7287,25 +7311,25 @@ jobs:
         flowey e 8 flowey_lib_hvlite::run_cargo_build 9
         flowey e 8 flowey_lib_hvlite::build_openvmm_vhost 0
         flowey e 8 flowey_core::pipeline::artifact::publish 1
-        flowey e 8 flowey_lib_hvlite::init_cross_build 4
+        flowey e 8 flowey_lib_hvlite::init_cross_build 5
       shell: bash
     - name: cargo build vmgstool
       run: |-
-        flowey e 8 flowey_lib_common::run_cargo_build 7
-        flowey e 8 flowey_lib_hvlite::run_cargo_build 13
+        flowey e 8 flowey_lib_common::run_cargo_build 8
+        flowey e 8 flowey_lib_hvlite::run_cargo_build 15
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 8 flowey_lib_hvlite::run_split_debug_info 6
-        flowey e 8 flowey_lib_hvlite::run_cargo_build 14
+        flowey e 8 flowey_lib_hvlite::run_split_debug_info 7
+        flowey e 8 flowey_lib_hvlite::run_cargo_build 16
         flowey e 8 flowey_lib_hvlite::build_vmgstool 0
         flowey e 8 flowey_core::pipeline::artifact::publish 2
-        flowey e 8 flowey_lib_hvlite::init_cross_build 3
+        flowey e 8 flowey_lib_hvlite::init_cross_build 4
       shell: bash
     - name: cargo build vmgs_lib
       run: |-
-        flowey e 8 flowey_lib_common::run_cargo_build 6
-        flowey e 8 flowey_lib_hvlite::run_cargo_build 12
+        flowey e 8 flowey_lib_common::run_cargo_build 7
+        flowey e 8 flowey_lib_hvlite::run_cargo_build 14
         flowey e 8 flowey_lib_hvlite::build_and_test_vmgs_lib 0
         flowey e 8 flowey_lib_hvlite::build_and_test_vmgs_lib 1
         flowey e 8 flowey_core::pipeline::artifact::publish 3
@@ -7318,11 +7342,11 @@ jobs:
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 8 flowey_lib_hvlite::run_split_debug_info 5
+        flowey e 8 flowey_lib_hvlite::run_split_debug_info 6
         flowey e 8 flowey_lib_hvlite::run_cargo_build 1
         flowey e 8 flowey_lib_hvlite::build_igvmfilegen 0
         flowey e 8 flowey_core::pipeline::artifact::publish 4
-        flowey e 8 flowey_lib_hvlite::init_cross_build 5
+        flowey e 8 flowey_lib_hvlite::init_cross_build 6
       shell: bash
     - name: cargo build ohcldiag-dev
       run: |-
@@ -7342,7 +7366,7 @@ jobs:
     - name: extract Aarch64 sysroot.tar.gz
       run: |-
         flowey e 8 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
-        flowey e 8 flowey_lib_hvlite::init_cross_build 6
+        flowey e 8 flowey_lib_hvlite::init_cross_build 7
       shell: bash
     - name: cargo build openvmm
       run: |-
@@ -7355,7 +7379,7 @@ jobs:
         flowey e 8 flowey_lib_hvlite::run_cargo_build 7
         flowey e 8 flowey_lib_hvlite::build_openvmm 1
         flowey e 8 flowey_core::pipeline::artifact::publish 6
-        flowey e 8 flowey_lib_hvlite::init_cross_build 7
+        flowey e 8 flowey_lib_hvlite::init_cross_build 8
       shell: bash
     - name: cargo build openvmm_vhost
       run: |-
@@ -7368,6 +7392,19 @@ jobs:
         flowey e 8 flowey_lib_hvlite::run_cargo_build 11
         flowey e 8 flowey_lib_hvlite::build_openvmm_vhost 1
         flowey e 8 flowey_core::pipeline::artifact::publish 7
+        flowey e 8 flowey_lib_hvlite::init_cross_build 3
+      shell: bash
+    - name: cargo build prep_steps
+      run: |-
+        flowey e 8 flowey_lib_common::run_cargo_build 6
+        flowey e 8 flowey_lib_hvlite::run_cargo_build 12
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 8 flowey_lib_hvlite::run_split_debug_info 5
+        flowey e 8 flowey_lib_hvlite::run_cargo_build 13
+        flowey e 8 flowey_lib_hvlite::build_prep_steps 0
+        flowey e 8 flowey_core::pipeline::artifact::publish 8
       shell: bash
     - name: 'validate cache entry: gh-release-download'
       run: flowey e 8 flowey_lib_common::cache 3
@@ -7407,6 +7444,12 @@ jobs:
       with:
         name: aarch64-linux-openvmm_vhost
         path: ${{ runner.temp }}/publish_artifacts/aarch64-linux-openvmm_vhost/
+        include-hidden-files: true
+    - name: 🌼📦 Publish aarch64-linux-prep_steps
+      uses: actions/upload-artifact@v7
+      with:
+        name: aarch64-linux-prep_steps
+        path: ${{ runner.temp }}/publish_artifacts/aarch64-linux-prep_steps/
         include-hidden-files: true
     - name: 🌼📦 Publish aarch64-linux-vmgs_lib
       uses: actions/upload-artifact@v7
@@ -7470,6 +7513,8 @@ jobs:
         echo "$AgentTempDirNormal/publish_artifacts/x64-linux-openvmm" | flowey v 9 'artifact_publish_from_x64-linux-openvmm' --is-raw-string update
         mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-openvmm_vhost"
         echo "$AgentTempDirNormal/publish_artifacts/x64-linux-openvmm_vhost" | flowey v 9 'artifact_publish_from_x64-linux-openvmm_vhost' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-prep_steps"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-prep_steps" | flowey v 9 'artifact_publish_from_x64-linux-prep_steps' --is-raw-string update
         mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-vmgs_lib"
         echo "$AgentTempDirNormal/publish_artifacts/x64-linux-vmgs_lib" | flowey v 9 'artifact_publish_from_x64-linux-vmgs_lib' --is-raw-string update
         mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-vmgstool"
@@ -7576,25 +7621,25 @@ jobs:
         flowey e 9 flowey_lib_hvlite::run_cargo_build 9
         flowey e 9 flowey_lib_hvlite::build_openvmm_vhost 0
         flowey e 9 flowey_core::pipeline::artifact::publish 1
-        flowey e 9 flowey_lib_hvlite::init_cross_build 5
+        flowey e 9 flowey_lib_hvlite::init_cross_build 6
       shell: bash
     - name: cargo build vmgstool
       run: |-
-        flowey e 9 flowey_lib_common::run_cargo_build 7
-        flowey e 9 flowey_lib_hvlite::run_cargo_build 13
+        flowey e 9 flowey_lib_common::run_cargo_build 8
+        flowey e 9 flowey_lib_hvlite::run_cargo_build 15
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 9 flowey_lib_hvlite::run_split_debug_info 6
-        flowey e 9 flowey_lib_hvlite::run_cargo_build 14
+        flowey e 9 flowey_lib_hvlite::run_split_debug_info 7
+        flowey e 9 flowey_lib_hvlite::run_cargo_build 16
         flowey e 9 flowey_lib_hvlite::build_vmgstool 0
         flowey e 9 flowey_core::pipeline::artifact::publish 2
-        flowey e 9 flowey_lib_hvlite::init_cross_build 4
+        flowey e 9 flowey_lib_hvlite::init_cross_build 5
       shell: bash
     - name: cargo build vmgs_lib
       run: |-
-        flowey e 9 flowey_lib_common::run_cargo_build 6
-        flowey e 9 flowey_lib_hvlite::run_cargo_build 12
+        flowey e 9 flowey_lib_common::run_cargo_build 7
+        flowey e 9 flowey_lib_hvlite::run_cargo_build 14
         flowey e 9 flowey_lib_hvlite::build_and_test_vmgs_lib 0
       shell: bash
     - name: test vmgs_lib
@@ -7611,11 +7656,11 @@ jobs:
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 9 flowey_lib_hvlite::run_split_debug_info 5
+        flowey e 9 flowey_lib_hvlite::run_split_debug_info 6
         flowey e 9 flowey_lib_hvlite::run_cargo_build 1
         flowey e 9 flowey_lib_hvlite::build_igvmfilegen 0
         flowey e 9 flowey_core::pipeline::artifact::publish 4
-        flowey e 9 flowey_lib_hvlite::init_cross_build 6
+        flowey e 9 flowey_lib_hvlite::init_cross_build 7
       shell: bash
     - name: cargo build ohcldiag-dev
       run: |-
@@ -7635,7 +7680,7 @@ jobs:
     - name: extract X86_64 sysroot.tar.gz
       run: |-
         flowey e 9 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
-        flowey e 9 flowey_lib_hvlite::init_cross_build 8
+        flowey e 9 flowey_lib_hvlite::init_cross_build 9
       shell: bash
     - name: cargo build openvmm
       run: |-
@@ -7648,7 +7693,7 @@ jobs:
         flowey e 9 flowey_lib_hvlite::run_cargo_build 7
         flowey e 9 flowey_lib_hvlite::build_openvmm 1
         flowey e 9 flowey_core::pipeline::artifact::publish 6
-        flowey e 9 flowey_lib_hvlite::init_cross_build 9
+        flowey e 9 flowey_lib_hvlite::init_cross_build 10
       shell: bash
     - name: cargo build openvmm_vhost
       run: |-
@@ -7661,6 +7706,19 @@ jobs:
         flowey e 9 flowey_lib_hvlite::run_cargo_build 11
         flowey e 9 flowey_lib_hvlite::build_openvmm_vhost 1
         flowey e 9 flowey_core::pipeline::artifact::publish 7
+        flowey e 9 flowey_lib_hvlite::init_cross_build 4
+      shell: bash
+    - name: cargo build prep_steps
+      run: |-
+        flowey e 9 flowey_lib_common::run_cargo_build 6
+        flowey e 9 flowey_lib_hvlite::run_cargo_build 12
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 9 flowey_lib_hvlite::run_split_debug_info 5
+        flowey e 9 flowey_lib_hvlite::run_cargo_build 13
+        flowey e 9 flowey_lib_hvlite::build_prep_steps 0
+        flowey e 9 flowey_core::pipeline::artifact::publish 8
       shell: bash
     - name: create cargo-nextest cache dir
       run: |-
@@ -7701,14 +7759,14 @@ jobs:
       run: |-
         flowey e 9 flowey_lib_common::run_cargo_nextest_archive 0
         flowey e 9 flowey_lib_hvlite::build_nextest_vmm_tests 0
-        flowey e 9 flowey_core::pipeline::artifact::publish 8
-        flowey e 9 flowey_lib_hvlite::init_cross_build 7
+        flowey e 9 flowey_core::pipeline::artifact::publish 9
+        flowey e 9 flowey_lib_hvlite::init_cross_build 8
       shell: bash
     - name: build + archive 'vmm_tests' nextests
       run: |-
         flowey e 9 flowey_lib_common::run_cargo_nextest_archive 1
         flowey e 9 flowey_lib_hvlite::build_nextest_vmm_tests 1
-        flowey e 9 flowey_core::pipeline::artifact::publish 9
+        flowey e 9 flowey_core::pipeline::artifact::publish 10
       shell: bash
     - name: 'validate cache entry: cargo-nextest'
       run: flowey e 9 flowey_lib_common::cache 3
@@ -7757,6 +7815,12 @@ jobs:
       with:
         name: x64-linux-openvmm_vhost
         path: ${{ runner.temp }}/publish_artifacts/x64-linux-openvmm_vhost/
+        include-hidden-files: true
+    - name: 🌼📦 Publish x64-linux-prep_steps
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-linux-prep_steps
+        path: ${{ runner.temp }}/publish_artifacts/x64-linux-prep_steps/
         include-hidden-files: true
     - name: 🌼📦 Publish x64-linux-vmgs_lib
       uses: actions/upload-artifact@v7

--- a/.github/workflows/openvmm-pr.yaml
+++ b/.github/workflows/openvmm-pr.yaml
@@ -4038,7 +4038,12 @@ jobs:
       run: flowey.exe e 21 flowey_lib_hvlite::install_vmm_tests_deps 0
       shell: bash
     - name: starting test_igvm_agent_rpc_server
-      run: flowey.exe e 21 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
+      run: |-
+        flowey.exe e 21 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
+        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 7
+      shell: bash
+    - name: running vmm_test prep_steps
+      run: flowey.exe e 21 flowey_lib_hvlite::run_prep_steps 0
       shell: bash
     - name: run 'vmm_tests' nextest tests
       run: |-
@@ -4742,6 +4747,7 @@ jobs:
         flowey.exe e 24 flowey_lib_common::git_checkout 3
         flowey.exe e 24 flowey_lib_hvlite::git_checkout_openvmm_repo 0
         flowey.exe e 24 flowey_lib_hvlite::run_cargo_nextest_run 0
+        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 4
         flowey.exe e 24 flowey_core::pipeline::artifact::resolve 11
         flowey.exe e 24 flowey_core::pipeline::artifact::resolve 10
         flowey.exe e 24 flowey_core::pipeline::artifact::resolve 3
@@ -4752,7 +4758,6 @@ jobs:
         flowey.exe e 24 flowey_core::pipeline::artifact::resolve 0
         flowey.exe e 24 flowey_core::pipeline::artifact::resolve 9
         flowey.exe e 24 flowey_core::pipeline::artifact::resolve 2
-        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 4
       shell: bash
     - name: creating new test content dir
       run: flowey.exe e 24 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
@@ -4857,7 +4862,12 @@ jobs:
       run: flowey.exe e 24 flowey_lib_hvlite::install_vmm_tests_deps 0
       shell: bash
     - name: starting test_igvm_agent_rpc_server
-      run: flowey.exe e 24 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
+      run: |-
+        flowey.exe e 24 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
+        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 7
+      shell: bash
+    - name: running vmm_test prep_steps
+      run: flowey.exe e 24 flowey_lib_hvlite::run_prep_steps 0
       shell: bash
     - name: run 'vmm_tests' nextest tests
       run: |-
@@ -5206,7 +5216,7 @@ jobs:
     - name: 🌼📦 Download artifacts
       uses: actions/download-artifact@v8
       with:
-        pattern: '{_internal-flowey-bootstrap-x86_64-linux-uid-1,x64-guest_test_uefi,x64-linux-musl-pipette,x64-linux-musl-tmk_vmm,x64-linux-openvmm,x64-linux-openvmm_vhost,x64-linux-vmm-tests-archive,x64-tmks,x64-windows-pipette}'
+        pattern: '{_internal-flowey-bootstrap-x86_64-linux-uid-1,x64-guest_test_uefi,x64-linux-musl-pipette,x64-linux-musl-tmk_vmm,x64-linux-openvmm,x64-linux-openvmm_vhost,x64-linux-prep_steps,x64-linux-vmm-tests-archive,x64-tmks,x64-windows-pipette}'
         path: ${{ runner.temp }}/used_artifacts/
     - run: echo "${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-1" >> $GITHUB_PATH
       shell: bash
@@ -5230,6 +5240,7 @@ jobs:
         echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-tmk_vmm" | flowey v 26 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
         echo "$AgentTempDirNormal/used_artifacts/x64-linux-openvmm" | flowey v 26 'artifact_use_from_x64-linux-openvmm' --is-raw-string update
         echo "$AgentTempDirNormal/used_artifacts/x64-linux-openvmm_vhost" | flowey v 26 'artifact_use_from_x64-linux-openvmm_vhost' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-prep_steps" | flowey v 26 'artifact_use_from_x64-linux-prep_steps' --is-raw-string update
         echo "$AgentTempDirNormal/used_artifacts/x64-linux-vmm-tests-archive" | flowey v 26 'artifact_use_from_x64-linux-vmm-tests-archive' --is-raw-string update
         echo "$AgentTempDirNormal/used_artifacts/x64-tmks" | flowey v 26 'artifact_use_from_x64-tmks' --is-raw-string update
         echo "$AgentTempDirNormal/used_artifacts/x64-windows-pipette" | flowey v 26 'artifact_use_from_x64-windows-pipette' --is-raw-string update
@@ -5238,11 +5249,11 @@ jobs:
       run: |-
         flowey e 26 flowey_core::pipeline::artifact::resolve 3
         flowey e 26 flowey_core::pipeline::artifact::resolve 4
-        flowey e 26 flowey_core::pipeline::artifact::resolve 7
+        flowey e 26 flowey_core::pipeline::artifact::resolve 8
         flowey e 26 flowey_core::pipeline::artifact::resolve 1
         flowey e 26 flowey_core::pipeline::artifact::resolve 0
         flowey e 26 flowey_core::pipeline::artifact::resolve 2
-        flowey e 26 flowey_core::pipeline::artifact::resolve 6
+        flowey e 26 flowey_core::pipeline::artifact::resolve 7
         flowey e 26 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
       shell: bash
     - name: checking if packages need to be installed
@@ -5394,14 +5405,19 @@ jobs:
         flowey e 26 flowey_lib_hvlite::run_cargo_nextest_run 0
         flowey e 26 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
         flowey e 26 flowey_lib_hvlite::run_cargo_nextest_run 1
-        flowey e 26 flowey_core::pipeline::artifact::resolve 5
+        flowey e 26 flowey_core::pipeline::artifact::resolve 6
         flowey e 26 flowey_lib_hvlite::test_nextest_vmm_tests_archive 3
       shell: bash
     - name: generate nextest command
       run: flowey e 26 flowey_lib_common::gen_cargo_nextest_run_cmd 0
       shell: bash
     - name: install vmm tests deps (linux)
-      run: flowey e 26 flowey_lib_hvlite::install_vmm_tests_deps 0
+      run: |-
+        flowey e 26 flowey_lib_hvlite::install_vmm_tests_deps 0
+        flowey e 26 flowey_core::pipeline::artifact::resolve 5
+      shell: bash
+    - name: running vmm_test prep_steps
+      run: flowey e 26 flowey_lib_hvlite::run_prep_steps 0
       shell: bash
     - name: run 'vmm_tests' nextest tests
       run: |-
@@ -5507,7 +5523,7 @@ jobs:
     - name: 🌼📦 Download artifacts
       uses: actions/download-artifact@v8
       with:
-        pattern: '{x64-guest_test_uefi,x64-linux-musl-openvmm,x64-linux-musl-openvmm_vhost,x64-linux-musl-pipette,x64-linux-musl-tmk_vmm,x64-linux-musl-vmm-tests-archive,x64-tmks,x64-windows-pipette}'
+        pattern: '{x64-guest_test_uefi,x64-linux-musl-openvmm,x64-linux-musl-openvmm_vhost,x64-linux-musl-pipette,x64-linux-musl-tmk_vmm,x64-linux-musl-vmm-tests-archive,x64-linux-prep_steps,x64-tmks,x64-windows-pipette}'
         path: ${{ runner.temp }}/used_artifacts/
     - run: echo "${{ runner.temp }}/bootstrapped-flowey" >> $GITHUB_PATH
       shell: bash
@@ -5541,6 +5557,7 @@ jobs:
         echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-pipette" | flowey v 27 'artifact_use_from_x64-linux-musl-pipette' --is-raw-string update
         echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-tmk_vmm" | flowey v 27 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
         echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-vmm-tests-archive" | flowey v 27 'artifact_use_from_x64-linux-musl-vmm-tests-archive' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-prep_steps" | flowey v 27 'artifact_use_from_x64-linux-prep_steps' --is-raw-string update
         echo "$AgentTempDirNormal/used_artifacts/x64-tmks" | flowey v 27 'artifact_use_from_x64-tmks' --is-raw-string update
         echo "$AgentTempDirNormal/used_artifacts/x64-windows-pipette" | flowey v 27 'artifact_use_from_x64-windows-pipette' --is-raw-string update
       shell: bash
@@ -5548,11 +5565,11 @@ jobs:
       run: |-
         flowey e 27 flowey_core::pipeline::artifact::resolve 1
         flowey e 27 flowey_core::pipeline::artifact::resolve 2
-        flowey e 27 flowey_core::pipeline::artifact::resolve 7
+        flowey e 27 flowey_core::pipeline::artifact::resolve 8
         flowey e 27 flowey_core::pipeline::artifact::resolve 3
         flowey e 27 flowey_core::pipeline::artifact::resolve 0
         flowey e 27 flowey_core::pipeline::artifact::resolve 4
-        flowey e 27 flowey_core::pipeline::artifact::resolve 6
+        flowey e 27 flowey_core::pipeline::artifact::resolve 7
         flowey e 27 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
       shell: bash
     - name: checking if packages need to be installed
@@ -5707,7 +5724,12 @@ jobs:
       run: flowey e 27 flowey_lib_common::gen_cargo_nextest_run_cmd 0
       shell: bash
     - name: install vmm tests deps (linux)
-      run: flowey e 27 flowey_lib_hvlite::install_vmm_tests_deps 0
+      run: |-
+        flowey e 27 flowey_lib_hvlite::install_vmm_tests_deps 0
+        flowey e 27 flowey_core::pipeline::artifact::resolve 6
+      shell: bash
+    - name: running vmm_test prep_steps
+      run: flowey e 27 flowey_lib_hvlite::run_prep_steps 0
       shell: bash
     - name: run 'vmm_tests' nextest tests
       run: |-
@@ -7641,6 +7663,8 @@ jobs:
         echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-openvmm" | flowey v 8 'artifact_publish_from_aarch64-linux-openvmm' --is-raw-string update
         mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-openvmm_vhost"
         echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-openvmm_vhost" | flowey v 8 'artifact_publish_from_aarch64-linux-openvmm_vhost' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-prep_steps"
+        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-prep_steps" | flowey v 8 'artifact_publish_from_aarch64-linux-prep_steps' --is-raw-string update
         mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-vmgs_lib"
         echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-vmgs_lib" | flowey v 8 'artifact_publish_from_aarch64-linux-vmgs_lib' --is-raw-string update
         mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-vmgstool"
@@ -7745,25 +7769,25 @@ jobs:
         flowey e 8 flowey_lib_hvlite::run_cargo_build 9
         flowey e 8 flowey_lib_hvlite::build_openvmm_vhost 0
         flowey e 8 flowey_core::pipeline::artifact::publish 1
-        flowey e 8 flowey_lib_hvlite::init_cross_build 4
+        flowey e 8 flowey_lib_hvlite::init_cross_build 5
       shell: bash
     - name: cargo build vmgstool
       run: |-
-        flowey e 8 flowey_lib_common::run_cargo_build 7
-        flowey e 8 flowey_lib_hvlite::run_cargo_build 13
+        flowey e 8 flowey_lib_common::run_cargo_build 8
+        flowey e 8 flowey_lib_hvlite::run_cargo_build 15
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 8 flowey_lib_hvlite::run_split_debug_info 6
-        flowey e 8 flowey_lib_hvlite::run_cargo_build 14
+        flowey e 8 flowey_lib_hvlite::run_split_debug_info 7
+        flowey e 8 flowey_lib_hvlite::run_cargo_build 16
         flowey e 8 flowey_lib_hvlite::build_vmgstool 0
         flowey e 8 flowey_core::pipeline::artifact::publish 2
-        flowey e 8 flowey_lib_hvlite::init_cross_build 3
+        flowey e 8 flowey_lib_hvlite::init_cross_build 4
       shell: bash
     - name: cargo build vmgs_lib
       run: |-
-        flowey e 8 flowey_lib_common::run_cargo_build 6
-        flowey e 8 flowey_lib_hvlite::run_cargo_build 12
+        flowey e 8 flowey_lib_common::run_cargo_build 7
+        flowey e 8 flowey_lib_hvlite::run_cargo_build 14
         flowey e 8 flowey_lib_hvlite::build_and_test_vmgs_lib 0
         flowey e 8 flowey_lib_hvlite::build_and_test_vmgs_lib 1
         flowey e 8 flowey_core::pipeline::artifact::publish 3
@@ -7776,11 +7800,11 @@ jobs:
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 8 flowey_lib_hvlite::run_split_debug_info 5
+        flowey e 8 flowey_lib_hvlite::run_split_debug_info 6
         flowey e 8 flowey_lib_hvlite::run_cargo_build 1
         flowey e 8 flowey_lib_hvlite::build_igvmfilegen 0
         flowey e 8 flowey_core::pipeline::artifact::publish 4
-        flowey e 8 flowey_lib_hvlite::init_cross_build 5
+        flowey e 8 flowey_lib_hvlite::init_cross_build 6
       shell: bash
     - name: cargo build ohcldiag-dev
       run: |-
@@ -7800,7 +7824,7 @@ jobs:
     - name: extract Aarch64 sysroot.tar.gz
       run: |-
         flowey e 8 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
-        flowey e 8 flowey_lib_hvlite::init_cross_build 6
+        flowey e 8 flowey_lib_hvlite::init_cross_build 7
       shell: bash
     - name: cargo build openvmm
       run: |-
@@ -7813,7 +7837,7 @@ jobs:
         flowey e 8 flowey_lib_hvlite::run_cargo_build 7
         flowey e 8 flowey_lib_hvlite::build_openvmm 1
         flowey e 8 flowey_core::pipeline::artifact::publish 6
-        flowey e 8 flowey_lib_hvlite::init_cross_build 7
+        flowey e 8 flowey_lib_hvlite::init_cross_build 8
       shell: bash
     - name: cargo build openvmm_vhost
       run: |-
@@ -7826,6 +7850,19 @@ jobs:
         flowey e 8 flowey_lib_hvlite::run_cargo_build 11
         flowey e 8 flowey_lib_hvlite::build_openvmm_vhost 1
         flowey e 8 flowey_core::pipeline::artifact::publish 7
+        flowey e 8 flowey_lib_hvlite::init_cross_build 3
+      shell: bash
+    - name: cargo build prep_steps
+      run: |-
+        flowey e 8 flowey_lib_common::run_cargo_build 6
+        flowey e 8 flowey_lib_hvlite::run_cargo_build 12
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 8 flowey_lib_hvlite::run_split_debug_info 5
+        flowey e 8 flowey_lib_hvlite::run_cargo_build 13
+        flowey e 8 flowey_lib_hvlite::build_prep_steps 0
+        flowey e 8 flowey_core::pipeline::artifact::publish 8
       shell: bash
     - name: 'validate cache entry: gh-release-download'
       run: flowey e 8 flowey_lib_common::cache 3
@@ -7865,6 +7902,12 @@ jobs:
       with:
         name: aarch64-linux-openvmm_vhost
         path: ${{ runner.temp }}/publish_artifacts/aarch64-linux-openvmm_vhost/
+        include-hidden-files: true
+    - name: 🌼📦 Publish aarch64-linux-prep_steps
+      uses: actions/upload-artifact@v7
+      with:
+        name: aarch64-linux-prep_steps
+        path: ${{ runner.temp }}/publish_artifacts/aarch64-linux-prep_steps/
         include-hidden-files: true
     - name: 🌼📦 Publish aarch64-linux-vmgs_lib
       uses: actions/upload-artifact@v7
@@ -7928,6 +7971,8 @@ jobs:
         echo "$AgentTempDirNormal/publish_artifacts/x64-linux-openvmm" | flowey v 9 'artifact_publish_from_x64-linux-openvmm' --is-raw-string update
         mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-openvmm_vhost"
         echo "$AgentTempDirNormal/publish_artifacts/x64-linux-openvmm_vhost" | flowey v 9 'artifact_publish_from_x64-linux-openvmm_vhost' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-prep_steps"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-prep_steps" | flowey v 9 'artifact_publish_from_x64-linux-prep_steps' --is-raw-string update
         mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-vmgs_lib"
         echo "$AgentTempDirNormal/publish_artifacts/x64-linux-vmgs_lib" | flowey v 9 'artifact_publish_from_x64-linux-vmgs_lib' --is-raw-string update
         mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-vmgstool"
@@ -8034,25 +8079,25 @@ jobs:
         flowey e 9 flowey_lib_hvlite::run_cargo_build 9
         flowey e 9 flowey_lib_hvlite::build_openvmm_vhost 0
         flowey e 9 flowey_core::pipeline::artifact::publish 1
-        flowey e 9 flowey_lib_hvlite::init_cross_build 5
+        flowey e 9 flowey_lib_hvlite::init_cross_build 6
       shell: bash
     - name: cargo build vmgstool
       run: |-
-        flowey e 9 flowey_lib_common::run_cargo_build 7
-        flowey e 9 flowey_lib_hvlite::run_cargo_build 13
+        flowey e 9 flowey_lib_common::run_cargo_build 8
+        flowey e 9 flowey_lib_hvlite::run_cargo_build 15
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 9 flowey_lib_hvlite::run_split_debug_info 6
-        flowey e 9 flowey_lib_hvlite::run_cargo_build 14
+        flowey e 9 flowey_lib_hvlite::run_split_debug_info 7
+        flowey e 9 flowey_lib_hvlite::run_cargo_build 16
         flowey e 9 flowey_lib_hvlite::build_vmgstool 0
         flowey e 9 flowey_core::pipeline::artifact::publish 2
-        flowey e 9 flowey_lib_hvlite::init_cross_build 4
+        flowey e 9 flowey_lib_hvlite::init_cross_build 5
       shell: bash
     - name: cargo build vmgs_lib
       run: |-
-        flowey e 9 flowey_lib_common::run_cargo_build 6
-        flowey e 9 flowey_lib_hvlite::run_cargo_build 12
+        flowey e 9 flowey_lib_common::run_cargo_build 7
+        flowey e 9 flowey_lib_hvlite::run_cargo_build 14
         flowey e 9 flowey_lib_hvlite::build_and_test_vmgs_lib 0
       shell: bash
     - name: test vmgs_lib
@@ -8069,11 +8114,11 @@ jobs:
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 9 flowey_lib_hvlite::run_split_debug_info 5
+        flowey e 9 flowey_lib_hvlite::run_split_debug_info 6
         flowey e 9 flowey_lib_hvlite::run_cargo_build 1
         flowey e 9 flowey_lib_hvlite::build_igvmfilegen 0
         flowey e 9 flowey_core::pipeline::artifact::publish 4
-        flowey e 9 flowey_lib_hvlite::init_cross_build 6
+        flowey e 9 flowey_lib_hvlite::init_cross_build 7
       shell: bash
     - name: cargo build ohcldiag-dev
       run: |-
@@ -8093,7 +8138,7 @@ jobs:
     - name: extract X86_64 sysroot.tar.gz
       run: |-
         flowey e 9 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
-        flowey e 9 flowey_lib_hvlite::init_cross_build 8
+        flowey e 9 flowey_lib_hvlite::init_cross_build 9
       shell: bash
     - name: cargo build openvmm
       run: |-
@@ -8106,7 +8151,7 @@ jobs:
         flowey e 9 flowey_lib_hvlite::run_cargo_build 7
         flowey e 9 flowey_lib_hvlite::build_openvmm 1
         flowey e 9 flowey_core::pipeline::artifact::publish 6
-        flowey e 9 flowey_lib_hvlite::init_cross_build 9
+        flowey e 9 flowey_lib_hvlite::init_cross_build 10
       shell: bash
     - name: cargo build openvmm_vhost
       run: |-
@@ -8119,6 +8164,19 @@ jobs:
         flowey e 9 flowey_lib_hvlite::run_cargo_build 11
         flowey e 9 flowey_lib_hvlite::build_openvmm_vhost 1
         flowey e 9 flowey_core::pipeline::artifact::publish 7
+        flowey e 9 flowey_lib_hvlite::init_cross_build 4
+      shell: bash
+    - name: cargo build prep_steps
+      run: |-
+        flowey e 9 flowey_lib_common::run_cargo_build 6
+        flowey e 9 flowey_lib_hvlite::run_cargo_build 12
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 9 flowey_lib_hvlite::run_split_debug_info 5
+        flowey e 9 flowey_lib_hvlite::run_cargo_build 13
+        flowey e 9 flowey_lib_hvlite::build_prep_steps 0
+        flowey e 9 flowey_core::pipeline::artifact::publish 8
       shell: bash
     - name: create cargo-nextest cache dir
       run: |-
@@ -8159,14 +8217,14 @@ jobs:
       run: |-
         flowey e 9 flowey_lib_common::run_cargo_nextest_archive 0
         flowey e 9 flowey_lib_hvlite::build_nextest_vmm_tests 0
-        flowey e 9 flowey_core::pipeline::artifact::publish 8
-        flowey e 9 flowey_lib_hvlite::init_cross_build 7
+        flowey e 9 flowey_core::pipeline::artifact::publish 9
+        flowey e 9 flowey_lib_hvlite::init_cross_build 8
       shell: bash
     - name: build + archive 'vmm_tests' nextests
       run: |-
         flowey e 9 flowey_lib_common::run_cargo_nextest_archive 1
         flowey e 9 flowey_lib_hvlite::build_nextest_vmm_tests 1
-        flowey e 9 flowey_core::pipeline::artifact::publish 9
+        flowey e 9 flowey_core::pipeline::artifact::publish 10
       shell: bash
     - name: 'validate cache entry: cargo-nextest'
       run: flowey e 9 flowey_lib_common::cache 3
@@ -8215,6 +8273,12 @@ jobs:
       with:
         name: x64-linux-openvmm_vhost
         path: ${{ runner.temp }}/publish_artifacts/x64-linux-openvmm_vhost/
+        include-hidden-files: true
+    - name: 🌼📦 Publish x64-linux-prep_steps
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-linux-prep_steps
+        path: ${{ runner.temp }}/publish_artifacts/x64-linux-prep_steps/
         include-hidden-files: true
     - name: 🌼📦 Publish x64-linux-vmgs_lib
       uses: actions/upload-artifact@v7

--- a/.github/workflows/openvmm-pr.yaml
+++ b/.github/workflows/openvmm-pr.yaml
@@ -7769,7 +7769,7 @@ jobs:
         flowey e 8 flowey_lib_hvlite::run_cargo_build 9
         flowey e 8 flowey_lib_hvlite::build_openvmm_vhost 0
         flowey e 8 flowey_core::pipeline::artifact::publish 1
-        flowey e 8 flowey_lib_hvlite::init_cross_build 5
+        flowey e 8 flowey_lib_hvlite::init_cross_build 4
       shell: bash
     - name: cargo build vmgstool
       run: |-
@@ -7782,7 +7782,7 @@ jobs:
         flowey e 8 flowey_lib_hvlite::run_cargo_build 16
         flowey e 8 flowey_lib_hvlite::build_vmgstool 0
         flowey e 8 flowey_core::pipeline::artifact::publish 2
-        flowey e 8 flowey_lib_hvlite::init_cross_build 4
+        flowey e 8 flowey_lib_hvlite::init_cross_build 3
       shell: bash
     - name: cargo build vmgs_lib
       run: |-
@@ -7804,7 +7804,7 @@ jobs:
         flowey e 8 flowey_lib_hvlite::run_cargo_build 1
         flowey e 8 flowey_lib_hvlite::build_igvmfilegen 0
         flowey e 8 flowey_core::pipeline::artifact::publish 4
-        flowey e 8 flowey_lib_hvlite::init_cross_build 6
+        flowey e 8 flowey_lib_hvlite::init_cross_build 5
       shell: bash
     - name: cargo build ohcldiag-dev
       run: |-
@@ -7824,7 +7824,7 @@ jobs:
     - name: extract Aarch64 sysroot.tar.gz
       run: |-
         flowey e 8 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
-        flowey e 8 flowey_lib_hvlite::init_cross_build 7
+        flowey e 8 flowey_lib_hvlite::init_cross_build 6
       shell: bash
     - name: cargo build openvmm
       run: |-
@@ -7837,7 +7837,7 @@ jobs:
         flowey e 8 flowey_lib_hvlite::run_cargo_build 7
         flowey e 8 flowey_lib_hvlite::build_openvmm 1
         flowey e 8 flowey_core::pipeline::artifact::publish 6
-        flowey e 8 flowey_lib_hvlite::init_cross_build 8
+        flowey e 8 flowey_lib_hvlite::init_cross_build 7
       shell: bash
     - name: cargo build openvmm_vhost
       run: |-
@@ -7850,7 +7850,7 @@ jobs:
         flowey e 8 flowey_lib_hvlite::run_cargo_build 11
         flowey e 8 flowey_lib_hvlite::build_openvmm_vhost 1
         flowey e 8 flowey_core::pipeline::artifact::publish 7
-        flowey e 8 flowey_lib_hvlite::init_cross_build 3
+        flowey e 8 flowey_lib_hvlite::init_cross_build 8
       shell: bash
     - name: cargo build prep_steps
       run: |-
@@ -8079,7 +8079,7 @@ jobs:
         flowey e 9 flowey_lib_hvlite::run_cargo_build 9
         flowey e 9 flowey_lib_hvlite::build_openvmm_vhost 0
         flowey e 9 flowey_core::pipeline::artifact::publish 1
-        flowey e 9 flowey_lib_hvlite::init_cross_build 6
+        flowey e 9 flowey_lib_hvlite::init_cross_build 5
       shell: bash
     - name: cargo build vmgstool
       run: |-
@@ -8092,7 +8092,7 @@ jobs:
         flowey e 9 flowey_lib_hvlite::run_cargo_build 16
         flowey e 9 flowey_lib_hvlite::build_vmgstool 0
         flowey e 9 flowey_core::pipeline::artifact::publish 2
-        flowey e 9 flowey_lib_hvlite::init_cross_build 5
+        flowey e 9 flowey_lib_hvlite::init_cross_build 4
       shell: bash
     - name: cargo build vmgs_lib
       run: |-
@@ -8118,7 +8118,7 @@ jobs:
         flowey e 9 flowey_lib_hvlite::run_cargo_build 1
         flowey e 9 flowey_lib_hvlite::build_igvmfilegen 0
         flowey e 9 flowey_core::pipeline::artifact::publish 4
-        flowey e 9 flowey_lib_hvlite::init_cross_build 7
+        flowey e 9 flowey_lib_hvlite::init_cross_build 6
       shell: bash
     - name: cargo build ohcldiag-dev
       run: |-
@@ -8138,7 +8138,7 @@ jobs:
     - name: extract X86_64 sysroot.tar.gz
       run: |-
         flowey e 9 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
-        flowey e 9 flowey_lib_hvlite::init_cross_build 9
+        flowey e 9 flowey_lib_hvlite::init_cross_build 8
       shell: bash
     - name: cargo build openvmm
       run: |-
@@ -8151,7 +8151,7 @@ jobs:
         flowey e 9 flowey_lib_hvlite::run_cargo_build 7
         flowey e 9 flowey_lib_hvlite::build_openvmm 1
         flowey e 9 flowey_core::pipeline::artifact::publish 6
-        flowey e 9 flowey_lib_hvlite::init_cross_build 10
+        flowey e 9 flowey_lib_hvlite::init_cross_build 9
       shell: bash
     - name: cargo build openvmm_vhost
       run: |-
@@ -8164,7 +8164,7 @@ jobs:
         flowey e 9 flowey_lib_hvlite::run_cargo_build 11
         flowey e 9 flowey_lib_hvlite::build_openvmm_vhost 1
         flowey e 9 flowey_core::pipeline::artifact::publish 7
-        flowey e 9 flowey_lib_hvlite::init_cross_build 4
+        flowey e 9 flowey_lib_hvlite::init_cross_build 10
       shell: bash
     - name: cargo build prep_steps
       run: |-
@@ -8218,7 +8218,7 @@ jobs:
         flowey e 9 flowey_lib_common::run_cargo_nextest_archive 0
         flowey e 9 flowey_lib_hvlite::build_nextest_vmm_tests 0
         flowey e 9 flowey_core::pipeline::artifact::publish 9
-        flowey e 9 flowey_lib_hvlite::init_cross_build 8
+        flowey e 9 flowey_lib_hvlite::init_cross_build 7
       shell: bash
     - name: build + archive 'vmm_tests' nextests
       run: |-

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6451,6 +6451,7 @@ name = "prep_steps"
 version = "0.0.0"
 dependencies = [
  "anyhow",
+ "gptman",
  "guid",
  "openvmm_defs",
  "openvmm_helpers",
@@ -6459,6 +6460,7 @@ dependencies = [
  "petri_artifact_resolver_openvmm_known_paths",
  "petri_artifacts_common",
  "petri_artifacts_vmm_test",
+ "pipette_protocol",
  "scsidisk_resources",
  "storvsp_resources",
  "tracing",

--- a/ci-flowey/openvmm-pr.yaml
+++ b/ci-flowey/openvmm-pr.yaml
@@ -1939,6 +1939,8 @@ jobs:
       echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/x64-linux-openvmm" | $FLOWEY_BIN v 9 'artifact_publish_from_x64-linux-openvmm' --is-raw-string update
       mkdir -p "$(AgentTempDirNormal)/publish_artifacts/x64-linux-openvmm_vhost"
       echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/x64-linux-openvmm_vhost" | $FLOWEY_BIN v 9 'artifact_publish_from_x64-linux-openvmm_vhost' --is-raw-string update
+      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/x64-linux-prep_steps"
+      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/x64-linux-prep_steps" | $FLOWEY_BIN v 9 'artifact_publish_from_x64-linux-prep_steps' --is-raw-string update
       mkdir -p "$(AgentTempDirNormal)/publish_artifacts/x64-linux-vmgs_lib"
       echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/x64-linux-vmgs_lib" | $FLOWEY_BIN v 9 'artifact_publish_from_x64-linux-vmgs_lib' --is-raw-string update
       mkdir -p "$(AgentTempDirNormal)/publish_artifacts/x64-linux-vmgstool"
@@ -2035,25 +2037,25 @@ jobs:
       $(FLOWEY_BIN) e 9 flowey_lib_hvlite::run_cargo_build 9
       $(FLOWEY_BIN) e 9 flowey_lib_hvlite::build_openvmm_vhost 0
       $(FLOWEY_BIN) e 9 flowey_core::pipeline::artifact::publish 1
+      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::init_cross_build 6
+    displayName: split debug symbols
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 9 flowey_lib_common::run_cargo_build 8
+      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::run_cargo_build 15
+    displayName: cargo build vmgstool
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::run_split_debug_info 7
+      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::run_cargo_build 16
+      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::build_vmgstool 0
+      $(FLOWEY_BIN) e 9 flowey_core::pipeline::artifact::publish 2
       $(FLOWEY_BIN) e 9 flowey_lib_hvlite::init_cross_build 5
     displayName: split debug symbols
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 9 flowey_lib_common::run_cargo_build 7
-      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::run_cargo_build 13
-    displayName: cargo build vmgstool
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::run_split_debug_info 6
       $(FLOWEY_BIN) e 9 flowey_lib_hvlite::run_cargo_build 14
-      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::build_vmgstool 0
-      $(FLOWEY_BIN) e 9 flowey_core::pipeline::artifact::publish 2
-      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::init_cross_build 4
-    displayName: split debug symbols
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 9 flowey_lib_common::run_cargo_build 6
-      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::run_cargo_build 12
       $(FLOWEY_BIN) e 9 flowey_lib_hvlite::build_and_test_vmgs_lib 0
     displayName: cargo build vmgs_lib
   - bash: |-
@@ -2070,11 +2072,11 @@ jobs:
     displayName: cargo build igvmfilegen
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::run_split_debug_info 5
+      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::run_split_debug_info 6
       $(FLOWEY_BIN) e 9 flowey_lib_hvlite::run_cargo_build 1
       $(FLOWEY_BIN) e 9 flowey_lib_hvlite::build_igvmfilegen 0
       $(FLOWEY_BIN) e 9 flowey_core::pipeline::artifact::publish 4
-      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::init_cross_build 6
+      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::init_cross_build 7
     displayName: split debug symbols
   - bash: |-
       set -e
@@ -2093,7 +2095,7 @@ jobs:
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 9 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
-      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::init_cross_build 8
+      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::init_cross_build 9
     displayName: extract X86_64 sysroot.tar.gz
   - bash: |-
       set -e
@@ -2106,7 +2108,7 @@ jobs:
       $(FLOWEY_BIN) e 9 flowey_lib_hvlite::run_cargo_build 7
       $(FLOWEY_BIN) e 9 flowey_lib_hvlite::build_openvmm 1
       $(FLOWEY_BIN) e 9 flowey_core::pipeline::artifact::publish 6
-      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::init_cross_build 9
+      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::init_cross_build 10
     displayName: split debug symbols
   - bash: |-
       set -e
@@ -2119,6 +2121,19 @@ jobs:
       $(FLOWEY_BIN) e 9 flowey_lib_hvlite::run_cargo_build 11
       $(FLOWEY_BIN) e 9 flowey_lib_hvlite::build_openvmm_vhost 1
       $(FLOWEY_BIN) e 9 flowey_core::pipeline::artifact::publish 7
+      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::init_cross_build 4
+    displayName: split debug symbols
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 9 flowey_lib_common::run_cargo_build 6
+      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::run_cargo_build 12
+    displayName: cargo build prep_steps
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::run_split_debug_info 5
+      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::run_cargo_build 13
+      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::build_prep_steps 0
+      $(FLOWEY_BIN) e 9 flowey_core::pipeline::artifact::publish 8
     displayName: split debug symbols
   - bash: |-
       set -e
@@ -2159,14 +2174,14 @@ jobs:
       set -e
       $(FLOWEY_BIN) e 9 flowey_lib_common::run_cargo_nextest_archive 0
       $(FLOWEY_BIN) e 9 flowey_lib_hvlite::build_nextest_vmm_tests 0
-      $(FLOWEY_BIN) e 9 flowey_core::pipeline::artifact::publish 8
-      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::init_cross_build 7
+      $(FLOWEY_BIN) e 9 flowey_core::pipeline::artifact::publish 9
+      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::init_cross_build 8
     displayName: build + archive 'vmm_tests' nextests
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 9 flowey_lib_common::run_cargo_nextest_archive 1
       $(FLOWEY_BIN) e 9 flowey_lib_hvlite::build_nextest_vmm_tests 1
-      $(FLOWEY_BIN) e 9 flowey_core::pipeline::artifact::publish 9
+      $(FLOWEY_BIN) e 9 flowey_core::pipeline::artifact::publish 10
     displayName: build + archive 'vmm_tests' nextests
   - bash: $(FLOWEY_BIN) e 9 flowey_lib_common::cache 3
     displayName: 'validate cache entry: cargo-nextest'
@@ -2193,6 +2208,9 @@ jobs:
   - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/x64-linux-openvmm_vhost
     displayName: 🌼📦 Publish x64-linux-openvmm_vhost
     artifact: x64-linux-openvmm_vhost
+  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/x64-linux-prep_steps
+    displayName: 🌼📦 Publish x64-linux-prep_steps
+    artifact: x64-linux-prep_steps
   - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/x64-linux-vmgs_lib
     displayName: 🌼📦 Publish x64-linux-vmgs_lib
     artifact: x64-linux-vmgs_lib
@@ -2250,6 +2268,8 @@ jobs:
       echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-linux-openvmm" | $FLOWEY_BIN v 8 'artifact_publish_from_aarch64-linux-openvmm' --is-raw-string update
       mkdir -p "$(AgentTempDirNormal)/publish_artifacts/aarch64-linux-openvmm_vhost"
       echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-linux-openvmm_vhost" | $FLOWEY_BIN v 8 'artifact_publish_from_aarch64-linux-openvmm_vhost' --is-raw-string update
+      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/aarch64-linux-prep_steps"
+      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-linux-prep_steps" | $FLOWEY_BIN v 8 'artifact_publish_from_aarch64-linux-prep_steps' --is-raw-string update
       mkdir -p "$(AgentTempDirNormal)/publish_artifacts/aarch64-linux-vmgs_lib"
       echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-linux-vmgs_lib" | $FLOWEY_BIN v 8 'artifact_publish_from_aarch64-linux-vmgs_lib' --is-raw-string update
       mkdir -p "$(AgentTempDirNormal)/publish_artifacts/aarch64-linux-vmgstool"
@@ -2344,25 +2364,25 @@ jobs:
       $(FLOWEY_BIN) e 8 flowey_lib_hvlite::run_cargo_build 9
       $(FLOWEY_BIN) e 8 flowey_lib_hvlite::build_openvmm_vhost 0
       $(FLOWEY_BIN) e 8 flowey_core::pipeline::artifact::publish 1
+      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::init_cross_build 5
+    displayName: split debug symbols
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 8 flowey_lib_common::run_cargo_build 8
+      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::run_cargo_build 15
+    displayName: cargo build vmgstool
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::run_split_debug_info 7
+      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::run_cargo_build 16
+      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::build_vmgstool 0
+      $(FLOWEY_BIN) e 8 flowey_core::pipeline::artifact::publish 2
       $(FLOWEY_BIN) e 8 flowey_lib_hvlite::init_cross_build 4
     displayName: split debug symbols
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 8 flowey_lib_common::run_cargo_build 7
-      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::run_cargo_build 13
-    displayName: cargo build vmgstool
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::run_split_debug_info 6
       $(FLOWEY_BIN) e 8 flowey_lib_hvlite::run_cargo_build 14
-      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::build_vmgstool 0
-      $(FLOWEY_BIN) e 8 flowey_core::pipeline::artifact::publish 2
-      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::init_cross_build 3
-    displayName: split debug symbols
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 8 flowey_lib_common::run_cargo_build 6
-      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::run_cargo_build 12
       $(FLOWEY_BIN) e 8 flowey_lib_hvlite::build_and_test_vmgs_lib 0
       $(FLOWEY_BIN) e 8 flowey_lib_hvlite::build_and_test_vmgs_lib 1
       $(FLOWEY_BIN) e 8 flowey_core::pipeline::artifact::publish 3
@@ -2375,11 +2395,11 @@ jobs:
     displayName: cargo build igvmfilegen
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::run_split_debug_info 5
+      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::run_split_debug_info 6
       $(FLOWEY_BIN) e 8 flowey_lib_hvlite::run_cargo_build 1
       $(FLOWEY_BIN) e 8 flowey_lib_hvlite::build_igvmfilegen 0
       $(FLOWEY_BIN) e 8 flowey_core::pipeline::artifact::publish 4
-      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::init_cross_build 5
+      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::init_cross_build 6
     displayName: split debug symbols
   - bash: |-
       set -e
@@ -2398,7 +2418,7 @@ jobs:
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 8 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
-      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::init_cross_build 6
+      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::init_cross_build 7
     displayName: extract Aarch64 sysroot.tar.gz
   - bash: |-
       set -e
@@ -2411,7 +2431,7 @@ jobs:
       $(FLOWEY_BIN) e 8 flowey_lib_hvlite::run_cargo_build 7
       $(FLOWEY_BIN) e 8 flowey_lib_hvlite::build_openvmm 1
       $(FLOWEY_BIN) e 8 flowey_core::pipeline::artifact::publish 6
-      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::init_cross_build 7
+      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::init_cross_build 8
     displayName: split debug symbols
   - bash: |-
       set -e
@@ -2424,6 +2444,19 @@ jobs:
       $(FLOWEY_BIN) e 8 flowey_lib_hvlite::run_cargo_build 11
       $(FLOWEY_BIN) e 8 flowey_lib_hvlite::build_openvmm_vhost 1
       $(FLOWEY_BIN) e 8 flowey_core::pipeline::artifact::publish 7
+      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::init_cross_build 3
+    displayName: split debug symbols
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 8 flowey_lib_common::run_cargo_build 6
+      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::run_cargo_build 12
+    displayName: cargo build prep_steps
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::run_split_debug_info 5
+      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::run_cargo_build 13
+      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::build_prep_steps 0
+      $(FLOWEY_BIN) e 8 flowey_core::pipeline::artifact::publish 8
     displayName: split debug symbols
   - bash: $(FLOWEY_BIN) e 8 flowey_lib_common::cache 3
     displayName: 'validate cache entry: gh-release-download'
@@ -2445,6 +2478,9 @@ jobs:
   - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-linux-openvmm_vhost
     displayName: 🌼📦 Publish aarch64-linux-openvmm_vhost
     artifact: aarch64-linux-openvmm_vhost
+  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-linux-prep_steps
+    displayName: 🌼📦 Publish aarch64-linux-prep_steps
+    artifact: aarch64-linux-prep_steps
   - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-linux-vmgs_lib
     displayName: 🌼📦 Publish aarch64-linux-vmgs_lib
     artifact: aarch64-linux-vmgs_lib
@@ -3910,6 +3946,11 @@ jobs:
       artifact: x64-linux-openvmm_vhost
       path: $(FLOWEY_TEMP_DIR)/used_artifacts/x64-linux-openvmm_vhost
   - task: DownloadPipelineArtifact@2
+    displayName: 🌼📦 Download x64-linux-prep_steps
+    inputs:
+      artifact: x64-linux-prep_steps
+      path: $(FLOWEY_TEMP_DIR)/used_artifacts/x64-linux-prep_steps
+  - task: DownloadPipelineArtifact@2
     displayName: 🌼📦 Download x64-linux-vmm-tests-archive
     inputs:
       artifact: x64-linux-vmm-tests-archive
@@ -3947,6 +3988,7 @@ jobs:
       echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-linux-musl-tmk_vmm" | $FLOWEY_BIN v 19 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
       echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-linux-openvmm" | $FLOWEY_BIN v 19 'artifact_use_from_x64-linux-openvmm' --is-raw-string update
       echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-linux-openvmm_vhost" | $FLOWEY_BIN v 19 'artifact_use_from_x64-linux-openvmm_vhost' --is-raw-string update
+      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-linux-prep_steps" | $FLOWEY_BIN v 19 'artifact_use_from_x64-linux-prep_steps' --is-raw-string update
       echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-linux-vmm-tests-archive" | $FLOWEY_BIN v 19 'artifact_use_from_x64-linux-vmm-tests-archive' --is-raw-string update
       echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-tmks" | $FLOWEY_BIN v 19 'artifact_use_from_x64-tmks' --is-raw-string update
       echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-pipette" | $FLOWEY_BIN v 19 'artifact_use_from_x64-windows-pipette' --is-raw-string update
@@ -4002,13 +4044,13 @@ jobs:
       $(FLOWEY_BIN) e 19 flowey_lib_common::git_checkout 2
       $(FLOWEY_BIN) e 19 flowey_lib_hvlite::git_checkout_openvmm_repo 0
       $(FLOWEY_BIN) e 19 flowey_lib_hvlite::run_cargo_nextest_run 0
+      $(FLOWEY_BIN) e 19 flowey_core::pipeline::artifact::resolve 7
       $(FLOWEY_BIN) e 19 flowey_core::pipeline::artifact::resolve 3
       $(FLOWEY_BIN) e 19 flowey_core::pipeline::artifact::resolve 4
-      $(FLOWEY_BIN) e 19 flowey_core::pipeline::artifact::resolve 7
+      $(FLOWEY_BIN) e 19 flowey_core::pipeline::artifact::resolve 8
       $(FLOWEY_BIN) e 19 flowey_core::pipeline::artifact::resolve 1
       $(FLOWEY_BIN) e 19 flowey_core::pipeline::artifact::resolve 0
       $(FLOWEY_BIN) e 19 flowey_core::pipeline::artifact::resolve 2
-      $(FLOWEY_BIN) e 19 flowey_core::pipeline::artifact::resolve 6
     displayName: report cloned repo directories
   - bash: $(FLOWEY_BIN) e 19 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
     displayName: creating new test content dir
@@ -4061,13 +4103,18 @@ jobs:
       $(FLOWEY_BIN) e 19 flowey_lib_hvlite::init_vmm_tests_env 0
       $(FLOWEY_BIN) e 19 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
       $(FLOWEY_BIN) e 19 flowey_lib_hvlite::run_cargo_nextest_run 1
-      $(FLOWEY_BIN) e 19 flowey_core::pipeline::artifact::resolve 5
+      $(FLOWEY_BIN) e 19 flowey_core::pipeline::artifact::resolve 6
       $(FLOWEY_BIN) e 19 flowey_lib_hvlite::test_nextest_vmm_tests_archive 3
     displayName: setting up vmm_tests env
   - bash: $(FLOWEY_BIN) e 19 flowey_lib_common::gen_cargo_nextest_run_cmd 0
     displayName: generate nextest command
-  - bash: $(FLOWEY_BIN) e 19 flowey_lib_hvlite::install_vmm_tests_deps 0
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 19 flowey_lib_hvlite::install_vmm_tests_deps 0
+      $(FLOWEY_BIN) e 19 flowey_core::pipeline::artifact::resolve 5
     displayName: install vmm tests deps (linux)
+  - bash: $(FLOWEY_BIN) e 19 flowey_lib_hvlite::run_prep_steps 0
+    displayName: running vmm_test prep_steps
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 19 flowey_lib_common::run_cargo_nextest_run 0
@@ -4336,8 +4383,13 @@ jobs:
     displayName: generate nextest command
   - bash: $(FLOWEY_BIN) e 18 flowey_lib_hvlite::install_vmm_tests_deps 0
     displayName: install vmm tests deps (windows)
-  - bash: $(FLOWEY_BIN) e 18 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
+      $(FLOWEY_BIN) e 18 flowey_core::pipeline::artifact::resolve 7
     displayName: starting test_igvm_agent_rpc_server
+  - bash: $(FLOWEY_BIN) e 18 flowey_lib_hvlite::run_prep_steps 0
+    displayName: running vmm_test prep_steps
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 18 flowey_lib_common::run_cargo_nextest_run 0
@@ -4886,8 +4938,13 @@ jobs:
     displayName: generate nextest command
   - bash: $(FLOWEY_BIN) e 16 flowey_lib_hvlite::install_vmm_tests_deps 0
     displayName: install vmm tests deps (windows)
-  - bash: $(FLOWEY_BIN) e 16 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 16 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
+      $(FLOWEY_BIN) e 16 flowey_core::pipeline::artifact::resolve 7
     displayName: starting test_igvm_agent_rpc_server
+  - bash: $(FLOWEY_BIN) e 16 flowey_lib_hvlite::run_prep_steps 0
+    displayName: running vmm_test prep_steps
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 16 flowey_lib_common::run_cargo_nextest_run 0

--- a/ci-flowey/openvmm-pr.yaml
+++ b/ci-flowey/openvmm-pr.yaml
@@ -2037,7 +2037,7 @@ jobs:
       $(FLOWEY_BIN) e 9 flowey_lib_hvlite::run_cargo_build 9
       $(FLOWEY_BIN) e 9 flowey_lib_hvlite::build_openvmm_vhost 0
       $(FLOWEY_BIN) e 9 flowey_core::pipeline::artifact::publish 1
-      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::init_cross_build 6
+      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::init_cross_build 5
     displayName: split debug symbols
   - bash: |-
       set -e
@@ -2050,7 +2050,7 @@ jobs:
       $(FLOWEY_BIN) e 9 flowey_lib_hvlite::run_cargo_build 16
       $(FLOWEY_BIN) e 9 flowey_lib_hvlite::build_vmgstool 0
       $(FLOWEY_BIN) e 9 flowey_core::pipeline::artifact::publish 2
-      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::init_cross_build 5
+      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::init_cross_build 4
     displayName: split debug symbols
   - bash: |-
       set -e
@@ -2076,7 +2076,7 @@ jobs:
       $(FLOWEY_BIN) e 9 flowey_lib_hvlite::run_cargo_build 1
       $(FLOWEY_BIN) e 9 flowey_lib_hvlite::build_igvmfilegen 0
       $(FLOWEY_BIN) e 9 flowey_core::pipeline::artifact::publish 4
-      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::init_cross_build 7
+      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::init_cross_build 6
     displayName: split debug symbols
   - bash: |-
       set -e
@@ -2095,7 +2095,7 @@ jobs:
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 9 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
-      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::init_cross_build 9
+      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::init_cross_build 8
     displayName: extract X86_64 sysroot.tar.gz
   - bash: |-
       set -e
@@ -2108,7 +2108,7 @@ jobs:
       $(FLOWEY_BIN) e 9 flowey_lib_hvlite::run_cargo_build 7
       $(FLOWEY_BIN) e 9 flowey_lib_hvlite::build_openvmm 1
       $(FLOWEY_BIN) e 9 flowey_core::pipeline::artifact::publish 6
-      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::init_cross_build 10
+      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::init_cross_build 9
     displayName: split debug symbols
   - bash: |-
       set -e
@@ -2121,7 +2121,7 @@ jobs:
       $(FLOWEY_BIN) e 9 flowey_lib_hvlite::run_cargo_build 11
       $(FLOWEY_BIN) e 9 flowey_lib_hvlite::build_openvmm_vhost 1
       $(FLOWEY_BIN) e 9 flowey_core::pipeline::artifact::publish 7
-      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::init_cross_build 4
+      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::init_cross_build 10
     displayName: split debug symbols
   - bash: |-
       set -e
@@ -2175,7 +2175,7 @@ jobs:
       $(FLOWEY_BIN) e 9 flowey_lib_common::run_cargo_nextest_archive 0
       $(FLOWEY_BIN) e 9 flowey_lib_hvlite::build_nextest_vmm_tests 0
       $(FLOWEY_BIN) e 9 flowey_core::pipeline::artifact::publish 9
-      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::init_cross_build 8
+      $(FLOWEY_BIN) e 9 flowey_lib_hvlite::init_cross_build 7
     displayName: build + archive 'vmm_tests' nextests
   - bash: |-
       set -e
@@ -2364,7 +2364,7 @@ jobs:
       $(FLOWEY_BIN) e 8 flowey_lib_hvlite::run_cargo_build 9
       $(FLOWEY_BIN) e 8 flowey_lib_hvlite::build_openvmm_vhost 0
       $(FLOWEY_BIN) e 8 flowey_core::pipeline::artifact::publish 1
-      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::init_cross_build 5
+      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::init_cross_build 4
     displayName: split debug symbols
   - bash: |-
       set -e
@@ -2377,7 +2377,7 @@ jobs:
       $(FLOWEY_BIN) e 8 flowey_lib_hvlite::run_cargo_build 16
       $(FLOWEY_BIN) e 8 flowey_lib_hvlite::build_vmgstool 0
       $(FLOWEY_BIN) e 8 flowey_core::pipeline::artifact::publish 2
-      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::init_cross_build 4
+      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::init_cross_build 3
     displayName: split debug symbols
   - bash: |-
       set -e
@@ -2399,7 +2399,7 @@ jobs:
       $(FLOWEY_BIN) e 8 flowey_lib_hvlite::run_cargo_build 1
       $(FLOWEY_BIN) e 8 flowey_lib_hvlite::build_igvmfilegen 0
       $(FLOWEY_BIN) e 8 flowey_core::pipeline::artifact::publish 4
-      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::init_cross_build 6
+      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::init_cross_build 5
     displayName: split debug symbols
   - bash: |-
       set -e
@@ -2418,7 +2418,7 @@ jobs:
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 8 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
-      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::init_cross_build 7
+      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::init_cross_build 6
     displayName: extract Aarch64 sysroot.tar.gz
   - bash: |-
       set -e
@@ -2431,7 +2431,7 @@ jobs:
       $(FLOWEY_BIN) e 8 flowey_lib_hvlite::run_cargo_build 7
       $(FLOWEY_BIN) e 8 flowey_lib_hvlite::build_openvmm 1
       $(FLOWEY_BIN) e 8 flowey_core::pipeline::artifact::publish 6
-      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::init_cross_build 8
+      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::init_cross_build 7
     displayName: split debug symbols
   - bash: |-
       set -e
@@ -2444,7 +2444,7 @@ jobs:
       $(FLOWEY_BIN) e 8 flowey_lib_hvlite::run_cargo_build 11
       $(FLOWEY_BIN) e 8 flowey_lib_hvlite::build_openvmm_vhost 1
       $(FLOWEY_BIN) e 8 flowey_core::pipeline::artifact::publish 7
-      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::init_cross_build 3
+      $(FLOWEY_BIN) e 8 flowey_lib_hvlite::init_cross_build 8
     displayName: split debug symbols
   - bash: |-
       set -e

--- a/flowey/flowey_hvlite/src/pipelines/checkin_gates.rs
+++ b/flowey/flowey_hvlite/src/pipelines/checkin_gates.rs
@@ -1316,7 +1316,7 @@ impl IntoPipeline for CheckinGatesCli {
             resolve_vmm_tests_artifacts: vmm_tests_artifact_builders::ResolveVmmTestsDepArtifacts,
             nextest_filter_expr: String,
             test_artifacts: Vec<KnownTestArtifacts>,
-            needs_prep_run: bool,
+            prep_steps_variants: Vec<String>,
             hugetlb_2mb_overcommit_pages: Option<u64>,
         }
 
@@ -1414,7 +1414,7 @@ impl IntoPipeline for CheckinGatesCli {
             resolve_vmm_tests_artifacts,
             nextest_filter_expr,
             test_artifacts,
-            needs_prep_run,
+            prep_steps_variants,
             hugetlb_2mb_overcommit_pages,
         } in [
             VmmTestJobParams {
@@ -1427,7 +1427,7 @@ impl IntoPipeline for CheckinGatesCli {
                 resolve_vmm_tests_artifacts: vmm_tests_artifacts_windows_intel_x86,
                 nextest_filter_expr: standard_filter.clone(),
                 test_artifacts: standard_x64_test_artifacts.clone(),
-                needs_prep_run: false,
+                prep_steps_variants: Vec::new(),
                 hugetlb_2mb_overcommit_pages: None,
             },
             VmmTestJobParams {
@@ -1441,7 +1441,7 @@ impl IntoPipeline for CheckinGatesCli {
                 nextest_filter_expr: "test(openhcl) & !test(servicing) & !test(cvm) & !test(memory_validation) & !test(very_heavy) & !test(hyperv_openhcl_pcat) & !test(prepped_vbs) & !test(256mb)"
                     .to_string(),
                 test_artifacts: standard_x64_test_artifacts.clone(),
-                needs_prep_run: false,
+                prep_steps_variants: Vec::new(),
                 hugetlb_2mb_overcommit_pages: None,
             },
             VmmTestJobParams {
@@ -1454,7 +1454,7 @@ impl IntoPipeline for CheckinGatesCli {
                 resolve_vmm_tests_artifacts: vmm_tests_artifacts_windows_intel_tdx_x86,
                 nextest_filter_expr: cvm_filter("tdx"),
                 test_artifacts: cvm_x64_test_artifacts.clone(),
-                needs_prep_run: true,
+                prep_steps_variants: vec!["standard".into()],
                 hugetlb_2mb_overcommit_pages: None,
             },
             VmmTestJobParams {
@@ -1467,7 +1467,7 @@ impl IntoPipeline for CheckinGatesCli {
                 resolve_vmm_tests_artifacts: vmm_tests_artifacts_windows_amd_x86,
                 nextest_filter_expr: standard_filter.clone(),
                 test_artifacts: standard_x64_test_artifacts.clone(),
-                needs_prep_run: false,
+                prep_steps_variants: Vec::new(),
                 hugetlb_2mb_overcommit_pages: None,
             },
             VmmTestJobParams {
@@ -1480,7 +1480,7 @@ impl IntoPipeline for CheckinGatesCli {
                 resolve_vmm_tests_artifacts: vmm_tests_artifacts_windows_amd_snp_x86,
                 nextest_filter_expr: cvm_filter("snp"),
                 test_artifacts: cvm_x64_test_artifacts,
-                needs_prep_run: true,
+                prep_steps_variants: vec!["standard".into()],
                 hugetlb_2mb_overcommit_pages: None,
             },
             VmmTestJobParams {
@@ -1494,7 +1494,7 @@ impl IntoPipeline for CheckinGatesCli {
                 // - No legal way to obtain gen1 pcat blobs on non-msft linux machines
                 nextest_filter_expr: format!("{standard_filter} & !test(pcat_x64)"),
                 test_artifacts: standard_x64_test_artifacts.clone(),
-                needs_prep_run: false,
+                prep_steps_variants: Vec::new(),
                 hugetlb_2mb_overcommit_pages: Some(HUGETLB_2MB_OVERCOMMIT_PAGES),
             },
             VmmTestJobParams {
@@ -1508,7 +1508,7 @@ impl IntoPipeline for CheckinGatesCli {
                 // - No legal way to obtain gen1 pcat blobs on non-msft linux machines
                 nextest_filter_expr: format!("{standard_filter} & !test(pcat_x64)"),
                 test_artifacts: standard_x64_test_artifacts.clone(),
-                needs_prep_run: false,
+                prep_steps_variants: Vec::new(),
                 hugetlb_2mb_overcommit_pages: None,
             },
             VmmTestJobParams {
@@ -1527,7 +1527,7 @@ impl IntoPipeline for CheckinGatesCli {
                     KnownTestArtifacts::VmgsWithBootEntry,
                     KnownTestArtifacts::VmgsWith16kTpm,
                 ],
-                needs_prep_run: false,
+                prep_steps_variants: Vec::new(),
                 hugetlb_2mb_overcommit_pages: None,
             },
         ] {
@@ -1571,7 +1571,7 @@ impl IntoPipeline for CheckinGatesCli {
                     test_artifacts,
                     fail_job_on_test_fail: true,
                     artifact_dir: pub_vmm_tests_results.map(|x| ctx.publish_artifact(x)),
-                    needs_prep_run,
+                    prep_steps_variants,
                     hugetlb_2mb_overcommit_pages,
                     done: ctx.new_done_handle(),
                 }

--- a/flowey/flowey_hvlite/src/pipelines/checkin_gates.rs
+++ b/flowey/flowey_hvlite/src/pipelines/checkin_gates.rs
@@ -890,7 +890,7 @@ impl IntoPipeline for CheckinGatesCli {
                     flowey_lib_hvlite::build_prep_steps::Request {
                         target: CommonTriple::Common {
                             arch,
-                            platform: CommonPlatform::LinuxGnu,
+                            platform: CommonPlatform::LinuxMusl,
                         },
                         profile: CommonProfile::from_release(release),
                         prep_steps,

--- a/flowey/flowey_hvlite/src/pipelines/checkin_gates.rs
+++ b/flowey/flowey_hvlite/src/pipelines/checkin_gates.rs
@@ -1369,6 +1369,10 @@ impl IntoPipeline for CheckinGatesCli {
             KnownTestArtifacts::VmgsWith16kTpm,
         ];
 
+        // Prep variants needed by tests in the standard x64 filter
+        // (e.g. boot_no_vmbus_windows needs the no-vmbus prepped VHD).
+        let standard_x64_prep_variants: Vec<String> = vec!["no-vmbus".into()];
+
         let cvm_filter = |isolation_type| {
             let mut filter = format!(
                 "test({isolation_type}) + (test(vbs) & test(hyperv)) + test(very_heavy) + test(openvmm_openhcl_uefi_x64_windows_datacenter_core_2025_x64_prepped_vbs)"
@@ -1427,7 +1431,7 @@ impl IntoPipeline for CheckinGatesCli {
                 resolve_vmm_tests_artifacts: vmm_tests_artifacts_windows_intel_x86,
                 nextest_filter_expr: standard_filter.clone(),
                 test_artifacts: standard_x64_test_artifacts.clone(),
-                prep_steps_variants: Vec::new(),
+                prep_steps_variants: standard_x64_prep_variants.clone(),
                 hugetlb_2mb_overcommit_pages: None,
             },
             VmmTestJobParams {
@@ -1467,7 +1471,7 @@ impl IntoPipeline for CheckinGatesCli {
                 resolve_vmm_tests_artifacts: vmm_tests_artifacts_windows_amd_x86,
                 nextest_filter_expr: standard_filter.clone(),
                 test_artifacts: standard_x64_test_artifacts.clone(),
-                prep_steps_variants: Vec::new(),
+                prep_steps_variants: standard_x64_prep_variants.clone(),
                 hugetlb_2mb_overcommit_pages: None,
             },
             VmmTestJobParams {
@@ -1494,7 +1498,7 @@ impl IntoPipeline for CheckinGatesCli {
                 // - No legal way to obtain gen1 pcat blobs on non-msft linux machines
                 nextest_filter_expr: format!("{standard_filter} & !test(pcat_x64)"),
                 test_artifacts: standard_x64_test_artifacts.clone(),
-                prep_steps_variants: Vec::new(),
+                prep_steps_variants: standard_x64_prep_variants.clone(),
                 hugetlb_2mb_overcommit_pages: Some(HUGETLB_2MB_OVERCOMMIT_PAGES),
             },
             VmmTestJobParams {
@@ -1508,7 +1512,7 @@ impl IntoPipeline for CheckinGatesCli {
                 // - No legal way to obtain gen1 pcat blobs on non-msft linux machines
                 nextest_filter_expr: format!("{standard_filter} & !test(pcat_x64)"),
                 test_artifacts: standard_x64_test_artifacts.clone(),
-                prep_steps_variants: Vec::new(),
+                prep_steps_variants: standard_x64_prep_variants.clone(),
                 hugetlb_2mb_overcommit_pages: None,
             },
             VmmTestJobParams {

--- a/flowey/flowey_hvlite/src/pipelines/checkin_gates.rs
+++ b/flowey/flowey_hvlite/src/pipelines/checkin_gates.rs
@@ -750,6 +750,8 @@ impl IntoPipeline for CheckinGatesCli {
                 pipeline.new_typed_artifact(format!("{arch_tag}-linux-musl-openvmm"));
             let (pub_openvmm_vhost_musl, use_openvmm_vhost_musl) =
                 pipeline.new_typed_artifact(format!("{arch_tag}-linux-musl-openvmm_vhost"));
+            let (pub_prep_steps, use_prep_steps) =
+                pipeline.new_typed_artifact(format!("{arch_tag}-linux-prep_steps"));
 
             // skim off interesting artifacts required by the VMM tests job
             match arch {
@@ -757,9 +759,12 @@ impl IntoPipeline for CheckinGatesCli {
                     vmm_tests_artifacts_linux_x86.use_openvmm = Some(use_openvmm.clone());
                     vmm_tests_artifacts_linux_x86.use_openvmm_vhost =
                         Some(use_openvmm_vhost.clone());
+                    vmm_tests_artifacts_linux_x86.use_prep_steps = Some(use_prep_steps.clone());
                     vmm_tests_artifacts_linux_musl_x86.use_openvmm = Some(use_openvmm_musl.clone());
                     vmm_tests_artifacts_linux_musl_x86.use_openvmm_vhost =
                         Some(use_openvmm_vhost_musl.clone());
+                    vmm_tests_artifacts_linux_musl_x86.use_prep_steps =
+                        Some(use_prep_steps.clone());
                 }
                 CommonArch::Aarch64 => {}
             }
@@ -879,6 +884,16 @@ impl IntoPipeline for CheckinGatesCli {
                             profile: CommonProfile::from_release(release),
                         },
                         openvmm_vhost,
+                    }
+                })
+                .publish(pub_prep_steps, |prep_steps| {
+                    flowey_lib_hvlite::build_prep_steps::Request {
+                        target: CommonTriple::Common {
+                            arch,
+                            platform: CommonPlatform::LinuxGnu,
+                        },
+                        profile: CommonProfile::from_release(release),
+                        prep_steps,
                     }
                 });
 
@@ -1720,6 +1735,7 @@ mod vmm_tests_artifact_builders {
         pub use_openvmm: Option<UseTypedArtifact<OpenvmmOutput>>,
         pub use_openvmm_vhost: Option<UseTypedArtifact<OpenvmmVhostOutput>>,
         pub use_pipette_linux_musl: Option<UseTypedArtifact<PipetteOutput>>,
+        pub use_prep_steps: Option<UseTypedArtifact<PrepStepsOutput>>,
         // any machine
         pub use_guest_test_uefi: Option<UseTypedArtifact<GuestTestUefiOutput>>,
         pub use_tmks: Option<UseTypedArtifact<TmksOutput>>,
@@ -1733,6 +1749,7 @@ mod vmm_tests_artifact_builders {
                 use_guest_test_uefi,
                 use_pipette_windows,
                 use_pipette_linux_musl,
+                use_prep_steps,
                 use_tmk_vmm,
                 use_tmks,
             } = self;
@@ -1757,7 +1774,7 @@ mod vmm_tests_artifact_builders {
                 // not currently required, since OpenHCL tests cannot be run on OpenVMM on linux
                 artifact_dir_openhcl_igvm_files: None,
                 tmk_vmm_linux_musl: None,
-                prep_steps: None,
+                prep_steps: use_prep_steps.as_ref().map(|a| ctx.use_typed_artifact(a)),
                 vmgstool: None,
                 tpm_guest_tests_windows: None,
                 tpm_guest_tests_linux: None,

--- a/flowey/flowey_hvlite/src/pipelines/vmm_tests_run.rs
+++ b/flowey/flowey_hvlite/src/pipelines/vmm_tests_run.rs
@@ -131,6 +131,9 @@ struct ResolvedArtifactSelections {
     build: BuildSelections,
     /// What to download
     downloads: BTreeSet<KnownTestArtifacts>,
+    /// Downloads that must happen even when lazy fetch is enabled (e.g.
+    /// VHDs needed by prep_steps, which copies them to create prepped images).
+    force_downloads: BTreeSet<KnownTestArtifacts>,
     /// Whether any tests need release IGVM files from GitHub
     needs_release_igvm: bool,
     /// Whether any of the tests require Hyper-V
@@ -258,6 +261,11 @@ impl IntoPipeline for VmmTestsRunCli {
             }
 
             resolved.downloads.retain(|a| !a.supports_blob_disk());
+
+            // Re-add force_downloads (prep_steps dependencies) that were removed.
+            resolved
+                .downloads
+                .extend(resolved.force_downloads.iter().cloned());
 
             if hyperv_tests == 0 {
                 log::info!("Lazy fetch enabled: disk images will be streamed on demand via HTTP");
@@ -736,7 +744,19 @@ impl ResolvedArtifactSelections {
             }
             petri_artifacts_vmm_test::artifacts::test_vhd::GEN2_WINDOWS_DATA_CENTER_CORE2025_X64_PREPPED::GLOBAL_UNIQUE_ID =>
             {
-                self.build.prep_steps = true;
+                self.build.prep_steps_standard = true;
+                // prep_steps needs actual VHD files on disk to copy them.
+                // Force download even when lazy fetch is enabled.
+                self.force_downloads
+                    .insert(KnownTestArtifacts::Gen2WindowsDataCenterCore2022X64Vhd);
+                self.force_downloads
+                    .insert(KnownTestArtifacts::Gen2WindowsDataCenterCore2025X64Vhd);
+            }
+            petri_artifacts_vmm_test::artifacts::test_vhd::GEN2_WINDOWS_DATA_CENTER_CORE2022_X64_NO_VMBUS_PREPPED::GLOBAL_UNIQUE_ID =>
+            {
+                self.build.prep_steps_no_vmbus = true;
+                self.force_downloads
+                    .insert(KnownTestArtifacts::Gen2WindowsDataCenterCore2022X64Vhd);
             }
             petri_artifacts_vmm_test::artifacts::test_vhd::FREE_BSD_13_2_X64::GLOBAL_UNIQUE_ID => {
                 self.downloads.insert(KnownTestArtifacts::FreeBsd13_2X64Vhd);

--- a/flowey/flowey_lib_hvlite/src/_jobs/consume_and_test_nextest_vmm_tests_archive.rs
+++ b/flowey/flowey_lib_hvlite/src/_jobs/consume_and_test_nextest_vmm_tests_archive.rs
@@ -213,6 +213,7 @@ impl SimpleFlowNode for Node {
         if needs_prep_run {
             pre_run_deps.push(ctx.reqv(|done| crate::run_prep_steps::Request {
                 prep_steps: register_prep_steps.expect("Test run indicated prep_steps was needed but built prep_steps binary was not given"),
+                args: Vec::new(),
                 env: extra_env.clone(),
                 done,
             }));

--- a/flowey/flowey_lib_hvlite/src/_jobs/consume_and_test_nextest_vmm_tests_archive.rs
+++ b/flowey/flowey_lib_hvlite/src/_jobs/consume_and_test_nextest_vmm_tests_archive.rs
@@ -55,8 +55,9 @@ flowey_request! {
         pub dep_artifact_dirs: VmmTestsDepArtifacts,
         /// Test artifacts to download
         pub test_artifacts: Vec<KnownTestArtifacts>,
-        /// Whether the prep steps should be run before the tests
-        pub needs_prep_run: bool,
+        /// Which prep_steps variants to run before tests (e.g. "standard", "no-vmbus").
+        /// Empty means no prep steps are needed.
+        pub prep_steps_variants: Vec<String>,
         /// If set, configure this 2 MiB hugetlb surplus page overcommit limit before running tests.
         pub hugetlb_2mb_overcommit_pages: Option<u64>,
 
@@ -98,7 +99,7 @@ impl SimpleFlowNode for Node {
             dep_artifact_dirs,
             test_artifacts,
             fail_job_on_test_fail,
-            needs_prep_run,
+            prep_steps_variants,
             hugetlb_2mb_overcommit_pages,
             artifact_dir,
             done,
@@ -210,13 +211,16 @@ impl SimpleFlowNode for Node {
             );
         }
 
-        if needs_prep_run {
-            pre_run_deps.push(ctx.reqv(|done| crate::run_prep_steps::Request {
-                prep_steps: register_prep_steps.expect("Test run indicated prep_steps was needed but built prep_steps binary was not given"),
-                args: Vec::new(),
-                env: extra_env.clone(),
-                done,
-            }));
+        if !prep_steps_variants.is_empty() {
+            let prep_steps = register_prep_steps.expect("Test run indicated prep_steps was needed but built prep_steps binary was not given");
+            for variant in &prep_steps_variants {
+                pre_run_deps.push(ctx.reqv(|done| crate::run_prep_steps::Request {
+                    prep_steps: prep_steps.clone(),
+                    args: vec![variant.clone()],
+                    env: extra_env.clone(),
+                    done,
+                }));
+            }
         } else if let Some(register_prep_steps) = register_prep_steps {
             register_prep_steps.claim_unused(ctx);
         }

--- a/flowey/flowey_lib_hvlite/src/_jobs/local_build_and_run_nextest_vmm_tests.rs
+++ b/flowey/flowey_lib_hvlite/src/_jobs/local_build_and_run_nextest_vmm_tests.rs
@@ -45,7 +45,8 @@ pub struct BuildSelections {
     pub openvmm_vhost: bool,
     pub pipette_windows: bool,
     pub pipette_linux: bool,
-    pub prep_steps: bool,
+    pub prep_steps_standard: bool,
+    pub prep_steps_no_vmbus: bool,
     pub guest_test_uefi: bool,
     pub tmks: bool,
     pub tmk_vmm_windows: bool,
@@ -521,17 +522,28 @@ impl SimpleFlowNode for Node {
             output
         });
 
-        let register_prep_steps = build.prep_steps.then(|| {
-            let prep_steps_bin = Path::new(match target_triple.operating_system {
-                target_lexicon::OperatingSystem::Windows => "prep_steps.exe",
+        let needs_prep_steps = build.prep_steps_standard || build.prep_steps_no_vmbus;
+        let mut prep_steps_variants: Vec<String> = Vec::new();
+        if build.prep_steps_standard {
+            prep_steps_variants.push("standard".into());
+        }
+        if build.prep_steps_no_vmbus {
+            prep_steps_variants.push("no-vmbus".into());
+        }
+
+        let register_prep_steps = needs_prep_steps.then(|| {
+            let (prep_steps_bin, platform) = match target_triple.operating_system {
+                target_lexicon::OperatingSystem::Windows => {
+                    (Path::new("prep_steps.exe"), CommonPlatform::WindowsMsvc)
+                }
+                target_lexicon::OperatingSystem::Linux => {
+                    (Path::new("prep_steps"), CommonPlatform::LinuxGnu)
+                }
                 _ => unreachable!(),
-            });
+            };
 
             let output = ctx.reqv(|v| crate::build_prep_steps::Request {
-                target: CommonTriple::Common {
-                    arch,
-                    platform: CommonPlatform::WindowsMsvc,
-                },
+                target: CommonTriple::Common { arch, platform },
                 profile: CommonProfile::from_release(release),
                 prep_steps: v,
             });
@@ -541,7 +553,7 @@ impl SimpleFlowNode for Node {
                 output.map(ctx, |x| {
                     Some(match x {
                         crate::build_prep_steps::PrepStepsOutput::WindowsBin { exe, pdb: _ } => exe,
-                        _ => unreachable!(),
+                        crate::build_prep_steps::PrepStepsOutput::LinuxBin { bin, dbg: _ } => bin,
                     })
                 }),
             ));
@@ -554,28 +566,41 @@ impl SimpleFlowNode for Node {
                                 exe: _,
                                 pdb,
                             } => pdb,
-                            _ => unreachable!(),
+                            crate::build_prep_steps::PrepStepsOutput::LinuxBin { bin: _, dbg } => {
+                                dbg
+                            }
                         })
                     }),
                 ));
             }
 
-            let cmd = (
-                format!("$PSScriptRoot\\{}", prep_steps_bin.to_string_lossy()).into(),
-                Vec::new(),
+            let is_windows_target = matches!(
+                target_triple.operating_system,
+                target_lexicon::OperatingSystem::Windows
             );
+            let cmds: Vec<(std::ffi::OsString, Vec<std::ffi::OsString>)> = prep_steps_variants
+                .iter()
+                .map(|variant| {
+                    let cmd_path = if is_windows_target {
+                        format!("$PSScriptRoot\\{}", prep_steps_bin.to_string_lossy())
+                    } else {
+                        format!("./{}", prep_steps_bin.to_string_lossy())
+                    };
+                    (cmd_path.into(), vec![variant.clone().into()])
+                })
+                .collect();
 
             let prep_steps_bin = test_content_dir.join(prep_steps_bin);
             let output = output.map(ctx, |mut output| {
                 let path = match &mut output {
                     crate::build_prep_steps::PrepStepsOutput::WindowsBin { exe, pdb: _ } => exe,
-                    _ => unreachable!(),
+                    crate::build_prep_steps::PrepStepsOutput::LinuxBin { bin, dbg: _ } => bin,
                 };
                 *path = prep_steps_bin;
                 output
             });
 
-            (output, cmd)
+            (output, cmds)
         });
 
         let register_vmgstool = build.vmgstool.then(|| {
@@ -777,7 +802,7 @@ impl SimpleFlowNode for Node {
             extra_env: Some(extra_env.clone()),
             extra_commands: register_prep_steps
                 .clone()
-                .map(|(_, cmd)| ReadVar::from_static(vec![cmd])),
+                .map(|(_, cmds)| ReadVar::from_static(cmds)),
             portable: true,
             command: v,
         });
@@ -821,11 +846,14 @@ impl SimpleFlowNode for Node {
             }
 
             if let Some((prep_steps, _)) = register_prep_steps {
-                side_effects.push(ctx.reqv(|done| crate::run_prep_steps::Request {
-                    prep_steps,
-                    env: extra_env.clone(),
-                    done,
-                }));
+                for variant in &prep_steps_variants {
+                    side_effects.push(ctx.reqv(|done| crate::run_prep_steps::Request {
+                        prep_steps: prep_steps.clone(),
+                        args: vec![variant.clone()],
+                        env: extra_env.clone(),
+                        done,
+                    }));
+                }
             }
 
             let results = ctx.reqv(|v| crate::test_nextest_vmm_tests_archive::Request {

--- a/flowey/flowey_lib_hvlite/src/run_prep_steps.rs
+++ b/flowey/flowey_lib_hvlite/src/run_prep_steps.rs
@@ -11,6 +11,8 @@ flowey_request! {
     pub struct Request {
         /// Path to prep_steps bin to use
         pub prep_steps: ReadVar<PrepStepsOutput>,
+        /// Arguments to pass to prep_steps (e.g. "standard" or "no-vmbus")
+        pub args: Vec<String>,
         /// Environment variables to set when running prep_steps
         pub env: ReadVar<BTreeMap<String, String>>,
         /// Completion indicator
@@ -28,6 +30,7 @@ impl SimpleFlowNode for Node {
     fn process_request(request: Self::Request, ctx: &mut NodeCtx<'_>) -> anyhow::Result<()> {
         let Request {
             prep_steps,
+            args,
             env,
             done,
         } = request;
@@ -101,7 +104,10 @@ impl SimpleFlowNode for Node {
                     );
                 }
 
-                flowey::shell_cmd!(rt, "{binary_path}").envs(env).run()?;
+                flowey::shell_cmd!(rt, "{binary_path}")
+                    .args(&args)
+                    .envs(env)
+                    .run()?;
 
                 Ok(())
             }

--- a/flowey/flowey_lib_hvlite/src/run_prep_steps.rs
+++ b/flowey/flowey_lib_hvlite/src/run_prep_steps.rs
@@ -78,7 +78,10 @@ impl SimpleFlowNode for Node {
 
                 let binary_path = match &prep_steps {
                     PrepStepsOutput::WindowsBin { exe, .. } => exe,
-                    PrepStepsOutput::LinuxBin { bin, .. } => bin,
+                    PrepStepsOutput::LinuxBin { bin, .. } => {
+                        bin.make_executable()?;
+                        bin
+                    }
                 };
 
                 // When running a Windows exe from WSL2, environment variables don't

--- a/petri/pipette/src/agent.rs
+++ b/petri/pipette/src/agent.rs
@@ -53,7 +53,7 @@ impl Agent {
                 Self::from_conn(driver, socket)
             }
             Transport::Tcp => {
-                let socket = connect_server_tcp(&driver).await;
+                let socket = connect_server_tcp(&driver).await?;
                 Self::from_conn(driver, socket)
             }
         }
@@ -168,34 +168,25 @@ async fn connect_client(driver: &DefaultDriver) -> PolledSocket<Socket> {
 }
 
 /// Listen for an incoming TCP connection from the host on the pipette TCP port.
-async fn connect_server_tcp(driver: &DefaultDriver) -> PolledSocket<std::net::TcpStream> {
-    let server_core = async || {
-        let listener =
-            std::net::TcpListener::bind(("0.0.0.0", pipette_protocol::PIPETTE_PORT as u16))
-                .context("failed to bind TCP listener")?;
-        listener
-            .set_nonblocking(true)
-            .context("failed to set nonblocking")?;
-        let mut listener =
-            PolledSocket::new(driver, listener).context("failed to create polled TCP listener")?;
-        let (stream, addr) = listener
-            .accept()
-            .await
-            .context("failed to accept TCP connection")?;
-        stream
-            .set_nodelay(true)
-            .context("failed to set TCP_NODELAY")?;
-        eprintln!("Pipette accepted TCP connection from {addr}");
-        PolledSocket::new(driver, stream).context("failed to create polled TCP stream")
-    };
-
-    match server_core().await {
-        Ok(socket) => socket,
-        Err(err) => {
-            eprintln!("failed to stand up TCP server: {:?}", err);
-            std::future::pending().await
-        }
-    }
+async fn connect_server_tcp(
+    driver: &DefaultDriver,
+) -> anyhow::Result<PolledSocket<std::net::TcpStream>> {
+    let listener = std::net::TcpListener::bind(("0.0.0.0", pipette_protocol::PIPETTE_PORT as u16))
+        .context("failed to bind TCP listener")?;
+    listener
+        .set_nonblocking(true)
+        .context("failed to set nonblocking")?;
+    let mut listener =
+        PolledSocket::new(driver, listener).context("failed to create polled TCP listener")?;
+    let (stream, addr) = listener
+        .accept()
+        .await
+        .context("failed to accept TCP connection")?;
+    stream
+        .set_nodelay(true)
+        .context("failed to set TCP_NODELAY")?;
+    eprintln!("Pipette accepted TCP connection from {addr}");
+    PolledSocket::new(driver, stream).context("failed to create polled TCP stream")
 }
 
 async fn handle_request(

--- a/petri/pipette/src/agent.rs
+++ b/petri/pipette/src/agent.rs
@@ -4,6 +4,8 @@
 //! The main pipette agent, which is run when the process starts.
 
 use anyhow::Context;
+use futures::AsyncRead;
+use futures::AsyncWrite;
 use futures::future::FutureExt;
 use futures_concurrency::future::Race;
 use mesh_remote::PointToPointMesh;
@@ -21,6 +23,15 @@ use unicycle::FuturesUnordered;
 use vmsocket::VmAddress;
 use vmsocket::VmSocket;
 
+/// The transport used by the pipette agent to communicate with the host.
+#[derive(Clone, Copy, Debug)]
+pub enum Transport {
+    /// Hyper-V sockets or virtio-vsock (the default).
+    Vsock,
+    /// TCP over a network interface (e.g. virtio-net + consomme).
+    Tcp,
+}
+
 pub struct Agent {
     driver: DefaultDriver,
     mesh: PointToPointMesh,
@@ -33,14 +44,28 @@ pub struct Agent {
 pub struct DiagnosticSender(mesh::Sender<DiagnosticFile>);
 
 impl Agent {
-    pub async fn new(driver: DefaultDriver) -> anyhow::Result<Self> {
-        let socket = (connect_client(&driver), connect_server(&driver))
-            .race()
-            .await;
+    pub async fn new(driver: DefaultDriver, transport: Transport) -> anyhow::Result<Self> {
+        match transport {
+            Transport::Vsock => {
+                let socket = (connect_client(&driver), connect_server(&driver))
+                    .race()
+                    .await;
+                Self::from_conn(driver, socket)
+            }
+            Transport::Tcp => {
+                let socket = connect_server_tcp(&driver).await;
+                Self::from_conn(driver, socket)
+            }
+        }
+    }
 
+    fn from_conn(
+        driver: DefaultDriver,
+        conn: impl 'static + AsyncRead + AsyncWrite + Send + Unpin,
+    ) -> anyhow::Result<Self> {
         eprintln!("Pipette handshaking with host");
         let (bootstrap_send, bootstrap_recv) = mesh::oneshot::<PipetteBootstrap>();
-        let mesh = PointToPointMesh::new(&driver, socket, bootstrap_recv.into());
+        let mesh = PointToPointMesh::new(&driver, conn, bootstrap_recv.into());
 
         let (request_send, request_recv) = mesh::channel();
         let (diag_file_send, diag_file_recv) = mesh::channel();
@@ -92,7 +117,7 @@ impl Agent {
 async fn connect_server(driver: &DefaultDriver) -> PolledSocket<Socket> {
     let server_core = async || {
         let mut socket = VmSocket::new()?;
-        socket.bind(VmAddress::vsock_any(pipette_protocol::PIPETTE_VSOCK_PORT))?;
+        socket.bind(VmAddress::vsock_any(pipette_protocol::PIPETTE_PORT))?;
         let mut socket =
             PolledSocket::new(driver, socket.into()).context("failed to create polled socket")?;
         socket.listen(1)?;
@@ -125,7 +150,7 @@ async fn connect_client(driver: &DefaultDriver) -> PolledSocket<Socket> {
             .context("failed to create polled client socket")?
             .convert();
         socket
-            .connect(&VmAddress::vsock_host(pipette_protocol::PIPETTE_VSOCK_PORT).into())
+            .connect(&VmAddress::vsock_host(pipette_protocol::PIPETTE_PORT).into())
             .await
             .context("failed to connect")
             .map(|()| socket)
@@ -138,6 +163,37 @@ async fn connect_client(driver: &DefaultDriver) -> PolledSocket<Socket> {
                 eprintln!("failed to connect to server, retrying: {:?}", err);
                 timer.sleep(Duration::from_secs(1)).await;
             }
+        }
+    }
+}
+
+/// Listen for an incoming TCP connection from the host on the pipette TCP port.
+async fn connect_server_tcp(driver: &DefaultDriver) -> PolledSocket<std::net::TcpStream> {
+    let server_core = async || {
+        let listener =
+            std::net::TcpListener::bind(("0.0.0.0", pipette_protocol::PIPETTE_PORT as u16))
+                .context("failed to bind TCP listener")?;
+        listener
+            .set_nonblocking(true)
+            .context("failed to set nonblocking")?;
+        let mut listener =
+            PolledSocket::new(driver, listener).context("failed to create polled TCP listener")?;
+        let (stream, addr) = listener
+            .accept()
+            .await
+            .context("failed to accept TCP connection")?;
+        stream
+            .set_nodelay(true)
+            .context("failed to set TCP_NODELAY")?;
+        eprintln!("Pipette accepted TCP connection from {addr}");
+        PolledSocket::new(driver, stream).context("failed to create polled TCP stream")
+    };
+
+    match server_core().await {
+        Ok(socket) => socket,
+        Err(err) => {
+            eprintln!("failed to stand up TCP server: {:?}", err);
+            std::future::pending().await
         }
     }
 }

--- a/petri/pipette/src/main.rs
+++ b/petri/pipette/src/main.rs
@@ -26,6 +26,45 @@ mod trace;
 mod winsvc;
 
 #[cfg(any(target_os = "linux", windows))]
+struct Args {
+    #[cfg(windows)]
+    service: bool,
+    transport: agent::Transport,
+}
+
+#[cfg(any(target_os = "linux", windows))]
+fn parse_args() -> anyhow::Result<Args> {
+    use anyhow::Context;
+
+    #[cfg(windows)]
+    let mut service = false;
+    let mut transport = agent::Transport::Vsock;
+    let mut args = std::env::args().skip(1);
+    while let Some(arg) = args.next() {
+        match arg.as_str() {
+            #[cfg(windows)]
+            "--service" => service = true,
+            "--transport" => {
+                let val = args
+                    .next()
+                    .context("--transport requires a value (tcp or vsock)")?;
+                match val.as_str() {
+                    "tcp" => transport = agent::Transport::Tcp,
+                    "vsock" => transport = agent::Transport::Vsock,
+                    other => anyhow::bail!("unknown transport {other:?}, expected tcp or vsock"),
+                }
+            }
+            other => anyhow::bail!("unknown argument {other:?}"),
+        }
+    }
+    Ok(Args {
+        #[cfg(windows)]
+        service,
+        transport,
+    })
+}
+
+#[cfg(any(target_os = "linux", windows))]
 fn main() -> anyhow::Result<()> {
     eprintln!("Pipette starting up");
 
@@ -42,14 +81,18 @@ fn main() -> anyhow::Result<()> {
         init::init_as_pid1()?;
     }
 
+    let args = parse_args()?;
+
     #[cfg(windows)]
-    if std::env::args().nth(1).as_deref() == Some("--service") {
+    if args.service {
         return winsvc::start_service();
     }
 
+    let transport = args.transport;
+
     pal_async::DefaultPool::run_with(async |driver| {
         loop {
-            let agent = agent::Agent::new(driver.clone()).await?;
+            let agent = agent::Agent::new(driver.clone(), transport).await?;
             agent.run().await?;
             eprintln!("Pipette disconnected, reconnecting...");
         }

--- a/petri/pipette/src/main.rs
+++ b/petri/pipette/src/main.rs
@@ -85,7 +85,7 @@ fn main() -> anyhow::Result<()> {
 
     #[cfg(windows)]
     if args.service {
-        return winsvc::start_service();
+        return winsvc::start_service(args.transport);
     }
 
     let transport = args.transport;

--- a/petri/pipette/src/winsvc.rs
+++ b/petri/pipette/src/winsvc.rs
@@ -9,6 +9,7 @@ use futures_concurrency::future::Race;
 use pal_async::DefaultDriver;
 use pal_async::DefaultPool;
 use std::ffi::OsString;
+use std::sync::OnceLock;
 use std::time::Duration;
 use windows_service::define_windows_service;
 use windows_service::service;
@@ -18,23 +19,32 @@ use windows_service::service_dispatcher;
 
 const SERVICE_NAME: &str = "pipette";
 
-pub fn start_service() -> anyhow::Result<()> {
+/// Configuration parsed in `main()` that must be forwarded to `service_main`.
+///
+/// The Windows service dispatcher calls `service_main` with a fixed callback
+/// signature (`fn(Vec<OsString>)`), so there is no way to pass arbitrary state
+/// through it. We use a global `OnceLock` to bridge the gap: `start_service`
+/// stores the config before entering the dispatcher, and `service_main`
+/// retrieves it on the other side.
+#[derive(Clone, Copy)]
+struct ServiceConfig {
+    transport: crate::agent::Transport,
+}
+
+static SERVICE_CONFIG: OnceLock<ServiceConfig> = OnceLock::new();
+
+pub fn start_service(transport: crate::agent::Transport) -> anyhow::Result<()> {
     // TODO: retarget stderr somewhere that the host can see (serial port?)
+    SERVICE_CONFIG.set(ServiceConfig { transport }).unwrap();
     define_windows_service!(ffi_service_main, service_main);
     service_dispatcher::start(SERVICE_NAME, ffi_service_main).context("failed to start service")?;
     Ok(())
 }
 
 fn service_main(_args: Vec<OsString>) {
-    let transport = match super::parse_args() {
-        Ok(args) => args.transport,
-        Err(e) => {
-            eprintln!("failed to parse args: {e:#}");
-            return;
-        }
-    };
+    let config = SERVICE_CONFIG.get().unwrap();
     DefaultPool::run_with(async |driver| {
-        if let Err(e) = service_main_inner(driver, transport).await {
+        if let Err(e) = service_main_inner(driver, config.transport).await {
             eprintln!("service_main failed: {:#}", e);
         }
     })

--- a/petri/pipette/src/winsvc.rs
+++ b/petri/pipette/src/winsvc.rs
@@ -26,7 +26,7 @@ const SERVICE_NAME: &str = "pipette";
 /// through it. We use a global `OnceLock` to bridge the gap: `start_service`
 /// stores the config before entering the dispatcher, and `service_main`
 /// retrieves it on the other side.
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug)]
 struct ServiceConfig {
     transport: crate::agent::Transport,
 }

--- a/petri/pipette/src/winsvc.rs
+++ b/petri/pipette/src/winsvc.rs
@@ -26,14 +26,24 @@ pub fn start_service() -> anyhow::Result<()> {
 }
 
 fn service_main(_args: Vec<OsString>) {
+    let transport = match super::parse_args() {
+        Ok(args) => args.transport,
+        Err(e) => {
+            eprintln!("failed to parse args: {e:#}");
+            return;
+        }
+    };
     DefaultPool::run_with(async |driver| {
-        if let Err(e) = service_main_inner(driver).await {
+        if let Err(e) = service_main_inner(driver, transport).await {
             eprintln!("service_main failed: {:#}", e);
         }
     })
 }
 
-async fn service_main_inner(driver: DefaultDriver) -> anyhow::Result<()> {
+async fn service_main_inner(
+    driver: DefaultDriver,
+    transport: crate::agent::Transport,
+) -> anyhow::Result<()> {
     let (send, recv) = mesh::oneshot::<()>();
     let mut send = Some(send);
     let event_handler = move |control_event| match control_event {
@@ -63,7 +73,7 @@ async fn service_main_inner(driver: DefaultDriver) -> anyhow::Result<()> {
     set_status(service::ServiceState::StartPending)?;
 
     let run = async {
-        let agent = Agent::new(driver).await?;
+        let agent = Agent::new(driver, transport).await?;
         set_status(service::ServiceState::Running)?;
         agent.run().await
     };

--- a/petri/pipette_client/src/lib.rs
+++ b/petri/pipette_client/src/lib.rs
@@ -9,7 +9,7 @@ pub mod process;
 mod send;
 pub mod shell;
 
-pub use pipette_protocol::PIPETTE_VSOCK_PORT;
+pub use pipette_protocol::PIPETTE_PORT;
 
 use crate::send::PipetteSender;
 use anyhow::Context;

--- a/petri/pipette_protocol/src/lib.rs
+++ b/petri/pipette_protocol/src/lib.rs
@@ -13,8 +13,8 @@ use mesh::pipe::WritePipe;
 use mesh::rpc::FailableRpc;
 use mesh::rpc::Rpc;
 
-/// The port used for the pipette connection over AF_VSOCK.
-pub const PIPETTE_VSOCK_PORT: u32 = 0x1337;
+/// The port used for the pipette connection (AF_VSOCK or TCP).
+pub const PIPETTE_PORT: u32 = 0x1337;
 
 /// The bootstrap message sent from the agent to the host.
 #[derive(MeshPayload)]

--- a/petri/src/vm/hyperv/mod.rs
+++ b/petri/src/vm/hyperv/mod.rs
@@ -506,9 +506,7 @@ impl PetriVmRuntime for HyperVPetriRuntime {
                 .context("failed to create polled client socket")?
                 .convert();
             socket
-                .connect(
-                    &VmAddress::hyperv_vsock(*vm.vmid(), pipette_client::PIPETTE_VSOCK_PORT).into(),
-                )
+                .connect(&VmAddress::hyperv_vsock(*vm.vmid(), pipette_client::PIPETTE_PORT).into())
                 .await
                 .context("failed to connect")
                 .map(|()| socket)

--- a/petri/src/vm/mod.rs
+++ b/petri/src/vm/mod.rs
@@ -208,6 +208,7 @@ impl<T: PetriVmmBackend> Debug for PetriVmBuilder<T> {
             .field("prebuilt_initrd", &self.prebuilt_initrd)
             .field("use_virtio_vsock", &self.use_virtio_vsock)
             .field("no_vmbus", &self.no_vmbus)
+            .field("use_tcp_pipette", &self.use_tcp_pipette)
             .finish()
     }
 }

--- a/petri/src/vm/mod.rs
+++ b/petri/src/vm/mod.rs
@@ -184,8 +184,6 @@ pub struct PetriVmBuilder<T: PetriVmmBackend> {
     use_virtio_vsock: bool,
     // Disable VMBus entirely (no vmbus server, no vmbus storage controllers).
     no_vmbus: bool,
-    // Use TCP over virtio-net + consomme as the pipette transport (for Windows no-vmbus).
-    use_tcp_pipette: bool,
 }
 
 impl<T: PetriVmmBackend> Debug for PetriVmBuilder<T> {
@@ -208,7 +206,6 @@ impl<T: PetriVmmBackend> Debug for PetriVmBuilder<T> {
             .field("prebuilt_initrd", &self.prebuilt_initrd)
             .field("use_virtio_vsock", &self.use_virtio_vsock)
             .field("no_vmbus", &self.no_vmbus)
-            .field("use_tcp_pipette", &self.use_tcp_pipette)
             .finish()
     }
 }
@@ -296,8 +293,6 @@ pub struct PetriVmProperties {
     pub use_virtio_vsock: bool,
     /// VMBus is entirely disabled
     pub no_vmbus: bool,
-    /// Use TCP pipette transport (for Windows no-vmbus)
-    pub use_tcp_pipette: bool,
 }
 
 /// VM configuration that can be changed after the VM is created
@@ -470,7 +465,6 @@ impl<T: PetriVmmBackend> PetriVmBuilder<T> {
             prebuilt_initrd: None,
             use_virtio_vsock: false,
             no_vmbus: false,
-            use_tcp_pipette: false,
         }
         .add_petri_scsi_controllers()
         .add_guest_crash_disk(params.post_test_hooks))
@@ -547,7 +541,6 @@ impl<T: PetriVmmBackend> PetriVmBuilder<T> {
             prebuilt_initrd: None,
             use_virtio_vsock: false,
             no_vmbus: false,
-            use_tcp_pipette: false,
         })
     }
 
@@ -662,14 +655,12 @@ impl<T: PetriVmmBackend> PetriVmBuilder<T> {
     ///
     /// This removes all VMBus storage controllers. For Linux guests,
     /// virtio-vsock is used for pipette communication. For Windows guests,
-    /// TCP over virtio-net + consomme is used instead (since Windows has no
-    /// virtio-vsock driver). The guest must boot from a non-VMBus device
-    /// (e.g. PCIe NVMe).
+    /// the caller must also configure TCP pipette transport via
+    /// `modify_backend(|b| b.with_tcp_pipette_nic())`. The guest must boot
+    /// from a non-VMBus device (e.g. PCIe NVMe).
     pub fn with_no_vmbus(mut self) -> Self {
         self.no_vmbus = true;
-        if self.config.firmware.os_flavor() == OsFlavor::Windows {
-            self.use_tcp_pipette = true;
-        } else {
+        if self.config.firmware.os_flavor() != OsFlavor::Windows {
             self.use_virtio_vsock = true;
         }
         self.config.vmbus_storage_controllers.clear();
@@ -975,7 +966,6 @@ impl<T: PetriVmmBackend> PetriVmBuilder<T> {
             has_agent_disk: self.has_agent_disk(),
             use_virtio_vsock: self.use_virtio_vsock,
             no_vmbus: self.no_vmbus,
-            use_tcp_pipette: self.use_tcp_pipette,
         }
     }
 

--- a/petri/src/vm/mod.rs
+++ b/petri/src/vm/mod.rs
@@ -184,6 +184,8 @@ pub struct PetriVmBuilder<T: PetriVmmBackend> {
     use_virtio_vsock: bool,
     // Disable VMBus entirely (no vmbus server, no vmbus storage controllers).
     no_vmbus: bool,
+    // Use TCP over virtio-net + consomme as the pipette transport (for Windows no-vmbus).
+    use_tcp_pipette: bool,
 }
 
 impl<T: PetriVmmBackend> Debug for PetriVmBuilder<T> {
@@ -293,6 +295,8 @@ pub struct PetriVmProperties {
     pub use_virtio_vsock: bool,
     /// VMBus is entirely disabled
     pub no_vmbus: bool,
+    /// Use TCP pipette transport (for Windows no-vmbus)
+    pub use_tcp_pipette: bool,
 }
 
 /// VM configuration that can be changed after the VM is created
@@ -465,6 +469,7 @@ impl<T: PetriVmmBackend> PetriVmBuilder<T> {
             prebuilt_initrd: None,
             use_virtio_vsock: false,
             no_vmbus: false,
+            use_tcp_pipette: false,
         }
         .add_petri_scsi_controllers()
         .add_guest_crash_disk(params.post_test_hooks))
@@ -541,6 +546,7 @@ impl<T: PetriVmmBackend> PetriVmBuilder<T> {
             prebuilt_initrd: None,
             use_virtio_vsock: false,
             no_vmbus: false,
+            use_tcp_pipette: false,
         })
     }
 
@@ -653,12 +659,18 @@ impl<T: PetriVmmBackend> PetriVmBuilder<T> {
 
     /// Disable VMBus entirely.
     ///
-    /// This removes all VMBus storage controllers and forces virtio-vsock
-    /// for pipette communication. The guest must boot from a non-VMBus
-    /// device (e.g. PCIe NVMe).
+    /// This removes all VMBus storage controllers. For Linux guests,
+    /// virtio-vsock is used for pipette communication. For Windows guests,
+    /// TCP over virtio-net + consomme is used instead (since Windows has no
+    /// virtio-vsock driver). The guest must boot from a non-VMBus device
+    /// (e.g. PCIe NVMe).
     pub fn with_no_vmbus(mut self) -> Self {
         self.no_vmbus = true;
-        self.use_virtio_vsock = true;
+        if self.config.firmware.os_flavor() == OsFlavor::Windows {
+            self.use_tcp_pipette = true;
+        } else {
+            self.use_virtio_vsock = true;
+        }
         self.config.vmbus_storage_controllers.clear();
         self
     }
@@ -962,6 +974,7 @@ impl<T: PetriVmmBackend> PetriVmBuilder<T> {
             has_agent_disk: self.has_agent_disk(),
             use_virtio_vsock: self.use_virtio_vsock,
             no_vmbus: self.no_vmbus,
+            use_tcp_pipette: self.use_tcp_pipette,
         }
     }
 

--- a/petri/src/vm/openvmm/construct.rs
+++ b/petri/src/vm/openvmm/construct.rs
@@ -561,42 +561,7 @@ impl PetriVmConfigOpenVmm {
             });
         }
 
-        // Add a virtio-net NIC with consomme + TCP port forwarding for
-        // pipette when using TCP transport (Windows no-vmbus guests).
-        let tcp_pipette_port = if properties.use_tcp_pipette {
-            let nic_port = (0..)
-                .map(|i| format!("s0rc0rp{i}"))
-                .find(|name| !pcie_devices.iter().any(|d| d.port_name == *name))
-                .unwrap();
-            let (port_send, port_recv) = mesh::oneshot();
-            let endpoint = net_backend_resources::consomme::ConsommeHandle {
-                cidr: None,
-                ports: vec![net_backend_resources::consomme::HostPortConfig {
-                    protocol: net_backend_resources::consomme::HostPortProtocol::Tcp,
-                    host_address: Some(net_backend_resources::consomme::HostIpAddress::Ipv4(
-                        std::net::Ipv4Addr::LOCALHOST,
-                    )),
-                    host_port: net_backend_resources::consomme::HostPort::Dynamic(port_send),
-                    guest_port: PIPETTE_PORT as u16,
-                }],
-            }
-            .into_resource();
-            pcie_devices.push(PcieDeviceConfig {
-                port_name: nic_port,
-                resource: VirtioPciDeviceHandle(
-                    virtio_resources::net::VirtioNetHandle {
-                        max_queues: None,
-                        mac_address: super::NIC_MAC_ADDRESS,
-                        endpoint,
-                    }
-                    .into_resource(),
-                )
-                .into_resource(),
-            });
-            Some(port_recv)
-        } else {
-            None
-        };
+        let tcp_pipette_port = None;
 
         let config = Config {
             // Firmware

--- a/petri/src/vm/openvmm/construct.rs
+++ b/petri/src/vm/openvmm/construct.rs
@@ -561,8 +561,6 @@ impl PetriVmConfigOpenVmm {
             });
         }
 
-        let tcp_pipette_port = None;
-
         let config = Config {
             // Firmware
             load_mode,
@@ -689,7 +687,7 @@ impl PetriVmConfigOpenVmm {
                 pipette_listener,
                 vtl2_pipette_listener,
                 linux_direct_serial_agent,
-                tcp_pipette_port,
+                tcp_pipette_port: None,
                 driver: driver.clone(),
                 output_dir: log_source.output_dir().to_owned(),
                 openvmm_path: openvmm_path.clone(),

--- a/petri/src/vm/openvmm/construct.rs
+++ b/petri/src/vm/openvmm/construct.rs
@@ -68,7 +68,7 @@ use pal_async::task::Spawn;
 use pal_async::task::Task;
 use petri_artifacts_common::tags::MachineArch;
 use petri_artifacts_core::ResolvedArtifact;
-use pipette_client::PIPETTE_VSOCK_PORT;
+use pipette_client::PIPETTE_PORT;
 use scsidisk_resources::SimpleScsiDiskHandle;
 use scsidisk_resources::SimpleScsiDvdHandle;
 use serial_16550_resources::ComPort;
@@ -561,6 +561,43 @@ impl PetriVmConfigOpenVmm {
             });
         }
 
+        // Add a virtio-net NIC with consomme + TCP port forwarding for
+        // pipette when using TCP transport (Windows no-vmbus guests).
+        let tcp_pipette_port = if properties.use_tcp_pipette {
+            let nic_port = (0..)
+                .map(|i| format!("s0rc0rp{i}"))
+                .find(|name| !pcie_devices.iter().any(|d| d.port_name == *name))
+                .unwrap();
+            let (port_send, port_recv) = mesh::oneshot();
+            let endpoint = net_backend_resources::consomme::ConsommeHandle {
+                cidr: None,
+                ports: vec![net_backend_resources::consomme::HostPortConfig {
+                    protocol: net_backend_resources::consomme::HostPortProtocol::Tcp,
+                    host_address: Some(net_backend_resources::consomme::HostIpAddress::Ipv4(
+                        std::net::Ipv4Addr::LOCALHOST,
+                    )),
+                    host_port: net_backend_resources::consomme::HostPort::Dynamic(port_send),
+                    guest_port: PIPETTE_PORT as u16,
+                }],
+            }
+            .into_resource();
+            pcie_devices.push(PcieDeviceConfig {
+                port_name: nic_port,
+                resource: VirtioPciDeviceHandle(
+                    virtio_resources::net::VirtioNetHandle {
+                        max_queues: None,
+                        mac_address: super::NIC_MAC_ADDRESS,
+                        endpoint,
+                    }
+                    .into_resource(),
+                )
+                .into_resource(),
+            });
+            Some(port_recv)
+        } else {
+            None
+        };
+
         let config = Config {
             // Firmware
             load_mode,
@@ -653,7 +690,7 @@ impl PetriVmConfigOpenVmm {
         };
 
         // Make the pipette connection listener.
-        let path = format!("{vsock_path_string}_{PIPETTE_VSOCK_PORT}");
+        let path = format!("{vsock_path_string}_{PIPETTE_PORT}");
         let pipette_listener = PolledSocket::new(
             driver,
             UnixListener::bind(path).context("failed to bind to pipette listener")?,
@@ -662,7 +699,7 @@ impl PetriVmConfigOpenVmm {
         // Make the vtl2 pipette connection listener.
         let vtl2_pipette_listener = if let Some(vtl2_vmbus) = &config.vtl2_vmbus {
             let path = vtl2_vmbus.vsock_path.as_ref().unwrap();
-            let path = format!("{path}_{PIPETTE_VSOCK_PORT}");
+            let path = format!("{path}_{PIPETTE_PORT}");
             Some(PolledSocket::new(
                 driver,
                 UnixListener::bind(path).context("failed to bind to vtl2 pipette listener")?,
@@ -687,6 +724,7 @@ impl PetriVmConfigOpenVmm {
                 pipette_listener,
                 vtl2_pipette_listener,
                 linux_direct_serial_agent,
+                tcp_pipette_port,
                 driver: driver.clone(),
                 output_dir: log_source.output_dir().to_owned(),
                 openvmm_path: openvmm_path.clone(),

--- a/petri/src/vm/openvmm/mod.rs
+++ b/petri/src/vm/openvmm/mod.rs
@@ -190,6 +190,13 @@ struct PetriVmResourcesOpenVmm {
     vtl2_pipette_listener: Option<PolledSocket<UnixListener>>,
     linux_direct_serial_agent: Option<LinuxDirectSerialAgent>,
 
+    /// When set, the host connects to pipette via TCP through consomme
+    /// port forwarding instead of accepting on the Unix socket listener.
+    /// Used for Windows no-vmbus guests where virtio-vsock is unavailable.
+    /// The receiver yields the OS-assigned host port once the consomme
+    /// resolver has bound the socket.
+    tcp_pipette_port: Option<mesh::OneshotReceiver<u16>>,
+
     // Externally injected management stuff also needed at runtime.
     driver: DefaultDriver,
     openvmm_path: ResolvedArtifact,

--- a/petri/src/vm/openvmm/modify.rs
+++ b/petri/src/vm/openvmm/modify.rs
@@ -203,6 +203,43 @@ impl PetriVmConfigOpenVmm {
         self
     }
 
+    /// Add a virtio-net NIC with consomme and TCP port forwarding for
+    /// pipette. Used for Windows no-vmbus guests where virtio-vsock is
+    /// unavailable.
+    ///
+    /// This configures consomme to forward the pipette TCP port from the
+    /// host into the guest, so the petri framework can connect to the
+    /// pipette agent over TCP.
+    pub fn with_tcp_pipette_nic(mut self, port_name: &str) -> Self {
+        let (port_send, port_recv) = mesh::oneshot();
+        let endpoint = net_backend_resources::consomme::ConsommeHandle {
+            cidr: None,
+            ports: vec![net_backend_resources::consomme::HostPortConfig {
+                protocol: net_backend_resources::consomme::HostPortProtocol::Tcp,
+                host_address: Some(net_backend_resources::consomme::HostIpAddress::Ipv4(
+                    std::net::Ipv4Addr::LOCALHOST,
+                )),
+                host_port: net_backend_resources::consomme::HostPort::Dynamic(port_send),
+                guest_port: pipette_client::PIPETTE_PORT as u16,
+            }],
+        }
+        .into_resource();
+        self.config.pcie_devices.push(PcieDeviceConfig {
+            port_name: port_name.to_string(),
+            resource: virtio_resources::VirtioPciDeviceHandle(
+                virtio_resources::net::VirtioNetHandle {
+                    max_queues: None,
+                    mac_address: NIC_MAC_ADDRESS,
+                    endpoint,
+                }
+                .into_resource(),
+            )
+            .into_resource(),
+        });
+        self.resources.tcp_pipette_port = Some(port_recv);
+        self
+    }
+
     /// Enable a synthnic for the VM backed by the Windows vmswitch
     /// DirectIO (`-net dio`) backend.
     ///

--- a/petri/src/vm/openvmm/runtime.rs
+++ b/petri/src/vm/openvmm/runtime.rs
@@ -204,6 +204,9 @@ pub(super) struct PetriVmInner {
     /// Used to skip re-mounting after save/restore (where guest state is
     /// preserved) while still mounting after a full reset/reboot.
     pub(super) cidata_mounted: bool,
+    /// Resolved TCP pipette port for no-vmbus Windows guests. Set once
+    /// during startup and reused across reconnections (e.g. after reset).
+    pub(super) tcp_pipette_port: Option<u16>,
     pub(super) pid: i32,
 }
 
@@ -562,11 +565,8 @@ impl PetriVmInner {
 
     async fn wait_for_agent(&mut self, set_high_vtl: bool) -> anyhow::Result<PipetteClient> {
         // Use TCP transport if configured (Windows no-vmbus guests).
-        if let Some(port_recv) = self.resources.tcp_pipette_port.take() {
+        if let Some(port) = self.tcp_pipette_port {
             assert!(!set_high_vtl, "TCP pipette transport does not support VTL2");
-            let port = port_recv
-                .await
-                .context("failed to receive TCP pipette port from consomme")?;
             return self.wait_for_agent_tcp(port).await;
         }
 

--- a/petri/src/vm/openvmm/runtime.rs
+++ b/petri/src/vm/openvmm/runtime.rs
@@ -658,26 +658,21 @@ impl PetriVmInner {
                     // drop the initial SYN to the guest if no RX buffers are
                     // available yet, leaving the connection open but dead.
                     // Reconnecting forces a new SYN attempt.
-                    let mut timer = pal_async::timer::PolledTimer::new(&self.resources.driver);
                     let handshake = PipetteClient::new(
                         &self.resources.driver,
                         socket,
                         &self.resources.output_dir,
                     );
-                    match futures::future::select(
-                        std::pin::pin!(handshake),
-                        std::pin::pin!(timer.sleep(Duration::from_secs(5))),
-                    )
-                    .await
-                    {
-                        futures::future::Either::Left((Ok(client), _)) => break client,
-                        futures::future::Either::Left((Err(e), _)) => {
+                    let mut c = CancelContext::new().with_timeout(Duration::from_secs(5));
+                    match c.until_cancelled(handshake).await {
+                        Ok(Ok(client)) => break client,
+                        Ok(Err(e)) => {
                             tracing::warn!(
                                 error = &e as &dyn std::error::Error,
                                 "pipette TCP handshake failed, retrying"
                             );
                         }
-                        futures::future::Either::Right(_) => {
+                        Err(_) => {
                             tracing::warn!("pipette TCP handshake timed out, reconnecting");
                         }
                     }

--- a/petri/src/vm/openvmm/runtime.rs
+++ b/petri/src/vm/openvmm/runtime.rs
@@ -561,6 +561,15 @@ impl PetriVmInner {
     }
 
     async fn wait_for_agent(&mut self, set_high_vtl: bool) -> anyhow::Result<PipetteClient> {
+        // Use TCP transport if configured (Windows no-vmbus guests).
+        if let Some(port_recv) = self.resources.tcp_pipette_port.take() {
+            assert!(!set_high_vtl, "TCP pipette transport does not support VTL2");
+            let port = port_recv
+                .await
+                .context("failed to receive TCP pipette port from consomme")?;
+            return self.wait_for_agent_tcp(port).await;
+        }
+
         let listener = if set_high_vtl {
             self.resources
                 .vtl2_pipette_listener
@@ -626,6 +635,69 @@ impl PetriVmInner {
             self.cidata_mounted = true;
         }
 
+        Ok(client)
+    }
+
+    /// Connect to pipette via TCP through consomme port forwarding.
+    ///
+    /// The guest pipette agent listens on `0.0.0.0:{port}` and consomme
+    /// forwards connections from `localhost:{port}` on the host into the
+    /// guest. We retry until the guest's network stack and pipette are up.
+    async fn wait_for_agent_tcp(&mut self, port: u16) -> anyhow::Result<PipetteClient> {
+        tracing::info!(port, "connecting to pipette via TCP");
+        let addr = std::net::SocketAddr::from((std::net::Ipv4Addr::LOCALHOST, port));
+        let client = loop {
+            match std::net::TcpStream::connect_timeout(&addr, Duration::from_secs(2)) {
+                Ok(stream) => {
+                    stream
+                        .set_nonblocking(true)
+                        .context("failed to set TCP stream nonblocking")?;
+                    stream
+                        .set_nodelay(true)
+                        .context("failed to set TCP_NODELAY")?;
+                    tracing::info!("TCP connected, handshaking with pipette");
+                    let socket = PolledSocket::new(&self.resources.driver, stream)?;
+                    // Time out the handshake — consomme's port forwarding may
+                    // drop the initial SYN to the guest if no RX buffers are
+                    // available yet, leaving the connection open but dead.
+                    // Reconnecting forces a new SYN attempt.
+                    let mut timer = pal_async::timer::PolledTimer::new(&self.resources.driver);
+                    let handshake = PipetteClient::new(
+                        &self.resources.driver,
+                        socket,
+                        &self.resources.output_dir,
+                    );
+                    match futures::future::select(
+                        std::pin::pin!(handshake),
+                        std::pin::pin!(timer.sleep(Duration::from_secs(5))),
+                    )
+                    .await
+                    {
+                        futures::future::Either::Left((Ok(client), _)) => break client,
+                        futures::future::Either::Left((Err(e), _)) => {
+                            tracing::warn!(
+                                error = &e as &dyn std::error::Error,
+                                "pipette TCP handshake failed, retrying"
+                            );
+                        }
+                        futures::future::Either::Right(_) => {
+                            tracing::warn!("pipette TCP handshake timed out, reconnecting");
+                        }
+                    }
+                }
+                Err(e) => {
+                    tracing::debug!(
+                        error = &e as &dyn std::error::Error,
+                        "TCP connect failed, guest not ready yet"
+                    );
+                }
+            }
+            // Wait before retrying — guest network stack may not be up yet.
+            pal_async::timer::PolledTimer::new(&self.resources.driver)
+                .sleep(Duration::from_secs(1))
+                .await;
+        };
+        tracing::info!("completed pipette TCP handshake");
         Ok(client)
     }
 

--- a/petri/src/vm/openvmm/runtime.rs
+++ b/petri/src/vm/openvmm/runtime.rs
@@ -647,16 +647,13 @@ impl PetriVmInner {
         tracing::info!(port, "connecting to pipette via TCP");
         let addr = std::net::SocketAddr::from((std::net::Ipv4Addr::LOCALHOST, port));
         let client = loop {
-            match std::net::TcpStream::connect_timeout(&addr, Duration::from_secs(2)) {
-                Ok(stream) => {
-                    stream
-                        .set_nonblocking(true)
-                        .context("failed to set TCP stream nonblocking")?;
-                    stream
+            match PolledSocket::connect_tcp(&self.resources.driver, addr).await {
+                Ok(socket) => {
+                    socket
+                        .get()
                         .set_nodelay(true)
                         .context("failed to set TCP_NODELAY")?;
                     tracing::info!("TCP connected, handshaking with pipette");
-                    let socket = PolledSocket::new(&self.resources.driver, stream)?;
                     // Time out the handshake — consomme's port forwarding may
                     // drop the initial SYN to the guest if no RX buffers are
                     // available yet, leaving the connection open but dead.

--- a/petri/src/vm/openvmm/start.rs
+++ b/petri/src/vm/openvmm/start.rs
@@ -154,9 +154,12 @@ impl PetriVmConfigOpenVmm {
     /// included in the config
     pub async fn run(mut self) -> anyhow::Result<(PetriVmOpenVmm, PetriVmRuntimeConfig)> {
         // Set up the IMC hive for Windows guests that use pipette in VTL0.
+        // Skip when VMBus is disabled — the no-vmbus prepped image has
+        // pipette pre-configured via offline registry injection.
         if self.resources.properties.using_vtl0_pipette
             && matches!(self.resources.properties.os_flavor, OsFlavor::Windows)
             && !self.resources.properties.is_isolated
+            && !self.resources.properties.no_vmbus
         {
             let mut imc_hive_file = tempfile::tempfile().context("failed to create temp file")?;
             imc_hive_file

--- a/petri/src/vm/openvmm/start.rs
+++ b/petri/src/vm/openvmm/start.rs
@@ -125,6 +125,18 @@ impl PetriVmConfigOpenVmm {
 
         let is_minimal = resources.properties.minimal_mode;
 
+        // Resolve the TCP pipette port now, while the VM is starting.
+        // Consomme binds the port during launch, so the oneshot should
+        // be ready.  Caching the resolved port here lets wait_for_agent
+        // reconnect after a reset without needing the oneshot again.
+        let tcp_pipette_port = match resources.tcp_pipette_port.take() {
+            Some(recv) => Some(
+                recv.await
+                    .context("failed to receive TCP pipette port from consomme")?,
+            ),
+            None => None,
+        };
+
         let mut vm = PetriVmOpenVmm::new(
             super::runtime::PetriVmInner {
                 resources,
@@ -132,6 +144,7 @@ impl PetriVmConfigOpenVmm {
                 worker,
                 framebuffer_view,
                 cidata_mounted: false,
+                tcp_pipette_port,
                 pid,
             },
             halt_notif,

--- a/support/pal/pal_async/src/socket.rs
+++ b/support/pal/pal_async/src/socket.rs
@@ -294,6 +294,24 @@ impl PolledSocket<UnixStream> {
     }
 }
 
+impl PolledSocket<std::net::TcpStream> {
+    /// Creates a new connected TCP stream socket.
+    pub async fn connect_tcp(
+        driver: &(impl ?Sized + Driver),
+        addr: std::net::SocketAddr,
+    ) -> io::Result<Self> {
+        let domain = match addr {
+            std::net::SocketAddr::V4(_) => socket2::Domain::IPV4,
+            std::net::SocketAddr::V6(_) => socket2::Domain::IPV6,
+        };
+        let socket =
+            socket2::Socket::new(domain, socket2::Type::STREAM, Some(socket2::Protocol::TCP))?;
+        let mut socket = PolledSocket::new(driver, socket)?;
+        socket.connect(&addr.into()).await?;
+        Ok(socket.convert())
+    }
+}
+
 impl<T: AsSockRef + Read> AsyncRead for PolledSocket<T> {
     fn poll_read(
         mut self: Pin<&mut Self>,

--- a/vmm_tests/petri_artifact_resolver_openvmm_known_paths/src/lib.rs
+++ b/vmm_tests/petri_artifact_resolver_openvmm_known_paths/src/lib.rs
@@ -119,9 +119,9 @@ impl petri_artifacts_core::ResolveTestArtifact for OpenvmmKnownPathsTestArtifact
                 get_path(
                     full_path,
                     prepped_filename,
-                    MissingCommand::Run {
+                    MissingCommand::Custom {
                         description: "no-vmbus prepped test image",
-                        package: "prep_steps",
+                        cmd: "cargo run -p prep_steps -- no-vmbus",
                     },
                 )
             }

--- a/vmm_tests/petri_artifact_resolver_openvmm_known_paths/src/lib.rs
+++ b/vmm_tests/petri_artifact_resolver_openvmm_known_paths/src/lib.rs
@@ -111,6 +111,21 @@ impl petri_artifacts_core::ResolveTestArtifact for OpenvmmKnownPathsTestArtifact
                 )
             }
 
+            _ if id == test_vhd::GEN2_WINDOWS_DATA_CENTER_CORE2022_X64_NO_VMBUS_PREPPED => {
+                let base_filename = test_vhd::GEN2_WINDOWS_DATA_CENTER_CORE2022_X64::FILENAME;
+                let prepped_filename = base_filename.replace(".vhd", "-no-vmbus-prepped.vhd");
+                let images_dir = std::env::var("VMM_TEST_IMAGES");
+                let full_path = Path::new(images_dir.as_deref().unwrap_or("images"));
+                get_path(
+                    full_path,
+                    prepped_filename,
+                    MissingCommand::Run {
+                        description: "no-vmbus prepped test image",
+                        package: "prep_steps",
+                    },
+                )
+            }
+
             _ if id == tmks::TMK_VMM_NATIVE => tmk_vmm_native_executable_path(),
             _ if id == tmks::TMK_VMM_LINUX_X64_MUSL => tmk_vmm_paravisor_path(MachineArch::X86_64),
             _ if id == tmks::TMK_VMM_LINUX_AARCH64_MUSL => tmk_vmm_paravisor_path(MachineArch::Aarch64),
@@ -126,12 +141,12 @@ impl petri_artifacts_core::ResolveTestArtifact for OpenvmmKnownPathsTestArtifact
                 tpm_guest_tests_linux_path(MachineArch::X86_64)
             }
 
-            _ if id == host_tools::TEST_IGVM_AGENT_RPC_SERVER_WINDOWS_X64 => {
-                test_igvm_agent_rpc_server_windows_path(MachineArch::X86_64)
-            }
-
             _ if id == virtio_win::VIRTIO_WIN_DRIVERS => {
                 virtio_win_path()
+            }
+
+            _ if id == host_tools::TEST_IGVM_AGENT_RPC_SERVER_WINDOWS_X64 => {
+                test_igvm_agent_rpc_server_windows_path(MachineArch::X86_64)
             }
 
             // Blob-hosted artifacts: resolved via blob_artifact_info.

--- a/vmm_tests/petri_artifacts_vmm_test/src/lib.rs
+++ b/vmm_tests/petri_artifacts_vmm_test/src/lib.rs
@@ -567,6 +567,17 @@ pub mod artifacts {
                 GEN2_WINDOWS_DATA_CENTER_CORE2025_X64::quirks()
             }
         }
+
+        declare_artifacts! {
+            /// Generation 2 Windows test image, prepped for no-vmbus testing
+            /// with NetKVM driver and TCP pipette transport pre-configured.
+            GEN2_WINDOWS_DATA_CENTER_CORE2022_X64_NO_VMBUS_PREPPED
+        }
+
+        impl IsTestVhd for GEN2_WINDOWS_DATA_CENTER_CORE2022_X64_NO_VMBUS_PREPPED {
+            const OS_FLAVOR: OsFlavor = GEN2_WINDOWS_DATA_CENTER_CORE2022_X64::OS_FLAVOR;
+            const ARCH: MachineArch = GEN2_WINDOWS_DATA_CENTER_CORE2022_X64::ARCH;
+        }
     }
 
     /// Test ISO artifacts

--- a/vmm_tests/prep_steps/Cargo.toml
+++ b/vmm_tests/prep_steps/Cargo.toml
@@ -18,7 +18,9 @@ storvsp_resources.workspace = true
 vm_resource.workspace = true
 
 guid.workspace = true
+gptman.workspace = true
 pal_async.workspace = true
+pipette_protocol.workspace = true
 
 anyhow.workspace = true
 tracing.workspace = true

--- a/vmm_tests/prep_steps/src/main.rs
+++ b/vmm_tests/prep_steps/src/main.rs
@@ -153,22 +153,24 @@ fn build_no_vmbus(
     let (artifacts, source_disk, output_dir, virtio_win) = build_with_artifacts(
         name,
         |resolver| {
+            let boot_disk = resolver.require_source(
+                petri_artifacts_vmm_test::artifacts::test_vhd::GEN2_WINDOWS_DATA_CENTER_CORE2022_X64,
+                petri::RemoteAccess::Allow,
+            );
             let artifacts = PetriVmArtifacts::<OpenVmmPetriBackend>::new(
-            &resolver,
-            Firmware::uefi(
                 &resolver,
+                Firmware::uefi(
+                    &resolver,
+                    MachineArch::X86_64,
+                    UefiGuest::Vhd(BootImageConfig::from_vhd(boot_disk)),
+                ),
                 MachineArch::X86_64,
-                UefiGuest::Vhd(BootImageConfig::from_vhd(
-                    resolver.require_source(petri_artifacts_vmm_test::artifacts::test_vhd::GEN2_WINDOWS_DATA_CENTER_CORE2022_X64, petri::RemoteAccess::Allow),
-                )),
-            ),
-            MachineArch::X86_64,
-            true,
-        )
-        .unwrap();
+                true,
+            )
+            .unwrap();
             let source_disk = resolver.require(
-            petri_artifacts_vmm_test::artifacts::test_vhd::GEN2_WINDOWS_DATA_CENTER_CORE2022_X64,
-        );
+                petri_artifacts_vmm_test::artifacts::test_vhd::GEN2_WINDOWS_DATA_CENTER_CORE2022_X64,
+            );
             let output_dir =
                 resolver.require(petri_artifacts_common::artifacts::TEST_LOG_DIRECTORY);
             let virtio_win = resolver

--- a/vmm_tests/prep_steps/src/main.rs
+++ b/vmm_tests/prep_steps/src/main.rs
@@ -25,25 +25,30 @@ use petri::ResolvedArtifact;
 use petri::TestArtifactRequirements;
 use petri::UefiGuest;
 use petri::openvmm::OpenVmmPetriBackend;
+use petri::pipette::PipetteClient;
 use petri::pipette::cmd;
 use petri_artifacts_common::tags::MachineArch;
 use pipette_protocol::PIPETTE_PORT;
 use vm_resource::IntoResource;
 
 fn main() -> anyhow::Result<()> {
+    DefaultPool::run_with(async |driver| async_main(&driver).await)
+}
+
+async fn async_main(driver: &pal_async::DefaultDriver) -> anyhow::Result<()> {
     let step = std::env::args().nth(1).unwrap_or_default();
     match step.as_str() {
         "" | "standard" => {
             let name = "prep_steps";
             let (logger, artifacts, source_disk) = build(name)?;
-            let r = run(name, &logger, artifacts, source_disk);
+            let r = run(driver, name, &logger, artifacts, source_disk).await;
             logger.log_test_result(name, &r, false);
             r
         }
         "no-vmbus" => {
             let name = "prep_steps_no_vmbus";
             let (logger, artifacts, source_disk, virtio_win) = build_no_vmbus(name)?;
-            let r = run_no_vmbus(name, &logger, artifacts, source_disk, virtio_win);
+            let r = run_no_vmbus(driver, name, &logger, artifacts, source_disk, virtio_win).await;
             logger.log_test_result(name, &r, false);
             r
         }
@@ -86,7 +91,8 @@ fn build(
     Ok((logger, artifacts, source_disk.erase()))
 }
 
-fn run(
+async fn run(
+    driver: &pal_async::DefaultDriver,
     name: &str,
     logger: &PetriLogSource,
     artifacts: PetriVmArtifacts<OpenVmmPetriBackend>,
@@ -99,117 +105,40 @@ fn run(
     else {
         return Ok(());
     };
-    let result_disk = DefaultPool::run_with(async |_driver| {
-        openvmm_helpers::disk::open_disk_type(
-            &result_disk_path,
-            openvmm_helpers::disk::OpenDiskOptions {
-                read_only: false,
-                direct: false,
-            },
-        )
-        .await
-    })?;
 
-    DefaultPool::run_with(async move |driver| {
-        let (vm, agent) = PetriVmBuilder::new(
-            PetriTestParams {
-                test_name: name,
-                logger,
-                // FUTURE: To properly support post_test_hooks we'd need to catch panics
-                // and early failure returns. Not worth it for this simple prep step tool.
-                post_test_hooks: &mut vec![],
-            },
-            artifacts,
-            &driver,
-        )?
-        // Add the second disk as a separate controller to avoid interfering with
-        // the boot disk.
-        .modify_backend(|v| {
-            v.with_custom_config(|c| {
-                c.vmbus_devices.push((
-                    openvmm_defs::config::DeviceVtl::Vtl0,
-                    storvsp_resources::ScsiControllerHandle {
-                        instance_id: guid::guid!("766e96f8-2ceb-437e-afe3-a93169e48aff"),
-                        max_sub_channel_count: 1,
-                        io_queue_depth: None,
-                        devices: vec![storvsp_resources::ScsiDeviceAndPath {
-                            path: storvsp_resources::ScsiPath {
-                                path: 0,
-                                target: 0,
-                                lun: 0,
-                            },
-                            device: scsidisk_resources::SimpleScsiDiskHandle {
-                                read_only: false,
-                                parameters: Default::default(),
-                                disk: result_disk,
-                            }
-                            .into_resource(),
-                        }],
-                        requests: None,
-                        poll_mode_queue_depth: None,
-                    }
-                    .into_resource(),
-                ))
-            })
-        })
+    // Randomize GPT GUIDs so the result disk doesn't collide with the source
+    // if they're ever both attached to the same VM.
+    change_gpt_disk_guid(&result_disk_path)?;
+
+    let result_disk = openvmm_helpers::disk::open_disk_type(
+        &result_disk_path,
+        openvmm_helpers::disk::OpenDiskOptions {
+            read_only: false,
+            direct: false,
+        },
+    )
+    .await?;
+
+    let (vm, agent) =
+        boot_vm_with_target_disk(driver, name, logger, artifacts, result_disk).await?;
+
+    copy_imc_to_target(&agent).await?;
+
+    // Unload the target hive.
+    let shell = agent.windows_shell();
+    cmd!(shell, "reg")
+        .args(["unload", "HKLM\\TargetTemp"])
         .run()
         .await?;
 
-        // Reuse the IMC hive from petri/guest-bootstrap to configure pipette.
-        // This ensures we stay in sync with any changes in petri.
-        agent
-            .write_file(
-                "C:\\imc.hiv",
-                include_bytes!("../../../petri/guest-bootstrap/imc.hiv").as_slice(),
-            )
-            .await?;
+    agent.power_off().await?;
+    vm.wait_for_clean_teardown().await?;
 
-        // Load the IMC hive to read keys from.
-        let shell = agent.windows_shell();
-        cmd!(shell, "reg")
-            .args(["load", "HKLM\\IMCTemp", "C:\\imc.hiv"])
-            .run()
-            .await?;
+    // Now that everything is done we can keep the file.
+    std::mem::forget(drop_guard);
+    tracing::info!("Prep steps completed successfully.");
 
-        // Load the target's SYSTEM hive to write to.
-        cmd!(shell, "reg")
-            .args([
-                "load",
-                "HKLM\\TargetTemp",
-                "E:\\Windows\\System32\\config\\SYSTEM",
-            ])
-            .run()
-            .await?;
-
-        // Copy the keys over.
-        // Until a machine boots it doesn't have a 'CurrentControlSet', so we
-        // copy to 'ControlSet001' instead.
-        cmd!(shell, "reg")
-            .args([
-                "copy",
-                "HKLM\\IMCTemp\\SYSTEM\\CurrentControlSet",
-                "HKLM\\TargetTemp\\ControlSet001",
-                "/s",
-                "/f",
-            ])
-            .run()
-            .await?;
-
-        // Unload the target hive.
-        cmd!(shell, "reg")
-            .args(["unload", "HKLM\\TargetTemp"])
-            .run()
-            .await?;
-
-        agent.power_off().await?;
-        vm.wait_for_clean_teardown().await?;
-
-        // Now that everything is done we can keep the file.
-        std::mem::forget(drop_guard);
-        tracing::info!("Prep steps completed successfully.");
-
-        Ok(())
-    })
+    Ok(())
 }
 
 fn build_no_vmbus(
@@ -253,7 +182,8 @@ fn build_no_vmbus(
     Ok((logger, artifacts, source_disk.erase(), virtio_win.erase()))
 }
 
-fn run_no_vmbus(
+async fn run_no_vmbus(
+    driver: &pal_async::DefaultDriver,
     name: &str,
     logger: &PetriLogSource,
     artifacts: PetriVmArtifacts<OpenVmmPetriBackend>,
@@ -271,9 +201,6 @@ fn run_no_vmbus(
         return Ok(());
     };
 
-    // The target disk is a copy of the boot disk, so it has the same GPT disk
-    // and partition GUIDs. Windows will shadow the duplicate and hide its
-    // volumes. Change the disk GUID directly in the VHD file.
     change_gpt_disk_guid(&result_disk_path)?;
     tracing::info!("Changed target disk GUID to avoid collision with boot disk.");
 
@@ -297,167 +224,195 @@ fn run_no_vmbus(
         })
         .collect::<anyhow::Result<_>>()?;
 
-    let result_disk = DefaultPool::run_with(async |_driver| {
-        openvmm_helpers::disk::open_disk_type(
-            &result_disk_path,
-            openvmm_helpers::disk::OpenDiskOptions {
-                read_only: false,
-                direct: false,
-            },
-        )
-        .await
-    })?;
+    let result_disk = openvmm_helpers::disk::open_disk_type(
+        &result_disk_path,
+        openvmm_helpers::disk::OpenDiskOptions {
+            read_only: false,
+            direct: false,
+        },
+    )
+    .await?;
 
-    DefaultPool::run_with(async move |driver| {
-        let (vm, agent) = PetriVmBuilder::new(
-            PetriTestParams {
-                test_name: name,
-                logger,
-                post_test_hooks: &mut vec![],
-            },
-            artifacts,
-            &driver,
-        )?
-        .modify_backend(|v| {
-            v.with_custom_config(|c| {
-                c.vmbus_devices.push((
-                    openvmm_defs::config::DeviceVtl::Vtl0,
-                    storvsp_resources::ScsiControllerHandle {
-                        instance_id: guid::guid!("766e96f8-2ceb-437e-afe3-a93169e48aff"),
-                        max_sub_channel_count: 1,
-                        io_queue_depth: None,
-                        devices: vec![storvsp_resources::ScsiDeviceAndPath {
-                            path: storvsp_resources::ScsiPath {
-                                path: 0,
-                                target: 0,
-                                lun: 0,
-                            },
-                            device: scsidisk_resources::SimpleScsiDiskHandle {
-                                read_only: false,
-                                parameters: Default::default(),
-                                disk: result_disk,
-                            }
-                            .into_resource(),
-                        }],
-                        requests: None,
-                        poll_mode_queue_depth: None,
-                    }
-                    .into_resource(),
-                ))
-            })
-        })
+    let (vm, agent) =
+        boot_vm_with_target_disk(driver, name, logger, artifacts, result_disk).await?;
+
+    let shell = agent.windows_shell();
+
+    // Create the driver directory on the target disk.
+    cmd!(shell, "cmd.exe /c mkdir E:\\drivers").run().await?;
+
+    // Copy NetKVM driver files to the target disk for offline injection.
+    for (name, data) in &driver_files {
+        agent
+            .write_file(&format!("E:\\drivers\\{name}"), data.as_slice())
+            .await?;
+    }
+
+    // Inject the NetKVM driver into the offline Windows installation on E:.
+    cmd!(shell, "dism.exe")
+        .args([
+            "/image:E:\\",
+            "/add-driver",
+            "/driver:E:\\drivers\\netkvm.inf",
+        ])
         .run()
         .await?;
 
-        let shell = agent.windows_shell();
+    copy_imc_to_target(&agent).await?;
 
-        // Create the driver directory on the target disk.
-        cmd!(shell, "cmd.exe /c mkdir E:\\drivers").run().await?;
+    // Override pipette ImagePath to use TCP transport — Windows has no
+    // virtio-vsock driver, so pipette listens on TCP instead.
+    cmd!(shell, "reg")
+        .args([
+            "add",
+            "HKLM\\TargetTemp\\ControlSet001\\Services\\pipette",
+            "/v",
+            "ImagePath",
+            "/t",
+            "REG_EXPAND_SZ",
+            "/d",
+            "D:\\pipette.exe --service --transport tcp",
+            "/f",
+        ])
+        .run()
+        .await?;
 
-        // Copy NetKVM driver files to the target disk for offline injection.
-        for (name, data) in &driver_files {
-            agent
-                .write_file(&format!("E:\\drivers\\{name}"), data.as_slice())
-                .await?;
-        }
+    // Add a Windows Firewall rule to allow inbound TCP on the pipette
+    // port. Without this, the firewall blocks the consomme port forward
+    // connection.
+    let firewall_rule = format!(
+        "v2.10|Action=Allow|Active=TRUE|Dir=In|Protocol=6|LPort={}|Name=Pipette TCP|",
+        PIPETTE_PORT
+    );
+    cmd!(shell, "reg")
+        .args([
+            "add",
+            "HKLM\\TargetTemp\\ControlSet001\\Services\\SharedAccess\\Parameters\\FirewallPolicy\\FirewallRules",
+            "/v",
+            "pipette-tcp-in",
+            "/t",
+            "REG_SZ",
+            "/d",
+            &firewall_rule,
+            "/f",
+        ])
+        .run()
+        .await?;
 
-        // Inject the NetKVM driver into the offline Windows installation on E:.
-        cmd!(shell, "dism.exe")
-            .args([
-                "/image:E:\\",
-                "/add-driver",
-                "/driver:E:\\drivers\\netkvm.inf",
-            ])
-            .run()
-            .await?;
+    cmd!(shell, "reg")
+        .args(["unload", "HKLM\\TargetTemp"])
+        .run()
+        .await?;
 
-        // Reuse the IMC hive from petri/guest-bootstrap to configure pipette.
-        // No need to unload IMCTemp later—the VM is powered off after prep.
-        agent
-            .write_file(
-                "C:\\imc.hiv",
-                include_bytes!("../../../petri/guest-bootstrap/imc.hiv").as_slice(),
-            )
-            .await?;
+    agent.power_off().await?;
+    vm.wait_for_clean_teardown().await?;
 
-        cmd!(shell, "reg")
-            .args(["load", "HKLM\\IMCTemp", "C:\\imc.hiv"])
-            .run()
-            .await?;
+    std::mem::forget(drop_guard);
+    tracing::info!("No-vmbus prep steps completed successfully.");
 
-        cmd!(shell, "reg")
-            .args([
-                "load",
-                "HKLM\\TargetTemp",
-                "E:\\Windows\\System32\\config\\SYSTEM",
-            ])
-            .run()
-            .await?;
+    Ok(())
+}
 
-        // Copy IMC keys (including pipette service registration) to the target.
-        cmd!(shell, "reg")
-            .args([
-                "copy",
-                "HKLM\\IMCTemp\\SYSTEM\\CurrentControlSet",
-                "HKLM\\TargetTemp\\ControlSet001",
-                "/s",
-                "/f",
-            ])
-            .run()
-            .await?;
-
-        // Override pipette ImagePath to use TCP transport — Windows has no
-        // virtio-vsock driver, so pipette listens on TCP instead.
-        cmd!(shell, "reg")
-            .args([
-                "add",
-                "HKLM\\TargetTemp\\ControlSet001\\Services\\pipette",
-                "/v",
-                "ImagePath",
-                "/t",
-                "REG_EXPAND_SZ",
-                "/d",
-                "D:\\pipette.exe --service --transport tcp",
-                "/f",
-            ])
-            .run()
-            .await?;
-
-        // Add a Windows Firewall rule to allow inbound TCP on the pipette
-        // port. Without this, the firewall blocks the consomme port forward
-        // connection.
-        let firewall_rule = format!(
-            "v2.10|Action=Allow|Active=TRUE|Dir=In|Protocol=6|LPort={}|Name=Pipette TCP|",
-            PIPETTE_PORT
-        );
-        cmd!(shell, "reg")
-            .args([
-                "add",
-                "HKLM\\TargetTemp\\ControlSet001\\Services\\SharedAccess\\Parameters\\FirewallPolicy\\FirewallRules",
-                "/v",
-                "pipette-tcp-in",
-                "/t",
-                "REG_SZ",
-                "/d",
-                &firewall_rule,
-                "/f",
-            ])
-            .run()
-            .await?;
-
-        cmd!(shell, "reg")
-            .args(["unload", "HKLM\\TargetTemp"])
-            .run()
-            .await?;
-
-        agent.power_off().await?;
-        vm.wait_for_clean_teardown().await?;
-
-        std::mem::forget(drop_guard);
-        tracing::info!("No-vmbus prep steps completed successfully.");
-
-        Ok(())
+/// Boot a prep VM with a target disk attached as a second SCSI controller.
+///
+/// The target disk is exposed to the guest as drive E:. Returns the running
+/// VM and pipette agent.
+async fn boot_vm_with_target_disk(
+    driver: &pal_async::DefaultDriver,
+    name: &str,
+    logger: &PetriLogSource,
+    artifacts: PetriVmArtifacts<OpenVmmPetriBackend>,
+    target_disk: vm_resource::Resource<vm_resource::kind::DiskHandleKind>,
+) -> anyhow::Result<(petri::PetriVm<OpenVmmPetriBackend>, PipetteClient)> {
+    PetriVmBuilder::new(
+        PetriTestParams {
+            test_name: name,
+            logger,
+            // FUTURE: To properly support post_test_hooks we'd need to catch panics
+            // and early failure returns. Not worth it for this simple prep step tool.
+            post_test_hooks: &mut vec![],
+        },
+        artifacts,
+        driver,
+    )?
+    .modify_backend(|v| {
+        v.with_custom_config(|c| {
+            c.vmbus_devices.push((
+                openvmm_defs::config::DeviceVtl::Vtl0,
+                storvsp_resources::ScsiControllerHandle {
+                    instance_id: guid::guid!("766e96f8-2ceb-437e-afe3-a93169e48aff"),
+                    max_sub_channel_count: 1,
+                    io_queue_depth: None,
+                    devices: vec![storvsp_resources::ScsiDeviceAndPath {
+                        path: storvsp_resources::ScsiPath {
+                            path: 0,
+                            target: 0,
+                            lun: 0,
+                        },
+                        device: scsidisk_resources::SimpleScsiDiskHandle {
+                            read_only: false,
+                            parameters: Default::default(),
+                            disk: target_disk,
+                        }
+                        .into_resource(),
+                    }],
+                    requests: None,
+                    poll_mode_queue_depth: None,
+                }
+                .into_resource(),
+            ))
+        })
     })
+    .run()
+    .await
+}
+
+/// Copy the IMC hive's pipette service registration into the target disk's
+/// SYSTEM hive.
+///
+/// Loads the IMC hive and the target's SYSTEM hive, then copies
+/// `CurrentControlSet` into `ControlSet001`. Leaves `HKLM\TargetTemp`
+/// loaded so the caller can make further modifications before unloading.
+async fn copy_imc_to_target(agent: &PipetteClient) -> anyhow::Result<()> {
+    // Reuse the IMC hive from petri/guest-bootstrap to configure pipette.
+    // This ensures we stay in sync with any changes in petri.
+    agent
+        .write_file(
+            "C:\\imc.hiv",
+            include_bytes!("../../../petri/guest-bootstrap/imc.hiv").as_slice(),
+        )
+        .await?;
+
+    // No need to unload IMCTemp — the VM is powered off after prep.
+    let shell = agent.windows_shell();
+    cmd!(shell, "reg")
+        .args(["load", "HKLM\\IMCTemp", "C:\\imc.hiv"])
+        .run()
+        .await?;
+
+    cmd!(shell, "reg")
+        .args([
+            "load",
+            "HKLM\\TargetTemp",
+            "E:\\Windows\\System32\\config\\SYSTEM",
+        ])
+        .run()
+        .await?;
+
+    // Copy the keys over. Until a machine boots it doesn't have a
+    // 'CurrentControlSet', so we copy to 'ControlSet001' instead.
+    cmd!(shell, "reg")
+        .args([
+            "copy",
+            "HKLM\\IMCTemp\\SYSTEM\\CurrentControlSet",
+            "HKLM\\TargetTemp\\ControlSet001",
+            "/s",
+            "/f",
+        ])
+        .run()
+        .await?;
+
+    Ok(())
 }
 
 fn build_with_artifacts<R>(

--- a/vmm_tests/prep_steps/src/main.rs
+++ b/vmm_tests/prep_steps/src/main.rs
@@ -372,6 +372,7 @@ fn run_no_vmbus(
             .await?;
 
         // Reuse the IMC hive from petri/guest-bootstrap to configure pipette.
+        // No need to unload IMCTemp later—the VM is powered off after prep.
         agent
             .write_file(
                 "C:\\imc.hiv",

--- a/vmm_tests/prep_steps/src/main.rs
+++ b/vmm_tests/prep_steps/src/main.rs
@@ -27,14 +27,28 @@ use petri::UefiGuest;
 use petri::openvmm::OpenVmmPetriBackend;
 use petri::pipette::cmd;
 use petri_artifacts_common::tags::MachineArch;
+use pipette_protocol::PIPETTE_PORT;
 use vm_resource::IntoResource;
 
 fn main() -> anyhow::Result<()> {
-    let name = "prep_steps";
-    let (logger, artifacts, source_disk) = build(name)?;
-    let r = run(name, &logger, artifacts, source_disk);
-    logger.log_test_result(name, &r, false);
-    r
+    let step = std::env::args().nth(1).unwrap_or_default();
+    match step.as_str() {
+        "" | "standard" => {
+            let name = "prep_steps";
+            let (logger, artifacts, source_disk) = build(name)?;
+            let r = run(name, &logger, artifacts, source_disk);
+            logger.log_test_result(name, &r, false);
+            r
+        }
+        "no-vmbus" => {
+            let name = "prep_steps_no_vmbus";
+            let (logger, artifacts, source_disk, virtio_win) = build_no_vmbus(name)?;
+            let r = run_no_vmbus(name, &logger, artifacts, source_disk, virtio_win);
+            logger.log_test_result(name, &r, false);
+            r
+        }
+        other => anyhow::bail!("unknown prep step: {other:?} (expected 'standard' or 'no-vmbus')"),
+    }
 }
 
 fn build(
@@ -81,37 +95,13 @@ fn run(
     tracing::info!("Running VMM test prep steps");
 
     let source_disk = source_disk.get();
-    // FUTURE: This file path should be obtainable from the artifact infrstructure.
-    // For now the logic of getting a prepped image filename from its source is
-    // duplicated.
-    let result_disk = source_disk.with_file_name(
-        source_disk
-            .file_name()
-            .unwrap()
-            .to_string_lossy()
-            .replace(".vhd", "-prepped.vhd"),
-    );
-    if result_disk.exists() {
-        if std::env::var("PETRI_REUSE_PREPPED_VHDS")
-            .ok()
-            .is_some_and(|v| v.eq_ignore_ascii_case("true") || v == "1")
-        {
-            tracing::info!("Result disk already exists, skipping...");
-            return Ok(());
-        } else {
-            tracing::warn!("Result disk already exists, recreating it.");
-        }
-    } else {
-        tracing::info!("Copying source disk to result disk.");
-    }
-    // Create a drop guard so that if anything goes wrong anywhere the incomplete
-    // result disk is deleted.
-    let drop_guard = DeleteFileOnDrop(result_disk.clone());
-    std::fs::copy(source_disk, &result_disk)?;
-    tracing::info!("Copied source disk successfully.");
+    let Some((result_disk_path, drop_guard)) = prepare_result_disk(source_disk, "-prepped.vhd")?
+    else {
+        return Ok(());
+    };
     let result_disk = DefaultPool::run_with(async |_driver| {
         openvmm_helpers::disk::open_disk_type(
-            &result_disk,
+            &result_disk_path,
             openvmm_helpers::disk::OpenDiskOptions {
                 read_only: false,
                 direct: false,
@@ -222,6 +212,253 @@ fn run(
     })
 }
 
+fn build_no_vmbus(
+    name: &str,
+) -> anyhow::Result<(
+    PetriLogSource,
+    PetriVmArtifacts<OpenVmmPetriBackend>,
+    ResolvedArtifact,
+    ResolvedArtifact,
+)> {
+    // Use WS2022 as both the boot VM and the source disk to prep.
+    let (artifacts, source_disk, output_dir, virtio_win) = build_with_artifacts(
+        name,
+        |resolver| {
+            let artifacts = PetriVmArtifacts::<OpenVmmPetriBackend>::new(
+            &resolver,
+            Firmware::uefi(
+                &resolver,
+                MachineArch::X86_64,
+                UefiGuest::Vhd(BootImageConfig::from_vhd(
+                    resolver.require_source(petri_artifacts_vmm_test::artifacts::test_vhd::GEN2_WINDOWS_DATA_CENTER_CORE2022_X64, petri::RemoteAccess::Allow),
+                )),
+            ),
+            MachineArch::X86_64,
+            true,
+        )
+        .unwrap();
+            let source_disk = resolver.require(
+            petri_artifacts_vmm_test::artifacts::test_vhd::GEN2_WINDOWS_DATA_CENTER_CORE2022_X64,
+        );
+            let output_dir =
+                resolver.require(petri_artifacts_common::artifacts::TEST_LOG_DIRECTORY);
+            let virtio_win = resolver
+                .require(petri_artifacts_vmm_test::artifacts::virtio_win::VIRTIO_WIN_DRIVERS);
+            (artifacts, source_disk, output_dir, virtio_win)
+        },
+    )?;
+
+    let output_dir = output_dir.get();
+    let logger = petri::try_init_tracing(output_dir, tracing::level_filters::LevelFilter::DEBUG)?;
+    Ok((logger, artifacts, source_disk.erase(), virtio_win.erase()))
+}
+
+fn run_no_vmbus(
+    name: &str,
+    logger: &PetriLogSource,
+    artifacts: PetriVmArtifacts<OpenVmmPetriBackend>,
+    source_disk: ResolvedArtifact,
+    virtio_win: ResolvedArtifact,
+) -> anyhow::Result<()> {
+    use anyhow::Context;
+
+    tracing::info!("Running no-vmbus prep steps");
+
+    let source_disk = source_disk.get();
+    let Some((result_disk_path, drop_guard)) =
+        prepare_result_disk(source_disk, "-no-vmbus-prepped.vhd")?
+    else {
+        return Ok(());
+    };
+
+    // The target disk is a copy of the boot disk, so it has the same GPT disk
+    // and partition GUIDs. Windows will shadow the duplicate and hide its
+    // volumes. Change the disk GUID directly in the VHD file.
+    change_gpt_disk_guid(&result_disk_path)?;
+    tracing::info!("Changed target disk GUID to avoid collision with boot disk.");
+
+    // Read NetKVM driver files from the virtio-win artifact.
+    let driver_dir = virtio_win.get().join("NetKVM/2k22/amd64");
+    const NETKVM_FILES: &[&str] = &[
+        "netkvm.cat",
+        "netkvm.inf",
+        "netkvm.sys",
+        "netkvmco.exe",
+        "netkvmp.exe",
+    ];
+    let driver_files: Vec<(&str, Vec<u8>)> = NETKVM_FILES
+        .iter()
+        .map(|name| {
+            let path = driver_dir.join(name);
+            let data = std::fs::read(&path).with_context(|| {
+                format!("failed to read NetKVM driver file: {}", path.display())
+            })?;
+            Ok((*name, data))
+        })
+        .collect::<anyhow::Result<_>>()?;
+
+    let result_disk = DefaultPool::run_with(async |_driver| {
+        openvmm_helpers::disk::open_disk_type(
+            &result_disk_path,
+            openvmm_helpers::disk::OpenDiskOptions {
+                read_only: false,
+                direct: false,
+            },
+        )
+        .await
+    })?;
+
+    DefaultPool::run_with(async move |driver| {
+        let (vm, agent) = PetriVmBuilder::new(
+            PetriTestParams {
+                test_name: name,
+                logger,
+                post_test_hooks: &mut vec![],
+            },
+            artifacts,
+            &driver,
+        )?
+        .modify_backend(|v| {
+            v.with_custom_config(|c| {
+                c.vmbus_devices.push((
+                    openvmm_defs::config::DeviceVtl::Vtl0,
+                    storvsp_resources::ScsiControllerHandle {
+                        instance_id: guid::guid!("766e96f8-2ceb-437e-afe3-a93169e48aff"),
+                        max_sub_channel_count: 1,
+                        io_queue_depth: None,
+                        devices: vec![storvsp_resources::ScsiDeviceAndPath {
+                            path: storvsp_resources::ScsiPath {
+                                path: 0,
+                                target: 0,
+                                lun: 0,
+                            },
+                            device: scsidisk_resources::SimpleScsiDiskHandle {
+                                read_only: false,
+                                parameters: Default::default(),
+                                disk: result_disk,
+                            }
+                            .into_resource(),
+                        }],
+                        requests: None,
+                        poll_mode_queue_depth: None,
+                    }
+                    .into_resource(),
+                ))
+            })
+        })
+        .run()
+        .await?;
+
+        let shell = agent.windows_shell();
+
+        // Create the driver directory on the target disk.
+        cmd!(shell, "cmd.exe /c mkdir E:\\drivers").run().await?;
+
+        // Copy NetKVM driver files to the target disk for offline injection.
+        for (name, data) in &driver_files {
+            agent
+                .write_file(&format!("E:\\drivers\\{name}"), data.as_slice())
+                .await?;
+        }
+
+        // Inject the NetKVM driver into the offline Windows installation on E:.
+        cmd!(shell, "dism.exe")
+            .args([
+                "/image:E:\\",
+                "/add-driver",
+                "/driver:E:\\drivers\\netkvm.inf",
+            ])
+            .run()
+            .await?;
+
+        // Reuse the IMC hive from petri/guest-bootstrap to configure pipette.
+        agent
+            .write_file(
+                "C:\\imc.hiv",
+                include_bytes!("../../../petri/guest-bootstrap/imc.hiv").as_slice(),
+            )
+            .await?;
+
+        cmd!(shell, "reg")
+            .args(["load", "HKLM\\IMCTemp", "C:\\imc.hiv"])
+            .run()
+            .await?;
+
+        cmd!(shell, "reg")
+            .args([
+                "load",
+                "HKLM\\TargetTemp",
+                "E:\\Windows\\System32\\config\\SYSTEM",
+            ])
+            .run()
+            .await?;
+
+        // Copy IMC keys (including pipette service registration) to the target.
+        cmd!(shell, "reg")
+            .args([
+                "copy",
+                "HKLM\\IMCTemp\\SYSTEM\\CurrentControlSet",
+                "HKLM\\TargetTemp\\ControlSet001",
+                "/s",
+                "/f",
+            ])
+            .run()
+            .await?;
+
+        // Override pipette ImagePath to use TCP transport — Windows has no
+        // virtio-vsock driver, so pipette listens on TCP instead.
+        cmd!(shell, "reg")
+            .args([
+                "add",
+                "HKLM\\TargetTemp\\ControlSet001\\Services\\pipette",
+                "/v",
+                "ImagePath",
+                "/t",
+                "REG_EXPAND_SZ",
+                "/d",
+                "D:\\pipette.exe --service --transport tcp",
+                "/f",
+            ])
+            .run()
+            .await?;
+
+        // Add a Windows Firewall rule to allow inbound TCP on the pipette
+        // port. Without this, the firewall blocks the consomme port forward
+        // connection.
+        let firewall_rule = format!(
+            "v2.10|Action=Allow|Active=TRUE|Dir=In|Protocol=6|LPort={}|Name=Pipette TCP|",
+            PIPETTE_PORT
+        );
+        cmd!(shell, "reg")
+            .args([
+                "add",
+                "HKLM\\TargetTemp\\ControlSet001\\Services\\SharedAccess\\Parameters\\FirewallPolicy\\FirewallRules",
+                "/v",
+                "pipette-tcp-in",
+                "/t",
+                "REG_SZ",
+                "/d",
+                &firewall_rule,
+                "/f",
+            ])
+            .run()
+            .await?;
+
+        cmd!(shell, "reg")
+            .args(["unload", "HKLM\\TargetTemp"])
+            .run()
+            .await?;
+
+        agent.power_off().await?;
+        vm.wait_for_clean_teardown().await?;
+
+        std::mem::forget(drop_guard);
+        tracing::info!("No-vmbus prep steps completed successfully.");
+
+        Ok(())
+    })
+}
+
 fn build_with_artifacts<R>(
     name: &str,
     mut f: impl FnMut(ArtifactResolver<'_>) -> R,
@@ -236,6 +473,41 @@ fn build_with_artifacts<R>(
     Ok(f(ArtifactResolver::resolver(&artifacts)))
 }
 
+/// Copy a source VHD to a result disk with the given suffix, handling reuse.
+///
+/// Returns `None` if the result disk already exists and `PETRI_REUSE_PREPPED_VHDS`
+/// is set. Otherwise returns the result path and a drop guard that deletes the
+/// file on failure (caller must `std::mem::forget` the guard on success).
+fn prepare_result_disk(
+    source_disk: &std::path::Path,
+    suffix: &str,
+) -> anyhow::Result<Option<(std::path::PathBuf, DeleteFileOnDrop)>> {
+    let result_disk = source_disk.with_file_name(
+        source_disk
+            .file_name()
+            .unwrap()
+            .to_string_lossy()
+            .replace(".vhd", suffix),
+    );
+    if result_disk.exists() {
+        if std::env::var("PETRI_REUSE_PREPPED_VHDS")
+            .ok()
+            .is_some_and(|v| v.eq_ignore_ascii_case("true") || v == "1")
+        {
+            tracing::info!("Result disk already exists, skipping...");
+            return Ok(None);
+        } else {
+            tracing::warn!("Result disk already exists, recreating it.");
+        }
+    } else {
+        tracing::info!("Copying source disk to result disk.");
+    }
+    let drop_guard = DeleteFileOnDrop(result_disk.clone());
+    std::fs::copy(source_disk, &result_disk)?;
+    tracing::info!("Copied source disk successfully.");
+    Ok(Some((result_disk, drop_guard)))
+}
+
 struct DeleteFileOnDrop(std::path::PathBuf);
 
 impl Drop for DeleteFileOnDrop {
@@ -246,4 +518,26 @@ impl Drop for DeleteFileOnDrop {
             tracing::info!("Deleted file {}", self.0.display());
         }
     }
+}
+
+/// Change the GPT disk and partition GUIDs in a fixed VHD file so that
+/// Windows doesn't treat it as a duplicate of another disk with the same
+/// GUIDs.
+fn change_gpt_disk_guid(path: &std::path::Path) -> anyhow::Result<()> {
+    use std::io::Seek;
+
+    let sector_size = 512u64;
+    let mut file = std::fs::OpenOptions::new()
+        .read(true)
+        .write(true)
+        .open(path)?;
+    let mut gpt = gptman::GPT::read_from(&mut file, sector_size)?;
+    gpt.header.disk_guid = guid::Guid::new_random().into();
+    // Also change partition GUIDs so Windows doesn't see duplicate volumes.
+    for (_, partition) in gpt.iter_mut() {
+        partition.unique_partition_guid = guid::Guid::new_random().into();
+    }
+    file.seek(std::io::SeekFrom::Start(0))?;
+    gpt.write_into(&mut file)?;
+    Ok(())
 }

--- a/vmm_tests/vmm_test_macros/src/lib.rs
+++ b/vmm_tests/vmm_test_macros/src/lib.rs
@@ -588,6 +588,15 @@ fn parse_vhd(input: ParseStream<'_>, generation: Generation) -> syn::Result<Imag
                 ::petri_artifacts_vmm_test::artifacts::test_vhd::GEN2_WINDOWS_DATA_CENTER_CORE2025_X64_PREPPED
             )),
         },
+        "windows_datacenter_core_2022_x64_no_vmbus_prepped" => match generation {
+            Generation::Gen1 => Err(Error::new(
+                word.span(),
+                "Windows Server 2022 no-vmbus prepped is not available for PCAT",
+            )),
+            Generation::Gen2 => Ok(image_info!(
+                ::petri_artifacts_vmm_test::artifacts::test_vhd::GEN2_WINDOWS_DATA_CENTER_CORE2022_X64_NO_VMBUS_PREPPED
+            )),
+        },
         "ubuntu_2404_server_x64" => Ok(image_info!(
             ::petri_artifacts_vmm_test::artifacts::test_vhd::UBUNTU_2404_SERVER_X64
         )),
@@ -751,6 +760,8 @@ fn parse_extra_deps(input: ParseStream<'_>) -> syn::Result<Vec<Path>> {
 /// - `windows_datacenter_core_2025_x64`: Windows Server Datacenter Core 2025 from the Azure Marketplace
 /// - `windows_datacenter_core_2025_x64_prepped`: Windows Server Datacenter Core 2025 from the Azure Marketplace,
 ///   pre-prepped with the pipette guest agent configured.
+/// - `windows_datacenter_core_2022_x64_no_vmbus_prepped`: Windows Server Datacenter Core 2022,
+///   pre-prepped with NetKVM driver and TCP pipette transport for no-vmbus testing.
 /// - `freebsd_13_2_x64`: FreeBSD 13.2 from the FreeBSD Project
 ///
 /// Valid aarch64 VHD options are:

--- a/vmm_tests/vmm_tests/tests/tests/multiarch/pcie.rs
+++ b/vmm_tests/vmm_tests/tests/tests/multiarch/pcie.rs
@@ -752,7 +752,10 @@ async fn boot_no_vmbus_windows(config: PetriVmBuilder<OpenVmmPetriBackend>) -> a
         .with_no_vmbus()
         .with_boot_device_type(petri::BootDeviceType::PcieNvme)
         .with_default_boot_always_attempt(true)
-        .modify_backend(|b| b.with_pcie_root_topology(1, 1, 3))
+        .modify_backend(|b| {
+            b.with_pcie_root_topology(1, 1, 2)
+                .with_tcp_pipette_nic("s0rc0rp1")
+        })
         .run()
         .await?;
 

--- a/vmm_tests/vmm_tests/tests/tests/multiarch/pcie.rs
+++ b/vmm_tests/vmm_tests/tests/tests/multiarch/pcie.rs
@@ -753,8 +753,8 @@ async fn boot_no_vmbus_windows(config: PetriVmBuilder<OpenVmmPetriBackend>) -> a
         .with_boot_device_type(petri::BootDeviceType::PcieNvme)
         .with_default_boot_always_attempt(true)
         .modify_backend(|b| {
-            b.with_pcie_root_topology(1, 1, 2)
-                .with_tcp_pipette_nic("s0rc0rp1")
+            b.with_pcie_root_topology(1, 1, 3)
+                .with_tcp_pipette_nic("s0rc0rp2")
         })
         .run()
         .await?;

--- a/vmm_tests/vmm_tests/tests/tests/multiarch/pcie.rs
+++ b/vmm_tests/vmm_tests/tests/tests/multiarch/pcie.rs
@@ -741,6 +741,26 @@ async fn verify_net_interface_count(
     Ok(())
 }
 
+/// Boot Windows with VMBus entirely disabled.
+///
+/// Uses a prepped Windows image with NetKVM pre-installed and pipette
+/// configured for TCP transport. Boots from PCIe NVMe, uses virtio-net +
+/// consomme for TCP pipette communication.
+#[openvmm_test(uefi_x64(vhd(windows_datacenter_core_2022_x64_no_vmbus_prepped)))]
+async fn boot_no_vmbus_windows(config: PetriVmBuilder<OpenVmmPetriBackend>) -> anyhow::Result<()> {
+    let (vm, agent) = config
+        .with_no_vmbus()
+        .with_boot_device_type(petri::BootDeviceType::PcieNvme)
+        .with_default_boot_always_attempt(true)
+        .modify_backend(|b| b.with_pcie_root_topology(1, 1, 3))
+        .run()
+        .await?;
+
+    agent.power_off().await?;
+    vm.wait_for_clean_teardown().await?;
+    Ok(())
+}
+
 /// Boot Windows with a virtio-net NIC on PCIe, install the NetKVM driver
 /// online via pipette, and verify the NIC gets a DHCP address from consomme.
 ///


### PR DESCRIPTION
Add a VMM test that boots Windows with VMBus entirely disabled, using PCIe NVMe for the boot disk and TCP over virtio-net + consomme for pipette communication.

This requires substantial infrastructure changes:

Pipette TCP transport: add `--transport tcp` flag to pipette so it can listen on a TCP port instead of vsock. Windows has no virtio-vsock driver, so TCP through consomme port forwarding is used instead. Rename PIPETTE_VSOCK_PORT to PIPETTE_PORT since it is now transport-agnostic.

Petri framework: add no-vmbus and TCP pipette support to the VM builder. Add wait_for_agent_tcp() to connect to pipette over TCP with retry logic. Skip IMC hive injection and shutdown IC checks for no-vmbus guests.

Prep steps: add a no-vmbus prep mode that creates a prepped Windows VHD with the NetKVM driver pre-installed via DISM offline injection, pipette configured for TCP transport via offline registry, and a firewall rule allowing inbound TCP on the pipette port. Uses gptman to change GPT disk GUIDs to avoid collisions when the boot and target disks are copies of the same image.

Flowey: split prep_steps into standard and no-vmbus variants with argument passing, add force_downloads for prep_steps VHD dependencies.