### PR TITLE
netvsp: gdma driver report git commit on release 1.7.2511

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3830,6 +3830,7 @@ name = "mana_driver"
 version = "0.0.0"
 dependencies = [
  "anyhow",
+ "build_info",
  "chipset_device",
  "futures",
  "gdma",

--- a/openhcl/build_info/src/lib.rs
+++ b/openhcl/build_info/src/lib.rs
@@ -102,7 +102,7 @@ const fn const_split_once_dot(s: &str) -> Option<(&str, &str)> {
 
 // Parse the `OPENHCL_VERSION` environment variable into four u32 components.
 // Strictly enforces the format to be "major.minor.build.platform",
-// where each is a valid u32 and non-zero (except for platform).
+// where each is a valid u32.
 // Empty string is permitted to not panic on builds which omit the
 // `OPENHCL_VERSION` environment variable like `cargo test`.
 const fn const_parse_version(s: &str) -> [u32; 4] {
@@ -130,10 +130,6 @@ const fn const_parse_version(s: &str) -> [u32; 4] {
     let minor = const_parse_u32_segment(minor);
     let build = const_parse_u32_segment(build);
     let platform = const_parse_u32_segment(platform);
-    assert!(major != 0, "major version must be non-zero");
-    assert!(minor != 0, "minor version must be non-zero");
-    assert!(build != 0, "build version must be non-zero");
-    // Platform is allowed to be zero.
     [major, minor, build, platform]
 }
 
@@ -231,21 +227,18 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "major version must be non-zero")]
-    fn zero_major_panics() {
-        const_parse_version("0.1.1.0");
+    fn zero_major_allowed() {
+        assert_eq!(const_parse_version("0.1.1.0"), [0, 1, 1, 0]);
     }
 
     #[test]
-    #[should_panic(expected = "minor version must be non-zero")]
-    fn zero_minor_panics() {
-        const_parse_version("1.0.1.0");
+    fn zero_minor_allowed() {
+        assert_eq!(const_parse_version("1.0.1.0"), [1, 0, 1, 0]);
     }
 
     #[test]
-    #[should_panic(expected = "build version must be non-zero")]
-    fn zero_build_panics() {
-        const_parse_version("1.1.0.0");
+    fn zero_build_allowed() {
+        assert_eq!(const_parse_version("1.1.0.0"), [1, 1, 0, 0]);
     }
 
     #[test]

--- a/openhcl/build_info/src/lib.rs
+++ b/openhcl/build_info/src/lib.rs
@@ -70,7 +70,118 @@ impl BuildInfo {
     pub fn scm_branch(&self) -> &'static str {
         self.branch
     }
+
+    pub fn openhcl_version(&self) -> &'static str {
+        self.openhcl_version
+    }
 }
+
+// Parse a `&str` segment as a u32. Panics if the segment is empty or not a valid u32.
+const fn const_parse_u32_segment(s: &str) -> u32 {
+    assert!(!s.is_empty(), "version segment must not be empty");
+    match u32::from_str_radix(s, 10) {
+        Ok(v) => v,
+        Err(_) => panic!("version segment is not a valid u32"),
+    }
+}
+
+// Const-compatible equivalent of `s.split_once('.')`.
+const fn const_split_once_dot(s: &str) -> Option<(&str, &str)> {
+    let bytes = s.as_bytes();
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == b'.' {
+            let (left, dot_right) = s.split_at(i);
+            let (_, right) = dot_right.split_at(1);
+            return Some((left, right));
+        }
+        i += 1;
+    }
+    None
+}
+
+// Parse the `OPENHCL_VERSION` environment variable into four u32 components.
+// Strictly enforces the format to be "major.minor.build.platform",
+// where each is a valid u32 and non-zero (except for platform).
+// Empty string is permitted to not panic on builds which omit the
+// `OPENHCL_VERSION` environment variable like `cargo test`.
+const fn const_parse_version(s: &str) -> [u32; 4] {
+    if s.is_empty() {
+        return [0, 0, 0, 0];
+    }
+    let (major, rest) = match const_split_once_dot(s) {
+        Some(pair) => pair,
+        None => panic!("expected 4 dot-separated components in version string"),
+    };
+    let (minor, rest) = match const_split_once_dot(rest) {
+        Some(pair) => pair,
+        None => panic!("expected 4 dot-separated components in version string"),
+    };
+    let (build, platform) = match const_split_once_dot(rest) {
+        Some(pair) => pair,
+        None => panic!("expected 4 dot-separated components in version string"),
+    };
+    // The fourth segment must not contain additional dots.
+    assert!(
+        const_split_once_dot(platform).is_none(),
+        "expected exactly 4 dot-separated components in version string"
+    );
+    let major = const_parse_u32_segment(major);
+    let minor = const_parse_u32_segment(minor);
+    let build = const_parse_u32_segment(build);
+    let platform = const_parse_u32_segment(platform);
+    assert!(major != 0, "major version must be non-zero");
+    assert!(minor != 0, "minor version must be non-zero");
+    assert!(build != 0, "build version must be non-zero");
+    // Platform is allowed to be zero.
+    [major, minor, build, platform]
+}
+
+/// Parsed components of the OPENHCL_VERSION env var (major.minor.build.platform).
+/// All parsing happens at compile time — components are stored as u32.
+#[derive(Debug)]
+pub struct OpenHclVersion {
+    product_name: &'static str,
+    major: u32,
+    minor: u32,
+    build: u32,
+    platform: u32,
+}
+
+impl OpenHclVersion {
+    pub const fn new() -> Self {
+        let [major, minor, build, platform] = const_parse_version(BuildInfo::new().openhcl_version);
+        Self {
+            product_name: "OpenHCL",
+            major,
+            minor,
+            build,
+            platform,
+        }
+    }
+
+    pub const fn product_name(&self) -> &'static str {
+        self.product_name
+    }
+
+    pub const fn major(&self) -> u32 {
+        self.major
+    }
+
+    pub const fn minor(&self) -> u32 {
+        self.minor
+    }
+
+    pub const fn build(&self) -> u32 {
+        self.build
+    }
+
+    pub const fn platform(&self) -> u32 {
+        self.platform
+    }
+}
+
+pub static OPENHCL_VERSION: OpenHclVersion = OpenHclVersion::new();
 
 // Placing into a separate section to make easier to discover
 // the build information even without a debugger.
@@ -97,4 +208,79 @@ pub fn get() -> &'static BuildInfo {
     // Without `black_box`, BUILD_INFO is optimized away
     // in the release builds with `fat` LTO.
     std::hint::black_box(&BUILD_INFO)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::const_parse_version;
+
+    #[test]
+    fn empty_string() {
+        // Ensure running `cargo test` doesn't panic.
+        assert_eq!(const_parse_version(""), [0, 0, 0, 0]);
+    }
+
+    #[test]
+    fn full_version() {
+        assert_eq!(const_parse_version("1.6.499.2"), [1, 6, 499, 2]);
+    }
+
+    #[test]
+    fn zero_platform() {
+        assert_eq!(const_parse_version("1.1.1.0"), [1, 1, 1, 0]);
+    }
+
+    #[test]
+    #[should_panic(expected = "major version must be non-zero")]
+    fn zero_major_panics() {
+        const_parse_version("0.1.1.0");
+    }
+
+    #[test]
+    #[should_panic(expected = "minor version must be non-zero")]
+    fn zero_minor_panics() {
+        const_parse_version("1.0.1.0");
+    }
+
+    #[test]
+    #[should_panic(expected = "build version must be non-zero")]
+    fn zero_build_panics() {
+        const_parse_version("1.1.0.0");
+    }
+
+    #[test]
+    #[should_panic(expected = "expected 4 dot-separated components")]
+    fn partial_version_panics() {
+        const_parse_version("1.2");
+    }
+
+    #[test]
+    #[should_panic(expected = "version segment is not a valid u32")]
+    fn non_digit_segment_panics() {
+        const_parse_version("1.2.3A.4");
+    }
+
+    #[test]
+    #[should_panic(expected = "expected exactly 4 dot-separated components")]
+    fn extra_segments_panics() {
+        const_parse_version("1.2.3.4.5");
+    }
+
+    #[test]
+    #[should_panic(expected = "expected 4 dot-separated components")]
+    fn single_component_panics() {
+        const_parse_version("42");
+    }
+
+    #[test]
+    #[should_panic(expected = "version segment is not a valid u32")]
+    fn overflow_panics() {
+        const_parse_version("9999999999.0.0.0");
+    }
+
+    #[test]
+    #[should_panic(expected = "version segment must not be empty")]
+    fn empty_segment_panics() {
+        const_parse_version("1..3.4");
+    }
 }

--- a/vm/devices/net/gdma/src/hwc.rs
+++ b/vm/devices/net/gdma/src/hwc.rs
@@ -316,6 +316,29 @@ impl HwControl {
                 let req: GdmaVerifyVerReq = read
                     .read_plain()
                     .context("reading verify vf driver request")?;
+
+                let drv_name = core::ffi::CStr::from_bytes_until_nul(&req.os_ver_str1)
+                    .ok()
+                    .and_then(|c| c.to_str().ok())
+                    .unwrap_or("<invalid>");
+                let drv_commit = core::ffi::CStr::from_bytes_until_nul(&req.os_ver_str2)
+                    .ok()
+                    .and_then(|c| c.to_str().ok())
+                    .unwrap_or("<invalid>");
+                tracing::info!(
+                    drv_name,
+                    drv_commit,
+                    os_type = format_args!("{:#x}", req.os_type),
+                    os_ver_major = req.os_ver_major,
+                    os_ver_minor = req.os_ver_minor,
+                    os_ver_build = req.os_ver_build,
+                    os_ver_platform = req.os_ver_platform,
+                    cap_flags1 = format_args!("{:#x}", req.gd_drv_cap_flags1),
+                    protocol_ver_min = req.protocol_ver_min,
+                    protocol_ver_max = req.protocol_ver_max,
+                    "vf driver version",
+                );
+
                 let resp = GdmaVerifyVerResp {
                     gdma_protocol_ver: req.protocol_ver_min,
                     pf_cap_flags1: 0,

--- a/vm/devices/net/gdma_defs/src/lib.rs
+++ b/vm/devices/net/gdma_defs/src/lib.rs
@@ -457,6 +457,8 @@ pub const DRIVER_CAP_FLAG_1_HW_VPORT_LINK_AWARE: u64 = 0x40;
 pub const DRIVER_CAP_FLAG_1_SELF_RESET_ON_EQE_NOTIFICATION: u64 = 0x4000;
 pub const DRIVER_CAP_FLAG_1_VTL2_REVOKE_SUB_ON_RESET_EQE: u64 = 0x10000;
 
+pub const OS_TYPE_OHCL: u32 = 0x60;
+
 #[repr(C)]
 #[derive(Debug, IntoBytes, Immutable, KnownLayout, FromBytes)]
 pub struct GdmaVerifyVerReq {

--- a/vm/devices/net/mana_driver/Cargo.toml
+++ b/vm/devices/net/mana_driver/Cargo.toml
@@ -7,6 +7,7 @@ edition.workspace = true
 rust-version.workspace = true
 
 [dependencies]
+build_info.workspace = true
 gdma_defs.workspace = true
 net_backend.workspace = true
 net_backend_resources.workspace = true

--- a/vm/devices/net/mana_driver/src/gdma_driver.rs
+++ b/vm/devices/net/mana_driver/src/gdma_driver.rs
@@ -1246,7 +1246,6 @@ impl<T: DeviceBacking> GdmaDriver<T> {
             ..FromZeros::new_zeroed()
         };
 
-        // Identify the driver and build to the SOC
         // str1 = "OpenHCL", str2 = build identity.
         let name = ver.product_name().as_bytes();
         let len = name.len().min(req.os_ver_str1.len().saturating_sub(1));

--- a/vm/devices/net/mana_driver/src/gdma_driver.rs
+++ b/vm/devices/net/mana_driver/src/gdma_driver.rs
@@ -1228,20 +1228,39 @@ impl<T: DeviceBacking> GdmaDriver<T> {
 
     #[tracing::instrument(skip(self), level = "debug", err)]
     pub async fn verify_vf_driver_version(&mut self) -> anyhow::Result<()> {
+        let ver = &build_info::OPENHCL_VERSION;
+
+        let mut req = GdmaVerifyVerReq {
+            protocol_ver_min: 1,
+            protocol_ver_max: 1,
+            gd_drv_cap_flags1: DRIVER_CAP_FLAG_1_VARIABLE_INDIRECTION_TABLE_SUPPORT
+                | DRIVER_CAP_FLAG_1_HW_VPORT_LINK_AWARE
+                | DRIVER_CAP_FLAG_1_HWC_TIMEOUT_RECONFIG
+                | DRIVER_CAP_FLAG_1_SELF_RESET_ON_EQE_NOTIFICATION
+                | DRIVER_CAP_FLAG_1_VTL2_REVOKE_SUB_ON_RESET_EQE,
+            os_type: gdma_defs::OS_TYPE_OHCL,
+            os_ver_major: ver.major(),
+            os_ver_minor: ver.minor(),
+            os_ver_build: ver.build(),
+            os_ver_platform: ver.platform(),
+            ..FromZeros::new_zeroed()
+        };
+
+        // Identify the driver and build to the SOC
+        // str1 = "OpenHCL", str2 = build identity.
+        let name = ver.product_name().as_bytes();
+        let len = name.len().min(req.os_ver_str1.len().saturating_sub(1));
+        req.os_ver_str1[..len].copy_from_slice(&name[..len]);
+
+        let revision = build_info::get().scm_revision().as_bytes();
+        let len = revision.len().min(req.os_ver_str2.len().saturating_sub(1));
+        req.os_ver_str2[..len].copy_from_slice(&revision[..len]);
+
         let resp: GdmaVerifyVerResp = self
             .request(
                 GdmaRequestType::GDMA_VERIFY_VF_DRIVER_VERSION.0,
                 HWC_DEV_ID,
-                GdmaVerifyVerReq {
-                    protocol_ver_min: 1,
-                    protocol_ver_max: 1,
-                    gd_drv_cap_flags1: DRIVER_CAP_FLAG_1_VARIABLE_INDIRECTION_TABLE_SUPPORT
-                        | DRIVER_CAP_FLAG_1_HW_VPORT_LINK_AWARE
-                        | DRIVER_CAP_FLAG_1_HWC_TIMEOUT_RECONFIG
-                        | DRIVER_CAP_FLAG_1_SELF_RESET_ON_EQE_NOTIFICATION
-                        | DRIVER_CAP_FLAG_1_VTL2_REVOKE_SUB_ON_RESET_EQE,
-                    ..FromZeros::new_zeroed()
-                },
+                req,
             )
             .await?;
 


### PR DESCRIPTION
Cherry Picks of:

(https://github.com/microsoft/openvmm/pull/2963) | netvsp: gdma driver report git commit | https://github.com/microsoft/openvmm/commit/29434413e7255c9c5c0fd98e00ecbbb5be488026
(https://github.com/microsoft/openvmm/pull/3071) | build_info: relax requirement that openhcl version... | https://github.com/microsoft/openvmm/commit/692483adc052c3696a311c1d9fd1a0430585975e

Cherry-pick was almost clean. Two exceptions:

* Needed to add OS_TYPE_OHCL const to gdma_defs lib.rs (one line)
* Merge conflict in verify_vf_driver_version gdma_driver.rs