### PR TITLE
crypto: Fallback to symcrypt default on musl

### DIFF
--- a/support/crypto/Cargo.toml
+++ b/support/crypto/Cargo.toml
@@ -91,10 +91,20 @@ pkcs8 = { workspace = true, features = ["alloc"] }
 signature = { workspace = true, features = ["alloc"] }
 x509-cert.workspace = true
 
-# Default to OpenSSL on Linux since there is no native backend available
-[target.'cfg(target_os = "linux")'.dependencies]
+# Default to OpenSSL on Linux since there is no native backend available,
+# except on musl targets where we use Symcrypt instead.
+[target.'cfg(all(target_os = "linux", not(target_env = "musl")))'.dependencies]
 openssl_kdf.workspace = true
 openssl.workspace = true
+
+[target.'cfg(all(target_os = "linux", target_env = "musl"))'.dependencies]
+symcrypt = { workspace = true, features = ["sha1"] }
+cms.workspace = true
+der.workspace = true
+pkcs1.workspace = true
+pkcs8 = { workspace = true, features = ["alloc"] }
+signature = { workspace = true, features = ["alloc"] }
+x509-cert.workspace = true
 
 [dev-dependencies]
 hex.workspace = true

--- a/support/crypto/build.rs
+++ b/support/crypto/build.rs
@@ -10,6 +10,7 @@ fn main() {
     println!("cargo::rerun-if-env-changed=CARGO_FEATURE_SYMCRYPT");
     println!("cargo::rerun-if-env-changed=CARGO_FEATURE_VENDORED");
     println!("cargo::rerun-if-env-changed=CARGO_CFG_TARGET_OS");
+    println!("cargo::rerun-if-env-changed=CARGO_CFG_TARGET_ENV");
 
     println!("cargo::rustc-check-cfg=cfg(native)");
     println!("cargo::rustc-check-cfg=cfg(openssl)");
@@ -18,6 +19,7 @@ fn main() {
     println!("cargo::rustc-check-cfg=cfg(single_backend)");
 
     let linux = std::env::var("CARGO_CFG_TARGET_OS").unwrap() == "linux";
+    let musl = std::env::var("CARGO_CFG_TARGET_ENV").unwrap_or_default() == "musl";
 
     let native = std::env::var_os("CARGO_FEATURE_NATIVE").is_some();
     let openssl = std::env::var_os("CARGO_FEATURE_OPENSSL").is_some();
@@ -31,7 +33,9 @@ fn main() {
     // so that operations like `cargo check` and `cargo test` can succeed, but
     // emit a warning.
     if backend_count != 1 {
-        if linux {
+        if linux && musl {
+            println!("cargo::rustc-cfg=symcrypt");
+        } else if linux {
             println!("cargo::rustc-cfg=openssl");
         } else {
             println!("cargo::rustc-cfg=native");

--- a/support/crypto/build.rs
+++ b/support/crypto/build.rs
@@ -61,7 +61,10 @@ fn main() {
         } else if rust {
             println!("cargo::rustc-cfg=rust");
             secure = false;
-        } else if native && linux {
+        } else if native && linux && musl {
+            println!("cargo::rustc-cfg=symcrypt");
+            secure = true;
+        } else if native && linux && !musl {
             println!("cargo::rustc-cfg=openssl");
             secure = true;
         } else if native && !linux {


### PR DESCRIPTION
When no backend or multiple backends are selected the crypto crate falls back to a platform-appropriate default, so that commands like `cargo test -p underhill_attestation` can work. Change this fallback to use symcrypt on musl instead of openssl, to get us one step closer to not having openssl anywhere in openhcl.