### PR TITLE
pci_core: terminate extended capability list with all-zero header

### DIFF
--- a/vm/devices/pci/pci_core/src/cfg_space_emu.rs
+++ b/vm/devices/pci/pci_core/src/cfg_space_emu.rs
@@ -737,7 +737,10 @@ impl<const N: usize> ConfigSpaceCommonHeaderEmulator<N> {
                     *value = result;
                     CommonHeaderResult::Handled
                 } else {
-                    *value = 0xffffffff;
+                    // An all-zero extended capability header (capability ID 0)
+                    // terminates the list. All-ones would be misread as a
+                    // capability with a next pointer of 0xfff.
+                    *value = 0;
                     CommonHeaderResult::Handled
                 }
             } else {
@@ -2372,13 +2375,14 @@ mod tests {
             CommonHeaderResult::Failed(IoError::InvalidRegister)
         ));
 
-        // Test reading extended capabilities - PCIe device should return 0xffffffff
+        // A PCIe device with no extended capabilities returns an all-zero
+        // header, terminating the list.
         let mut value = 0;
         assert!(matches!(
             common_emu_pcie.read_extended_capabilities(EXT_CAP_START, &mut value),
             CommonHeaderResult::Handled
         ));
-        assert_eq!(value, 0xffffffff);
+        assert_eq!(value, 0);
 
         // Test writing extended capabilities - non-PCIe device should return error
         assert!(matches!(

--- a/vm/devices/pci/pcie/src/port.rs
+++ b/vm/devices/pci/pcie/src/port.rs
@@ -1268,7 +1268,7 @@ mod tests {
             None,
         );
         without_acs.cfg_space.read_u32(0x100, &mut value).unwrap();
-        assert_eq!(value, 0xffff_ffff);
+        assert_eq!(value, 0);
     }
 
     #[test]
@@ -1316,7 +1316,7 @@ mod tests {
         let mut value = 0u32;
         port.cfg_space.read_u32(0x100, &mut value).unwrap();
         assert_eq!(
-            value, 0xffff_ffff,
+            value, 0,
             "CXL DVSECs should be absent when CXL component-register BAR backing is invalid"
         );
         assert!(

--- a/vm/devices/pci/pcie/src/switch.rs
+++ b/vm/devices/pci/pcie/src/switch.rs
@@ -1557,7 +1557,7 @@ mod tests {
             .cfg_space()
             .read_u32(0x100, &mut upstream_header)
             .unwrap();
-        assert_eq!(upstream_header, 0xffff_ffff);
+        assert_eq!(upstream_header, 0);
 
         let mut switch = switch;
         let (_, downstream_port) = switch


### PR DESCRIPTION
When a guest reads the extended capability header at an offset that no extended capability backs, we returned all-ones (0xffffffff). All-ones is the convention for an absent function, not an empty capability list: a guest walking the list decodes it as a capability with a next pointer of 0xfff and chases that bogus pointer off the end of config space.

Return an all-zero header instead, which has capability ID 0 and a next pointer of 0, correctly terminating the list. This fixes binding Windows' pcip.sys to one of our emulated PCIe devices, which previously failed because the driver walked the malformed extended capability list.