### PR TITLE
vmm_tests: storage: wait for SCSI device teardown, not just block/sd*

### DIFF
--- a/vmm_tests/vmm_tests/tests/tests/utils.rs
+++ b/vmm_tests/vmm_tests/tests/tests/utils.rs
@@ -101,6 +101,28 @@ pub(crate) async fn get_device_paths(
         );
     }
 
+    // Also check the underlying SCSI device dirs (one level above
+    // `block/sd*`). The `block/sd*` symlink can disappear before the kernel
+    // finishes tearing down the SCSI device entry; if the next add reuses
+    // the same LUN location, the in-flight cleanup races with the re-add
+    // and the new `block/sd*` may never materialize for the highest LUN.
+    // Waiting for the SCSI dirs to also match the expected count gives the
+    // kernel time to finish cleanup.
+    let list_scsi_cmd = format!(
+        "ls -d /sys/bus/vmbus/devices/{}/host*/target*/*:0:0:* || true",
+        controller_guid
+    );
+    let scsi_devices = cmd!(sh, "sh -c {list_scsi_cmd}").read().await?;
+    let scsi_devices_count = scsi_devices.lines().count();
+    if scsi_devices_count != expected_devices.len() {
+        anyhow::bail!(
+            "Expected {} SCSI devices, found {} devices: {:?}",
+            expected_devices.len(),
+            scsi_devices_count,
+            scsi_devices
+        );
+    }
+
     // Verify each device is in the "running" SCSI state before declaring
     // discovery successful.
     //


### PR DESCRIPTION
storvsp_dynamic_add_disk rapidly cycles 8 SCSI LUNs (locations 0..7) through add → remove → add three times, reusing the same LUN numbers. It intermittently fails iter 2 with "Failed to get device paths after 20 attempts" / "ls: .../1:0:0:7/block/sd*: No such file or directory".

Root cause: Linux SCSI removal tears down block/sdX first, then issues SYNCHRONIZE CACHE (slow here — DID_NO_CONNECT because the host is already gone), then removes the parent :0:0:N/ dir. The current absence check only counts :0:0:/block/sd, so it returns "0 devices" the moment the block child is unlinked. The test then fires iter 2's add at the same LUN locations, racing the in-flight iter-1 teardown. The kernel re-attaches sdb..sdh, but the in-flight cleanup runs against the freshly-attached sdi — guest log shows "device offline error, dev sdi" / "Buffer I/O error" / "sdi: unable to read partition table" / "Synchronizing SCSI cache", and ls .../1:0:0:7/block/sd* returns nothing for the next 60s.

Fix: in get_device_paths, also count the parent SCSI device dirs .../host*/target*/:0:0: and require they match expected_devices.len(). On the absence path this gates iter N's add on iter N-1 being fully removed (parent dir gone), not just block/sdX unlinked. The existing 20 × 3s retry loop does the waiting.

Should hopefully fix test flakiness.