### PR TITLE
vmbus_server: reject client-only messages instead of panicking

### DIFF
--- a/vm/devices/vmbus/vmbus_server/src/channels.rs
+++ b/vm/devices/vmbus/vmbus_server/src/channels.rs
@@ -96,6 +96,8 @@ pub enum ChannelError {
     InvalidTargetVp,
     #[error("interrupts are disabled for this channel")]
     InterruptsDisabled,
+    #[error("received a message that is only valid in the server-to-client direction")]
+    InvalidMessageType,
 }
 
 #[derive(Debug, Error)]
@@ -3686,7 +3688,14 @@ impl<'a, N: 'a + Notifier> ServerWithNotifier<'a, N> {
             | Message::ModifyChannelResponse(..)
             | Message::ModifyConnectionResponse(..)
             | Message::PauseResponse(..) => {
-                unreachable!("Server received client message {:?}", msg);
+                // These messages are only valid in the server-to-client
+                // direction, but `Message::parse` will happily decode them
+                // from guest-supplied bytes. A misbehaving or malicious guest
+                // can therefore send one to the server; reject it rather than
+                // panicking (this path is reached directly from
+                // guest-controlled input).
+                tracelimit::warn_ratelimited!(?msg, "received client-only message from guest");
+                return Err(ChannelError::InvalidMessageType);
             }
         }
         Ok(())


### PR DESCRIPTION
## Summary

`Message::parse` decodes both directions of the vmbus protocol based solely on the guest-supplied `message_type`. As a result, a guest can post a *server-to-client* message, such as `VersionResponse`, which requires no version negotiation, to `handle_synic_message`.

The dispatch arm for those client-only messages reached `unreachable!`, so an unprivileged guest could panic the vmbus server in the paravisor.

## Fix

Reject these messages with a rate-limited warning and a new `ChannelError::InvalidMessageType` instead of panicking. This reuses the existing `ChannelError` path the caller already handles, so a malformed or hostile message is treated as a normal protocol error rather than crashing the server.

## Impact

Denial of service only: a reachable `unreachable!`, not memory unsafety.

The impact is scoped to the attacking guest's own VM — an unprivileged VTL0 guest crashing the VTL2 paravisor that serves it, meaning a self-DoS. There is no cross-VM or host impact.

Even so, the paravisor should not panic on guest-controlled input, so this hardens it.

`message_type = 15` (`VERSION_RESPONSE`) triggers it with no prior negotiation. Other server-to-client types trigger after the relevant version is negotiated.
