### PR TITLE
flowey: add JobId label to self-hosted GitHub runner jobs

### DIFF
--- a/.github/workflows/openvmm-ci.yaml
+++ b/.github/workflows/openvmm-ci.yaml
@@ -347,6 +347,7 @@ jobs:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
     - 1ES.ImageOverride=win-amd64
+    - JobId=job10-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
@@ -587,6 +588,7 @@ jobs:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
     - 1ES.ImageOverride=ubuntu2404-amd64-256gb
+    - JobId=job11-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
@@ -863,6 +865,7 @@ jobs:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
     - 1ES.ImageOverride=ubuntu2404-amd64-256gb
+    - JobId=job12-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
@@ -1130,6 +1133,7 @@ jobs:
     - self-hosted
     - 1ES.Pool=openvmm-gh-arm-westus2
     - 1ES.ImageOverride=win-arm64
+    - JobId=job13-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
@@ -1370,6 +1374,7 @@ jobs:
     - self-hosted
     - 1ES.Pool=openvmm-gh-arm-westus2
     - 1ES.ImageOverride=ubuntu2404-arm64
+    - JobId=job14-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
@@ -1626,6 +1631,7 @@ jobs:
     - self-hosted
     - 1ES.Pool=openvmm-gh-arm-westus2
     - 1ES.ImageOverride=ubuntu2404-arm64
+    - JobId=job15-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
@@ -1893,6 +1899,7 @@ jobs:
     - self-hosted
     - 1ES.Pool=openvmm-gh-intel-westus3
     - 1ES.ImageOverride=win-amd64
+    - JobId=job16-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
@@ -2406,6 +2413,7 @@ jobs:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
     - 1ES.ImageOverride=win-amd64
+    - JobId=job18-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
@@ -2919,6 +2927,7 @@ jobs:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
     - 1ES.ImageOverride=win-amd64
+    - JobId=job2-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
@@ -3133,6 +3142,7 @@ jobs:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
     - 1ES.ImageOverride=ubuntu2404-amd64-256gb
+    - JobId=job20-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
@@ -3790,6 +3800,7 @@ jobs:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
     - 1ES.ImageOverride=win-amd64
+    - JobId=job3-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
@@ -4089,6 +4100,7 @@ jobs:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
     - 1ES.ImageOverride=win-amd64
+    - JobId=job4-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
@@ -4307,6 +4319,7 @@ jobs:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
     - 1ES.ImageOverride=win-amd64
+    - JobId=job5-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
@@ -4614,6 +4627,7 @@ jobs:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
     - 1ES.ImageOverride=ubuntu2404-amd64-256gb
+    - JobId=job6-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
@@ -4933,6 +4947,7 @@ jobs:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
     - 1ES.ImageOverride=ubuntu2404-amd64-256gb
+    - JobId=job7-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
@@ -5308,6 +5323,7 @@ jobs:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
     - 1ES.ImageOverride=ubuntu2404-amd64-256gb
+    - JobId=job8-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
@@ -5657,6 +5673,7 @@ jobs:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
     - 1ES.ImageOverride=ubuntu2404-amd64-256gb
+    - JobId=job9-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/openvmm-pr-release.yaml
+++ b/.github/workflows/openvmm-pr-release.yaml
@@ -31,6 +31,7 @@ jobs:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
     - 1ES.ImageOverride=ubuntu2404-amd64-256gb
+    - JobId=job0-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
@@ -379,6 +380,7 @@ jobs:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
     - 1ES.ImageOverride=ubuntu2404-amd64-256gb
+    - JobId=job10-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
@@ -808,6 +810,7 @@ jobs:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
     - 1ES.ImageOverride=win-amd64
+    - JobId=job11-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
@@ -1048,6 +1051,7 @@ jobs:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
     - 1ES.ImageOverride=ubuntu2404-amd64-256gb
+    - JobId=job12-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
@@ -1303,6 +1307,7 @@ jobs:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
     - 1ES.ImageOverride=ubuntu2404-amd64-256gb
+    - JobId=job13-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
@@ -1570,6 +1575,7 @@ jobs:
     - self-hosted
     - 1ES.Pool=openvmm-gh-arm-westus2
     - 1ES.ImageOverride=win-arm64
+    - JobId=job14-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
@@ -1810,6 +1816,7 @@ jobs:
     - self-hosted
     - 1ES.Pool=openvmm-gh-arm-westus2
     - 1ES.ImageOverride=ubuntu2404-arm64
+    - JobId=job15-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
@@ -2066,6 +2073,7 @@ jobs:
     - self-hosted
     - 1ES.Pool=openvmm-gh-arm-westus2
     - 1ES.ImageOverride=ubuntu2404-arm64
+    - JobId=job16-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
@@ -2333,6 +2341,7 @@ jobs:
     - self-hosted
     - 1ES.Pool=openvmm-gh-intel-westus3
     - 1ES.ImageOverride=win-amd64
+    - JobId=job17-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
@@ -2846,6 +2855,7 @@ jobs:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
     - 1ES.ImageOverride=win-amd64
+    - JobId=job19-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
@@ -3526,6 +3536,7 @@ jobs:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
     - 1ES.ImageOverride=ubuntu2404-amd64-256gb
+    - JobId=job21-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
@@ -4183,6 +4194,7 @@ jobs:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
     - 1ES.ImageOverride=win-amd64
+    - JobId=job3-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
@@ -4397,6 +4409,7 @@ jobs:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
     - 1ES.ImageOverride=win-amd64
+    - JobId=job4-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
@@ -4696,6 +4709,7 @@ jobs:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
     - 1ES.ImageOverride=win-amd64
+    - JobId=job5-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
@@ -4914,6 +4928,7 @@ jobs:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
     - 1ES.ImageOverride=win-amd64
+    - JobId=job6-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
@@ -5221,6 +5236,7 @@ jobs:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
     - 1ES.ImageOverride=ubuntu2404-amd64-256gb
+    - JobId=job7-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
@@ -5540,6 +5556,7 @@ jobs:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
     - 1ES.ImageOverride=ubuntu2404-amd64-256gb
+    - JobId=job8-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
@@ -5915,6 +5932,7 @@ jobs:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
     - 1ES.ImageOverride=ubuntu2404-amd64-256gb
+    - JobId=job9-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/openvmm-pr.yaml
+++ b/.github/workflows/openvmm-pr.yaml
@@ -30,6 +30,7 @@ jobs:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
     - 1ES.ImageOverride=ubuntu2404-amd64-256gb
+    - JobId=job0-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
@@ -616,6 +617,7 @@ jobs:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
     - 1ES.ImageOverride=ubuntu2404-amd64-256gb
+    - JobId=job11-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
@@ -1520,6 +1522,7 @@ jobs:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
     - 1ES.ImageOverride=ubuntu2404-amd64-256gb
+    - JobId=job14-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
@@ -1775,6 +1778,7 @@ jobs:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
     - 1ES.ImageOverride=ubuntu2404-amd64-256gb
+    - JobId=job15-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
@@ -2796,6 +2800,7 @@ jobs:
     - self-hosted
     - 1ES.Pool=openvmm-gh-intel-westus3
     - 1ES.ImageOverride=win-amd64
+    - JobId=job19-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
@@ -3476,6 +3481,7 @@ jobs:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
     - 1ES.ImageOverride=win-amd64
+    - JobId=job21-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
@@ -3989,6 +3995,7 @@ jobs:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
     - 1ES.ImageOverride=ubuntu2404-amd64-256gb
+    - JobId=job23-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
@@ -4708,6 +4715,7 @@ jobs:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
     - 1ES.ImageOverride=win-amd64
+    - JobId=job3-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
@@ -4922,6 +4930,7 @@ jobs:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
     - 1ES.ImageOverride=win-amd64
+    - JobId=job4-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
@@ -5221,6 +5230,7 @@ jobs:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
     - 1ES.ImageOverride=win-amd64
+    - JobId=job5-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
@@ -5439,6 +5449,7 @@ jobs:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
     - 1ES.ImageOverride=win-amd64
+    - JobId=job6-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
@@ -5746,6 +5757,7 @@ jobs:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
     - 1ES.ImageOverride=ubuntu2404-amd64-256gb
+    - JobId=job7-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
@@ -6065,6 +6077,7 @@ jobs:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
     - 1ES.ImageOverride=ubuntu2404-amd64-256gb
+    - JobId=job8-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
@@ -6440,6 +6453,7 @@ jobs:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
     - 1ES.ImageOverride=ubuntu2404-amd64-256gb
+    - JobId=job9-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write

--- a/flowey/flowey_cli/src/pipeline_resolver/github_yaml/mod.rs
+++ b/flowey/flowey_cli/src/pipeline_resolver/github_yaml/mod.rs
@@ -553,7 +553,18 @@ EOF
             github_yaml_defs::Job {
                 name: label.clone(),
                 timeout_minutes,
-                runs_on: gh_pool.clone().map(|runner| runner_kind_to_yaml(&runner)),
+                runs_on: gh_pool.clone().map(|runner| {
+                    let mut yaml_runner = runner_kind_to_yaml(&runner);
+                    if let github_yaml_defs::Runner::SelfHosted(ref mut labels) = yaml_runner {
+                        if labels.iter().any(|l| l.starts_with("1ES.Pool=")) {
+                            labels.push(format!(
+                                "JobId=job{}-${{{{ github.run_id }}}}-${{{{ github.run_number }}}}-${{{{ github.run_attempt }}}}",
+                                job_idx.index()
+                            ));
+                        }
+                    }
+                    yaml_runner
+                }),
                 permissions: job_permissions
                     .iter()
                     .map(|k| (perm_kind_to_yaml(k.0), perm_val_to_yaml(k.1)))


### PR DESCRIPTION
Ben added a reliability fix for self-hosted runners, which has stabilized CI for main, but we are still seeing those reliability issues in 1.7 CI.

This is a clean cherry pick of a0de2d2b (#3155)