### PR TITLE
consomme: allow binding same port for different family

### DIFF
--- a/vm/devices/net/net_consomme/consomme/src/lib.rs
+++ b/vm/devices/net/net_consomme/consomme/src/lib.rs
@@ -47,6 +47,7 @@ use smoltcp::wire::IPV4_HEADER_LEN;
 use smoltcp::wire::Icmpv6Packet;
 use smoltcp::wire::IpAddress;
 use smoltcp::wire::IpProtocol;
+pub use smoltcp::wire::IpVersion;
 use smoltcp::wire::Ipv4Address;
 use smoltcp::wire::Ipv4Packet;
 use smoltcp::wire::Ipv6Address;
@@ -68,6 +69,32 @@ struct FourTuple {
 impl core::fmt::Display for FourTuple {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(f, "{}-{}", self.src, self.dst)
+    }
+}
+
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
+struct PortForwardKey {
+    family: IpVersion,
+    guest_port: u16,
+}
+
+impl PortForwardKey {
+    fn new(family: IpVersion, guest_port: u16) -> Self {
+        Self { family, guest_port }
+    }
+
+    fn from_socket_addr(addr: SocketAddr, guest_port: u16) -> Self {
+        let family = match addr {
+            SocketAddr::V4(_) => IpVersion::Ipv4,
+            SocketAddr::V6(_) => IpVersion::Ipv6,
+        };
+        Self::new(family, guest_port)
+    }
+}
+
+impl core::fmt::Display for PortForwardKey {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "{}:{}", self.family, self.guest_port)
     }
 }
 

--- a/vm/devices/net/net_consomme/consomme/src/tcp.rs
+++ b/vm/devices/net/net_consomme/consomme/src/tcp.rs
@@ -335,8 +335,14 @@ impl<T: Client> Access<'_, T> {
                         // the original guest port. This allows loopback to work as expected.
                         if self.inner.state.params.is_local_address(&other_addr) {
                             for (other_ft, connection) in self.inner.tcp.connections.iter() {
-                                if matches!(connection.inner.state, TcpState::Connecting | TcpState::SynReceived) && other_ft.dst.port() == key.guest_port {
-                                    if let LoopbackPortInfo::ProxyForGuestPort{sending_port, guest_port} = connection.inner.loopback_port {
+                                if matches!(connection.inner.state, TcpState::Connecting | TcpState::SynReceived)
+                                    && PortForwardKey::from_socket_addr(other_ft.dst, other_ft.dst.port()) == *key
+                                {
+                                    if let LoopbackPortInfo::ProxyForGuestPort {
+                                        sending_port,
+                                        guest_port,
+                                    } = connection.inner.loopback_port
+                                    {
                                         if sending_port == other_addr.port() {
                                             other_addr.set_port(guest_port);
                                             break;

--- a/vm/devices/net/net_consomme/consomme/src/tcp.rs
+++ b/vm/devices/net/net_consomme/consomme/src/tcp.rs
@@ -12,6 +12,8 @@ use crate::ChecksumState;
 use crate::ConsommeState;
 use crate::FourTuple;
 use crate::IpAddresses;
+use crate::IpVersion;
+use crate::PortForwardKey;
 use crate::dns_resolver::DnsResolver;
 use crate::dns_resolver::dns_tcp::DnsTcpHandler;
 use futures::AsyncRead;
@@ -65,7 +67,7 @@ pub(crate) struct Tcp {
     #[inspect(iter_by_key)]
     connections: HashMap<FourTuple, TcpConnection>,
     #[inspect(iter_by_key)]
-    listeners: HashMap<u16, TcpListener>,
+    listeners: HashMap<PortForwardKey, TcpListener>,
     #[inspect(mut)]
     connection_params: ConnectionParams,
     aggregate_stats: TcpAggregateStats,
@@ -326,14 +328,14 @@ impl<T: Client> Access<'_, T> {
         self.inner
             .tcp
             .listeners
-            .retain(|port, listener| match listener.poll_listener(cx) {
+            .retain(|key, listener| match listener.poll_listener(cx) {
                 Ok(result) => {
                     if let Some((socket, mut other_addr)) = result {
                         // If this packet was originally from the guest, update the port to match
                         // the original guest port. This allows loopback to work as expected.
                         if self.inner.state.params.is_local_address(&other_addr) {
                             for (other_ft, connection) in self.inner.tcp.connections.iter() {
-                                if matches!(connection.inner.state, TcpState::Connecting | TcpState::SynReceived) && other_ft.dst.port() == *port {
+                                if matches!(connection.inner.state, TcpState::Connecting | TcpState::SynReceived) && other_ft.dst.port() == key.guest_port {
                                     if let LoopbackPortInfo::ProxyForGuestPort{sending_port, guest_port} = connection.inner.loopback_port {
                                         if sending_port == other_addr.port() {
                                             other_addr.set_port(guest_port);
@@ -343,7 +345,7 @@ impl<T: Client> Access<'_, T> {
                                 }
                             }
                         }
-                        let Some(ft) = self.inner.state.try_ft_from_remote_address(&other_addr, *port) else {
+                        let Some(ft) = self.inner.state.try_ft_from_remote_address(&other_addr, key.guest_port) else {
                             return true;
                         };
 
@@ -541,9 +543,10 @@ impl<T: Client> Access<'_, T> {
                         // If this is directed to a local port owned by the guest, use the
                         // appropriate host port substitution.
                         let is_local_address = sender.state.params.is_local_address(&resolved_dst);
+                        let key =
+                            PortForwardKey::from_socket_addr(resolved_dst, resolved_dst.port());
                         let ft = if is_local_address
-                            && let Some(listener) =
-                                self.inner.tcp.listeners.get(&resolved_dst.port())
+                            && let Some(listener) = self.inner.tcp.listeners.get(&key)
                         {
                             FourTuple {
                                 src: sender.ft.src,
@@ -586,7 +589,9 @@ impl<T: Client> Access<'_, T> {
     /// Binds to the specified host IP and port for listening for incoming
     /// connections.
     pub fn bind_tcp_port(&mut self, socket: Socket, guest_port: u16) -> Result<(), BindError> {
-        match self.inner.tcp.listeners.entry(guest_port) {
+        let host_addr = Self::socket_local_addr(&socket)?;
+        let key = PortForwardKey::from_socket_addr(host_addr, guest_port);
+        match self.inner.tcp.listeners.entry(key) {
             hash_map::Entry::Occupied(_) => {
                 return Err(BindError::PortAlreadyBound(guest_port));
             }
@@ -598,15 +603,28 @@ impl<T: Client> Access<'_, T> {
         Ok(())
     }
 
-    /// Unbinds from the specified host port.
-    pub fn unbind_tcp_port(&mut self, port: u16) -> Result<(), BindError> {
-        match self.inner.tcp.listeners.entry(port) {
+    /// Unbinds from the specified guest port and IP family.
+    pub fn unbind_tcp_port(&mut self, family: IpVersion, port: u16) -> Result<(), BindError> {
+        match self
+            .inner
+            .tcp
+            .listeners
+            .entry(PortForwardKey::new(family, port))
+        {
             hash_map::Entry::Occupied(e) => {
                 e.remove();
                 Ok(())
             }
             hash_map::Entry::Vacant(_) => Err(BindError::PortNotBound),
         }
+    }
+
+    fn socket_local_addr(socket: &Socket) -> Result<SocketAddr, BindError> {
+        socket
+            .local_addr()
+            .map_err(BindError::Io)?
+            .as_socket()
+            .ok_or_else(|| BindError::Io(io::Error::other("socket local address is invalid")))
     }
 }
 

--- a/vm/devices/net/net_consomme/consomme/src/tcp/tests.rs
+++ b/vm/devices/net/net_consomme/consomme/src/tcp/tests.rs
@@ -7,6 +7,8 @@ use crate::ChecksumState;
 use crate::Client;
 use crate::Consomme;
 use crate::ConsommeParams;
+use crate::IpVersion;
+use crate::PortForwardKey;
 use futures::AsyncRead;
 use pal_async::DefaultDriver;
 use pal_async::socket::PolledSocket;
@@ -14,8 +16,11 @@ use parking_lot::Mutex;
 use smoltcp::wire::EthernetAddress;
 use smoltcp::wire::Ipv4Address;
 use smoltcp::wire::Ipv4Repr;
+use std::io::ErrorKind;
 use std::net::Ipv4Addr;
+use std::net::Ipv6Addr;
 use std::net::SocketAddrV4;
+use std::net::SocketAddrV6;
 use std::sync::Arc;
 
 // ── Mock client ────────────────────────────────────────────────────
@@ -584,7 +589,11 @@ async fn test_tcp_bind_port_forward(driver: DefaultDriver) {
             .expect("bind should succeed");
 
         assert!(
-            access.inner.tcp.listeners.contains_key(&guest_port),
+            access
+                .inner
+                .tcp
+                .listeners
+                .contains_key(&PortForwardKey::new(IpVersion::Ipv4, guest_port)),
             "listener should be registered"
         );
     }
@@ -744,6 +753,55 @@ async fn test_tcp_bind_duplicate_port(driver: DefaultDriver) {
     assert!(
         matches!(err, BindError::PortAlreadyBound(_)),
         "error should be PortAlreadyBound"
+    );
+}
+
+/// Test that the same guest TCP port can be bound separately for IPv4 and IPv6.
+#[pal_async::async_test]
+async fn test_tcp_bind_same_port_different_families(driver: DefaultDriver) {
+    let mut consomme = Consomme::new(ConsommeParams::new().unwrap());
+    let mut client = TestClient::new(driver);
+
+    let guest_port = 8889;
+
+    let socket_v4 = Socket::new(Domain::IPV4, Type::STREAM, None).unwrap();
+    socket_v4
+        .bind(&SocketAddrV4::new(Ipv4Addr::LOCALHOST, 0).into())
+        .unwrap();
+
+    let socket_v6 = Socket::new(Domain::IPV6, Type::STREAM, None).unwrap();
+    socket_v6.set_only_v6(true).unwrap();
+    match socket_v6.bind(&SocketAddrV6::new(Ipv6Addr::LOCALHOST, 0, 0, 0).into()) {
+        Ok(()) => {}
+        Err(err)
+            if matches!(
+                err.kind(),
+                ErrorKind::AddrNotAvailable | ErrorKind::Unsupported
+            ) =>
+        {
+            return;
+        }
+        Err(err) => panic!("IPv6 bind failed: {err}"),
+    }
+
+    let mut access = consomme.access(&mut client);
+    access
+        .bind_tcp_port(socket_v4, guest_port)
+        .expect("IPv4 bind should succeed");
+    access
+        .bind_tcp_port(socket_v6, guest_port)
+        .expect("IPv6 bind should succeed");
+
+    access
+        .unbind_tcp_port(IpVersion::Ipv4, guest_port)
+        .expect("IPv4 unbind should succeed");
+    assert!(
+        access
+            .inner
+            .tcp
+            .listeners
+            .contains_key(&PortForwardKey::new(IpVersion::Ipv6, guest_port)),
+        "IPv6 listener should remain registered"
     );
 }
 

--- a/vm/devices/net/net_consomme/consomme/src/udp.rs
+++ b/vm/devices/net/net_consomme/consomme/src/udp.rs
@@ -12,8 +12,10 @@ use crate::ChecksumState;
 use crate::ConsommeState;
 use crate::FourTuple;
 use crate::IpAddresses;
+use crate::IpVersion;
 use crate::Ipv4Addresses;
 use crate::Ipv6Addresses;
+use crate::PortForwardKey;
 use crate::dns_resolver::DnsFlow;
 use crate::dns_resolver::DnsRequest;
 use crate::dns_resolver::DnsResponse;
@@ -65,7 +67,7 @@ use crate::windows as platform;
 
 pub(crate) struct Udp {
     connections: HashMap<SocketAddr, UdpConnection>,
-    listeners: HashMap<u16, UdpListener>,
+    listeners: HashMap<PortForwardKey, UdpListener>,
     timeout: Duration,
 }
 
@@ -86,8 +88,8 @@ impl InspectMut for Udp {
             let key = addr.to_string();
             resp.field_mut(&key, conn);
         }
-        for (port, listener) in &mut self.listeners {
-            resp.field_mut(&format!("listener:{port}"), listener);
+        for (key, listener) in &mut self.listeners {
+            resp.field_mut(&format!("listener:{key}"), listener);
         }
     }
 }
@@ -352,7 +354,7 @@ impl<T: Client> Access<'_, T> {
                 }
             }
         });
-        self.inner.udp.listeners.retain(|port, listener| {
+        self.inner.udp.listeners.retain(|key, listener| {
             let socket = listener.socket.take().unwrap().into_inner();
             match PolledSocket::new(self.client.driver(), socket) {
                 Ok(socket) => {
@@ -361,7 +363,8 @@ impl<T: Client> Access<'_, T> {
                 }
                 Err(err) => {
                     tracing::warn!(
-                        guest_port = port,
+                        guest_port = key.guest_port,
+                        family = %key.family,
                         error = &err as &dyn std::error::Error,
                         "failed to update driver for udp listener"
                     );
@@ -437,7 +440,8 @@ impl<T: Client> Access<'_, T> {
         if self.inner.state.params.is_local_address(&dst_sock_addr) {
             // This packet is destined for a local address. If the port matches a listener,
             // translate it so that the connection loops back to the expected destination.
-            if let Some(listener) = self.inner.udp.listeners.get(&dst_sock_addr.port()) {
+            let key = PortForwardKey::from_socket_addr(dst_sock_addr, dst_sock_addr.port());
+            if let Some(listener) = self.inner.udp.listeners.get(&key) {
                 dst_sock_addr.set_port(listener.host_addr.port());
             }
         }
@@ -549,14 +553,15 @@ impl<T: Client> Access<'_, T> {
     /// Binds to the specified host IP and port for forwarding inbound UDP
     /// packets to the guest.
     pub fn bind_udp_port(&mut self, socket: Socket, guest_port: u16) -> Result<(), BindError> {
-        if self.inner.udp.listeners.contains_key(&guest_port) {
-            return Err(BindError::PortAlreadyBound(guest_port));
-        }
         let socket: UdpSocket = socket.into();
         let socket = PolledSocket::new(self.client.driver(), socket).map_err(BindError::Io)?;
         let host_addr = socket.get().local_addr().map_err(BindError::Io)?;
+        let key = PortForwardKey::from_socket_addr(host_addr, guest_port);
+        if self.inner.udp.listeners.contains_key(&key) {
+            return Err(BindError::PortAlreadyBound(guest_port));
+        }
         self.inner.udp.listeners.insert(
-            guest_port,
+            key,
             UdpListener {
                 socket: Some(socket),
                 host_addr,
@@ -568,8 +573,14 @@ impl<T: Client> Access<'_, T> {
     }
 
     /// Unbinds from the specified guest port.
-    pub fn unbind_udp_port(&mut self, port: u16) -> Result<(), BindError> {
-        if self.inner.udp.listeners.remove(&port).is_some() {
+    pub fn unbind_udp_port(&mut self, family: IpVersion, port: u16) -> Result<(), BindError> {
+        if self
+            .inner
+            .udp
+            .listeners
+            .remove(&PortForwardKey::new(family, port))
+            .is_some()
+        {
             Ok(())
         } else {
             Err(BindError::PortNotBound)
@@ -743,9 +754,14 @@ mod tests {
     use super::*;
     use crate::Consomme;
     use crate::ConsommeParams;
+    use crate::IpVersion;
+    use crate::PortForwardKey;
     use pal_async::DefaultDriver;
     use parking_lot::Mutex;
     use smoltcp::wire::Ipv4Address;
+    use std::io::ErrorKind;
+    use std::net::Ipv6Addr;
+    use std::net::SocketAddrV6;
     use std::sync::Arc;
 
     /// Mock test client that captures received packets
@@ -862,7 +878,11 @@ mod tests {
             .expect("bind should succeed");
 
         assert!(
-            access.inner.udp.listeners.contains_key(&guest_port),
+            access
+                .inner
+                .udp
+                .listeners
+                .contains_key(&PortForwardKey::new(IpVersion::Ipv4, guest_port)),
             "listener should be registered"
         );
 
@@ -934,6 +954,55 @@ mod tests {
         assert!(
             matches!(err, BindError::PortAlreadyBound(_)),
             "error should be PortAlreadyBound"
+        );
+    }
+
+    #[pal_async::async_test]
+    async fn test_udp_bind_same_port_different_families(driver: DefaultDriver) {
+        let driver = Arc::new(driver);
+        let mut consomme = create_consomme_with_timeout(Duration::from_secs(30));
+        let mut client = TestClient::new(driver);
+
+        let guest_port = 6667;
+
+        let socket_v4 = Socket::new(socket2::Domain::IPV4, socket2::Type::DGRAM, None).unwrap();
+        socket_v4
+            .bind(&SocketAddrV4::new(Ipv4Addr::LOCALHOST, 0).into())
+            .unwrap();
+
+        let socket_v6 = Socket::new(socket2::Domain::IPV6, socket2::Type::DGRAM, None).unwrap();
+        socket_v6.set_only_v6(true).unwrap();
+        match socket_v6.bind(&SocketAddrV6::new(Ipv6Addr::LOCALHOST, 0, 0, 0).into()) {
+            Ok(()) => {}
+            Err(err)
+                if matches!(
+                    err.kind(),
+                    ErrorKind::AddrNotAvailable | ErrorKind::Unsupported
+                ) =>
+            {
+                return;
+            }
+            Err(err) => panic!("IPv6 bind failed: {err}"),
+        }
+
+        let mut access = consomme.access(&mut client);
+        access
+            .bind_udp_port(socket_v4, guest_port)
+            .expect("IPv4 bind should succeed");
+        access
+            .bind_udp_port(socket_v6, guest_port)
+            .expect("IPv6 bind should succeed");
+
+        access
+            .unbind_udp_port(IpVersion::Ipv4, guest_port)
+            .expect("IPv4 unbind should succeed");
+        assert!(
+            access
+                .inner
+                .udp
+                .listeners
+                .contains_key(&PortForwardKey::new(IpVersion::Ipv6, guest_port)),
+            "IPv6 listener should remain registered"
         );
     }
 

--- a/vm/devices/net/net_consomme/consomme/src/udp.rs
+++ b/vm/devices/net/net_consomme/consomme/src/udp.rs
@@ -572,7 +572,7 @@ impl<T: Client> Access<'_, T> {
         Ok(())
     }
 
-    /// Unbinds from the specified guest port.
+    /// Unbinds from the specified guest port and IP family.
     pub fn unbind_udp_port(&mut self, family: IpVersion, port: u16) -> Result<(), BindError> {
         if self
             .inner

--- a/vm/devices/net/net_consomme/src/lib.rs
+++ b/vm/devices/net/net_consomme/src/lib.rs
@@ -10,6 +10,7 @@ use async_trait::async_trait;
 use consomme::ChecksumState;
 use consomme::Consomme;
 use consomme::ConsommeParams;
+pub use consomme::IpVersion;
 use inspect::Inspect;
 use inspect::InspectMut;
 use inspect_counters::Counter;
@@ -44,7 +45,7 @@ use thiserror::Error;
 /// Creates and binds a socket for the given protocol, address, and port.
 ///
 /// When `ip_addr` is `None`, binds to `0.0.0.0` (IPv4 only).
-pub fn create_bound_socket(
+pub(crate) fn create_bound_socket(
     protocol: &IpProtocol,
     ip_addr: Option<IpAddr>,
     port: u16,
@@ -54,17 +55,36 @@ pub fn create_bound_socket(
         Some(IpAddr::V6(ip)) => SocketAddr::V6(SocketAddrV6::new(ip, port, 0, 0)),
         None => SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, port)),
     };
-    let domain = match bind_addr {
-        SocketAddr::V4(_) => socket2::Domain::IPV4,
-        SocketAddr::V6(_) => socket2::Domain::IPV6,
+    let (domain, is_ipv6) = match bind_addr {
+        SocketAddr::V4(_) => (socket2::Domain::IPV4, false),
+        SocketAddr::V6(_) => (socket2::Domain::IPV6, true),
     };
     let (sock_type, sock_protocol) = match protocol {
         IpProtocol::Tcp => (socket2::Type::STREAM, socket2::Protocol::TCP),
         IpProtocol::Udp => (socket2::Type::DGRAM, socket2::Protocol::UDP),
     };
     let socket = socket2::Socket::new(domain, sock_type, Some(sock_protocol))?;
+    if is_ipv6 {
+        socket.set_only_v6(true)?;
+    }
     socket.bind(&bind_addr.into())?;
     Ok(socket)
+}
+
+fn socket_addr(socket: &socket2::Socket) -> Result<SocketAddr, consomme::BindError> {
+    socket
+        .local_addr()
+        .map_err(consomme::BindError::Io)?
+        .as_socket()
+        .ok_or_else(|| consomme::BindError::Io(std::io::Error::other("invalid socket address")))
+}
+
+fn socket_family(socket: &socket2::Socket) -> Result<IpVersion, consomme::BindError> {
+    let addr = socket_addr(socket)?;
+    Ok(match addr.ip() {
+        IpAddr::V4(_) => IpVersion::Ipv4,
+        IpAddr::V6(_) => IpVersion::Ipv6,
+    })
 }
 
 pub struct ConsommeEndpoint {
@@ -164,6 +184,8 @@ pub enum IpProtocol {
 struct PortUnbindConfig {
     /// The protocol that was forwarded.
     protocol: IpProtocol,
+    /// The IP address family that was forwarded.
+    family: IpVersion,
     /// The guest port that was forwarded.
     guest_port: u16,
 }
@@ -180,28 +202,35 @@ impl ConsommeControl {
         &self,
         protocol: IpProtocol,
         ip_addr: Option<IpAddr>,
-        port: u16,
-    ) -> Result<(), ConsommeMessageError> {
-        let socket = create_bound_socket(&protocol, ip_addr, port)
+        host_port: u16,
+        guest_port: u16,
+    ) -> Result<u16, ConsommeMessageError> {
+        let socket = create_bound_socket(&protocol, ip_addr, host_port)
             .map_err(|e| ConsommeMessageError::Bind(consomme::BindError::Io(e)))?;
-        let host_addr = socket.local_addr().ok().and_then(|a| a.as_socket());
-        tracing::info!(
-            ?protocol,
-            host_addr = %host_addr.map(|a| a.to_string()).unwrap_or_default(),
-            guest_port = %port,
-            "port forward socket created"
-        );
+        let host_addr = socket_addr(&socket).map_err(ConsommeMessageError::Bind)?;
         self.send
             .call(
                 ConsommeMessage::BindPort,
                 PortForwardConfig {
                     protocol,
                     socket,
-                    guest_port: port,
+                    guest_port,
                 },
             )
             .await
             .map_err(ConsommeMessageError::Mesh)?
+            .map(|()| {
+                let bound_host_port = host_addr.port();
+                tracing::info!(
+                    ?protocol,
+                    requested_host_port = host_port,
+                    bound_host_addr = %host_addr,
+                    bound_host_port,
+                    guest_port,
+                    "port forward bound"
+                );
+                bound_host_port
+            })
             .map_err(ConsommeMessageError::Bind)
     }
 
@@ -209,14 +238,16 @@ impl ConsommeControl {
     pub async fn unbind_port(
         &self,
         protocol: IpProtocol,
-        port: u16,
+        family: IpVersion,
+        guest_port: u16,
     ) -> Result<(), ConsommeMessageError> {
         self.send
             .call(
                 ConsommeMessage::UnbindPort,
                 PortUnbindConfig {
                     protocol,
-                    guest_port: port,
+                    family,
+                    guest_port,
                 },
             )
             .await
@@ -267,22 +298,28 @@ impl net_backend::Endpoint for ConsommeEndpoint {
             std::mem::take(&mut queue.endpoint_state.as_mut().unwrap().port_forwards);
         let bind_result: Result<Vec<_>, _> = queue.with_consomme_no_pool(|c| {
             c.refresh_driver();
-            let mut bound: Vec<(IpProtocol, u16)> = Vec::new();
+            let mut bound: Vec<(IpProtocol, IpVersion, u16)> = Vec::new();
             for fwd in port_forwards {
                 let protocol = fwd.protocol;
                 let guest_port = fwd.guest_port;
-                let result = match protocol {
-                    IpProtocol::Tcp => c.bind_tcp_port(fwd.socket, guest_port),
-                    IpProtocol::Udp => c.bind_udp_port(fwd.socket, guest_port),
+                let result = match socket_family(&fwd.socket) {
+                    Ok(family) => {
+                        let result = match protocol {
+                            IpProtocol::Tcp => c.bind_tcp_port(fwd.socket, guest_port),
+                            IpProtocol::Udp => c.bind_udp_port(fwd.socket, guest_port),
+                        };
+                        result.map(|()| (protocol, family, guest_port))
+                    }
+                    Err(err) => Err(err),
                 };
                 match result {
-                    Ok(()) => bound.push((protocol, guest_port)),
+                    Ok(bound_entry) => bound.push(bound_entry),
                     Err(err) => {
                         // Roll back successful binds before returning error.
-                        for (prev_protocol, prev_guest_port) in &bound {
-                            let _ = match prev_protocol {
-                                IpProtocol::Tcp => c.unbind_tcp_port(*prev_guest_port),
-                                IpProtocol::Udp => c.unbind_udp_port(*prev_guest_port),
+                        for (protocol, family, guest_port) in &bound {
+                            let _ = match protocol {
+                                IpProtocol::Tcp => c.unbind_tcp_port(*family, *guest_port),
+                                IpProtocol::Udp => c.unbind_udp_port(*family, *guest_port),
                             };
                         }
                         return Err(err);
@@ -418,8 +455,12 @@ fn process_message(
         }
         ConsommeMessage::UnbindPort(rpc) => {
             rpc.handle_sync(|unbind_message| match unbind_message.protocol {
-                IpProtocol::Tcp => consomme.unbind_tcp_port(unbind_message.guest_port),
-                IpProtocol::Udp => consomme.unbind_udp_port(unbind_message.guest_port),
+                IpProtocol::Tcp => {
+                    consomme.unbind_tcp_port(unbind_message.family, unbind_message.guest_port)
+                }
+                IpProtocol::Udp => {
+                    consomme.unbind_udp_port(unbind_message.family, unbind_message.guest_port)
+                }
             });
         }
         ConsommeMessage::UpdateState(rpc) => {

--- a/vm/devices/net/net_consomme/src/lib.rs
+++ b/vm/devices/net/net_consomme/src/lib.rs
@@ -234,7 +234,7 @@ impl ConsommeControl {
             .map_err(ConsommeMessageError::Bind)
     }
 
-    /// Unbinds a port previously reserved with bind_port()
+    /// Unbinds a port and IP family previously reserved with bind_port().
     pub async fn unbind_port(
         &self,
         protocol: IpProtocol,


### PR DESCRIPTION
Allow port forwarding of the same port to both Ipv4 and Ipv6 addresses as this is allowed by normal sockets, and it also means we don't have to deal with IpV4 traffic over an Ipv6 socket.