### PR TITLE
Fix race condition in FramebufferDevice::reset

### DIFF
--- a/vm/devices/framebuffer/src/lib.rs
+++ b/vm/devices/framebuffer/src/lib.rs
@@ -326,7 +326,6 @@ impl ChangeDeviceState for FramebufferDevice {
 
     async fn reset(&mut self) {
         let mut inner = self.inner.lock();
-        inner.mapping_state = Default::default();
         if let Some(mut state) = inner.mapping_state.take() {
             state.mem.unmap_from_guest();
         }


### PR DESCRIPTION
The race here isn't super obvious, but the code is very obviously wrong anyways. The problem is that the Drop impl for inner.mapping_state queues up an unmap to happen asynchronously. So the unmap operation isn't lost, it just becomes a race that tends to be successful. Should fix some test flakiness.