### PR TITLE
lxutil: use permissive drvfs modes by default without metadata

### DIFF
--- a/vm/devices/support/fs/lxutil/src/windows/mod.rs
+++ b/vm/devices/support/fs/lxutil/src/windows/mod.rs
@@ -102,11 +102,19 @@ impl LxVolume {
         )?;
 
         // Determine the capabilities of the file system.
-        let fs_context = fs::FsContext::new(&root, fs::LX_DRVFS_DISABLE_NONE, false)?;
+        let mut fs_context = fs::FsContext::new(&root, fs::LX_DRVFS_DISABLE_NONE, false)?;
 
         let mut options = options.clone();
         if !fs_context.compatibility_flags.supports_metadata() {
             options.metadata = false;
+        }
+
+        // Without metadata, ACL-derived modes plus a default owner deny the guest write access to
+        // its own files. Use the permissive drvfs default instead; the host ACL is the real gate.
+        if !options.metadata {
+            fs_context
+                .compatibility_flags
+                .set_supports_permission_mapping(false);
         }
 
         if !fs_context.compatibility_flags.supports_case_sensitive_dir() {


### PR DESCRIPTION
# lxutil: use permissive drvfs modes by default without metadata

## Problem

When a drvfs volume is served **without** the `metadata` mount option (the default), newly created files come back to the Linux guest owned by the volume's default `uid`/`gid` (frequently `0`/root) with ACL-derived, fmask-masked modes such as `0o644`. A non-root guest user is then denied write access to files it just created.

This is a regression from the legacy 9p drvfs server, which exposes the permissive `0o777` default for non-metadata mounts. It surfaces most visibly under containers using a `uid=0` bind mount over virtiofs, where a non-root process cannot write files it owns. See microsoft/WSL#40719.

## Root cause

`FsContext` enables `supports_permission_mapping` for any local (non-remote) NTFS volume. With permission mapping on, `convert_mode` derives the Linux mode from the Windows ACL `EffectiveAccess` (`0o666` for a normal writable file) and then masks it with the mount `fmask` (default `022`), yielding `0o644`. Because no-metadata mounts cannot record real ownership, the file also falls back to the volume default uid/gid. The combination (root owner + `0o644`) blocks the non-root creator.

Permission mapping only makes sense when `metadata` is enabled, because without metadata there is no way to record real ownership and the per-class permission bits are advisory — the host ACL remains the real access gate regardless of the guest mode bits.

## Change

In `LxVolume::new`, disable `supports_permission_mapping` whenever `metadata` is off, so the default mount uses the permissive legacy drvfs model (`0o777`, still clearing write bits for read-only files). Metadata mounts are unchanged and keep deriving modes from the Windows ACL and stored ownership.

```rust
if !options.metadata {
    fs_context
        .compatibility_flags
        .set_supports_permission_mapping(false);
}
```

## Validation

- `cargo check -p lxutil` — passes.
- `cargo test -p lxutil` — 44 passed, 0 failed. No existing test asserts a specific no-metadata mode, so none regress.
- Audited the only other `supports_permission_mapping` consumer (the stat fallback in `fs.rs`): reachable only on legacy filesystems lacking `FILE_STAT_INFORMATION`, where `granted_access = 0` is consistent with the permissive fallback path.

Filed as a **draft** for review of the approach before adding a regression test.
