### PR TITLE
CI: Remove a use of RUSTC_BOOTSTRAP

### DIFF
--- a/ci-flowey/openvmm-pr.yaml
+++ b/ci-flowey/openvmm-pr.yaml
@@ -57,7 +57,7 @@ jobs:
     fetchTags: false
     fetchDepth: 1
     path: flowey_bootstrap
-  - bash: CARGO_INCREMENTAL=0 RUSTC_BOOTSTRAP=1 RUSTFLAGS="-Z threads=8" cargo build -p flowey_hvlite --target x86_64-unknown-linux-gnu --profile flowey-ci
+  - bash: CARGO_INCREMENTAL=0 cargo build -p flowey_hvlite --target x86_64-unknown-linux-gnu --profile flowey-ci
     workingDirectory: ../flowey_bootstrap
     displayName: Build flowey
   - bash: |
@@ -852,7 +852,7 @@ jobs:
     fetchTags: false
     fetchDepth: 1
     path: flowey_bootstrap
-  - bash: CARGO_INCREMENTAL=0 RUSTC_BOOTSTRAP=1 RUSTFLAGS="-Z threads=8" cargo build -p flowey_hvlite --target x86_64-pc-windows-msvc --profile flowey-ci
+  - bash: CARGO_INCREMENTAL=0 cargo build -p flowey_hvlite --target x86_64-pc-windows-msvc --profile flowey-ci
     workingDirectory: ../flowey_bootstrap
     displayName: Build flowey
   - bash: |
@@ -2488,7 +2488,7 @@ jobs:
     fetchTags: false
     fetchDepth: 1
     path: flowey_bootstrap
-  - bash: CARGO_INCREMENTAL=0 RUSTC_BOOTSTRAP=1 RUSTFLAGS="-Z threads=8" cargo build -p flowey_hvlite --target x86_64-pc-windows-msvc --profile flowey-ci
+  - bash: CARGO_INCREMENTAL=0 cargo build -p flowey_hvlite --target x86_64-pc-windows-msvc --profile flowey-ci
     workingDirectory: ../flowey_bootstrap
     displayName: Build flowey
   - bash: |
@@ -2767,7 +2767,7 @@ jobs:
     fetchTags: false
     fetchDepth: 1
     path: flowey_bootstrap
-  - bash: CARGO_INCREMENTAL=0 RUSTC_BOOTSTRAP=1 RUSTFLAGS="-Z threads=8" cargo build -p flowey_hvlite --target x86_64-pc-windows-msvc --profile flowey-ci
+  - bash: CARGO_INCREMENTAL=0 cargo build -p flowey_hvlite --target x86_64-pc-windows-msvc --profile flowey-ci
     workingDirectory: ../flowey_bootstrap
     displayName: Build flowey
   - bash: |
@@ -2968,7 +2968,7 @@ jobs:
     fetchTags: false
     fetchDepth: 1
     path: flowey_bootstrap
-  - bash: CARGO_INCREMENTAL=0 RUSTC_BOOTSTRAP=1 RUSTFLAGS="-Z threads=8" cargo build -p flowey_hvlite --target x86_64-pc-windows-msvc --profile flowey-ci
+  - bash: CARGO_INCREMENTAL=0 cargo build -p flowey_hvlite --target x86_64-pc-windows-msvc --profile flowey-ci
     workingDirectory: ../flowey_bootstrap
     displayName: Build flowey
   - bash: |
@@ -3242,7 +3242,7 @@ jobs:
     fetchTags: false
     fetchDepth: 1
     path: flowey_bootstrap
-  - bash: CARGO_INCREMENTAL=0 RUSTC_BOOTSTRAP=1 RUSTFLAGS="-Z threads=8" cargo build -p flowey_hvlite --target x86_64-pc-windows-msvc --profile flowey-ci
+  - bash: CARGO_INCREMENTAL=0 cargo build -p flowey_hvlite --target x86_64-pc-windows-msvc --profile flowey-ci
     workingDirectory: ../flowey_bootstrap
     displayName: Build flowey
   - bash: |
@@ -3730,7 +3730,7 @@ jobs:
     fetchTags: false
     fetchDepth: 1
     path: flowey_bootstrap
-  - bash: CARGO_INCREMENTAL=0 RUSTC_BOOTSTRAP=1 RUSTFLAGS="-Z threads=8" cargo build -p flowey_hvlite --target x86_64-pc-windows-msvc --profile flowey-ci
+  - bash: CARGO_INCREMENTAL=0 cargo build -p flowey_hvlite --target x86_64-pc-windows-msvc --profile flowey-ci
     workingDirectory: ../flowey_bootstrap
     displayName: Build flowey
   - bash: |
@@ -4959,7 +4959,7 @@ jobs:
     fetchTags: false
     fetchDepth: 1
     path: flowey_bootstrap
-  - bash: CARGO_INCREMENTAL=0 RUSTC_BOOTSTRAP=1 RUSTFLAGS="-Z threads=8" cargo build -p flowey_hvlite --target x86_64-pc-windows-msvc --profile flowey-ci
+  - bash: CARGO_INCREMENTAL=0 cargo build -p flowey_hvlite --target x86_64-pc-windows-msvc --profile flowey-ci
     workingDirectory: ../flowey_bootstrap
     displayName: Build flowey
   - bash: |

--- a/flowey/flowey_hvlite/src/pipelines_shared/ado_flowey_bootstrap_template.yml
+++ b/flowey/flowey_hvlite/src/pipelines_shared/ado_flowey_bootstrap_template.yml
@@ -45,9 +45,7 @@
   path: flowey_bootstrap
 
 # - CARGO_INCREMENTAL=0 - no need to waste time on incremental artifacts in CI
-# - RUSTC_BOOTSTRAP=1 + RUSTFLAGS="-Z threads=8" - use of the unstable parallel
-#   frontend to go f a s t
-- bash: CARGO_INCREMENTAL=0 RUSTC_BOOTSTRAP=1 RUSTFLAGS="-Z threads=8" cargo build -p {{FLOWEY_CRATE}} --target {{FLOWEY_TARGET}} --profile flowey-ci
+- bash: CARGO_INCREMENTAL=0 cargo build -p {{FLOWEY_CRATE}} --target {{FLOWEY_TARGET}} --profile flowey-ci
   workingDirectory: ../flowey_bootstrap
   displayName: Build flowey
 


### PR DESCRIPTION
RUSTC_BOOTSTRAP is bad, and we should be avoiding using it whenever possible. There are a few places where we need it for functionality, this is not one of them. And honestly the perf improvement isn't even that large (seconds).