### PR TITLE
virt: add new isolation types and page data for loading isolated partitions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9845,6 +9845,7 @@ dependencies = [
  "loader",
  "memory_range",
  "range_map_vec",
+ "test_with_tracing",
  "tracing",
  "virt",
  "vm_topology",

--- a/openhcl/underhill_core/src/wrapped_partition.rs
+++ b/openhcl/underhill_core/src/wrapped_partition.rs
@@ -4,9 +4,7 @@
 use async_trait::async_trait;
 use hvdef::Vtl;
 use inspect::InspectMut;
-use memory_range::MemoryRange;
 use std::sync::Arc;
-use virt::PageVisibility;
 use virt_mshv_vtl::UhPartition;
 use vmcore::save_restore::NoSavedState;
 use vmcore::save_restore::RestoreError;
@@ -29,10 +27,7 @@ impl VmPartition for WrappedPartition {
         unreachable!()
     }
 
-    fn accept_initial_pages(
-        &mut self,
-        _pages: Vec<(MemoryRange, PageVisibility)>,
-    ) -> anyhow::Result<()> {
+    fn accept_initial_pages(&mut self, _pages: Vec<virt::InitialPageImport>) -> anyhow::Result<()> {
         unreachable!()
     }
 }

--- a/openvmm/openvmm_core/src/partition.rs
+++ b/openvmm/openvmm_core/src/partition.rs
@@ -17,13 +17,12 @@ use guestmem::DoorbellRegistration;
 use hvdef::Vtl;
 use inspect::Inspect;
 use inspect::InspectMut;
-use memory_range::MemoryRange;
 use pci_core::msi::SignalMsi;
 use std::convert::Infallible;
 use std::sync::Arc;
 #[cfg(guest_arch = "aarch64")]
 use virt::Aarch64Partition as ArchPartition;
-use virt::PageVisibility;
+use virt::InitialPageImport;
 use virt::Partition;
 use virt::PartitionAccessState;
 use virt::PartitionCapabilities;
@@ -123,8 +122,7 @@ pub trait BasicPartitionStateAccess: 'static + Send + Sync + Inspect {
     fn restore(&self, state: VmSavedState) -> anyhow::Result<()>;
     fn reset(&self) -> anyhow::Result<()>;
     fn scrub_vtl(&self, vtl: Vtl) -> anyhow::Result<()>;
-    fn accept_initial_pages(&self, pages: Vec<(MemoryRange, PageVisibility)>)
-    -> anyhow::Result<()>;
+    fn accept_initial_pages(&self, pages: Vec<InitialPageImport>) -> anyhow::Result<()>;
     fn guest_os_id(&self) -> u64;
 }
 
@@ -160,12 +158,9 @@ impl<T: Partition + PartitionAccessState> BasicPartitionStateAccess for T {
         Ok(())
     }
 
-    fn accept_initial_pages(
-        &self,
-        pages: Vec<(MemoryRange, PageVisibility)>,
-    ) -> anyhow::Result<()> {
-        self.supports_initial_accept_pages()
-            .context("accept pages not supported")?
+    fn accept_initial_pages(&self, pages: Vec<InitialPageImport>) -> anyhow::Result<()> {
+        self.supports_initial_page_acceptance()
+            .context("initial page import finalization not supported")?
             .accept_initial_pages(&pages)?;
         Ok(())
     }
@@ -281,10 +276,7 @@ impl VmPartition for WrappedPartition {
         self.0.scrub_vtl(vtl)
     }
 
-    fn accept_initial_pages(
-        &mut self,
-        pages: Vec<(MemoryRange, PageVisibility)>,
-    ) -> anyhow::Result<()> {
+    fn accept_initial_pages(&mut self, pages: Vec<InitialPageImport>) -> anyhow::Result<()> {
         self.0.accept_initial_pages(pages)
     }
 

--- a/openvmm/openvmm_core/src/worker/dispatch.rs
+++ b/openvmm/openvmm_core/src/worker/dispatch.rs
@@ -3334,15 +3334,6 @@ impl LoadedVmInner {
             ));
         }
 
-        // Only set initial page visibility on isolated partitions.
-        if self.hypervisor_cfg.with_isolation.is_some() {
-            tracing::debug!(?initial_page_vis, "initial_page_vis");
-            self.partition_unit
-                .set_initial_page_visibility(initial_page_vis)
-                .await
-                .context("failed to set initial page visibility")?;
-        }
-
         let initial_regs = initial_regs(
             &regs,
             self.partition.caps(),
@@ -3361,6 +3352,22 @@ impl LoadedVmInner {
             )
             .await
             .context("failed to set initial register state")?;
+
+        // Only finalize initial page imports on isolated partitions.
+        //
+        // TODO: Today with SNP guests, this issues a SNP_LAUNCH_FINISH on the
+        // only supported backend KVM, so load the initial registers before
+        // finalizing the imported pages. We should revisit this in the future
+        // when KVM supports loading VMSA pages, which would probably be
+        // imported as a page, not registers, along with revisiting other
+        // isolation architectures and backends.
+        if self.hypervisor_cfg.with_isolation.is_some() {
+            tracing::debug!(?initial_page_vis, "initial_page_imports");
+            self.partition_unit
+                .accept_initial_pages(initial_page_vis)
+                .await
+                .context("failed to finalize initial page imports")?;
+        }
 
         Ok(())
     }

--- a/openvmm/openvmm_core/src/worker/vm_loaders/igvm.rs
+++ b/openvmm/openvmm_core/src/worker/vm_loaders/igvm.rs
@@ -34,7 +34,7 @@ use std::collections::HashMap;
 use std::io::Read;
 use std::io::Seek;
 use thiserror::Error;
-use virt::PageVisibility;
+use virt::InitialPageImport;
 use vm_loader::Loader;
 use vm_topology::memory::MemoryLayout;
 use vm_topology::memory::MemoryRangeWithNode;
@@ -532,13 +532,7 @@ pub struct LoadIgvmParams<'a, T: ArchTopology> {
 
 pub fn load_igvm(
     params: LoadIgvmParams<'_, vm_topology::processor::TargetTopology>,
-) -> Result<
-    (
-        Vec<loader::importer::Register>,
-        Vec<(MemoryRange, PageVisibility)>,
-    ),
-    Error,
-> {
+) -> Result<(Vec<loader::importer::Register>, Vec<InitialPageImport>), Error> {
     #[cfg(guest_arch = "x86_64")]
     {
         load_igvm_x86(params)
@@ -556,7 +550,7 @@ pub fn load_igvm(
 #[cfg_attr(not(guest_arch = "x86_64"), expect(dead_code))]
 fn load_igvm_x86(
     params: LoadIgvmParams<'_, X86Topology>,
-) -> Result<(Vec<X86Register>, Vec<(MemoryRange, PageVisibility)>), Error> {
+) -> Result<(Vec<X86Register>, Vec<InitialPageImport>), Error> {
     let LoadIgvmParams {
         igvm_file,
         gm,
@@ -1232,7 +1226,7 @@ fn load_igvm_x86(
             .map_err(Error::Loader)?;
     }
 
-    Ok(loader.initial_regs_and_accepted_ranges())
+    Ok(loader.initial_regs_and_page_imports())
 }
 
 /// Build the IGVM memory map reported to the guest, with the specified memory
@@ -1278,7 +1272,7 @@ fn build_memory_map(
 #[cfg_attr(not(guest_arch = "aarch64"), expect(dead_code))]
 fn load_igvm_aarch64(
     _params: LoadIgvmParams<'_, Aarch64Topology>,
-) -> Result<(Vec<Aarch64Register>, Vec<(MemoryRange, PageVisibility)>), Error> {
+) -> Result<(Vec<Aarch64Register>, Vec<InitialPageImport>), Error> {
     Err(Error::UnsupportedGuestArch)
 }
 

--- a/openvmm/openvmm_defs/src/config.rs
+++ b/openvmm/openvmm_defs/src/config.rs
@@ -579,12 +579,16 @@ pub struct Vtl2Config {
 #[derive(Eq, PartialEq, Debug, Copy, Clone, MeshPayload)]
 pub enum IsolationType {
     Vbs,
+    Snp,
+    Cca,
 }
 
 impl From<IsolationType> for virt::IsolationType {
     fn from(value: IsolationType) -> Self {
         match value {
             IsolationType::Vbs => Self::Vbs,
+            IsolationType::Snp => Self::Snp,
+            IsolationType::Cca => Self::Cca,
         }
     }
 }

--- a/vm/loader/igvmfilegen/src/file_loader.rs
+++ b/vm/loader/igvmfilegen/src/file_loader.rs
@@ -878,7 +878,6 @@ impl<R: IgvmLoaderRegister + GuestArch + 'static> IgvmLoader<R> {
                         IgvmPageDataType::NORMAL,
                         IgvmPageDataFlags::new().with_unmeasured(true),
                     ),
-                    BootPageAcceptance::ErrorPage => todo!(),
                     BootPageAcceptance::SecretsPage => {
                         (IgvmPageDataType::SECRETS, IgvmPageDataFlags::new())
                     }

--- a/vm/loader/src/importer.rs
+++ b/vm/loader/src/importer.rs
@@ -20,8 +20,6 @@ pub enum BootPageAcceptance {
     ExclusiveUnmeasured,
     /// The page contains hardware-specific VP context information.
     VpContext,
-    /// This page communicates error information to the host.
-    ErrorPage,
     /// This page communicates hardware-specific secret information and the page
     /// data is unmeasured.
     SecretsPage,

--- a/vmm_core/src/partition_unit.rs
+++ b/vmm_core/src/partition_unit.rs
@@ -22,7 +22,6 @@ use futures::StreamExt;
 use guestmem::GuestMemory;
 use hvdef::Vtl;
 use inspect::InspectMut;
-use memory_range::MemoryRange;
 use mesh::Receiver;
 use mesh::rpc::Rpc;
 use mesh::rpc::RpcSend;
@@ -35,8 +34,8 @@ use state_unit::UnitBuilder;
 use state_unit::UnitHandle;
 use std::sync::Arc;
 use thiserror::Error;
+use virt::InitialPageImport;
 use virt::InitialRegs;
-use virt::PageVisibility;
 #[cfg(feature = "dump")]
 use virt::VpIndex;
 use vm_topology::processor::ProcessorTopology;
@@ -62,11 +61,8 @@ pub trait VmPartition: 'static + Send + Sync + InspectMut + ProtobufSaveRestore 
     /// Scrubs the VTL state for a partition.
     fn scrub_vtl(&mut self, vtl: Vtl) -> anyhow::Result<()>;
 
-    /// Accepts pages on behalf of the loader.
-    fn accept_initial_pages(
-        &mut self,
-        pages: Vec<(MemoryRange, PageVisibility)>,
-    ) -> anyhow::Result<()>;
+    /// Finalizes initial page imports on behalf of the loader.
+    fn accept_initial_pages(&mut self, pages: Vec<InitialPageImport>) -> anyhow::Result<()>;
 
     /// Returns the guest OS ID (from `HV_X64_MSR_GUEST_OS_ID`).
     ///
@@ -128,9 +124,7 @@ impl InspectMut for PartitionUnitRunner {
 enum PartitionRequest {
     ClearHalt(Rpc<(), bool>), // TODO: remove this, and use DebugRequest::Resume
     SetInitialRegs(Rpc<(Vtl, Arc<InitialRegs>), Result<(), InitialRegError>>),
-    SetInitialPageVisibility(
-        Rpc<Vec<(MemoryRange, PageVisibility)>, Result<(), InitialVisibilityError>>,
-    ),
+    AcceptInitialPages(Rpc<Vec<InitialPageImport>, Result<(), AcceptInitialPagesError>>),
     StopVps(Rpc<(), ()>),
     StartVps,
     /// Build the partition state blob for a dump file.
@@ -179,11 +173,11 @@ pub enum InitialRegError {
     ScrubVtl(#[source] anyhow::Error),
 }
 
-/// Error returned by [`PartitionUnit::set_initial_page_visibility()`].
+/// Error returned by [`PartitionUnit::accept_initial_pages()`].
 #[derive(Debug, Error)]
-pub enum InitialVisibilityError {
-    #[error("failed to set initial page acceptance")]
-    PageAcceptance(#[source] anyhow::Error),
+pub enum AcceptInitialPagesError {
+    #[error("failed to finalize initial page imports")]
+    Finalize(#[source] anyhow::Error),
 }
 
 impl PartitionUnit {
@@ -291,12 +285,12 @@ impl PartitionUnit {
             .unwrap()
     }
 
-    pub async fn set_initial_page_visibility(
+    pub async fn accept_initial_pages(
         &mut self,
-        vis: Vec<(MemoryRange, PageVisibility)>,
-    ) -> Result<(), InitialVisibilityError> {
+        initial_pages: Vec<InitialPageImport>,
+    ) -> Result<(), AcceptInitialPagesError> {
         self.req_send
-            .call(PartitionRequest::SetInitialPageVisibility, vis)
+            .call(PartitionRequest::AcceptInitialPages, initial_pages)
             .await
             .unwrap()
     }
@@ -372,9 +366,11 @@ impl PartitionUnitRunner {
                         rpc.handle(async |(vtl, state)| self.set_initial_regs(vtl, state).await)
                             .await
                     }
-                    PartitionRequest::SetInitialPageVisibility(rpc) => {
-                        rpc.handle(async |vis| self.set_initial_page_visibility(vis).await)
-                            .await
+                    PartitionRequest::AcceptInitialPages(rpc) => {
+                        rpc.handle(async |initial_pages| {
+                            self.accept_initial_pages(initial_pages).await
+                        })
+                        .await
                     }
                     PartitionRequest::StopVps(rpc) => {
                         rpc.handle(async |()| self.stop_vps().await).await
@@ -492,15 +488,15 @@ impl PartitionUnitRunner {
         Ok(())
     }
 
-    async fn set_initial_page_visibility(
+    async fn accept_initial_pages(
         &mut self,
-        visibility: Vec<(MemoryRange, PageVisibility)>,
-    ) -> Result<(), InitialVisibilityError> {
+        initial_pages: Vec<InitialPageImport>,
+    ) -> Result<(), AcceptInitialPagesError> {
         assert!(!self.unit_started);
 
         self.partition
-            .accept_initial_pages(visibility)
-            .map_err(InitialVisibilityError::PageAcceptance)
+            .accept_initial_pages(initial_pages)
+            .map_err(AcceptInitialPagesError::Finalize)
     }
 
     fn try_start(&mut self) {

--- a/vmm_core/virt/src/generic.rs
+++ b/vmm_core/virt/src/generic.rs
@@ -171,6 +171,51 @@ pub enum PageVisibility {
     Shared,
 }
 
+/// Initial page import type for isolated partitions.
+#[derive(Eq, PartialEq, Debug, Copy, Clone, Inspect)]
+pub enum InitialPageImportType {
+    /// A measured page with exclusive guest access.
+    Normal,
+    /// An unmeasured page with exclusive guest access.
+    NormalUnmeasured,
+    /// A page shared between the guest and host.
+    Shared,
+    /// A virtual processor context page.
+    VpContext,
+    /// An SNP secrets page.
+    Secrets,
+    /// An SNP CPUID page.
+    Cpuid,
+    /// An SNP CPUID extended state page.
+    CpuidExtendedState,
+}
+
+impl InitialPageImportType {
+    /// Returns the visibility implied by this import type.
+    pub fn page_visibility(self) -> PageVisibility {
+        match self {
+            Self::Shared => PageVisibility::Shared,
+            Self::Normal
+            | Self::NormalUnmeasured
+            | Self::VpContext
+            | Self::Secrets
+            | Self::Cpuid
+            | Self::CpuidExtendedState => PageVisibility::Exclusive,
+        }
+    }
+}
+
+/// Initial page import metadata for isolated partitions.
+#[derive(Eq, PartialEq, Debug, Clone)]
+pub struct InitialPageImport {
+    /// The guest physical range being imported.
+    pub range: MemoryRange,
+    /// The hypervisor-facing import type for this range.
+    pub import_type: InitialPageImportType,
+    /// Loader-provided debug tag identifying the source of this range.
+    pub tag: String,
+}
+
 /// Prototype partition creation configuration.
 pub struct ProtoPartitionConfig<'a> {
     /// The set of VPs to create.
@@ -299,9 +344,9 @@ pub struct HvConfig {
 
 /// Methods for manipulating a VM partition.
 pub trait Partition: 'static + Hv1 + Inspect + Send + Sync {
-    /// Returns a trait object to accept pages on behalf of the guest during the
-    /// initial start import flow.
-    fn supports_initial_accept_pages(
+    /// Returns a trait object for initial page imports during the initial start
+    /// flow.
+    fn supports_initial_page_acceptance(
         &self,
     ) -> Option<&dyn AcceptInitialPages<Error = <Self as Hv1>::Error>> {
         None
@@ -388,10 +433,7 @@ pub trait AcceptInitialPages {
     /// accept pages on behalf of the guest that were set as part of the load
     /// process. The host virtstack cannot accept pages on behalf of the guest
     /// once it has started running.
-    fn accept_initial_pages(
-        &self,
-        pages: &[(MemoryRange, PageVisibility)],
-    ) -> Result<(), Self::Error>;
+    fn accept_initial_pages(&self, pages: &[InitialPageImport]) -> Result<(), Self::Error>;
 }
 
 /// Extension trait for resetting the partition.

--- a/vmm_core/virt_whp/src/lib.rs
+++ b/vmm_core/virt_whp/src/lib.rs
@@ -570,17 +570,18 @@ impl virt::ScrubVtl for WhpPartition {
 impl virt::AcceptInitialPages for WhpPartition {
     type Error = Error;
 
-    fn accept_initial_pages(&self, pages: &[(MemoryRange, PageVisibility)]) -> Result<(), Error> {
+    fn accept_initial_pages(&self, pages: &[virt::InitialPageImport]) -> Result<(), Error> {
         assert!(self.inner.isolation.is_isolated());
 
-        for (range, vis) in pages {
+        for page in pages {
             self.inner
                 .vtl0
-                .accept_pages(range, *vis)
+                .accept_pages(&page.range, page.import_type.page_visibility())
                 .map_err(Error::AcceptPages)?;
 
             if let Some(vtl2) = &self.inner.vtl2 {
-                vtl2.accept_pages(range, *vis).map_err(Error::AcceptPages)?;
+                vtl2.accept_pages(&page.range, page.import_type.page_visibility())
+                    .map_err(Error::AcceptPages)?;
             }
         }
 
@@ -603,7 +604,7 @@ impl virt::Partition for WhpPartition {
         (!self.inner.isolation.is_isolated()).then_some(self)
     }
 
-    fn supports_initial_accept_pages(
+    fn supports_initial_page_acceptance(
         &self,
     ) -> Option<&dyn virt::AcceptInitialPages<Error = <Self as virt::Hv1>::Error>> {
         self.inner.isolation.is_isolated().then_some(self)

--- a/vmm_core/vm_loader/Cargo.toml
+++ b/vmm_core/vm_loader/Cargo.toml
@@ -19,6 +19,9 @@ range_map_vec.workspace = true
 anyhow.workspace = true
 tracing.workspace = true
 
+[dev-dependencies]
+test_with_tracing.workspace = true
+
 [build-dependencies]
 build_rs_guest_arch.workspace = true
 

--- a/vmm_core/vm_loader/src/lib.rs
+++ b/vmm_core/vm_loader/src/lib.rs
@@ -22,7 +22,8 @@ use range_map_vec::RangeMap;
 use std::collections::HashMap;
 use std::fmt::Debug;
 use std::mem::Discriminant;
-use virt::PageVisibility;
+use virt::InitialPageImport;
+use virt::InitialPageImportType;
 use vm_topology::memory::MemoryLayout;
 
 pub mod initial_regs;
@@ -38,7 +39,7 @@ pub struct Loader<'a, R> {
     gm: GuestMemory,
     regs: HashMap<Discriminant<R>, R>,
     mem_layout: &'a MemoryLayout,
-    accepted_ranges: RangeMap<u64, RangeInfo>,
+    page_imports: RangeMap<u64, RangeInfo>,
     max_vtl: Vtl,
 }
 
@@ -48,7 +49,7 @@ impl<R> Loader<'_, R> {
             gm,
             regs: HashMap::new(),
             mem_layout,
-            accepted_ranges: RangeMap::new(),
+            page_imports: RangeMap::new(),
             max_vtl,
         }
     }
@@ -57,43 +58,29 @@ impl<R> Loader<'_, R> {
         self.regs.into_values().collect()
     }
 
-    pub fn initial_regs_and_accepted_ranges(
-        mut self,
-    ) -> (Vec<R>, Vec<(MemoryRange, PageVisibility)>) {
-        let regs = self.regs.into_values().collect();
-
+    pub fn initial_regs_and_page_imports(mut self) -> (Vec<R>, Vec<InitialPageImport>) {
         // Merge adjacent ranges first to help cut down on the number of entries
-        // in the initial acceptance list. Since we load from an IGVM file, most
-        // ranges are a single 4K page which can be merged for easier viewing.
-        self.accepted_ranges
+        // in the initial page import list. Since we load from an IGVM file,
+        // most ranges are a single 4K page which can be merged for easier
+        // viewing.
+        self.page_imports
             .merge_adjacent(range_map_vec::u64_is_adjacent);
 
-        let pages = self
-            .accepted_ranges
-            .into_vec()
-            .iter()
-            .map(|(start, end, info)| {
-                let range = MemoryRange::from_4k_gpn_range(*start..(*end + 1));
-                let vis = match info.acceptance {
-                    BootPageAcceptance::Exclusive => PageVisibility::Exclusive,
-                    BootPageAcceptance::ExclusiveUnmeasured => PageVisibility::Exclusive,
-                    BootPageAcceptance::Shared => PageVisibility::Shared,
-                    // TODO: These are required for hardware isolation but
-                    // support for that doesn't exist in any virt backend yet.
-                    // Handling these will require more virt::generic types.
-                    BootPageAcceptance::VpContext => todo!(),
-                    BootPageAcceptance::SecretsPage => todo!(),
-                    BootPageAcceptance::CpuidPage => todo!(),
-                    BootPageAcceptance::CpuidExtendedStatePage => todo!(),
-                };
-                (range, vis)
-            })
+        let page_imports = self
+             .page_imports
+             .into_vec()
+             .into_iter()
+             .map(|(start, end, info)| InitialPageImport {
+                 range: MemoryRange::from_4k_gpn_range(start..(end + 1)),
+                 import_type: boot_page_acceptance_to_import_type(info.acceptance),
+                 tag: info.tag,
+             })
             .collect();
 
-        (regs, pages)
+        (self.regs.into_values().collect(), page_imports)
     }
 
-    /// Accept a new page range with a given acceptance into the map of accepted ranges.
+    /// Track a new imported page range with a given acceptance.
     pub fn accept_new_range(
         &mut self,
         page_base: u64,
@@ -102,7 +89,7 @@ impl<R> Loader<'_, R> {
         acceptance: BootPageAcceptance,
     ) -> anyhow::Result<()> {
         let page_end = page_base + page_count - 1;
-        match self.accepted_ranges.entry(page_base..=page_end) {
+        match self.page_imports.entry(page_base..=page_end) {
             Entry::Overlapping(entry) => {
                 let (overlap_start, overlap_end, ref overlap_info) = *entry.get();
                 Err(anyhow::anyhow!(
@@ -152,7 +139,7 @@ impl<R: Debug + GuestArch> ImageLoad<R> for Loader<'_, R> {
             "importing pages"
         );
 
-        // Track accepted ranges for duplicate imports.
+        // Track imported ranges for duplicate imports.
         self.accept_new_range(page_base, page_count, debug_tag, acceptance)?;
 
         // Page count must be larger or equal to data.
@@ -182,7 +169,7 @@ impl<R: Debug + GuestArch> ImageLoad<R> for Loader<'_, R> {
         let entry = self.regs.entry(std::mem::discriminant(&register));
         match entry {
             std::collections::hash_map::Entry::Occupied(_) => {
-                panic!("duplicate register import {:?}", register)
+                anyhow::bail!("duplicate register import {:?}", register)
             }
             std::collections::hash_map::Entry::Vacant(ve) => ve.insert(register),
         };
@@ -323,5 +310,76 @@ impl<R: Debug + GuestArch> ImageLoad<R> for Loader<'_, R> {
 
     fn set_imported_regions_config_page(&mut self, _page_base: u64) {
         unimplemented!()
+    }
+}
+
+fn boot_page_acceptance_to_import_type(acceptance: BootPageAcceptance) -> InitialPageImportType {
+    match acceptance {
+        BootPageAcceptance::Exclusive => InitialPageImportType::Normal,
+        BootPageAcceptance::ExclusiveUnmeasured => InitialPageImportType::NormalUnmeasured,
+        BootPageAcceptance::Shared => InitialPageImportType::Shared,
+        BootPageAcceptance::VpContext => InitialPageImportType::VpContext,
+        BootPageAcceptance::SecretsPage => InitialPageImportType::Secrets,
+        BootPageAcceptance::CpuidPage => InitialPageImportType::Cpuid,
+        BootPageAcceptance::CpuidExtendedStatePage => InitialPageImportType::CpuidExtendedState,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use loader::importer::X86Register;
+    use test_with_tracing::test;
+
+    fn test_memory_layout() -> MemoryLayout {
+        MemoryLayout::new(0x10000, &[], &[], &[], None).unwrap()
+    }
+
+    #[test]
+    fn initial_regs_and_page_imports_preserve_import_metadata() {
+        let gm = GuestMemory::allocate(0x10000);
+        let mem_layout = test_memory_layout();
+        let mut loader = Loader::<X86Register>::new(gm, &mem_layout, Vtl::Vtl0);
+
+        loader
+            .import_pages(
+                1,
+                2,
+                "test-pages",
+                BootPageAcceptance::ExclusiveUnmeasured,
+                &[1, 2, 3, 4],
+            )
+            .unwrap();
+        loader
+            .import_vp_register(X86Register::Rip(0x100000))
+            .unwrap();
+
+        let (initial_regs, page_imports) = loader.initial_regs_and_page_imports();
+
+        assert_eq!(initial_regs, vec![X86Register::Rip(0x100000)]);
+        assert_eq!(
+            page_imports,
+            vec![InitialPageImport {
+                range: MemoryRange::from_4k_gpn_range(1..3),
+                import_type: InitialPageImportType::NormalUnmeasured,
+                tag: "test-pages".to_string(),
+            }]
+        );
+    }
+
+    #[test]
+    fn duplicate_register_import_returns_error() {
+        let gm = GuestMemory::allocate(0x10000);
+        let mem_layout = test_memory_layout();
+        let mut loader = Loader::<X86Register>::new(gm, &mem_layout, Vtl::Vtl0);
+
+        loader
+            .import_vp_register(X86Register::Rip(0x100000))
+            .unwrap();
+        let err = loader
+            .import_vp_register(X86Register::Rip(0x200000))
+            .unwrap_err();
+
+        assert!(err.to_string().contains("duplicate register import"));
     }
 }

--- a/vmm_core/vm_loader/src/lib.rs
+++ b/vmm_core/vm_loader/src/lib.rs
@@ -82,7 +82,6 @@ impl<R> Loader<'_, R> {
                     // support for that doesn't exist in any virt backend yet.
                     // Handling these will require more virt::generic types.
                     BootPageAcceptance::VpContext => todo!(),
-                    BootPageAcceptance::ErrorPage => todo!(),
                     BootPageAcceptance::SecretsPage => todo!(),
                     BootPageAcceptance::CpuidPage => todo!(),
                     BootPageAcceptance::CpuidExtendedStatePage => todo!(),


### PR DESCRIPTION
Add new isolation types and CCA shared gpa bit. Isolated partitions additionally require more than just the visibility of the page, in order to set memory attributes correctly for guest pages that were written to as part of the import process.

These changes are used in upcoming changes to launch SNP and CCA guests on KVM. 