### PR TITLE
petri: Add test to force bounce buffering for DMA in UEFI

### DIFF
--- a/openhcl/underhill_core/src/loader/mod.rs
+++ b/openhcl/underhill_core/src/loader/mod.rs
@@ -689,6 +689,7 @@ pub fn write_uefi_config(
         flags.set_cxl_memory_enabled(platform_config.general.cxl_memory_enabled);
         flags.set_default_boot_always_attempt(platform_config.general.default_boot_always_attempt);
         flags.set_hv_sint_enabled(platform_config.general.hv_sint_enabled);
+        flags.set_force_dma_bounce_enabled(platform_config.general.force_dma_bounce_enabled);
 
         // Some settings do not depend on host config
 

--- a/openhcl/underhill_core/src/worker.rs
+++ b/openhcl/underhill_core/src/worker.rs
@@ -3781,6 +3781,7 @@ fn validate_isolated_configuration(dps: &DevicePlatformSettings) -> Result<(), a
         guest_state_lifetime: _,
         management_vtl_features: _,
         hv_sint_enabled: _,
+        force_dma_bounce_enabled: _,
         battery_enabled: _, // TODO: Add this to attestation later
     } = &dps.general;
 

--- a/openvmm/openvmm_core/src/worker/dispatch.rs
+++ b/openvmm/openvmm_core/src/worker/dispatch.rs
@@ -2994,6 +2994,7 @@ impl LoadedVmInner {
                 default_boot_always_attempt,
                 bios_guid,
                 enable_vmbus,
+                force_dma_bounce,
             } => {
                 let madt = acpi_builder.build_madt();
                 let srat = acpi_builder.build_srat();
@@ -3013,6 +3014,7 @@ impl LoadedVmInner {
                     default_boot_always_attempt,
                     bios_guid,
                     vmbus: enable_vmbus,
+                    force_dma_bounce,
                 };
                 let regs =
                     super::vm_loaders::uefi::load_uefi(&super::vm_loaders::uefi::LoadUefiParams {

--- a/openvmm/openvmm_core/src/worker/vm_loaders/uefi.rs
+++ b/openvmm/openvmm_core/src/worker/vm_loaders/uefi.rs
@@ -48,6 +48,8 @@ pub struct UefiLoadSettings {
     /// but the high MMIO range will be empty. The firmware must support this
     /// mode.
     pub vmbus: bool,
+    /// Force UEFI to bounce-buffer all DMA traffic.
+    pub force_dma_bounce: bool,
 }
 
 /// All inputs needed by [`load_uefi`].
@@ -140,7 +142,8 @@ pub fn load_uefi(params: &LoadUefiParams<'_>) -> Result<Vec<Register>, Error> {
         )
         .with_default_boot_always_attempt(settings.default_boot_always_attempt)
         .with_vmbus_disabled(!settings.vmbus)
-        .with_pci_resources_pre_assigned(true);
+        .with_pci_resources_pre_assigned(true)
+        .with_force_dma_bounce_enabled(settings.force_dma_bounce);
 
     let mut cfg = config::Blob::new();
     cfg.add(&config::BiosInformation {

--- a/openvmm/openvmm_defs/src/config.rs
+++ b/openvmm/openvmm_defs/src/config.rs
@@ -136,6 +136,7 @@ pub enum LoadMode {
         default_boot_always_attempt: bool,
         bios_guid: Guid,
         enable_vmbus: bool,
+        force_dma_bounce: bool,
     },
     Pcat {
         firmware: RomFileLocation,

--- a/openvmm/openvmm_entry/src/cli_args.rs
+++ b/openvmm/openvmm_entry/src/cli_args.rs
@@ -620,6 +620,10 @@ options:
     #[clap(long, requires("uefi"))]
     pub uefi_enable_memory_protections: bool,
 
+    /// force UEFI to bounce-buffer all DMA traffic
+    #[clap(long, requires("uefi"))]
+    pub uefi_force_dma_bounce: bool,
+
     /// set PCAT boot order as comma-separated string of boot device types
     /// (e.g: floppy,hdd,optical,net).
     ///

--- a/openvmm/openvmm_entry/src/lib.rs
+++ b/openvmm/openvmm_entry/src/lib.rs
@@ -1243,6 +1243,7 @@ async fn vm_config_from_command_line(
             default_boot_always_attempt: opt.default_boot_always_attempt,
             bios_guid,
             enable_vmbus: !opt.no_vmbus,
+            force_dma_bounce: opt.uefi_force_dma_bounce,
         };
     } else {
         // Linux Direct
@@ -1422,6 +1423,7 @@ async fn vm_config_from_command_line(
                         }
                     },
                     hv_sint_enabled: false,
+                    force_dma_bounce_enabled: opt.uefi_force_dma_bounce,
                 }
                 .into_resource(),
             ),

--- a/petri/src/vm/mod.rs
+++ b/petri/src/vm/mod.rs
@@ -1418,6 +1418,16 @@ impl<T: PetriVmmBackend> PetriVmBuilder<T> {
         self
     }
 
+    /// Force UEFI to bounce-buffer all DMA traffic.
+    pub fn with_uefi_force_dma_bounce(mut self, enable: bool) -> Self {
+        self.config
+            .firmware
+            .uefi_config_mut()
+            .expect("force DMA bounce is only supported for UEFI firmware.")
+            .force_dma_bounce = enable;
+        self
+    }
+
     /// Run the VM with Enable VMBus relay enabled
     pub fn with_vmbus_redirect(mut self, enable: bool) -> Self {
         self.config
@@ -2270,6 +2280,8 @@ pub struct UefiConfig {
     pub default_boot_always_attempt: bool,
     /// Enable vPCI boot (for NVMe)
     pub enable_vpci_boot: bool,
+    /// Force UEFI to bounce-buffer all DMA traffic in its IOMMU layer.
+    pub force_dma_bounce: bool,
     /// EFI diagnostics log level filter
     pub efi_diagnostics_log_level: EfiDiagnosticsLogLevel,
     /// Per-period rate-limit override for EFI diagnostics emission.
@@ -2285,6 +2297,7 @@ impl Default for UefiConfig {
             disable_frontpage: true,
             default_boot_always_attempt: false,
             enable_vpci_boot: false,
+            force_dma_bounce: false,
             efi_diagnostics_log_level: EfiDiagnosticsLogLevel::Default,
             efi_diagnostics_rate_limit: None,
         }

--- a/petri/src/vm/mod.rs
+++ b/petri/src/vm/mod.rs
@@ -2280,7 +2280,7 @@ pub struct UefiConfig {
     pub default_boot_always_attempt: bool,
     /// Enable vPCI boot (for NVMe)
     pub enable_vpci_boot: bool,
-    /// Force UEFI to bounce-buffer all DMA traffic in its IOMMU layer.
+    /// Force UEFI to bounce-buffer all DMA traffic
     pub force_dma_bounce: bool,
     /// EFI diagnostics log level filter
     pub efi_diagnostics_log_level: EfiDiagnosticsLogLevel,

--- a/petri/src/vm/openvmm/construct.rs
+++ b/petri/src/vm/openvmm/construct.rs
@@ -884,6 +884,7 @@ impl PetriVmConfigSetupCore<'_> {
                             disable_frontpage,
                             default_boot_always_attempt,
                             enable_vpci_boot,
+                            force_dma_bounce,
                             efi_diagnostics_log_level: _, // applied to top-level Config below
                             efi_diagnostics_rate_limit: _, // applied to top-level Config below
                         },
@@ -905,6 +906,7 @@ impl PetriVmConfigSetupCore<'_> {
                     default_boot_always_attempt: *default_boot_always_attempt,
                     bios_guid: Guid::new_random(),
                     enable_vmbus: !self.no_vmbus,
+                    force_dma_bounce: *force_dma_bounce,
                 }
             }
             (
@@ -1063,6 +1065,7 @@ impl PetriVmConfigSetupCore<'_> {
                 disable_frontpage,
                 default_boot_always_attempt,
                 enable_vpci_boot,
+                force_dma_bounce,
                 efi_diagnostics_log_level,
                 efi_diagnostics_rate_limit: _, // applied device-side via UefiManifest::new
             },
@@ -1129,6 +1132,7 @@ impl PetriVmConfigSetupCore<'_> {
                 }
             },
             hv_sint_enabled: false,
+            force_dma_bounce_enabled: *force_dma_bounce,
         };
 
         Ok((ged, guest_request_send))

--- a/vm/devices/get/get_protocol/src/dps_json.rs
+++ b/vm/devices/get/get_protocol/src/dps_json.rs
@@ -221,6 +221,8 @@ pub struct HclDevicePlatformSettingsV2Static {
     pub management_vtl_features: ManagementVtlFeatures,
     #[serde(default)]
     pub hv_sint_enabled: bool,
+    #[serde(default)]
+    pub force_dma_bounce_enabled: bool,
 }
 
 #[derive(Debug, Default, Deserialize, Serialize)]

--- a/vm/devices/get/get_resources/src/lib.rs
+++ b/vm/devices/get/get_resources/src/lib.rs
@@ -97,6 +97,8 @@ pub mod ged {
         pub efi_diagnostics_log_level: EfiDiagnosticsLogLevelType,
         /// Enable PPI-based SINT ACPI device for ARM64 Linux L1VH
         pub hv_sint_enabled: bool,
+        /// Force UEFI to bounce-buffer all DMA traffic.
+        pub force_dma_bounce_enabled: bool,
     }
 
     /// The firmware and chipset configuration for the guest.

--- a/vm/devices/get/guest_emulation_device/src/lib.rs
+++ b/vm/devices/get/guest_emulation_device/src/lib.rs
@@ -163,6 +163,8 @@ pub struct GuestConfig {
     pub efi_diagnostics_log_level: EfiDiagnosticsLogLevelType,
     /// Enable PPI-based SINT ACPI device for ARM64 Linux L1VH
     pub hv_sint_enabled: bool,
+    /// Force UEFI to bounce-buffer all DMA traffic.
+    pub force_dma_bounce_enabled: bool,
 }
 
 #[derive(Debug, Clone, Inspect)]
@@ -1356,6 +1358,7 @@ impl<T: RingMem + Unpin> GedChannel<T> {
                     management_vtl_features: state.config.management_vtl_features,
                     efi_diagnostics_log_level: state.config.efi_diagnostics_log_level,
                     hv_sint_enabled: state.config.hv_sint_enabled,
+                    force_dma_bounce_enabled: state.config.force_dma_bounce_enabled,
                 },
                 dynamic: get_protocol::dps_json::HclDevicePlatformSettingsV2Dynamic {
                     is_servicing_scenario: state.save_restore_buf.is_some(),

--- a/vm/devices/get/guest_emulation_device/src/resolver.rs
+++ b/vm/devices/get/guest_emulation_device/src/resolver.rs
@@ -208,6 +208,7 @@ impl AsyncResolveResource<VmbusDeviceHandleKind, GuestEmulationDeviceHandle>
                     }
                 },
                 hv_sint_enabled: resource.hv_sint_enabled,
+                force_dma_bounce_enabled: resource.force_dma_bounce_enabled,
             },
             halt,
             resource.firmware_event_send,

--- a/vm/devices/get/guest_emulation_device/src/test_utilities.rs
+++ b/vm/devices/get/guest_emulation_device/src/test_utilities.rs
@@ -263,6 +263,7 @@ pub fn create_host_channel(
         management_vtl_features: Default::default(),
         efi_diagnostics_log_level: Default::default(),
         hv_sint_enabled: false,
+        force_dma_bounce_enabled: false,
     };
 
     let halt_reason = Arc::new(Mutex::new(None));

--- a/vm/devices/get/guest_emulation_transport/src/api.rs
+++ b/vm/devices/get/guest_emulation_transport/src/api.rs
@@ -136,6 +136,7 @@ pub mod platform_settings {
         #[inspect(debug)]
         pub management_vtl_features: ManagementVtlFeatures,
         pub hv_sint_enabled: bool,
+        pub force_dma_bounce_enabled: bool,
     }
 
     #[derive(Copy, Clone, Debug, Inspect)]

--- a/vm/devices/get/guest_emulation_transport/src/client.rs
+++ b/vm/devices/get/guest_emulation_transport/src/client.rs
@@ -345,6 +345,7 @@ impl GuestEmulationTransportClient {
                 guest_state_encryption_policy: json.v2.r#static.guest_state_encryption_policy,
                 management_vtl_features: json.v2.r#static.management_vtl_features,
                 hv_sint_enabled: json.v2.r#static.hv_sint_enabled,
+                force_dma_bounce_enabled: json.v2.r#static.force_dma_bounce_enabled,
             },
             acpi_tables: json.v2.dynamic.acpi_tables,
         })

--- a/vm/loader/src/uefi/config.rs
+++ b/vm/loader/src/uefi/config.rs
@@ -326,8 +326,9 @@ pub struct Flags {
     pub hv_sint_enabled: bool,
     pub vmbus_disabled: bool,
     pub pci_resources_pre_assigned: bool,
+    pub force_dma_bounce_enabled: bool,
 
-    #[bits(32)]
+    #[bits(31)]
     _reserved: u64,
 }
 

--- a/vmm_tests/vmm_tests/tests/tests/multiarch.rs
+++ b/vmm_tests/vmm_tests/tests/tests/multiarch.rs
@@ -577,7 +577,7 @@ async fn uefi_force_dma_bounce<T: PetriVmmBackend>(
         .with_uefi_force_dma_bounce(true)
         .with_efi_diagnostics_log_level(EfiDiagnosticsLogLevel::Info)
         .with_efi_diagnostics_rate_limit(0)
-        .with_openhcl_command_line("log_buf_len=512K") // allows for more INFO logs to show
+        .with_openhcl_command_line("log_buf_len=1M") // allows for more INFO logs to show
         .run()
         .await?;
 

--- a/vmm_tests/vmm_tests/tests/tests/multiarch.rs
+++ b/vmm_tests/vmm_tests/tests/tests/multiarch.rs
@@ -564,6 +564,46 @@ async fn efi_diagnostics_info_level<T: PetriVmmBackend>(
     anyhow::bail!("Did not find expected INFO-level UEFI diagnostics entry ({MARKER:?}) in kmsg");
 }
 
+/// Smoke test for the `force_dma_bounce` UEFI config flag.
+///
+/// Boots OpenHCL UEFI with an NVMe device attached, then verifies
+/// whether IoMmuDxe will force bounce buffering on all DMA operations.
+#[vmm_test_with(vpci(openvmm_openhcl_uefi_x64(vhd(windows_datacenter_core_2022_x64))))]
+async fn uefi_force_dma_bounce<T: PetriVmmBackend>(
+    config: PetriVmBuilder<T>,
+) -> anyhow::Result<()> {
+    let (vm, agent) = config
+        .with_boot_device_type(petri::BootDeviceType::Nvme)
+        .with_uefi_force_dma_bounce(true)
+        .with_efi_diagnostics_log_level(EfiDiagnosticsLogLevel::Info)
+        .with_efi_diagnostics_rate_limit(0)
+        .with_openhcl_command_line("log_buf_len=512K") // allows for more INFO logs to show
+        .run()
+        .await?;
+
+    const MARKER: &str = "Forcing DMA bounce";
+
+    let mut found = false;
+    let mut kmsg = vm.kmsg().await?;
+    while let Some(data) = kmsg.next().await {
+        let data = data.context("reading kmsg")?;
+        let msg = kmsg::KmsgParsedEntry::new(&data).unwrap();
+        if msg.message.as_raw().contains(MARKER) {
+            found = true;
+            break;
+        }
+    }
+    drop(kmsg);
+
+    agent.power_off().await?;
+    vm.wait_for_clean_teardown().await?;
+
+    if !found {
+        anyhow::bail!("Did not find {MARKER:?} in kmsg");
+    }
+    Ok(())
+}
+
 /// Boot our guest-test UEFI image, which will run some tests,
 /// and then purposefully triple fault itself via an expiring
 /// watchdog timer.


### PR DESCRIPTION
Adds the necessary plumbing to create a test that instructs our UEFI firmware to force bounce buffering on. This tells IommuDxe driver to pre-allocate bounce buffers and use them whenever a PCI device DMAs to some region of memory. 

Today, this test is done by booting off NVMe.