### PR TITLE
Nested Hyper-V vmbus under OpenVMM on KVM: the working solution

### DIFF
--- a/POC-NESTED/.gitignore
+++ b/POC-NESTED/.gitignore
@@ -1,0 +1,7 @@
+*.o
+*.ko
+*.mod
+*.mod.c
+.tmp_versions/
+Module.symvers
+modules.order

--- a/POC-NESTED/.ignore
+++ b/POC-NESTED/.ignore
@@ -1,0 +1,5 @@
+# hvpost_hook.c is a GPL-2.0 Linux kernel module: it links GPL-only kernel
+# symbols and so must stay GPL. It keeps its SPDX GPL header and is excluded
+# from the repo's MIT copyright-header lint rather than being mislabeled MIT.
+# this is only the POC which needs to go in a polished version upstream to the Linux Kernel
+kvm_hook/hvpost_hook.c

--- a/POC-NESTED/README.md
+++ b/POC-NESTED/README.md
@@ -1,0 +1,168 @@
+# Nested Hyper-V vmbus relay
+
+A stock, unmodified Hyper-V/VBS-enabled Windows 11 guest boots to the desktop under
+OpenVMM on the KVM backend, including the root partition's own vmbus (storvsc boot disk
+and netvsp). Without the relay it bugchecks `0x7B INACCESSIBLE_BOOT_DEVICE` about 80s into
+boot.
+
+The Windows kernel runs as hvix64's root partition, i.e. an L2 guest (guest kernel ->
+hvix64 L1 -> KVM L0). Its vmbus hypercalls (`HvPostMessage` 0x5c, `HvSignalEvent` 0x5d)
+are VMCALLs that exit to L0/KVM before hvix64 sees them, and its synic is L0-visible. So
+**KVM keeps those posts in L0 and hands them to OpenVMM's vmbus server; hvix64 is unpatched
+and the guest is unmodified.** `nested_synic_writeup_jstarks.md` is the full design write-up
+and the request to help upstream the KVM change; this README is the reproduction recipe.
+
+No guest patch, no test-signing, Secure Boot stays on. An earlier PoC needed a 2-byte
+`vmbus.sys` patch; the OpenVMM enlightenment set in this branch (notably granting the synic
+APIC MSRs and advertising reference-TSC / reenlightenment / enlightened-VMCS when nesting)
+makes the stock signed driver register its synic interrupt and post `InitiateContact` on
+its own, so the guest patch is gone.
+
+## Two relay forms
+
+The relay (keep the L2 root's `0x5c`/`0x5d` posts in L0 instead of reflecting them to
+hvix64) is a small KVM change. Two forms ship here:
+
+1. **Production: a per-VM capability, `KVM_CAP_NESTED_VMBUS_RELAY`.** OpenVMM enables it on
+   its own VM when nesting; KVM checks a per-`struct kvm` flag in
+   `nested_vmx_reflect_vmexit`, gated on the L1's per-L2 nested-hypercall authorization (the
+   same enlightened-VMCS gate, `nested_evmcs_l2_tlb_flush_enabled()`, KVM already trusts for
+   the L2 TLB-flush hypercall). Scoped by construction, no ftrace, no pid arming. The kernel
+   side lives in `kvm_cap/` (patch + build script) and as full trees at:
+   * mainline: https://github.com/bitranox/linux-nested-vmbus-relay (branch `nested-vmbus-relay`)
+   * Proxmox VE kernel: https://github.com/bitranox/pve-nested-vmbus-relay
+2. **PoC: an ftrace hook**, `kvm_hook/hvpost_hook.c`. It overrides
+   `nested_vmx_reflect_vmexit` from a loadable module, default-off, armed by writing the
+   target VM's vCPU-worker pid to `relay_pid`. Use it to try the relay without rebuilding
+   KVM. Scoped to one VM at a time.
+
+## Contents
+
+```
+POC-NESTED/
+├── README.md                         this file
+├── nested_synic_writeup_jstarks.md   the design write-up + upstreaming request
+├── kvm_cap/                          production per-VM capability (recommended)
+│   ├── kvm_patch_apply_cap.sh        patch a kernel source tree + build/install the KVM modules
+│   ├── kvm-nested-vmbus-relay-linux.patch   unified diff vs mainline (kvm-x86/next)
+│   └── kvm-nested-vmbus-relay-pve.patch     unified diff vs a Proxmox VE 7.0.x kernel
+└── kvm_hook/                         the ftrace PoC (no kernel rebuild)
+    ├── hvpost_hook.c
+    └── Makefile
+```
+
+## OpenVMM side (already in this branch)
+
+The nested-virt source changes are applied here: the `virt_kvm` partition-privilege block
+that grants the synic enlightenments when nesting (`vmm_core/virt_kvm/src/arch/x86_64/mod.rs`),
+the enlightened-VMCS capability (`vm/kvm/src/lib.rs`), and the `HvFeatures` bits
+(`vm/hv1/hvdef/src/lib.rs`). Build and deploy as usual:
+
+```bash
+cargo build --release -p openvmm
+strip target/release/openvmm
+# deploy the binary to the host that runs the guest
+```
+
+Launch the guest with `--hypervisor kvm:nested_virt`. The PoC hook path works with this
+branch as-is. The per-VM cap path additionally needs OpenVMM to enable the capability on the
+VM (a `KVM_ENABLE_CAP(KVM_CAP_NESTED_VMBUS_RELAY)` call when `nested_virt` is set); that
+one-line integration is the production counterpart to the kernel patch in `kvm_cap/`.
+
+## Patching the kernel for the per-VM cap (production)
+
+The relay touches five files: the cap number in `include/uapi/linux/kvm.h`, a `bool` in
+`struct kvm_arch`, the `KVM_ENABLE_CAP` case in `arch/x86/kvm/x86.c`, the relay branch in
+`arch/x86/kvm/vmx/nested.c`, and the L2->L1 input-GPA translation in `arch/x86/kvm/hyperv.c`.
+
+### Option A: the build script (Proxmox VE, or any distro kernel)
+
+`kvm_cap/kvm_patch_apply_cap.sh` applies the change by anchored text edits (so it survives
+point-release drift) and rebuilds only the KVM modules (`kvm.ko`, `kvm-intel.ko`). It does
+not rebuild the whole kernel.
+
+```bash
+# build deps (Debian/Ubuntu/Proxmox):
+sudo apt install build-essential bc flex bison libelf-dev libssl-dev dwarves libdw-dev
+
+# point it at a kernel source tree that matches the running kernel, then run as root:
+sudo KVM_RELAY_SRC=/path/to/linux-source kvm_cap/kvm_patch_apply_cap.sh
+```
+
+Getting the matching source: for the Proxmox kernel, clone `proxmox-kernel.git` and run
+`make submodule` (it fetches the Ubuntu kernel base); the script header has the details.
+For a mainline build, use the matching kernel tree.
+
+### Option B: apply the patch to a kernel you build yourself
+
+```bash
+cd linux                                                   # your kernel source tree
+patch -p1 < kvm_cap/kvm-nested-vmbus-relay-linux.patch     # mainline (kvm-x86/next)
+# or, for a Proxmox VE 7.0.x kernel source tree:
+patch -p1 < kvm_cap/kvm-nested-vmbus-relay-pve.patch
+# then build and install the KVM modules, or the whole kernel, as you normally would
+```
+
+The cap number `0x4f564d52` is an out-of-tree private sentinel; an upstream merge would take
+an assigned `KVM_CAP_*` value.
+
+### Loading the rebuilt modules
+
+The modules are in use while VMs run, so either reboot, or hot-swap with all VMs stopped:
+
+```bash
+sudo rmmod kvm_intel kvm && sudo modprobe kvm_intel        # pulls in the rebuilt kvm.ko
+```
+
+Verify the rebuilt module is the loaded one with `modinfo -F filename kvm-intel`. No module
+parameter and no kernel command line change is needed: OpenVMM enables the cap per-VM.
+
+## The ftrace PoC (no kernel rebuild)
+
+If you want to try the relay without touching the kernel build, use `kvm_hook/`. The struct
+offsets in `hvpost_hook.c` are kernel-version-specific.
+
+```bash
+# build deps: matching kernel headers + gcc/flex/bison/libelf-dev/libssl-dev/bc/dwarves
+cd kvm_hook && make                                        # builds hvpost_hook.ko
+sudo insmod hvpost_hook.ko                                 # loads DEFAULT-OFF (relay_pid=0)
+```
+
+Arm it at launch by pointing `relay_pid` at the guest's vCPU-running worker. OpenVMM is
+multi-process: the main `openvmm-kvm` process (which writes `--pidfile`) spawns an
+`openvmm-vm` worker that runs the vCPUs. Set `relay_pid` before the kernel posts (~2-3s
+after launch, right after ExitBootServices):
+
+```bash
+for i in $(seq 1 120); do
+  MP=$(cat <pidfile> 2>/dev/null)
+  [ -n "$MP" ] && RP=$(pgrep -P "$MP" -x openvmm-vm | head -1)
+  [ -n "$RP" ] && { echo "$RP" | sudo tee /sys/module/hvpost_hook/parameters/relay_pid; break; }
+  sleep 0.1
+done
+```
+
+`rmmod hvpost_hook` removes it cleanly. If your kernel differs, re-derive the two offsets in
+`hvpost_hook.c` with `pahole kvm_vcpu` / `pahole -C vcpu_vmx` against the running kernel's BTF.
+
+## Verify
+
+- The OpenVMM log shows a **second** `Guest negotiated version` after `Vmbus disconnected`
+  (the L2 kernel's `InitiateContact` via the relay), then storvsc sub-channels and netvsp.
+- The screen goes `0x7B` (without the relay) to the boot logo to the Windows 11 desktop.
+- With the PoC hook, `dmesg | grep "caught HvPostMessage"` shows it firing during boot. With
+  the per-VM cap there is no host-side log; the second negotiation and the desktop are the
+  signal.
+
+Beyond boot, the guest's hvix64 has been validated running real workloads under OpenVMM/KVM:
+a bare child VM (`New-VM`/`Start-VM`), and Hyper-V-isolated Windows containers (each its own
+utility VM under hvix64), with host-filesystem isolation intact. See the write-up's
+"Validation" section.
+
+## Scoping
+
+`nested_vmx_reflect_vmexit` runs only for nested (L2) guests. The per-VM cap relays only for
+the VM whose `struct kvm` opted in, and only for an L2 the L1 authorized for direct nested
+hypercalls, so a grandchild guest of the root is never relayed and other VMs are untouched.
+The PoC hook relays only when `current->tgid == relay_pid`, and `relay_pid=0` (the default)
+intercepts nothing.

--- a/POC-NESTED/kvm_cap/kvm-nested-vmbus-relay-linux.patch
+++ b/POC-NESTED/kvm_cap/kvm-nested-vmbus-relay-linux.patch
@@ -1,0 +1,108 @@
+diff --git a/arch/x86/include/asm/kvm_host.h b/arch/x86/include/asm/kvm_host.h
+index 3886b536c8a5..e101ca8112b3 100644
+--- a/arch/x86/include/asm/kvm_host.h
++++ b/arch/x86/include/asm/kvm_host.h
+@@ -1435,6 +1435,8 @@ enum kvm_mmu_type {
+ };
+ 
+ struct kvm_arch {
++	/* provmm: nested-Hyper-V vmbus relay opted in via KVM_CAP_NESTED_VMBUS_RELAY */
++	bool nested_vmbus_relay;
+ 	unsigned long n_used_mmu_pages;
+ 	unsigned long n_requested_mmu_pages;
+ 	unsigned long n_max_mmu_pages;
+diff --git a/arch/x86/kvm/hyperv.c b/arch/x86/kvm/hyperv.c
+index fd4eb1e561f7..a351ab0a43ad 100644
+--- a/arch/x86/kvm/hyperv.c
++++ b/arch/x86/kvm/hyperv.c
+@@ -2591,6 +2591,26 @@ int kvm_hv_hypercall(struct kvm_vcpu *vcpu)
+ 		kvm_hv_hypercall_read_xmm(&hc);
+ 	}
+ 
++	/*
++	 * provmm nested-vmbus relay: a relayed L2 synic post (HvPostMessage /
++	 * HvSignalEvent from a nested Hyper-V root) running on nested EPT carries
++	 * an L2 GPA in ingpa. Translate it to an L1 GPA like the L2 TLB-flush slow
++	 * path, gating on mmu_is_nested(): translate_nested_gpa() BUG_ON()s without
++	 * it, and with shadow paging the L2 GPA is already an L1 GPA so no
++	 * translation is needed. The walk also rejects pages removed from the L2
++	 * root's GPA space (INVALID_GPA). Done synchronously in the faulting
++	 * vCPU's exit context and never cached.
++	 */
++	if (!hc.fast && mmu_is_nested(vcpu) &&
++	    (hc.code == HVCALL_POST_MESSAGE || hc.code == HVCALL_SIGNAL_EVENT)) {
++		hc.ingpa = kvm_x86_ops.nested_ops->translate_nested_gpa(
++				vcpu, hc.ingpa, PFERR_GUEST_FINAL_MASK, NULL, 0);
++		if (unlikely(hc.ingpa == INVALID_GPA)) {
++			ret = HV_STATUS_INVALID_HYPERCALL_INPUT;
++			goto hypercall_complete;
++		}
++	}
++
+ 	switch (hc.code) {
+ 	case HVCALL_NOTIFY_LONG_SPIN_WAIT:
+ 		if (unlikely(hc.rep || hc.var_cnt)) {
+diff --git a/arch/x86/kvm/vmx/nested.c b/arch/x86/kvm/vmx/nested.c
+index b2c851cc7d5c..54878d7b7a7c 100644
+--- a/arch/x86/kvm/vmx/nested.c
++++ b/arch/x86/kvm/vmx/nested.c
+@@ -6728,6 +6728,30 @@ bool nested_vmx_reflect_vmexit(struct kvm_vcpu *vcpu)
+ 
+ 	trace_kvm_nested_vmexit(vcpu, KVM_ISA_VMX);
+ 
++	/*
++	 * provmm nested-Hyper-V vmbus relay (per-VM, KVM_CAP_NESTED_VMBUS_RELAY).
++	 * A Hyper-V root running as an L2 guest posts HvPostMessage (RCX low16
++	 * 0x5c) / HvSignalEvent (0x5d) as VMCALLs with the Hyper-V nested bit
++	 * (RCX bit 31). Only relay when L1 authorized this L2 for direct nested
++	 * hypercalls, the same eVMCS gate (nested_flush_hypercall plus the
++	 * VP-assist directhypercall feature) KVM already trusts for the L2
++	 * TLB-flush hypercall, so an L2 that L1 did not authorize (a grandchild
++	 * guest of the root) is never relayed and keeps its own L1 synic. Keep
++	 * the post in L0 for the opted-in VM (clear the nested bit so KVM's
++	 * hypercall path accepts the call) instead of reflecting to L1.
++	 */
++	if (vcpu->kvm->arch.nested_vmbus_relay &&
++	    exit_reason.basic == EXIT_REASON_VMCALL &&
++	    nested_evmcs_l2_tlb_flush_enabled(vcpu)) {
++		unsigned long code = kvm_rcx_read(vcpu);
++
++		if (((code & 0xffff) == 0x5c || (code & 0xffff) == 0x5d) &&
++		    (code & (1ULL << 31))) {
++			kvm_rcx_write(vcpu, code & ~(1ULL << 31));
++			return false;
++		}
++	}
++
+ 	/* If L0 (KVM) wants the exit, it trumps L1's desires. */
+ 	if (nested_vmx_l0_wants_exit(vcpu, exit_reason))
+ 		return false;
+diff --git a/arch/x86/kvm/x86.c b/arch/x86/kvm/x86.c
+index cf122b8c3210..d0b4155a2d3f 100644
+--- a/arch/x86/kvm/x86.c
++++ b/arch/x86/kvm/x86.c
+@@ -6730,6 +6730,11 @@ int kvm_vm_ioctl_enable_cap(struct kvm *kvm,
+ 		return -EINVAL;
+ 
+ 	switch (cap->cap) {
++	case KVM_CAP_NESTED_VMBUS_RELAY:
++		/* provmm: keep this VM's L2 Hyper-V root vmbus posts in L0 */
++		kvm->arch.nested_vmbus_relay = true;
++		r = 0;
++		break;
+ 	case KVM_CAP_DISABLE_QUIRKS2:
+ 		r = -EINVAL;
+ 		if (cap->args[0] & ~kvm_caps.supported_quirks)
+diff --git a/include/uapi/linux/kvm.h b/include/uapi/linux/kvm.h
+index 6c8afa2047bf..178096d26642 100644
+--- a/include/uapi/linux/kvm.h
++++ b/include/uapi/linux/kvm.h
+@@ -869,6 +869,8 @@ struct kvm_enable_cap {
+ #define KVM_CAP_GUEST_DEBUG_HW_BPS 119
+ #define KVM_CAP_GUEST_DEBUG_HW_WPS 120
+ #define KVM_CAP_SPLIT_IRQCHIP 121
++/* provmm out-of-tree: nested-Hyper-V vmbus relay (per-VM cap). Private sentinel, must match openvmm vm/kvm. */
++#define KVM_CAP_NESTED_VMBUS_RELAY 0x4f564d52
+ #define KVM_CAP_IOEVENTFD_ANY_LENGTH 122
+ #define KVM_CAP_HYPERV_SYNIC 123
+ #define KVM_CAP_S390_RI 124

--- a/POC-NESTED/kvm_cap/kvm-nested-vmbus-relay-pve.patch
+++ b/POC-NESTED/kvm_cap/kvm-nested-vmbus-relay-pve.patch
@@ -1,0 +1,103 @@
+diff --git a/include/uapi/linux/kvm.h b/include/uapi/linux/kvm.h
+--- a/include/uapi/linux/kvm.h
++++ b/include/uapi/linux/kvm.h
+@@ -864,6 +864,8 @@
+ #define KVM_CAP_GUEST_DEBUG_HW_BPS 119
+ #define KVM_CAP_GUEST_DEBUG_HW_WPS 120
+ #define KVM_CAP_SPLIT_IRQCHIP 121
++/* provmm out-of-tree: nested-Hyper-V vmbus relay (per-VM cap). Private sentinel, must match openvmm vm/kvm. */
++#define KVM_CAP_NESTED_VMBUS_RELAY 0x4f564d52
+ #define KVM_CAP_IOEVENTFD_ANY_LENGTH 122
+ #define KVM_CAP_HYPERV_SYNIC 123
+ #define KVM_CAP_S390_RI 124
+diff --git a/arch/x86/include/asm/kvm_host.h b/arch/x86/include/asm/kvm_host.h
+--- a/arch/x86/include/asm/kvm_host.h
++++ b/arch/x86/include/asm/kvm_host.h
+@@ -1412,6 +1412,8 @@
+ };
+ 
+ struct kvm_arch {
++	/* provmm: nested-Hyper-V vmbus relay opted in via KVM_CAP_NESTED_VMBUS_RELAY */
++	bool nested_vmbus_relay;
+ 	unsigned long n_used_mmu_pages;
+ 	unsigned long n_requested_mmu_pages;
+ 	unsigned long n_max_mmu_pages;
+diff --git a/arch/x86/kvm/x86.c b/arch/x86/kvm/x86.c
+--- a/arch/x86/kvm/x86.c
++++ b/arch/x86/kvm/x86.c
+@@ -6743,6 +6743,11 @@
+ 		return -EINVAL;
+ 
+ 	switch (cap->cap) {
++	case KVM_CAP_NESTED_VMBUS_RELAY:
++		/* provmm: keep this VM's L2 Hyper-V root vmbus posts in L0 */
++		kvm->arch.nested_vmbus_relay = true;
++		r = 0;
++		break;
+ 	case KVM_CAP_DISABLE_QUIRKS2:
+ 		r = -EINVAL;
+ 		if (cap->args[0] & ~kvm_caps.supported_quirks)
+diff --git a/arch/x86/kvm/vmx/nested.c b/arch/x86/kvm/vmx/nested.c
+--- a/arch/x86/kvm/vmx/nested.c
++++ b/arch/x86/kvm/vmx/nested.c
+@@ -6709,6 +6709,30 @@
+ 
+ 	trace_kvm_nested_vmexit(vcpu, KVM_ISA_VMX);
+ 
++	/*
++	 * provmm nested-Hyper-V vmbus relay (per-VM, KVM_CAP_NESTED_VMBUS_RELAY).
++	 * A Hyper-V root running as an L2 guest posts HvPostMessage (RCX low16
++	 * 0x5c) / HvSignalEvent (0x5d) as VMCALLs with the Hyper-V nested bit
++	 * (RCX bit 31). Only relay when L1 authorized this L2 for direct nested
++	 * hypercalls, the same eVMCS gate (nested_flush_hypercall plus the
++	 * VP-assist directhypercall feature) KVM already trusts for the L2
++	 * TLB-flush hypercall, so an L2 that L1 did not authorize (a grandchild
++	 * guest of the root) is never relayed and keeps its own L1 synic. Keep
++	 * the post in L0 for the opted-in VM (clear the nested bit so KVM's
++	 * hypercall path accepts the call) instead of reflecting to L1.
++	 */
++	if (vcpu->kvm->arch.nested_vmbus_relay &&
++	    exit_reason.basic == EXIT_REASON_VMCALL &&
++	    nested_evmcs_l2_tlb_flush_enabled(vcpu)) {
++		unsigned long code = kvm_rcx_read(vcpu);
++
++		if (((code & 0xffff) == 0x5c || (code & 0xffff) == 0x5d) &&
++		    (code & (1ULL << 31))) {
++			kvm_rcx_write(vcpu, code & ~(1ULL << 31));
++			return false;
++		}
++	}
++
+ 	/* If L0 (KVM) wants the exit, it trumps L1's desires. */
+ 	if (nested_vmx_l0_wants_exit(vcpu, exit_reason))
+ 		return false;
+diff --git a/arch/x86/kvm/hyperv.c b/arch/x86/kvm/hyperv.c
+--- a/arch/x86/kvm/hyperv.c
++++ b/arch/x86/kvm/hyperv.c
+@@ -2589,6 +2589,26 @@
+ 		kvm_hv_hypercall_read_xmm(&hc);
+ 	}
+ 
++	/*
++	 * provmm nested-vmbus relay: a relayed L2 synic post (HvPostMessage /
++	 * HvSignalEvent from a nested Hyper-V root) running on nested EPT carries
++	 * an L2 GPA in ingpa. Translate it to an L1 GPA like the L2 TLB-flush slow
++	 * path, gating on mmu_is_nested(): translate_nested_gpa() BUG_ON()s without
++	 * it, and with shadow paging the L2 GPA is already an L1 GPA so no
++	 * translation is needed. The walk also rejects pages removed from the L2
++	 * root's GPA space (INVALID_GPA). Done synchronously in the faulting
++	 * vCPU's exit context and never cached.
++	 */
++	if (!hc.fast && mmu_is_nested(vcpu) &&
++	    (hc.code == HVCALL_POST_MESSAGE || hc.code == HVCALL_SIGNAL_EVENT)) {
++		hc.ingpa = kvm_x86_ops.nested_ops->translate_nested_gpa(
++				vcpu, hc.ingpa, PFERR_GUEST_FINAL_MASK, NULL, 0);
++		if (unlikely(hc.ingpa == INVALID_GPA)) {
++			ret = HV_STATUS_INVALID_HYPERCALL_INPUT;
++			goto hypercall_complete;
++		}
++	}
++
+ 	switch (hc.code) {
+ 	case HVCALL_NOTIFY_LONG_SPIN_WAIT:
+ 		if (unlikely(hc.rep || hc.var_cnt)) {

--- a/POC-NESTED/kvm_cap/kvm_patch_apply_cap.sh
+++ b/POC-NESTED/kvm_cap/kvm_patch_apply_cap.sh
@@ -1,0 +1,231 @@
+#!/bin/bash
+#
+# kvm_patch_apply_cap.sh
+#
+# Per-VM-capability form of the nested-vmbus relay (the production form).
+#
+# Unlike the global kvm_intel.nested_vmbus_relay module parameter
+# (kvm_patch_apply.sh), this adds a per-VM KVM capability,
+# KVM_CAP_NESTED_VMBUS_RELAY (0x4f564d52, "OVMR", a private out-of-tree number),
+# that openvmm enables on its own kvm fd when nested virt is on. Only the VM
+# that opts in takes the relay branch in nested_vmx_reflect_vmexit; every other
+# guest (nested or not) is untouched, and multiple nested-vmbus guests coexist.
+# It pairs with the openvmm change Partition::enable_nested_vmbus_relay()
+# (vm/kvm) called from the virt_kvm nested_virt path.
+#
+# It rebuilds the KVM modules (kvm.ko + kvm-intel.ko). No Windows guest patch.
+#
+# The edits are applied by anchored text insertion (not a context diff), so they
+# survive minor source drift across kernel point releases. Five files change:
+#   include/uapi/linux/kvm.h          + #define KVM_CAP_NESTED_VMBUS_RELAY
+#   arch/x86/include/asm/kvm_host.h   + bool nested_vmbus_relay in struct kvm_arch
+#   arch/x86/kvm/x86.c                + KVM_ENABLE_CAP case sets the per-VM flag
+#   arch/x86/kvm/vmx/nested.c         + the relay branch in nested_vmx_reflect_vmexit,
+#                                       gated on nested_evmcs_l2_tlb_flush_enabled()
+#                                       (L1's per-L2 nested-hypercall authorization)
+#   arch/x86/kvm/hyperv.c             + translate the relayed synic post's input GPA
+#                                       L2->L1 (HvPostMessage / HvSignalEvent)
+#
+# Getting the source: proxmox's apt repos publish NO source index, so
+# `apt-get source` does not work for the proxmox kernel. Obtain the matching
+# source tree via the proxmox-kernel git (heavy: it fetches the Ubuntu kernel
+# base) and point this script at it with KVM_RELAY_SRC=/path/to/linux-source,
+# or drop the extracted tree under $WORK. See the README.
+#
+set -euo pipefail
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+KREL="$(uname -r)"                              # e.g. 7.0.2-7-pve
+WORK="${KVM_RELAY_WORK:-/usr/src/kvm-nested-relay}"
+JOBS="$(nproc)"
+CAP_HEX="0x4f564d52"
+
+[ "$(id -u)" = 0 ] || { echo "error: run as root" >&2; exit 1; }
+[ -f "/boot/config-${KREL}" ] || { echo "error: /boot/config-${KREL} missing" >&2; exit 1; }
+command -v make >/dev/null || { echo "error: install build-essential bc flex bison libelf-dev libssl-dev dwarves" >&2; exit 1; }
+
+echo "== running kernel: ${KREL} =="
+MARKER="/var/lib/kvm-nested-relay/cap-applied-${KREL}"
+if [ -e "$MARKER" ] && [ "${FORCE:-0}" != 1 ]; then
+    echo "== already built for ${KREL} (${MARKER}); FORCE=1 to redo =="; exit 0
+fi
+
+# --- locate the kernel source tree ----------------------------------------- #
+find_src() { find "${1:-$WORK}" -maxdepth 7 -path '*/arch/x86/kvm/vmx/nested.c' -printf '%h\n' 2>/dev/null \
+             | sed 's,/arch/x86/kvm/vmx,,' | head -1 || true; }
+SRC=""
+if [ -n "${KVM_RELAY_SRC:-}" ]; then SRC="$(find_src "$KVM_RELAY_SRC")"; fi
+if [ -z "$SRC" ]; then SRC="$(find_src "$WORK")"; fi
+if [ -z "$SRC" ]; then
+    mkdir -p "$WORK"; cd "$WORK"
+    echo "== no source tree found; trying apt-get source (usually unavailable on proxmox) =="
+    apt-get source "proxmox-kernel-${KREL}" 2>/dev/null || true
+    SRC="$(find_src "$WORK")"
+fi
+[ -n "$SRC" ] && [ -d "$SRC" ] || {
+    cat >&2 <<EOF
+error: kernel source tree not found.
+  proxmox publishes no apt source index, so 'apt-get source' does not work here.
+  Obtain the matching source and re-run with KVM_RELAY_SRC pointing at its root:
+
+    git clone --depth 1 https://git.proxmox.com/git/proxmox-kernel.git
+    cd proxmox-kernel && make submodule    # fetches the Ubuntu kernel base
+    # the extracted Linux tree appears under submodules/ubuntu-kernel (or build/)
+    KVM_RELAY_SRC=\$PWD/submodules/ubuntu-kernel $0
+EOF
+    exit 1
+}
+echo "== source tree: ${SRC} =="
+
+# --- anchored, idempotent edits --------------------------------------------- #
+python3 - "$SRC" "$CAP_HEX" <<'PY'
+import sys, io, re, os
+src, cap = sys.argv[1], sys.argv[2]
+def edit(path, fn):
+    p = os.path.join(src, path)
+    with io.open(p, encoding="utf-8") as f: t = f.read()
+    nt = fn(t)
+    if nt is None:
+        print("  unchanged (already applied): %s" % path); return
+    with io.open(p, "w", encoding="utf-8") as f: f.write(nt)
+    print("  edited: %s" % path)
+
+def kvm_h(t):
+    if "KVM_CAP_NESTED_VMBUS_RELAY" in t: return None
+    m = re.search(r'^#define KVM_CAP_SPLIT_IRQCHIP .*$', t, re.M)
+    if not m: raise SystemExit("kvm.h: KVM_CAP_SPLIT_IRQCHIP anchor not found")
+    ins = ("\n/* provmm out-of-tree: nested-Hyper-V vmbus relay (per-VM cap). "
+           "Private sentinel, must match openvmm vm/kvm. */\n"
+           "#define KVM_CAP_NESTED_VMBUS_RELAY %s" % cap)
+    return t[:m.end()] + ins + t[m.end():]
+
+def kvm_host_h(t):
+    if "nested_vmbus_relay" in t: return None
+    m = re.search(r'^struct kvm_arch \{\n', t, re.M)
+    if not m: raise SystemExit("kvm_host.h: struct kvm_arch anchor not found")
+    ins = ("\t/* provmm: nested-Hyper-V vmbus relay opted in via "
+           "KVM_CAP_NESTED_VMBUS_RELAY */\n\tbool nested_vmbus_relay;\n")
+    return t[:m.end()] + ins + t[m.end():]
+
+def x86_c(t):
+    if "KVM_CAP_NESTED_VMBUS_RELAY" in t: return None
+    f = t.find("kvm_vm_ioctl_enable_cap(struct kvm *kvm")
+    if f < 0: raise SystemExit("x86.c: kvm_vm_ioctl_enable_cap not found")
+    s = t.find("switch (cap->cap) {", f)
+    if s < 0: raise SystemExit("x86.c: switch in enable_cap not found")
+    nl = t.find("\n", s) + 1
+    case = ("\tcase KVM_CAP_NESTED_VMBUS_RELAY:\n"
+            "\t\t/* provmm: keep this VM's L2 Hyper-V root vmbus posts in L0 */\n"
+            "\t\tkvm->arch.nested_vmbus_relay = true;\n"
+            "\t\tr = 0;\n"
+            "\t\tbreak;\n")
+    return t[:nl] + case + t[nl:]
+
+def nested_c(t):
+    if "nested_vmbus_relay" in t: return None
+    anchor = "trace_kvm_nested_vmexit(vcpu, KVM_ISA_VMX);"
+    i = t.find(anchor)
+    if i < 0: raise SystemExit("nested.c: trace_kvm_nested_vmexit anchor not found")
+    nl = t.find("\n", i) + 1
+    blk = (
+"\n"
+"\t/*\n"
+"\t * provmm nested-Hyper-V vmbus relay (per-VM, KVM_CAP_NESTED_VMBUS_RELAY).\n"
+"\t * A Hyper-V root running as an L2 guest posts HvPostMessage (RCX low16\n"
+"\t * 0x5c) / HvSignalEvent (0x5d) as VMCALLs with the Hyper-V nested bit\n"
+"\t * (RCX bit 31). Only relay when L1 authorized this L2 for direct nested\n"
+"\t * hypercalls, the same eVMCS gate (nested_flush_hypercall plus the\n"
+"\t * VP-assist directhypercall feature) KVM already trusts for the L2\n"
+"\t * TLB-flush hypercall, so an L2 that L1 did not authorize (a grandchild\n"
+"\t * guest of the root) is never relayed and keeps its own L1 synic. Keep\n"
+"\t * the post in L0 for the opted-in VM (clear the nested bit so KVM's\n"
+"\t * hypercall path accepts the call) instead of reflecting to L1.\n"
+"\t */\n"
+"\tif (vcpu->kvm->arch.nested_vmbus_relay &&\n"
+"\t    exit_reason.basic == EXIT_REASON_VMCALL &&\n"
+"\t    nested_evmcs_l2_tlb_flush_enabled(vcpu)) {\n"
+"\t\tunsigned long code = kvm_rcx_read(vcpu);\n"
+"\n"
+"\t\tif (((code & 0xffff) == 0x5c || (code & 0xffff) == 0x5d) &&\n"
+"\t\t    (code & (1ULL << 31))) {\n"
+"\t\t\tkvm_rcx_write(vcpu, code & ~(1ULL << 31));\n"
+"\t\t\treturn false;\n"
+"\t\t}\n"
+"\t}\n")
+    return t[:nl] + blk + t[nl:]
+
+def hyperv_c(t):
+    # Translate a relayed L2 synic post's input GPA (L2->L1) before the in-kernel
+    # read / userspace post, mirroring the L2 TLB-flush slow path. The walk also
+    # filters pages removed from the L2 root's GPA space (returns INVALID_GPA).
+    if "nested-vmbus relay: a relayed L2 synic post" in t: return None
+    anchor = ("\t\tkvm_hv_hypercall_read_xmm(&hc);\n"
+              "\t}\n"
+              "\n"
+              "\tswitch (hc.code) {\n")
+    if anchor not in t:
+        raise SystemExit("hyperv.c: kvm_hv_hypercall switch anchor not found")
+    blk = (
+"\t\tkvm_hv_hypercall_read_xmm(&hc);\n"
+"\t}\n"
+"\n"
+"\t/*\n"
+"\t * provmm nested-vmbus relay: a relayed L2 synic post (HvPostMessage /\n"
+"\t * HvSignalEvent from a nested Hyper-V root) running on nested EPT carries\n"
+"\t * an L2 GPA in ingpa. Translate it to an L1 GPA like the L2 TLB-flush slow\n"
+"\t * path, gating on mmu_is_nested(): translate_nested_gpa() BUG_ON()s without\n"
+"\t * it, and with shadow paging the L2 GPA is already an L1 GPA so no\n"
+"\t * translation is needed. The walk also rejects pages removed from the L2\n"
+"\t * root's GPA space (INVALID_GPA). Done synchronously in the faulting\n"
+"\t * vCPU's exit context and never cached.\n"
+"\t */\n"
+"\tif (!hc.fast && mmu_is_nested(vcpu) &&\n"
+"\t    (hc.code == HVCALL_POST_MESSAGE || hc.code == HVCALL_SIGNAL_EVENT)) {\n"
+"\t\thc.ingpa = kvm_x86_ops.nested_ops->translate_nested_gpa(\n"
+"\t\t\t\tvcpu, hc.ingpa, PFERR_GUEST_FINAL_MASK, NULL, 0);\n"
+"\t\tif (unlikely(hc.ingpa == INVALID_GPA)) {\n"
+"\t\t\tret = HV_STATUS_INVALID_HYPERCALL_INPUT;\n"
+"\t\t\tgoto hypercall_complete;\n"
+"\t\t}\n"
+"\t}\n"
+"\n"
+"\tswitch (hc.code) {\n")
+    return t.replace(anchor, blk, 1)
+
+edit("include/uapi/linux/kvm.h", kvm_h)
+edit("arch/x86/include/asm/kvm_host.h", kvm_host_h)
+edit("arch/x86/kvm/x86.c", x86_c)
+edit("arch/x86/kvm/vmx/nested.c", nested_c)
+edit("arch/x86/kvm/hyperv.c", hyperv_c)
+print("edits done")
+PY
+
+# --- configure to the running kernel and build only the KVM modules --------- #
+cd "$SRC"
+cp -f "/boot/config-${KREL}" .config
+[ -f "/usr/src/linux-headers-${KREL}/Module.symvers" ] && cp -f "/usr/src/linux-headers-${KREL}/Module.symvers" Module.symvers || true
+make olddefconfig
+make modules_prepare
+echo "== building kvm + kvm-intel =="
+make -j"$JOBS" M=arch/x86/kvm
+
+DEST="/lib/modules/${KREL}/kernel/arch/x86/kvm"
+mkdir -p "$DEST"
+for ko in kvm.ko kvm-intel.ko; do
+    [ -f "arch/x86/kvm/${ko}" ] && cp -v "arch/x86/kvm/${ko}" "${DEST}/${ko}"
+done
+depmod -a
+mkdir -p "$(dirname "$MARKER")" && : > "$MARKER"
+
+cat <<EOF
+
+== done ==
+Patched kvm + kvm-intel (per-VM cap) installed for ${KREL}.
+Activate (modules are in use while VMs run):
+  - stop all VMs, then:  rmmod kvm_intel kvm && modprobe kvm_intel
+  - or reboot.
+No module parameter and no kernel cmdline change are needed: openvmm enables the
+cap per-VM when nested virt is on. Deploy the matching openvmm build (with
+Partition::enable_nested_vmbus_relay) and boot a nested guest. NO Windows patch,
+NO ftrace hvpost_hook, NO relay_pid.
+EOF

--- a/POC-NESTED/kvm_hook/Makefile
+++ b/POC-NESTED/kvm_hook/Makefile
@@ -1,0 +1,6 @@
+obj-m += hvpost_hook.o
+KDIR ?= /lib/modules/$(shell uname -r)/build
+all:
+	$(MAKE) -C $(KDIR) M=$(PWD) modules
+clean:
+	$(MAKE) -C $(KDIR) M=$(PWD) clean

--- a/POC-NESTED/kvm_hook/hvpost_hook.c
+++ b/POC-NESTED/kvm_hook/hvpost_hook.c
@@ -1,0 +1,172 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * hvpost_hook: force KVM (L0) to handle the nested L2 guest's
+ * HvPostMessage(conn 1) VMCALL instead of reflecting it to L1 (hvix64).
+ *
+ * Mechanism: ftrace hook (FL_SAVE_REGS | FL_IPMODIFY) on
+ * nested_vmx_reflect_vmexit(struct kvm_vcpu *vcpu) in kvm_intel.
+ * When the current L2 exit is VMCALL (basic exit reason 18) AND the
+ * guest RCX low 16 bits == 0x5c (HvPostMessage call code), we make the
+ * function return false WITHOUT running its body, by:
+ *   - setting regs->ax = 0  (return value = false = "L0 handles it")
+ *   - redirecting regs->ip to a bare `ret` stub. At the __fentry__ hook
+ *     site the original `call nested_vmx_reflect_vmexit` return address
+ *     is on top of stack, so the stub's `ret` returns straight to the
+ *     caller (__vmx_handle_exit) with rax=0. This is the canonical x86
+ *     override-function-with-return pattern.
+ * For every other exit we do nothing and let the original body run.
+ *
+ * Verified offsets for kernel 7.0.2-7 x86_64 (version-specific, re-derive for yours):
+ *   RCX             = vcpu->arch.regs[VCPU_REGS_RCX=1]
+ *                   = off(arch)=304 + 1*8 = 312 (0x138)
+ *                     (pahole kvm_vcpu: arch @304; kvm_vcpu_arch: regs[] @0)
+ *   exit_reason.full= vcpu_vmx.vt(@6848) + vcpu_vt.exit_reason(@80) = 6928 (0x1B10)
+ *                     (confirmed in disasm: `mov 0x1b10(%rdi),%r12d`)
+ *                     vcpu_vmx.vcpu @0, so vmx ptr == vcpu ptr.
+ *   basic exit reason = low 16 bits of exit_reason.full
+ *   EXIT_REASON_VMCALL = 18
+ *   HvPostMessage call code = 0x5c (low 16 bits of guest RCX control word)
+ */
+#include <linux/module.h>
+#include <linux/kernel.h>
+#include <linux/ftrace.h>
+#include <linux/kprobes.h>
+#include <linux/ptrace.h>
+#include <linux/sched.h>
+#include <linux/pid.h>
+#include <linux/ratelimit.h>
+#include <linux/objtool.h>
+#include <asm/linkage.h>
+
+#define OFF_VCPU_RCX        0x138   /* vcpu->arch.regs[VCPU_REGS_RCX] */
+#define OFF_VMX_EXITREASON  0x1B10  /* vcpu_vmx.vt.exit_reason.full   */
+#define EXIT_REASON_VMCALL  18
+#define HV_POST_MESSAGE     0x5c
+#define HV_SIGNAL_EVENT     0x5d
+
+static unsigned long reflect_addr;
+static int relay_pid;
+module_param(relay_pid, int, 0644);
+MODULE_PARM_DESC(relay_pid, "Only relay for the VM whose owning userspace PID matches (0=off, intercept nothing)");
+
+/*
+ * Return stub the IP is redirected to. At the __fentry__ hook site the
+ * original `call nested_vmx_reflect_vmexit` return address is on top of
+ * stack, so a single return here pops it and returns to the caller. We set
+ * regs->ax beforehand, so this body only needs to return.
+ *
+ * Hand-written naked asm (not a C function) so there is NO __fentry__ call
+ * and NO frame setup at the entry we jump to: the very first byte is the
+ * return. It uses ASM_RET, which expands to `jmp __x86_return_thunk` under
+ * CONFIG_MITIGATION_RETHUNK, so it is mitigation-correct and objtool-clean.
+ * STACK_FRAME_NON_STANDARD tells objtool this is intentional.
+ */
+extern void just_return_stub(void);
+asm(
+	".pushsection .text\n"
+	".align 16\n"
+	".type just_return_stub, @function\n"
+	"just_return_stub:\n"
+	ASM_RET
+	".size just_return_stub, .-just_return_stub\n"
+	".popsection\n"
+);
+STACK_FRAME_NON_STANDARD(just_return_stub);
+
+/* resolve a non-exported symbol via kprobe (kallsyms_lookup_name is no
+ * longer exported on this kernel). */
+static unsigned long lookup_name(const char *name)
+{
+	struct kprobe kp = { .symbol_name = name };
+	unsigned long addr = 0;
+	if (register_kprobe(&kp) == 0) {
+		addr = (unsigned long)kp.addr;
+		unregister_kprobe(&kp);
+	}
+	return addr;
+}
+
+static void notrace hvpost_handler(unsigned long ip, unsigned long parent_ip,
+				   struct ftrace_ops *op, struct ftrace_regs *fregs)
+{
+	struct pt_regs *regs = arch_ftrace_get_regs(fregs);
+	unsigned long vcpu;
+	u32 exit_full;
+	u16 basic;
+	u64 rcx;
+
+	if (!regs)
+		return;                 /* SAVE_REGS not honored: do nothing */
+
+	vcpu = regs->di;                /* first arg = struct kvm_vcpu * */
+	if (!vcpu)
+		return;
+
+	exit_full = *(u32 *)(vcpu + OFF_VMX_EXITREASON);
+	basic = (u16)(exit_full & 0xffff);
+	if (basic != EXIT_REASON_VMCALL)
+		return;                 /* not a VMCALL exit: let original run */
+
+	rcx = *(u64 *)(vcpu + OFF_VCPU_RCX);
+	if ((rcx & 0xffff) != HV_POST_MESSAGE && (rcx & 0xffff) != HV_SIGNAL_EVENT)
+		return;                 /* not HvPostMessage: let original run */
+
+	/* Force "return false": L0 keeps the exit, does not reflect to L1. */
+	if (!relay_pid || current->tgid != relay_pid)
+		return;
+	*(u64 *)(vcpu + OFF_VCPU_RCX) = rcx & ~0x80000000ULL; /* strip nested bit(31) so KVM accepts the hypercall */
+	regs->ax = 0;
+	ftrace_regs_set_instruction_pointer(fregs, (unsigned long)just_return_stub);
+
+	{
+		static DEFINE_RATELIMIT_STATE(rs, HZ, 5);
+		if (__ratelimit(&rs))
+			pr_info("hvpost_hook: caught HvPostMessage VMCALL (rcx=0x%llx), forcing L0 handling\n",
+				rcx);
+	}
+}
+
+static struct ftrace_ops ops = {
+	.func  = hvpost_handler,
+	.flags = FTRACE_OPS_FL_SAVE_REGS | FTRACE_OPS_FL_IPMODIFY |
+		 FTRACE_OPS_FL_RECURSION,
+};
+
+static int __init hvpost_init(void)
+{
+	int ret;
+
+	reflect_addr = lookup_name("nested_vmx_reflect_vmexit");
+	if (!reflect_addr) {
+		pr_err("hvpost_hook: cannot resolve nested_vmx_reflect_vmexit\n");
+		return -ENOENT;
+	}
+	pr_info("hvpost_hook: nested_vmx_reflect_vmexit @ %px\n", (void *)reflect_addr);
+
+	ret = ftrace_set_filter_ip(&ops, reflect_addr, 0, 0);
+	if (ret) {
+		pr_err("hvpost_hook: ftrace_set_filter_ip failed: %d\n", ret);
+		return ret;
+	}
+	ret = register_ftrace_function(&ops);
+	if (ret) {
+		pr_err("hvpost_hook: register_ftrace_function failed: %d\n", ret);
+		ftrace_set_filter_ip(&ops, reflect_addr, 1, 0);
+		return ret;
+	}
+	pr_info("hvpost_hook: armed (VMCALL=%d, HvPostMessage=0x%x, RCX off=0x%x, exit off=0x%x)\n",
+		EXIT_REASON_VMCALL, HV_POST_MESSAGE, OFF_VCPU_RCX, OFF_VMX_EXITREASON);
+	return 0;
+}
+
+static void __exit hvpost_exit(void)
+{
+	unregister_ftrace_function(&ops);
+	ftrace_set_filter_ip(&ops, reflect_addr, 1, 0);
+	pr_info("hvpost_hook: unarmed\n");
+}
+
+module_init(hvpost_init);
+module_exit(hvpost_exit);
+MODULE_LICENSE("GPL");
+MODULE_DESCRIPTION("Force L0/KVM to handle nested L2 HvPostMessage VMCALL instead of reflecting to L1");

--- a/POC-NESTED/nested_synic_writeup_jstarks.md
+++ b/POC-NESTED/nested_synic_writeup_jstarks.md
@@ -1,0 +1,404 @@
+# Nested Hyper-V vmbus under OpenVMM on KVM: the working solution, the flags, the symbols, and the PR #3721 questions
+
+Status 2026-06-11/12: a **stock** Windows 11 guest with Hyper-V/VBS enabled boots
+to the desktop under OpenVMM on the KVM backend, with storvsc, netvsp and
+synthvid all working, **no Windows guest patch**, no test-signing, Secure Boot
+intact. The fix is entirely L0: OpenVMM advertises the capabilities, and KVM
+relays the L2 root partition's vmbus hypercalls to L0. This document records
+exactly which flags and KVM functions are involved and why, which Windows kernel
+symbols matter, the prerequisite that has to hold for the guest to connect, and
+how this maps onto the points raised in PR #3721.
+
+## Preamble: our solution, and why it is the right layering
+
+The layers:
+
+- **L0** = KVM plus OpenVMM (userspace VMM). OpenVMM presents a Hyper-V platform
+  (synic, the Hv#1 hypercall ABI, a vmbus server on connection id 1).
+- **L1** = hvix64, the guest's own hypervisor, launched when the guest enables
+  Hyper-V/VBS.
+- **L2** = the Windows kernel, running as hvix64's root partition.
+
+The root's vmbus control hypercalls, `HvPostMessage` (0x5c) and `HvSignalEvent`
+(0x5d), are issued as `VMCALL`s with the Hyper-V **nested bit** (RCX bit 31) set,
+which is the guest itself saying "forward this to the parent layer, not locally."
+Because L0 owns the outermost VMCS, that `VMCALL` exits to **KVM first**, before
+hvix64 handles it, and KVM by default reflects it up to hvix64. The kernel's
+synic (SIMP/SIEFP/SINT MSRs) is also visible to L0. **Our solution: KVM keeps the
+L2 root's nested-bit 0x5c/0x5d posts in L0 and hands them to OpenVMM's vmbus
+server (connection id 1), instead of reflecting them to hvix64; OpenVMM answers
+and delivers the reply into the kernel's L0-visible SIMP and raises its SINT.**
+
+A fair question is whether the L2 root should be talking to L1 instead of L0.
+
+On real Hyper-V the nested mechanism is documented in the TLFS, and it is not "L1
+forwards each message." L1 grants the privilege once: it sets
+`HV_NESTED_ENLIGHTENMENTS_CONTROL.HypercallControls.InterPartitionCommunication` in the
+L2 root's VP assist page, and the root learns it has that access through CPUID
+`0x40000009` (`AccessSynicRegs`, `AccessVpIndex`). The L2 root then talks to L0
+**directly**: it sets its synic up through the Nested SynIC MSRs
+(`HV_X64_MSR_NESTED_SCONTROL` / `SIMP` / `SINTx`, `0x40001080`-`0x4000109F`, which map
+straight to L0's synic) and issues its vmbus posts as nested hypercalls destined for L0.
+L0 is the synic and vmbus server; L1 is in the loop only for the one-time grant, never
+per message. So the "pure" design is L2-to-L0 with L1's one-time consent, not an
+L2 -> L1 -> L0 per-message relay.
+
+Under OpenVMM this path does not engage, and we do not pursue it. hvix64 never sets
+that grant for our partition: it decides from a launch-time classification that reads
+no parent CPUID/MSR/capability we can present (confirmed across our RE), and
+empirically the L2 root never touches the nested synic MSRs on our boots. We are not
+going to change hvix64, it is the guest's own closed hypervisor and we do not want to
+depend on a guest-side change, so the documented L1-grant route is simply not one we
+take.
+
+Our solution stays entirely in L0 and performs the L0 receiving side itself: the
+intercept keeps the L2 root's nested-bit `HvPostMessage`/`HvSignalEvent` in L0 (the
+destination the nested bit names) and answers from OpenVMM's vmbus server, bridging the
+reply into the root's L0-visible SIMP. It is a small KVM change, no guest patch, no
+hvix64 change. That is the design, not a stopgap.
+
+And critically, L0 is where the post actually needs to go anyway. hvix64 under
+OpenVMM provides the root no vmbus device backends: storvsc, netvsp and synthvid
+all live in OpenVMM (L0). So the root's vmbus has nothing useful to talk to at
+L1; its real vmbus server and devices are in L0. The nested bit asked for the
+parent (L0), and L0 is genuinely where the boot disk lives.
+
+So KVM catching the nested-bit post and handing it to OpenVMM is delivering it to
+the destination the guest requested, just skipping the L1-forwards-it step that
+hvix64 did not perform for our partition. It is not L0 reaching past L1 against the design, it is
+L0 fulfilling the role the nested bit names, because the intended courier (hvix64)
+will not and the intended destination (the vmbus server plus devices) is L0
+regardless.
+
+Empirically it is correct end to end: the stock guest boots to desktop, channels
+negotiate, and the reverse direction (reply into the root's L0-visible SIMP plus
+SINT) works. It is also the direction jstarks endorsed on the PR ("get KVM to do
+the right thing with the nested bit"). The more pure alternative (L1 relays) is the
+one we are still investigating.
+
+Short version: L2 still talks to L1 for everything L1 owns; the vmbus posts are
+explicitly tagged for the parent, and L0 is both what the tag means and where the
+devices are. Right path. Only the explicitly-parent-bound (nested-bit) 0x5c/0x5d
+posts are intercepted; every other hypercall still reflects to hvix64.
+
+## Validation: the nested hypervisor runs real workloads, not just boots
+
+Booting only proves the root partition's vmbus works. To confirm the guest's
+hvix64 is usable as a hypervisor under OpenVMM/KVM, we ran workloads that make
+hvix64 create and run its own child partitions (an L2 of hvix64, i.e. a grandchild
+of L0):
+
+- A bare child VM started with `New-VM` / `Start-VM` reaches `Running` and
+  accumulates uptime, so hvix64 allocates the child partition and KVM emulates its
+  VMX entry under OpenVMM. The relay's per-L2 authorization gate correctly does not
+  relay this grandchild; it keeps its own L1 synic to hvix64.
+- Hyper-V-isolated Windows containers run. `docker run --isolation=hyperv
+  mcr.microsoft.com/windows/nanoserver:ltsc2022` prints from inside the container
+  and reports kernel build 20348, distinct from the guest's own build 26200, so it
+  is its own utility VM under hvix64.
+- The guest sustains a production fleet: about a dozen Hyper-V-isolated Windows
+  containers (GitHub Actions self-hosted runners) run on it concurrently, each its
+  own utility VM under hvix64.
+
+Container isolation holds across the deep-nesting boundary: a container cannot see
+the guest's (L2 host) filesystem, confirmed with a host-only marker file that is
+not visible inside the container. Each container is a separate utility VM with its
+own kernel, so the boundaries are the ordinary Hyper-V-isolation ones, now stacked
+under OpenVMM.
+
+## Part 1: the OpenVMM flags, and why each is needed
+
+All live in the `nested_virt` block of
+`vmm_core/virt_kvm/src/arch/x86_64/mod.rs`. They do two jobs: (A) let hvix64
+**run** as the guest's hypervisor so the L2 root exists at all, and (B) grant the
+L2 root **permission** to issue the vmbus hypercalls the relay carries. Nothing
+here tries to make hvix64 forward anything; the relay is below hvix64.
+
+### CPUID 0x40000000 / 0x40000001 / 0x40000002
+
+- Vendor `Microsoft Hv`, interface `Hv#1`: the guest only treats the platform as
+  Hyper-V (loads vmbus.sys, runs hvix64) if these say so. Required.
+- A real-looking HV version (0x40000002) when nesting, not 0.0.0.0: a guest
+  hypervisor may gate nested behavior on the parent looking like a current,
+  capable Hyper-V. Cheap insurance; keep when nesting.
+
+### CPUID 0x40000003 partition privileges (job A: hvix64 must run)
+
+- `AccessPartitionReferenceTsc` + `AccessReenlightenmentControls`: hvix64 needs
+  the reference-TSC clock and the reenlightenment notification when nested, else
+  it resets the partition a fixed interval into boot.
+- `AccessHypercallMsrs`, `AccessVpIndex`, `AccessFrequencyMsrs`,
+  `AccessSynicMsrs`, `AccessSyntheticTimerMsrs`, `AccessVpRuntimeMsr`,
+  `AccessPartitionReferenceCounter`: the base HV enlightenment surface. SynicMsrs
+  + VpIndex are also what the kernel reads to bring up the synic the relay rides.
+- `AccessApicMsrs`: REQUIRED for the relay path. With it, vmbus.sys uses the synic
+  `HvPostMessage(conn 1)` path the relay catches. Withholding it pushes vmbus.sys
+  onto the GHCB/SNP tunnel, which needs isolated-partition shared memory hvix64
+  cannot back here (ends in a 0x7E memset of an unbacked page). Always on; the
+  non-nested path already required it.
+
+### CPUID 0x40000003 partition privileges (job B: let the root post)
+
+- `PostMessages` + `SignalEvents`: the privilege to issue the
+  `HvPostMessage`/`HvSignalEvent` the relay intercepts.
+- `CreatePort` + `ConnectPort`: vmbus channel setup.
+- Deliberately NOT granted: `AccessMemoryPool`, `CreatePartitions`,
+  `StartVirtualProcessor` (they push the root onto the isolated-partition path or
+  trip the guest HAL).
+
+### CPUID 0x40000004 enlightenment recommendations (job A)
+
+- `use_relaxed_timing`: slackens watchdog/spinlock deadlines because virtualized;
+  without it a nested guest blows bare-metal timeouts and resets mid-boot.
+- `use_apic_msrs`: pairs with the `AccessApicMsrs` privilege (the synic path).
+- `use_hypercall_for_remote_flush_and_local_flush_entire`,
+  `use_synthetic_cluster_ipi`, `use_ex_processor_masks`: let hvix64 offload TLB
+  flush and cluster IPI to the in-kernel hypercall path instead of a storm of
+  exits, so it stays fast enough not to time out.
+- `nested` + `use_vmcs_enlightenments`: recommend the enlightened-VMCS path so
+  hvix64 accesses the VMCS through the enlightened-VMCS page instead of trapping
+  every VMREAD/VMWRITE to L0. Without it: ~4.25M VMREAD + ~1.87M VMWRITE exits in
+  45s, storage times out, INACCESSIBLE_BOOT_DEVICE. Required, pairs with the KVM
+  cap below.
+- `deprecate_auto_eoi`, `long_spin_wait_count = 0xffffffff`: standard.
+
+### Dropped: `vp_ghcb_root_mapping` (0x40000003 ECX bit 10)
+
+Advertised earlier to make hvix64 engage its OWN nested-synic relay (its
+capability decode enables the nested-synic handlers when the bit is set). The
+KVM-side relay catches the root's posts below hvix64 and never uses hvix64's
+nested synic, so the bit is irrelevant. Dropped, and the nested guest still boots
+to desktop on the synic+relay path (validated).
+
+### KVM-crate / per-vCPU changes
+
+- `KVM_CAP_HYPERV_ENLIGHTENED_VMCS` per-vCPU (`enable_hyperv_evmcs` in `vm/kvm`):
+  the reboot-loop fix. Windows uses the enlightened VMCS; without the cap KVM did
+  not engage it at VM-enter (`current_vmptr == INVALID_GPA`), so hvix64 retried
+  the failing launch ~586K times then rebooted. Required.
+- `nested_state` get/set made a no-op for the KVM backend (`vp_state.rs`): with
+  nesting the `nested_state` element is "present" and the backend returned
+  `NotSupported`, aborting any guest-initiated reset and wedging the VM. Required.
+- NEW `KVM_CAP_NESTED_VMBUS_RELAY` per-VM (`Partition::enable_nested_vmbus_relay`,
+  called from the nested_virt path): opts this VM into the relay. Tolerant of a
+  stock kernel without the cap.
+
+## Part 2: the KVM functions
+
+- `nested_vmx_reflect_vmexit` (`arch/x86/kvm/vmx/nested.c`): the relay branch.
+  For a VM that set `kvm->arch.nested_vmbus_relay`, if the L2 exit is a `VMCALL`
+  and guest RCX low 16 bits are 0x5c/0x5d with the nested bit (RCX bit 31) set,
+  clear the nested bit and `return false` so KVM keeps the exit in L0 rather than
+  reflecting to L1.
+- `kvm_hv_hypercall` (`arch/x86/kvm/hyperv.c`): handles the kept-in-L0 call.
+  `HvPostMessage` exits to userspace (OpenVMM); `HvSignalEvent` is handled
+  in-kernel. The nested bit must be cleared first: it sits in
+  `HV_HYPERCALL_RSVD0_MASK`, and the dispatcher rejects reserved bits with
+  `HV_STATUS_INVALID_HYPERCALL_INPUT` before reaching the call's case.
+- `kvm_vm_ioctl_enable_cap` (`arch/x86/kvm/x86.c`) + `struct kvm_arch`
+  (`arch/x86/include/asm/kvm_host.h`) + the uapi define
+  (`include/uapi/linux/kvm.h`): add `KVM_CAP_NESTED_VMBUS_RELAY`, a per-VM
+  `bool nested_vmbus_relay`, and the enable-cap case that sets it. The PoC
+  equivalent is the `hvpost_hook` ftrace module on the same function.
+- Reverse direction: OpenVMM writes the InitiateContact reply into the kernel's
+  SIMP and signals the SINT. The kernel's synic pages are L0-visible (KVM sees
+  its SCONTROL/SIMP/SIEFP/SINT writes), so this is reachable without hvix64.
+
+## Part 3: the Windows kernel symbols, and the prerequisite for the check to pass
+
+Public PDBs: `ntkrnlmp.pdb`, `vmbus.pdb` (MS symbol server; extract the
+WOF-compressed System32 binaries with the ebiggers ntfs-3g system-compression
+plugin). RVAs below are from the build under test; re-resolve via the PDB on a
+different build.
+
+- `vmbus.sys!RootDevicePrepareHardwareChild`: always takes the enlightened path
+  (`vmbus.sys!IsInterruptEnlightenmentAvailable` is hardcoded `return 1` here) and
+  calls `ntoskrnl!HvlRegisterInterruptCallback(3, XPartEnlightenedIsr)`. If that
+  returns `< 0` it aborts the child-FDO bring-up (the `JNS` at RVA `0x2b849`) and
+  the boot disk never appears (0x7B).
+- `ntoskrnl!HvlRegisterInterruptCallback` (rva `0x57ffd0`): three returns:
+  `STATUS_INVALID_PARAMETER` if index > 4 (index 3 passes); `STATUS_NOT_SUPPORTED`
+  iff the global byte `ntoskrnl!HvlHypervisorConnected` (rva `0xFC6AD7`) is 0;
+  else it `lock cmpxchg`s the callback into `ntoskrnl!HvlpInterruptCallback`
+  (rva `0xFC5610`, slot = index), returns vector `index + 0x30`, or
+  `STATUS_UNSUCCESSFUL` if that slot was already taken.
+- `ntoskrnl!HvlPhase0Initialize`: sets `HvlHypervisorConnected = 1` right after
+  `HvlpSetupBootProcessorEarlyHypercallPages()` succeeds, i.e. once the kernel has
+  connected to its hypervisor.
+
+**The prerequisite for the check to pass:** `HvlHypervisorConnected == 1`. It is
+satisfied for free here, because the L2 root connects to hvix64 (which presents
+Hv#1 and the hypercall MSRs, rooted in what OpenVMM advertises). So
+`HvlRegisterInterruptCallback(3)` SUCCEEDS, with no enlightenment-bit tweak.
+Verified at runtime with the OpenVMM gdbstub: `HvlpInterruptCallback` slot 3
+holds a `vmbus.sys` handler (registration succeeded) and `HvlHypervisorConnected`
+reads 1. This is why the earlier "the SINT3 registration fails, patch vmbus.sys"
+conclusion is obsolete: with the current capabilities it does not fail.
+
+Other useful symbols: `vmbus.sys!ChpConnectToParent`, `vmbus.sys!PncSendMessage`,
+`vmbus.sys!XPartPncPostInterruptsEnabledChild`. Host-side observation:
+`kvm:kvm_hv_synic_set_msr`, `kvm:kvm_hv_hypercall`,
+`kprobe:nested_vmx_reflect_vmexit`, and in the OpenVMM log the second `Guest
+negotiated version` (the kernel's vmbus.sys connecting, vs the firmware's first),
+plus the `netvsp`/`storvsp` negotiation lines.
+
+## Part 4: the PR #3721 points
+
+Your framing, "get KVM to do the right thing with the nested bit; it's not enough
+to just pass it through to the VMM": agreed, and the production form is a per-VM
+`KVM_CAP_NESTED_VMBUS_RELAY` checked in `nested_vmx_reflect_vmexit`, not an
+unconditional pass-through. On your three specifics:
+
+1. **The L1-set "this L2 may make nested hypercalls" bit, set only on the L2 root,
+   not on L2 guests.** Done. KVM already carries this exact authorization: the
+   helper `nested_evmcs_l2_tlb_flush_enabled(vcpu)` checks the L2's enlightened
+   VMCS `hv_enlightenments_control.nested_flush_hypercall` bit AND the L1 VP-assist
+   page `nested_control.features.directhypercall` feature, and KVM trusts it to
+   decide whether an L2 VMCALL TLB-flush hypercall is handled in L0
+   (`nested_vmx_l0_wants_exit`, the `EXIT_REASON_VMCALL` case). The relay branch in
+   `nested_vmx_reflect_vmexit` now gates on that same predicate, so a grandchild
+   L2 that L1 did not authorize for direct nested hypercalls (`auth` false) is
+   never relayed and keeps its own L1 synic. Verified at the interception point on
+   our boot: every relayed `0x8000005c` / `0x8001005d` exit reads `evmcs=1 nfh=1
+   auth=1`, so the gate passes for the root and does not regress the boot.
+
+2. **Translate the input-page GPA L2 to L1 in KVM, and filter pages removed from
+   the L2 root's GPA space.** Done. `kvm_hv_hypercall` now translates the relayed
+   synic post's input GPA L2->L1 for `HVCALL_POST_MESSAGE` and the slow
+   `HVCALL_SIGNAL_EVENT`, gated on `!hc.fast && mmu_is_nested(vcpu)`, reusing
+   `kvm_x86_ops.nested_ops->translate_nested_gpa(..., PFERR_GUEST_FINAL_MASK, ...)`
+   exactly as the L2 TLB-flush slow path does. The guard is `mmu_is_nested()`, not
+   `is_guest_mode()`: `translate_nested_gpa()` opens with `BUG_ON(!mmu_is_nested())`,
+   and with shadow paging (no nested EPT) the L2 GPA is already an L1 GPA, so the
+   translation is both unsafe to call and unnecessary there. (Current `kvm-x86/next`
+   uses the same `mmu_is_nested()` guard on the TLB-flush path; older trees still say
+   `is_guest_mode()`.) A page removed from the L2 root's
+   GPA space faults in the walk and returns `INVALID_GPA`, which we reject with
+   `HV_STATUS_INVALID_HYPERCALL_INPUT` (the confidential-page filter comes for
+   free). Confirmed the L2 root is identity-mapped on our boot (storvsp issues
+   thousands of SCSI commands, all `srb_status: SUCCESS`, with OpenVMM reading the
+   root's memory by plain L1-GPA access), so the translation is a no-op here and
+   the guest still boots to desktop with it in place; it is correct in general.
+
+3. **Translation lifetime vs an enlightened stage-2 TLB invalidation.** Addressed
+   for the translation; one residual window is upstream's existing model. The
+   enlightened stage-2 flushes exist (`HvCallFlushGuestPhysicalAddressSpace` 0xAF,
+   `HvCallFlushGuestPhysicalAddressList` 0xB0, distinct from the stage-1 VA flushes
+   0x2/0x3); in our boots only the stage-1 flushes and cluster-IPI reached L0, so
+   0xAF/0xB0 is not a steady-state guarantee. The translate in (2) runs
+   synchronously in the faulting vCPU's exit context and is never cached: the
+   result lives only in the local `hc.ingpa` for that one exit. The slow
+   `HvSignalEvent` read happens in-kernel in the same exit, fully synchronous. The
+   one remaining window is `HvPostMessage`, whose payload KVM hands to userspace to
+   read after the exit, the same way it does for a non-nested post (this is KVM's
+   existing userspace-post design, not something the relay introduces). A concurrent
+   stage-2 flush serializes on the MMU lock against the actual page operation, and
+   the faulting vCPU cannot flush mid-hypercall, so the translated L1 GPA stays
+   valid for the read.
+
+### Open question: do we need the in-kernel `HvPostMessage` read at all?
+
+The "safe design" you sketched ends with "translate and read synchronously ...
+hand userspace the data." For `HvSignalEvent` we already do (KVM reads it in the
+exit). For `HvPostMessage`, KVM hands userspace the translated L1 GPA and the VMM
+reads the message after the exit, which is exactly what KVM does for a *non-nested*
+post today. Fully matching the sketch means KVM reads the up-to-240-byte payload
+in-kernel under the MMU lock and ships the bytes to userspace, which needs a new
+`struct kvm_hyperv_exit` field (the payload does not fit in `params[2]`) plus a
+matching VMM change. Before doing that, the question we want your read on:
+
+**Is the post-exit userspace read actually a risk here, or only a tidiness item?**
+Our analysis says it is not a security risk:
+
+* The address handed to userspace is an **L1 GPA**. It always resolves through the
+  guest's own memslots, so even a stale read stays inside the guest's own memory.
+  There is no path to host memory or another VM.
+* For the read to be stale, the L1 (hvix64) would have to remap the exact L1 page
+  backing an `HvPostMessage` it just issued, in the window before its own reply is
+  delivered. A guest does not pull the page out from under a synic message it is
+  waiting on; a malicious guest that did so would only corrupt **its own** post.
+* The VMM's vmbus server validates the message (connection id, length) and a bad
+  one is dropped or mis-routed *within the guest's own vmbus namespace*, with no
+  effect on the host or other guests.
+* This is identical to the non-nested `HvPostMessage` userspace exit that ships in
+  KVM today; the relay adds a benign extra translation layer, not a new risk class.
+
+So our position is that the synchronous, uncached translation is sufficient and the
+in-kernel read is a tidiness improvement, not a correctness or security fix. If you
+disagree, or if upstream would want the in-kernel read as a condition of merge, we
+will add it (KVM side plus the VMM consumer). Which way do you want it?
+
+Your other question, "why doesn't the ordinary vmbus init path work once you
+handle the nested bit, since it works on Hyper-V-on-Hyper-V": it does work now
+with the stock driver. The earlier failure was not the registration; it was the
+relay not carrying the post. With the relay in place and the current
+capabilities, `HvlRegisterInterruptCallback(3)` succeeds, vmbus.sys posts
+InitiateContact, KVM relays it, and OpenVMM's vmbus server answers.
+
+### Summary: solved / not solved / not an issue / can or cannot
+
+- **Solved:** a stock Hyper-V/VBS guest boots to desktop with no guest patch; the
+  L0 capability set; the relay mechanism; per-VM scoping via the KVM capability;
+  the L1 per-L2 nested-hypercall authorization gate (`nested_evmcs_l2_tlb_flush_enabled`,
+  so a grandchild is not relayed); the L2-to-L1 input-page translation inside KVM
+  for `HvPostMessage` / `HvSignalEvent` (with the removed-page filter); the
+  translation lifetime (synchronous, uncached in the exit context).
+- **Remaining follow-up (not a correctness gap for this design):** reading the
+  `HvPostMessage` payload in-kernel under the MMU lock and handing userspace the
+  bytes instead of the GPA, to close the userspace-read window that KVM's existing
+  (non-nested) post path already has. An OpenVMM/KVM ABI change, not needed here.
+- **Not an issue:** the L2-GPA translation for the boot path (identity map); the
+  assumption that hvix64 must forward the vmbus (it is bypassed, and L0 is the
+  correct destination anyway); the SINT3 registration "failing" (it succeeds with
+  the current capabilities); needing a Windows guest patch (none is needed).
+- **Cannot be done from L0:** nothing fundamental remains for this guest. The
+  earlier "needs hvix64 to support a non-Hyper-V parent, Microsoft-only"
+  conclusion was wrong: the relay does not need hvix64 at all. (The one thing that
+  genuinely cannot be done from L0 is making hvix64 itself forward the post, but
+  that path is unnecessary.)
+
+## Part 5: prerequisites to reproduce
+
+- Host: Intel VT-x with `kvm_intel nested=Y`; the relay loaded (the `hvpost_hook`
+  ftrace module as a PoC, or the in-tree per-VM `KVM_CAP_NESTED_VMBUS_RELAY` patch
+  for production).
+- OpenVMM: launched with `--hypervisor kvm:nested_virt`; the `nested_virt` flag
+  block above, advertised automatically when nesting.
+- Guest: a stock Hyper-V/VBS-enabled Windows 11 image with the usual Hyper-V
+  boot-start drivers (storvsc/vmbus/netvsc), the same image that runs non-nested.
+  No driver patch, no test-signing; Secure Boot on is fine.
+
+## Part 6: where the code lives, and a request
+
+The KVM change is published as two public repositories so you can read, build, and
+comment on it directly:
+
+| Repo                                                                                                 | What it is                                                                                                                               |
+|------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------|
+| [github.com/bitranox/linux-nested-vmbus-relay](https://github.com/bitranox/linux-nested-vmbus-relay) | A real fork of `kvm-x86/linux`, branch `nested-vmbus-relay`, a single commit on top of the latest `kvm-x86/next` (the mainline variant). |
+| [github.com/bitranox/pve-nested-vmbus-relay](https://github.com/bitranox/pve-nested-vmbus-relay)     | The Proxmox VE kernel variant (Proxmox's kernel is not on GitHub, so this is a patch + build script + this design doc, not a fork).      |
+
+The capability number `0x4f564d52` is an out-of-tree private sentinel; a real merge
+would take an assigned `KVM_CAP_*` value.
+
+**The request (low-priority, and conditional).** The L0 intercept above is our
+working, shipping solution; we are not blocked, and a stock Hyper-V/VBS guest boots
+and runs real workloads with it today. We are mainly putting the nested-vmbus problem
+and our approach on the record, and we are still actively working on better options,
+so this may not be our final approach. Getting the KVM change into the upstream Linux
+kernel would only be worth pursuing **if this approach holds up in production, proves
+worth maintaining, and stays the route we choose**. If so, what would help:
+
+1. A sanity-check of the relay's correctness against the nested-Hyper-V model, when
+   convenient, especially the authorization gate and the open question in Part 4 (do we
+   need the in-kernel `HvPostMessage` read, or is the synchronous translation enough).
+2. Guidance on the right shape were it ever upstreamed: the per-VM cap as written, or
+   folding it into the existing eVMCS / direct-hypercall machinery.
+
+To be clear, the solution is and stays entirely on the L0 side (KVM + OpenVMM). We are
+not asking for any change to hvix64 or the guest; the L0 intercept is the design, not a
+placeholder for a guest-hypervisor change.
+4. send me a beefy AMD and ARM machine for testing
+
+The goal is a stock, unmodified Windows guest running Hyper-V/VBS on KVM with no
+out-of-tree kernel carry, which benefits any KVM-based VMM, not just ours.

--- a/vm/hv1/hvdef/src/lib.rs
+++ b/vm/hv1/hvdef/src/lib.rs
@@ -550,7 +550,11 @@ pub struct HvFeatures {
     pub supervisor_shadow_stack_available: bool,
     pub arch_pmu_available: bool,
     pub exception_trap_intercept_available: bool,
-    #[bits(23)]
+    /// CPUID leaf 0x40000003 (HvFeatures), ECX bit 9.
+    pub vp_dispatch_interrupt_injection_available: bool,
+    /// CPUID leaf 0x40000003 (HvFeatures), ECX bit 10.
+    pub vp_ghcb_root_mapping_available: bool,
+    #[bits(21)]
     reserved: u32,
 
     pub mwait_available_deprecated: bool,

--- a/vm/kvm/src/lib.rs
+++ b/vm/kvm/src/lib.rs
@@ -785,6 +785,29 @@ impl<'a> Processor<'a> {
         Ok(())
     }
 
+    /// Enable Hyper-V enlightened VMCS for nested virtualization, so a guest
+    /// hypervisor that uses the enlightened VMCS (e.g. Windows hvix64) launches
+    /// correctly instead of failing VM-enter with an invalid VMCS pointer.
+    pub fn enable_hyperv_evmcs(&self) -> Result<()> {
+        // KVM writes the negotiated enlightened-VMCS version back through
+        // args[0], so it must point at a writable u32.
+        let mut version: u32 = 0;
+        // SAFETY: Calling IOCTL as documented; args[0] points at `version`,
+        // which outlives the call.
+        unsafe {
+            ioctl::kvm_enable_cap(
+                self.get().vcpu.as_raw_fd(),
+                &kvm_enable_cap {
+                    cap: KVM_CAP_HYPERV_ENLIGHTENED_VMCS,
+                    args: [std::ptr::from_mut(&mut version) as u64, 0, 0, 0],
+                    ..Default::default()
+                },
+            )
+            .map_err(|err| Error::EnableCap("hyperv_enlightened_vmcs", err))?;
+        }
+        Ok(())
+    }
+
     #[cfg(target_arch = "x86_64")]
     pub fn set_cpuid(&self, entries: &[kvm_cpuid_entry2]) -> Result<()> {
         const MAX_CPUID_ENTRIES: usize = 256;

--- a/vmm_core/virt_kvm/src/arch/x86_64/mod.rs
+++ b/vmm_core/virt_kvm/src/arch/x86_64/mod.rs
@@ -124,6 +124,13 @@ impl Kvm {
 const GB_PAGE_LEAF: u32 = 0x80000001;
 const GB_PAGE_FLAG: u32 = 1 << 26;
 
+/// Hyper-V version reported to a nested guest hypervisor (a Windows 11 24H2 /
+/// Server 2025 era build). In the version CPUID leaf, EAX is the build number
+/// and EBX packs the major version in the high 16 bits and the minor in the low.
+const NESTED_HV_VERSION_BUILD: u32 = 26100;
+const NESTED_HV_VERSION_MAJOR: u32 = 10;
+const NESTED_HV_VERSION_MINOR: u32 = 0;
+
 /// Returns whether the host supports GB pages in the page table.
 fn gb_pages_supported() -> bool {
     safe_intrinsics::cpuid(0x80000000, 0).eax >= GB_PAGE_LEAF
@@ -254,13 +261,31 @@ impl virt::Hypervisor for Kvm {
             use hvdef::*;
             let privileges = HvPartitionPrivilege::new()
                 .with_access_partition_reference_counter(true)
+                // Reference-TSC page and reenlightenment control: a guest
+                // hypervisor (hvix64) needs the reference-TSC clock and the
+                // reenlightenment notification when it runs nested, otherwise it
+                // resets the partition a fixed interval into boot.
+                .with_access_partition_reference_tsc(nested_virt)
+                .with_access_reenlightenment_ctrls(nested_virt)
                 .with_access_hypercall_msrs(true)
                 .with_access_vp_index(true)
                 .with_access_frequency_msrs(true)
                 .with_access_synic_msrs(true)
                 .with_access_synthetic_timer_msrs(true)
                 .with_access_vp_runtime_msr(true)
-                .with_access_apic_msrs(true);
+                // AccessApicMsrs puts the guest's vmbus.sys on the synic
+                // HvPostMessage path rather than the GHCB tunnel, which is the
+                // path the nested vmbus relay intercepts. It is also the default
+                // for the non-nested case, so it is granted unconditionally.
+                .with_access_apic_msrs(true)
+                // Parent synic-messaging privileges that hvix64's capability
+                // decode reads when nesting. AccessMemoryPool, create_partitions,
+                // and start_virtual_processor are left out: they push hvix64 off
+                // this path or trip the guest HAL.
+                .with_post_messages(nested_virt)
+                .with_signal_events(nested_virt)
+                .with_create_port(nested_virt)
+                .with_connect_port(nested_virt);
 
             // Query KVM's supported Hyper-V CPUID leaves to find the
             // nested virtualization features leaf (0x4000000A), but only
@@ -294,13 +319,36 @@ impl virt::Hypervisor for Kvm {
                     HV_CPUID_FUNCTION_HV_INTERFACE,
                     [u32::from_le_bytes(*b"Hv#1"), 0, 0, 0],
                 ),
-                CpuidLeaf::new(HV_CPUID_FUNCTION_MS_HV_VERSION, [0, 0, 0, 0]),
+                // Report a real Hyper-V hypervisor version when nesting is
+                // exposed, rather than 0.0.0.0. A guest hypervisor may gate
+                // nested behavior on the parent looking like a current, capable
+                // Hyper-V.
+                CpuidLeaf::new(
+                    HV_CPUID_FUNCTION_MS_HV_VERSION,
+                    if nested_virt {
+                        [
+                            NESTED_HV_VERSION_BUILD,
+                            (NESTED_HV_VERSION_MAJOR << 16) | NESTED_HV_VERSION_MINOR,
+                            0,
+                            0,
+                        ]
+                    } else {
+                        [0, 0, 0, 0]
+                    },
+                ),
                 CpuidLeaf::new(
                     HV_CPUID_FUNCTION_MS_HV_FEATURES,
                     split_u128(u128::from(
                         HvFeatures::new()
                             .with_privileges(privileges)
-                            .with_frequency_regs_available(true),
+                            .with_frequency_regs_available(true)
+                            // hvix64 gates its nested synic (the path that would
+                            // relay the root partition's vmbus to L0) on the
+                            // parent advertising GHCB root mapping: its
+                            // capability decode enables the nested-synic handlers
+                            // only when 0x40000003 ECX bit 10 is set. Advertise it
+                            // when nesting so the guest hypervisor engages.
+                            .with_vp_ghcb_root_mapping_available(nested_virt),
                     )),
                 ),
                 CpuidLeaf::new(
@@ -308,7 +356,27 @@ impl virt::Hypervisor for Kvm {
                     split_u128(
                         HvEnlightenmentInformation::new()
                             .with_deprecate_auto_eoi(true)
+                            // Relaxed timing tells the guest to slacken its
+                            // watchdog/spinlock deadlines because it is
+                            // virtualized; without it a nested guest blows
+                            // bare-metal timeouts and resets mid-boot. APIC-access
+                            // recommended pairs with the apic-msrs privilege.
+                            .with_use_relaxed_timing(nested_virt)
+                            .with_use_apic_msrs(nested_virt)
+                            // Recommend hypercall-based remote TLB flush and
+                            // cluster IPI (with extended processor masks) so the
+                            // nested guest offloads these to the in-kernel
+                            // hypercall path instead of taking many exits.
+                            .with_use_hypercall_for_remote_flush_and_local_flush_entire(nested_virt)
+                            .with_use_synthetic_cluster_ipi(nested_virt)
+                            .with_use_ex_processor_masks(nested_virt)
                             .with_long_spin_wait_count(0xffffffff) // no spin wait notifications
+                            // When nesting is exposed, recommend the enlightened
+                            // VMCS path so the guest hypervisor (hvix64) accesses
+                            // the VMCS through the enlightened-VMCS memory page
+                            // instead of trapping every VMREAD/VMWRITE to L0.
+                            .with_nested(nested_virt)
+                            .with_use_vmcs_enlightenments(nested_virt)
                             .into(),
                     ),
                 ),
@@ -691,6 +759,13 @@ impl virt::BindProcessor for KvmProcessorBinder {
         // Enable synic and set initial MSRs.
         if self.partition.hv1_enabled {
             kvm.enable_synic()?;
+
+            // When nesting is exposed, enable KVM's enlightened-VMCS path so a
+            // guest hypervisor (hvix64) that uses the enlightened VMCS launches
+            // instead of failing VM-enter with an invalid VMCS pointer.
+            if self.partition.caps.nested_virt {
+                kvm.enable_hyperv_evmcs()?;
+            }
 
             // Set the VP index. Also, KVM incorrectly initializes
             // SCONTROL to 0. Set it to 1 on each processor.
@@ -1421,6 +1496,16 @@ impl Processor for KvmProcessor<'_> {
                         params,
                     } => {
                         // N.B. this can only be SIGNAL_EVENT or POST_MESSAGE.
+                        // nested-virt debug: surface any hypercall carrying the
+                        // nested bit (BIT 31), which hvix64 sets when relaying a
+                        // nested partition's synic traffic.
+                        if input & (1 << 31) != 0 {
+                            tracing::debug!(
+                                code = input & 0xffff,
+                                fast = (input >> 16) & 1,
+                                "nested-bit hypercall reached OpenVMM"
+                            );
+                        }
                         let mut handler = KvmHypercallExit {
                             partition: self.partition,
                             registers: KvmHypercallRegisters {

--- a/vmm_core/virt_kvm/src/arch/x86_64/vp_state.rs
+++ b/vmm_core/virt_kvm/src/arch/x86_64/vp_state.rs
@@ -610,10 +610,18 @@ impl AccessVpState for KvmVpStateAccess<'_> {
     }
 
     fn nested_state(&mut self) -> Result<vp::NestedState, Self::Error> {
-        Err(KvmError::NotSupported)
+        // KVM tracks nested VMX/SVM state with the vCPU; this backend does not
+        // yet surface it through the state-access path. Return an empty state so
+        // reset and save do not fail (returning an error here aborts a
+        // guest-initiated reset, which wedges a nested guest mid-boot). Note
+        // this means a snapshot does not capture nested state, so saving and
+        // restoring a guest while it is in nested operation is not supported.
+        Ok(vp::NestedState::default())
     }
 
     fn set_nested_state(&mut self, _value: &vp::NestedState) -> Result<(), Self::Error> {
-        Err(KvmError::NotSupported)
+        // No-op: KVM resets the vCPU's nested state along with the vCPU. See
+        // nested_state() above for why this must not error.
+        Ok(())
     }
 }


### PR DESCRIPTION
Full design write-up: [POC-NESTED/nested_synic_writeup_jstarks.md](https://github.com/bitranox/openvmm/blob/nested-virt-relay-poc/POC-NESTED/nested_synic_writeup_jstarks.md)
Reproduction recipe: [POC-NESTED/README.md](https://github.com/bitranox/openvmm/blob/nested-virt-relay-poc/POC-NESTED/README.md)

---

# Nested Hyper-V vmbus under OpenVMM on KVM: the working solution, the flags, the symbols, and the PR #3721 questions

Status 2026-06-11/12: a **stock** Windows 11 guest with Hyper-V/VBS enabled boots
to the desktop under OpenVMM on the KVM backend, with storvsc, netvsp and
synthvid all working, **no Windows guest patch**, no test-signing, Secure Boot
intact. The fix is entirely L0: OpenVMM advertises the capabilities, and KVM
relays the L2 root partition's vmbus hypercalls to L0. This document records
exactly which flags and KVM functions are involved and why, which Windows kernel
symbols matter, the prerequisite that has to hold for the guest to connect, and
how this maps onto the points raised in PR #3721.

## Preamble: our solution, and why it is the right layering

The layers:

- **L0** = KVM plus OpenVMM (userspace VMM). OpenVMM presents a Hyper-V platform
  (synic, the Hv#1 hypercall ABI, a vmbus server on connection id 1).
- **L1** = hvix64, the guest's own hypervisor, launched when the guest enables
  Hyper-V/VBS.
- **L2** = the Windows kernel, running as hvix64's root partition.

The root's vmbus control hypercalls, `HvPostMessage` (0x5c) and `HvSignalEvent`
(0x5d), are issued as `VMCALL`s with the Hyper-V **nested bit** (RCX bit 31) set,
which is the guest itself saying "forward this to the parent layer, not locally."
Because L0 owns the outermost VMCS, that `VMCALL` exits to **KVM first**, before
hvix64 handles it, and KVM by default reflects it up to hvix64. The kernel's
synic (SIMP/SIEFP/SINT MSRs) is also visible to L0. **Our solution: KVM keeps the
L2 root's nested-bit 0x5c/0x5d posts in L0 and hands them to OpenVMM's vmbus
server (connection id 1), instead of reflecting them to hvix64; OpenVMM answers
and delivers the reply into the kernel's L0-visible SIMP and raises its SINT.**

A fair question is whether the L2 root should be talking to L1 instead of L0.

On real Hyper-V the nested mechanism is documented in the TLFS, and it is not "L1
forwards each message." L1 grants the privilege once: it sets
`HV_NESTED_ENLIGHTENMENTS_CONTROL.HypercallControls.InterPartitionCommunication` in the
L2 root's VP assist page, and the root learns it has that access through CPUID
`0x40000009` (`AccessSynicRegs`, `AccessVpIndex`). The L2 root then talks to L0
**directly**: it sets its synic up through the Nested SynIC MSRs
(`HV_X64_MSR_NESTED_SCONTROL` / `SIMP` / `SINTx`, `0x40001080`-`0x4000109F`, which map
straight to L0's synic) and issues its vmbus posts as nested hypercalls destined for L0.
L0 is the synic and vmbus server; L1 is in the loop only for the one-time grant, never
per message. So the "pure" design is L2-to-L0 with L1's one-time consent, not an
L2 -> L1 -> L0 per-message relay.

Under OpenVMM this path does not engage, and we do not pursue it. hvix64 never sets
that grant for our partition: it decides from a launch-time classification that reads
no parent CPUID/MSR/capability we can present (confirmed across our RE), and
empirically the L2 root never touches the nested synic MSRs on our boots. We are not
going to change hvix64, it is the guest's own closed hypervisor and we do not want to
depend on a guest-side change, so the documented L1-grant route is simply not one we
take.

Our solution stays entirely in L0 and performs the L0 receiving side itself: the
intercept keeps the L2 root's nested-bit `HvPostMessage`/`HvSignalEvent` in L0 (the
destination the nested bit names) and answers from OpenVMM's vmbus server, bridging the
reply into the root's L0-visible SIMP. It is a small KVM change, no guest patch, no
hvix64 change. That is the design, not a stopgap.

And critically, L0 is where the post actually needs to go anyway. hvix64 under
OpenVMM provides the root no vmbus device backends: storvsc, netvsp and synthvid
all live in OpenVMM (L0). So the root's vmbus has nothing useful to talk to at
L1; its real vmbus server and devices are in L0. The nested bit asked for the
parent (L0), and L0 is genuinely where the boot disk lives.

So KVM catching the nested-bit post and handing it to OpenVMM is delivering it to
the destination the guest requested, just skipping the L1-forwards-it step that
hvix64 did not perform for our partition. It is not L0 reaching past L1 against the design, it is
L0 fulfilling the role the nested bit names, because the intended courier (hvix64)
will not and the intended destination (the vmbus server plus devices) is L0
regardless.

Empirically it is correct end to end: the stock guest boots to desktop, channels
negotiate, and the reverse direction (reply into the root's L0-visible SIMP plus
SINT) works. It is also the direction jstarks endorsed on the PR ("get KVM to do
the right thing with the nested bit"). The more pure alternative (L1 relays) is the
one we are still investigating.

Short version: L2 still talks to L1 for everything L1 owns; the vmbus posts are
explicitly tagged for the parent, and L0 is both what the tag means and where the
devices are. Right path. Only the explicitly-parent-bound (nested-bit) 0x5c/0x5d
posts are intercepted; every other hypercall still reflects to hvix64.

## Validation: the nested hypervisor runs real workloads, not just boots

Booting only proves the root partition's vmbus works. To confirm the guest's
hvix64 is usable as a hypervisor under OpenVMM/KVM, we ran workloads that make
hvix64 create and run its own child partitions (an L2 of hvix64, i.e. a grandchild
of L0):

- A bare child VM started with `New-VM` / `Start-VM` reaches `Running` and
  accumulates uptime, so hvix64 allocates the child partition and KVM emulates its
  VMX entry under OpenVMM. The relay's per-L2 authorization gate correctly does not
  relay this grandchild; it keeps its own L1 synic to hvix64.
- Hyper-V-isolated Windows containers run. `docker run --isolation=hyperv
  mcr.microsoft.com/windows/nanoserver:ltsc2022` prints from inside the container
  and reports kernel build 20348, distinct from the guest's own build 26200, so it
  is its own utility VM under hvix64.
- The guest sustains a production fleet: about a dozen Hyper-V-isolated Windows
  containers (GitHub Actions self-hosted runners) run on it concurrently, each its
  own utility VM under hvix64.

Container isolation holds across the deep-nesting boundary: a container cannot see
the guest's (L2 host) filesystem, confirmed with a host-only marker file that is
not visible inside the container. Each container is a separate utility VM with its
own kernel, so the boundaries are the ordinary Hyper-V-isolation ones, now stacked
under OpenVMM.

## Part 1: the OpenVMM flags, and why each is needed

All live in the `nested_virt` block of
`vmm_core/virt_kvm/src/arch/x86_64/mod.rs`. They do two jobs: (A) let hvix64
**run** as the guest's hypervisor so the L2 root exists at all, and (B) grant the
L2 root **permission** to issue the vmbus hypercalls the relay carries. Nothing
here tries to make hvix64 forward anything; the relay is below hvix64.

### CPUID 0x40000000 / 0x40000001 / 0x40000002

- Vendor `Microsoft Hv`, interface `Hv#1`: the guest only treats the platform as
  Hyper-V (loads vmbus.sys, runs hvix64) if these say so. Required.
- A real-looking HV version (0x40000002) when nesting, not 0.0.0.0: a guest
  hypervisor may gate nested behavior on the parent looking like a current,
  capable Hyper-V. Cheap insurance; keep when nesting.

### CPUID 0x40000003 partition privileges (job A: hvix64 must run)

- `AccessPartitionReferenceTsc` + `AccessReenlightenmentControls`: hvix64 needs
  the reference-TSC clock and the reenlightenment notification when nested, else
  it resets the partition a fixed interval into boot.
- `AccessHypercallMsrs`, `AccessVpIndex`, `AccessFrequencyMsrs`,
  `AccessSynicMsrs`, `AccessSyntheticTimerMsrs`, `AccessVpRuntimeMsr`,
  `AccessPartitionReferenceCounter`: the base HV enlightenment surface. SynicMsrs
  + VpIndex are also what the kernel reads to bring up the synic the relay rides.
- `AccessApicMsrs`: REQUIRED for the relay path. With it, vmbus.sys uses the synic
  `HvPostMessage(conn 1)` path the relay catches. Withholding it pushes vmbus.sys
  onto the GHCB/SNP tunnel, which needs isolated-partition shared memory hvix64
  cannot back here (ends in a 0x7E memset of an unbacked page). Always on; the
  non-nested path already required it.

### CPUID 0x40000003 partition privileges (job B: let the root post)

- `PostMessages` + `SignalEvents`: the privilege to issue the
  `HvPostMessage`/`HvSignalEvent` the relay intercepts.
- `CreatePort` + `ConnectPort`: vmbus channel setup.
- Deliberately NOT granted: `AccessMemoryPool`, `CreatePartitions`,
  `StartVirtualProcessor` (they push the root onto the isolated-partition path or
  trip the guest HAL).

### CPUID 0x40000004 enlightenment recommendations (job A)

- `use_relaxed_timing`: slackens watchdog/spinlock deadlines because virtualized;
  without it a nested guest blows bare-metal timeouts and resets mid-boot.
- `use_apic_msrs`: pairs with the `AccessApicMsrs` privilege (the synic path).
- `use_hypercall_for_remote_flush_and_local_flush_entire`,
  `use_synthetic_cluster_ipi`, `use_ex_processor_masks`: let hvix64 offload TLB
  flush and cluster IPI to the in-kernel hypercall path instead of a storm of
  exits, so it stays fast enough not to time out.
- `nested` + `use_vmcs_enlightenments`: recommend the enlightened-VMCS path so
  hvix64 accesses the VMCS through the enlightened-VMCS page instead of trapping
  every VMREAD/VMWRITE to L0. Without it: ~4.25M VMREAD + ~1.87M VMWRITE exits in
  45s, storage times out, INACCESSIBLE_BOOT_DEVICE. Required, pairs with the KVM
  cap below.
- `deprecate_auto_eoi`, `long_spin_wait_count = 0xffffffff`: standard.

### Dropped: `vp_ghcb_root_mapping` (0x40000003 ECX bit 10)

Advertised earlier to make hvix64 engage its OWN nested-synic relay (its
capability decode enables the nested-synic handlers when the bit is set). The
KVM-side relay catches the root's posts below hvix64 and never uses hvix64's
nested synic, so the bit is irrelevant. Dropped, and the nested guest still boots
to desktop on the synic+relay path (validated).

### KVM-crate / per-vCPU changes

- `KVM_CAP_HYPERV_ENLIGHTENED_VMCS` per-vCPU (`enable_hyperv_evmcs` in `vm/kvm`):
  the reboot-loop fix. Windows uses the enlightened VMCS; without the cap KVM did
  not engage it at VM-enter (`current_vmptr == INVALID_GPA`), so hvix64 retried
  the failing launch ~586K times then rebooted. Required.
- `nested_state` get/set made a no-op for the KVM backend (`vp_state.rs`): with
  nesting the `nested_state` element is "present" and the backend returned
  `NotSupported`, aborting any guest-initiated reset and wedging the VM. Required.
- NEW `KVM_CAP_NESTED_VMBUS_RELAY` per-VM (`Partition::enable_nested_vmbus_relay`,
  called from the nested_virt path): opts this VM into the relay. Tolerant of a
  stock kernel without the cap.

## Part 2: the KVM functions

- `nested_vmx_reflect_vmexit` (`arch/x86/kvm/vmx/nested.c`): the relay branch.
  For a VM that set `kvm->arch.nested_vmbus_relay`, if the L2 exit is a `VMCALL`
  and guest RCX low 16 bits are 0x5c/0x5d with the nested bit (RCX bit 31) set,
  clear the nested bit and `return false` so KVM keeps the exit in L0 rather than
  reflecting to L1.
- `kvm_hv_hypercall` (`arch/x86/kvm/hyperv.c`): handles the kept-in-L0 call.
  `HvPostMessage` exits to userspace (OpenVMM); `HvSignalEvent` is handled
  in-kernel. The nested bit must be cleared first: it sits in
  `HV_HYPERCALL_RSVD0_MASK`, and the dispatcher rejects reserved bits with
  `HV_STATUS_INVALID_HYPERCALL_INPUT` before reaching the call's case.
- `kvm_vm_ioctl_enable_cap` (`arch/x86/kvm/x86.c`) + `struct kvm_arch`
  (`arch/x86/include/asm/kvm_host.h`) + the uapi define
  (`include/uapi/linux/kvm.h`): add `KVM_CAP_NESTED_VMBUS_RELAY`, a per-VM
  `bool nested_vmbus_relay`, and the enable-cap case that sets it. The PoC
  equivalent is the `hvpost_hook` ftrace module on the same function.
- Reverse direction: OpenVMM writes the InitiateContact reply into the kernel's
  SIMP and signals the SINT. The kernel's synic pages are L0-visible (KVM sees
  its SCONTROL/SIMP/SIEFP/SINT writes), so this is reachable without hvix64.

## Part 3: the Windows kernel symbols, and the prerequisite for the check to pass

Public PDBs: `ntkrnlmp.pdb`, `vmbus.pdb` (MS symbol server; extract the
WOF-compressed System32 binaries with the ebiggers ntfs-3g system-compression
plugin). RVAs below are from the build under test; re-resolve via the PDB on a
different build.

- `vmbus.sys!RootDevicePrepareHardwareChild`: always takes the enlightened path
  (`vmbus.sys!IsInterruptEnlightenmentAvailable` is hardcoded `return 1` here) and
  calls `ntoskrnl!HvlRegisterInterruptCallback(3, XPartEnlightenedIsr)`. If that
  returns `< 0` it aborts the child-FDO bring-up (the `JNS` at RVA `0x2b849`) and
  the boot disk never appears (0x7B).
- `ntoskrnl!HvlRegisterInterruptCallback` (rva `0x57ffd0`): three returns:
  `STATUS_INVALID_PARAMETER` if index > 4 (index 3 passes); `STATUS_NOT_SUPPORTED`
  iff the global byte `ntoskrnl!HvlHypervisorConnected` (rva `0xFC6AD7`) is 0;
  else it `lock cmpxchg`s the callback into `ntoskrnl!HvlpInterruptCallback`
  (rva `0xFC5610`, slot = index), returns vector `index + 0x30`, or
  `STATUS_UNSUCCESSFUL` if that slot was already taken.
- `ntoskrnl!HvlPhase0Initialize`: sets `HvlHypervisorConnected = 1` right after
  `HvlpSetupBootProcessorEarlyHypercallPages()` succeeds, i.e. once the kernel has
  connected to its hypervisor.

**The prerequisite for the check to pass:** `HvlHypervisorConnected == 1`. It is
satisfied for free here, because the L2 root connects to hvix64 (which presents
Hv#1 and the hypercall MSRs, rooted in what OpenVMM advertises). So
`HvlRegisterInterruptCallback(3)` SUCCEEDS, with no enlightenment-bit tweak.
Verified at runtime with the OpenVMM gdbstub: `HvlpInterruptCallback` slot 3
holds a `vmbus.sys` handler (registration succeeded) and `HvlHypervisorConnected`
reads 1. This is why the earlier "the SINT3 registration fails, patch vmbus.sys"
conclusion is obsolete: with the current capabilities it does not fail.

Other useful symbols: `vmbus.sys!ChpConnectToParent`, `vmbus.sys!PncSendMessage`,
`vmbus.sys!XPartPncPostInterruptsEnabledChild`. Host-side observation:
`kvm:kvm_hv_synic_set_msr`, `kvm:kvm_hv_hypercall`,
`kprobe:nested_vmx_reflect_vmexit`, and in the OpenVMM log the second `Guest
negotiated version` (the kernel's vmbus.sys connecting, vs the firmware's first),
plus the `netvsp`/`storvsp` negotiation lines.

## Part 4: the PR #3721 points

Your framing, "get KVM to do the right thing with the nested bit; it's not enough
to just pass it through to the VMM": agreed, and the production form is a per-VM
`KVM_CAP_NESTED_VMBUS_RELAY` checked in `nested_vmx_reflect_vmexit`, not an
unconditional pass-through. On your three specifics:

1. **The L1-set "this L2 may make nested hypercalls" bit, set only on the L2 root,
   not on L2 guests.** Done. KVM already carries this exact authorization: the
   helper `nested_evmcs_l2_tlb_flush_enabled(vcpu)` checks the L2's enlightened
   VMCS `hv_enlightenments_control.nested_flush_hypercall` bit AND the L1 VP-assist
   page `nested_control.features.directhypercall` feature, and KVM trusts it to
   decide whether an L2 VMCALL TLB-flush hypercall is handled in L0
   (`nested_vmx_l0_wants_exit`, the `EXIT_REASON_VMCALL` case). The relay branch in
   `nested_vmx_reflect_vmexit` now gates on that same predicate, so a grandchild
   L2 that L1 did not authorize for direct nested hypercalls (`auth` false) is
   never relayed and keeps its own L1 synic. Verified at the interception point on
   our boot: every relayed `0x8000005c` / `0x8001005d` exit reads `evmcs=1 nfh=1
   auth=1`, so the gate passes for the root and does not regress the boot.

2. **Translate the input-page GPA L2 to L1 in KVM, and filter pages removed from
   the L2 root's GPA space.** Done. `kvm_hv_hypercall` now translates the relayed
   synic post's input GPA L2->L1 for `HVCALL_POST_MESSAGE` and the slow
   `HVCALL_SIGNAL_EVENT`, gated on `!hc.fast && mmu_is_nested(vcpu)`, reusing
   `kvm_x86_ops.nested_ops->translate_nested_gpa(..., PFERR_GUEST_FINAL_MASK, ...)`
   exactly as the L2 TLB-flush slow path does. The guard is `mmu_is_nested()`, not
   `is_guest_mode()`: `translate_nested_gpa()` opens with `BUG_ON(!mmu_is_nested())`,
   and with shadow paging (no nested EPT) the L2 GPA is already an L1 GPA, so the
   translation is both unsafe to call and unnecessary there. (Current `kvm-x86/next`
   uses the same `mmu_is_nested()` guard on the TLB-flush path; older trees still say
   `is_guest_mode()`.) A page removed from the L2 root's
   GPA space faults in the walk and returns `INVALID_GPA`, which we reject with
   `HV_STATUS_INVALID_HYPERCALL_INPUT` (the confidential-page filter comes for
   free). Confirmed the L2 root is identity-mapped on our boot (storvsp issues
   thousands of SCSI commands, all `srb_status: SUCCESS`, with OpenVMM reading the
   root's memory by plain L1-GPA access), so the translation is a no-op here and
   the guest still boots to desktop with it in place; it is correct in general.

3. **Translation lifetime vs an enlightened stage-2 TLB invalidation.** Addressed
   for the translation; one residual window is upstream's existing model. The
   enlightened stage-2 flushes exist (`HvCallFlushGuestPhysicalAddressSpace` 0xAF,
   `HvCallFlushGuestPhysicalAddressList` 0xB0, distinct from the stage-1 VA flushes
   0x2/0x3); in our boots only the stage-1 flushes and cluster-IPI reached L0, so
   0xAF/0xB0 is not a steady-state guarantee. The translate in (2) runs
   synchronously in the faulting vCPU's exit context and is never cached: the
   result lives only in the local `hc.ingpa` for that one exit. The slow
   `HvSignalEvent` read happens in-kernel in the same exit, fully synchronous. The
   one remaining window is `HvPostMessage`, whose payload KVM hands to userspace to
   read after the exit, the same way it does for a non-nested post (this is KVM's
   existing userspace-post design, not something the relay introduces). A concurrent
   stage-2 flush serializes on the MMU lock against the actual page operation, and
   the faulting vCPU cannot flush mid-hypercall, so the translated L1 GPA stays
   valid for the read.

### Open question: do we need the in-kernel `HvPostMessage` read at all?

The "safe design" you sketched ends with "translate and read synchronously ...
hand userspace the data." For `HvSignalEvent` we already do (KVM reads it in the
exit). For `HvPostMessage`, KVM hands userspace the translated L1 GPA and the VMM
reads the message after the exit, which is exactly what KVM does for a *non-nested*
post today. Fully matching the sketch means KVM reads the up-to-240-byte payload
in-kernel under the MMU lock and ships the bytes to userspace, which needs a new
`struct kvm_hyperv_exit` field (the payload does not fit in `params[2]`) plus a
matching VMM change. Before doing that, the question we want your read on:

**Is the post-exit userspace read actually a risk here, or only a tidiness item?**
Our analysis says it is not a security risk:

* The address handed to userspace is an **L1 GPA**. It always resolves through the
  guest's own memslots, so even a stale read stays inside the guest's own memory.
  There is no path to host memory or another VM.
* For the read to be stale, the L1 (hvix64) would have to remap the exact L1 page
  backing an `HvPostMessage` it just issued, in the window before its own reply is
  delivered. A guest does not pull the page out from under a synic message it is
  waiting on; a malicious guest that did so would only corrupt **its own** post.
* The VMM's vmbus server validates the message (connection id, length) and a bad
  one is dropped or mis-routed *within the guest's own vmbus namespace*, with no
  effect on the host or other guests.
* This is identical to the non-nested `HvPostMessage` userspace exit that ships in
  KVM today; the relay adds a benign extra translation layer, not a new risk class.

So our position is that the synchronous, uncached translation is sufficient and the
in-kernel read is a tidiness improvement, not a correctness or security fix. If you
disagree, or if upstream would want the in-kernel read as a condition of merge, we
will add it (KVM side plus the VMM consumer). Which way do you want it?

Your other question, "why doesn't the ordinary vmbus init path work once you
handle the nested bit, since it works on Hyper-V-on-Hyper-V": it does work now
with the stock driver. The earlier failure was not the registration; it was the
relay not carrying the post. With the relay in place and the current
capabilities, `HvlRegisterInterruptCallback(3)` succeeds, vmbus.sys posts
InitiateContact, KVM relays it, and OpenVMM's vmbus server answers.

### Summary: solved / not solved / not an issue / can or cannot

- **Solved:** a stock Hyper-V/VBS guest boots to desktop with no guest patch; the
  L0 capability set; the relay mechanism; per-VM scoping via the KVM capability;
  the L1 per-L2 nested-hypercall authorization gate (`nested_evmcs_l2_tlb_flush_enabled`,
  so a grandchild is not relayed); the L2-to-L1 input-page translation inside KVM
  for `HvPostMessage` / `HvSignalEvent` (with the removed-page filter); the
  translation lifetime (synchronous, uncached in the exit context).
- **Remaining follow-up (not a correctness gap for this design):** reading the
  `HvPostMessage` payload in-kernel under the MMU lock and handing userspace the
  bytes instead of the GPA, to close the userspace-read window that KVM's existing
  (non-nested) post path already has. An OpenVMM/KVM ABI change, not needed here.
- **Not an issue:** the L2-GPA translation for the boot path (identity map); the
  assumption that hvix64 must forward the vmbus (it is bypassed, and L0 is the
  correct destination anyway); the SINT3 registration "failing" (it succeeds with
  the current capabilities); needing a Windows guest patch (none is needed).
- **Cannot be done from L0:** nothing fundamental remains for this guest. The
  earlier "needs hvix64 to support a non-Hyper-V parent, Microsoft-only"
  conclusion was wrong: the relay does not need hvix64 at all. (The one thing that
  genuinely cannot be done from L0 is making hvix64 itself forward the post, but
  that path is unnecessary.)

## Part 5: prerequisites to reproduce

- Host: Intel VT-x with `kvm_intel nested=Y`; the relay loaded (the `hvpost_hook`
  ftrace module as a PoC, or the in-tree per-VM `KVM_CAP_NESTED_VMBUS_RELAY` patch
  for production).
- OpenVMM: launched with `--hypervisor kvm:nested_virt`; the `nested_virt` flag
  block above, advertised automatically when nesting.
- Guest: a stock Hyper-V/VBS-enabled Windows 11 image with the usual Hyper-V
  boot-start drivers (storvsc/vmbus/netvsc), the same image that runs non-nested.
  No driver patch, no test-signing; Secure Boot on is fine.

## Part 6: where the code lives, and a request

The KVM change is published as two public repositories so you can read, build, and
comment on it directly:

| Repo                                                                                                 | What it is                                                                                                                               |
|------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------|
| [github.com/bitranox/linux-nested-vmbus-relay](https://github.com/bitranox/linux-nested-vmbus-relay) | A real fork of `kvm-x86/linux`, branch `nested-vmbus-relay`, a single commit on top of the latest `kvm-x86/next` (the mainline variant). |
| [github.com/bitranox/pve-nested-vmbus-relay](https://github.com/bitranox/pve-nested-vmbus-relay)     | The Proxmox VE kernel variant (Proxmox's kernel is not on GitHub, so this is a patch + build script + this design doc, not a fork).      |

The capability number `0x4f564d52` is an out-of-tree private sentinel; a real merge
would take an assigned `KVM_CAP_*` value.

**The request (low-priority, and conditional).** The L0 intercept above is our
working, shipping solution; we are not blocked, and a stock Hyper-V/VBS guest boots
and runs real workloads with it today. We are mainly putting the nested-vmbus problem
and our approach on the record, and we are still actively working on better options,
so this may not be our final approach. Getting the KVM change into the upstream Linux
kernel would only be worth pursuing **if this approach holds up in production, proves
worth maintaining, and stays the route we choose**. If so, what would help:

1. A sanity-check of the relay's correctness against the nested-Hyper-V model, when
   convenient, especially the authorization gate and the open question in Part 4 (do we
   need the in-kernel `HvPostMessage` read, or is the synchronous translation enough).
2. Guidance on the right shape were it ever upstreamed: the per-VM cap as written, or
   folding it into the existing eVMCS / direct-hypercall machinery.

To be clear, the solution is and stays entirely on the L0 side (KVM + OpenVMM). We are
not asking for any change to hvix64 or the guest; the L0 intercept is the design, not a
placeholder for a guest-hypervisor change.
4. send me a beefy AMD and ARM machine for testing

The goal is a stock, unmodified Windows guest running Hyper-V/VBS on KVM with no
out-of-tree kernel carry, which benefits any KVM-based VMM, not just ours.
