### PR TITLE
nvme: use allocated device ID 0xc03e

### DIFF
--- a/vm/devices/storage/nvme/src/lib.rs
+++ b/vm/devices/storage/nvme/src/lib.rs
@@ -61,7 +61,10 @@ use nvme_spec as spec;
 
 // Device configuration shared by PCI and NVMe.
 const DOORBELL_STRIDE_BITS: u8 = 2;
+/// Microsoft vendor ID.
 const VENDOR_ID: u16 = 0x1414;
+/// Device ID allocated to the OpenVMM NVMe emulator.
+const DEVICE_ID: u16 = 0xc03e;
 const NVME_VERSION: u32 = 0x00020000;
 const MAX_QES: u16 = 256;
 const BAR0_LEN: u64 = 0x10000;

--- a/vm/devices/storage/nvme/src/pci.rs
+++ b/vm/devices/storage/nvme/src/pci.rs
@@ -4,6 +4,7 @@
 //! The NVMe PCI device implementation.
 
 use crate::BAR0_LEN;
+use crate::DEVICE_ID;
 use crate::DOORBELL_STRIDE_BITS;
 use crate::IOCQES;
 use crate::IOSQES;
@@ -129,7 +130,7 @@ impl NvmeController {
         let cfg_space = ConfigSpaceType0Emulator::new(
             HardwareIds {
                 vendor_id: VENDOR_ID,
-                device_id: 0x00a9,
+                device_id: DEVICE_ID,
                 revision_id: 0,
                 prog_if: ProgrammingInterface::MASS_STORAGE_CONTROLLER_NON_VOLATILE_MEMORY_NVME,
                 sub_class: Subclass::MASS_STORAGE_CONTROLLER_NON_VOLATILE_MEMORY,

--- a/vm/devices/storage/nvme_resources/src/fault.rs
+++ b/vm/devices/storage/nvme_resources/src/fault.rs
@@ -337,7 +337,7 @@ pub struct CommandMatch {
 ///         .with_hardware_config_fault(
 ///             HardwareConfigFaultConfig::new()
 ///                 .with_vendor_id(0x1414)
-///                 .with_device_id(0x00a9),
+///                 .with_device_id(0xc03e),
 ///         )
 /// }
 /// ```

--- a/vm/devices/storage/nvme_test/src/lib.rs
+++ b/vm/devices/storage/nvme_test/src/lib.rs
@@ -28,6 +28,7 @@ use workers::NsidConflict;
 // Device configuration shared by PCI and NVMe.
 const DOORBELL_STRIDE_BITS: u8 = 2;
 const VENDOR_ID: u16 = 0x1414;
+const DEVICE_ID: u16 = 0xc03e;
 const NVME_VERSION: u32 = 0x00020000;
 const MAX_QES: u16 = 256;
 const BAR0_LEN: u64 = 0x10000;

--- a/vm/devices/storage/nvme_test/src/pci.rs
+++ b/vm/devices/storage/nvme_test/src/pci.rs
@@ -4,6 +4,7 @@
 //! The NVMe (Fault Injection) PCI device implementation.
 
 use crate::BAR0_LEN;
+use crate::DEVICE_ID;
 use crate::DOORBELL_STRIDE_BITS;
 use crate::IOCQES;
 use crate::IOSQES;
@@ -146,7 +147,7 @@ impl NvmeFaultController {
             .unwrap_or(VENDOR_ID);
         let device_id = hardware_config_fault
             .and_then(|f| f.device_id)
-            .unwrap_or(0x00a9);
+            .unwrap_or(DEVICE_ID);
 
         let cfg_space = ConfigSpaceType0Emulator::new(
             HardwareIds {

--- a/vmm_tests/vmm_tests/tests/tests/x86_64.rs
+++ b/vmm_tests/vmm_tests/tests/tests/x86_64.rs
@@ -214,7 +214,7 @@ async fn vpci_filter(config: PetriVmBuilder<OpenVmmPetriBackend>) -> anyhow::Res
 
     // The virtio device should not have made it through, but the NVMe
     // controller should be there.
-    assert_eq!(devices, vec![Ok(("00:00.0", "Class 0108: 1414:00a9"))]);
+    assert_eq!(devices, vec![Ok(("00:00.0", "Class 0108: 1414:c03e"))]);
 
     agent.power_off().await?;
     vm.wait_for_clean_teardown().await?;
@@ -267,7 +267,7 @@ async fn vpci_relay_tdisp_device(
         .collect::<Vec<_>>();
 
     // The NVMe controller should be present after the HCL performs its TDISP test.
-    assert_eq!(devices, vec![Ok(("00:00.0", "Class 0108: 1414:00a9"))]);
+    assert_eq!(devices, vec![Ok(("00:00.0", "Class 0108: 1414:c03e"))]);
 
     agent.power_off().await?;
     vm.wait_for_clean_teardown().await?;


### PR DESCRIPTION
The NVMe emulator was using device ID 0x00a9, which is used by another NVMe implementation. Use 0xc03e, which has been allocated within Microsoft to the OpenVMM NVMe emulator. Extract the value into a named DEVICE_ID constant in both the nvme and nvme_test crates, matching the existing pattern for VENDOR_ID.