### PR TITLE
iommu: make max_iova() return an exclusive upper bound

### DIFF
--- a/vm/devices/iommu/amd_iommu/src/lib.rs
+++ b/vm/devices/iommu/amd_iommu/src/lib.rs
@@ -900,7 +900,7 @@ impl iommu_common::IommuTranslator for AmdTranslator {
         // The AMD IOMMU architecture supports up to 48-bit virtual
         // addresses (VA_SIZE), the architectural maximum for all
         // paging modes and translation configurations.
-        (1u64 << VA_SIZE) - 1
+        1u64 << VA_SIZE
     }
 
     fn translate<R>(

--- a/vm/devices/iommu/iommu_common/src/lib.rs
+++ b/vm/devices/iommu/iommu_common/src/lib.rs
@@ -39,10 +39,10 @@ pub trait IommuTranslator: Send + Sync + 'static {
     /// The IOMMU-specific error type for translation faults.
     type Error: std::error::Error + Send + Sync + 'static;
 
-    /// The maximum IOVA that can be translated (inclusive).
+    /// The exclusive upper bound of translatable IOVAs.
     ///
-    /// This is typically `(1 << va_bits) - 1` for the IOMMU's virtual
-    /// address width. Used as the `max_address` for the `GuestMemoryAccess`
+    /// This is typically `1 << va_bits` for the IOMMU's virtual address
+    /// width. Used as the `max_address` for the `GuestMemoryAccess`
     /// implementation, which rejects out-of-range accesses before they
     /// reach the translator.
     fn max_iova(&self) -> u64;

--- a/vm/devices/iommu/smmu/src/emulator.rs
+++ b/vm/devices/iommu/smmu/src/emulator.rs
@@ -1857,7 +1857,7 @@ mod tests {
     /// 1. Probe: read IDR registers, verify feature bits.
     /// 2. Reset: disable SMMU, program CR1, stream table, queues, enable.
     /// 3. Attach: configure STE and CD for a device.
-    /// 4. DMA: read/write through SmmuTranslatingMemory.
+    /// 4. DMA: read/write through TranslatingMemory.
     /// 5. MSI: fire MSI through SmmuSignalMsi with translated address.
     /// 6. Fault: access unmapped IOVA, verify EVTQ event.
     #[test]
@@ -2265,7 +2265,7 @@ mod tests {
         assert_eq!(sync_val, 0xCCCC, "CFGI+SYNC completion must be signaled");
 
         // =====================================================================
-        // Step 4: DMA — read/write through SmmuTranslatingMemory
+        // Step 4: DMA — read/write through TranslatingMemory
         // =====================================================================
 
         // Create per-device wrappers.
@@ -2375,7 +2375,7 @@ mod tests {
     // Save/Restore tests
     // =========================================================================
 
-    /// Verifies that DMA translation through SmmuTranslatingMemory
+    /// Verifies that DMA translation through TranslatingMemory
     /// continues to work after a save/restore cycle.
     ///
     /// This tests the critical restore path: re-syncing SharedStateInner

--- a/vm/devices/iommu/smmu/src/shared.rs
+++ b/vm/devices/iommu/smmu/src/shared.rs
@@ -548,7 +548,7 @@ impl iommu_common::IommuTranslator for SmmuTranslator {
         // This is the maximum across all configurations: stage-1 only,
         // stage-2 only, and nested (stage-1 IAS and stage-2 IPA width
         // are both bounded by 48 bits).
-        (1u64 << 48) - 1
+        1u64 << 48
     }
 
     fn translate<R>(
@@ -922,7 +922,7 @@ mod tests {
     }
 
     // =========================================================================
-    // SmmuTranslatingMemory tests
+    // TranslatingMemory tests
     // =========================================================================
 
     #[test]


### PR DESCRIPTION
Change IommuTranslator::max_iova() from returning the inclusive maximum IOVA (last valid address) to returning the exclusive upper bound (one past the last valid address). This aligns with GuestMemoryAccess's max_address semantics, which treats the value as an exclusive bound when rejecting out-of-range accesses.

Both the AMD IOMMU and SMMU implementations are updated accordingly, removing the `- 1` from their return values.