### PR TITLE
DO NOT MERGE OpenHCL: Use symcrypt

### DIFF
--- a/openhcl/openvmm_hcl/Cargo.toml
+++ b/openhcl/openvmm_hcl/Cargo.toml
@@ -34,6 +34,12 @@ dev_snp_ohcl_tio_support = ["underhill_entry/dev_snp_ohcl_tio_support"]
 underhill_entry.workspace = true
 openvmm_hcl_resources.workspace = true
 tracing.workspace = true
+
+# Only use Symcrypt when building for musl, since that's the only configuration
+# with a prebuilt lib in deps.
+[target.'cfg(target_env = "musl")'.dependencies]
+crypto = { workspace = true, features = ["symcrypt"] }
+[target.'cfg(not(target_env = "musl"))'.dependencies]
 crypto = { workspace = true, features = ["openssl"] }
 # OpenVMM-HCL only needs libcrypto from openssl
 openssl_crypto_only.workspace = true

--- a/openhcl/openvmm_hcl/Cargo.toml
+++ b/openhcl/openvmm_hcl/Cargo.toml
@@ -37,9 +37,9 @@ tracing.workspace = true
 
 # Only use Symcrypt when building for musl, since that's the only configuration
 # with a prebuilt lib in deps.
-[target.'cfg(target_env = "musl")'.dependencies]
+[target.'cfg(all(target_os = "linux", target_env = "musl"))'.dependencies]
 crypto = { workspace = true, features = ["symcrypt"] }
-[target.'cfg(not(target_env = "musl"))'.dependencies]
+[target.'cfg(all(target_os = "linux", not(target_env = "musl")))'.dependencies]
 crypto = { workspace = true, features = ["openssl"] }
 # OpenVMM-HCL only needs libcrypto from openssl
 openssl_crypto_only.workspace = true

--- a/openhcl/openvmm_hcl/Cargo.toml
+++ b/openhcl/openvmm_hcl/Cargo.toml
@@ -34,6 +34,8 @@ dev_snp_ohcl_tio_support = ["underhill_entry/dev_snp_ohcl_tio_support"]
 underhill_entry.workspace = true
 openvmm_hcl_resources.workspace = true
 tracing.workspace = true
+# OpenVMM-HCL only needs libcrypto from openssl
+openssl_crypto_only.workspace = true
 
 # Only use Symcrypt when building for musl, since that's the only configuration
 # with a prebuilt lib in deps.
@@ -41,8 +43,6 @@ tracing.workspace = true
 crypto = { workspace = true, features = ["symcrypt"] }
 [target.'cfg(all(target_os = "linux", not(target_env = "musl")))'.dependencies]
 crypto = { workspace = true, features = ["openssl"] }
-# OpenVMM-HCL only needs libcrypto from openssl
-openssl_crypto_only.workspace = true
 
 [package.metadata.xtask.unused-deps]
 ignored = ["tracing"] # Present to specify features from flowey

--- a/openhcl/openvmm_hcl/src/main.rs
+++ b/openhcl/openvmm_hcl/src/main.rs
@@ -10,7 +10,7 @@
 use openvmm_hcl_resources as _;
 
 // OpenVMM-HCL only needs libcrypto from openssl, not libssl.
-#[cfg(all(target_os = "linux", not(target_env = "musl")))]
+#[cfg(target_os = "linux")]
 openssl_crypto_only::openssl_crypto_only!();
 
 #[cfg(all(not(test), target_os = "linux"))]

--- a/openhcl/openvmm_hcl/src/main.rs
+++ b/openhcl/openvmm_hcl/src/main.rs
@@ -10,7 +10,7 @@
 use openvmm_hcl_resources as _;
 
 // OpenVMM-HCL only needs libcrypto from openssl, not libssl.
-#[cfg(target_os = "linux")]
+#[cfg(all(target_os = "linux", not(target_env = "musl")))]
 openssl_crypto_only::openssl_crypto_only!();
 
 #[cfg(all(not(test), target_os = "linux"))]


### PR DESCRIPTION
Configured to only do so on proper musl builds, builds using the gnu toolchain (what most people are likely running locally for e.g. rust-analyzer) continue to use openssl, for ease of development.