### PR TITLE
openhcl_boot: com3 serial support for vtl2 kernel on ARM

### DIFF
--- a/openhcl/host_fdt_parser/src/lib.rs
+++ b/openhcl/host_fdt_parser/src/lib.rs
@@ -64,16 +64,20 @@ pub enum ComInfo {
     /// Serial device on x86
     ///
     /// Parameters are hard coded based on port number for this device.
-    Ns16550,
+    Ns16550 {
+        /// Base IO port
+        #[cfg_attr(feature = "inspect", inspect(hex))]
+        base: u64,
+        /// Speed
+        current_speed: u32,
+    },
     /// Serial device on ARM64
     Pl011 {
         /// Base MMIO address
         #[cfg_attr(feature = "inspect", inspect(hex))]
         base: u32,
-
         /// Interrupt ID
         intid: u32,
-
         /// Speed
         current_speed: u32,
     },
@@ -1030,7 +1034,7 @@ fn parse_io_bus<'a>(
             .transpose()?
             .unwrap_or("");
 
-        let _current_speed = io_bus_child
+        let current_speed = io_bus_child
             .find_property("current-speed")
             .map_err(ErrorKind::Prop)?
             .ok_or(ErrorKind::PropMissing {
@@ -1048,17 +1052,20 @@ fn parse_io_bus<'a>(
                 prop_name: "reg",
             })?;
 
-        let reg_base = reg.read_u64(0).map_err(ErrorKind::Prop)?;
-        let _reg_len = reg.read_u64(1).map_err(ErrorKind::Prop)?;
+        let base = reg.read_u64(0).map_err(ErrorKind::Prop)?;
+        let _base_len = reg.read_u64(1).map_err(ErrorKind::Prop)?;
 
         // Linux kernel hard-codes COM3 to COM3_REG_BASE.
         // If work is ever done in the Linux kernel to instead
         // parse from DT, the 2nd condition can be removed.
-        if compatible == "ns16550" && reg_base == COM3_REG_BASE {
-            *com3_serial = ComInfo::Ns16550;
+        if compatible == "ns16550" && base == COM3_REG_BASE {
+            *com3_serial = ComInfo::Ns16550 {
+                base,
+                current_speed,
+            };
         } else {
             #[cfg(feature = "tracing")]
-            tracing::warn!(?node.name, ?compatible, ?reg_base,
+            tracing::warn!(?node.name, ?compatible, ?base, ?current_speed,
                 "unrecognized io bus child"
             );
         }
@@ -1067,6 +1074,7 @@ fn parse_io_bus<'a>(
     Ok(())
 }
 
+/// parse an arm,sbsa-uart node
 fn parse_pl011<'a>(
     node: &fdt::parser::Node<'a>,
     com3_serial: &mut ComInfo,
@@ -1106,6 +1114,11 @@ fn parse_pl011<'a>(
             intid,
             current_speed,
         };
+    } else {
+        #[cfg(feature = "tracing")]
+        tracing::warn!(?node.name, ?base, ?intid, ?current_speed,
+            "unrecognized arm,sbsa-uart device"
+        );
     }
 
     Ok(())
@@ -1496,7 +1509,10 @@ mod tests {
 
         // Com3 serial node
         match context.com3_serial {
-            ComInfo::Ns16550 => {
+            ComInfo::Ns16550 {
+                base,
+                current_speed,
+            } => {
                 let mut io_port_bus = root
                     .start_node("io-bus")
                     .unwrap()
@@ -1509,7 +1525,7 @@ mod tests {
                     .add_prop_array(p_ranges, &[])
                     .unwrap();
 
-                let serial_name = format!("serial@{:x}", COM3_REG_BASE);
+                let serial_name = format!("serial@{:x}", base);
                 io_port_bus = io_port_bus
                     .start_node(&serial_name)
                     .unwrap()
@@ -1517,9 +1533,9 @@ mod tests {
                     .unwrap()
                     .add_u32(p_clock_frequency, 0)
                     .unwrap()
-                    .add_u32(p_current_speed, 115200)
+                    .add_u32(p_current_speed, current_speed)
                     .unwrap()
-                    .add_u64_array(p_reg, &[COM3_REG_BASE, 0x8])
+                    .add_u64_array(p_reg, &[base, 0x8])
                     .unwrap()
                     .add_u64_array(p_interrupts, &[4])
                     .unwrap()
@@ -1936,6 +1952,11 @@ mod tests {
     /// tests serial output
     #[test]
     fn test_com3_serial_output() {
+        let com3_serial = ComInfo::Ns16550 {
+            base: COM3_REG_BASE,
+            current_speed: 115200,
+        };
+
         let orig = create_parsed(
             2560,
             &[
@@ -1979,7 +2000,7 @@ mod tests {
                 connection_id: 4,
             }),
             "THIS_IS_A_BOOT_ARG=1",
-            ComInfo::Ns16550,
+            com3_serial.clone(),
             None,
             None,
             MemoryAllocationMode::Host,
@@ -1991,6 +2012,6 @@ mod tests {
         let parsed = TestParsedDeviceTree::parse(&dt, &mut parsed).unwrap();
 
         assert_eq!(&orig, parsed);
-        assert_eq!(parsed.com3_serial, ComInfo::Ns16550);
+        assert_eq!(parsed.com3_serial, com3_serial);
     }
 }

--- a/openhcl/host_fdt_parser/src/lib.rs
+++ b/openhcl/host_fdt_parser/src/lib.rs
@@ -57,7 +57,7 @@ pub struct GicInfo {
 
 /// Information about a COM port.
 #[derive(Clone, Debug, PartialEq, Eq)]
-#[cfg_attr(feature = "inspect", derive(Inspect))]
+#[cfg_attr(feature = "inspect", derive(Inspect), inspect(tag = "com_info"))]
 pub enum ComInfo {
     /// No serial port configured
     None,

--- a/openhcl/host_fdt_parser/src/lib.rs
+++ b/openhcl/host_fdt_parser/src/lib.rs
@@ -55,6 +55,40 @@ pub struct GicInfo {
     pub gic_redistributor_stride: u64,
 }
 
+/// Information about a COM port.
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "inspect", derive(Inspect))]
+pub enum ComInfo {
+    /// No serial port configured
+    None,
+    /// Serial device on x86
+    ///
+    /// Parameters are hard coded based on port number for this device.
+    Ns16550,
+    /// Serial device on ARM64
+    Pl011 {
+        /// Base MMIO address
+        #[cfg_attr(feature = "inspect", inspect(hex))]
+        base: u32,
+
+        /// Interrupt ID
+        intid: u32,
+
+        /// Speed
+        current_speed: u32,
+    },
+}
+
+impl ComInfo {
+    /// Whether the serial port is configured
+    pub fn is_some(&self) -> bool {
+        match self {
+            ComInfo::None => false,
+            _ => true,
+        }
+    }
+}
+
 /// Errors returned by parsing.
 #[derive(Debug)]
 pub struct Error<'a>(ErrorKind<'a>);
@@ -220,7 +254,7 @@ pub struct ParsedDeviceTree<
     #[cfg_attr(feature = "inspect", inspect(display))]
     pub command_line: ArrayString<MAX_COMMAND_LINE_SIZE>,
     /// Is a com3 device present
-    pub com3_serial: bool,
+    pub com3_serial: ComInfo,
     /// The vtl2 memory allocation mode OpenHCL should use for memory.
     pub memory_allocation_mode: MemoryAllocationMode,
     /// Entropy from the host to be used by the OpenHCL kernel
@@ -313,7 +347,7 @@ impl<
             vmbus_vtl0: None,
             vmbus_vtl2: None,
             command_line: ArrayString::new_const(),
-            com3_serial: false,
+            com3_serial: ComInfo::None,
             gic: None,
             pmu_gsiv: None,
             memory_allocation_mode: MemoryAllocationMode::Host,
@@ -755,7 +789,7 @@ fn parse_compatible<'a>(
     vmbus_vtl0: &mut Option<VmbusInfo>,
     vmbus_vtl2: &mut Option<VmbusInfo>,
     pmu_gsiv: &mut Option<u32>,
-    com3_serial: &mut bool,
+    com3_serial: &mut ComInfo,
 ) -> Result<(), ErrorKind<'a>> {
     let compatible = node
         .find_property("compatible")
@@ -764,17 +798,25 @@ fn parse_compatible<'a>(
         .transpose()?
         .unwrap_or("");
 
-    if compatible == "simple-bus" {
-        parse_simple_bus(node, vmbus_vtl0, vmbus_vtl2)?;
-    } else if compatible == "x86-pio-bus" {
-        parse_io_bus(node, com3_serial)?;
-    } else if compatible == "arm,armv8-pmuv3" {
-        parse_pmu_gsiv(node, pmu_gsiv)?;
-    } else {
-        #[cfg(feature = "tracing")]
-        tracing::warn!(?compatible, ?node.name,
-            "Unrecognized compatible field",
-        );
+    match compatible {
+        "simple-bus" => {
+            parse_simple_bus(node, vmbus_vtl0, vmbus_vtl2)?;
+        }
+        "x86-pio-bus" => {
+            parse_io_bus(node, com3_serial)?;
+        }
+        "arm,sbsa-uart" => {
+            parse_pl011(node, com3_serial)?;
+        }
+        "arm,armv8-pmuv3" => {
+            parse_pmu_gsiv(node, pmu_gsiv)?;
+        }
+        _ => {
+            #[cfg(feature = "tracing")]
+            tracing::warn!(?compatible, ?node.name,
+                "Unrecognized compatible field",
+            );
+        }
     }
 
     Ok(())
@@ -973,7 +1015,7 @@ fn parse_simple_bus<'a>(
 
 fn parse_io_bus<'a>(
     node: &fdt::parser::Node<'a>,
-    com3_serial: &mut bool,
+    com3_serial: &mut ComInfo,
 ) -> Result<(), ErrorKind<'a>> {
     for io_bus_child in node.children() {
         let io_bus_child = io_bus_child.map_err(|error| ErrorKind::Node {
@@ -1013,13 +1055,57 @@ fn parse_io_bus<'a>(
         // If work is ever done in the Linux kernel to instead
         // parse from DT, the 2nd condition can be removed.
         if compatible == "ns16550" && reg_base == COM3_REG_BASE {
-            *com3_serial = true
+            *com3_serial = ComInfo::Ns16550;
         } else {
             #[cfg(feature = "tracing")]
             tracing::warn!(?node.name, ?compatible, ?reg_base,
                 "unrecognized io bus child"
             );
         }
+    }
+
+    Ok(())
+}
+
+fn parse_pl011<'a>(
+    node: &fdt::parser::Node<'a>,
+    com3_serial: &mut ComInfo,
+) -> Result<(), ErrorKind<'a>> {
+    let reg =
+        node.find_property("reg")
+            .map_err(ErrorKind::Prop)?
+            .ok_or(ErrorKind::PropMissing {
+                node_name: node.name,
+                prop_name: "reg",
+            })?;
+
+    let interrupts = node
+        .find_property("interrupts")
+        .map_err(ErrorKind::Prop)?
+        .ok_or(ErrorKind::PropMissing {
+            node_name: node.name,
+            prop_name: "reg",
+        })?;
+
+    let current_speed = node
+        .find_property("current-speed")
+        .map_err(ErrorKind::Prop)?
+        .ok_or(ErrorKind::PropMissing {
+            node_name: node.name,
+            prop_name: "current-speed",
+        })?
+        .read_u32(0)
+        .map_err(ErrorKind::Prop)?;
+
+    let base = reg.read_u32(1).map_err(ErrorKind::Prop)?;
+    let intid = interrupts.read_u32(1).map_err(ErrorKind::Prop)?;
+
+    if intid == 3 {
+        *com3_serial = ComInfo::Pl011 {
+            base,
+            intid,
+            current_speed,
+        };
     }
 
     Ok(())
@@ -1409,37 +1495,41 @@ mod tests {
         root = simple_bus.end_node().unwrap();
 
         // Com3 serial node
-        if context.com3_serial {
-            let mut io_port_bus = root
-                .start_node("io-bus")
-                .unwrap()
-                .add_str(p_compatible, "x86-pio-bus")
-                .unwrap()
-                .add_u32(p_address_cells, 1)
-                .unwrap()
-                .add_u32(p_size_cells, 0)
-                .unwrap()
-                .add_prop_array(p_ranges, &[])
-                .unwrap();
+        match context.com3_serial {
+            ComInfo::Ns16550 => {
+                let mut io_port_bus = root
+                    .start_node("io-bus")
+                    .unwrap()
+                    .add_str(p_compatible, "x86-pio-bus")
+                    .unwrap()
+                    .add_u32(p_address_cells, 1)
+                    .unwrap()
+                    .add_u32(p_size_cells, 0)
+                    .unwrap()
+                    .add_prop_array(p_ranges, &[])
+                    .unwrap();
 
-            let serial_name = format!("serial@{:x}", COM3_REG_BASE);
-            io_port_bus = io_port_bus
-                .start_node(&serial_name)
-                .unwrap()
-                .add_str(p_compatible, "ns16550")
-                .unwrap()
-                .add_u32(p_clock_frequency, 0)
-                .unwrap()
-                .add_u32(p_current_speed, 115200)
-                .unwrap()
-                .add_u64_array(p_reg, &[COM3_REG_BASE, 0x8])
-                .unwrap()
-                .add_u64_array(p_interrupts, &[4])
-                .unwrap()
-                .end_node()
-                .unwrap();
+                let serial_name = format!("serial@{:x}", COM3_REG_BASE);
+                io_port_bus = io_port_bus
+                    .start_node(&serial_name)
+                    .unwrap()
+                    .add_str(p_compatible, "ns16550")
+                    .unwrap()
+                    .add_u32(p_clock_frequency, 0)
+                    .unwrap()
+                    .add_u32(p_current_speed, 115200)
+                    .unwrap()
+                    .add_u64_array(p_reg, &[COM3_REG_BASE, 0x8])
+                    .unwrap()
+                    .add_u64_array(p_interrupts, &[4])
+                    .unwrap()
+                    .end_node()
+                    .unwrap();
 
-            root = io_port_bus.end_node().unwrap();
+                root = io_port_bus.end_node().unwrap();
+            }
+            ComInfo::Pl011 { .. } => todo!("pl011 dt test"),
+            ComInfo::None => {}
         }
 
         // Chosen node - contains cmdline.
@@ -1513,7 +1603,7 @@ mod tests {
         vmbus_vtl0: Option<VmbusInfo>,
         vmbus_vtl2: Option<VmbusInfo>,
         command_line: &str,
-        com3_serial: bool,
+        com3_serial: ComInfo,
         gic: Option<GicInfo>,
         pmu_gsiv: Option<u32>,
         memory_allocation_mode: MemoryAllocationMode,
@@ -1580,7 +1670,7 @@ mod tests {
                 connection_id: 4,
             }),
             "THIS_IS_A_BOOT_ARG=1",
-            false,
+            ComInfo::None,
             Some(GicInfo {
                 gic_distributor_base: 0x20000,
                 gic_distributor_size: 0x10000,
@@ -1650,7 +1740,7 @@ mod tests {
             None,
             None,
             "",
-            false,
+            ComInfo::None,
             None,
             None,
             MemoryAllocationMode::Vtl2 {
@@ -1701,7 +1791,7 @@ mod tests {
             None,
             None,
             "THIS_IS_A_BOOT_ARG=1",
-            false,
+            ComInfo::None,
             None,
             None,
             MemoryAllocationMode::Host,
@@ -1740,7 +1830,7 @@ mod tests {
             None,
             None,
             "THIS_IS_A_BOOT_ARG=1",
-            false,
+            ComInfo::None,
             None,
             None,
             MemoryAllocationMode::Host,
@@ -1784,7 +1874,7 @@ mod tests {
                 connection_id: 4,
             }),
             "THIS_IS_A_BOOT_ARG=1",
-            false,
+            ComInfo::None,
             None,
             None,
             MemoryAllocationMode::Host,
@@ -1828,7 +1918,7 @@ mod tests {
                 connection_id: 4,
             }),
             "THIS_IS_A_BOOT_ARG=1",
-            false,
+            ComInfo::None,
             None,
             None,
             MemoryAllocationMode::Host,
@@ -1889,7 +1979,7 @@ mod tests {
                 connection_id: 4,
             }),
             "THIS_IS_A_BOOT_ARG=1",
-            true,
+            ComInfo::Ns16550,
             None,
             None,
             MemoryAllocationMode::Host,
@@ -1901,6 +1991,6 @@ mod tests {
         let parsed = TestParsedDeviceTree::parse(&dt, &mut parsed).unwrap();
 
         assert_eq!(&orig, parsed);
-        assert!(parsed.com3_serial);
+        assert_eq!(parsed.com3_serial, ComInfo::Ns16550);
     }
 }

--- a/openhcl/host_fdt_parser/src/lib.rs
+++ b/openhcl/host_fdt_parser/src/lib.rs
@@ -62,8 +62,6 @@ pub enum ComInfo {
     /// No serial port configured
     None,
     /// Serial device on x86
-    ///
-    /// Parameters are hard coded based on port number for this device.
     Ns16550 {
         /// Base IO port
         #[cfg_attr(feature = "inspect", inspect(hex))]
@@ -81,16 +79,6 @@ pub enum ComInfo {
         /// Speed
         current_speed: u32,
     },
-}
-
-impl ComInfo {
-    /// Whether the serial port is configured
-    pub fn is_some(&self) -> bool {
-        match self {
-            ComInfo::None => false,
-            _ => true,
-        }
-    }
 }
 
 /// Errors returned by parsing.
@@ -1092,7 +1080,7 @@ fn parse_pl011<'a>(
         .map_err(ErrorKind::Prop)?
         .ok_or(ErrorKind::PropMissing {
             node_name: node.name,
-            prop_name: "reg",
+            prop_name: "interrupts",
         })?;
 
     let current_speed = node
@@ -1353,6 +1341,7 @@ mod tests {
         let p_clock_frequency = builder.add_string("clock-frequency").unwrap();
         let p_current_speed = builder.add_string("current-speed").unwrap();
         let p_interrupts = builder.add_string("interrupts").unwrap();
+        let p_interrupt_parent = builder.add_string("interrupt-parent").unwrap();
 
         let mut cpus = builder
             .start_node("")
@@ -1544,7 +1533,29 @@ mod tests {
 
                 root = io_port_bus.end_node().unwrap();
             }
-            ComInfo::Pl011 { .. } => todo!("pl011 dt test"),
+            ComInfo::Pl011 {
+                base,
+                intid,
+                current_speed,
+            } => {
+                let name = format!("serial@{:x}", base);
+                let serial = root
+                    .start_node(&name)
+                    .unwrap()
+                    .add_str(p_compatible, "arm,sbsa-uart")
+                    .unwrap()
+                    .add_u32_array(p_reg, &[0, base, 0, 0x1000])
+                    .unwrap()
+                    .add_u32(p_interrupt_parent, 1)
+                    .unwrap()
+                    .add_u32_array(p_interrupts, &[0, intid, 4])
+                    .unwrap()
+                    .add_u32(p_current_speed, current_speed)
+                    .unwrap()
+                    .add_str(p_status, "okay")
+                    .unwrap();
+                root = serial.end_node().unwrap();
+            }
             ComInfo::None => {}
         }
 
@@ -1951,14 +1962,34 @@ mod tests {
 
     /// tests serial output
     #[test]
-    fn test_com3_serial_output() {
+    fn test_com3_serial_output_x86() {
         let com3_serial = ComInfo::Ns16550 {
             base: COM3_REG_BASE,
             current_speed: 115200,
         };
 
+        test_com3_serial_output(com3_serial);
+    }
+
+    /// tests serial output
+    #[test]
+    fn test_com3_serial_output_aarch64() {
+        let com3_serial = ComInfo::Pl011 {
+            base: 0xEFFE_7000,
+            intid: 3,
+            current_speed: 115200,
+        };
+
+        test_com3_serial_output(com3_serial);
+    }
+
+    fn test_com3_serial_output(com3_serial: ComInfo) {
         let orig = create_parsed(
-            2560,
+            match com3_serial {
+                ComInfo::None => unreachable!(),
+                ComInfo::Ns16550 { .. } => 2560,
+                ComInfo::Pl011 { .. } => 2512,
+            },
             &[
                 MemoryEntry {
                     range: MemoryRange::try_new(0..(1024 * HV_PAGE_SIZE)).unwrap(),

--- a/openhcl/minimal_rt/src/arch/aarch64/serial.rs
+++ b/openhcl/minimal_rt/src/arch/aarch64/serial.rs
@@ -37,6 +37,7 @@
 
 use core::hint::spin_loop;
 use core::sync::atomic::AtomicBool;
+use core::sync::atomic::AtomicU64;
 use core::sync::atomic::Ordering;
 
 #[derive(Debug, Clone, Copy)]
@@ -96,19 +97,25 @@ const FR_BUSY: u32 = 0x008;
 /// base addresses. Should come from ACPI or DT of course yet
 /// due to having been hardcoded in some products makes that
 /// virtually constants.
-const PL011_HYPER_V_BASE_1: u64 = 0xeffec000;
+const _PL011_HYPER_V_BASE_1: u64 = 0xeffec000;
 const _PL011_HYPER_V_BASE_2: u64 = 0xeffeb000;
-const PL011_BASE: u64 = PL011_HYPER_V_BASE_1;
+const PL011_HYPER_V_BASE_3: u64 = 0xeffe9000;
+const _PL011_HYPER_V_BASE_3: u64 = 0xeffe8000;
 
 fn read_register(reg: Pl011Register) -> u32 {
     // SAFETY: using the PL011 MMIO address.
-    unsafe { core::ptr::read_volatile((PL011_BASE + reg as u64) as *const u32) }
+    unsafe {
+        core::ptr::read_volatile((PL011_BASE.load(Ordering::Relaxed) + reg as u64) as *const u32)
+    }
 }
 
 fn write_register(reg: Pl011Register, val: u32) {
     // SAFETY: using the PL011 MMIO address.
     unsafe {
-        core::ptr::write_volatile((PL011_BASE + reg as u64) as *mut u32, val);
+        core::ptr::write_volatile(
+            (PL011_BASE.load(Ordering::Relaxed) + reg as u64) as *mut u32,
+            val,
+        );
     }
 }
 
@@ -207,10 +214,11 @@ fn reset_and_init() {
 pub struct Serial;
 
 static SUPPORTED: AtomicBool = AtomicBool::new(false);
+static PL011_BASE: AtomicU64 = AtomicU64::new(PL011_HYPER_V_BASE_3);
 
 impl Serial {
     /// Initializes the serial port.
-    pub fn init() -> Serial {
+    pub fn init(base_address: Option<u64>) -> Serial {
         const SUPPORTED_PL011_CELLS: &[u32] = &[0xB105_F00D];
 
         let cell_id = cell_id();
@@ -219,6 +227,10 @@ impl Serial {
             reset_and_init();
         }
         SUPPORTED.store(supported, Ordering::Relaxed);
+
+        if let Some(base_address) = base_address {
+            PL011_BASE.store(base_address, Ordering::Relaxed);
+        }
 
         Self
     }

--- a/openhcl/minimal_rt/src/arch/aarch64/serial.rs
+++ b/openhcl/minimal_rt/src/arch/aarch64/serial.rs
@@ -37,7 +37,6 @@
 
 use core::hint::spin_loop;
 use core::sync::atomic::AtomicBool;
-use core::sync::atomic::AtomicU64;
 use core::sync::atomic::Ordering;
 
 #[derive(Debug, Clone, Copy)]
@@ -97,25 +96,19 @@ const FR_BUSY: u32 = 0x008;
 /// base addresses. Should come from ACPI or DT of course yet
 /// due to having been hardcoded in some products makes that
 /// virtually constants.
-const _PL011_HYPER_V_BASE_1: u64 = 0xeffec000;
+const PL011_HYPER_V_BASE_1: u64 = 0xeffec000;
 const _PL011_HYPER_V_BASE_2: u64 = 0xeffeb000;
-const PL011_HYPER_V_BASE_3: u64 = 0xeffe9000;
-const _PL011_HYPER_V_BASE_3: u64 = 0xeffe8000;
+const PL011_BASE: u64 = PL011_HYPER_V_BASE_1;
 
 fn read_register(reg: Pl011Register) -> u32 {
     // SAFETY: using the PL011 MMIO address.
-    unsafe {
-        core::ptr::read_volatile((PL011_BASE.load(Ordering::Relaxed) + reg as u64) as *const u32)
-    }
+    unsafe { core::ptr::read_volatile((PL011_BASE + reg as u64) as *const u32) }
 }
 
 fn write_register(reg: Pl011Register, val: u32) {
     // SAFETY: using the PL011 MMIO address.
     unsafe {
-        core::ptr::write_volatile(
-            (PL011_BASE.load(Ordering::Relaxed) + reg as u64) as *mut u32,
-            val,
-        );
+        core::ptr::write_volatile((PL011_BASE + reg as u64) as *mut u32, val);
     }
 }
 
@@ -214,11 +207,10 @@ fn reset_and_init() {
 pub struct Serial;
 
 static SUPPORTED: AtomicBool = AtomicBool::new(false);
-static PL011_BASE: AtomicU64 = AtomicU64::new(PL011_HYPER_V_BASE_3);
 
 impl Serial {
     /// Initializes the serial port.
-    pub fn init(base_address: Option<u64>) -> Serial {
+    pub fn init() -> Serial {
         const SUPPORTED_PL011_CELLS: &[u32] = &[0xB105_F00D];
 
         let cell_id = cell_id();
@@ -227,10 +219,6 @@ impl Serial {
             reset_and_init();
         }
         SUPPORTED.store(supported, Ordering::Relaxed);
-
-        if let Some(base_address) = base_address {
-            PL011_BASE.store(base_address, Ordering::Relaxed);
-        }
 
         Self
     }

--- a/openhcl/openhcl_boot/src/boot_logger.rs
+++ b/openhcl/openhcl_boot/src/boot_logger.rs
@@ -28,6 +28,7 @@ enum Logger {
     #[cfg(target_arch = "x86_64")]
     Serial(Serial<InstrIoAccess>),
     #[cfg(target_arch = "aarch64")]
+    #[expect(dead_code)]
     Serial(Serial),
     #[cfg(all(target_arch = "x86_64", feature = "cvm_boot_log"))]
     TdxSerial(Serial<TdxIoAccess>),
@@ -90,15 +91,21 @@ pub fn boot_logger_runtime_init(isolation_type: IsolationType, com3_serial_avail
 
     *logger = match (isolation_type, com3_serial_available) {
         #[cfg(target_arch = "x86_64")]
-        (IsolationType::None, true) => Logger::Serial(Serial::init(InstrIoAccess)),
-        #[cfg(target_arch = "aarch64")]
-        (IsolationType::None, ComInfo::Pl011 { base, .. }) => {
-            Logger::Serial(Serial::init(Some(base as u64)))
+        (IsolationType::None, ComInfo::Ns16550 { .. }) => {
+            Logger::Serial(Serial::init(InstrIoAccess))
+        }
+        // TODO: fix the PL011 minimal_rt driver. Currently hangs even if
+        // the MMIO address is correctly configured.
+        // #[cfg(target_arch = "aarch64")]
+        // (IsolationType::None, ComInfo::Pl011 { .. }) => Logger::Serial(Serial::init()),
+        #[cfg(all(target_arch = "x86_64", feature = "cvm_boot_log"))]
+        (IsolationType::Tdx, ComInfo::Ns16550 { .. }) => {
+            Logger::TdxSerial(Serial::init(TdxIoAccess))
         }
         #[cfg(all(target_arch = "x86_64", feature = "cvm_boot_log"))]
-        (IsolationType::Tdx, true) => Logger::TdxSerial(Serial::init(TdxIoAccess)),
-        #[cfg(all(target_arch = "x86_64", feature = "cvm_boot_log"))]
-        (IsolationType::Snp, true) => Logger::SnpSerial(Serial::init(SnpIoAccess)),
+        (IsolationType::Snp, ComInfo::Ns16550 { .. }) => {
+            Logger::SnpSerial(Serial::init(SnpIoAccess))
+        }
         _ => Logger::None,
     };
 

--- a/openhcl/openhcl_boot/src/boot_logger.rs
+++ b/openhcl/openhcl_boot/src/boot_logger.rs
@@ -17,6 +17,7 @@ use crate::single_threaded::SingleThreaded;
 use core::cell::RefCell;
 use core::fmt;
 use core::fmt::Write;
+use host_fdt_parser::ComInfo;
 use memory_range::MemoryRange;
 #[cfg(target_arch = "x86_64")]
 use minimal_rt::arch::InstrIoAccess;
@@ -84,14 +85,16 @@ pub fn boot_logger_memory_init(buffer: MemoryRange) {
 ///
 /// If a runtime logger was initialized, emit any in-memory log to the
 /// configured runtime output.
-pub fn boot_logger_runtime_init(isolation_type: IsolationType, com3_serial_available: bool) {
+pub fn boot_logger_runtime_init(isolation_type: IsolationType, com3_serial_available: ComInfo) {
     let mut logger = BOOT_LOGGER.logger.borrow_mut();
 
     *logger = match (isolation_type, com3_serial_available) {
         #[cfg(target_arch = "x86_64")]
         (IsolationType::None, true) => Logger::Serial(Serial::init(InstrIoAccess)),
         #[cfg(target_arch = "aarch64")]
-        (IsolationType::None, true) => Logger::Serial(Serial::init()),
+        (IsolationType::None, ComInfo::Pl011 { base, .. }) => {
+            Logger::Serial(Serial::init(Some(base as u64)))
+        }
         #[cfg(all(target_arch = "x86_64", feature = "cvm_boot_log"))]
         (IsolationType::Tdx, true) => Logger::TdxSerial(Serial::init(TdxIoAccess)),
         #[cfg(all(target_arch = "x86_64", feature = "cvm_boot_log"))]

--- a/openhcl/openhcl_boot/src/dt.rs
+++ b/openhcl/openhcl_boot/src/dt.rs
@@ -17,6 +17,7 @@ use core::fmt;
 use core::ops::Range;
 use fdt::builder::Builder;
 use fdt::builder::StringId;
+use host_fdt_parser::ComInfo;
 use host_fdt_parser::GicInfo;
 use host_fdt_parser::MemoryAllocationMode;
 use host_fdt_parser::VmbusInfo;
@@ -223,6 +224,7 @@ pub fn write_dt(
     let p_interrupt_parent = builder.add_string("interrupt-parent")?;
     let p_interrupts = builder.add_string("interrupts")?;
     let p_enable_method = builder.add_string("enable-method")?;
+    let p_current_speed = builder.add_string("current-speed")?;
 
     let num_cpus = partition_info.cpus.len();
 
@@ -437,6 +439,25 @@ pub fn write_dt(
                 ],
             )?;
         root_builder = pmu.end_node()?;
+
+        // ARM64 PL011 Serial device for COM3 OpenHCL logs
+        if let ComInfo::Pl011 {
+            base,
+            intid,
+            current_speed,
+        } = partition_info.com3_serial
+        {
+            let name = format_fixed!(32, "serial@{:x}", base);
+            let serial = root_builder
+                .start_node(&name)?
+                .add_str(p_compatible, "arm,sbsa-uart")?
+                .add_u32_array(p_reg, &[0, base, 0, 0x1000])?
+                .add_u32(p_interrupt_parent, aarch64::GIC_PHANDLE)?
+                .add_u32_array(p_interrupts, &[0, intid, 4])?
+                .add_u32(p_current_speed, current_speed)?
+                .add_str(p_status, "okay")?;
+            root_builder = serial.end_node()?;
+        }
     }
 
     // Linux requires vmbus to be under a simple-bus node.

--- a/openhcl/openhcl_boot/src/host_params/dt/mod.rs
+++ b/openhcl/openhcl_boot/src/host_params/dt/mod.rs
@@ -1056,7 +1056,7 @@ impl PartitionInfo {
             vmbus_vtl0,
             vmbus_vtl2,
             cmdline: _,
-            com3_serial_available: com3_serial,
+            com3_serial,
             gic,
             pmu_gsiv,
             memory_allocation_mode,
@@ -1144,7 +1144,7 @@ impl PartitionInfo {
 
         *bsp_reg = parsed.boot_cpuid_phys;
         cpus.extend(parsed.cpus.iter().copied());
-        *com3_serial = parsed.com3_serial;
+        *com3_serial = parsed.com3_serial.clone();
         *gic = parsed.gic.clone();
         *pmu_gsiv = parsed.pmu_gsiv;
         *entropy = parsed.entropy.clone();

--- a/openhcl/openhcl_boot/src/host_params/mod.rs
+++ b/openhcl/openhcl_boot/src/host_params/mod.rs
@@ -8,6 +8,7 @@ use crate::cmdline::BootCommandLineOptions;
 use crate::host_params::shim_params::IsolationType;
 use arrayvec::ArrayString;
 use arrayvec::ArrayVec;
+use host_fdt_parser::ComInfo;
 use host_fdt_parser::CpuEntry;
 use host_fdt_parser::GicInfo;
 use host_fdt_parser::MemoryAllocationMode;
@@ -64,8 +65,8 @@ pub struct PartitionInfo {
     pub vmbus_vtl0: VmbusInfo,
     /// Command line to be used for the underhill kernel.
     pub cmdline: ArrayString<COMMAND_LINE_SIZE>,
-    /// Com3 serial device is available
-    pub com3_serial_available: bool,
+    /// Com3 serial device
+    pub com3_serial: ComInfo,
     /// Memory allocation mode that was performed.
     pub memory_allocation_mode: MemoryAllocationMode,
     /// Entropy from the host to be used by the OpenHCL kernel
@@ -105,7 +106,7 @@ impl PartitionInfo {
                 connection_id: 0,
             },
             cmdline: ArrayString::new_const(),
-            com3_serial_available: false,
+            com3_serial: ComInfo::None,
             memory_allocation_mode: MemoryAllocationMode::Host,
             entropy: None,
             vtl0_alias_map: None,

--- a/openhcl/openhcl_boot/src/main.rs
+++ b/openhcl/openhcl_boot/src/main.rs
@@ -265,19 +265,12 @@ fn build_kernel_command_line(
     // com1. This is overridden by any user customizations in the static or
     // dynamic command line, as this console argument provided by the bootloader
     // comes first.
-    write!(cmdline, "console=")?;
-    match (&partition_info.com3_serial, can_trust_host) {
-        (ComInfo::Ns16550, true) => write!(cmdline, "ttyS2,115200 ")?,
-        (
-            ComInfo::Pl011 {
-                base: _,
-                intid,
-                current_speed,
-            },
-            true,
-        ) => write!(cmdline, "ttyS{},{} ", intid - 1, current_speed)?,
-        _ => write!(cmdline, "ttynull ")?,
+    let console = match (&partition_info.com3_serial, can_trust_host) {
+        (ComInfo::Ns16550, true) => "ttyS2,115200",
+        (ComInfo::Pl011 { .. }, true) => "ttyAMA0,115200",
+        _ => "ttynull",
     };
+    write!(cmdline, "console={console} ")?;
 
     if params.isolation_type != IsolationType::None {
         write!(

--- a/openhcl/openhcl_boot/src/main.rs
+++ b/openhcl/openhcl_boot/src/main.rs
@@ -44,6 +44,7 @@ use cmdline::BootCommandLineOptions;
 use core::fmt::Write;
 use dt::BootTimes;
 use dt::write_dt;
+use host_fdt_parser::ComInfo;
 use host_params::COMMAND_LINE_SIZE;
 use host_params::PartitionInfo;
 use host_params::shim_params::IsolationType;
@@ -264,12 +265,19 @@ fn build_kernel_command_line(
     // com1. This is overridden by any user customizations in the static or
     // dynamic command line, as this console argument provided by the bootloader
     // comes first.
-    let console = if partition_info.com3_serial_available && can_trust_host {
-        "ttyS2,115200"
-    } else {
-        "ttynull"
+    write!(cmdline, "console=")?;
+    match (&partition_info.com3_serial, can_trust_host) {
+        (ComInfo::Ns16550, true) => write!(cmdline, "ttyS2,115200 ")?,
+        (
+            ComInfo::Pl011 {
+                base: _,
+                intid,
+                current_speed,
+            },
+            true,
+        ) => write!(cmdline, "ttyS{},{} ", intid - 1, current_speed)?,
+        _ => write!(cmdline, "ttynull ")?,
     };
-    write!(cmdline, "console={console} ")?;
 
     if params.isolation_type != IsolationType::None {
         write!(
@@ -605,7 +613,7 @@ fn shim_main(shim_params_raw_offset: isize) -> ! {
 
     // Enable logging ASAP. This is fine even when isolated, as we don't have
     // any access to secrets in the boot shim.
-    boot_logger_runtime_init(p.isolation_type, partition_info.com3_serial_available);
+    boot_logger_runtime_init(p.isolation_type, partition_info.com3_serial.clone());
     log::info!("openhcl_boot: logging enabled");
 
     // Confidential debug will show up in boot_options only if included in the
@@ -894,6 +902,7 @@ mod test {
     use arrayvec::ArrayString;
     use arrayvec::ArrayVec;
     use core::ops::Range;
+    use host_fdt_parser::ComInfo;
     use host_fdt_parser::CpuEntry;
     use host_fdt_parser::MemoryEntry;
     use host_fdt_parser::VmbusInfo;
@@ -944,7 +953,7 @@ mod test {
                 mmio: ArrayVec::new(),
                 connection_id: 0,
             },
-            com3_serial_available: false,
+            com3_serial: ComInfo::None,
             gic: None,
             pmu_gsiv: None,
             memory_allocation_mode: host_fdt_parser::MemoryAllocationMode::Host,

--- a/openhcl/openhcl_boot/src/main.rs
+++ b/openhcl/openhcl_boot/src/main.rs
@@ -265,12 +265,16 @@ fn build_kernel_command_line(
     // com1. This is overridden by any user customizations in the static or
     // dynamic command line, as this console argument provided by the bootloader
     // comes first.
-    let console = match (&partition_info.com3_serial, can_trust_host) {
-        (ComInfo::Ns16550, true) => "ttyS2,115200",
-        (ComInfo::Pl011 { .. }, true) => "ttyAMA0,115200",
-        _ => "ttynull",
-    };
-    write!(cmdline, "console={console} ")?;
+    write!(cmdline, "console=")?;
+    match (&partition_info.com3_serial, can_trust_host) {
+        (ComInfo::Ns16550 { current_speed, .. }, true) => {
+            write!(cmdline, "ttyS2,{current_speed} ")?
+        }
+        (ComInfo::Pl011 { current_speed, .. }, true) => {
+            write!(cmdline, "ttyAMA0,{current_speed} ")?
+        }
+        _ => write!(cmdline, "ttynull ")?,
+    }
 
     if params.isolation_type != IsolationType::None {
         write!(


### PR DESCRIPTION
Pass through PL011 COM3 serial configuration from the host device tree to the vtl2 kernel device tree and configure the vtl2 kernel to use it for console output when available.