### PR TITLE
pci_core/pcie: quiet down noisy PCI config space traces

### DIFF
--- a/vm/devices/pci/pci_core/src/cfg_space_emu.rs
+++ b/vm/devices/pci/pci_core/src/cfg_space_emu.rs
@@ -350,13 +350,13 @@ impl<const N: usize> ConfigSpaceCommonHeaderEmulator<N> {
 
     /// Reset the common header state
     pub fn reset(&mut self) {
-        tracing::info!("ConfigSpaceCommonHeaderEmulator: resetting state");
+        tracing::debug!("ConfigSpaceCommonHeaderEmulator: resetting state");
         self.state = ConfigSpaceCommonHeaderEmulatorState::new();
 
-        tracing::info!("ConfigSpaceCommonHeaderEmulator: syncing command register after reset");
+        tracing::debug!("ConfigSpaceCommonHeaderEmulator: syncing command register after reset");
         self.sync_command_register(self.state.command);
 
-        tracing::info!(
+        tracing::debug!(
             "ConfigSpaceCommonHeaderEmulator: resetting {} capabilities",
             self.capabilities.len()
         );
@@ -364,7 +364,7 @@ impl<const N: usize> ConfigSpaceCommonHeaderEmulator<N> {
             cap.reset();
         }
 
-        tracing::info!(
+        tracing::debug!(
             "ConfigSpaceCommonHeaderEmulator: resetting {} extended capabilities",
             self.extended_capabilities.len()
         );
@@ -373,10 +373,10 @@ impl<const N: usize> ConfigSpaceCommonHeaderEmulator<N> {
         }
 
         if let Some(intx) = &mut self.intx_interrupt {
-            tracing::info!("ConfigSpaceCommonHeaderEmulator: resetting interrupt level");
+            tracing::debug!("ConfigSpaceCommonHeaderEmulator: resetting interrupt level");
             intx.set_level(false);
         }
-        tracing::info!("ConfigSpaceCommonHeaderEmulator: reset completed");
+        tracing::debug!("ConfigSpaceCommonHeaderEmulator: reset completed");
     }
 
     /// Get hardware IDs
@@ -449,7 +449,7 @@ impl<const N: usize> ConfigSpaceCommonHeaderEmulator<N> {
 
     /// Sync command register changes by updating both interrupt and MMIO state
     pub fn sync_command_register(&mut self, command: cfg_space::Command) {
-        tracing::info!(
+        tracing::debug!(
             "ConfigSpaceCommonHeaderEmulator: syncing command register - intx_disable={}, mmio_enabled={}",
             command.intx_disable(),
             command.mmio_enabled()
@@ -460,7 +460,7 @@ impl<const N: usize> ConfigSpaceCommonHeaderEmulator<N> {
 
     /// Update interrupt disable setting
     pub fn update_intx_disable(&mut self, disabled: bool) {
-        tracing::info!(
+        tracing::debug!(
             "ConfigSpaceCommonHeaderEmulator: updating intx_disable={}",
             disabled
         );
@@ -471,7 +471,7 @@ impl<const N: usize> ConfigSpaceCommonHeaderEmulator<N> {
 
     /// Update MMIO enabled setting and handle BAR mapping
     pub fn update_mmio_enabled(&mut self, enabled: bool) {
-        tracing::info!(
+        tracing::debug!(
             "ConfigSpaceCommonHeaderEmulator: updating mmio_enabled={}",
             enabled
         );

--- a/vm/devices/pci/pcie/src/root.rs
+++ b/vm/devices/pci/pcie/src/root.rs
@@ -659,10 +659,10 @@ impl MmioIntercept for GenericPcieRootComplex {
         let start_bus = self.start_bus;
         match self.decode_ecam_access(dword_aligned_addr) {
             DecodedEcamAccess::UnexpectedIntercept => {
-                tracing::error!("unexpected intercept at address 0x{:16x}", addr);
+                tracelimit::warn_ratelimited!(addr, "unexpected intercept at ECAM address");
             }
             DecodedEcamAccess::Unroutable => {
-                tracelimit::warn_ratelimited!("unroutable config space access");
+                tracing::debug!(addr, "unroutable config space access");
             }
             DecodedEcamAccess::InternalBus(port, cfg_offset) => {
                 check_result!(port.port.cfg_space.read_u32(cfg_offset, &mut dword_value));
@@ -734,10 +734,10 @@ impl MmioIntercept for GenericPcieRootComplex {
         let start_bus = self.start_bus;
         match self.decode_ecam_access(dword_aligned_addr) {
             DecodedEcamAccess::UnexpectedIntercept => {
-                tracing::error!("unexpected intercept at address 0x{:16x}", addr);
+                tracelimit::warn_ratelimited!(addr, "unexpected intercept at ECAM address");
             }
             DecodedEcamAccess::Unroutable => {
-                tracelimit::warn_ratelimited!("unroutable config space access");
+                tracing::debug!(addr, "unroutable config space access");
             }
             DecodedEcamAccess::InternalBus(port, cfg_offset) => {
                 check_result!(port.port.cfg_space.write_u32(cfg_offset, write_dword));


### PR DESCRIPTION
Downgrade routine PCI config space traces that flood logs during normal operation. In cfg_space_emu, demote info-level reset and command register traces to debug. In the PCIe root complex, demote the non-ratelimited "unexpected intercept" error to warn_ratelimited, and demote "unroutable config space access" to debug since it fires hundreds of times during normal PCI bus enumeration.