### PR TITLE
consomme: ignore ipv6 extension headers

### DIFF
--- a/vm/devices/net/net_consomme/consomme/src/lib.rs
+++ b/vm/devices/net/net_consomme/consomme/src/lib.rs
@@ -51,6 +51,7 @@ use smoltcp::wire::Ipv4Address;
 use smoltcp::wire::Ipv4Packet;
 use smoltcp::wire::Ipv6Address;
 use smoltcp::wire::Ipv6ExtHeader;
+use smoltcp::wire::Ipv6ExtHeaderRepr;
 use smoltcp::wire::Ipv6Packet;
 use std::net::Ipv4Addr;
 use std::net::SocketAddr;
@@ -595,8 +596,6 @@ struct Ipv6UpperLayerPayload<'a> {
     payload: &'a [u8],
 }
 
-const IPV6_EXT_HEADER_FIXED_LEN: usize = 2;
-
 impl IpAddresses {
     fn src_addr(&self) -> IpAddress {
         match self {
@@ -654,8 +653,9 @@ fn ipv6_upper_layer_payload(
         match next_header {
             IpProtocol::HopByHop | IpProtocol::Ipv6Route | IpProtocol::Ipv6Opts => {
                 let header = Ipv6ExtHeader::new_checked(payload)?;
-                next_header = header.next_header();
-                payload = &payload[IPV6_EXT_HEADER_FIXED_LEN + header.payload().len()..];
+                let header = Ipv6ExtHeaderRepr::parse(&header)?;
+                next_header = header.next_header;
+                payload = &payload[header.header_len() + header.data.len()..];
             }
             IpProtocol::Ipv6Frag => return Err(DropReason::FragmentedPacket),
             _ => {

--- a/vm/devices/net/net_consomme/consomme/src/lib.rs
+++ b/vm/devices/net/net_consomme/consomme/src/lib.rs
@@ -50,6 +50,7 @@ use smoltcp::wire::IpProtocol;
 use smoltcp::wire::Ipv4Address;
 use smoltcp::wire::Ipv4Packet;
 use smoltcp::wire::Ipv6Address;
+use smoltcp::wire::Ipv6ExtHeader;
 use smoltcp::wire::Ipv6Packet;
 use std::net::Ipv4Addr;
 use std::net::SocketAddr;
@@ -589,6 +590,13 @@ enum IpAddresses {
     V6(Ipv6Addresses),
 }
 
+struct Ipv6UpperLayerPayload<'a> {
+    next_header: IpProtocol,
+    payload: &'a [u8],
+}
+
+const IPV6_EXT_HEADER_FIXED_LEN: usize = 2;
+
 impl IpAddresses {
     fn src_addr(&self) -> IpAddress {
         match self {
@@ -631,6 +639,33 @@ pub(crate) fn is_same_ipv6_subnet(addr1: Ipv6Address, addr2: Ipv6Address, prefix
 /// address (i.e., not loopback, unspecified, or link-local).
 fn is_routable_ipv6(addr: &std::net::Ipv6Addr) -> bool {
     !addr.is_loopback() && !addr.is_unspecified() && !addr.is_unicast_link_local()
+}
+
+/// Skips IPv6 extension headers that do not require Consomme handling and
+/// returns the upper-layer protocol and payload.
+///
+/// Fragment headers are rejected because Consomme does not support IP
+/// reassembly.
+fn ipv6_upper_layer_payload(
+    mut next_header: IpProtocol,
+    mut payload: &[u8],
+) -> Result<Ipv6UpperLayerPayload<'_>, DropReason> {
+    loop {
+        match next_header {
+            IpProtocol::HopByHop | IpProtocol::Ipv6Route | IpProtocol::Ipv6Opts => {
+                let header = Ipv6ExtHeader::new_checked(payload)?;
+                next_header = header.next_header();
+                payload = &payload[IPV6_EXT_HEADER_FIXED_LEN + header.payload().len()..];
+            }
+            IpProtocol::Ipv6Frag => return Err(DropReason::FragmentedPacket),
+            _ => {
+                return Ok(Ipv6UpperLayerPayload {
+                    next_header,
+                    payload,
+                });
+            }
+        }
+    }
 }
 
 impl Consomme {
@@ -856,16 +891,24 @@ impl<T: Client> Access<'_, T> {
         // may not reflect the actual buffer size. Skip the length validation
         // and use the full buffer.
         let segmentation_offload = checksum.tso.is_some() || checksum.gso.is_some();
+        let total_len = if segmentation_offload {
+            payload.len()
+        } else {
+            smoltcp::wire::IPV6_HEADER_LEN + ipv6.payload_len() as usize
+        };
         if !segmentation_offload {
-            let required_len = smoltcp::wire::IPV6_HEADER_LEN + ipv6.payload_len() as usize;
-            if payload.len() < required_len {
+            if payload.len() < total_len {
                 return Err(DropReason::MalformedPacket);
             }
         }
 
         let next_header = ipv6.next_header();
         let src_addr = ipv6.src_addr();
-        let inner = &payload[smoltcp::wire::IPV6_HEADER_LEN..];
+        let upper_layer = ipv6_upper_layer_payload(
+            next_header,
+            &payload[smoltcp::wire::IPV6_HEADER_LEN..total_len],
+        )?;
+        let inner = upper_layer.payload;
         let addresses = Ipv6Addresses {
             src_addr,
             dst_addr: ipv6.dst_addr(),
@@ -886,7 +929,7 @@ impl<T: Client> Access<'_, T> {
             self.inner.state.params.client_ip_ipv6_routable = Some(src_addr);
         }
 
-        match next_header {
+        match upper_layer.next_header {
             IpProtocol::Udp => {
                 self.handle_udp(frame, &IpAddresses::V6(addresses), inner, checksum)?
             }
@@ -903,7 +946,7 @@ impl<T: Client> Access<'_, T> {
                 {
                     self.handle_ndp(frame, inner, ipv6.src_addr())?;
                 } else {
-                    return Err(DropReason::UnsupportedIpProtocol(next_header));
+                    return Err(DropReason::UnsupportedIpProtocol(upper_layer.next_header));
                 }
             }
 
@@ -964,5 +1007,39 @@ mod tests {
         // prefix_len > 128 should behave like /128 (exact match), not panic.
         assert!(is_same_ipv6_subnet(a, a, 200));
         assert!(!is_same_ipv6_subnet(a, b, 255));
+    }
+
+    #[test]
+    fn ipv6_hop_by_hop_skips_to_upper_layer_payload() {
+        let tcp_payload = [0xaa, 0xbb, 0xcc, 0xdd];
+        let mut payload = [0u8; 12];
+        payload[0] = IpProtocol::Tcp.into();
+        payload[1] = 0;
+        payload[2] = 1;
+        payload[3] = 4;
+        payload[8..].copy_from_slice(&tcp_payload);
+
+        let upper_layer = ipv6_upper_layer_payload(IpProtocol::HopByHop, &payload).unwrap();
+
+        assert_eq!(upper_layer.next_header, IpProtocol::Tcp);
+        assert_eq!(upper_layer.payload, tcp_payload);
+    }
+
+    #[test]
+    fn ipv6_extension_header_length_is_validated() {
+        let payload = [IpProtocol::Tcp.into(), 1, 0, 0, 0, 0, 0, 0];
+
+        assert!(matches!(
+            ipv6_upper_layer_payload(IpProtocol::HopByHop, &payload),
+            Err(DropReason::Packet(_))
+        ));
+    }
+
+    #[test]
+    fn ipv6_fragment_header_is_dropped() {
+        assert!(matches!(
+            ipv6_upper_layer_payload(IpProtocol::Ipv6Frag, &[0; 8]),
+            Err(DropReason::FragmentedPacket)
+        ));
     }
 }

--- a/vm/devices/net/net_consomme/consomme/src/lib.rs
+++ b/vm/devices/net/net_consomme/consomme/src/lib.rs
@@ -641,8 +641,8 @@ fn is_routable_ipv6(addr: &std::net::Ipv6Addr) -> bool {
     !addr.is_loopback() && !addr.is_unspecified() && !addr.is_unicast_link_local()
 }
 
-/// Skips IPv6 extension headers that do not require Consomme handling and
-/// returns the upper-layer protocol and payload.
+/// Skips IPv6 Hop-by-Hop, Routing, and Destination Options extension headers
+/// and returns the upper-layer protocol and payload.
 ///
 /// Fragment headers are rejected because Consomme does not support IP
 /// reassembly.
@@ -1010,7 +1010,7 @@ mod tests {
     }
 
     #[test]
-    fn ipv6_hop_by_hop_skips_to_upper_layer_payload() {
+    fn test_ipv6_hop_by_hop_skips_to_upper_layer_payload() {
         let tcp_payload = [0xaa, 0xbb, 0xcc, 0xdd];
         let mut payload = [0u8; 12];
         payload[0] = IpProtocol::Tcp.into();
@@ -1026,7 +1026,7 @@ mod tests {
     }
 
     #[test]
-    fn ipv6_extension_header_length_is_validated() {
+    fn test_ipv6_extension_header_length_is_validated() {
         let payload = [IpProtocol::Tcp.into(), 1, 0, 0, 0, 0, 0, 0];
 
         assert!(matches!(
@@ -1036,7 +1036,7 @@ mod tests {
     }
 
     #[test]
-    fn ipv6_fragment_header_is_dropped() {
+    fn test_ipv6_fragment_header_is_dropped() {
         assert!(matches!(
             ipv6_upper_layer_payload(IpProtocol::Ipv6Frag, &[0; 8]),
             Err(DropReason::FragmentedPacket)


### PR DESCRIPTION
Ignore any Ipv6 extension headers provided by the guest and just parse the payload.