### PR TITLE
vmbus_server: use a separate max restore version

### DIFF
--- a/openvmm/openvmm_core/src/worker/dispatch.rs
+++ b/openvmm/openvmm_core/src/worker/dispatch.rs
@@ -2304,16 +2304,16 @@ impl InitializedVm {
             let (vtl2_vmbus, vtl2_request_send) = if let Some(vtl2_vmbus_cfg) = cfg.vtl2_vmbus {
                 let (server_request_send, server_request_recv) = mesh::channel();
                 let vtl2_hvsock_channel = HvsockRelayChannel::new();
+                let vtl2_max_version = vtl2_vmbus_cfg
+                    .vmbus_max_version
+                    .map(vmbus_core::MaxVersionInfo::new);
 
                 let vmbus_driver = driver_source.simple();
                 let vtl2_vmbus =
                     VmbusServer::builder(vmbus_driver.clone(), synic.clone(), gm.clone())
                         .vtl(Vtl::Vtl2)
-                        .max_version(
-                            vtl2_vmbus_cfg
-                                .vmbus_max_version
-                                .map(vmbus_core::MaxVersionInfo::new),
-                        )
+                        .max_version(vtl2_max_version)
+                        .max_restore_version(vtl2_max_version)
                         .hvsock_notify(Some(vtl2_hvsock_channel.server_half))
                         .external_requests(Some(server_request_recv))
                         .enable_mnf(true)
@@ -2343,16 +2343,16 @@ impl InitializedVm {
                 (None, None)
             };
 
+            let vmbus_max_version = vmbus_cfg
+                .vmbus_max_version
+                .map(vmbus_core::MaxVersionInfo::new);
             let vmbus_driver = driver_source.simple();
             let vmbus = VmbusServer::builder(vmbus_driver.clone(), synic.clone(), gm.clone())
                 .hvsock_notify(Some(hvsock_channel.server_half))
                 .external_server(vtl2_request_send)
                 .use_message_redirect(vmbus_cfg.vtl2_redirect)
-                .max_version(
-                    vmbus_cfg
-                        .vmbus_max_version
-                        .map(vmbus_core::MaxVersionInfo::new),
-                )
+                .max_version(vmbus_max_version)
+                .max_restore_version(vmbus_max_version)
                 .delay_max_version(matches!(cfg.load_mode, LoadMode::Uefi { .. }))
                 .enable_mnf(true)
                 .build()

--- a/vm/devices/vmbus/vmbus_server/src/channels.rs
+++ b/vm/devices/vmbus/vmbus_server/src/channels.rs
@@ -134,8 +134,8 @@ pub struct Server {
     /// Limits the protocol version and feature flags that will be accepted for the next connection.
     max_version: Option<MaxVersionInfo>,
     /// Version limit that will be applied after the next connection is established. This is used
-    /// for testing scenarios where the first client to connect (usually UEFI) may not be be able
-    /// to support the older protocol version being tested.
+    /// for testing scenarios where the first client to connect (usually UEFI) may not be able to
+    /// support the older protocol version being tested.
     delayed_max_version: Option<MaxVersionInfo>,
     /// Limits the protocol version and feature flags that will be accepted when restoring from
     /// saved state.
@@ -1416,7 +1416,7 @@ impl Server {
         }
     }
 
-    /// Sets a limit on the version and featuref flags that will be offered to nthe guest.
+    /// Sets a limit on the version and featuref flags that will be offered to the guest.
     ///
     /// If `delay` is true, the limit will not apply to the first connection, but to all subsequent
     /// connections.

--- a/vm/devices/vmbus/vmbus_server/src/channels.rs
+++ b/vm/devices/vmbus/vmbus_server/src/channels.rs
@@ -131,8 +131,15 @@ pub struct Server {
     gpadls: GpadlMap,
     incomplete_gpadls: IncompleteGpadlMap,
     child_connection_id: u32,
+    /// Limits the protocol version and feature flags that will be accepted for the next connection.
     max_version: Option<MaxVersionInfo>,
+    /// Version limit that will be applied after the next connection is established. This is used
+    /// for testing scenarios where the first client to connect (usually UEFI) may not be be able
+    /// to support the older protocol version being tested.
     delayed_max_version: Option<MaxVersionInfo>,
+    /// Limits the protocol version and feature flags that will be accepted when restoring from
+    /// saved state.
+    max_restore_version: Option<MaxVersionInfo>,
     // This must be separate from the connection state because e.g. the UnloadComplete message,
     // or messages for reserved channels, can be pending even when disconnected.
     pending_messages: PendingMessages,
@@ -1374,6 +1381,7 @@ impl Server {
             child_connection_id,
             max_version: None,
             delayed_max_version: None,
+            max_restore_version: None,
             pending_messages: PendingMessages(VecDeque::new()),
             require_server_allocated_mnf: false,
             use_absolute_channel_order,
@@ -1408,7 +1416,10 @@ impl Server {
         }
     }
 
-    /// Indicates the maximum supported version by the real host in an Underhill relay scenario.
+    /// Sets a limit on the version and featuref flags that will be offered to nthe guest.
+    ///
+    /// If `delay` is true, the limit will not apply to the first connection, but to all subsequent
+    /// connections.
     pub fn set_compatibility_version(&mut self, version: MaxVersionInfo, delay: bool) {
         if delay {
             self.delayed_max_version = Some(version)
@@ -1416,6 +1427,18 @@ impl Server {
             tracing::info!(?version, "Limiting VmBus connections to version");
             self.max_version = Some(version);
         }
+    }
+
+    /// Indicates the maximum supported version when restoring from saved
+    /// state. This is configured separately from [`Self::set_compatibility_version`]
+    /// so that the restore-time limit can be configured independently of the
+    /// limit used for live negotiation.
+    ///
+    /// This allows features to be enabled for rollback scenarios while not yet enabling them for
+    /// new connections.
+    pub fn set_restore_compatibility_version(&mut self, version: MaxVersionInfo) {
+        tracing::info!(?version, "Limiting VmBus restore to version");
+        self.max_restore_version = Some(version);
     }
 
     pub fn channel_gpadls(&self, offer_id: OfferId) -> Vec<RestoredGpadl> {

--- a/vm/devices/vmbus/vmbus_server/src/channels/saved_state.rs
+++ b/vm/devices/vmbus/vmbus_server/src/channels/saved_state.rs
@@ -25,7 +25,7 @@ use vmcore::monitor::MonitorId;
 
 impl super::Server {
     fn restore_one_channel(&mut self, saved_channel: Channel) -> Result<(), RestoreError> {
-        let (info, stub_offer, state) = saved_channel.restore(self.max_version)?;
+        let (info, stub_offer, state) = saved_channel.restore(self.max_restore_version)?;
         if let Some((offer_id, channel)) = self.channels.get_by_key_mut(&saved_channel.key) {
             // There is an existing channel. Restore on top of it.
 
@@ -191,7 +191,7 @@ impl<'a, N: 'a + Notifier> super::ServerWithNotifier<'a, N> {
         let saved = SavedStateData::from(saved);
         match saved.state {
             SavedConnectionState::Connected(saved) => {
-                self.inner.state = saved.connection.restore(self.inner.max_version)?;
+                self.inner.state = saved.connection.restore(self.inner.max_restore_version)?;
 
                 // Restore server state, and resend server notifications if needed. If these notifications
                 // were processed before the save, it's harmless as the values will be the same.

--- a/vm/devices/vmbus/vmbus_server/src/channels/tests.rs
+++ b/vm/devices/vmbus/vmbus_server/src/channels/tests.rs
@@ -754,7 +754,7 @@ fn test_restore_max_version_rejects_higher_version() {
 
     let mut env2 = TestEnv::new();
     env2.server
-        .set_compatibility_version(MaxVersionInfo::new(Version::Win10 as u32), false);
+        .set_restore_compatibility_version(MaxVersionInfo::new(Version::Win10 as u32));
 
     let err = env2.c().restore(state).unwrap_err();
     assert!(
@@ -774,13 +774,11 @@ fn test_restore_max_version_rejects_disallowed_feature_flags() {
     let state = env.server.save();
 
     let mut env2 = TestEnv::new();
-    env2.server.set_compatibility_version(
-        MaxVersionInfo {
+    env2.server
+        .set_restore_compatibility_version(MaxVersionInfo {
             version: Version::Copper as u32,
             feature_flags: FeatureFlags::new().with_guest_specified_signal_parameters(true),
-        },
-        false,
-    );
+        });
 
     let err = env2.c().restore(state).unwrap_err();
     assert!(
@@ -806,7 +804,7 @@ fn test_restore_max_version_pre_copper() {
     let mut env2 = TestEnv::new();
     let offer_id2 = env2.offer(1);
     env2.server
-        .set_compatibility_version(MaxVersionInfo::new(Version::Win10Rs5 as u32), false);
+        .set_restore_compatibility_version(MaxVersionInfo::new(Version::Win10Rs5 as u32));
 
     env2.c().restore(state).unwrap();
     env2.c().restore_channel(offer_id2, false).unwrap();
@@ -825,13 +823,11 @@ fn test_restore_max_version_copper_with_feature_flags() {
 
     let mut env2 = TestEnv::new();
     let offer_id2 = env2.offer(1);
-    env2.server.set_compatibility_version(
-        MaxVersionInfo {
+    env2.server
+        .set_restore_compatibility_version(MaxVersionInfo {
             version: Version::Copper as u32,
             feature_flags,
-        },
-        false,
-    );
+        });
 
     env2.c().restore(state).unwrap();
     env2.c().restore_channel(offer_id2, false).unwrap();
@@ -896,13 +892,11 @@ fn test_restore_max_version_reserved_channel_success() {
 
     let mut env2 = TestEnv::new();
     let offer_id1 = env2.offer(1);
-    env2.server.set_compatibility_version(
-        MaxVersionInfo {
+    env2.server
+        .set_restore_compatibility_version(MaxVersionInfo {
             version: Version::Copper as u32,
             feature_flags,
-        },
-        false,
-    );
+        });
 
     env2.c().restore(state).unwrap();
     env2.c().restore_channel(offer_id1, true).unwrap();
@@ -926,7 +920,7 @@ fn test_restore_max_version_reserved_channel_rejects_higher_version() {
     let mut env2 = TestEnv::new();
     let _offer_id1 = env2.offer(1);
     env2.server
-        .set_compatibility_version(MaxVersionInfo::new(Version::Win10 as u32), false);
+        .set_restore_compatibility_version(MaxVersionInfo::new(Version::Win10 as u32));
 
     let err = env2.c().restore(state).unwrap_err();
     assert!(
@@ -953,13 +947,11 @@ fn test_restore_max_version_reserved_channel_rejects_disallowed_feature_flags() 
 
     let mut env2 = TestEnv::new();
     let _offer_id1 = env2.offer(1);
-    env2.server.set_compatibility_version(
-        MaxVersionInfo {
+    env2.server
+        .set_restore_compatibility_version(MaxVersionInfo {
             version: Version::Copper as u32,
             feature_flags: FeatureFlags::new().with_guest_specified_signal_parameters(true),
-        },
-        false,
-    );
+        });
 
     let err = env2.c().restore(state).unwrap_err();
     assert!(

--- a/vm/devices/vmbus/vmbus_server/src/lib.rs
+++ b/vm/devices/vmbus/vmbus_server/src/lib.rs
@@ -136,6 +136,7 @@ pub struct VmbusServerBuilder<T: SpawnDriver> {
     channel_id_offset: u16,
     max_version: Option<MaxVersionInfo>,
     delay_max_version: bool,
+    max_restore_version: Option<MaxVersionInfo>,
     enable_mnf: bool,
     force_confidential_external_memory: bool,
     send_messages_while_stopped: bool,
@@ -307,6 +308,7 @@ impl<T: SpawnDriver + Clone> VmbusServerBuilder<T> {
             channel_id_offset: 0,
             max_version: None,
             delay_max_version: false,
+            max_restore_version: None,
             enable_mnf: false,
             force_confidential_external_memory: false,
             send_messages_while_stopped: false,
@@ -399,6 +401,16 @@ impl<T: SpawnDriver + Clone> VmbusServerBuilder<T> {
     ///      since that's the oldest version the Uefi client supports.
     pub fn delay_max_version(mut self, delay: bool) -> Self {
         self.delay_max_version = delay;
+        self
+    }
+
+    /// Tells the server to limit the protocol version accepted when restoring from saved state.
+    ///
+    /// This is configured separately from [`Self::max_version`] so that the version limit enforced
+    /// during restore can differ from the limit used for new connections. This allows a feature to
+    /// be available for rollback from a future version that has enabled it by default.
+    pub fn max_restore_version(mut self, max_restore_version: Option<MaxVersionInfo>) -> Self {
+        self.max_restore_version = max_restore_version;
         self
     }
 
@@ -528,6 +540,11 @@ impl<T: SpawnDriver + Clone> VmbusServerBuilder<T> {
         if let Some(version) = self.max_version {
             server.set_compatibility_version(version, self.delay_max_version);
         }
+
+        if let Some(version) = self.max_restore_version {
+            server.set_restore_compatibility_version(version);
+        }
+
         let (relay_request_send, relay_response_recv) =
             if let Some(server_relay) = self.server_relay {
                 let r = server_relay.response_receive.boxed().fuse();


### PR DESCRIPTION
in #3482, the restore process for VMBus was updated to respect the configured max protocol version and feature flags. However, this is not the behavior we necessarily want in all cases. For example, in OpenHCL we want to be able to allow a feature to be enabled for restore even if otherwise still disabled, so that we can later enable it once we know that all versions we might roll back to can support it.

For this reason, this change makes the version limit during restore operations a separately configurable value.