### PR TITLE
hv1_emulator: bounds-check guest-controlled synic indices

### DIFF
--- a/vm/hv1/hv1_emulator/src/synic.rs
+++ b/vm/hv1/hv1_emulator/src/synic.rs
@@ -237,8 +237,18 @@ impl GlobalSynic {
         };
         let vp = vp.read();
         let sint_index = sint_index as usize;
+        if sint_index >= NUM_SINTS {
+            return Ok(false);
+        }
         let sint = vp.sint[sint_index];
         let flag = flag as usize;
+        // Each SINT owns this many event flags in the SIEFP page. `flag` is
+        // guest-controllable (e.g. via a guest-configured event port), so an
+        // out-of-range value must be rejected rather than indexing past the
+        // page below (which would be a guest-triggerable OOB panic).
+        if flag >= (HV_PAGE_SIZE_USIZE / NUM_SINTS) * 8 {
+            return Ok(false);
+        }
         if sint.proxy() {
             return Err(SintProxied);
         }
@@ -435,6 +445,11 @@ impl ProcessorSynic {
         message: &HvMessage,
         interrupt: &mut dyn RequestInterrupt,
     ) -> Result<(), HvError> {
+        // `sint_index` may be caller/guest-influenced; reject out-of-range
+        // values rather than indexing the SINT array (and shifting by it) below.
+        if sint_index as usize >= NUM_SINTS {
+            return Err(HvError::InvalidSynicState);
+        }
         let sint = &self.sints.sint[sint_index as usize];
         if sint.masked() || sint.proxy() {
             return Err(HvError::InvalidSynicState);

--- a/vm/hv1/hv1_emulator/src/synic.rs
+++ b/vm/hv1/hv1_emulator/src/synic.rs
@@ -242,10 +242,7 @@ impl GlobalSynic {
         }
         let sint = vp.sint[sint_index];
         let flag = flag as usize;
-        // Each SINT owns this many event flags in the SIEFP page. `flag` is
-        // guest-controllable (e.g. via a guest-configured event port), so an
-        // out-of-range value must be rejected rather than indexing past the
-        // page below (which would be a guest-triggerable OOB panic).
+        // Each SINT owns this many event flags in the SIEFP page
         if flag >= (HV_PAGE_SIZE_USIZE / NUM_SINTS) * 8 {
             return Ok(false);
         }
@@ -445,8 +442,6 @@ impl ProcessorSynic {
         message: &HvMessage,
         interrupt: &mut dyn RequestInterrupt,
     ) -> Result<(), HvError> {
-        // `sint_index` may be caller/guest-influenced; reject out-of-range
-        // values rather than indexing the SINT array (and shifting by it) below.
         if sint_index as usize >= NUM_SINTS {
             return Err(HvError::InvalidSynicState);
         }


### PR DESCRIPTION
  ## Summary
  `signal_event` indexed the SINT array with an unchecked `sint_index` and the SIEFP page with an unchecked,
  guest-controllable `flag`; `post_message` indexed (and shifted by) an unchecked `sint_index`. An out-of-range value — e.g.
  a guest-configured event flag >= 2048, which reaches `signal_event` via a guest-opened channel's `event_flag` — caused an
  out-of-bounds panic in the paravisor.

  ## Fix
  - `signal_event`: return `Ok(false)` (the existing benign "not signaled" path used for masked/proxy SINTs) when
  `sint_index >= NUM_SINTS` or `flag >= (HV_PAGE_SIZE_USIZE / NUM_SINTS) * 8` (= 2048, the number of event flags one SINT
  owns in the SIEFP page).
  - `post_message`: return the existing `HvError::InvalidSynicState` when `sint_index >= NUM_SINTS`, guarding both the array
  index and the `1 << sint_index` shift.

  ## Impact
  Denial of service (out-of-bounds array/page index → panic), not memory unsafety. Scoped to the attacking guest's own VM —
  an unprivileged VTL0 guest crashing the VTL2 paravisor that serves it (a self-DoS); no cross-VM/host impact. The paravisor
  should not panic on guest-controlled indices regardless.