### PR TITLE
petri: plumb configurable rate limit for efi diagnostics

### DIFF
--- a/openhcl/underhill_core/src/lib.rs
+++ b/openhcl/underhill_core/src/lib.rs
@@ -349,6 +349,7 @@ async fn launch_workers(
         guest_state_lifetime: opt.guest_state_lifetime,
         guest_state_encryption_policy: opt.guest_state_encryption_policy,
         efi_diagnostics_log_level: opt.efi_diagnostics_log_level,
+        efi_diagnostics_rate_limit: opt.efi_diagnostics_rate_limit,
         strict_encryption_policy: opt.strict_encryption_policy,
         attempt_ak_cert_callback: opt.attempt_ak_cert_callback,
         enable_vpci_relay: opt.enable_vpci_relay,

--- a/openhcl/underhill_core/src/options.rs
+++ b/openhcl/underhill_core/src/options.rs
@@ -289,6 +289,18 @@ pub struct Options {
     /// Overrides the value in DPS when set.
     pub efi_diagnostics_log_level: Option<EfiDiagnosticsLogLevelCli>,
 
+    /// (HCL_EFI_DIAGNOSTICS_RATE_LIMIT=\<number\>)
+    /// Override the per-period rate limit applied to EFI diagnostics log
+    /// entries forwarded to host tracing.
+    ///
+    /// - Not set: use the built-in defaults.
+    /// - `0`: disable rate limiting entirely (emit every entry).
+    /// - `n > 0`: use `n` as the per-period limit.
+    ///
+    /// Intended for tests that need to deterministically observe every
+    /// diagnostics entry.
+    pub efi_diagnostics_rate_limit: Option<u32>,
+
     /// (HCL_STRICT_ENCRYPTION_POLICY=1) Strict guest state encryption policy.
     pub strict_encryption_policy: Option<bool>,
 
@@ -491,6 +503,8 @@ impl Options {
                 })
                 .ok()
         });
+        let efi_diagnostics_rate_limit =
+            parse_env_number("HCL_EFI_DIAGNOSTICS_RATE_LIMIT")?.map(|x| x as u32);
         let strict_encryption_policy = parse_env_bool_opt("HCL_STRICT_ENCRYPTION_POLICY");
         let attempt_ak_cert_callback = parse_env_bool_opt("HCL_ATTEMPT_AK_CERT_CALLBACK");
         let enable_vpci_relay = parse_env_bool_opt("OPENHCL_ENABLE_VPCI_RELAY");
@@ -560,6 +574,7 @@ impl Options {
             guest_state_lifetime,
             guest_state_encryption_policy,
             efi_diagnostics_log_level,
+            efi_diagnostics_rate_limit,
             strict_encryption_policy,
             attempt_ak_cert_callback,
             enable_vpci_relay,

--- a/openhcl/underhill_core/src/options.rs
+++ b/openhcl/underhill_core/src/options.rs
@@ -296,9 +296,6 @@ pub struct Options {
     /// - Not set: use the built-in defaults.
     /// - `0`: disable rate limiting entirely (emit every entry).
     /// - `n > 0`: use `n` as the per-period limit.
-    ///
-    /// Intended for tests that need to deterministically observe every
-    /// diagnostics entry.
     pub efi_diagnostics_rate_limit: Option<u32>,
 
     /// (HCL_STRICT_ENCRYPTION_POLICY=1) Strict guest state encryption policy.

--- a/openhcl/underhill_core/src/options.rs
+++ b/openhcl/underhill_core/src/options.rs
@@ -503,8 +503,9 @@ impl Options {
                 })
                 .ok()
         });
-        let efi_diagnostics_rate_limit =
-            parse_env_number("HCL_EFI_DIAGNOSTICS_RATE_LIMIT")?.map(|x| x as u32);
+        let efi_diagnostics_rate_limit = parse_env_number("HCL_EFI_DIAGNOSTICS_RATE_LIMIT")?
+            .map(|x| u32::try_from(x).context("HCL_EFI_DIAGNOSTICS_RATE_LIMIT out of range"))
+            .transpose()?;
         let strict_encryption_policy = parse_env_bool_opt("HCL_STRICT_ENCRYPTION_POLICY");
         let attempt_ak_cert_callback = parse_env_bool_opt("HCL_ATTEMPT_AK_CERT_CALLBACK");
         let enable_vpci_relay = parse_env_bool_opt("OPENHCL_ENABLE_VPCI_RELAY");

--- a/openhcl/underhill_core/src/worker.rs
+++ b/openhcl/underhill_core/src/worker.rs
@@ -309,6 +309,9 @@ pub struct UnderhillEnvCfg {
     pub guest_state_encryption_policy: Option<GuestStateEncryptionPolicyCli>,
     /// EFI diagnostics log level filter (overrides DPS value when set)
     pub efi_diagnostics_log_level: Option<EfiDiagnosticsLogLevelCli>,
+    /// EFI diagnostics rate-limit override (overrides device defaults when
+    /// set). `Some(0)` disables rate limiting entirely.
+    pub efi_diagnostics_rate_limit: Option<u32>,
     /// Strict guest state encryption policy
     pub strict_encryption_policy: Option<bool>,
     /// Attempt to renew the AK cert
@@ -2572,6 +2575,7 @@ async fn new_underhill_vm(
                     _ => LogLevel::make_default(),
                 }
             },
+            diagnostics_rate_limit: env_cfg.efi_diagnostics_rate_limit,
         };
 
         // Register the platform resolvers used by the resource-model UEFI

--- a/openhcl/underhill_core/src/worker.rs
+++ b/openhcl/underhill_core/src/worker.rs
@@ -309,8 +309,7 @@ pub struct UnderhillEnvCfg {
     pub guest_state_encryption_policy: Option<GuestStateEncryptionPolicyCli>,
     /// EFI diagnostics log level filter (overrides DPS value when set)
     pub efi_diagnostics_log_level: Option<EfiDiagnosticsLogLevelCli>,
-    /// EFI diagnostics rate-limit override (overrides device defaults when
-    /// set). `Some(0)` disables rate limiting entirely.
+    /// EFI diagnostics rate-limit override (overrides device defaults when set)
     pub efi_diagnostics_rate_limit: Option<u32>,
     /// Strict guest state encryption policy
     pub strict_encryption_policy: Option<bool>,

--- a/openvmm/openvmm_entry/src/lib.rs
+++ b/openvmm/openvmm_entry/src/lib.rs
@@ -1155,6 +1155,7 @@ async fn vm_config_from_command_line(
             custom_uefi_vars.clone(),
             opt.secure_boot,
             log_level,
+            None,
             nvram_storage,
             None,
         ));

--- a/petri/src/vm/hyperv/mod.rs
+++ b/petri/src/vm/hyperv/mod.rs
@@ -192,6 +192,7 @@ impl PetriVmmBackend for HyperVPetriBackend {
             secure_boot_enabled,
             default_boot_always_attempt,
             efi_diagnostics_log_level,
+            efi_diagnostics_rate_limit,
             ..
         }) = config.firmware.uefi_config()
         {
@@ -245,6 +246,23 @@ impl PetriVmmBackend for HyperVPetriBackend {
                 append_cmdline(
                     &mut openhcl_command_line,
                     format!("HCL_EFI_DIAGNOSTICS_LOG_LEVEL={cli}"),
+                );
+            }
+
+            // Plumb the EFI diagnostics rate-limit override via the OpenHCL
+            // command line. Like the log level, this is currently only
+            // supported on OpenHCL-backed VMs.
+            if let Some(limit) = efi_diagnostics_rate_limit {
+                if !properties.is_openhcl {
+                    anyhow::bail!(
+                        "with_efi_diagnostics_rate_limit({}) is only supported for \
+                         OpenHCL-backed Hyper-V UEFI VMs in this code path",
+                        limit
+                    );
+                }
+                append_cmdline(
+                    &mut openhcl_command_line,
+                    format!("HCL_EFI_DIAGNOSTICS_RATE_LIMIT={limit}"),
                 );
             }
 

--- a/petri/src/vm/hyperv/mod.rs
+++ b/petri/src/vm/hyperv/mod.rs
@@ -250,8 +250,7 @@ impl PetriVmmBackend for HyperVPetriBackend {
             }
 
             // Plumb the EFI diagnostics rate-limit override via the OpenHCL
-            // command line. Like the log level, this is currently only
-            // supported on OpenHCL-backed VMs.
+            // command line.
             if let Some(limit) = efi_diagnostics_rate_limit {
                 if !properties.is_openhcl {
                     anyhow::bail!(

--- a/petri/src/vm/mod.rs
+++ b/petri/src/vm/mod.rs
@@ -1399,9 +1399,6 @@ impl<T: PetriVmmBackend> PetriVmBuilder<T> {
     /// - Not called: use the built-in defaults.
     /// - `0`: disable rate limiting entirely (emit every entry).
     /// - `n > 0`: use `n` as the per-period limit.
-    ///
-    /// Intended for tests that need to deterministically observe every
-    /// diagnostics entry without losing entries to rate limiting.
     pub fn with_efi_diagnostics_rate_limit(mut self, limit: u32) -> Self {
         self.config
             .firmware
@@ -2275,14 +2272,8 @@ pub struct UefiConfig {
     pub enable_vpci_boot: bool,
     /// EFI diagnostics log level filter
     pub efi_diagnostics_log_level: EfiDiagnosticsLogLevel,
-    /// Optional per-period rate-limit override for EFI diagnostics emission.
-    ///
-    /// - `None`: use the built-in defaults.
-    /// - `Some(0)`: disable rate limiting entirely (emit every entry).
-    /// - `Some(n)`: use `n` as the per-period limit.
-    ///
-    /// Intended for tests that need to deterministically observe every
-    /// diagnostics entry.
+    /// Per-period rate-limit override for EFI diagnostics emission.
+    /// See [`PetriVmBuilder::with_efi_diagnostics_rate_limit()`] for more information.
     pub efi_diagnostics_rate_limit: Option<u32>,
 }
 

--- a/petri/src/vm/mod.rs
+++ b/petri/src/vm/mod.rs
@@ -1394,6 +1394,23 @@ impl<T: PetriVmmBackend> PetriVmBuilder<T> {
         self
     }
 
+    /// Sets the per-period rate-limit override for UEFI diagnostics emission.
+    ///
+    /// - Not called: use the built-in defaults.
+    /// - `0`: disable rate limiting entirely (emit every entry).
+    /// - `n > 0`: use `n` as the per-period limit.
+    ///
+    /// Intended for tests that need to deterministically observe every
+    /// diagnostics entry without losing entries to rate limiting.
+    pub fn with_efi_diagnostics_rate_limit(mut self, limit: u32) -> Self {
+        self.config
+            .firmware
+            .uefi_config_mut()
+            .expect("EFI diagnostics rate limit is only supported for UEFI firmware.")
+            .efi_diagnostics_rate_limit = Some(limit);
+        self
+    }
+
     /// Sets whether UEFI should always attempt a default boot.
     pub fn with_default_boot_always_attempt(mut self, enable: bool) -> Self {
         self.config
@@ -2258,6 +2275,15 @@ pub struct UefiConfig {
     pub enable_vpci_boot: bool,
     /// EFI diagnostics log level filter
     pub efi_diagnostics_log_level: EfiDiagnosticsLogLevel,
+    /// Optional per-period rate-limit override for EFI diagnostics emission.
+    ///
+    /// - `None`: use the built-in defaults.
+    /// - `Some(0)`: disable rate limiting entirely (emit every entry).
+    /// - `Some(n)`: use `n` as the per-period limit.
+    ///
+    /// Intended for tests that need to deterministically observe every
+    /// diagnostics entry.
+    pub efi_diagnostics_rate_limit: Option<u32>,
 }
 
 impl Default for UefiConfig {
@@ -2269,6 +2295,7 @@ impl Default for UefiConfig {
             default_boot_always_attempt: false,
             enable_vpci_boot: false,
             efi_diagnostics_log_level: EfiDiagnosticsLogLevel::Default,
+            efi_diagnostics_rate_limit: None,
         }
     }
 }

--- a/petri/src/vm/openvmm/construct.rs
+++ b/petri/src/vm/openvmm/construct.rs
@@ -389,6 +389,7 @@ impl PetriVmConfigOpenVmm {
                 EfiDiagnosticsLogLevel::Info => firmware_uefi_resources::LogLevel::make_info(),
                 EfiDiagnosticsLogLevel::Full => firmware_uefi_resources::LogLevel::make_full(),
             };
+            let diagnostics_rate_limit = uefi_cfg.and_then(|c| c.efi_diagnostics_rate_limit);
             let nvram_storage = if vmgs.disk().is_some() {
                 VmgsFileHandle::new(vmgs_format::FileId::BIOS_NVRAM, true).into_resource()
             } else {
@@ -402,6 +403,7 @@ impl PetriVmConfigOpenVmm {
                 custom_uefi_vars,
                 secure_boot,
                 log_level,
+                diagnostics_rate_limit,
                 nvram_storage,
                 None,
             ));
@@ -883,6 +885,7 @@ impl PetriVmConfigSetupCore<'_> {
                             default_boot_always_attempt,
                             enable_vpci_boot,
                             efi_diagnostics_log_level: _, // applied to top-level Config below
+                            efi_diagnostics_rate_limit: _, // applied to top-level Config below
                         },
                 },
             ) => {
@@ -971,6 +974,25 @@ impl PetriVmConfigSetupCore<'_> {
                     }
                 }
 
+                // Plumb the EFI diagnostics rate-limit override to the
+                // OpenHCL-side UEFI device via env var. The OpenVMM-side
+                // UEFI device (used when not in OpenHCL) already picks up
+                // the same value through `UefiManifest::new` above.
+                if let Firmware::OpenhclUefi {
+                    uefi_config:
+                        UefiConfig {
+                            efi_diagnostics_rate_limit: Some(limit),
+                            ..
+                        },
+                    ..
+                } = self.firmware
+                {
+                    append_cmdline(
+                        &mut cmdline,
+                        format!("HCL_EFI_DIAGNOSTICS_RATE_LIMIT={limit}"),
+                    );
+                }
+
                 let vtl2_base_address = vtl2_base_address_type.unwrap_or_else(|| {
                     if isolated {
                         // Isolated VMs must load at the location specified by
@@ -1044,6 +1066,7 @@ impl PetriVmConfigSetupCore<'_> {
                 default_boot_always_attempt,
                 enable_vpci_boot,
                 efi_diagnostics_log_level,
+                efi_diagnostics_rate_limit: _, // applied device-side via UefiManifest::new
             },
             OpenHclConfig { vmbus_redirect, .. },
         ) = match self.firmware {

--- a/petri/src/vm/openvmm/construct.rs
+++ b/petri/src/vm/openvmm/construct.rs
@@ -975,9 +975,7 @@ impl PetriVmConfigSetupCore<'_> {
                 }
 
                 // Plumb the EFI diagnostics rate-limit override to the
-                // OpenHCL-side UEFI device via env var. The OpenVMM-side
-                // UEFI device (used when not in OpenHCL) already picks up
-                // the same value through `UefiManifest::new` above.
+                // OpenHCL-side UEFI device via env var.
                 if let Firmware::OpenhclUefi {
                     uefi_config:
                         UefiConfig {

--- a/vm/devices/firmware/firmware_uefi/src/lib.rs
+++ b/vm/devices/firmware/firmware_uefi/src/lib.rs
@@ -124,8 +124,8 @@ pub struct UefiDevice {
     // Fixed configuration
     use_mmio: bool,
     command_set: UefiCommandSet,
-    /// Override for the per-period rate limit applied to diagnostics log
-    /// entries. See [`UefiConfig::diagnostics_rate_limit`].
+    /// Overrides the per-period rate limit applied to EfiDiagnostics
+    /// See [`UefiDevice::resolve_rate_limit`] for more information.
     diagnostics_rate_limit: Option<u32>,
 
     // Runtime glue
@@ -374,8 +374,6 @@ impl PollDevice for UefiDevice {
             // NOTE: Do not allow reprocessing diagnostics here.
             // UEFI programs the watchdog's configuration, so we should assume that
             // this path could trigger multiple times.
-            //
-            // Here, we emit diagnostics to tracing with INFO level and no limit
             let _ = self.process_diagnostics(
                 false,
                 service::diagnostics::DiagnosticsEmitter::Tracing {

--- a/vm/devices/firmware/firmware_uefi/src/lib.rs
+++ b/vm/devices/firmware/firmware_uefi/src/lib.rs
@@ -124,6 +124,9 @@ pub struct UefiDevice {
     // Fixed configuration
     use_mmio: bool,
     command_set: UefiCommandSet,
+    /// Override for the per-period rate limit applied to diagnostics log
+    /// entries. See [`UefiConfig::diagnostics_rate_limit`].
+    diagnostics_rate_limit: Option<u32>,
 
     // Runtime glue
     gm: GuestMemory,
@@ -163,6 +166,7 @@ impl UefiDevice {
         let uefi = UefiDevice {
             use_mmio: cfg.use_mmio,
             command_set: cfg.command_set,
+            diagnostics_rate_limit: cfg.diagnostics_rate_limit,
             address: 0,
             gm,
             watchdog_recv,
@@ -194,6 +198,20 @@ impl UefiDevice {
         };
 
         Ok(uefi)
+    }
+
+    /// Resolves the effective per-period rate limit for diagnostics emission,
+    /// given a built-in default and the device's optional override.
+    ///
+    /// - override is `None`: use the built-in default.
+    /// - override is `Some(0)`: disable rate limiting entirely.
+    /// - override is `Some(n)`: use `n` as the override limit.
+    fn resolve_rate_limit(&self, default_limit: u32) -> Option<u32> {
+        match self.diagnostics_rate_limit {
+            None => Some(default_limit),
+            Some(0) => None,
+            Some(n) => Some(n),
+        }
     }
 
     fn read_data(&mut self, addr: u32) -> u32 {
@@ -252,7 +270,7 @@ impl UefiDevice {
                 let _ = self.process_diagnostics(
                     false,
                     service::diagnostics::DiagnosticsEmitter::Tracing {
-                        limit: Some(DEFAULT_LOGS_PER_PERIOD),
+                        limit: self.resolve_rate_limit(DEFAULT_LOGS_PER_PERIOD),
                     },
                     None,
                 );
@@ -361,7 +379,7 @@ impl PollDevice for UefiDevice {
             let _ = self.process_diagnostics(
                 false,
                 service::diagnostics::DiagnosticsEmitter::Tracing {
-                    limit: Some(WATCHDOG_LOGS_PER_PERIOD),
+                    limit: self.resolve_rate_limit(WATCHDOG_LOGS_PER_PERIOD),
                 },
                 Some(LogLevel::make_info()),
             );
@@ -562,6 +580,7 @@ mod save_restore {
                         diagnostics,
                     },
                 address,
+                diagnostics_rate_limit: _,
             } = self;
 
             Ok(state::SavedState {

--- a/vm/devices/firmware/firmware_uefi_resources/src/lib.rs
+++ b/vm/devices/firmware/firmware_uefi_resources/src/lib.rs
@@ -159,15 +159,8 @@ pub struct UefiConfig {
     pub use_mmio: bool,
     pub command_set: UefiCommandSet,
     pub diagnostics_log_level: LogLevel,
-    /// Override for the per-period rate limit applied to diagnostics log
-    /// entries forwarded to host tracing.
-    ///
-    /// - `None`: use the built-in defaults.
-    /// - `Some(0)`: disable rate limiting entirely (emit every entry).
-    /// - `Some(n)`: use `n` as the per-period limit.
-    ///
-    /// Intended primarily for tests that need to deterministically observe
-    /// every diagnostics entry.
+    /// Overrides the per-period rate limit applied to EfiDiagnostics.
+    /// See [`UefiDevice::resolve_rate_limit`] for more information.
     pub diagnostics_rate_limit: Option<u32>,
 }
 

--- a/vm/devices/firmware/firmware_uefi_resources/src/lib.rs
+++ b/vm/devices/firmware/firmware_uefi_resources/src/lib.rs
@@ -159,6 +159,16 @@ pub struct UefiConfig {
     pub use_mmio: bool,
     pub command_set: UefiCommandSet,
     pub diagnostics_log_level: LogLevel,
+    /// Override for the per-period rate limit applied to diagnostics log
+    /// entries forwarded to host tracing.
+    ///
+    /// - `None`: use the built-in defaults.
+    /// - `Some(0)`: disable rate limiting entirely (emit every entry).
+    /// - `Some(n)`: use `n` as the per-period limit.
+    ///
+    /// Intended primarily for tests that need to deterministically observe
+    /// every diagnostics entry.
+    pub diagnostics_rate_limit: Option<u32>,
 }
 
 /// Resource kind for the platform-provided UEFI logger.

--- a/vm/devices/firmware/firmware_uefi_resources/src/lib.rs
+++ b/vm/devices/firmware/firmware_uefi_resources/src/lib.rs
@@ -159,8 +159,6 @@ pub struct UefiConfig {
     pub use_mmio: bool,
     pub command_set: UefiCommandSet,
     pub diagnostics_log_level: LogLevel,
-    /// Overrides the per-period rate limit applied to EfiDiagnostics.
-    /// See [`UefiDevice::resolve_rate_limit`] for more information.
     pub diagnostics_rate_limit: Option<u32>,
 }
 

--- a/vmm_core/vm_manifest_builder/src/lib.rs
+++ b/vmm_core/vm_manifest_builder/src/lib.rs
@@ -115,6 +115,7 @@ impl UefiManifest {
         custom_uefi_vars: CustomVars,
         secure_boot: bool,
         diagnostics_log_level: LogLevel,
+        diagnostics_rate_limit: Option<u32>,
         nvram_storage: Resource<NonVolatileStoreKind>,
         storage_quirks: Option<HclCompatNvramQuirks>,
     ) -> Self {
@@ -131,6 +132,7 @@ impl UefiManifest {
                     MachineArch::Aarch64 => UefiCommandSet::Aarch64,
                 },
                 diagnostics_log_level,
+                diagnostics_rate_limit,
             },
             storage_quirks,
             generation_id_recv: mesh::channel().1,

--- a/vmm_tests/vmm_tests/tests/tests/multiarch.rs
+++ b/vmm_tests/vmm_tests/tests/tests/multiarch.rs
@@ -537,14 +537,18 @@ async fn efi_diagnostics_info_level<T: PetriVmmBackend>(
     let vm = config
         .with_uefi_frontpage(true)
         .with_efi_diagnostics_log_level(EfiDiagnosticsLogLevel::Info)
+        .with_efi_diagnostics_rate_limit(0)
         .run_without_agent()
         .await?;
 
-    // Marker emitted by `firmware_uefi::service::diagnostics` for every
-    // UEFI log entry tagged with `DEBUG_INFO`.
-    //
-    // Presence of this marker in the kmsg output validates that.
-    const INFO_MARKER: &str = "debug_level=INFO";
+    // The last INFO-level entry emitted by the Hyper-V UEFI firmware right
+    // before it hands control to `firmware_uefi::service::diagnostics` to
+    // collect entries. It only appears in the trace stream when:
+    //   1. The diagnostics log level is INFO
+    //   2. Rate limiting is disabled — UEFI emits ~1000 INFO entries in a
+    //      single burst, and this is one of the very last; with the default
+    //      rate limit it gets dropped.
+    const MARKER: &str = "Signaling BIOS device to collect EFI diagnostics";
 
     let mut kmsg = vm.kmsg().await?;
 
@@ -552,12 +556,12 @@ async fn efi_diagnostics_info_level<T: PetriVmmBackend>(
         let data = data.context("reading kmsg")?;
         let msg = kmsg::KmsgParsedEntry::new(&data).unwrap();
         let raw = msg.message.as_raw();
-        if raw.contains(INFO_MARKER) {
+        if raw.contains(MARKER) {
             return Ok(());
         }
     }
 
-    anyhow::bail!("Did not find any INFO-level UEFI diagnostics entry ({INFO_MARKER:?}) in kmsg");
+    anyhow::bail!("Did not find expected INFO-level UEFI diagnostics entry ({MARKER:?}) in kmsg");
 }
 
 /// Boot our guest-test UEFI image, which will run some tests,


### PR DESCRIPTION
This PR does the plumbing necessary to let petri tests configure efi diagnostics' rate limiting so that we can see more logs at once per test.