### PR TITLE
CI: Restrict bootstrap to just the crates it needs

### DIFF
--- a/flowey/flowey_lib_hvlite/src/build_openhcl_boot.rs
+++ b/flowey/flowey_lib_hvlite/src/build_openhcl_boot.rs
@@ -90,7 +90,7 @@ impl FlowNode for Node {
                 target,
                 no_split_dbg_info: false,
                 extra_env: Some(ReadVar::from_static(
-                    [("RUSTC_BOOTSTRAP".to_string(), "1".to_string())]
+                    [("RUSTC_BOOTSTRAP".to_string(), "minimal_rt".to_string())]
                         .into_iter()
                         .collect(),
                 )),

--- a/flowey/flowey_lib_hvlite/src/build_sidecar.rs
+++ b/flowey/flowey_lib_hvlite/src/build_sidecar.rs
@@ -81,7 +81,7 @@ impl FlowNode for Node {
                 target,
                 no_split_dbg_info: false,
                 extra_env: Some(ReadVar::from_static(
-                    [("RUSTC_BOOTSTRAP".to_string(), "1".to_string())]
+                    [("RUSTC_BOOTSTRAP".to_string(), "minimal_rt".to_string())]
                         .into_iter()
                         .collect(),
                 )),

--- a/flowey/flowey_lib_hvlite/src/build_tmks.rs
+++ b/flowey/flowey_lib_hvlite/src/build_tmks.rs
@@ -69,7 +69,7 @@ impl FlowNode for Node {
                 target,
                 no_split_dbg_info: false,
                 extra_env: Some(ReadVar::from_static(
-                    [("RUSTC_BOOTSTRAP".to_string(), "1".to_string())]
+                    [("RUSTC_BOOTSTRAP".to_string(), "minimal_rt".to_string())]
                         .into_iter()
                         .collect(),
                 )),

--- a/vmm_tests/petri_artifact_resolver_openvmm_known_paths/src/lib.rs
+++ b/vmm_tests/petri_artifact_resolver_openvmm_known_paths/src/lib.rs
@@ -436,7 +436,7 @@ fn simple_tmk_path(arch: MachineArch) -> anyhow::Result<PathBuf> {
         MissingCommand::Custom {
             description: "simple_tmk",
             cmd: &format!(
-                "RUSTC_BOOTSTRAP=1 cargo build -p simple_tmk --config openhcl/minimal_rt/{arch_str}-config.toml"
+                "RUSTC_BOOTSTRAP=\"minimal_rt\" cargo build -p simple_tmk --config openhcl/minimal_rt/{arch_str}-config.toml"
             ),
         },
     )


### PR DESCRIPTION
RUSTC_BOOTSTRAP supports being enabled globally by setting its value to '1', but it also supports being enabled just for specific crates by settings its value to their names. Make use of this in CI to reduce our blast zone of this ugly escape hatch.