### PR TITLE
crypto: Clean up pointers in windows code, use NonNull more

### DIFF
--- a/support/crypto/src/pkcs7/win.rs
+++ b/support/crypto/src/pkcs7/win.rs
@@ -5,6 +5,7 @@
 
 use super::*;
 use std::ffi::c_void;
+use std::ptr::NonNull;
 use windows::Win32::Security::Cryptography::CMSG_CERT_COUNT_PARAM;
 use windows::Win32::Security::Cryptography::CMSG_CERT_PARAM;
 use windows::Win32::Security::Cryptography::CMSG_SIGNED;
@@ -32,7 +33,7 @@ fn bogus_err(op: &'static str) -> Pkcs7Error {
 }
 
 /// RAII wrapper around `HCRYPTMSG`.
-struct Msg(*const c_void);
+struct Msg(NonNull<c_void>);
 // SAFETY: handle can be sent across threads.
 unsafe impl Send for Msg {}
 // SAFETY: handle is read-only after the final CryptMsgUpdate.
@@ -41,7 +42,8 @@ unsafe impl Sync for Msg {}
 impl Drop for Msg {
     fn drop(&mut self) {
         // SAFETY: handle is valid; CryptMsgClose tolerates a single close.
-        let _ = unsafe { windows::Win32::Security::Cryptography::CryptMsgClose(Some(self.0)) };
+        let _ =
+            unsafe { windows::Win32::Security::Cryptography::CryptMsgClose(Some(self.0.as_ptr())) };
     }
 }
 
@@ -60,14 +62,14 @@ impl Pkcs7SignedDataInner {
                 encoding, 0, 0, None, None, None,
             )
         };
-        if h.is_null() {
-            return Err(last_err("CryptMsgOpenToDecode"));
-        }
+        let h = NonNull::new(h).ok_or_else(|| last_err("CryptMsgOpenToDecode"))?;
         let msg = Msg(h);
 
         // SAFETY: `data` is a valid byte slice; msg is a fresh decode handle.
-        unsafe { windows::Win32::Security::Cryptography::CryptMsgUpdate(h, Some(data), true) }
-            .map_err(|e| err(e, "CryptMsgUpdate"))?;
+        unsafe {
+            windows::Win32::Security::Cryptography::CryptMsgUpdate(h.as_ptr(), Some(data), true)
+        }
+        .map_err(|e| err(e, "CryptMsgUpdate"))?;
 
         // Confirm the message is SignedData (type 2)
         let mtype: u32 = get_param_value::<u32>(&msg, CMSG_TYPE_PARAM, 0)?;
@@ -148,12 +150,12 @@ impl Pkcs7SignedDataInner {
         let cert_der = cert.to_der().map_err(|e| crate::rsa::RsaError(e.0))?;
         // SAFETY: cert_der is a valid DER X.509 byte slice.
         let ctx_ptr = unsafe { CertCreateCertificateContext(X509_ASN_ENCODING, &cert_der) };
-        if ctx_ptr.is_null() {
-            return Err(rsa_err(
+        let ctx_ptr = NonNull::new(ctx_ptr).ok_or_else(|| {
+            rsa_err(
                 windows_result::Error::from_thread(),
                 "CertCreateCertificateContext",
-            ));
-        }
+            )
+        })?;
         let signing_ctx = OwnedCertContext(ctx_ptr);
 
         let key_ctx = CERT_KEY_CONTEXT {
@@ -165,7 +167,7 @@ impl Pkcs7SignedDataInner {
         // to match CERT_KEY_CONTEXT.
         unsafe {
             CertSetCertificateContextProperty(
-                signing_ctx.0,
+                signing_ctx.0.as_ptr(),
                 CERT_KEY_CONTEXT_PROP_ID,
                 0,
                 Some(std::ptr::from_ref(&key_ctx).cast::<c_void>()),
@@ -183,11 +185,11 @@ impl Pkcs7SignedDataInner {
         // CryptSignMessage omits the signing cert from the message by
         // default; embed it explicitly so signer_cert_sig() can find it.
         let mut msg_cert: *mut windows::Win32::Security::Cryptography::CERT_CONTEXT =
-            signing_ctx.0.cast_mut();
+            signing_ctx.0.as_ptr();
         let params = CRYPT_SIGN_MESSAGE_PARA {
             cbSize: size_of::<CRYPT_SIGN_MESSAGE_PARA>() as u32,
             dwMsgEncodingType: PKCS_7_ASN_ENCODING.0 | X509_ASN_ENCODING.0,
-            pSigningCert: signing_ctx.0,
+            pSigningCert: signing_ctx.0.as_ptr(),
             HashAlgorithm: hash_alg,
             cMsgCert: 1,
             rgpMsgCert: &mut msg_cert,
@@ -312,7 +314,11 @@ fn get_param_bytes(msg: &Msg, param: u32, index: u32) -> Result<Vec<u8>, Pkcs7Er
     // SAFETY: size query; passing None for the output buffer.
     unsafe {
         windows::Win32::Security::Cryptography::CryptMsgGetParam(
-            msg.0, param, index, None, &mut size,
+            msg.0.as_ptr(),
+            param,
+            index,
+            None,
+            &mut size,
         )
     }
     .map_err(|e| err(e, "CryptMsgGetParam (size query)"))?;
@@ -320,7 +326,7 @@ fn get_param_bytes(msg: &Msg, param: u32, index: u32) -> Result<Vec<u8>, Pkcs7Er
     // SAFETY: buf is sized per the size query.
     unsafe {
         windows::Win32::Security::Cryptography::CryptMsgGetParam(
-            msg.0,
+            msg.0.as_ptr(),
             param,
             index,
             Some(buf.as_mut_ptr().cast::<c_void>()),
@@ -396,7 +402,7 @@ impl Drop for NCryptKey {
 }
 
 #[cfg(any(test, feature = "test_helpers"))]
-struct OwnedCertContext(*const windows::Win32::Security::Cryptography::CERT_CONTEXT);
+struct OwnedCertContext(NonNull<windows::Win32::Security::Cryptography::CERT_CONTEXT>);
 
 #[cfg(any(test, feature = "test_helpers"))]
 impl Drop for OwnedCertContext {
@@ -404,7 +410,9 @@ impl Drop for OwnedCertContext {
         // SAFETY: produced by CertCreateCertificateContext; safe to free
         // exactly once.
         let _ = unsafe {
-            windows::Win32::Security::Cryptography::CertFreeCertificateContext(Some(self.0))
+            windows::Win32::Security::Cryptography::CertFreeCertificateContext(Some(
+                self.0.as_ptr(),
+            ))
         };
     }
 }

--- a/support/crypto/src/x509/win.rs
+++ b/support/crypto/src/x509/win.rs
@@ -8,6 +8,7 @@
 use super::X509Error;
 use crate::win::KeyHandle;
 use std::ffi::c_void;
+use std::ptr::NonNull;
 use windows::Win32::Security::Cryptography::BCRYPT_KEY_HANDLE;
 use windows::Win32::Security::Cryptography::CERT_AUTHORITY_KEY_ID2_INFO;
 use windows::Win32::Security::Cryptography::CERT_CONTEXT;
@@ -35,6 +36,8 @@ use windows::Win32::Security::Cryptography::szOID_RSA_RSA;
 use windows::Win32::Security::Cryptography::szOID_RSA_SHA256RSA;
 use windows::Win32::Security::Cryptography::szOID_SUBJECT_KEY_IDENTIFIER;
 use windows::core::PCSTR;
+#[cfg(any(test, feature = "test_helpers"))]
+use zerocopy::IntoBytes;
 
 fn err(err: windows_result::Error, op: &'static str) -> X509Error {
     X509Error(crate::BackendError(err, op))
@@ -49,7 +52,7 @@ fn last_err(op: &'static str) -> X509Error {
 }
 
 /// RAII wrapper around `PCCERT_CONTEXT`.
-pub(crate) struct CertContext(pub(crate) *const CERT_CONTEXT);
+pub(crate) struct CertContext(pub(crate) NonNull<CERT_CONTEXT>);
 
 // SAFETY: cert context can be sent across threads.
 unsafe impl Send for CertContext {}
@@ -61,7 +64,9 @@ impl Drop for CertContext {
         // SAFETY: handle is valid; CertFreeCertificateContext tolerates
         // the call exactly once per CertCreateCertificateContext.
         let _ = unsafe {
-            windows::Win32::Security::Cryptography::CertFreeCertificateContext(Some(self.0))
+            windows::Win32::Security::Cryptography::CertFreeCertificateContext(Some(
+                self.0.as_ptr().cast_const(),
+            ))
         };
     }
 }
@@ -70,7 +75,7 @@ impl CertContext {
     pub(crate) fn cert_context(&self) -> &CERT_CONTEXT {
         // SAFETY: self.0 is a valid PCCERT_CONTEXT owned by `self`, and the
         // pointed-to CERT_CONTEXT is immutable for the lifetime of `self`.
-        unsafe { &*self.0 }
+        unsafe { self.0.as_ref() }
     }
 
     pub(crate) fn cert_info(&self) -> &CERT_INFO {
@@ -92,9 +97,7 @@ impl X509CertificateInner {
                 data,
             )
         };
-        if p.is_null() {
-            return Err(last_err("CertCreateCertificateContext"));
-        }
+        let p = NonNull::new(p).ok_or_else(|| last_err("CertCreateCertificateContext"))?;
         Ok(Self(CertContext(p)))
     }
 
@@ -395,7 +398,7 @@ impl X509CertificateInner {
         // required size.
         let needed = unsafe {
             windows::Win32::Security::Cryptography::CertGetNameStringW(
-                self.0.0,
+                self.0.0.as_ptr().cast_const(),
                 CERT_NAME_ATTR_TYPE,
                 0,
                 Some(oid),
@@ -414,7 +417,7 @@ impl X509CertificateInner {
         // SAFETY: buf is sized per the previous query.
         let written = unsafe {
             windows::Win32::Security::Cryptography::CertGetNameStringW(
-                self.0.0,
+                self.0.0.as_ptr().cast_const(),
                 CERT_NAME_ATTR_TYPE,
                 0,
                 Some(oid),
@@ -500,11 +503,8 @@ impl X509CertificateInner {
             rgExtension: std::ptr::null_mut(),
         };
 
-        let tbs = encode_object(
-            X509_CERT_TO_BE_SIGNED,
-            std::ptr::from_ref(&cert_info).cast(),
-        )
-        .context("encoding TBS certificate")?;
+        let tbs = encode_object(X509_CERT_TO_BE_SIGNED, &cert_info)
+            .context("encoding TBS certificate")?;
 
         // 4. Sign the TBS.
         let signature = key.pkcs1_sign(&tbs, crate::HashAlgorithm::Sha256)?;
@@ -531,8 +531,7 @@ impl X509CertificateInner {
                 cUnusedBits: 0,
             },
         };
-        let cert_der = encode_object(X509_CERT, std::ptr::from_ref(&signed).cast())
-            .context("encoding X.509 certificate")?;
+        let cert_der = encode_object(X509_CERT, &signed).context("encoding X.509 certificate")?;
 
         Ok(Self::from_der(&cert_der)?)
     }
@@ -574,7 +573,7 @@ fn find_extension(info: &CERT_INFO, oid: PCSTR) -> Option<&CERT_EXTENSION> {
 /// RAII wrapper for a CryptoAPI-allocated decoded structure. Frees with
 /// `LocalFree` when dropped.
 struct Decoded<T> {
-    raw: *mut c_void,
+    raw: NonNull<c_void>,
     /// Layout-compatible reference to the decoded structure inside `raw`.
     value: T,
     _phantom: std::marker::PhantomData<*const T>,
@@ -585,7 +584,7 @@ impl<T> Drop for Decoded<T> {
         // SAFETY: raw was allocated by CryptoAPI via CRYPT_DECODE_ALLOC_FLAG.
         unsafe {
             let _ = windows::Win32::Foundation::LocalFree(Some(
-                windows::Win32::Foundation::HLOCAL(self.raw),
+                windows::Win32::Foundation::HLOCAL(self.raw.as_ptr()),
             ));
         }
     }
@@ -621,12 +620,12 @@ fn decode_object<T: Copy>(
         )
     }
     .map_err(|e| err(e, "CryptDecodeObjectEx"))?;
-    if raw.is_null() {
-        return Err(err(
+    let raw = NonNull::new(raw).ok_or_else(|| {
+        err(
             windows_result::Error::from_hresult(windows::core::HRESULT(-1)),
             "CryptDecodeObjectEx returned null",
-        ));
-    }
+        )
+    })?;
     // Validate the API actually wrote a `T`-sized header before reading
     // it. A short buffer here would mean `read_unaligned` reads past the
     // allocation.
@@ -634,7 +633,7 @@ fn decode_object<T: Copy>(
         // SAFETY: raw was allocated by CryptoAPI via CRYPT_DECODE_ALLOC_FLAG.
         unsafe {
             let _ = windows::Win32::Foundation::LocalFree(Some(
-                windows::Win32::Foundation::HLOCAL(raw),
+                windows::Win32::Foundation::HLOCAL(raw.as_ptr()),
             ));
         }
         return Err(err(
@@ -645,7 +644,7 @@ fn decode_object<T: Copy>(
     // SAFETY: raw points to a `T` written by CryptoAPI (validated above to
     // be at least size_of::<T>() bytes). We copy it out so that `value`
     // lives at a stable address.
-    let value = unsafe { std::ptr::read_unaligned(raw.cast::<T>()) };
+    let value = unsafe { std::ptr::read_unaligned(raw.as_ptr().cast::<T>()) };
     Ok(Decoded {
         raw,
         value,
@@ -654,11 +653,12 @@ fn decode_object<T: Copy>(
 }
 
 #[cfg(any(test, feature = "test_helpers"))]
-fn encode_object(
+fn encode_object<T: ?Sized>(
     struct_type: PCSTR,
-    value: *const c_void,
+    value: &T,
 ) -> Result<Vec<u8>, windows_result::Error> {
     let mut size: u32 = 0;
+    let value = std::ptr::from_ref(value).cast();
     // SAFETY: first call queries size.
     unsafe {
         windows::Win32::Security::Cryptography::CryptEncodeObjectEx(
@@ -761,7 +761,7 @@ fn encode_x500_name(
     };
     let out = encode_object(
         windows::Win32::Security::Cryptography::X509_NAME,
-        std::ptr::from_ref(&name_info).cast(),
+        &name_info,
     )?;
     drop(rdns);
     drop(attrs);
@@ -811,5 +811,5 @@ fn encode_pkcs1_rsa_pubkey(n: &[u8], e: &[u8]) -> Result<Vec<u8>, windows_result
     blob.extend_from_slice(e);
     blob.extend_from_slice(n);
 
-    encode_object(CNG_RSA_PUBLIC_KEY_BLOB, blob.as_ptr().cast())
+    encode_object(CNG_RSA_PUBLIC_KEY_BLOB, blob.as_bytes())
 }

--- a/support/crypto/src/x509/win.rs
+++ b/support/crypto/src/x509/win.rs
@@ -36,8 +36,6 @@ use windows::Win32::Security::Cryptography::szOID_RSA_RSA;
 use windows::Win32::Security::Cryptography::szOID_RSA_SHA256RSA;
 use windows::Win32::Security::Cryptography::szOID_SUBJECT_KEY_IDENTIFIER;
 use windows::core::PCSTR;
-#[cfg(any(test, feature = "test_helpers"))]
-use zerocopy::IntoBytes;
 
 fn err(err: windows_result::Error, op: &'static str) -> X509Error {
     X509Error(crate::BackendError(err, op))
@@ -811,5 +809,5 @@ fn encode_pkcs1_rsa_pubkey(n: &[u8], e: &[u8]) -> Result<Vec<u8>, windows_result
     blob.extend_from_slice(e);
     blob.extend_from_slice(n);
 
-    encode_object(CNG_RSA_PUBLIC_KEY_BLOB, blob.as_bytes())
+    encode_object(CNG_RSA_PUBLIC_KEY_BLOB, blob.as_slice())
 }


### PR DESCRIPTION
As the title says, just mechanical refactoring to move non-nullness into the types.