### PR TITLE
vmbus_serial_host: implement RX_CLEAR_BUFFER instead of todo!()

### DIFF
--- a/vm/devices/serial/vmbus_serial_host/src/lib.rs
+++ b/vm/devices/serial/vmbus_serial_host/src/lib.rs
@@ -410,9 +410,6 @@ impl<T: RingMem + Unpin> SerialChannel<T> {
     ) -> Result<(), Error> {
         match notification {
             HostNotifications::RX_CLEAR_BUFFER => {
-                // The guest asked to discard buffered host->guest RX data. This
-                // is guest-controlled, so it must not panic (the previous
-                // `todo!()` was a guest-triggerable DoS); just clear the buffer.
                 self.state.rx_bytes.clear();
             }
             HostNotifications::TX_DATA_AVAILABLE => {

--- a/vm/devices/serial/vmbus_serial_host/src/lib.rs
+++ b/vm/devices/serial/vmbus_serial_host/src/lib.rs
@@ -410,7 +410,10 @@ impl<T: RingMem + Unpin> SerialChannel<T> {
     ) -> Result<(), Error> {
         match notification {
             HostNotifications::RX_CLEAR_BUFFER => {
-                todo!("clear rx buffer unimplemented")
+                // The guest asked to discard buffered host->guest RX data. This
+                // is guest-controlled, so it must not panic (the previous
+                // `todo!()` was a guest-triggerable DoS); just clear the buffer.
+                self.state.rx_bytes.clear();
             }
             HostNotifications::TX_DATA_AVAILABLE => {
                 let message = protocol::TxDataAvailableMessage::read_from_prefix(buf)


### PR DESCRIPTION
  ## Summary
  The `RX_CLEAR_BUFFER` host notification is guest-triggerable but reached `todo!("clear rx buffer unimplemented")`, so a
  guest could panic the serial device in the paravisor after the VERSION handshake.

  ## Fix
  Implement the branch by clearing the buffered host->guest RX data (`self.state.rx_bytes.clear();`). This is both the
  security fix (no longer panics on guest input) and the intended functionality.

  ## Impact
  Denial of service (reachable `todo!()` panic), not memory unsafety. Scoped to the attacking guest's own VM — an
  unprivileged VTL0 guest crashing the VTL2 paravisor that serves it (a self-DoS); no cross-VM/host impact.