### PR TITLE
kernel upgrade: Update OpenHCL to use v6.18.0.6

### DIFF
--- a/flowey/flowey_lib_hvlite/src/_jobs/cfg_versions.rs
+++ b/flowey/flowey_lib_hvlite/src/_jobs/cfg_versions.rs
@@ -30,8 +30,8 @@ pub const NODEJS: &str = "24.x";
 // N.B. Kernel version numbers for dev and stable branches are not directly
 //      comparable. They originate from separate branches, and the fourth digit
 //      increases with each release from the respective branch.
-pub const OPENHCL_KERNEL_DEV_VERSION: &str = "6.18.0.4";
-pub const OPENHCL_KERNEL_STABLE_VERSION: &str = "6.18.0.4";
+pub const OPENHCL_KERNEL_DEV_VERSION: &str = "6.18.0.6";
+pub const OPENHCL_KERNEL_STABLE_VERSION: &str = "6.18.0.6";
 pub const OPENVMM_DEPS: &str = "0.3.0-43";
 pub const PROTOC: &str = "27.1";
 

--- a/nix/openhcl_kernel.nix
+++ b/nix/openhcl_kernel.nix
@@ -1,7 +1,7 @@
 { system, stdenv, fetchzip, targetArch ? null, is_dev ? false, is_cvm ? false }:
 
 let
-  version = if is_dev then "6.18.0.4" else "6.18.0.4";
+  version = if is_dev then "6.18.0.6" else "6.18.0.6";
   # Allow explicit override of architecture, otherwise derive from host system
   # Note: targetArch uses "x86_64"/"aarch64", but URLs use "x64"/"arm64"
   arch = if targetArch == "x86_64" then "x64"
@@ -18,21 +18,21 @@ let
   hashes = {
     hcl-main = {
       std = {
-        x64 = "sha256-YqmF+1CY2vvRhktPMZM2PtFGzhXRBVvYt7+CYOAQH/E=";
-        arm64 = "sha256-4Ntvl9WSZ3u+MDy6iQC4lEoRTWfFAbt6N+4l8kGySek=";
+        x64 = "sha256-j2ED/aSHpqQ0LFMUf0DS9Vhb/PfOoaUq0I6pt1ALIBo=";
+        arm64 = "sha256-NG4Lsf8EXiWh2h9vFjxQvtiuPOGrWxNcHfbcUxrDmBk=";
       };
       cvm = {
-        x64 = "sha256-VumSnRGNNee0Xx34y/sVo4vWTcnHAtIsnBQ7loZqMJw=";
+        x64 = "sha256-NJE1O56L0NWmPswGz7Po2vG8E5ifR8/uT+zTB0gz5iI=";
         arm64 = throw "openhcl-kernel: cvm arm64 variant not available";
       };
     };
     hcl-dev = {
       std = {
-        x64 = "sha256-hAIJc1aKEVu7+pLpIfdS9S47ajVQhYuVnSAfF4anIK8=";
-        arm64 = "sha256-7d16HiNDxWB9TD5bbqhtdltj0/nOmw3PjG380w+kNSE=";
+        x64 = "sha256-+gGo/niYk5OUX7LuNEJAv+IVh8l6GbOghWe9sXmzJZ0=";
+        arm64 = "sha256-2te4dN1yasAQ+L/E9/RjaTOzn/uwOy0VvjHoTpLqLhQ=";
       };
       cvm = {
-        x64 = "sha256-wmegRN+QO3J7ksDLXVe7j4qmIMlR8Wyv46+hnKa91h8=";
+        x64 = "sha256-GAWE3Il9aZH0rTvrYh4s5BCD07MjKuuLTi1XeAG1LBc=";
         arm64 = throw "openhcl-kernel: dev cvm arm64 variant not available";
       };
     };


### PR DESCRIPTION
Upgrade kernel used in OpenHCL to 6.18.0.6 release tag. This adds a fix for try_grab_folio warning in VTL2 kernel and associated Hyper-V GuestBVT test failure.

Kernel PRs:
https://github.com/microsoft/OHCL-Linux-Kernel/pull/141
https://github.com/microsoft/OHCL-Linux-Kernel/pull/144
Bug: https://microsoft.visualstudio.com/OS/_workitems/edit/62100614