### PR TITLE
deps: Update mu_msvm to v26.0.12 release

### DIFF
--- a/flowey/flowey_lib_hvlite/src/_jobs/cfg_versions.rs
+++ b/flowey/flowey_lib_hvlite/src/_jobs/cfg_versions.rs
@@ -24,7 +24,7 @@ pub const GH_CLI: &str = "2.52.0";
 pub const MDBOOK: &str = "0.4.40";
 pub const MDBOOK_ADMONISH: &str = "1.18.0";
 pub const MDBOOK_MERMAID: &str = "0.14.0";
-pub const MU_MSVM: &str = "26.0.9";
+pub const MU_MSVM: &str = "26.0.12";
 pub const NEXTEST: &str = "0.9.133";
 pub const NODEJS: &str = "24.x";
 // N.B. Kernel version numbers for dev and stable branches are not directly

--- a/nix/uefi_mu_msvm.nix
+++ b/nix/uefi_mu_msvm.nix
@@ -8,17 +8,17 @@ let
          else if system == "aarch64-linux" then "AARCH64-CLANGPDB"
          else "X64-VS2022";
   hash = {
-    "AARCH64-CLANGPDB" = "sha256-9LkUNHeK3KLoxKIe5kl3uX2BwNlmvM0qJF2aIgwef08=";
-    "X64-VS2022" = "sha256-51f/LWRfx5pg0ZjwI1FUxvqaXPO0F1A9dalFvtWDIv4=";
+    "AARCH64-CLANGPDB" = "sha256-sRw5LZMt2C9GRJL4oHgiaTgxEJDTJt2PUuAlpALzGwE=";
+    "X64-VS2022" = "sha256-zUip/3YobjlcPca40Da3qxqn0XcQeCtHGw8KAyNg/ks=";
   }.${archToolchain};
 
-in stdenv.mkDerivation {
+in stdenv.mkDerivation rec {
   pname = "uefi-mu-msvm-${archToolchain}";
   version = "26.0.12";
 
   src = fetchzip {
     url =
-      "https://github.com/microsoft/mu_msvm/releases/download/v26.0.6/RELEASE-${archToolchain}-artifacts.tar.gz";
+      "https://github.com/microsoft/mu_msvm/releases/download/v${version}/RELEASE-${archToolchain}-artifacts.tar.gz";
     stripRoot = false;
     inherit hash;
   };

--- a/nix/uefi_mu_msvm.nix
+++ b/nix/uefi_mu_msvm.nix
@@ -14,7 +14,7 @@ let
 
 in stdenv.mkDerivation {
   pname = "uefi-mu-msvm-${archToolchain}";
-  version = "26.0.6";
+  version = "26.0.12";
 
   src = fetchzip {
     url =


### PR DESCRIPTION
Full change log: https://github.com/microsoft/mu_msvm/compare/v26.0.11...v26.0.12