### PR TITLE
openhcl_boot: allow any interrupt id for com3 serial on ARM

### DIFF
--- a/openhcl/host_fdt_parser/src/lib.rs
+++ b/openhcl/host_fdt_parser/src/lib.rs
@@ -1096,7 +1096,10 @@ fn parse_pl011<'a>(
     let base = reg.read_u32(1).map_err(ErrorKind::Prop)?;
     let intid = interrupts.read_u32(1).map_err(ErrorKind::Prop)?;
 
-    if intid == 3 {
+    // use the first serial port found in the dt.
+    // this could be made to be configurable, but
+    // hyper-v only provides one today
+    if matches!(com3_serial, ComInfo::None) {
         *com3_serial = ComInfo::Pl011 {
             base,
             intid,
@@ -1105,7 +1108,7 @@ fn parse_pl011<'a>(
     } else {
         #[cfg(feature = "tracing")]
         tracing::warn!(?node.name, ?base, ?intid, ?current_speed,
-            "unrecognized arm,sbsa-uart device"
+            "multiple serial devices"
         );
     }
 

--- a/openhcl/openhcl_boot/src/main.rs
+++ b/openhcl/openhcl_boot/src/main.rs
@@ -612,6 +612,7 @@ fn shim_main(shim_params_raw_offset: isize) -> ! {
     // any access to secrets in the boot shim.
     boot_logger_runtime_init(p.isolation_type, partition_info.com3_serial.clone());
     log::info!("openhcl_boot: logging enabled");
+    log::info!("serial configuration: {:#x?}", partition_info.com3_serial);
 
     // Confidential debug will show up in boot_options only if included in the
     // static command line, or if can_trust_host is true (so the dynamic command


### PR DESCRIPTION
Instead of only looking for a PL011 serial device with interrupt ID 3, use the first serial device found regardless of interrupt ID. (Hyper-V already uses interrupt ID 3 for the generation ID counter device in and will specify interrupt ID 7 for COM3. With this change, OpenHCL doesn't need to have these details hardcoded.) Also logs the serial configuration so it is easier to debug why serial isn't working if kmsg logs are accessible in some other way (diag_client or dump).