### PR TITLE
virt_mshv_vtl: Fix an mshv x64 AP startup race condition

### DIFF
--- a/openhcl/virt_mshv_vtl/src/processor/mshv/x64.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/mshv/x64.rs
@@ -89,8 +89,11 @@ pub struct HypervisorBackedX86 {
     #[inspect(hex, with = "|&x| u64::from(x)")]
     pub(super) next_deliverability_notifications: HvDeliverabilityNotificationsRegister,
     stats: ProcessorStatsX86,
-    /// Send an INIT to VTL0 before running the VP, to simulate setting startup
-    /// suspend. Newer hypervisors allow setting startup suspend explicitly.
+    /// Fallback for hypervisors that don't support setting the startup suspend
+    /// state explicitly via the internal activity register: send an INIT to
+    /// VTL0 before running the VP to simulate setting startup suspend. Prefer
+    /// the synchronous register write where possible; see `init` and
+    /// `set_vtl0_startup_suspend`.
     deferred_init: bool,
 }
 
@@ -183,10 +186,29 @@ impl BackingPrivate for HypervisorBackedX86 {
     }
 
     fn init(this: &mut UhProcessor<'_, Self>) {
-        // The hypervisor initializes startup suspend to false. Set it to the
-        // architectural default.
+        // The hypervisor initializes startup suspend to false. Application
+        // processors must instead come up in the wait-for-SIPI state, so set
+        // the architectural default of startup suspend for them.
+        //
+        // Prefer setting the startup suspend state synchronously by writing the
+        // internal activity register directly. The alternative--sending a
+        // deferred INIT (see `pre_run_vp`)--is asynchronous and races against
+        // the guest's own INIT-SIPI-SIPI sequence: if the hypervisor delivers
+        // the deferred INIT after the guest has already sent a SIPI, it resets
+        // the AP and discards the applied SIPI vector, stranding the VP in the
+        // wait-for-SIPI state. Fall back to the deferred INIT only on
+        // hypervisors that don't support setting the register directly.
         if !this.vp_index().is_bsp() {
-            this.backing.deferred_init = true;
+            this.backing.deferred_init = match this.set_vtl0_startup_suspend(true) {
+                Ok(()) => false,
+                Err(err) => {
+                    tracing::warn!(
+                        error = &err as &dyn std::error::Error,
+                        "unable to set internal activity register, falling back to deferred init"
+                    );
+                    true
+                }
+            };
         }
     }
 


### PR DESCRIPTION
# Summary
Fixes an intermittent guest SMP bring-up hang on non-isolated x64 OpenHCL VMs, where application processors could get stranded in the wait-for-SIPI state early in boot. Observed as a flaky timeout: the guest hangs ~10s in with most VPs stuck in wait_for_sipi, several never having executed an instruction.

# Root cause
For non-isolated VMs the hypervisor owns the VTL0 APIC and INIT/SIPI delivery, and brings APs up with startup-suspend cleared, so the paravisor must establish wait-for-SIPI itself.

On x64 cold boot OpenHCL did this asynchronously: [init()](vscode-file://vscode-app/c:/Users/stevenmalis/AppData/Local/Programs/Microsoft%20VS%20Code/6a44c352bd/resources/app/out/vs/code/electron-browser/workbench/workbench.html) set [deferred_init = true](vscode-file://vscode-app/c:/Users/stevenmalis/AppData/Local/Programs/Microsoft%20VS%20Code/6a44c352bd/resources/app/out/vs/code/electron-browser/workbench/workbench.html), and [pre_run_vp()](vscode-file://vscode-app/c:/Users/stevenmalis/AppData/Local/Programs/Microsoft%20VS%20Code/6a44c352bd/resources/app/out/vs/code/electron-browser/workbench/workbench.html) later sent a self-INIT to VTL0. That async INIT races the guest's own INIT-SIPI-SIPI. Under load, if the deferred INIT lands after the guest has already sent a SIPI, it resets the AP and discards the applied SIPI vector, stranding the VP and deadlocking the SMP rendezvous.

# Fix
Establish AP startup-suspend synchronously in [HypervisorBackedX86::init()](vscode-file://vscode-app/c:/Users/stevenmalis/AppData/Local/Programs/Microsoft%20VS%20Code/6a44c352bd/resources/app/out/vs/code/electron-browser/workbench/workbench.html) via [set_vtl0_startup_suspend(true)](vscode-file://vscode-app/c:/Users/stevenmalis/AppData/Local/Programs/Microsoft%20VS%20Code/6a44c352bd/resources/app/out/vs/code/electron-browser/workbench/workbench.html), before the VP runs. The async deferred INIT is kept only as a fallback for hypervisors that don't support the register write. This mirrors the existing arm64 [init()](vscode-file://vscode-app/c:/Users/stevenmalis/AppData/Local/Programs/Microsoft%20VS%20Code/6a44c352bd/resources/app/out/vs/code/electron-browser/workbench/workbench.html) and x64 [restore()](vscode-file://vscode-app/c:/Users/stevenmalis/AppData/Local/Programs/Microsoft%20VS%20Code/6a44c352bd/resources/app/out/vs/code/electron-browser/workbench/workbench.html) paths and closes the race on modern hypervisors.

Hopefully this will reduce test flakiness.
