### PR TITLE
flowey: update mu_msvm UEFI to v26.0.12

### DIFF
--- a/flowey/flowey_lib_hvlite/src/_jobs/cfg_versions.rs
+++ b/flowey/flowey_lib_hvlite/src/_jobs/cfg_versions.rs
@@ -24,7 +24,7 @@ pub const GH_CLI: &str = "2.52.0";
 pub const MDBOOK: &str = "0.4.40";
 pub const MDBOOK_ADMONISH: &str = "1.18.0";
 pub const MDBOOK_MERMAID: &str = "0.14.0";
-pub const MU_MSVM: &str = "26.0.9";
+pub const MU_MSVM: &str = "26.0.12";
 pub const NEXTEST: &str = "0.9.133";
 pub const NODEJS: &str = "24.x";
 // N.B. Kernel version numbers for dev and stable branches are not directly


### PR DESCRIPTION
Update the mu_msvm UEFI firmware from v26.0.9 to v26.0.12. This picks up several fixes needed for PCI resource pre-assignment support and other improvements:

- v26.0.10: Set ResourceAssigned when bus enumeration is disabled, which is required for the pre-assigned PCI resources flow to work correctly.
- v26.0.11: Fix off-by-one MMIO bounds checks in the AARCH64 PEI MMU.
- v26.0.12: Harden VmbfsDxe against malicious host responses.