### PR TITLE
virt_kvm: model synic overlay pages with OverlayPage

### DIFF
--- a/vm/hv1/hv1_emulator/src/hv.rs
+++ b/vm/hv1/hv1_emulator/src/hv.rs
@@ -213,17 +213,13 @@ impl ProcessorVtlHv {
         }
         let new_vp_assist_page_reg = HvRegisterVpAssistPage::from(v);
 
-        if new_vp_assist_page_reg.enabled()
-            && (!self.vp_assist_page_reg.enabled()
-                || new_vp_assist_page_reg.gpa_page_number()
-                    != self.vp_assist_page_reg.gpa_page_number())
-        {
-            self.vp_assist_page
-                .remap(new_vp_assist_page_reg.gpa_page_number(), prot_access)
-                .map_err(|_| MsrError::InvalidAccess)?
-        } else if !new_vp_assist_page_reg.enabled() {
-            self.vp_assist_page.unmap(prot_access);
-        }
+        self.vp_assist_page
+            .sync(
+                new_vp_assist_page_reg.enabled(),
+                new_vp_assist_page_reg.gpa_page_number(),
+                prot_access,
+            )
+            .map_err(|_| MsrError::InvalidAccess)?;
 
         self.vp_assist_page_reg = new_vp_assist_page_reg;
 

--- a/vm/hv1/hv1_emulator/src/lib.rs
+++ b/vm/hv1/hv1_emulator/src/lib.rs
@@ -18,7 +18,7 @@ pub mod cpuid;
 pub mod hv;
 pub mod hypercall;
 pub mod message_queues;
-mod pages;
+pub mod pages;
 pub mod synic;
 pub mod x86;
 

--- a/vm/hv1/hv1_emulator/src/pages.rs
+++ b/vm/hv1/hv1_emulator/src/pages.rs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+//! Overlay page management for synthetic registers backed by guest pages.
+
 use crate::VtlProtectAccess;
 use guestmem::LockedPages;
 use guestmem::Page;
@@ -10,12 +12,15 @@ use safeatomic::AtomicSliceOps;
 use std::ops::Deref;
 use std::sync::atomic::AtomicU8;
 
-pub(crate) struct LockedPage {
+/// A single guest page locked into memory, tracked by its GPN.
+pub struct LockedPage {
     page: LockedPages,
+    /// The guest page number that backs this locked page.
     pub gpn: u64,
 }
 
 impl LockedPage {
+    /// Creates a new locked page from a single-page [`LockedPages`] and its GPN.
     pub fn new(gpn: u64, page: LockedPages) -> Self {
         assert!(page.pages().len() == 1);
         Self { page, gpn }
@@ -30,16 +35,24 @@ impl Deref for LockedPage {
     }
 }
 
+/// A page that is either backed by a local (VMM-owned) buffer when no guest
+/// page is mapped, or by a locked guest page when mapped. The logical page
+/// contents follow the overlay: remapping or unmapping copies the current
+/// contents to the new backing, matching hypervisor overlay semantics.
 #[derive(Inspect)]
 #[inspect(external_tag)]
-pub(crate) enum OverlayPage {
+pub enum OverlayPage {
+    /// Backed by a VMM-owned buffer; no guest page is currently mapped.
     Local(#[inspect(skip)] Box<Page>),
+    /// Backed by a locked guest page.
     Mapped(#[inspect(skip)] LockedPage),
 }
 
 // FUTURE: Technically we should restore the prior contents of a mapped location when we
 // remap/unmap it, but we don't know of any scenario that actually requires this.
 impl OverlayPage {
+    /// Maps the overlay to `new_gpn`, copying the current overlay contents into
+    /// the newly mapped guest page and releasing any previously mapped page.
     pub fn remap(
         &mut self,
         new_gpn: u64,
@@ -59,6 +72,8 @@ impl OverlayPage {
         Ok(())
     }
 
+    /// Unmaps the overlay, copying the current contents back into a
+    /// VMM-owned buffer and releasing the previously mapped guest page.
     pub fn unmap(&mut self, prot_access: &mut dyn VtlProtectAccess) {
         let new_page = Box::new(std::array::from_fn(|_| AtomicU8::new(0)));
         new_page.atomic_write_obj(&self.atomic_read_obj::<[u8; 4096]>());
@@ -72,6 +87,16 @@ impl OverlayPage {
         if let Self::Mapped(page) = self {
             prot_access.unlock_overlay_page(page.gpn).unwrap();
         }
+    }
+
+    /// Reads the full 4096-byte logical contents of the overlay page.
+    pub fn save_page(&self) -> [u8; 4096] {
+        self.atomic_read_obj()
+    }
+
+    /// Writes the full 4096-byte logical contents of the overlay page.
+    pub fn restore_page(&self, data: &[u8; 4096]) {
+        self.atomic_write_obj(data);
     }
 }
 

--- a/vm/hv1/hv1_emulator/src/pages.rs
+++ b/vm/hv1/hv1_emulator/src/pages.rs
@@ -51,6 +51,36 @@ pub enum OverlayPage {
 // FUTURE: Technically we should restore the prior contents of a mapped location when we
 // remap/unmap it, but we don't know of any scenario that actually requires this.
 impl OverlayPage {
+    /// Synchronizes the overlay's mapping to the desired state.
+    ///
+    /// When `enabled` is true, maps the overlay at `gpn`, remapping if the
+    /// overlay is currently mapped at a different GPN and doing nothing if it
+    /// is already mapped there. When `enabled` is false, unmaps the overlay if
+    /// it is currently mapped.
+    ///
+    /// This encapsulates the common "remap on enable/move, unmap on disable"
+    /// flow shared by the synthetic registers that are backed by an overlay
+    /// page, using the overlay's own mapped GPN as the source of truth.
+    pub fn sync(
+        &mut self,
+        enabled: bool,
+        gpn: u64,
+        prot_access: &mut dyn VtlProtectAccess,
+    ) -> Result<(), hvdef::HvError> {
+        let mapped_gpn = match self {
+            OverlayPage::Mapped(page) => Some(page.gpn),
+            OverlayPage::Local(_) => None,
+        };
+        if enabled {
+            if mapped_gpn != Some(gpn) {
+                self.remap(gpn, prot_access)?;
+            }
+        } else if mapped_gpn.is_some() {
+            self.unmap(prot_access);
+        }
+        Ok(())
+    }
+
     /// Maps the overlay to `new_gpn`, copying the current overlay contents into
     /// the newly mapped guest page and releasing any previously mapped page.
     pub fn remap(

--- a/vm/hv1/hv1_emulator/src/synic.rs
+++ b/vm/hv1/hv1_emulator/src/synic.rs
@@ -347,16 +347,10 @@ impl ProcessorSynic {
         let siefp = HvSynicSimpSiefp::from(v);
         tracing::debug!(?siefp, "setting siefp");
         let mut shared = self.shared.write();
-        if siefp.enabled()
-            && (!self.sints.siefp.enabled() || siefp.base_gpn() != self.sints.siefp.base_gpn())
-        {
-            shared
-                .siefp_page
-                .remap(siefp.base_gpn(), prot_access)
-                .map_err(|_| MsrError::InvalidAccess)?;
-        } else if !siefp.enabled() {
-            shared.siefp_page.unmap(prot_access);
-        }
+        shared
+            .siefp_page
+            .sync(siefp.enabled(), siefp.base_gpn(), prot_access)
+            .map_err(|_| MsrError::InvalidAccess)?;
         self.sints.siefp = siefp;
         Ok(())
     }
@@ -369,16 +363,10 @@ impl ProcessorSynic {
     ) -> Result<(), MsrError> {
         let simp = HvSynicSimpSiefp::from(v);
         tracing::debug!(?simp, "setting simp");
-        if simp.enabled()
-            && (!self.sints.simp.enabled() || simp.base_gpn() != self.sints.simp.base_gpn())
-        {
-            self.sints
-                .simp_page
-                .remap(simp.base_gpn(), prot_access)
-                .map_err(|_| MsrError::InvalidAccess)?;
-        } else if !simp.enabled() {
-            self.sints.simp_page.unmap(prot_access);
-        }
+        self.sints
+            .simp_page
+            .sync(simp.enabled(), simp.base_gpn(), prot_access)
+            .map_err(|_| MsrError::InvalidAccess)?;
         self.sints.simp = simp;
         Ok(())
     }

--- a/vmm_core/virt/src/x86/vp.rs
+++ b/vmm_core/virt/src/x86/vp.rs
@@ -11,6 +11,7 @@ use crate::state::StateElement;
 use crate::state::state_trait;
 use hvdef::HV_MESSAGE_SIZE;
 use hvdef::HvInternalActivityRegister;
+use hvdef::HvMessage;
 use hvdef::HvRegisterValue;
 use hvdef::HvX64InterruptStateRegister;
 use hvdef::HvX64PendingEventReg0;
@@ -1862,12 +1863,31 @@ impl StateElement<X86PartitionCapabilities, X86VpInfo> for SynicMessageQueues {
     }
 }
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Protobuf, Inspect)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Protobuf)]
 #[mesh(package = "virt.x86")]
-#[inspect(skip)]
 pub struct SynicMessagePage {
     #[mesh(1)]
     pub data: [u8; 4096],
+}
+
+impl Inspect for SynicMessagePage {
+    fn inspect(&self, req: inspect::Request<'_>) {
+        let mut resp = req.respond();
+        let mut occupied = 0u16;
+        for (sint, slot) in self
+            .data
+            .as_chunks::<HV_MESSAGE_SIZE>()
+            .0
+            .iter()
+            .enumerate()
+        {
+            let msg: HvMessage = zerocopy::transmute!(*slot);
+            if msg.header.typ != hvdef::HvMessageType::HvMessageTypeNone {
+                occupied |= 1 << sint;
+            }
+        }
+        resp.binary("occupied_bitmap", occupied);
+    }
 }
 
 impl StateElement<X86PartitionCapabilities, X86VpInfo> for SynicMessagePage {

--- a/vmm_core/virt_kvm/src/arch/x86_64/mod.rs
+++ b/vmm_core/virt_kvm/src/arch/x86_64/mod.rs
@@ -21,6 +21,7 @@ use guestmem::DoorbellRegistration;
 use guestmem::GuestMemory;
 use guestmem::GuestMemoryError;
 use hv1_emulator::message_queues::MessageQueues;
+use hv1_emulator::pages::OverlayPage;
 use hvdef::HV_PAGE_SIZE;
 use hvdef::HvError;
 use hvdef::HvMessage;
@@ -801,6 +802,8 @@ impl virt::BindProcessor for KvmProcessorBinder {
             scontrol: HvSynicScontrol::new().with_enabled(true),
             siefp: 0.into(),
             simp: 0.into(),
+            simp_overlay: OverlayPage::default(),
+            siefp_overlay: OverlayPage::default(),
             vmtime: &mut self.vmtime,
         };
 
@@ -847,6 +850,10 @@ pub struct KvmProcessor<'a> {
     siefp: HvSynicSimpSiefp,
     #[inspect(hex, with = "|&x| u64::from(x)")]
     simp: HvSynicSimpSiefp,
+    /// Overlay backing the synic message page (SIMP).
+    simp_overlay: OverlayPage,
+    /// Overlay backing the synic event flags page (SIEFP).
+    siefp_overlay: OverlayPage,
 }
 
 impl KvmProcessor<'_> {
@@ -915,6 +922,57 @@ impl KvmProcessor<'_> {
         self.partition.gm.write_at(simp + 4, &msg.as_bytes()[4..])?;
         self.partition.gm.write_plain(simp, &msg.header.typ)?;
         Ok(true)
+    }
+}
+
+/// Maps, moves, or unmaps a synic overlay page (SIMP or SIEFP) to match `reg`.
+///
+/// KVM (with `KVM_CAP_HYPERV_SYNIC2`) keeps the live page in guest RAM and does
+/// not zero it when the guest enables the overlay. But the overlay is logically
+/// separate from guest RAM: it is zeroed once and thereafter follows the
+/// overlay. Routing through [`OverlayPage`] preserves that, so a freshly enabled
+/// page is zeroed rather than exposing stale guest data that the in-kernel synic
+/// would treat as an occupied message slot and refuse to deliver into.
+fn sync_synic_overlay(overlay: &mut OverlayPage, reg: HvSynicSimpSiefp, gm: &GuestMemory) {
+    let mut prot = KvmNoVtlProtections(gm);
+    let mapped_gpn = match overlay {
+        OverlayPage::Mapped(page) => Some(page.gpn),
+        OverlayPage::Local(_) => None,
+    };
+    if reg.enabled() {
+        if mapped_gpn != Some(reg.base_gpn()) {
+            if let Err(err) = overlay.remap(reg.base_gpn(), &mut prot) {
+                tracelimit::warn_ratelimited!(
+                    error = &err as &dyn std::error::Error,
+                    gpn = reg.base_gpn(),
+                    "failed to map synic overlay page"
+                );
+            }
+        }
+    } else if mapped_gpn.is_some() {
+        overlay.unmap(&mut prot);
+    }
+}
+
+/// A no-op [`VtlProtectAccess`] implementation for use without VTL protections,
+/// as is the case for KVM. Locking a page simply pins it in guest memory;
+/// unlocking is a no-op.
+struct KvmNoVtlProtections<'a>(&'a GuestMemory);
+
+impl hv1_emulator::VtlProtectAccess for KvmNoVtlProtections<'_> {
+    fn check_modify_and_lock_overlay_page(
+        &mut self,
+        gpn: u64,
+        _check_perms: hvdef::HvMapGpaFlags,
+        _new_perms: Option<hvdef::HvMapGpaFlags>,
+    ) -> Result<guestmem::LockedPages, HvError> {
+        self.0
+            .lock_gpns(false, &[gpn])
+            .map_err(|_| HvError::OperationDenied)
+    }
+
+    fn unlock_overlay_page(&mut self, _gpn: u64) -> Result<(), HvError> {
+        Ok(())
     }
 }
 
@@ -1260,9 +1318,9 @@ impl hv1_hypercall::SignalEvent for KvmHypercallExit<'_> {
     }
 }
 
-impl Processor for KvmProcessor<'_> {
+impl<'p> Processor for KvmProcessor<'p> {
     type StateAccess<'a>
-        = KvmVpStateAccess<'a>
+        = KvmVpStateAccess<'a, 'p>
     where
         Self: 'a;
 
@@ -1270,7 +1328,7 @@ impl Processor for KvmProcessor<'_> {
         &mut self,
         _vtl: Vtl,
         state: Option<&virt::x86::DebugState>,
-    ) -> Result<(), <KvmVpStateAccess<'_> as AccessVpState>::Error> {
+    ) -> Result<(), <KvmVpStateAccess<'_, '_> as AccessVpState>::Error> {
         let mut control = 0;
         let mut db = [0; 4];
         let mut dr7 = 0;
@@ -1406,6 +1464,16 @@ impl Processor for KvmProcessor<'_> {
                         siefp,
                         simp,
                     } => {
+                        // Bring the overlay pages into agreement with the new
+                        // SIMP/SIEFP values the guest just programmed. The
+                        // overlays are owned by this processor; the save/restore
+                        // path reaches them through the bound processor.
+                        sync_synic_overlay(&mut self.simp_overlay, simp.into(), &self.partition.gm);
+                        sync_synic_overlay(
+                            &mut self.siefp_overlay,
+                            siefp.into(),
+                            &self.partition.gm,
+                        );
                         self.scontrol = control.into();
                         self.siefp = siefp.into();
                         self.simp = simp.into();
@@ -1476,14 +1544,13 @@ impl Processor for KvmProcessor<'_> {
     fn flush_async_requests(&mut self) {}
 
     fn reset(&mut self) -> Result<(), impl std::error::Error + Send + Sync + 'static> {
-        self.partition
-            .vp_state_access(self.vpindex)
-            .reset_all(&self.inner.vp_info)
+        let vp_info = self.inner.vp_info;
+        self.access_state(Vtl::Vtl0).reset_all(&vp_info)
     }
 
     fn access_state(&mut self, vtl: Vtl) -> Self::StateAccess<'_> {
         assert_eq!(vtl, Vtl::Vtl0);
-        self.partition.vp_state_access(self.vpindex)
+        KvmVpStateAccess::new(self)
     }
 }
 

--- a/vmm_core/virt_kvm/src/arch/x86_64/mod.rs
+++ b/vmm_core/virt_kvm/src/arch/x86_64/mod.rs
@@ -935,22 +935,12 @@ impl KvmProcessor<'_> {
 /// would treat as an occupied message slot and refuse to deliver into.
 fn sync_synic_overlay(overlay: &mut OverlayPage, reg: HvSynicSimpSiefp, gm: &GuestMemory) {
     let mut prot = KvmNoVtlProtections(gm);
-    let mapped_gpn = match overlay {
-        OverlayPage::Mapped(page) => Some(page.gpn),
-        OverlayPage::Local(_) => None,
-    };
-    if reg.enabled() {
-        if mapped_gpn != Some(reg.base_gpn()) {
-            if let Err(err) = overlay.remap(reg.base_gpn(), &mut prot) {
-                tracelimit::warn_ratelimited!(
-                    error = &err as &dyn std::error::Error,
-                    gpn = reg.base_gpn(),
-                    "failed to map synic overlay page"
-                );
-            }
-        }
-    } else if mapped_gpn.is_some() {
-        overlay.unmap(&mut prot);
+    if let Err(err) = overlay.sync(reg.enabled(), reg.base_gpn(), &mut prot) {
+        tracelimit::warn_ratelimited!(
+            error = &err as &dyn std::error::Error,
+            gpn = reg.base_gpn(),
+            "failed to map synic overlay page"
+        );
     }
 }
 

--- a/vmm_core/virt_kvm/src/arch/x86_64/vm_state.rs
+++ b/vmm_core/virt_kvm/src/arch/x86_64/vm_state.rs
@@ -20,16 +20,14 @@ impl AccessVmState for &'_ KvmPartition {
     }
 
     fn hypercall(&mut self) -> Result<vm::HypercallMsrs, Self::Error> {
-        self.inner
-            .vp_state_access(VpIndex::BSP)
-            .get_register_state()
+        super::vp_state::get_msrs_state(&self.inner.vp_kvm(VpIndex::BSP))
     }
 
     fn set_hypercall(&mut self, value: &vm::HypercallMsrs) -> Result<(), Self::Error> {
         // Work around a KVM bug that prevents setting the hypercall value when
         // the guest OS ID is not set.
         assert_eq!(value.names().len(), 2);
-        self.inner.vp_state_access(VpIndex::BSP).kvm().set_msrs(&[
+        self.inner.vp_kvm(VpIndex::BSP).set_msrs(&[
             (hvdef::HV_X64_MSR_GUEST_OS_ID, 1),
             (hvdef::HV_X64_MSR_HYPERCALL, value.hypercall),
             (hvdef::HV_X64_MSR_GUEST_OS_ID, value.guest_os_id),
@@ -38,9 +36,7 @@ impl AccessVmState for &'_ KvmPartition {
     }
 
     fn reftime(&mut self) -> Result<vm::ReferenceTime, Self::Error> {
-        self.inner
-            .vp_state_access(VpIndex::BSP)
-            .get_register_state()
+        super::vp_state::get_msrs_state(&self.inner.vp_kvm(VpIndex::BSP))
     }
 
     fn set_reftime(&mut self, _value: &vm::ReferenceTime) -> Result<(), Self::Error> {
@@ -50,14 +46,10 @@ impl AccessVmState for &'_ KvmPartition {
     }
 
     fn reference_tsc_page(&mut self) -> Result<vm::ReferenceTscPage, Self::Error> {
-        self.inner
-            .vp_state_access(VpIndex::BSP)
-            .get_register_state()
+        super::vp_state::get_msrs_state(&self.inner.vp_kvm(VpIndex::BSP))
     }
 
     fn set_reference_tsc_page(&mut self, value: &vm::ReferenceTscPage) -> Result<(), Self::Error> {
-        self.inner
-            .vp_state_access(VpIndex::BSP)
-            .set_register_state(value)
+        super::vp_state::set_msrs_state(&self.inner.vp_kvm(VpIndex::BSP), value)
     }
 }

--- a/vmm_core/virt_kvm/src/arch/x86_64/vp_state.rs
+++ b/vmm_core/virt_kvm/src/arch/x86_64/vp_state.rs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+use super::KvmProcessor;
 use super::regs::register_to_msr;
 use crate::KvmError;
 use crate::KvmPartitionInner;
@@ -12,58 +13,85 @@ use virt::x86::SegmentRegister;
 use virt::x86::TableRegister;
 use virt::x86::vp;
 use virt::x86::vp::AccessVpState;
-use vm_topology::processor::x86::X86VpInfo;
 use x86defs::SegmentAttributes;
 use zerocopy::FromZeros;
 
-pub struct KvmVpStateAccess<'a> {
-    partition: &'a KvmPartitionInner,
-    vp_info: X86VpInfo,
+/// Per-VP state access for a bound [`KvmProcessor`].
+///
+/// This borrows the processor mutably so that synic save/restore can read and
+/// re-establish the SIMP/SIEFP overlay pages (and the processor's tracked synic
+/// register state) through the very same `OverlayPage` instances the run loop
+/// maintains.
+pub struct KvmVpStateAccess<'a, 'b> {
+    vp: &'a mut KvmProcessor<'b>,
+}
+
+impl<'a, 'b> KvmVpStateAccess<'a, 'b> {
+    pub(crate) fn new(vp: &'a mut KvmProcessor<'b>) -> Self {
+        Self { vp }
+    }
 }
 
 impl KvmPartitionInner {
-    #[track_caller]
-    pub fn vp_state_access(&self, vp_index: VpIndex) -> KvmVpStateAccess<'_> {
-        KvmVpStateAccess {
-            partition: self,
-            vp_info: self.vp(vp_index).unwrap().vp_info,
-        }
+    /// Returns a KVM vcpu handle for the given VP, for partition-level register
+    /// access that does not require a bound [`KvmProcessor`].
+    pub(crate) fn vp_kvm(&self, vp_index: VpIndex) -> kvm::Processor<'_> {
+        self.kvm.vp(self.vp(vp_index).unwrap().vp_info.apic_id)
     }
 }
 
-impl KvmVpStateAccess<'_> {
+/// Reads MSR-backed register state from a KVM vcpu.
+pub(crate) fn get_msrs_state<T, const N: usize>(kvm: &kvm::Processor<'_>) -> Result<T, KvmError>
+where
+    T: HvRegisterState<HvX64RegisterName, N>,
+{
+    let mut msrs = T::default();
+    let names = msrs.names().map(|name| register_to_msr(name).unwrap());
+    let mut values = [0; N];
+    kvm.get_msrs(&names, &mut values)?;
+    msrs.set_values(values.into_iter().map(|v| v.into()));
+    Ok(msrs)
+}
+
+/// Writes MSR-backed register state to a KVM vcpu.
+pub(crate) fn set_msrs_state<T, const N: usize>(
+    kvm: &kvm::Processor<'_>,
+    value: &T,
+) -> Result<(), KvmError>
+where
+    T: HvRegisterState<HvX64RegisterName, N>,
+{
+    let mut values = [HvRegisterValue::new_zeroed(); N];
+    value.get_values(values.iter_mut());
+
+    let msrs: Vec<_> = value
+        .names()
+        .map(|name| register_to_msr(name).unwrap())
+        .into_iter()
+        .zip(values.map(|v| v.as_u64()))
+        .collect();
+
+    kvm.set_msrs(&msrs)?;
+    Ok(())
+}
+
+impl KvmVpStateAccess<'_, '_> {
     pub(crate) fn kvm(&self) -> kvm::Processor<'_> {
-        self.partition.kvm.vp(self.vp_info.apic_id)
+        self.vp.partition.kvm.vp(self.vp.inner.vp_info.apic_id)
     }
 
-    pub(crate) fn set_register_state<T, const N: usize>(&self, value: &T) -> Result<(), KvmError>
+    fn set_register_state<T, const N: usize>(&self, value: &T) -> Result<(), KvmError>
     where
         T: HvRegisterState<HvX64RegisterName, N>,
     {
-        let mut values = [HvRegisterValue::new_zeroed(); N];
-        value.get_values(values.iter_mut());
-
-        let msrs: Vec<_> = value
-            .names()
-            .map(|name| register_to_msr(name).unwrap())
-            .into_iter()
-            .zip(values.map(|v| v.as_u64()))
-            .collect();
-
-        self.kvm().set_msrs(&msrs)?;
-        Ok(())
+        set_msrs_state(&self.kvm(), value)
     }
 
-    pub(crate) fn get_register_state<T, const N: usize>(&self) -> Result<T, KvmError>
+    fn get_register_state<T, const N: usize>(&self) -> Result<T, KvmError>
     where
         T: HvRegisterState<HvX64RegisterName, N>,
     {
-        let mut msrs = T::default();
-        let names = msrs.names().map(|name| register_to_msr(name).unwrap());
-        let mut values = [0; N];
-        self.kvm().get_msrs(&names, &mut values)?;
-        msrs.set_values(values.into_iter().map(|v| v.into()));
-        Ok(msrs)
+        get_msrs_state(&self.kvm())
     }
 }
 
@@ -121,11 +149,11 @@ fn table_reg_from_kvm(reg: kvm::kvm_dtable) -> TableRegister {
     }
 }
 
-impl AccessVpState for KvmVpStateAccess<'_> {
+impl AccessVpState for KvmVpStateAccess<'_, '_> {
     type Error = KvmError;
 
     fn caps(&self) -> &virt::PartitionCapabilities {
-        &self.partition.caps
+        &self.vp.partition.caps
     }
 
     fn commit(&mut self) -> Result<(), Self::Error> {
@@ -363,12 +391,12 @@ impl AccessVpState for KvmVpStateAccess<'_> {
     fn xsave(&mut self) -> Result<vp::Xsave, Self::Error> {
         let mut data = [0; 4096];
         self.kvm().get_xsave(&mut data)?;
-        Ok(vp::Xsave::from_standard(&data, &self.partition.caps))
+        Ok(vp::Xsave::from_standard(&data, &self.vp.partition.caps))
     }
 
     fn set_xsave(&mut self, value: &vp::Xsave) -> Result<(), Self::Error> {
         let mut data = [0; 4096];
-        value.write_standard(&mut data, &self.partition.caps);
+        value.write_standard(&mut data, &self.vp.partition.caps);
         self.kvm().set_xsave(&data)?;
         Ok(())
     }
@@ -506,42 +534,59 @@ impl AccessVpState for KvmVpStateAccess<'_> {
     }
 
     fn set_synic_msrs(&mut self, value: &vp::SyntheticMsrs) -> Result<(), Self::Error> {
-        self.set_register_state(value)
+        self.set_register_state(value)?;
+
+        // Mirror the restored synic MSRs into the processor's tracked state and
+        // overlay pages. Runs before set_synic_{message,event_flags}_page (per
+        // the state_trait! ordering) so those writes land in the right backing.
+        let scontrol = hvdef::HvSynicScontrol::from(value.scontrol);
+        let simp = hvdef::HvSynicSimpSiefp::from(value.simp);
+        let siefp = hvdef::HvSynicSimpSiefp::from(value.siefp);
+        let partition = self.vp.partition;
+        super::sync_synic_overlay(&mut self.vp.simp_overlay, simp, &partition.gm);
+        super::sync_synic_overlay(&mut self.vp.siefp_overlay, siefp, &partition.gm);
+        self.vp.scontrol = scontrol;
+        self.vp.simp = simp;
+        self.vp.siefp = siefp;
+        *self.vp.inner.siefp.write() = if scontrol.enabled() { siefp } else { 0.into() };
+        Ok(())
     }
 
     fn synic_message_page(&mut self) -> Result<vp::SynicMessagePage, Self::Error> {
-        // TODO
-        Ok(vp::SynicMessagePage { data: [0; 4096] })
+        let data = self.vp.simp_overlay.save_page();
+        Ok(vp::SynicMessagePage { data })
     }
 
-    fn set_synic_message_page(&mut self, _value: &vp::SynicMessagePage) -> Result<(), Self::Error> {
-        // TODO
+    fn set_synic_message_page(&mut self, value: &vp::SynicMessagePage) -> Result<(), Self::Error> {
+        // set_synic_msrs has already synced the overlay to the restored SIMP
+        // MSR, so this lands the contents in the right backing.
+        self.vp.simp_overlay.restore_page(&value.data);
         Ok(())
     }
 
     fn synic_event_flags_page(&mut self) -> Result<vp::SynicEventFlagsPage, Self::Error> {
-        // TODO
-        Ok(vp::SynicEventFlagsPage { data: [0; 4096] })
+        let data = self.vp.siefp_overlay.save_page();
+        Ok(vp::SynicEventFlagsPage { data })
     }
 
     fn set_synic_event_flags_page(
         &mut self,
-        _value: &vp::SynicEventFlagsPage,
+        value: &vp::SynicEventFlagsPage,
     ) -> Result<(), Self::Error> {
-        // TODO
+        // See set_synic_message_page.
+        self.vp.siefp_overlay.restore_page(&value.data);
         Ok(())
     }
 
     fn synic_message_queues(&mut self) -> Result<vp::SynicMessageQueues, Self::Error> {
-        // TODO
-        Ok(Default::default())
+        Ok(self.vp.inner.synic_message_queue.save())
     }
 
     fn set_synic_message_queues(
         &mut self,
-        _value: &vp::SynicMessageQueues,
+        value: &vp::SynicMessageQueues,
     ) -> Result<(), Self::Error> {
-        // TODO
+        self.vp.inner.synic_message_queue.restore(value);
         Ok(())
     }
 


### PR DESCRIPTION
KVM's in-kernel synic (KVM_CAP_HYPERV_SYNIC2) places the SIMP and SIEFP pages directly in guest RAM at the GPA the guest programs, and does not zero them when the guest enables the overlay. We were relying on whatever happened to be in guest memory at that GPA being usable as the page contents. That is wrong: the hypervisor contract is that an overlay page is logically separate from guest RAM -- zeroed once when first enabled, and thereafter following the overlay as it is mapped or moved. When the guest enables the overlay over a page containing stale data, the in-kernel synic interprets a non-zero message type as a pending (occupied) message slot and refuses to deliver into it, wedging message delivery.

This models the SIMP and SIEFP pages with hv1_emulator's OverlayPage, which owns the logical page contents and copies them across map/move/unmap transitions to match hypervisor semantics -- so a freshly enabled page is zeroed rather than exposing whatever the guest left behind. A single helper drives those transitions whenever the guest reprograms the registers, so the overlay always reflects the programmed state.

Having a faithful model of the overlay contents also lets save/restore work properly, which was previously stubbed out: the message and event flags pages are now read from and written to the overlays rather than re-derived from raw guest RAM, and the synic message queues (which OpenVMM owns) are snapshotted through the existing MessageQueues API. Reaching the overlays from the state path required KvmVpStateAccess to borrow the bound KvmProcessor; the few VM-scoped MSR accesses with no bound processor moved to standalone helpers.

SynicMessagePage also gets a custom Inspect that surfaces a bitmap of occupied SINT message slots instead of the raw 4096 bytes, making a stuck message easy to spot.