### PR TITLE
membacking: make partition VA mappings eager

### DIFF
--- a/openvmm/membacking/src/lib.rs
+++ b/openvmm/membacking/src/lib.rs
@@ -99,6 +99,8 @@ pub use memory_manager::RamBackingRequest;
 pub use memory_manager::RamVisibility;
 pub use memory_manager::RamVisibilityControl;
 pub use memory_manager::SharedMemoryBacking;
+pub use region_manager::DmaMapRequest;
 pub use region_manager::DmaMapperClient;
 pub use region_manager::DmaMapperHandle;
 pub use region_manager::DmaTarget;
+pub use region_manager::MappingType;

--- a/openvmm/membacking/src/mapping_manager/manager.rs
+++ b/openvmm/membacking/src/mapping_manager/manager.rs
@@ -21,6 +21,7 @@ use inspect::InspectMut;
 use memory_range::MemoryRange;
 use mesh::MeshPayload;
 use mesh::error::RemoteError;
+use mesh::rpc::FailableRpc;
 use mesh::rpc::Rpc;
 use mesh::rpc::RpcSend;
 use pal_async::task::Spawn;
@@ -90,87 +91,53 @@ pub struct MappingManagerClient {
 static MAPPER_CACHE: ObjectCache<VaMapper> = ObjectCache::new();
 
 impl MappingManagerClient {
-    /// Returns an eager VA mapper for this guest memory.
+    /// Returns a VA mapper for this guest memory.
     ///
-    /// Eager mappers receive mappings immediately when they are added and
-    /// get all existing mappings replayed on creation. File-backed page
-    /// faults will fail (since mappings should already be established).
+    /// When `eager` is true, the mapper receives all existing mappings
+    /// immediately and gets new ones pushed synchronously. File-backed
+    /// page faults will fail (since mappings should already be
+    /// established). This is the right choice for the VP process, where
+    /// the hypervisor does not forward page faults back to the VMM.
     ///
-    /// This is the right choice for the VP process, where the hypervisor
-    /// does not forward page faults back to the VMM.
+    /// When `eager` is false, the mapper is lazy: mappings are populated
+    /// on demand via page faults. This avoids the cost of pushing every
+    /// mapping change to processes that rarely access the mapped regions
+    /// (e.g., device-emulation processes with virtio-fs DAX). Lazy
+    /// mappers cannot be used with private memory mode.
     ///
     /// The mapper is single-instanced per process via a cache. If a lazy
-    /// mapper was previously created for this guest memory, calling this
-    /// returns the same mapper (the mapping manager will have already
-    /// replayed and marked it as eager on first call).
-    pub async fn new_mapper(&self) -> Result<Arc<VaMapper>, VaMapperError> {
+    /// mapper was previously created and an eager one is now requested,
+    /// it is upgraded in place.
+    pub async fn new_mapper(&self, eager: bool) -> Result<Arc<VaMapper>, VaMapperError> {
         let mapper = MAPPER_CACHE
             .get_or_insert_with(&self.id, async {
+                assert!(
+                    eager || self.private_ranges.is_empty(),
+                    "lazy mappers are not supported with private memory"
+                );
                 VaMapper::new(
                     self.req_send.clone(),
                     self.max_addr,
                     None,
                     self.private_ranges.clone(),
                     self.minimum_va_alignment,
-                    true, // eager
+                    eager,
                 )
                 .await
             })
             .await?;
 
-        // If the cached mapper is lazy (created by an earlier
-        // new_lazy_mapper call), upgrade it to eager. The UpgradeToEager
-        // Rpc replays all mappings and then sends SetEager to the mapper
-        // task, which marks it eager after replay completes.
-        if !mapper.is_eager() {
+        // If we need eager but the cached mapper is lazy (created by an
+        // earlier lazy call), upgrade it.
+        if eager && !mapper.is_eager() {
             self.req_send
                 .call(MappingRequest::UpgradeToEager, mapper.mapper_id())
                 .await
                 .map_err(VaMapperError::MemoryManagerGone)?
                 .map_err(VaMapperError::Registration)?;
-
-            // The UpgradeToEager RPC replayed all mappings and queued
-            // SetEager to the mapper task, but that message may not be
-            // processed yet. Set the flag here so callers can rely on
-            // is_eager() immediately.
-            mapper.set_eager();
         }
 
         Ok(mapper)
-    }
-
-    /// Returns a lazy VA mapper for this guest memory.
-    ///
-    /// Lazy mappers are not notified when mappings are added. Instead,
-    /// they populate on demand via page faults, requesting the current
-    /// mapping from the mapping manager at fault time. This avoids the
-    /// cost of pushing every mapping change to processes that rarely
-    /// access the mapped regions (e.g., device-emulation processes with
-    /// virtio-fs DAX).
-    ///
-    /// If an eager mapper already exists in the cache for this guest
-    /// memory, it is returned instead — eager is strictly better.
-    ///
-    /// Returns an error if private memory mode is enabled, since private
-    /// anonymous pages are committed in-process and cannot be populated
-    /// on demand across a lazy mapping channel.
-    pub async fn new_lazy_mapper(&self) -> Result<Arc<VaMapper>, VaMapperError> {
-        MAPPER_CACHE
-            .get_or_insert_with(&self.id, async {
-                if !self.private_ranges.is_empty() {
-                    return Err(VaMapperError::LazyWithPrivateMemory);
-                }
-                VaMapper::new(
-                    self.req_send.clone(),
-                    self.max_addr,
-                    None,
-                    self.private_ranges.clone(),
-                    self.minimum_va_alignment,
-                    false, // lazy
-                )
-                .await
-            })
-            .await
     }
 
     /// Returns a VA mapper for this guest memory, but map everything into the
@@ -233,7 +200,7 @@ pub enum MappingRequest {
     /// Register a new VA mapper. The `bool` indicates whether the mapper is
     /// eager (mappings pushed immediately and replayed on creation) or lazy
     /// (mappings populated on demand via page faults).
-    AddMapper(Rpc<(mesh::Sender<MapperRequest>, bool), Result<MapperId, RemoteError>>),
+    AddMapper(FailableRpc<(mesh::Sender<MapperRequest>, bool), MapperId>),
     RemoveMapper(MapperId),
     /// Request that mappings covering the given range be sent to the specified
     /// mapper via fire-and-forget `MapLazy` messages. Used by lazy mappers
@@ -241,8 +208,8 @@ pub enum MappingRequest {
     SendMappings(MapperId, MemoryRange),
     /// Upgrade a lazy mapper to eager: replay all existing mappings and
     /// mark it for future pushes.
-    UpgradeToEager(Rpc<MapperId, Result<(), RemoteError>>),
-    AddMapping(Rpc<MappingParams, Result<(), RemoteError>>),
+    UpgradeToEager(FailableRpc<MapperId, ()>),
+    AddMapping(FailableRpc<MappingParams, ()>),
     RemoveMappings(Rpc<MemoryRange, ()>),
     /// Returns all mappings that have [`MappingType::Ram`] type.
     GetDmaTargetMappings(Rpc<(), Vec<MappingParams>>),
@@ -266,7 +233,7 @@ fn inspect_mappings(mappings: &Vec<Mapping>) -> impl '_ + Inspect {
                 inspect::adhoc(|req| {
                     req.respond()
                         .field("writable", mapping.params.writable)
-                        .field("mapping_type", format!("{:?}", mapping.params.mapping_type))
+                        .field("mapping_type", mapping.params.mapping_type)
                         .hex("file_offset", mapping.params.file_offset);
                 }),
             );
@@ -327,7 +294,7 @@ struct MapperComm {
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, MeshPayload)]
-pub struct MapperId(usize);
+pub struct MapperId(pub(crate) usize);
 
 /// A request to a VA mapper.
 #[derive(Debug, MeshPayload)]
@@ -344,9 +311,10 @@ pub enum MapperRequest {
     NoMapping(MemoryRange),
     /// Unmap the specified range and send a response when it's done.
     Unmap(Rpc<MemoryRange, ()>),
-    /// Mark this mapper as eager. Sent after all replay `MapEager` Rpcs
-    /// have completed, so the mapper task processes it after all replays.
-    SetEager,
+    /// Mark this mapper as eager and respond when done. Sent after all
+    /// replay `MapEager` Rpcs have completed, so the mapper task
+    /// processes it after all replays.
+    SetEager(Rpc<(), ()>),
 }
 
 impl MappingManagerTask {
@@ -411,9 +379,7 @@ impl MappingManagerTask {
                     .await
                 {
                     Ok(Ok(())) => {
-                        if !mapping.active_mappers.contains(&mapper_id) {
-                            mapping.active_mappers.push(mapper_id);
-                        }
+                        mapping.active_mappers.push(mapper_id);
                     }
                     Ok(Err(e)) => {
                         failed = Some(MappingError::new(
@@ -496,11 +462,11 @@ impl MappingManagerTask {
         }
 
         if let Some(err) = failed {
-            // Roll back: unmark eager, remove from active_mappers.
+            // Roll back: unmark eager so future add_mapping calls don't
+            // push to this mapper. Keep successfully-replayed entries in
+            // active_mappers so the mapper gets Unmap when those mappings
+            // are removed (the VA space already has them mapped).
             self.mappers.mappers[id.0].eager = false;
-            for m in &mut self.mappings {
-                m.active_mappers.retain(|mid| *mid != id);
-            }
             return Err(err);
         }
 
@@ -509,7 +475,9 @@ impl MappingManagerTask {
         // replays above.
         self.mappers.mappers[id.0]
             .req_send
-            .send(MapperRequest::SetEager);
+            .call(MapperRequest::SetEager, ())
+            .await
+            .ok();
 
         Ok(())
     }
@@ -546,17 +514,14 @@ impl MappingManagerTask {
                 (range.end(), None)
             };
             let this_range = MemoryRange::new(range.start()..this_end);
-            if let Some(params) = params {
+            let req = if let Some(params) = params {
                 tracing::debug!(range = %this_range, full_range = %params.range, "sending lazy mapping");
-                self.mappers.mappers[id.0]
-                    .req_send
-                    .send(MapperRequest::MapLazy(params));
+                MapperRequest::MapLazy(params)
             } else {
                 tracing::debug!(range = %this_range, "no mapping for range");
-                self.mappers.mappers[id.0]
-                    .req_send
-                    .send(MapperRequest::NoMapping(this_range));
-            }
+                MapperRequest::NoMapping(this_range)
+            };
+            self.mappers.mappers[id.0].req_send.send(req);
             range = MemoryRange::new(this_end..range.end());
         }
     }
@@ -568,6 +533,7 @@ impl MappingManagerTask {
 
         // Push to eager mappers only. Lazy mappers will request on demand.
         let mut active_mappers = Vec::new();
+        let mut dead_mappers = Vec::new();
         for (i, mapper) in self.mappers.mappers.iter() {
             if !mapper.eager {
                 continue;
@@ -599,10 +565,15 @@ impl MappingManagerTask {
                     return Err(e);
                 }
                 Err(_) => {
-                    // Mapper gone, skip.
+                    // Mapper channel closed — remove after iteration.
                     tracing::debug!(?id, "mapper gone during add_mapping");
+                    dead_mappers.push(id);
                 }
             }
+        }
+
+        for id in dead_mappers {
+            self.remove_mapper(id);
         }
 
         self.mappings.push(Mapping {
@@ -901,6 +872,12 @@ mod tests {
                 }
                 other => panic!("expected MapEager during upgrade, got {other:?}"),
             }
+            // Respond to the SetEager RPC.
+            let msg = recv.recv().await.unwrap();
+            match msg {
+                MapperRequest::SetEager(rpc) => rpc.complete(()),
+                other => panic!("expected SetEager, got {other:?}"),
+            }
         });
         result.unwrap();
 
@@ -941,11 +918,16 @@ mod tests {
         let id = task.add_mapper(send, false).await.unwrap();
 
         // Upgrade to eager (no existing mappings, so no replay, but SetEager
-        // is still sent).
-        task.upgrade_to_eager(id).await.unwrap();
-        // Consume the SetEager message.
-        let msg = recv.recv().await.unwrap();
-        assert!(matches!(msg, MapperRequest::SetEager));
+        // is still sent as an RPC).
+        let upgrade_future = task.upgrade_to_eager(id);
+        let (result, _) = futures::join!(upgrade_future, async {
+            let msg = recv.recv().await.unwrap();
+            match msg {
+                MapperRequest::SetEager(rpc) => rpc.complete(()),
+                other => panic!("expected SetEager, got {other:?}"),
+            }
+        });
+        result.unwrap();
 
         // Now add a mapping — should be pushed to the upgraded mapper.
         let mappable: Mappable = sparse_mmap::alloc_shared_memory(0x1000, "test")
@@ -1244,13 +1226,17 @@ mod tests {
         // The mapper should still be lazy (rolled back).
         assert!(!task.mappers.mappers[id.0].eager);
 
-        // active_mappers should be cleaned up.
-        for mapping in &task.mappings {
-            assert!(
-                !mapping.active_mappers.contains(&id),
-                "mapper should not be in active_mappers after rollback"
-            );
-        }
+        // The first mapping should still have this mapper in active_mappers
+        // (it was successfully replayed), so it will get Unmap when that
+        // mapping is removed.
+        assert!(
+            task.mappings[0].active_mappers.contains(&id),
+            "first mapping should retain mapper in active_mappers"
+        );
+        assert!(
+            !task.mappings[1].active_mappers.contains(&id),
+            "second mapping should not have mapper (replay failed)"
+        );
 
         // The mapper should still be in the slab (not removed, just stayed lazy).
         assert!(task.mappers.mappers.contains(id.0));
@@ -1379,7 +1365,7 @@ mod tests {
             .unwrap();
 
         // Create a lazy mapper.
-        let mapper = client.new_lazy_mapper().await.unwrap();
+        let mapper = client.new_mapper(false).await.unwrap();
         assert!(!mapper.is_eager());
 
         // page_fault calls block_on(request_mapping(...)), which blocks the
@@ -1437,7 +1423,7 @@ mod tests {
         let _handle = std::thread::spawn(move || {
             let result =
                 pal_async::DefaultPool::run_with(
-                    |_driver| async move { client.new_mapper().await },
+                    |_driver| async move { client.new_mapper(true).await },
                 );
             let _ = done_send.send(result);
         });
@@ -1488,11 +1474,11 @@ mod tests {
             .unwrap();
 
         // Create a lazy mapper first — this gets cached.
-        let lazy = client.new_lazy_mapper().await.unwrap();
+        let lazy = client.new_mapper(false).await.unwrap();
         assert!(!lazy.is_eager());
 
         // Now request an eager mapper — should upgrade the cached lazy one.
-        let eager = client.new_mapper().await.unwrap();
+        let eager = client.new_mapper(true).await.unwrap();
 
         // They should be the same Arc (same underlying mapper).
         assert!(Arc::ptr_eq(&lazy, &eager));

--- a/openvmm/membacking/src/mapping_manager/manager.rs
+++ b/openvmm/membacking/src/mapping_manager/manager.rs
@@ -19,11 +19,13 @@ use inspect::Inspect;
 use inspect::InspectMut;
 use memory_range::MemoryRange;
 use mesh::MeshPayload;
+use mesh::error::RemoteError;
 use mesh::rpc::Rpc;
 use mesh::rpc::RpcSend;
 use pal_async::task::Spawn;
 use slab::Slab;
 use std::sync::Arc;
+use thiserror::Error;
 
 /// The mapping manager.
 #[derive(Debug, Inspect)]
@@ -87,14 +89,21 @@ pub struct MappingManagerClient {
 static MAPPER_CACHE: ObjectCache<VaMapper> = ObjectCache::new();
 
 impl MappingManagerClient {
-    /// Returns a VA mapper for this guest memory.
+    /// Returns an eager VA mapper for this guest memory.
     ///
-    /// This will single instance the mapper, so this is safe to call multiple
-    /// times.
+    /// Eager mappers receive mappings immediately when they are added and
+    /// get all existing mappings replayed on creation. File-backed page
+    /// faults will fail (since mappings should already be established).
+    ///
+    /// This is the right choice for the VP process, where the hypervisor
+    /// does not forward page faults back to the VMM.
+    ///
+    /// The mapper is single-instanced per process via a cache. If a lazy
+    /// mapper was previously created for this guest memory, calling this
+    /// returns the same mapper (the mapping manager will have already
+    /// replayed and marked it as eager on first call).
     pub async fn new_mapper(&self) -> Result<Arc<VaMapper>, VaMapperError> {
-        // Get the VA mapper from the mapper cache if possible to avoid keeping
-        // multiple VA ranges for this memory per process.
-        MAPPER_CACHE
+        let mapper = MAPPER_CACHE
             .get_or_insert_with(&self.id, async {
                 VaMapper::new(
                     self.req_send.clone(),
@@ -102,6 +111,55 @@ impl MappingManagerClient {
                     None,
                     self.private_ranges.clone(),
                     self.minimum_va_alignment,
+                    true, // eager
+                )
+                .await
+            })
+            .await?;
+
+        // If the cached mapper is lazy (created by an earlier
+        // new_lazy_mapper call), upgrade it to eager. The UpgradeToEager
+        // Rpc replays all mappings and then sends SetEager to the mapper
+        // task, which marks it eager after replay completes.
+        if !mapper.is_eager() {
+            self.req_send
+                .call(MappingRequest::UpgradeToEager, mapper.mapper_id())
+                .await
+                .map_err(VaMapperError::MemoryManagerGone)?
+                .map_err(VaMapperError::Registration)?;
+        }
+
+        Ok(mapper)
+    }
+
+    /// Returns a lazy VA mapper for this guest memory.
+    ///
+    /// Lazy mappers are not notified when mappings are added. Instead,
+    /// they populate on demand via page faults, requesting the current
+    /// mapping from the mapping manager at fault time. This avoids the
+    /// cost of pushing every mapping change to processes that rarely
+    /// access the mapped regions (e.g., device-emulation processes with
+    /// virtio-fs DAX).
+    ///
+    /// If an eager mapper already exists in the cache for this guest
+    /// memory, it is returned instead — eager is strictly better.
+    ///
+    /// Returns an error if private memory mode is enabled, since private
+    /// anonymous pages are committed in-process and cannot be populated
+    /// on demand across a lazy mapping channel.
+    pub async fn new_lazy_mapper(&self) -> Result<Arc<VaMapper>, VaMapperError> {
+        MAPPER_CACHE
+            .get_or_insert_with(&self.id, async {
+                if !self.private_ranges.is_empty() {
+                    return Err(VaMapperError::LazyWithPrivateMemory);
+                }
+                VaMapper::new(
+                    self.req_send.clone(),
+                    self.max_addr,
+                    None,
+                    self.private_ranges.clone(),
+                    self.minimum_va_alignment,
+                    false, // lazy
                 )
                 .await
             })
@@ -130,6 +188,7 @@ impl MappingManagerClient {
                 Some(process),
                 Vec::new(),
                 self.minimum_va_alignment,
+                false, // remote mappers are always lazy
             )
             .await?,
         ))
@@ -137,14 +196,17 @@ impl MappingManagerClient {
 
     /// Adds an active mapping.
     ///
+    /// The mapping is pushed eagerly to all existing VA mappers. Returns an
+    /// error if any mapper fails to establish the mapping.
+    ///
     /// TODO: currently this will panic if the mapping overlaps an existing
     /// mapping. This needs to be fixed to allow this to overlap existing
     /// mappings, in which case the old ones will be split and replaced.
-    pub async fn add_mapping(&self, params: MappingParams) {
+    pub async fn add_mapping(&self, params: MappingParams) -> Result<(), RemoteError> {
         self.req_send
             .call(MappingRequest::AddMapping, params)
             .await
-            .unwrap();
+            .map_err(RemoteError::new)?
     }
 
     /// Removes all mappings in `range`.
@@ -161,10 +223,19 @@ impl MappingManagerClient {
 /// A mapping request message.
 #[derive(MeshPayload)]
 pub enum MappingRequest {
-    AddMapper(Rpc<mesh::Sender<MapperRequest>, MapperId>),
+    /// Register a new VA mapper. The `bool` indicates whether the mapper is
+    /// eager (mappings pushed immediately and replayed on creation) or lazy
+    /// (mappings populated on demand via page faults).
+    AddMapper(Rpc<(mesh::Sender<MapperRequest>, bool), Result<MapperId, RemoteError>>),
     RemoveMapper(MapperId),
+    /// Request that mappings covering the given range be sent to the specified
+    /// mapper via fire-and-forget `MapLazy` messages. Used by lazy mappers
+    /// to populate on demand.
     SendMappings(MapperId, MemoryRange),
-    AddMapping(Rpc<MappingParams, ()>),
+    /// Upgrade a lazy mapper to eager: replay all existing mappings and
+    /// mark it for future pushes.
+    UpgradeToEager(Rpc<MapperId, Result<(), RemoteError>>),
+    AddMapping(Rpc<MappingParams, Result<(), RemoteError>>),
     RemoveMappings(Rpc<MemoryRange, ()>),
     /// Returns all mappings that have `dma_target` set.
     GetDmaTargetMappings(Rpc<(), Vec<MappingParams>>),
@@ -202,7 +273,7 @@ struct Mapping {
 }
 
 /// The mapping parameters.
-#[derive(MeshPayload, Clone)]
+#[derive(Debug, MeshPayload, Clone)]
 pub struct MappingParams {
     /// The memory range for the mapping.
     pub range: MemoryRange,
@@ -222,27 +293,53 @@ pub struct MappingParams {
     pub numa_node: Option<u32>,
 }
 
+/// Error from a failed VA mapping operation.
+#[derive(Debug, Error)]
+#[error("failed to map {range}")]
+pub struct MappingError {
+    /// The GPA range that failed to map.
+    pub range: MemoryRange,
+    /// The underlying OS error.
+    #[source]
+    pub error: std::io::Error,
+}
+
+impl MappingError {
+    pub(crate) fn new(range: MemoryRange, error: std::io::Error) -> Self {
+        Self { range, error }
+    }
+}
+
 struct Mappers {
     mappers: Slab<MapperComm>,
 }
 
 struct MapperComm {
     req_send: mesh::Sender<MapperRequest>,
+    eager: bool,
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, MeshPayload)]
 pub struct MapperId(usize);
 
 /// A request to a VA mapper.
-#[derive(MeshPayload)]
+#[derive(Debug, MeshPayload)]
 pub enum MapperRequest {
-    /// Map the specified mapping.
-    Map(MappingParams),
-    /// There is no mapping for the specified range, so release anything waiting
-    /// on such a mapping to arrive.
+    /// Map the specified mapping and respond with success/failure.
+    /// Used by the eager path (`add_mapping`).
+    MapEager(Rpc<MappingParams, Result<(), RemoteError>>),
+    /// Map the specified mapping (fire-and-forget).
+    /// Used by the lazy path (`send_mappings`). The mapper task wakes
+    /// any pending waiters after processing.
+    MapLazy(MappingParams),
+    /// There is no mapping for the specified range. The mapper task
+    /// wakes waiters with a failure.
     NoMapping(MemoryRange),
     /// Unmap the specified range and send a response when it's done.
     Unmap(Rpc<MemoryRange, ()>),
+    /// Mark this mapper as eager. Sent after all replay `MapEager` Rpcs
+    /// have completed, so the mapper task processes it after all replays.
+    SetEager,
 }
 
 impl MappingManagerTask {
@@ -258,15 +355,23 @@ impl MappingManagerTask {
     async fn run(&mut self, req_recv: &mut mesh::Receiver<MappingRequest>) {
         while let Some(req) = req_recv.next().await {
             match req {
-                MappingRequest::AddMapper(rpc) => rpc.handle_sync(|send| self.add_mapper(send)),
+                MappingRequest::AddMapper(rpc) => {
+                    rpc.handle_failable(async |(send, eager)| self.add_mapper(send, eager).await)
+                        .await
+                }
                 MappingRequest::RemoveMapper(id) => {
                     self.remove_mapper(id);
                 }
                 MappingRequest::SendMappings(id, range) => {
                     self.send_mappings(id, range);
                 }
+                MappingRequest::UpgradeToEager(rpc) => {
+                    rpc.handle_failable(async |id| self.upgrade_to_eager(id).await)
+                        .await
+                }
                 MappingRequest::AddMapping(rpc) => {
-                    rpc.handle_sync(|params| self.add_mapping(params))
+                    rpc.handle(async |params| self.add_mapping(params).await)
+                        .await
                 }
                 MappingRequest::RemoveMappings(rpc) => {
                     rpc.handle(async |range| self.remove_mappings(range).await)
@@ -280,10 +385,52 @@ impl MappingManagerTask {
         }
     }
 
-    fn add_mapper(&mut self, req_send: mesh::Sender<MapperRequest>) -> MapperId {
-        let id = self.mappers.mappers.insert(MapperComm { req_send });
-        tracing::debug!(?id, "adding mapper");
-        MapperId(id)
+    async fn add_mapper(
+        &mut self,
+        req_send: mesh::Sender<MapperRequest>,
+        eager: bool,
+    ) -> Result<MapperId, MappingError> {
+        let id = self.mappers.mappers.insert(MapperComm { req_send, eager });
+        let mapper_id = MapperId(id);
+        tracing::debug!(?id, eager, "adding mapper");
+
+        if eager {
+            // Replay all existing mappings to the new eager mapper.
+            let mut failed = None;
+            for mapping in &mut self.mappings {
+                match self.mappers.mappers[id]
+                    .req_send
+                    .call(MapperRequest::MapEager, mapping.params.clone())
+                    .await
+                {
+                    Ok(Ok(())) => {
+                        if !mapping.active_mappers.contains(&mapper_id) {
+                            mapping.active_mappers.push(mapper_id);
+                        }
+                    }
+                    Ok(Err(e)) => {
+                        failed = Some(MappingError::new(
+                            mapping.params.range,
+                            std::io::Error::other(e),
+                        ));
+                        break;
+                    }
+                    Err(_) => {
+                        failed = Some(MappingError::new(
+                            MemoryRange::EMPTY,
+                            std::io::Error::other("mapper gone during replay"),
+                        ));
+                        break;
+                    }
+                }
+            }
+            if let Some(err) = failed {
+                self.remove_mapper(mapper_id);
+                return Err(err);
+            }
+        }
+
+        Ok(mapper_id)
     }
 
     fn remove_mapper(&mut self, id: MapperId) {
@@ -294,6 +441,77 @@ impl MappingManagerTask {
         }
     }
 
+    /// Upgrade a mapper from lazy to eager: mark it eager and replay all
+    /// existing mappings. On failure, the mapper stays lazy.
+    async fn upgrade_to_eager(&mut self, id: MapperId) -> Result<(), MappingError> {
+        let mapper = &mut self.mappers.mappers[id.0];
+        if mapper.eager {
+            return Ok(()); // already eager
+        }
+        // Mark eager on the manager side first so new add_mapping calls
+        // will push to this mapper. The mapper task itself isn't marked
+        // eager until SetEager is processed (after all replays succeed).
+        //
+        // This is safe because the manager task processes requests
+        // sequentially — no concurrent add_mapping can run while this
+        // method is executing. If the upgrade fails, we roll back
+        // `mapper.eager` to `false` before returning.
+        mapper.eager = true;
+        tracing::debug!(?id, "upgrading mapper to eager");
+
+        let mut failed = None;
+        for mapping in &mut self.mappings {
+            match self.mappers.mappers[id.0]
+                .req_send
+                .call(MapperRequest::MapEager, mapping.params.clone())
+                .await
+            {
+                Ok(Ok(())) => {
+                    if !mapping.active_mappers.contains(&id) {
+                        mapping.active_mappers.push(id);
+                    }
+                }
+                Ok(Err(e)) => {
+                    failed = Some(MappingError::new(
+                        mapping.params.range,
+                        std::io::Error::other(e),
+                    ));
+                    break;
+                }
+                Err(_) => {
+                    failed = Some(MappingError::new(
+                        MemoryRange::EMPTY,
+                        std::io::Error::other("mapper gone during eager upgrade"),
+                    ));
+                    break;
+                }
+            }
+        }
+
+        if let Some(err) = failed {
+            // Roll back: unmark eager, remove from active_mappers.
+            self.mappers.mappers[id.0].eager = false;
+            for m in &mut self.mappings {
+                m.active_mappers.retain(|mid| *mid != id);
+            }
+            return Err(err);
+        }
+
+        // Tell the mapper task to mark itself eager. Since the mapper task
+        // processes messages sequentially, this runs after all the MapEager
+        // replays above.
+        self.mappers.mappers[id.0]
+            .req_send
+            .send(MapperRequest::SetEager);
+
+        Ok(())
+    }
+
+    /// Handle a lazy mapper's on-demand request for mappings covering `range`.
+    ///
+    /// Finds all mappings that overlap the requested range and sends them
+    /// to the mapper via fire-and-forget `MapLazy` messages. Gaps send
+    /// `NoMapping` so the mapper task can wake waiters with failure.
     fn send_mappings(&mut self, id: MapperId, mut range: MemoryRange) {
         while !range.is_empty() {
             // Find the next mapping that overlaps range.
@@ -321,27 +539,70 @@ impl MappingManagerTask {
                 (range.end(), None)
             };
             let this_range = MemoryRange::new(range.start()..this_end);
-            let req = if let Some(params) = params {
-                tracing::debug!(range = %this_range, full_range = %params.range, "sending mapping for range");
-                MapperRequest::Map(params)
+            if let Some(params) = params {
+                tracing::debug!(range = %this_range, full_range = %params.range, "sending lazy mapping");
+                self.mappers.mappers[id.0]
+                    .req_send
+                    .send(MapperRequest::MapLazy(params));
             } else {
                 tracing::debug!(range = %this_range, "no mapping for range");
-                MapperRequest::NoMapping(this_range)
-            };
-            self.mappers.mappers[id.0].req_send.send(req);
+                self.mappers.mappers[id.0]
+                    .req_send
+                    .send(MapperRequest::NoMapping(this_range));
+            }
             range = MemoryRange::new(this_end..range.end());
         }
     }
 
-    fn add_mapping(&mut self, params: MappingParams) {
+    async fn add_mapping(&mut self, params: MappingParams) -> Result<(), RemoteError> {
         tracing::debug!(range = %params.range, "adding mapping");
 
         assert!(!self.mappings.iter().any(|m| m.params.range == params.range));
 
+        // Push to eager mappers only. Lazy mappers will request on demand.
+        let mut active_mappers = Vec::new();
+        for (i, mapper) in self.mappers.mappers.iter() {
+            if !mapper.eager {
+                continue;
+            }
+            let id = MapperId(i);
+            match mapper
+                .req_send
+                .call(MapperRequest::MapEager, params.clone())
+                .await
+            {
+                Ok(Ok(())) => {
+                    active_mappers.push(id);
+                }
+                Ok(Err(e)) => {
+                    // Unmap from mappers that already succeeded before returning
+                    // the error.
+                    for &rollback_id in &active_mappers {
+                        if let Err(err) = self.mappers.mappers[rollback_id.0]
+                            .req_send
+                            .call(MapperRequest::Unmap, params.range)
+                            .await
+                        {
+                            tracing::warn!(
+                                error = &err as &dyn std::error::Error,
+                                "mapper dropped unmap during rollback"
+                            );
+                        }
+                    }
+                    return Err(e);
+                }
+                Err(_) => {
+                    // Mapper gone, skip.
+                    tracing::debug!(?id, "mapper gone during add_mapping");
+                }
+            }
+        }
+
         self.mappings.push(Mapping {
             params,
-            active_mappers: Vec::new(),
+            active_mappers,
         });
+        Ok(())
     }
 
     fn get_dma_target_mappings(&self) -> Vec<MappingParams> {
@@ -420,6 +681,7 @@ impl ProvideShareableRegions for DmaRegionProvider {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use guestmem::GuestMemoryAccess;
     use guestmem::ProvideShareableRegions;
     use memory_range::MemoryRange;
 
@@ -444,7 +706,8 @@ mod tests {
                 dma_target: true,
                 numa_node: None,
             })
-            .await;
+            .await
+            .unwrap();
 
         client
             .add_mapping(MappingParams {
@@ -455,7 +718,8 @@ mod tests {
                 dma_target: false,
                 numa_node: None,
             })
-            .await;
+            .await
+            .unwrap();
 
         let provider = DmaRegionProvider {
             req_send: client.req_send.clone(),
@@ -487,12 +751,707 @@ mod tests {
                 dma_target: false,
                 numa_node: None,
             })
-            .await;
+            .await
+            .unwrap();
 
         let provider = DmaRegionProvider {
             req_send: client.req_send.clone(),
         };
         let regions = provider.get_regions().await.unwrap();
         assert!(regions.is_empty());
+    }
+
+    /// Helper: create a MappingManagerTask and add a mapping.
+    async fn task_with_mapping() -> (MappingManagerTask, MappingParams) {
+        let mut task = MappingManagerTask::new();
+        let mappable: Mappable = sparse_mmap::alloc_shared_memory(0x10000, "test")
+            .unwrap()
+            .into();
+        let params = MappingParams {
+            range: MemoryRange::new(0..0x10000),
+            mappable,
+            file_offset: 0,
+            writable: true,
+            dma_target: true,
+            numa_node: None,
+        };
+        task.add_mapping(params.clone()).await.unwrap();
+        (task, params)
+    }
+
+    /// Helper: add a mapper to a task and collect the MapEager/MapLazy messages
+    /// it receives.
+    async fn add_mapper_and_drain(
+        task: &mut MappingManagerTask,
+        eager: bool,
+    ) -> (MapperId, Vec<MapperRequest>) {
+        let (send, mut recv) = mesh::channel();
+        let id = task.add_mapper(send, eager).await.unwrap();
+        // Drain all pending messages.
+        let mut msgs = Vec::new();
+        while let Ok(msg) = recv.try_recv() {
+            msgs.push(msg);
+        }
+        (id, msgs)
+    }
+
+    #[pal_async::async_test]
+    async fn test_eager_mapper_gets_replay(_spawn: impl Spawn) {
+        let (mut task, _params) = task_with_mapping().await;
+
+        let (send, mut recv) = mesh::channel();
+        // add_mapper for eager blocks on the MapEager Rpc, so drive both
+        // concurrently.
+        let (id, _) = futures::join!(task.add_mapper(send, true), async {
+            let msg = recv.recv().await.unwrap();
+            match msg {
+                MapperRequest::MapEager(rpc) => {
+                    let (params, rpc) = rpc.split();
+                    assert_eq!(params.range, MemoryRange::new(0..0x10000));
+                    rpc.complete(Ok(()));
+                }
+                other => panic!("expected MapEager, got {other:?}"),
+            }
+        });
+        let _ = id;
+    }
+
+    #[pal_async::async_test]
+    async fn test_lazy_mapper_no_replay(_spawn: impl Spawn) {
+        let (mut task, _params) = task_with_mapping().await;
+
+        let (_id, msgs) = add_mapper_and_drain(&mut task, false).await;
+
+        // Lazy mapper should receive no messages on creation.
+        assert!(msgs.is_empty(), "lazy mapper should not get replay");
+    }
+
+    #[pal_async::async_test]
+    async fn test_add_mapping_pushes_only_to_eager(_spawn: impl Spawn) {
+        let mut task = MappingManagerTask::new();
+
+        // Add one eager and one lazy mapper.
+        let (eager_send, mut eager_recv) = mesh::channel();
+        let _eager_id = task.add_mapper(eager_send, true).await.unwrap();
+
+        let (lazy_send, mut lazy_recv) = mesh::channel();
+        let _lazy_id = task.add_mapper(lazy_send, false).await.unwrap();
+
+        // Add a mapping.
+        let mappable: Mappable = sparse_mmap::alloc_shared_memory(0x1000, "test")
+            .unwrap()
+            .into();
+        let params = MappingParams {
+            range: MemoryRange::new(0..0x1000),
+            mappable,
+            file_offset: 0,
+            writable: true,
+            dma_target: false,
+            numa_node: None,
+        };
+
+        // The eager mapper needs to respond to the MapEager Rpc.
+        let add_future = task.add_mapping(params);
+        // Drive the add_mapping by responding to the eager mapper's Rpc.
+        let (add_result, _) = futures::join!(add_future, async {
+            let msg = eager_recv.recv().await.unwrap();
+            match msg {
+                MapperRequest::MapEager(rpc) => rpc.complete(Ok(())),
+                other => panic!("expected MapEager, got {other:?}"),
+            }
+        });
+        add_result.unwrap();
+
+        // Lazy mapper should have received nothing.
+        assert!(
+            lazy_recv.try_recv().is_err(),
+            "lazy mapper should not be notified on add_mapping"
+        );
+    }
+
+    #[pal_async::async_test]
+    async fn test_upgrade_to_eager_replays(_spawn: impl Spawn) {
+        let (mut task, _params) = task_with_mapping().await;
+
+        // Add a lazy mapper — no replay.
+        let (send, mut recv) = mesh::channel();
+        let id = task.add_mapper(send, false).await.unwrap();
+        assert!(
+            recv.try_recv().is_err(),
+            "lazy mapper should not get replay"
+        );
+
+        // Upgrade to eager — should replay existing mappings.
+        let upgrade_future = task.upgrade_to_eager(id);
+        let (result, _) = futures::join!(upgrade_future, async {
+            let msg = recv.recv().await.unwrap();
+            match msg {
+                MapperRequest::MapEager(rpc) => {
+                    let (params, rpc) = rpc.split();
+                    assert_eq!(params.range, MemoryRange::new(0..0x10000));
+                    rpc.complete(Ok(()));
+                }
+                other => panic!("expected MapEager during upgrade, got {other:?}"),
+            }
+        });
+        result.unwrap();
+
+        // Verify the mapper is now marked eager.
+        assert!(task.mappers.mappers[id.0].eager);
+    }
+
+    #[pal_async::async_test]
+    async fn test_upgrade_already_eager_is_noop(_spawn: impl Spawn) {
+        let (mut task, _params) = task_with_mapping().await;
+
+        // Add an eager mapper (responds to replay).
+        let (send, mut recv) = mesh::channel();
+        let upgrade_future = task.add_mapper(send, true);
+        let (id, _) = futures::join!(upgrade_future, async {
+            let msg = recv.recv().await.unwrap();
+            match msg {
+                MapperRequest::MapEager(rpc) => rpc.complete(Ok(())),
+                other => panic!("expected MapEager, got {other:?}"),
+            }
+        });
+        let id = id.unwrap();
+
+        // Upgrade again — should be a no-op, no messages sent.
+        task.upgrade_to_eager(id).await.unwrap();
+        assert!(
+            recv.try_recv().is_err(),
+            "upgrade of already-eager mapper should send nothing"
+        );
+    }
+
+    #[pal_async::async_test]
+    async fn test_after_upgrade_new_mappings_are_pushed(_spawn: impl Spawn) {
+        let mut task = MappingManagerTask::new();
+
+        // Add a lazy mapper.
+        let (send, mut recv) = mesh::channel();
+        let id = task.add_mapper(send, false).await.unwrap();
+
+        // Upgrade to eager (no existing mappings, so no replay, but SetEager
+        // is still sent).
+        task.upgrade_to_eager(id).await.unwrap();
+        // Consume the SetEager message.
+        let msg = recv.recv().await.unwrap();
+        assert!(matches!(msg, MapperRequest::SetEager));
+
+        // Now add a mapping — should be pushed to the upgraded mapper.
+        let mappable: Mappable = sparse_mmap::alloc_shared_memory(0x1000, "test")
+            .unwrap()
+            .into();
+        let params = MappingParams {
+            range: MemoryRange::new(0..0x1000),
+            mappable,
+            file_offset: 0,
+            writable: true,
+            dma_target: false,
+            numa_node: None,
+        };
+
+        let add_future = task.add_mapping(params);
+        let (result, _) = futures::join!(add_future, async {
+            let msg = recv.recv().await.unwrap();
+            match msg {
+                MapperRequest::MapEager(rpc) => rpc.complete(Ok(())),
+                other => panic!("expected MapEager after upgrade, got {other:?}"),
+            }
+        });
+        result.unwrap();
+    }
+
+    #[pal_async::async_test]
+    async fn test_send_mappings_for_lazy(_spawn: impl Spawn) {
+        let (mut task, _params) = task_with_mapping().await;
+
+        // Add a lazy mapper.
+        let (send, mut recv) = mesh::channel();
+        let id = task.add_mapper(send, false).await.unwrap();
+
+        // Request mappings for the range (simulates page fault path).
+        task.send_mappings(id, MemoryRange::new(0..0x10000));
+
+        // Should receive a MapLazy.
+        let msg = recv.recv().await.unwrap();
+        match msg {
+            MapperRequest::MapLazy(params) => {
+                assert_eq!(params.range, MemoryRange::new(0..0x10000));
+            }
+            other => panic!("expected MapLazy, got {other:?}"),
+        }
+    }
+
+    #[pal_async::async_test]
+    async fn test_send_mappings_gap_sends_no_mapping(_spawn: impl Spawn) {
+        let (mut task, _params) = task_with_mapping().await;
+
+        let (send, mut recv) = mesh::channel();
+        let id = task.add_mapper(send, false).await.unwrap();
+
+        // Request a range that is partially unmapped (0x10000..0x20000 has no mapping).
+        task.send_mappings(id, MemoryRange::new(0x10000..0x20000));
+
+        let msg = recv.recv().await.unwrap();
+        match msg {
+            MapperRequest::NoMapping(range) => {
+                assert_eq!(range, MemoryRange::new(0x10000..0x20000));
+            }
+            other => panic!("expected NoMapping, got {other:?}"),
+        }
+    }
+
+    #[pal_async::async_test]
+    async fn test_remove_mapping_invalidates_both_eager_and_lazy(_spawn: impl Spawn) {
+        let (mut task, _params) = task_with_mapping().await;
+
+        // Add eager mapper (responds to replay).
+        let (eager_send, mut eager_recv) = mesh::channel();
+        let add_future = task.add_mapper(eager_send, true);
+        let (_eager_id, _) = futures::join!(add_future, async {
+            let msg = eager_recv.recv().await.unwrap();
+            match msg {
+                MapperRequest::MapEager(rpc) => rpc.complete(Ok(())),
+                other => panic!("expected MapEager, got {other:?}"),
+            }
+        });
+
+        // Add lazy mapper and fault in the mapping.
+        let (lazy_send, mut lazy_recv) = mesh::channel();
+        let lazy_id = task.add_mapper(lazy_send, false).await.unwrap();
+        task.send_mappings(lazy_id, MemoryRange::new(0..0x10000));
+        // Consume the MapLazy.
+        let _ = lazy_recv.recv().await.unwrap();
+
+        // Remove the mapping — both should get Unmap.
+        let remove_future = task.remove_mappings(MemoryRange::new(0..0x10000));
+        let ((), _, _) = futures::join!(
+            remove_future,
+            async {
+                let msg = eager_recv.recv().await.unwrap();
+                match msg {
+                    MapperRequest::Unmap(rpc) => {
+                        let (range, rpc) = rpc.split();
+                        assert_eq!(range, MemoryRange::new(0..0x10000));
+                        rpc.complete(());
+                    }
+                    other => panic!("expected Unmap for eager, got {other:?}"),
+                }
+            },
+            async {
+                let msg = lazy_recv.recv().await.unwrap();
+                match msg {
+                    MapperRequest::Unmap(rpc) => {
+                        let (range, rpc) = rpc.split();
+                        assert_eq!(range, MemoryRange::new(0..0x10000));
+                        rpc.complete(());
+                    }
+                    other => panic!("expected Unmap for lazy, got {other:?}"),
+                }
+            }
+        );
+    }
+
+    /// Helper: create a task with two mappings for rollback tests.
+    async fn task_with_two_mappings() -> MappingManagerTask {
+        let mut task = MappingManagerTask::new();
+        for (start, end) in [(0u64, 0x10000u64), (0x10000, 0x20000)] {
+            let mappable: Mappable = sparse_mmap::alloc_shared_memory(0x10000, "test")
+                .unwrap()
+                .into();
+            task.add_mapping(MappingParams {
+                range: MemoryRange::new(start..end),
+                mappable,
+                file_offset: 0,
+                writable: true,
+                dma_target: true,
+                numa_node: None,
+            })
+            .await
+            .unwrap();
+        }
+        task
+    }
+
+    #[pal_async::async_test]
+    async fn test_add_eager_mapper_rollback_on_replay_failure(_spawn: impl Spawn) {
+        let mut task = task_with_two_mappings().await;
+
+        // Create a mapper that succeeds on the first mapping but fails
+        // on the second.
+        let (send, mut recv) = mesh::channel();
+        let add_future = task.add_mapper(send, true);
+        let (result, _) = futures::join!(add_future, async {
+            // First MapEager: succeed.
+            let msg = recv.recv().await.unwrap();
+            match msg {
+                MapperRequest::MapEager(rpc) => rpc.complete(Ok(())),
+                other => panic!("expected MapEager #1, got {other:?}"),
+            }
+            // Second MapEager: fail.
+            let msg = recv.recv().await.unwrap();
+            match msg {
+                MapperRequest::MapEager(rpc) => {
+                    rpc.complete(Err(RemoteError::new(std::io::Error::other(
+                        "simulated failure",
+                    ))));
+                }
+                other => panic!("expected MapEager #2, got {other:?}"),
+            }
+        });
+
+        // add_mapper should return an error.
+        assert!(result.is_err());
+
+        // The mapper should have been removed from the slab.
+        assert_eq!(task.mappers.mappers.len(), 0);
+
+        // The first mapping's active_mappers should have been cleaned up.
+        for mapping in &task.mappings {
+            assert!(
+                mapping.active_mappers.is_empty(),
+                "active_mappers should be empty after rollback, got {:?} for {}",
+                mapping.active_mappers,
+                mapping.params.range
+            );
+        }
+
+        // Behavioral check: adding another eager mapper should succeed and
+        // replay both mappings cleanly (no stale state from failed mapper).
+        let (send2, mut recv2) = mesh::channel();
+        let add_future2 = task.add_mapper(send2, true);
+        let (result2, _) = futures::join!(add_future2, async {
+            for _ in 0..2 {
+                let msg = recv2.recv().await.unwrap();
+                match msg {
+                    MapperRequest::MapEager(rpc) => rpc.complete(Ok(())),
+                    other => panic!("expected MapEager during second add, got {other:?}"),
+                }
+            }
+        });
+        assert!(result2.is_ok());
+    }
+
+    #[pal_async::async_test]
+    async fn test_add_mapping_rollback_on_eager_failure(_spawn: impl Spawn) {
+        let mut task = MappingManagerTask::new();
+
+        // Add two eager mappers.
+        let (send1, mut recv1) = mesh::channel();
+        let _id1 = task.add_mapper(send1, true).await.unwrap();
+
+        let (send2, mut recv2) = mesh::channel();
+        let _id2 = task.add_mapper(send2, true).await.unwrap();
+
+        // Add a mapping. Mapper 1 succeeds, mapper 2 fails.
+        let mappable: Mappable = sparse_mmap::alloc_shared_memory(0x1000, "test")
+            .unwrap()
+            .into();
+        let params = MappingParams {
+            range: MemoryRange::new(0..0x1000),
+            mappable,
+            file_offset: 0,
+            writable: true,
+            dma_target: false,
+            numa_node: None,
+        };
+
+        let add_future = task.add_mapping(params);
+        let (result, _, _) = futures::join!(
+            add_future,
+            async {
+                // Mapper 1: succeed.
+                let msg = recv1.recv().await.unwrap();
+                match msg {
+                    MapperRequest::MapEager(rpc) => rpc.complete(Ok(())),
+                    other => panic!("expected MapEager, got {other:?}"),
+                }
+                // Mapper 1 should then receive an Unmap (rollback).
+                let msg = recv1.recv().await.unwrap();
+                match msg {
+                    MapperRequest::Unmap(rpc) => {
+                        let (range, rpc) = rpc.split();
+                        assert_eq!(range, MemoryRange::new(0..0x1000));
+                        rpc.complete(());
+                    }
+                    other => panic!("expected Unmap rollback, got {other:?}"),
+                }
+            },
+            async {
+                // Mapper 2: fail.
+                let msg = recv2.recv().await.unwrap();
+                match msg {
+                    MapperRequest::MapEager(rpc) => {
+                        rpc.complete(Err(RemoteError::new(std::io::Error::other(
+                            "simulated failure",
+                        ))));
+                    }
+                    other => panic!("expected MapEager, got {other:?}"),
+                }
+            }
+        );
+
+        // add_mapping should return an error.
+        assert!(result.is_err());
+
+        // The mapping should not have been added.
+        assert!(task.mappings.is_empty());
+    }
+
+    #[pal_async::async_test]
+    async fn test_upgrade_to_eager_rollback_on_failure(_spawn: impl Spawn) {
+        let mut task = task_with_two_mappings().await;
+
+        // Add a lazy mapper.
+        let (send, mut recv) = mesh::channel();
+        let id = task.add_mapper(send, false).await.unwrap();
+        assert!(!task.mappers.mappers[id.0].eager);
+
+        // Upgrade: succeed on first mapping, fail on second.
+        let upgrade_future = task.upgrade_to_eager(id);
+        let (result, _) = futures::join!(upgrade_future, async {
+            // First MapEager: succeed.
+            let msg = recv.recv().await.unwrap();
+            match msg {
+                MapperRequest::MapEager(rpc) => rpc.complete(Ok(())),
+                other => panic!("expected MapEager #1, got {other:?}"),
+            }
+            // Second MapEager: fail.
+            let msg = recv.recv().await.unwrap();
+            match msg {
+                MapperRequest::MapEager(rpc) => {
+                    rpc.complete(Err(RemoteError::new(std::io::Error::other(
+                        "simulated failure",
+                    ))));
+                }
+                other => panic!("expected MapEager #2, got {other:?}"),
+            }
+        });
+
+        // upgrade_to_eager should return an error.
+        assert!(result.is_err());
+
+        // The mapper should still be lazy (rolled back).
+        assert!(!task.mappers.mappers[id.0].eager);
+
+        // active_mappers should be cleaned up.
+        for mapping in &task.mappings {
+            assert!(
+                !mapping.active_mappers.contains(&id),
+                "mapper should not be in active_mappers after rollback"
+            );
+        }
+
+        // The mapper should still be in the slab (not removed, just stayed lazy).
+        assert!(task.mappers.mappers.contains(id.0));
+
+        // Behavioral check: a subsequent add_mapping should NOT push to
+        // this mapper (it's still lazy).
+        let mappable: Mappable = sparse_mmap::alloc_shared_memory(0x1000, "test")
+            .unwrap()
+            .into();
+        task.add_mapping(MappingParams {
+            range: MemoryRange::new(0x20000..0x21000),
+            mappable,
+            file_offset: 0,
+            writable: true,
+            dma_target: false,
+            numa_node: None,
+        })
+        .await
+        .unwrap();
+
+        // The lazy mapper should have received nothing.
+        assert!(
+            recv.try_recv().is_err(),
+            "lazy mapper should not receive add_mapping push after failed upgrade"
+        );
+    }
+
+    #[pal_async::async_test]
+    async fn test_eager_page_fault_fails_immediately(_spawn: impl Spawn) {
+        use super::super::va_mapper::VaMapper;
+
+        // Create a VaMapper directly, manually driving the AddMapper RPC.
+        let (req_send, mut req_recv) = mesh::channel::<MappingRequest>();
+        let mapper_future = VaMapper::new(
+            req_send,
+            0x10000,
+            None,
+            Vec::new(),
+            None,
+            true, // eager
+        );
+        let (mapper, _) = futures::join!(mapper_future, async {
+            let msg = req_recv.recv().await.unwrap();
+            match msg {
+                MappingRequest::AddMapper(rpc) => {
+                    rpc.handle_failable_sync(|(_send, eager)| {
+                        assert!(eager);
+                        Ok::<_, MappingError>(MapperId(0))
+                    });
+                }
+                _ => panic!("expected AddMapper"),
+            }
+        });
+        let mapper = mapper.unwrap();
+        assert!(mapper.is_eager());
+
+        // No mappings have been established, so a page fault on a
+        // file-backed address should fail immediately rather than
+        // trying to request the mapping lazily.
+        let action = mapper.page_fault(0x1000, 0x1000, false, false);
+        assert!(
+            matches!(action, guestmem::PageFaultAction::Fail(_)),
+            "eager mapper should fail page faults on unmapped file-backed ranges"
+        );
+    }
+
+    #[pal_async::async_test]
+    async fn test_va_mapper_drop_removes_mapper(_spawn: impl Spawn) {
+        use super::super::va_mapper::VaMapper;
+
+        let (req_send, mut req_recv) = mesh::channel::<MappingRequest>();
+        let mapper_future = VaMapper::new(
+            req_send,
+            0x10000,
+            None,
+            Vec::new(),
+            None,
+            true, // eager
+        );
+        let (mapper, mapper_req_send) = futures::join!(mapper_future, async {
+            let msg = req_recv.recv().await.unwrap();
+            match msg {
+                MappingRequest::AddMapper(rpc) => {
+                    let ((mapper_req_send, eager), rpc) = rpc.split();
+                    assert!(eager);
+                    rpc.complete(Ok(MapperId(7)));
+                    mapper_req_send
+                }
+                _ => panic!("expected AddMapper"),
+            }
+        });
+        drop(mapper.unwrap());
+
+        match req_recv.recv().await.unwrap() {
+            MappingRequest::RemoveMapper(id) => assert_eq!(id, MapperId(7)),
+            _ => panic!("expected RemoveMapper"),
+        }
+
+        // In production, MappingManagerTask::remove_mapper drops this sender.
+        // Do the same here so the mapper thread can exit.
+        drop(mapper_req_send);
+    }
+
+    #[pal_async::async_test]
+    async fn test_lazy_page_fault_requests_mapping(spawn: impl Spawn) {
+        let _ = spawn;
+        let (manager_thread, manager_driver) =
+            pal_async::DefaultPool::spawn_on_thread("mapping-manager-test");
+        let mm = MappingManager::new(&manager_driver, 0x10000, Vec::new(), None);
+        let client = mm.client().clone();
+
+        // Add a mapping so the lazy mapper can find it.
+        let mappable: Mappable = sparse_mmap::alloc_shared_memory(0x10000, "test")
+            .unwrap()
+            .into();
+        client
+            .add_mapping(MappingParams {
+                range: MemoryRange::new(0..0x10000),
+                mappable,
+                file_offset: 0,
+                writable: true,
+                dma_target: false,
+                numa_node: None,
+            })
+            .await
+            .unwrap();
+
+        // Create a lazy mapper.
+        let mapper = client.new_lazy_mapper().await.unwrap();
+        assert!(!mapper.is_eager());
+
+        // page_fault calls block_on(request_mapping(...)), which blocks the
+        // calling thread. The MappingManager task is running on its own pool
+        // thread, so it can still serve SendMappings while this test thread is
+        // blocked here.
+        let action = mapper.page_fault(0x1000, 0x1000, false, false);
+        assert!(
+            matches!(action, guestmem::PageFaultAction::Retry),
+            "lazy mapper should request mapping on page fault and succeed"
+        );
+
+        drop(mapper);
+        drop(client);
+        drop(mm);
+        drop(manager_driver);
+        manager_thread.join().unwrap();
+    }
+
+    #[pal_async::async_test]
+    async fn test_new_mapper_upgrades_cached_lazy_to_eager(spawn: impl Spawn) {
+        let _ = spawn;
+        let (manager_thread, manager_driver) =
+            pal_async::DefaultPool::spawn_on_thread("mapping-manager-test");
+        let mm = MappingManager::new(&manager_driver, 0x20000, Vec::new(), None);
+        let client = mm.client().clone();
+
+        // Add a mapping first so replay has something to push.
+        let mappable: Mappable = sparse_mmap::alloc_shared_memory(0x10000, "test")
+            .unwrap()
+            .into();
+        client
+            .add_mapping(MappingParams {
+                range: MemoryRange::new(0..0x10000),
+                mappable,
+                file_offset: 0,
+                writable: true,
+                dma_target: false,
+                numa_node: None,
+            })
+            .await
+            .unwrap();
+
+        // Create a lazy mapper first — this gets cached.
+        let lazy = client.new_lazy_mapper().await.unwrap();
+        assert!(!lazy.is_eager());
+
+        // Now request an eager mapper — should upgrade the cached lazy one.
+        let eager = client.new_mapper().await.unwrap();
+
+        // They should be the same Arc (same underlying mapper).
+        assert!(Arc::ptr_eq(&lazy, &eager));
+
+        // Queue one more eager mapping. The manager sends SetEager before
+        // returning from the upgrade RPC, and this MapEager is queued after
+        // that, so a successful add_mapping means the mapper thread has
+        // processed SetEager.
+        let mappable: Mappable = sparse_mmap::alloc_shared_memory(0x1000, "test")
+            .unwrap()
+            .into();
+        client
+            .add_mapping(MappingParams {
+                range: MemoryRange::new(0x10000..0x11000),
+                mappable,
+                file_offset: 0,
+                writable: true,
+                dma_target: false,
+                numa_node: None,
+            })
+            .await
+            .unwrap();
+
+        // The mapper is now observably eager.
+        assert!(eager.is_eager());
+
+        drop(eager);
+        drop(lazy);
+        drop(client);
+        drop(mm);
+        drop(manager_driver);
+        manager_thread.join().unwrap();
     }
 }

--- a/openvmm/membacking/src/mapping_manager/manager.rs
+++ b/openvmm/membacking/src/mapping_manager/manager.rs
@@ -434,15 +434,17 @@ impl MappingManagerTask {
 
         let mut failed = None;
         for mapping in &mut self.mappings {
+            // Skip mappings already established by lazy resolution.
+            if mapping.active_mappers.contains(&id) {
+                continue;
+            }
             match self.mappers.mappers[id.0]
                 .req_send
                 .call(MapperRequest::MapEager, mapping.params.clone())
                 .await
             {
                 Ok(Ok(())) => {
-                    if !mapping.active_mappers.contains(&id) {
-                        mapping.active_mappers.push(id);
-                    }
+                    mapping.active_mappers.push(id);
                 }
                 Ok(Err(e)) => {
                     failed = Some(MappingError::new(

--- a/openvmm/membacking/src/mapping_manager/manager.rs
+++ b/openvmm/membacking/src/mapping_manager/manager.rs
@@ -1399,6 +1399,70 @@ mod tests {
         manager_thread.join().unwrap();
     }
 
+    /// Demonstrates the deadlock in VaMapper::new() when creating an eager
+    /// mapper while mappings already exist: the manager's add_mapper() replays
+    /// mappings via MapEager RPCs to the mapper channel, but the mapper thread
+    /// that would process those RPCs hasn't been spawned yet (it's spawned
+    /// after AddMapper returns).
+    #[pal_async::async_test]
+    async fn test_eager_mapper_with_existing_mappings_deadlocks(spawn: impl Spawn) {
+        let _ = spawn;
+        let (manager_thread, manager_driver) =
+            pal_async::DefaultPool::spawn_on_thread("mapping-manager-test");
+        let mm = MappingManager::new(&manager_driver, 0x10000, Vec::new(), None);
+        let client = mm.client().clone();
+
+        // Add a mapping while no mappers exist — it is stored for replay.
+        let mappable: Mappable = sparse_mmap::alloc_shared_memory(0x10000, "test")
+            .unwrap()
+            .into();
+        client
+            .add_mapping(MappingParams {
+                range: MemoryRange::new(0..0x10000),
+                mappable,
+                file_offset: 0,
+                writable: true,
+                mapping_type: MappingType::Ram,
+                numa_node: None,
+            })
+            .await
+            .unwrap();
+
+        // Try to create an eager mapper on a separate thread. The call chain:
+        //   VaMapper::new() --AddMapper RPC--> manager task
+        //   manager::add_mapper() --MapEager RPC--> mapper channel (no reader!)
+        // The mapper thread is only spawned after AddMapper returns, so the
+        // MapEager RPC has no one to respond and the whole chain deadlocks.
+        let (done_send, done_recv) = std::sync::mpsc::channel();
+        let _handle = std::thread::spawn(move || {
+            let result =
+                pal_async::DefaultPool::run_with(
+                    |_driver| async move { client.new_mapper().await },
+                );
+            let _ = done_send.send(result);
+        });
+
+        match done_recv.recv_timeout(std::time::Duration::from_secs(5)) {
+            Ok(result) => {
+                let mapper = result.unwrap();
+                assert!(mapper.is_eager());
+                drop(mapper);
+            }
+            Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {
+                panic!(
+                    "DEADLOCK: new_mapper() did not complete within 5 s. \
+                     The manager task is blocked awaiting a MapEager response \
+                     from a mapper thread that has not been spawned yet."
+                );
+            }
+            Err(e) => panic!("mapper thread died: {e}"),
+        }
+
+        drop(mm);
+        drop(manager_driver);
+        manager_thread.join().unwrap();
+    }
+
     #[pal_async::async_test]
     async fn test_new_mapper_upgrades_cached_lazy_to_eager(spawn: impl Spawn) {
         let _ = spawn;

--- a/openvmm/membacking/src/mapping_manager/manager.rs
+++ b/openvmm/membacking/src/mapping_manager/manager.rs
@@ -176,11 +176,11 @@ impl MappingManagerClient {
     /// TODO: currently this will panic if the mapping overlaps an existing
     /// mapping. This needs to be fixed to allow this to overlap existing
     /// mappings, in which case the old ones will be split and replaced.
-    pub async fn add_mapping(&self, params: MappingParams) -> Result<(), RemoteError> {
+    pub async fn add_mapping(&self, params: MappingParams) -> anyhow::Result<()> {
         self.req_send
-            .call(MappingRequest::AddMapping, params)
-            .await
-            .map_err(RemoteError::new)?
+            .call_failable(MappingRequest::AddMapping, params)
+            .await?;
+        Ok(())
     }
 
     /// Removes all mappings in `range`.
@@ -1392,13 +1392,11 @@ mod tests {
         manager_thread.join().unwrap();
     }
 
-    /// Demonstrates the deadlock in VaMapper::new() when creating an eager
-    /// mapper while mappings already exist: the manager's add_mapper() replays
-    /// mappings via MapEager RPCs to the mapper channel, but the mapper thread
-    /// that would process those RPCs hasn't been spawned yet (it's spawned
-    /// after AddMapper returns).
+    /// Tests that creating an eager mapper succeeds even when mappings
+    /// already exist (the mapper thread must be running to service the
+    /// replay RPCs during AddMapper).
     #[pal_async::async_test]
-    async fn test_eager_mapper_with_existing_mappings_deadlocks(spawn: impl Spawn) {
+    async fn test_eager_mapper_with_existing_mappings(spawn: impl Spawn) {
         let _ = spawn;
         let (manager_thread, manager_driver) =
             pal_async::DefaultPool::spawn_on_thread("mapping-manager-test");
@@ -1421,36 +1419,13 @@ mod tests {
             .await
             .unwrap();
 
-        // Try to create an eager mapper on a separate thread. The call chain:
-        //   VaMapper::new() --AddMapper RPC--> manager task
-        //   manager::add_mapper() --MapEager RPC--> mapper channel (no reader!)
-        // The mapper thread is only spawned after AddMapper returns, so the
-        // MapEager RPC has no one to respond and the whole chain deadlocks.
-        let (done_send, done_recv) = std::sync::mpsc::channel();
-        let _handle = std::thread::spawn(move || {
-            let result =
-                pal_async::DefaultPool::run_with(
-                    |_driver| async move { client.new_mapper(true).await },
-                );
-            let _ = done_send.send(result);
-        });
+        // Create an eager mapper. The mapper thread must be spawned before
+        // the AddMapper RPC so it can respond to replay MapEager RPCs.
+        let mapper = client.new_mapper(true).await.unwrap();
+        assert!(mapper.is_eager());
 
-        match done_recv.recv_timeout(std::time::Duration::from_secs(5)) {
-            Ok(result) => {
-                let mapper = result.unwrap();
-                assert!(mapper.is_eager());
-                drop(mapper);
-            }
-            Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {
-                panic!(
-                    "DEADLOCK: new_mapper() did not complete within 5 s. \
-                     The manager task is blocked awaiting a MapEager response \
-                     from a mapper thread that has not been spawned yet."
-                );
-            }
-            Err(e) => panic!("mapper thread died: {e}"),
-        }
-
+        drop(mapper);
+        drop(client);
         drop(mm);
         drop(manager_driver);
         manager_thread.join().unwrap();

--- a/openvmm/membacking/src/mapping_manager/manager.rs
+++ b/openvmm/membacking/src/mapping_manager/manager.rs
@@ -535,7 +535,6 @@ impl MappingManagerTask {
 
         // Push to eager mappers only. Lazy mappers will request on demand.
         let mut active_mappers = Vec::new();
-        let mut dead_mappers = Vec::new();
         for (i, mapper) in self.mappers.mappers.iter() {
             if !mapper.eager {
                 continue;
@@ -567,15 +566,11 @@ impl MappingManagerTask {
                     return Err(e);
                 }
                 Err(_) => {
-                    // Mapper channel closed — remove after iteration.
+                    // Mapper gone, skip. VaMapper::drop sends RemoveMapper
+                    // which cleans up the stale entry.
                     tracing::debug!(?id, "mapper gone during add_mapping");
-                    dead_mappers.push(id);
                 }
             }
-        }
-
-        for id in dead_mappers {
-            self.remove_mapper(id);
         }
 
         self.mappings.push(Mapping {

--- a/openvmm/membacking/src/mapping_manager/manager.rs
+++ b/openvmm/membacking/src/mapping_manager/manager.rs
@@ -11,6 +11,7 @@ use super::object_cache::ObjectId;
 use super::va_mapper::VaMapper;
 use super::va_mapper::VaMapperError;
 use crate::RemoteProcess;
+use crate::region_manager::MappingType;
 use futures::StreamExt;
 use futures::future::join_all;
 use guestmem::ProvideShareableRegions;
@@ -127,6 +128,12 @@ impl MappingManagerClient {
                 .await
                 .map_err(VaMapperError::MemoryManagerGone)?
                 .map_err(VaMapperError::Registration)?;
+
+            // The UpgradeToEager RPC replayed all mappings and queued
+            // SetEager to the mapper task, but that message may not be
+            // processed yet. Set the flag here so callers can rely on
+            // is_eager() immediately.
+            mapper.set_eager();
         }
 
         Ok(mapper)
@@ -188,7 +195,7 @@ impl MappingManagerClient {
                 Some(process),
                 Vec::new(),
                 self.minimum_va_alignment,
-                false, // remote mappers are always lazy
+                true, // eager — remote mappers used for partition mappings
             )
             .await?,
         ))
@@ -237,7 +244,7 @@ pub enum MappingRequest {
     UpgradeToEager(Rpc<MapperId, Result<(), RemoteError>>),
     AddMapping(Rpc<MappingParams, Result<(), RemoteError>>),
     RemoveMappings(Rpc<MemoryRange, ()>),
-    /// Returns all mappings that have `dma_target` set.
+    /// Returns all mappings that have [`MappingType::Ram`] type.
     GetDmaTargetMappings(Rpc<(), Vec<MappingParams>>),
     Inspect(inspect::Deferred),
 }
@@ -259,7 +266,7 @@ fn inspect_mappings(mappings: &Vec<Mapping>) -> impl '_ + Inspect {
                 inspect::adhoc(|req| {
                     req.respond()
                         .field("writable", mapping.params.writable)
-                        .field("dma_target", mapping.params.dma_target)
+                        .field("mapping_type", format!("{:?}", mapping.params.mapping_type))
                         .hex("file_offset", mapping.params.file_offset);
                 }),
             );
@@ -283,12 +290,12 @@ pub struct MappingParams {
     pub file_offset: u64,
     /// Whether to map the memory as writable.
     pub writable: bool,
-    /// Whether this mapping is a DMA target (guest RAM or similar).
+    /// The type of memory being mapped.
     ///
-    /// DMA-target mappings are exposed via [`GuestMemorySharing`](guestmem::GuestMemorySharing) so
-    /// that external consumers (vhost-user backends, etc.) can share the
-    /// backing memory.
-    pub dma_target: bool,
+    /// [`MappingType::Ram`] mappings are exposed via
+    /// [`GuestMemorySharing`](guestmem::GuestMemorySharing) so that external
+    /// consumers (vhost-user backends, etc.) can share the backing memory.
+    pub mapping_type: MappingType,
     /// Host NUMA node for this mapping. `None` means OS default placement.
     pub numa_node: Option<u32>,
 }
@@ -608,7 +615,7 @@ impl MappingManagerTask {
     fn get_dma_target_mappings(&self) -> Vec<MappingParams> {
         self.mappings
             .iter()
-            .filter(|m| m.params.dma_target)
+            .filter(|m| m.params.mapping_type == MappingType::Ram)
             .map(|m| m.params.clone())
             .collect()
     }
@@ -681,6 +688,7 @@ impl ProvideShareableRegions for DmaRegionProvider {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::region_manager::MappingType;
     use guestmem::GuestMemoryAccess;
     use guestmem::ProvideShareableRegions;
     use memory_range::MemoryRange;
@@ -703,7 +711,7 @@ mod tests {
                 mappable: ram,
                 file_offset: 0,
                 writable: true,
-                dma_target: true,
+                mapping_type: MappingType::Ram,
                 numa_node: None,
             })
             .await
@@ -715,7 +723,7 @@ mod tests {
                 mappable: device,
                 file_offset: 0,
                 writable: true,
-                dma_target: false,
+                mapping_type: MappingType::Device,
                 numa_node: None,
             })
             .await
@@ -748,7 +756,7 @@ mod tests {
                 mappable,
                 file_offset: 0,
                 writable: true,
-                dma_target: false,
+                mapping_type: MappingType::Device,
                 numa_node: None,
             })
             .await
@@ -772,7 +780,7 @@ mod tests {
             mappable,
             file_offset: 0,
             writable: true,
-            dma_target: true,
+            mapping_type: MappingType::Ram,
             numa_node: None,
         };
         task.add_mapping(params.clone()).await.unwrap();
@@ -846,7 +854,7 @@ mod tests {
             mappable,
             file_offset: 0,
             writable: true,
-            dma_target: false,
+            mapping_type: MappingType::Device,
             numa_node: None,
         };
 
@@ -948,7 +956,7 @@ mod tests {
             mappable,
             file_offset: 0,
             writable: true,
-            dma_target: false,
+            mapping_type: MappingType::Device,
             numa_node: None,
         };
 
@@ -1066,7 +1074,7 @@ mod tests {
                 mappable,
                 file_offset: 0,
                 writable: true,
-                dma_target: true,
+                mapping_type: MappingType::Ram,
                 numa_node: None,
             })
             .await
@@ -1154,7 +1162,7 @@ mod tests {
             mappable,
             file_offset: 0,
             writable: true,
-            dma_target: false,
+            mapping_type: MappingType::Device,
             numa_node: None,
         };
 
@@ -1257,7 +1265,7 @@ mod tests {
             mappable,
             file_offset: 0,
             writable: true,
-            dma_target: false,
+            mapping_type: MappingType::Device,
             numa_node: None,
         })
         .await
@@ -1364,7 +1372,7 @@ mod tests {
                 mappable,
                 file_offset: 0,
                 writable: true,
-                dma_target: false,
+                mapping_type: MappingType::Device,
                 numa_node: None,
             })
             .await
@@ -1409,7 +1417,7 @@ mod tests {
                 mappable,
                 file_offset: 0,
                 writable: true,
-                dma_target: false,
+                mapping_type: MappingType::Device,
                 numa_node: None,
             })
             .await
@@ -1438,7 +1446,7 @@ mod tests {
                 mappable,
                 file_offset: 0,
                 writable: true,
-                dma_target: false,
+                mapping_type: MappingType::Device,
                 numa_node: None,
             })
             .await

--- a/openvmm/membacking/src/mapping_manager/manager.rs
+++ b/openvmm/membacking/src/mapping_manager/manager.rs
@@ -194,13 +194,21 @@ impl MappingManagerClient {
     }
 }
 
+/// Parameters for registering a new VA mapper.
+#[derive(MeshPayload)]
+pub struct AddMapperParams {
+    /// Channel for sending mapping requests to the mapper task.
+    pub send: mesh::Sender<MapperRequest>,
+    /// Whether the mapper is eager (mappings pushed immediately and replayed
+    /// on creation) or lazy (mappings populated on demand via page faults).
+    pub eager: bool,
+}
+
 /// A mapping request message.
 #[derive(MeshPayload)]
 pub enum MappingRequest {
-    /// Register a new VA mapper. The `bool` indicates whether the mapper is
-    /// eager (mappings pushed immediately and replayed on creation) or lazy
-    /// (mappings populated on demand via page faults).
-    AddMapper(FailableRpc<(mesh::Sender<MapperRequest>, bool), MapperId>),
+    /// Register a new VA mapper.
+    AddMapper(FailableRpc<AddMapperParams, MapperId>),
     RemoveMapper(MapperId),
     /// Request that mappings covering the given range be sent to the specified
     /// mapper via fire-and-forget `MapLazy` messages. Used by lazy mappers
@@ -331,8 +339,10 @@ impl MappingManagerTask {
         while let Some(req) = req_recv.next().await {
             match req {
                 MappingRequest::AddMapper(rpc) => {
-                    rpc.handle_failable(async |(send, eager)| self.add_mapper(send, eager).await)
-                        .await
+                    rpc.handle_failable(async |params: AddMapperParams| {
+                        self.add_mapper(params.send, params.eager).await
+                    })
+                    .await
                 }
                 MappingRequest::RemoveMapper(id) => {
                     self.remove_mapper(id);
@@ -1279,8 +1289,8 @@ mod tests {
             let msg = req_recv.recv().await.unwrap();
             match msg {
                 MappingRequest::AddMapper(rpc) => {
-                    rpc.handle_failable_sync(|(_send, eager)| {
-                        assert!(eager);
+                    rpc.handle_failable_sync(|params| {
+                        assert!(params.eager);
                         Ok::<_, MappingError>(MapperId(0))
                     });
                 }
@@ -1317,10 +1327,10 @@ mod tests {
             let msg = req_recv.recv().await.unwrap();
             match msg {
                 MappingRequest::AddMapper(rpc) => {
-                    let ((mapper_req_send, eager), rpc) = rpc.split();
-                    assert!(eager);
+                    let (params, rpc) = rpc.split();
+                    assert!(params.eager);
                     rpc.complete(Ok(MapperId(7)));
-                    mapper_req_send
+                    params.send
                 }
                 _ => panic!("expected AddMapper"),
             }

--- a/openvmm/membacking/src/mapping_manager/va_mapper.rs
+++ b/openvmm/membacking/src/mapping_manager/va_mapper.rs
@@ -50,12 +50,17 @@ use std::sync::atomic::Ordering;
 use std::thread::JoinHandle;
 use thiserror::Error;
 
+#[derive(Debug, Error)]
+#[error("unexpected page fault")]
+struct UnexpectedPageFault;
+
 /// A virtual address space mapper for guest memory.
 ///
 /// Maintains a reserved VA range and maps file-backed or anonymous memory
 /// into it as directed by the mapping manager.
 pub struct VaMapper {
     inner: Arc<MapperInner>,
+    id: MapperId,
     process: Option<RemoteProcess>,
     /// Ranges backed by private anonymous memory.
     /// Page faults in these ranges commit pages directly instead of
@@ -82,7 +87,7 @@ impl Drop for VaMapper {
         // exits naturally.
         self.inner
             .req_send
-            .send(MappingRequest::RemoveMapper(self.inner.id));
+            .send(MappingRequest::RemoveMapper(self.id));
     }
 }
 
@@ -102,7 +107,6 @@ struct MapperInner {
     /// is eventually updated after `SetEager` is processed.
     eager: AtomicBool,
     req_send: mesh::Sender<MappingRequest>,
-    id: MapperId,
 }
 
 /// A pending lazy mapping request.
@@ -159,20 +163,28 @@ impl MapperTask {
                 MapperRequest::MapLazy(params) => {
                     tracing::debug!(range = %params.range, "lazy mapping received");
                     let (range, writable) = (params.range, params.writable);
-                    if self.map_file(params).is_ok() {
-                        self.wake_waiters(range, Some(writable));
-                    } else {
-                        self.wake_waiters(range, None);
+                    match self.map_file(params) {
+                        Ok(()) => self.wake_waiters(range, Some(writable)),
+                        Err(e) => {
+                            tracing::error!(
+                                error = &e as &dyn std::error::Error,
+                                %range,
+                                "failed to map file for range"
+                            );
+                            self.wake_waiters(range, None);
+                        }
                     }
                 }
                 MapperRequest::NoMapping(range) => {
+                    // Wake up waiters. They'll see a failure when they try
+                    // to access the VA.
                     tracing::debug!(%range, "no mapping for range");
                     self.wake_waiters(range, None);
                 }
-                MapperRequest::SetEager => {
+                MapperRequest::SetEager(rpc) => rpc.handle_sync(|()| {
                     tracing::debug!("mapper upgraded to eager");
                     self.inner.eager.store(true, Ordering::Relaxed);
-                }
+                }),
             }
         }
         // Don't allow more waiters.
@@ -273,8 +285,6 @@ pub enum VaMapperError {
     Reserve(#[source] std::io::Error),
     #[error("remote mappers are not supported when any RAM backing uses private memory")]
     RemoteWithPrivateMemory,
-    #[error("lazy mappers are not supported when any RAM backing uses private memory")]
-    LazyWithPrivateMemory,
 }
 
 /// Error returned when a lazy mapping request cannot be fulfilled.
@@ -288,7 +298,12 @@ impl MapperInner {
     /// Registers a waiter, sends `SendMappings` (fire-and-forget), and
     /// awaits the waiter oneshot. The mapping manager will send `MapLazy`
     /// or `NoMapping` messages to the mapper task, which wakes the waiter.
-    async fn request_mapping(&self, range: MemoryRange, writable: bool) -> Result<(), NoMapping> {
+    async fn request_mapping(
+        &self,
+        id: MapperId,
+        range: MemoryRange,
+        writable: bool,
+    ) -> Result<(), NoMapping> {
         let (send, recv) = mesh::oneshot();
         self.waiters
             .lock()
@@ -301,8 +316,7 @@ impl MapperInner {
             });
 
         tracing::debug!(%range, "waiting for mappings");
-        self.req_send
-            .send(MappingRequest::SendMappings(self.id, range));
+        self.req_send.send(MappingRequest::SendMappings(id, range));
         match recv.await {
             Ok(true) => Ok(()),
             Ok(false) | Err(_) => Err(NoMapping(range)),
@@ -341,20 +355,18 @@ impl VaMapper {
         mapping.set_name(0, mapping.len(), "guest-memory");
 
         let (send, req_recv) = mesh::channel();
-        let id = req_send
-            .call(MappingRequest::AddMapper, (send, eager))
-            .await
-            .map_err(VaMapperError::MemoryManagerGone)?
-            .map_err(VaMapperError::Registration)?;
 
         let inner = Arc::new(MapperInner {
             mapping,
             waiters: Mutex::new(Some(Vec::new())),
             eager: AtomicBool::new(eager),
             req_send,
-            id,
         });
 
+        // Spawn the mapper thread *before* the AddMapper RPC. The manager
+        // replays existing mappings to eager mappers during AddMapper, so
+        // the mapper thread must be running to respond to those RPCs.
+        //
         // FUTURE: use a task once we resolve the block_ons in the
         // GuestMemoryAccess implementation.
         let thread = std::thread::Builder::new()
@@ -367,8 +379,28 @@ impl VaMapper {
             })
             .unwrap();
 
+        let id = match inner
+            .req_send
+            .call(MappingRequest::AddMapper, (send, eager))
+            .await
+        {
+            Ok(Ok(id)) => id,
+            Ok(Err(e)) => {
+                // Drop inner to shut down the mapper thread (closes req_recv).
+                drop(inner);
+                let _ = thread.join();
+                return Err(VaMapperError::Registration(e));
+            }
+            Err(e) => {
+                drop(inner);
+                let _ = thread.join();
+                return Err(VaMapperError::MemoryManagerGone(e));
+            }
+        };
+
         Ok(VaMapper {
             inner,
+            id,
             process: remote_process,
             private_ranges,
             _thread: thread,
@@ -395,18 +427,9 @@ impl VaMapper {
         self.inner.eager.load(Ordering::Relaxed)
     }
 
-    /// Marks this mapper as eager.
-    ///
-    /// Called after an `UpgradeToEager` RPC completes so that `is_eager()`
-    /// returns `true` immediately, without waiting for the mapper task to
-    /// process the `SetEager` message.
-    pub(crate) fn set_eager(&self) {
-        self.inner.eager.store(true, Ordering::Relaxed);
-    }
-
     /// Returns the mapper's ID, used internally for upgrade requests.
     pub(crate) fn mapper_id(&self) -> MapperId {
-        self.inner.id
+        self.id
     }
 
     /// Returns the remote process, if this mapper maps into a remote process.
@@ -525,7 +548,7 @@ unsafe impl GuestMemoryAccess for VaMapper {
                 // If we get here, something is wrong.
                 return PageFaultAction::Fail(PageFaultError::new(
                     guestmem::GuestMemoryErrorKind::Other,
-                    std::io::Error::other("unexpected page fault in private RAM range on Linux"),
+                    UnexpectedPageFault,
                 ));
             }
         }
@@ -536,15 +559,13 @@ unsafe impl GuestMemoryAccess for VaMapper {
             // torn down.
             return PageFaultAction::Fail(PageFaultError::new(
                 guestmem::GuestMemoryErrorKind::OutOfRange,
-                std::io::Error::other(format!(
-                    "page fault at {address:#x}+{len:#x}: no eager mapping established"
-                )),
+                UnexpectedPageFault,
             ));
         }
 
         // Lazy mapper: request the mapping on demand from the mapping manager.
         let range = MemoryRange::bounding(address..address + len as u64);
-        if let Err(err) = block_on(self.inner.request_mapping(range, write)) {
+        if let Err(err) = block_on(self.inner.request_mapping(self.id, range, write)) {
             return PageFaultAction::Fail(PageFaultError::new(
                 guestmem::GuestMemoryErrorKind::OutOfRange,
                 err,

--- a/openvmm/membacking/src/mapping_manager/va_mapper.rs
+++ b/openvmm/membacking/src/mapping_manager/va_mapper.rs
@@ -4,20 +4,22 @@
 //! Implements the VA mapper, which maintains a linear virtual address space for
 //! all memory mapped into a partition.
 //!
-//! The VA mapper sends messages to the mapping manager to request mappings for
-//! specific address ranges, on demand. The mapping manager later sends
-//! invalidation requests back when tearing down mappings, e.g. when some device
-//! memory is unmapped from the partition.
+//! VA mappers come in two modes:
 //!
-//! This lazy approach is taken to avoid having to keep each VA mapper
-//! up-to-date with all mappings at all times.
+//! - **Eager**: mappings are pushed by the mapping manager when they are added
+//!   and replayed when the mapper is created. Page faults on file-backed ranges
+//!   fail immediately — the mapping should already be established. This is the
+//!   right mode for the VP process, where hypervisors like KVM do not forward
+//!   page faults back to the VMM.
 //!
-//! TODO: This is a bit dubious because the backing hypervisor will not
-//! necessarily propagate a page fault. E.g., KVM will just fail the VP. So at
-//! least for the mapper used by the partition itself, this optimization
-//! probably needs to be removed and replaced with a guarantee that replacement
-//! mappings are established immediately (and atomically?) instead of just by
-//! invalidating the existing mappings.
+//! - **Lazy**: mappings are not pushed proactively. Instead, page faults
+//!   trigger an on-demand request to the mapping manager, which finds the
+//!   backing mapping and pushes it to the mapper via Rpc. This avoids the cost
+//!   of notifying processes that rarely access certain mappings (e.g.,
+//!   device-emulation processes with virtio-fs DAX).
+//!
+//! In both modes, private memory ranges use commit-on-fault (Windows) or are
+//! handled transparently by the kernel (Linux).
 
 // UNSAFETY: Implementing the unsafe GuestMemoryAccess trait by calling unsafe
 // low level memory manipulation functions.
@@ -26,6 +28,7 @@
 use super::manager::DmaRegionProvider;
 use super::manager::MapperId;
 use super::manager::MapperRequest;
+use super::manager::MappingError;
 use super::manager::MappingParams;
 use super::manager::MappingRequest;
 use crate::RemoteProcess;
@@ -35,12 +38,15 @@ use guestmem::GuestMemorySharing;
 use guestmem::PageFaultAction;
 use guestmem::PageFaultError;
 use memory_range::MemoryRange;
+use mesh::error::RemoteError;
 use mesh::rpc::RpcError;
 use mesh::rpc::RpcSend;
 use parking_lot::Mutex;
 use sparse_mmap::SparseMapping;
 use std::ptr::NonNull;
 use std::sync::Arc;
+use std::sync::atomic::AtomicBool;
+use std::sync::atomic::Ordering;
 use std::thread::JoinHandle;
 use thiserror::Error;
 
@@ -67,14 +73,39 @@ impl std::fmt::Debug for VaMapper {
     }
 }
 
+impl Drop for VaMapper {
+    fn drop(&mut self) {
+        // Do not join the mapper thread here. The mapping manager must process
+        // this request before the mapper request channel closes, and joining in
+        // Drop could deadlock if the manager task needs the current executor to
+        // make progress. Once the manager removes its sender, the mapper thread
+        // exits naturally.
+        self.inner
+            .req_send
+            .send(MappingRequest::RemoveMapper(self.inner.id));
+    }
+}
+
 #[derive(Debug)]
 struct MapperInner {
     mapping: SparseMapping,
+    /// Waiters for lazy mapping requests. `None` after the mapper task exits.
     waiters: Mutex<Option<Vec<MapWaiter>>>,
+    /// Whether this mapper receives mappings eagerly (pushed by the
+    /// mapping manager) or lazily (on demand via page faults).
+    /// Set by the mapping manager task after replay is complete.
+    ///
+    /// `Relaxed` ordering is sufficient: this flag is only read by the
+    /// page-fault handler to decide between eager-fail and lazy-request
+    /// paths. A stale `false` (lazy) is harmless — the lazy path
+    /// succeeds because the mapping is already established. The flag
+    /// is eventually updated after `SetEager` is processed.
+    eager: AtomicBool,
     req_send: mesh::Sender<MappingRequest>,
     id: MapperId,
 }
 
+/// A pending lazy mapping request.
 #[derive(Debug)]
 struct MapWaiter {
     range: MemoryRange,
@@ -83,6 +114,10 @@ struct MapWaiter {
 }
 
 impl MapWaiter {
+    /// Check whether the established mapping satisfies this waiter.
+    /// Returns `Some(true)` if fully satisfied, `Some(false)` if the
+    /// mapping doesn't meet requirements (e.g., read-only when write
+    /// needed), or `None` if the waiter still has remaining range.
     fn complete(&mut self, range: MemoryRange, writable: Option<bool>) -> Option<bool> {
         if range.contains_addr(self.range.start()) {
             if writable.is_none() || (self.writable && writable == Some(false)) {
@@ -115,21 +150,28 @@ impl MapperTask {
                         .unmap(range.start() as usize, range.len() as usize)
                         .expect("invalidate request should be valid");
                 }),
-                MapperRequest::Map(params) => {
-                    tracing::debug!(range = %params.range, "mapping received for range");
-
+                MapperRequest::MapEager(rpc) => {
+                    rpc.handle_failable_sync(|params| {
+                        tracing::debug!(range = %params.range, "eager mapping received");
+                        self.map_file(params)
+                    });
+                }
+                MapperRequest::MapLazy(params) => {
+                    tracing::debug!(range = %params.range, "lazy mapping received");
                     let (range, writable) = (params.range, params.writable);
-                    if self.map_file(params) {
+                    if self.map_file(params).is_ok() {
                         self.wake_waiters(range, Some(writable));
                     } else {
                         self.wake_waiters(range, None);
                     }
                 }
                 MapperRequest::NoMapping(range) => {
-                    // Wake up waiters. They'll see a failure when they try to
-                    // access the VA.
-                    tracing::debug!(%range, "no mapping received for range");
+                    tracing::debug!(%range, "no mapping for range");
                     self.wake_waiters(range, None);
+                }
+                MapperRequest::SetEager => {
+                    tracing::debug!("mapper upgraded to eager");
+                    self.inner.eager.store(true, Ordering::Relaxed);
                 }
             }
         }
@@ -140,8 +182,8 @@ impl MapperTask {
     }
 
     /// Maps a file-backed region into the VA space, applying NUMA policy where
-    /// supported. Returns `true` on success.
-    fn map_file(&self, params: MappingParams) -> bool {
+    /// supported.
+    fn map_file(&self, params: MappingParams) -> Result<(), MappingError> {
         let MappingParams {
             range,
             mappable,
@@ -174,12 +216,7 @@ impl MapperTask {
         };
 
         if let Err(e) = map_result {
-            tracing::error!(
-                error = &e as &dyn std::error::Error,
-                %range,
-                "failed to map file for range"
-            );
-            return false;
+            return Err(MappingError::new(range, e));
         }
 
         cfg_select! {
@@ -208,7 +245,7 @@ impl MapperTask {
             }
         }
 
-        true
+        Ok(())
     }
 
     fn wake_waiters(&mut self, range: MemoryRange, writable: Option<bool>) {
@@ -230,17 +267,27 @@ impl MapperTask {
 pub enum VaMapperError {
     #[error("failed to communicate with the memory manager")]
     MemoryManagerGone(#[source] RpcError),
+    #[error("failed to register mapper")]
+    Registration(#[source] RemoteError),
     #[error("failed to reserve address space")]
     Reserve(#[source] std::io::Error),
     #[error("remote mappers are not supported when any RAM backing uses private memory")]
     RemoteWithPrivateMemory,
+    #[error("lazy mappers are not supported when any RAM backing uses private memory")]
+    LazyWithPrivateMemory,
 }
 
+/// Error returned when a lazy mapping request cannot be fulfilled.
 #[derive(Debug, Error)]
 #[error("no mapping for {0}")]
 pub struct NoMapping(MemoryRange);
 
 impl MapperInner {
+    /// Request that the mapping manager send mappings for the given range.
+    ///
+    /// Registers a waiter, sends `SendMappings` (fire-and-forget), and
+    /// awaits the waiter oneshot. The mapping manager will send `MapLazy`
+    /// or `NoMapping` messages to the mapper task, which wakes the waiter.
     async fn request_mapping(&self, range: MemoryRange, writable: bool) -> Result<(), NoMapping> {
         let (send, recv) = mesh::oneshot();
         self.waiters
@@ -270,6 +317,7 @@ impl VaMapper {
         remote_process: Option<RemoteProcess>,
         private_ranges: Vec<MemoryRange>,
         minimum_alignment: Option<usize>,
+        eager: bool,
     ) -> Result<Self, VaMapperError> {
         let mapping = match &remote_process {
             None => SparseMapping::new_with_minimum_alignment(
@@ -294,13 +342,15 @@ impl VaMapper {
 
         let (send, req_recv) = mesh::channel();
         let id = req_send
-            .call(MappingRequest::AddMapper, send)
+            .call(MappingRequest::AddMapper, (send, eager))
             .await
-            .map_err(VaMapperError::MemoryManagerGone)?;
+            .map_err(VaMapperError::MemoryManagerGone)?
+            .map_err(VaMapperError::Registration)?;
 
         let inner = Arc::new(MapperInner {
             mapping,
             waiters: Mutex::new(Some(Vec::new())),
+            eager: AtomicBool::new(eager),
             req_send,
             id,
         });
@@ -330,11 +380,6 @@ impl VaMapper {
         self.private_ranges.iter().any(|r| r.contains_addr(addr))
     }
 
-    /// Ensures a mapping has been established for the given range.
-    pub async fn ensure_mapped(&self, range: MemoryRange) -> Result<(), NoMapping> {
-        self.inner.request_mapping(range, false).await
-    }
-
     /// Returns the base pointer of the VA reservation.
     pub fn as_ptr(&self) -> *mut u8 {
         self.inner.mapping.as_ptr().cast()
@@ -343,6 +388,16 @@ impl VaMapper {
     /// Returns the length of the VA reservation in bytes.
     pub fn len(&self) -> usize {
         self.inner.mapping.len()
+    }
+
+    /// Returns true if this mapper receives mappings eagerly.
+    pub fn is_eager(&self) -> bool {
+        self.inner.eager.load(Ordering::Relaxed)
+    }
+
+    /// Returns the mapper's ID, used internally for upgrade requests.
+    pub(crate) fn mapper_id(&self) -> MapperId {
+        self.inner.id
     }
 
     /// Returns the remote process, if this mapper maps into a remote process.
@@ -466,17 +521,21 @@ unsafe impl GuestMemoryAccess for VaMapper {
             }
         }
 
-        // File-backed path: request mapping from MappingManager.
-        // `block_on` is OK to call here (will not deadlock) because this is
-        // never called from the page fault handler thread or any threads it
-        // depends on.
-        //
-        // Removing this `block_on` would make all guest memory access `async`,
-        // which would be a difficult change.
-        if let Err(err) = block_on(
-            self.inner
-                .request_mapping(MemoryRange::bounding(address..address + len as u64), write),
-        ) {
+        if self.inner.eager.load(Ordering::Relaxed) {
+            // Eager mapper: file-backed mappings are established proactively.
+            // If we get a page fault, the mapping was never set up or was
+            // torn down.
+            return PageFaultAction::Fail(PageFaultError::new(
+                guestmem::GuestMemoryErrorKind::OutOfRange,
+                std::io::Error::other(format!(
+                    "page fault at {address:#x}+{len:#x}: no eager mapping established"
+                )),
+            ));
+        }
+
+        // Lazy mapper: request the mapping on demand from the mapping manager.
+        let range = MemoryRange::bounding(address..address + len as u64);
+        if let Err(err) = block_on(self.inner.request_mapping(range, write)) {
             return PageFaultAction::Fail(PageFaultError::new(
                 guestmem::GuestMemoryErrorKind::OutOfRange,
                 err,

--- a/openvmm/membacking/src/mapping_manager/va_mapper.rs
+++ b/openvmm/membacking/src/mapping_manager/va_mapper.rs
@@ -395,6 +395,15 @@ impl VaMapper {
         self.inner.eager.load(Ordering::Relaxed)
     }
 
+    /// Marks this mapper as eager.
+    ///
+    /// Called after an `UpgradeToEager` RPC completes so that `is_eager()`
+    /// returns `true` immediately, without waiting for the mapper task to
+    /// process the `SetEager` message.
+    pub(crate) fn set_eager(&self) {
+        self.inner.eager.store(true, Ordering::Relaxed);
+    }
+
     /// Returns the mapper's ID, used internally for upgrade requests.
     pub(crate) fn mapper_id(&self) -> MapperId {
         self.inner.id

--- a/openvmm/membacking/src/mapping_manager/va_mapper.rs
+++ b/openvmm/membacking/src/mapping_manager/va_mapper.rs
@@ -178,7 +178,7 @@ impl MapperTask {
                 MapperRequest::NoMapping(range) => {
                     // Wake up waiters. They'll see a failure when they try
                     // to access the VA.
-                    tracing::debug!(%range, "no mapping for range");
+                    tracing::debug!(%range, "no mapping received for range");
                     self.wake_waiters(range, None);
                 }
                 MapperRequest::SetEager(rpc) => rpc.handle_sync(|()| {

--- a/openvmm/membacking/src/mapping_manager/va_mapper.rs
+++ b/openvmm/membacking/src/mapping_manager/va_mapper.rs
@@ -381,7 +381,10 @@ impl VaMapper {
 
         let id = match inner
             .req_send
-            .call(MappingRequest::AddMapper, (send, eager))
+            .call(
+                MappingRequest::AddMapper,
+                super::manager::AddMapperParams { send, eager },
+            )
             .await
         {
             Ok(Ok(id)) => id,

--- a/openvmm/membacking/src/memory_manager/device_memory.rs
+++ b/openvmm/membacking/src/memory_manager/device_memory.rs
@@ -161,10 +161,7 @@ impl MappableGuestMemory for DeviceMemoryControl {
                     MemoryRange::try_from(gpa..gpa.wrapping_add(self.0.len as u64))
                         .map_err(|err| io::Error::new(io::ErrorKind::InvalidInput, err))?,
                     DEVICE_PRIORITY,
-                    false, // not a DMA target: excludes device BARs from
-                           // GuestMemorySharing (vhost-user). IOMMU consumers
-                           // get notified of these mappings via the DmaMapper
-                           // path regardless of this flag.
+                    crate::region_manager::MappingType::Device,
                 )
                 .await
                 .map_err(io::Error::other)?;

--- a/openvmm/membacking/src/memory_manager/device_memory.rs
+++ b/openvmm/membacking/src/memory_manager/device_memory.rs
@@ -111,13 +111,15 @@ impl MappedMemoryRegion for DeviceMemoryRegion {
         }
 
         if let Some(handle) = &state.handle {
-            block_on(handle.add_mapping(
+            if let Err(e) = block_on(handle.add_mapping(
                 new_mapping.range,
                 new_mapping.mappable.clone(),
                 new_mapping.file_offset,
                 new_mapping.writable,
                 None,
-            ));
+            )) {
+                return Err(io::Error::other(e));
+            }
         }
         state.mappings.push(new_mapping);
         Ok(())
@@ -176,7 +178,8 @@ impl MappableGuestMemory for DeviceMemoryControl {
                         mapping.writable,
                         None,
                     )
-                    .await;
+                    .await
+                    .map_err(io::Error::other)?;
             }
 
             handle
@@ -185,7 +188,8 @@ impl MappableGuestMemory for DeviceMemoryControl {
                     executable: true,
                     prefetch: false,
                 })
-                .await;
+                .await
+                .map_err(io::Error::other)?;
 
             state.handle = Some(handle);
             Ok(())

--- a/openvmm/membacking/src/memory_manager/mod.rs
+++ b/openvmm/membacking/src/memory_manager/mod.rs
@@ -116,6 +116,24 @@ pub enum MemoryBuildError {
     /// Couldn't allocate VA mapper.
     #[error("failed to create VA mapper")]
     VaMapper(#[source] VaMapperError),
+    /// Failed to map RAM into VA space.
+    #[error("failed to map RAM range {range}")]
+    RamMapping {
+        /// The GPA range that failed to map.
+        range: MemoryRange,
+        /// The mapping error.
+        #[source]
+        error: mesh::error::RemoteError,
+    },
+    /// Failed to enable RAM region.
+    #[error("failed to enable RAM region {range}")]
+    RamRegionEnable {
+        /// The GPA range that failed.
+        range: MemoryRange,
+        /// The error.
+        #[source]
+        error: mesh::error::RemoteError,
+    },
     /// Memory layout incompatible with VTL0 alias map.
     #[error("not enough guest address space available for the vtl0 alias map")]
     AliasMapWontFit,
@@ -577,11 +595,11 @@ impl GuestMemoryBuilder {
                                 true,
                                 backing.host_numa_node,
                             )
-                            .await;
-                        // TODO: file-backed RAM mappings are established lazily
-                        // via page faults, so NUMA binding errors are not
-                        // caught here. Replace lazy mapping with eager push
-                        // model to propagate errors at build time.
+                            .await
+                            .map_err(|error| MemoryBuildError::RamMapping {
+                                range: *sub_range,
+                                error,
+                            })?;
                     } else {
                         va_mapper
                             .alloc_range(
@@ -617,7 +635,11 @@ impl GuestMemoryBuilder {
                             executable: true,
                             prefetch: backing.prefetch && backing.mappable.is_some(),
                         })
-                        .await;
+                        .await
+                        .map_err(|error| MemoryBuildError::RamRegionEnable {
+                            range: *sub_range,
+                            error,
+                        })?;
 
                     ram_regions.push(RamRegion {
                         range: *sub_range,
@@ -676,7 +698,7 @@ impl GuestMemoryClient {
     pub async fn guest_memory(&self) -> Result<GuestMemory, VaMapperError> {
         Ok(GuestMemory::new(
             "ram",
-            self.mapping_manager.new_mapper().await?,
+            self.mapping_manager.new_lazy_mapper().await?,
         ))
     }
 }
@@ -805,8 +827,20 @@ pub enum RamVisibility {
 
 /// An error returned by [`RamVisibilityControl::set_ram_visibility`].
 #[derive(Debug, Error)]
-#[error("{0} is not a controllable RAM range")]
-pub struct InvalidRamRegion(MemoryRange);
+pub enum RamVisibilityError {
+    /// The range is not a controllable RAM region.
+    #[error("{0} is not a controllable RAM range")]
+    InvalidRange(MemoryRange),
+    /// Failed to map the region.
+    #[error("failed to map RAM range {range}")]
+    Map {
+        /// The range that failed.
+        range: MemoryRange,
+        /// The error.
+        #[source]
+        error: mesh::error::RemoteError,
+    },
+}
 
 impl RamVisibilityControl {
     /// Sets the visibility of a RAM region.
@@ -819,12 +853,12 @@ impl RamVisibilityControl {
         &self,
         range: MemoryRange,
         visibility: RamVisibility,
-    ) -> Result<(), InvalidRamRegion> {
+    ) -> Result<(), RamVisibilityError> {
         let region = self
             .regions
             .iter()
             .find(|region| region.range == range)
-            .ok_or(InvalidRamRegion(range))?;
+            .ok_or(RamVisibilityError::InvalidRange(range))?;
 
         match visibility {
             RamVisibility::ReadWrite | RamVisibility::ReadOnly => {
@@ -836,6 +870,7 @@ impl RamVisibilityControl {
                         prefetch: false,
                     })
                     .await
+                    .map_err(|error| RamVisibilityError::Map { range, error })?;
             }
             RamVisibility::Unmapped => region.handle.unmap().await,
         }

--- a/openvmm/membacking/src/memory_manager/mod.rs
+++ b/openvmm/membacking/src/memory_manager/mod.rs
@@ -550,7 +550,7 @@ impl GuestMemoryBuilder {
 
         let va_mapper = mapping_manager
             .client()
-            .new_mapper()
+            .new_mapper(true)
             .await
             .map_err(MemoryBuildError::VaMapper)?;
 
@@ -703,7 +703,7 @@ impl GuestMemoryClient {
     pub async fn guest_memory(&self) -> Result<GuestMemory, VaMapperError> {
         Ok(GuestMemory::new(
             "ram",
-            self.mapping_manager.new_lazy_mapper().await?,
+            self.mapping_manager.new_mapper(false).await?,
         ))
     }
 }

--- a/openvmm/membacking/src/memory_manager/mod.rs
+++ b/openvmm/membacking/src/memory_manager/mod.rs
@@ -582,7 +582,12 @@ impl GuestMemoryBuilder {
                 for sub_range in &sub_ranges {
                     let region = region_manager
                         .client()
-                        .new_region("ram".into(), *sub_range, RAM_PRIORITY, true)
+                        .new_region(
+                            "ram".into(),
+                            *sub_range,
+                            RAM_PRIORITY,
+                            crate::region_manager::MappingType::Ram,
+                        )
                         .await
                         .expect("regions cannot overlap yet");
 

--- a/openvmm/membacking/src/partition_mapper.rs
+++ b/openvmm/membacking/src/partition_mapper.rs
@@ -43,6 +43,10 @@ impl PartitionMapper {
         offset: u64,
         pin_mappings: bool,
     ) -> Self {
+        assert!(
+            mapper.is_eager(),
+            "partition mapper requires an eager VaMapper"
+        );
         Self {
             partition: Arc::downgrade(partition),
             mapper,
@@ -64,10 +68,6 @@ impl PartitionMapper {
         let Some(partition) = self.partition.upgrade() else {
             return Ok(());
         };
-
-        // Wait for the range to be mapped so that any second level faults can
-        // be satisfied by the kernel/hypervisor without VMM interaction.
-        let _ = self.mapper.ensure_mapped(range).await;
 
         let addr = range.start().checked_add(self.offset).unwrap();
         let size = range.len() as usize;
@@ -140,14 +140,6 @@ impl PartitionMapper {
                 .unmap_range(range.start().checked_add(self.offset).unwrap(), range.len())
                 .expect("unmap cannot fail");
         }
-    }
-
-    /// Notifies the partition that a new mapping has been mapped into a
-    /// previously mapped region.
-    pub async fn notify_new_mapping(&mut self, range: MemoryRange) {
-        // Ensure the VA range has been mapped for this mapping so that the
-        // kernel can update the hypervisor's SLAT on page fault.
-        let _ = self.mapper.ensure_mapped(range).await;
     }
 }
 

--- a/openvmm/membacking/src/region_manager.rs
+++ b/openvmm/membacking/src/region_manager.rs
@@ -18,6 +18,7 @@ use inspect::Inspect;
 use inspect::InspectMut;
 use memory_range::MemoryRange;
 use mesh::MeshPayload;
+use mesh::error::RemoteError;
 use mesh::rpc::Rpc;
 use mesh::rpc::RpcSend;
 use pal_async::task::Spawn;
@@ -54,7 +55,8 @@ pub trait DmaTarget: Send + Sync {
     /// When `host_va` is `Some`, the pointed-to memory must be backed and
     /// must not be unmapped for the duration of the resulting IOMMU mapping.
     /// The caller (the crate-internal `DmaMapper`) guarantees this by holding an
-    /// [`Arc<VaMapper>`] and calling `ensure_mapped` before each invocation.
+    /// [`Arc<VaMapper>`] whose mappings are established eagerly by the
+    /// mapping manager.
     unsafe fn map_dma(
         &self,
         range: MemoryRange,
@@ -76,8 +78,9 @@ pub trait DmaTarget: Send + Sync {
 
 /// Wraps a [`DmaTarget`] for use by the region manager.
 ///
-/// Holds an optional [`VaMapper`] to ensure pages are faulted in before
-/// `map_dma` (needed for VFIO type1's `pin_user_pages`).
+/// Holds an optional [`VaMapper`] to provide host VA pointers for IOMMU
+/// programming. Mappings in the VaMapper are established eagerly by the
+/// mapping manager.
 struct DmaMapper {
     id: DmaMapperId,
     target: Arc<dyn DmaTarget>,
@@ -89,32 +92,24 @@ struct DmaMapperId(u64);
 
 impl DmaMapper {
     /// Map a sub-mapping into the IOMMU.
-    async fn map_dma(
+    fn map_dma(
         &self,
         range: MemoryRange,
         mappable: &Mappable,
         file_offset: u64,
     ) -> anyhow::Result<()> {
-        // Ensure the VaMapper has the backing pages faulted in and compute
-        // the host VA for type1 backends.
-        let host_va = if let Some(va_mapper) = &self.va_mapper {
-            va_mapper
-                .ensure_mapped(range)
-                .await
-                .context("VA range has no backing mapping")?;
-            // SAFETY: range.start() is within the VA reservation (ensured by
-            // ensure_mapped succeeding), so this produces a valid pointer
-            // within the mapping.
-            Some(unsafe { va_mapper.as_ptr().add(range.start() as usize).cast_const() })
-        } else {
-            None
-        };
-        // SAFETY: When host_va is Some, the VaMapper has been ensure_mapped
-        // for this range. The VaMapper is held alive by this DmaMapper (via
-        // Arc), so the VA reservation persists. The pages are backed because
-        // ensure_mapped succeeded. The IOMMU mapping will be torn down
-        // (via unmap_dma in disable_region or remove_dma_mapper) before the
-        // VaMapper releases the VA range.
+        // Compute the host VA for type1/iommufd backends. The VaMapper
+        // is always eager, so the backing is already established.
+        //
+        // SAFETY: range.start() is within the VA reservation, and
+        // the eager mapper has already established the backing.
+        let host_va = self.va_mapper.as_ref().map(|va_mapper| unsafe {
+            va_mapper.as_ptr().add(range.start() as usize).cast_const()
+        });
+        // SAFETY: When host_va is Some, the VaMapper is eager and the mapping
+        // has been established. The VaMapper is held alive by this DmaMapper
+        // (via Arc). The IOMMU mapping will be torn down (via unmap_dma)
+        // before the VaMapper releases the VA range.
         unsafe { self.target.map_dma(range, host_va, mappable, file_offset) }
     }
 
@@ -249,9 +244,9 @@ struct RegionManagerTaskInner {
 enum RegionRequest {
     AddRegion(Rpc<RegionParams, Result<RegionId, AddRegionError>>),
     RemoveRegion(Rpc<RegionId, ()>),
-    MapRegion(Rpc<(RegionId, MapParams), ()>),
+    MapRegion(Rpc<(RegionId, MapParams), Result<(), RemoteError>>),
     UnmapRegion(Rpc<RegionId, ()>),
-    AddMapping(Rpc<(RegionId, RegionMappingParams), ()>),
+    AddMapping(Rpc<(RegionId, RegionMappingParams), Result<(), RemoteError>>),
     RemoveMappings(Rpc<(RegionId, MemoryRange), ()>),
     AddPartition(
         LocalOnly<Rpc<PartitionMapper, Result<(), crate::partition_mapper::PartitionMapperError>>>,
@@ -328,7 +323,7 @@ impl RegionManagerTask {
                         .await
                 }
                 RegionRequest::MapRegion(rpc) => {
-                    rpc.handle(async |(id, params)| self.map_region(id, params).await)
+                    rpc.handle_failable(async |(id, params)| self.map_region(id, params).await)
                         .await
                 }
                 RegionRequest::UnmapRegion(rpc) => {
@@ -366,13 +361,9 @@ impl RegionManagerTask {
     ) -> anyhow::Result<DmaMapperId> {
         // Create a VaMapper if the target needs host VAs for IOMMU programming.
         let va_mapper = if needs_va {
-            Some(
-                self.inner
-                    .mapping_manager
-                    .new_mapper()
-                    .await
-                    .map_err(|e| anyhow::anyhow!(e))?,
-            )
+            let mapper = self.inner.mapping_manager.new_mapper().await?;
+            assert!(mapper.is_eager(), "DMA mapper requires an eager VaMapper");
+            Some(mapper)
         } else {
             None
         };
@@ -392,9 +383,7 @@ impl RegionManagerTask {
             if region.is_active {
                 for mapping in &region.mappings {
                     let range = range_within(region.params.range, mapping.params.range_in_region);
-                    mapper
-                        .map_dma(range, &mapping.params.mappable, mapping.params.file_offset)
-                        .await?;
+                    mapper.map_dma(range, &mapping.params.mappable, mapping.params.file_offset)?;
                 }
             }
         }
@@ -467,7 +456,7 @@ impl RegionManagerTask {
 
     /// Enables the highest priority region in `range`. Panics if any regions in
     /// `range` are already enabled.
-    async fn enable_best_region(&mut self, mut range: MemoryRange) {
+    async fn enable_best_region(&mut self, mut range: MemoryRange) -> anyhow::Result<()> {
         while !range.is_empty() {
             // Pick the highest priority region with the lowest startest address
             // in the range. Since lower priority ranges must be fully contained
@@ -495,21 +484,22 @@ impl RegionManagerTask {
                     )
                 })
             {
-                self.inner.enable_region(region).await;
+                self.inner.enable_region(region).await?;
                 range = MemoryRange::new(region.params.range.end()..range.end());
             } else {
                 range = MemoryRange::EMPTY;
             }
         }
+        Ok(())
     }
 
-    async fn map_region(&mut self, id: RegionId, map_params: MapParams) {
+    async fn map_region(&mut self, id: RegionId, map_params: MapParams) -> anyhow::Result<()> {
         let index = self.region_index(id);
         let region = &mut self.regions[index];
         let range = region.params.range;
         let priority = region.params.priority;
         if region.map_params == Some(map_params) {
-            return;
+            return Ok(());
         }
 
         tracing::debug!(
@@ -538,8 +528,9 @@ impl RegionManagerTask {
 
         self.regions[index].map_params = Some(map_params);
         if enable {
-            self.enable_best_region(range).await;
+            self.enable_best_region(range).await?;
         }
+        Ok(())
     }
 
     async fn unmap_region(&mut self, id: RegionId, remove: bool) {
@@ -563,11 +554,18 @@ impl RegionManagerTask {
             region.map_params = None;
         }
         if let Some(range) = active_range {
-            self.enable_best_region(range).await;
+            self.enable_best_region(range).await.expect(
+                "failed to re-enable region after unmap; \
+                 this should not fail because the region was previously active",
+            );
         }
     }
 
-    async fn add_mapping(&mut self, id: RegionId, params: RegionMappingParams) {
+    async fn add_mapping(
+        &mut self,
+        id: RegionId,
+        params: RegionMappingParams,
+    ) -> Result<(), RemoteError> {
         let index = self.region_index(id);
         let region = &mut self.regions[index];
 
@@ -592,17 +590,10 @@ impl RegionManagerTask {
                     dma_target: region.params.dma_target,
                     numa_node: params.numa_node,
                 })
-                .await;
-
-            for partition in &mut self.inner.partitions {
-                partition.notify_new_mapping(range).await;
-            }
+                .await?;
 
             for dma_mapper in &self.inner.dma_mappers {
-                if let Err(e) = dma_mapper
-                    .map_dma(range, &params.mappable, params.file_offset)
-                    .await
-                {
+                if let Err(e) = dma_mapper.map_dma(range, &params.mappable, params.file_offset) {
                     tracing::warn!(
                         error = &*e as &dyn std::error::Error,
                         %range,
@@ -613,6 +604,7 @@ impl RegionManagerTask {
         }
 
         region.mappings.push(RegionMapping { params });
+        Ok(())
     }
 
     async fn remove_mappings(&mut self, id: RegionId, range_in_region: MemoryRange) {
@@ -666,7 +658,7 @@ impl RegionManagerTask {
 }
 
 impl RegionManagerTaskInner {
-    async fn enable_region(&mut self, region: &mut Region) {
+    async fn enable_region(&mut self, region: &mut Region) -> anyhow::Result<()> {
         assert!(!region.is_active);
         let map_params = region.map_params.unwrap();
 
@@ -677,9 +669,11 @@ impl RegionManagerTaskInner {
             "enabling region"
         );
 
-        // Add the mappings for the region.
-        for mapping in &region.mappings {
-            self.mapping_manager
+        // Add the mappings for the region. On failure, roll back any
+        // sub-mappings that were successfully added.
+        for (mapped_count, mapping) in region.mappings.iter().enumerate() {
+            if let Err(e) = self
+                .mapping_manager
                 .add_mapping(MappingParams {
                     range: range_within(region.params.range, mapping.params.range_in_region),
                     mappable: mapping.params.mappable.clone(),
@@ -688,22 +682,45 @@ impl RegionManagerTaskInner {
                     dma_target: region.params.dma_target,
                     numa_node: mapping.params.numa_node,
                 })
-                .await;
-        }
+                .await
+            {
+                // Roll back: remove sub-mappings that were already added.
+                for prev in &region.mappings[..mapped_count] {
+                    let range = range_within(region.params.range, prev.params.range_in_region);
+                    for dma_mapper in &self.dma_mappers {
+                        dma_mapper.unmap_dma(range);
+                    }
+                }
+                self.mapping_manager
+                    .remove_mappings(region.params.range)
+                    .await;
+                return Err(anyhow::Error::new(e)).context(format!(
+                    "failed to map {} during region enable",
+                    range_within(region.params.range, mapping.params.range_in_region),
+                ));
+            }
 
-        // Map sub-mappings into DMA mappers (per-sub-mapping granularity).
-        for mapping in &region.mappings {
+            // Map into DMA mappers.
             let range = range_within(region.params.range, mapping.params.range_in_region);
             for dma_mapper in &self.dma_mappers {
-                if let Err(e) = dma_mapper
-                    .map_dma(range, &mapping.params.mappable, mapping.params.file_offset)
-                    .await
+                if let Err(e) =
+                    dma_mapper.map_dma(range, &mapping.params.mappable, mapping.params.file_offset)
                 {
-                    tracing::warn!(
-                        error = &*e as &dyn std::error::Error,
-                        %range,
-                        "DMA mapper failed to map sub-mapping during region enable"
-                    );
+                    // Roll back DMA mappings for this sub-mapping and all
+                    // previous ones, then roll back VA mappings.
+                    for prev in &region.mappings[..mapped_count] {
+                        let prev_range =
+                            range_within(region.params.range, prev.params.range_in_region);
+                        for dm in &self.dma_mappers {
+                            dm.unmap_dma(prev_range);
+                        }
+                    }
+                    self.mapping_manager
+                        .remove_mappings(region.params.range)
+                        .await;
+                    return Err(e).context(format!(
+                        "DMA mapper failed to map {range} during region enable"
+                    ));
                 }
             }
         }
@@ -717,6 +734,7 @@ impl RegionManagerTaskInner {
         }
 
         region.is_active = true;
+        Ok(())
     }
 
     async fn disable_region(&mut self, region: &mut Region) {
@@ -896,11 +914,11 @@ pub struct RegionHandle {
 
 impl RegionHandle {
     /// Maps this region to a guest address.
-    pub async fn map(&self, params: MapParams) {
+    pub async fn map(&self, params: MapParams) -> Result<(), RemoteError> {
         self.req_send
             .call(RegionRequest::MapRegion, (self.id.unwrap(), params))
             .await
-            .unwrap()
+            .map_err(RemoteError::new)?
     }
 
     /// Unmaps this region.
@@ -921,9 +939,8 @@ impl RegionHandle {
         file_offset: u64,
         writable: bool,
         numa_node: Option<u32>,
-    ) {
-        let _ = self
-            .req_send
+    ) -> Result<(), RemoteError> {
+        self.req_send
             .call(
                 RegionRequest::AddMapping,
                 (
@@ -937,7 +954,8 @@ impl RegionHandle {
                     },
                 ),
             )
-            .await;
+            .await
+            .map_err(RemoteError::new)?
     }
 
     /// Removes the mappings in `range` within this region.
@@ -1053,7 +1071,8 @@ mod tests {
                             prefetch: false,
                         },
                     )
-                    .await;
+                    .await
+                    .unwrap();
                 Ok(id)
             }
 
@@ -1119,7 +1138,8 @@ mod tests {
                         prefetch: false,
                     },
                 )
-                .await;
+                .await
+                .unwrap();
             id
         }
 
@@ -1135,7 +1155,8 @@ mod tests {
                         numa_node: None,
                     },
                 )
-                .await;
+                .await
+                .unwrap();
         }
     }
 
@@ -1247,5 +1268,106 @@ mod tests {
         // Adding a mapping while inactive should also not notify.
         t.add_mapping(r, 0x8000..0xC000).await;
         assert_eq!(target.take_events(), vec![]);
+    }
+
+    /// A DMA target that fails map_dma after a configurable number of
+    /// successful calls.
+    struct FailAfterDmaTarget {
+        /// Number of map_dma calls to succeed before failing.
+        fail_after: usize,
+        inner: RecordingDmaTarget,
+        call_count: Mutex<usize>,
+    }
+
+    impl FailAfterDmaTarget {
+        fn new(fail_after: usize) -> Self {
+            Self {
+                fail_after,
+                inner: RecordingDmaTarget::default(),
+                call_count: Mutex::new(0),
+            }
+        }
+
+        fn take_events(&self) -> Vec<DmaEvent> {
+            self.inner.take_events()
+        }
+    }
+
+    impl DmaTarget for FailAfterDmaTarget {
+        unsafe fn map_dma(
+            &self,
+            range: MemoryRange,
+            host_va: Option<*const u8>,
+            mappable: &Mappable,
+            file_offset: u64,
+        ) -> anyhow::Result<()> {
+            let mut count = self.call_count.lock();
+            if *count >= self.fail_after {
+                anyhow::bail!("simulated DMA mapping failure at {range}");
+            }
+            *count += 1;
+            drop(count);
+            // SAFETY: delegating to RecordingDmaTarget.
+            unsafe { self.inner.map_dma(range, host_va, mappable, file_offset) }
+        }
+
+        fn unmap_dma(&self, range: MemoryRange) -> anyhow::Result<()> {
+            self.inner.unmap_dma(range)
+        }
+    }
+
+    #[async_test]
+    async fn test_enable_region_rollback_unmaps_dma_sub_mappings(spawn: impl Spawn) {
+        let mut t = DmaTestTask::new(&spawn);
+
+        // Create a region with three sub-mappings.
+        let r = t.add_region(0x0..0x18000).await;
+        t.add_mapping(r, 0x0..0x4000).await;
+        t.add_mapping(r, 0x4000..0x8000).await;
+        t.add_mapping(r, 0x8000..0xC000).await;
+
+        // Disable the region so we can re-enable with a DMA mapper present.
+        t.task.unmap_region(r, false).await;
+
+        // Register a DMA mapper that fails on the third map_dma call
+        // (i.e., the third sub-mapping). The first two succeed.
+        let target = Arc::new(FailAfterDmaTarget::new(2));
+        let _id = t.task.add_dma_mapper(target.clone(), false).await.unwrap();
+
+        // Re-enable the region. Sub-mappings 0 and 1 succeed, sub-mapping 2
+        // fails. Rollback should unmap sub-mappings 0 and 1.
+        let result = t
+            .task
+            .map_region(
+                r,
+                MapParams {
+                    writable: true,
+                    executable: true,
+                    prefetch: false,
+                },
+            )
+            .await;
+
+        assert!(
+            result.is_err(),
+            "enable should fail on third DMA sub-mapping"
+        );
+
+        let region = t.task.regions.iter().find(|reg| reg.id == r).unwrap();
+        assert!(
+            !region.is_active,
+            "region should not be active after failed enable"
+        );
+
+        assert_eq!(
+            target.take_events(),
+            vec![
+                DmaEvent::Map(MemoryRange::new(0x0..0x4000)),
+                DmaEvent::Map(MemoryRange::new(0x4000..0x8000)),
+                DmaEvent::Unmap(MemoryRange::new(0x0..0x4000)),
+                DmaEvent::Unmap(MemoryRange::new(0x4000..0x8000)),
+            ],
+            "successful DMA sub-mappings should be rolled back exactly once"
+        );
     }
 }

--- a/openvmm/membacking/src/region_manager.rs
+++ b/openvmm/membacking/src/region_manager.rs
@@ -27,6 +27,37 @@ use std::sync::Arc;
 use thiserror::Error;
 use vmcore::local_only::LocalOnly;
 
+/// The type of memory backing a region or mapping.
+#[derive(Debug, Copy, Clone, PartialEq, Eq, MeshPayload)]
+pub enum MappingType {
+    /// Guest RAM or similar shareable memory. IOMMU mapping failures are
+    /// fatal. Exposed via `GuestMemorySharing` (vhost-user).
+    Ram,
+    /// Device memory (e.g., a PCI BAR). IOMMU mapping failures are
+    /// non-fatal — they only affect peer-to-peer DMA to this region.
+    /// Not exposed via `GuestMemorySharing`.
+    Device,
+}
+
+/// Parameters for a DMA mapping request.
+pub struct DmaMapRequest<'a> {
+    /// The guest physical address range to map.
+    pub range: MemoryRange,
+    /// Host virtual address of the mapping, provided when the target was
+    /// registered with `needs_va = true`. When `None`, the implementation
+    /// should use `mappable` and `file_offset` directly (e.g., iommufd).
+    pub host_va: Option<*const u8>,
+    /// The backing object (fd or handle) for the mapping.
+    pub mappable: &'a Mappable,
+    /// Offset within `mappable` where the mapping starts.
+    pub file_offset: u64,
+    /// Whether the mapping should allow writes. When `false`, the IOMMU
+    /// entry should be read-only.
+    pub writable: bool,
+    /// The type of memory being mapped.
+    pub mapping_type: MappingType,
+}
+
 /// A consumer of IOMMU-granularity DMA mapping events.
 ///
 /// Unlike [`PartitionMemoryMap`](virt::PartitionMemoryMap), which maps entire
@@ -35,35 +66,24 @@ use vmcore::local_only::LocalOnly;
 /// explicit IOMMU programming (VFIO type1, iommufd, etc.).
 ///
 /// DMA targets receive notifications for **all** active sub-mappings,
-/// including device BAR memory (regions with `dma_target: false`). The
-/// `dma_target` flag controls only whether a region is exposed via
-/// `GuestMemorySharing` (for vhost-user); IOMMU consumers need the full
-/// GPA→backing map to program identity mappings for all guest-visible memory.
+/// including device BAR memory ([`MappingType::Device`] regions). The
+/// mapping type controls whether a region is exposed via
+/// `GuestMemorySharing` (for vhost-user) and whether IOMMU mapping
+/// failures are fatal; IOMMU consumers receive the full GPA→backing map
+/// regardless.
 ///
 /// Implementations must be `Send + Sync` because they are stored behind `Arc`
 /// in the region manager task.
 pub trait DmaTarget: Send + Sync {
-    /// Program an IOMMU mapping for `range` to the backing described by
-    /// `mappable` at `file_offset`.
-    ///
-    /// `host_va` is the host virtual address of the mapping, provided when
-    /// the target was registered with `needs_va = true`. When `None`, the
-    /// implementation should use `mappable` and `file_offset` directly
-    /// (e.g., iommufd).
+    /// Program an IOMMU mapping.
     ///
     /// # Safety
-    /// When `host_va` is `Some`, the pointed-to memory must be backed and
-    /// must not be unmapped for the duration of the resulting IOMMU mapping.
-    /// The caller (the crate-internal `DmaMapper`) guarantees this by holding an
-    /// [`Arc<VaMapper>`] whose mappings are established eagerly by the
-    /// mapping manager.
-    unsafe fn map_dma(
-        &self,
-        range: MemoryRange,
-        host_va: Option<*const u8>,
-        mappable: &Mappable,
-        file_offset: u64,
-    ) -> anyhow::Result<()>;
+    /// When `request.host_va` is `Some`, the pointed-to memory must be
+    /// backed and must not be unmapped for the duration of the resulting
+    /// IOMMU mapping. The caller (the crate-internal `DmaMapper`) guarantees
+    /// this by holding an [`Arc<VaMapper>`] whose mappings are established
+    /// eagerly by the mapping manager.
+    unsafe fn map_dma(&self, request: DmaMapRequest<'_>) -> anyhow::Result<()>;
 
     /// Remove IOMMU mappings within `range`.
     ///
@@ -92,25 +112,23 @@ struct DmaMapperId(u64);
 
 impl DmaMapper {
     /// Map a sub-mapping into the IOMMU.
-    fn map_dma(
-        &self,
-        range: MemoryRange,
-        mappable: &Mappable,
-        file_offset: u64,
-    ) -> anyhow::Result<()> {
+    fn map_dma(&self, mut request: DmaMapRequest<'_>) -> anyhow::Result<()> {
         // Compute the host VA for type1/iommufd backends. The VaMapper
         // is always eager, so the backing is already established.
         //
         // SAFETY: range.start() is within the VA reservation, and
         // the eager mapper has already established the backing.
-        let host_va = self.va_mapper.as_ref().map(|va_mapper| unsafe {
-            va_mapper.as_ptr().add(range.start() as usize).cast_const()
+        request.host_va = self.va_mapper.as_ref().map(|va_mapper| unsafe {
+            va_mapper
+                .as_ptr()
+                .add(request.range.start() as usize)
+                .cast_const()
         });
         // SAFETY: When host_va is Some, the VaMapper is eager and the mapping
         // has been established. The VaMapper is held alive by this DmaMapper
         // (via Arc). The IOMMU mapping will be torn down (via unmap_dma)
         // before the VaMapper releases the VA range.
-        unsafe { self.target.map_dma(range, host_va, mappable, file_offset) }
+        unsafe { self.target.map_dma(request) }
     }
 
     /// Unmap a range from the IOMMU.
@@ -154,9 +172,8 @@ struct RegionParams {
     name: String,
     range: MemoryRange,
     priority: u8,
-    /// Whether mappings in this region are DMA targets (guest RAM or
-    /// similar shareable memory).
-    dma_target: bool,
+    /// The type of memory in this region.
+    mapping_type: MappingType,
 }
 
 #[derive(Copy, Clone, Debug, MeshPayload, PartialEq, Eq, Inspect)]
@@ -383,7 +400,15 @@ impl RegionManagerTask {
             if region.is_active {
                 for mapping in &region.mappings {
                     let range = range_within(region.params.range, mapping.params.range_in_region);
-                    mapper.map_dma(range, &mapping.params.mappable, mapping.params.file_offset)?;
+                    let writable = mapping.params.writable && region.map_params.unwrap().writable;
+                    mapper.map_dma(DmaMapRequest {
+                        range,
+                        host_va: None,
+                        mappable: &mapping.params.mappable,
+                        file_offset: mapping.params.file_offset,
+                        writable,
+                        mapping_type: region.params.mapping_type,
+                    })?;
                 }
             }
         }
@@ -587,13 +612,20 @@ impl RegionManagerTask {
                     mappable: params.mappable.clone(),
                     file_offset: params.file_offset,
                     writable: params.writable,
-                    dma_target: region.params.dma_target,
+                    mapping_type: region.params.mapping_type,
                     numa_node: params.numa_node,
                 })
                 .await?;
 
             for dma_mapper in &self.inner.dma_mappers {
-                if let Err(e) = dma_mapper.map_dma(range, &params.mappable, params.file_offset) {
+                if let Err(e) = dma_mapper.map_dma(DmaMapRequest {
+                    range,
+                    host_va: None,
+                    mappable: &params.mappable,
+                    file_offset: params.file_offset,
+                    writable: params.writable,
+                    mapping_type: region.params.mapping_type,
+                }) {
                     tracing::warn!(
                         error = &*e as &dyn std::error::Error,
                         %range,
@@ -679,7 +711,7 @@ impl RegionManagerTaskInner {
                     mappable: mapping.params.mappable.clone(),
                     file_offset: mapping.params.file_offset,
                     writable: mapping.params.writable && map_params.writable,
-                    dma_target: region.params.dma_target,
+                    mapping_type: region.params.mapping_type,
                     numa_node: mapping.params.numa_node,
                 })
                 .await
@@ -702,12 +734,23 @@ impl RegionManagerTaskInner {
 
             // Map into DMA mappers.
             let range = range_within(region.params.range, mapping.params.range_in_region);
-            for dma_mapper in &self.dma_mappers {
-                if let Err(e) =
-                    dma_mapper.map_dma(range, &mapping.params.mappable, mapping.params.file_offset)
-                {
-                    // Roll back DMA mappings for this sub-mapping and all
-                    // previous ones, then roll back VA mappings.
+            let writable = mapping.params.writable && map_params.writable;
+            for (dma_idx, dma_mapper) in self.dma_mappers.iter().enumerate() {
+                if let Err(e) = dma_mapper.map_dma(DmaMapRequest {
+                    range,
+                    host_va: None,
+                    mappable: &mapping.params.mappable,
+                    file_offset: mapping.params.file_offset,
+                    writable,
+                    mapping_type: region.params.mapping_type,
+                }) {
+                    // Roll back the current sub-mapping from DMA mappers
+                    // that already succeeded (before the failing one).
+                    for dm in &self.dma_mappers[..dma_idx] {
+                        dm.unmap_dma(range);
+                    }
+                    // Roll back all previous sub-mappings from all DMA
+                    // mappers.
                     for prev in &region.mappings[..mapped_count] {
                         let prev_range =
                             range_within(region.params.range, prev.params.range_in_region);
@@ -808,13 +851,13 @@ impl RegionManagerClient {
         name: String,
         range: MemoryRange,
         priority: u8,
-        dma_target: bool,
+        mapping_type: MappingType,
     ) -> Result<RegionHandle, AddRegionError> {
         let params = RegionParams {
             name,
             range,
             priority,
-            dma_target,
+            mapping_type,
         };
 
         let id = self
@@ -993,7 +1036,9 @@ mod tests {
     use crate::mapping_manager::Mappable;
     use crate::mapping_manager::MappingManager;
     use crate::region_manager::AddRegionError;
+    use crate::region_manager::DmaMapRequest;
     use crate::region_manager::DmaTarget;
+    use crate::region_manager::MappingType;
     use crate::region_manager::RegionId;
     use crate::region_manager::RegionMappingParams;
     use crate::region_manager::RegionParams;
@@ -1017,14 +1062,8 @@ mod tests {
     }
 
     impl DmaTarget for RecordingDmaTarget {
-        unsafe fn map_dma(
-            &self,
-            range: MemoryRange,
-            _host_va: Option<*const u8>,
-            _mappable: &Mappable,
-            _file_offset: u64,
-        ) -> anyhow::Result<()> {
-            self.events.lock().push(DmaEvent::Map(range));
+        unsafe fn map_dma(&self, request: DmaMapRequest<'_>) -> anyhow::Result<()> {
+            self.events.lock().push(DmaEvent::Map(request.range));
             Ok(())
         }
 
@@ -1060,7 +1099,7 @@ mod tests {
                     priority,
                     name: priority.to_string(),
                     range: MemoryRange::new(range),
-                    dma_target: false,
+                    mapping_type: MappingType::Device,
                 })?;
                 self.0
                     .map_region(
@@ -1126,7 +1165,7 @@ mod tests {
                     priority: 0,
                     name: format!("{range:x?}"),
                     range: MemoryRange::new(range),
-                    dma_target: false,
+                    mapping_type: MappingType::Device,
                 })
                 .unwrap();
             self.task
@@ -1294,26 +1333,84 @@ mod tests {
     }
 
     impl DmaTarget for FailAfterDmaTarget {
-        unsafe fn map_dma(
-            &self,
-            range: MemoryRange,
-            host_va: Option<*const u8>,
-            mappable: &Mappable,
-            file_offset: u64,
-        ) -> anyhow::Result<()> {
+        unsafe fn map_dma(&self, request: DmaMapRequest<'_>) -> anyhow::Result<()> {
             let mut count = self.call_count.lock();
             if *count >= self.fail_after {
-                anyhow::bail!("simulated DMA mapping failure at {range}");
+                anyhow::bail!("simulated DMA mapping failure at {}", request.range);
             }
             *count += 1;
             drop(count);
             // SAFETY: delegating to RecordingDmaTarget.
-            unsafe { self.inner.map_dma(range, host_va, mappable, file_offset) }
+            unsafe { self.inner.map_dma(request) }
         }
 
         fn unmap_dma(&self, range: MemoryRange) -> anyhow::Result<()> {
             self.inner.unmap_dma(range)
         }
+    }
+
+    #[async_test]
+    async fn test_enable_region_rollback_unmaps_current_sub_mapping_from_earlier_dma_mappers(
+        spawn: impl Spawn,
+    ) {
+        // Two DMA mappers: the first always succeeds, the second fails
+        // immediately. With one sub-mapping, enable_region should:
+        //   1. Map sub-mapping into mapper A (succeeds)
+        //   2. Map sub-mapping into mapper B (fails)
+        //   3. Roll back: unmap sub-mapping from mapper A
+        //
+        // The bug: rollback only unmaps `mappings[..mapped_count]` (previous
+        // sub-mappings), but `mapped_count` is 0 for the first sub-mapping,
+        // so mapper A's successful map is never rolled back.
+        let mut t = DmaTestTask::new(&spawn);
+
+        let r = t.add_region(0x0..0x10000).await;
+        t.add_mapping(r, 0x0..0x4000).await;
+
+        // Disable so we can re-enable with DMA mappers present.
+        t.task.unmap_region(r, false).await;
+
+        let good_target = Arc::new(RecordingDmaTarget::default());
+        let _good_id = t
+            .task
+            .add_dma_mapper(good_target.clone(), false)
+            .await
+            .unwrap();
+
+        let bad_target = Arc::new(FailAfterDmaTarget::new(0)); // fails immediately
+        let _bad_id = t
+            .task
+            .add_dma_mapper(bad_target.clone(), false)
+            .await
+            .unwrap();
+
+        // Drain replay events (region is inactive, so there should be none).
+        good_target.take_events();
+        bad_target.take_events();
+
+        let result = t
+            .task
+            .map_region(
+                r,
+                MapParams {
+                    writable: true,
+                    executable: true,
+                    prefetch: false,
+                },
+            )
+            .await;
+
+        assert!(result.is_err(), "enable should fail");
+
+        // good_target should see: Map(0..0x4000) then Unmap(0..0x4000).
+        assert_eq!(
+            good_target.take_events(),
+            vec![
+                DmaEvent::Map(MemoryRange::new(0x0..0x4000)),
+                DmaEvent::Unmap(MemoryRange::new(0x0..0x4000)),
+            ],
+            "the successful DMA mapper must have its mapping rolled back"
+        );
     }
 
     #[async_test]

--- a/openvmm/membacking/src/region_manager.rs
+++ b/openvmm/membacking/src/region_manager.rs
@@ -46,7 +46,7 @@ pub struct DmaMapRequest<'a> {
     pub range: MemoryRange,
     /// Host virtual address of the mapping, provided when the target was
     /// registered with `needs_va = true`. When `None`, the implementation
-    /// should use `mappable` and `file_offset` directly (e.g., iommufd).
+    /// should use `mappable` and `file_offset` directly.
     pub host_va: Option<*const u8>,
     /// The backing object (fd or handle) for the mapping.
     pub mappable: &'a Mappable,
@@ -317,7 +317,7 @@ impl RegionManagerTask {
         while let Some(req) = req_recv.next().await {
             match req {
                 RegionRequest::AddMapping(rpc) => {
-                    rpc.handle(async |(id, params)| self.add_mapping(id, params).await)
+                    rpc.handle_failable(async |(id, params)| self.add_mapping(id, params).await)
                         .await
                 }
                 RegionRequest::RemoveMappings(rpc) => {
@@ -592,7 +592,7 @@ impl RegionManagerTask {
         &mut self,
         id: RegionId,
         params: RegionMappingParams,
-    ) -> Result<(), RemoteError> {
+    ) -> anyhow::Result<()> {
         let index = self.region_index(id);
         let region = &mut self.regions[index];
 
@@ -607,32 +607,35 @@ impl RegionManagerTask {
 
         if let Some(region_range) = region.active_range() {
             let range = range_within(region_range, params.range_in_region);
+            let writable = params.writable && region.map_params.unwrap().writable;
             self.inner
                 .mapping_manager
                 .add_mapping(MappingParams {
                     range,
                     mappable: params.mappable.clone(),
                     file_offset: params.file_offset,
-                    writable: params.writable,
+                    writable,
                     mapping_type: region.params.mapping_type,
                     numa_node: params.numa_node,
                 })
                 .await?;
 
-            for dma_mapper in &self.inner.dma_mappers {
+            for (dma_idx, dma_mapper) in self.inner.dma_mappers.iter().enumerate() {
                 if let Err(e) = dma_mapper.map_dma(DmaMapRequest {
                     range,
                     host_va: None,
                     mappable: &params.mappable,
                     file_offset: params.file_offset,
-                    writable: params.writable,
+                    writable,
                     mapping_type: region.params.mapping_type,
                 }) {
-                    tracing::warn!(
-                        error = &*e as &dyn std::error::Error,
-                        %range,
-                        "DMA mapper failed to map new sub-mapping"
-                    );
+                    // Roll back: unmap from DMA mappers that already
+                    // succeeded, then remove the VA mapping.
+                    for dm in &self.inner.dma_mappers[..dma_idx] {
+                        dm.unmap_dma(range);
+                    }
+                    self.inner.mapping_manager.remove_mappings(range).await;
+                    return Err(e);
                 }
             }
         }
@@ -728,7 +731,7 @@ impl RegionManagerTaskInner {
                 self.mapping_manager
                     .remove_mappings(region.params.range)
                     .await;
-                return Err(anyhow::Error::new(e)).context(format!(
+                return Err(e).context(format!(
                     "failed to map {} during region enable",
                     range_within(region.params.range, mapping.params.range_in_region),
                 ));
@@ -1349,6 +1352,35 @@ mod tests {
         fn unmap_dma(&self, range: MemoryRange) -> anyhow::Result<()> {
             self.inner.unmap_dma(range)
         }
+    }
+
+    #[async_test]
+    async fn test_add_mapping_dma_failure_propagates(spawn: impl Spawn) {
+        let mut t = DmaTestTask::new(&spawn);
+        let r = t.add_region(0x0..0x10000).await;
+
+        // Register a DMA mapper that fails immediately.
+        let target = Arc::new(FailAfterDmaTarget::new(0));
+        let _id = t.task.add_dma_mapper(target.clone(), false).await.unwrap();
+        target.take_events();
+
+        // Adding a sub-mapping to the active region should fail because
+        // the DMA mapper fails. The VA mapping should be rolled back.
+        let result = t
+            .task
+            .add_mapping(
+                r,
+                RegionMappingParams {
+                    range_in_region: MemoryRange::new(0x0..0x4000),
+                    mappable: t.mappable.clone(),
+                    file_offset: 0,
+                    writable: true,
+                    numa_node: None,
+                },
+            )
+            .await;
+
+        assert!(result.is_err(), "add_mapping should propagate DMA failure");
     }
 
     #[async_test]

--- a/openvmm/membacking/src/region_manager.rs
+++ b/openvmm/membacking/src/region_manager.rs
@@ -19,6 +19,7 @@ use inspect::InspectMut;
 use memory_range::MemoryRange;
 use mesh::MeshPayload;
 use mesh::error::RemoteError;
+use mesh::rpc::FailableRpc;
 use mesh::rpc::Rpc;
 use mesh::rpc::RpcSend;
 use pal_async::task::Spawn;
@@ -28,7 +29,7 @@ use thiserror::Error;
 use vmcore::local_only::LocalOnly;
 
 /// The type of memory backing a region or mapping.
-#[derive(Debug, Copy, Clone, PartialEq, Eq, MeshPayload)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Inspect, MeshPayload)]
 pub enum MappingType {
     /// Guest RAM or similar shareable memory. IOMMU mapping failures are
     /// fatal. Exposed via `GuestMemorySharing` (vhost-user).
@@ -69,8 +70,8 @@ pub struct DmaMapRequest<'a> {
 /// including device BAR memory ([`MappingType::Device`] regions). The
 /// mapping type controls whether a region is exposed via
 /// `GuestMemorySharing` (for vhost-user) and whether IOMMU mapping
-/// failures are fatal; IOMMU consumers receive the full GPA→backing map
-/// regardless.
+/// failures are fatal; IOMMU consumers need the full GPA→backing map
+/// to program identity mappings for all guest-visible memory.
 ///
 /// Implementations must be `Send + Sync` because they are stored behind `Arc`
 /// in the region manager task.
@@ -82,7 +83,8 @@ pub trait DmaTarget: Send + Sync {
     /// backed and must not be unmapped for the duration of the resulting
     /// IOMMU mapping. The caller (the crate-internal `DmaMapper`) guarantees
     /// this by holding an [`Arc<VaMapper>`] whose mappings are established
-    /// eagerly by the mapping manager.
+    /// eagerly by the mapping manager. The IOMMU mapping will be torn down
+    /// (via `unmap_dma`) before the `VaMapper` releases the VA range.
     unsafe fn map_dma(&self, request: DmaMapRequest<'_>) -> anyhow::Result<()>;
 
     /// Remove IOMMU mappings within `range`.
@@ -261,9 +263,9 @@ struct RegionManagerTaskInner {
 enum RegionRequest {
     AddRegion(Rpc<RegionParams, Result<RegionId, AddRegionError>>),
     RemoveRegion(Rpc<RegionId, ()>),
-    MapRegion(Rpc<(RegionId, MapParams), Result<(), RemoteError>>),
+    MapRegion(FailableRpc<(RegionId, MapParams), ()>),
     UnmapRegion(Rpc<RegionId, ()>),
-    AddMapping(Rpc<(RegionId, RegionMappingParams), Result<(), RemoteError>>),
+    AddMapping(FailableRpc<(RegionId, RegionMappingParams), ()>),
     RemoveMappings(Rpc<(RegionId, MemoryRange), ()>),
     AddPartition(
         LocalOnly<Rpc<PartitionMapper, Result<(), crate::partition_mapper::PartitionMapperError>>>,
@@ -378,7 +380,7 @@ impl RegionManagerTask {
     ) -> anyhow::Result<DmaMapperId> {
         // Create a VaMapper if the target needs host VAs for IOMMU programming.
         let va_mapper = if needs_va {
-            let mapper = self.inner.mapping_manager.new_mapper().await?;
+            let mapper = self.inner.mapping_manager.new_mapper(true).await?;
             assert!(mapper.is_eager(), "DMA mapper requires an eager VaMapper");
             Some(mapper)
         } else {

--- a/vm/devices/pci/vfio_assigned_device/src/manager.rs
+++ b/vm/devices/pci/vfio_assigned_device/src/manager.rs
@@ -41,7 +41,7 @@ impl membacking::DmaTarget for VfioType1DmaTarget {
         let vaddr = host_va.expect("VFIO type1 requires host VA (registered with needs_va=true)");
         let _span = tracing::info_span!("vfio map", %range).entered();
         // SAFETY: The caller (DmaMapper in membacking) guarantees that the
-        // host VA is backed and stable via ensure_mapped + VaMapper lifetime.
+        // host VA is backed and stable via eager mapping + VaMapper lifetime.
         unsafe {
             self.container
                 .map_dma(range.start(), vaddr, range.len())
@@ -480,7 +480,7 @@ impl membacking::DmaTarget for IommufdDmaTarget {
         let user_va = vaddr as u64;
         let length = range.len();
         // SAFETY: The caller (DmaMapper in membacking) guarantees that the
-        // host VA is backed and stable via ensure_mapped + VaMapper lifetime.
+        // host VA is backed and stable via eager mapping + VaMapper lifetime.
         unsafe {
             self.ctx
                 .ioas_map(self.ioas_id, iova, user_va, length)

--- a/vm/devices/pci/vfio_assigned_device/src/manager.rs
+++ b/vm/devices/pci/vfio_assigned_device/src/manager.rs
@@ -31,22 +31,34 @@ struct VfioType1DmaTarget {
 }
 
 impl membacking::DmaTarget for VfioType1DmaTarget {
-    unsafe fn map_dma(
-        &self,
-        range: memory_range::MemoryRange,
-        host_va: Option<*const u8>,
-        _mappable: &membacking::Mappable,
-        _file_offset: u64,
-    ) -> anyhow::Result<()> {
-        let vaddr = host_va.expect("VFIO type1 requires host VA (registered with needs_va=true)");
+    unsafe fn map_dma(&self, request: membacking::DmaMapRequest<'_>) -> anyhow::Result<()> {
+        let vaddr = request
+            .host_va
+            .expect("VFIO type1 requires host VA (registered with needs_va=true)");
+        let range = request.range;
         let _span = tracing::info_span!("vfio map", %range).entered();
         // SAFETY: The caller (DmaMapper in membacking) guarantees that the
         // host VA is backed and stable via eager mapping + VaMapper lifetime.
-        unsafe {
+        let result = unsafe {
             self.container
-                .map_dma(range.start(), vaddr, range.len())
+                .map_dma(range.start(), vaddr, range.len(), request.writable)
                 .context("VFIO DMA map failed")
+        };
+        if let Err(e) = &result {
+            if request.mapping_type == membacking::MappingType::Device {
+                // Device BAR memory may not be mappable into the IOMMU (e.g.,
+                // if the kernel cannot pin device MMIO pages). This is not
+                // fatal — it only means P2P DMA to this BAR won't work.
+                tracelimit::warn_ratelimited!(
+                    error = e.as_ref() as &dyn std::error::Error,
+                    %range,
+                    "failed to map device memory into VFIO container; \
+                     P2P DMA to this region will not work"
+                );
+                return Ok(());
+            }
         }
+        result
     }
 
     fn unmap_dma(&self, range: memory_range::MemoryRange) -> anyhow::Result<()> {
@@ -467,23 +479,19 @@ struct IommufdDmaTarget {
 }
 
 impl membacking::DmaTarget for IommufdDmaTarget {
-    unsafe fn map_dma(
-        &self,
-        range: memory_range::MemoryRange,
-        host_va: Option<*const u8>,
-        _mappable: &membacking::Mappable,
-        _file_offset: u64,
-    ) -> anyhow::Result<()> {
-        let vaddr =
-            host_va.expect("iommufd IOAS map requires host VA (registered with needs_va=true)");
+    unsafe fn map_dma(&self, request: membacking::DmaMapRequest<'_>) -> anyhow::Result<()> {
+        let vaddr = request
+            .host_va
+            .expect("iommufd IOAS map requires host VA (registered with needs_va=true)");
+        let range = request.range;
         let iova = range.start();
         let user_va = vaddr as u64;
         let length = range.len();
         // SAFETY: The caller (DmaMapper in membacking) guarantees that the
         // host VA is backed and stable via eager mapping + VaMapper lifetime.
-        unsafe {
+        let result = unsafe {
             self.ctx
-                .ioas_map(self.ioas_id, iova, user_va, length)
+                .ioas_map(self.ioas_id, iova, user_va, length, request.writable)
                 .with_context(|| {
                     format!(
                         "iommufd IOAS DMA map failed: iova={iova:#x} user_va={user_va:#x} \
@@ -491,7 +499,22 @@ impl membacking::DmaTarget for IommufdDmaTarget {
                         self.ioas_id
                     )
                 })
+        };
+        if let Err(e) = &result {
+            if request.mapping_type == membacking::MappingType::Device {
+                // Device BAR memory may not be mappable into the IOMMU (e.g.,
+                // if the kernel cannot pin device MMIO pages). This is not
+                // fatal — it only means P2P DMA to this BAR won't work.
+                tracelimit::warn_ratelimited!(
+                    error = e.as_ref() as &dyn std::error::Error,
+                    %range,
+                    "failed to map device memory into iommufd IOAS; \
+                     P2P DMA to this region will not work"
+                );
+                return Ok(());
+            }
         }
+        result
     }
 
     fn unmap_dma(&self, range: memory_range::MemoryRange) -> anyhow::Result<()> {

--- a/vm/devices/user_driver/vfio_sys/src/iommufd.rs
+++ b/vm/devices/user_driver/vfio_sys/src/iommufd.rs
@@ -157,10 +157,15 @@ impl IommufdCtx {
         iova: u64,
         user_va: u64,
         length: u64,
+        writable: bool,
     ) -> anyhow::Result<()> {
+        let mut flags = IOMMU_IOAS_MAP_FIXED_IOVA | IOMMU_IOAS_MAP_READABLE;
+        if writable {
+            flags |= IOMMU_IOAS_MAP_WRITEABLE;
+        }
         let mut cmd = IommuIoasMap {
             size: size_of::<IommuIoasMap>() as u32,
-            flags: IOMMU_IOAS_MAP_FIXED_IOVA | IOMMU_IOAS_MAP_READABLE | IOMMU_IOAS_MAP_WRITEABLE,
+            flags,
             ioas_id,
             __reserved: 0,
             user_va,

--- a/vm/devices/user_driver/vfio_sys/src/lib.rs
+++ b/vm/devices/user_driver/vfio_sys/src/lib.rs
@@ -168,7 +168,13 @@ impl Container {
     /// `vaddr` must point to valid, backed memory for `size` bytes. The
     /// memory must not be unmapped while the IOMMU mapping is live (until
     /// a corresponding `unmap_dma` call).
-    pub unsafe fn map_dma(&self, iova: u64, vaddr: *const u8, size: u64) -> anyhow::Result<()> {
+    pub unsafe fn map_dma(
+        &self,
+        iova: u64,
+        vaddr: *const u8,
+        size: u64,
+        writable: bool,
+    ) -> anyhow::Result<()> {
         use vfio_bindings::bindings::vfio::VFIO_DMA_MAP_FLAG_READ;
         use vfio_bindings::bindings::vfio::VFIO_DMA_MAP_FLAG_WRITE;
 
@@ -180,9 +186,14 @@ impl Container {
             "VFIO DMA mapping requires page-aligned iova ({iova:#x}), vaddr ({vaddr:#x}), and size ({size:#x}), page size {page_size:#x}"
         );
 
+        let mut flags = VFIO_DMA_MAP_FLAG_READ;
+        if writable {
+            flags |= VFIO_DMA_MAP_FLAG_WRITE;
+        }
+
         let dma_map = vfio_bindings::bindings::vfio::vfio_iommu_type1_dma_map {
             argsz: size_of::<vfio_bindings::bindings::vfio::vfio_iommu_type1_dma_map>() as u32,
-            flags: VFIO_DMA_MAP_FLAG_READ | VFIO_DMA_MAP_FLAG_WRITE,
+            flags,
             vaddr,
             iova,
             size,


### PR DESCRIPTION
The mapping manager used a single lazy VA mapper where all mappings were populated on demand via page faults. This was always unsound for the partition path—KVM does not forward userspace page faults back to the VMM, so a VP access to a lazily-mapped range fails the instruction rather than triggering population. The ensure_mapped workaround blocked to fault in pages before handing the VA to the hypervisor, but it didn't cover all paths, and VFIO type1 has the same problem since pin_user_pages expects the VA to already be backed.

This splits VaMapper into eager and lazy modes. Eager mappers receive all existing mappings on creation and get new ones pushed synchronously, so the backing is fully established before any host VA reaches the hypervisor or IOMMU. Lazy mappers keep the on-demand page-fault path for device-emulation processes that access guest memory infrequently. With eager mappers guaranteeing the backing is present, ensure_mapped and notify_new_mapping are removed.

Mapping failures now propagate as errors through add_mapping, region enablement, and RAM visibility changes, with rollback on partial failure. VaMapper also unregisters itself on drop so the manager doesn't accumulate stale registrations.

Fixes #3591.