### PR TITLE
petri/logview: pin react-router-dom to 7.15.0 (CVE fixes) + add min-release-age

### DIFF
--- a/petri/logview/.npmrc
+++ b/petri/logview/.npmrc
@@ -1,0 +1,4 @@
+# Refuse to install package versions released within the last 7 days, to
+# reduce the window of exposure to undetected supply-chain attacks in the
+# npm ecosystem. Supported by npm >= 11.10.0.
+min-release-age=7

--- a/petri/logview/package-lock.json
+++ b/petri/logview/package-lock.json
@@ -14,7 +14,7 @@
         "@tanstack/react-virtual": "^3.13.12",
         "react": "^19.2.1",
         "react-dom": "^19.2.1",
-        "react-router-dom": "^7.15.0"
+        "react-router-dom": "7.15.0"
       },
       "devDependencies": {
         "@types/react": "^19.2.7",
@@ -2392,9 +2392,9 @@
       }
     },
     "node_modules/react-router": {
-      "version": "7.17.0",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.17.0.tgz",
-      "integrity": "sha512-FDELK7rTMlCHO5+reyXsPlmfr7N1F91lPHsWYfMEGQm/KQ+F4JFM8jGoeQDmDvdTs93Fw9aSilH+uKRb4/jXvQ==",
+      "version": "7.15.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.15.0.tgz",
+      "integrity": "sha512-HW9vYwuM8f4yx66Izy8xfrzCM+SBJluoZcCbww9A1TySax11S5Vgw6fi3ZjMONw9J4gQwngL7PzkyIpJJpJ7RQ==",
       "license": "MIT",
       "dependencies": {
         "cookie": "^1.0.1",
@@ -2414,12 +2414,12 @@
       }
     },
     "node_modules/react-router-dom": {
-      "version": "7.17.0",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.17.0.tgz",
-      "integrity": "sha512-fyU2yjGups/hE6Xz0I5ZYbVL8Gx29eCjgpHaRaTaVU+OOAdfRX05KsvyRm0GO8YQwOkhpU3MurW1jyMUJn+zSw==",
+      "version": "7.15.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.15.0.tgz",
+      "integrity": "sha512-VcrVg64Fo8nwBvDscajG8gRTLIuTC6N50nb22l2HOOV4PTOHgoGp8mUjy9wLiHYoYTSYI36tUnXZgasSRFZorQ==",
       "license": "MIT",
       "dependencies": {
-        "react-router": "7.17.0"
+        "react-router": "7.15.0"
       },
       "engines": {
         "node": ">=20.0.0"

--- a/petri/logview/package-lock.json
+++ b/petri/logview/package-lock.json
@@ -14,7 +14,7 @@
         "@tanstack/react-virtual": "^3.13.12",
         "react": "^19.2.1",
         "react-dom": "^19.2.1",
-        "react-router-dom": "^7.12.0"
+        "react-router-dom": "^7.15.0"
       },
       "devDependencies": {
         "@types/react": "^19.2.7",
@@ -2392,9 +2392,9 @@
       }
     },
     "node_modules/react-router": {
-      "version": "7.14.0",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.14.0.tgz",
-      "integrity": "sha512-m/xR9N4LQLmAS0ZhkY2nkPA1N7gQ5TUVa5n8TgANuDTARbn1gt+zLPXEm7W0XDTbrQ2AJSJKhoa6yx1D8BcpxQ==",
+      "version": "7.17.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.17.0.tgz",
+      "integrity": "sha512-FDELK7rTMlCHO5+reyXsPlmfr7N1F91lPHsWYfMEGQm/KQ+F4JFM8jGoeQDmDvdTs93Fw9aSilH+uKRb4/jXvQ==",
       "license": "MIT",
       "dependencies": {
         "cookie": "^1.0.1",
@@ -2414,12 +2414,12 @@
       }
     },
     "node_modules/react-router-dom": {
-      "version": "7.14.0",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.14.0.tgz",
-      "integrity": "sha512-2G3ajSVSZMEtmTjIklRWlNvo8wICEpLihfD/0YMDxbWK2UyP5EGfnoIn9AIQGnF3G/FX0MRbHXdFcD+rL1ZreQ==",
+      "version": "7.17.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.17.0.tgz",
+      "integrity": "sha512-fyU2yjGups/hE6Xz0I5ZYbVL8Gx29eCjgpHaRaTaVU+OOAdfRX05KsvyRm0GO8YQwOkhpU3MurW1jyMUJn+zSw==",
       "license": "MIT",
       "dependencies": {
-        "react-router": "7.14.0"
+        "react-router": "7.17.0"
       },
       "engines": {
         "node": ">=20.0.0"

--- a/petri/logview/package.json
+++ b/petri/logview/package.json
@@ -5,7 +5,7 @@
     "@tanstack/react-virtual": "^3.13.12",
     "react": "^19.2.1",
     "react-dom": "^19.2.1",
-    "react-router-dom": "^7.12.0"
+    "react-router-dom": "^7.15.0"
   },
   "devDependencies": {
     "@types/react": "^19.2.7",

--- a/petri/logview/package.json
+++ b/petri/logview/package.json
@@ -5,7 +5,7 @@
     "@tanstack/react-virtual": "^3.13.12",
     "react": "^19.2.1",
     "react-dom": "^19.2.1",
-    "react-router-dom": "^7.15.0"
+    "react-router-dom": "7.15.0"
   },
   "devDependencies": {
     "@types/react": "^19.2.7",


### PR DESCRIPTION
Pins `react-router-dom` in `petri/logview` to the oldest release that fixes all flagged Component Governance advisories, and adds an `.npmrc` supply-chain guard.

## Dependency fix

Pins `react-router-dom` to exactly `7.15.0` (lockfile resolves `react-router`/`react-router-dom` to `7.15.0`). `7.15.0` is the oldest release that fixes all three flagged advisories:

| CVE | Severity | First patched |
| --- | --- | --- |
| CVE-2026-42211 | High | 7.14.2 |
| CVE-2026-42342 | High | 7.15.0 |
| CVE-2026-40181 | Med  | 7.14.1 |

Previously the range was `^7.12.0`/`^7.15.0`, which floated the lockfile to `7.17.0` (only a couple days old at the time). We now pin to the minimal fixed version rather than the latest, to avoid pulling in very new, undetected supply-chain attacks.

logview is a client-side SPA (not Framework Mode), so real exposure was low, but this clears the CG alerts.

## Supply-chain guard

Adds `petri/logview/.npmrc` with `min-release-age=7`, which refuses to install any npm release published within the last 7 days (supported by npm >= 11.10.0). This reduces the window of exposure to undetected supply-chain attacks in the npm ecosystem.

## Validation

- `npm install` reports 0 vulnerabilities
- `npm run build` (vite) succeeds