### PR TITLE
pci_resource_assignment: static BAR address assignment for P2P DMA

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5564,6 +5564,7 @@ dependencies = [
  "input_core",
  "inspect",
  "inspect_proto",
+ "memory_range",
  "mesh",
  "mesh_process",
  "mesh_rpc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6061,6 +6061,7 @@ dependencies = [
 name = "pci_resource_assignment"
 version = "0.0.0"
 dependencies = [
+ "memory_range",
  "pal_async",
  "parking_lot",
  "pci_core",

--- a/Guide/src/reference/openvmm/management/cli.md
+++ b/Guide/src/reference/openvmm/management/cli.md
@@ -249,6 +249,12 @@ complex name:
 - `start_bus=<N>` and `end_bus=<N>`: inclusive bus range assigned to that
   root complex.
 - `low_mmio=<SIZE>` and `high_mmio=<SIZE>`: low/high MMIO window sizes.
+- `low_mmio_base=<ADDR>` and `high_mmio_base=<ADDR>`: pin the low/high
+  MMIO window to a fixed base address instead of letting the VM topology
+  allocate it dynamically. Used with `preserve_bars` for P2P DMA.
+- `preserve_bars`: treat non-zero BAR values found during PCI probing as
+  pinned addresses (GPA = HPA). Required for peer-to-peer DMA between
+  VFIO passthrough devices without ATS.
 - `hdm=<SIZE>`: CXL HDM decoder MMIO window size (CFMWS window). Default
   is `1G`.
 - `hdm_window_restrictions=<MASK>`: CFMWS window restrictions bitmask
@@ -355,6 +361,9 @@ For `--virtio-rng` and `--virtio-console`, use their separate PCIe port flags:
 
 # Modern VFIO cdev + iommufd path (Linux >= 6.6):
 --iommu id=iommu0 --vfio host=0000:01:00.0,port=rp0,iommu=iommu0
+
+# Pin BAR0 to its physical address for P2P DMA:
+--vfio host=0000:01:00.0,port=rp0,bar0=pt
 ```
 
 ### SMMU (aarch64 only)

--- a/Guide/src/user_guide/openvmm/vfio.md
+++ b/Guide/src/user_guide/openvmm/vfio.md
@@ -118,6 +118,9 @@ The `--vfio` value is a comma-separated list of `key=value` pairs:
 - `host=<pci_bdf>` (required) — the PCI BDF of the VFIO device on the host (e.g., `0000:01:00.0`)
 - `port=<name>` (required) — the name of the PCIe root port to attach the device to (must match a `--pcie-root-port` name)
 - `iommu=<id>` (optional) — reference to an `--iommu` context; see [Using iommufd (cdev path)](#using-iommufd-cdev-path) below
+- `bar0=pt` through `bar5=pt` (optional) — pin the specified BAR to its
+  physical host address (GPA = HPA); see [Peer-to-peer DMA](#peer-to-peer-dma)
+  below
 
 ```admonish tip
 You can assign multiple devices by adding more root ports and `--vfio` flags:
@@ -163,6 +166,39 @@ lspci
 ```
 
 The device will appear with its real vendor and device ID from the physical hardware.
+
+## Peer-to-peer DMA
+
+Normally, peer-to-peer (P2P) DMA between two passthrough devices works
+via ATS (Address Translation Services): each device translates DMA
+addresses through the IOMMU, so guest BAR placement doesn't matter.
+
+Some platforms — notably NVIDIA GH200 and GB300 — do not support ATS in
+their root complex. On these machines, P2P DMA between devices (e.g., GPU
+and NIC) works by disabling ACS on the physical PCIe switch so that TLPs
+route directly between devices without going through the IOMMU. Since
+there is no translation layer, the devices use raw physical addresses for
+P2P DMA. This means the guest BAR addresses must be identity-mapped to
+the host BAR addresses (GPA = HPA), or P2P DMA will target the wrong
+location.
+
+To enable this, pin the relevant BARs with `bar<N>=pt` on each `--vfio`
+device and set `preserve_bars` on the root complex so the PCI resource
+allocator keeps pinned BARs at their physical addresses:
+
+```bash
+sudo openvmm \
+  --pcie-root-complex rc0,preserve_bars,low_mmio_base=0xc0000000,high_mmio_base=0x100000000 \
+  --pcie-root-port rc0:rp0 \
+  --pcie-root-port rc0:rp1 \
+  --vfio host=0000:01:00.0,port=rp0,bar0=pt \
+  --vfio host=0000:02:00.0,port=rp1,bar0=pt \
+  ...
+```
+
+The `low_mmio_base=` and `high_mmio_base=` options pin the MMIO apertures
+to fixed addresses so the allocator can place both pinned and dynamic BARs
+correctly.
 
 ## Optional: use hugetlb-backed guest RAM
 

--- a/Guide/src/user_guide/openvmm/vfio.md
+++ b/Guide/src/user_guide/openvmm/vfio.md
@@ -188,7 +188,8 @@ allocator keeps pinned BARs at their physical addresses:
 
 ```bash
 sudo openvmm \
-  --pcie-root-complex rc0,preserve_bars,low_mmio_base=0xc0000000,high_mmio_base=0x100000000 \
+  --pcie-root-complex \
+    rc0,preserve_bars,low_mmio_base=0xc0000000,high_mmio_base=0x100000000 \
   --pcie-root-port rc0:rp0 \
   --pcie-root-port rc0:rp1 \
   --vfio host=0000:01:00.0,port=rp0,bar0=pt \

--- a/Guide/src/user_guide/openvmm/vfio.md
+++ b/Guide/src/user_guide/openvmm/vfio.md
@@ -173,7 +173,7 @@ Normally, peer-to-peer (P2P) DMA between two passthrough devices works
 via ATS (Address Translation Services): each device translates DMA
 addresses through the IOMMU, so guest BAR placement doesn't matter.
 
-Some platforms — notably NVIDIA GH200 and GB300 — do not support ATS in
+Some platforms — notably NVIDIA GB200 and GB300 — do not support ATS in
 their root complex. On these machines, P2P DMA between devices (e.g., GPU
 and NIC) works by disabling ACS on the physical PCIe switch so that TLPs
 route directly between devices without going through the IOMMU. Since

--- a/openvmm/openvmm_core/src/worker/dispatch.rs
+++ b/openvmm/openvmm_core/src/worker/dispatch.rs
@@ -2021,6 +2021,7 @@ impl InitializedVm {
                     high_mmio: ranges.high_mmio,
                     cxl,
                     vnode: rc.vnode,
+                    preserve_bars: rc.preserve_bars,
                 });
 
                 pcie_root_complexes.push(root_complex.clone());

--- a/openvmm/openvmm_core/src/worker/dispatch/ecam_config_access.rs
+++ b/openvmm/openvmm_core/src/worker/dispatch/ecam_config_access.rs
@@ -66,6 +66,7 @@ pub async fn assign_pci_resources_for_root_complexes(
                 base: hb.high_mmio.start(),
                 len: hb.high_mmio.len(),
             }),
+            preserve_bars: hb.preserve_bars,
         };
         let mut ecam =
             EcamConfigAccess::new(chipset, hb.ecam_range.start(), hb.start_bus, hb.end_bus);

--- a/openvmm/openvmm_core/src/worker/dispatch/ecam_config_access.rs
+++ b/openvmm/openvmm_core/src/worker/dispatch/ecam_config_access.rs
@@ -58,14 +58,8 @@ pub async fn assign_pci_resources_for_root_complexes(
         let params = pci_resource_assignment::AssignmentParams {
             start_bus: hb.start_bus,
             end_bus: hb.end_bus,
-            low_mmio: (!hb.low_mmio.is_empty()).then(|| pci_resource_assignment::MmioAperture {
-                base: hb.low_mmio.start(),
-                len: hb.low_mmio.len(),
-            }),
-            high_mmio: (!hb.high_mmio.is_empty()).then(|| pci_resource_assignment::MmioAperture {
-                base: hb.high_mmio.start(),
-                len: hb.high_mmio.len(),
-            }),
+            low_mmio: hb.low_mmio,
+            high_mmio: hb.high_mmio,
             preserve_bars: hb.preserve_bars,
         };
         let mut ecam =

--- a/openvmm/openvmm_core/src/worker/memory_layout.rs
+++ b/openvmm/openvmm_core/src/worker/memory_layout.rs
@@ -640,6 +640,7 @@ mod tests {
             cxl: None,
             iommu: None,
             vnode: None,
+            preserve_bars: false,
         }
     }
 
@@ -754,6 +755,7 @@ mod tests {
                 cxl: None,
                 iommu: None,
                 vnode: None,
+                preserve_bars: false,
             },
             PcieRootComplexConfig {
                 index: 1,
@@ -767,6 +769,7 @@ mod tests {
                 cxl: None,
                 iommu: None,
                 vnode: None,
+                preserve_bars: false,
             },
         ];
         let mut config = input(&[2 * GB], None);
@@ -804,6 +807,7 @@ mod tests {
             cxl: None,
             iommu: None,
             vnode: None,
+            preserve_bars: false,
         }];
         let mut config = input(&[2 * GB], None);
         config.pcie_root_complexes = &root_complexes;

--- a/openvmm/openvmm_core/src/worker/vm_loaders/linux.rs
+++ b/openvmm/openvmm_core/src/worker/vm_loaders/linux.rs
@@ -241,6 +241,7 @@ fn build_dt(
     let p_arm_msi_num_spis = builder.add_string("arm,msi-num-spis")?;
     let p_iommu_cells = builder.add_string("#iommu-cells")?;
     let p_iommu_map = builder.add_string("iommu-map")?;
+    let p_linux_pci_probe_only = builder.add_string("linux,pci-probe-only")?;
 
     // Property handle values.
     const PHANDLE_GIC: u32 = 1;
@@ -507,6 +508,11 @@ fn build_dt(
             // through its SMMU instance. stream_id_base is 0 because each
             // SMMU is 1:1 with its RC — stream IDs are plain BDFs.
             node = node.add_u32_array(p_iommu_map, &[0, *phandle, 0, 0x10000])?;
+        }
+        if bridge.preserve_bars {
+            // Tell Linux to keep firmware-assigned BAR values instead of
+            // reprogramming them. Linux checks this via of_pci_preserve_config().
+            node = node.add_u32(p_linux_pci_probe_only, 1)?;
         }
         root_builder = node.end_node()?;
     }

--- a/openvmm/openvmm_defs/src/config.rs
+++ b/openvmm/openvmm_defs/src/config.rs
@@ -224,6 +224,9 @@ pub struct PcieRootComplexConfig {
     /// the ACPI SSDT so the guest OS sees correct NUMA locality for devices
     /// under this root complex.
     pub vnode: Option<u32>,
+    /// When true, treat non-zero BAR values found during probing as pinned
+    /// addresses. Used for P2P DMA with GPA = HPA.
+    pub preserve_bars: bool,
 }
 
 #[derive(Debug, MeshPayload)]

--- a/openvmm/openvmm_entry/Cargo.toml
+++ b/openvmm/openvmm_entry/Cargo.toml
@@ -20,6 +20,7 @@ cxl_spec.workspace = true
 debug_worker_defs.workspace = true
 vmotherboard.workspace = true
 diag_client.workspace = true
+memory_range.workspace = true
 openvmm_defs.workspace = true
 openvmm_helpers.workspace = true
 vmm_core_defs.workspace = true

--- a/openvmm/openvmm_entry/src/cli_args.rs
+++ b/openvmm/openvmm_entry/src/cli_args.rs
@@ -2911,6 +2911,9 @@ pub struct PcieRootComplexCli {
     pub end_bus: u8,
     pub low_mmio: u32,
     pub high_mmio: u64,
+    pub low_mmio_base: Option<u64>,
+    pub high_mmio_base: Option<u64>,
+    pub preserve_bars: bool,
     pub hdm: u64,
     pub hdm_window_restrictions: CfmwsWindowRestrictions,
     pub vnode: Option<u32>,
@@ -2937,6 +2940,9 @@ impl FromStr for PcieRootComplexCli {
         let mut end_bus = 255;
         let mut low_mmio = DEFAULT_PCIE_CRS_LOW_SIZE;
         let mut high_mmio = DEFAULT_PCIE_CRS_HIGH_SIZE;
+        let mut low_mmio_base = None;
+        let mut high_mmio_base = None;
+        let mut preserve_bars = false;
         let mut hdm = DEFAULT_PCIE_HDM_SIZE;
         let mut hdm_window_restrictions = DEFAULT_HDM_WINDOW_RESTRICTIONS;
         let mut vnode = None;
@@ -2967,6 +2973,21 @@ impl FromStr for PcieRootComplexCli {
                     let high_mmio_str = s.next().context("expected high MMIO size")?;
                     high_mmio =
                         parse_memory(high_mmio_str).context("failed to parse high MMIO size")?;
+                }
+                "low_mmio_base" => {
+                    let base_str = s.next().context("expected low MMIO base address")?;
+                    low_mmio_base = Some(
+                        parse_memory(base_str).context("failed to parse low MMIO base address")?,
+                    );
+                }
+                "high_mmio_base" => {
+                    let base_str = s.next().context("expected high MMIO base address")?;
+                    high_mmio_base = Some(
+                        parse_memory(base_str).context("failed to parse high MMIO base address")?,
+                    );
+                }
+                "preserve_bars" => {
+                    preserve_bars = true;
                 }
                 "hdm" => {
                     let hdm_str = s.next().context("expected HDM decoder size")?;
@@ -3000,6 +3021,9 @@ impl FromStr for PcieRootComplexCli {
             end_bus,
             low_mmio,
             high_mmio,
+            low_mmio_base,
+            high_mmio_base,
+            preserve_bars,
             hdm,
             hdm_window_restrictions,
             vnode,
@@ -3233,7 +3257,7 @@ impl FromStr for PcieRemoteCli {
 
 /// CLI configuration for a VFIO-assigned PCI device.
 ///
-/// Syntax: `host=<bdf>,port=<name>[,iommu=<id>]`
+/// Syntax: `host=<bdf>,port=<name>[,iommu=<id>][,bar0=pt..bar5=pt]`
 #[cfg(target_os = "linux")]
 #[derive(Clone, Debug)]
 pub struct VfioDeviceCli {
@@ -3244,6 +3268,9 @@ pub struct VfioDeviceCli {
     /// Optional iommufd context ID. When set, uses VFIO cdev + iommufd
     /// instead of the legacy group/container path.
     pub iommu: Option<String>,
+    /// Per-BAR passthrough flags. When `bar_pt[i]` is true, the virtual
+    /// BAR is pre-programmed with the physical BAR address (GPA = HPA).
+    pub bar_pt: [bool; 6],
 }
 
 #[cfg(target_os = "linux")]
@@ -3254,6 +3281,7 @@ impl FromStr for VfioDeviceCli {
         let mut host: Option<String> = None;
         let mut port: Option<String> = None;
         let mut iommu: Option<String> = None;
+        let mut bar_pt = [false; 6];
 
         for kv in s.split(',') {
             let (key, value) = kv
@@ -3281,6 +3309,13 @@ impl FromStr for VfioDeviceCli {
                     }
                     iommu = Some(value.to_string());
                 }
+                "bar0" | "bar1" | "bar2" | "bar3" | "bar4" | "bar5" => {
+                    if value != "pt" {
+                        anyhow::bail!("--vfio: '{key}' only accepts 'pt' as a value");
+                    }
+                    let idx: usize = key[3..].parse().unwrap();
+                    bar_pt[idx] = true;
+                }
                 _ => anyhow::bail!("unknown --vfio key: '{key}'"),
             }
         }
@@ -3297,6 +3332,7 @@ impl FromStr for VfioDeviceCli {
             port_name,
             pci_id,
             iommu,
+            bar_pt,
         })
     }
 }
@@ -4270,6 +4306,9 @@ mod tests {
                 hdm: DEFAULT_HDM,
                 hdm_window_restrictions: DEFAULT_HDM_WINDOW_RESTRICTIONS,
                 vnode: None,
+                low_mmio_base: None,
+                high_mmio_base: None,
+                preserve_bars: false,
             }
         );
 
@@ -4285,6 +4324,9 @@ mod tests {
                 hdm: DEFAULT_HDM,
                 hdm_window_restrictions: DEFAULT_HDM_WINDOW_RESTRICTIONS,
                 vnode: None,
+                low_mmio_base: None,
+                high_mmio_base: None,
+                preserve_bars: false,
             }
         );
 
@@ -4300,6 +4342,9 @@ mod tests {
                 hdm: DEFAULT_HDM,
                 hdm_window_restrictions: DEFAULT_HDM_WINDOW_RESTRICTIONS,
                 vnode: None,
+                low_mmio_base: None,
+                high_mmio_base: None,
+                preserve_bars: false,
             }
         );
 
@@ -4315,6 +4360,9 @@ mod tests {
                 hdm: DEFAULT_HDM,
                 hdm_window_restrictions: DEFAULT_HDM_WINDOW_RESTRICTIONS,
                 vnode: None,
+                low_mmio_base: None,
+                high_mmio_base: None,
+                preserve_bars: false,
             }
         );
 
@@ -4330,6 +4378,9 @@ mod tests {
                 hdm: DEFAULT_HDM,
                 hdm_window_restrictions: DEFAULT_HDM_WINDOW_RESTRICTIONS,
                 vnode: None,
+                low_mmio_base: None,
+                high_mmio_base: None,
+                preserve_bars: false,
             }
         );
 
@@ -4345,6 +4396,9 @@ mod tests {
                 hdm: DEFAULT_HDM,
                 hdm_window_restrictions: DEFAULT_HDM_WINDOW_RESTRICTIONS,
                 vnode: None,
+                low_mmio_base: None,
+                high_mmio_base: None,
+                preserve_bars: false,
             }
         );
 
@@ -4360,6 +4414,9 @@ mod tests {
                 hdm: DEFAULT_HDM,
                 hdm_window_restrictions: DEFAULT_HDM_WINDOW_RESTRICTIONS,
                 vnode: None,
+                low_mmio_base: None,
+                high_mmio_base: None,
+                preserve_bars: false,
             }
         );
 
@@ -4375,6 +4432,9 @@ mod tests {
                 hdm: 2 * ONE_GB,
                 hdm_window_restrictions: DEFAULT_HDM_WINDOW_RESTRICTIONS,
                 vnode: None,
+                low_mmio_base: None,
+                high_mmio_base: None,
+                preserve_bars: false,
             }
         );
 
@@ -4390,6 +4450,9 @@ mod tests {
                 hdm: DEFAULT_HDM,
                 hdm_window_restrictions: CfmwsWindowRestrictions::try_from_bits(0x21).unwrap(),
                 vnode: None,
+                low_mmio_base: None,
+                high_mmio_base: None,
+                preserve_bars: false,
             }
         );
 

--- a/openvmm/openvmm_entry/src/cli_args.rs
+++ b/openvmm/openvmm_entry/src/cli_args.rs
@@ -4487,6 +4487,9 @@ mod tests {
                 hdm: DEFAULT_HDM,
                 hdm_window_restrictions: DEFAULT_HDM_WINDOW_RESTRICTIONS,
                 vnode: Some(1),
+                low_mmio_base: None,
+                high_mmio_base: None,
+                preserve_bars: false,
             }
         );
     }

--- a/openvmm/openvmm_entry/src/lib.rs
+++ b/openvmm/openvmm_entry/src/lib.rs
@@ -862,11 +862,23 @@ async fn vm_config_from_command_line(
             segment: rc_cli.segment,
             start_bus: rc_cli.start_bus,
             end_bus: rc_cli.end_bus,
-            low_mmio: PcieMmioRangeConfig::Dynamic {
-                size: low_mmio_size,
+            low_mmio: if let Some(base) = rc_cli.low_mmio_base {
+                PcieMmioRangeConfig::Fixed(memory_range::MemoryRange::new(
+                    base..base + low_mmio_size,
+                ))
+            } else {
+                PcieMmioRangeConfig::Dynamic {
+                    size: low_mmio_size,
+                }
             },
-            high_mmio: PcieMmioRangeConfig::Dynamic {
-                size: high_mmio_size,
+            high_mmio: if let Some(base) = rc_cli.high_mmio_base {
+                PcieMmioRangeConfig::Fixed(memory_range::MemoryRange::new(
+                    base..base + high_mmio_size,
+                ))
+            } else {
+                PcieMmioRangeConfig::Dynamic {
+                    size: high_mmio_size,
+                }
             },
             cxl,
             ports,
@@ -883,6 +895,7 @@ async fn vm_config_from_command_line(
                 .any(|s| s == &rc_cli.name)
                 .then_some(openvmm_defs::config::PcieIommuConfig::AmdVi),
             vnode: rc_cli.vnode,
+            preserve_bars: rc_cli.preserve_bars,
         });
     }
 
@@ -974,6 +987,7 @@ async fn vm_config_from_command_line(
                             cdev,
                             iommufd,
                             iommu_id: iommu_id.clone(),
+                            bar_pt: cli_cfg.bar_pt,
                         }
                         .into_resource(),
                     })
@@ -1000,6 +1014,7 @@ async fn vm_config_from_command_line(
                         resource: vfio_assigned_device_resources::VfioDeviceHandle {
                             pci_id: cli_cfg.pci_id.clone(),
                             group,
+                            bar_pt: cli_cfg.bar_pt,
                         }
                         .into_resource(),
                     })

--- a/openvmm/openvmm_entry/src/lib.rs
+++ b/openvmm/openvmm_entry/src/lib.rs
@@ -863,12 +863,9 @@ async fn vm_config_from_command_line(
             start_bus: rc_cli.start_bus,
             end_bus: rc_cli.end_bus,
             low_mmio: if let Some(base) = rc_cli.low_mmio_base {
-                let end = base
-                    .checked_add(low_mmio_size)
-                    .context("low_mmio_base + low_mmio size overflows")?;
                 PcieMmioRangeConfig::Fixed(
-                    memory_range::MemoryRange::try_new(base..end)
-                        .context("low_mmio_base is not page-aligned")?,
+                    memory_range::MemoryRange::try_new(base..base.wrapping_add(low_mmio_size))
+                        .context("invalid low MMIO range")?,
                 )
             } else {
                 PcieMmioRangeConfig::Dynamic {
@@ -876,12 +873,9 @@ async fn vm_config_from_command_line(
                 }
             },
             high_mmio: if let Some(base) = rc_cli.high_mmio_base {
-                let end = base
-                    .checked_add(high_mmio_size)
-                    .context("high_mmio_base + high_mmio size overflows")?;
                 PcieMmioRangeConfig::Fixed(
-                    memory_range::MemoryRange::try_new(base..end)
-                        .context("high_mmio_base is not page-aligned")?,
+                    memory_range::MemoryRange::try_new(base..base.wrapping_add(high_mmio_size))
+                        .context("invalid high MMIO range")?,
                 )
             } else {
                 PcieMmioRangeConfig::Dynamic {

--- a/openvmm/openvmm_entry/src/lib.rs
+++ b/openvmm/openvmm_entry/src/lib.rs
@@ -863,18 +863,26 @@ async fn vm_config_from_command_line(
             start_bus: rc_cli.start_bus,
             end_bus: rc_cli.end_bus,
             low_mmio: if let Some(base) = rc_cli.low_mmio_base {
-                PcieMmioRangeConfig::Fixed(memory_range::MemoryRange::new(
-                    base..base + low_mmio_size,
-                ))
+                let end = base
+                    .checked_add(low_mmio_size)
+                    .context("low_mmio_base + low_mmio size overflows")?;
+                PcieMmioRangeConfig::Fixed(
+                    memory_range::MemoryRange::try_new(base..end)
+                        .context("low_mmio_base is not page-aligned")?,
+                )
             } else {
                 PcieMmioRangeConfig::Dynamic {
                     size: low_mmio_size,
                 }
             },
             high_mmio: if let Some(base) = rc_cli.high_mmio_base {
-                PcieMmioRangeConfig::Fixed(memory_range::MemoryRange::new(
-                    base..base + high_mmio_size,
-                ))
+                let end = base
+                    .checked_add(high_mmio_size)
+                    .context("high_mmio_base + high_mmio size overflows")?;
+                PcieMmioRangeConfig::Fixed(
+                    memory_range::MemoryRange::try_new(base..end)
+                        .context("high_mmio_base is not page-aligned")?,
+                )
             } else {
                 PcieMmioRangeConfig::Dynamic {
                     size: high_mmio_size,

--- a/petri/src/vm/openvmm/modify.rs
+++ b/petri/src/vm/openvmm/modify.rs
@@ -396,6 +396,7 @@ impl PetriVmConfigOpenVmm {
                     ports,
                     iommu: None,
                     vnode: None,
+                    preserve_bars: false,
                 });
             }
         }

--- a/vm/acpi/src/ssdt.rs
+++ b/vm/acpi/src/ssdt.rs
@@ -60,6 +60,9 @@ pub struct PcieHostBridgeEntry {
     pub cxl: bool,
     /// NUMA proximity domain.
     pub vnode: Option<u32>,
+    /// When true, emit a `_DSM` method instructing the OS to preserve
+    /// firmware-assigned BAR values. Used for P2P DMA with GPA = HPA.
+    pub preserve_bars: bool,
 }
 
 impl Ssdt {
@@ -148,6 +151,7 @@ impl Ssdt {
             high_mmio,
             cxl,
             vnode,
+            preserve_bars,
         } = entry;
         let mut pcie = Device::new(encode_pcie_name(index).as_slice());
         if cxl {
@@ -307,6 +311,77 @@ impl Ssdt {
 
         pcie.add_object(&osc_method);
 
+        // _DSM: Device Specific Method for preserving firmware BAR assignments.
+        //
+        // UUID {E5C937D0-3553-4D7A-9117-EA4D19C3434D} is the PCI/PCIe host
+        // bridge _DSM defined in the PCI Firmware Specification §4.6.
+        //
+        // Function 0: returns a buffer with supported function bitmask
+        // Function 5: returns 0 to indicate firmware-assigned BAR values
+        //             should be preserved by the OS
+        //
+        // When preserve_bars is false, no _DSM is emitted and the guest
+        // OS is free to reprogram BARs.
+        if preserve_bars {
+            let mut dsm_method = Method::new(b"_DSM");
+            dsm_method.set_arg_count(4);
+
+            let dsm_uuid = guid::guid!("E5C937D0-3553-4D7A-9117-EA4D19C3434D");
+            let dsm_uuid_buffer = Buffer(dsm_uuid.as_bytes()).to_bytes();
+
+            // If (LEqual(Arg0, UUID))
+            let uuid_match = LEqualOp {
+                left: encode_arg(0),
+                right: dsm_uuid_buffer,
+            };
+
+            // Function 0: return supported function bitmask (bits 0 and 5).
+            // Bit 0 = Function 0 supported, Bit 5 = Function 5 supported.
+            let fn0_match = LEqualOp {
+                left: encode_arg(2),
+                right: encode_integer(0),
+            };
+            let fn0_return = ReturnOp {
+                result: Buffer(&[0x21u8]).to_bytes(),
+            };
+            let fn0_if = IfOp {
+                predicate: fn0_match.to_bytes(),
+                body: fn0_return.to_bytes(),
+            };
+
+            // Function 5: return 0 (preserve firmware BAR assignments).
+            let fn5_match = LEqualOp {
+                left: encode_arg(2),
+                right: encode_integer(5),
+            };
+            let fn5_return = ReturnOp {
+                result: encode_integer(0),
+            };
+            let fn5_if = IfOp {
+                predicate: fn5_match.to_bytes(),
+                body: fn5_return.to_bytes(),
+            };
+
+            let uuid_if = IfOp {
+                predicate: uuid_match.to_bytes(),
+                body: {
+                    let mut body = Vec::new();
+                    fn0_if.append_to_vec(&mut body);
+                    fn5_if.append_to_vec(&mut body);
+                    body
+                },
+            };
+
+            dsm_method.add_operation(&uuid_if);
+
+            // Unrecognized UUID or function: return empty buffer.
+            dsm_method.add_operation(&ReturnOp {
+                result: Buffer(&[] as &[u8]).to_bytes(),
+            });
+
+            pcie.add_object(&dsm_method);
+        }
+
         let mut crs = CurrentResourceSettings::new();
         crs.add_resource(&BusNumber::new(
             start_bus.into(),
@@ -418,7 +493,16 @@ mod tests {
             high_mmio: MemoryRange::new(0x10_0000_0000..0x10_4000_0000),
             cxl: false,
             vnode,
+            preserve_bars: false,
         }
+    }
+
+    fn contains_name(bytes: &[u8], name: &[u8; 4]) -> bool {
+        bytes.windows(4).any(|w| w == name)
+    }
+
+    fn contains_bytes(bytes: &[u8], needle: &[u8]) -> bool {
+        bytes.windows(needle.len()).any(|w| w == needle)
     }
 
     #[test]
@@ -479,5 +563,48 @@ mod tests {
                 .windows(7)
                 .any(|window| window == [8, b'_', b'P', b'X', b'M', 0x0a, 3,])
         );
+    }
+
+    #[test]
+    fn pcie_dsm_present_when_preserve_bars() {
+        let mut ssdt = Ssdt::new();
+        ssdt.add_pcie(PcieHostBridgeEntry {
+            preserve_bars: true,
+            ..test_pcie_entry(None)
+        });
+
+        let bytes = ssdt.to_bytes();
+        verify_header(&bytes);
+
+        // _DSM method name must be present.
+        assert!(contains_name(&bytes, b"_DSM"));
+
+        // The PCI firmware _DSM UUID must appear in mixed-endian form
+        // (GUID wire format).
+        let uuid = guid::guid!("E5C937D0-3553-4D7A-9117-EA4D19C3434D");
+        assert!(contains_bytes(&bytes, uuid.as_bytes()));
+
+        // The supported-functions bitmask byte (0x21 = bits 0+5) must
+        // appear somewhere in the buffer encoding.
+        assert!(contains_bytes(&bytes, &[0x21]));
+    }
+
+    #[test]
+    fn pcie_dsm_absent_without_preserve_bars() {
+        let mut ssdt = Ssdt::new();
+        ssdt.add_pcie(PcieHostBridgeEntry {
+            preserve_bars: false,
+            ..test_pcie_entry(None)
+        });
+
+        let bytes = ssdt.to_bytes();
+        verify_header(&bytes);
+
+        // _DSM must NOT be present.
+        assert!(!contains_name(&bytes, b"_DSM"));
+
+        // The PCI firmware _DSM UUID must NOT appear.
+        let uuid = guid::guid!("E5C937D0-3553-4D7A-9117-EA4D19C3434D");
+        assert!(!contains_bytes(&bytes, uuid.as_bytes()));
     }
 }

--- a/vm/devices/pci/pci_resource_assignment/Cargo.toml
+++ b/vm/devices/pci/pci_resource_assignment/Cargo.toml
@@ -7,6 +7,7 @@ edition.workspace = true
 rust-version.workspace = true
 
 [dependencies]
+memory_range.workspace = true
 pci_core.workspace = true
 thiserror.workspace = true
 tracing.workspace = true

--- a/vm/devices/pci/pci_resource_assignment/src/assign.rs
+++ b/vm/devices/pci/pci_resource_assignment/src/assign.rs
@@ -40,6 +40,12 @@ pub(crate) struct SubtreeState {
     /// If pinned demands exist in the mem64 pool, the required base address
     /// for this subtree's window.
     constrained_base64: Option<u64>,
+    /// Pre-computed free gaps in the mem32 pool, covering the window
+    /// [constrained_base, constrained_base + align_up(mem, 1 MB)).
+    /// Empty when there are no pinned demands.
+    gaps32: Vec<(u64, u64)>,
+    /// Pre-computed free gaps in the mem64 pool.
+    gaps64: Vec<(u64, u64)>,
 }
 
 /// A single resource demand at one level of the PCI tree.
@@ -154,7 +160,7 @@ pub fn assign_addresses(
     // Step 1: Bottom-up — compute total resource requirements.
     // This also stores per-bridge requirements on the DiscoveredDevice
     // nodes so that the assignment pass can read them without recomputing.
-    let root_req = compute_subtree_state(devices);
+    let mut root_req = compute_subtree_state(devices);
 
     // Validate pinned BAR constraints before assigning addresses.
     validate_pinned_bars(devices, params)?;
@@ -194,7 +200,10 @@ pub fn assign_addresses(
             });
         }
 
-        assign_subtree(devices, &root_req.demands, false, base, aperture_end);
+        if root_req.constrained_base32.is_none() {
+            root_req.gaps32.push((base, aperture_end));
+        }
+        assign_subtree(devices, &root_req.demands, &mut root_req.gaps32, false);
 
         mem32_end = Some(base + root_req.mem32);
     }
@@ -231,7 +240,10 @@ pub fn assign_addresses(
             });
         }
 
-        assign_subtree(devices, &root_req.demands, true, base, aperture_end);
+        if root_req.constrained_base64.is_none() {
+            root_req.gaps64.push((base, aperture_end));
+        }
+        assign_subtree(devices, &root_req.demands, &mut root_req.gaps64, true);
     }
 
     validate_assignments(devices, params);
@@ -424,11 +436,9 @@ fn compute_subtree_state(devices: &mut [DiscoveredDevice]) -> SubtreeState {
     // alignment-demanding items first minimizes padding waste.
     demands.sort_by_key(|d| std::cmp::Reverse(d.alignment()));
 
-    // Collect fixed-position demands (pinned BARs and constrained bridges)
-    // per pool to compute the base offset for dynamic allocations.
+    // Collect fixed-position demands per pool.
     let mut pin32: Vec<(u64, u64)> = Vec::new();
     let mut pin64: Vec<(u64, u64)> = Vec::new();
-
     for d in &demands {
         if let Some((addr, size)) = d.fixed_position() {
             if d.is_mem64() {
@@ -439,114 +449,142 @@ fn compute_subtree_state(devices: &mut [DiscoveredDevice]) -> SubtreeState {
         }
     }
 
-    let (mut mem32, constrained_base32) = if !pin32.is_empty() {
-        let min_addr = pin32.iter().map(|(a, _)| *a).min().unwrap();
-        let max_end = pin32.iter().map(|(a, s)| a + s).max().unwrap();
-        let base = align_down(min_addr, BRIDGE_WINDOW_ALIGN);
-        (max_end - base, Some(base))
-    } else {
-        (0, None)
-    };
+    // Size each pool: compute the pinned span, build gaps, trial-allocate
+    // dynamic demands, and extend the window for anything that didn't fit.
+    let mut pool32 = size_pool(&mut pin32, &demands, false);
+    let mut pool64 = size_pool(&mut pin64, &demands, true);
 
-    let (mut mem64, constrained_base64) = if !pin64.is_empty() {
-        let min_addr = pin64.iter().map(|(a, _)| *a).min().unwrap();
-        let max_end = pin64.iter().map(|(a, s)| a + s).max().unwrap();
-        let base = align_down(min_addr, BRIDGE_WINDOW_ALIGN);
-        (max_end - base, Some(base))
-    } else {
-        (0, None)
-    };
-
-    let mut align32 = BRIDGE_WINDOW_ALIGN;
-    let mut align64 = BRIDGE_WINDOW_ALIGN;
-
+    // Trial-allocate dynamic demands into gap clones to determine which
+    // fit in the pinned span and which extend the window.
+    let mut sizing_gaps32 = pool32.gaps.clone();
+    let mut sizing_gaps64 = pool64.gaps.clone();
     for d in &demands {
-        // Skip fixed-position demands; they are already accounted for
-        // in the pinned region above.
         if d.fixed_position().is_some() {
             continue;
         }
         if d.is_mem64() {
-            mem64 = align_up(mem64, d.alignment());
-            mem64 += d.size();
-            align64 = align64.max(d.alignment());
+            pool64.align = pool64.align.max(d.alignment());
+            if allocate_from_gaps(&mut sizing_gaps64, d.size(), d.alignment()).is_none() {
+                pool64.mem = align_up(pool64.mem, d.alignment());
+                pool64.mem += d.size();
+            }
         } else {
-            mem32 = align_up(mem32, d.alignment());
-            mem32 += d.size();
-            align32 = align32.max(d.alignment());
+            pool32.align = pool32.align.max(d.alignment());
+            if allocate_from_gaps(&mut sizing_gaps32, d.size(), d.alignment()).is_none() {
+                pool32.mem = align_up(pool32.mem, d.alignment());
+                pool32.mem += d.size();
+            }
         }
     }
 
+    // Extend gap lists with the tail region for demands that didn't fit.
+    pool32.extend_tail();
+    pool64.extend_tail();
+
     SubtreeState {
-        mem32,
-        mem64,
-        align32,
-        align64,
+        mem32: pool32.mem,
+        mem64: pool64.mem,
+        align32: pool32.align,
+        align64: pool64.align,
         demands,
         memory_window: None,
         prefetchable_window: None,
-        constrained_base32,
-        constrained_base64,
+        constrained_base32: pool32.constrained_base,
+        constrained_base64: pool64.constrained_base,
+        gaps32: pool32.gaps,
+        gaps64: pool64.gaps,
     }
 }
+
+/// Per-pool sizing state produced by `size_pool`.
+struct PoolState {
+    /// Total window size needed (pinned span + dynamic overflow).
+    mem: u64,
+    /// Required alignment (max of bridge granularity and largest demand).
+    align: u64,
+    /// If pinned demands exist, the required window base address.
+    constrained_base: Option<u64>,
+    /// Pre-computed gap list covering the pinned span, for reuse by
+    /// `assign_subtree`. Empty when there are no pinned demands.
+    gaps: Vec<(u64, u64)>,
+    /// End of the pinned span, for extending gaps after sizing.
+    pinned_span_end: Option<u64>,
+}
+
+impl PoolState {
+    /// Append a tail gap for dynamic demands that didn't fit in the
+    /// pinned-span gaps. Called after the sizing trial.
+    fn extend_tail(&mut self) {
+        if let Some(pin_end) = self.pinned_span_end {
+            let window_end = self.constrained_base.unwrap() + self.mem;
+            if pin_end < window_end {
+                self.gaps.push((pin_end, window_end));
+            }
+        }
+    }
+}
+
+/// Compute the pinned span, gap list, and initial window size for one
+/// pool (mem32 or mem64). `pins` is sorted in place.
+fn size_pool(pins: &mut [(u64, u64)], demands: &[Demand], is_mem64: bool) -> PoolState {
+    pins.sort_by_key(|&(a, _)| a);
+
+    let (mem, constrained_base) = if !pins.is_empty() {
+        let min_addr = pins.iter().map(|(a, _)| *a).min().unwrap();
+        let max_end = pins.iter().map(|(a, s)| a + s).max().unwrap();
+        let base = align_down(min_addr, BRIDGE_WINDOW_ALIGN);
+        (max_end - base, Some(base))
+    } else {
+        (0, None)
+    };
+
+    let _ = (demands, is_mem64); // used by caller for trial allocation
+
+    let gaps = if let Some(base) = constrained_base {
+        build_gap_list(base, base + mem, pins)
+    } else {
+        Vec::new()
+    };
+
+    let pinned_span_end = constrained_base.map(|b| b + mem);
+
+    PoolState {
+        mem,
+        align: BRIDGE_WINDOW_ALIGN,
+        constrained_base,
+        gaps,
+        pinned_span_end,
+    }
+}
+
 /// Top-down: assign addresses to devices within a subtree, carving from
-/// the given base address. `alloc_64bit` selects which pool (mem32 or
+/// the given gap list. `alloc_64bit` selects which pool (mem32 or
 /// mem64) we are assigning.
 ///
 /// Fixed-position demands (pinned BARs and constrained bridges) are placed
-/// at their predetermined addresses. Dynamic demands bump-allocate after
-/// the highest fixed-position end.
-///
-/// TODO: Replace bump-from-max-end with a gap allocator that can place
-/// dynamic demands in free space before and between pinned regions. The
-/// current approach wastes space below the first pin. This is acceptable
-/// when the admin controls aperture placement, but a gap allocator would
-/// handle awkward pin positions without requiring oversized apertures.
+/// at their predetermined addresses. Dynamic demands are placed into free
+/// gaps using a first-fit strategy.
 ///
 /// `demands` is the pre-sorted demand list built by `compute_subtree_state`.
 fn assign_subtree(
     devices: &mut [DiscoveredDevice],
     demands: &[Demand],
+    gaps: &mut Vec<(u64, u64)>,
     alloc_64bit: bool,
-    base: u64,
-    limit: u64,
 ) {
-    // Compute the starting offset for bump allocation: after all
-    // fixed-position demands.
-    let max_fixed_end = demands
-        .iter()
-        .filter(|d| d.is_mem64() == alloc_64bit)
-        .filter_map(|d| d.fixed_position())
-        .map(|(addr, size)| addr + size)
-        .max()
-        .unwrap_or(base);
-    let mut offset = max_fixed_end.max(base);
-
     for demand in demands {
         if demand.is_mem64() != alloc_64bit {
             continue;
         }
 
-        // For fixed-position demands, use the fixed address.
-        // For dynamic demands, bump-allocate.
+        // Fixed-position demands use their predetermined address.
+        // Dynamic demands are placed via the gap allocator.
         let assign_addr = if let Some((addr, _)) = demand.fixed_position() {
             addr
         } else {
-            offset = align_up(offset, demand.alignment());
-            let addr = offset;
-            offset += demand.size();
-            addr
+            allocate_from_gaps(gaps, demand.size(), demand.alignment())
+                .expect("demand must fit (sizing pass guarantees sufficient space)")
         };
-
-        // Every placement must fit within the parent's window.
-        assert!(
-            assign_addr >= base && assign_addr + demand.size() <= limit,
-            "assignment at {:#x}..{:#x} exceeds parent window {:#x}..{:#x}",
-            assign_addr,
-            assign_addr + demand.size(),
-            base,
-            limit,
-        );
 
         match *demand {
             Demand::Bar {
@@ -573,18 +611,24 @@ fn assign_subtree(
                 }
 
                 // Recurse into children with this bridge's carved-out range.
-                let child_demands = &dev
+                let req = dev
                     .subtree_req
-                    .as_ref()
-                    .expect("subtree_req must be populated by compute_subtree_state")
-                    .demands;
-                assign_subtree(
-                    &mut dev.children,
-                    child_demands,
-                    alloc_64bit,
-                    window_base,
-                    window_limit + 1,
-                );
+                    .as_mut()
+                    .expect("subtree_req must be populated by compute_subtree_state");
+                let has_pins = if alloc_64bit {
+                    req.constrained_base64.is_some()
+                } else {
+                    req.constrained_base32.is_some()
+                };
+                let (child_demands, child_gaps) = if alloc_64bit {
+                    (&req.demands, &mut req.gaps64)
+                } else {
+                    (&req.demands, &mut req.gaps32)
+                };
+                if !has_pins {
+                    child_gaps.push((window_base, window_limit + 1));
+                }
+                assign_subtree(&mut dev.children, child_demands, child_gaps, alloc_64bit);
             }
             Demand::SriovVfBars {
                 dev_idx, bar_index, ..
@@ -768,6 +812,49 @@ fn align_up(value: u64, alignment: u64) -> u64 {
 fn align_down(value: u64, alignment: u64) -> u64 {
     assert!(alignment.is_power_of_two());
     value & !(alignment - 1)
+}
+
+/// Build a list of free gaps within [base, limit) given sorted,
+/// non-overlapping fixed regions. Each gap is a (start, end) pair
+/// where start is inclusive and end is exclusive.
+fn build_gap_list(base: u64, limit: u64, fixed_regions: &[(u64, u64)]) -> Vec<(u64, u64)> {
+    let mut gaps = Vec::new();
+    let mut cursor = base;
+    for &(addr, size) in fixed_regions {
+        if cursor < addr {
+            gaps.push((cursor, addr));
+        }
+        cursor = cursor.max(addr + size);
+    }
+    if cursor < limit {
+        gaps.push((cursor, limit));
+    }
+    gaps
+}
+
+/// Allocate `size` bytes with the given `alignment` from the first gap
+/// that fits (first-fit). Returns the allocated address, or `None` if
+/// no gap is large enough. Updates `gaps` in place.
+fn allocate_from_gaps(gaps: &mut Vec<(u64, u64)>, size: u64, alignment: u64) -> Option<u64> {
+    let gap_idx = gaps
+        .iter()
+        .position(|&(start, end)| align_up(start, alignment) + size <= end)?;
+
+    let (gap_start, gap_end) = gaps[gap_idx];
+    let addr = align_up(gap_start, alignment);
+    let alloc_end = addr + size;
+
+    gaps.remove(gap_idx);
+    let mut insert_at = gap_idx;
+    if gap_start < addr {
+        gaps.insert(insert_at, (gap_start, addr));
+        insert_at += 1;
+    }
+    if alloc_end < gap_end {
+        gaps.insert(insert_at, (alloc_end, gap_end));
+    }
+
+    Some(addr)
 }
 
 /// Validate pinned BAR constraints: alignment, overlap, and aperture fit.

--- a/vm/devices/pci/pci_resource_assignment/src/assign.rs
+++ b/vm/devices/pci/pci_resource_assignment/src/assign.rs
@@ -206,8 +206,13 @@ pub fn assign_addresses(
 
     if root_sizing.mem64 > 0 {
         // If sharing the same aperture as mem32, start after mem32.
-        let after_mem32 = mem32_end.filter(|_| params.high_mmio.is_none());
+        let after_mem32 = mem32_end.filter(|_| params.high_mmio.is_empty());
 
+        let aperture = if params.high_mmio.is_empty() {
+            params.low_mmio
+        } else {
+            params.high_mmio
+        };
         allocate_pool(
             devices,
             &root_sizing.demands,
@@ -215,7 +220,7 @@ pub fn assign_addresses(
             root_sizing.constrained_base64,
             root_sizing.align64,
             root_sizing.mem64,
-            params.high_mmio.or(params.low_mmio),
+            aperture,
             true,
             after_mem32,
         )?;
@@ -245,9 +250,8 @@ fn validate_assignments(devices: &[DiscoveredDevice], params: &AssignmentParams)
             if let Some((base, limit)) = ba.memory_window {
                 let size = limit - base + 1;
                 assert!(
-                    params
-                        .low_mmio
-                        .is_some_and(|a| base >= a.base && base + size <= a.base + a.len),
+                    params.low_mmio.contains_addr(base)
+                        && params.low_mmio.contains_addr(base + size - 1),
                     "bridge {bus:02x}:{device:02x}.{func} memory window \
                      {base:#x}..={limit:#x} exceeds low_mmio aperture",
                     bus = dev.bus,
@@ -257,12 +261,10 @@ fn validate_assignments(devices: &[DiscoveredDevice], params: &AssignmentParams)
             }
             if let Some((base, limit)) = ba.prefetchable_window {
                 let size = limit - base + 1;
-                let in_low = params
-                    .low_mmio
-                    .is_some_and(|a| base >= a.base && base + size <= a.base + a.len);
-                let in_high = params
-                    .high_mmio
-                    .is_some_and(|a| base >= a.base && base + size <= a.base + a.len);
+                let in_low = params.low_mmio.contains_addr(base)
+                    && params.low_mmio.contains_addr(base + size - 1);
+                let in_high = params.high_mmio.contains_addr(base)
+                    && params.high_mmio.contains_addr(base + size - 1);
                 assert!(
                     in_low || in_high,
                     "bridge {bus:02x}:{device:02x}.{func} prefetchable window \
@@ -314,12 +316,8 @@ fn assert_bar_in_aperture(
     params: &AssignmentParams,
 ) {
     let bar_end = address + size;
-    let in_low = params
-        .low_mmio
-        .is_some_and(|a| address >= a.base && bar_end <= a.base + a.len);
-    let in_high = params
-        .high_mmio
-        .is_some_and(|a| address >= a.base && bar_end <= a.base + a.len);
+    let in_low = address >= params.low_mmio.start() && bar_end <= params.low_mmio.end();
+    let in_high = address >= params.high_mmio.start() && bar_end <= params.high_mmio.end();
     assert!(
         in_low || in_high,
         "BAR {bus:02x}:{device:02x}.{func} index {idx} at {addr:#x}..{end:#x} \
@@ -551,36 +549,30 @@ fn allocate_pool(
     constrained_base: Option<u64>,
     alignment: u64,
     required: u64,
-    aperture: Option<crate::MmioAperture>,
+    aperture: memory_range::MemoryRange,
     is_mem64: bool,
     after: Option<u64>,
 ) -> Result<u64, AssignmentError> {
     let aperture_name = if is_mem64 { "high_mmio" } else { "low_mmio" };
-    let aperture = aperture.ok_or(AssignmentError::MmioExhaustion {
-        required,
-        available: 0,
-        aperture: aperture_name,
-    })?;
     let base = if let Some(cbase) = constrained_base {
         cbase
     } else if let Some(end) = after {
         align_up(end, alignment)
     } else {
-        align_up(aperture.base, alignment)
+        align_up(aperture.start(), alignment)
     };
 
     // Bridge windows are 1 MB granular, so the constrained base
     // (align_down of the lowest pinned address) can precede the
     // aperture. Reject this rather than placing BARs outside it.
-    if base < aperture.base {
+    if base < aperture.start() {
         return Err(AssignmentError::MmioExhaustion {
             required,
-            available: aperture.len,
+            available: aperture.len(),
             aperture: aperture_name,
         });
     }
-    let aperture_end = aperture.base + aperture.len;
-    let available = aperture_end.saturating_sub(base);
+    let available = aperture.end().saturating_sub(base);
     if required > available {
         return Err(AssignmentError::MmioExhaustion {
             required,
@@ -590,7 +582,7 @@ fn allocate_pool(
     }
 
     if constrained_base.is_none() {
-        gaps.push((base, aperture_end));
+        gaps.push((base, aperture.end()));
     }
     assign_subtree(devices, demands, gaps, is_mem64);
     Ok(base)
@@ -952,16 +944,13 @@ fn validate_pinned_bars(
 
     // Check aperture containment.
     for p in &all_pinned {
-        let (aperture, aperture_name) = if p.is_mem64 && params.high_mmio.is_some() {
+        let (aperture, aperture_name) = if p.is_mem64 && !params.high_mmio.is_empty() {
             (params.high_mmio, "high_mmio")
         } else {
             (params.low_mmio, "low_mmio")
         };
         let bar_end = p.addr.saturating_add(p.size);
-        let fits = aperture.is_some_and(|a| {
-            let aperture_end = a.base.saturating_add(a.len);
-            p.addr >= a.base && bar_end <= aperture_end
-        });
+        let fits = p.addr >= aperture.start() && bar_end <= aperture.end();
         if !fits {
             return Err(AssignmentError::PinnedBarOutOfAperture {
                 bus: p.bus,

--- a/vm/devices/pci/pci_resource_assignment/src/assign.rs
+++ b/vm/devices/pci/pci_resource_assignment/src/assign.rs
@@ -18,7 +18,7 @@ const BRIDGE_WINDOW_ALIGN: u64 = 1 << 20;
 /// Sizing requirement for a subtree (bridge or root), computed during
 /// the bottom-up pass.
 #[derive(Debug, Clone)]
-struct SubtreeSizing {
+struct SubtreeLayout {
     /// Total aligned size needed in the mem32 (non-prefetchable) pool.
     mem32: u64,
     /// Total aligned size needed in the mem64 (prefetchable) pool.
@@ -28,21 +28,19 @@ struct SubtreeSizing {
     align32: u64,
     /// Required alignment for the mem64 pool.
     align64: u64,
-    /// Sorted demands for this level's devices, used by the assignment
-    /// pass to avoid recomputing them.
+    /// Sorted demands for this level's devices.
     demands: Vec<Demand>,
+    /// Offset within the pool for each demand (parallel to `demands`).
+    /// Always relative to the pool base (0 for unconstrained pools,
+    /// `constrained_base` for constrained pools). The final address
+    /// is `pool_base + offset`.
+    offsets: Vec<u64>,
     /// If pinned demands exist in the mem32 pool, the required base address
     /// for this subtree's window (align_down of the lowest pinned address).
     constrained_base32: Option<u64>,
     /// If pinned demands exist in the mem64 pool, the required base address
     /// for this subtree's window.
     constrained_base64: Option<u64>,
-    /// Pre-computed free gaps in the mem32 pool, covering the window
-    /// [constrained_base, constrained_base + align_up(mem, 1 MB)).
-    /// Empty when there are no pinned demands.
-    gaps32: Vec<(u64, u64)>,
-    /// Pre-computed free gaps in the mem64 pool.
-    gaps64: Vec<(u64, u64)>,
 }
 
 /// All bridge-specific state populated by the assignment phase.
@@ -53,7 +51,7 @@ struct SubtreeSizing {
 #[derive(Debug, Clone)]
 pub(crate) struct BridgeAssignment {
     /// Subtree sizing computed during the bottom-up pass.
-    sizing: SubtreeSizing,
+    layout: SubtreeLayout,
     /// Assigned non-prefetchable bridge window (base, limit).
     memory_window: Option<(u64, u64)>,
     /// Assigned prefetchable bridge window (base, limit).
@@ -61,9 +59,6 @@ pub(crate) struct BridgeAssignment {
 }
 
 /// A single resource demand at one level of the PCI tree.
-///
-/// Shared between the sizing pass (which sums sizes) and the assignment
-/// pass (which bump-allocates addresses).
 #[derive(Debug, Clone)]
 enum Demand {
     /// An endpoint BAR.
@@ -150,11 +145,12 @@ impl Demand {
 ///
 /// Uses hierarchical bottom-up/top-down allocation:
 ///
-/// 1. **Bottom-up sizing**: Each bridge computes the total aligned
-///    resource requirement of its subtree.
-/// 2. **Top-down assignment**: The host bridge carves its aperture among
-///    top-level devices/bridges. Each bridge subdivides its allocated
-///    range among children, largest-first.
+/// 1. **Bottom-up layout**: Each bridge computes the total aligned
+///    resource requirement of its subtree and allocates offsets for
+///    each demand within the subtree window.
+/// 2. **Top-down fixup**: Starting from the aperture base, each
+///    bridge's window base is resolved and added to the pre-computed
+///    offsets to produce final addresses.
 ///
 /// BARs are split into two pools:
 ///
@@ -169,19 +165,17 @@ pub fn assign_addresses(
     devices: &mut [DiscoveredDevice],
     params: &AssignmentParams,
 ) -> Result<(), AssignmentError> {
-    // Validate pinned BAR constraints before sizing, since the sizing
+    // Validate pinned BAR constraints before layout, since the layout
     // pass builds gap lists from pinned positions and assumes they are
     // valid (naturally aligned, non-overlapping, within apertures).
     validate_pinned_bars(devices, params)?;
 
-    // Step 1: Bottom-up — compute total resource requirements.
-    // This also stores per-bridge requirements on the DiscoveredDevice
-    // nodes so that the assignment pass can read them without recomputing.
-    let mut root_sizing = compute_subtree_sizing(devices);
+    // Step 1: Bottom-up — compute total resource requirements and
+    // allocate pool-local positions for each demand.
+    let root_sizing = compute_subtree_layout(devices);
 
-    // Step 2: Top-down — allocate from apertures and assign addresses.
-    // Track where mem32 ends so that mem64 can start after it when
-    // sharing the same aperture.
+    // Step 2: Top-down — determine aperture base addresses and apply
+    // the pre-computed placements to devices.
     let mut mem32_end: Option<u64> = None;
 
     if root_sizing.mem32 > 0 {
@@ -189,10 +183,7 @@ pub fn assign_addresses(
         // 32-bit, so the aperture must be below 4 GB. Do not fall back
         // to high_mmio — placing 32-bit BARs above 4 GB would silently
         // truncate addresses.
-        let base = allocate_pool(
-            devices,
-            &root_sizing.demands,
-            &mut root_sizing.gaps32,
+        let base = resolve_pool_base(
             root_sizing.constrained_base32,
             root_sizing.align32,
             root_sizing.mem32,
@@ -200,6 +191,13 @@ pub fn assign_addresses(
             false,
             None,
         )?;
+        apply_offsets(
+            devices,
+            &root_sizing.demands,
+            &root_sizing.offsets,
+            base,
+            false,
+        );
 
         mem32_end = Some(base + root_sizing.mem32);
     }
@@ -213,10 +211,7 @@ pub fn assign_addresses(
         } else {
             params.high_mmio
         };
-        allocate_pool(
-            devices,
-            &root_sizing.demands,
-            &mut root_sizing.gaps64,
+        let base = resolve_pool_base(
             root_sizing.constrained_base64,
             root_sizing.align64,
             root_sizing.mem64,
@@ -224,6 +219,13 @@ pub fn assign_addresses(
             true,
             after_mem32,
         )?;
+        apply_offsets(
+            devices,
+            &root_sizing.demands,
+            &root_sizing.offsets,
+            base,
+            true,
+        );
     }
 
     validate_assignments(devices, params);
@@ -235,6 +237,19 @@ fn validate_assignments(devices: &[DiscoveredDevice], params: &AssignmentParams)
     for dev in devices {
         for bar in &dev.bars {
             let address = bar.address.unwrap();
+            if let Some(pinned) = bar.pinned_address {
+                assert_eq!(
+                    address,
+                    pinned,
+                    "BAR {bus:02x}:{device:02x}.{func} index {idx} assigned {addr:#x} \
+                     but pinned to {pinned:#x}",
+                    bus = dev.bus,
+                    device = dev.device,
+                    func = dev.function,
+                    idx = bar.index,
+                    addr = address,
+                );
+            }
             assert_bar_in_aperture(address, bar.size, dev, bar.index, params);
         }
         if let Some(sriov) = &dev.sriov {
@@ -338,12 +353,12 @@ fn bar_is_mem64(bar: &crate::enumerate::DiscoveredBar) -> bool {
     }
 }
 
-/// Bottom-up: compute the total aligned resource requirement for a list
-/// of devices (which may be the root level or children behind a bridge).
+/// Bottom-up: compute the layout for a list of devices (which may be
+/// the root level or children behind a bridge).
 ///
-/// Also builds and stores the sorted demand list so that `assign_subtree`
-/// can reuse it without recomputing.
-fn compute_subtree_sizing(devices: &mut [DiscoveredDevice]) -> SubtreeSizing {
+/// Builds the sorted demand list, allocates pool-local offsets for each
+/// demand, and computes the total window size for each pool.
+fn compute_subtree_layout(devices: &mut [DiscoveredDevice]) -> SubtreeLayout {
     let mut demands: Vec<Demand> = Vec::new();
 
     for (i, dev) in devices.iter_mut().enumerate() {
@@ -375,7 +390,7 @@ fn compute_subtree_sizing(devices: &mut [DiscoveredDevice]) -> SubtreeSizing {
         }
 
         if dev.is_bridge {
-            let child_req = compute_subtree_sizing(&mut dev.children);
+            let child_req = compute_subtree_layout(&mut dev.children);
             if child_req.mem32 > 0 {
                 let size = align_up(child_req.mem32, BRIDGE_WINDOW_ALIGN);
                 demands.push(Demand::BridgeSubtree {
@@ -397,7 +412,7 @@ fn compute_subtree_sizing(devices: &mut [DiscoveredDevice]) -> SubtreeSizing {
                 });
             }
             dev.bridge_assignment = Some(BridgeAssignment {
-                sizing: child_req,
+                layout: child_req,
                 memory_window: None,
                 prefetchable_window: None,
             });
@@ -421,131 +436,110 @@ fn compute_subtree_sizing(devices: &mut [DiscoveredDevice]) -> SubtreeSizing {
         }
     }
 
-    // Size each pool: compute the pinned span, build gaps, trial-allocate
-    // dynamic demands, and extend the window for anything that didn't fit.
+    // Build gap lists for each pool and allocate all demands in a
+    // single pass. All placements are stored as offsets from the pool
+    // base (0 for unconstrained, constrained_base for constrained).
     let mut pool32 = PoolState::new(&mut pin32);
     let mut pool64 = PoolState::new(&mut pin64);
 
-    // Trial-allocate dynamic demands into gap clones to determine which
-    // fit in the pinned span and which extend the window.
-    let mut sizing_gaps32 = pool32.gaps.clone();
-    let mut sizing_gaps64 = pool64.gaps.clone();
-    for d in &demands {
-        if d.fixed_position().is_some() {
-            continue;
-        }
-        if d.is_mem64() {
-            pool64.align = pool64.align.max(d.alignment());
-            if allocate_from_gaps(&mut sizing_gaps64, d.size(), d.alignment()).is_none() {
-                pool64.extend_for_demand(d.size(), d.alignment());
-            }
+    let mut offsets = vec![0u64; demands.len()];
+    for (i, d) in demands.iter().enumerate() {
+        let pool = if d.is_mem64() {
+            &mut pool64
         } else {
-            pool32.align = pool32.align.max(d.alignment());
-            if allocate_from_gaps(&mut sizing_gaps32, d.size(), d.alignment()).is_none() {
-                pool32.extend_for_demand(d.size(), d.alignment());
-            }
-        }
+            &mut pool32
+        };
+        pool.align = pool.align.max(d.alignment());
+
+        let addr = if let Some((addr, _)) = d.fixed_position() {
+            addr
+        } else {
+            allocate_from_gaps(&mut pool.gaps, d.size(), d.alignment())
+                .expect("pool gap list has sentinel — allocation cannot fail")
+        };
+        offsets[i] = addr - pool.constrained_base.unwrap_or(0);
     }
 
-    // Extend gap lists with the tail region for demands that didn't fit.
-    pool32.extend_tail();
-    pool64.extend_tail();
+    // Derive pool sizes from the furthest allocation endpoint.
+    let mut mem32 = 0u64;
+    let mut mem64 = 0u64;
+    for (i, d) in demands.iter().enumerate() {
+        let endpoint = offsets[i] + d.size();
+        if d.is_mem64() {
+            mem64 = mem64.max(endpoint);
+        } else {
+            mem32 = mem32.max(endpoint);
+        }
+    }
+    if mem32 > 0 {
+        mem32 = align_up(mem32, BRIDGE_WINDOW_ALIGN);
+    }
+    if mem64 > 0 {
+        mem64 = align_up(mem64, BRIDGE_WINDOW_ALIGN);
+    }
 
-    SubtreeSizing {
-        mem32: pool32.mem,
-        mem64: pool64.mem,
+    SubtreeLayout {
+        mem32,
+        mem64,
         align32: pool32.align,
         align64: pool64.align,
         demands,
+        offsets,
         constrained_base32: pool32.constrained_base,
         constrained_base64: pool64.constrained_base,
-        gaps32: pool32.gaps,
-        gaps64: pool64.gaps,
     }
 }
 
-/// Per-pool sizing state produced by `size_pool`.
+/// Sentinel upper bound for gap lists. Large enough that any realistic
+/// allocation fits, small enough that `align_up(addr, align) + size`
+/// cannot overflow.
+const POOL_SENTINEL: u64 = 1u64 << 60;
+
+/// Per-pool state: gap list and alignment, built from pinned demands.
 struct PoolState {
-    /// Total window size needed (pinned span + dynamic overflow).
-    mem: u64,
     /// Required alignment (max of bridge granularity and largest demand).
     align: u64,
     /// If pinned demands exist, the required window base address.
     constrained_base: Option<u64>,
-    /// Pre-computed gap list covering the pinned span, for reuse by
-    /// `assign_subtree`. Empty when there are no pinned demands.
+    /// Free gap list for allocation.
     gaps: Vec<(u64, u64)>,
-    /// End of the pinned span, for extending gaps after sizing.
-    pinned_span_end: Option<u64>,
 }
 
 impl PoolState {
-    /// Compute the pinned span, gap list, and initial window size for one
-    /// pool (mem32 or mem64). `pins` is sorted in place.
+    /// Build the gap list for one pool. For constrained pools (pins
+    /// present), gaps cover spaces between pins plus a sentinel tail.
+    /// For unconstrained pools, a single `[0, SENTINEL)` gap.
     fn new(pins: &mut [(u64, u64)]) -> Self {
         pins.sort_by_key(|&(a, _)| a);
 
-        let (mem, constrained_base) = if !pins.is_empty() {
-            let min_addr = pins.iter().map(|(a, _)| *a).min().unwrap();
-            let max_end = pins.iter().map(|(a, s)| a + s).max().unwrap();
-            let base = align_down(min_addr, BRIDGE_WINDOW_ALIGN);
-            (max_end - base, Some(base))
-        } else {
-            (0, None)
-        };
+        if pins.is_empty() {
+            return Self {
+                align: BRIDGE_WINDOW_ALIGN,
+                constrained_base: None,
+                gaps: vec![(0, POOL_SENTINEL)],
+            };
+        }
 
-        let gaps = if let Some(base) = constrained_base {
-            build_gap_list(base, base + mem, pins)
-        } else {
-            Vec::new()
-        };
-
-        let pinned_span_end = constrained_base.map(|b| b + mem);
+        let min_addr = pins.iter().map(|(a, _)| *a).min().unwrap();
+        let max_end = pins.iter().map(|(a, s)| a + s).max().unwrap();
+        let base = align_down(min_addr, BRIDGE_WINDOW_ALIGN);
+        let mut gaps = build_gap_list(base, max_end, pins);
+        // Sentinel tail for dynamic demands that don't fit between pins.
+        gaps.push((max_end, POOL_SENTINEL));
 
         Self {
-            mem,
             align: BRIDGE_WINDOW_ALIGN,
-            constrained_base,
+            constrained_base: Some(base),
             gaps,
-            pinned_span_end,
-        }
-    }
-
-    /// Append a tail gap for dynamic demands that didn't fit in the
-    /// pinned-span gaps. Called after the sizing trial.
-    fn extend_tail(&mut self) {
-        if let Some(pin_end) = self.pinned_span_end {
-            let window_end = self.constrained_base.unwrap() + self.mem;
-            if pin_end < window_end {
-                self.gaps.push((pin_end, window_end));
-            }
-        }
-    }
-
-    /// Extend the window to fit a dynamic demand that didn't fit in
-    /// any existing gap. When `constrained_base` is set, alignment
-    /// padding must be computed using absolute addresses (base + mem)
-    /// rather than relative offsets, because the real allocator works
-    /// in absolute address space.
-    fn extend_for_demand(&mut self, size: u64, alignment: u64) {
-        if let Some(base) = self.constrained_base {
-            let abs_end = base + self.mem;
-            let aligned = align_up(abs_end, alignment);
-            self.mem = (aligned - base) + size;
-        } else {
-            self.mem = align_up(self.mem, alignment) + size;
         }
     }
 }
 
-/// Compute the base address for a pool, validate it fits in the aperture,
-/// populate gaps, and assign addresses to all demands in the pool.
+/// Determine the base address for a pool within an aperture, validating
+/// that the required size fits.
 ///
 /// Returns the effective base address on success.
-fn allocate_pool(
-    devices: &mut [DiscoveredDevice],
-    demands: &[Demand],
-    gaps: &mut Vec<(u64, u64)>,
+fn resolve_pool_base(
     constrained_base: Option<u64>,
     alignment: u64,
     required: u64,
@@ -581,41 +575,27 @@ fn allocate_pool(
         });
     }
 
-    if constrained_base.is_none() {
-        gaps.push((base, aperture.end()));
-    }
-    assign_subtree(devices, demands, gaps, is_mem64);
     Ok(base)
 }
 
-/// Top-down: assign addresses to devices within a subtree, carving from
-/// the given gap list. `alloc_64bit` selects which pool (mem32 or
-/// mem64) we are assigning.
+/// Top-down: apply pre-computed offsets to devices.
 ///
-/// Fixed-position demands (pinned BARs and constrained bridges) are placed
-/// at their predetermined addresses. Dynamic demands are placed into free
-/// gaps using a first-fit strategy.
-///
-/// `demands` is the pre-sorted demand list built by `compute_subtree_state`.
-fn assign_subtree(
+/// `base` is the pool's starting address (aperture-derived for the root,
+/// or the bridge window base for children). Each demand's final address
+/// is `base + offset`.
+fn apply_offsets(
     devices: &mut [DiscoveredDevice],
     demands: &[Demand],
-    gaps: &mut Vec<(u64, u64)>,
-    alloc_64bit: bool,
+    offsets: &[u64],
+    base: u64,
+    is_mem64: bool,
 ) {
-    for demand in demands {
-        if demand.is_mem64() != alloc_64bit {
+    for (demand, &offset) in demands.iter().zip(offsets) {
+        if demand.is_mem64() != is_mem64 {
             continue;
         }
 
-        // Fixed-position demands use their predetermined address.
-        // Dynamic demands are placed via the gap allocator.
-        let assign_addr = if let Some((addr, _)) = demand.fixed_position() {
-            addr
-        } else {
-            allocate_from_gaps(gaps, demand.size(), demand.alignment())
-                .expect("demand must fit (sizing pass guarantees sufficient space)")
-        };
+        let final_addr = base + offset;
 
         match *demand {
             Demand::Bar {
@@ -626,45 +606,33 @@ fn assign_subtree(
                     .iter_mut()
                     .find(|b| b.index == bar_index)
                     .expect("demand references a BAR that exists");
-                bar.address = Some(assign_addr);
+                bar.address = Some(final_addr);
             }
             Demand::BridgeSubtree { dev_idx, size, .. } => {
                 let dev = &mut devices[dev_idx];
-
-                // Set the bridge window to the carved-out range.
-                let window_base = assign_addr;
-                let window_limit = assign_addr + size - 1;
+                let window_base = final_addr;
+                let window_limit = final_addr + size - 1;
                 let ba = dev
                     .bridge_assignment
                     .as_mut()
-                    .expect("bridge_assignment must be populated by compute_subtree_sizing");
-                if alloc_64bit {
+                    .expect("bridge_assignment must be populated by compute_subtree_layout");
+                if is_mem64 {
                     ba.prefetchable_window = Some((window_base, window_limit));
                 } else {
                     ba.memory_window = Some((window_base, window_limit));
                 }
 
-                // Recurse into children with this bridge's carved-out range.
-                let sizing = &mut ba.sizing;
-                let has_pins = if alloc_64bit {
-                    sizing.constrained_base64.is_some()
-                } else {
-                    sizing.constrained_base32.is_some()
-                };
-                let (child_demands, child_gaps) = if alloc_64bit {
-                    (&sizing.demands, &mut sizing.gaps64)
-                } else {
-                    (&sizing.demands, &mut sizing.gaps32)
-                };
-                if !has_pins {
-                    child_gaps.push((window_base, window_limit + 1));
-                }
-                assign_subtree(&mut dev.children, child_demands, child_gaps, alloc_64bit);
+                apply_offsets(
+                    &mut dev.children,
+                    &ba.layout.demands,
+                    &ba.layout.offsets,
+                    window_base,
+                    is_mem64,
+                );
             }
             Demand::SriovVfBars {
                 dev_idx, bar_index, ..
             } => {
-                // Record the assigned base address on the VF BAR.
                 let sriov = devices[dev_idx]
                     .sriov
                     .as_mut()
@@ -674,7 +642,7 @@ fn assign_subtree(
                     .iter_mut()
                     .find(|b| b.index == bar_index)
                     .expect("demand references a VF BAR that exists");
-                vf_bar.address = Some(assign_addr);
+                vf_bar.address = Some(final_addr);
             }
         }
     }

--- a/vm/devices/pci/pci_resource_assignment/src/assign.rs
+++ b/vm/devices/pci/pci_resource_assignment/src/assign.rs
@@ -169,17 +169,17 @@ pub fn assign_addresses(
     devices: &mut [DiscoveredDevice],
     params: &AssignmentParams,
 ) -> Result<(), AssignmentError> {
+    // Validate pinned BAR constraints before sizing, since the sizing
+    // pass builds gap lists from pinned positions and assumes they are
+    // valid (naturally aligned, non-overlapping, within apertures).
+    validate_pinned_bars(devices, params)?;
+
     // Step 1: Bottom-up — compute total resource requirements.
     // This also stores per-bridge requirements on the DiscoveredDevice
     // nodes so that the assignment pass can read them without recomputing.
     let mut root_sizing = compute_subtree_sizing(devices);
 
-    // Validate pinned BAR constraints before assigning addresses.
-    validate_pinned_bars(devices, params)?;
-
     // Step 2: Top-down — allocate from apertures and assign addresses.
-    // Align the effective base to the root's alignment requirement so that
-    // internal bump allocation matches the sizing (which starts from zero).
     // Track where mem32 ends so that mem64 can start after it when
     // sharing the same aperture.
     let mut mem32_end: Option<u64> = None;
@@ -189,78 +189,36 @@ pub fn assign_addresses(
         // 32-bit, so the aperture must be below 4 GB. Do not fall back
         // to high_mmio — placing 32-bit BARs above 4 GB would silently
         // truncate addresses.
-        let aperture = params.low_mmio.ok_or(AssignmentError::MmioExhaustion {
-            required: root_sizing.mem32,
-            available: 0,
-            aperture: "low_mmio",
-        })?;
-
-        // If there are constrained (pinned) demands, use their base.
-        // Otherwise, align to the aperture base as before.
-        let base = if let Some(cbase) = root_sizing.constrained_base32 {
-            cbase
-        } else {
-            align_up(aperture.base, root_sizing.align32)
-        };
-        let aperture_end = aperture.base + aperture.len;
-        let available = aperture_end.saturating_sub(base);
-        if root_sizing.mem32 > available {
-            return Err(AssignmentError::MmioExhaustion {
-                required: root_sizing.mem32,
-                available,
-                aperture: "low_mmio",
-            });
-        }
-
-        if root_sizing.constrained_base32.is_none() {
-            root_sizing.gaps32.push((base, aperture_end));
-        }
-        assign_subtree(
+        let base = allocate_pool(
             devices,
             &root_sizing.demands,
             &mut root_sizing.gaps32,
+            root_sizing.constrained_base32,
+            root_sizing.align32,
+            root_sizing.mem32,
+            params.low_mmio,
             false,
-        );
+            None,
+        )?;
 
         mem32_end = Some(base + root_sizing.mem32);
     }
 
     if root_sizing.mem64 > 0 {
-        let aperture =
-            params
-                .high_mmio
-                .or(params.low_mmio)
-                .ok_or(AssignmentError::MmioExhaustion {
-                    required: root_sizing.mem64,
-                    available: 0,
-                    aperture: "high_mmio",
-                })?;
+        // If sharing the same aperture as mem32, start after mem32.
+        let after_mem32 = mem32_end.filter(|_| params.high_mmio.is_none());
 
-        // If there are constrained (pinned) demands, use their base.
-        let base = if let Some(cbase) = root_sizing.constrained_base64 {
-            cbase
-        } else if let Some(end) = mem32_end.filter(|_| params.high_mmio.is_none()) {
-            // If sharing the same aperture as mem32, allocate after the
-            // actual aligned mem32 end to avoid overlapping assignments.
-            align_up(end, root_sizing.align64)
-        } else {
-            align_up(aperture.base, root_sizing.align64)
-        };
-
-        let aperture_end = aperture.base + aperture.len;
-        let available = aperture_end.saturating_sub(base);
-        if root_sizing.mem64 > available {
-            return Err(AssignmentError::MmioExhaustion {
-                required: root_sizing.mem64,
-                available,
-                aperture: "high_mmio",
-            });
-        }
-
-        if root_sizing.constrained_base64.is_none() {
-            root_sizing.gaps64.push((base, aperture_end));
-        }
-        assign_subtree(devices, &root_sizing.demands, &mut root_sizing.gaps64, true);
+        allocate_pool(
+            devices,
+            &root_sizing.demands,
+            &mut root_sizing.gaps64,
+            root_sizing.constrained_base64,
+            root_sizing.align64,
+            root_sizing.mem64,
+            params.high_mmio.or(params.low_mmio),
+            true,
+            after_mem32,
+        )?;
     }
 
     validate_assignments(devices, params);
@@ -585,6 +543,62 @@ impl PoolState {
             self.mem = align_up(self.mem, alignment) + size;
         }
     }
+}
+
+/// Compute the base address for a pool, validate it fits in the aperture,
+/// populate gaps, and assign addresses to all demands in the pool.
+///
+/// Returns the effective base address on success.
+fn allocate_pool(
+    devices: &mut [DiscoveredDevice],
+    demands: &[Demand],
+    gaps: &mut Vec<(u64, u64)>,
+    constrained_base: Option<u64>,
+    alignment: u64,
+    required: u64,
+    aperture: Option<crate::MmioAperture>,
+    is_mem64: bool,
+    after: Option<u64>,
+) -> Result<u64, AssignmentError> {
+    let aperture_name = if is_mem64 { "high_mmio" } else { "low_mmio" };
+    let aperture = aperture.ok_or(AssignmentError::MmioExhaustion {
+        required,
+        available: 0,
+        aperture: aperture_name,
+    })?;
+    let base = if let Some(cbase) = constrained_base {
+        cbase
+    } else if let Some(end) = after {
+        align_up(end, alignment)
+    } else {
+        align_up(aperture.base, alignment)
+    };
+
+    // Bridge windows are 1 MB granular, so the constrained base
+    // (align_down of the lowest pinned address) can precede the
+    // aperture. Reject this rather than placing BARs outside it.
+    if base < aperture.base {
+        return Err(AssignmentError::MmioExhaustion {
+            required,
+            available: aperture.len,
+            aperture: aperture_name,
+        });
+    }
+    let aperture_end = aperture.base + aperture.len;
+    let available = aperture_end.saturating_sub(base);
+    if required > available {
+        return Err(AssignmentError::MmioExhaustion {
+            required,
+            available,
+            aperture: aperture_name,
+        });
+    }
+
+    if constrained_base.is_none() {
+        gaps.push((base, aperture_end));
+    }
+    assign_subtree(devices, demands, gaps, is_mem64);
+    Ok(base)
 }
 
 /// Top-down: assign addresses to devices within a subtree, carving from

--- a/vm/devices/pci/pci_resource_assignment/src/assign.rs
+++ b/vm/devices/pci/pci_resource_assignment/src/assign.rs
@@ -15,9 +15,10 @@ use pci_core::spec::cfg_space::MEMORY_BASE_LIMIT_ADDRESS_MASK;
 /// Bridge memory window granularity: 1 MB.
 const BRIDGE_WINDOW_ALIGN: u64 = 1 << 20;
 
-/// Resource requirement for a subtree (bridge or root).
+/// Sizing requirement for a subtree (bridge or root), computed during
+/// the bottom-up pass.
 #[derive(Debug, Clone)]
-pub(crate) struct SubtreeState {
+struct SubtreeSizing {
     /// Total aligned size needed in the mem32 (non-prefetchable) pool.
     mem32: u64,
     /// Total aligned size needed in the mem64 (prefetchable) pool.
@@ -30,10 +31,6 @@ pub(crate) struct SubtreeState {
     /// Sorted demands for this level's devices, used by the assignment
     /// pass to avoid recomputing them.
     demands: Vec<Demand>,
-    /// Assigned non-prefetchable bridge window (base, limit). Set by assign_subtree.
-    memory_window: Option<(u64, u64)>,
-    /// Assigned prefetchable bridge window (base, limit). Set by assign_subtree.
-    prefetchable_window: Option<(u64, u64)>,
     /// If pinned demands exist in the mem32 pool, the required base address
     /// for this subtree's window (align_down of the lowest pinned address).
     constrained_base32: Option<u64>,
@@ -46,6 +43,21 @@ pub(crate) struct SubtreeState {
     gaps32: Vec<(u64, u64)>,
     /// Pre-computed free gaps in the mem64 pool.
     gaps64: Vec<(u64, u64)>,
+}
+
+/// All bridge-specific state populated by the assignment phase.
+///
+/// Groups the subtree sizing (computed bottom-up) and the assigned
+/// bridge windows (set top-down) so that [`DiscoveredDevice`] only
+/// needs a single `Option` field for assignment state.
+#[derive(Debug, Clone)]
+pub(crate) struct BridgeAssignment {
+    /// Subtree sizing computed during the bottom-up pass.
+    sizing: SubtreeSizing,
+    /// Assigned non-prefetchable bridge window (base, limit).
+    memory_window: Option<(u64, u64)>,
+    /// Assigned prefetchable bridge window (base, limit).
+    prefetchable_window: Option<(u64, u64)>,
 }
 
 /// A single resource demand at one level of the PCI tree.
@@ -160,7 +172,7 @@ pub fn assign_addresses(
     // Step 1: Bottom-up — compute total resource requirements.
     // This also stores per-bridge requirements on the DiscoveredDevice
     // nodes so that the assignment pass can read them without recomputing.
-    let mut root_req = compute_subtree_state(devices);
+    let mut root_sizing = compute_subtree_sizing(devices);
 
     // Validate pinned BAR constraints before assigning addresses.
     validate_pinned_bars(devices, params)?;
@@ -172,78 +184,83 @@ pub fn assign_addresses(
     // sharing the same aperture.
     let mut mem32_end: Option<u64> = None;
 
-    if root_req.mem32 > 0 {
+    if root_sizing.mem32 > 0 {
         // 32-bit BARs and non-prefetchable bridge windows are inherently
         // 32-bit, so the aperture must be below 4 GB. Do not fall back
         // to high_mmio — placing 32-bit BARs above 4 GB would silently
         // truncate addresses.
         let aperture = params.low_mmio.ok_or(AssignmentError::MmioExhaustion {
-            required: root_req.mem32,
+            required: root_sizing.mem32,
             available: 0,
             aperture: "low_mmio",
         })?;
 
         // If there are constrained (pinned) demands, use their base.
         // Otherwise, align to the aperture base as before.
-        let base = if let Some(cbase) = root_req.constrained_base32 {
+        let base = if let Some(cbase) = root_sizing.constrained_base32 {
             cbase
         } else {
-            align_up(aperture.base, root_req.align32)
+            align_up(aperture.base, root_sizing.align32)
         };
         let aperture_end = aperture.base + aperture.len;
         let available = aperture_end.saturating_sub(base);
-        if root_req.mem32 > available {
+        if root_sizing.mem32 > available {
             return Err(AssignmentError::MmioExhaustion {
-                required: root_req.mem32,
+                required: root_sizing.mem32,
                 available,
                 aperture: "low_mmio",
             });
         }
 
-        if root_req.constrained_base32.is_none() {
-            root_req.gaps32.push((base, aperture_end));
+        if root_sizing.constrained_base32.is_none() {
+            root_sizing.gaps32.push((base, aperture_end));
         }
-        assign_subtree(devices, &root_req.demands, &mut root_req.gaps32, false);
+        assign_subtree(
+            devices,
+            &root_sizing.demands,
+            &mut root_sizing.gaps32,
+            false,
+        );
 
-        mem32_end = Some(base + root_req.mem32);
+        mem32_end = Some(base + root_sizing.mem32);
     }
 
-    if root_req.mem64 > 0 {
+    if root_sizing.mem64 > 0 {
         let aperture =
             params
                 .high_mmio
                 .or(params.low_mmio)
                 .ok_or(AssignmentError::MmioExhaustion {
-                    required: root_req.mem64,
+                    required: root_sizing.mem64,
                     available: 0,
                     aperture: "high_mmio",
                 })?;
 
         // If there are constrained (pinned) demands, use their base.
-        let base = if let Some(cbase) = root_req.constrained_base64 {
+        let base = if let Some(cbase) = root_sizing.constrained_base64 {
             cbase
         } else if let Some(end) = mem32_end.filter(|_| params.high_mmio.is_none()) {
             // If sharing the same aperture as mem32, allocate after the
             // actual aligned mem32 end to avoid overlapping assignments.
-            align_up(end, root_req.align64)
+            align_up(end, root_sizing.align64)
         } else {
-            align_up(aperture.base, root_req.align64)
+            align_up(aperture.base, root_sizing.align64)
         };
 
         let aperture_end = aperture.base + aperture.len;
         let available = aperture_end.saturating_sub(base);
-        if root_req.mem64 > available {
+        if root_sizing.mem64 > available {
             return Err(AssignmentError::MmioExhaustion {
-                required: root_req.mem64,
+                required: root_sizing.mem64,
                 available,
                 aperture: "high_mmio",
             });
         }
 
-        if root_req.constrained_base64.is_none() {
-            root_req.gaps64.push((base, aperture_end));
+        if root_sizing.constrained_base64.is_none() {
+            root_sizing.gaps64.push((base, aperture_end));
         }
-        assign_subtree(devices, &root_req.demands, &mut root_req.gaps64, true);
+        assign_subtree(devices, &root_sizing.demands, &mut root_sizing.gaps64, true);
     }
 
     validate_assignments(devices, params);
@@ -266,8 +283,8 @@ fn validate_assignments(devices: &[DiscoveredDevice], params: &AssignmentParams)
         }
         // Validate bridge windows fit within their respective apertures
         // and that child windows fit within parent windows.
-        if let Some(req) = &dev.subtree_req {
-            if let Some((base, limit)) = req.memory_window {
+        if let Some(ba) = &dev.bridge_assignment {
+            if let Some((base, limit)) = ba.memory_window {
                 let size = limit - base + 1;
                 assert!(
                     params
@@ -280,7 +297,7 @@ fn validate_assignments(devices: &[DiscoveredDevice], params: &AssignmentParams)
                     func = dev.function,
                 );
             }
-            if let Some((base, limit)) = req.prefetchable_window {
+            if let Some((base, limit)) = ba.prefetchable_window {
                 let size = limit - base + 1;
                 let in_low = params
                     .low_mmio
@@ -299,31 +316,31 @@ fn validate_assignments(devices: &[DiscoveredDevice], params: &AssignmentParams)
             }
             // Check child bridge windows are contained within this bridge's windows.
             for child in &dev.children {
-                if let Some(child_req) = &child.subtree_req {
-                    if let (Some((cb, cl)), Some((pb, pl))) =
-                        (child_req.memory_window, req.memory_window)
-                    {
-                        assert!(
-                            cb >= pb && cl <= pl,
-                            "child bridge {cbus:02x}:{cdev:02x}.{cfunc} memory window \
-                             {cb:#x}..={cl:#x} exceeds parent {pb:#x}..={pl:#x}",
-                            cbus = child.bus,
-                            cdev = child.device,
-                            cfunc = child.function,
-                        );
-                    }
-                    if let (Some((cb, cl)), Some((pb, pl))) =
-                        (child_req.prefetchable_window, req.prefetchable_window)
-                    {
-                        assert!(
-                            cb >= pb && cl <= pl,
-                            "child bridge {cbus:02x}:{cdev:02x}.{cfunc} prefetchable window \
-                             {cb:#x}..={cl:#x} exceeds parent {pb:#x}..={pl:#x}",
-                            cbus = child.bus,
-                            cdev = child.device,
-                            cfunc = child.function,
-                        );
-                    }
+                let child_ba = child.bridge_assignment.as_ref();
+                if let (Some((cb, cl)), Some((pb, pl))) =
+                    (child_ba.and_then(|b| b.memory_window), ba.memory_window)
+                {
+                    assert!(
+                        cb >= pb && cl <= pl,
+                        "child bridge {cbus:02x}:{cdev:02x}.{cfunc} memory window \
+                         {cb:#x}..={cl:#x} exceeds parent {pb:#x}..={pl:#x}",
+                        cbus = child.bus,
+                        cdev = child.device,
+                        cfunc = child.function,
+                    );
+                }
+                if let (Some((cb, cl)), Some((pb, pl))) = (
+                    child_ba.and_then(|b| b.prefetchable_window),
+                    ba.prefetchable_window,
+                ) {
+                    assert!(
+                        cb >= pb && cl <= pl,
+                        "child bridge {cbus:02x}:{cdev:02x}.{cfunc} prefetchable window \
+                         {cb:#x}..={cl:#x} exceeds parent {pb:#x}..={pl:#x}",
+                        cbus = child.bus,
+                        cdev = child.device,
+                        cfunc = child.function,
+                    );
                 }
             }
         }
@@ -366,7 +383,7 @@ fn is_mem64_bar(bar: &crate::enumerate::DiscoveredBar) -> bool {
 ///
 /// Also builds and stores the sorted demand list so that `assign_subtree`
 /// can reuse it without recomputing.
-fn compute_subtree_state(devices: &mut [DiscoveredDevice]) -> SubtreeState {
+fn compute_subtree_sizing(devices: &mut [DiscoveredDevice]) -> SubtreeSizing {
     let mut demands: Vec<Demand> = Vec::new();
 
     for (i, dev) in devices.iter_mut().enumerate() {
@@ -407,7 +424,7 @@ fn compute_subtree_state(devices: &mut [DiscoveredDevice]) -> SubtreeState {
         }
 
         if dev.is_bridge {
-            let child_req = compute_subtree_state(&mut dev.children);
+            let child_req = compute_subtree_sizing(&mut dev.children);
             if child_req.mem32 > 0 {
                 let size = align_up(child_req.mem32, BRIDGE_WINDOW_ALIGN);
                 demands.push(Demand::BridgeSubtree {
@@ -428,7 +445,11 @@ fn compute_subtree_state(devices: &mut [DiscoveredDevice]) -> SubtreeState {
                     constrained_base: child_req.constrained_base64,
                 });
             }
-            dev.subtree_req = Some(child_req);
+            dev.bridge_assignment = Some(BridgeAssignment {
+                sizing: child_req,
+                memory_window: None,
+                prefetchable_window: None,
+            });
         }
     }
 
@@ -451,8 +472,8 @@ fn compute_subtree_state(devices: &mut [DiscoveredDevice]) -> SubtreeState {
 
     // Size each pool: compute the pinned span, build gaps, trial-allocate
     // dynamic demands, and extend the window for anything that didn't fit.
-    let mut pool32 = size_pool(&mut pin32, &demands, false);
-    let mut pool64 = size_pool(&mut pin64, &demands, true);
+    let mut pool32 = PoolState::new(&mut pin32);
+    let mut pool64 = PoolState::new(&mut pin64);
 
     // Trial-allocate dynamic demands into gap clones to determine which
     // fit in the pinned span and which extend the window.
@@ -465,14 +486,12 @@ fn compute_subtree_state(devices: &mut [DiscoveredDevice]) -> SubtreeState {
         if d.is_mem64() {
             pool64.align = pool64.align.max(d.alignment());
             if allocate_from_gaps(&mut sizing_gaps64, d.size(), d.alignment()).is_none() {
-                pool64.mem = align_up(pool64.mem, d.alignment());
-                pool64.mem += d.size();
+                pool64.extend_for_demand(d.size(), d.alignment());
             }
         } else {
             pool32.align = pool32.align.max(d.alignment());
             if allocate_from_gaps(&mut sizing_gaps32, d.size(), d.alignment()).is_none() {
-                pool32.mem = align_up(pool32.mem, d.alignment());
-                pool32.mem += d.size();
+                pool32.extend_for_demand(d.size(), d.alignment());
             }
         }
     }
@@ -481,14 +500,12 @@ fn compute_subtree_state(devices: &mut [DiscoveredDevice]) -> SubtreeState {
     pool32.extend_tail();
     pool64.extend_tail();
 
-    SubtreeState {
+    SubtreeSizing {
         mem32: pool32.mem,
         mem64: pool64.mem,
         align32: pool32.align,
         align64: pool64.align,
         demands,
-        memory_window: None,
-        prefetchable_window: None,
         constrained_base32: pool32.constrained_base,
         constrained_base64: pool64.constrained_base,
         gaps32: pool32.gaps,
@@ -512,6 +529,37 @@ struct PoolState {
 }
 
 impl PoolState {
+    /// Compute the pinned span, gap list, and initial window size for one
+    /// pool (mem32 or mem64). `pins` is sorted in place.
+    fn new(pins: &mut [(u64, u64)]) -> Self {
+        pins.sort_by_key(|&(a, _)| a);
+
+        let (mem, constrained_base) = if !pins.is_empty() {
+            let min_addr = pins.iter().map(|(a, _)| *a).min().unwrap();
+            let max_end = pins.iter().map(|(a, s)| a + s).max().unwrap();
+            let base = align_down(min_addr, BRIDGE_WINDOW_ALIGN);
+            (max_end - base, Some(base))
+        } else {
+            (0, None)
+        };
+
+        let gaps = if let Some(base) = constrained_base {
+            build_gap_list(base, base + mem, pins)
+        } else {
+            Vec::new()
+        };
+
+        let pinned_span_end = constrained_base.map(|b| b + mem);
+
+        Self {
+            mem,
+            align: BRIDGE_WINDOW_ALIGN,
+            constrained_base,
+            gaps,
+            pinned_span_end,
+        }
+    }
+
     /// Append a tail gap for dynamic demands that didn't fit in the
     /// pinned-span gaps. Called after the sizing trial.
     fn extend_tail(&mut self) {
@@ -522,38 +570,20 @@ impl PoolState {
             }
         }
     }
-}
 
-/// Compute the pinned span, gap list, and initial window size for one
-/// pool (mem32 or mem64). `pins` is sorted in place.
-fn size_pool(pins: &mut [(u64, u64)], demands: &[Demand], is_mem64: bool) -> PoolState {
-    pins.sort_by_key(|&(a, _)| a);
-
-    let (mem, constrained_base) = if !pins.is_empty() {
-        let min_addr = pins.iter().map(|(a, _)| *a).min().unwrap();
-        let max_end = pins.iter().map(|(a, s)| a + s).max().unwrap();
-        let base = align_down(min_addr, BRIDGE_WINDOW_ALIGN);
-        (max_end - base, Some(base))
-    } else {
-        (0, None)
-    };
-
-    let _ = (demands, is_mem64); // used by caller for trial allocation
-
-    let gaps = if let Some(base) = constrained_base {
-        build_gap_list(base, base + mem, pins)
-    } else {
-        Vec::new()
-    };
-
-    let pinned_span_end = constrained_base.map(|b| b + mem);
-
-    PoolState {
-        mem,
-        align: BRIDGE_WINDOW_ALIGN,
-        constrained_base,
-        gaps,
-        pinned_span_end,
+    /// Extend the window to fit a dynamic demand that didn't fit in
+    /// any existing gap. When `constrained_base` is set, alignment
+    /// padding must be computed using absolute addresses (base + mem)
+    /// rather than relative offsets, because the real allocator works
+    /// in absolute address space.
+    fn extend_for_demand(&mut self, size: u64, alignment: u64) {
+        if let Some(base) = self.constrained_base {
+            let abs_end = base + self.mem;
+            let aligned = align_up(abs_end, alignment);
+            self.mem = (aligned - base) + size;
+        } else {
+            self.mem = align_up(self.mem, alignment) + size;
+        }
     }
 }
 
@@ -603,27 +633,27 @@ fn assign_subtree(
                 // Set the bridge window to the carved-out range.
                 let window_base = assign_addr;
                 let window_limit = assign_addr + size - 1;
-                let req = dev.subtree_req.as_mut().unwrap();
+                let ba = dev
+                    .bridge_assignment
+                    .as_mut()
+                    .expect("bridge_assignment must be populated by compute_subtree_sizing");
                 if alloc_64bit {
-                    req.prefetchable_window = Some((window_base, window_limit));
+                    ba.prefetchable_window = Some((window_base, window_limit));
                 } else {
-                    req.memory_window = Some((window_base, window_limit));
+                    ba.memory_window = Some((window_base, window_limit));
                 }
 
                 // Recurse into children with this bridge's carved-out range.
-                let req = dev
-                    .subtree_req
-                    .as_mut()
-                    .expect("subtree_req must be populated by compute_subtree_state");
+                let sizing = &mut ba.sizing;
                 let has_pins = if alloc_64bit {
-                    req.constrained_base64.is_some()
+                    sizing.constrained_base64.is_some()
                 } else {
-                    req.constrained_base32.is_some()
+                    sizing.constrained_base32.is_some()
                 };
                 let (child_demands, child_gaps) = if alloc_64bit {
-                    (&req.demands, &mut req.gaps64)
+                    (&sizing.demands, &mut sizing.gaps64)
                 } else {
-                    (&req.demands, &mut req.gaps32)
+                    (&sizing.demands, &mut sizing.gaps32)
                 };
                 if !has_pins {
                     child_gaps.push((window_base, window_limit + 1));
@@ -693,10 +723,9 @@ pub async fn program_assignments(cfg: &mut impl PciConfigAccess, devices: &[Disc
         // window by writing base > limit so that the guest OS's probe
         // (write-readback) doesn't mistake zeroed registers for a valid window.
         if dev.is_bridge {
-            let (memory_window, prefetchable_window) = dev
-                .subtree_req
-                .as_ref()
-                .map(|r| (r.memory_window, r.prefetchable_window))
+            let ba = dev.bridge_assignment.as_ref();
+            let (memory_window, prefetchable_window) = ba
+                .map(|b| (b.memory_window, b.prefetchable_window))
                 .unwrap_or((None, None));
 
             // I/O window — we don't assign I/O BARs, so always disable.
@@ -756,8 +785,9 @@ pub async fn program_assignments(cfg: &mut impl PciConfigAccess, devices: &[Disc
         }
 
         if dev.bars.is_empty() && dev.is_bridge {
-            let memory_window = dev.subtree_req.as_ref().and_then(|r| r.memory_window);
-            let prefetchable_window = dev.subtree_req.as_ref().and_then(|r| r.prefetchable_window);
+            let ba = dev.bridge_assignment.as_ref();
+            let memory_window = ba.and_then(|b| b.memory_window);
+            let prefetchable_window = ba.and_then(|b| b.prefetchable_window);
             tracing::debug!(
                 bus = dev.bus,
                 device = dev.device,

--- a/vm/devices/pci/pci_resource_assignment/src/assign.rs
+++ b/vm/devices/pci/pci_resource_assignment/src/assign.rs
@@ -194,7 +194,7 @@ pub fn assign_addresses(
             });
         }
 
-        assign_subtree(devices, &root_req.demands, false, base);
+        assign_subtree(devices, &root_req.demands, false, base, aperture_end);
 
         mem32_end = Some(base + root_req.mem32);
     }
@@ -231,7 +231,7 @@ pub fn assign_addresses(
             });
         }
 
-        assign_subtree(devices, &root_req.demands, true, base);
+        assign_subtree(devices, &root_req.demands, true, base, aperture_end);
     }
 
     validate_assignments(devices, params);
@@ -250,6 +250,69 @@ fn validate_assignments(devices: &[DiscoveredDevice], params: &AssignmentParams)
                 let address = bar.address.unwrap();
                 let total_size = bar.size * sriov.total_vfs as u64;
                 assert_bar_in_aperture(address, total_size, dev, bar.index, params);
+            }
+        }
+        // Validate bridge windows fit within their respective apertures
+        // and that child windows fit within parent windows.
+        if let Some(req) = &dev.subtree_req {
+            if let Some((base, limit)) = req.memory_window {
+                let size = limit - base + 1;
+                assert!(
+                    params
+                        .low_mmio
+                        .is_some_and(|a| base >= a.base && base + size <= a.base + a.len),
+                    "bridge {bus:02x}:{device:02x}.{func} memory window \
+                     {base:#x}..={limit:#x} exceeds low_mmio aperture",
+                    bus = dev.bus,
+                    device = dev.device,
+                    func = dev.function,
+                );
+            }
+            if let Some((base, limit)) = req.prefetchable_window {
+                let size = limit - base + 1;
+                let in_low = params
+                    .low_mmio
+                    .is_some_and(|a| base >= a.base && base + size <= a.base + a.len);
+                let in_high = params
+                    .high_mmio
+                    .is_some_and(|a| base >= a.base && base + size <= a.base + a.len);
+                assert!(
+                    in_low || in_high,
+                    "bridge {bus:02x}:{device:02x}.{func} prefetchable window \
+                     {base:#x}..={limit:#x} exceeds MMIO apertures",
+                    bus = dev.bus,
+                    device = dev.device,
+                    func = dev.function,
+                );
+            }
+            // Check child bridge windows are contained within this bridge's windows.
+            for child in &dev.children {
+                if let Some(child_req) = &child.subtree_req {
+                    if let (Some((cb, cl)), Some((pb, pl))) =
+                        (child_req.memory_window, req.memory_window)
+                    {
+                        assert!(
+                            cb >= pb && cl <= pl,
+                            "child bridge {cbus:02x}:{cdev:02x}.{cfunc} memory window \
+                             {cb:#x}..={cl:#x} exceeds parent {pb:#x}..={pl:#x}",
+                            cbus = child.bus,
+                            cdev = child.device,
+                            cfunc = child.function,
+                        );
+                    }
+                    if let (Some((cb, cl)), Some((pb, pl))) =
+                        (child_req.prefetchable_window, req.prefetchable_window)
+                    {
+                        assert!(
+                            cb >= pb && cl <= pl,
+                            "child bridge {cbus:02x}:{cdev:02x}.{cfunc} prefetchable window \
+                             {cb:#x}..={cl:#x} exceeds parent {pb:#x}..={pl:#x}",
+                            cbus = child.bus,
+                            cdev = child.device,
+                            cfunc = child.function,
+                        );
+                    }
+                }
             }
         }
         validate_assignments(&dev.children, params);
@@ -296,11 +359,21 @@ fn compute_subtree_state(devices: &mut [DiscoveredDevice]) -> SubtreeState {
 
     for (i, dev) in devices.iter_mut().enumerate() {
         for bar in &dev.bars {
+            // For pinned BARs below 4 GB, treat them as mem32 regardless
+            // of encoding. Prefetchable vs. non-prefetchable is not a real
+            // distinction in virtualization, and placing a pinned BAR in the
+            // mem64 pool when its address is in the low MMIO range would
+            // create a bridge window spanning across apertures.
+            let is_mem64 = if let Some(addr) = bar.pinned_address {
+                addr >= 0x1_0000_0000 && is_mem64_bar(bar)
+            } else {
+                is_mem64_bar(bar)
+            };
             demands.push(Demand::Bar {
                 dev_idx: i,
                 bar_index: bar.index,
                 size: bar.size,
-                is_mem64: is_mem64_bar(bar),
+                is_mem64,
                 pinned_address: bar.pinned_address,
             });
         }
@@ -436,6 +509,7 @@ fn assign_subtree(
     demands: &[Demand],
     alloc_64bit: bool,
     base: u64,
+    limit: u64,
 ) {
     // Compute the starting offset for bump allocation: after all
     // fixed-position demands.
@@ -463,6 +537,16 @@ fn assign_subtree(
             offset += demand.size();
             addr
         };
+
+        // Every placement must fit within the parent's window.
+        assert!(
+            assign_addr >= base && assign_addr + demand.size() <= limit,
+            "assignment at {:#x}..{:#x} exceeds parent window {:#x}..{:#x}",
+            assign_addr,
+            assign_addr + demand.size(),
+            base,
+            limit,
+        );
 
         match *demand {
             Demand::Bar {
@@ -494,7 +578,13 @@ fn assign_subtree(
                     .as_ref()
                     .expect("subtree_req must be populated by compute_subtree_state")
                     .demands;
-                assign_subtree(&mut dev.children, child_demands, alloc_64bit, window_base);
+                assign_subtree(
+                    &mut dev.children,
+                    child_demands,
+                    alloc_64bit,
+                    window_base,
+                    window_limit + 1,
+                );
             }
             Demand::SriovVfBars {
                 dev_idx, bar_index, ..
@@ -724,10 +814,10 @@ fn validate_pinned_bars(
 
     // Check aperture containment.
     for &(addr, size, bus, device, function, bar_index, is_mem64) in &all_pinned {
-        let (aperture, aperture_name) = if is_mem64 {
-            (params.high_mmio.or(params.low_mmio), "high_mmio")
+        let aperture = if is_mem64 {
+            params.high_mmio.or(params.low_mmio)
         } else {
-            (params.low_mmio, "low_mmio")
+            params.low_mmio
         };
         let fits = aperture.is_some_and(|a| addr >= a.base && addr + size <= a.base + a.len);
         if !fits {
@@ -738,7 +828,7 @@ fn validate_pinned_bars(
                 bar_index,
                 address: addr,
                 size,
-                aperture: aperture_name,
+                aperture: if is_mem64 { "high_mmio" } else { "low_mmio" },
             });
         }
     }
@@ -755,6 +845,8 @@ fn collect_pinned_bars(
     for dev in devices {
         for bar in &dev.bars {
             if let Some(addr) = bar.pinned_address {
+                // Pinned BARs below 4 GB are treated as mem32.
+                let is_mem64 = addr >= 0x1_0000_0000 && is_mem64_bar(bar);
                 out.push((
                     addr,
                     bar.size,
@@ -762,7 +854,7 @@ fn collect_pinned_bars(
                     dev.device,
                     dev.function,
                     bar.index,
-                    is_mem64_bar(bar),
+                    is_mem64,
                 ));
             }
         }

--- a/vm/devices/pci/pci_resource_assignment/src/assign.rs
+++ b/vm/devices/pci/pci_resource_assignment/src/assign.rs
@@ -332,8 +332,12 @@ fn assert_bar_in_aperture(
         end = bar_end,
     );
 }
-fn is_mem64_bar(bar: &crate::enumerate::DiscoveredBar) -> bool {
-    bar.is_64bit && bar.is_prefetchable
+fn bar_is_mem64(bar: &crate::enumerate::DiscoveredBar) -> bool {
+    if let Some(addr) = bar.pinned_address {
+        addr >= 0x1_0000_0000 && bar.is_64bit && bar.is_prefetchable
+    } else {
+        bar.is_64bit && bar.is_prefetchable
+    }
 }
 
 /// Bottom-up: compute the total aligned resource requirement for a list
@@ -346,16 +350,7 @@ fn compute_subtree_sizing(devices: &mut [DiscoveredDevice]) -> SubtreeSizing {
 
     for (i, dev) in devices.iter_mut().enumerate() {
         for bar in &dev.bars {
-            // For pinned BARs below 4 GB, treat them as mem32 regardless
-            // of encoding. Prefetchable vs. non-prefetchable is not a real
-            // distinction in virtualization, and placing a pinned BAR in the
-            // mem64 pool when its address is in the low MMIO range would
-            // create a bridge window spanning across apertures.
-            let is_mem64 = if let Some(addr) = bar.pinned_address {
-                addr >= 0x1_0000_0000 && is_mem64_bar(bar)
-            } else {
-                is_mem64_bar(bar)
-            };
+            let is_mem64 = bar_is_mem64(bar);
             demands.push(Demand::Bar {
                 dev_idx: i,
                 bar_index: bar.index,
@@ -376,7 +371,7 @@ fn compute_subtree_sizing(devices: &mut [DiscoveredDevice]) -> SubtreeSizing {
                     // VF BAR region base must be aligned to per-VF BAR size
                     // (each VF's BAR is at base + n * bar_size).
                     alignment: bar.size,
-                    is_mem64: is_mem64_bar(bar),
+                    is_mem64: bar.is_64bit && bar.is_prefetchable,
                 });
             }
         }
@@ -901,24 +896,35 @@ fn allocate_from_gaps(gaps: &mut Vec<(u64, u64)>, size: u64, alignment: u64) -> 
     Some(addr)
 }
 
+#[derive(Clone, Copy)]
+struct PinnedBar {
+    addr: u64,
+    size: u64,
+    bus: u8,
+    device: u8,
+    function: u8,
+    bar_index: u8,
+    is_mem64: bool,
+}
+
 /// Validate pinned BAR constraints: alignment, overlap, and aperture fit.
 fn validate_pinned_bars(
     devices: &[DiscoveredDevice],
     params: &AssignmentParams,
 ) -> Result<(), AssignmentError> {
-    let mut all_pinned: Vec<(u64, u64, u8, u8, u8, u8, bool)> = Vec::new();
+    let mut all_pinned = Vec::new();
     collect_pinned_bars(devices, &mut all_pinned);
 
     // Check natural alignment.
-    for &(addr, size, bus, device, function, bar_index, _) in &all_pinned {
-        if addr % size != 0 {
+    for p in &all_pinned {
+        if p.addr % p.size != 0 {
             return Err(AssignmentError::PinnedBarMisaligned {
-                bus,
-                device,
-                function,
-                bar_index,
-                address: addr,
-                required_alignment: size,
+                bus: p.bus,
+                device: p.device,
+                function: p.function,
+                bar_index: p.bar_index,
+                address: p.addr,
+                required_alignment: p.size,
             });
         }
     }
@@ -927,43 +933,43 @@ fn validate_pinned_bars(
     for is_mem64 in [false, true] {
         let mut pool: Vec<_> = all_pinned
             .iter()
-            .filter(|p| p.6 == is_mem64)
+            .filter(|p| p.is_mem64 == is_mem64)
             .copied()
             .collect();
-        pool.sort_by_key(|p| p.0);
-        for w in pool.windows(2) {
-            let first_end = w[0].0.saturating_add(w[0].1);
-            if first_end > w[1].0 {
+        pool.sort_by_key(|p| p.addr);
+        for [a, b] in pool.array_windows::<2>() {
+            let first_end = a.addr.saturating_add(a.size);
+            if first_end > b.addr {
                 return Err(AssignmentError::PinnedBarOverlap {
-                    first_address: w[0].0,
+                    first_address: a.addr,
                     first_end,
-                    second_address: w[1].0,
-                    second_end: w[1].0.saturating_add(w[1].1),
+                    second_address: b.addr,
+                    second_end: b.addr.saturating_add(b.size),
                 });
             }
         }
     }
 
     // Check aperture containment.
-    for &(addr, size, bus, device, function, bar_index, is_mem64) in &all_pinned {
-        let (aperture, aperture_name) = if is_mem64 && params.high_mmio.is_some() {
+    for p in &all_pinned {
+        let (aperture, aperture_name) = if p.is_mem64 && params.high_mmio.is_some() {
             (params.high_mmio, "high_mmio")
         } else {
             (params.low_mmio, "low_mmio")
         };
-        let bar_end = addr.saturating_add(size);
+        let bar_end = p.addr.saturating_add(p.size);
         let fits = aperture.is_some_and(|a| {
             let aperture_end = a.base.saturating_add(a.len);
-            addr >= a.base && bar_end <= aperture_end
+            p.addr >= a.base && bar_end <= aperture_end
         });
         if !fits {
             return Err(AssignmentError::PinnedBarOutOfAperture {
-                bus,
-                device,
-                function,
-                bar_index,
-                address: addr,
-                size,
+                bus: p.bus,
+                device: p.device,
+                function: p.function,
+                bar_index: p.bar_index,
+                address: p.addr,
+                size: p.size,
                 aperture: aperture_name,
             });
         }
@@ -973,25 +979,20 @@ fn validate_pinned_bars(
 }
 
 /// Recursively collect all pinned BARs from the device tree.
-/// Each entry: (address, size, bus, device, function, bar_index, is_mem64).
-fn collect_pinned_bars(
-    devices: &[DiscoveredDevice],
-    out: &mut Vec<(u64, u64, u8, u8, u8, u8, bool)>,
-) {
+fn collect_pinned_bars(devices: &[DiscoveredDevice], out: &mut Vec<PinnedBar>) {
     for dev in devices {
         for bar in &dev.bars {
             if let Some(addr) = bar.pinned_address {
-                // Pinned BARs below 4 GB are treated as mem32.
-                let is_mem64 = addr >= 0x1_0000_0000 && is_mem64_bar(bar);
-                out.push((
+                let is_mem64 = bar_is_mem64(bar);
+                out.push(PinnedBar {
                     addr,
-                    bar.size,
-                    dev.bus,
-                    dev.device,
-                    dev.function,
-                    bar.index,
+                    size: bar.size,
+                    bus: dev.bus,
+                    device: dev.device,
+                    function: dev.function,
+                    bar_index: bar.index,
                     is_mem64,
-                ));
+                });
             }
         }
         collect_pinned_bars(&dev.children, out);

--- a/vm/devices/pci/pci_resource_assignment/src/assign.rs
+++ b/vm/devices/pci/pci_resource_assignment/src/assign.rs
@@ -34,6 +34,12 @@ pub(crate) struct SubtreeState {
     memory_window: Option<(u64, u64)>,
     /// Assigned prefetchable bridge window (base, limit). Set by assign_subtree.
     prefetchable_window: Option<(u64, u64)>,
+    /// If pinned demands exist in the mem32 pool, the required base address
+    /// for this subtree's window (align_down of the lowest pinned address).
+    constrained_base32: Option<u64>,
+    /// If pinned demands exist in the mem64 pool, the required base address
+    /// for this subtree's window.
+    constrained_base64: Option<u64>,
 }
 
 /// A single resource demand at one level of the PCI tree.
@@ -48,6 +54,9 @@ enum Demand {
         bar_index: u8,
         size: u64,
         is_mem64: bool,
+        /// If set, this BAR is pinned to a specific address (pre-programmed
+        /// in config space, discovered via `preserve_bars`).
+        pinned_address: Option<u64>,
     },
     /// A bridge's child subtree window.
     BridgeSubtree {
@@ -56,6 +65,9 @@ enum Demand {
         size: u64,
         alignment: u64,
         is_mem64: bool,
+        /// If set, this bridge has pinned descendants and must be placed
+        /// at this specific base address.
+        constrained_base: Option<u64>,
     },
     /// VF BAR space — reserved for SR-IOV VFs.
     SriovVfBars {
@@ -96,6 +108,24 @@ impl Demand {
             | Demand::SriovVfBars { is_mem64, .. } => *is_mem64,
         }
     }
+
+    /// Returns `Some((address, size))` if this demand has a fixed position
+    /// (pinned BAR or constrained bridge).
+    fn fixed_position(&self) -> Option<(u64, u64)> {
+        match self {
+            Demand::Bar {
+                pinned_address: Some(addr),
+                size,
+                ..
+            } => Some((*addr, *size)),
+            Demand::BridgeSubtree {
+                constrained_base: Some(base),
+                size,
+                ..
+            } => Some((*base, *size)),
+            _ => None,
+        }
+    }
 }
 
 /// Assign addresses to all discovered devices.
@@ -126,6 +156,9 @@ pub fn assign_addresses(
     // nodes so that the assignment pass can read them without recomputing.
     let root_req = compute_subtree_state(devices);
 
+    // Validate pinned BAR constraints before assigning addresses.
+    validate_pinned_bars(devices, params)?;
+
     // Step 2: Top-down — allocate from apertures and assign addresses.
     // Align the effective base to the root's alignment requirement so that
     // internal bump allocation matches the sizing (which starts from zero).
@@ -144,7 +177,13 @@ pub fn assign_addresses(
             aperture: "low_mmio",
         })?;
 
-        let base = align_up(aperture.base, root_req.align32);
+        // If there are constrained (pinned) demands, use their base.
+        // Otherwise, align to the aperture base as before.
+        let base = if let Some(cbase) = root_req.constrained_base32 {
+            cbase
+        } else {
+            align_up(aperture.base, root_req.align32)
+        };
         let aperture_end = aperture.base + aperture.len;
         let available = aperture_end.saturating_sub(base);
         if root_req.mem32 > available {
@@ -171,9 +210,12 @@ pub fn assign_addresses(
                     aperture: "high_mmio",
                 })?;
 
-        // If sharing the same aperture as mem32, allocate after the
-        // actual aligned mem32 end to avoid overlapping assignments.
-        let base = if let Some(end) = mem32_end.filter(|_| params.high_mmio.is_none()) {
+        // If there are constrained (pinned) demands, use their base.
+        let base = if let Some(cbase) = root_req.constrained_base64 {
+            cbase
+        } else if let Some(end) = mem32_end.filter(|_| params.high_mmio.is_none()) {
+            // If sharing the same aperture as mem32, allocate after the
+            // actual aligned mem32 end to avoid overlapping assignments.
             align_up(end, root_req.align64)
         } else {
             align_up(aperture.base, root_req.align64)
@@ -259,6 +301,7 @@ fn compute_subtree_state(devices: &mut [DiscoveredDevice]) -> SubtreeState {
                 bar_index: bar.index,
                 size: bar.size,
                 is_mem64: is_mem64_bar(bar),
+                pinned_address: bar.pinned_address,
             });
         }
 
@@ -287,6 +330,7 @@ fn compute_subtree_state(devices: &mut [DiscoveredDevice]) -> SubtreeState {
                     size,
                     alignment: child_req.align32,
                     is_mem64: false,
+                    constrained_base: child_req.constrained_base32,
                 });
             }
             if child_req.mem64 > 0 {
@@ -296,22 +340,59 @@ fn compute_subtree_state(devices: &mut [DiscoveredDevice]) -> SubtreeState {
                     size,
                     alignment: child_req.align64,
                     is_mem64: true,
+                    constrained_base: child_req.constrained_base64,
                 });
             }
             dev.subtree_req = Some(child_req);
         }
     }
 
-    // Sum with proper alignment, largest-alignment-first. Placing the most
+    // Sort dynamic demands by alignment descending. Placing the most
     // alignment-demanding items first minimizes padding waste.
     demands.sort_by_key(|d| std::cmp::Reverse(d.alignment()));
 
-    let mut mem32: u64 = 0;
-    let mut mem64: u64 = 0;
+    // Collect fixed-position demands (pinned BARs and constrained bridges)
+    // per pool to compute the base offset for dynamic allocations.
+    let mut pin32: Vec<(u64, u64)> = Vec::new();
+    let mut pin64: Vec<(u64, u64)> = Vec::new();
+
+    for d in &demands {
+        if let Some((addr, size)) = d.fixed_position() {
+            if d.is_mem64() {
+                pin64.push((addr, size));
+            } else {
+                pin32.push((addr, size));
+            }
+        }
+    }
+
+    let (mut mem32, constrained_base32) = if !pin32.is_empty() {
+        let min_addr = pin32.iter().map(|(a, _)| *a).min().unwrap();
+        let max_end = pin32.iter().map(|(a, s)| a + s).max().unwrap();
+        let base = align_down(min_addr, BRIDGE_WINDOW_ALIGN);
+        (max_end - base, Some(base))
+    } else {
+        (0, None)
+    };
+
+    let (mut mem64, constrained_base64) = if !pin64.is_empty() {
+        let min_addr = pin64.iter().map(|(a, _)| *a).min().unwrap();
+        let max_end = pin64.iter().map(|(a, s)| a + s).max().unwrap();
+        let base = align_down(min_addr, BRIDGE_WINDOW_ALIGN);
+        (max_end - base, Some(base))
+    } else {
+        (0, None)
+    };
+
     let mut align32 = BRIDGE_WINDOW_ALIGN;
     let mut align64 = BRIDGE_WINDOW_ALIGN;
 
     for d in &demands {
+        // Skip fixed-position demands; they are already accounted for
+        // in the pinned region above.
+        if d.fixed_position().is_some() {
+            continue;
+        }
         if d.is_mem64() {
             mem64 = align_up(mem64, d.alignment());
             mem64 += d.size();
@@ -331,29 +412,57 @@ fn compute_subtree_state(devices: &mut [DiscoveredDevice]) -> SubtreeState {
         demands,
         memory_window: None,
         prefetchable_window: None,
+        constrained_base32,
+        constrained_base64,
     }
 }
 /// Top-down: assign addresses to devices within a subtree, carving from
 /// the given base address. `alloc_64bit` selects which pool (mem32 or
 /// mem64) we are assigning.
 ///
-/// `demands` is the pre-sorted demand list built by `compute_subtree_requirement`.
+/// Fixed-position demands (pinned BARs and constrained bridges) are placed
+/// at their predetermined addresses. Dynamic demands bump-allocate after
+/// the highest fixed-position end.
+///
+/// TODO: Replace bump-from-max-end with a gap allocator that can place
+/// dynamic demands in free space before and between pinned regions. The
+/// current approach wastes space below the first pin. This is acceptable
+/// when the admin controls aperture placement, but a gap allocator would
+/// handle awkward pin positions without requiring oversized apertures.
+///
+/// `demands` is the pre-sorted demand list built by `compute_subtree_state`.
 fn assign_subtree(
     devices: &mut [DiscoveredDevice],
     demands: &[Demand],
     alloc_64bit: bool,
     base: u64,
 ) {
-    // Bump-allocate from the pre-sorted demands, skipping demands that
-    // belong to the other pool.
-    let mut offset = base;
+    // Compute the starting offset for bump allocation: after all
+    // fixed-position demands.
+    let max_fixed_end = demands
+        .iter()
+        .filter(|d| d.is_mem64() == alloc_64bit)
+        .filter_map(|d| d.fixed_position())
+        .map(|(addr, size)| addr + size)
+        .max()
+        .unwrap_or(base);
+    let mut offset = max_fixed_end.max(base);
+
     for demand in demands {
         if demand.is_mem64() != alloc_64bit {
             continue;
         }
 
-        let size = demand.size();
-        offset = align_up(offset, demand.alignment());
+        // For fixed-position demands, use the fixed address.
+        // For dynamic demands, bump-allocate.
+        let assign_addr = if let Some((addr, _)) = demand.fixed_position() {
+            addr
+        } else {
+            offset = align_up(offset, demand.alignment());
+            let addr = offset;
+            offset += demand.size();
+            addr
+        };
 
         match *demand {
             Demand::Bar {
@@ -364,14 +473,14 @@ fn assign_subtree(
                     .iter_mut()
                     .find(|b| b.index == bar_index)
                     .expect("demand references a BAR that exists");
-                bar.address = Some(offset);
+                bar.address = Some(assign_addr);
             }
             Demand::BridgeSubtree { dev_idx, size, .. } => {
                 let dev = &mut devices[dev_idx];
 
                 // Set the bridge window to the carved-out range.
-                let window_base = offset;
-                let window_limit = offset + size - 1;
+                let window_base = assign_addr;
+                let window_limit = assign_addr + size - 1;
                 let req = dev.subtree_req.as_mut().unwrap();
                 if alloc_64bit {
                     req.prefetchable_window = Some((window_base, window_limit));
@@ -383,9 +492,9 @@ fn assign_subtree(
                 let child_demands = &dev
                     .subtree_req
                     .as_ref()
-                    .expect("subtree_req must be populated by compute_subtree_requirement")
+                    .expect("subtree_req must be populated by compute_subtree_state")
                     .demands;
-                assign_subtree(&mut dev.children, child_demands, alloc_64bit, offset);
+                assign_subtree(&mut dev.children, child_demands, alloc_64bit, window_base);
             }
             Demand::SriovVfBars {
                 dev_idx, bar_index, ..
@@ -400,11 +509,9 @@ fn assign_subtree(
                     .iter_mut()
                     .find(|b| b.index == bar_index)
                     .expect("demand references a VF BAR that exists");
-                vf_bar.address = Some(offset);
+                vf_bar.address = Some(assign_addr);
             }
         }
-
-        offset += size;
     }
 }
 
@@ -566,4 +673,99 @@ pub async fn program_assignments(cfg: &mut impl PciConfigAccess, devices: &[Disc
 fn align_up(value: u64, alignment: u64) -> u64 {
     assert!(alignment.is_power_of_two());
     (value + alignment - 1) & !(alignment - 1)
+}
+
+fn align_down(value: u64, alignment: u64) -> u64 {
+    assert!(alignment.is_power_of_two());
+    value & !(alignment - 1)
+}
+
+/// Validate pinned BAR constraints: alignment, overlap, and aperture fit.
+fn validate_pinned_bars(
+    devices: &[DiscoveredDevice],
+    params: &AssignmentParams,
+) -> Result<(), AssignmentError> {
+    let mut all_pinned: Vec<(u64, u64, u8, u8, u8, u8, bool)> = Vec::new();
+    collect_pinned_bars(devices, &mut all_pinned);
+
+    // Check natural alignment.
+    for &(addr, size, bus, device, function, bar_index, _) in &all_pinned {
+        if addr % size != 0 {
+            return Err(AssignmentError::PinnedBarMisaligned {
+                bus,
+                device,
+                function,
+                bar_index,
+                address: addr,
+                required_alignment: size,
+            });
+        }
+    }
+
+    // Check for overlap within each pool.
+    for is_mem64 in [false, true] {
+        let mut pool: Vec<_> = all_pinned
+            .iter()
+            .filter(|p| p.6 == is_mem64)
+            .copied()
+            .collect();
+        pool.sort_by_key(|p| p.0);
+        for w in pool.windows(2) {
+            if w[0].0 + w[0].1 > w[1].0 {
+                return Err(AssignmentError::PinnedBarOverlap {
+                    first_address: w[0].0,
+                    first_end: w[0].0 + w[0].1,
+                    second_address: w[1].0,
+                    second_end: w[1].0 + w[1].1,
+                });
+            }
+        }
+    }
+
+    // Check aperture containment.
+    for &(addr, size, bus, device, function, bar_index, is_mem64) in &all_pinned {
+        let (aperture, aperture_name) = if is_mem64 {
+            (params.high_mmio.or(params.low_mmio), "high_mmio")
+        } else {
+            (params.low_mmio, "low_mmio")
+        };
+        let fits = aperture.is_some_and(|a| addr >= a.base && addr + size <= a.base + a.len);
+        if !fits {
+            return Err(AssignmentError::PinnedBarOutOfAperture {
+                bus,
+                device,
+                function,
+                bar_index,
+                address: addr,
+                size,
+                aperture: aperture_name,
+            });
+        }
+    }
+
+    Ok(())
+}
+
+/// Recursively collect all pinned BARs from the device tree.
+/// Each entry: (address, size, bus, device, function, bar_index, is_mem64).
+fn collect_pinned_bars(
+    devices: &[DiscoveredDevice],
+    out: &mut Vec<(u64, u64, u8, u8, u8, u8, bool)>,
+) {
+    for dev in devices {
+        for bar in &dev.bars {
+            if let Some(addr) = bar.pinned_address {
+                out.push((
+                    addr,
+                    bar.size,
+                    dev.bus,
+                    dev.device,
+                    dev.function,
+                    bar.index,
+                    is_mem64_bar(bar),
+                ));
+            }
+        }
+        collect_pinned_bars(&dev.children, out);
+    }
 }

--- a/vm/devices/pci/pci_resource_assignment/src/assign.rs
+++ b/vm/devices/pci/pci_resource_assignment/src/assign.rs
@@ -946,10 +946,10 @@ fn validate_pinned_bars(
 
     // Check aperture containment.
     for &(addr, size, bus, device, function, bar_index, is_mem64) in &all_pinned {
-        let aperture = if is_mem64 {
-            params.high_mmio.or(params.low_mmio)
+        let (aperture, aperture_name) = if is_mem64 && params.high_mmio.is_some() {
+            (params.high_mmio, "high_mmio")
         } else {
-            params.low_mmio
+            (params.low_mmio, "low_mmio")
         };
         let bar_end = addr.saturating_add(size);
         let fits = aperture.is_some_and(|a| {
@@ -964,7 +964,7 @@ fn validate_pinned_bars(
                 bar_index,
                 address: addr,
                 size,
-                aperture: if is_mem64 { "high_mmio" } else { "low_mmio" },
+                aperture: aperture_name,
             });
         }
     }

--- a/vm/devices/pci/pci_resource_assignment/src/assign.rs
+++ b/vm/devices/pci/pci_resource_assignment/src/assign.rs
@@ -932,12 +932,13 @@ fn validate_pinned_bars(
             .collect();
         pool.sort_by_key(|p| p.0);
         for w in pool.windows(2) {
-            if w[0].0 + w[0].1 > w[1].0 {
+            let first_end = w[0].0.saturating_add(w[0].1);
+            if first_end > w[1].0 {
                 return Err(AssignmentError::PinnedBarOverlap {
                     first_address: w[0].0,
-                    first_end: w[0].0 + w[0].1,
+                    first_end,
                     second_address: w[1].0,
-                    second_end: w[1].0 + w[1].1,
+                    second_end: w[1].0.saturating_add(w[1].1),
                 });
             }
         }
@@ -950,7 +951,11 @@ fn validate_pinned_bars(
         } else {
             params.low_mmio
         };
-        let fits = aperture.is_some_and(|a| addr >= a.base && addr + size <= a.base + a.len);
+        let bar_end = addr.saturating_add(size);
+        let fits = aperture.is_some_and(|a| {
+            let aperture_end = a.base.saturating_add(a.len);
+            addr >= a.base && bar_end <= aperture_end
+        });
         if !fits {
             return Err(AssignmentError::PinnedBarOutOfAperture {
                 bus,

--- a/vm/devices/pci/pci_resource_assignment/src/assign.rs
+++ b/vm/devices/pci/pci_resource_assignment/src/assign.rs
@@ -455,7 +455,7 @@ fn compute_subtree_layout(devices: &mut [DiscoveredDevice]) -> SubtreeLayout {
             addr
         } else {
             allocate_from_gaps(&mut pool.gaps, d.size(), d.alignment())
-                .expect("pool gap list has sentinel — allocation cannot fail")
+                .expect("gap list has open-ended tail — allocation cannot fail")
         };
         offsets[i] = addr - pool.constrained_base.unwrap_or(0);
     }
@@ -490,11 +490,6 @@ fn compute_subtree_layout(devices: &mut [DiscoveredDevice]) -> SubtreeLayout {
     }
 }
 
-/// Sentinel upper bound for gap lists. Large enough that any realistic
-/// allocation fits, small enough that `align_up(addr, align) + size`
-/// cannot overflow.
-const POOL_SENTINEL: u64 = 1u64 << 60;
-
 /// Per-pool state: gap list and alignment, built from pinned demands.
 struct PoolState {
     /// Required alignment (max of bridge granularity and largest demand).
@@ -507,8 +502,8 @@ struct PoolState {
 
 impl PoolState {
     /// Build the gap list for one pool. For constrained pools (pins
-    /// present), gaps cover spaces between pins plus a sentinel tail.
-    /// For unconstrained pools, a single `[0, SENTINEL)` gap.
+    /// present), gaps cover spaces between pins plus an open-ended tail.
+    /// For unconstrained pools, a single `[0, u64::MAX)` gap.
     fn new(pins: &mut [(u64, u64)]) -> Self {
         pins.sort_by_key(|&(a, _)| a);
 
@@ -516,7 +511,7 @@ impl PoolState {
             return Self {
                 align: BRIDGE_WINDOW_ALIGN,
                 constrained_base: None,
-                gaps: vec![(0, POOL_SENTINEL)],
+                gaps: vec![(0, u64::MAX)],
             };
         }
 
@@ -524,8 +519,8 @@ impl PoolState {
         let max_end = pins.iter().map(|(a, s)| a + s).max().unwrap();
         let base = align_down(min_addr, BRIDGE_WINDOW_ALIGN);
         let mut gaps = build_gap_list(base, max_end, pins);
-        // Sentinel tail for dynamic demands that don't fit between pins.
-        gaps.push((max_end, POOL_SENTINEL));
+        // Tail gap for dynamic demands that don't fit between pins.
+        gaps.push((max_end, u64::MAX));
 
         Self {
             align: BRIDGE_WINDOW_ALIGN,
@@ -835,9 +830,10 @@ fn build_gap_list(base: u64, limit: u64, fixed_regions: &[(u64, u64)]) -> Vec<(u
 /// that fits (first-fit). Returns the allocated address, or `None` if
 /// no gap is large enough. Updates `gaps` in place.
 fn allocate_from_gaps(gaps: &mut Vec<(u64, u64)>, size: u64, alignment: u64) -> Option<u64> {
-    let gap_idx = gaps
-        .iter()
-        .position(|&(start, end)| align_up(start, alignment) + size <= end)?;
+    let gap_idx = gaps.iter().position(|&(start, end)| {
+        let aligned = align_up(start, alignment);
+        aligned <= end && end - aligned >= size
+    })?;
 
     let (gap_start, gap_end) = gaps[gap_idx];
     let addr = align_up(gap_start, alignment);

--- a/vm/devices/pci/pci_resource_assignment/src/enumerate.rs
+++ b/vm/devices/pci/pci_resource_assignment/src/enumerate.rs
@@ -51,6 +51,9 @@ pub struct DiscoveredBar {
     pub is_prefetchable: bool,
     /// Assigned base address (populated by the assignment pass).
     pub(crate) address: Option<u64>,
+    /// Pre-programmed BAR address to preserve (set when `preserve_bars` is
+    /// enabled and the BAR contained a non-zero address before probing).
+    pub pinned_address: Option<u64>,
 }
 
 /// SR-IOV information for a PF.
@@ -77,7 +80,14 @@ pub async fn enumerate_and_probe(
     params: &AssignmentParams,
 ) -> Result<Vec<DiscoveredDevice>, AssignmentError> {
     let mut next_bus = params.start_bus as u16 + 1;
-    scan_bus(cfg, params.start_bus, params.end_bus, &mut next_bus).await
+    scan_bus(
+        cfg,
+        params.start_bus,
+        params.end_bus,
+        &mut next_bus,
+        params.preserve_bars,
+    )
+    .await
 }
 
 /// Scan a single bus (non-recursive helper that does DFS via inner calls).
@@ -88,6 +98,7 @@ async fn scan_bus(
     bus: u8,
     end_bus: u8,
     next_bus: &mut u16,
+    preserve_bars: bool,
 ) -> Result<Vec<DiscoveredDevice>, AssignmentError> {
     let mut devices = Vec::new();
 
@@ -136,7 +147,7 @@ async fn scan_bus(
             };
 
             let is_bridge = func_header == 1;
-            let bars = probe_bars(cfg, bus, devfn, is_bridge).await;
+            let bars = probe_bars(cfg, bus, devfn, is_bridge, preserve_bars).await;
 
             let mut dev = DiscoveredDevice {
                 bus,
@@ -173,7 +184,8 @@ async fn scan_bus(
                 // handles it because each call is a separate monomorphized
                 // async block that goes through the same function, and we
                 // box it to avoid infinite-size futures.
-                let children = Box::pin(scan_bus(cfg, secondary, end_bus, next_bus)).await?;
+                let children =
+                    Box::pin(scan_bus(cfg, secondary, end_bus, next_bus, preserve_bars)).await?;
 
                 let subordinate = (*next_bus - 1).max(secondary as u16) as u8;
                 let bus_reg =
@@ -195,7 +207,7 @@ async fn scan_bus(
                 );
             } else {
                 // Probe SR-IOV capability for bus reservation and VF BAR sizes.
-                if let Some(sriov_result) = probe_sriov(cfg, bus, devfn).await {
+                if let Some(sriov_result) = probe_sriov(cfg, bus, devfn, preserve_bars).await {
                     let max_vf_bus = sriov_result.max_vf_bus;
                     if max_vf_bus > end_bus as u16 {
                         return Err(AssignmentError::BusExhaustion {
@@ -256,6 +268,7 @@ async fn probe_bars(
     bus: u8,
     devfn: u8,
     is_bridge: bool,
+    preserve_bars: bool,
 ) -> Vec<DiscoveredBar> {
     let max_bars: u8 = if is_bridge { 2 } else { 6 };
 
@@ -278,7 +291,15 @@ async fn probe_bars(
         .await;
     }
 
-    probe_bar_range(cfg, bus, devfn, HeaderType00::BAR0.0, max_bars).await
+    probe_bar_range(
+        cfg,
+        bus,
+        devfn,
+        HeaderType00::BAR0.0,
+        max_bars,
+        preserve_bars,
+    )
+    .await
 }
 
 /// Probe VF BAR sizes from the SR-IOV capability's VF BAR registers.
@@ -290,6 +311,7 @@ async fn probe_vf_bars(
     bus: u8,
     devfn: u8,
     sriov_offset: u16,
+    preserve_bars: bool,
 ) -> Vec<DiscoveredBar> {
     probe_bar_range(
         cfg,
@@ -297,6 +319,7 @@ async fn probe_vf_bars(
         devfn,
         sriov_offset + SriovExtendedCapabilityHeader::VF_BAR0.0,
         6,
+        preserve_bars,
     )
     .await
 }
@@ -319,6 +342,7 @@ async fn probe_sriov(
     cfg: &mut impl PciConfigAccess,
     bus: u8,
     devfn: u8,
+    preserve_bars: bool,
 ) -> Option<SriovProbeResult> {
     // Walk extended capabilities starting at 0x100.
     let mut offset = EXT_CAP_START;
@@ -373,7 +397,7 @@ async fn probe_sriov(
             let max_vf_bus = (last_vf_rid >> 8) as u16;
 
             // Probe VF BAR sizes (same write-all-ones/readback technique).
-            let vf_bars = probe_vf_bars(cfg, bus, devfn, offset).await;
+            let vf_bars = probe_vf_bars(cfg, bus, devfn, offset, preserve_bars).await;
 
             return Some(SriovProbeResult {
                 cap_offset: offset,
@@ -395,18 +419,30 @@ async fn probe_sriov(
 ///
 /// Writes all-ones to each BAR and reads back to determine size. BAR
 /// registers are left in an undefined state after probing.
+///
+/// When `preserve_bars` is true, reads each BAR's current value before
+/// probing. If non-zero, records it as `pinned_address` on the
+/// resulting [`DiscoveredBar`].
 async fn probe_bar_range(
     cfg: &mut impl PciConfigAccess,
     bus: u8,
     devfn: u8,
     base_offset: u16,
     max_bars: u8,
+    preserve_bars: bool,
 ) -> Vec<DiscoveredBar> {
     let mut bars = Vec::new();
 
     let mut i = 0u8;
     while i < max_bars {
         let offset = base_offset + (i as u16) * 4;
+
+        // Read the current BAR value before probing (for preserve_bars).
+        let original_lower = if preserve_bars {
+            cfg.read_u32(bus, devfn, offset).await
+        } else {
+            0
+        };
 
         // Write all-ones to probe size.
         cfg.write_u32(bus, devfn, offset, !0u32).await;
@@ -429,9 +465,16 @@ async fn probe_bar_range(
         let is_64bit = encoding.type_64_bit();
         let is_prefetchable = encoding.prefetchable();
 
-        let size = if is_64bit && (i + 1) < max_bars {
+        let (size, pinned_address) = if is_64bit && (i + 1) < max_bars {
             // Probe upper 32 bits.
             let upper_offset = base_offset + ((i + 1) as u16) * 4;
+
+            let original_upper = if preserve_bars {
+                cfg.read_u32(bus, devfn, upper_offset).await
+            } else {
+                0
+            };
+
             cfg.write_u32(bus, devfn, upper_offset, !0u32).await;
             let upper_readback = cfg.read_u32(bus, devfn, upper_offset).await;
 
@@ -440,14 +483,32 @@ async fn probe_bar_range(
                 i += 2;
                 continue;
             }
-            (!mask).wrapping_add(1)
+            let size = (!mask).wrapping_add(1);
+
+            let pinned = if preserve_bars {
+                let addr = ((original_upper as u64) << 32) | ((original_lower & !0xF) as u64);
+                (addr != 0).then_some(addr)
+            } else {
+                None
+            };
+
+            (size, pinned)
         } else {
             let mask = readback & !0xF;
             if mask == 0 {
                 i += 1;
                 continue;
             }
-            (!(mask as u64 | (!0u64 << 32))).wrapping_add(1)
+            let size = (!(mask as u64 | (!0u64 << 32))).wrapping_add(1);
+
+            let pinned = if preserve_bars {
+                let addr = (original_lower & !0xF) as u64;
+                (addr != 0).then_some(addr)
+            } else {
+                None
+            };
+
+            (size, pinned)
         };
 
         if size > 0 {
@@ -457,6 +518,7 @@ async fn probe_bar_range(
                 is_64bit,
                 is_prefetchable,
                 address: None,
+                pinned_address,
             });
         }
 

--- a/vm/devices/pci/pci_resource_assignment/src/enumerate.rs
+++ b/vm/devices/pci/pci_resource_assignment/src/enumerate.rs
@@ -22,11 +22,7 @@ pub struct DiscoveredDevice {
     pub bus: u8,
     pub device: u8,
     pub function: u8,
-    #[expect(dead_code)] // stored for future use in Phase 2+ diagnostics
-    pub(crate) header_type: u8,
     pub is_bridge: bool,
-    #[expect(dead_code)] // stored for future use in Phase 2+ diagnostics
-    pub(crate) is_multi_function: bool,
     pub bars: Vec<DiscoveredBar>,
     /// For bridges: children behind this bridge.
     pub children: Vec<DiscoveredDevice>,
@@ -36,10 +32,9 @@ pub struct DiscoveredDevice {
     pub subordinate_bus: Option<u8>,
     /// For SR-IOV PFs: total VFs and per-VF BAR sizes.
     pub(crate) sriov: Option<DiscoveredSriov>,
-    /// Computed during the sizing pass for bridges: the total resource
-    /// requirement of this bridge's children. Avoids recomputation during
-    /// address assignment.
-    pub(crate) subtree_req: Option<crate::assign::SubtreeState>,
+    /// Bridge assignment state (sizing + windows), populated by the
+    /// assignment pass. `None` for endpoints and before assignment runs.
+    pub(crate) bridge_assignment: Option<crate::assign::BridgeAssignment>,
 }
 
 /// A discovered BAR with its size.
@@ -153,15 +148,13 @@ async fn scan_bus(
                 bus,
                 device: device_num,
                 function,
-                header_type: func_header,
                 is_bridge,
-                is_multi_function: multi_function,
                 bars,
                 children: Vec::new(),
                 secondary_bus: None,
                 subordinate_bus: None,
                 sriov: None,
-                subtree_req: None,
+                bridge_assignment: None,
             };
 
             if is_bridge {

--- a/vm/devices/pci/pci_resource_assignment/src/lib.rs
+++ b/vm/devices/pci/pci_resource_assignment/src/lib.rs
@@ -46,15 +46,7 @@ pub trait PciConfigAccess {
     ) -> impl Future<Output = ()>;
 }
 
-/// MMIO aperture available for allocation.
-#[derive(Debug, Clone, Copy)]
-pub struct MmioAperture {
-    /// Base address of the aperture (must be naturally aligned to the
-    /// aperture's purpose — typically 1 MB for bridge windows).
-    pub base: u64,
-    /// Length in bytes.
-    pub len: u64,
-}
+pub use memory_range::MemoryRange;
 
 /// Parameters for PCI resource assignment on a single host bridge.
 #[derive(Debug, Clone)]
@@ -64,9 +56,11 @@ pub struct AssignmentParams {
     /// Last bus number owned by this host bridge (inclusive).
     pub end_bus: u8,
     /// Low MMIO aperture (below 4 GB) available for BAR allocation.
-    pub low_mmio: Option<MmioAperture>,
+    /// Empty if no low MMIO is available.
+    pub low_mmio: MemoryRange,
     /// High MMIO aperture (above 4 GB) available for 64-bit BAR allocation.
-    pub high_mmio: Option<MmioAperture>,
+    /// Empty if no high MMIO is available.
+    pub high_mmio: MemoryRange,
     /// When true, treat non-zero BAR values found during probing as pinned
     /// addresses rather than clearing them. Used for P2P DMA where GPA = HPA.
     pub preserve_bars: bool,

--- a/vm/devices/pci/pci_resource_assignment/src/lib.rs
+++ b/vm/devices/pci/pci_resource_assignment/src/lib.rs
@@ -67,6 +67,9 @@ pub struct AssignmentParams {
     pub low_mmio: Option<MmioAperture>,
     /// High MMIO aperture (above 4 GB) available for 64-bit BAR allocation.
     pub high_mmio: Option<MmioAperture>,
+    /// When true, treat non-zero BAR values found during probing as pinned
+    /// addresses rather than clearing them. Used for P2P DMA where GPA = HPA.
+    pub preserve_bars: bool,
 }
 
 /// Assign PCI resources (bus numbers and BAR addresses) for a host bridge.
@@ -113,6 +116,61 @@ pub enum AssignmentError {
         max_vf_bus: u16,
         /// Next bus number already allocated (VF buses below this are taken).
         next_bus: u16,
+    },
+    /// A pinned BAR address is not naturally aligned to the BAR size.
+    #[error(
+        "pinned BAR {bus:02x}:{device:02x}.{function} index {bar_index} at {address:#x} \
+         is not aligned to {required_alignment:#x}"
+    )]
+    PinnedBarMisaligned {
+        /// Bus number.
+        bus: u8,
+        /// Device number.
+        device: u8,
+        /// Function number.
+        function: u8,
+        /// BAR register index.
+        bar_index: u8,
+        /// The pinned address.
+        address: u64,
+        /// Required alignment (BAR size).
+        required_alignment: u64,
+    },
+    /// Two pinned BAR regions overlap.
+    #[error(
+        "pinned BAR regions overlap: {first_address:#x}..{first_end:#x} and \
+         {second_address:#x}..{second_end:#x}"
+    )]
+    PinnedBarOverlap {
+        /// Start of the first pinned region.
+        first_address: u64,
+        /// End of the first pinned region.
+        first_end: u64,
+        /// Start of the second pinned region.
+        second_address: u64,
+        /// End of the second pinned region.
+        second_end: u64,
+    },
+    /// A pinned BAR address falls outside the MMIO aperture.
+    #[error(
+        "pinned BAR {bus:02x}:{device:02x}.{function} index {bar_index} at \
+         {address:#x}+{size:#x} outside {aperture} aperture"
+    )]
+    PinnedBarOutOfAperture {
+        /// Bus number.
+        bus: u8,
+        /// Device number.
+        device: u8,
+        /// Function number.
+        function: u8,
+        /// BAR register index.
+        bar_index: u8,
+        /// The pinned address.
+        address: u64,
+        /// BAR size.
+        size: u64,
+        /// Which aperture was checked.
+        aperture: &'static str,
     },
     /// Not enough MMIO space for all BAR allocations.
     #[error("{aperture} MMIO exhaustion: need {required:#x} bytes, have {available:#x}")]

--- a/vm/devices/pci/pci_resource_assignment/src/tests.rs
+++ b/vm/devices/pci/pci_resource_assignment/src/tests.rs
@@ -4,9 +4,9 @@
 #![cfg(test)]
 
 use crate::AssignmentParams;
-use crate::MmioAperture;
 use crate::PciConfigAccess;
 use crate::assign_pci_resources;
+use memory_range::MemoryRange;
 use parking_lot::Mutex;
 use std::collections::BTreeMap;
 use std::sync::Arc;
@@ -320,11 +320,8 @@ async fn single_endpoint_32bit_bar() {
     let params = AssignmentParams {
         start_bus: 0,
         end_bus: 255,
-        low_mmio: Some(MmioAperture {
-            base: 0x1000_0000,
-            len: 0x1000_0000,
-        }),
-        high_mmio: None,
+        low_mmio: MemoryRange::new(0x1000_0000..0x1000_0000 + 0x1000_0000),
+        high_mmio: MemoryRange::EMPTY,
         preserve_bars: false,
     };
 
@@ -344,11 +341,8 @@ async fn single_endpoint_64bit_bar() {
     let params = AssignmentParams {
         start_bus: 0,
         end_bus: 255,
-        low_mmio: None,
-        high_mmio: Some(MmioAperture {
-            base: 0x1_0000_0000,
-            len: 0x1_0000_0000,
-        }),
+        low_mmio: MemoryRange::EMPTY,
+        high_mmio: MemoryRange::new(0x1_0000_0000..0x1_0000_0000 + 0x1_0000_0000),
         preserve_bars: false,
     };
 
@@ -372,11 +366,8 @@ async fn bridge_with_endpoint() {
     let params = AssignmentParams {
         start_bus: 0,
         end_bus: 255,
-        low_mmio: Some(MmioAperture {
-            base: 0x1000_0000,
-            len: 0x1000_0000,
-        }),
-        high_mmio: None,
+        low_mmio: MemoryRange::new(0x1000_0000..0x1000_0000 + 0x1000_0000),
+        high_mmio: MemoryRange::EMPTY,
         preserve_bars: false,
     };
 
@@ -409,11 +400,8 @@ async fn multiple_endpoints_sorted_by_size() {
     let params = AssignmentParams {
         start_bus: 0,
         end_bus: 255,
-        low_mmio: Some(MmioAperture {
-            base: 0x1000_0000,
-            len: 0x1000_0000,
-        }),
-        high_mmio: None,
+        low_mmio: MemoryRange::new(0x1000_0000..0x1000_0000 + 0x1000_0000),
+        high_mmio: MemoryRange::EMPTY,
         preserve_bars: false,
     };
 
@@ -441,11 +429,8 @@ async fn multi_function_device() {
     let params = AssignmentParams {
         start_bus: 0,
         end_bus: 255,
-        low_mmio: Some(MmioAperture {
-            base: 0x1000_0000,
-            len: 0x1000_0000,
-        }),
-        high_mmio: None,
+        low_mmio: MemoryRange::new(0x1000_0000..0x1000_0000 + 0x1000_0000),
+        high_mmio: MemoryRange::EMPTY,
         preserve_bars: false,
     };
 
@@ -478,14 +463,8 @@ async fn switch_with_multiple_endpoints() {
     let params = AssignmentParams {
         start_bus: 0,
         end_bus: 255,
-        low_mmio: Some(MmioAperture {
-            base: 0x1000_0000,
-            len: 0x1000_0000,
-        }),
-        high_mmio: Some(MmioAperture {
-            base: 0x1_0000_0000,
-            len: 0x1_0000_0000,
-        }),
+        low_mmio: MemoryRange::new(0x1000_0000..0x1000_0000 + 0x1000_0000),
+        high_mmio: MemoryRange::new(0x1_0000_0000..0x1_0000_0000 + 0x1_0000_0000),
         preserve_bars: false,
     };
 
@@ -529,8 +508,8 @@ async fn bus_exhaustion_error() {
     let params = AssignmentParams {
         start_bus: 0,
         end_bus: 0, // No room for secondary bus.
-        low_mmio: None,
-        high_mmio: None,
+        low_mmio: MemoryRange::EMPTY,
+        high_mmio: MemoryRange::EMPTY,
         preserve_bars: false,
     };
 
@@ -553,11 +532,8 @@ async fn no_devices_is_ok() {
     let params = AssignmentParams {
         start_bus: 0,
         end_bus: 255,
-        low_mmio: Some(MmioAperture {
-            base: 0x1000_0000,
-            len: 0x1000_0000,
-        }),
-        high_mmio: None,
+        low_mmio: MemoryRange::new(0x1000_0000..0x1000_0000 + 0x1000_0000),
+        high_mmio: MemoryRange::EMPTY,
         preserve_bars: false,
     };
 
@@ -577,11 +553,8 @@ async fn mmio_exhaustion_error() {
     let params = AssignmentParams {
         start_bus: 0,
         end_bus: 255,
-        low_mmio: Some(MmioAperture {
-            base: 0x1000_0000,
-            len: 0x20000, // 128KB — not enough for both
-        }),
-        high_mmio: None,
+        low_mmio: MemoryRange::new(0x1000_0000..0x1000_0000 + 0x20000), // 128KB — not enough for both
+        high_mmio: MemoryRange::EMPTY,
         preserve_bars: false,
     };
 
@@ -607,8 +580,8 @@ async fn no_aperture_error() {
     let params = AssignmentParams {
         start_bus: 0,
         end_bus: 255,
-        low_mmio: None,
-        high_mmio: None,
+        low_mmio: MemoryRange::EMPTY,
+        high_mmio: MemoryRange::EMPTY,
         preserve_bars: false,
     };
 
@@ -640,11 +613,8 @@ async fn sriov_reserves_bus_numbers() {
     let params = AssignmentParams {
         start_bus: 0,
         end_bus: 255,
-        low_mmio: Some(MmioAperture {
-            base: 0x1000_0000,
-            len: 0x1000_0000,
-        }),
-        high_mmio: None,
+        low_mmio: MemoryRange::new(0x1000_0000..0x1000_0000 + 0x1000_0000),
+        high_mmio: MemoryRange::EMPTY,
         preserve_bars: false,
     };
 
@@ -682,11 +652,8 @@ async fn sriov_no_vfs_no_reservation() {
     let params = AssignmentParams {
         start_bus: 0,
         end_bus: 255,
-        low_mmio: Some(MmioAperture {
-            base: 0x1000_0000,
-            len: 0x1000_0000,
-        }),
-        high_mmio: None,
+        low_mmio: MemoryRange::new(0x1000_0000..0x1000_0000 + 0x1000_0000),
+        high_mmio: MemoryRange::EMPTY,
         preserve_bars: false,
     };
 
@@ -709,11 +676,8 @@ async fn bridge_prefetchable_window_programmed() {
     let params = AssignmentParams {
         start_bus: 0,
         end_bus: 255,
-        low_mmio: None,
-        high_mmio: Some(MmioAperture {
-            base: 0x1_0000_0000,
-            len: 0x1_0000_0000,
-        }),
+        low_mmio: MemoryRange::EMPTY,
+        high_mmio: MemoryRange::new(0x1_0000_0000..0x1_0000_0000 + 0x1_0000_0000),
         preserve_bars: false,
     };
 
@@ -778,11 +742,8 @@ async fn sibling_bridge_windows_must_not_overlap() {
     let params = AssignmentParams {
         start_bus: 0,
         end_bus: 255,
-        low_mmio: Some(MmioAperture {
-            base: 0x1000_0000,
-            len: 0x1000_0000,
-        }),
-        high_mmio: None,
+        low_mmio: MemoryRange::new(0x1000_0000..0x1000_0000 + 0x1000_0000),
+        high_mmio: MemoryRange::EMPTY,
         preserve_bars: false,
     };
 
@@ -818,11 +779,8 @@ async fn large_bar_alignment_fits_in_bridge_window() {
     let params = AssignmentParams {
         start_bus: 0,
         end_bus: 255,
-        low_mmio: Some(MmioAperture {
-            base: 0x1000_0000,  // 256 MB — not 1 GB aligned
-            len: 0x2_0000_0000, // 8 GB
-        }),
-        high_mmio: None,
+        low_mmio: MemoryRange::new(0x1000_0000..0x1000_0000 + 0x2_0000_0000), // 8 GB (256 MB — not 1 GB aligned)
+        high_mmio: MemoryRange::EMPTY,
         preserve_bars: false,
     };
 
@@ -866,11 +824,8 @@ async fn alignment_first_sort_avoids_wasted_padding() {
     let params = AssignmentParams {
         start_bus: 0,
         end_bus: 255,
-        low_mmio: Some(MmioAperture {
-            base: 0x1000_0000,
-            len: 0x500000, // 5 MB
-        }),
-        high_mmio: None,
+        low_mmio: MemoryRange::new(0x1000_0000..0x1000_0000 + 0x500000), // 5 MB
+        high_mmio: MemoryRange::EMPTY,
         preserve_bars: false,
     };
 
@@ -904,11 +859,8 @@ async fn misaligned_aperture_does_not_overflow() {
     let params = AssignmentParams {
         start_bus: 0,
         end_bus: 255,
-        low_mmio: Some(MmioAperture {
-            base: 0x1020_0000, // 2 MB aligned, NOT 4 MB aligned
-            len: 0x400000,     // 4 MB — exactly the BAR size, but not enough after alignment
-        }),
-        high_mmio: None,
+        low_mmio: MemoryRange::new(0x1020_0000..0x1020_0000 + 0x400000), // 4 MB (2 MB aligned, NOT 4 MB aligned)
+        high_mmio: MemoryRange::EMPTY,
         preserve_bars: false,
     };
 
@@ -935,11 +887,8 @@ async fn alignment_exceeds_aperture_returns_error() {
     let params = AssignmentParams {
         start_bus: 0,
         end_bus: 255,
-        low_mmio: Some(MmioAperture {
-            base: 0x1020_0000, // 2 MB past a 16 MB boundary
-            len: 0x200000,     // 2 MB total
-        }),
-        high_mmio: None,
+        low_mmio: MemoryRange::new(0x1020_0000..0x1020_0000 + 0x200000), // 2 MB total (2 MB past a 16 MB boundary)
+        high_mmio: MemoryRange::EMPTY,
         preserve_bars: false,
     };
 
@@ -969,11 +918,8 @@ async fn sriov_bus_reservation_exceeding_end_bus_returns_error() {
     let params = AssignmentParams {
         start_bus: 0,
         end_bus: 1, // Only buses 0 and 1 allowed.
-        low_mmio: Some(MmioAperture {
-            base: 0x1000_0000,
-            len: 0x1000_0000,
-        }),
-        high_mmio: None,
+        low_mmio: MemoryRange::new(0x1000_0000..0x1000_0000 + 0x1000_0000),
+        high_mmio: MemoryRange::EMPTY,
         preserve_bars: false,
     };
 
@@ -1003,11 +949,8 @@ async fn mem32_bar_must_not_be_placed_above_4gb() {
     let params = AssignmentParams {
         start_bus: 0,
         end_bus: 255,
-        low_mmio: None,
-        high_mmio: Some(MmioAperture {
-            base: 0x1_0000_0000, // Above 4 GB
-            len: 0x1_0000_0000,
-        }),
+        low_mmio: MemoryRange::EMPTY,
+        high_mmio: MemoryRange::new(0x1_0000_0000..0x1_0000_0000 + 0x1_0000_0000), // Above 4 GB
         preserve_bars: false,
     };
 
@@ -1046,11 +989,8 @@ async fn shared_aperture_mem32_mem64_must_not_overlap() {
     let params = AssignmentParams {
         start_bus: 0,
         end_bus: 255,
-        low_mmio: Some(MmioAperture {
-            base: 0x1020_0000,
-            len: 0x0100_0000, // 16 MB — plenty of room
-        }),
-        high_mmio: None,
+        low_mmio: MemoryRange::new(0x1020_0000..0x1020_0000 + 0x0100_0000), // 16 MB — plenty of room
+        high_mmio: MemoryRange::EMPTY,
         preserve_bars: false,
     };
 
@@ -1100,11 +1040,8 @@ async fn bus_wrap_to_zero_must_return_exhaustion() {
     let params = AssignmentParams {
         start_bus: 0,
         end_bus: 255,
-        low_mmio: Some(MmioAperture {
-            base: 0x1000_0000,
-            len: 0x1000_0000,
-        }),
-        high_mmio: None,
+        low_mmio: MemoryRange::new(0x1000_0000..0x1000_0000 + 0x1000_0000),
+        high_mmio: MemoryRange::EMPTY,
         preserve_bars: false,
     };
 
@@ -1141,11 +1078,8 @@ async fn sriov_vf_bars_included_in_bridge_window() {
     let params = AssignmentParams {
         start_bus: 0,
         end_bus: 255,
-        low_mmio: Some(MmioAperture {
-            base: 0x1000_0000,
-            len: 0x1000_0000,
-        }),
-        high_mmio: None,
+        low_mmio: MemoryRange::new(0x1000_0000..0x1000_0000 + 0x1000_0000),
+        high_mmio: MemoryRange::EMPTY,
         preserve_bars: false,
     };
 
@@ -1201,11 +1135,8 @@ async fn sriov_non_power_of_two_vf_count() {
     let params = AssignmentParams {
         start_bus: 0,
         end_bus: 255,
-        low_mmio: Some(MmioAperture {
-            base: 0x1000_0000,
-            len: 0x1000_0000,
-        }),
-        high_mmio: None,
+        low_mmio: MemoryRange::new(0x1000_0000..0x1000_0000 + 0x1000_0000),
+        high_mmio: MemoryRange::EMPTY,
         preserve_bars: false,
     };
 
@@ -1243,14 +1174,8 @@ async fn sriov_vf_bars_64bit_prefetchable() {
     let params = AssignmentParams {
         start_bus: 0,
         end_bus: 255,
-        low_mmio: Some(MmioAperture {
-            base: 0x1000_0000,
-            len: 0x1000_0000,
-        }),
-        high_mmio: Some(MmioAperture {
-            base: 0x1_0000_0000,
-            len: 0x1_0000_0000,
-        }),
+        low_mmio: MemoryRange::new(0x1000_0000..0x1000_0000 + 0x1000_0000),
+        high_mmio: MemoryRange::new(0x1_0000_0000..0x1_0000_0000 + 0x1_0000_0000),
         preserve_bars: false,
     };
 
@@ -1319,14 +1244,8 @@ async fn sriov_mixed_vf_bar_types() {
     let params = AssignmentParams {
         start_bus: 0,
         end_bus: 255,
-        low_mmio: Some(MmioAperture {
-            base: 0x1000_0000,
-            len: 0x1000_0000,
-        }),
-        high_mmio: Some(MmioAperture {
-            base: 0x1_0000_0000,
-            len: 0x1_0000_0000,
-        }),
+        low_mmio: MemoryRange::new(0x1000_0000..0x1000_0000 + 0x1000_0000),
+        high_mmio: MemoryRange::new(0x1_0000_0000..0x1_0000_0000 + 0x1_0000_0000),
         preserve_bars: false,
     };
 
@@ -1382,11 +1301,8 @@ async fn sriov_top_level_pf_no_bridge() {
     let params = AssignmentParams {
         start_bus: 0,
         end_bus: 255,
-        low_mmio: Some(MmioAperture {
-            base: 0x1000_0000,
-            len: 0x1000_0000,
-        }),
-        high_mmio: None,
+        low_mmio: MemoryRange::new(0x1000_0000..0x1000_0000 + 0x1000_0000),
+        high_mmio: MemoryRange::EMPTY,
         preserve_bars: false,
     };
 
@@ -1435,11 +1351,8 @@ async fn sriov_multiple_pfs_behind_bridge() {
     let params = AssignmentParams {
         start_bus: 0,
         end_bus: 255,
-        low_mmio: Some(MmioAperture {
-            base: 0x1000_0000,
-            len: 0x1000_0000,
-        }),
-        high_mmio: None,
+        low_mmio: MemoryRange::new(0x1000_0000..0x1000_0000 + 0x1000_0000),
+        high_mmio: MemoryRange::EMPTY,
         preserve_bars: false,
     };
 
@@ -1512,11 +1425,8 @@ async fn sriov_vf_bars_cause_mmio_exhaustion() {
     let params = AssignmentParams {
         start_bus: 0,
         end_bus: 255,
-        low_mmio: Some(MmioAperture {
-            base: 0x1000_0000,
-            len: 0x20_0000, // Only 2 MB — not enough for 16 MB of VF BARs
-        }),
-        high_mmio: None,
+        low_mmio: MemoryRange::new(0x1000_0000..0x1000_0000 + 0x20_0000), // Only 2 MB — not enough for 16 MB of VF BARs
+        high_mmio: MemoryRange::EMPTY,
         preserve_bars: false,
     };
 
@@ -1543,11 +1453,8 @@ async fn single_pinned_bar() {
     let params = AssignmentParams {
         start_bus: 0,
         end_bus: 255,
-        low_mmio: Some(MmioAperture {
-            base: 0x1000_0000,
-            len: 0x1000_0000,
-        }),
-        high_mmio: None,
+        low_mmio: MemoryRange::new(0x1000_0000..0x1000_0000 + 0x1000_0000),
+        high_mmio: MemoryRange::EMPTY,
         preserve_bars: true,
     };
 
@@ -1581,11 +1488,8 @@ async fn two_pinned_bars_behind_switch() {
     let params = AssignmentParams {
         start_bus: 0,
         end_bus: 255,
-        low_mmio: Some(MmioAperture {
-            base: 0x1000_0000,
-            len: 0x1000_0000,
-        }),
-        high_mmio: None,
+        low_mmio: MemoryRange::new(0x1000_0000..0x1000_0000 + 0x1000_0000),
+        high_mmio: MemoryRange::EMPTY,
         preserve_bars: true,
     };
 
@@ -1630,11 +1534,8 @@ async fn mixed_pinned_and_dynamic_bars() {
     let params = AssignmentParams {
         start_bus: 0,
         end_bus: 255,
-        low_mmio: Some(MmioAperture {
-            base: 0x1000_0000,
-            len: 0x1000_0000,
-        }),
-        high_mmio: None,
+        low_mmio: MemoryRange::new(0x1000_0000..0x1000_0000 + 0x1000_0000),
+        high_mmio: MemoryRange::EMPTY,
         preserve_bars: true,
     };
 
@@ -1665,11 +1566,8 @@ async fn pinned_bar_misaligned_error() {
     let params = AssignmentParams {
         start_bus: 0,
         end_bus: 255,
-        low_mmio: Some(MmioAperture {
-            base: 0x1000_0000,
-            len: 0x1000_0000,
-        }),
-        high_mmio: None,
+        low_mmio: MemoryRange::new(0x1000_0000..0x1000_0000 + 0x1000_0000),
+        high_mmio: MemoryRange::EMPTY,
         preserve_bars: true,
     };
 
@@ -1698,11 +1596,8 @@ async fn pinned_bar_overlap_error() {
     let params = AssignmentParams {
         start_bus: 0,
         end_bus: 255,
-        low_mmio: Some(MmioAperture {
-            base: 0x1000_0000,
-            len: 0x1000_0000,
-        }),
-        high_mmio: None,
+        low_mmio: MemoryRange::new(0x1000_0000..0x1000_0000 + 0x1000_0000),
+        high_mmio: MemoryRange::EMPTY,
         preserve_bars: true,
     };
 
@@ -1725,11 +1620,8 @@ async fn pinned_bar_out_of_aperture_error() {
     let params = AssignmentParams {
         start_bus: 0,
         end_bus: 255,
-        low_mmio: Some(MmioAperture {
-            base: 0x1000_0000,
-            len: 0x1000_0000, // ends at 0x2000_0000
-        }),
-        high_mmio: None,
+        low_mmio: MemoryRange::new(0x1000_0000..0x1000_0000 + 0x1000_0000), // ends at 0x2000_0000
+        high_mmio: MemoryRange::EMPTY,
         preserve_bars: true,
     };
 
@@ -1759,14 +1651,8 @@ async fn pinned_bar_64bit_non_prefetchable_above_4gb_rejected() {
     let params = AssignmentParams {
         start_bus: 0,
         end_bus: 255,
-        low_mmio: Some(MmioAperture {
-            base: 0x1000_0000,
-            len: 0x1000_0000,
-        }),
-        high_mmio: Some(MmioAperture {
-            base: 0x1_0000_0000,
-            len: 0x1_0000_0000,
-        }),
+        low_mmio: MemoryRange::new(0x1000_0000..0x1000_0000 + 0x1000_0000),
+        high_mmio: MemoryRange::new(0x1_0000_0000..0x1_0000_0000 + 0x1_0000_0000),
         preserve_bars: true,
     };
 
@@ -1798,11 +1684,8 @@ async fn bridge_window_from_pinned_and_dynamic() {
     let params = AssignmentParams {
         start_bus: 0,
         end_bus: 255,
-        low_mmio: Some(MmioAperture {
-            base: 0x1000_0000,
-            len: 0x1000_0000,
-        }),
-        high_mmio: None,
+        low_mmio: MemoryRange::new(0x1000_0000..0x1000_0000 + 0x1000_0000),
+        high_mmio: MemoryRange::EMPTY,
         preserve_bars: true,
     };
 
@@ -1850,11 +1733,8 @@ async fn preserve_bars_no_pins_identical_to_dynamic() {
     let params_no_preserve = AssignmentParams {
         start_bus: 0,
         end_bus: 255,
-        low_mmio: Some(MmioAperture {
-            base: 0x1000_0000,
-            len: 0x1000_0000,
-        }),
-        high_mmio: None,
+        low_mmio: MemoryRange::new(0x1000_0000..0x1000_0000 + 0x1000_0000),
+        high_mmio: MemoryRange::EMPTY,
         preserve_bars: false,
     };
 
@@ -1877,11 +1757,8 @@ async fn preserve_bars_no_pins_identical_to_dynamic() {
     let params_preserve = AssignmentParams {
         start_bus: 0,
         end_bus: 255,
-        low_mmio: Some(MmioAperture {
-            base: 0x1000_0000,
-            len: 0x1000_0000,
-        }),
-        high_mmio: None,
+        low_mmio: MemoryRange::new(0x1000_0000..0x1000_0000 + 0x1000_0000),
+        high_mmio: MemoryRange::EMPTY,
         preserve_bars: true,
     };
 
@@ -1914,14 +1791,8 @@ async fn pinned_bar_64bit_prefetchable() {
     let params = AssignmentParams {
         start_bus: 0,
         end_bus: 255,
-        low_mmio: Some(MmioAperture {
-            base: 0x1000_0000,
-            len: 0x1000_0000,
-        }),
-        high_mmio: Some(MmioAperture {
-            base: 0x3_8380_0000,
-            len: 0x0100_0000,
-        }),
+        low_mmio: MemoryRange::new(0x1000_0000..0x1000_0000 + 0x1000_0000),
+        high_mmio: MemoryRange::new(0x3_8380_0000..0x3_8380_0000 + 0x0100_0000),
         preserve_bars: true,
     };
 
@@ -1966,14 +1837,8 @@ async fn pinned_bar_64bit_prefetchable_in_low_mmio() {
     let params = AssignmentParams {
         start_bus: 0,
         end_bus: 255,
-        low_mmio: Some(MmioAperture {
-            base: 0x1000_0000,
-            len: 0x1000_0000,
-        }),
-        high_mmio: Some(MmioAperture {
-            base: 0x1_0000_0000,
-            len: 0x1_0000_0000,
-        }),
+        low_mmio: MemoryRange::new(0x1000_0000..0x1000_0000 + 0x1000_0000),
+        high_mmio: MemoryRange::new(0x1_0000_0000..0x1_0000_0000 + 0x1_0000_0000),
         preserve_bars: true,
     };
 
@@ -2043,11 +1908,8 @@ async fn two_pinned_bars_same_bridge() {
     let params = AssignmentParams {
         start_bus: 0,
         end_bus: 255,
-        low_mmio: Some(MmioAperture {
-            base: 0x1000_0000,
-            len: 0x1000_0000,
-        }),
-        high_mmio: None,
+        low_mmio: MemoryRange::new(0x1000_0000..0x1000_0000 + 0x1000_0000),
+        high_mmio: MemoryRange::EMPTY,
         preserve_bars: true,
     };
 
@@ -2094,11 +1956,8 @@ async fn pinned_bar_with_large_alignment_dynamic() {
     let params = AssignmentParams {
         start_bus: 0,
         end_bus: 255,
-        low_mmio: Some(MmioAperture {
-            base: 0x1000_0000,
-            len: 0x1000_0000,
-        }),
-        high_mmio: None,
+        low_mmio: MemoryRange::new(0x1000_0000..0x1000_0000 + 0x1000_0000),
+        high_mmio: MemoryRange::EMPTY,
         preserve_bars: true,
     };
 
@@ -2147,11 +2006,8 @@ async fn pinned_sibling_bridge_windows_do_not_overlap() {
     let params = AssignmentParams {
         start_bus: 0,
         end_bus: 255,
-        low_mmio: Some(MmioAperture {
-            base: 0x1000_0000,
-            len: 0x1000_0000,
-        }),
-        high_mmio: None,
+        low_mmio: MemoryRange::new(0x1000_0000..0x1000_0000 + 0x1000_0000),
+        high_mmio: MemoryRange::EMPTY,
         preserve_bars: true,
     };
 
@@ -2194,11 +2050,8 @@ async fn preserve_bars_false_ignores_preprogrammed() {
     let params = AssignmentParams {
         start_bus: 0,
         end_bus: 255,
-        low_mmio: Some(MmioAperture {
-            base: 0x1000_0000,
-            len: 0x1000_0000,
-        }),
-        high_mmio: None,
+        low_mmio: MemoryRange::new(0x1000_0000..0x1000_0000 + 0x1000_0000),
+        high_mmio: MemoryRange::EMPTY,
         preserve_bars: false,
     };
 
@@ -2235,11 +2088,8 @@ async fn gap_allocator_uses_space_before_pinned_bar() {
     let params = AssignmentParams {
         start_bus: 0,
         end_bus: 255,
-        low_mmio: Some(MmioAperture {
-            base: 0x1000_0000,
-            len: 0x1000_0000,
-        }),
-        high_mmio: None,
+        low_mmio: MemoryRange::new(0x1000_0000..0x1000_0000 + 0x1000_0000),
+        high_mmio: MemoryRange::EMPTY,
         preserve_bars: true,
     };
 
@@ -2282,11 +2132,8 @@ async fn gap_allocator_uses_space_between_pinned_bars() {
     let params = AssignmentParams {
         start_bus: 0,
         end_bus: 255,
-        low_mmio: Some(MmioAperture {
-            base: 0x1000_0000,
-            len: 0x1000_0000,
-        }),
-        high_mmio: None,
+        low_mmio: MemoryRange::new(0x1000_0000..0x1000_0000 + 0x1000_0000),
+        high_mmio: MemoryRange::EMPTY,
         preserve_bars: true,
     };
 
@@ -2334,11 +2181,8 @@ async fn sizing_accounts_for_gap_before_pinned_bar() {
     let params = AssignmentParams {
         start_bus: 0,
         end_bus: 255,
-        low_mmio: Some(MmioAperture {
-            base: 0x1010_0000,
-            len: 0x10_0000, // 1 MB
-        }),
-        high_mmio: None,
+        low_mmio: MemoryRange::new(0x1010_0000..0x1010_0000 + 0x10_0000), // 1 MB
+        high_mmio: MemoryRange::EMPTY,
         preserve_bars: true,
     };
 
@@ -2385,11 +2229,8 @@ async fn sizing_accounts_for_gap_between_pinned_bars() {
     let params = AssignmentParams {
         start_bus: 0,
         end_bus: 255,
-        low_mmio: Some(MmioAperture {
-            base: 0x1020_0000,
-            len: 0x100_0000, // 16 MB
-        }),
-        high_mmio: None,
+        low_mmio: MemoryRange::new(0x1020_0000..0x1020_0000 + 0x100_0000), // 16 MB
+        high_mmio: MemoryRange::EMPTY,
         preserve_bars: true,
     };
 
@@ -2457,11 +2298,8 @@ async fn sizing_underestimate_constrained_base_misaligned() {
     let params = AssignmentParams {
         start_bus: 0,
         end_bus: 255,
-        low_mmio: Some(MmioAperture {
-            base: 0x1000_0000,
-            len: 0x4000_0000,
-        }),
-        high_mmio: None,
+        low_mmio: MemoryRange::new(0x1000_0000..0x1000_0000 + 0x4000_0000),
+        high_mmio: MemoryRange::EMPTY,
         preserve_bars: true,
     };
 
@@ -2519,11 +2357,8 @@ async fn constrained_base_before_aperture_returns_error() {
     let params = AssignmentParams {
         start_bus: 0,
         end_bus: 255,
-        low_mmio: Some(MmioAperture {
-            base: 0x1008_0000,
-            len: 0x100_0000,
-        }),
-        high_mmio: None,
+        low_mmio: MemoryRange::new(0x1008_0000..0x1008_0000 + 0x100_0000),
+        high_mmio: MemoryRange::EMPTY,
         preserve_bars: true,
     };
 
@@ -2554,11 +2389,8 @@ async fn pinned_bar_near_u64_max_no_overflow() {
     let params = AssignmentParams {
         start_bus: 0,
         end_bus: 255,
-        low_mmio: None,
-        high_mmio: Some(MmioAperture {
-            base: 0x1_0000_0000,
-            len: 0xFFFF_FFFE_0000_0000,
-        }),
+        low_mmio: MemoryRange::EMPTY,
+        high_mmio: MemoryRange::new(0x1_0000_0000..0x1_0000_0000 + 0xFFFF_FFFE_0000_0000),
         preserve_bars: true,
     };
 

--- a/vm/devices/pci/pci_resource_assignment/src/tests.rs
+++ b/vm/devices/pci/pci_resource_assignment/src/tests.rs
@@ -2536,3 +2536,45 @@ async fn constrained_base_before_aperture_returns_error() {
         "should fail when constrained bridge window starts before aperture"
     );
 }
+
+/// A pinned BAR address near u64::MAX must not cause arithmetic overflow
+/// in the overlap or aperture containment checks. Without saturating_add,
+/// `addr + size` wraps to a small value that passes the `<= aperture_end`
+/// check, causing the BAR to be incorrectly accepted.
+#[async_test]
+async fn pinned_bar_near_u64_max_no_overflow() {
+    let mock = MockConfigSpace::new();
+
+    // 64-bit prefetchable 1 MB BAR, pinned at an address where
+    // addr + size wraps: 0xFFFF_FFFF_FFF0_0000 + 0x10_0000 = 0x0.
+    // With wrapping, bar_end=0 < aperture_end, so it looks like it fits.
+    mock.add_endpoint(0, 0, 0, &[(0, 0x10_0000, true, true)]);
+    mock.set_bar_address(0, 0, 0, 0, 0xFFFF_FFFF_FFF0_0000);
+
+    let params = AssignmentParams {
+        start_bus: 0,
+        end_bus: 255,
+        low_mmio: None,
+        high_mmio: Some(MmioAperture {
+            base: 0x1_0000_0000,
+            len: 0xFFFF_FFFE_0000_0000,
+        }),
+        preserve_bars: true,
+    };
+
+    let mut cfg = mock.clone();
+    let result = assign_pci_resources(&mut cfg, &params).await;
+
+    // Must return PinnedBarOutOfAperture. Without saturating_add, the
+    // wrapped bar_end (0x0) passes the containment check and the BAR
+    // is incorrectly accepted.
+    assert!(
+        result.is_err(),
+        "near-u64::MAX pinned BAR should be rejected, not overflow"
+    );
+    let err = result.unwrap_err();
+    assert!(
+        matches!(err, crate::AssignmentError::PinnedBarOutOfAperture { .. }),
+        "expected PinnedBarOutOfAperture, got {err}"
+    );
+}

--- a/vm/devices/pci/pci_resource_assignment/src/tests.rs
+++ b/vm/devices/pci/pci_resource_assignment/src/tests.rs
@@ -1645,15 +1645,8 @@ async fn mixed_pinned_and_dynamic_bars() {
     let bar_a = read_bar32(&mock, 1, 0, 0, 0) as u64;
     assert_eq!(bar_a, 0x1020_0000);
 
-    // Dynamic BAR should be placed after the pinned BAR's end (0x1020_0000 + 0x10000).
+    // Dynamic BAR must not overlap the pinned BAR.
     let bar_b = read_bar32(&mock, 1, 1, 0, 0) as u64;
-    assert!(
-        bar_b >= 0x1020_0000 + 0x10000,
-        "dynamic BAR {bar_b:#x} should be after pinned BAR end at {:#x}",
-        0x1020_0000u64 + 0x10000
-    );
-
-    // They must not overlap.
     assert!(
         bar_a + 0x10000 <= bar_b || bar_b + 0x10000 <= bar_a,
         "BARs overlap: A={bar_a:#x}, B={bar_b:#x}"
@@ -1826,17 +1819,18 @@ async fn bridge_window_from_pinned_and_dynamic() {
         window.0
     );
 
-    // Dynamic 1 MB BAR should be after pinned end.
+    // Dynamic 1 MB BAR must not overlap pinned BAR.
     let bar_b = read_bar32(&mock, 1, 1, 0, 0) as u64;
     assert!(
-        bar_b >= 0x1030_0000,
-        "dynamic BAR {bar_b:#x} should be >= pinned end 0x1030_0000"
+        bar_b + 0x100000 <= 0x1020_0000 || bar_b >= 0x1030_0000,
+        "dynamic BAR {bar_b:#x} overlaps pinned BAR [0x1020_0000, 0x1030_0000)"
     );
 
     // Window should cover both BARs.
     assert!(
-        window.1 >= bar_b + 0x100000 - 1,
-        "window limit {:#x} should cover dynamic BAR end {:#x}",
+        window.0 <= bar_b && window.1 >= bar_b + 0x100000 - 1,
+        "window {:#x}..={:#x} should cover dynamic BAR {bar_b:#x}..{:#x}",
+        window.0,
         window.1,
         bar_b + 0x100000 - 1
     );
@@ -2067,16 +2061,18 @@ async fn two_pinned_bars_same_bridge() {
     assert_eq!(bar_a, 0x1020_0000, "pinned BAR A");
     assert_eq!(bar_b, 0x1030_0000, "pinned BAR B");
 
-    // Dynamic BAR must be after both pinned BARs' ends.
-    let max_pinned_end = 0x1030_0000u64 + 0x10000;
+    // Dynamic BAR should be placed in the gap between the two pinned
+    // BARs (gap allocator), not after both of them.
     assert!(
-        bar_c >= max_pinned_end,
-        "dynamic BAR {bar_c:#x} should be >= max pinned end {max_pinned_end:#x}"
+        bar_c >= bar_a + 0x10000 && bar_c + 0x10000 <= bar_b,
+        "dynamic BAR {bar_c:#x} should be between pinned A end {:#x} and B start {bar_b:#x}",
+        bar_a + 0x10000,
     );
 
     // No overlaps.
     assert!(bar_a + 0x10000 <= bar_b, "A and B overlap");
-    assert!(bar_b + 0x10000 <= bar_c, "B and C overlap");
+    assert!(bar_a + 0x10000 <= bar_c, "A and C overlap");
+    assert!(bar_c + 0x10000 <= bar_b, "C and B overlap");
 }
 
 /// Dynamic BAR with large alignment coexisting with a small pinned BAR.
@@ -2121,11 +2117,7 @@ async fn pinned_bar_with_large_alignment_dynamic() {
         "dynamic 1 MB BAR at {bar_b:#x} is not 1 MB aligned"
     );
 
-    // Must be after pinned end (0x1020_0000) and not overlap.
-    assert!(
-        bar_b >= 0x1010_0000 + 0x10000,
-        "dynamic BAR {bar_b:#x} should be after pinned end"
-    );
+    // Must not overlap pinned BAR.
     assert!(
         bar_b + 0x100000 <= bar_a || bar_a + 0x10000 <= bar_b,
         "BARs overlap"
@@ -2218,5 +2210,200 @@ async fn preserve_bars_false_ignores_preprogrammed() {
         read_bar32(&mock, 0, 0, 0, 0),
         0x1000_0000,
         "with preserve_bars=false, pre-programmed address should be ignored"
+    );
+}
+
+/// When a pinned BAR leaves a gap between the bridge window base and the
+/// pinned address, the gap allocator places dynamic demands in that gap
+/// instead of wasting the space and extending the window.
+#[async_test]
+async fn gap_allocator_uses_space_before_pinned_bar() {
+    let mock = MockConfigSpace::new();
+
+    mock.add_bridge(0, 0, 0);
+
+    // Device A: 256 KB non-pref BAR, pinned at 0x1024_0000.
+    // Bridge window base = align_down(0x1024_0000, 1 MB) = 0x1020_0000.
+    // This leaves a 256 KB gap from 0x1020_0000..0x1024_0000.
+    mock.add_endpoint(1, 0, 0, &[(0, 0x40000, false, false)]);
+    mock.set_bar_address(1, 0, 0, 0, 0x1024_0000);
+
+    // Device B: 64 KB non-pref BAR, dynamic. Small enough to fit in the
+    // 256 KB gap before the pinned BAR.
+    mock.add_endpoint(1, 1, 0, &[(0, 0x10000, false, false)]);
+
+    let params = AssignmentParams {
+        start_bus: 0,
+        end_bus: 255,
+        low_mmio: Some(MmioAperture {
+            base: 0x1000_0000,
+            len: 0x1000_0000,
+        }),
+        high_mmio: None,
+        preserve_bars: true,
+    };
+
+    let mut cfg = mock.clone();
+    assign_pci_resources(&mut cfg, &params).await.unwrap();
+
+    let bar_a = read_bar32(&mock, 1, 0, 0, 0) as u64;
+    let bar_b = read_bar32(&mock, 1, 1, 0, 0) as u64;
+
+    // Pinned BAR stays at its fixed address.
+    assert_eq!(bar_a, 0x1024_0000, "pinned BAR should be at its address");
+
+    // Dynamic BAR should be placed in the gap *before* the pinned BAR.
+    assert!(
+        bar_b >= 0x1020_0000 && bar_b + 0x10000 <= 0x1024_0000,
+        "dynamic BAR {bar_b:#x} should be in the gap [0x1020_0000, 0x1024_0000)"
+    );
+}
+
+/// Dynamic BAR fits in a gap between two pinned BARs instead of being
+/// placed after both of them.
+#[async_test]
+async fn gap_allocator_uses_space_between_pinned_bars() {
+    let mock = MockConfigSpace::new();
+
+    mock.add_bridge(0, 0, 0);
+
+    // Device A: 64 KB non-pref BAR, pinned at 0x1020_0000.
+    mock.add_endpoint(1, 0, 0, &[(0, 0x10000, false, false)]);
+    mock.set_bar_address(1, 0, 0, 0, 0x1020_0000);
+
+    // Device B: 64 KB non-pref BAR, pinned at 0x1040_0000.
+    // Gap between A's end and B's start: [0x1030_0000, 0x1040_0000).
+    mock.add_endpoint(1, 1, 0, &[(0, 0x10000, false, false)]);
+    mock.set_bar_address(1, 1, 0, 0, 0x1040_0000);
+
+    // Device C: 64 KB non-pref BAR, dynamic.
+    mock.add_endpoint(1, 2, 0, &[(0, 0x10000, false, false)]);
+
+    let params = AssignmentParams {
+        start_bus: 0,
+        end_bus: 255,
+        low_mmio: Some(MmioAperture {
+            base: 0x1000_0000,
+            len: 0x1000_0000,
+        }),
+        high_mmio: None,
+        preserve_bars: true,
+    };
+
+    let mut cfg = mock.clone();
+    assign_pci_resources(&mut cfg, &params).await.unwrap();
+
+    let bar_a = read_bar32(&mock, 1, 0, 0, 0) as u64;
+    let bar_b = read_bar32(&mock, 1, 1, 0, 0) as u64;
+    let bar_c = read_bar32(&mock, 1, 2, 0, 0) as u64;
+
+    assert_eq!(bar_a, 0x1020_0000, "pinned BAR A");
+    assert_eq!(bar_b, 0x1040_0000, "pinned BAR B");
+
+    // Dynamic BAR should be placed in the gap between the two pinned BARs.
+    assert!(
+        bar_c >= bar_a + 0x10000 && bar_c + 0x10000 <= bar_b,
+        "dynamic BAR {bar_c:#x} should be between pinned A end {:#x} and pinned B start {:#x}",
+        bar_a + 0x10000,
+        bar_b,
+    );
+}
+
+/// Sizing must account for gaps within the pinned span. A dynamic BAR
+/// that fits in the gap before a pinned BAR should not inflate the
+/// bridge window beyond the pinned span.
+#[async_test]
+async fn sizing_accounts_for_gap_before_pinned_bar() {
+    let mock = MockConfigSpace::new();
+
+    mock.add_bridge(0, 0, 0);
+
+    // Device A: 512 KB non-pref BAR, pinned at 0x1018_0000.
+    // constrained_base = align_down(0x1018_0000, 1 MB) = 0x1010_0000.
+    // Pinned span = 0x1010_0000..0x1020_0000 = 1 MB.
+    // Gap before pin: [0x1010_0000, 0x1018_0000) = 512 KB.
+    mock.add_endpoint(1, 0, 0, &[(0, 0x80000, false, false)]);
+    mock.set_bar_address(1, 0, 0, 0, 0x1018_0000);
+
+    // Device B: 256 KB non-pref BAR, dynamic. Fits in the 512 KB gap.
+    mock.add_endpoint(1, 1, 0, &[(0, 0x40000, false, false)]);
+
+    // Aperture is exactly 1 MB at the constrained base. With gap-aware
+    // sizing the bridge window is 1 MB and fits. Without gap-aware
+    // sizing the window inflates to 2 MB and overflows.
+    let params = AssignmentParams {
+        start_bus: 0,
+        end_bus: 255,
+        low_mmio: Some(MmioAperture {
+            base: 0x1010_0000,
+            len: 0x10_0000, // 1 MB
+        }),
+        high_mmio: None,
+        preserve_bars: true,
+    };
+
+    let mut cfg = mock.clone();
+    let result = assign_pci_resources(&mut cfg, &params).await;
+    assert!(
+        result.is_ok(),
+        "1 MB aperture should suffice when dynamic BAR fits in gap: {result:?}"
+    );
+
+    // Verify placement.
+    let bar_a = read_bar32(&mock, 1, 0, 0, 0) as u64;
+    let bar_b = read_bar32(&mock, 1, 1, 0, 0) as u64;
+    assert_eq!(bar_a, 0x1018_0000, "pinned BAR");
+    assert!(
+        bar_b >= 0x1010_0000 && bar_b + 0x40000 <= 0x1018_0000,
+        "dynamic BAR {bar_b:#x} should be in the gap [0x1010_0000, 0x1018_0000)"
+    );
+}
+
+/// Sizing must account for gaps between pinned BARs. A dynamic BAR
+/// that fits between two pinned BARs should not extend the window.
+#[async_test]
+async fn sizing_accounts_for_gap_between_pinned_bars() {
+    let mock = MockConfigSpace::new();
+
+    mock.add_bridge(0, 0, 0);
+
+    // Device A: 64 KB non-pref BAR, pinned at 0x1020_0000.
+    mock.add_endpoint(1, 0, 0, &[(0, 0x10000, false, false)]);
+    mock.set_bar_address(1, 0, 0, 0, 0x1020_0000);
+
+    // Device B: 64 KB non-pref BAR, pinned at 0x1110_0000.
+    // Pinned span base = 0x1020_0000, end = 0x1120_0000 = 16 MB.
+    // Gap between: [0x1030_0000, 0x1110_0000) = 14 MB.
+    mock.add_endpoint(1, 1, 0, &[(0, 0x10000, false, false)]);
+    mock.set_bar_address(1, 1, 0, 0, 0x1110_0000);
+
+    // Device C: 1 MB non-pref BAR, dynamic. Fits in the 14 MB gap.
+    mock.add_endpoint(1, 2, 0, &[(0, 0x100000, false, false)]);
+
+    // Aperture = 16 MB starting at constrained base. Gap-aware sizing
+    // keeps the window at 16 MB; naive sizing adds 1 MB → 17 MB → overflow.
+    let params = AssignmentParams {
+        start_bus: 0,
+        end_bus: 255,
+        low_mmio: Some(MmioAperture {
+            base: 0x1020_0000,
+            len: 0x100_0000, // 16 MB
+        }),
+        high_mmio: None,
+        preserve_bars: true,
+    };
+
+    let mut cfg = mock.clone();
+    let result = assign_pci_resources(&mut cfg, &params).await;
+    assert!(
+        result.is_ok(),
+        "16 MB aperture should suffice when dynamic BAR fits in gap: {result:?}"
+    );
+
+    // Dynamic BAR should be between the two pinned BARs.
+    let bar_c = read_bar32(&mock, 1, 2, 0, 0) as u64;
+    assert!(
+        bar_c >= 0x1030_0000 && bar_c + 0x100000 <= 0x1110_0000,
+        "dynamic BAR {bar_c:#x} should be in the gap between pinned BARs"
     );
 }

--- a/vm/devices/pci/pci_resource_assignment/src/tests.rs
+++ b/vm/devices/pci/pci_resource_assignment/src/tests.rs
@@ -2407,3 +2407,90 @@ async fn sizing_accounts_for_gap_between_pinned_bars() {
         "dynamic BAR {bar_c:#x} should be in the gap between pinned BARs"
     );
 }
+
+/// Sizing underestimate when constrained_base is not aligned to a large
+/// dynamic demand's alignment.
+///
+/// The trial overflow path in compute_subtree_state uses relative offsets
+/// for alignment padding:
+///     pool.mem = align_up(pool.mem, alignment) + size
+///
+/// But the real allocator in assign_subtree uses absolute addresses.
+/// When the pinned span is an exact multiple of the dynamic BAR's
+/// alignment but constrained_base is not, the trial computes zero
+/// alignment padding while the real allocation needs up to
+/// (alignment - 1) bytes of padding, causing the gap to be too small.
+#[async_test]
+async fn sizing_underestimate_constrained_base_misaligned() {
+    let mock = MockConfigSpace::new();
+
+    mock.add_bridge(0, 0, 0);
+
+    // Device A: 64 KB non-pref BAR, pinned at 0x1010_0000.
+    // constrained_base = align_down(0x1010_0000, 1 MB) = 0x1010_0000.
+    // This is NOT 16 MB aligned (0x1010_0000 % 0x100_0000 = 0x10_0000).
+    mock.add_endpoint(1, 0, 0, &[(0, 0x10000, false, false)]);
+    mock.set_bar_address(1, 0, 0, 0, 0x1010_0000);
+
+    // Device B: 1 MB non-pref BAR, pinned at 0x1100_0000.
+    // Pinned span: [0x1010_0000, 0x1110_0000) = 16 MB (0x100_0000).
+    // 16 MB is an exact multiple of the dynamic BAR's alignment (16 MB),
+    // so align_up(16 MB, 16 MB) = 16 MB — the trial adds zero padding.
+    mock.add_endpoint(1, 1, 0, &[(0, 0x100000, false, false)]);
+    mock.set_bar_address(1, 1, 0, 0, 0x1100_0000);
+
+    // Device C: 16 MB non-pref BAR, dynamic (not pinned).
+    //
+    // Trial overflow path:
+    //   pool.mem = 0x100_0000 (pinned span = 16 MB)
+    //   align_up(0x100_0000, 0x100_0000) = 0x100_0000 (no padding!)
+    //   pool.mem = 0x100_0000 + 0x100_0000 = 0x200_0000 (32 MB)
+    //   Window: [0x1010_0000, 0x1210_0000).
+    //
+    // Real allocation: tail gap = [0x1110_0000, 0x1210_0000) = 16 MB.
+    //   align_up(0x1110_0000, 0x100_0000) = 0x1200_0000
+    //   0x1200_0000 + 0x100_0000 = 0x1300_0000 > 0x1210_0000 → panic!
+    mock.add_endpoint(1, 2, 0, &[(0, 0x1000000, false, false)]);
+
+    // Aperture is generous (1 GB). The issue is that the bridge window
+    // is undersized, not that the aperture is too small.
+    let params = AssignmentParams {
+        start_bus: 0,
+        end_bus: 255,
+        low_mmio: Some(MmioAperture {
+            base: 0x1000_0000,
+            len: 0x4000_0000,
+        }),
+        high_mmio: None,
+        preserve_bars: true,
+    };
+
+    let mut cfg = mock.clone();
+    let result = assign_pci_resources(&mut cfg, &params).await;
+
+    // This should succeed — there is more than enough aperture space.
+    // BUG: the sizing pass underestimates the bridge window, causing
+    // assign_subtree to panic ("demand must fit").
+    assert!(
+        result.is_ok(),
+        "should succeed with generous aperture: {result:?}"
+    );
+
+    // Verify pinned BARs are at their expected addresses.
+    let bar_a = read_bar32(&mock, 1, 0, 0, 0) as u64;
+    let bar_b = read_bar32(&mock, 1, 1, 0, 0) as u64;
+    let bar_c = read_bar32(&mock, 1, 2, 0, 0) as u64;
+    assert_eq!(bar_a, 0x1010_0000, "pinned BAR A");
+    assert_eq!(bar_b, 0x1100_0000, "pinned BAR B");
+
+    // Dynamic 16 MB BAR must be 16 MB aligned and not overlap pinned BARs.
+    assert_eq!(
+        bar_c % 0x100_0000,
+        0,
+        "dynamic 16 MB BAR at {bar_c:#x} must be 16 MB aligned"
+    );
+    assert!(
+        bar_c + 0x100_0000 <= bar_a || bar_c >= 0x1110_0000,
+        "dynamic BAR at {bar_c:#x} must not overlap pinned BARs"
+    );
+}

--- a/vm/devices/pci/pci_resource_assignment/src/tests.rs
+++ b/vm/devices/pci/pci_resource_assignment/src/tests.rs
@@ -1751,6 +1751,43 @@ async fn pinned_bar_out_of_aperture_error() {
     );
 }
 
+/// A 64-bit non-prefetchable BAR pinned above 4 GB should be rejected.
+/// The non-prefetchable bridge window is 32-bit only and cannot represent
+/// addresses above 4 GB.
+#[async_test]
+async fn pinned_bar_64bit_non_prefetchable_above_4gb_rejected() {
+    let mock = MockConfigSpace::new();
+
+    mock.add_bridge(0, 0, 0);
+    // 1 MB 64-bit non-prefetchable BAR pinned above 4 GB.
+    mock.add_endpoint(1, 0, 0, &[(0, 0x100000, true, false)]);
+    mock.set_bar_address(1, 0, 0, 0, 0x1_0010_0000);
+
+    let params = AssignmentParams {
+        start_bus: 0,
+        end_bus: 255,
+        low_mmio: Some(MmioAperture {
+            base: 0x1000_0000,
+            len: 0x1000_0000,
+        }),
+        high_mmio: Some(MmioAperture {
+            base: 0x1_0000_0000,
+            len: 0x1_0000_0000,
+        }),
+        preserve_bars: true,
+    };
+
+    let mut cfg = mock;
+    let result = assign_pci_resources(&mut cfg, &params).await;
+    assert!(
+        matches!(
+            result,
+            Err(crate::AssignmentError::PinnedBarOutOfAperture { .. })
+        ),
+        "expected PinnedBarOutOfAperture, got {result:?}"
+    );
+}
+
 /// Bridge window should be computed from pinned + dynamic children.
 #[async_test]
 async fn bridge_window_from_pinned_and_dynamic() {
@@ -1911,6 +1948,82 @@ async fn pinned_bar_64bit_prefetchable() {
         "pref window {:#x}..={:#x} must contain pinned BAR",
         pref.0,
         pref.1
+    );
+}
+
+/// Two pinned 64-bit prefetchable BARs: one below 4 GB (in the low MMIO
+/// aperture) and one above 4 GB (in the high MMIO aperture). Pinned BARs
+/// below 4 GB are treated as mem32 (prefetchable vs. non-prefetchable is
+/// not a real distinction in virtualization), so the low BAR goes in the
+/// non-prefetchable bridge window and the high BAR goes in the
+/// prefetchable bridge window. Each window must stay within its aperture.
+#[async_test]
+async fn pinned_bar_64bit_prefetchable_in_low_mmio() {
+    let mock = MockConfigSpace::new();
+
+    mock.add_bridge(0, 0, 0);
+    // Device 0: 1 MB 64-bit prefetchable BAR pinned below 4 GB.
+    mock.add_endpoint(1, 0, 0, &[(0, 0x100000, true, true)]);
+    mock.set_bar_address(1, 0, 0, 0, 0x1020_0000);
+    // Device 1: 1 MB 64-bit prefetchable BAR pinned above 4 GB.
+    mock.add_endpoint(1, 1, 0, &[(0, 0x100000, true, true)]);
+    mock.set_bar_address(1, 1, 0, 0, 0x1_0010_0000);
+
+    let params = AssignmentParams {
+        start_bus: 0,
+        end_bus: 255,
+        low_mmio: Some(MmioAperture {
+            base: 0x1000_0000,
+            len: 0x1000_0000,
+        }),
+        high_mmio: Some(MmioAperture {
+            base: 0x1_0000_0000,
+            len: 0x1_0000_0000,
+        }),
+        preserve_bars: true,
+    };
+
+    let mut cfg = mock.clone();
+    assign_pci_resources(&mut cfg, &params).await.unwrap();
+
+    // Both BARs should be at their pinned addresses.
+    let bar_low = read_bar64(&mock, 1, 0, 0, 0);
+    let bar_high = read_bar64(&mock, 1, 1, 0, 0);
+    assert_eq!(bar_low, 0x1020_0000);
+    assert_eq!(bar_high, 0x1_0010_0000);
+
+    // Low BAR is treated as mem32, so it should be in the non-prefetchable window.
+    let mem_win = read_memory_window(&mock, 0, 0, 0)
+        .expect("bridge should have a non-prefetchable window for the low pinned BAR");
+    assert!(
+        mem_win.0 <= bar_low && bar_low + 0x100000 - 1 <= mem_win.1,
+        "memory window {:#x}..={:#x} must contain low BAR [{:#x}..{:#x})",
+        mem_win.0,
+        mem_win.1,
+        bar_low,
+        bar_low + 0x100000
+    );
+
+    // High BAR stays in the prefetchable window.
+    let pref_win = read_prefetchable_window(&mock, 0, 0, 0)
+        .expect("bridge should have a prefetchable window for the high pinned BAR");
+    assert!(
+        pref_win.0 <= bar_high && bar_high + 0x100000 - 1 <= pref_win.1,
+        "prefetchable window {:#x}..={:#x} must contain high BAR [{:#x}..{:#x})",
+        pref_win.0,
+        pref_win.1,
+        bar_high,
+        bar_high + 0x100000
+    );
+
+    // The two bridge windows must not overlap.
+    assert!(
+        mem_win.1 < pref_win.0 || pref_win.1 < mem_win.0,
+        "bridge windows overlap: mem {:#x}..={:#x} vs pref {:#x}..={:#x}",
+        mem_win.0,
+        mem_win.1,
+        pref_win.0,
+        pref_win.1
     );
 }
 

--- a/vm/devices/pci/pci_resource_assignment/src/tests.rs
+++ b/vm/devices/pci/pci_resource_assignment/src/tests.rs
@@ -90,6 +90,22 @@ impl MockConfigSpace {
         inner.regs.insert(key, val | 0x0080_0000); // multi-function bit
     }
 
+    /// Pre-program a BAR with an address (for testing preserve_bars).
+    /// The address is written into the BAR register along with the existing
+    /// encoding bits.
+    fn set_bar_address(&self, bus: u8, device: u8, function: u8, bar_idx: u8, address: u64) {
+        let mut inner = self.inner.lock();
+        let offset = 0x10 + (bar_idx as u16) * 4;
+        let key = (bus, device, function, offset);
+        let encoding = inner.regs.get(&key).copied().unwrap_or(0) & 0xf;
+        inner.regs.insert(key, (address as u32 & !0xf) | encoding);
+        // If 64-bit, also set the upper DWORD.
+        if encoding & 0x04 != 0 {
+            let upper_key = (bus, device, function, offset + 4);
+            inner.regs.insert(upper_key, (address >> 32) as u32);
+        }
+    }
+
     /// Add a Type 1 bridge at (bus, device, function).
     fn add_bridge(&self, bus: u8, device: u8, function: u8) {
         let mut inner = self.inner.lock();
@@ -309,6 +325,7 @@ async fn single_endpoint_32bit_bar() {
             len: 0x1000_0000,
         }),
         high_mmio: None,
+        preserve_bars: false,
     };
 
     let mut cfg = mock.clone();
@@ -332,6 +349,7 @@ async fn single_endpoint_64bit_bar() {
             base: 0x1_0000_0000,
             len: 0x1_0000_0000,
         }),
+        preserve_bars: false,
     };
 
     let mut cfg = mock.clone();
@@ -359,6 +377,7 @@ async fn bridge_with_endpoint() {
             len: 0x1000_0000,
         }),
         high_mmio: None,
+        preserve_bars: false,
     };
 
     let mut cfg = mock.clone();
@@ -395,6 +414,7 @@ async fn multiple_endpoints_sorted_by_size() {
             len: 0x1000_0000,
         }),
         high_mmio: None,
+        preserve_bars: false,
     };
 
     let mut cfg = mock.clone();
@@ -426,6 +446,7 @@ async fn multi_function_device() {
             len: 0x1000_0000,
         }),
         high_mmio: None,
+        preserve_bars: false,
     };
 
     let mut cfg = mock.clone();
@@ -465,6 +486,7 @@ async fn switch_with_multiple_endpoints() {
             base: 0x1_0000_0000,
             len: 0x1_0000_0000,
         }),
+        preserve_bars: false,
     };
 
     let mut cfg = mock.clone();
@@ -509,6 +531,7 @@ async fn bus_exhaustion_error() {
         end_bus: 0, // No room for secondary bus.
         low_mmio: None,
         high_mmio: None,
+        preserve_bars: false,
     };
 
     let mut cfg = mock;
@@ -535,6 +558,7 @@ async fn no_devices_is_ok() {
             len: 0x1000_0000,
         }),
         high_mmio: None,
+        preserve_bars: false,
     };
 
     let mut cfg = mock;
@@ -558,6 +582,7 @@ async fn mmio_exhaustion_error() {
             len: 0x20000, // 128KB — not enough for both
         }),
         high_mmio: None,
+        preserve_bars: false,
     };
 
     let mut cfg = mock;
@@ -584,6 +609,7 @@ async fn no_aperture_error() {
         end_bus: 255,
         low_mmio: None,
         high_mmio: None,
+        preserve_bars: false,
     };
 
     let mut cfg = mock;
@@ -619,6 +645,7 @@ async fn sriov_reserves_bus_numbers() {
             len: 0x1000_0000,
         }),
         high_mmio: None,
+        preserve_bars: false,
     };
 
     let mut cfg = mock.clone();
@@ -660,6 +687,7 @@ async fn sriov_no_vfs_no_reservation() {
             len: 0x1000_0000,
         }),
         high_mmio: None,
+        preserve_bars: false,
     };
 
     let mut cfg = mock.clone();
@@ -686,6 +714,7 @@ async fn bridge_prefetchable_window_programmed() {
             base: 0x1_0000_0000,
             len: 0x1_0000_0000,
         }),
+        preserve_bars: false,
     };
 
     let mut cfg = mock.clone();
@@ -754,6 +783,7 @@ async fn sibling_bridge_windows_must_not_overlap() {
             len: 0x1000_0000,
         }),
         high_mmio: None,
+        preserve_bars: false,
     };
 
     let mut cfg = mock.clone();
@@ -793,6 +823,7 @@ async fn large_bar_alignment_fits_in_bridge_window() {
             len: 0x2_0000_0000, // 8 GB
         }),
         high_mmio: None,
+        preserve_bars: false,
     };
 
     let mut cfg = mock.clone();
@@ -840,6 +871,7 @@ async fn alignment_first_sort_avoids_wasted_padding() {
             len: 0x500000, // 5 MB
         }),
         high_mmio: None,
+        preserve_bars: false,
     };
 
     let mut cfg = mock.clone();
@@ -877,6 +909,7 @@ async fn misaligned_aperture_does_not_overflow() {
             len: 0x400000,     // 4 MB — exactly the BAR size, but not enough after alignment
         }),
         high_mmio: None,
+        preserve_bars: false,
     };
 
     let mut cfg = mock.clone();
@@ -907,6 +940,7 @@ async fn alignment_exceeds_aperture_returns_error() {
             len: 0x200000,     // 2 MB total
         }),
         high_mmio: None,
+        preserve_bars: false,
     };
 
     let mut cfg = mock.clone();
@@ -940,6 +974,7 @@ async fn sriov_bus_reservation_exceeding_end_bus_returns_error() {
             len: 0x1000_0000,
         }),
         high_mmio: None,
+        preserve_bars: false,
     };
 
     let mut cfg = mock;
@@ -973,6 +1008,7 @@ async fn mem32_bar_must_not_be_placed_above_4gb() {
             base: 0x1_0000_0000, // Above 4 GB
             len: 0x1_0000_0000,
         }),
+        preserve_bars: false,
     };
 
     let mut cfg = mock;
@@ -1015,6 +1051,7 @@ async fn shared_aperture_mem32_mem64_must_not_overlap() {
             len: 0x0100_0000, // 16 MB — plenty of room
         }),
         high_mmio: None,
+        preserve_bars: false,
     };
 
     let mut cfg = mock.clone();
@@ -1068,6 +1105,7 @@ async fn bus_wrap_to_zero_must_return_exhaustion() {
             len: 0x1000_0000,
         }),
         high_mmio: None,
+        preserve_bars: false,
     };
 
     let mut cfg = mock;
@@ -1108,6 +1146,7 @@ async fn sriov_vf_bars_included_in_bridge_window() {
             len: 0x1000_0000,
         }),
         high_mmio: None,
+        preserve_bars: false,
     };
 
     let mut cfg = mock.clone();
@@ -1167,6 +1206,7 @@ async fn sriov_non_power_of_two_vf_count() {
             len: 0x1000_0000,
         }),
         high_mmio: None,
+        preserve_bars: false,
     };
 
     let mut cfg = mock.clone();
@@ -1211,6 +1251,7 @@ async fn sriov_vf_bars_64bit_prefetchable() {
             base: 0x1_0000_0000,
             len: 0x1_0000_0000,
         }),
+        preserve_bars: false,
     };
 
     let mut cfg = mock.clone();
@@ -1286,6 +1327,7 @@ async fn sriov_mixed_vf_bar_types() {
             base: 0x1_0000_0000,
             len: 0x1_0000_0000,
         }),
+        preserve_bars: false,
     };
 
     let mut cfg = mock.clone();
@@ -1345,6 +1387,7 @@ async fn sriov_top_level_pf_no_bridge() {
             len: 0x1000_0000,
         }),
         high_mmio: None,
+        preserve_bars: false,
     };
 
     let mut cfg = mock.clone();
@@ -1397,6 +1440,7 @@ async fn sriov_multiple_pfs_behind_bridge() {
             len: 0x1000_0000,
         }),
         high_mmio: None,
+        preserve_bars: false,
     };
 
     let mut cfg = mock.clone();
@@ -1473,6 +1517,7 @@ async fn sriov_vf_bars_cause_mmio_exhaustion() {
             len: 0x20_0000, // Only 2 MB — not enough for 16 MB of VF BARs
         }),
         high_mmio: None,
+        preserve_bars: false,
     };
 
     let mut cfg = mock;
@@ -1480,5 +1525,585 @@ async fn sriov_vf_bars_cause_mmio_exhaustion() {
     assert!(
         result.is_err(),
         "should fail with MMIO exhaustion, got {result:?}"
+    );
+}
+
+// ---- Pinned BAR tests ----
+
+/// Single device with one pinned BAR: the BAR should be assigned at the
+/// pre-programmed address, not at the aperture base.
+#[async_test]
+async fn single_pinned_bar() {
+    let mock = MockConfigSpace::new();
+    // 64 KB 32-bit non-pref BAR at index 0.
+    mock.add_endpoint(0, 0, 0, &[(0, 0x10000, false, false)]);
+    // Pre-program BAR0 with a specific address.
+    mock.set_bar_address(0, 0, 0, 0, 0x1050_0000);
+
+    let params = AssignmentParams {
+        start_bus: 0,
+        end_bus: 255,
+        low_mmio: Some(MmioAperture {
+            base: 0x1000_0000,
+            len: 0x1000_0000,
+        }),
+        high_mmio: None,
+        preserve_bars: true,
+    };
+
+    let mut cfg = mock.clone();
+    assign_pci_resources(&mut cfg, &params).await.unwrap();
+
+    // BAR0 should be at the pinned address, not at the aperture base.
+    assert_eq!(read_bar32(&mock, 0, 0, 0, 0), 0x1050_0000);
+}
+
+/// Two devices with pinned BARs behind a switch.
+#[async_test]
+async fn two_pinned_bars_behind_switch() {
+    let mock = MockConfigSpace::new();
+
+    // Upstream bridge.
+    mock.add_bridge(0, 0, 0);
+    // Downstream bridge A.
+    mock.add_bridge(1, 0, 0);
+    // Downstream bridge B.
+    mock.add_bridge(1, 1, 0);
+
+    // Endpoint A behind bridge A: 64 KB non-pref BAR, pinned.
+    mock.add_endpoint(2, 0, 0, &[(0, 0x10000, false, false)]);
+    mock.set_bar_address(2, 0, 0, 0, 0x1080_0000);
+
+    // Endpoint B behind bridge B: 64 KB non-pref BAR, pinned.
+    mock.add_endpoint(3, 0, 0, &[(0, 0x10000, false, false)]);
+    mock.set_bar_address(3, 0, 0, 0, 0x1090_0000);
+
+    let params = AssignmentParams {
+        start_bus: 0,
+        end_bus: 255,
+        low_mmio: Some(MmioAperture {
+            base: 0x1000_0000,
+            len: 0x1000_0000,
+        }),
+        high_mmio: None,
+        preserve_bars: true,
+    };
+
+    let mut cfg = mock.clone();
+    assign_pci_resources(&mut cfg, &params).await.unwrap();
+
+    // Both BARs should be at their pinned addresses.
+    assert_eq!(read_bar32(&mock, 2, 0, 0, 0), 0x1080_0000);
+    assert_eq!(read_bar32(&mock, 3, 0, 0, 0), 0x1090_0000);
+
+    // Bridge windows should encompass the pinned addresses.
+    let win_a = read_memory_window(&mock, 1, 0, 0).expect("bridge A should have memory window");
+    assert!(
+        win_a.0 <= 0x1080_0000 && 0x1080_0000 + 0x10000 - 1 <= win_a.1,
+        "bridge A window {:#x}..={:#x} must contain pinned BAR at 0x1080_0000",
+        win_a.0,
+        win_a.1
+    );
+    let win_b = read_memory_window(&mock, 1, 1, 0).expect("bridge B should have memory window");
+    assert!(
+        win_b.0 <= 0x1090_0000 && 0x1090_0000 + 0x10000 - 1 <= win_b.1,
+        "bridge B window {:#x}..={:#x} must contain pinned BAR at 0x1090_0000",
+        win_b.0,
+        win_b.1
+    );
+}
+
+/// Mixed pinned + dynamic BARs behind the same bridge.
+#[async_test]
+async fn mixed_pinned_and_dynamic_bars() {
+    let mock = MockConfigSpace::new();
+
+    mock.add_bridge(0, 0, 0);
+
+    // Device A: 64 KB non-pref BAR, pinned at 0x1020_0000.
+    mock.add_endpoint(1, 0, 0, &[(0, 0x10000, false, false)]);
+    mock.set_bar_address(1, 0, 0, 0, 0x1020_0000);
+
+    // Device B: 64 KB non-pref BAR, dynamic (not pinned).
+    mock.add_endpoint(1, 1, 0, &[(0, 0x10000, false, false)]);
+
+    let params = AssignmentParams {
+        start_bus: 0,
+        end_bus: 255,
+        low_mmio: Some(MmioAperture {
+            base: 0x1000_0000,
+            len: 0x1000_0000,
+        }),
+        high_mmio: None,
+        preserve_bars: true,
+    };
+
+    let mut cfg = mock.clone();
+    assign_pci_resources(&mut cfg, &params).await.unwrap();
+
+    // Pinned BAR at its fixed address.
+    let bar_a = read_bar32(&mock, 1, 0, 0, 0) as u64;
+    assert_eq!(bar_a, 0x1020_0000);
+
+    // Dynamic BAR should be placed after the pinned BAR's end (0x1020_0000 + 0x10000).
+    let bar_b = read_bar32(&mock, 1, 1, 0, 0) as u64;
+    assert!(
+        bar_b >= 0x1020_0000 + 0x10000,
+        "dynamic BAR {bar_b:#x} should be after pinned BAR end at {:#x}",
+        0x1020_0000u64 + 0x10000
+    );
+
+    // They must not overlap.
+    assert!(
+        bar_a + 0x10000 <= bar_b || bar_b + 0x10000 <= bar_a,
+        "BARs overlap: A={bar_a:#x}, B={bar_b:#x}"
+    );
+}
+
+/// Pinned BAR misaligned to its size should produce an error.
+#[async_test]
+async fn pinned_bar_misaligned_error() {
+    let mock = MockConfigSpace::new();
+    // 64 KB BAR at index 0.
+    mock.add_endpoint(0, 0, 0, &[(0, 0x10000, false, false)]);
+    // Pre-program at a non-64KB-aligned address.
+    mock.set_bar_address(0, 0, 0, 0, 0x1000_8000);
+
+    let params = AssignmentParams {
+        start_bus: 0,
+        end_bus: 255,
+        low_mmio: Some(MmioAperture {
+            base: 0x1000_0000,
+            len: 0x1000_0000,
+        }),
+        high_mmio: None,
+        preserve_bars: true,
+    };
+
+    let mut cfg = mock;
+    let result = assign_pci_resources(&mut cfg, &params).await;
+    assert!(
+        matches!(
+            result,
+            Err(crate::AssignmentError::PinnedBarMisaligned { .. })
+        ),
+        "expected PinnedBarMisaligned, got {result:?}"
+    );
+}
+
+/// Overlapping pinned BARs should produce an error.
+#[async_test]
+async fn pinned_bar_overlap_error() {
+    let mock = MockConfigSpace::new();
+    // Two devices with overlapping pinned BARs.
+    mock.add_endpoint(0, 0, 0, &[(0, 0x20000, false, false)]); // 128 KB
+    mock.set_bar_address(0, 0, 0, 0, 0x1010_0000);
+
+    mock.add_endpoint(0, 1, 0, &[(0, 0x10000, false, false)]); // 64 KB
+    mock.set_bar_address(0, 1, 0, 0, 0x1011_0000); // overlaps with first
+
+    let params = AssignmentParams {
+        start_bus: 0,
+        end_bus: 255,
+        low_mmio: Some(MmioAperture {
+            base: 0x1000_0000,
+            len: 0x1000_0000,
+        }),
+        high_mmio: None,
+        preserve_bars: true,
+    };
+
+    let mut cfg = mock;
+    let result = assign_pci_resources(&mut cfg, &params).await;
+    assert!(
+        matches!(result, Err(crate::AssignmentError::PinnedBarOverlap { .. })),
+        "expected PinnedBarOverlap, got {result:?}"
+    );
+}
+
+/// Pinned BAR outside aperture should produce an error.
+#[async_test]
+async fn pinned_bar_out_of_aperture_error() {
+    let mock = MockConfigSpace::new();
+    mock.add_endpoint(0, 0, 0, &[(0, 0x10000, false, false)]);
+    // Pinned at an address outside the low MMIO aperture.
+    mock.set_bar_address(0, 0, 0, 0, 0x3000_0000);
+
+    let params = AssignmentParams {
+        start_bus: 0,
+        end_bus: 255,
+        low_mmio: Some(MmioAperture {
+            base: 0x1000_0000,
+            len: 0x1000_0000, // ends at 0x2000_0000
+        }),
+        high_mmio: None,
+        preserve_bars: true,
+    };
+
+    let mut cfg = mock;
+    let result = assign_pci_resources(&mut cfg, &params).await;
+    assert!(
+        matches!(
+            result,
+            Err(crate::AssignmentError::PinnedBarOutOfAperture { .. })
+        ),
+        "expected PinnedBarOutOfAperture, got {result:?}"
+    );
+}
+
+/// Bridge window should be computed from pinned + dynamic children.
+#[async_test]
+async fn bridge_window_from_pinned_and_dynamic() {
+    let mock = MockConfigSpace::new();
+
+    mock.add_bridge(0, 0, 0);
+
+    // Device A: 1 MB non-pref BAR, pinned at 0x1020_0000.
+    mock.add_endpoint(1, 0, 0, &[(0, 0x100000, false, false)]);
+    mock.set_bar_address(1, 0, 0, 0, 0x1020_0000);
+
+    // Device B: 1 MB non-pref BAR, dynamic.
+    mock.add_endpoint(1, 1, 0, &[(0, 0x100000, false, false)]);
+
+    let params = AssignmentParams {
+        start_bus: 0,
+        end_bus: 255,
+        low_mmio: Some(MmioAperture {
+            base: 0x1000_0000,
+            len: 0x1000_0000,
+        }),
+        high_mmio: None,
+        preserve_bars: true,
+    };
+
+    let mut cfg = mock.clone();
+    assign_pci_resources(&mut cfg, &params).await.unwrap();
+
+    let window = read_memory_window(&mock, 0, 0, 0).expect("bridge should have memory window");
+
+    // Pinned BAR at 0x1020_0000 with size 1 MB → ends at 0x1030_0000.
+    // Bridge window base should be align_down(0x1020_0000, 1 MB) = 0x1020_0000.
+    assert!(
+        window.0 <= 0x1020_0000,
+        "window base {:#x} should be <= pinned BAR at 0x1020_0000",
+        window.0
+    );
+
+    // Dynamic 1 MB BAR should be after pinned end.
+    let bar_b = read_bar32(&mock, 1, 1, 0, 0) as u64;
+    assert!(
+        bar_b >= 0x1030_0000,
+        "dynamic BAR {bar_b:#x} should be >= pinned end 0x1030_0000"
+    );
+
+    // Window should cover both BARs.
+    assert!(
+        window.1 >= bar_b + 0x100000 - 1,
+        "window limit {:#x} should cover dynamic BAR end {:#x}",
+        window.1,
+        bar_b + 0x100000 - 1
+    );
+}
+
+/// No-pin case with preserve_bars=true should produce identical results
+/// to preserve_bars=false when no BARs are pre-programmed.
+#[async_test]
+async fn preserve_bars_no_pins_identical_to_dynamic() {
+    let mock = MockConfigSpace::new();
+
+    mock.add_bridge(0, 0, 0);
+    mock.add_endpoint(1, 0, 0, &[(0, 0x10000, false, false)]);
+    mock.add_endpoint(1, 1, 0, &[(0, 0x20000, false, false)]);
+
+    // Run with preserve_bars=false.
+    let params_no_preserve = AssignmentParams {
+        start_bus: 0,
+        end_bus: 255,
+        low_mmio: Some(MmioAperture {
+            base: 0x1000_0000,
+            len: 0x1000_0000,
+        }),
+        high_mmio: None,
+        preserve_bars: false,
+    };
+
+    let mut cfg_a = mock.clone();
+    assign_pci_resources(&mut cfg_a, &params_no_preserve)
+        .await
+        .unwrap();
+
+    let bar_a0 = read_bar32(&mock, 1, 0, 0, 0);
+    let bar_a1 = read_bar32(&mock, 1, 1, 0, 0);
+    let window_a = read_memory_window(&mock, 0, 0, 0);
+
+    // Re-create mock (reset BAR values).
+    let mock2 = MockConfigSpace::new();
+    mock2.add_bridge(0, 0, 0);
+    mock2.add_endpoint(1, 0, 0, &[(0, 0x10000, false, false)]);
+    mock2.add_endpoint(1, 1, 0, &[(0, 0x20000, false, false)]);
+
+    // Run with preserve_bars=true but no pre-programmed addresses.
+    let params_preserve = AssignmentParams {
+        start_bus: 0,
+        end_bus: 255,
+        low_mmio: Some(MmioAperture {
+            base: 0x1000_0000,
+            len: 0x1000_0000,
+        }),
+        high_mmio: None,
+        preserve_bars: true,
+    };
+
+    let mut cfg_b = mock2.clone();
+    assign_pci_resources(&mut cfg_b, &params_preserve)
+        .await
+        .unwrap();
+
+    let bar_b0 = read_bar32(&mock2, 1, 0, 0, 0);
+    let bar_b1 = read_bar32(&mock2, 1, 1, 0, 0);
+    let window_b = read_memory_window(&mock2, 0, 0, 0);
+
+    // Results should be identical.
+    assert_eq!(bar_a0, bar_b0, "BAR0 mismatch");
+    assert_eq!(bar_a1, bar_b1, "BAR1 mismatch");
+    assert_eq!(window_a, window_b, "bridge window mismatch");
+}
+
+/// 64-bit prefetchable pinned BAR should be placed in high MMIO at its
+/// pre-programmed address.
+#[async_test]
+async fn pinned_bar_64bit_prefetchable() {
+    let mock = MockConfigSpace::new();
+
+    mock.add_bridge(0, 0, 0);
+    // 1 MB 64-bit prefetchable BAR at index 0.
+    mock.add_endpoint(1, 0, 0, &[(0, 0x100000, true, true)]);
+    mock.set_bar_address(1, 0, 0, 0, 0x3_8380_0000);
+
+    let params = AssignmentParams {
+        start_bus: 0,
+        end_bus: 255,
+        low_mmio: Some(MmioAperture {
+            base: 0x1000_0000,
+            len: 0x1000_0000,
+        }),
+        high_mmio: Some(MmioAperture {
+            base: 0x3_8380_0000,
+            len: 0x0100_0000,
+        }),
+        preserve_bars: true,
+    };
+
+    let mut cfg = mock.clone();
+    assign_pci_resources(&mut cfg, &params).await.unwrap();
+
+    // BAR should be at the pinned address.
+    assert_eq!(read_bar64(&mock, 1, 0, 0, 0), 0x3_8380_0000);
+
+    // Bridge should have a prefetchable window, not a non-prefetchable one.
+    assert!(
+        read_memory_window(&mock, 0, 0, 0).is_none(),
+        "no non-prefetchable window expected"
+    );
+    let pref = read_prefetchable_window(&mock, 0, 0, 0).expect("prefetchable window expected");
+    assert!(
+        pref.0 <= 0x3_8380_0000 && 0x3_8380_0000 + 0x100000 - 1 <= pref.1,
+        "pref window {:#x}..={:#x} must contain pinned BAR",
+        pref.0,
+        pref.1
+    );
+}
+
+/// Two pinned BARs as siblings behind the same bridge. Both must be at
+/// their pinned addresses and dynamic demands must follow.
+#[async_test]
+async fn two_pinned_bars_same_bridge() {
+    let mock = MockConfigSpace::new();
+
+    mock.add_bridge(0, 0, 0);
+
+    // Device A: 64 KB non-pref BAR, pinned.
+    mock.add_endpoint(1, 0, 0, &[(0, 0x10000, false, false)]);
+    mock.set_bar_address(1, 0, 0, 0, 0x1020_0000);
+
+    // Device B: 64 KB non-pref BAR, pinned.
+    mock.add_endpoint(1, 1, 0, &[(0, 0x10000, false, false)]);
+    mock.set_bar_address(1, 1, 0, 0, 0x1030_0000);
+
+    // Device C: 64 KB non-pref BAR, dynamic.
+    mock.add_endpoint(1, 2, 0, &[(0, 0x10000, false, false)]);
+
+    let params = AssignmentParams {
+        start_bus: 0,
+        end_bus: 255,
+        low_mmio: Some(MmioAperture {
+            base: 0x1000_0000,
+            len: 0x1000_0000,
+        }),
+        high_mmio: None,
+        preserve_bars: true,
+    };
+
+    let mut cfg = mock.clone();
+    assign_pci_resources(&mut cfg, &params).await.unwrap();
+
+    let bar_a = read_bar32(&mock, 1, 0, 0, 0) as u64;
+    let bar_b = read_bar32(&mock, 1, 1, 0, 0) as u64;
+    let bar_c = read_bar32(&mock, 1, 2, 0, 0) as u64;
+
+    assert_eq!(bar_a, 0x1020_0000, "pinned BAR A");
+    assert_eq!(bar_b, 0x1030_0000, "pinned BAR B");
+
+    // Dynamic BAR must be after both pinned BARs' ends.
+    let max_pinned_end = 0x1030_0000u64 + 0x10000;
+    assert!(
+        bar_c >= max_pinned_end,
+        "dynamic BAR {bar_c:#x} should be >= max pinned end {max_pinned_end:#x}"
+    );
+
+    // No overlaps.
+    assert!(bar_a + 0x10000 <= bar_b, "A and B overlap");
+    assert!(bar_b + 0x10000 <= bar_c, "B and C overlap");
+}
+
+/// Dynamic BAR with large alignment coexisting with a small pinned BAR.
+/// The dynamic BAR's alignment must be honored even though the pinned
+/// BAR occupies a lower address.
+#[async_test]
+async fn pinned_bar_with_large_alignment_dynamic() {
+    let mock = MockConfigSpace::new();
+
+    mock.add_bridge(0, 0, 0);
+
+    // Device A: 64 KB non-pref BAR, pinned at 0x1010_0000.
+    mock.add_endpoint(1, 0, 0, &[(0, 0x10000, false, false)]);
+    mock.set_bar_address(1, 0, 0, 0, 0x1010_0000);
+
+    // Device B: 1 MB non-pref BAR, dynamic (needs 1 MB alignment).
+    mock.add_endpoint(1, 1, 0, &[(0, 0x100000, false, false)]);
+
+    let params = AssignmentParams {
+        start_bus: 0,
+        end_bus: 255,
+        low_mmio: Some(MmioAperture {
+            base: 0x1000_0000,
+            len: 0x1000_0000,
+        }),
+        high_mmio: None,
+        preserve_bars: true,
+    };
+
+    let mut cfg = mock.clone();
+    assign_pci_resources(&mut cfg, &params).await.unwrap();
+
+    let bar_a = read_bar32(&mock, 1, 0, 0, 0) as u64;
+    let bar_b = read_bar32(&mock, 1, 1, 0, 0) as u64;
+
+    assert_eq!(bar_a, 0x1010_0000, "pinned BAR should be at its address");
+
+    // Dynamic 1 MB BAR must be 1 MB aligned.
+    assert_eq!(
+        bar_b % 0x100000,
+        0,
+        "dynamic 1 MB BAR at {bar_b:#x} is not 1 MB aligned"
+    );
+
+    // Must be after pinned end (0x1020_0000) and not overlap.
+    assert!(
+        bar_b >= 0x1010_0000 + 0x10000,
+        "dynamic BAR {bar_b:#x} should be after pinned end"
+    );
+    assert!(
+        bar_b + 0x100000 <= bar_a || bar_a + 0x10000 <= bar_b,
+        "BARs overlap"
+    );
+}
+
+/// Sibling bridge windows for pinned devices behind different downstream
+/// bridges must not overlap.
+#[async_test]
+async fn pinned_sibling_bridge_windows_do_not_overlap() {
+    let mock = MockConfigSpace::new();
+
+    // Upstream bridge.
+    mock.add_bridge(0, 0, 0);
+    // Two downstream bridges.
+    mock.add_bridge(1, 0, 0);
+    mock.add_bridge(1, 1, 0);
+
+    // Endpoint behind bridge A: 1 MB BAR pinned at 0x1010_0000.
+    mock.add_endpoint(2, 0, 0, &[(0, 0x100000, false, false)]);
+    mock.set_bar_address(2, 0, 0, 0, 0x1010_0000);
+
+    // Endpoint behind bridge B: 1 MB BAR pinned at 0x1020_0000.
+    mock.add_endpoint(3, 0, 0, &[(0, 0x100000, false, false)]);
+    mock.set_bar_address(3, 0, 0, 0, 0x1020_0000);
+
+    let params = AssignmentParams {
+        start_bus: 0,
+        end_bus: 255,
+        low_mmio: Some(MmioAperture {
+            base: 0x1000_0000,
+            len: 0x1000_0000,
+        }),
+        high_mmio: None,
+        preserve_bars: true,
+    };
+
+    let mut cfg = mock.clone();
+    assign_pci_resources(&mut cfg, &params).await.unwrap();
+
+    let win_a = read_memory_window(&mock, 1, 0, 0).expect("bridge A memory window");
+    let win_b = read_memory_window(&mock, 1, 1, 0).expect("bridge B memory window");
+
+    // Sibling windows must not overlap.
+    assert!(
+        win_a.1 < win_b.0 || win_b.1 < win_a.0,
+        "sibling bridge windows overlap: A=[{:#x}..={:#x}], B=[{:#x}..={:#x}]",
+        win_a.0,
+        win_a.1,
+        win_b.0,
+        win_b.1
+    );
+
+    // Each window must contain its pinned BAR.
+    assert!(
+        win_a.0 <= 0x1010_0000 && 0x1010_0000 + 0x100000 - 1 <= win_a.1,
+        "bridge A window must contain pinned BAR at 0x1010_0000"
+    );
+    assert!(
+        win_b.0 <= 0x1020_0000 && 0x1020_0000 + 0x100000 - 1 <= win_b.1,
+        "bridge B window must contain pinned BAR at 0x1020_0000"
+    );
+}
+
+/// When preserve_bars=false, pre-programmed BAR values are ignored and
+/// the BAR is dynamically allocated.
+#[async_test]
+async fn preserve_bars_false_ignores_preprogrammed() {
+    let mock = MockConfigSpace::new();
+    mock.add_endpoint(0, 0, 0, &[(0, 0x10000, false, false)]);
+    // Pre-program BAR0 with a specific address.
+    mock.set_bar_address(0, 0, 0, 0, 0x1050_0000);
+
+    let params = AssignmentParams {
+        start_bus: 0,
+        end_bus: 255,
+        low_mmio: Some(MmioAperture {
+            base: 0x1000_0000,
+            len: 0x1000_0000,
+        }),
+        high_mmio: None,
+        preserve_bars: false,
+    };
+
+    let mut cfg = mock.clone();
+    assign_pci_resources(&mut cfg, &params).await.unwrap();
+
+    // BAR should be at the aperture base, not at the pre-programmed address.
+    assert_eq!(
+        read_bar32(&mock, 0, 0, 0, 0),
+        0x1000_0000,
+        "with preserve_bars=false, pre-programmed address should be ignored"
     );
 }

--- a/vm/devices/pci/pci_resource_assignment/src/tests.rs
+++ b/vm/devices/pci/pci_resource_assignment/src/tests.rs
@@ -2494,3 +2494,45 @@ async fn sizing_underestimate_constrained_base_misaligned() {
         "dynamic BAR at {bar_c:#x} must not overlap pinned BARs"
     );
 }
+
+/// Constrained bridge window can start before the aperture when the
+/// aperture base is not 1 MB aligned. The pinned BAR is inside the
+/// aperture, but align_down to bridge granularity pushes the window
+/// base before it. Dynamic BARs placed in that pre-aperture gap would
+/// be outside the aperture, triggering an assertion failure.
+#[async_test]
+async fn constrained_base_before_aperture_returns_error() {
+    let mock = MockConfigSpace::new();
+
+    mock.add_bridge(0, 0, 0);
+
+    // Pinned BAR at 0x1008_0000 (64 KB) — inside the aperture.
+    // constrained_base = align_down(0x1008_0000, 1 MB) = 0x1000_0000,
+    // which is BEFORE the aperture base of 0x1008_0000.
+    mock.add_endpoint(1, 0, 0, &[(0, 0x10000, false, false)]);
+    mock.set_bar_address(1, 0, 0, 0, 0x1008_0000);
+
+    // Dynamic BAR (64 KB) — would be placed in the gap
+    // [0x1000_0000, 0x1008_0000) which is outside the aperture.
+    mock.add_endpoint(1, 1, 0, &[(0, 0x10000, false, false)]);
+
+    let params = AssignmentParams {
+        start_bus: 0,
+        end_bus: 255,
+        low_mmio: Some(MmioAperture {
+            base: 0x1008_0000,
+            len: 0x100_0000,
+        }),
+        high_mmio: None,
+        preserve_bars: true,
+    };
+
+    let mut cfg = mock.clone();
+    let result = assign_pci_resources(&mut cfg, &params).await;
+
+    // Should return an error, not panic with an assertion failure.
+    assert!(
+        result.is_err(),
+        "should fail when constrained bridge window starts before aperture"
+    );
+}

--- a/vm/devices/pci/vfio_assigned_device/src/lib.rs
+++ b/vm/devices/pci/vfio_assigned_device/src/lib.rs
@@ -803,10 +803,10 @@ fn read_physical_bar_addresses(pci_id: &str) -> anyhow::Result<[u64; 6]> {
             .split_whitespace()
             .next()
             .with_context(|| format!("malformed resource line {i} in {path}"))?;
-        addresses[i] = u64::from_str_radix(start_str.strip_prefix("0x").unwrap_or(start_str), 16)
-            .with_context(|| {
-            format!("failed to parse BAR{i} address '{start_str}' in {path}")
-        })?;
+        addresses[i] = start_str
+            .strip_prefix("0x")
+            .and_then(|s| u64::from_str_radix(s, 16).ok())
+            .with_context(|| format!("failed to parse BAR{i} address '{start_str}' in {path}"))?;
     }
 
     Ok(addresses)

--- a/vm/devices/pci/vfio_assigned_device/src/lib.rs
+++ b/vm/devices/pci/vfio_assigned_device/src/lib.rs
@@ -467,30 +467,9 @@ impl VfioAssignedPciDevice {
         );
 
         // Build initial BAR values. Start from bar_flags (encoding bits
-        // only — guaranteed clean). For passthrough BARs, read the physical
-        // address from the kernel's sysfs resource table and overlay it.
-        // VFIO config space returns cleared BARs after device reset, so
-        // sysfs is the only reliable source of physical addresses.
-        let bars = if bar_pt.iter().any(|&pt| pt) {
-            let phys = read_physical_bar_addresses(&pci_id)?;
-            let mut b = bar_flags;
-            for i in 0..6 {
-                if bar_pt[i] {
-                    b[i] = (phys[i] as u32 & !0xf) | bar_flags[i];
-                    if cfg_space::BarEncodingBits::from(bar_flags[i]).type_64_bit() && i + 1 < 6 {
-                        b[i + 1] = (phys[i] >> 32) as u32;
-                    }
-                    tracing::info!(
-                        bar_index = i,
-                        addr = format_args!("{:#x}", phys[i]),
-                        "passthrough BAR"
-                    );
-                }
-            }
-            b
-        } else {
-            bar_flags
-        };
+        // only — guaranteed clean). For passthrough BARs, overlay the
+        // physical addresses from sysfs.
+        let bars = apply_bar_passthrough(&pci_id, &bar_flags, &bar_masks, &bar_pt)?;
 
         Ok(Self {
             pci_id,
@@ -732,6 +711,59 @@ fn subtract_msix_regions(bar_mmap_areas: &mut [Vec<MemoryRange>; 6], msix: &Msix
 
 fn page_size() -> u64 {
     vfio_sys::host_page_size()
+}
+
+/// Apply BAR passthrough: validate the `bar_pt` flags against the discovered
+/// BAR layout and overlay physical addresses from sysfs.
+///
+/// Rejects requests for unimplemented BARs (zero mask) and for the upper half
+/// of a 64-bit BAR pair (the lower BAR implicitly covers both halves).
+fn apply_bar_passthrough(
+    pci_id: &str,
+    bar_flags: &[u32; 6],
+    bar_masks: &[u32; 6],
+    bar_pt: &[bool; 6],
+) -> anyhow::Result<[u32; 6]> {
+    if !bar_pt.iter().any(|&pt| pt) {
+        return Ok(*bar_flags);
+    }
+
+    // Validate before reading sysfs.
+    for i in 0..6 {
+        if !bar_pt[i] {
+            continue;
+        }
+        if bar_masks[i] == 0 {
+            anyhow::bail!("BAR {i} is not implemented by the device");
+        }
+        // If the previous BAR is 64-bit, this index is its upper half.
+        if i > 0
+            && cfg_space::BarEncodingBits::from(bar_flags[i - 1]).type_64_bit()
+            && bar_masks[i - 1] != 0
+        {
+            anyhow::bail!("BAR {i} is the upper half of a 64-bit BAR pair");
+        }
+    }
+
+    // VFIO config space returns cleared BARs after device reset, so sysfs
+    // is the only reliable source of physical addresses.
+    let phys = read_physical_bar_addresses(pci_id)?;
+    let mut bars = *bar_flags;
+    for i in 0..6 {
+        if bar_pt[i] {
+            bars[i] = (phys[i] as u32 & !0xf) | bar_flags[i];
+            if cfg_space::BarEncodingBits::from(bar_flags[i]).type_64_bit() && i + 1 < 6 {
+                bars[i + 1] = (phys[i] >> 32) as u32;
+            }
+            tracing::info!(
+                pci_id,
+                bar_index = i,
+                addr = format_args!("{:#x}", phys[i]),
+                "passthrough BAR"
+            );
+        }
+    }
+    Ok(bars)
 }
 
 /// Read physical BAR base addresses from the host kernel's resource table.

--- a/vm/devices/pci/vfio_assigned_device/src/lib.rs
+++ b/vm/devices/pci/vfio_assigned_device/src/lib.rs
@@ -264,6 +264,7 @@ impl VfioAssignedPciDevice {
         register_mmio: &mut (dyn chipset_device::mmio::RegisterMmioIntercept + Send),
         msi_target: &MsiTarget,
         memory_mapper: &dyn MemoryMapper,
+        bar_pt: [bool; 6],
     ) -> anyhow::Result<Self> {
         let driver = driver_source.simple();
         let retry = vfio_sys::VfioRetry::new(&driver, &pci_id);
@@ -290,6 +291,7 @@ impl VfioAssignedPciDevice {
             register_mmio,
             msi_target,
             memory_mapper,
+            bar_pt,
         )
         .await
     }
@@ -301,6 +303,7 @@ impl VfioAssignedPciDevice {
         register_mmio: &mut (dyn chipset_device::mmio::RegisterMmioIntercept + Send),
         msi_target: &MsiTarget,
         memory_mapper: &dyn MemoryMapper,
+        bar_pt: [bool; 6],
     ) -> anyhow::Result<Self> {
         let (device, binding) = cdev_binding.into_parts();
         Self::from_device(
@@ -310,6 +313,7 @@ impl VfioAssignedPciDevice {
             register_mmio,
             msi_target,
             memory_mapper,
+            bar_pt,
         )
         .await
     }
@@ -321,6 +325,7 @@ impl VfioAssignedPciDevice {
         register_mmio: &mut (dyn chipset_device::mmio::RegisterMmioIntercept + Send),
         msi_target: &MsiTarget,
         memory_mapper: &dyn MemoryMapper,
+        bar_pt: [bool; 6],
     ) -> anyhow::Result<Self> {
         let config_info = vfio_device
             .region_info(vfio_bindings::bindings::vfio::VFIO_PCI_CONFIG_REGION_INDEX)
@@ -332,16 +337,11 @@ impl VfioAssignedPciDevice {
             config_size: config_info.size,
         };
 
-        // Read BAR values and derive masks from VFIO region sizes.
-        // This avoids the standard write-all-ones probe cycle — VFIO already
-        // knows the BAR sizes from the host kernel.
+        // Read BAR encoding bits from config space and derive masks from
+        // VFIO region sizes. This avoids the standard write-all-ones probe
+        // cycle — VFIO already knows the BAR sizes from the host kernel.
         let mut bar_masks = [0u32; 6];
         let mut bar_flags = [0u32; 6];
-
-        let mut bars = [0u32; 6];
-        for (i, bar) in bars.iter_mut().enumerate() {
-            *bar = vfio_device.read_config_u32(HeaderType00::BAR0.0 + (i as u16) * 4)?;
-        }
 
         let mut bar_regions = [None; 6];
         let mut bar_mmio_controls = [(); 6].map(|_| None);
@@ -357,7 +357,7 @@ impl VfioAssignedPciDevice {
                 continue;
             }
 
-            let flags = bars[i] & 0xf;
+            let flags = vfio_device.read_config_u32(HeaderType00::BAR0.0 + (i as u16) * 4)? & 0xf;
             bar_flags[i] = flags;
             let encoded = cfg_space::BarEncodingBits::from(flags);
             if encoded.use_pio() {
@@ -466,11 +466,37 @@ impl VfioAssignedPciDevice {
             "VFIO assigned PCI device initialized"
         );
 
+        // Build initial BAR values. Start from bar_flags (encoding bits
+        // only — guaranteed clean). For passthrough BARs, read the physical
+        // address from the kernel's sysfs resource table and overlay it.
+        // VFIO config space returns cleared BARs after device reset, so
+        // sysfs is the only reliable source of physical addresses.
+        let bars = if bar_pt.iter().any(|&pt| pt) {
+            let phys = read_physical_bar_addresses(&pci_id)?;
+            let mut b = bar_flags;
+            for i in 0..6 {
+                if bar_pt[i] {
+                    b[i] = (phys[i] as u32 & !0xf) | bar_flags[i];
+                    if cfg_space::BarEncodingBits::from(bar_flags[i]).type_64_bit() && i + 1 < 6 {
+                        b[i + 1] = (phys[i] >> 32) as u32;
+                    }
+                    tracing::info!(
+                        bar_index = i,
+                        addr = format_args!("{:#x}", phys[i]),
+                        "passthrough BAR"
+                    );
+                }
+            }
+            b
+        } else {
+            bar_flags
+        };
+
         Ok(Self {
             pci_id,
             vfio_device,
             bar_masks,
-            bars: bar_flags, // Ignore the current BAR values--we don't care what the device thinks the BARs are.
+            bars,
             bar_flags,
             mmio_enabled: false,
             pm_csr_offset,
@@ -706,6 +732,36 @@ fn subtract_msix_regions(bar_mmap_areas: &mut [Vec<MemoryRange>; 6], msix: &Msix
 
 fn page_size() -> u64 {
     vfio_sys::host_page_size()
+}
+
+/// Read physical BAR base addresses from the host kernel's resource table.
+///
+/// Parses `/sys/bus/pci/devices/<bdf>/resource` which has one line per
+/// PCI resource: `start end flags` in hex. Lines 0–5 correspond to
+/// BAR0–BAR5. For 64-bit BARs, the full 64-bit address appears on the
+/// line for the lower BAR index; the upper-half line is zero.
+///
+/// This is necessary because VFIO config space returns cleared BARs after
+/// device reset — only the encoding bits (type, prefetchable) survive.
+/// The kernel's resource table retains the physical addresses.
+fn read_physical_bar_addresses(pci_id: &str) -> anyhow::Result<[u64; 6]> {
+    let path = format!("/sys/bus/pci/devices/{pci_id}/resource");
+    let content =
+        std::fs::read_to_string(&path).with_context(|| format!("failed to read {path}"))?;
+
+    let mut addresses = [0u64; 6];
+    for (i, line) in content.lines().take(6).enumerate() {
+        let start_str = line
+            .split_whitespace()
+            .next()
+            .with_context(|| format!("malformed resource line {i} in {path}"))?;
+        addresses[i] = u64::from_str_radix(start_str.strip_prefix("0x").unwrap_or(start_str), 16)
+            .with_context(|| {
+            format!("failed to parse BAR{i} address '{start_str}' in {path}")
+        })?;
+    }
+
+    Ok(addresses)
 }
 
 /// Abstraction over PCI config space reads, allowing the capability

--- a/vm/devices/pci/vfio_assigned_device/src/lib.rs
+++ b/vm/devices/pci/vfio_assigned_device/src/lib.rs
@@ -148,6 +148,12 @@ pub(crate) struct VfioAssignedPciDevice {
     #[inspect(iter_by_index, hex)]
     bar_flags: [u32; 6],
 
+    /// BAR values to restore on reset. For passthrough BARs, these include
+    /// the physical addresses from sysfs overlaid on the encoding bits.
+    /// For non-passthrough BARs, these are the same as `bar_flags`.
+    #[inspect(iter_by_index, hex)]
+    bar_reset_defaults: [u32; 6],
+
     /// Current MMIO-enabled state (from PCI Command register bit 1).
     mmio_enabled: bool,
 
@@ -470,6 +476,7 @@ impl VfioAssignedPciDevice {
         // only — guaranteed clean). For passthrough BARs, overlay the
         // physical addresses from sysfs.
         let bars = apply_bar_passthrough(&pci_id, &bar_flags, &bar_masks, &bar_pt)?;
+        let bar_reset_defaults = bars;
 
         Ok(Self {
             pci_id,
@@ -477,6 +484,7 @@ impl VfioAssignedPciDevice {
             bar_masks,
             bars,
             bar_flags,
+            bar_reset_defaults,
             mmio_enabled: false,
             pm_csr_offset,
             in_d0: true,
@@ -751,14 +759,22 @@ fn apply_bar_passthrough(
     let mut bars = *bar_flags;
     for i in 0..6 {
         if bar_pt[i] {
-            bars[i] = (phys[i] as u32 & !0xf) | bar_flags[i];
-            if cfg_space::BarEncodingBits::from(bar_flags[i]).type_64_bit() && i + 1 < 6 {
-                bars[i + 1] = (phys[i] >> 32) as u32;
+            let addr = phys[i];
+            if addr == 0 {
+                anyhow::bail!("BAR {i} passthrough requested but sysfs address is 0");
+            }
+            let is_64bit = cfg_space::BarEncodingBits::from(bar_flags[i]).type_64_bit();
+            if !is_64bit && addr > u32::MAX as u64 {
+                anyhow::bail!("BAR {i} is 32-bit but sysfs address {addr:#x} exceeds 4 GB");
+            }
+            bars[i] = (addr as u32 & !0xf) | bar_flags[i];
+            if is_64bit && i + 1 < 6 {
+                bars[i + 1] = (addr >> 32) as u32;
             }
             tracing::info!(
                 pci_id,
                 bar_index = i,
-                addr = format_args!("{:#x}", phys[i]),
+                addr = format_args!("{:#x}", addr),
                 "passthrough BAR"
             );
         }
@@ -1072,7 +1088,8 @@ impl ChangeDeviceState for VfioAssignedPciDevice {
             ref vfio_device,
             bar_masks: _, // immutable device geometry
             ref mut bars,
-            bar_flags,
+            bar_flags: _,
+            bar_reset_defaults,
             mmio_enabled: _,  // handled above
             pm_csr_offset: _, // not used during reset
             ref mut in_d0,
@@ -1094,9 +1111,10 @@ impl ChangeDeviceState for VfioAssignedPciDevice {
             msix.capability.reset();
         }
 
-        // Reset cached BAR addresses to power-on defaults (flags only, no
-        // address bits). The guest will re-probe and re-program BARs.
-        *bars = bar_flags;
+        // Reset cached BAR addresses to power-on defaults. For passthrough
+        // BARs, this restores the physical addresses so that preserve_bars
+        // in the PCI assignment pass will see them after VM reset.
+        *bars = bar_reset_defaults;
 
         // Reset the physical device via VFIO so it starts in a clean state.
         //

--- a/vm/devices/pci/vfio_assigned_device/src/resolver.rs
+++ b/vm/devices/pci/vfio_assigned_device/src/resolver.rs
@@ -61,7 +61,11 @@ impl AsyncResolveResource<PciDeviceHandleKind, VfioDeviceHandle> for VfioDeviceR
         resource: VfioDeviceHandle,
         input: ResolvePciDeviceHandleParams<'_>,
     ) -> Result<Self::Output, Self::Error> {
-        let VfioDeviceHandle { pci_id, group } = resource;
+        let VfioDeviceHandle {
+            pci_id,
+            group,
+            bar_pt,
+        } = resource;
 
         if input.software_iommu {
             anyhow::bail!(
@@ -93,6 +97,7 @@ impl AsyncResolveResource<PciDeviceHandleKind, VfioDeviceHandle> for VfioDeviceR
             input.register_mmio,
             input.msi_target,
             memory_mapper,
+            bar_pt,
         )
         .await?;
 
@@ -148,6 +153,7 @@ impl AsyncResolveResource<PciDeviceHandleKind, VfioCdevDeviceHandle> for VfioCde
             cdev,
             iommufd,
             iommu_id,
+            bar_pt,
         } = resource;
 
         tracing::info!(pci_id, iommu_id, "opening VFIO cdev device with iommufd");
@@ -175,6 +181,7 @@ impl AsyncResolveResource<PciDeviceHandleKind, VfioCdevDeviceHandle> for VfioCde
             input.register_mmio,
             input.msi_target,
             memory_mapper,
+            bar_pt,
         )
         .await?;
 

--- a/vm/devices/pci/vfio_assigned_device_resources/src/lib.rs
+++ b/vm/devices/pci/vfio_assigned_device_resources/src/lib.rs
@@ -21,6 +21,9 @@ pub struct VfioDeviceHandle {
     pub pci_id: String,
     /// Pre-opened VFIO group file descriptor (`/dev/vfio/<group_id>`).
     pub group: File,
+    /// Per-BAR passthrough flags. When `bar_pt[i]` is true, the virtual
+    /// BAR is pre-programmed with the physical BAR address (GPA = HPA).
+    pub bar_pt: [bool; 6],
 }
 
 impl ResourceId<PciDeviceHandleKind> for VfioDeviceHandle {
@@ -44,6 +47,9 @@ pub struct VfioCdevDeviceHandle {
     /// The `--iommu` context ID this device belongs to. All devices
     /// sharing the same ID share a single IOAS (one set of page tables).
     pub iommu_id: String,
+    /// Per-BAR passthrough flags. When `bar_pt[i]` is true, the virtual
+    /// BAR is pre-programmed with the physical BAR address (GPA = HPA).
+    pub bar_pt: [bool; 6],
 }
 
 impl ResourceId<PciDeviceHandleKind> for VfioCdevDeviceHandle {

--- a/vm/vmcore/vm_topology/src/pcie.rs
+++ b/vm/vmcore/vm_topology/src/pcie.rs
@@ -36,4 +36,7 @@ pub struct PcieHostBridge {
     pub cxl: Option<PcieHostBridgeCxlInfo>,
     /// NUMA node affinity for this host bridge.
     pub vnode: Option<u32>,
+    /// When true, treat non-zero BAR values found during probing as pinned
+    /// addresses. Used for P2P DMA with GPA = HPA.
+    pub preserve_bars: bool,
 }

--- a/vmm_core/src/acpi_builder.rs
+++ b/vmm_core/src/acpi_builder.rs
@@ -180,13 +180,6 @@ pub struct BuiltPcieAcpiTables {
 }
 
 /// Build PCIe SSDT/CEDT payloads from host-bridge topology.
-///
-/// TODO: When any bridge has `preserve_bars`, emit `_DSM` UUID
-/// `{E5C937D0-3553-4D7A-9117-EA4D19C3434D}` Function 5 returning 0
-/// on that host bridge so the guest OS preserves firmware BAR assignments.
-/// See QEMU `gpex-acpi.c` `build_pci_host_bridge_dsm_method` for reference.
-/// For device tree guests, set `linux,pci-probe-only = <1>` on the host
-/// bridge or `/chosen` node (Linux checks this via `of_pci_preserve_config()`).
 pub fn build_pcie_acpi_tables(
     pcie_host_bridges: &[PcieHostBridge],
 ) -> Result<BuiltPcieAcpiTables, PcieAcpiBuildError> {
@@ -205,6 +198,7 @@ pub fn build_pcie_acpi_tables(
             high_mmio: bridge.high_mmio,
             cxl: bridge.cxl.is_some(),
             vnode: bridge.vnode,
+            preserve_bars: bridge.preserve_bars,
         });
 
         if let Some(cxl) = &bridge.cxl {

--- a/vmm_core/src/acpi_builder.rs
+++ b/vmm_core/src/acpi_builder.rs
@@ -180,6 +180,13 @@ pub struct BuiltPcieAcpiTables {
 }
 
 /// Build PCIe SSDT/CEDT payloads from host-bridge topology.
+///
+/// TODO: When any bridge has `preserve_bars`, emit `_DSM` UUID
+/// `{E5C937D0-3553-4D7A-9117-EA4D19C3434D}` Function 5 returning 0
+/// on that host bridge so the guest OS preserves firmware BAR assignments.
+/// See QEMU `gpex-acpi.c` `build_pci_host_bridge_dsm_method` for reference.
+/// For device tree guests, set `linux,pci-probe-only = <1>` on the host
+/// bridge or `/chosen` node (Linux checks this via `of_pci_preserve_config()`).
 pub fn build_pcie_acpi_tables(
     pcie_host_bridges: &[PcieHostBridge],
 ) -> Result<BuiltPcieAcpiTables, PcieAcpiBuildError> {
@@ -1291,6 +1298,7 @@ mod test {
                 high_mmio: MemoryRange::new(0..0),
                 cxl: None,
                 vnode: None,
+                preserve_bars: false,
             },
             PcieHostBridge {
                 index: 1,
@@ -1302,6 +1310,7 @@ mod test {
                 high_mmio: MemoryRange::new(0..0),
                 cxl: None,
                 vnode: None,
+                preserve_bars: false,
             },
         ];
 
@@ -1400,6 +1409,7 @@ mod test {
                 high_mmio: MemoryRange::new(0x1000000000..0x1040000000),
                 cxl: None,
                 vnode: None,
+                preserve_bars: false,
             },
             PcieHostBridge {
                 index: 7,
@@ -1411,6 +1421,7 @@ mod test {
                 high_mmio: MemoryRange::new(0x1040000000..0x1080000000),
                 cxl: None,
                 vnode: None,
+                preserve_bars: false,
             },
         ];
         let builder = new_aarch64_builder(&mem, &topology, &pcie_host_bridges);
@@ -1471,6 +1482,7 @@ mod test {
             high_mmio: MemoryRange::new(0x1000000000..0x1040000000),
             cxl: None,
             vnode: None,
+            preserve_bars: false,
         }];
         let builder = new_builder(&mem, &topology, &pcie_host_bridges);
         assert!(builder.build_iort().is_none());
@@ -1502,6 +1514,7 @@ mod test {
             high_mmio: MemoryRange::new(0x1000000000..0x1040000000),
             cxl: None,
             vnode: None,
+            preserve_bars: false,
         }];
         let builder = new_aarch64_builder(&mem, &topology, &pcie_host_bridges);
 
@@ -1562,6 +1575,7 @@ mod test {
                 hdm_window_restrictions: Default::default(),
             }),
             vnode: None,
+            preserve_bars: false,
         }];
         let builder = new_builder(&mem, &topology, &pcie_host_bridges);
 
@@ -1586,6 +1600,7 @@ mod test {
             high_mmio: MemoryRange::new(0x1000000000..0x1040000000),
             cxl: None,
             vnode: None,
+            preserve_bars: false,
         }];
         let builder = new_aarch64_builder_with_smmu(&mem, &topology, &pcie_host_bridges, smmu_base);
 
@@ -1663,6 +1678,7 @@ mod test {
                 high_mmio: MemoryRange::new(0x1000000000..0x1040000000),
                 cxl: None,
                 vnode: None,
+                preserve_bars: false,
             },
             PcieHostBridge {
                 index: 1,
@@ -1674,6 +1690,7 @@ mod test {
                 high_mmio: MemoryRange::new(0x1040000000..0x1080000000),
                 cxl: None,
                 vnode: None,
+                preserve_bars: false,
             },
         ];
         let builder = new_aarch64_builder_with_smmu(&mem, &topology, &pcie_host_bridges, smmu_base);
@@ -1726,6 +1743,7 @@ mod test {
             high_mmio: MemoryRange::new(0x1000000000..0x1040000000),
             cxl: None,
             vnode: None,
+            preserve_bars: false,
         }];
         let builder = new_aarch64_builder(&mem, &topology, &pcie_host_bridges);
 
@@ -1759,6 +1777,7 @@ mod test {
             high_mmio: MemoryRange::new(0x1000000000..0x1040000000),
             cxl: None,
             vnode: None,
+            preserve_bars: false,
         }];
         let builder = new_aarch64_builder_with_smmu(&mem, &topology, &pcie_host_bridges, smmu_base);
 

--- a/vmm_tests/vmm_tests/tests/tests/multiarch/numa.rs
+++ b/vmm_tests/vmm_tests/tests/tests/multiarch/numa.rs
@@ -347,6 +347,7 @@ async fn pcie_device_numa_affinity(
                     }],
                     iommu: None,
                     vnode: Some(1),
+                    preserve_bars: false,
                 });
 
                 // Attach an NVMe device to the root port.


### PR DESCRIPTION
Allow specific PCI BARs to be pinned to their physical addresses so that VFIO passthrough devices can participate in peer-to-peer DMA without ATS. When a VFIO device is configured with `bar0=pt` (through `bar5=pt`) on the CLI, its virtual BAR is pre-programmed with the host physical BAR address read from sysfs. The `preserve_bars` flag on the root complex tells the resource allocator to treat non-zero BAR values found during probing as fixed--pinned BARs stay at their physical addresses (GPA=HPA) while dynamic BARs are bump-allocated after the pinned region.

The allocation algorithm extends the existing hierarchical bottom-up sizing / top-down assignment approach. During sizing, pinned BARs establish a constrained base for their bridge window; dynamic demands are summed on top. During assignment, pinned demands are placed at their fixed addresses and dynamic demands bump-allocate forward from the highest pinned end. Bridges with pinned descendants propagate their position constraint upward so parent windows are correctly sized and placed. When no BARs are pinned, the algorithm produces identical results to the previous code.

When `preserve_bars` is set, the ACPI SSDT emits a `_DSM` method telling the guest OS to preserve firmware-assigned BAR values, and the device tree path sets `linux,pci-probe-only` for the same effect.

New CLI surface:
- `--pcie-root-complex` gains `low_mmio_base=`, `high_mmio_base=` (producing Fixed MMIO ranges), and `preserve_bars`
- `--vfio` gains `bar0=pt` through `bar5=pt`

Validation rejects pinned BARs that are misaligned, overlapping, or outside the MMIO aperture. Physical BAR addresses are read from the kernel&#39;s `/sys/bus/pci/devices//resource` table rather than VFIO config space, which returns cleared BARs after device reset.