### PR TITLE
vmbus_ring: avoid u32 underflow in parse_packet range size

### DIFF
--- a/vm/devices/vmbus/vmbus_ring/src/lib.rs
+++ b/vm/devices/vmbus/vmbus_ring/src/lib.rs
@@ -399,7 +399,9 @@ fn parse_packet<M: RingMem>(
                 tph.range_count,
                 RingRange {
                     off: ring_off + 24,
-                    size: desc.data_offset8 as u32 * 8 - 24,
+                    size: (desc.data_offset8 as u32 * 8)
+                        .checked_sub(24)
+                        .ok_or(ReadError::Corrupt(Error::InvalidDescriptorLengths))?,
                 },
             )
         }
@@ -415,7 +417,9 @@ fn parse_packet<M: RingMem>(
                 gph.range_count,
                 RingRange {
                     off: ring_off + 24,
-                    size: desc.data_offset8 as u32 * 8 - 24,
+                    size: (desc.data_offset8 as u32 * 8)
+                        .checked_sub(24)
+                        .ok_or(ReadError::Corrupt(Error::InvalidDescriptorLengths))?,
                 },
             )
         }


### PR DESCRIPTION
## Summary

In `parse_packet`, the TRANSFER_PAGES / GPA_DIRECT external-range size is computed as `desc.data_offset8 as u32 * 8 - 24`.
The descriptor guard rejects `data_offset8 < 2` but allows `data_offset8 == 2`, so the size computes `16 - 24` and underflows.
With overflow-checks this panics; in a release build with overflow-checks off, it wraps to ~4 GiB, and a guest packet can use that oversized `RingRange` to drive a large allocation / out-of-range ring access downstream.

## Fix
Use `checked_sub(24)` and return `ReadError::Corrupt(Error::InvalidDescriptorLengths)`, the same error the surrounding guard already uses, when the subtraction would underflow.

## Impact

Denial of service, scoped to the attacking guest's own VM — an unprivileged VTL0 guest crashing the VTL2 paravisor that serves it, a self-DoS.
No cross-VM/host impact and no information disclosure.
Traced downstream, the oversized range terminates at bounds-checked allocation / slice access, so this is **not** an out-of-bounds read.
The corrupt descriptor should still be rejected, and the paravisor should not panic/abort on guest input.
