### PR TITLE
mana_driver: rename eqe 135 to align with mana on release 1.7.2511

### DIFF
--- a/openhcl/underhill_core/src/emuplat/netvsp.rs
+++ b/openhcl/underhill_core/src/emuplat/netvsp.rs
@@ -290,7 +290,7 @@ struct HclNetworkVFManagerWorker {
     #[inspect(skip)]
     dma_clients: VfioDmaClients,
     #[inspect(skip)]
-    vf_reconfig_receiver: Option<mesh::Receiver<()>>,
+    vf_reset_request_receiver: Option<mesh::Receiver<()>>,
 }
 
 impl HclNetworkVFManagerWorker {
@@ -337,7 +337,7 @@ impl HclNetworkVFManagerWorker {
                 vtl2_pci_id,
                 dma_mode,
                 dma_clients,
-                vf_reconfig_receiver: None,
+                vf_reset_request_receiver: None,
             },
             tx_to_worker,
         )
@@ -598,8 +598,8 @@ impl HclNetworkVFManagerWorker {
         .await
         {
             Ok(mut device) => {
-                // Subscribe to VF reconfigure events before starting notification task
-                self.vf_reconfig_receiver = Some(device.subscribe_vf_reconfig().await);
+                // Subscribe to HWC reset request events before starting notification task
+                self.vf_reset_request_receiver = Some(device.subscribe_vf_reset_request().await);
                 // Resubscribe to notifications from the MANA device.
                 device.start_notification_task(&self.driver_source).await;
 
@@ -691,8 +691,8 @@ impl HclNetworkVFManagerWorker {
                     }
                 });
 
-                let vf_reconfig = self
-                    .vf_reconfig_receiver
+                let vf_reset_request = self
+                    .vf_reset_request_receiver
                     .as_mut()
                     .unwrap()
                     .map(|()| NextWorkItem::VfReconfig);
@@ -714,7 +714,7 @@ impl HclNetworkVFManagerWorker {
                     next_message,
                     device_change,
                     device_arrival,
-                    vf_reconfig,
+                    vf_reset_request,
                     vf_restart_tick,
                 )
                     .merge()
@@ -1249,8 +1249,8 @@ impl HclNetworkVFManager {
         // Now that the endpoints are connected, start the device notification task that will
         // listen for and relay endpoint actions.
         let device = worker.mana_device.as_mut().unwrap();
-        // Subscribe to VF reconfig events before starting notification task
-        worker.vf_reconfig_receiver = Some(device.subscribe_vf_reconfig().await);
+        // Subscribe to HWC reset request events before starting notification task
+        worker.vf_reset_request_receiver = Some(device.subscribe_vf_reset_request().await);
         device.start_notification_task(driver_source).await;
         let endpoints = endpoints
             .into_iter()

--- a/vm/devices/net/gdma/src/hwc.rs
+++ b/vm/devices/net/gdma/src/hwc.rs
@@ -10,7 +10,7 @@ use anyhow::anyhow;
 use gdma_defs::GDMA_EQE_HWC_INIT_DATA;
 use gdma_defs::GDMA_EQE_HWC_INIT_DONE;
 use gdma_defs::GDMA_EQE_HWC_INIT_EQ_ID_DB;
-use gdma_defs::GDMA_EQE_HWC_RECONFIG_VF;
+use gdma_defs::GDMA_EQE_HWC_RESET_REQUEST;
 use gdma_defs::GDMA_EQE_TEST_EVENT;
 use gdma_defs::GdmaChangeMsixVectorIndexForEq;
 use gdma_defs::GdmaCreateDmaRegionReq;
@@ -303,13 +303,12 @@ impl HwControl {
 
                 0
             }
-            GdmaRequestType::GDMA_GENERATE_RECONFIG_VF_EVENT => {
-                let req: GdmaGenerateTestEventReq = read
-                    .read_plain()
-                    .context("reading test vf reconfig request")?;
+            GdmaRequestType::GDMA_GENERATE_RESET_REQUEST_EQE => {
+                let req: GdmaGenerateTestEventReq =
+                    read.read_plain().context("reading reset request EQE")?;
                 self.state
                     .queues
-                    .post_eq(req.queue_index, GDMA_EQE_HWC_RECONFIG_VF, &[]);
+                    .post_eq(req.queue_index, GDMA_EQE_HWC_RESET_REQUEST, &[]);
                 0
             }
             GdmaRequestType::GDMA_VERIFY_VF_DRIVER_VERSION => {

--- a/vm/devices/net/gdma_defs/src/lib.rs
+++ b/vm/devices/net/gdma_defs/src/lib.rs
@@ -260,8 +260,7 @@ pub const GDMA_EQE_HWC_INIT_EQ_ID_DB: u8 = 129;
 pub const GDMA_EQE_HWC_INIT_DATA: u8 = 130;
 pub const GDMA_EQE_HWC_INIT_DONE: u8 = 131;
 pub const GDMA_EQE_HWC_RECONFIG_DATA: u8 = 133;
-// Sent on the event of a SoC Crash or certain Firmware updates.
-pub const GDMA_EQE_HWC_RECONFIG_VF: u8 = 135;
+pub const GDMA_EQE_HWC_RESET_REQUEST: u8 = 135;
 
 #[bitfield(u32)]
 #[derive(IntoBytes, Immutable, KnownLayout, FromBytes)]
@@ -308,7 +307,7 @@ open_enum! {
         GDMA_REGISTER_DEVICE = 4,
         GDMA_DEREGISTER_DEVICE = 5,
         GDMA_GENERATE_TEST_EQE = 10,
-        GDMA_GENERATE_RECONFIG_VF_EVENT = 11,
+        GDMA_GENERATE_RESET_REQUEST_EQE = 11,
         GDMA_CREATE_QUEUE = 12,
         GDMA_DISABLE_QUEUE = 13,
         GDMA_CREATE_DMA_REGION = 25,

--- a/vm/devices/net/mana_driver/src/gdma_driver.rs
+++ b/vm/devices/net/mana_driver/src/gdma_driver.rs
@@ -27,7 +27,7 @@ use gdma_defs::GDMA_EQE_HWC_INIT_DATA;
 use gdma_defs::GDMA_EQE_HWC_INIT_DONE;
 use gdma_defs::GDMA_EQE_HWC_INIT_EQ_ID_DB;
 use gdma_defs::GDMA_EQE_HWC_RECONFIG_DATA;
-use gdma_defs::GDMA_EQE_HWC_RECONFIG_VF;
+use gdma_defs::GDMA_EQE_HWC_RESET_REQUEST;
 use gdma_defs::GDMA_EQE_TEST_EVENT;
 use gdma_defs::GDMA_MESSAGE_V1;
 use gdma_defs::GDMA_PAGE_TYPE_4K;
@@ -163,7 +163,7 @@ pub struct GdmaDriver<T: DeviceBacking> {
     hwc_failure: bool,
     db_id: u32,
     state_saved: bool,
-    vf_reconfiguration_pending: bool,
+    reset_request_pending: bool,
 }
 
 const EQ_PAGE: usize = 0;
@@ -210,9 +210,9 @@ impl<T: DeviceBacking> GdmaDriver<T> {
 
 impl<T: DeviceBacking> Drop for GdmaDriver<T> {
     fn drop(&mut self) {
-        tracing::info!(?self.state_saved, ?self.hwc_failure, ?self.vf_reconfiguration_pending, "dropping gdma driver");
+        tracing::info!(?self.state_saved, ?self.hwc_failure, ?self.reset_request_pending, "dropping gdma driver");
 
-        if self.vf_reconfiguration_pending {
+        if self.reset_request_pending {
             return;
         }
 
@@ -498,7 +498,7 @@ impl<T: DeviceBacking> GdmaDriver<T> {
             hwc_failure: false,
             state_saved: false,
             db_id,
-            vf_reconfiguration_pending: false,
+            reset_request_pending: false,
         };
 
         this.push_rqe();
@@ -528,8 +528,8 @@ impl<T: DeviceBacking> GdmaDriver<T> {
             anyhow::bail!("cannot save/restore after HWC failure");
         }
 
-        if self.vf_reconfiguration_pending {
-            anyhow::bail!("cannot save/restore with VF reconfiguration pending");
+        if self.reset_request_pending {
+            anyhow::bail!("cannot save/restore with HWC reset request pending");
         }
 
         self.state_saved = true;
@@ -677,7 +677,7 @@ impl<T: DeviceBacking> GdmaDriver<T> {
             hwc_failure: false,
             state_saved: false,
             db_id: db_id as u32,
-            vf_reconfiguration_pending: false,
+            reset_request_pending: false,
         };
 
         this.eq.arm();
@@ -692,8 +692,8 @@ impl<T: DeviceBacking> GdmaDriver<T> {
         interrupt_loss: bool,
         ms_elapsed: u32,
     ) {
-        // Don't report timeout once VF reconfiguration is pending, SoC will not respond.
-        if self.vf_reconfiguration_pending {
+        // Don't report timeout once HWC reset request is pending, SoC will not respond.
+        if self.reset_request_pending {
             return;
         }
         // Perform initial check for ownership, failing without wait if device
@@ -790,8 +790,8 @@ impl<T: DeviceBacking> GdmaDriver<T> {
         self.link_toggle.drain(..).collect()
     }
 
-    pub fn get_vf_reconfiguration_pending(&self) -> bool {
-        self.vf_reconfiguration_pending
+    pub fn get_reset_request_pending(&self) -> bool {
+        self.reset_request_pending
     }
 
     pub fn device(&self) -> &T {
@@ -846,8 +846,8 @@ impl<T: DeviceBacking> GdmaDriver<T> {
         dev_id: GdmaDevId,
         req: Req,
     ) -> anyhow::Result<(Resp, u32)> {
-        if self.vf_reconfiguration_pending {
-            anyhow::bail!("VF reconfiguration pending");
+        if self.reset_request_pending {
+            anyhow::bail!("HWC reset request pending");
         }
         if self.hwc_failure {
             anyhow::bail!("Previous hardware failure");
@@ -1027,10 +1027,10 @@ impl<T: DeviceBacking> GdmaDriver<T> {
                         unknown => tracing::error!(unknown, "unknown reconfig data type"),
                     }
                 }
-                GDMA_EQE_HWC_RECONFIG_VF => {
-                    // No data is supplied for VF reconfiguration events.
-                    tracing::info!("HWC VF reconfiguration event");
-                    self.vf_reconfiguration_pending = true;
+                GDMA_EQE_HWC_RESET_REQUEST => {
+                    // No data is supplied for HWC reset request events.
+                    tracing::info!("HWC reset request event");
+                    self.reset_request_pending = true;
                 }
                 ty => tracing::error!(ty, "unknown eq event"),
             }
@@ -1224,9 +1224,9 @@ impl<T: DeviceBacking> GdmaDriver<T> {
 
     #[cfg(test)]
     #[tracing::instrument(skip(self), level = "debug", err)]
-    pub async fn generate_reconfig_vf_event(&mut self) -> anyhow::Result<()> {
+    pub async fn generate_reset_request_eqe(&mut self) -> anyhow::Result<()> {
         self.request::<_, ()>(
-            GdmaRequestType::GDMA_GENERATE_RECONFIG_VF_EVENT.0,
+            GdmaRequestType::GDMA_GENERATE_RESET_REQUEST_EQE.0,
             HWC_DEV_ID,
             GdmaGenerateTestEventReq {
                 queue_index: self.eq.id(),

--- a/vm/devices/net/mana_driver/src/mana.rs
+++ b/vm/devices/net/mana_driver/src/mana.rs
@@ -69,7 +69,7 @@ struct Inner<T: DeviceBacking> {
     dev_config: ManaQueryDeviceCfgResp,
     doorbell: Arc<dyn Doorbell>,
     vport_link_status: Arc<Mutex<Vec<LinkStatus>>>,
-    vf_reconfig_sender: Arc<Mutex<Option<mesh::Sender<()>>>>,
+    vf_reset_request_sender: Arc<Mutex<Option<mesh::Sender<()>>>>,
 }
 
 impl<T: DeviceBacking> ManaDevice<T> {
@@ -137,7 +137,7 @@ impl<T: DeviceBacking> ManaDevice<T> {
             dev_config,
             doorbell,
             vport_link_status: Arc::new(Mutex::new(vport_link_status)),
-            vf_reconfig_sender: Arc::new(Mutex::new(None)),
+            vf_reset_request_sender: Arc::new(Mutex::new(None)),
         });
 
         let (inspect_send, mut inspect_recv) = mesh::channel::<inspect::Deferred>();
@@ -152,7 +152,7 @@ impl<T: DeviceBacking> ManaDevice<T> {
                         dev_config: _,
                         doorbell: _,
                         vport_link_status: _,
-                        vf_reconfig_sender: _,
+                        vf_reset_request_sender: _,
                     } = inner.as_ref();
                     let gdma = gdma.lock().await;
                     deferred.respond(|resp| {
@@ -238,8 +238,11 @@ impl<T: DeviceBacking> ManaDevice<T> {
                                 );
                             }
                         }
-                        if gdma.get_vf_reconfiguration_pending() {
-                            if let Some(sender) = inner.vf_reconfig_sender.lock().await.as_ref() {
+                        if gdma.get_reset_request_pending() {
+                            // `reset_request_pending` stays true until destruction.
+                            // Take the sender so we only notify once per lifetime.
+                            if let Some(sender) = inner.vf_reset_request_sender.lock().await.take()
+                            {
                                 sender.send(());
                             }
                         }
@@ -284,17 +287,17 @@ impl<T: DeviceBacking> ManaDevice<T> {
         Ok(vport)
     }
 
-    /// Subscribes to VF reconfiguration events.
-    /// Returned receiver will receive a message on VF reconfiguration events.
-    pub async fn subscribe_vf_reconfig(&self) -> mesh::Receiver<()> {
-        tracing::debug!("subscribing to VF reconfiguration events");
-        let mut vf_reconfig_sender = self.inner.vf_reconfig_sender.lock().await;
+    /// Subscribes to HWC reset request events.
+    /// Returned receiver will receive a message on HWC reset request events.
+    pub async fn subscribe_vf_reset_request(&self) -> mesh::Receiver<()> {
+        tracing::debug!("subscribing to HWC reset request events");
+        let mut reset_request_sender = self.inner.vf_reset_request_sender.lock().await;
         assert!(
-            vf_reconfig_sender.is_none(),
-            "multiple VF reconfiguration subscribers not supported"
+            reset_request_sender.is_none(),
+            "multiple HWC reset request subscribers not supported"
         );
         let (sender, receiver) = mesh::channel();
-        *vf_reconfig_sender = Some(sender);
+        *reset_request_sender = Some(sender);
         receiver
     }
 

--- a/vm/devices/net/mana_driver/src/resources.rs
+++ b/vm/devices/net/mana_driver/src/resources.rs
@@ -63,11 +63,11 @@ impl ResourceArena {
     }
 
     pub(crate) async fn destroy<T: DeviceBacking>(mut self, gdma: &mut GdmaDriver<T>) {
-        let skip_hwc = gdma.get_vf_reconfiguration_pending();
+        let skip_hwc = gdma.get_reset_request_pending();
         if skip_hwc {
             tracing::info!(
                 count = self.resources.len(),
-                "skipping HWC resource teardown during VF reconfiguration"
+                "skipping resource teardown during HWC reset request"
             );
         }
         for resource in self.resources.drain(..).rev() {
@@ -76,7 +76,7 @@ impl ResourceArena {
                     drop(ManuallyDrop::into_inner(mem));
                     Ok(())
                 }
-                // During VF reconfiguration, skip sending teardown commands for HWC resources.
+                // When an HWC reset request is pending, skip sending teardown commands for HWC resources.
                 // HWC requests will fail and the device reclaims resources on its own reset.
                 Resource::DmaRegion { .. } | Resource::Eq { .. } | Resource::BnicQueue { .. }
                     if skip_hwc =>

--- a/vm/devices/net/mana_driver/src/tests.rs
+++ b/vm/devices/net/mana_driver/src/tests.rs
@@ -228,8 +228,8 @@ async fn test_gdma_reconfig_vf(driver: DefaultDriver) {
         .unwrap();
 
     assert!(
-        !gdma.get_vf_reconfiguration_pending(),
-        "vf_reconfiguration_pending should be false"
+        !gdma.get_reset_request_pending(),
+        "reset_request_pending should be false"
     );
 
     // Get the device ID while HWC is still alive (needed for deregister later).
@@ -242,24 +242,24 @@ async fn test_gdma_reconfig_vf(driver: DefaultDriver) {
         .find(|dev_id| dev_id.ty == GdmaDevType::GDMA_DEVICE_MANA)
         .unwrap();
 
-    // Trigger the reconfig event (EQE 135).
-    gdma.generate_reconfig_vf_event().await.unwrap();
+    // Trigger the reset event (EQE 135).
+    gdma.generate_reset_request_eqe().await.unwrap();
 
     assert!(
-        gdma.get_vf_reconfiguration_pending(),
-        "vf_reconfiguration_pending should be true after reconfig event"
+        gdma.get_reset_request_pending(),
+        "reset_request_pending should be true after reset request"
     );
 
-    // Deregister should fail immediately because vf_reconfiguration_pending is set.
+    // Deregister should fail immediately because reset_request_pending is set.
     let deregister_result = gdma.deregister_device(dev_id).await;
     let err = deregister_result.expect_err("deregister_device should fail after EQE 135");
     let err_msg = format!("{err:#}");
     assert!(
-        err_msg.contains("VF reconfiguration pending"),
+        err_msg.contains("HWC reset request pending"),
         "unexpected error: {err_msg}"
     );
     assert!(
-        gdma.get_vf_reconfiguration_pending(),
-        "vf_reconfiguration_pending should remain true after deregister_device"
+        gdma.get_reset_request_pending(),
+        "reset_request_pending should remain true after deregister_device"
     );
 }


### PR DESCRIPTION
Cherry picks of:
(#3164) | mana_driver: vf reconfiguration revokes vtl0 vf faster   | 18256a2
(#3290) │ mana_driver: rename eqe 135 to align with mana       │ 7e7f10d7

3164 was a clean cherry pick.

3290 was not clean, two merge conflicts:
* `network_adapter_index` was from another PR was attempting to sneak in.
* Unrelated tests needed to be removed from test.rs