### PR TITLE
virtiofs: aggregate device + FAT-over-virtiofs fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9655,6 +9655,7 @@ dependencies = [
  "task_control",
  "tempfile",
  "test_with_tracing",
+ "tracelimit",
  "tracing",
  "virtio",
  "virtio_resources",

--- a/vm/devices/support/fs/fuse/src/protocol.rs
+++ b/vm/devices/support/fs/fuse/src/protocol.rs
@@ -65,7 +65,7 @@ pub struct fuse_attr {
     pub gid: u32,
     pub rdev: u32,
     pub blksize: u32,
-    pub padding: u32,
+    pub flags: u32,
 }
 
 #[repr(C)]
@@ -258,6 +258,17 @@ pub const FUSE_RELEASE_FLOCK_UNLOCK: u32 = (1 << 1);
  * Getattr flags
  */
 pub const FUSE_GETATTR_FH: u32 = (1 << 0);
+
+/**
+ * fuse_attr flags
+ *
+ * FUSE_ATTR_SUBMOUNT: directory contains a submount; the kernel will
+ *                     auto-mount it as a separate filesystem (needs
+ *                     FUSE_SUBMOUNTS negotiated in INIT)
+ * FUSE_ATTR_DAX: file supports DAX
+ */
+pub const FUSE_ATTR_SUBMOUNT: u32 = (1 << 1);
+pub const FUSE_ATTR_DAX: u32 = (1 << 0);
 
 /**
  * Lock flags

--- a/vm/devices/support/fs/lxutil/src/windows/fs.rs
+++ b/vm/devices/support/fs/lxutil/src/windows/fs.rs
@@ -295,13 +295,24 @@ pub fn analyze_delete_error(error: lx::Error, file_handle: &OwnedHandle) -> Dele
     {
         DeleteErrorAction::ReturnError(error)
     } else if error.value() == lx::EIO {
-        // EIO can come from STATUS_CANNOT_DELETE, which for directories means
-        // the directory is not empty. Check if this is a directory and return
-        // ENOTEMPTY in that case.
-        if is_directory(file_handle) {
-            DeleteErrorAction::ReturnError(lx::Error::ENOTEMPTY)
-        } else {
-            DeleteErrorAction::ReturnError(error)
+        // EIO can come from STATUS_CANNOT_DELETE. Inspect the file's attributes
+        // to decide how to proceed:
+        // - a non-empty directory surfaces as STATUS_CANNOT_DELETE, so map it to
+        //   ENOTEMPTY;
+        // - a read-only file cannot be deleted via the non-POSIX
+        //   FileDispositionInformation path, so clear the read-only attribute and
+        //   retry;
+        // - anything else (including a genuine I/O failure, or a handle without
+        //   FILE_READ_ATTRIBUTES) is returned as-is so the read-only attribute is
+        //   not disturbed.
+        match util::query_information_file::<FileSystem::FILE_BASIC_INFORMATION>(file_handle) {
+            Ok(info) if info.FileAttributes & W32Fs::FILE_ATTRIBUTE_DIRECTORY.0 != 0 => {
+                DeleteErrorAction::ReturnError(lx::Error::ENOTEMPTY)
+            }
+            Ok(info) if info.FileAttributes & W32Fs::FILE_ATTRIBUTE_READONLY.0 != 0 => {
+                DeleteErrorAction::TryReadOnlyWorkaround
+            }
+            _ => DeleteErrorAction::ReturnError(error),
         }
     } else {
         DeleteErrorAction::TryReadOnlyWorkaround
@@ -319,17 +330,6 @@ pub fn delete_file(fs_context: &FsContext, file_handle: &OwnedHandle) -> lx::Res
                 delete_read_only_file(fs_context, file_handle)
             }
         },
-    }
-}
-
-/// Check if a file handle refers to a directory.
-fn is_directory(file_handle: &OwnedHandle) -> bool {
-    if let Ok(info) =
-        util::query_information_file::<FileSystem::FILE_BASIC_INFORMATION>(file_handle)
-    {
-        info.FileAttributes & W32Fs::FILE_ATTRIBUTE_DIRECTORY.0 != 0
-    } else {
-        false
     }
 }
 

--- a/vm/devices/support/fs/lxutil/src/windows/mod.rs
+++ b/vm/devices/support/fs/lxutil/src/windows/mod.rs
@@ -405,6 +405,64 @@ impl LxVolume {
             Default::default(),
         )?;
 
+        // NT's POSIX rename (used by NTFS) natively enforces several Linux rename
+        // semantics. The classic non-POSIX path used by FAT/exFAT does not, so
+        // replicate them explicitly here. NTFS is left untouched: it returns the
+        // same errors from NT directly.
+        if !self
+            .state
+            .fs_context
+            .compatibility_flags
+            .supports_posix_unlink_rename()
+        {
+            let is_dir = |h: &OwnedHandle| -> lx::Result<bool> {
+                Ok(
+                    util::query_information_file::<FileSystem::FILE_BASIC_INFORMATION>(h)?
+                        .FileAttributes
+                        & W32Fs::FILE_ATTRIBUTE_DIRECTORY.0
+                        != 0,
+                )
+            };
+            let source_is_dir = is_dir(&handle)?;
+
+            // Linux returns EINVAL when renaming a directory into one of its own
+            // descendants; NT's classic rename instead reports STATUS_ACCESS_DENIED
+            // (-> EACCES). `Path::starts_with` compares whole path components, so
+            // "a/bc" is not treated as a descendant of "a/b". Only directories can
+            // have descendants, so non-directory sources are unaffected.
+            // N.B. The comparison is case-sensitive, so a case-only descendant such
+            //      as renaming "a/b" into "a/B/c" on a case-insensitive volume is not
+            //      caught here; NT still rejects it (as EACCES) so no data is lost.
+            if source_is_dir && new_path != path && new_path.starts_with(path) {
+                return Err(lx::Error::EINVAL);
+            }
+
+            // Linux forbids replacing a file with a directory (ENOTDIR) or a
+            // directory with a file (EISDIR). The classic non-POSIX path would
+            // instead silently supersede a file with a directory and report only a
+            // generic collision for the reverse, so detect type-incompatible targets
+            // up front before the destructive rename is attempted.
+            // N.B. `open_file` always sets FILE_OPEN_REPARSE_POINT, so a symlink
+            //      target is classified as the (non-directory) reparse point itself,
+            //      matching Linux. On case-insensitive volumes a case-only rename
+            //      (foo -> FOO) opens the same object as source and target, yielding
+            //      equal types and thus no false error.
+            match self.open_file(new_path, W32Fs::FILE_READ_ATTRIBUTES, Default::default()) {
+                Ok(target_handle) => {
+                    let target_is_dir = is_dir(&target_handle)?;
+                    if source_is_dir && !target_is_dir {
+                        return Err(lx::Error::ENOTDIR);
+                    }
+                    if !source_is_dir && target_is_dir {
+                        return Err(lx::Error::EISDIR);
+                    }
+                }
+                // A missing target is fine; the rename creates it.
+                Err(err) if err.value() == lx::ENOENT => {}
+                Err(err) => return Err(err),
+            }
+        }
+
         let flags = fs::RenameFlags::default();
         let error = match fs::rename(&handle, &self.root, new_path, &self.state.fs_context, flags) {
             Ok(_) => return Ok(()),
@@ -425,7 +483,11 @@ impl LxVolume {
                 .compatibility_flags
                 .supports_posix_unlink_rename()
         {
-            match self.open_file(new_path, W32Fs::DELETE, Default::default()) {
+            match self.open_file(
+                new_path,
+                W32Fs::FILE_READ_ATTRIBUTES | W32Fs::DELETE,
+                Default::default(),
+            ) {
                 Ok(target_handle) => self.delete_file(&target_handle)?,
                 Err(err) => {
                     // ENOENT means the rename can proceed.
@@ -699,6 +761,22 @@ impl LxVolume {
     ) -> lx::Result<OwnedHandle> {
         assert!(path.is_relative() && !path.as_os_str().is_empty());
         self.check_sandbox_enforcement(path)?;
+
+        // Symlinks are always implemented as reparse points (either an LX
+        // symlink reparse tag or an NT symlink). Filesystems that don't support
+        // reparse points (e.g. FAT) cannot store a symlink at all, so report
+        // EPERM up front rather than creating the file and then failing to set
+        // the reparse point (which would surface as EOPNOTSUPP). This matches
+        // the conventional Linux errno for symlink() on such filesystems and
+        // mirrors the hard link check in link_helper.
+        if !self
+            .state
+            .fs_context
+            .compatibility_flags
+            .supports_reparse_points()
+        {
+            return Err(lx::Error::EPERM);
+        }
 
         // Convert the target to its native Windows format.
         let win_target = Path::from_lx(target);

--- a/vm/devices/support/fs/lxutil/src/windows/util.rs
+++ b/vm/devices/support/fs/lxutil/src/windows/util.rs
@@ -155,29 +155,32 @@ fn get_token_for_access_check() -> lx::Result<OwnedHandle> {
     let mut client_token_raw = Foundation::HANDLE::default();
     let mut duplicate_token_raw = Foundation::HANDLE::default();
     // SAFETY: Calling Win32 API as documented.
-    let result = unsafe {
-        check_status(FileSystem::NtOpenThreadToken(
+    //
+    // N.B. The raw NTSTATUS is inspected directly (rather than going through
+    //      `check_status`) so that `STATUS_NO_TOKEN` can be distinguished from
+    //      other failures. `check_status` maps the NTSTATUS to an `lx::Error`
+    //      errno, which cannot be compared against an NTSTATUS constant.
+    let status = unsafe {
+        FileSystem::NtOpenThreadToken(
             Threading::GetCurrentThread(),
             Security::TOKEN_QUERY.0 | Security::TOKEN_DUPLICATE.0,
             true,
             &mut client_token_raw,
-        ))
+        )
     };
 
-    if let Err(e) = result {
-        // Use the process token if there's no token.
-        if e.value() == Foundation::STATUS_NO_TOKEN.0 {
-            // SAFETY: Calling Win32 API as documented.
-            unsafe {
-                let _ = check_status(FileSystem::NtOpenProcessToken(
-                    Threading::GetCurrentProcess(),
-                    Security::TOKEN_QUERY.0 | Security::TOKEN_DUPLICATE.0,
-                    &mut client_token_raw,
-                ))?;
-            }
-        } else {
-            return Err(e);
+    if status == Foundation::STATUS_NO_TOKEN {
+        // The thread is not impersonating, so use the process token instead.
+        // SAFETY: Calling Win32 API as documented.
+        unsafe {
+            let _ = check_status(FileSystem::NtOpenProcessToken(
+                Threading::GetCurrentProcess(),
+                Security::TOKEN_QUERY.0 | Security::TOKEN_DUPLICATE.0,
+                &mut client_token_raw,
+            ))?;
         }
+    } else {
+        let _ = check_status(status)?;
     }
 
     // Create the RAII handle now so it gets closed on drop if we need
@@ -213,7 +216,10 @@ fn get_token_for_access_check() -> lx::Result<OwnedHandle> {
             },
             EffectiveOnly: false,
         };
-        let mut object_attributes = Wdk::Foundation::OBJECT_ATTRIBUTES::default();
+        let mut object_attributes = Wdk::Foundation::OBJECT_ATTRIBUTES {
+            Length: size_of::<Wdk::Foundation::OBJECT_ATTRIBUTES>() as u32,
+            ..Default::default()
+        };
         object_attributes.SecurityQualityOfService =
             ptr::from_ref::<W32Sec::SECURITY_QUALITY_OF_SERVICE>(&security_qos).cast();
 
@@ -731,13 +737,14 @@ pub fn set_information_file<T: FileInformationClass>(
 
     // SAFETY: Calling NtSetInformationFile as documented.
     unsafe {
-        let _ = check_status(FileSystem::NtSetInformationFile(
+        let status = FileSystem::NtSetInformationFile(
             Foundation::HANDLE(handle.as_raw_handle()),
             &mut iosb,
             buf.cast(),
             len.try_into().unwrap(),
             info.file_information_class(),
-        ))?;
+        );
+        let _ = check_status(status)?;
 
         Ok(())
     }

--- a/vm/devices/virtio/virtiofs/Cargo.toml
+++ b/vm/devices/virtio/virtiofs/Cargo.toml
@@ -24,6 +24,7 @@ anyhow.workspace = true
 futures.workspace = true
 pal_async.workspace = true
 parking_lot.workspace = true
+tracelimit.workspace = true
 tracing.workspace = true
 zerocopy.workspace = true
 [target.'cfg(windows)'.dependencies]

--- a/vm/devices/virtio/virtiofs/src/file.rs
+++ b/vm/devices/virtio/virtiofs/src/file.rs
@@ -307,6 +307,12 @@ impl SyntheticRootDirFile {
 
             if plus {
                 let fuse_entry = if entry_offset < 2 {
+                    // For READDIRPLUS, "." and ".." are emitted with a zero
+                    // nodeid (left from new_zeroed). This is the standard FUSE
+                    // convention telling the kernel not to instantiate/cache an
+                    // inode for these entries (no matching FORGET is owed); the
+                    // attributes are advisory only. The root is never forgotten,
+                    // so its self/parent links don't need real node ids here.
                     let mut e = fuse_entry_out::new_zeroed();
                     e.attr.ino = FUSE_ROOT_ID;
                     e.attr.mode = lx::S_IFDIR | 0o555;

--- a/vm/devices/virtio/virtiofs/src/file.rs
+++ b/vm/devices/virtio/virtiofs/src/file.rs
@@ -8,60 +8,100 @@ use fuse::protocol::fuse_attr;
 use fuse::protocol::fuse_entry_out;
 use fuse::protocol::fuse_setattr_in;
 use fuse::protocol::fuse_statx;
+use fuse::protocol::*;
 use lxutil::LxFile;
 use parking_lot::RwLock;
 use std::sync::Arc;
 use zerocopy::FromZeros;
 
-/// Implements file callbacks for virtio-fs.
-pub struct VirtioFsFile {
+/// An open file handle backed by a real `LxFile`.
+struct RealFile {
     file: RwLock<LxFile>,
     inode: Arc<VirtioFsInode>,
 }
 
+/// An open handle on the synthetic root of an aggregate virtio-fs.
+///
+/// Holds only the inode; reads stream the in-memory child list.
+struct SyntheticRootDirFile {
+    inode: Arc<VirtioFsInode>,
+}
+
+/// The kind of open file backing a virtio-fs file handle.
+enum FileKind {
+    /// A file or directory handle backed by a real `LxFile`.
+    ///
+    /// Boxed to keep the enum small: `LxFile` is large and the
+    /// `SyntheticRootDir` variant only holds an `Arc`.
+    Real(Box<RealFile>),
+    /// An open handle on the synthetic root of an aggregate virtio-fs.
+    SyntheticRootDir(SyntheticRootDirFile),
+}
+
+/// Implements file callbacks for virtio-fs.
+pub struct VirtioFsFile {
+    kind: FileKind,
+}
+
 impl VirtioFsFile {
-    /// Create a new file.
-    pub fn new(file: LxFile, inode: Arc<VirtioFsInode>) -> Self {
+    /// Create a new file handle backed by a real `LxFile`.
+    pub fn new_real(file: LxFile, inode: Arc<VirtioFsInode>) -> Self {
         Self {
-            file: RwLock::new(file),
-            inode,
+            kind: FileKind::Real(Box::new(RealFile {
+                file: RwLock::new(file),
+                inode,
+            })),
+        }
+    }
+
+    /// Create a new file handle for the synthetic root directory of an
+    /// aggregate virtio-fs.
+    pub fn new_synthetic_root_dir(inode: Arc<VirtioFsInode>) -> Self {
+        debug_assert!(inode.is_synthetic_root());
+        Self {
+            kind: FileKind::SyntheticRootDir(SyntheticRootDirFile { inode }),
         }
     }
 
     /// Gets the attributes of the open file.
     pub fn get_attr(&self) -> lx::Result<fuse_attr> {
-        let stat = self.file.read().fstat()?.into();
-        Ok(util::stat_to_fuse_attr(&stat))
+        match &self.kind {
+            FileKind::Real(f) => f.get_attr(),
+            FileKind::SyntheticRootDir(f) => f.inode.get_attr(),
+        }
     }
 
     /// Gets the statx details for the open file.
     pub fn get_statx(&self) -> lx::Result<fuse_statx> {
-        let statx = self.file.read().fstat()?;
-        Ok(util::statx_to_fuse_statx(&statx))
+        match &self.kind {
+            FileKind::Real(f) => f.get_statx(),
+            FileKind::SyntheticRootDir(f) => f.inode.get_statx(),
+        }
     }
 
     /// Sets the attributes of the open file.
     pub fn set_attr(&self, arg: &fuse_setattr_in, request_uid: lx::uid_t) -> lx::Result<()> {
-        let attr = util::fuse_set_attr_to_lxutil(arg, request_uid);
-
-        // Because FUSE_HANDLE_KILLPRIV is set, set-user-ID and set-group-ID must be cleared
-        // depending on the attributes being set. Lxutil takes care of that on Windows (and Linux
-        // does it naturally).
-        self.file.read().set_attr(attr)
+        match &self.kind {
+            FileKind::Real(f) => f.set_attr(arg, request_uid),
+            FileKind::SyntheticRootDir(_) => Err(lx::Error::EROFS),
+        }
     }
 
     /// Read data from the file.
     pub fn read(&self, buffer: &mut [u8], offset: u64) -> lx::Result<usize> {
-        self.file.read().pread(buffer, offset as lx::off_t)
+        match &self.kind {
+            FileKind::Real(f) => f.read(buffer, offset),
+            // The synthetic root is a directory.
+            FileKind::SyntheticRootDir(_) => Err(lx::Error::EISDIR),
+        }
     }
 
     /// Write data to the file.
     pub fn write(&self, buffer: &[u8], offset: u64, thread_uid: lx::uid_t) -> lx::Result<usize> {
-        // Because FUSE_HANDLE_KILLPRIV is set, set-user-ID and set-group-ID must be cleared on
-        // write. Lxutil takes care of that on Windows (and Linux does it naturally).
-        self.file
-            .read()
-            .pwrite(buffer, offset as lx::off_t, thread_uid)
+        match &self.kind {
+            FileKind::Real(f) => f.write(buffer, offset, thread_uid),
+            FileKind::SyntheticRootDir(_) => Err(lx::Error::EISDIR),
+        }
     }
 
     /// Read directory contents.
@@ -72,9 +112,70 @@ impl VirtioFsFile {
         size: u32,
         plus: bool,
     ) -> lx::Result<Vec<u8>> {
+        match &self.kind {
+            FileKind::Real(f) => f.read_dir(fs, offset, size, plus),
+            FileKind::SyntheticRootDir(f) => f.read_dir(fs, offset, size, plus),
+        }
+    }
+
+    pub fn fsync(&self, data_only: bool) -> lx::Result<()> {
+        match &self.kind {
+            FileKind::Real(f) => f.file.read().fsync(data_only),
+            // Nothing to flush for a synthetic directory.
+            FileKind::SyntheticRootDir(_) => Ok(()),
+        }
+    }
+}
+
+impl RealFile {
+    fn get_attr(&self) -> lx::Result<fuse_attr> {
+        let stat = self.file.read().fstat()?.into();
+        let mut attr = util::stat_to_fuse_attr(&stat);
+        attr.ino = self.inode.namespaced_ino(attr.ino);
+        Ok(attr)
+    }
+
+    fn get_statx(&self) -> lx::Result<fuse_statx> {
+        let statx = self.file.read().fstat()?;
+        let mut sx = util::statx_to_fuse_statx(&statx);
+        sx.ino = self.inode.namespaced_ino(sx.ino);
+        Ok(sx)
+    }
+
+    fn set_attr(&self, arg: &fuse_setattr_in, request_uid: lx::uid_t) -> lx::Result<()> {
+        let attr = util::fuse_set_attr_to_lxutil(arg, request_uid);
+
+        // Because FUSE_HANDLE_KILLPRIV is set, set-user-ID and set-group-ID must be cleared
+        // depending on the attributes being set. Lxutil takes care of that on Windows (and Linux
+        // does it naturally).
+        self.file.read().set_attr(attr)
+    }
+
+    fn read(&self, buffer: &mut [u8], offset: u64) -> lx::Result<usize> {
+        self.file.read().pread(buffer, offset as lx::off_t)
+    }
+
+    fn write(&self, buffer: &[u8], offset: u64, thread_uid: lx::uid_t) -> lx::Result<usize> {
+        // Because FUSE_HANDLE_KILLPRIV is set, set-user-ID and set-group-ID must be cleared on
+        // write. Lxutil takes care of that on Windows (and Linux does it naturally).
+        self.file
+            .read()
+            .pwrite(buffer, offset as lx::off_t, thread_uid)
+    }
+
+    fn read_dir(
+        &self,
+        fs: &super::VirtioFs,
+        offset: u64,
+        size: u32,
+        plus: bool,
+    ) -> lx::Result<Vec<u8>> {
         let mut buffer = Vec::with_capacity(size as usize);
         let mut entry_count: u32 = 0;
-        let self_inode_nr = self.inode.inode_nr();
+        // Namespace `.`/`..` (and child entries below) so plain READDIR `d_ino`
+        // values match the inode numbers reported by LOOKUP/GETATTR/READDIRPLUS
+        // for the same inodes.
+        let self_inode_nr = self.inode.namespaced_ino(self.inode.inode_nr());
         let mut file = self.file.write();
         file.read_dir(offset as lx::off_t, |entry| {
             entry_count += 1;
@@ -130,7 +231,7 @@ impl VirtioFsFile {
                         entry_count -= 1;
                         return Ok(true);
                     }
-                    entry.inode_nr
+                    self.inode.namespaced_ino(entry.inode_nr)
                 };
 
                 Ok(buffer.dir_entry(
@@ -148,8 +249,91 @@ impl VirtioFsFile {
 
         Ok(buffer)
     }
+}
 
-    pub fn fsync(&self, data_only: bool) -> lx::Result<()> {
-        self.file.read().fsync(data_only)
+impl SyntheticRootDirFile {
+    /// Enumerate the synthetic root of an aggregate virtio-fs.
+    ///
+    /// Emits `.`, `..`, then one entry per aggregate child. Each child is
+    /// presented as a directory of type `DT_DIR`. For READDIRPLUS each child
+    /// goes through `lookup_helper`, which routes via
+    /// `VirtioFsInode::lookup_child` → `SyntheticRoot::lookup_child` and
+    /// registers the resulting submount-root inode in the `InodeMap` with a
+    /// valid FUSE node id (so subsequent ops against that node id resolve).
+    fn read_dir(
+        &self,
+        fs: &super::VirtioFs,
+        offset: u64,
+        size: u32,
+        plus: bool,
+    ) -> lx::Result<Vec<u8>> {
+        // Snapshot the child names under the AggregateState read lock and
+        // release before any FUSE work. Append-only ordering guarantees that
+        // any child added between the snapshot and the next READDIR call will
+        // simply appear in the next snapshot.
+        let names = self
+            .inode
+            .aggregate_state()
+            .expect("file was opened on synthetic root")
+            .snapshot_names();
+
+        let mut buffer: Vec<u8> = Vec::with_capacity(size as usize);
+
+        // Build the entry list: index 0 = ".", 1 = "..", 2.. = children.
+        // The kernel sends the offset of the *last* entry it accepted; the
+        // next read starts at offset+1. Emit entries whose own offset is
+        // strictly greater than the requested offset.
+        let total_entries = 2 + names.len() as u64;
+
+        for entry_offset in offset..total_entries {
+            let next_offset = entry_offset + 1;
+            let dir_type = lx::DT_DIR as u32;
+
+            // Compute name and per-entry dirent ino. The dirent ino is a
+            // userspace-visible hint only; FUSE routing is by node id, which
+            // for READDIRPLUS comes from the `lookup_helper` call below.
+            // Per-child synthetic ino values are stable across calls.
+            let (name_bytes, dirent_ino): (&[u8], u64) = match entry_offset {
+                0 => (b".", FUSE_ROOT_ID),
+                1 => (b"..", FUSE_ROOT_ID),
+                i => {
+                    let idx = (i - 2) as usize;
+                    // Use the synthetic offset itself as the dirent ino so
+                    // values are stable and unique per entry.
+                    (names[idx].as_bytes(), entry_offset)
+                }
+            };
+            let name = lx::LxStr::from_bytes(name_bytes);
+
+            if plus {
+                let fuse_entry = if entry_offset < 2 {
+                    let mut e = fuse_entry_out::new_zeroed();
+                    e.attr.ino = FUSE_ROOT_ID;
+                    e.attr.mode = lx::S_IFDIR | 0o555;
+                    e
+                } else {
+                    if !buffer.check_dir_entry_plus(name) {
+                        break;
+                    }
+                    // Look up the child by name. This registers the
+                    // submount-root inode in the InodeMap with a valid
+                    // node id and returns the correct fuse_entry_out
+                    // (including FUSE_ATTR_SUBMOUNT in the attr).
+                    match fs.lookup_helper(&self.inode, name) {
+                        Ok(e) => e,
+                        Err(e) if e.value() == lx::EACCES || e.value() == lx::ENOENT => continue,
+                        Err(e) => return Err(e),
+                    }
+                };
+
+                if !buffer.dir_entry_plus(name, next_offset, fuse_entry) {
+                    break;
+                }
+            } else if !buffer.dir_entry(name, dirent_ino, next_offset, dir_type) {
+                break;
+            }
+        }
+
+        Ok(buffer)
     }
 }

--- a/vm/devices/virtio/virtiofs/src/inode.rs
+++ b/vm/devices/virtio/virtiofs/src/inode.rs
@@ -91,16 +91,21 @@ impl Volume {
     /// same underlying inode number reported from two different aggregate
     /// shares no longer collides under the single shared superblock.
     ///
-    /// Identity (returns `raw` unchanged) for single-root mounts (`ino_ns ==
-    /// 0`) and for volumes whose inode numbers aren't stable (FAT/exFAT
-    /// recycle them — the same gate used by [`VirtioFsInode::dedup_key`]).
+    /// Identity (returns `raw` unchanged) only for single-root mounts
+    /// (`ino_ns == 0`). Applied to *every* aggregate child regardless of
+    /// inode-number stability: FAT/exFAT report directory-entry-derived
+    /// inode numbers that systematically collide across freshly-formatted
+    /// volumes (e.g. both roots), so namespacing them is what prevents the
+    /// cross-share `(st_dev, st_ino)` aliasing under a single shared
+    /// superblock. (Note this is independent of
+    /// [`VirtioFsInode::dedup_key`], which is already keyed by volume id.)
     ///
     /// XOR-by-constant is a bijection, so distinct files *within* a share
-    /// keep distinct inode numbers (preserving hard-link identity); the
-    /// distinct per-share key removes the systematic cross-share collision
-    /// where two volumes report the same small inode number.
+    /// keep distinct inode numbers (preserving hard-link identity on stable
+    /// filesystems); it never introduces a within-share collision, so it is
+    /// safe even for volumes whose raw inode numbers aren't stable.
     pub fn namespaced_ino(&self, raw: lx::ino_t) -> lx::ino_t {
-        if self.ino_ns == 0 || !self.volume.supports_stable_file_id() {
+        if self.ino_ns == 0 {
             return raw;
         }
         raw ^ self.ino_ns.wrapping_mul(0x9E37_79B9_7F4A_7C15)

--- a/vm/devices/virtio/virtiofs/src/inode.rs
+++ b/vm/devices/virtio/virtiofs/src/inode.rs
@@ -8,57 +8,406 @@ use lx::LxStr;
 use lx::LxString;
 use lxutil::LxCreateOptions;
 use lxutil::LxVolume;
+use lxutil::LxVolumeOptions;
 use lxutil::PathBufExt;
 use parking_lot::RwLock;
+use std::path::Path;
 use std::path::PathBuf;
 use std::sync::Arc;
+use std::sync::atomic::AtomicBool;
 use std::sync::atomic::AtomicU64;
 use std::sync::atomic::Ordering;
 
+/// Process-wide counter used to assign virtio-fs volume IDs. The id is
+/// paired with `lx::ino_t` in `InodeMap` to dedup inodes from distinct
+/// volumes that happen to share a numeric inode number.
+static NEXT_VOLUME_ID: AtomicU64 = AtomicU64::new(1);
+
+/// An `Arc<LxVolume>` paired with a virtio-fs-local numeric identifier.
+/// Cloned through child inode creation so all inodes rooted at the same
+/// physical volume share the same `id`.
+pub struct Volume {
+    id: u64,
+    /// Per-share key folded into reported inode numbers (see
+    /// [`Volume::namespaced_ino`]). Zero for single-root mounts (identity
+    /// transform); non-zero for children of an aggregate root.
+    ino_ns: u64,
+    volume: Arc<LxVolume>,
+}
+
+impl Volume {
+    fn with_namespace(volume: Arc<LxVolume>, aggregate_child: bool) -> Arc<Self> {
+        let id = NEXT_VOLUME_ID.fetch_add(1, Ordering::Relaxed);
+        // Key the inode namespace off the (process-unique) volume id so each
+        // aggregate child gets a distinct, stable key.
+        let ino_ns = if aggregate_child { id } else { 0 };
+        Arc::new(Self { id, ino_ns, volume })
+    }
+
+    /// Open an `LxVolume` rooted at `root_path` (honoring `options` when
+    /// supplied) and wrap it in a [`Volume`]. Single home for the
+    /// volume-construction pattern used by [`VirtioFs::new`](crate::VirtioFs)
+    /// and (via [`Volume::open_aggregate_child`]) the aggregate paths.
+    pub fn open(
+        root_path: impl AsRef<Path>,
+        options: Option<&LxVolumeOptions>,
+    ) -> lx::Result<Arc<Self>> {
+        Self::open_inner(root_path, options, false)
+    }
+
+    /// Like [`Volume::open`], but marks the resulting volume as a child of an
+    /// aggregate (multi-path) root, so its reported inode numbers are
+    /// namespaced (see [`Volume::namespaced_ino`]) to avoid cross-share
+    /// `(st_dev, st_ino)` collisions under the single shared superblock.
+    pub fn open_aggregate_child(
+        root_path: impl AsRef<Path>,
+        options: Option<&LxVolumeOptions>,
+    ) -> lx::Result<Arc<Self>> {
+        Self::open_inner(root_path, options, true)
+    }
+
+    fn open_inner(
+        root_path: impl AsRef<Path>,
+        options: Option<&LxVolumeOptions>,
+        aggregate_child: bool,
+    ) -> lx::Result<Arc<Self>> {
+        let volume = if let Some(options) = options {
+            options.new_volume(root_path)
+        } else {
+            LxVolume::new(root_path)
+        }?;
+        Ok(Self::with_namespace(Arc::new(volume), aggregate_child))
+    }
+
+    pub fn id(&self) -> u64 {
+        self.id
+    }
+
+    pub fn lx_volume(&self) -> &Arc<LxVolume> {
+        &self.volume
+    }
+
+    /// Fold this volume's per-share key into a raw host inode number so the
+    /// same underlying inode number reported from two different aggregate
+    /// shares no longer collides under the single shared superblock.
+    ///
+    /// Identity (returns `raw` unchanged) for single-root mounts (`ino_ns ==
+    /// 0`) and for volumes whose inode numbers aren't stable (FAT/exFAT
+    /// recycle them — the same gate used by [`VirtioFsInode::dedup_key`]).
+    ///
+    /// XOR-by-constant is a bijection, so distinct files *within* a share
+    /// keep distinct inode numbers (preserving hard-link identity); the
+    /// distinct per-share key removes the systematic cross-share collision
+    /// where two volumes report the same small inode number.
+    pub fn namespaced_ino(&self, raw: lx::ino_t) -> lx::ino_t {
+        if self.ino_ns == 0 || !self.volume.supports_stable_file_id() {
+            return raw;
+        }
+        raw ^ self.ino_ns.wrapping_mul(0x9E37_79B9_7F4A_7C15)
+    }
+}
+
+/// One child of an aggregate (multi-path) virtio-fs root.
+pub struct SyntheticChild {
+    pub name: LxString,
+    pub volume: Arc<Volume>,
+}
+
+/// Validates a name is acceptable as a child of the synthetic root: non-
+/// empty, no `/` or NUL, and not `.` or `..`.
+pub(crate) fn validate_child_name_bytes(name: &[u8]) -> lx::Result<()> {
+    if name.is_empty() || name == b"." || name == b".." {
+        return Err(lx::Error::EINVAL);
+    }
+    if name.iter().any(|b| *b == b'/' || *b == 0) {
+        return Err(lx::Error::EINVAL);
+    }
+    Ok(())
+}
+
+/// Shared state for an aggregate virtio-fs device. Held by the
+/// `SyntheticRoot` inode (for lookup/enumeration), by the optional
+/// [`crate::VirtiofsAggregateHandle`] (for live child appends), and by
+/// the owning [`crate::VirtioFs`] (to flip `tearing_down` on drop).
+pub(crate) struct AggregateState {
+    /// Synthetic children. Append-only — existing entries are never
+    /// removed or reordered, which keeps offset-based READDIR cookies
+    /// stable across concurrent appends.
+    children: RwLock<Vec<SyntheticChild>>,
+    readonly: bool,
+    /// Set to `true` by `VirtioFs::Drop` (via `mark_tearing_down`) to
+    /// reject subsequent `add_child` calls with `EAGAIN`.
+    tearing_down: AtomicBool,
+}
+
+impl AggregateState {
+    pub fn new(children: Vec<SyntheticChild>, readonly: bool) -> Arc<Self> {
+        Arc::new(Self {
+            children: RwLock::new(children),
+            readonly,
+            tearing_down: AtomicBool::new(false),
+        })
+    }
+
+    pub fn is_active(&self) -> bool {
+        !self.tearing_down.load(Ordering::Acquire)
+    }
+
+    /// The aggregate's readonly setting. Fixed at construction; every child
+    /// must match it.
+    pub fn readonly(&self) -> bool {
+        self.readonly
+    }
+
+    pub fn mark_tearing_down(&self) {
+        self.tearing_down.store(true, Ordering::Release);
+    }
+
+    /// Current child count; used to synthesize the root directory's `nlink`.
+    pub fn child_count(&self) -> usize {
+        self.children.read().len()
+    }
+
+    /// Looks up a child by name. Returns a cloned `Arc<Volume>` so the
+    /// caller can release the lock before doing slow I/O.
+    pub fn find_child(&self, name: &LxStr) -> Option<Arc<Volume>> {
+        self.children
+            .read()
+            .iter()
+            .find(|c| *c.name == *name)
+            .map(|c| Arc::clone(&c.volume))
+    }
+
+    /// Snapshots child names for READDIR; the lock is held only for the
+    /// clone. Children appended after the snapshot are invisible to this
+    /// call but appear on the next READDIR (append-only ordering keeps
+    /// cookies stable).
+    pub fn snapshot_names(&self) -> Vec<LxString> {
+        self.children
+            .read()
+            .iter()
+            .map(|c| c.name.clone())
+            .collect()
+    }
+
+    /// Appends a new child. Returns `EAGAIN` if tearing down, `EINVAL` on
+    /// readonly mismatch, or `EEXIST` if the name is already in use.
+    pub fn add_child(
+        &self,
+        name: LxString,
+        volume: Arc<Volume>,
+        child_readonly: bool,
+    ) -> lx::Result<()> {
+        if !self.is_active() {
+            return Err(lx::Error::EAGAIN);
+        }
+        if self.readonly != child_readonly {
+            return Err(lx::Error::EINVAL);
+        }
+        let mut guard = self.children.write();
+        // Re-check lifecycle under the lock; teardown could race the early check.
+        if !self.is_active() {
+            return Err(lx::Error::EAGAIN);
+        }
+        if guard.iter().any(|c| c.name == name) {
+            return Err(lx::Error::EEXIST);
+        }
+        guard.push(SyntheticChild { name, volume });
+        Ok(())
+    }
+}
+
+/// Key used to deduplicate inodes in the inode map so that repeated lookups
+/// of the same underlying file return one stable FUSE node id (which the
+/// guest needs for features such as inotify).
+#[derive(Clone, PartialEq, Eq, Hash)]
+pub enum DedupKey {
+    /// `(volume_id, host_inode_number)`, for volumes that report stable
+    /// inode numbers (e.g. NTFS). The inode number is a reliable identity
+    /// and is immutable for an inode's lifetime.
+    Ino(u64, lx::ino_t),
+    /// `(volume_id, host_path)`, for volumes that recycle inode numbers
+    /// (FAT/exFAT) where the inode number is not a safe identity. The path
+    /// is the stable identity instead.
+    Path(u64, PathBuf),
+}
+
+/// An inode backed by a real host path on a single [`Volume`]. This is the
+/// ordinary virtio-fs inode; all of its operations delegate straight to the
+/// backing `LxVolume`.
+struct RealInode {
+    volume: Arc<Volume>,
+    path: RwLock<PathBuf>,
+    inode_nr: lx::ino_t,
+    /// `true` if this inode is the root of an auto-mounted child of an
+    /// aggregate virtio-fs root. Such inodes return `FUSE_ATTR_SUBMOUNT`
+    /// in their attrs so the guest kernel mounts a new superblock for
+    /// them, isolating their inode-number namespace from siblings.
+    is_submount: bool,
+}
+
+/// The synthetic read-only root directory of an aggregate virtio-fs.
+///
+/// `SyntheticRoot` lives at FUSE_ROOT_ID. Its only meaningful operation is
+/// `lookup_child(name)` which routes to one of the children; readdir
+/// enumerates them. All mutating ops return EROFS. The shared
+/// `AggregateState` is also held by the device's
+/// [`crate::VirtiofsAggregateHandle`] (if any) so that children can be
+/// appended after construction.
+struct SyntheticRoot {
+    state: Arc<AggregateState>,
+}
+
+/// The kind of file system inode being represented.
+enum InodeKind {
+    /// An inode backed by a real host path on a single [`Volume`].
+    Real(RealInode),
+    /// The synthetic read-only root of an aggregate virtio-fs.
+    SyntheticRoot(SyntheticRoot),
+}
+
 /// Implements inode callbacks for virtio-fs.
 pub struct VirtioFsInode {
-    volume: Arc<LxVolume>,
-    path: RwLock<PathBuf>,
+    kind: InodeKind,
     lookup_count: AtomicU64,
-    inode_nr: lx::ino_t,
 }
 
 impl VirtioFsInode {
-    /// Create a new inode for the specified path.
-    pub fn new(volume: Arc<LxVolume>, path: PathBuf) -> lx::Result<(Self, lx::Stat)> {
-        let stat = volume.lstat(&path)?;
+    /// Create a new `Real` inode for the specified path, fetching its
+    /// attributes via `LxVolume::lstat`.
+    pub fn new(volume: Arc<Volume>, path: PathBuf) -> lx::Result<(Self, lx::Stat)> {
+        let stat = volume.lx_volume().lstat(&path)?;
         let inode = Self::with_attr(volume, path, &stat);
         Ok((inode, stat))
     }
 
-    /// Create a new inode for the specified path, with previously retrieved attributes.
-    pub fn with_attr(volume: Arc<LxVolume>, path: PathBuf, stat: &lx::Stat) -> Self {
+    /// Create a new `Real` inode for the specified path, using previously
+    /// retrieved attributes.
+    pub fn with_attr(volume: Arc<Volume>, path: PathBuf, stat: &lx::Stat) -> Self {
+        Self::new_real(volume, path, stat.inode_nr, false)
+    }
+
+    /// Create a new `Real` inode flagged as the root of an auto-mount
+    /// submount (used when the guest looks up a child of the synthetic
+    /// aggregate root).
+    pub fn new_submount_root(volume: Arc<Volume>, inode_nr: lx::ino_t) -> Self {
+        Self::new_real(volume, PathBuf::new(), inode_nr, true)
+    }
+
+    fn new_real(
+        volume: Arc<Volume>,
+        path: PathBuf,
+        inode_nr: lx::ino_t,
+        is_submount: bool,
+    ) -> Self {
         Self {
-            volume,
-            path: RwLock::new(path),
+            kind: InodeKind::Real(RealInode {
+                volume,
+                path: RwLock::new(path),
+                inode_nr,
+                is_submount,
+            }),
             lookup_count: AtomicU64::new(1),
-            inode_nr: stat.inode_nr,
         }
     }
 
-    /// Return the files inode number as reported by the underlying file system.
-    ///
-    /// N.B. This may be different from its FUSE node ID.
-    pub fn inode_nr(&self) -> lx::ino_t {
-        self.inode_nr
+    /// Create the synthetic root inode for an aggregate virtio-fs.
+    pub fn new_synthetic_root(state: Arc<AggregateState>) -> Self {
+        Self {
+            kind: InodeKind::SyntheticRoot(SyntheticRoot { state }),
+            lookup_count: AtomicU64::new(1),
+        }
     }
 
-    /// Increments the lookup count.
+    /// Returns the backing [`RealInode`], or `None` for the synthetic root.
+    fn real(&self) -> Option<&RealInode> {
+        match &self.kind {
+            InodeKind::Real(real) => Some(real),
+            InodeKind::SyntheticRoot(_) => None,
+        }
+    }
+
+    /// Returns the backing [`RealInode`], or `EROFS` for the synthetic root.
+    /// Used by mutating operations to consolidate the "not on synthetic
+    /// root" check.
+    fn real_for_mutate(&self) -> lx::Result<&RealInode> {
+        self.real().ok_or(lx::Error::EROFS)
+    }
+
+    /// Returns true if this inode is the synthetic root of an aggregate
+    /// virtio-fs.
+    pub fn is_synthetic_root(&self) -> bool {
+        matches!(self.kind, InodeKind::SyntheticRoot(_))
+    }
+
+    /// Returns the inode number as reported by the underlying host file
+    /// system, or `0` for the synthetic root (which has no host inode).
+    ///
+    /// N.B. This may be different from the inode's FUSE node ID.
+    pub fn inode_nr(&self) -> lx::ino_t {
+        match &self.kind {
+            InodeKind::Real(real) => real.inode_nr,
+            InodeKind::SyntheticRoot(_) => 0,
+        }
+    }
+
+    /// Applies this inode's volume namespace to a raw host inode number (see
+    /// [`Volume::namespaced_ino`]). Identity for the synthetic root, which
+    /// has no backing volume.
+    pub fn namespaced_ino(&self, raw: lx::ino_t) -> lx::ino_t {
+        match &self.kind {
+            InodeKind::Real(real) => real.volume.namespaced_ino(raw),
+            InodeKind::SyntheticRoot(_) => raw,
+        }
+    }
+
+    /// Returns the dedup key for this inode, or `None` if the inode should
+    /// not participate in deduplication.
+    ///
+    /// `SyntheticRoot` never dedupes. `Real` inodes on a volume that reports
+    /// stable inode numbers dedupe by [`DedupKey::Ino`]. On volumes that
+    /// recycle inode numbers (FAT/exFAT), the inode number is not a safe
+    /// identity, so non-empty paths dedupe by [`DedupKey::Path`] instead —
+    /// keeping a single FUSE node id stable across repeated lookups of the
+    /// same path. A path-keyed inode with an empty path (a submount or
+    /// volume root) returns `None`.
+    pub fn dedup_key(&self) -> Option<DedupKey> {
+        match &self.kind {
+            InodeKind::Real(real) => real.dedup_key(),
+            InodeKind::SyntheticRoot(_) => None,
+        }
+    }
+
+    /// Computes the [`DedupKey::Path`] that a child named `name` of this
+    /// inode would use, for path-keyed (non-stable-id) volumes only.
+    ///
+    /// Returns `None` for stable-id volumes — those dedupe by inode number,
+    /// which a delete/recreate naturally changes, so there is no stale path
+    /// entry to evict — and for the synthetic root. Used to evict the dedup
+    /// entry when a path is removed (unlink/rmdir) or vacated (rename), so a
+    /// later create at the same path cannot alias a stale node id.
+    pub fn child_path_dedup_key(&self, name: &LxStr) -> Option<DedupKey> {
+        let real = self.real()?;
+        if real.volume.lx_volume().supports_stable_file_id() {
+            return None;
+        }
+        let path = child_path(&real.path.read(), name).ok()?;
+        Some(DedupKey::Path(real.volume.id(), path))
+    }
+
+    /// Increments the lookup count and replaces the recorded path.
     pub fn lookup(&self, new_path: PathBuf) {
         self.lookup_count.fetch_add(1, Ordering::AcqRel);
-        let mut path = self.path.write();
-        *path = new_path;
+        if let InodeKind::Real(real) = &self.kind {
+            *real.path.write() = new_path;
+        }
     }
 
     /// Increments the lookup count without updating the path.
     ///
-    /// This is used when returning an existing inode in a FUSE reply (e.g., for hard links)
-    /// where the kernel will track the reference and later send a forget.
+    /// Used when returning an existing inode in a FUSE reply (e.g. for hard
+    /// links) where the kernel will track the reference and later send a
+    /// forget.
     pub fn inc_lookup(&self) {
         self.lookup_count.fetch_add(1, Ordering::AcqRel);
     }
@@ -88,40 +437,52 @@ impl VirtioFsInode {
 
     /// Performs a lookup for a child of this inode.
     pub fn lookup_child(&self, name: &LxStr) -> lx::Result<(VirtioFsInode, fuse_attr)> {
-        let path = self.child_path(name)?;
-        let (inode, stat) = VirtioFsInode::new(Arc::clone(&self.volume), path)?;
-        let attr = util::stat_to_fuse_attr(&stat);
-        Ok((inode, attr))
+        match &self.kind {
+            InodeKind::Real(real) => real.lookup_child(name),
+            InodeKind::SyntheticRoot(root) => root.lookup_child(name),
+        }
     }
 
     /// Retrieves the attributes of this inode.
     pub fn get_attr(&self) -> lx::Result<fuse_attr> {
-        let stat = self.volume.lstat(&*self.get_path())?;
-        Ok(util::stat_to_fuse_attr(&stat))
+        match &self.kind {
+            InodeKind::Real(real) => real.get_attr(),
+            InodeKind::SyntheticRoot(root) => Ok(root.get_attr()),
+        }
     }
 
     /// Retrieves the extended attributes of this inode.
     pub fn get_statx(&self) -> lx::Result<fuse_statx> {
-        let statx = self.volume.statx(&*self.get_path())?;
-        Ok(util::statx_to_fuse_statx(&statx))
+        match &self.kind {
+            InodeKind::Real(real) => real.get_statx(),
+            InodeKind::SyntheticRoot(root) => Ok(root.get_statx()),
+        }
     }
 
     /// Sets the attributes of this inode.
     pub fn set_attr(&self, arg: &fuse_setattr_in, request_uid: lx::uid_t) -> lx::Result<fuse_attr> {
-        let attr = util::fuse_set_attr_to_lxutil(arg, request_uid);
-
-        // Because FUSE_HANDLE_KILLPRIV is set, set-user-ID and set-group-ID must be cleared
-        // depending on the attributes being set. Lxutil takes care of that on Windows (and Linux
-        // does it naturally).
-        let stat = self.volume.set_attr_stat(&*self.get_path(), attr)?;
-        Ok(util::stat_to_fuse_attr(&stat))
+        self.real_for_mutate()?.set_attr(arg, request_uid)
     }
 
     /// Opens the inode, creating a file object.
     pub fn open(self: Arc<VirtioFsInode>, flags: u32) -> lx::Result<VirtioFsFile> {
-        let flags = (flags as i32) | lx::O_NOFOLLOW;
-        let file = self.volume.open(&*self.get_path(), flags, None)?;
-        Ok(VirtioFsFile::new(file, self))
+        match &self.kind {
+            InodeKind::Real(real) => {
+                let flags = (flags as i32) | lx::O_NOFOLLOW;
+                let file = real
+                    .volume
+                    .lx_volume()
+                    .open(&*real.path.read(), flags, None)?;
+                Ok(VirtioFsFile::new_real(file, self))
+            }
+            InodeKind::SyntheticRoot(_) => {
+                // The synthetic root is a directory; the kernel uses
+                // OPENDIR, which the FUSE layer routes through `open`.
+                // Hand back a synthetic directory file object that knows
+                // how to enumerate the aggregate children.
+                Ok(VirtioFsFile::new_synthetic_root_dir(self))
+            }
+        }
     }
 
     /// Creates a new file as a child of this inode, and opens it.
@@ -133,14 +494,7 @@ impl VirtioFsInode {
         uid: u32,
         gid: u32,
     ) -> lx::Result<(VirtioFsInode, fuse_attr, lxutil::LxFile)> {
-        let path = self.child_path(name)?;
-        let options = LxCreateOptions::new(mode, uid, gid);
-        let flags = (flags as i32) | lx::O_CREAT | lx::O_NOFOLLOW;
-        let file = self.volume.open(&path, flags, Some(options))?;
-        let stat = file.fstat()?.into();
-        let inode = Self::with_attr(Arc::clone(&self.volume), path, &stat);
-        let attr = util::stat_to_fuse_attr(&stat);
-        Ok((inode, attr, file))
+        self.real_for_mutate()?.create(name, flags, mode, uid, gid)
     }
 
     /// Creates a new directory as a child of this inode.
@@ -151,14 +505,7 @@ impl VirtioFsInode {
         uid: u32,
         gid: u32,
     ) -> lx::Result<(VirtioFsInode, fuse_attr)> {
-        let path = self.child_path(name)?;
-        let stat = self
-            .volume
-            .mkdir_stat(&path, LxCreateOptions::new(mode, uid, gid))?;
-
-        let inode = Self::with_attr(Arc::clone(&self.volume), path, &stat);
-        let attr = util::stat_to_fuse_attr(&stat);
-        Ok((inode, attr))
+        self.real_for_mutate()?.mkdir(name, mode, uid, gid)
     }
 
     /// Creates a new regular, device, socket, or fifo file as a child of this inode.
@@ -170,16 +517,8 @@ impl VirtioFsInode {
         gid: u32,
         device_id: u32,
     ) -> lx::Result<(VirtioFsInode, fuse_attr)> {
-        let path = self.child_path(name)?;
-        let stat = self.volume.mknod_stat(
-            &path,
-            LxCreateOptions::new(mode, uid, gid),
-            device_id as usize,
-        )?;
-
-        let inode = Self::with_attr(Arc::clone(&self.volume), path, &stat);
-        let attr = util::stat_to_fuse_attr(&stat);
-        Ok((inode, attr))
+        self.real_for_mutate()?
+            .mknod(name, mode, uid, gid, device_id)
     }
 
     /// Creates a new symlink as a child of this inode.
@@ -190,34 +529,27 @@ impl VirtioFsInode {
         uid: u32,
         gid: u32,
     ) -> lx::Result<(VirtioFsInode, fuse_attr)> {
-        let path = self.child_path(name)?;
-        let stat = self.volume.symlink_stat(
-            &path,
-            target,
-            LxCreateOptions::new(lx::S_IFLNK | 0o777, uid, gid),
-        )?;
-
-        let inode = Self::with_attr(Arc::clone(&self.volume), path, &stat);
-        let attr = util::stat_to_fuse_attr(&stat);
-        Ok((inode, attr))
+        self.real_for_mutate()?.symlink(name, target, uid, gid)
     }
 
     /// Creates a new hard link as a child of this inode.
     pub fn link(&self, name: &LxStr, target: &VirtioFsInode) -> lx::Result<fuse_attr> {
-        let path = self.child_path(name)?;
-        let stat = self.volume.link_stat(&*target.get_path(), path)?;
-        Ok(util::stat_to_fuse_attr(&stat))
+        let target = target.real_for_mutate()?;
+        self.real_for_mutate()?.link(name, target)
     }
 
     /// Reads the target of the symbolic link, if this inode is a symbolic link.
     pub fn read_link(&self) -> lx::Result<LxString> {
-        self.volume.read_link(&*self.get_path())
+        match &self.kind {
+            InodeKind::Real(real) => real.read_link(),
+            // Synthetic root is a directory, not a symlink.
+            InodeKind::SyntheticRoot(_) => Err(lx::Error::EINVAL),
+        }
     }
 
     /// Removes a file or directory child of this inode.
     pub fn unlink(&self, name: &LxStr, flags: i32) -> lx::Result<()> {
-        let path = self.child_path(name)?;
-        self.volume.unlink(path, flags)
+        self.real_for_mutate()?.unlink(name, flags)
     }
 
     /// Renames a child of this inode.
@@ -228,14 +560,245 @@ impl VirtioFsInode {
         new_name: &LxStr,
         flags: u32,
     ) -> lx::Result<()> {
-        let path = self.child_path(name)?;
-        let new_path = new_dir.child_path(new_name)?;
-        self.volume.rename(path, new_path, flags)
+        let new_dir = new_dir.real_for_mutate()?;
+        self.real_for_mutate()?
+            .rename(name, new_dir, new_name, flags)
     }
 
     /// Gets the attributes of the file system that the inode resides on.
     pub fn stat_fs(&self) -> lx::Result<fuse_kstatfs> {
-        let stat_fs = self.volume.stat_fs(&*self.get_path())?;
+        match &self.kind {
+            InodeKind::Real(real) => real.stat_fs(),
+            InodeKind::SyntheticRoot(_) => Ok(synthetic_root_statfs()),
+        }
+    }
+
+    /// Gets the value or the size of an extended attribute on this inode.
+    pub fn get_xattr(&self, name: &LxStr, value: Option<&mut [u8]>) -> lx::Result<usize> {
+        match &self.kind {
+            InodeKind::Real(real) => real.get_xattr(name, value),
+            // Synthetic root has no xattrs.
+            InodeKind::SyntheticRoot(_) => Err(lx::Error::ENODATA),
+        }
+    }
+
+    /// Sets an extended attribute on this inode.
+    pub fn set_xattr(&self, name: &LxStr, value: &[u8], flags: u32) -> lx::Result<()> {
+        self.real_for_mutate()?.set_xattr(name, value, flags)
+    }
+
+    /// Lists the extended attributes on this inode.
+    pub fn list_xattr(&self, list: Option<&mut [u8]>) -> lx::Result<usize> {
+        match &self.kind {
+            InodeKind::Real(real) => real.list_xattr(list),
+            // Synthetic root has no xattrs: report zero bytes.
+            InodeKind::SyntheticRoot(_) => Ok(0),
+        }
+    }
+
+    /// Removes an extended attribute from this inode.
+    pub fn remove_xattr(&self, name: &LxStr) -> lx::Result<()> {
+        self.real_for_mutate()?.remove_xattr(name)
+    }
+
+    /// Gets a clone of the stored path. Returns an empty `PathBuf` for the
+    /// synthetic root (which has no host path).
+    pub fn clone_path(&self) -> PathBuf {
+        match &self.kind {
+            InodeKind::Real(real) => real.path.read().clone(),
+            InodeKind::SyntheticRoot(_) => PathBuf::new(),
+        }
+    }
+
+    /// Provides read-only access to the aggregate state of a synthetic
+    /// root, for use by readdir on the synthetic root directory.
+    pub fn aggregate_state(&self) -> Option<&Arc<AggregateState>> {
+        match &self.kind {
+            InodeKind::SyntheticRoot(root) => Some(&root.state),
+            InodeKind::Real(_) => None,
+        }
+    }
+}
+
+impl RealInode {
+    /// See [`VirtioFsInode::dedup_key`].
+    fn dedup_key(&self) -> Option<DedupKey> {
+        if self.volume.lx_volume().supports_stable_file_id() {
+            return Some(DedupKey::Ino(self.volume.id(), self.inode_nr));
+        }
+        let path = self.path.read();
+        if path.as_os_str().is_empty() {
+            None
+        } else {
+            Some(DedupKey::Path(self.volume.id(), path.clone()))
+        }
+    }
+
+    /// Builds a `fuse_attr` from a host stat, applying this volume's inode
+    /// namespace and the supplied `FUSE_ATTR_*` flags.
+    fn attr(&self, stat: &lx::Stat, attr_flags: u32) -> fuse_attr {
+        let mut attr = util::stat_to_fuse_attr_with_flags(stat, attr_flags);
+        attr.ino = self.volume.namespaced_ino(attr.ino);
+        attr
+    }
+
+    /// Builds a `fuse_statx` from a host statx, applying this volume's inode
+    /// namespace.
+    fn statx_attr(&self, statx: &lx::StatEx) -> fuse_statx {
+        let mut sx = util::statx_to_fuse_statx(statx);
+        sx.ino = self.volume.namespaced_ino(sx.ino);
+        sx
+    }
+
+    fn lookup_child(&self, name: &LxStr) -> lx::Result<(VirtioFsInode, fuse_attr)> {
+        let path = child_path(&self.path.read(), name)?;
+        let stat = self.volume.lx_volume().lstat(&path)?;
+        // Descendants of a submount root are *not* themselves submounts —
+        // the kernel has already mounted a fresh superblock at the submount
+        // root, so children are just ordinary inodes within it.
+        let inode = VirtioFsInode::new_real(Arc::clone(&self.volume), path, stat.inode_nr, false);
+        let attr = self.attr(&stat, 0);
+        Ok((inode, attr))
+    }
+
+    fn get_attr(&self) -> lx::Result<fuse_attr> {
+        let stat = self.volume.lx_volume().lstat(&*self.path.read())?;
+        Ok(self.attr(&stat, submount_flag(self.is_submount)))
+    }
+
+    fn get_statx(&self) -> lx::Result<fuse_statx> {
+        // `fuse_statx` has no flags field for `FUSE_ATTR_SUBMOUNT`, so the
+        // submount marker is intentionally omitted from statx replies. The
+        // kernel only consumes `FUSE_ATTR_SUBMOUNT` from `fuse_attr`
+        // (LOOKUP, GETATTR, READDIRPLUS) anyway.
+        let statx = self.volume.lx_volume().statx(&*self.path.read())?;
+        Ok(self.statx_attr(&statx))
+    }
+
+    fn set_attr(&self, arg: &fuse_setattr_in, request_uid: lx::uid_t) -> lx::Result<fuse_attr> {
+        let attr = util::fuse_set_attr_to_lxutil(arg, request_uid);
+        // Because FUSE_HANDLE_KILLPRIV is set, set-user-ID and set-group-ID must be cleared
+        // depending on the attributes being set. Lxutil takes care of that on Windows (and Linux
+        // does it naturally).
+        let stat = self
+            .volume
+            .lx_volume()
+            .set_attr_stat(&*self.path.read(), attr)?;
+        Ok(self.attr(&stat, submount_flag(self.is_submount)))
+    }
+
+    fn create(
+        &self,
+        name: &LxStr,
+        flags: u32,
+        mode: u32,
+        uid: u32,
+        gid: u32,
+    ) -> lx::Result<(VirtioFsInode, fuse_attr, lxutil::LxFile)> {
+        let path = child_path(&self.path.read(), name)?;
+        let options = LxCreateOptions::new(mode, uid, gid);
+        let flags = (flags as i32) | lx::O_CREAT | lx::O_NOFOLLOW;
+        let file = self.volume.lx_volume().open(&path, flags, Some(options))?;
+        let stat = file.fstat()?.into();
+        let inode = VirtioFsInode::with_attr(Arc::clone(&self.volume), path, &stat);
+        let attr = self.attr(&stat, 0);
+        Ok((inode, attr, file))
+    }
+
+    fn mkdir(
+        &self,
+        name: &LxStr,
+        mode: u32,
+        uid: u32,
+        gid: u32,
+    ) -> lx::Result<(VirtioFsInode, fuse_attr)> {
+        let path = child_path(&self.path.read(), name)?;
+        let stat = self
+            .volume
+            .lx_volume()
+            .mkdir_stat(&path, LxCreateOptions::new(mode, uid, gid))?;
+        let inode = VirtioFsInode::with_attr(Arc::clone(&self.volume), path, &stat);
+        let attr = self.attr(&stat, 0);
+        Ok((inode, attr))
+    }
+
+    fn mknod(
+        &self,
+        name: &LxStr,
+        mode: u32,
+        uid: u32,
+        gid: u32,
+        device_id: u32,
+    ) -> lx::Result<(VirtioFsInode, fuse_attr)> {
+        let path = child_path(&self.path.read(), name)?;
+        let stat = self.volume.lx_volume().mknod_stat(
+            &path,
+            LxCreateOptions::new(mode, uid, gid),
+            device_id as usize,
+        )?;
+        let inode = VirtioFsInode::with_attr(Arc::clone(&self.volume), path, &stat);
+        let attr = self.attr(&stat, 0);
+        Ok((inode, attr))
+    }
+
+    fn symlink(
+        &self,
+        name: &LxStr,
+        target: &LxStr,
+        uid: u32,
+        gid: u32,
+    ) -> lx::Result<(VirtioFsInode, fuse_attr)> {
+        let path = child_path(&self.path.read(), name)?;
+        let stat = self.volume.lx_volume().symlink_stat(
+            &path,
+            target,
+            LxCreateOptions::new(lx::S_IFLNK | 0o777, uid, gid),
+        )?;
+        let inode = VirtioFsInode::with_attr(Arc::clone(&self.volume), path, &stat);
+        let attr = self.attr(&stat, 0);
+        Ok((inode, attr))
+    }
+
+    fn link(&self, name: &LxStr, target: &RealInode) -> lx::Result<fuse_attr> {
+        // Hard links cannot cross filesystems.
+        if self.volume.id() != target.volume.id() {
+            return Err(lx::Error::EXDEV);
+        }
+        let path = child_path(&self.path.read(), name)?;
+        let stat = self
+            .volume
+            .lx_volume()
+            .link_stat(&*target.path.read(), path)?;
+        Ok(self.attr(&stat, 0))
+    }
+
+    fn read_link(&self) -> lx::Result<LxString> {
+        self.volume.lx_volume().read_link(&*self.path.read())
+    }
+
+    fn unlink(&self, name: &LxStr, flags: i32) -> lx::Result<()> {
+        let path = child_path(&self.path.read(), name)?;
+        self.volume.lx_volume().unlink(path, flags)
+    }
+
+    fn rename(
+        &self,
+        name: &LxStr,
+        new_dir: &RealInode,
+        new_name: &LxStr,
+        flags: u32,
+    ) -> lx::Result<()> {
+        // Renames cannot cross filesystems.
+        if self.volume.id() != new_dir.volume.id() {
+            return Err(lx::Error::EXDEV);
+        }
+        let path = child_path(&self.path.read(), name)?;
+        let new_path = child_path(&new_dir.path.read(), new_name)?;
+        self.volume.lx_volume().rename(path, new_path, flags)
+    }
+
+    fn stat_fs(&self) -> lx::Result<fuse_kstatfs> {
+        let stat_fs = self.volume.lx_volume().stat_fs(&*self.path.read())?;
         Ok(fuse_kstatfs::new(
             stat_fs.block_count,
             stat_fs.free_block_count,
@@ -248,47 +811,142 @@ impl VirtioFsInode {
         ))
     }
 
-    /// Gets the value or the size of an extended attribute on this inode.
-    pub fn get_xattr(&self, name: &LxStr, value: Option<&mut [u8]>) -> lx::Result<usize> {
-        self.volume.get_xattr(&*self.get_path(), name, value)
-    }
-
-    /// Sets an extended attribute on this inode.
-    pub fn set_xattr(&self, name: &LxStr, value: &[u8], flags: u32) -> lx::Result<()> {
+    fn get_xattr(&self, name: &LxStr, value: Option<&mut [u8]>) -> lx::Result<usize> {
         self.volume
-            .set_xattr(&*self.get_path(), name, value, flags as i32)
+            .lx_volume()
+            .get_xattr(&*self.path.read(), name, value)
     }
 
-    /// Lists the extended attributes on this inode.
-    pub fn list_xattr(&self, list: Option<&mut [u8]>) -> lx::Result<usize> {
-        self.volume.list_xattr(&*self.get_path(), list)
+    fn set_xattr(&self, name: &LxStr, value: &[u8], flags: u32) -> lx::Result<()> {
+        self.volume
+            .lx_volume()
+            .set_xattr(&*self.path.read(), name, value, flags as i32)
     }
 
-    /// Removes an extended attribute from this inode.
-    pub fn remove_xattr(&self, name: &LxStr) -> lx::Result<()> {
-        self.volume.remove_xattr(&*self.get_path(), name)
+    fn list_xattr(&self, list: Option<&mut [u8]>) -> lx::Result<usize> {
+        self.volume.lx_volume().list_xattr(&*self.path.read(), list)
     }
 
-    /// Gets a clone of the stored path.
-    pub fn clone_path(&self) -> PathBuf {
-        self.get_path().clone()
+    fn remove_xattr(&self, name: &LxStr) -> lx::Result<()> {
+        self.volume
+            .lx_volume()
+            .remove_xattr(&*self.path.read(), name)
+    }
+}
+
+impl SyntheticRoot {
+    /// Looks up a child of the synthetic root, returning a submount-root
+    /// inode flagged with `FUSE_ATTR_SUBMOUNT`.
+    fn lookup_child(&self, name: &LxStr) -> lx::Result<(VirtioFsInode, fuse_attr)> {
+        // Snapshot the matching child's volume, then release the lock
+        // before the slow stat.
+        let volume = self.state.find_child(name).ok_or(lx::Error::ENOENT)?;
+        let stat = volume.lx_volume().lstat(PathBuf::new())?;
+        let mut attr = util::stat_to_fuse_attr_with_flags(&stat, FUSE_ATTR_SUBMOUNT);
+        attr.ino = volume.namespaced_ino(attr.ino);
+        let inode = VirtioFsInode::new_submount_root(volume, stat.inode_nr);
+        Ok((inode, attr))
     }
 
-    /// Appends a child name to this inode's path.
-    fn child_path(&self, name: &LxStr) -> lx::Result<PathBuf> {
-        // Defense in depth: the FUSE request parser already validates names,
-        // but assert here to catch any bypass.
-        assert!(!name.is_empty(), "empty child name");
-        assert!(!name.as_bytes().contains(&b'/'), "child name contains '/'");
-        assert!(name != "." && name != "..", "child name is '.' or '..'");
-
-        let mut path = self.clone_path();
-        path.push_lx(name)?;
-        Ok(path)
+    fn get_attr(&self) -> fuse_attr {
+        synthetic_root_attr(self.state.child_count())
     }
 
-    /// Locks the path and returns the value.
-    fn get_path(&self) -> parking_lot::RwLockReadGuard<'_, PathBuf> {
-        self.path.read()
+    fn get_statx(&self) -> fuse_statx {
+        synthetic_root_statx(self.state.child_count())
     }
+}
+
+fn submount_flag(is_submount: bool) -> u32 {
+    if is_submount { FUSE_ATTR_SUBMOUNT } else { 0 }
+}
+
+/// Build a child path by appending `name` to `parent`. Defense in depth:
+/// the FUSE request parser already rejects bad names, but validate here too
+/// so a bypass becomes `EINVAL` rather than a path-traversal hazard.
+fn child_path(parent: &Path, name: &LxStr) -> lx::Result<PathBuf> {
+    validate_child_name_bytes(name.as_bytes())?;
+    let mut path = parent.to_path_buf();
+    path.push_lx(name)?;
+    Ok(path)
+}
+
+/// Synthesizes a `fuse_attr` for the synthetic aggregate root directory.
+fn synthetic_root_attr(child_count: usize) -> fuse_attr {
+    // The mode MUST include the directory file-type bits or Linux will
+    // reject the attr as malformed (S_IFMT is zero -> "unknown type").
+    let mode = lx::S_IFDIR | 0o555;
+    // For a directory, nlink conventionally counts ".", "..", and each
+    // subdirectory's "..". With N children that's `2 + N`.
+    let nlink: u32 = 2u32.saturating_add(child_count as u32);
+    fuse_attr {
+        ino: FUSE_ROOT_ID,
+        size: 0,
+        blocks: 0,
+        atime: 0,
+        mtime: 0,
+        ctime: 0,
+        atimensec: 0,
+        mtimensec: 0,
+        ctimensec: 0,
+        mode,
+        nlink,
+        uid: 0,
+        gid: 0,
+        rdev: 0,
+        blksize: 4096,
+        flags: 0,
+    }
+}
+
+/// Synthesizes a `fuse_statx` for the synthetic aggregate root directory.
+fn synthetic_root_statx(child_count: usize) -> fuse_statx {
+    let mode = (lx::S_IFDIR | 0o555) as u16;
+    let nlink: u32 = 2u32.saturating_add(child_count as u32);
+    let zero_ts = || fuse_sx_time {
+        sec: 0,
+        nsec: 0,
+        _rsvd: 0,
+    };
+    let mask = lx::StatExMask::new()
+        .with_file_type(true)
+        .with_mode(true)
+        .with_nlink(true)
+        .with_uid(true)
+        .with_gid(true)
+        .with_ino(true)
+        .with_size(true)
+        .with_blocks(true);
+    fuse_statx {
+        mask: mask.into_bits(),
+        blksize: 4096,
+        attributes: 0,
+        nlink,
+        uid: 0,
+        gid: 0,
+        mode,
+        ino: FUSE_ROOT_ID,
+        size: 0,
+        blocks: 0,
+        attributes_mask: 0,
+        atime: zero_ts(),
+        btime: zero_ts(),
+        mtime: zero_ts(),
+        ctime: zero_ts(),
+        rdev_major: 0,
+        rdev_minor: 0,
+        dev_major: 0,
+        dev_minor: 0,
+        _rsvd1: 0,
+        _rsvd2: [0; 14],
+    }
+}
+
+/// Synthesizes a `fuse_kstatfs` for the synthetic aggregate root. The
+/// reported sizes are sane defaults; capacity numbers are zero (this is a
+/// "filesystem" with no real backing storage).
+fn synthetic_root_statfs() -> fuse_kstatfs {
+    // Note: `fuse_kstatfs::new` ordering -- (blocks, bfree, bavail, files,
+    // ffree, bsize, namelen, frsize).
+    fuse_kstatfs::new(0, 0, 0, 0, 0, 4096, 255, 4096)
 }

--- a/vm/devices/virtio/virtiofs/src/integration_tests.rs
+++ b/vm/devices/virtio/virtiofs/src/integration_tests.rs
@@ -7,6 +7,7 @@
 //! directory, then drive FUSE requests through the descriptor ring just
 //! as a guest kernel would.
 
+use crate::LxVolumeOptions;
 use crate::VirtioFs;
 use crate::virtio::VirtioFsDevice;
 use fuse::protocol::*;
@@ -48,7 +49,10 @@ const OUT_HEADER_SIZE: u32 = size_of::<fuse_out_header>() as u32;
 
 // --- Test Harness ---
 
-struct TestHarness {
+/// Shared FUSE virtqueue plumbing. Holds the device, guest memory, queue
+/// rings, and helpers for posting/reading FUSE requests. Used by both the
+/// single-root and aggregate test harnesses via `Deref`/`DerefMut`.
+struct FuseRing {
     device: VirtioFsDevice,
     mem: GuestMemory,
     driver: DefaultDriver,
@@ -58,35 +62,25 @@ struct TestHarness {
     used_idx: u16,
     next_data_offset: u64,
     next_unique: u64,
-    _tmpdir: tempfile::TempDir,
 }
 
-impl TestHarness {
-    fn new(driver: &DefaultDriver) -> Self {
-        let tmpdir = tempfile::tempdir().unwrap();
-
+impl FuseRing {
+    fn new(driver: &DefaultDriver, fs: VirtioFs, name: &str) -> Self {
         let mem = GuestMemory::allocate(TOTAL_MEM_SIZE);
         init_avail_ring(&mem, AVAIL_ADDR);
         init_used_ring(&mem, USED_ADDR);
-
-        let fs = VirtioFs::new(tmpdir.path(), None).unwrap();
         let driver_source = VmTaskDriverSource::new(SingleDriverBackend::new(driver.clone()));
-        let device = VirtioFsDevice::new(&driver_source, "testfs", fs, 0, None);
-
-        let queue_event = Event::new();
-        let interrupt_event = Event::new();
-
+        let device = VirtioFsDevice::new(&driver_source, name, fs, 0, None);
         Self {
             device,
             mem,
             driver: driver.clone(),
-            queue_event,
-            interrupt_event,
+            queue_event: Event::new(),
+            interrupt_event: Event::new(),
             avail_idx: 0,
             used_idx: 0,
             next_data_offset: DATA_BASE,
             next_unique: 1,
-            _tmpdir: tmpdir,
         }
     }
 
@@ -130,9 +124,9 @@ impl TestHarness {
         u
     }
 
-    /// Post a FUSE request with a readable descriptor (header + args) and a
-    /// writable descriptor (response buffer). Returns `(unique, resp_gpa)` —
-    /// the request's unique ID and the GPA of the response buffer.
+    /// Post a FUSE request with a readable descriptor (header + args) and
+    /// a writable descriptor (response buffer). Returns
+    /// `(unique, resp_gpa)`.
     fn post_fuse_request(
         &mut self,
         head_desc: u16,
@@ -146,7 +140,6 @@ impl TestHarness {
         let req_gpa = self.alloc_data(total_in_len);
         let resp_gpa = self.alloc_data(response_buf_size);
 
-        // Write the FUSE in_header + args
         let header = fuse_in_header {
             len: total_in_len,
             opcode,
@@ -164,11 +157,9 @@ impl TestHarness {
                 .unwrap();
         }
 
-        // Zero the response buffer
         let zeroes = vec![0u8; response_buf_size as usize];
         self.mem.write_at(resp_gpa, &zeroes).unwrap();
 
-        // desc 0: request (readable)
         let flags0 = DescriptorFlags::new().with_next(true);
         write_descriptor(
             &self.mem,
@@ -179,8 +170,6 @@ impl TestHarness {
             flags0,
             head_desc + 1,
         );
-
-        // desc 1: response (writable)
         let flags1 = DescriptorFlags::new().with_write(true);
         write_descriptor(
             &self.mem,
@@ -200,12 +189,11 @@ impl TestHarness {
             &mut self.avail_idx,
         );
         self.queue_event.signal();
-
         (unique, resp_gpa)
     }
 
-    /// Post a FUSE request that expects no reply (e.g. FORGET).
-    /// Uses a single readable descriptor with no writable descriptor.
+    /// Post a FUSE request that expects no reply (e.g. FORGET) using a
+    /// single readable descriptor.
     fn post_fuse_no_reply(&mut self, head_desc: u16, opcode: u32, nodeid: u64, args: &[u8]) {
         let unique = self.next_unique();
         let total_in_len = IN_HEADER_SIZE + args.len() as u32;
@@ -228,7 +216,6 @@ impl TestHarness {
                 .unwrap();
         }
 
-        // Single readable descriptor, no writable descriptor
         let flags = DescriptorFlags::new();
         write_descriptor(
             &self.mem,
@@ -262,14 +249,12 @@ impl TestHarness {
         .await
     }
 
-    /// Read the FUSE out_header from a response buffer GPA.
     fn read_out_header(&self, resp_gpa: u64) -> fuse_out_header {
         let mut buf = [0u8; size_of::<fuse_out_header>()];
         self.mem.read_at(resp_gpa, &mut buf).unwrap();
         fuse_out_header::read_from_bytes(&buf).unwrap()
     }
 
-    /// Read a response payload (after the out_header) from a response buffer.
     fn read_response<T: FromBytes>(&self, resp_gpa: u64) -> T {
         let offset = size_of::<fuse_out_header>() as u64;
         let mut buf = vec![0u8; size_of::<T>()];
@@ -277,35 +262,91 @@ impl TestHarness {
         T::read_from_bytes(&buf).unwrap()
     }
 
-    /// Send FUSE_INIT and wait for the response. Panics on failure.
-    async fn fuse_init(&mut self, head_desc: u16) {
+    /// Send FUSE_INIT with `flags`/`flags2` and wait for success. Returns
+    /// the device's `fuse_init_out` response.
+    async fn fuse_init_with(&mut self, head_desc: u16, flags: u32, flags2: u32) -> fuse_init_out {
         let init_args = fuse_init_in {
             major: FUSE_KERNEL_VERSION,
             minor: FUSE_KERNEL_MINOR_VERSION,
             max_readahead: 0,
-            flags: 0,
-            flags2: 0,
+            flags,
+            flags2,
             unused: [0; 11],
         };
-
         let resp_size = OUT_HEADER_SIZE + size_of::<fuse_init_out>() as u32;
         let (unique, resp_gpa) =
             self.post_fuse_request(head_desc, FUSE_INIT, 0, init_args.as_bytes(), resp_size);
-
         let (_used_id, used_len) = self.wait_for_used().await;
         assert!(used_len > 0, "FUSE_INIT response should not be empty");
-
         let out_header = self.read_out_header(resp_gpa);
         assert_eq!(out_header.unique, unique);
         assert_eq!(out_header.error, 0, "FUSE_INIT failed");
-
         let init_out: fuse_init_out = self.read_response(resp_gpa);
         assert_eq!(init_out.major, FUSE_KERNEL_VERSION);
+        init_out
     }
 
-    /// Return the path to the temp directory backing the filesystem.
+    /// Send a plain FUSE_INIT (no flags) and wait for success.
+    async fn fuse_init(&mut self, head_desc: u16) {
+        let _ = self.fuse_init_with(head_desc, 0, 0).await;
+    }
+
+    /// Issue FUSE_LOOKUP for `name` under `parent_nodeid`. Returns the
+    /// `fuse_entry_out`. Panics if lookup fails.
+    async fn lookup_child(
+        &mut self,
+        head_desc: u16,
+        parent_nodeid: u64,
+        name: &[u8],
+    ) -> fuse_entry_out {
+        let mut name_bytes = name.to_vec();
+        name_bytes.push(0);
+        let resp_size = OUT_HEADER_SIZE + size_of::<fuse_entry_out>() as u32;
+        let (unique, resp_gpa) = self.post_fuse_request(
+            head_desc,
+            FUSE_LOOKUP,
+            parent_nodeid,
+            &name_bytes,
+            resp_size,
+        );
+        let (_used_id, _used_len) = self.wait_for_used().await;
+        let out_header = self.read_out_header(resp_gpa);
+        assert_eq!(out_header.unique, unique);
+        assert_eq!(out_header.error, 0, "LOOKUP failed");
+        self.read_response::<fuse_entry_out>(resp_gpa)
+    }
+}
+
+struct TestHarness {
+    ring: FuseRing,
+    _tmpdir: tempfile::TempDir,
+}
+
+impl TestHarness {
+    fn new(driver: &DefaultDriver) -> Self {
+        let tmpdir = tempfile::tempdir().unwrap();
+        let fs = VirtioFs::new(tmpdir.path(), None).unwrap();
+        Self {
+            ring: FuseRing::new(driver, fs, "testfs"),
+            _tmpdir: tmpdir,
+        }
+    }
+
     fn tmpdir_path(&self) -> &std::path::Path {
         self._tmpdir.path()
+    }
+}
+
+impl std::ops::Deref for TestHarness {
+    type Target = FuseRing;
+    fn deref(&self) -> &FuseRing {
+        &self.ring
+    }
+}
+
+impl std::ops::DerefMut for TestHarness {
+    fn deref_mut(&mut self) -> &mut FuseRing {
+        &mut self.ring
     }
 }
 
@@ -386,22 +427,24 @@ async fn malformed_request_completes_descriptor(driver: DefaultDriver) {
     let mut harness = TestHarness::new(&driver);
     harness.enable().await;
 
+    // Use the inner ring directly so we can split borrows over distinct fields.
+    let ring = &mut harness.ring;
+
     // Post a descriptor with garbage data (not a valid FUSE header).
     let garbage = [0xFFu8; 4]; // Too short to be a fuse_in_header
-    let req_gpa = harness.alloc_data(garbage.len() as u32);
-    harness.mem.write_at(req_gpa, &garbage).unwrap();
+    let req_gpa = ring.alloc_data(garbage.len() as u32);
+    ring.mem.write_at(req_gpa, &garbage).unwrap();
 
     let resp_size = 256u32;
-    let resp_gpa = harness.alloc_data(resp_size);
-    harness
-        .mem
+    let resp_gpa = ring.alloc_data(resp_size);
+    ring.mem
         .write_at(resp_gpa, &vec![0u8; resp_size as usize])
         .unwrap();
 
     // desc 0: garbage request (readable)
     let flags0 = DescriptorFlags::new().with_next(true);
     write_descriptor(
-        &harness.mem,
+        &ring.mem,
         DESC_ADDR,
         0,
         req_gpa,
@@ -412,18 +455,12 @@ async fn malformed_request_completes_descriptor(driver: DefaultDriver) {
 
     // desc 1: response buffer (writable)
     let flags1 = DescriptorFlags::new().with_write(true);
-    write_descriptor(&harness.mem, DESC_ADDR, 1, resp_gpa, resp_size, flags1, 0);
+    write_descriptor(&ring.mem, DESC_ADDR, 1, resp_gpa, resp_size, flags1, 0);
 
-    make_available(
-        &harness.mem,
-        AVAIL_ADDR,
-        QUEUE_SIZE,
-        0,
-        &mut harness.avail_idx,
-    );
-    harness.queue_event.signal();
+    make_available(&ring.mem, AVAIL_ADDR, QUEUE_SIZE, 0, &mut ring.avail_idx);
+    ring.queue_event.signal();
 
-    let (_used_id, used_len) = harness.wait_for_used().await;
+    let (_used_id, used_len) = ring.wait_for_used().await;
     // The device should complete the descriptor (possibly with 0 bytes)
     // rather than hanging.
     let _ = used_len; // Any completion is acceptable.
@@ -466,6 +503,28 @@ async fn lookup_existing_file(driver: DefaultDriver) {
     );
 }
 
+/// Repeated LOOKUP of the same path on a stable-id volume must return the
+/// same FUSE node id, proving the inode map deduplicates by identity. A
+/// stable node id is what the guest relies on for inode-keyed features such
+/// as inotify; the aggregate/FAT path achieves the same via path-based
+/// dedup, which can only be exercised against a real FAT volume.
+#[async_test]
+async fn repeated_lookup_returns_stable_nodeid(driver: DefaultDriver) {
+    let mut harness = TestHarness::new(&driver);
+    std::fs::write(harness.tmpdir_path().join("hello.txt"), "test data").unwrap();
+
+    harness.enable().await;
+    harness.fuse_init(0).await;
+
+    let first = harness.lookup_child(2, FUSE_ROOT_ID, b"hello.txt").await;
+    let second = harness.lookup_child(2, FUSE_ROOT_ID, b"hello.txt").await;
+    assert_ne!(first.nodeid, 0, "returned nodeid should be non-zero");
+    assert_eq!(
+        first.nodeid, second.nodeid,
+        "repeated lookup of the same path must return a stable node id"
+    );
+}
+
 /// LOOKUP on a non-existent file returns ENOENT.
 #[async_test]
 async fn lookup_nonexistent_returns_enoent(driver: DefaultDriver) {
@@ -497,31 +556,9 @@ async fn lookup_nonexistent_returns_enoent(driver: DefaultDriver) {
 async fn init_negotiates_direct_io_allow_mmap(driver: DefaultDriver) {
     let mut harness = TestHarness::new(&driver);
     harness.enable().await;
-
-    // Send FUSE_INIT with FUSE_INIT_EXT set in flags and
-    // FUSE_DIRECT_IO_ALLOW_MMAP_FLAG2 advertised in flags2.
-    let init_args = fuse_init_in {
-        major: FUSE_KERNEL_VERSION,
-        minor: FUSE_KERNEL_MINOR_VERSION,
-        max_readahead: 131072,
-        flags: FUSE_INIT_EXT,
-        flags2: FUSE_DIRECT_IO_ALLOW_MMAP_FLAG2,
-        unused: [0; 11],
-    };
-
-    let resp_size = OUT_HEADER_SIZE + size_of::<fuse_init_out>() as u32;
-    let (unique, resp_gpa) =
-        harness.post_fuse_request(0, FUSE_INIT, 0, init_args.as_bytes(), resp_size);
-
-    let (_used_id, used_len) = harness.wait_for_used().await;
-    assert!(used_len > 0, "FUSE_INIT response should not be empty");
-
-    let out_header = harness.read_out_header(resp_gpa);
-    assert_eq!(out_header.unique, unique);
-    assert_eq!(out_header.error, 0, "FUSE_INIT failed");
-
-    let init_out: fuse_init_out = harness.read_response(resp_gpa);
-    assert_eq!(init_out.major, FUSE_KERNEL_VERSION);
+    let init_out = harness
+        .fuse_init_with(0, FUSE_INIT_EXT, FUSE_DIRECT_IO_ALLOW_MMAP_FLAG2)
+        .await;
     assert_ne!(
         init_out.flags & FUSE_INIT_EXT,
         0,
@@ -532,4 +569,515 @@ async fn init_negotiates_direct_io_allow_mmap(driver: DefaultDriver) {
         0,
         "VirtioFs should request FUSE_DIRECT_IO_ALLOW_MMAP_FLAG2 when kernel advertises it"
     );
+}
+
+// --- Aggregate (multi-path) tests ---
+
+/// Aggregate-virtio-fs harness: wraps a [`FuseRing`] with multiple backing
+/// tempdirs and a live [`crate::VirtiofsAggregateHandle`] for tests that
+/// exercise post-construction `add_child`.
+struct AggregateTestHarness {
+    ring: FuseRing,
+    tmpdirs: Vec<tempfile::TempDir>,
+    aggregate_handle: crate::VirtiofsAggregateHandle,
+}
+
+impl AggregateTestHarness {
+    fn new(driver: &DefaultDriver, child_names: &[&str]) -> Self {
+        let mut tmpdirs = Vec::with_capacity(child_names.len());
+        let mut children = Vec::with_capacity(child_names.len());
+        for name in child_names {
+            let tmpdir = tempfile::tempdir().unwrap();
+            children.push(crate::VirtioFsChild {
+                name: (*name).to_string(),
+                root_path: tmpdir.path().to_path_buf(),
+                options: None,
+            });
+            tmpdirs.push(tmpdir);
+        }
+        let fs = VirtioFs::new_aggregate(children).unwrap();
+        let aggregate_handle = fs.aggregate_handle().unwrap();
+        Self {
+            ring: FuseRing::new(driver, fs, "aggfs"),
+            tmpdirs,
+            aggregate_handle,
+        }
+    }
+
+    /// Allocate a fresh tempdir owned by this harness so backing storage
+    /// for a dynamically-added child lives until the harness drops.
+    fn alloc_child_tmpdir(&mut self) -> std::path::PathBuf {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().to_path_buf();
+        self.tmpdirs.push(dir);
+        path
+    }
+
+    /// Build a harness where every named child is backed by the *same* host
+    /// directory. Used to prove per-share inode namespacing: the children
+    /// stat identical underlying inodes, so any difference in the reported
+    /// `st_ino` comes purely from namespacing.
+    fn new_shared_backing(driver: &DefaultDriver, child_names: &[&str]) -> Self {
+        let tmpdir = tempfile::tempdir().unwrap();
+        let children = child_names
+            .iter()
+            .map(|name| crate::VirtioFsChild {
+                name: (*name).to_string(),
+                root_path: tmpdir.path().to_path_buf(),
+                options: None,
+            })
+            .collect();
+        let fs = VirtioFs::new_aggregate(children).unwrap();
+        let aggregate_handle = fs.aggregate_handle().unwrap();
+        Self {
+            ring: FuseRing::new(driver, fs, "aggfs"),
+            tmpdirs: vec![tmpdir],
+            aggregate_handle,
+        }
+    }
+}
+
+impl std::ops::Deref for AggregateTestHarness {
+    type Target = FuseRing;
+    fn deref(&self) -> &FuseRing {
+        &self.ring
+    }
+}
+
+impl std::ops::DerefMut for AggregateTestHarness {
+    fn deref_mut(&mut self) -> &mut FuseRing {
+        &mut self.ring
+    }
+}
+
+/// FUSE_INIT with FUSE_SUBMOUNTS advertised: VirtioFs::init should request
+/// the feature back in the response so the kernel will honor
+/// FUSE_ATTR_SUBMOUNT.
+#[async_test]
+async fn aggregate_init_negotiates_submounts(driver: DefaultDriver) {
+    let mut harness = AggregateTestHarness::new(&driver, &["alpha", "beta"]);
+    harness.enable().await;
+    let init_out = harness.fuse_init_with(0, FUSE_SUBMOUNTS, 0).await;
+    assert_ne!(
+        init_out.flags & FUSE_SUBMOUNTS,
+        0,
+        "VirtioFs should accept FUSE_SUBMOUNTS when the kernel advertises it"
+    );
+}
+
+/// GETATTR on the synthetic root reports a directory with nlink = 2 +
+/// number of children.
+#[async_test]
+async fn aggregate_root_getattr_returns_directory(driver: DefaultDriver) {
+    let mut harness = AggregateTestHarness::new(&driver, &["alpha", "beta", "gamma"]);
+    harness.enable().await;
+    harness.fuse_init(0).await;
+
+    let getattr_args = fuse_getattr_in {
+        getattr_flags: 0,
+        dummy: 0,
+        fh: 0,
+    };
+    let resp_size = OUT_HEADER_SIZE + size_of::<fuse_attr_out>() as u32;
+    let (_unique, resp_gpa) = harness.post_fuse_request(
+        2,
+        FUSE_GETATTR,
+        FUSE_ROOT_ID,
+        getattr_args.as_bytes(),
+        resp_size,
+    );
+    let (_used_id, _used_len) = harness.wait_for_used().await;
+    let out_header = harness.read_out_header(resp_gpa);
+    assert_eq!(out_header.error, 0, "GETATTR on aggregate root failed");
+    let attr_out: fuse_attr_out = harness.read_response(resp_gpa);
+    assert_eq!(
+        attr_out.attr.mode & 0o170000,
+        0o040000,
+        "synthetic root should be a directory"
+    );
+    assert_eq!(attr_out.attr.ino, FUSE_ROOT_ID);
+    assert_eq!(
+        attr_out.attr.nlink, 5,
+        "nlink should be 2 + child count (3) = 5"
+    );
+}
+
+/// LOOKUP of a named child returns a directory inode with
+/// FUSE_ATTR_SUBMOUNT set in attr.flags, so the kernel auto-mounts it.
+#[async_test]
+async fn aggregate_lookup_child_sets_submount_flag(driver: DefaultDriver) {
+    let mut harness = AggregateTestHarness::new(&driver, &["alpha", "beta"]);
+    harness.enable().await;
+    harness.fuse_init(0).await;
+
+    let entry = harness.lookup_child(2, FUSE_ROOT_ID, b"alpha").await;
+    assert_ne!(entry.nodeid, 0, "child nodeid must be non-zero");
+    assert_ne!(
+        entry.nodeid, FUSE_ROOT_ID,
+        "child nodeid must differ from root"
+    );
+    assert_eq!(
+        entry.attr.mode & 0o170000,
+        0o040000,
+        "child root should be a directory"
+    );
+    assert_ne!(
+        entry.attr.flags & FUSE_ATTR_SUBMOUNT,
+        0,
+        "child lookup must set FUSE_ATTR_SUBMOUNT so the kernel auto-mounts the subtree"
+    );
+}
+
+/// Two aggregate children backed by the *same* host directory must report
+/// *distinct* inode numbers for their (identical) submount roots, proving
+/// per-share inode namespacing prevents cross-share `(st_dev, st_ino)`
+/// collisions under the single shared superblock. The reported number must
+/// also be stable across repeated lookups of the same child.
+#[async_test]
+async fn aggregate_children_namespace_inode_numbers(driver: DefaultDriver) {
+    let mut harness = AggregateTestHarness::new_shared_backing(&driver, &["alpha", "beta"]);
+    harness.enable().await;
+    harness.fuse_init(0).await;
+
+    let alpha = harness.lookup_child(2, FUSE_ROOT_ID, b"alpha").await;
+    let beta = harness.lookup_child(2, FUSE_ROOT_ID, b"beta").await;
+
+    // Both submount roots stat the same physical directory, so any
+    // difference in the reported inode number comes purely from namespacing.
+    assert_ne!(
+        alpha.attr.ino, beta.attr.ino,
+        "children backed by the same directory must get distinct namespaced inode numbers"
+    );
+
+    let alpha_again = harness.lookup_child(2, FUSE_ROOT_ID, b"alpha").await;
+    assert_eq!(
+        alpha.attr.ino, alpha_again.attr.ino,
+        "repeated lookup of the same child must report a stable inode number"
+    );
+}
+
+/// The inode number reported for a child's submount root via LOOKUP must
+/// match the one reported via GETATTR on the same nodeid, i.e. namespacing
+/// is applied consistently across reply paths.
+#[async_test]
+async fn aggregate_child_inode_number_consistent_across_lookup_and_getattr(driver: DefaultDriver) {
+    let mut harness = AggregateTestHarness::new(&driver, &["alpha", "beta"]);
+    harness.enable().await;
+    harness.fuse_init(0).await;
+
+    let entry = harness.lookup_child(2, FUSE_ROOT_ID, b"alpha").await;
+
+    let getattr_args = fuse_getattr_in {
+        getattr_flags: 0,
+        dummy: 0,
+        fh: 0,
+    };
+    let resp_size = OUT_HEADER_SIZE + size_of::<fuse_attr_out>() as u32;
+    let (_unique, resp_gpa) = harness.post_fuse_request(
+        2,
+        FUSE_GETATTR,
+        entry.nodeid,
+        getattr_args.as_bytes(),
+        resp_size,
+    );
+    let (_used_id, _used_len) = harness.wait_for_used().await;
+    let out_header = harness.read_out_header(resp_gpa);
+    assert_eq!(out_header.error, 0, "GETATTR on child failed");
+    let attr_out: fuse_attr_out = harness.read_response(resp_gpa);
+    assert_eq!(
+        entry.attr.ino, attr_out.attr.ino,
+        "LOOKUP and GETATTR must agree on the namespaced inode number"
+    );
+}
+
+/// LOOKUP of a non-existent child returns ENOENT.
+#[async_test]
+async fn aggregate_lookup_missing_child_returns_enoent(driver: DefaultDriver) {
+    let mut harness = AggregateTestHarness::new(&driver, &["alpha", "beta"]);
+    harness.enable().await;
+    harness.fuse_init(0).await;
+
+    let name = b"does_not_exist\0";
+    let resp_size = OUT_HEADER_SIZE + size_of::<fuse_entry_out>() as u32;
+    let (_unique, resp_gpa) =
+        harness.post_fuse_request(2, FUSE_LOOKUP, FUSE_ROOT_ID, name, resp_size);
+    let (_used_id, _used_len) = harness.wait_for_used().await;
+    let out_header = harness.read_out_header(resp_gpa);
+    assert_eq!(
+        out_header.error, -2,
+        "LOOKUP on missing aggregate child should return ENOENT"
+    );
+}
+
+/// Mutating operations on the synthetic root must fail with EROFS even
+/// though the children themselves are writable, because the synthetic
+/// root is purely a navigation layer (it has nowhere to put new files).
+#[async_test]
+async fn aggregate_mkdir_on_root_returns_erofs(driver: DefaultDriver) {
+    let mut harness = AggregateTestHarness::new(&driver, &["alpha", "beta"]);
+    harness.enable().await;
+    harness.fuse_init(0).await;
+
+    let mkdir_args = fuse_mkdir_in {
+        mode: 0o755,
+        umask: 0,
+    };
+    let mut args = mkdir_args.as_bytes().to_vec();
+    args.extend_from_slice(b"new_dir\0");
+
+    let resp_size = OUT_HEADER_SIZE + size_of::<fuse_entry_out>() as u32;
+    let (_unique, resp_gpa) =
+        harness.post_fuse_request(2, FUSE_MKDIR, FUSE_ROOT_ID, &args, resp_size);
+    let (_used_id, _used_len) = harness.wait_for_used().await;
+    let out_header = harness.read_out_header(resp_gpa);
+    // EROFS = -30
+    assert_eq!(
+        out_header.error, -30,
+        "MKDIR on synthetic root should return EROFS"
+    );
+}
+
+/// Cross-volume rename: rename a file from inside child A's volume to
+/// inside child B's volume must return EXDEV.
+#[async_test]
+async fn aggregate_rename_across_children_returns_exdev(driver: DefaultDriver) {
+    let mut harness = AggregateTestHarness::new(&driver, &["alpha", "beta"]);
+    harness.enable().await;
+    harness.fuse_init(0).await;
+
+    // Look up both child submount roots so we have FUSE node IDs for
+    // each. (Order matters: each lookup posts at a different head_desc.)
+    let alpha = harness.lookup_child(2, FUSE_ROOT_ID, b"alpha").await;
+    let beta = harness.lookup_child(4, FUSE_ROOT_ID, b"beta").await;
+    assert_ne!(alpha.nodeid, beta.nodeid);
+
+    // Issue FUSE_RENAME with olddir = alpha.nodeid, newdir = beta.nodeid.
+    // The names don't need to exist — `Real::rename` checks the volume IDs
+    // first and short-circuits with EXDEV before any host I/O.
+    let rename_args = fuse_rename_in {
+        newdir: beta.nodeid,
+    };
+    let mut args = rename_args.as_bytes().to_vec();
+    args.extend_from_slice(b"src\0");
+    args.extend_from_slice(b"dst\0");
+
+    let resp_size = OUT_HEADER_SIZE;
+    let (_unique, resp_gpa) =
+        harness.post_fuse_request(6, FUSE_RENAME, alpha.nodeid, &args, resp_size);
+    let (_used_id, _used_len) = harness.wait_for_used().await;
+    let out_header = harness.read_out_header(resp_gpa);
+    // EXDEV = -18
+    assert_eq!(
+        out_header.error, -18,
+        "rename across aggregate children should return EXDEV"
+    );
+}
+
+/// `VirtioFs::new_aggregate` rejects an empty children list.
+#[test]
+fn aggregate_constructor_rejects_empty_children() {
+    let err = VirtioFs::new_aggregate(Vec::new()).err();
+    assert!(matches!(err, Some(e) if e.value() == lx::Error::EINVAL.value()));
+}
+
+/// `VirtioFs::new_aggregate` rejects duplicate child names.
+#[test]
+fn aggregate_constructor_rejects_duplicate_names() {
+    let tmp = tempfile::tempdir().unwrap();
+    let children = vec![
+        crate::VirtioFsChild {
+            name: "shared".into(),
+            root_path: tmp.path().to_path_buf(),
+            options: None,
+        },
+        crate::VirtioFsChild {
+            name: "shared".into(),
+            root_path: tmp.path().to_path_buf(),
+            options: None,
+        },
+    ];
+    let err = VirtioFs::new_aggregate(children).err();
+    assert!(err.is_some(), "duplicate names must be rejected");
+}
+
+/// `VirtioFs::new_aggregate` rejects names containing `/` or NUL, and
+/// `.` / `..`.
+#[test]
+fn aggregate_constructor_rejects_invalid_names() {
+    let tmp = tempfile::tempdir().unwrap();
+    for bad in ["", ".", "..", "a/b", "with\0nul"] {
+        let children = vec![crate::VirtioFsChild {
+            name: bad.into(),
+            root_path: tmp.path().to_path_buf(),
+            options: None,
+        }];
+        let err = VirtioFs::new_aggregate(children).err();
+        assert!(err.is_some(), "name {bad:?} must be rejected");
+    }
+}
+
+// -------------------------------------------------------------------
+// Live aggregate extension (`VirtiofsAggregateHandle::add_child`).
+// -------------------------------------------------------------------
+
+/// After `add_child`, the new entry appears in readdir of the synthetic
+/// root and is lookup-able by name with FUSE_ATTR_SUBMOUNT set.
+#[async_test]
+async fn aggregate_live_extension_visible_to_lookup(driver: DefaultDriver) {
+    let mut harness = AggregateTestHarness::new(&driver, &["alpha"]);
+    harness.enable().await;
+    harness.fuse_init(0).await;
+
+    // Sanity: looking up "beta" before extension returns ENOENT.
+    let name = b"beta\0";
+    let resp_size = OUT_HEADER_SIZE + size_of::<fuse_entry_out>() as u32;
+    let (_unique, resp_gpa) =
+        harness.post_fuse_request(2, FUSE_LOOKUP, FUSE_ROOT_ID, name, resp_size);
+    let (_used_id, _used_len) = harness.wait_for_used().await;
+    let out_header = harness.read_out_header(resp_gpa);
+    assert_eq!(
+        out_header.error, -2,
+        "LOOKUP before add_child should be ENOENT"
+    );
+
+    // Append a new child.
+    let path = harness.alloc_child_tmpdir();
+    harness
+        .aggregate_handle
+        .add_child(crate::VirtioFsChild {
+            name: "beta".into(),
+            root_path: path,
+            options: None,
+        })
+        .expect("add_child should succeed");
+
+    // GETATTR on root now reports nlink = 2 + 2 = 4.
+    let getattr_args = fuse_getattr_in {
+        getattr_flags: 0,
+        dummy: 0,
+        fh: 0,
+    };
+    let resp_size = OUT_HEADER_SIZE + size_of::<fuse_attr_out>() as u32;
+    let (_unique, resp_gpa) = harness.post_fuse_request(
+        4,
+        FUSE_GETATTR,
+        FUSE_ROOT_ID,
+        getattr_args.as_bytes(),
+        resp_size,
+    );
+    let (_used_id, _used_len) = harness.wait_for_used().await;
+    let out_header = harness.read_out_header(resp_gpa);
+    assert_eq!(out_header.error, 0);
+    let attr_out: fuse_attr_out = harness.read_response(resp_gpa);
+    assert_eq!(
+        attr_out.attr.nlink, 4,
+        "nlink should grow to 2 + 2 after add_child"
+    );
+
+    // LOOKUP of new child succeeds and carries FUSE_ATTR_SUBMOUNT.
+    let entry = harness.lookup_child(6, FUSE_ROOT_ID, b"beta").await;
+    assert_ne!(entry.nodeid, 0);
+    assert_ne!(
+        entry.attr.flags & FUSE_ATTR_SUBMOUNT,
+        0,
+        "dynamically-added child must also carry FUSE_ATTR_SUBMOUNT"
+    );
+}
+
+/// `add_child` rejects a duplicate name with EEXIST. The original child
+/// is not disturbed.
+#[test]
+fn aggregate_add_child_duplicate_name_returns_eexist() {
+    let tmp1 = tempfile::tempdir().unwrap();
+    let tmp2 = tempfile::tempdir().unwrap();
+    let children = vec![crate::VirtioFsChild {
+        name: "shared".into(),
+        root_path: tmp1.path().to_path_buf(),
+        options: None,
+    }];
+    let fs = VirtioFs::new_aggregate(children).unwrap();
+    let handle = fs.aggregate_handle().unwrap();
+    let err = handle
+        .add_child(crate::VirtioFsChild {
+            name: "shared".into(),
+            root_path: tmp2.path().to_path_buf(),
+            options: None,
+        })
+        .expect_err("duplicate add_child must fail");
+    assert_eq!(err.value(), lx::Error::EEXIST.value());
+}
+
+/// `add_child` rejects an invalid name with EINVAL (delegating to
+/// `validate_child_name`).
+#[test]
+fn aggregate_add_child_invalid_name_returns_einval() {
+    let tmp = tempfile::tempdir().unwrap();
+    let other = tempfile::tempdir().unwrap();
+    let children = vec![crate::VirtioFsChild {
+        name: "alpha".into(),
+        root_path: tmp.path().to_path_buf(),
+        options: None,
+    }];
+    let fs = VirtioFs::new_aggregate(children).unwrap();
+    let handle = fs.aggregate_handle().unwrap();
+    for bad in ["", ".", "..", "a/b", "with\0nul"] {
+        let err = handle
+            .add_child(crate::VirtioFsChild {
+                name: bad.into(),
+                root_path: other.path().to_path_buf(),
+                options: None,
+            })
+            .err()
+            .unwrap_or_else(|| panic!("name {bad:?} should be rejected"));
+        assert_eq!(err.value(), lx::Error::EINVAL.value(), "name = {bad:?}");
+    }
+}
+
+/// `add_child` rejects a child whose readonly setting differs from the
+/// aggregate's. The initial aggregate here is read-write (default), so
+/// adding a read-only child must fail with EINVAL.
+#[test]
+fn aggregate_add_child_readonly_mismatch_returns_einval() {
+    let tmp = tempfile::tempdir().unwrap();
+    let other = tempfile::tempdir().unwrap();
+    let children = vec![crate::VirtioFsChild {
+        name: "rw".into(),
+        root_path: tmp.path().to_path_buf(),
+        options: None,
+    }];
+    let fs = VirtioFs::new_aggregate(children).unwrap();
+    let handle = fs.aggregate_handle().unwrap();
+    let ro_opts = LxVolumeOptions::from_option_string("ro");
+    let err = handle
+        .add_child(crate::VirtioFsChild {
+            name: "ro".into(),
+            root_path: other.path().to_path_buf(),
+            options: Some(ro_opts),
+        })
+        .expect_err("readonly mismatch must fail");
+    assert_eq!(err.value(), lx::Error::EINVAL.value());
+}
+
+/// After the owning `VirtioFs` drops, calls on a retained handle must
+/// return EAGAIN (the aggregate is `TearingDown`).
+#[test]
+fn aggregate_add_child_after_drop_returns_eagain() {
+    let tmp = tempfile::tempdir().unwrap();
+    let other = tempfile::tempdir().unwrap();
+    let children = vec![crate::VirtioFsChild {
+        name: "alpha".into(),
+        root_path: tmp.path().to_path_buf(),
+        options: None,
+    }];
+    let fs = VirtioFs::new_aggregate(children).unwrap();
+    let handle = fs.aggregate_handle().unwrap();
+    drop(fs);
+    let err = handle
+        .add_child(crate::VirtioFsChild {
+            name: "beta".into(),
+            root_path: other.path().to_path_buf(),
+            options: None,
+        })
+        .expect_err("add_child after device drop must fail");
+    assert_eq!(err.value(), lx::Error::EAGAIN.value());
 }

--- a/vm/devices/virtio/virtiofs/src/lib.rs
+++ b/vm/devices/virtio/virtiofs/src/lib.rs
@@ -21,10 +21,15 @@ pub use section::SectionFs;
 use file::VirtioFsFile;
 use fuse::protocol::*;
 use fuse::*;
+use inode::AggregateState;
+use inode::DedupKey;
+use inode::SyntheticChild;
 use inode::VirtioFsInode;
+use inode::Volume;
 pub use lxutil::LxVolumeOptions;
 use parking_lot::RwLock;
 use std::collections::HashMap;
+use std::collections::HashSet;
 use std::collections::hash_map::Entry;
 use std::path::Path;
 use std::path::PathBuf;
@@ -47,6 +52,65 @@ pub struct VirtioFs {
     inodes: RwLock<InodeMap>,
     files: RwLock<HandleMap<Arc<VirtioFsFile>>>,
     readonly: bool,
+    /// `Some` only for aggregate devices. Held so that `Drop` can mark the
+    /// state as `TearingDown`, causing any externally-held
+    /// [`VirtiofsAggregateHandle`] to start rejecting `add_child`.
+    aggregate_state: Option<Arc<AggregateState>>,
+}
+
+impl Drop for VirtioFs {
+    fn drop(&mut self) {
+        if let Some(state) = &self.aggregate_state {
+            state.mark_tearing_down();
+        }
+    }
+}
+
+/// Handle to a live aggregate virtio-fs device that can append new
+/// children after construction. Obtained from
+/// [`VirtioFs::aggregate_handle`]; `add_child` is visible to the guest on
+/// the next LOOKUP/READDIR. Cloning shares the underlying state.
+#[derive(Clone)]
+pub struct VirtiofsAggregateHandle {
+    state: Arc<AggregateState>,
+}
+
+impl VirtiofsAggregateHandle {
+    /// Append a new child to the live aggregate.
+    ///
+    /// Errors:
+    /// - `EAGAIN` — the owning device has begun tearing down.
+    /// - `EINVAL` — `child.name` failed validation, or its readonly setting
+    ///   does not match the aggregate's.
+    /// - `EEXIST` — a child with this name is already present.
+    /// - any `lx::Error` propagated from `LxVolume` construction.
+    ///
+    /// Slow operations (volume creation, root stat) run outside the
+    /// children write lock so they do not block concurrent LOOKUP/READDIR.
+    pub fn add_child(&self, child: VirtioFsChild) -> lx::Result<()> {
+        inode::validate_child_name_bytes(child.name.as_bytes())?;
+
+        // Fast-fail without paying for volume construction if the device is
+        // already tearing down. The duplicate-name check is enforced
+        // authoritatively (under the lock) by `AggregateState::add_child`.
+        if !self.state.is_active() {
+            return Err(lx::Error::EAGAIN);
+        }
+
+        // Reject a readonly mismatch before building the (expensive) volume.
+        // The aggregate's readonly value is fixed at construction. The check
+        // is repeated authoritatively under the lock in
+        // `AggregateState::add_child`.
+        let child_readonly = child.readonly();
+        if child_readonly != self.state.readonly() {
+            return Err(lx::Error::EINVAL);
+        }
+
+        let volume = child.build_volume()?;
+        let name = lx::LxString::from_vec(child.name.into_bytes());
+
+        self.state.add_child(name, volume, child_readonly)
+    }
 }
 
 impl Fuse for VirtioFs {
@@ -67,6 +131,25 @@ impl Fuse for VirtioFs {
         // coherency issues with the host, but applications still need mmap.
         if info.capable2() & FUSE_DIRECT_IO_ALLOW_MMAP_FLAG2 != 0 {
             info.want2 |= FUSE_DIRECT_IO_ALLOW_MMAP_FLAG2;
+        }
+
+        // Opt in to FUSE_SUBMOUNTS so the kernel honors the
+        // `FUSE_ATTR_SUBMOUNT` flag returned on the root inode of each
+        // child of an aggregate (multi-path) virtio-fs root. The flag is
+        // harmless when single-root mounts never set the attr bit.
+        //
+        // N.B. FUSE_SUBMOUNTS is best-effort isolation: when honored it
+        // gives each child its own superblock (distinct `st_dev`). But
+        // whether the kernel actually instantiates the submount depends on
+        // guest-side mount mechanics (e.g. WSL bind-mounts each child from a
+        // subpath of the synthetic root, which can pin the child dentry as a
+        // plain, non-automount dentry so the submount never fires). The
+        // correctness of the aggregate therefore does *not* rely on
+        // submounts: child inode numbers are namespaced per share (see
+        // `Volume::namespaced_ino`) so `(st_dev, st_ino)` collisions across
+        // children are avoided even under a single shared superblock.
+        if info.capable() & FUSE_SUBMOUNTS != 0 {
+            info.want |= FUSE_SUBMOUNTS;
         }
     }
 
@@ -138,6 +221,14 @@ impl Fuse for VirtioFs {
     }
 
     fn forget(&self, node_id: u64, lookup_count: u64) {
+        // The FUSE protocol guarantees that the kernel never forgets the
+        // root inode. Defend against malformed/forged guest requests
+        // anyway: dropping the root would corrupt all subsequent lookups
+        // (every path resolves through FUSE_ROOT_ID).
+        if node_id == FUSE_ROOT_ID {
+            tracing::warn!(lookup_count, "ignoring forget on root inode");
+            return;
+        }
         // This must be done under lock so an inode can't be resurrected between the lookup count
         // reaching zero and removing it from the list.
         let mut inodes = self.inodes.write();
@@ -174,7 +265,7 @@ impl Fuse for VirtioFs {
         // on the inode number (if this is a non-exclusive create), so make sure to associate the
         // file with the returned inode.
         let (new_inode, node_id) = self.insert_inode(new_inode);
-        let file = VirtioFsFile::new(file, new_inode);
+        let file = VirtioFsFile::new_real(file, new_inode);
         let fh = self.insert_file(file);
         Ok(CreateOut {
             entry: fuse_entry_out::new(node_id, ENTRY_TIMEOUT, ATTRIBUTE_TIMEOUT, attr),
@@ -320,7 +411,22 @@ impl Fuse for VirtioFs {
         let inode = self.get_inode(request.node_id())?;
         let new_inode = self.get_inode(new_dir)?;
         self.check_writable()?;
-        inode.rename(name, &new_inode, new_name, flags)
+        inode.rename(name, &new_inode, new_name, flags)?;
+        // On path-keyed (non-stable-id) volumes a rename moves data between
+        // paths without preserving inode identity, so detach both the source
+        // path (now vacated) and the destination path (its prior occupant, if
+        // any, was replaced) from any node ids they referenced. This avoids a
+        // later lookup aliasing a stale node id. (Descendants of a renamed
+        // directory keep stale path keys; this is a known, narrow limitation
+        // — FAT cannot preserve inode identity across rename regardless.)
+        let mut inodes = self.inodes.write();
+        if let Some(key) = inode.child_path_dedup_key(name) {
+            inodes.evict_dedup_key(&key);
+        }
+        if let Some(key) = new_inode.child_path_dedup_key(new_name) {
+            inodes.evict_dedup_key(&key);
+        }
+        Ok(())
     }
 
     fn statfs(&self, request: &Request) -> lx::Result<fuse_kstatfs> {
@@ -440,23 +546,103 @@ impl VirtioFs {
         mount_options: Option<&LxVolumeOptions>,
     ) -> lx::Result<Self> {
         let readonly = mount_options.is_some_and(|o| o.is_readonly());
-        let volume = if let Some(mount_options) = mount_options {
-            mount_options.new_volume(root_path)
-        } else {
-            lxutil::LxVolume::new(root_path)
-        }?;
-        let mut inodes = InodeMap::new(volume.supports_stable_file_id());
-        let (root_inode, _) = VirtioFsInode::new(Arc::new(volume), PathBuf::new())?;
+        let volume = Volume::open(root_path, mount_options)?;
+        let (root_inode, _) = VirtioFsInode::new(volume, PathBuf::new())?;
+        Ok(Self::from_root_inode(root_inode, readonly, None))
+    }
+
+    /// Assemble a `VirtioFs` from an already-built root inode. Shared tail
+    /// of `new` and `new_aggregate`: inserts `root_inode` at
+    /// [`FUSE_ROOT_ID`] and initializes the remaining fields.
+    fn from_root_inode(
+        root_inode: VirtioFsInode,
+        readonly: bool,
+        aggregate_state: Option<Arc<AggregateState>>,
+    ) -> Self {
+        let mut inodes = InodeMap::new();
         assert!(inodes.insert(root_inode).1 == FUSE_ROOT_ID);
-        Ok(Self {
+        Self {
             inodes: RwLock::new(inodes),
             files: RwLock::new(HandleMap::new()),
             readonly,
-        })
+            aggregate_state,
+        }
+    }
+
+    /// Create a new virtio-fs that aggregates multiple host paths under a
+    /// synthetic read-only root. Each child appears at `/<name>` and is
+    /// auto-mounted as a separate Linux superblock via `FUSE_ATTR_SUBMOUNT`
+    /// (requires guest kernel negotiating `FUSE_SUBMOUNTS`, Linux >= 5.10).
+    /// All children must share the same readonly setting.
+    ///
+    /// Use [`VirtioFs::aggregate_handle`] to obtain a
+    /// [`VirtiofsAggregateHandle`] for appending further children to the
+    /// live device.
+    pub fn new_aggregate(children: Vec<VirtioFsChild>) -> lx::Result<Self> {
+        if children.is_empty() {
+            return Err(lx::Error::EINVAL);
+        }
+
+        // Validate child names + uniqueness, and determine the shared
+        // readonly setting, before opening any host volumes.
+        let mut seen: HashSet<&[u8]> = HashSet::with_capacity(children.len());
+        let mut readonly: Option<bool> = None;
+        for child in &children {
+            inode::validate_child_name_bytes(child.name.as_bytes())?;
+            if !seen.insert(child.name.as_bytes()) {
+                tracing::warn!(
+                    name = ?child.name,
+                    "duplicate child name in aggregate virtio-fs"
+                );
+                return Err(lx::Error::EEXIST);
+            }
+            let child_readonly = child.readonly();
+            match readonly {
+                None => readonly = Some(child_readonly),
+                Some(r) if r != child_readonly => {
+                    tracing::warn!(
+                        "aggregate virtio-fs children must all share the same readonly setting"
+                    );
+                    return Err(lx::Error::EINVAL);
+                }
+                _ => (),
+            }
+        }
+        let readonly = readonly.unwrap_or(false);
+
+        // Build a `Volume` per child.
+        let mut synthetic_children: Vec<SyntheticChild> = Vec::with_capacity(children.len());
+        for child in children {
+            let volume = child.build_volume()?;
+            synthetic_children.push(SyntheticChild {
+                name: lx::LxString::from_vec(child.name.into_bytes()),
+                volume,
+            });
+        }
+
+        let state = AggregateState::new(synthetic_children, readonly);
+        let root_inode = VirtioFsInode::new_synthetic_root(Arc::clone(&state));
+        Ok(Self::from_root_inode(root_inode, readonly, Some(state)))
+    }
+
+    /// Obtain a [`VirtiofsAggregateHandle`] for appending children to a
+    /// live aggregate device. Returns `None` for non-aggregate devices
+    /// (those created via [`VirtioFs::new`]). Each call returns a fresh
+    /// clone that shares the underlying aggregate state.
+    pub fn aggregate_handle(&self) -> Option<VirtiofsAggregateHandle> {
+        self.aggregate_state
+            .as_ref()
+            .map(|state| VirtiofsAggregateHandle {
+                state: Arc::clone(state),
+            })
     }
 
     /// Perform lookup on a specified directory inode.
-    fn lookup_helper(&self, inode: &VirtioFsInode, name: &lx::LxStr) -> lx::Result<fuse_entry_out> {
+    pub(crate) fn lookup_helper(
+        &self,
+        inode: &VirtioFsInode,
+        name: &lx::LxStr,
+    ) -> lx::Result<fuse_entry_out> {
         let (new_inode, attr) = inode.lookup_child(name)?;
         let (_, new_inode_nr) = self.insert_inode(new_inode);
         Ok(fuse_entry_out::new(
@@ -471,7 +657,14 @@ impl VirtioFs {
     fn unlink_helper(&self, request: &Request, name: &lx::LxStr, flags: i32) -> lx::Result<()> {
         let inode = self.get_inode(request.node_id())?;
         self.check_writable()?;
-        inode.unlink(name, flags)
+        inode.unlink(name, flags)?;
+        // On path-keyed (non-stable-id) volumes the path is the inode's
+        // identity, so detach it from any node id now that it is gone; a
+        // later create at the same path must not alias the removed inode.
+        if let Some(key) = inode.child_path_dedup_key(name) {
+            self.inodes.write().evict_dedup_key(&key);
+        }
+        Ok(())
     }
 
     /// Retrieve the inode with the specified node ID.
@@ -566,30 +759,29 @@ impl<T> HandleMap<T> {
     }
 }
 
-/// Assigns node IDs to inodes, and keeps track of in-use inodes by their actual inode number.
+/// Assigns node IDs to inodes, and keeps track of in-use inodes by their actual
+/// (volume_id, inode_nr) pair.
 ///
 /// We cannot use the real inode number as the FUSE node ID:
 /// - FUSE node ID 1 is reserved for the root, so this would break if a file system used that inode
 ///   number.
-/// - When we want to support multiple volumes in a single file system, node IDs still need to be
-///   globally unique, whereas inode numbers are per-volume.
+/// - Multiple volumes can share the same inode number value, so the key must include the
+///   volume id.
 struct InodeMap {
     inodes_by_node_id: HandleMap<Arc<VirtioFsInode>>,
-    inodes_by_inode_nr: Option<HashMap<lx::ino_t, (Arc<VirtioFsInode>, u64)>>,
+    /// Maps a [`DedupKey`] to the registered inode and its FUSE node id, for
+    /// inodes eligible for deduplication. Stable-id volumes key by inode
+    /// number ([`DedupKey::Ino`]); volumes that recycle inode numbers
+    /// (FAT/exFAT) key by path ([`DedupKey::Path`]). The synthetic root and
+    /// empty-path submount/volume roots are not entered here.
+    inodes_by_key: HashMap<DedupKey, (Arc<VirtioFsInode>, u64)>,
 }
 
 impl InodeMap {
-    /// Create a new `InodeMap`.
-    pub fn new(supports_stable_file_id: bool) -> Self {
-        // TODO: Once multiple volumes are supported, the inodes_by_inode_nr map should be per
-        // volume.
+    pub fn new() -> Self {
         Self {
             inodes_by_node_id: HandleMap::new(),
-            inodes_by_inode_nr: if supports_stable_file_id {
-                Some(HashMap::new())
-            } else {
-                None
-            },
+            inodes_by_key: HashMap::new(),
         }
     }
 
@@ -601,15 +793,15 @@ impl InodeMap {
 
     /// Insert an inode into the map, returning its node ID.
     pub fn insert(&mut self, inode: VirtioFsInode) -> (Arc<VirtioFsInode>, u64) {
-        // If stable inode numbers are supported, look for the inode by its number.
-        if let Some(inodes_by_inode_nr) = self.inodes_by_inode_nr.as_mut() {
-            match inodes_by_inode_nr.entry(inode.inode_nr()) {
+        // If this inode has a valid dedup key, look for it in the map.
+        if let Some(key) = inode.dedup_key() {
+            match self.inodes_by_key.entry(key) {
                 Entry::Occupied(entry) => {
                     // Inode found; increment its count and return the existing FUSE node ID.
                     let new_path = inode.clone_path();
-                    let (inode, node_id) = entry.get();
-                    inode.lookup(new_path);
-                    return (Arc::clone(inode), *node_id);
+                    let (existing, node_id) = entry.get();
+                    existing.lookup(new_path);
+                    return (Arc::clone(existing), *node_id);
                 }
                 Entry::Vacant(entry) => {
                     // Inode not found, so insert it into both maps.
@@ -621,7 +813,8 @@ impl InodeMap {
             }
         }
 
-        // No support for stable inode numbers, so just use node ID.
+        // Inode is not eligible for dedup (synthetic root or
+        // non-stable-inode volume); just allocate a fresh node id.
         let inode = Arc::new(inode);
         let node_id = self.inodes_by_node_id.insert(Arc::clone(&inode));
         (inode, node_id)
@@ -630,8 +823,31 @@ impl InodeMap {
     /// Remove an inode with the specified FUSE node ID from the map.
     pub fn remove(&mut self, node_id: u64) {
         let inode = self.inodes_by_node_id.remove(node_id).unwrap();
-        if let Some(inodes_by_inode_nr) = self.inodes_by_inode_nr.as_mut() {
-            inodes_by_inode_nr.remove(&inode.inode_nr());
+        if let Some(key) = inode.dedup_key() {
+            // Only drop the by-key entry if it still points at THIS node.
+            // For path-keyed volumes a delete+recreate (or an explicit
+            // `evict_dedup_key`) can repoint the path to a newer inode while
+            // this (older) one lingers behind a live fd or inotify watch;
+            // removing it unconditionally would orphan that newer inode.
+            if let Entry::Occupied(entry) = self.inodes_by_key.entry(key) {
+                if entry.get().1 == node_id {
+                    entry.remove();
+                }
+            }
+        }
+    }
+
+    /// Detach a [`DedupKey::Path`] entry from whatever inode it currently
+    /// maps to, leaving that inode in `inodes_by_node_id` (a live fd or
+    /// inotify watch may still reference it) but no longer reachable for
+    /// dedup. A subsequent create at the same path therefore gets a fresh
+    /// node id rather than aliasing the removed/renamed file.
+    ///
+    /// No-op for [`DedupKey::Ino`] keys: stable-id volumes get a different
+    /// inode number on recreate, so the stale key cannot alias.
+    pub fn evict_dedup_key(&mut self, key: &DedupKey) {
+        if matches!(key, DedupKey::Path(..)) {
+            self.inodes_by_key.remove(key);
         }
     }
 
@@ -643,10 +859,38 @@ impl InodeMap {
         // Re-insert the root inode.
         assert!(self.inodes_by_node_id.insert(Arc::clone(&root_inode)) == FUSE_ROOT_ID);
 
-        // Clear the inode number map if it's supported.
-        if let Some(inodes_by_inode_nr) = self.inodes_by_inode_nr.as_mut() {
-            inodes_by_inode_nr.clear();
-            inodes_by_inode_nr.insert(root_inode.inode_nr(), (root_inode, FUSE_ROOT_ID));
+        // Rebuild the dedup map containing only the root, if eligible.
+        self.inodes_by_key.clear();
+        if let Some(key) = root_inode.dedup_key() {
+            self.inodes_by_key.insert(key, (root_inode, FUSE_ROOT_ID));
         }
+    }
+}
+
+/// Description of one child path to expose at a named subdirectory of an
+/// aggregate (multi-path) virtio-fs root. See [`VirtioFs::new_aggregate`].
+pub struct VirtioFsChild {
+    /// Name of the child as it appears in the synthetic root directory.
+    /// Must be non-empty, not contain `/` or NUL, and not be `.` or `..`.
+    pub name: String,
+    /// Host path to use as the root of this child volume.
+    pub root_path: PathBuf,
+    /// Optional mount options. If supplied, all children passed in the
+    /// same call must agree on the `readonly` setting.
+    pub options: Option<LxVolumeOptions>,
+}
+
+impl VirtioFsChild {
+    /// The readonly setting for this child (defaults to read-write when no
+    /// options are supplied).
+    fn readonly(&self) -> bool {
+        self.options.as_ref().is_some_and(|o| o.is_readonly())
+    }
+
+    /// Open the backing host volume for this child. Borrows `self` so the
+    /// caller can subsequently move `self.name` after the (slow) volume
+    /// construction succeeds.
+    fn build_volume(&self) -> lx::Result<Arc<Volume>> {
+        Volume::open_aggregate_child(&self.root_path, self.options.as_ref())
     }
 }

--- a/vm/devices/virtio/virtiofs/src/lib.rs
+++ b/vm/devices/virtio/virtiofs/src/lib.rs
@@ -226,7 +226,9 @@ impl Fuse for VirtioFs {
         // anyway: dropping the root would corrupt all subsequent lookups
         // (every path resolves through FUSE_ROOT_ID).
         if node_id == FUSE_ROOT_ID {
-            tracing::warn!(lookup_count, "ignoring forget on root inode");
+            // A buggy or malicious guest can send this repeatedly, so rate-limit
+            // the warning to avoid unbounded log spam.
+            tracelimit::warn_ratelimited!(lookup_count, "ignoring forget on root inode");
             return;
         }
         // This must be done under lock so an inode can't be resurrected between the lookup count

--- a/vm/devices/virtio/virtiofs/src/section.rs
+++ b/vm/devices/virtio/virtiofs/src/section.rs
@@ -59,7 +59,7 @@ fn get_attr_with_cur_time() -> fuse::protocol::fuse_attr {
         gid: 0,
         rdev: 0,
         blksize: 0,
-        padding: 0,
+        flags: 0,
     }
 }
 

--- a/vm/devices/virtio/virtiofs/src/util.rs
+++ b/vm/devices/virtio/virtiofs/src/util.rs
@@ -8,6 +8,13 @@ use std::time::Duration;
 
 /// Convert a Linux stat struct to FUSE attributes.
 pub fn stat_to_fuse_attr(stat: &lx::Stat) -> fuse_attr {
+    stat_to_fuse_attr_with_flags(stat, 0)
+}
+
+/// Convert a Linux stat struct to FUSE attributes, with extra `FUSE_ATTR_*`
+/// flag bits ORed into `fuse_attr.flags` (e.g. `FUSE_ATTR_SUBMOUNT` for the
+/// root of an auto-mounted subdirectory).
+pub fn stat_to_fuse_attr_with_flags(stat: &lx::Stat, attr_flags: u32) -> fuse_attr {
     fuse_attr {
         ino: stat.inode_nr,
         size: stat.file_size,
@@ -26,7 +33,7 @@ pub fn stat_to_fuse_attr(stat: &lx::Stat) -> fuse_attr {
         rdev: stat.device_nr_special as u32,
         // This is `usize` on x64 and `u32` on arm64, avoid a warning.
         blksize: stat.block_size as _,
-        padding: 0,
+        flags: attr_flags,
     }
 }
 


### PR DESCRIPTION
Add an `aggregate` virtio-fs device that shares multiple host mounts through a single virtiofs PCI device. Each child mount appears at `/<name>` under a synthetic read-only root; `FUSE_ATTR_SUBMOUNT` on each child root inode asks the guest to mount a separate superblock with a distinct `st_dev`, isolating per-child inode namespaces.

- `VirtioFs::new_aggregate` builds the device from an initial set of children; `VirtioFs::aggregate_handle` exposes a `VirtiofsAggregateHandle` for adding more children to a live device. The append-only child list keeps READDIR cookies stable. `add_child` rejects invalid names (EINVAL), additions during teardown (EAGAIN), readonly mismatches (EINVAL), and duplicates (EEXIST), in that precedence.
- `Fuse::init` opts into `FUSE_SUBMOUNTS`. Correctness does not rely on submounts actually firing: each aggregate child namespaces its reported inode numbers (`Volume::namespaced_ino`) so `(st_dev, st_ino)` collisions across children are avoided even under one shared superblock, while hard-link identity within a share is preserved.

FAT-over-virtiofs fixes (now that FAT drvfs runs over virtiofs instead of Plan 9):
- lxutil rename: up-front type-compatibility pre-check reports POSIX errnos on filesystems without posix rename (FAT) instead of leaking NT status codes.
- lxutil delete: `analyze_delete_error` classifies FAT delete failures into the expected errno.
- lxutil symlink: filesystems without reparse-point support (FAT) return EPERM up front.
- lxutil access check: inspect raw NTSTATUS so `STATUS_NO_TOKEN` falls back to the process token; set `OBJECT_ATTRIBUTES.Length`.
- virtiofs inode dedup: key inodes by path on volumes with unstable file ids (FAT/exFAT) so repeated LOOKUPs return a stable `node_id`; stale path keys evicted on unlink/rmdir/rename.