### PR TITLE
Wire optional NUMA node affinity for PCIe and VPCI devices

### DIFF
--- a/Guide/src/reference/architecture/openvmm/numa.md
+++ b/Guide/src/reference/architecture/openvmm/numa.md
@@ -93,6 +93,31 @@ On Linux guests, the topology is visible via `numactl --hardware`.
 On Windows guests, it appears in Task Manager and via the
 `GetLogicalProcessorInformationEx` API.
 
+## Device NUMA affinity
+
+PCIe root complexes and VPCI devices can optionally be assigned to a
+NUMA node so the guest OS sees correct device locality. When no node is
+specified, the ACPI `_PXM` method is omitted and the VPCI NUMA flag is
+not set — the guest treats the device as having no specific NUMA
+affinity and uses its default (current-node) allocation policy.
+
+For PCIe, each root complex can specify a `vnode` that is exposed via
+the ACPI `_PXM` method on the host bridge. Linux reads this to populate
+`/sys/bus/pci/devices/<BDF>/numa_node` for all devices under that root
+complex. Use `node=N` on `--pcie-root-complex`:
+
+```bash
+# Root complex on NUMA node 1
+openvmm --numa size=2G --numa size=2G \
+        --pcie-root-complex rc0,node=1 \
+        --pcie-root-port rc0:rp0 ...
+```
+
+For VPCI devices, the NUMA node can be set in the config (`vnode` field
+on `VpciDeviceConfig`) and is reported to the guest via the VPCI
+protocol's `BusRelations2` message. There is no CLI flag for VPCI
+device affinity yet — it is set programmatically.
+
 ## CLI usage
 
 The `--numa` flag replaces `--memory` for multi-node VMs. It is
@@ -124,8 +149,6 @@ reference.
 
 ## Limitations
 
-- **Device NUMA affinity** is not yet implemented. PCIe root complexes
-  and VPCI devices do not expose NUMA node assignments to the guest.
 - **Snapshot/restore** with multi-node topologies is not yet supported.
 - **Linux direct boot with devicetree** (aarch64) does not include
   NUMA information in the generated devicetree. The guest sees a flat

--- a/Guide/src/reference/architecture/openvmm/numa.md
+++ b/Guide/src/reference/architecture/openvmm/numa.md
@@ -97,12 +97,12 @@ On Windows guests, it appears in Task Manager and via the
 
 PCIe root complexes and VPCI devices can optionally be assigned to a
 NUMA node so the guest OS sees correct device locality. When no node is
-specified, the ACPI `_PXM` method is omitted and the VPCI NUMA flag is
+specified, the ACPI `_PXM` object is omitted and the VPCI NUMA flag is
 not set — the guest treats the device as having no specific NUMA
 affinity and uses its default (current-node) allocation policy.
 
 For PCIe, each root complex can specify a `vnode` that is exposed via
-the ACPI `_PXM` method on the host bridge. Linux reads this to populate
+the ACPI `_PXM` object on the host bridge. Linux reads this to populate
 `/sys/bus/pci/devices/<BDF>/numa_node` for all devices under that root
 complex. Use `node=N` on `--pcie-root-complex`:
 

--- a/Guide/src/reference/openvmm/management/cli.md
+++ b/Guide/src/reference/openvmm/management/cli.md
@@ -230,6 +230,9 @@ complex name:
   4: fixed device configuration
   5: BI
   Bits 15:6 are reserved and rejected.
+- `node=<N>`: NUMA node affinity for this root complex. The guest sees
+  this via the ACPI `_PXM` method. When omitted, no `_PXM` is emitted
+  and the guest uses its default allocation policy.
 
 ### Root port and switch options
 

--- a/Guide/src/reference/openvmm/management/cli.md
+++ b/Guide/src/reference/openvmm/management/cli.md
@@ -231,7 +231,7 @@ complex name:
   5: BI
   Bits 15:6 are reserved and rejected.
 - `node=<N>`: NUMA node affinity for this root complex. The guest sees
-  this via the ACPI `_PXM` method. When omitted, no `_PXM` is emitted
+  this via the ACPI `_PXM` object. When omitted, no `_PXM` is emitted
   and the guest uses its default allocation policy.
 
 ### Root port and switch options

--- a/openhcl/underhill_core/src/worker.rs
+++ b/openhcl/underhill_core/src/worker.rs
@@ -3419,8 +3419,12 @@ async fn new_underhill_vm(
                     software_iommu: false,
                 },
                 vmbus.control(),
-                instance_id,
                 &chipset_builder,
+                vpci::bus::VpciBusConfig {
+                    instance_id,
+                    vtom,
+                    vnode: None,
+                },
                 |device_id| {
                     let device = partition
                         .new_virtual_device()
@@ -3429,7 +3433,6 @@ async fn new_underhill_vm(
                     let device = Arc::new(device);
                     Ok((device.clone(), VpciInterruptMapper::new(device)))
                 },
-                vtom,
             )
             .await?;
         }

--- a/openvmm/openvmm_core/src/worker/dispatch.rs
+++ b/openvmm/openvmm_core/src/worker/dispatch.rs
@@ -143,6 +143,7 @@ use vmgs_resources::GuestStateEncryptionPolicy;
 use vmgs_resources::VmgsResource;
 use vmm_core::acpi_builder::AcpiTablesBuilder;
 use vmm_core::acpi_builder::SlitInfo;
+use vmm_core::device_builder::VpciBusConfig;
 use vmm_core::input_distributor::InputDistributor;
 use vmm_core::partition_unit::Halt;
 use vmm_core::partition_unit::PartitionUnit;
@@ -164,8 +165,6 @@ use vmotherboard::options::BaseChipsetManifest;
 use vmotherboard::options::VmChipsetCapabilities;
 #[cfg(all(windows, feature = "virt_whp"))]
 use vpci::bus::VpciBus;
-#[cfg(all(windows, feature = "virt_whp"))]
-use vpci::bus::VpciBusConfig;
 use watchdog_core::platform::BaseWatchdogPlatform;
 use watchdog_core::platform::WatchdogCallback;
 use watchdog_core::platform::WatchdogPlatform;
@@ -2488,12 +2487,12 @@ impl InitializedVm {
                         },
                         vmbus.control(),
                         &chipset_builder,
-                        vmm_core::device_builder::VpciBusConfig {
+                        VpciBusConfig {
                             instance_id: dev_cfg.instance_id,
                             vtom: None,
                             vnode: dev_cfg
                                 .vnode
-                                .map(|v| u16::try_from(v))
+                                .map(u16::try_from)
                                 .transpose()
                                 .context("vpci device vnode exceeds 65535")?,
                         },

--- a/openvmm/openvmm_core/src/worker/dispatch.rs
+++ b/openvmm/openvmm_core/src/worker/dispatch.rs
@@ -164,6 +164,8 @@ use vmotherboard::options::BaseChipsetManifest;
 use vmotherboard::options::VmChipsetCapabilities;
 #[cfg(all(windows, feature = "virt_whp"))]
 use vpci::bus::VpciBus;
+#[cfg(all(windows, feature = "virt_whp"))]
+use vpci::bus::VpciBusConfig;
 use watchdog_core::platform::BaseWatchdogPlatform;
 use watchdog_core::platform::WatchdogCallback;
 use watchdog_core::platform::WatchdogPlatform;
@@ -2019,6 +2021,7 @@ impl InitializedVm {
                     low_mmio: ranges.low_mmio,
                     high_mmio: ranges.high_mmio,
                     cxl,
+                    vnode: rc.vnode,
                 });
 
                 pcie_root_complexes.push(root_complex.clone());
@@ -2484,8 +2487,16 @@ impl InitializedVm {
                             software_iommu: false,
                         },
                         vmbus.control(),
-                        dev_cfg.instance_id,
                         &chipset_builder,
+                        vmm_core::device_builder::VpciBusConfig {
+                            instance_id: dev_cfg.instance_id,
+                            vtom: None,
+                            vnode: dev_cfg
+                                .vnode
+                                .map(|v| u16::try_from(v))
+                                .transpose()
+                                .context("vpci device vnode exceeds 65535")?,
+                        },
                         |device_id| {
                             let hv_device = partition.new_virtual_device(
                                 match dev_cfg.vtl {
@@ -2500,7 +2511,6 @@ impl InitializedVm {
                                 hv_device.clone().interrupt_mapper(),
                             ))
                         },
-                        None,
                     )
                     .await?;
                 }
@@ -2540,12 +2550,15 @@ impl InitializedVm {
                         .try_add_async(async |services| {
                             VpciBus::new(
                                 &driver_source,
-                                instance_id,
+                                VpciBusConfig {
+                                    instance_id,
+                                    vtom: None,
+                                    vnode: None,
+                                },
                                 device,
                                 &mut services.register_mmio(),
                                 vmbus,
                                 crate::partition::VpciDevice::interrupt_mapper(hv_device),
-                                None,
                             )
                             .await
                         })

--- a/openvmm/openvmm_core/src/worker/memory_layout.rs
+++ b/openvmm/openvmm_core/src/worker/memory_layout.rs
@@ -639,6 +639,7 @@ mod tests {
             ports: Vec::new(),
             cxl: None,
             iommu: None,
+            vnode: None,
         }
     }
 
@@ -752,6 +753,7 @@ mod tests {
                 ports: Vec::new(),
                 cxl: None,
                 iommu: None,
+                vnode: None,
             },
             PcieRootComplexConfig {
                 index: 1,
@@ -764,6 +766,7 @@ mod tests {
                 ports: Vec::new(),
                 cxl: None,
                 iommu: None,
+                vnode: None,
             },
         ];
         let mut config = input(&[2 * GB], None);
@@ -800,6 +803,7 @@ mod tests {
             ports: Vec::new(),
             cxl: None,
             iommu: None,
+            vnode: None,
         }];
         let mut config = input(&[2 * GB], None);
         config.pcie_root_complexes = &root_complexes;

--- a/openvmm/openvmm_defs/src/config.rs
+++ b/openvmm/openvmm_defs/src/config.rs
@@ -220,6 +220,10 @@ pub struct PcieRootComplexConfig {
     pub cxl: Option<RootComplexCxlConfig>,
     /// Optional IOMMU for this root complex.
     pub iommu: Option<PcieIommuConfig>,
+    /// NUMA node affinity for this root complex. Used to generate `_PXM` in
+    /// the ACPI SSDT so the guest OS sees correct NUMA locality for devices
+    /// under this root complex.
+    pub vnode: Option<u32>,
 }
 
 #[derive(Debug, MeshPayload)]
@@ -259,6 +263,8 @@ pub struct VpciDeviceConfig {
     /// instance ID, which is used to generate the guest-visible device ID.
     pub instance_id: Guid,
     pub resource: Resource<PciDeviceHandleKind>,
+    /// NUMA node affinity for this VPCI device.
+    pub vnode: Option<u32>,
 }
 
 #[derive(Debug, Protobuf)]

--- a/openvmm/openvmm_entry/src/cli_args.rs
+++ b/openvmm/openvmm_entry/src/cli_args.rs
@@ -2860,6 +2860,7 @@ pub struct PcieRootComplexCli {
     pub high_mmio: u64,
     pub hdm: u64,
     pub hdm_window_restrictions: CfmwsWindowRestrictions,
+    pub vnode: Option<u32>,
 }
 
 impl FromStr for PcieRootComplexCli {
@@ -2885,6 +2886,7 @@ impl FromStr for PcieRootComplexCli {
         let mut high_mmio = DEFAULT_PCIE_CRS_HIGH_SIZE;
         let mut hdm = DEFAULT_PCIE_HDM_SIZE;
         let mut hdm_window_restrictions = DEFAULT_HDM_WINDOW_RESTRICTIONS;
+        let mut vnode = None;
         for opt in opts {
             let mut s = opt.split('=');
             let opt = s.next().context("expected option")?;
@@ -2925,6 +2927,11 @@ impl FromStr for PcieRootComplexCli {
                         parse_cxl_cfmws_window_restriction_u16_bitmask(mask_str)
                             .context("failed to parse HDM window restrictions bitmask")?;
                 }
+                "node" => {
+                    let node_str = s.next().context("expected NUMA node number")?;
+                    vnode =
+                        Some(u32::from_str(node_str).context("failed to parse NUMA node number")?);
+                }
                 opt => anyhow::bail!("unknown option: '{opt}'"),
             }
         }
@@ -2942,6 +2949,7 @@ impl FromStr for PcieRootComplexCli {
             high_mmio,
             hdm,
             hdm_window_restrictions,
+            vnode,
         })
     }
 }
@@ -4208,6 +4216,7 @@ mod tests {
                 high_mmio: DEFAULT_HIGH_MMIO,
                 hdm: DEFAULT_HDM,
                 hdm_window_restrictions: DEFAULT_HDM_WINDOW_RESTRICTIONS,
+                vnode: None,
             }
         );
 
@@ -4222,6 +4231,7 @@ mod tests {
                 high_mmio: DEFAULT_HIGH_MMIO,
                 hdm: DEFAULT_HDM,
                 hdm_window_restrictions: DEFAULT_HDM_WINDOW_RESTRICTIONS,
+                vnode: None,
             }
         );
 
@@ -4236,6 +4246,7 @@ mod tests {
                 high_mmio: DEFAULT_HIGH_MMIO,
                 hdm: DEFAULT_HDM,
                 hdm_window_restrictions: DEFAULT_HDM_WINDOW_RESTRICTIONS,
+                vnode: None,
             }
         );
 
@@ -4250,6 +4261,7 @@ mod tests {
                 high_mmio: DEFAULT_HIGH_MMIO,
                 hdm: DEFAULT_HDM,
                 hdm_window_restrictions: DEFAULT_HDM_WINDOW_RESTRICTIONS,
+                vnode: None,
             }
         );
 
@@ -4264,6 +4276,7 @@ mod tests {
                 high_mmio: 2 * ONE_GB,
                 hdm: DEFAULT_HDM,
                 hdm_window_restrictions: DEFAULT_HDM_WINDOW_RESTRICTIONS,
+                vnode: None,
             }
         );
 
@@ -4278,6 +4291,7 @@ mod tests {
                 high_mmio: DEFAULT_HIGH_MMIO,
                 hdm: DEFAULT_HDM,
                 hdm_window_restrictions: DEFAULT_HDM_WINDOW_RESTRICTIONS,
+                vnode: None,
             }
         );
 
@@ -4292,6 +4306,7 @@ mod tests {
                 high_mmio: 64 * ONE_GB,
                 hdm: DEFAULT_HDM,
                 hdm_window_restrictions: DEFAULT_HDM_WINDOW_RESTRICTIONS,
+                vnode: None,
             }
         );
 
@@ -4306,6 +4321,7 @@ mod tests {
                 high_mmio: DEFAULT_HIGH_MMIO,
                 hdm: 2 * ONE_GB,
                 hdm_window_restrictions: DEFAULT_HDM_WINDOW_RESTRICTIONS,
+                vnode: None,
             }
         );
 
@@ -4320,6 +4336,7 @@ mod tests {
                 high_mmio: DEFAULT_HIGH_MMIO,
                 hdm: DEFAULT_HDM,
                 hdm_window_restrictions: CfmwsWindowRestrictions::try_from_bits(0x21).unwrap(),
+                vnode: None,
             }
         );
 
@@ -4340,6 +4357,22 @@ mod tests {
         assert!(PcieRootComplexCli::from_str("rc,hdm_window_restrictions=bad").is_err());
         assert!(PcieRootComplexCli::from_str("rc,hdm_window_restrictions").is_err());
         assert!(PcieRootComplexCli::from_str("rc,cxl").is_err());
+
+        // node option
+        assert_eq!(
+            PcieRootComplexCli::from_str("rc9,node=1").unwrap(),
+            PcieRootComplexCli {
+                name: "rc9".to_string(),
+                segment: 0,
+                start_bus: 0,
+                end_bus: 255,
+                low_mmio: DEFAULT_LOW_MMIO,
+                high_mmio: DEFAULT_HIGH_MMIO,
+                hdm: DEFAULT_HDM,
+                hdm_window_restrictions: DEFAULT_HDM_WINDOW_RESTRICTIONS,
+                vnode: Some(1),
+            }
+        );
     }
 
     #[test]

--- a/openvmm/openvmm_entry/src/lib.rs
+++ b/openvmm/openvmm_entry/src/lib.rs
@@ -793,6 +793,7 @@ async fn vm_config_from_command_line(
                     },
                     instance_id,
                     resource: handle.into_resource(),
+                    vnode: None,
                 })
             }),
     );
@@ -880,6 +881,7 @@ async fn vm_config_from_command_line(
                 .iter()
                 .any(|s| s == &rc_cli.name)
                 .then_some(openvmm_defs::config::PcieIommuConfig::AmdVi),
+            vnode: rc_cli.vnode,
         });
     }
 
@@ -1621,6 +1623,7 @@ async fn vm_config_from_command_line(
                 vtl: DeviceVtl::Vtl0,
                 instance_id: Guid::new_random(),
                 resource: VirtioPciDeviceHandle(resource).into_resource(),
+                vnode: None,
             });
         }
     };

--- a/openvmm/openvmm_entry/src/storage_builder.rs
+++ b/openvmm/openvmm_entry/src/storage_builder.rs
@@ -774,6 +774,7 @@ impl StorageBuilder {
                                     requests: ctrl.requests,
                                 }
                                 .into_resource(),
+                                vnode: None,
                             });
 
                             // Tell UEFI to try to enumerate VPCI devices since there
@@ -803,6 +804,7 @@ impl StorageBuilder {
                     requests: None,
                 }
                 .into_resource(),
+                vnode: None,
             });
 
             // Tell UEFI to try to enumerate VPCI devices since there might be
@@ -840,6 +842,7 @@ impl StorageBuilder {
                     requests: Some(recv),
                 }
                 .into_resource(),
+                vnode: None,
             });
             resources.nvme_vtl2_rpc = Some(send);
         }
@@ -861,6 +864,7 @@ impl StorageBuilder {
                     .into_resource(),
                 )
                 .into_resource(),
+                vnode: None,
             });
         }
 

--- a/openvmm/openvmm_entry/src/ttrpc/mod.rs
+++ b/openvmm/openvmm_entry/src/ttrpc/mod.rs
@@ -671,6 +671,7 @@ impl VmService {
                         vtl: DeviceVtl::Vtl0,
                         instance_id: Guid::new_random(),
                         resource: VirtioPciDeviceHandle(resource).into_resource(),
+                        vnode: None,
                     });
                 } else {
                     config.virtio_devices.push((VirtioBus::Mmio, resource));
@@ -694,6 +695,7 @@ impl VmService {
                             vtl: DeviceVtl::Vtl0,
                             instance_id: Guid::new_random(),
                             resource: VirtioPciDeviceHandle(resource).into_resource(),
+                            vnode: None,
                         });
                     } else {
                         config.virtio_devices.push((VirtioBus::Mmio, resource));

--- a/petri/src/vm/openvmm/construct.rs
+++ b/petri/src/vm/openvmm/construct.rs
@@ -1373,6 +1373,7 @@ async fn vmbus_storage_controllers_to_openvmm(
                         requests: None,
                     }
                     .into_resource(),
+                    vnode: None,
                 });
             }
             VmbusStorageType::VirtioBlk => {
@@ -1404,6 +1405,7 @@ async fn vmbus_storage_controllers_to_openvmm(
                             .into_resource(),
                         )
                         .into_resource(),
+                        vnode: None,
                     });
                 }
             }

--- a/petri/src/vm/openvmm/modify.rs
+++ b/petri/src/vm/openvmm/modify.rs
@@ -104,6 +104,7 @@ impl PetriVmConfigOpenVmm {
                     }],
                 }
                 .into_resource(),
+                vnode: None,
             });
 
             vtl2_settings.dynamic.as_mut().unwrap().nic_devices.push(
@@ -286,6 +287,7 @@ impl PetriVmConfigOpenVmm {
                     }],
                 }
                 .into_resource(),
+                vnode: None,
             });
 
             vtl2_settings.dynamic.as_mut().unwrap().nic_devices.push(
@@ -393,6 +395,7 @@ impl PetriVmConfigOpenVmm {
                     cxl: None,
                     ports,
                     iommu: None,
+                    vnode: None,
                 });
             }
         }

--- a/vm/acpi/src/ssdt.rs
+++ b/vm/acpi/src/ssdt.rs
@@ -40,6 +40,28 @@ pub struct Ssdt {
     pcie_ecam_ranges: Vec<MemoryRange>,
 }
 
+/// Parameters for adding a PCIe host bridge to the SSDT.
+pub struct PcieHostBridgeEntry {
+    /// Unique index of this host bridge.
+    pub index: u32,
+    /// PCIe segment number.
+    pub segment: u16,
+    /// Lowest valid bus number.
+    pub start_bus: u8,
+    /// Highest valid bus number.
+    pub end_bus: u8,
+    /// Memory range for ECAM configuration space access.
+    pub ecam_range: MemoryRange,
+    /// Memory range for low MMIO.
+    pub low_mmio: MemoryRange,
+    /// Memory range for high MMIO.
+    pub high_mmio: MemoryRange,
+    /// Whether this host bridge supports CXL.
+    pub cxl: bool,
+    /// NUMA proximity domain.
+    pub vnode: Option<u32>,
+}
+
 impl Ssdt {
     pub fn new() -> Self {
         Self {
@@ -115,17 +137,18 @@ impl Ssdt {
     ///     })
     /// }
     /// ```
-    pub fn add_pcie(
-        &mut self,
-        index: u32,
-        segment: u16,
-        start_bus: u8,
-        end_bus: u8,
-        ecam_range: MemoryRange,
-        low_mmio: MemoryRange,
-        high_mmio: MemoryRange,
-        cxl: bool,
-    ) {
+    pub fn add_pcie(&mut self, entry: PcieHostBridgeEntry) {
+        let PcieHostBridgeEntry {
+            index,
+            segment,
+            start_bus,
+            end_bus,
+            ecam_range,
+            low_mmio,
+            high_mmio,
+            cxl,
+            vnode,
+        } = entry;
         let mut pcie = Device::new(encode_pcie_name(index).as_slice());
         if cxl {
             // As recommended by the CXL specification, describe CXL host bridges with _HID "ACPI0016"
@@ -149,6 +172,9 @@ impl Ssdt {
         pcie.add_object(&NamedInteger::new(b"_SEG", segment.into()));
         pcie.add_object(&NamedInteger::new(b"_BBN", start_bus.into()));
         pcie.add_object(&NamedInteger::new(b"_CCA", 1));
+        if let Some(vnode) = vnode {
+            pcie.add_object(&NamedInteger::new(b"_PXM", vnode.into()));
+        }
 
         // _OSC method: negotiate native control with the guest OS.
         //
@@ -381,19 +407,24 @@ mod tests {
         verify_expected_bytes(&bytes[36..], &[8, b'_', b'S', b'0', b'_', 0x12, 4, 2, 0, 0]);
     }
 
+    fn test_pcie_entry(vnode: Option<u32>) -> PcieHostBridgeEntry {
+        PcieHostBridgeEntry {
+            index: 0,
+            segment: 0,
+            start_bus: 0,
+            end_bus: 255,
+            ecam_range: MemoryRange::new(0x1000_0000..0x2000_0000),
+            low_mmio: MemoryRange::new(0xdc00_0000..0xe000_0000),
+            high_mmio: MemoryRange::new(0x10_0000_0000..0x10_4000_0000),
+            cxl: false,
+            vnode,
+        }
+    }
+
     #[test]
     fn pcie_includes_cca() {
         let mut ssdt = Ssdt::new();
-        ssdt.add_pcie(
-            0,
-            0,
-            0,
-            255,
-            MemoryRange::new(0x1000_0000..0x2000_0000),
-            MemoryRange::new(0xdc00_0000..0xe000_0000),
-            MemoryRange::new(0x10_0000_0000..0x10_4000_0000),
-            false,
-        );
+        ssdt.add_pcie(test_pcie_entry(None));
 
         let bytes = ssdt.to_bytes();
         verify_header(&bytes);
@@ -401,6 +432,52 @@ mod tests {
             bytes
                 .windows(6)
                 .any(|window| window == [8, b'_', b'C', b'C', b'A', 1,])
+        );
+    }
+
+    #[test]
+    fn pcie_no_pxm_when_vnode_none() {
+        let mut ssdt = Ssdt::new();
+        ssdt.add_pcie(test_pcie_entry(None));
+
+        let bytes = ssdt.to_bytes();
+        verify_header(&bytes);
+        // _PXM should NOT be present when vnode is None.
+        assert!(
+            !bytes
+                .windows(4)
+                .any(|window| window == [b'_', b'P', b'X', b'M']),
+            "_PXM should not be emitted when vnode is None"
+        );
+    }
+
+    #[test]
+    fn pcie_includes_pxm() {
+        let mut ssdt = Ssdt::new();
+        ssdt.add_pcie(test_pcie_entry(Some(0)));
+
+        let bytes = ssdt.to_bytes();
+        verify_header(&bytes);
+        // _PXM with value 0
+        assert!(
+            bytes
+                .windows(6)
+                .any(|window| window == [8, b'_', b'P', b'X', b'M', 0,])
+        );
+    }
+
+    #[test]
+    fn pcie_pxm_nonzero_node() {
+        let mut ssdt = Ssdt::new();
+        ssdt.add_pcie(test_pcie_entry(Some(3)));
+
+        let bytes = ssdt.to_bytes();
+        verify_header(&bytes);
+        // _PXM with value 3: Name op (0x08) + "_PXM" + BytePrefix (0x0a) + 3
+        assert!(
+            bytes
+                .windows(7)
+                .any(|window| window == [8, b'_', b'P', b'X', b'M', 0x0a, 3,])
         );
     }
 }

--- a/vm/devices/pci/vpci/src/bus.rs
+++ b/vm/devices/pci/vpci/src/bus.rs
@@ -106,32 +106,48 @@ pub enum CreateBusError {
     Offer(#[source] anyhow::Error),
 }
 
+/// Configuration for a VPCI bus instance.
+pub struct VpciBusConfig {
+    /// The VPCI device instance ID.
+    pub instance_id: Guid,
+    /// VTOM value for isolated VMs, if applicable.
+    pub vtom: Option<u64>,
+    /// NUMA node affinity reported to the guest.
+    pub vnode: Option<u16>,
+}
+
 impl VpciBusDevice {
     /// Returns a new VPCI bus device, along with the vmbus channel used for bus
     /// communications.
     pub fn new(
-        instance_id: Guid,
+        config: VpciBusConfig,
         device: Arc<CloseableMutex<dyn ChipsetDevice>>,
         register_mmio: &mut dyn RegisterMmioIntercept,
         msi_controller: VpciInterruptMapper,
-        vtom: Option<u64>,
     ) -> Result<(Self, VpciChannel), NotPciDevice> {
+        let instance_id = config.instance_id;
         let config_space = VpciConfigSpace::new(
             register_mmio.new_io_region(&format!("vpci-{instance_id}-config"), 2 * HV_PAGE_SIZE),
-            vtom.map(|vtom| VpciConfigSpaceVtom {
+            config.vtom.map(|vtom| VpciConfigSpaceVtom {
                 vtom,
                 control_mmio: register_mmio
                     .new_io_region(&format!("vpci-{instance_id}-config-vtom"), 2 * HV_PAGE_SIZE),
             }),
         );
         let config_space_offset = config_space.offset().clone();
-        let channel = VpciChannel::new(&device, instance_id, config_space, msi_controller)?;
+        let channel = VpciChannel::new(
+            &device,
+            instance_id,
+            config_space,
+            msi_controller,
+            config.vnode,
+        )?;
 
         let this = Self {
             device,
             config_space_offset,
             current_slot: SlotNumber::from(0),
-            vtom,
+            vtom: config.vtom,
             pending_actions: Vec::new(),
             waker: Waker::noop().clone(),
         };
@@ -149,19 +165,17 @@ impl VpciBus {
     /// Creates a new VPCI bus.
     pub async fn new(
         driver_source: &VmTaskDriverSource,
-        instance_id: Guid,
+        config: VpciBusConfig,
         device: Arc<CloseableMutex<dyn ChipsetDevice>>,
         register_mmio: &mut dyn RegisterMmioIntercept,
         vmbus: &dyn vmbus_channel::bus::ParentBus,
         msi_controller: VpciInterruptMapper,
-        vtom: Option<u64>,
     ) -> Result<Self, CreateBusError> {
         let (bus, channel) = VpciBusDevice::new(
-            instance_id,
+            config,
             device.clone(),
             register_mmio,
             msi_controller.clone(),
-            vtom,
         )
         .map_err(CreateBusError::NotPci)?;
         let channel = offer_simple_device(driver_source, vmbus, channel)
@@ -564,11 +578,14 @@ mod tests {
             Arc::new(CloseableMutex::new(DeferWriteDevice::new()));
 
         let (bus, _channel) = VpciBusDevice::new(
-            Guid::new_random(),
+            VpciBusConfig {
+                instance_id: Guid::new_random(),
+                vtom: None,
+                vnode: None,
+            },
             device.clone(),
             &mut ExternallyManagedMmioIntercepts,
             VpciInterruptMapper::new(msi_controller),
-            None,
         )
         .unwrap();
 

--- a/vm/devices/pci/vpci/src/device.rs
+++ b/vm/devices/pci/vpci/src/device.rs
@@ -707,12 +707,20 @@ impl ReadyState {
                 device_count: 1,
                 device: [],
             };
+            let (flags, numa_node) = if let Some(vnode) = dev.vnode {
+                (
+                    protocol::DeviceDescription2Flags::new().with_numa_affinity_specified(true),
+                    vnode,
+                )
+            } else {
+                (protocol::DeviceDescription2Flags::new(), 0)
+            };
             let device = protocol::DeviceDescription2 {
                 pnp_id,
                 slot: SlotNumber::new(),
                 serial_num: dev.serial_num,
-                flags: 0,
-                numa_node: 0,
+                flags,
+                numa_node,
                 rsvd: 0,
             };
 
@@ -1221,6 +1229,8 @@ pub struct VpciChannel {
     hardware_ids: HardwareIds,
     #[inspect(hex, iter_by_index)]
     bar_masks: [u32; 6],
+    /// NUMA node affinity reported to the guest in `DeviceDescription2`.
+    vnode: Option<u16>,
 
     // The underlying device.
     #[inspect(skip)]
@@ -1335,6 +1345,7 @@ impl VpciChannel {
         instance_id: Guid,
         config_space: VpciConfigSpace,
         msi_mapper: VpciInterruptMapper,
+        vnode: Option<u16>,
     ) -> Result<Self, NotPciDevice> {
         let (hardware_ids, bar_masks);
         {
@@ -1351,6 +1362,7 @@ impl VpciChannel {
             serial_num: instance_id.data1, // Use FIOV precedent of serial number from first block of GUID
             hardware_ids,
             bar_masks,
+            vnode,
             device: device.clone(),
             bars_set: false,
             interrupts: Vec::new(),
@@ -1540,6 +1552,7 @@ mod tests {
             serial_num: 0x1234,
             hardware_ids,
             bar_masks,
+            vnode: None,
             device,
             bars_set: false,
             interrupts: Vec::new(),
@@ -1704,7 +1717,7 @@ mod tests {
             assert_eq!(device.pnp_id.sub_vendor_id, self.config.type0_sub_vendor_id);
             assert_eq!(device.pnp_id.sub_system_id, self.config.type0_sub_system_id);
             assert_eq!(device.slot, SlotNumber::new());
-            assert_eq!(device.flags, 0,);
+            assert_eq!(device.flags, protocol::DeviceDescription2Flags::new());
             assert_eq!(device.numa_node, 0);
             assert_eq!(device.rsvd, 0);
         }

--- a/vm/devices/pci/vpci_client/src/tests.rs
+++ b/vm/devices/pci/vpci_client/src/tests.rs
@@ -29,6 +29,7 @@ use vmcore::vpci_msi::MapVpciInterrupt;
 use vmcore::vpci_msi::MsiAddressData;
 use vmcore::vpci_msi::VpciInterruptMapper;
 use vmcore::vpci_msi::VpciInterruptParameters;
+use vpci::bus::VpciBusConfig;
 use vpci::bus::VpciBusDevice;
 use vpci::test_helpers::TestVpciInterruptController;
 
@@ -94,11 +95,14 @@ async fn test_negotiate_version(driver: DefaultDriver) {
     let device = make_noop_device();
     let msi_controller = TestVpciInterruptController::new();
     let (bus, mut channel) = VpciBusDevice::new(
-        Guid::new_random(),
+        VpciBusConfig {
+            instance_id: Guid::new_random(),
+            vtom: None,
+            vnode: None,
+        },
         device,
         &mut ExternallyManagedMmioIntercepts,
         VpciInterruptMapper::new(msi_controller),
-        None,
     )
     .unwrap();
 
@@ -147,11 +151,14 @@ async fn test_tdisp_interface_get_device_interface_info(driver: DefaultDriver) {
     let device = make_noop_device();
     let msi_controller = TestVpciInterruptController::new();
     let (bus, mut channel) = VpciBusDevice::new(
-        Guid::new_random(),
+        VpciBusConfig {
+            instance_id: Guid::new_random(),
+            vtom: None,
+            vnode: None,
+        },
         device,
         &mut ExternallyManagedMmioIntercepts,
         VpciInterruptMapper::new(msi_controller),
-        None,
     )
     .unwrap();
 

--- a/vm/devices/pci/vpci_protocol/src/lib.rs
+++ b/vm/devices/pci/vpci_protocol/src/lib.rs
@@ -256,6 +256,17 @@ pub struct QueryBusRelations {
     pub device: [DeviceDescription; 0],
 }
 
+/// Flags for [`DeviceDescription2`].
+#[bitfield(u32)]
+#[derive(IntoBytes, Immutable, KnownLayout, FromBytes, PartialEq, Eq)]
+pub struct DeviceDescription2Flags {
+    /// The `numa_node` field contains valid NUMA affinity information.
+    pub numa_affinity_specified: bool,
+    /// Reserved bits.
+    #[bits(31)]
+    pub reserved: u32,
+}
+
 /// Extended device description (version 2).
 ///
 /// This version adds support for NUMA node information and additional flags.
@@ -269,7 +280,7 @@ pub struct DeviceDescription2 {
     /// Device serial number
     pub serial_num: u32,
     /// Device-specific flags
-    pub flags: u32,
+    pub flags: DeviceDescription2Flags,
     /// NUMA node the device is associated with
     pub numa_node: u16,
     /// Reserved field

--- a/vm/devices/pci/vpci_relay/src/lib.rs
+++ b/vm/devices/pci/vpci_relay/src/lib.rs
@@ -341,12 +341,15 @@ impl VpciRelay {
                     async |mmio| {
                         let bus = vpci::bus::VpciBus::new(
                             &self.driver_source,
-                            instance_id,
+                            vpci::bus::VpciBusConfig {
+                                instance_id,
+                                vtom: self.vtom,
+                                vnode: None,
+                            },
                             device,
                             mmio,
                             self.vmbus.as_ref(),
                             interrupt_mapper,
-                            self.vtom,
                         )
                         .await?;
 

--- a/vm/vmcore/vm_topology/src/pcie.rs
+++ b/vm/vmcore/vm_topology/src/pcie.rs
@@ -34,4 +34,6 @@ pub struct PcieHostBridge {
     pub high_mmio: MemoryRange,
     /// CXL metadata when this host bridge supports CXL.
     pub cxl: Option<PcieHostBridgeCxlInfo>,
+    /// NUMA node affinity for this host bridge.
+    pub vnode: Option<u32>,
 }

--- a/vmm_core/src/acpi_builder.rs
+++ b/vmm_core/src/acpi_builder.rs
@@ -188,16 +188,17 @@ pub fn build_pcie_acpi_tables(
     let mut has_cedt_entries = false;
 
     for bridge in pcie_host_bridges {
-        ssdt.add_pcie(
-            bridge.index,
-            bridge.segment,
-            bridge.start_bus,
-            bridge.end_bus,
-            bridge.ecam_range,
-            bridge.low_mmio,
-            bridge.high_mmio,
-            bridge.cxl.is_some(),
-        );
+        ssdt.add_pcie(acpi::ssdt::PcieHostBridgeEntry {
+            index: bridge.index,
+            segment: bridge.segment,
+            start_bus: bridge.start_bus,
+            end_bus: bridge.end_bus,
+            ecam_range: bridge.ecam_range,
+            low_mmio: bridge.low_mmio,
+            high_mmio: bridge.high_mmio,
+            cxl: bridge.cxl.is_some(),
+            vnode: bridge.vnode,
+        });
 
         if let Some(cxl) = &bridge.cxl {
             if let Err(source) = cedt.add_cxl_host_bridge(
@@ -1289,6 +1290,7 @@ mod test {
                 low_mmio: MemoryRange::new(0..0),
                 high_mmio: MemoryRange::new(0..0),
                 cxl: None,
+                vnode: None,
             },
             PcieHostBridge {
                 index: 1,
@@ -1299,6 +1301,7 @@ mod test {
                 low_mmio: MemoryRange::new(0..0),
                 high_mmio: MemoryRange::new(0..0),
                 cxl: None,
+                vnode: None,
             },
         ];
 
@@ -1396,6 +1399,7 @@ mod test {
                 low_mmio: MemoryRange::new(0xdc000000..0xe0000000),
                 high_mmio: MemoryRange::new(0x1000000000..0x1040000000),
                 cxl: None,
+                vnode: None,
             },
             PcieHostBridge {
                 index: 7,
@@ -1406,6 +1410,7 @@ mod test {
                 low_mmio: MemoryRange::new(0xe0000000..0xe4000000),
                 high_mmio: MemoryRange::new(0x1040000000..0x1080000000),
                 cxl: None,
+                vnode: None,
             },
         ];
         let builder = new_aarch64_builder(&mem, &topology, &pcie_host_bridges);
@@ -1465,6 +1470,7 @@ mod test {
             low_mmio: MemoryRange::new(0xdc000000..0xe0000000),
             high_mmio: MemoryRange::new(0x1000000000..0x1040000000),
             cxl: None,
+            vnode: None,
         }];
         let builder = new_builder(&mem, &topology, &pcie_host_bridges);
         assert!(builder.build_iort().is_none());
@@ -1495,6 +1501,7 @@ mod test {
             low_mmio: MemoryRange::new(0xdc000000..0xe0000000),
             high_mmio: MemoryRange::new(0x1000000000..0x1040000000),
             cxl: None,
+            vnode: None,
         }];
         let builder = new_aarch64_builder(&mem, &topology, &pcie_host_bridges);
 
@@ -1554,6 +1561,7 @@ mod test {
                 hdm_range: MemoryRange::new(0x1000000000..0x1040000000),
                 hdm_window_restrictions: Default::default(),
             }),
+            vnode: None,
         }];
         let builder = new_builder(&mem, &topology, &pcie_host_bridges);
 
@@ -1577,6 +1585,7 @@ mod test {
             low_mmio: MemoryRange::new(0xdc000000..0xe0000000),
             high_mmio: MemoryRange::new(0x1000000000..0x1040000000),
             cxl: None,
+            vnode: None,
         }];
         let builder = new_aarch64_builder_with_smmu(&mem, &topology, &pcie_host_bridges, smmu_base);
 
@@ -1653,6 +1662,7 @@ mod test {
                 low_mmio: MemoryRange::new(0xdc000000..0xe0000000),
                 high_mmio: MemoryRange::new(0x1000000000..0x1040000000),
                 cxl: None,
+                vnode: None,
             },
             PcieHostBridge {
                 index: 1,
@@ -1663,6 +1673,7 @@ mod test {
                 low_mmio: MemoryRange::new(0xe0000000..0xe4000000),
                 high_mmio: MemoryRange::new(0x1040000000..0x1080000000),
                 cxl: None,
+                vnode: None,
             },
         ];
         let builder = new_aarch64_builder_with_smmu(&mem, &topology, &pcie_host_bridges, smmu_base);
@@ -1714,6 +1725,7 @@ mod test {
             low_mmio: MemoryRange::new(0xdc000000..0xe0000000),
             high_mmio: MemoryRange::new(0x1000000000..0x1040000000),
             cxl: None,
+            vnode: None,
         }];
         let builder = new_aarch64_builder(&mem, &topology, &pcie_host_bridges);
 
@@ -1746,6 +1758,7 @@ mod test {
             low_mmio: MemoryRange::new(0xdc000000..0xe0000000),
             high_mmio: MemoryRange::new(0x1000000000..0x1040000000),
             cxl: None,
+            vnode: None,
         }];
         let builder = new_aarch64_builder_with_smmu(&mem, &topology, &pcie_host_bridges, smmu_base);
 

--- a/vmm_core/src/device_builder.rs
+++ b/vmm_core/src/device_builder.rs
@@ -13,12 +13,13 @@ use std::sync::Arc;
 use vm_resource::Resource;
 use vm_resource::ResourceResolver;
 use vm_resource::kind::PciDeviceHandleKind;
-use vmbus_server::Guid;
 use vmbus_server::VmbusServerControl;
 use vmcore::vm_task::VmTaskDriverSource;
 use vmcore::vpci_msi::VpciInterruptMapper;
 use vmotherboard::ArcMutexChipsetDeviceBuilder;
 use vmotherboard::ChipsetBuilder;
+
+pub use vpci::bus::VpciBusConfig;
 
 /// Common context for resolving and building a PCI device. These parameters
 /// are shared across PCIe and VPCI device construction.
@@ -46,11 +47,11 @@ pub struct PciDeviceResolveContext<'a> {
 pub async fn build_vpci_device(
     ctx: PciDeviceResolveContext<'_>,
     vmbus: &VmbusServerControl,
-    instance_id: Guid,
     chipset_builder: &ChipsetBuilder<'_>,
+    bus_config: VpciBusConfig,
     new_virtual_device: impl FnOnce(u64) -> anyhow::Result<(Arc<dyn SignalMsi>, VpciInterruptMapper)>,
-    vtom: Option<u64>,
 ) -> anyhow::Result<()> {
+    let instance_id = bus_config.instance_id;
     let device_name = format!("{}:vpci-{instance_id}", ctx.resource.id());
     let driver_source = ctx.driver_source;
 
@@ -79,12 +80,11 @@ pub async fn build_vpci_device(
 
                 let bus = vpci::bus::VpciBus::new(
                     driver_source,
-                    instance_id,
+                    bus_config,
                     device,
                     &mut services.register_mmio(),
                     vmbus,
                     interrupt_mapper,
-                    vtom,
                 )
                 .await?;
 

--- a/vmm_tests/vmm_tests/tests/tests/multiarch/numa.rs
+++ b/vmm_tests/vmm_tests/tests/tests/multiarch/numa.rs
@@ -8,11 +8,16 @@ use openvmm_defs::config::MemoryConfig;
 use openvmm_defs::config::NumaDistance;
 use openvmm_defs::config::NumaNode;
 use openvmm_defs::config::NumaTopology;
+use openvmm_defs::config::PcieDeviceConfig;
+use openvmm_defs::config::PcieMmioRangeConfig;
+use openvmm_defs::config::PcieRootComplexConfig;
+use openvmm_defs::config::PcieRootPortConfig;
 use openvmm_defs::config::VpAssignment;
 use petri::PetriVmBuilder;
 use petri::openvmm::OpenVmmPetriBackend;
 use pipette_client::PipetteClient;
 use pipette_client::cmd;
+use vm_resource::IntoResource;
 use vmm_test_macros::openvmm_test;
 
 const SIZE_1_GB: u64 = 1024 * 1024 * 1024;
@@ -281,6 +286,123 @@ async fn boot_numa_complex_topology(
     assert_eq!(guest_node_distances(&agent, 1).await?, vec![15, 10, 20, 25]);
     assert_eq!(guest_node_distances(&agent, 2).await?, vec![25, 20, 10, 15]);
     assert_eq!(guest_node_distances(&agent, 3).await?, vec![30, 25, 15, 10]);
+
+    agent.power_off().await?;
+    vm.wait_for_clean_teardown().await?;
+    Ok(())
+}
+
+/// Boot a 2-node NUMA VM with a PCIe root complex on node 1 and verify
+/// that the guest sees the correct NUMA affinity on the PCIe device.
+///
+/// Linux populates `/sys/bus/pci/devices/<BDF>/numa_node` from the ACPI
+/// `_PXM` method on the host bridge.
+#[openvmm_test(linux_direct_x64, linux_direct_aarch64)]
+async fn pcie_device_numa_affinity(
+    config: PetriVmBuilder<OpenVmmPetriBackend>,
+) -> anyhow::Result<()> {
+    let nvme_subsystem_id = guid::guid!("a1b2c3d4-e5f6-7890-abcd-ef0123456789");
+
+    let (vm, agent) = config
+        .with_processor_topology(petri::ProcessorTopology {
+            vp_count: 4,
+            vps_per_socket: Some(2),
+            ..Default::default()
+        })
+        .modify_backend(move |b| {
+            b.with_custom_config(|c| {
+                c.numa = NumaTopology {
+                    nodes: vec![
+                        NumaNode {
+                            mem: Some(make_mem(SIZE_2_GB)),
+                            vps: VpAssignment::Explicit(vec![0, 1]),
+                        },
+                        NumaNode {
+                            mem: Some(make_mem(SIZE_2_GB)),
+                            vps: VpAssignment::Explicit(vec![2, 3]),
+                        },
+                    ],
+                    distances: vec![],
+                };
+
+                // Add a PCIe root complex on NUMA node 1.
+                c.pcie_root_complexes.push(PcieRootComplexConfig {
+                    index: 0,
+                    name: "rc0".to_string(),
+                    segment: 0,
+                    start_bus: 0,
+                    end_bus: 255,
+                    low_mmio: PcieMmioRangeConfig::Dynamic {
+                        size: 64 * 1024 * 1024,
+                    },
+                    high_mmio: PcieMmioRangeConfig::Dynamic {
+                        size: 1024 * 1024 * 1024,
+                    },
+                    cxl: None,
+                    ports: vec![PcieRootPortConfig {
+                        name: "rp0".to_string(),
+                        hotplug: false,
+                        acs_capabilities_supported: None,
+                        cxl: false,
+                    }],
+                    iommu: None,
+                    vnode: Some(1),
+                });
+
+                // Attach an NVMe device to the root port.
+                c.pcie_devices.push(PcieDeviceConfig {
+                    port_name: "rp0".to_string(),
+                    resource: nvme_resources::NvmeControllerHandle {
+                        subsystem_id: nvme_subsystem_id,
+                        max_io_queues: 64,
+                        msix_count: 64,
+                        namespaces: vec![nvme_resources::NamespaceDefinition {
+                            nsid: 1,
+                            disk: disk_backend_resources::LayeredDiskHandle::single_layer(
+                                disk_backend_resources::layer::RamDiskLayerHandle {
+                                    len: Some(1024 * 1024),
+                                    sector_size: None,
+                                },
+                            )
+                            .into_resource(),
+                            read_only: false,
+                        }],
+                        requests: None,
+                    }
+                    .into_resource(),
+                });
+            })
+        })
+        .run()
+        .await?;
+
+    // Verify 2 NUMA nodes are visible.
+    assert_eq!(guest_numa_node_count(&agent).await?, 2);
+
+    // Find PCI devices and check their numa_node attribute.
+    let sh = agent.unix_shell();
+    let devices = cmd!(sh, "ls /sys/bus/pci/devices/").read().await?;
+    let mut found_nvme = false;
+    for bdf in devices.split_whitespace() {
+        // Read the class to identify NVMe (class 0x010802).
+        let class_path = format!("/sys/bus/pci/devices/{bdf}/class");
+        let class = sh.read_file(&class_path).await.unwrap_or_default();
+        let class = class.trim();
+        if class == "0x010802" {
+            let numa_path = format!("/sys/bus/pci/devices/{bdf}/numa_node");
+            let numa_node = sh
+                .read_file(&numa_path)
+                .await
+                .with_context(|| format!("reading numa_node for {bdf}"))?;
+            let numa_node: i32 = numa_node.trim().parse()?;
+            assert_eq!(
+                numa_node, 1,
+                "NVMe device {bdf} should be on NUMA node 1, got {numa_node}"
+            );
+            found_nvme = true;
+        }
+    }
+    assert!(found_nvme, "no NVMe device found in guest PCI devices");
 
     agent.power_off().await?;
     vm.wait_for_clean_teardown().await?;

--- a/vmm_tests/vmm_tests/tests/tests/multiarch/numa.rs
+++ b/vmm_tests/vmm_tests/tests/tests/multiarch/numa.rs
@@ -296,7 +296,7 @@ async fn boot_numa_complex_topology(
 /// that the guest sees the correct NUMA affinity on the PCIe device.
 ///
 /// Linux populates `/sys/bus/pci/devices/<BDF>/numa_node` from the ACPI
-/// `_PXM` method on the host bridge.
+/// `_PXM` object on the host bridge.
 #[openvmm_test(linux_direct_x64, linux_direct_aarch64)]
 async fn pcie_device_numa_affinity(
     config: PetriVmBuilder<OpenVmmPetriBackend>,

--- a/vmm_tests/vmm_tests/tests/tests/multiarch/openhcl_servicing.rs
+++ b/vmm_tests/vmm_tests/tests/tests/multiarch/openhcl_servicing.rs
@@ -1419,6 +1419,7 @@ async fn servicing_keepalive_per_device_gate(
                         enable_tdisp_tests: false,
                     }
                     .into_resource(),
+                    vnode: None,
                 });
                 c.vpci_devices.push(VpciDeviceConfig {
                     vtl: DeviceVtl::Vtl2,
@@ -1440,6 +1441,7 @@ async fn servicing_keepalive_per_device_gate(
                         enable_tdisp_tests: false,
                     }
                     .into_resource(),
+                    vnode: None,
                 });
             })
         })
@@ -1578,6 +1580,7 @@ async fn create_keepalive_test_config_default(
                         enable_tdisp_tests: false,
                     }
                     .into_resource(),
+                    vnode: None,
                 })
             })
         })
@@ -1691,6 +1694,7 @@ async fn create_keepalive_test_config_custom(
                         enable_tdisp_tests: false,
                     }
                     .into_resource(),
+                    vnode: None,
                 })
             })
         })

--- a/vmm_tests/vmm_tests/tests/tests/x86_64.rs
+++ b/vmm_tests/vmm_tests/tests/tests/x86_64.rs
@@ -185,6 +185,7 @@ async fn vpci_filter(config: PetriVmBuilder<OpenVmmPetriBackend>) -> anyhow::Res
                             requests: None,
                         }
                         .into_resource(),
+                        vnode: None,
                     },
                     VpciDeviceConfig {
                         vtl: DeviceVtl::Vtl0,
@@ -198,6 +199,7 @@ async fn vpci_filter(config: PetriVmBuilder<OpenVmmPetriBackend>) -> anyhow::Res
                             .into_resource(),
                         )
                         .into_resource(),
+                        vnode: None,
                     },
                 ])
             })
@@ -253,6 +255,7 @@ async fn vpci_relay_tdisp_device(
                         enable_tdisp_tests: true,
                     }
                     .into_resource(),
+                    vnode: None,
                 }])
             })
         })

--- a/vmm_tests/vmm_tests/tests/tests/x86_64/storage.rs
+++ b/vmm_tests/vmm_tests/tests/tests/x86_64/storage.rs
@@ -76,6 +76,7 @@ pub(crate) fn new_test_vtl2_nvme_device(
             requests: None,
         }
         .into_resource(),
+        vnode: None,
     }
 }
 
@@ -807,6 +808,7 @@ async fn storvsp_dynamic_add_disk(
                         requests: None,
                     }
                     .into_resource(),
+                    vnode: None,
                 });
             })
         })


### PR DESCRIPTION
Previously, all devices appeared with no NUMA affinity regardless of the VM's topology. This change adds optional per-device NUMA affinity through two paths.

For PCIe root complexes, the ACPI SSDT generator conditionally emits a `_PXM` (proximity) object on each host bridge device node when a NUMA node is specified. When unset, `_PXM` is omitted entirely — the guest uses its default allocation policy rather than being pinned to node 0.

For VPCI devices, the existing `DeviceDescription2` protocol message already had `flags` and `numa_node` fields but they were hardcoded to zero. These are now conditionally populated when a NUMA node is configured.

Along the way, several functions that had accumulated too many positional parameters (`add_pcie`, `build_vpci_device`, `VpciBus::new`) are refactored to use config structs instead.

The CLI gains a `node=N` option on `--pcie-root-complex`. A VMM integration test boots a 2-node VM with a PCIe root complex on node 1 and verifies the guest sees the correct affinity in sysfs. Guide docs are updated to reflect the new feature and its optional semantics.