### PR TITLE
amd_iommu/intel_vtd: enable IOAPIC interrupt remapping

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3928,6 +3928,7 @@ name = "iommu_common"
 version = "0.0.0"
 dependencies = [
  "guestmem",
+ "parking_lot",
  "pci_core",
  "thiserror 2.0.16",
 ]
@@ -5585,6 +5586,7 @@ dependencies = [
  "openvmm_pcat_locator",
  "pal",
  "pal_async",
+ "parking_lot",
  "pci_bus",
  "pci_core",
  "pci_resource_assignment",

--- a/openvmm/openvmm_core/Cargo.toml
+++ b/openvmm/openvmm_core/Cargo.toml
@@ -100,6 +100,7 @@ cfg-if.workspace = true
 futures.workspace = true
 futures-concurrency.workspace = true
 getrandom.workspace = true
+parking_lot.workspace = true
 thiserror.workspace = true
 tracelimit.workspace = true
 tracing.workspace = true

--- a/openvmm/openvmm_core/src/worker/dispatch.rs
+++ b/openvmm/openvmm_core/src/worker/dispatch.rs
@@ -2408,32 +2408,23 @@ impl InitializedVm {
             ResolvedIommu::None => IommuDevices::None,
         };
 
-        // Set up IOAPIC routing. When an AMD IOMMU is present, wrap the
-        // hypervisor's IoApicRouting through the IOMMU's interrupt
-        // remapping table so that IOAPIC-sourced interrupts are
-        // translated via the guest's IRTEs and invalidation commands
-        // trigger retranslation.
+        // Set up IOAPIC routing. When an AMD IOMMU covers the southbridge
+        // IOAPIC (segment 0, bus 0), wrap the hypervisor's IoApicRouting
+        // through that IOMMU's interrupt remapping table so IOAPIC-sourced
+        // interrupts are translated via the guest's IRTEs and invalidation
+        // commands trigger retranslation. The RID and the remapper come from
+        // the same IOMMU, so the IVRS DEV_SPECIAL(IOAPIC) entry and the
+        // runtime remapping always refer to the same DTE/IRTE context.
         #[cfg(guest_arch = "x86_64")]
         let ioapic_iommu_rid: Option<u16> = if let IommuDevices::AmdVi(amd_devices) = &iommu_devices
         {
-            if let (Some(first_iommu), Some(iommu_acpi)) = (
-                amd_devices.shared_states.iter().flatten().next(),
-                amd_devices.acpi_configs.first(),
-            ) {
-                // The IOAPIC RID. Linux expects the southbridge IOAPIC
-                // at 00:14.0 and disables interrupt remapping if this
-                // RID is not present in the IVRS.
-                let ioapic_rid = (iommu_acpi.start_bus as u16) << 8
-                    | ioapic_iommu_wiring::IOAPIC_PHANTOM_DEVFN as u16;
-
+            amd_devices.ioapic_iommu.as_ref().map(|sel| {
                 ioapic_routing.connect_remapper(
-                    ioapic_rid,
-                    first_iommu.clone() as Arc<dyn iommu_common::InterruptRemapper>,
+                    sel.ioapic_rid,
+                    sel.shared_state.clone() as Arc<dyn iommu_common::InterruptRemapper>,
                 );
-                Some(ioapic_rid)
-            } else {
-                None
-            }
+                sel.ioapic_rid
+            })
         } else {
             None
         };

--- a/openvmm/openvmm_core/src/worker/dispatch.rs
+++ b/openvmm/openvmm_core/src/worker/dispatch.rs
@@ -1048,7 +1048,7 @@ impl InitializedVm {
             let smmu_count = cfg
                 .pcie_root_complexes
                 .iter()
-                .filter(|rc| matches!(rc.iommu, Some(openvmm_defs::config::PcieIommuConfig::Smmu)))
+                .filter(|rc| matches!(rc.iommu, Some(PcieIommuConfig::Smmu)))
                 .count();
             let result =
                 build_aarch64_topology(&cfg.processor_topology, &platform_info, smmu_count)?;

--- a/openvmm/openvmm_core/src/worker/dispatch.rs
+++ b/openvmm/openvmm_core/src/worker/dispatch.rs
@@ -68,6 +68,7 @@ use openvmm_defs::config::HypervisorConfig;
 use openvmm_defs::config::LoadMode;
 use openvmm_defs::config::NumaTopology;
 use openvmm_defs::config::PcieDeviceConfig;
+use openvmm_defs::config::PcieIommuConfig;
 use openvmm_defs::config::PciePortConfig;
 use openvmm_defs::config::PcieRootComplexConfig;
 use openvmm_defs::config::PcieSwitchConfig;
@@ -2075,19 +2076,14 @@ impl InitializedVm {
                 // reserve device 0 for the IOMMU RCiEP and start root
                 // ports at device 1.
                 #[cfg(guest_arch = "x86_64")]
-                let amd_iommu_on_rc = matches!(
-                    &resolved_iommu,
-                    ResolvedIommu::AmdVi(resources)
-                        if resources.iter().any(|r| r.rc_idx == rc_idx)
-                );
+                let rc_iommu = rc.iommu.as_ref();
                 #[cfg(guest_arch = "x86_64")]
-                let intel_vtd_on_rc = matches!(
-                    &resolved_iommu,
-                    ResolvedIommu::IntelVtd(resources)
-                        if resources.iter().any(|r| r.rc_idx == rc_idx)
-                );
-                #[cfg(guest_arch = "x86_64")]
-                let root_port_start_device: u8 = if amd_iommu_on_rc { 1 } else { 0 };
+                let root_port_start_device: u8 = if matches!(rc_iommu, Some(PcieIommuConfig::AmdVi))
+                {
+                    1
+                } else {
+                    0
+                };
                 #[cfg(not(guest_arch = "x86_64"))]
                 let root_port_start_device: u8 = 0;
 
@@ -2101,13 +2097,16 @@ impl InitializedVm {
                 // that an overly large port count is rejected rather than
                 // silently shadowing the IOAPIC entry.
                 #[cfg(guest_arch = "x86_64")]
-                let reserved_device_numbers: u32 =
-                    if rc.segment == 0 && rc.start_bus == 0 && (amd_iommu_on_rc || intel_vtd_on_rc)
-                    {
-                        1u32 << (ioapic_iommu_wiring::IOAPIC_PHANTOM_DEVFN >> 3)
-                    } else {
-                        0
-                    };
+                let reserved_device_numbers: u32 = if rc.segment == 0
+                    && rc.start_bus == 0
+                    && matches!(
+                        rc_iommu,
+                        Some(PcieIommuConfig::AmdVi | PcieIommuConfig::IntelVtd)
+                    ) {
+                    1u32 << (ioapic_iommu_wiring::IOAPIC_PHANTOM_DEVFN >> 3)
+                } else {
+                    0
+                };
                 #[cfg(not(guest_arch = "x86_64"))]
                 let reserved_device_numbers: u32 = 0;
 

--- a/openvmm/openvmm_core/src/worker/dispatch.rs
+++ b/openvmm/openvmm_core/src/worker/dispatch.rs
@@ -2087,15 +2087,20 @@ impl InitializedVm {
 
                 // On the segment-0 root complex covered by the AMD IOMMU, the
                 // phantom southbridge IOAPIC occupies a fixed devfn whose
-                // device number must not be assigned to a root port. Reserve
-                // that device number so that an overly large port count is
-                // rejected rather than silently shadowing the IOAPIC entry.
+                // device number must not be assigned to a root port. The
+                // IOAPIC RID is on bus 0, so only reserve the device number on
+                // the root complex whose bus range includes bus 0; reserving
+                // it on other segment-0 root complexes would wrongly reject
+                // otherwise-valid port counts. Reserve that device number so
+                // that an overly large port count is rejected rather than
+                // silently shadowing the IOAPIC entry.
                 #[cfg(guest_arch = "x86_64")]
-                let reserved_device_numbers: u32 = if rc.segment == 0 && amd_iommu_on_rc {
-                    1u32 << (ioapic_iommu_wiring::IOAPIC_PHANTOM_DEVFN >> 3)
-                } else {
-                    0
-                };
+                let reserved_device_numbers: u32 =
+                    if rc.segment == 0 && rc.start_bus == 0 && amd_iommu_on_rc {
+                        1u32 << (ioapic_iommu_wiring::IOAPIC_PHANTOM_DEVFN >> 3)
+                    } else {
+                        0
+                    };
                 #[cfg(not(guest_arch = "x86_64"))]
                 let reserved_device_numbers: u32 = 0;
 

--- a/openvmm/openvmm_core/src/worker/dispatch.rs
+++ b/openvmm/openvmm_core/src/worker/dispatch.rs
@@ -5,6 +5,7 @@ mod amd_iommu_wiring;
 mod dump;
 mod ecam_config_access;
 mod intel_vtd_wiring;
+mod ioapic_iommu_wiring;
 mod pcie_wiring;
 mod smmu_wiring;
 
@@ -793,6 +794,11 @@ struct LoadedVmInner {
     /// Instantiated IOMMU devices (ACPI configs + per-RC shared state),
     /// keyed by IOMMU type. `IommuDevices::None` when no IOMMU is configured.
     iommu_devices: IommuDevices,
+    /// IOAPIC PCIe Requester ID for the IVRS DEV_SPECIAL(IOAPIC) entry,
+    /// when AMD IOMMU interrupt remapping is active. Threaded into the IVRS
+    /// ACPI config at firmware-load time.
+    #[cfg(guest_arch = "x86_64")]
+    ioapic_iommu_rid: Option<u16>,
     pcie_host_bridges: Vec<PcieHostBridge>,
     pcie_root_complexes: Vec<Arc<closeable_mutex::CloseableMutex<GenericPcieRootComplex>>>,
     /// Sources for SRAT generic-initiator entries, one per
@@ -1478,9 +1484,15 @@ impl InitializedVm {
 
         resolver.add_resolver(vmm_core::platform_resolvers::HaltResolver(halt_vps.clone()));
         #[cfg(guest_arch = "x86_64")]
-        resolver.add_resolver(vmm_core::platform_resolvers::IoApicRoutingResolver(
-            partition.clone().ioapic_routing(),
-        ));
+        let ioapic_routing_slot = {
+            let slot = ioapic_iommu_wiring::SwappableIoApicRouting::new(
+                partition.clone().ioapic_routing(),
+            );
+            resolver.add_resolver(vmm_core::platform_resolvers::IoApicRoutingResolver(
+                slot.clone(),
+            ));
+            slot
+        };
         resolver.add_resolver(emuplat::i440bx_host_pci_bridge::AdjustGpaRangeResolver(
             memory_manager.ram_visibility_control(),
         ));
@@ -2063,16 +2075,29 @@ impl InitializedVm {
                 // reserve device 0 for the IOMMU RCiEP and start root
                 // ports at device 1.
                 #[cfg(guest_arch = "x86_64")]
-                let root_port_start_device: u8 = match &resolved_iommu {
+                let amd_iommu_on_rc = matches!(
+                    &resolved_iommu,
                     ResolvedIommu::AmdVi(resources)
-                        if resources.iter().any(|r| r.rc_idx == rc_idx) =>
-                    {
-                        1
-                    }
-                    _ => 0,
-                };
+                        if resources.iter().any(|r| r.rc_idx == rc_idx)
+                );
+                #[cfg(guest_arch = "x86_64")]
+                let root_port_start_device: u8 = if amd_iommu_on_rc { 1 } else { 0 };
                 #[cfg(not(guest_arch = "x86_64"))]
                 let root_port_start_device: u8 = 0;
+
+                // On the segment-0 root complex covered by the AMD IOMMU, the
+                // phantom southbridge IOAPIC occupies a fixed devfn whose
+                // device number must not be assigned to a root port. Reserve
+                // that device number so that an overly large port count is
+                // rejected rather than silently shadowing the IOAPIC entry.
+                #[cfg(guest_arch = "x86_64")]
+                let reserved_device_numbers: u32 = if rc.segment == 0 && amd_iommu_on_rc {
+                    1u32 << (ioapic_iommu_wiring::IOAPIC_PHANTOM_DEVFN >> 3)
+                } else {
+                    0
+                };
+                #[cfg(not(guest_arch = "x86_64"))]
+                let reserved_device_numbers: u32 = 0;
 
                 let root_complex =
                     chipset_builder
@@ -2090,6 +2115,7 @@ impl InitializedVm {
                                 &msi_conn.msi_target(rc_bus_range, 0),
                             )
                             .first_port_device_number(root_port_start_device)
+                            .reserved_device_numbers(reserved_device_numbers)
                             .chbcr_range(chbcr_range)
                             .build()
                         })?;
@@ -2380,6 +2406,38 @@ impl InitializedVm {
         let iommu_devices = match resolved_iommu {
             ResolvedIommu::Smmu(_) => IommuDevices::Smmu(smmu_devices),
             ResolvedIommu::None => IommuDevices::None,
+        };
+
+        // Set up IOAPIC routing. When an AMD IOMMU is present, wrap the
+        // hypervisor's IoApicRouting through the IOMMU's interrupt
+        // remapping table so that IOAPIC-sourced interrupts are
+        // translated via the guest's IRTEs and invalidation commands
+        // trigger retranslation.
+        #[cfg(guest_arch = "x86_64")]
+        let ioapic_iommu_rid: Option<u16> = if let IommuDevices::AmdVi(amd_devices) = &iommu_devices
+        {
+            if let (Some(first_iommu), Some(iommu_acpi)) = (
+                amd_devices.shared_states.iter().flatten().next(),
+                amd_devices.acpi_configs.first(),
+            ) {
+                // The IOAPIC RID. Linux expects the southbridge IOAPIC
+                // at 00:14.0 and disables interrupt remapping if this
+                // RID is not present in the IVRS.
+                let ioapic_rid = (iommu_acpi.start_bus as u16) << 8
+                    | ioapic_iommu_wiring::IOAPIC_PHANTOM_DEVFN as u16;
+
+                let wrapped = ioapic_iommu_wiring::IommuIoApicRouting::new(
+                    partition.clone().ioapic_routing(),
+                    ioapic_rid,
+                    first_iommu.clone() as Arc<dyn iommu_common::InterruptRemapper>,
+                );
+                ioapic_routing_slot.swap(wrapped);
+                Some(ioapic_rid)
+            } else {
+                None
+            }
+        } else {
+            None
         };
 
         // Wire deferred root complex and switch MSI connections now that
@@ -2970,6 +3028,8 @@ impl InitializedVm {
                 automatic_guest_reset: cfg.automatic_guest_reset,
                 chipset: chipset.chipset.clone(),
                 iommu_devices,
+                #[cfg(guest_arch = "x86_64")]
+                ioapic_iommu_rid,
                 pcie_host_bridges,
                 pcie_root_complexes,
                 generic_initiator_sources,
@@ -3061,6 +3121,7 @@ impl LoadedVmInner {
                                 pa_size: amd_iommu::PA_SIZE,
                                 va_size: amd_iommu::VA_SIZE,
                                 iommus: devices.acpi_configs.clone(),
+                                ioapic_rid: self.ioapic_iommu_rid,
                             },
                         ))
                     }

--- a/openvmm/openvmm_core/src/worker/dispatch.rs
+++ b/openvmm/openvmm_core/src/worker/dispatch.rs
@@ -3127,6 +3127,7 @@ impl LoadedVmInner {
                             vmm_core::acpi_builder::IntelVtdDmarConfig {
                                 host_address_width: 48,
                                 units: devices.acpi_configs.clone(),
+                                ioapic_rid: self.ioapic_iommu_rid,
                             },
                         ))
                     }

--- a/openvmm/openvmm_core/src/worker/dispatch.rs
+++ b/openvmm/openvmm_core/src/worker/dispatch.rs
@@ -1182,7 +1182,7 @@ impl InitializedVm {
                 amd_iommu_wiring::resolve_iommu_resources(&cfg.pcie_root_complexes, ranges),
             ),
             ResolvedIommuRanges::IntelVtd(ranges) => ResolvedIommu::IntelVtd(
-                intel_vtd_wiring::resolve_vtd_resources(&cfg.pcie_root_complexes, ranges),
+                intel_vtd_wiring::resolve_vtd_resources(&cfg.pcie_root_complexes, ranges)?,
             ),
             _ => ResolvedIommu::None,
         };

--- a/openvmm/openvmm_core/src/worker/dispatch.rs
+++ b/openvmm/openvmm_core/src/worker/dispatch.rs
@@ -1484,14 +1484,14 @@ impl InitializedVm {
 
         resolver.add_resolver(vmm_core::platform_resolvers::HaltResolver(halt_vps.clone()));
         #[cfg(guest_arch = "x86_64")]
-        let ioapic_routing_slot = {
-            let slot = ioapic_iommu_wiring::SwappableIoApicRouting::new(
+        let ioapic_routing = {
+            let conn = ioapic_iommu_wiring::IoApicRoutingConnection::new(
                 partition.clone().ioapic_routing(),
             );
             resolver.add_resolver(vmm_core::platform_resolvers::IoApicRoutingResolver(
-                slot.clone(),
+                conn.target(),
             ));
-            slot
+            conn
         };
         resolver.add_resolver(emuplat::i440bx_host_pci_bridge::AdjustGpaRangeResolver(
             memory_manager.ram_visibility_control(),
@@ -2426,12 +2426,10 @@ impl InitializedVm {
                 let ioapic_rid = (iommu_acpi.start_bus as u16) << 8
                     | ioapic_iommu_wiring::IOAPIC_PHANTOM_DEVFN as u16;
 
-                let wrapped = ioapic_iommu_wiring::IommuIoApicRouting::new(
-                    partition.clone().ioapic_routing(),
+                ioapic_routing.connect_remapper(
                     ioapic_rid,
                     first_iommu.clone() as Arc<dyn iommu_common::InterruptRemapper>,
                 );
-                ioapic_routing_slot.swap(wrapped);
                 Some(ioapic_rid)
             } else {
                 None

--- a/openvmm/openvmm_core/src/worker/dispatch.rs
+++ b/openvmm/openvmm_core/src/worker/dispatch.rs
@@ -794,9 +794,9 @@ struct LoadedVmInner {
     /// Instantiated IOMMU devices (ACPI configs + per-RC shared state),
     /// keyed by IOMMU type. `IommuDevices::None` when no IOMMU is configured.
     iommu_devices: IommuDevices,
-    /// IOAPIC PCIe Requester ID for the IVRS DEV_SPECIAL(IOAPIC) entry,
-    /// when AMD IOMMU interrupt remapping is active. Threaded into the IVRS
-    /// ACPI config at firmware-load time.
+    /// IOAPIC PCIe Requester ID when x86 IOMMU interrupt remapping is active.
+    /// For AMD this is threaded into IVRS at firmware-load time; for Intel
+    /// the matching DMAR device scope is carried by the per-unit ACPI config.
     #[cfg(guest_arch = "x86_64")]
     ioapic_iommu_rid: Option<u16>,
     pcie_host_bridges: Vec<PcieHostBridge>,
@@ -2081,11 +2081,17 @@ impl InitializedVm {
                         if resources.iter().any(|r| r.rc_idx == rc_idx)
                 );
                 #[cfg(guest_arch = "x86_64")]
+                let intel_vtd_on_rc = matches!(
+                    &resolved_iommu,
+                    ResolvedIommu::IntelVtd(resources)
+                        if resources.iter().any(|r| r.rc_idx == rc_idx)
+                );
+                #[cfg(guest_arch = "x86_64")]
                 let root_port_start_device: u8 = if amd_iommu_on_rc { 1 } else { 0 };
                 #[cfg(not(guest_arch = "x86_64"))]
                 let root_port_start_device: u8 = 0;
 
-                // On the segment-0 root complex covered by the AMD IOMMU, the
+                // On the segment-0 root complex covered by an x86 IOMMU, the
                 // phantom southbridge IOAPIC occupies a fixed devfn whose
                 // device number must not be assigned to a root port. The
                 // IOAPIC RID is on bus 0, so only reserve the device number on
@@ -2096,7 +2102,8 @@ impl InitializedVm {
                 // silently shadowing the IOAPIC entry.
                 #[cfg(guest_arch = "x86_64")]
                 let reserved_device_numbers: u32 =
-                    if rc.segment == 0 && rc.start_bus == 0 && amd_iommu_on_rc {
+                    if rc.segment == 0 && rc.start_bus == 0 && (amd_iommu_on_rc || intel_vtd_on_rc)
+                    {
                         1u32 << (ioapic_iommu_wiring::IOAPIC_PHANTOM_DEVFN >> 3)
                     } else {
                         0
@@ -2413,26 +2420,23 @@ impl InitializedVm {
             ResolvedIommu::None => IommuDevices::None,
         };
 
-        // Set up IOAPIC routing. When an AMD IOMMU covers the southbridge
+        // Set up IOAPIC routing. When an x86 IOMMU covers the southbridge
         // IOAPIC (segment 0, bus 0), wrap the hypervisor's IoApicRouting
         // through that IOMMU's interrupt remapping table so IOAPIC-sourced
         // interrupts are translated via the guest's IRTEs and invalidation
         // commands trigger retranslation. The RID and the remapper come from
-        // the same IOMMU, so the IVRS DEV_SPECIAL(IOAPIC) entry and the
-        // runtime remapping always refer to the same DTE/IRTE context.
+        // the same IOMMU, so ACPI discovery and runtime remapping agree.
         #[cfg(guest_arch = "x86_64")]
-        let ioapic_iommu_rid: Option<u16> = if let IommuDevices::AmdVi(amd_devices) = &iommu_devices
-        {
-            amd_devices.ioapic_iommu.as_ref().map(|sel| {
-                ioapic_routing.connect_remapper(
-                    sel.ioapic_rid,
-                    sel.shared_state.clone() as Arc<dyn iommu_common::InterruptRemapper>,
-                );
-                sel.ioapic_rid
-            })
-        } else {
-            None
+        let ioapic_iommu = match &iommu_devices {
+            IommuDevices::AmdVi(devices) => devices.ioapic_iommu.as_ref(),
+            IommuDevices::IntelVtd(devices) => devices.ioapic_iommu.as_ref(),
+            IommuDevices::None => None,
         };
+        #[cfg(guest_arch = "x86_64")]
+        let ioapic_iommu_rid: Option<u16> = ioapic_iommu.map(|sel| {
+            ioapic_routing.connect_remapper(sel.ioapic_rid, sel.remapper.clone());
+            sel.ioapic_rid
+        });
 
         // Wire deferred root complex and switch MSI connections now that
         // IOMMU setup is complete. On x86_64, this applies IOMMU

--- a/openvmm/openvmm_core/src/worker/dispatch/amd_iommu_wiring.rs
+++ b/openvmm/openvmm_core/src/worker/dispatch/amd_iommu_wiring.rs
@@ -8,6 +8,7 @@
 //! This module handles instantiating AMD IOMMU chipset devices on each
 //! requested root complex.
 
+use super::ioapic_iommu_wiring::IoapicIommuSelection;
 use crate::partition::HvlitePartition;
 use guestmem::GuestMemory;
 use hvdef::Vtl;
@@ -57,17 +58,6 @@ pub(super) struct IommuDevicesResult {
     /// DEV_SPECIAL(IOAPIC) entry. `None` if no AMD IOMMU covers that
     /// location, in which case IOAPIC interrupt remapping stays disabled.
     pub ioapic_iommu: Option<IoapicIommuSelection>,
-}
-
-/// The AMD IOMMU selected to host the southbridge IOAPIC's interrupt
-/// remapping context.
-pub(super) struct IoapicIommuSelection {
-    /// Interrupt remapper backing the IOAPIC routes. This is the same IOMMU
-    /// whose IVHD carries the DEV_SPECIAL(IOAPIC) entry, so the RID used for
-    /// remapping and the RID published in the IVRS always agree.
-    pub shared_state: Arc<amd_iommu::IommuSharedState>,
-    /// IOAPIC PCIe Requester ID (RID) for the IVRS DEV_SPECIAL(IOAPIC) entry.
-    pub ioapic_rid: u16,
 }
 
 /// Instantiate AMD IOMMU chipset devices.
@@ -145,7 +135,7 @@ pub(super) fn setup_amd_iommu(
             let ioapic_rid = (hb.start_bus as u16) << 8
                 | super::ioapic_iommu_wiring::IOAPIC_PHANTOM_DEVFN as u16;
             ioapic_iommu = Some(IoapicIommuSelection {
-                shared_state: shared,
+                remapper: shared,
                 ioapic_rid,
             });
         }

--- a/openvmm/openvmm_core/src/worker/dispatch/amd_iommu_wiring.rs
+++ b/openvmm/openvmm_core/src/worker/dispatch/amd_iommu_wiring.rs
@@ -52,6 +52,22 @@ pub(super) struct IommuDevicesResult {
     /// Per-RC IOMMU shared state, indexed parallel to `pcie_host_bridges`.
     /// `None` for root complexes without an AMD IOMMU.
     pub shared_states: Vec<Option<Arc<amd_iommu::IommuSharedState>>>,
+    /// The IOMMU that covers the southbridge IOAPIC (segment 0, bus 0), if
+    /// any. Used to wire IOAPIC interrupt remapping and publish the IVRS
+    /// DEV_SPECIAL(IOAPIC) entry. `None` if no AMD IOMMU covers that
+    /// location, in which case IOAPIC interrupt remapping stays disabled.
+    pub ioapic_iommu: Option<IoapicIommuSelection>,
+}
+
+/// The AMD IOMMU selected to host the southbridge IOAPIC's interrupt
+/// remapping context.
+pub(super) struct IoapicIommuSelection {
+    /// Interrupt remapper backing the IOAPIC routes. This is the same IOMMU
+    /// whose IVHD carries the DEV_SPECIAL(IOAPIC) entry, so the RID used for
+    /// remapping and the RID published in the IVRS always agree.
+    pub shared_state: Arc<amd_iommu::IommuSharedState>,
+    /// IOAPIC PCIe Requester ID (RID) for the IVRS DEV_SPECIAL(IOAPIC) entry.
+    pub ioapic_rid: u16,
 }
 
 /// Instantiate AMD IOMMU chipset devices.
@@ -70,6 +86,7 @@ pub(super) fn setup_amd_iommu(
     let mut shared_states: Vec<Option<Arc<amd_iommu::IommuSharedState>>> =
         vec![None; pcie_host_bridges.len()];
     let mut acpi_configs: Vec<vmm_core::acpi_builder::AmdIommuAcpiConfig> = Vec::new();
+    let mut ioapic_iommu: Option<IoapicIommuSelection> = None;
 
     for res in resolved_resources {
         let rc_pos = res.rc_idx;
@@ -109,7 +126,7 @@ pub(super) fn setup_amd_iommu(
             iommu_msi_conn.connect(signal_msi);
         }
         let shared = iommu_dev.lock().shared_state().clone();
-        shared_states[rc_pos] = Some(shared);
+        shared_states[rc_pos] = Some(shared.clone());
 
         acpi_configs.push(vmm_core::acpi_builder::AmdIommuAcpiConfig {
             device_id: (hb.start_bus as u16) << 8, // device 0, function 0
@@ -120,10 +137,29 @@ pub(super) fn setup_amd_iommu(
             start_bus: hb.start_bus,
             end_bus: hb.end_bus,
         });
+
+        // The southbridge IOAPIC lives at segment 0, bus 0. Select the IOMMU
+        // covering it so the RID and the remapper come from the same IOMMU,
+        // keeping the IVRS entry and runtime remapping in agreement.
+        if hb.segment == 0 && hb.start_bus == 0 {
+            let ioapic_rid = (hb.start_bus as u16) << 8
+                | super::ioapic_iommu_wiring::IOAPIC_PHANTOM_DEVFN as u16;
+            ioapic_iommu = Some(IoapicIommuSelection {
+                shared_state: shared,
+                ioapic_rid,
+            });
+        }
+    }
+
+    // At least one IOMMU exists but none covers the IOAPIC, so interrupt
+    // remapping can't be enabled (breaks nested PCI device assignment).
+    if ioapic_iommu.is_none() && !acpi_configs.is_empty() {
+        tracing::warn!("no AMD IOMMU covers segment 0 bus 0; IOAPIC interrupt remapping disabled");
     }
 
     Ok(IommuDevicesResult {
         acpi_configs,
         shared_states,
+        ioapic_iommu,
     })
 }

--- a/openvmm/openvmm_core/src/worker/dispatch/intel_vtd_wiring.rs
+++ b/openvmm/openvmm_core/src/worker/dispatch/intel_vtd_wiring.rs
@@ -9,6 +9,7 @@
 //! requested root complex. Unlike AMD IOMMU (which is a PCI device), VT-d is a
 //! pure MMIO platform device discovered via the ACPI DMAR table.
 
+use super::ioapic_iommu_wiring::IoapicIommuSelection;
 use anyhow::Context as _;
 use guestmem::GuestMemory;
 use hvdef::Vtl;
@@ -79,6 +80,10 @@ pub(super) struct VtdDevicesResult {
     /// Per-RC VT-d shared state, indexed parallel to `pcie_host_bridges`.
     /// `None` for root complexes without an Intel VT-d unit.
     pub shared_states: Vec<Option<Arc<intel_vtd::VtdSharedState>>>,
+    /// The VT-d unit that covers the southbridge IOAPIC (segment 0, bus 0),
+    /// if any. Used to wire IOAPIC interrupt remapping and publish the DMAR
+    /// IOAPIC device scope.
+    pub ioapic_iommu: Option<IoapicIommuSelection>,
 }
 
 /// Instantiate Intel VT-d chipset devices.
@@ -97,6 +102,7 @@ pub(super) fn setup_intel_vtd(
     let mut shared_states: Vec<Option<Arc<intel_vtd::VtdSharedState>>> =
         vec![None; pcie_host_bridges.len()];
     let mut acpi_configs: Vec<vmm_core::acpi_builder::IntelVtdAcpiConfig> = Vec::new();
+    let mut ioapic_iommu: Option<IoapicIommuSelection> = None;
 
     for res in resolved_resources {
         let rc_pos = res.rc_idx;
@@ -128,18 +134,45 @@ pub(super) fn setup_intel_vtd(
             device
         })?;
         let shared = vtd_dev.lock().shared_state().clone();
-        shared_states[rc_pos] = Some(shared);
+        shared_states[rc_pos] = Some(shared.clone());
+
+        let ioapic_rid = if hb.segment == 0 && hb.start_bus == 0 {
+            Some(
+                ((hb.start_bus as u16) << 8)
+                    | super::ioapic_iommu_wiring::IOAPIC_PHANTOM_DEVFN as u16,
+            )
+        } else {
+            None
+        };
 
         acpi_configs.push(vmm_core::acpi_builder::IntelVtdAcpiConfig {
             mmio_base,
             pci_segment: hb.segment,
             start_bus: hb.start_bus,
             device_scopes: res.device_scopes.clone(),
+            ioapic: ioapic_rid.map(|_| vmm_core::acpi_builder::IntelVtdIoapicScope {
+                enumeration_id: 0,
+                devfn: super::ioapic_iommu_wiring::IOAPIC_PHANTOM_DEVFN,
+            }),
         });
+
+        if let Some(ioapic_rid) = ioapic_rid {
+            ioapic_iommu = Some(IoapicIommuSelection {
+                remapper: shared,
+                ioapic_rid,
+            });
+        }
+    }
+
+    if ioapic_iommu.is_none() && !acpi_configs.is_empty() {
+        tracing::warn!(
+            "no Intel VT-d unit covers segment 0 bus 0; IOAPIC interrupt remapping disabled"
+        );
     }
 
     Ok(VtdDevicesResult {
         acpi_configs,
         shared_states,
+        ioapic_iommu,
     })
 }

--- a/openvmm/openvmm_core/src/worker/dispatch/intel_vtd_wiring.rs
+++ b/openvmm/openvmm_core/src/worker/dispatch/intel_vtd_wiring.rs
@@ -150,10 +150,7 @@ pub(super) fn setup_intel_vtd(
             pci_segment: hb.segment,
             start_bus: hb.start_bus,
             device_scopes: res.device_scopes.clone(),
-            ioapic: ioapic_rid.map(|_| vmm_core::acpi_builder::IntelVtdIoapicScope {
-                enumeration_id: 0,
-                devfn: super::ioapic_iommu_wiring::IOAPIC_PHANTOM_DEVFN,
-            }),
+            ioapic_rid,
         });
 
         if let Some(ioapic_rid) = ioapic_rid {

--- a/openvmm/openvmm_core/src/worker/dispatch/intel_vtd_wiring.rs
+++ b/openvmm/openvmm_core/src/worker/dispatch/intel_vtd_wiring.rs
@@ -35,11 +35,29 @@ pub(super) struct ResolvedVtdResources {
 
 /// Combines Intel VT-d RC configs with MMIO ranges from the memory layout
 /// engine into resolved per-instance resources.
+///
+/// Intel VT-d forces global interrupt remapping (x2APIC), under which Linux
+/// gives any device not covered by a DRHD a NULL MSI domain and its MSI
+/// allocation fails. Each VT-d unit covers only its own root complex, so
+/// reject mixing VT-d and non-VT-d root complexes.
 pub(super) fn resolve_vtd_resources(
     root_complexes: &[openvmm_defs::config::PcieRootComplexConfig],
     mmio_ranges: &[memory_range::MemoryRange],
-) -> Vec<ResolvedVtdResources> {
-    root_complexes
+) -> anyhow::Result<Vec<ResolvedVtdResources>> {
+    for rc in root_complexes {
+        if !matches!(
+            rc.iommu,
+            Some(openvmm_defs::config::PcieIommuConfig::IntelVtd)
+        ) {
+            anyhow::bail!(
+                "root complex '{}' has no Intel VT-d unit; with Intel \
+                 VT-d, every root complex must have one",
+                rc.name,
+            );
+        }
+    }
+
+    Ok(root_complexes
         .iter()
         .enumerate()
         .filter(|(_, rc)| {
@@ -70,7 +88,7 @@ pub(super) fn resolve_vtd_resources(
                 device_scopes,
             }
         })
-        .collect()
+        .collect())
 }
 
 /// Result of [`setup_intel_vtd`].
@@ -171,4 +189,54 @@ pub(super) fn setup_intel_vtd(
         shared_states,
         ioapic_iommu,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use memory_range::MemoryRange;
+    use openvmm_defs::config::PcieIommuConfig;
+    use openvmm_defs::config::PcieMmioRangeConfig;
+    use openvmm_defs::config::PcieRootComplexConfig;
+
+    fn rc(name: &str, segment: u16, iommu: Option<PcieIommuConfig>) -> PcieRootComplexConfig {
+        PcieRootComplexConfig {
+            index: 0,
+            name: name.to_string(),
+            segment,
+            start_bus: 0,
+            end_bus: 0,
+            low_mmio: PcieMmioRangeConfig::Dynamic { size: 0 },
+            high_mmio: PcieMmioRangeConfig::Dynamic { size: 0 },
+            ports: Vec::new(),
+            cxl: None,
+            iommu,
+            vnode: None,
+            preserve_bars: false,
+        }
+    }
+
+    #[test]
+    fn rejects_mixed_vtd_topology() {
+        // A root complex without its own VT-d unit is unreachable by interrupt
+        // remapping once VT-d forces global x2APIC, so the config is rejected.
+        let rcs = [
+            rc("s0rc0", 0, Some(PcieIommuConfig::IntelVtd)),
+            rc("s1rc0", 1, None),
+        ];
+        assert!(resolve_vtd_resources(&rcs, &[]).is_err());
+    }
+
+    #[test]
+    fn accepts_vtd_on_every_rc() {
+        let rcs = [
+            rc("s0rc0", 0, Some(PcieIommuConfig::IntelVtd)),
+            rc("s1rc0", 1, Some(PcieIommuConfig::IntelVtd)),
+        ];
+        let ranges = [
+            MemoryRange::new(0..0x1000),
+            MemoryRange::new(0x1000..0x2000),
+        ];
+        assert_eq!(resolve_vtd_resources(&rcs, &ranges).unwrap().len(), 2);
+    }
 }

--- a/openvmm/openvmm_core/src/worker/dispatch/intel_vtd_wiring.rs
+++ b/openvmm/openvmm_core/src/worker/dispatch/intel_vtd_wiring.rs
@@ -150,7 +150,6 @@ pub(super) fn setup_intel_vtd(
             pci_segment: hb.segment,
             start_bus: hb.start_bus,
             device_scopes: res.device_scopes.clone(),
-            ioapic_rid,
         });
 
         if let Some(ioapic_rid) = ioapic_rid {

--- a/openvmm/openvmm_core/src/worker/dispatch/ioapic_iommu_wiring.rs
+++ b/openvmm/openvmm_core/src/worker/dispatch/ioapic_iommu_wiring.rs
@@ -1,0 +1,148 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#![cfg(guest_arch = "x86_64")]
+
+//! IOAPIC-to-IOMMU interrupt remapping wiring.
+//!
+//! Wraps an inner `virt::irqcon::IoApicRouting` to translate MSI
+//! address/data through the IOMMU's interrupt remapping table before
+//! pushing routes to the hypervisor.
+
+use iommu_common::InterruptRemapper;
+use iommu_common::RetranslateInterrupts;
+use parking_lot::Mutex;
+use parking_lot::RwLock;
+use std::sync::Arc;
+use virt::irqcon::IoApicRouting;
+use virt::irqcon::MsiRequest;
+
+/// Number of IOAPIC redirection table entries.
+const NUM_ENTRIES: usize = 24;
+
+/// Device/function (devfn) used as the IOAPIC requestor ID (RID) for
+/// interrupt remapping, as required by the Linux AMD-Vi driver.
+///
+/// Linux expects the southbridge IOAPIC RID to be 00:14.0
+/// (devfn `0xA0` = device `0x14`, function 0) and disables
+/// interrupt remapping entirely if a matching DEV_SPECIAL(IOAPIC) entry isn't
+/// present in the IVRS. We reserve this devfn on segment 0 and publish it via
+/// IVRS DEV_SPECIAL(IOAPIC) so Linux can resolve the IOAPIC RID for IRTE/DTE
+/// lookup.
+pub const IOAPIC_PHANTOM_DEVFN: u8 = 0xA0;
+
+/// An `IoApicRouting` implementation that delegates to a swappable inner.
+///
+/// Registered early so that the base chipset build can resolve the IOAPIC
+/// routing resource. After IOMMU setup, the inner is swapped to an
+/// [`IommuIoApicRouting`] wrapper that remaps through the IOMMU.
+pub struct SwappableIoApicRouting {
+    inner: RwLock<Arc<dyn IoApicRouting>>,
+}
+
+impl SwappableIoApicRouting {
+    /// Create with an initial (plain) routing implementation.
+    pub fn new(inner: Arc<dyn IoApicRouting>) -> Arc<Self> {
+        Arc::new(Self {
+            inner: RwLock::new(inner),
+        })
+    }
+
+    /// Replace the inner routing implementation.
+    pub fn swap(&self, new_inner: Arc<dyn IoApicRouting>) {
+        *self.inner.write() = new_inner;
+    }
+}
+
+impl IoApicRouting for SwappableIoApicRouting {
+    fn set_irq_route(&self, irq: u8, request: Option<MsiRequest>) {
+        self.inner.read().set_irq_route(irq, request);
+    }
+
+    fn assert_irq(&self, irq: u8) {
+        self.inner.read().assert_irq(irq);
+    }
+}
+
+/// An `IoApicRouting` wrapper that remaps MSI address/data through an
+/// IOMMU's interrupt remapping table.
+///
+/// Stores the raw (guest-written) MSI parameters for each IRQ line and
+/// translates them through the IOMMU before forwarding to the inner
+/// `IoApicRouting` implementation.
+///
+/// On `INVALIDATE_INTERRUPT_TABLE`, the IOMMU calls [`retranslate`],
+/// which re-translates all stored routes and re-pushes any that changed.
+pub struct IommuIoApicRouting {
+    inner: Arc<dyn IoApicRouting>,
+    rid: u16,
+    remapper: Arc<dyn InterruptRemapper>,
+    /// Raw (pre-remapping) MSI requests from the IOAPIC, indexed by IRQ.
+    raw_routes: Mutex<[Option<MsiRequest>; NUM_ENTRIES]>,
+}
+
+impl IommuIoApicRouting {
+    /// Create a new IOMMU-aware IOAPIC routing wrapper.
+    ///
+    /// - `inner`: the hypervisor's IoApicRouting implementation
+    /// - `rid`: IOAPIC RID (used for DTE/IRTE lookup)
+    /// - `remapper`: the IOMMU's interrupt remapper
+    pub fn new(
+        inner: Arc<dyn IoApicRouting>,
+        rid: u16,
+        remapper: Arc<dyn InterruptRemapper>,
+    ) -> Arc<Self> {
+        let this = Arc::new(Self {
+            inner,
+            rid,
+            remapper: remapper.clone(),
+            raw_routes: Mutex::new([None; NUM_ENTRIES]),
+        });
+        remapper.register_route(&(this.clone() as Arc<dyn RetranslateInterrupts>));
+        this
+    }
+
+    /// Translate and forward a single route to the inner implementation.
+    fn translate_and_set(
+        &self,
+        irq: u8,
+        raw: Option<MsiRequest>,
+        remapper: &dyn InterruptRemapper,
+    ) {
+        let translated = raw.and_then(|r| {
+            remapper
+                .remap_msi(self.rid, r.address, r.data)
+                .map(|(address, data)| MsiRequest { address, data })
+        });
+        self.inner.set_irq_route(irq, translated);
+    }
+}
+
+impl IoApicRouting for IommuIoApicRouting {
+    fn set_irq_route(&self, irq: u8, request: Option<MsiRequest>) {
+        let mut routes = self.raw_routes.lock();
+        if let Some(slot) = routes.get_mut(irq as usize) {
+            *slot = request;
+        }
+        // Hold the lock across translate to serialize with retranslate().
+        self.translate_and_set(irq, request, &*self.remapper);
+    }
+
+    fn assert_irq(&self, irq: u8) {
+        // Route is already programmed in the hypervisor; just forward.
+        self.inner.assert_irq(irq);
+    }
+}
+
+impl RetranslateInterrupts for IommuIoApicRouting {
+    fn device_id(&self) -> u16 {
+        self.rid
+    }
+
+    fn retranslate(&self) {
+        let routes = self.raw_routes.lock();
+        for (irq, raw) in routes.iter().enumerate() {
+            self.translate_and_set(irq as u8, *raw, &*self.remapper);
+        }
+    }
+}

--- a/openvmm/openvmm_core/src/worker/dispatch/ioapic_iommu_wiring.rs
+++ b/openvmm/openvmm_core/src/worker/dispatch/ioapic_iommu_wiring.rs
@@ -28,6 +28,17 @@ use virt::irqcon::MsiRequest;
 /// lookup.
 pub const IOAPIC_PHANTOM_DEVFN: u8 = 0xA0;
 
+/// The x86 IOMMU selected to host the southbridge IOAPIC's interrupt
+/// remapping context.
+pub(super) struct IoapicIommuSelection {
+    /// Interrupt remapper backing the IOAPIC routes. This is the same IOMMU
+    /// whose ACPI table entry publishes [`ioapic_rid`](Self::ioapic_rid), so
+    /// ACPI discovery and runtime remapping always agree.
+    pub remapper: Arc<dyn InterruptRemapper>,
+    /// IOAPIC PCIe Requester ID (RID) published in the IOMMU ACPI table.
+    pub ioapic_rid: u16,
+}
+
 /// The control side of the IOAPIC interrupt-remapping connection.
 ///
 /// Modeled after [`pci_core::msi::MsiConnection`](pci_core::msi::MsiConnection):
@@ -165,5 +176,111 @@ impl RetranslateInterrupts for IoApicRoutingInner {
     fn retranslate(&self) {
         let mut state = self.state.lock();
         self.set_all_routes(&mut state);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::AtomicU32;
+    use std::sync::atomic::Ordering;
+
+    #[derive(Default)]
+    struct RecordingIoApicRouting {
+        routes: Mutex<Vec<(u8, Option<MsiRequest>)>>,
+    }
+
+    impl RecordingIoApicRouting {
+        fn last_route(&self, irq: u8) -> Option<MsiRequest> {
+            self.routes
+                .lock()
+                .iter()
+                .rev()
+                .find(|(route_irq, _)| *route_irq == irq)
+                .and_then(|(_, request)| *request)
+        }
+    }
+
+    impl IoApicRouting for RecordingIoApicRouting {
+        fn set_irq_route(&self, irq: u8, request: Option<MsiRequest>) {
+            self.routes.lock().push((irq, request));
+        }
+
+        fn assert_irq(&self, _irq: u8) {}
+    }
+
+    struct TestRemapper {
+        data_delta: AtomicU32,
+        routes: iommu_common::RetranslateInterruptsList,
+        seen_device_ids: Mutex<Vec<u16>>,
+    }
+
+    impl TestRemapper {
+        fn new(data_delta: u32) -> Self {
+            Self {
+                data_delta: AtomicU32::new(data_delta),
+                routes: iommu_common::RetranslateInterruptsList::new(),
+                seen_device_ids: Mutex::new(Vec::new()),
+            }
+        }
+    }
+
+    impl InterruptRemapper for TestRemapper {
+        fn remap_msi(&self, device_id: u16, address: u64, data: u32) -> Option<(u64, u32)> {
+            self.seen_device_ids.lock().push(device_id);
+            Some((
+                address + 0x1000,
+                data + self.data_delta.load(Ordering::SeqCst),
+            ))
+        }
+
+        fn register_route(&self, route: &Arc<dyn RetranslateInterrupts>) {
+            self.routes.register(route);
+        }
+
+        fn unregister_route(&self, route: &Arc<dyn RetranslateInterrupts>) {
+            self.routes.unregister(route);
+        }
+    }
+
+    #[test]
+    fn ioapic_routes_are_remapped_and_retranslated() {
+        let hv_routing = Arc::new(RecordingIoApicRouting::default());
+        let connection = IoApicRoutingConnection::new(hv_routing.clone());
+        let target = connection.target();
+        let raw = MsiRequest {
+            address: 0xFEE0_0000,
+            data: 0x20,
+        };
+
+        target.set_irq_route(4, Some(raw));
+        assert_eq!(hv_routing.last_route(4), Some(raw));
+
+        let remapper = Arc::new(TestRemapper::new(1));
+        connection.connect_remapper(0x00A0, remapper.clone());
+        assert_eq!(
+            hv_routing.last_route(4),
+            Some(MsiRequest {
+                address: raw.address + 0x1000,
+                data: raw.data + 1,
+            })
+        );
+
+        remapper.data_delta.store(2, Ordering::SeqCst);
+        remapper.routes.invalidate(None);
+        assert_eq!(
+            hv_routing.last_route(4),
+            Some(MsiRequest {
+                address: raw.address + 0x1000,
+                data: raw.data + 2,
+            })
+        );
+        assert!(
+            remapper
+                .seen_device_ids
+                .lock()
+                .iter()
+                .all(|device_id| *device_id == 0x00A0)
+        );
     }
 }

--- a/openvmm/openvmm_core/src/worker/dispatch/ioapic_iommu_wiring.rs
+++ b/openvmm/openvmm_core/src/worker/dispatch/ioapic_iommu_wiring.rs
@@ -12,7 +12,6 @@
 use iommu_common::InterruptRemapper;
 use iommu_common::RetranslateInterrupts;
 use parking_lot::Mutex;
-use parking_lot::RwLock;
 use std::sync::Arc;
 use virt::irqcon::IoApicRouting;
 use virt::irqcon::MsiRequest;
@@ -31,118 +30,133 @@ const NUM_ENTRIES: usize = 24;
 /// lookup.
 pub const IOAPIC_PHANTOM_DEVFN: u8 = 0xA0;
 
-/// An `IoApicRouting` implementation that delegates to a swappable inner.
+/// The control side of the IOAPIC interrupt-remapping connection.
 ///
-/// Registered early so that the base chipset build can resolve the IOAPIC
-/// routing resource. After IOMMU setup, the inner is swapped to an
-/// [`IommuIoApicRouting`] wrapper that remaps through the IOMMU.
-pub struct SwappableIoApicRouting {
-    inner: RwLock<Arc<dyn IoApicRouting>>,
+/// Modeled after [`pci_core::msi::MsiConnection`](pci_core::msi::MsiConnection):
+/// [`target`](Self::target) hands the routing interface to the IOAPIC device
+/// (via the resolver) while it is still in passthrough mode, and
+/// [`connect_remapper`](Self::connect_remapper) wires in the IOMMU later, once
+/// it exists. The two roles share the same [`Inner`], but callers only see the
+/// control handle and the `dyn IoApicRouting` target. Cached routes are
+/// re-translated when the remapper connects and on each
+/// [`retranslate`](RetranslateInterrupts::retranslate).
+pub struct IoApicRoutingConnection {
+    inner: Arc<IoApicRoutingInner>,
 }
 
-impl SwappableIoApicRouting {
-    /// Create with an initial (plain) routing implementation.
-    pub fn new(inner: Arc<dyn IoApicRouting>) -> Arc<Self> {
-        Arc::new(Self {
-            inner: RwLock::new(inner),
-        })
-    }
-
-    /// Replace the inner routing implementation.
-    pub fn swap(&self, new_inner: Arc<dyn IoApicRouting>) {
-        *self.inner.write() = new_inner;
-    }
+struct IoApicRoutingInner {
+    /// The hypervisor's `IoApicRouting` implementation; final routes go here.
+    hv_routing: Arc<dyn IoApicRouting>,
+    state: Mutex<IoApicRoutingState>,
 }
 
-impl IoApicRouting for SwappableIoApicRouting {
-    fn set_irq_route(&self, irq: u8, request: Option<MsiRequest>) {
-        self.inner.read().set_irq_route(irq, request);
-    }
-
-    fn assert_irq(&self, irq: u8) {
-        self.inner.read().assert_irq(irq);
-    }
-}
-
-/// An `IoApicRouting` wrapper that remaps MSI address/data through an
-/// IOMMU's interrupt remapping table.
-///
-/// Stores the raw (guest-written) MSI parameters for each IRQ line and
-/// translates them through the IOMMU before forwarding to the inner
-/// `IoApicRouting` implementation.
-///
-/// On `INVALIDATE_INTERRUPT_TABLE`, the IOMMU calls [`retranslate`],
-/// which re-translates all stored routes and re-pushes any that changed.
-pub struct IommuIoApicRouting {
-    inner: Arc<dyn IoApicRouting>,
-    rid: u16,
-    remapper: Arc<dyn InterruptRemapper>,
+struct IoApicRoutingState {
+    /// Remapping state; `None` while in passthrough mode.
+    remap: Option<RemapState>,
     /// Raw (pre-remapping) MSI requests from the IOAPIC, indexed by IRQ.
-    raw_routes: Mutex<[Option<MsiRequest>; NUM_ENTRIES]>,
+    raw_routes: [Option<MsiRequest>; NUM_ENTRIES],
 }
 
-impl IommuIoApicRouting {
-    /// Create a new IOMMU-aware IOAPIC routing wrapper.
+struct RemapState {
+    /// IOAPIC RID (used for DTE/IRTE lookup).
+    rid: u16,
+    /// The IOMMU's interrupt remapper.
+    remapper: Arc<dyn InterruptRemapper>,
+}
+
+impl IoApicRoutingConnection {
+    /// Create a connection in passthrough mode, forwarding routes to
+    /// `hv_routing`.
+    pub fn new(hv_routing: Arc<dyn IoApicRouting>) -> Self {
+        Self {
+            inner: Arc::new(IoApicRoutingInner {
+                hv_routing,
+                state: Mutex::new(IoApicRoutingState {
+                    remap: None,
+                    raw_routes: [None; NUM_ENTRIES],
+                }),
+            }),
+        }
+    }
+
+    /// The routing interface handed to the IOAPIC device via the resolver.
+    pub fn target(&self) -> Arc<dyn IoApicRouting> {
+        self.inner.clone()
+    }
+
+    /// Transition into remapping mode, re-translating already-programmed routes.
     ///
-    /// - `inner`: the hypervisor's IoApicRouting implementation
-    /// - `rid`: IOAPIC RID (used for DTE/IRTE lookup)
-    /// - `remapper`: the IOMMU's interrupt remapper
-    pub fn new(
-        inner: Arc<dyn IoApicRouting>,
-        rid: u16,
-        remapper: Arc<dyn InterruptRemapper>,
-    ) -> Arc<Self> {
-        let this = Arc::new(Self {
-            inner,
-            rid,
-            remapper: remapper.clone(),
-            raw_routes: Mutex::new([None; NUM_ENTRIES]),
-        });
-        remapper.register_route(&(this.clone() as Arc<dyn RetranslateInterrupts>));
-        this
-    }
-
-    /// Translate and forward a single route to the inner implementation.
-    fn translate_and_set(
-        &self,
-        irq: u8,
-        raw: Option<MsiRequest>,
-        remapper: &dyn InterruptRemapper,
-    ) {
-        let translated = raw.and_then(|r| {
-            remapper
-                .remap_msi(self.rid, r.address, r.data)
-                .map(|(address, data)| MsiRequest { address, data })
-        });
-        self.inner.set_irq_route(irq, translated);
+    /// Panics if called more than once.
+    pub fn connect_remapper(&self, rid: u16, remapper: Arc<dyn InterruptRemapper>) {
+        {
+            let mut state = self.inner.state.lock();
+            assert!(
+                state.remap.is_none(),
+                "IOAPIC remapper connected more than once"
+            );
+            state.remap = Some(RemapState {
+                rid,
+                remapper: remapper.clone(),
+            });
+            self.inner.set_all_routes(&state);
+        }
+        // Register outside the lock: `register_route` may synchronously invoke
+        // `retranslate`, which acquires the same lock.
+        remapper.register_route(&(self.inner.clone() as Arc<dyn RetranslateInterrupts>));
     }
 }
 
-impl IoApicRouting for IommuIoApicRouting {
+impl IoApicRoutingInner {
+    /// Translate `raw` through the remapper (if any) and program it into
+    /// `hv_routing`.
+    fn set_route(&self, state: &IoApicRoutingState, irq: u8, raw: Option<MsiRequest>) {
+        let translated = match &state.remap {
+            Some(remap) => raw.and_then(|r| {
+                remap
+                    .remapper
+                    .remap_msi(remap.rid, r.address, r.data)
+                    .map(|(address, data)| MsiRequest { address, data })
+            }),
+            None => raw,
+        };
+        self.hv_routing.set_irq_route(irq, translated);
+    }
+
+    /// Re-translate and re-program all cached routes.
+    fn set_all_routes(&self, state: &IoApicRoutingState) {
+        for (irq, raw) in state.raw_routes.iter().enumerate() {
+            self.set_route(state, irq as u8, *raw);
+        }
+    }
+}
+
+impl IoApicRouting for IoApicRoutingInner {
     fn set_irq_route(&self, irq: u8, request: Option<MsiRequest>) {
-        let mut routes = self.raw_routes.lock();
-        if let Some(slot) = routes.get_mut(irq as usize) {
+        // Hold the lock across translate to serialize with retranslate().
+        let mut state = self.state.lock();
+        if let Some(slot) = state.raw_routes.get_mut(irq as usize) {
             *slot = request;
         }
-        // Hold the lock across translate to serialize with retranslate().
-        self.translate_and_set(irq, request, &*self.remapper);
+        self.set_route(&state, irq, request);
     }
 
     fn assert_irq(&self, irq: u8) {
         // Route is already programmed in the hypervisor; just forward.
-        self.inner.assert_irq(irq);
+        self.hv_routing.assert_irq(irq);
     }
 }
 
-impl RetranslateInterrupts for IommuIoApicRouting {
+impl RetranslateInterrupts for IoApicRoutingInner {
     fn device_id(&self) -> u16 {
-        self.rid
+        self.state
+            .lock()
+            .remap
+            .as_ref()
+            .map_or(0, |remap| remap.rid)
     }
 
     fn retranslate(&self) {
-        let routes = self.raw_routes.lock();
-        for (irq, raw) in routes.iter().enumerate() {
-            self.translate_and_set(irq as u8, *raw, &*self.remapper);
-        }
+        let state = self.state.lock();
+        self.set_all_routes(&state);
     }
 }

--- a/openvmm/openvmm_core/src/worker/dispatch/ioapic_iommu_wiring.rs
+++ b/openvmm/openvmm_core/src/worker/dispatch/ioapic_iommu_wiring.rs
@@ -13,13 +13,9 @@ use iommu_common::InterruptRemapper;
 use iommu_common::RetranslateInterrupts;
 use parking_lot::Mutex;
 use std::sync::Arc;
+use virt::irqcon::IRQ_LINES;
 use virt::irqcon::IoApicRouting;
 use virt::irqcon::MsiRequest;
-
-/// Number of IOAPIC redirection table entries. Must match
-/// `chipset_resources::ioapic::IOAPIC_NUM_ENTRIES`, which bounds the `irq`
-/// values the IOAPIC device passes to [`IoApicRouting`].
-const NUM_ENTRIES: usize = 24;
 
 /// Device/function (devfn) used as the IOAPIC requestor ID (RID) for
 /// interrupt remapping, as required by the Linux AMD-Vi driver.
@@ -56,7 +52,7 @@ struct IoApicRoutingState {
     /// Remapping state; `None` while in passthrough mode.
     remap: Option<RemapState>,
     /// Per-IRQ route state.
-    routes: [Route; NUM_ENTRIES],
+    routes: [Route; IRQ_LINES],
 }
 
 #[derive(Copy, Clone, Default)]
@@ -84,7 +80,7 @@ impl IoApicRoutingConnection {
                 hv_routing,
                 state: Mutex::new(IoApicRoutingState {
                     remap: None,
-                    routes: [Route::default(); NUM_ENTRIES],
+                    routes: [Route::default(); IRQ_LINES],
                 }),
             }),
         }
@@ -137,7 +133,7 @@ impl IoApicRoutingInner {
 
     /// Re-translate and re-program all cached routes.
     fn set_all_routes(&self, state: &mut IoApicRoutingState) {
-        for irq in 0..NUM_ENTRIES {
+        for irq in 0..IRQ_LINES {
             self.set_route(state, irq as u8);
         }
     }

--- a/openvmm/openvmm_core/src/worker/dispatch/ioapic_iommu_wiring.rs
+++ b/openvmm/openvmm_core/src/worker/dispatch/ioapic_iommu_wiring.rs
@@ -16,7 +16,9 @@ use std::sync::Arc;
 use virt::irqcon::IoApicRouting;
 use virt::irqcon::MsiRequest;
 
-/// Number of IOAPIC redirection table entries.
+/// Number of IOAPIC redirection table entries. Must match
+/// `chipset_resources::ioapic::IOAPIC_NUM_ENTRIES`, which bounds the `irq`
+/// values the IOAPIC device passes to [`IoApicRouting`].
 const NUM_ENTRIES: usize = 24;
 
 /// Device/function (devfn) used as the IOAPIC requestor ID (RID) for
@@ -53,8 +55,17 @@ struct IoApicRoutingInner {
 struct IoApicRoutingState {
     /// Remapping state; `None` while in passthrough mode.
     remap: Option<RemapState>,
-    /// Raw (pre-remapping) MSI requests from the IOAPIC, indexed by IRQ.
-    raw_routes: [Option<MsiRequest>; NUM_ENTRIES],
+    /// Per-IRQ route state.
+    routes: [Route; NUM_ENTRIES],
+}
+
+#[derive(Copy, Clone, Default)]
+struct Route {
+    /// Raw (pre-remapping) MSI request from the IOAPIC.
+    raw: Option<MsiRequest>,
+    /// Last translated route programmed into `hv_routing`. Used to skip
+    /// redundant `set_irq_route` calls on retranslation.
+    programmed: Option<MsiRequest>,
 }
 
 struct RemapState {
@@ -73,7 +84,7 @@ impl IoApicRoutingConnection {
                 hv_routing,
                 state: Mutex::new(IoApicRoutingState {
                     remap: None,
-                    raw_routes: [None; NUM_ENTRIES],
+                    routes: [Route::default(); NUM_ENTRIES],
                 }),
             }),
         }
@@ -88,44 +99,46 @@ impl IoApicRoutingConnection {
     ///
     /// Panics if called more than once.
     pub fn connect_remapper(&self, rid: u16, remapper: Arc<dyn InterruptRemapper>) {
-        {
-            let mut state = self.inner.state.lock();
-            assert!(
-                state.remap.is_none(),
-                "IOAPIC remapper connected more than once"
-            );
-            state.remap = Some(RemapState {
-                rid,
-                remapper: remapper.clone(),
-            });
-            self.inner.set_all_routes(&state);
-        }
-        // Register outside the lock: `register_route` may synchronously invoke
-        // `retranslate`, which acquires the same lock.
+        // Register before recording the remapper so an invalidation racing
+        // this can't be missed (it retranslates as a harmless passthrough
+        // until `remap` is set). Register outside the state lock: `invalidate`
+        // takes the route-list lock then the state lock, so the reverse order
+        // here would deadlock.
         remapper.register_route(&(self.inner.clone() as Arc<dyn RetranslateInterrupts>));
+        let mut state = self.inner.state.lock();
+        assert!(
+            state.remap.is_none(),
+            "IOAPIC remapper connected more than once"
+        );
+        state.remap = Some(RemapState { rid, remapper });
+        self.inner.set_all_routes(&mut state);
     }
 }
 
 impl IoApicRoutingInner {
-    /// Translate `raw` through the remapper (if any) and program it into
-    /// `hv_routing`.
-    fn set_route(&self, state: &IoApicRoutingState, irq: u8, raw: Option<MsiRequest>) {
+    /// Translate the cached raw route for `irq` through the remapper (if any)
+    /// and program it into `hv_routing`, skipping the call if unchanged.
+    fn set_route(&self, state: &mut IoApicRoutingState, irq: u8) {
+        let route = &mut state.routes[irq as usize];
         let translated = match &state.remap {
-            Some(remap) => raw.and_then(|r| {
+            Some(remap) => route.raw.and_then(|r| {
                 remap
                     .remapper
                     .remap_msi(remap.rid, r.address, r.data)
                     .map(|(address, data)| MsiRequest { address, data })
             }),
-            None => raw,
+            None => route.raw,
         };
-        self.hv_routing.set_irq_route(irq, translated);
+        if route.programmed != translated {
+            route.programmed = translated;
+            self.hv_routing.set_irq_route(irq, translated);
+        }
     }
 
     /// Re-translate and re-program all cached routes.
-    fn set_all_routes(&self, state: &IoApicRoutingState) {
-        for (irq, raw) in state.raw_routes.iter().enumerate() {
-            self.set_route(state, irq as u8, *raw);
+    fn set_all_routes(&self, state: &mut IoApicRoutingState) {
+        for irq in 0..NUM_ENTRIES {
+            self.set_route(state, irq as u8);
         }
     }
 }
@@ -134,10 +147,8 @@ impl IoApicRouting for IoApicRoutingInner {
     fn set_irq_route(&self, irq: u8, request: Option<MsiRequest>) {
         // Hold the lock across translate to serialize with retranslate().
         let mut state = self.state.lock();
-        if let Some(slot) = state.raw_routes.get_mut(irq as usize) {
-            *slot = request;
-        }
-        self.set_route(&state, irq, request);
+        state.routes[irq as usize].raw = request;
+        self.set_route(&mut state, irq);
     }
 
     fn assert_irq(&self, irq: u8) {
@@ -156,7 +167,7 @@ impl RetranslateInterrupts for IoApicRoutingInner {
     }
 
     fn retranslate(&self) {
-        let state = self.state.lock();
-        self.set_all_routes(&state);
+        let mut state = self.state.lock();
+        self.set_all_routes(&mut state);
     }
 }

--- a/petri/src/vm/openvmm/construct.rs
+++ b/petri/src/vm/openvmm/construct.rs
@@ -824,7 +824,13 @@ impl PetriVmConfigSetupCore<'_> {
         Ok(match (self.arch, &self.firmware) {
             (arch, Firmware::LinuxDirect { kernel, initrd }) => {
                 let console = match arch {
-                    MachineArch::X86_64 => "console=ttyS0",
+                    // `earlycon=uart8250,io,0x3f8` registers an early console on
+                    // COM1 (ttyS0) before `console_init`, so traces emitted from
+                    // early boot (e.g. `mm_core_init` / `amd_iommu_detect`) are
+                    // flushed immediately rather than only buffered. The port
+                    // must be explicit: the guest has no SPCR ACPI table, so a
+                    // bare `earlycon` has nothing to autodetect on x86.
+                    MachineArch::X86_64 => "console=ttyS0 earlycon=uart8250,io,0x3f8",
                     MachineArch::Aarch64 => "console=ttyAMA0 earlycon",
                 };
                 let kernel = File::open(kernel.clone())

--- a/petri/src/vm/openvmm/construct.rs
+++ b/petri/src/vm/openvmm/construct.rs
@@ -824,12 +824,9 @@ impl PetriVmConfigSetupCore<'_> {
         Ok(match (self.arch, &self.firmware) {
             (arch, Firmware::LinuxDirect { kernel, initrd }) => {
                 let console = match arch {
-                    // `earlycon=uart8250,io,0x3f8` registers an early console on
-                    // COM1 (ttyS0) before `console_init`, so traces emitted from
-                    // early boot (e.g. `mm_core_init` / `amd_iommu_detect`) are
-                    // flushed immediately rather than only buffered. The port
-                    // must be explicit: the guest has no SPCR ACPI table, so a
-                    // bare `earlycon` has nothing to autodetect on x86.
+                    // Explicit port: the guest has no SPCR table, so a bare
+                    // `earlycon` can't autodetect on x86. The early console
+                    // flushes boot traces immediately rather than buffering.
                     MachineArch::X86_64 => "console=ttyS0 earlycon=uart8250,io,0x3f8",
                     MachineArch::Aarch64 => "console=ttyAMA0 earlycon",
                 };

--- a/petri/src/vm/openvmm/construct.rs
+++ b/petri/src/vm/openvmm/construct.rs
@@ -824,10 +824,7 @@ impl PetriVmConfigSetupCore<'_> {
         Ok(match (self.arch, &self.firmware) {
             (arch, Firmware::LinuxDirect { kernel, initrd }) => {
                 let console = match arch {
-                    // Explicit port: the guest has no SPCR table, so a bare
-                    // `earlycon` can't autodetect on x86. The early console
-                    // flushes boot traces immediately rather than buffering.
-                    MachineArch::X86_64 => "console=ttyS0 earlycon=uart8250,io,0x3f8",
+                    MachineArch::X86_64 => "console=ttyS0",
                     MachineArch::Aarch64 => "console=ttyAMA0 earlycon",
                 };
                 let kernel = File::open(kernel.clone())

--- a/vm/acpi_spec/src/ivrs.rs
+++ b/vm/acpi_spec/src/ivrs.rs
@@ -46,6 +46,18 @@ pub const IVHD_DEV_RANGE_START: u8 = 0x03;
 /// IVHD device entry type: end of device range (§5.2.2.7, Table 93).
 pub const IVHD_DEV_RANGE_END: u8 = 0x04;
 
+/// IVHD device entry type: special device (§5.2.2.8, Table 96).
+///
+/// 8-byte entry used for IOAPIC, HPET, and other special devices that
+/// are not PCI devices but need IOMMU interrupt remapping.
+pub const IVHD_DEV_SPECIAL: u8 = 0x48;
+
+/// IVHD special device variety: IOAPIC (§5.2.2.8, Table 96).
+pub const IVHD_SPECIAL_IOAPIC: u8 = 0x01;
+
+/// IVHD special device variety: HPET (§5.2.2.8, Table 96).
+pub const IVHD_SPECIAL_HPET: u8 = 0x02;
+
 /// DTE setting: INITPass, EIntPass, NMIPass for fixed interrupt passthrough.
 pub const IVHD_DTE_SETTING_INIT_PASS: u8 = 0x01;
 pub const IVHD_DTE_SETTING_EINT_PASS: u8 = 0x02;
@@ -247,6 +259,51 @@ impl IvhdDeviceEntry4 {
 }
 
 const_assert_eq!(size_of::<IvhdDeviceEntry4>(), 4);
+
+/// IVHD 8-byte special device entry (§5.2.2.8, Table 96).
+///
+/// Used for non-PCI devices (IOAPIC, HPET) that need IOMMU interrupt
+/// remapping. The `handle` identifies the device instance (e.g., IOAPIC ID
+/// or HPET number), and the source RID identifies the remapping context used
+/// for DTE/IRTE lookup.
+#[repr(C)]
+#[derive(Copy, Clone, Debug, IntoBytes, Immutable, KnownLayout, FromBytes, Unaligned)]
+pub struct IvhdSpecialDeviceEntry8 {
+    /// Entry type (0x48 for special device).
+    pub entry_type: u8,
+    /// Reserved, must be zero (bytes 1-2 per spec Table 107).
+    _reserved: u16_ne,
+    /// DTE setting (same as `IvhdDeviceEntry4::dte_setting`).
+    pub dte_setting: u8,
+    /// Device handle — interpretation depends on `variety`:
+    /// - IOAPIC: IOAPIC ID (from ACPI MADT)
+    /// - HPET: HPET number
+    pub handle: u8,
+    /// Source DeviceID — the BDF used by the IOMMU for DTE/IRTE lookup
+    /// when this special device issues an interrupt.
+    pub source_device_id: u16_ne,
+    /// Variety of special device (see `IVHD_SPECIAL_*` constants).
+    pub variety: u8,
+}
+
+impl IvhdSpecialDeviceEntry8 {
+    /// Create a special device entry for an IOAPIC.
+    ///
+    /// - `rid`: IOAPIC RID for IOMMU DTE/IRTE lookup
+    /// - `ioapic_id`: the IOAPIC ID (matches the MADT entry)
+    pub fn ioapic(rid: u16, ioapic_id: u8) -> Self {
+        Self {
+            entry_type: IVHD_DEV_SPECIAL,
+            _reserved: 0.into(),
+            dte_setting: 0,
+            handle: ioapic_id,
+            source_device_id: rid.into(),
+            variety: IVHD_SPECIAL_IOAPIC,
+        }
+    }
+}
+
+const_assert_eq!(size_of::<IvhdSpecialDeviceEntry8>(), 8);
 
 #[cfg(test)]
 mod tests {

--- a/vm/devices/iommu/amd_iommu/src/lib.rs
+++ b/vm/devices/iommu/amd_iommu/src/lib.rs
@@ -1375,10 +1375,20 @@ impl AmdIommuDevice {
                 }
                 CommandOpcode::INVALIDATE_INTERRUPT_TABLE => {
                     let inv = spec::commands::InvalidateInterruptTable::from(&entry);
-                    // Coalesce: global invalidation supersedes per-device.
-                    if pending_invalidation != PendingInvalidation::All {
-                        pending_invalidation = PendingInvalidation::Device(inv.device_id());
-                    }
+                    // Coalesce within the batch: keep a single device ID only
+                    // while every invalidation seen so far targets that same
+                    // device; any mismatch (or a prior global) upgrades to a
+                    // full invalidation so no device's cached routes are
+                    // dropped.
+                    pending_invalidation = match pending_invalidation {
+                        PendingInvalidation::None => PendingInvalidation::Device(inv.device_id()),
+                        PendingInvalidation::Device(id) if id == inv.device_id() => {
+                            PendingInvalidation::Device(id)
+                        }
+                        PendingInvalidation::Device(_) | PendingInvalidation::All => {
+                            PendingInvalidation::All
+                        }
+                    };
                 }
                 CommandOpcode::INVALIDATE_IOMMU_ALL => {
                     pending_invalidation = PendingInvalidation::All;

--- a/vm/devices/iommu/amd_iommu/src/lib.rs
+++ b/vm/devices/iommu/amd_iommu/src/lib.rs
@@ -280,6 +280,8 @@ pub struct IommuSharedState {
     /// MSI interrupt for the IOMMU's own interrupts (completion wait,
     /// event log). Configured by the guest via the PCI MSI capability.
     msi_interrupt: Option<Interrupt>,
+    /// Registered interrupt routes for invalidation callbacks.
+    retranslate_interrupts: iommu_common::RetranslateInterruptsList,
 }
 
 impl IommuSharedState {
@@ -289,6 +291,7 @@ impl IommuSharedState {
             guest_memory,
             state: RwLock::new(AmdIommuState::default()),
             msi_interrupt,
+            retranslate_interrupts: iommu_common::RetranslateInterruptsList::new(),
         }
     }
 
@@ -953,6 +956,21 @@ fn evt_log_size_bytes(state: &AmdIommuState) -> Option<u64> {
     ring_size_bytes(EvtLogBase::from_bits(state.evt_log_base).length())
 }
 
+/// Pending interrupt invalidation from command buffer processing.
+///
+/// Returned by `process_commands` so the caller can drop the state write
+/// lock before executing the invalidation (avoiding deadlock with
+/// `remap_msi` which acquires a read lock).
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum PendingInvalidation {
+    /// No invalidation needed.
+    None,
+    /// Invalidate a specific device's interrupt table.
+    Device(u16),
+    /// Invalidate all interrupt tables.
+    All,
+}
+
 // =============================================================================
 // Per-Device MSI Remapping Wrapper
 // =============================================================================
@@ -990,6 +1008,30 @@ impl SignalMsi for IommuSignalMsi {
                 tracelimit::warn_ratelimited!(device_id, "MSI remapping fault, interrupt dropped");
             }
         }
+    }
+}
+
+impl iommu_common::InterruptRemapper for IommuSharedState {
+    fn remap_msi(&self, device_id: u16, address: u64, data: u32) -> Option<(u64, u32)> {
+        match self.remap_msi(device_id, address, data) {
+            Ok(result) => Some(result),
+            Err(fault) => {
+                self.queue_event(fault.to_event_entry());
+                tracelimit::warn_ratelimited!(
+                    device_id,
+                    "interrupt remapping fault on cached route, masking"
+                );
+                None
+            }
+        }
+    }
+
+    fn register_route(&self, route: &Arc<dyn iommu_common::RetranslateInterrupts>) {
+        self.retranslate_interrupts.register(route);
+    }
+
+    fn unregister_route(&self, route: &Arc<dyn iommu_common::RetranslateInterrupts>) {
+        self.retranslate_interrupts.unregister(route);
     }
 }
 
@@ -1099,6 +1141,8 @@ impl AmdIommuDevice {
 
         tracing::trace!(offset, value, "mmio_write");
 
+        let mut pending_invalidation = PendingInvalidation::None;
+
         match MmioRegister(offset as u16) {
             MmioRegister::DEV_TAB_BASE => {
                 if !ctrl.iommu_en() {
@@ -1135,7 +1179,7 @@ impl AmdIommuDevice {
                 // and there are pending commands, process them now.
                 let new_ctrl = IommuCtrl::from_bits(value);
                 if new_ctrl.iommu_en() && new_ctrl.cmd_buf_en() && !old_ctrl.cmd_buf_en() {
-                    Self::process_commands(&self.shared, &mut state);
+                    pending_invalidation = Self::process_commands(&self.shared, &mut state);
                 }
             }
             MmioRegister::EXCL_BASE => {
@@ -1154,7 +1198,7 @@ impl AmdIommuDevice {
             }
             MmioRegister::CMD_BUF_TAIL => {
                 state.cmd_buf_tail = value;
-                Self::process_commands(&self.shared, &mut state);
+                pending_invalidation = Self::process_commands(&self.shared, &mut state);
             }
             MmioRegister::EVT_LOG_HEAD => {
                 state.evt_log_head = value;
@@ -1192,6 +1236,18 @@ impl AmdIommuDevice {
             _ => {
                 tracelimit::warn_ratelimited!(offset, value, "MMIO write to unknown register");
             }
+        }
+
+        // Drop the write lock before executing invalidations to avoid
+        // deadlock: retranslate → remap_msi → state.read() would deadlock
+        // if state.write() were still held.
+        drop(state);
+        if let Some(device_id) = match pending_invalidation {
+            PendingInvalidation::None => None,
+            PendingInvalidation::Device(id) => Some(Some(id)),
+            PendingInvalidation::All => Some(None),
+        } {
+            self.shared.retranslate_interrupts.invalidate(device_id);
         }
     }
 
@@ -1235,10 +1291,17 @@ impl AmdIommuDevice {
     // =========================================================================
 
     /// Process all pending commands in the command buffer.
-    fn process_commands(shared: &IommuSharedState, state: &mut AmdIommuState) {
+    ///
+    /// Returns a pending interrupt invalidation request. The caller must
+    /// drop the state write lock before executing the invalidation to
+    /// avoid deadlock with `remap_msi` which acquires a read lock.
+    fn process_commands(
+        shared: &IommuSharedState,
+        state: &mut AmdIommuState,
+    ) -> PendingInvalidation {
         let ctrl = IommuCtrl::from_bits(state.iommu_ctrl);
         if !ctrl.iommu_en() || !ctrl.cmd_buf_en() {
-            return;
+            return PendingInvalidation::None;
         }
 
         let buf_size_bytes = match cmd_buf_size_bytes(state) {
@@ -1250,11 +1313,13 @@ impl AmdIommuDevice {
                 let mut status = IommuStatus::from_bits(state.iommu_status);
                 status.set_cmd_buf_run(false);
                 state.iommu_status = status.into_bits();
-                return;
+                return PendingInvalidation::None;
             }
         };
         let cmd_base = CmdBufBase::from_bits(state.cmd_buf_base);
         let base_gpa = cmd_base.base_addr() << 12;
+
+        let mut pending_invalidation = PendingInvalidation::None;
 
         loop {
             let head = CmdBufHead::from_bits(state.cmd_buf_head);
@@ -1292,7 +1357,7 @@ impl AmdIommuDevice {
                     let mut status = IommuStatus::from_bits(state.iommu_status);
                     status.set_cmd_buf_run(false);
                     state.iommu_status = status.into_bits();
-                    return;
+                    return pending_invalidation;
                 }
             };
 
@@ -1305,10 +1370,18 @@ impl AmdIommuDevice {
                 CommandOpcode::INVALIDATE_DEVTAB_ENTRY
                 | CommandOpcode::INVALIDATE_IOMMU_PAGES
                 | CommandOpcode::INVALIDATE_IOTLB_PAGES
-                | CommandOpcode::INVALIDATE_INTERRUPT_TABLE
-                | CommandOpcode::PREFETCH_IOMMU_PAGES
-                | CommandOpcode::INVALIDATE_IOMMU_ALL => {
-                    // No-op: no caches to invalidate in the emulator.
+                | CommandOpcode::PREFETCH_IOMMU_PAGES => {
+                    // No-op: no DMA translation caches in the emulator.
+                }
+                CommandOpcode::INVALIDATE_INTERRUPT_TABLE => {
+                    let inv = spec::commands::InvalidateInterruptTable::from(&entry);
+                    // Coalesce: global invalidation supersedes per-device.
+                    if pending_invalidation != PendingInvalidation::All {
+                        pending_invalidation = PendingInvalidation::Device(inv.device_id());
+                    }
+                }
+                CommandOpcode::INVALIDATE_IOMMU_ALL => {
+                    pending_invalidation = PendingInvalidation::All;
                 }
                 _ => {
                     tracelimit::warn_ratelimited!(
@@ -1326,7 +1399,7 @@ impl AmdIommuDevice {
                     let mut status = IommuStatus::from_bits(state.iommu_status);
                     status.set_cmd_buf_run(false);
                     state.iommu_status = status.into_bits();
-                    return;
+                    return pending_invalidation;
                 }
             }
 
@@ -1334,6 +1407,8 @@ impl AmdIommuDevice {
             let new_head = CmdBufHead::new().with_head_ptr((next_head >> 4) as u32);
             state.cmd_buf_head = new_head.into_bits();
         }
+
+        pending_invalidation
     }
 
     /// Process a COMPLETION_WAIT command (opcode 0x01).

--- a/vm/devices/iommu/intel_vtd/src/lib.rs
+++ b/vm/devices/iommu/intel_vtd/src/lib.rs
@@ -245,6 +245,8 @@ pub struct VtdSharedState {
     /// with no PCI MSI capability — it programs MSI address/data directly
     /// into MMIO registers (FEADDR/FEDATA, IEADDR/IEDATA).
     signal_msi: Arc<dyn SignalMsi>,
+    /// Registered interrupt routes for invalidation callbacks.
+    retranslate_interrupts: iommu_common::RetranslateInterruptsList,
 }
 
 impl VtdSharedState {
@@ -254,6 +256,7 @@ impl VtdSharedState {
             guest_memory,
             state: RwLock::new(VtdState::new()),
             signal_msi,
+            retranslate_interrupts: iommu_common::RetranslateInterruptsList::new(),
         }
     }
 
@@ -1044,6 +1047,32 @@ impl SignalMsi for VtdSignalMsi {
     }
 }
 
+impl iommu_common::InterruptRemapper for VtdSharedState {
+    fn remap_msi(&self, device_id: u16, address: u64, data: u32) -> Option<(u64, u32)> {
+        let state = self.state.read();
+        match self.remap_msi_locked(&state, device_id, address, data) {
+            Ok(result) => Some(result),
+            Err(fault) => {
+                drop(state);
+                fault.record(self, true);
+                tracelimit::warn_ratelimited!(
+                    device_id,
+                    "vtd: interrupt remapping fault on cached route, masking"
+                );
+                None
+            }
+        }
+    }
+
+    fn register_route(&self, route: &Arc<dyn iommu_common::RetranslateInterrupts>) {
+        self.retranslate_interrupts.register(route);
+    }
+
+    fn unregister_route(&self, route: &Arc<dyn iommu_common::RetranslateInterrupts>) {
+        self.retranslate_interrupts.unregister(route);
+    }
+}
+
 // =============================================================================
 // IntelVtdDevice
 // =============================================================================
@@ -1182,6 +1211,7 @@ impl IntelVtdDevice {
     /// write. No register requires atomic writes across both DWORDs.
     fn write_register_dword(&self, offset: u16, value: u32) {
         let mut state = self.shared.state.write();
+        let mut retranslate_interrupts = false;
         tracing::trace!(offset, value, "vtd mmio_write_dword");
 
         /// Merge a DWORD write into the lo or hi half of a 64-bit value.
@@ -1261,7 +1291,7 @@ impl IntelVtdDevice {
                 let full = write_lo(state.iqt.into_bits(), value);
                 let iqt = IqtReg::from(full);
                 state.iqt = IqtReg::new().with_qt(iqt.qt());
-                self.process_invalidation_queue(&mut state);
+                retranslate_interrupts = self.process_invalidation_queue(&mut state);
             }
             Reg::IQT_HI => {
                 state.iqt = IqtReg::from(write_hi(state.iqt.into_bits(), value));
@@ -1340,6 +1370,11 @@ impl IntelVtdDevice {
             }
 
             _ => {} // Unmapped offsets: silently ignored.
+        }
+
+        drop(state);
+        if retranslate_interrupts {
+            self.shared.retranslate_interrupts.invalidate(None);
         }
     }
 
@@ -1481,16 +1516,16 @@ impl IntelVtdDevice {
     ///
     /// Consumes descriptors from head to tail. Called when the guest writes
     /// IQT.
-    fn process_invalidation_queue(&self, state: &mut VtdState) {
+    fn process_invalidation_queue(&self, state: &mut VtdState) -> bool {
         let gsts = state.gsts;
         if !gsts.qies() {
-            return;
+            return false;
         }
 
         // Check for IQE — don't process if error is outstanding.
         let fsts = state.fsts;
         if fsts.iqe() {
-            return;
+            return false;
         }
 
         let iqa = state.iqa;
@@ -1501,7 +1536,7 @@ impl IntelVtdDevice {
             let mut fsts = state.fsts;
             fsts.set_iqe(true);
             state.fsts = fsts;
-            return;
+            return false;
         }
 
         let queue_base = iqa.queue_base_address();
@@ -1510,6 +1545,7 @@ impl IntelVtdDevice {
         let tail = state.iqt.tail_offset();
 
         let mut current_head = head;
+        let mut retranslate_interrupts = false;
 
         while current_head != tail {
             let entry_addr = queue_base + current_head;
@@ -1541,7 +1577,16 @@ impl IntelVtdDevice {
                         "vtd: unsupported DEVICE_TLB_INVALIDATE descriptor"
                     );
                 }
-                DescriptorType::INTERRUPT_ENTRY_CACHE_INVALIDATE => {} // no-op
+                DescriptorType::INTERRUPT_ENTRY_CACHE_INVALIDATE => {
+                    let desc = spec::invalidation::parse_interrupt_cache_invalidate(&desc);
+                    tracing::trace!(
+                        granularity = desc.granularity(),
+                        im = desc.im(),
+                        iidx = desc.iidx(),
+                        "vtd: interrupt entry cache invalidate"
+                    );
+                    retranslate_interrupts = true;
+                }
                 DescriptorType::INVALIDATION_WAIT => {
                     self.process_invalidation_wait(state, &descriptor);
                 }
@@ -1560,6 +1605,7 @@ impl IntelVtdDevice {
 
         // Update head register.
         state.iqh = IqhReg::new().with_qh((current_head >> 4) as u32);
+        retranslate_interrupts
     }
 
     /// Process an INVALIDATION_WAIT descriptor (type 0x05).
@@ -1741,6 +1787,8 @@ impl InspectMut for IntelVtdDevice {
 mod tests {
     use super::*;
     use guestmem::GuestMemory;
+    use std::sync::atomic::AtomicU32;
+    use std::sync::atomic::Ordering;
 
     const TEST_MMIO_BASE: u64 = 0xFED9_0000;
 
@@ -2692,6 +2740,21 @@ mod tests {
         state.gsts = gsts;
     }
 
+    struct CountingRoute {
+        device_id: u16,
+        retranslate_count: AtomicU32,
+    }
+
+    impl iommu_common::RetranslateInterrupts for CountingRoute {
+        fn device_id(&self) -> u16 {
+            self.device_id
+        }
+
+        fn retranslate(&self) {
+            self.retranslate_count.fetch_add(1, Ordering::SeqCst);
+        }
+    }
+
     #[test]
     fn test_remap_msi_basic() {
         let gm = GuestMemory::allocate(0x40_0000);
@@ -2789,6 +2852,42 @@ mod tests {
     }
 
     #[test]
+    fn test_interrupt_remapper_transitions_from_passthrough_to_remap() {
+        let gm = GuestMemory::allocate(0x40_0000);
+        let signal_msi = Arc::new(TestSignalMsi);
+        let (_dev, shared) = IntelVtdDevice::new(
+            gm.clone(),
+            IntelVtdConfig {
+                mmio_base: TEST_MMIO_BASE,
+            },
+            signal_msi,
+        );
+
+        let compat_addr = 0xFEE0_0000u64;
+        assert_eq!(
+            iommu_common::InterruptRemapper::remap_msi(&*shared, 0x00A0, compat_addr, 0x31),
+            Some((compat_addr, 0x31))
+        );
+
+        setup_ir_state(&shared, false);
+        let irte = Irte {
+            lo: IrteLo::new()
+                .with_p(true)
+                .with_vector(0x45)
+                .with_dst(0x0200)
+                .with_dlm(0)
+                .with_dm(false),
+            hi: IrteHi::new().with_svt(0b01).with_sq(0).with_sid(0x00A0),
+        };
+        gm.write_at(IRT_BASE_ADDR, irte.as_bytes()).unwrap();
+
+        let (new_addr, new_data) =
+            iommu_common::InterruptRemapper::remap_msi(&*shared, 0x00A0, 0xFEE0_0010, 0).unwrap();
+        assert_eq!((new_addr >> 12) & 0xFF, 2);
+        assert_eq!(new_data & 0xFF, 0x45);
+    }
+
+    #[test]
     fn test_remap_msi_irte_not_present() {
         let gm = GuestMemory::allocate(0x40_0000);
         let signal_msi = Arc::new(TestSignalMsi);
@@ -2809,6 +2908,76 @@ mod tests {
             .remap_msi_locked(&state, 0x0000, addr, 0)
             .unwrap_err();
         assert!(matches!(err, VtdFault::IrteNotPresent { .. }));
+    }
+
+    #[test]
+    fn test_remap_msi_posted_irte_rejected() {
+        let gm = GuestMemory::allocate(0x40_0000);
+        let signal_msi = Arc::new(TestSignalMsi);
+        let (_dev, shared) = IntelVtdDevice::new(
+            gm.clone(),
+            IntelVtdConfig {
+                mmio_base: TEST_MMIO_BASE,
+            },
+            signal_msi,
+        );
+
+        setup_ir_state(&shared, false);
+
+        let irte = Irte {
+            lo: IrteLo::new().with_p(true).with_im(true).with_vector(0x40),
+            hi: IrteHi::new().with_svt(0),
+        };
+        gm.write_at(IRT_BASE_ADDR, irte.as_bytes()).unwrap();
+
+        let state = shared.state.read();
+        let err = shared
+            .remap_msi_locked(&state, 0x0000, 0xFEE0_0010, 0)
+            .unwrap_err();
+        assert!(matches!(err, VtdFault::IrteReservedField { .. }));
+    }
+
+    #[test]
+    fn test_interrupt_entry_cache_invalidate_retranslates_routes() {
+        const IQ_BASE: u64 = 0x20_0000;
+
+        let gm = GuestMemory::allocate(0x40_0000);
+        let signal_msi = Arc::new(TestSignalMsi);
+        let (mut dev, shared) = IntelVtdDevice::new(
+            gm.clone(),
+            IntelVtdConfig {
+                mmio_base: TEST_MMIO_BASE,
+            },
+            signal_msi,
+        );
+
+        let route = Arc::new(CountingRoute {
+            device_id: 0x00A0,
+            retranslate_count: AtomicU32::new(0),
+        });
+        let route_dyn: Arc<dyn iommu_common::RetranslateInterrupts> = route.clone();
+        iommu_common::InterruptRemapper::register_route(&*shared, &route_dyn);
+
+        let iqa = IqaReg::new().with_qs(0).with_iqa(IQ_BASE >> 12);
+        write64(&mut dev, Reg::IQA.0, iqa.into_bits());
+        write32(
+            &mut dev,
+            Reg::GCMD.0,
+            GcmdReg::new().with_qie(true).into_bits(),
+        );
+
+        let desc = spec::invalidation::InvalidationDescriptor {
+            dw0: DescriptorType::INTERRUPT_ENTRY_CACHE_INVALIDATE.0 as u32,
+            dw1: 0,
+            dw2: 0,
+            dw3: 0,
+        };
+        gm.write_at(IQ_BASE, desc.as_bytes()).unwrap();
+
+        write64(&mut dev, Reg::IQT.0, IqtReg::new().with_qt(1).into_bits());
+
+        assert_eq!(route.retranslate_count.load(Ordering::SeqCst), 1);
+        assert_eq!(IqhReg::from(read64(&mut dev, Reg::IQH.0)).head_offset(), 16);
     }
 
     #[test]

--- a/vm/devices/iommu/intel_vtd/src/spec/invalidation.rs
+++ b/vm/devices/iommu/intel_vtd/src/spec/invalidation.rs
@@ -231,6 +231,14 @@ pub struct InterruptCacheInvalidateDw0Dw1 {
     _reserved3: u64,
 }
 
+/// Parse an `InvalidationDescriptor` as INTERRUPT_ENTRY_CACHE_INVALIDATE fields.
+pub fn parse_interrupt_cache_invalidate(
+    desc: &InvalidationDescriptor,
+) -> InterruptCacheInvalidateDw0Dw1 {
+    let lo = ((desc.dw1 as u64) << 32) | desc.dw0 as u64;
+    InterruptCacheInvalidateDw0Dw1::from(lo)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -257,5 +265,27 @@ mod tests {
         assert!(parsed_lo.sw());
         assert_eq!(parsed_lo.status_data(), 0x42);
         assert_eq!(parsed_hi.status_address(), 0x1000 << 2);
+    }
+
+    #[test]
+    fn test_parse_interrupt_cache_invalidate() {
+        let lo_val = InterruptCacheInvalidateDw0Dw1::new()
+            .with_desc_type(0x04)
+            .with_granularity(true)
+            .with_im(0x1f)
+            .with_iidx(0x1234);
+
+        let lo_raw = u64::from(lo_val);
+        let desc = InvalidationDescriptor {
+            dw0: lo_raw as u32,
+            dw1: (lo_raw >> 32) as u32,
+            dw2: 0,
+            dw3: 0,
+        };
+
+        let parsed = parse_interrupt_cache_invalidate(&desc);
+        assert!(parsed.granularity());
+        assert_eq!(parsed.im(), 0x1f);
+        assert_eq!(parsed.iidx(), 0x1234);
     }
 }

--- a/vm/devices/iommu/iommu_common/Cargo.toml
+++ b/vm/devices/iommu/iommu_common/Cargo.toml
@@ -8,6 +8,7 @@ rust-version.workspace = true
 
 [dependencies]
 guestmem.workspace = true
+parking_lot.workspace = true
 pci_core.workspace = true
 thiserror.workspace = true
 

--- a/vm/devices/iommu/iommu_common/src/lib.rs
+++ b/vm/devices/iommu/iommu_common/src/lib.rs
@@ -10,9 +10,9 @@
 //!   to GPAs via an [`IommuTranslator`] before delegating to an inner
 //!   [`GuestMemory`].
 //!
-//! - An [`InterruptRemapper`] trait and [`InterruptRemapRegistry`] for routing
-//!   pre-registered interrupt routes (IOAPIC, IrqFd) through an IOMMU's
-//!   interrupt remapping table, with invalidation support.
+//! - An [`InterruptRemapper`] trait and [`RetranslateInterruptsList`] for
+//!   routing pre-registered interrupt routes (IOAPIC, IrqFd) through an
+//!   IOMMU's interrupt remapping table, with invalidation support.
 //!
 //! Both the ARM SMMUv3 and AMD IOMMU implementations use this crate to avoid
 //! duplicating the per-page-boundary splitting, lock-across-translate-and-access

--- a/vm/devices/iommu/iommu_common/src/lib.rs
+++ b/vm/devices/iommu/iommu_common/src/lib.rs
@@ -131,7 +131,7 @@ impl<T: IommuTranslator> TranslatingMemory<T> {
     /// access: `(secondary_bus << 8)`. If the secondary bus is 0, the RID is
     /// 0 and the IOMMU translates or faults accordingly.
     pub fn new_guest_memory(
-        label: impl Into<std::sync::Arc<str>>,
+        label: impl Into<Arc<str>>,
         translator: T,
         bus_range: AssignedBusRange,
         inner_gm: GuestMemory,

--- a/vm/devices/iommu/iommu_common/src/lib.rs
+++ b/vm/devices/iommu/iommu_common/src/lib.rs
@@ -455,25 +455,37 @@ impl RetranslateInterruptsList {
     /// Invalidate routes for a specific device, or all routes if
     /// `device_id` is `None`.
     ///
-    /// For each matching route, calls `retranslate` with the provided
-    /// remapper. Dead references are cleaned up lazily.
+    /// For each matching route, calls `retranslate`. Dead references are
+    /// cleaned up lazily.
     pub fn invalidate(&self, device_id: Option<u16>) {
-        let mut routes = self.routes.lock();
-        routes.retain(|weak| {
-            let Some(route) = weak.upgrade() else {
-                return false; // dead, remove
-            };
+        let routes = {
+            let mut routes = self.routes.lock();
+            let mut live_routes = Vec::new();
+
+            routes.retain(|weak| {
+                let Some(route) = weak.upgrade() else {
+                    return false; // dead, remove
+                };
+                live_routes.push(route);
+                true
+            });
+
+            live_routes
+        };
+
+        for route in routes {
             if device_id.is_none() || device_id == Some(route.device_id()) {
                 route.retranslate();
             }
-            true
-        });
+        }
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::atomic::AtomicU32;
+    use std::sync::atomic::Ordering;
 
     /// Identity translator: GPA == IOVA, never faults. Records nothing — the
     /// `rid` validation happens in `TranslatingMemory` before `translate` is
@@ -507,6 +519,38 @@ mod tests {
         let r = AssignedBusRange::new();
         r.set_bus_range(secondary, subordinate);
         r
+    }
+
+    struct ReentrantRoute {
+        list: Arc<RetranslateInterruptsList>,
+        retranslates: AtomicU32,
+    }
+
+    impl RetranslateInterrupts for ReentrantRoute {
+        fn device_id(&self) -> u16 {
+            assert!(self.list.routes.try_lock().is_some());
+            7
+        }
+
+        fn retranslate(&self) {
+            self.retranslates.fetch_add(1, Ordering::SeqCst);
+            assert!(self.list.routes.try_lock().is_some());
+        }
+    }
+
+    #[test]
+    fn invalidate_does_not_hold_lock_during_retranslate() {
+        let list = Arc::new(RetranslateInterruptsList::new());
+        let route = Arc::new(ReentrantRoute {
+            list: list.clone(),
+            retranslates: AtomicU32::new(0),
+        });
+        let route_dyn = route.clone() as Arc<dyn RetranslateInterrupts>;
+        list.register(&route_dyn);
+
+        list.invalidate(Some(7));
+
+        assert_eq!(route.retranslates.load(Ordering::SeqCst), 1);
     }
 
     #[test]

--- a/vm/devices/iommu/iommu_common/src/lib.rs
+++ b/vm/devices/iommu/iommu_common/src/lib.rs
@@ -367,103 +367,6 @@ where
     pci_core::dma::DmaTarget::with_iommu(bus_range, devfn, iommu, msi)
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    /// Identity translator: GPA == IOVA, never faults. Records nothing — the
-    /// `rid` validation happens in `TranslatingMemory` before `translate` is
-    /// ever called.
-    #[derive(Clone)]
-    struct IdentityTranslator;
-
-    #[derive(Debug, thiserror::Error)]
-    #[error("identity translator never faults")]
-    struct NeverFault;
-
-    impl IommuTranslator for IdentityTranslator {
-        type Error = NeverFault;
-
-        fn max_iova(&self) -> u64 {
-            u64::MAX
-        }
-
-        fn translate<R>(
-            &self,
-            _rid: u16,
-            iova: u64,
-            _write: bool,
-            op: impl FnOnce(u64) -> R,
-        ) -> Result<R, TranslationFault<Self::Error>> {
-            Ok(op(iova))
-        }
-    }
-
-    fn bus_range(secondary: u8, subordinate: u8) -> AssignedBusRange {
-        let r = AssignedBusRange::new();
-        r.set_bus_range(secondary, subordinate);
-        r
-    }
-
-    #[test]
-    fn rid_offset_in_range_translates() {
-        let inner = GuestMemory::allocate(0x1000);
-        let gm = TranslatingMemory::new_guest_memory_for_rid_offset(
-            "test",
-            IdentityTranslator,
-            bus_range(5, 10),
-            (2 << 8) | 0x02, // secondary 5 + offset -> bus 7 within [5, 10]
-            inner.clone(),
-        );
-
-        gm.write_at(0x100, &[0xAB, 0xCD]).unwrap();
-        let mut buf = [0u8; 2];
-        gm.read_at(0x100, &mut buf).unwrap();
-        assert_eq!(buf, [0xAB, 0xCD]);
-
-        // Identity mapping wrote through to inner GPA 0x100.
-        let mut inner_buf = [0u8; 2];
-        inner.read_at(0x100, &mut inner_buf).unwrap();
-        assert_eq!(inner_buf, [0xAB, 0xCD]);
-    }
-
-    #[test]
-    fn rid_offset_out_of_range_faults() {
-        let inner = GuestMemory::allocate(0x1000);
-        let mut buf = [0u8; 2];
-
-        // secondary 5 + offset (6 << 8) -> bus 11, above subordinate 10 ->
-        // access faults
-        let gm_above = TranslatingMemory::new_guest_memory_for_rid_offset(
-            "test",
-            IdentityTranslator,
-            bus_range(5, 10),
-            6 << 8,
-            inner.clone(),
-        );
-        assert!(gm_above.read_at(0x100, &mut buf).is_err());
-        assert!(gm_above.write_at(0x100, &[1, 2]).is_err());
-    }
-
-    #[test]
-    fn derived_rid_uses_secondary_bus_in_range() {
-        // No override: the derived RID uses the secondary bus, which is
-        // always within the range, so the access translates.
-        let inner = GuestMemory::allocate(0x1000);
-        let gm = TranslatingMemory::new_guest_memory(
-            "test",
-            IdentityTranslator,
-            bus_range(5, 10),
-            inner.clone(),
-        );
-
-        gm.write_at(0x40, &[0x11]).unwrap();
-        let mut buf = [0u8; 1];
-        gm.read_at(0x40, &mut buf).unwrap();
-        assert_eq!(buf, [0x11]);
-    }
-}
-
 // =============================================================================
 // Interrupt Remapping Infrastructure
 // =============================================================================
@@ -565,5 +468,102 @@ impl RetranslateInterruptsList {
             }
             true
         });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Identity translator: GPA == IOVA, never faults. Records nothing — the
+    /// `rid` validation happens in `TranslatingMemory` before `translate` is
+    /// ever called.
+    #[derive(Clone)]
+    struct IdentityTranslator;
+
+    #[derive(Debug, thiserror::Error)]
+    #[error("identity translator never faults")]
+    struct NeverFault;
+
+    impl IommuTranslator for IdentityTranslator {
+        type Error = NeverFault;
+
+        fn max_iova(&self) -> u64 {
+            u64::MAX
+        }
+
+        fn translate<R>(
+            &self,
+            _rid: u16,
+            iova: u64,
+            _write: bool,
+            op: impl FnOnce(u64) -> R,
+        ) -> Result<R, TranslationFault<Self::Error>> {
+            Ok(op(iova))
+        }
+    }
+
+    fn bus_range(secondary: u8, subordinate: u8) -> AssignedBusRange {
+        let r = AssignedBusRange::new();
+        r.set_bus_range(secondary, subordinate);
+        r
+    }
+
+    #[test]
+    fn rid_offset_in_range_translates() {
+        let inner = GuestMemory::allocate(0x1000);
+        let gm = TranslatingMemory::new_guest_memory_for_rid_offset(
+            "test",
+            IdentityTranslator,
+            bus_range(5, 10),
+            (2 << 8) | 0x02, // secondary 5 + offset -> bus 7 within [5, 10]
+            inner.clone(),
+        );
+
+        gm.write_at(0x100, &[0xAB, 0xCD]).unwrap();
+        let mut buf = [0u8; 2];
+        gm.read_at(0x100, &mut buf).unwrap();
+        assert_eq!(buf, [0xAB, 0xCD]);
+
+        // Identity mapping wrote through to inner GPA 0x100.
+        let mut inner_buf = [0u8; 2];
+        inner.read_at(0x100, &mut inner_buf).unwrap();
+        assert_eq!(inner_buf, [0xAB, 0xCD]);
+    }
+
+    #[test]
+    fn rid_offset_out_of_range_faults() {
+        let inner = GuestMemory::allocate(0x1000);
+        let mut buf = [0u8; 2];
+
+        // secondary 5 + offset (6 << 8) -> bus 11, above subordinate 10 ->
+        // access faults
+        let gm_above = TranslatingMemory::new_guest_memory_for_rid_offset(
+            "test",
+            IdentityTranslator,
+            bus_range(5, 10),
+            6 << 8,
+            inner.clone(),
+        );
+        assert!(gm_above.read_at(0x100, &mut buf).is_err());
+        assert!(gm_above.write_at(0x100, &[1, 2]).is_err());
+    }
+
+    #[test]
+    fn derived_rid_uses_secondary_bus_in_range() {
+        // No override: the derived RID uses the secondary bus, which is
+        // always within the range, so the access translates.
+        let inner = GuestMemory::allocate(0x1000);
+        let gm = TranslatingMemory::new_guest_memory(
+            "test",
+            IdentityTranslator,
+            bus_range(5, 10),
+            inner.clone(),
+        );
+
+        gm.write_at(0x40, &[0x11]).unwrap();
+        let mut buf = [0u8; 1];
+        gm.read_at(0x40, &mut buf).unwrap();
+        assert_eq!(buf, [0x11]);
     }
 }

--- a/vm/devices/iommu/iommu_common/src/lib.rs
+++ b/vm/devices/iommu/iommu_common/src/lib.rs
@@ -358,7 +358,7 @@ pub fn new_dma_target<T>(
 where
     T: IommuTranslator + Clone,
 {
-    let iommu = std::sync::Arc::new(TranslatingDmaTarget::new(
+    let iommu = Arc::new(TranslatingDmaTarget::new(
         format!("{label}-translating"),
         translator,
         bus_range.clone(),

--- a/vm/devices/iommu/iommu_common/src/lib.rs
+++ b/vm/devices/iommu/iommu_common/src/lib.rs
@@ -147,7 +147,7 @@ impl<T: IommuTranslator> TranslatingMemory<T> {
     /// tracks the bus assignment. This is the primitive for SR-IOV virtual
     /// functions, which are constructed before the PF's bus is programmed.
     pub fn new_guest_memory_for_rid_offset(
-        label: impl Into<std::sync::Arc<str>>,
+        label: impl Into<Arc<str>>,
         translator: T,
         bus_range: AssignedBusRange,
         rid_offset: u16,
@@ -294,7 +294,7 @@ unsafe impl<T: IommuTranslator> guestmem::GuestMemoryAccess for TranslatingMemor
 /// construction generically.
 pub struct TranslatingDmaTarget<T: IommuTranslator + Clone> {
     /// Debug label applied to each VF's `GuestMemory`.
-    label: std::sync::Arc<str>,
+    label: Arc<str>,
     /// The IOMMU's arch-specific translator, cloned per derived VF.
     translator: T,
     /// The device's assigned bus range; the requester ID is derived as
@@ -313,7 +313,7 @@ impl<T: IommuTranslator + Clone> TranslatingDmaTarget<T> {
     ///   default function-0 RID
     /// - `inner_gm`: the raw (untranslated) guest memory
     pub fn new(
-        label: impl Into<std::sync::Arc<str>>,
+        label: impl Into<Arc<str>>,
         translator: T,
         bus_range: AssignedBusRange,
         inner_gm: GuestMemory,

--- a/vm/devices/iommu/iommu_common/src/lib.rs
+++ b/vm/devices/iommu/iommu_common/src/lib.rs
@@ -1,12 +1,18 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-//! Shared IOMMU DMA translation infrastructure.
+//! Shared IOMMU infrastructure for DMA translation and interrupt remapping.
 //!
-//! This crate provides a generic [`TranslatingMemory`] implementation of
-//! [`GuestMemoryAccess`](guestmem::GuestMemoryAccess) that translates IOVAs
-//! to GPAs via an [`IommuTranslator`] before delegating to an inner
-//! [`GuestMemory`].
+//! This crate provides:
+//!
+//! - A generic [`TranslatingMemory`] implementation of
+//!   [`GuestMemoryAccess`](guestmem::GuestMemoryAccess) that translates IOVAs
+//!   to GPAs via an [`IommuTranslator`] before delegating to an inner
+//!   [`GuestMemory`].
+//!
+//! - An [`InterruptRemapper`] trait and [`InterruptRemapRegistry`] for routing
+//!   pre-registered interrupt routes (IOAPIC, IrqFd) through an IOMMU's
+//!   interrupt remapping table, with invalidation support.
 //!
 //! Both the ARM SMMUv3 and AMD IOMMU implementations use this crate to avoid
 //! duplicating the per-page-boundary splitting, lock-across-translate-and-access
@@ -17,8 +23,11 @@
 
 use guestmem::GuestMemory;
 use guestmem::GuestMemoryBackingError;
+use parking_lot::Mutex;
 use pci_core::bus_range::AssignedBusRange;
 use std::ptr::NonNull;
+use std::sync::Arc;
+use std::sync::Weak;
 
 /// Trait for IOMMU translation backends.
 ///
@@ -452,5 +461,109 @@ mod tests {
         let mut buf = [0u8; 1];
         gm.read_at(0x40, &mut buf).unwrap();
         assert_eq!(buf, [0x11]);
+    }
+}
+
+// =============================================================================
+// Interrupt Remapping Infrastructure
+// =============================================================================
+
+/// Trait for IOMMU interrupt remapping backends.
+///
+/// Each IOMMU implementation (AMD IOMMU, SMMU, etc.) provides a type that
+/// implements this trait. Consumers use it both for on-demand MSI translation
+/// and for registering pre-cached routes that need retranslation on IOMMU
+/// invalidation commands.
+///
+/// When the IOMMU is disabled or interrupt remapping is not enabled,
+/// [`remap_msi`](InterruptRemapper::remap_msi) should return the input
+/// values unchanged (passthrough).
+///
+/// On remapping faults, the implementation is responsible for queuing any
+/// IOMMU-specific fault events internally before returning `None`.
+pub trait InterruptRemapper: Send + Sync {
+    /// Translate an MSI address/data pair for a device.
+    ///
+    /// Returns `Some((address, data))` with the translated values, or `None`
+    /// if the MSI should be masked (remapping fault or abort).
+    fn remap_msi(&self, device_id: u16, address: u64, data: u32) -> Option<(u64, u32)>;
+
+    /// Register a route for invalidation callbacks.
+    ///
+    /// When the IOMMU processes an `INVALIDATE_INTERRUPT_TABLE` command
+    /// matching this route's device ID, it will call
+    /// [`RetranslateInterrupts::retranslate`] so the route can re-translate
+    /// its cached MSI parameters.
+    fn register_route(&self, route: &Arc<dyn RetranslateInterrupts>);
+
+    /// Unregister a route. Dead (dropped) routes are also cleaned up
+    /// lazily during invalidation.
+    fn unregister_route(&self, route: &Arc<dyn RetranslateInterrupts>);
+}
+
+/// Trait for pre-registered interrupt routes that can be retranslated on
+/// IOMMU invalidation.
+///
+/// Routes that cache translated MSI parameters (e.g., IOAPIC routes
+/// registered with KVM, or IrqFd routes) implement this trait so the
+/// IOMMU can ask them to retranslate when the guest issues an
+/// `INVALIDATE_INTERRUPT_TABLE` command.
+pub trait RetranslateInterrupts: Send + Sync {
+    /// The device ID (BDF) this route is associated with.
+    fn device_id(&self) -> u16;
+
+    /// Re-translate all cached routes and re-push any that changed to
+    /// the hypervisor.
+    fn retranslate(&self);
+}
+
+/// Shared infrastructure for managing registered interrupt routes.
+///
+/// IOMMU implementations embed this struct and delegate
+/// `register_route`/`unregister_route` to it. On invalidation commands,
+/// call [`invalidate`](RetranslateInterruptsList::invalidate) to retranslate
+/// matching routes.
+///
+/// Routes are stored as `Weak` references and cleaned up lazily.
+pub struct RetranslateInterruptsList {
+    routes: Mutex<Vec<Weak<dyn RetranslateInterrupts>>>,
+}
+
+impl RetranslateInterruptsList {
+    /// Create an empty route list.
+    pub fn new() -> Self {
+        Self {
+            routes: Mutex::new(Vec::new()),
+        }
+    }
+
+    /// Register a route for invalidation callbacks.
+    pub fn register(&self, route: &Arc<dyn RetranslateInterrupts>) {
+        let mut routes = self.routes.lock();
+        routes.push(Arc::downgrade(route));
+    }
+
+    /// Unregister a route. Removes all dead weak references as well.
+    pub fn unregister(&self, route: &Arc<dyn RetranslateInterrupts>) {
+        let mut routes = self.routes.lock();
+        routes.retain(|w| w.upgrade().is_some_and(|r| !Arc::ptr_eq(&r, route)));
+    }
+
+    /// Invalidate routes for a specific device, or all routes if
+    /// `device_id` is `None`.
+    ///
+    /// For each matching route, calls `retranslate` with the provided
+    /// remapper. Dead references are cleaned up lazily.
+    pub fn invalidate(&self, device_id: Option<u16>) {
+        let mut routes = self.routes.lock();
+        routes.retain(|weak| {
+            let Some(route) = weak.upgrade() else {
+                return false; // dead, remove
+            };
+            if device_id.is_none() || device_id == Some(route.device_id()) {
+                route.retranslate();
+            }
+            true
+        });
     }
 }

--- a/vm/devices/pci/pcie/src/root.rs
+++ b/vm/devices/pci/pcie/src/root.rs
@@ -53,6 +53,14 @@ pub enum InvalidRootComplexError {
     /// A root port's devfn could not be assigned.
     #[error(transparent)]
     Devfn(#[from] crate::PortDevfnError),
+    /// A root port was assigned to a device number reserved for another use.
+    #[error("root port {port_index} would be placed at reserved device number {device:#x}")]
+    ReservedDeviceCollision {
+        /// Index of the root port that collided.
+        port_index: usize,
+        /// The reserved device number it would have occupied.
+        device: u8,
+    },
 }
 
 /// A generic PCI Express root complex emulator.
@@ -72,6 +80,8 @@ pub struct GenericPcieRootComplex {
     /// (device << 3 | function).
     #[inspect(with = "|x| inspect::iter_by_key(x.iter().map(|(k, v)| (k, v)))")]
     devices: Vec<(u8, BusDevice)>,
+    /// Bitmask of reserved root-bus device numbers (bit N => device N).
+    reserved_device_numbers: u32,
 }
 
 /// A device occupying a slot on the root complex bus.
@@ -162,7 +172,13 @@ pub struct GenericPcieRootComplexBuilder<'a> {
     ecam_range: MemoryRange,
     root_ports: Option<(Vec<GenericPciePortDefinition>, &'a MsiTarget)>,
     first_port_device_number: u8,
+    reserved_device_numbers: u32,
     chbcr_range: Option<MemoryRange>,
+}
+
+fn device_number_is_reserved(reserved_device_numbers: u32, device: u8) -> bool {
+    let bit = 1u32 << device;
+    reserved_device_numbers & bit != 0
 }
 
 impl<'a> GenericPcieRootComplexBuilder<'a> {
@@ -190,6 +206,17 @@ impl<'a> GenericPcieRootComplexBuilder<'a> {
         self
     }
 
+    /// Reserve root-bus device numbers via a bitmask.
+    ///
+    /// Root ports and RCiEPs are assigned into device/function slots; any
+    /// device number whose bit is set here is treated as occupied by another entity
+    /// (e.g. a phantom IOAPIC), and a configuration that would place a root
+    /// port on it is rejected at [`build`](Self::build) time.
+    pub fn reserved_device_numbers(mut self, mask: u32) -> Self {
+        self.reserved_device_numbers = mask;
+        self
+    }
+
     /// Set the CHBCR (Component Register BAR) MMIO range for CXL mode.
     ///
     /// When set, CXL component registers are allocated and a CHBCR MMIO
@@ -210,6 +237,7 @@ impl<'a> GenericPcieRootComplexBuilder<'a> {
             ecam_range,
             root_ports,
             first_port_device_number,
+            reserved_device_numbers,
             chbcr_range,
         } = self;
 
@@ -252,6 +280,13 @@ impl<'a> GenericPcieRootComplexBuilder<'a> {
             let placements = crate::assign_port_devfns(&ports, first_port_device_number)?;
 
             for (i, (definition, placement)) in ports.into_iter().zip(placements).enumerate() {
+                let device = placement.devfn >> crate::BDF_DEVICE_SHIFT;
+                if device_number_is_reserved(reserved_device_numbers, device) {
+                    return Err(InvalidRootComplexError::ReservedDeviceCollision {
+                        port_index: i,
+                        device,
+                    });
+                }
                 let hotplug_slot_number = if definition.hotplug {
                     Some(i as u32 + 1)
                 } else {
@@ -288,6 +323,7 @@ impl<'a> GenericPcieRootComplexBuilder<'a> {
             chbcr,
             cxl_component_registers,
             devices,
+            reserved_device_numbers,
         })
     }
 }
@@ -311,6 +347,7 @@ impl GenericPcieRootComplex {
             ecam_range,
             root_ports: None,
             first_port_device_number: 0,
+            reserved_device_numbers: 0,
             chbcr_range: None,
         }
     }
@@ -432,6 +469,11 @@ impl GenericPcieRootComplex {
         name: impl Into<Arc<str>>,
         dev: Box<dyn GenericPciBusDevice>,
     ) -> Result<(), Arc<str>> {
+        let device = devfn >> crate::BDF_DEVICE_SHIFT;
+        if device_number_is_reserved(self.reserved_device_numbers, device) {
+            return Err(format!("reserved device number {device:#x}").into());
+        }
+
         let name = name.into();
         match self.devices.binary_search_by_key(&devfn, |(d, _)| *d) {
             Ok(i) => {
@@ -1859,6 +1901,23 @@ mod tests {
             .add_rciep(0, "rciep-second", Box::new(rciep2))
             .expect_err("should fail: devfn already has an RCiEP");
         assert_eq!(err.as_ref(), "rciep-first");
+    }
+
+    #[test]
+    fn test_rciep_collision_with_reserved_device_number() {
+        // Reserve device 0 and verify RCiEP insertion at devfn 0 is rejected.
+        let mut register_mmio = TestPcieMmioRegistration {};
+        let ecam = MemoryRange::new(0..ecam_size_from_bus_numbers(0, 0));
+        let mut rc = GenericPcieRootComplex::builder(&mut register_mmio, 0..=0u8, ecam)
+            .reserved_device_numbers(1 << 0)
+            .build()
+            .unwrap();
+
+        let rciep = TestPcieEndpoint::new(|_, _| Some(IoResult::Ok), |_, _| Some(IoResult::Ok));
+        let err = rc
+            .add_rciep(0, "rciep-reserved", Box::new(rciep))
+            .expect_err("should fail: device 0 is reserved");
+        assert_eq!(err.as_ref(), "reserved device number 0x0");
     }
 
     #[test]

--- a/vmm_core/src/acpi_builder.rs
+++ b/vmm_core/src/acpi_builder.rs
@@ -817,7 +817,7 @@ impl<T: AcpiTopology> AcpiTablesBuilder<'_, T> {
                     && (config.start_bus..=config.end_bus).contains(&ioapic_bus))
                 .then(|| {
                     dev_entries_size += size_of::<ivrs::IvhdSpecialDeviceEntry8>();
-                    ivrs::IvhdSpecialDeviceEntry8::ioapic(ioapic_rid, 0)
+                    ivrs::IvhdSpecialDeviceEntry8::ioapic(ioapic_rid, X86_IOAPIC_ID)
                 })
             });
 

--- a/vmm_core/src/acpi_builder.rs
+++ b/vmm_core/src/acpi_builder.rs
@@ -161,6 +161,18 @@ pub struct IntelVtdAcpiConfig {
     /// on the root bus (bridges for root ports, endpoints for RCiEPs).
     /// The DMAR builder emits one DMAR device scope entry per element.
     pub device_scopes: Vec<IntelVtdDeviceScope>,
+    /// Optional IOAPIC device scope for the DRHD that covers the southbridge
+    /// IOAPIC's source ID.
+    pub ioapic: Option<IntelVtdIoapicScope>,
+}
+
+/// IOAPIC device scope entry for a VT-d DRHD.
+#[derive(Clone, Debug)]
+pub struct IntelVtdIoapicScope {
+    /// IOAPIC enumeration ID, matching the MADT IOAPIC ID.
+    pub enumeration_id: u8,
+    /// PCI device/function used as the IOAPIC source ID on the DRHD start bus.
+    pub devfn: u8,
 }
 
 /// A single device scope entry for the DMAR table's DRHD structure.
@@ -866,7 +878,9 @@ impl<T: AcpiTopology> AcpiTablesBuilder<'_, T> {
             // Each device scope entry is a DmarDeviceScope header (6 bytes)
             // plus one DmarDevicePath (2 bytes).
             let per_scope_size = size_of::<dmar::DmarDeviceScope>() + size_of::<DmarDevicePath>();
-            let total_scope_size = per_scope_size * config.device_scopes.len();
+            let ioapic_scope_count = if config.ioapic.is_some() { 1 } else { 0 };
+            let total_scope_size =
+                per_scope_size * (config.device_scopes.len() + ioapic_scope_count);
             let drhd_total = size_of::<dmar::DmarDrhd>() + total_scope_size;
 
             let drhd = dmar::DmarDrhd::new(
@@ -891,6 +905,20 @@ impl<T: AcpiTopology> AcpiTablesBuilder<'_, T> {
                     DmarDevicePath {
                         device: scope.devfn >> 3,
                         function: scope.devfn & 0x7,
+                    }
+                    .as_bytes(),
+                );
+            }
+
+            if let Some(ioapic) = &config.ioapic {
+                let mut scope =
+                    dmar::DmarDeviceScope::new(dmar::DEVICE_SCOPE_IOAPIC, config.start_bus);
+                scope.enumeration_id = ioapic.enumeration_id;
+                dmar_extra.extend_from_slice(scope.as_bytes());
+                dmar_extra.extend_from_slice(
+                    DmarDevicePath {
+                        device: ioapic.devfn >> 3,
+                        function: ioapic.devfn & 0x7,
                     }
                     .as_bytes(),
                 );
@@ -2291,6 +2319,7 @@ mod test {
                         is_bridge: true,
                     },
                 ],
+                ioapic: None,
             }],
         );
 
@@ -2345,6 +2374,48 @@ mod test {
     }
 
     #[test]
+    fn test_dmar_ioapic_scope() {
+        let mem = new_mem();
+        let topology = TopologyBuilder::new_x86().build(4).unwrap();
+        let pcie = vec![];
+        let mut builder = new_builder(&mem, &topology, &pcie);
+        set_intel_vtd(
+            &mut builder,
+            vec![IntelVtdAcpiConfig {
+                mmio_base: 0xFED9_0000,
+                pci_segment: 0,
+                start_bus: 0,
+                device_scopes: vec![IntelVtdDeviceScope {
+                    devfn: 0x00,
+                    is_bridge: true,
+                }],
+                ioapic: Some(IntelVtdIoapicScope {
+                    enumeration_id: 0,
+                    devfn: 0xA0,
+                }),
+            }],
+        );
+
+        let dmar = builder.build_dmar().unwrap();
+        assert_eq!(checksum(&dmar), 0);
+
+        let drhd_offset = 48;
+        let drhd_len =
+            u16::from_ne_bytes(dmar[drhd_offset + 2..drhd_offset + 4].try_into().unwrap());
+        assert_eq!(drhd_len, 32);
+
+        let ioapic_scope_offset = drhd_offset + 16 + 8;
+        assert_eq!(
+            dmar[ioapic_scope_offset],
+            acpi_spec::dmar::DEVICE_SCOPE_IOAPIC
+        );
+        assert_eq!(dmar[ioapic_scope_offset + 4], 0);
+        assert_eq!(dmar[ioapic_scope_offset + 5], 0);
+        assert_eq!(dmar[ioapic_scope_offset + 6], 0x14);
+        assert_eq!(dmar[ioapic_scope_offset + 7], 0);
+    }
+
+    #[test]
     fn test_dmar_not_generated_when_disabled() {
         let mem = new_mem();
         let topology = TopologyBuilder::new_x86().build(4).unwrap();
@@ -2373,6 +2444,7 @@ mod test {
                     devfn: 0x00,
                     is_bridge: true,
                 }],
+                ioapic: None,
             }],
         );
 
@@ -2397,6 +2469,7 @@ mod test {
                         devfn: 0x00,
                         is_bridge: true,
                     }],
+                    ioapic: None,
                 },
                 IntelVtdAcpiConfig {
                     mmio_base: 0xFED9_1000,
@@ -2406,6 +2479,7 @@ mod test {
                         devfn: 0x00,
                         is_bridge: true,
                     }],
+                    ioapic: None,
                 },
             ],
         );

--- a/vmm_core/src/acpi_builder.rs
+++ b/vmm_core/src/acpi_builder.rs
@@ -2026,6 +2026,23 @@ mod test {
         }
     }
 
+    fn set_amd_iommu_with_ioapic(
+        builder: &mut AcpiTablesBuilder<'_, X86Topology>,
+        configs: Vec<AmdIommuAcpiConfig>,
+        ioapic_rid: Option<u16>,
+    ) {
+        if let AcpiArchConfig::X86 { iommu, .. } = &mut builder.arch {
+            *iommu = Some(X86IommuAcpiConfig::AmdVi(AmdIommuIvrsConfig {
+                pa_size: 48,
+                va_size: 48,
+                iommus: configs,
+                ioapic_rid,
+            }));
+        } else {
+            panic!("expected X86 arch config");
+        }
+    }
+
     #[test]
     fn test_ivrs_basic() {
         let mem = new_mem();
@@ -2425,5 +2442,114 @@ mod test {
         // Second DRHD's device scope start_bus = 128
         let scope1_offset = drhd1_offset + 16;
         assert_eq!(dmar[scope1_offset + 5], 128);
+    }
+
+    /// The IOAPIC DEV_SPECIAL entry must be emitted on the IVHD whose
+    /// segment (0) and bus range cover the IOAPIC RID, regardless of where
+    /// that IOMMU sits in the config list. Here the covering IOMMU is listed
+    /// second, so a correct implementation must not assume index 0.
+    #[test]
+    fn test_ivrs_ioapic_special_entry_placement() {
+        let mem = new_mem();
+        let topology = TopologyBuilder::new_x86().build(4).unwrap();
+        let pcie = vec![];
+        let mut builder = new_builder(&mem, &topology, &pcie);
+        // RID 00:14.0 on segment 0, bus 0.
+        let ioapic_rid = 0x00A0u16;
+        set_amd_iommu_with_ioapic(
+            &mut builder,
+            vec![
+                // First config: segment 1, does NOT cover the IOAPIC.
+                AmdIommuAcpiConfig {
+                    device_id: 0x0000,
+                    capability_offset: 0x40,
+                    mmio_base: 0xFD00_4000,
+                    pci_segment: 1,
+                    ivhd_features: 0xC0,
+                    start_bus: 0,
+                    end_bus: 255,
+                },
+                // Second config: segment 0, bus 0 — covers the IOAPIC RID.
+                AmdIommuAcpiConfig {
+                    device_id: 0x0000,
+                    capability_offset: 0x40,
+                    mmio_base: 0xFD00_0000,
+                    pci_segment: 0,
+                    ivhd_features: 0xC0,
+                    start_bus: 0,
+                    end_bus: 127,
+                },
+            ],
+            Some(ioapic_rid),
+        );
+
+        let ivrs = builder.build_ivrs().unwrap();
+        assert_eq!(&ivrs[0..4], b"IVRS");
+        assert_eq!(checksum(&ivrs), 0);
+
+        // First IVHD (segment 1): only the range_start + range_end pair, so
+        // its length is header (40) + 2 * 4 = 48, and it carries no special
+        // device entry.
+        let ivhd0_offset = 48;
+        assert_eq!(ivrs[ivhd0_offset], 0x40);
+        let ivhd0_len =
+            u16::from_ne_bytes(ivrs[ivhd0_offset + 2..ivhd0_offset + 4].try_into().unwrap());
+        assert_eq!(ivhd0_len as usize, 40 + 2 * 4);
+
+        // Second IVHD (segment 0): range_start + range_end + the 8-byte
+        // IOAPIC special device entry, so its length is 40 + 2 * 4 + 8 = 56.
+        let ivhd1_offset = ivhd0_offset + ivhd0_len as usize;
+        assert_eq!(ivrs[ivhd1_offset], 0x40);
+        let ivhd1_len =
+            u16::from_ne_bytes(ivrs[ivhd1_offset + 2..ivhd1_offset + 4].try_into().unwrap());
+        assert_eq!(ivhd1_len as usize, 40 + 2 * 4 + 8);
+        let seg1 = u16::from_ne_bytes(
+            ivrs[ivhd1_offset + 16..ivhd1_offset + 18]
+                .try_into()
+                .unwrap(),
+        );
+        assert_eq!(seg1, 0);
+
+        // The special entry follows the two range entries (header + 8 bytes).
+        let special = ivhd1_offset + 40 + 2 * 4;
+        assert_eq!(ivrs[special], 0x48); // IVHD_DEV_SPECIAL
+        // source_device_id at +5 (u16) must equal the IOAPIC RID.
+        let src_rid = u16::from_ne_bytes(ivrs[special + 5..special + 7].try_into().unwrap());
+        assert_eq!(src_rid, ioapic_rid);
+        // variety at +7 must be IOAPIC (0x01).
+        assert_eq!(ivrs[special + 7], 0x01);
+    }
+
+    /// When an IOAPIC RID is supplied but no IOMMU covers segment 0 / bus 0,
+    /// no DEV_SPECIAL(IOAPIC) entry is emitted.
+    #[test]
+    fn test_ivrs_no_ioapic_entry_when_uncovered() {
+        let mem = new_mem();
+        let topology = TopologyBuilder::new_x86().build(4).unwrap();
+        let pcie = vec![];
+        let mut builder = new_builder(&mem, &topology, &pcie);
+        set_amd_iommu_with_ioapic(
+            &mut builder,
+            vec![AmdIommuAcpiConfig {
+                device_id: 0x0000,
+                capability_offset: 0x40,
+                mmio_base: 0xFD00_0000,
+                pci_segment: 1, // not segment 0
+                ivhd_features: 0xC0,
+                start_bus: 0,
+                end_bus: 255,
+            }],
+            Some(0x00A0),
+        );
+
+        let ivrs = builder.build_ivrs().unwrap();
+
+        // The single IVHD must contain only the range_start + range_end pair.
+        let ivhd_offset = 48;
+        let ivhd_len =
+            u16::from_ne_bytes(ivrs[ivhd_offset + 2..ivhd_offset + 4].try_into().unwrap());
+        assert_eq!(ivhd_len as usize, 40 + 2 * 4);
+        // No special device entry byte present anywhere after the header.
+        assert!(!ivrs[ivhd_offset..].contains(&0x48));
     }
 }

--- a/vmm_core/src/acpi_builder.rs
+++ b/vmm_core/src/acpi_builder.rs
@@ -2633,5 +2633,4 @@ mod test {
         // variety at +7 must be IOAPIC (0x01).
         assert_eq!(ivrs[special + 7], 0x01);
     }
-
 }

--- a/vmm_core/src/acpi_builder.rs
+++ b/vmm_core/src/acpi_builder.rs
@@ -2634,36 +2634,4 @@ mod test {
         assert_eq!(ivrs[special + 7], 0x01);
     }
 
-    /// When an IOAPIC RID is supplied but no IOMMU covers segment 0 / bus 0,
-    /// no DEV_SPECIAL(IOAPIC) entry is emitted.
-    #[test]
-    fn test_ivrs_no_ioapic_entry_when_uncovered() {
-        let mem = new_mem();
-        let topology = TopologyBuilder::new_x86().build(4).unwrap();
-        let pcie = vec![];
-        let mut builder = new_builder(&mem, &topology, &pcie);
-        set_amd_iommu_with_ioapic(
-            &mut builder,
-            vec![AmdIommuAcpiConfig {
-                device_id: 0x0000,
-                capability_offset: 0x40,
-                mmio_base: 0xFD00_0000,
-                pci_segment: 1, // not segment 0
-                ivhd_features: 0xC0,
-                start_bus: 0,
-                end_bus: 255,
-            }],
-            Some(0x00A0),
-        );
-
-        let ivrs = builder.build_ivrs().unwrap();
-
-        // The single IVHD must contain only the range_start + range_end pair.
-        let ivhd_offset = 48;
-        let ivhd_len =
-            u16::from_ne_bytes(ivrs[ivhd_offset + 2..ivhd_offset + 4].try_into().unwrap());
-        assert_eq!(ivhd_len as usize, 40 + 2 * 4);
-        // No special device entry byte present anywhere after the header.
-        assert!(!ivrs[ivhd_offset..].contains(&0x48));
-    }
 }

--- a/vmm_core/src/acpi_builder.rs
+++ b/vmm_core/src/acpi_builder.rs
@@ -142,9 +142,9 @@ pub struct AmdIommuIvrsConfig {
     /// IOAPIC PCIe Requester ID (RID) for the IVRS DEV_SPECIAL(IOAPIC)
     /// entry.
     ///
-    /// When set, a special device entry is added to the first IOMMU's IVHD
-    /// block so the guest can locate the IOAPIC's DTE/IRTE context for
-    /// interrupt remapping.
+    /// When set, a DEV_SPECIAL(IOAPIC) entry is added to the IVHD whose
+    /// segment (0) and bus range cover this RID, so the guest can locate the
+    /// IOAPIC's DTE/IRTE context for interrupt remapping.
     pub ioapic_rid: Option<u16>,
 }
 
@@ -791,22 +791,26 @@ impl<T: AcpiTopology> AcpiTablesBuilder<'_, T> {
 
         let mut ivrs_extra: Vec<u8> = Vec::new();
 
-        for (idx, config) in ivrs_config.iommus.iter().enumerate() {
+        for config in &ivrs_config.iommus {
             // Use a device range entry to cover the bus range owned by this
             // root complex's IOMMU (IVHD_DEV_RANGE_START + IVHD_DEV_RANGE_END).
             // This correctly supports multiple IOMMUs within a single PCI
             // segment, each covering its own bus range.
             let mut dev_entries_size = 2 * size_of::<ivrs::IvhdDeviceEntry4>();
 
-            // Add IOAPIC special device entry to the first IOMMU's IVHD.
-            let ioapic_special = if idx == 0 {
-                ivrs_config.ioapic_rid.map(|ioapic_rid| {
+            // Emit the IOAPIC DEV_SPECIAL entry on the IVHD whose segment (0)
+            // and bus range cover the IOAPIC RID, so the guest resolves the
+            // IOAPIC's DTE/IRTE from the correct IOMMU regardless of config
+            // ordering.
+            let ioapic_special = ivrs_config.ioapic_rid.and_then(|ioapic_rid| {
+                let ioapic_bus = (ioapic_rid >> 8) as u8;
+                (config.pci_segment == 0
+                    && (config.start_bus..=config.end_bus).contains(&ioapic_bus))
+                .then(|| {
                     dev_entries_size += size_of::<ivrs::IvhdSpecialDeviceEntry8>();
                     ivrs::IvhdSpecialDeviceEntry8::ioapic(ioapic_rid, 0)
                 })
-            } else {
-                None
-            };
+            });
 
             let ivhd_total = size_of::<ivrs::IvhdType40>() + dev_entries_size;
 

--- a/vmm_core/src/acpi_builder.rs
+++ b/vmm_core/src/acpi_builder.rs
@@ -161,11 +161,6 @@ pub struct IntelVtdAcpiConfig {
     /// on the root bus (bridges for root ports, endpoints for RCiEPs).
     /// The DMAR builder emits one DMAR device scope entry per element.
     pub device_scopes: Vec<IntelVtdDeviceScope>,
-    /// IOAPIC PCIe Requester ID (RID) for the DMAR IOAPIC device scope.
-    ///
-    /// When set, a DEVICE_SCOPE_IOAPIC entry is added to this DRHD so the
-    /// guest can locate the IOAPIC's source ID for interrupt remapping.
-    pub ioapic_rid: Option<u16>,
 }
 
 /// A single device scope entry for the DMAR table's DRHD structure.
@@ -190,6 +185,12 @@ pub struct IntelVtdDmarConfig {
     pub host_address_width: u8,
     /// Per-unit configurations, one per root complex with an Intel VT-d unit.
     pub units: Vec<IntelVtdAcpiConfig>,
+    /// IOAPIC PCIe Requester ID (RID) for the DMAR IOAPIC device scope.
+    ///
+    /// When set, a DEVICE_SCOPE_IOAPIC entry is added to the DRHD whose
+    /// segment (0) and start bus cover this RID, so the guest can locate the
+    /// IOAPIC's source ID for interrupt remapping.
+    pub ioapic_rid: Option<u16>,
 }
 
 /// x86 IOMMU ACPI table configuration.
@@ -869,12 +870,24 @@ impl<T: AcpiTopology> AcpiTablesBuilder<'_, T> {
         use acpi_spec::dmar::DmarDevicePath;
 
         let mut dmar_extra: Vec<u8> = Vec::new();
+        if let Some(ioapic_rid) = dmar_config.ioapic_rid {
+            let ioapic_bus = (ioapic_rid >> 8) as u8;
+            let matching_units = dmar_config
+                .units
+                .iter()
+                .filter(|config| config.pci_segment == 0 && config.start_bus == ioapic_bus)
+                .count();
+            assert_eq!(
+                matching_units, 1,
+                "VT-d IOAPIC RID {ioapic_rid:#06x} must be covered by exactly one segment-0 DRHD"
+            );
+        }
 
         for config in &dmar_config.units {
             // Each device scope entry is a DmarDeviceScope header (6 bytes)
             // plus one DmarDevicePath (2 bytes).
             let per_scope_size = size_of::<dmar::DmarDeviceScope>() + size_of::<DmarDevicePath>();
-            let ioapic_devfn = config.ioapic_rid.and_then(|ioapic_rid| {
+            let ioapic_devfn = dmar_config.ioapic_rid.and_then(|ioapic_rid| {
                 let ioapic_bus = (ioapic_rid >> 8) as u8;
                 (config.pci_segment == 0 && config.start_bus == ioapic_bus)
                     .then_some(ioapic_rid as u8)
@@ -2288,10 +2301,19 @@ mod test {
         builder: &mut AcpiTablesBuilder<'_, X86Topology>,
         configs: Vec<IntelVtdAcpiConfig>,
     ) {
+        set_intel_vtd_with_ioapic(builder, configs, None);
+    }
+
+    fn set_intel_vtd_with_ioapic(
+        builder: &mut AcpiTablesBuilder<'_, X86Topology>,
+        configs: Vec<IntelVtdAcpiConfig>,
+        ioapic_rid: Option<u16>,
+    ) {
         if let AcpiArchConfig::X86 { iommu, .. } = &mut builder.arch {
             *iommu = Some(X86IommuAcpiConfig::IntelVtd(IntelVtdDmarConfig {
                 host_address_width: 48,
                 units: configs,
+                ioapic_rid,
             }));
         } else {
             panic!("expected X86 arch config");
@@ -2320,7 +2342,6 @@ mod test {
                         is_bridge: true,
                     },
                 ],
-                ioapic_rid: None,
             }],
         );
 
@@ -2380,7 +2401,7 @@ mod test {
         let topology = TopologyBuilder::new_x86().build(4).unwrap();
         let pcie = vec![];
         let mut builder = new_builder(&mem, &topology, &pcie);
-        set_intel_vtd(
+        set_intel_vtd_with_ioapic(
             &mut builder,
             vec![IntelVtdAcpiConfig {
                 mmio_base: 0xFED9_0000,
@@ -2390,8 +2411,8 @@ mod test {
                     devfn: 0x00,
                     is_bridge: true,
                 }],
-                ioapic_rid: Some(0x00A0),
             }],
+            Some(0x00A0),
         );
 
         let dmar = builder.build_dmar().unwrap();
@@ -2411,6 +2432,30 @@ mod test {
         assert_eq!(dmar[ioapic_scope_offset + 5], 0);
         assert_eq!(dmar[ioapic_scope_offset + 6], 0x14);
         assert_eq!(dmar[ioapic_scope_offset + 7], 0);
+    }
+
+    #[test]
+    #[should_panic(expected = "must be covered by exactly one segment-0 DRHD")]
+    fn test_dmar_ioapic_rid_must_be_covered() {
+        let mem = new_mem();
+        let topology = TopologyBuilder::new_x86().build(4).unwrap();
+        let pcie = vec![];
+        let mut builder = new_builder(&mem, &topology, &pcie);
+        set_intel_vtd_with_ioapic(
+            &mut builder,
+            vec![IntelVtdAcpiConfig {
+                mmio_base: 0xFED9_0000,
+                pci_segment: 1,
+                start_bus: 0,
+                device_scopes: vec![IntelVtdDeviceScope {
+                    devfn: 0x00,
+                    is_bridge: true,
+                }],
+            }],
+            Some(0x00A0),
+        );
+
+        let _ = builder.build_dmar();
     }
 
     #[test]
@@ -2442,7 +2487,6 @@ mod test {
                     devfn: 0x00,
                     is_bridge: true,
                 }],
-                ioapic_rid: None,
             }],
         );
 
@@ -2467,7 +2511,6 @@ mod test {
                         devfn: 0x00,
                         is_bridge: true,
                     }],
-                    ioapic_rid: None,
                 },
                 IntelVtdAcpiConfig {
                     mmio_base: 0xFED9_1000,
@@ -2477,7 +2520,6 @@ mod test {
                         devfn: 0x00,
                         is_bridge: true,
                     }],
-                    ioapic_rid: None,
                 },
             ],
         );

--- a/vmm_core/src/acpi_builder.rs
+++ b/vmm_core/src/acpi_builder.rs
@@ -161,18 +161,11 @@ pub struct IntelVtdAcpiConfig {
     /// on the root bus (bridges for root ports, endpoints for RCiEPs).
     /// The DMAR builder emits one DMAR device scope entry per element.
     pub device_scopes: Vec<IntelVtdDeviceScope>,
-    /// Optional IOAPIC device scope for the DRHD that covers the southbridge
-    /// IOAPIC's source ID.
-    pub ioapic: Option<IntelVtdIoapicScope>,
-}
-
-/// IOAPIC device scope entry for a VT-d DRHD.
-#[derive(Clone, Debug)]
-pub struct IntelVtdIoapicScope {
-    /// IOAPIC enumeration ID, matching the MADT IOAPIC ID.
-    pub enumeration_id: u8,
-    /// PCI device/function used as the IOAPIC source ID on the DRHD start bus.
-    pub devfn: u8,
+    /// IOAPIC PCIe Requester ID (RID) for the DMAR IOAPIC device scope.
+    ///
+    /// When set, a DEVICE_SCOPE_IOAPIC entry is added to this DRHD so the
+    /// guest can locate the IOAPIC's source ID for interrupt remapping.
+    pub ioapic_rid: Option<u16>,
 }
 
 /// A single device scope entry for the DMAR table's DRHD structure.
@@ -349,6 +342,9 @@ pub trait AcpiTopology: ArchTopology + Inspect + Sized {
 ///
 /// This isn't 0xff because that's the broadcast ID.
 const MAX_LEGACY_APIC_ID: u32 = 0xfe;
+
+/// IOAPIC ID emitted in the x86 MADT and referenced by DMAR IOAPIC scopes.
+const X86_IOAPIC_ID: u8 = 0;
 
 impl AcpiTopology for X86Topology {
     fn extend_srat(topology: &ProcessorTopology<Self>, srat: &mut Vec<u8>) {
@@ -555,7 +551,7 @@ impl<T: AcpiTopology> AcpiTablesBuilder<'_, T> {
             if with_ioapic {
                 madt_extra.extend_from_slice(
                     acpi_spec::madt::MadtIoApic {
-                        io_apic_id: 0,
+                        io_apic_id: X86_IOAPIC_ID,
                         io_apic_address: ioapic::IOAPIC_DEVICE_MMIO_REGION_BASE_ADDRESS as u32,
                         ..acpi_spec::madt::MadtIoApic::new()
                     }
@@ -878,7 +874,12 @@ impl<T: AcpiTopology> AcpiTablesBuilder<'_, T> {
             // Each device scope entry is a DmarDeviceScope header (6 bytes)
             // plus one DmarDevicePath (2 bytes).
             let per_scope_size = size_of::<dmar::DmarDeviceScope>() + size_of::<DmarDevicePath>();
-            let ioapic_scope_count = if config.ioapic.is_some() { 1 } else { 0 };
+            let ioapic_devfn = config.ioapic_rid.and_then(|ioapic_rid| {
+                let ioapic_bus = (ioapic_rid >> 8) as u8;
+                (config.pci_segment == 0 && config.start_bus == ioapic_bus)
+                    .then_some(ioapic_rid as u8)
+            });
+            let ioapic_scope_count = if ioapic_devfn.is_some() { 1 } else { 0 };
             let total_scope_size =
                 per_scope_size * (config.device_scopes.len() + ioapic_scope_count);
             let drhd_total = size_of::<dmar::DmarDrhd>() + total_scope_size;
@@ -910,15 +911,15 @@ impl<T: AcpiTopology> AcpiTablesBuilder<'_, T> {
                 );
             }
 
-            if let Some(ioapic) = &config.ioapic {
+            if let Some(ioapic_devfn) = ioapic_devfn {
                 let mut scope =
                     dmar::DmarDeviceScope::new(dmar::DEVICE_SCOPE_IOAPIC, config.start_bus);
-                scope.enumeration_id = ioapic.enumeration_id;
+                scope.enumeration_id = X86_IOAPIC_ID;
                 dmar_extra.extend_from_slice(scope.as_bytes());
                 dmar_extra.extend_from_slice(
                     DmarDevicePath {
-                        device: ioapic.devfn >> 3,
-                        function: ioapic.devfn & 0x7,
+                        device: ioapic_devfn >> 3,
+                        function: ioapic_devfn & 0x7,
                     }
                     .as_bytes(),
                 );
@@ -2319,7 +2320,7 @@ mod test {
                         is_bridge: true,
                     },
                 ],
-                ioapic: None,
+                ioapic_rid: None,
             }],
         );
 
@@ -2389,10 +2390,7 @@ mod test {
                     devfn: 0x00,
                     is_bridge: true,
                 }],
-                ioapic: Some(IntelVtdIoapicScope {
-                    enumeration_id: 0,
-                    devfn: 0xA0,
-                }),
+                ioapic_rid: Some(0x00A0),
             }],
         );
 
@@ -2444,7 +2442,7 @@ mod test {
                     devfn: 0x00,
                     is_bridge: true,
                 }],
-                ioapic: None,
+                ioapic_rid: None,
             }],
         );
 
@@ -2469,7 +2467,7 @@ mod test {
                         devfn: 0x00,
                         is_bridge: true,
                     }],
-                    ioapic: None,
+                    ioapic_rid: None,
                 },
                 IntelVtdAcpiConfig {
                     mmio_base: 0xFED9_1000,
@@ -2479,7 +2477,7 @@ mod test {
                         devfn: 0x00,
                         is_bridge: true,
                     }],
-                    ioapic: None,
+                    ioapic_rid: None,
                 },
             ],
         );

--- a/vmm_core/src/acpi_builder.rs
+++ b/vmm_core/src/acpi_builder.rs
@@ -139,6 +139,13 @@ pub struct AmdIommuIvrsConfig {
     pub va_size: u8,
     /// Per-IOMMU configurations, one per root complex with an AMD IOMMU.
     pub iommus: Vec<AmdIommuAcpiConfig>,
+    /// IOAPIC PCIe Requester ID (RID) for the IVRS DEV_SPECIAL(IOAPIC)
+    /// entry.
+    ///
+    /// When set, a special device entry is added to the first IOMMU's IVHD
+    /// block so the guest can locate the IOAPIC's DTE/IRTE context for
+    /// interrupt remapping.
+    pub ioapic_rid: Option<u16>,
 }
 
 /// Configuration for a single Intel VT-d remapping unit in the DMAR table.
@@ -784,12 +791,23 @@ impl<T: AcpiTopology> AcpiTablesBuilder<'_, T> {
 
         let mut ivrs_extra: Vec<u8> = Vec::new();
 
-        for config in &ivrs_config.iommus {
+        for (idx, config) in ivrs_config.iommus.iter().enumerate() {
             // Use a device range entry to cover the bus range owned by this
             // root complex's IOMMU (IVHD_DEV_RANGE_START + IVHD_DEV_RANGE_END).
             // This correctly supports multiple IOMMUs within a single PCI
             // segment, each covering its own bus range.
-            let dev_entries_size = 2 * size_of::<ivrs::IvhdDeviceEntry4>();
+            let mut dev_entries_size = 2 * size_of::<ivrs::IvhdDeviceEntry4>();
+
+            // Add IOAPIC special device entry to the first IOMMU's IVHD.
+            let ioapic_special = if idx == 0 {
+                ivrs_config.ioapic_rid.map(|ioapic_rid| {
+                    dev_entries_size += size_of::<ivrs::IvhdSpecialDeviceEntry8>();
+                    ivrs::IvhdSpecialDeviceEntry8::ioapic(ioapic_rid, 0)
+                })
+            } else {
+                None
+            };
+
             let ivhd_total = size_of::<ivrs::IvhdType40>() + dev_entries_size;
 
             // Type 40h is the "mixed format" IVHD (§5.2.2.3) — same layout
@@ -812,6 +830,10 @@ impl<T: AcpiTopology> AcpiTablesBuilder<'_, T> {
             ivrs_extra
                 .extend_from_slice(ivrs::IvhdDeviceEntry4::range_start(start_bdf, 0).as_bytes());
             ivrs_extra.extend_from_slice(ivrs::IvhdDeviceEntry4::range_end(end_bdf).as_bytes());
+
+            if let Some(entry) = &ioapic_special {
+                ivrs_extra.extend_from_slice(entry.as_bytes());
+            }
         }
 
         let iv_info = ivrs::IvInfo::new()
@@ -1993,6 +2015,7 @@ mod test {
                 pa_size: 48,
                 va_size: 48,
                 iommus: configs,
+                ioapic_rid: None,
             }));
         } else {
             panic!("expected X86 arch config");

--- a/vmm_core/virt/src/irqcon.rs
+++ b/vmm_core/virt/src/irqcon.rs
@@ -18,6 +18,9 @@ use x86defs::msi::MsiData;
 /// hypervisors (notably KVM) will not generate EOI exits for a
 /// level-triggered interrupt request unless the request has been registered
 /// as a route on one of the IO-APIC IRQs.
+///
+/// `irq` must be less than [`IRQ_LINES`] for both methods; callers (the
+/// IO-APIC device) guarantee this, and implementations may panic otherwise.
 pub trait IoApicRouting: Send + Sync {
     /// Sets the associated interrupt request for the given irq.
     fn set_irq_route(&self, irq: u8, request: Option<MsiRequest>);
@@ -36,7 +39,7 @@ pub trait ControlGic: Send + Sync {
 pub const IRQ_LINES: usize = 24;
 
 /// An message-signaled interrupt request.
-#[derive(Debug, Copy, Clone, Inspect)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Inspect)]
 pub struct MsiRequest {
     /// The MSI address.
     #[inspect(hex)]

--- a/vmm_core/virt/src/irqcon.rs
+++ b/vmm_core/virt/src/irqcon.rs
@@ -38,7 +38,7 @@ pub trait ControlGic: Send + Sync {
 // The number of IRQ lines for the interrupt controller.
 pub const IRQ_LINES: usize = 24;
 
-/// An message-signaled interrupt request.
+/// A message-signaled interrupt request.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Inspect)]
 pub struct MsiRequest {
     /// The MSI address.

--- a/vmm_tests/vmm_tests/tests/tests/multiarch/pcie.rs
+++ b/vmm_tests/vmm_tests/tests/tests/multiarch/pcie.rs
@@ -629,6 +629,59 @@ async fn amd_iommu_mixed_topology(
         "IVRS ACPI table should be present. Tables: {acpi_tables}"
     );
 
+    // 3b. Verify interrupt remapping is active for IOAPIC interrupts.
+    //     Linux reports this path as "IR-IO-APIC" in /proc/interrupts.
+    tracing::info!(
+        ir_dmesg = %dmesg
+            .lines()
+            .filter(|l| {
+                let l = l.to_ascii_lowercase();
+                l.contains("remap") || l.contains("amd-vi")
+            })
+            .collect::<Vec<_>>()
+            .join("\n"),
+        "AMD-Vi / interrupt remapping dmesg lines"
+    );
+
+    let interrupts = cmd!(sh, "cat /proc/interrupts").read().await?;
+    tracing::info!(%interrupts, "/proc/interrupts");
+
+    // The serial port IRQ must be routed through the IR-aware IOAPIC chip,
+    // proving IOAPIC interrupts pass through the IOMMU's IRTEs.
+    let serial_irq = interrupts
+        .lines()
+        .find(|l| l.contains("ttyS0"))
+        .context("serial port IRQ (ttyS0) not present in /proc/interrupts")?;
+    assert!(
+        serial_irq.contains("IR-IO-APIC"),
+        "serial IRQ should route through the IR-IO-APIC chip once interrupt \
+         remapping is enabled, got: {serial_irq}"
+    );
+
+    // Confirm an IOAPIC interrupt actually arrives through the IR path:
+    // capture the serial interrupt count, generate serial traffic, then
+    // confirm the count increased.
+    let count_before = sum_irq_count(serial_irq);
+    cmd!(
+        sh,
+        "sh -c 'for i in $(seq 1 100); do echo ir-remap-test > /dev/ttyS0; done'"
+    )
+    .run()
+    .await?;
+    let interrupts_after = cmd!(sh, "cat /proc/interrupts").read().await?;
+    let serial_irq_after = interrupts_after
+        .lines()
+        .find(|l| l.contains("ttyS0"))
+        .context("serial port IRQ (ttyS0) disappeared from /proc/interrupts")?;
+    let count_after = sum_irq_count(serial_irq_after);
+    tracing::info!(count_before, count_after, "serial IOAPIC interrupt counts");
+    assert!(
+        count_after > count_before,
+        "serial (IOAPIC) interrupt count should increase after generating \
+         serial traffic with interrupt remapping enabled: \
+         before={count_before} after={count_after}"
+    );
+
     // 3–5. Common IOMMU validation: IOMMU groups, NVMe DMA, net, no faults.
     verify_iommu_mixed_topology(
         &sh,
@@ -793,6 +846,18 @@ async fn verify_iommu_mixed_topology(
     );
 
     Ok(())
+}
+
+/// Sum the per-CPU interrupt counts from a `/proc/interrupts` line.
+///
+/// A line looks like `" 4:   42    0   IR-IO-APIC   4-edge   ttyS0"`: the
+/// leading token is the IRQ label and the trailing tokens are the chip and
+/// device name, so only the numeric per-CPU columns in between are summed.
+fn sum_irq_count(line: &str) -> u64 {
+    line.split_whitespace()
+        .skip(1)
+        .map_while(|tok| tok.parse::<u64>().ok())
+        .sum()
 }
 
 /// Verify that NVMe block devices are visible in the guest and exercise DMA

--- a/vmm_tests/vmm_tests/tests/tests/multiarch/pcie.rs
+++ b/vmm_tests/vmm_tests/tests/tests/multiarch/pcie.rs
@@ -630,57 +630,11 @@ async fn amd_iommu_mixed_topology(
     );
 
     // 3b. Verify interrupt remapping is active for IOAPIC interrupts.
-    //     Linux reports this path as "IR-IO-APIC" in /proc/interrupts.
-    tracing::info!(
-        ir_dmesg = %dmesg
-            .lines()
-            .filter(|l| {
-                let l = l.to_ascii_lowercase();
-                l.contains("remap") || l.contains("amd-vi")
-            })
-            .collect::<Vec<_>>()
-            .join("\n"),
-        "AMD-Vi / interrupt remapping dmesg lines"
-    );
-
-    let interrupts = cmd!(sh, "cat /proc/interrupts").read().await?;
-    tracing::info!(%interrupts, "/proc/interrupts");
-
-    // The serial port IRQ must be routed through the IR-aware IOAPIC chip,
-    // proving IOAPIC interrupts pass through the IOMMU's IRTEs.
-    let serial_irq = interrupts
-        .lines()
-        .find(|l| l.contains("ttyS0"))
-        .context("serial port IRQ (ttyS0) not present in /proc/interrupts")?;
-    assert!(
-        serial_irq.contains("IR-IO-APIC"),
-        "serial IRQ should route through the IR-IO-APIC chip once interrupt \
-         remapping is enabled, got: {serial_irq}"
-    );
-
-    // Confirm an IOAPIC interrupt actually arrives through the IR path:
-    // capture the serial interrupt count, generate serial traffic, then
-    // confirm the count increased.
-    let count_before = sum_irq_count(serial_irq);
-    cmd!(
-        sh,
-        "sh -c 'for i in $(seq 1 100); do echo ir-remap-test > /dev/ttyS0; done'"
-    )
-    .run()
+    verify_ioapic_interrupt_remapping(&sh, &dmesg, "AMD-Vi", |l| {
+        let l = l.to_ascii_lowercase();
+        l.contains("remap") || l.contains("amd-vi")
+    })
     .await?;
-    let interrupts_after = cmd!(sh, "cat /proc/interrupts").read().await?;
-    let serial_irq_after = interrupts_after
-        .lines()
-        .find(|l| l.contains("ttyS0"))
-        .context("serial port IRQ (ttyS0) disappeared from /proc/interrupts")?;
-    let count_after = sum_irq_count(serial_irq_after);
-    tracing::info!(count_before, count_after, "serial IOAPIC interrupt counts");
-    assert!(
-        count_after > count_before,
-        "serial (IOAPIC) interrupt count should increase after generating \
-         serial traffic with interrupt remapping enabled: \
-         before={count_before} after={count_after}"
-    );
 
     // 3–5. Common IOMMU validation: IOMMU groups, NVMe DMA, net, no faults.
     verify_iommu_mixed_topology(
@@ -766,52 +720,11 @@ async fn intel_vtd_mixed_topology(
     );
 
     // 3b. Verify interrupt remapping is active for IOAPIC interrupts.
-    //     Linux reports this path as "IR-IO-APIC" in /proc/interrupts.
-    tracing::info!(
-        ir_dmesg = %dmesg
-            .lines()
-            .filter(|l| {
-                let l = l.to_ascii_lowercase();
-                l.contains("remap") || l.contains("dmar") || l.contains("intel-iommu")
-            })
-            .collect::<Vec<_>>()
-            .join("\n"),
-        "Intel VT-d / interrupt remapping dmesg lines"
-    );
-
-    let interrupts = cmd!(sh, "cat /proc/interrupts").read().await?;
-    tracing::info!(%interrupts, "/proc/interrupts");
-
-    let serial_irq = interrupts
-        .lines()
-        .find(|l| l.contains("ttyS0"))
-        .context("serial port IRQ (ttyS0) not present in /proc/interrupts")?;
-    assert!(
-        serial_irq.contains("IR-IO-APIC"),
-        "serial IRQ should route through the IR-IO-APIC chip once interrupt \
-         remapping is enabled, got: {serial_irq}"
-    );
-
-    let count_before = sum_irq_count(serial_irq);
-    cmd!(
-        sh,
-        "sh -c 'for i in $(seq 1 100); do echo ir-remap-test > /dev/ttyS0; done'"
-    )
-    .run()
+    verify_ioapic_interrupt_remapping(&sh, &dmesg, "Intel VT-d", |l| {
+        let l = l.to_ascii_lowercase();
+        l.contains("remap") || l.contains("dmar") || l.contains("intel-iommu")
+    })
     .await?;
-    let interrupts_after = cmd!(sh, "cat /proc/interrupts").read().await?;
-    let serial_irq_after = interrupts_after
-        .lines()
-        .find(|l| l.contains("ttyS0"))
-        .context("serial port IRQ (ttyS0) disappeared from /proc/interrupts")?;
-    let count_after = sum_irq_count(serial_irq_after);
-    tracing::info!(count_before, count_after, "serial IOAPIC interrupt counts");
-    assert!(
-        count_after > count_before,
-        "serial (IOAPIC) interrupt count should increase after generating \
-         serial traffic with interrupt remapping enabled: \
-         before={count_before} after={count_after}"
-    );
 
     // 3–6. Common IOMMU validation: IOMMU groups, NVMe DMA, net, no faults.
     verify_iommu_mixed_topology(
@@ -891,6 +804,64 @@ async fn verify_iommu_mixed_topology(
         faults.is_empty(),
         "IOMMU faults detected — DMA remapping is not working correctly:\n{}",
         faults.join("\n")
+    );
+
+    Ok(())
+}
+
+/// Verify that IOAPIC interrupts are routed through interrupt remapping.
+///
+/// Linux reports this path as `IR-IO-APIC` in `/proc/interrupts`. To prove the
+/// route is live, this captures the serial IRQ count, generates serial output,
+/// and confirms the count increases.
+async fn verify_ioapic_interrupt_remapping(
+    sh: &pipette_client::shell::UnixShell<'_>,
+    dmesg: &str,
+    iommu: &str,
+    ir_dmesg_filter: impl Fn(&str) -> bool,
+) -> anyhow::Result<()> {
+    tracing::info!(
+        iommu,
+        ir_dmesg = %dmesg
+            .lines()
+            .filter(|l| ir_dmesg_filter(l))
+            .collect::<Vec<_>>()
+            .join("\n"),
+        "interrupt remapping dmesg lines"
+    );
+
+    let interrupts = cmd!(sh, "cat /proc/interrupts").read().await?;
+    tracing::info!(%interrupts, "/proc/interrupts");
+
+    let serial_irq = interrupts
+        .lines()
+        .find(|l| l.contains("ttyS0"))
+        .context("serial port IRQ (ttyS0) not present in /proc/interrupts")?;
+    assert!(
+        serial_irq.contains("IR-IO-APIC"),
+        "serial IRQ should route through the IR-IO-APIC chip once interrupt \
+         remapping is enabled, got: {serial_irq}"
+    );
+
+    let count_before = sum_irq_count(serial_irq);
+    cmd!(
+        sh,
+        "sh -c 'for i in $(seq 1 100); do echo ir-remap-test > /dev/ttyS0; done'"
+    )
+    .run()
+    .await?;
+    let interrupts_after = cmd!(sh, "cat /proc/interrupts").read().await?;
+    let serial_irq_after = interrupts_after
+        .lines()
+        .find(|l| l.contains("ttyS0"))
+        .context("serial port IRQ (ttyS0) disappeared from /proc/interrupts")?;
+    let count_after = sum_irq_count(serial_irq_after);
+    tracing::info!(count_before, count_after, "serial IOAPIC interrupt counts");
+    assert!(
+        count_after > count_before,
+        "serial (IOAPIC) interrupt count should increase after generating \
+         serial traffic with interrupt remapping enabled: \
+         before={count_before} after={count_after}"
     );
 
     Ok(())

--- a/vmm_tests/vmm_tests/tests/tests/multiarch/pcie.rs
+++ b/vmm_tests/vmm_tests/tests/tests/multiarch/pcie.rs
@@ -649,10 +649,15 @@ async fn amd_iommu_mixed_topology(
     Ok(())
 }
 
-/// Test Intel VT-d IOMMU emulation with a mixed topology:
+/// Test Intel VT-d IOMMU emulation across a multi-segment topology:
 ///
 /// - Root complex s0rc0 (segment 0): VT-d IOMMU enabled, NVMe + virtio-net
-/// - Root complex s1rc0 (segment 1): no IOMMU, NVMe + virtio-net
+/// - Root complex s1rc0 (segment 1): VT-d IOMMU enabled, NVMe + virtio-net
+///
+/// Every root complex has its own VT-d unit. Unlike AMD-Vi, Intel VT-d cannot
+/// have a device on a segment with no VT-d unit: enabling VT-d forces global
+/// interrupt remapping (x2APIC), under which Linux can't allocate MSIs for a
+/// device outside every DRHD's scope (so OpenVMM rejects that configuration).
 ///
 /// Verifies:
 /// 1. Linux discovers the Intel IOMMU (dmesg shows DMAR/Intel IOMMU init)
@@ -661,13 +666,13 @@ async fn amd_iommu_mixed_topology(
 /// 4. Devices on both RCs enumerate and function (block I/O, network interface)
 /// 5. DMA through the IOMMU works (NVMe I/O behind the IOMMU)
 #[vmm_test_with(openvmm_intel(linux_direct_x64))]
-async fn intel_vtd_mixed_topology(
+async fn intel_vtd_multi_segment(
     config: PetriVmBuilder<OpenVmmPetriBackend>,
 ) -> anyhow::Result<()> {
     let (vm, agent) = config
         .modify_backend(|b| {
             b.with_pcie_root_topology(2, 1, 4) // 2 segments, 1 RC each, 4 ports each
-                .with_intel_vtd(&["s0rc0"]) // VT-d only on segment 0's RC
+                .with_intel_vtd(&["s0rc0", "s1rc0"]) // VT-d on every RC
                 .with_pcie_nvme("s0rc0rp0", PCIE_NVME_SUBSYSTEM_IDS[0])
                 .with_virtio_nic("s0rc0rp1")
                 .with_pcie_nvme("s1rc0rp0", PCIE_NVME_SUBSYSTEM_IDS[1])

--- a/vmm_tests/vmm_tests/tests/tests/multiarch/pcie.rs
+++ b/vmm_tests/vmm_tests/tests/tests/multiarch/pcie.rs
@@ -765,6 +765,54 @@ async fn intel_vtd_mixed_topology(
         "DMAR ACPI table should be present. Tables: {acpi_tables}"
     );
 
+    // 3b. Verify interrupt remapping is active for IOAPIC interrupts.
+    //     Linux reports this path as "IR-IO-APIC" in /proc/interrupts.
+    tracing::info!(
+        ir_dmesg = %dmesg
+            .lines()
+            .filter(|l| {
+                let l = l.to_ascii_lowercase();
+                l.contains("remap") || l.contains("dmar") || l.contains("intel-iommu")
+            })
+            .collect::<Vec<_>>()
+            .join("\n"),
+        "Intel VT-d / interrupt remapping dmesg lines"
+    );
+
+    let interrupts = cmd!(sh, "cat /proc/interrupts").read().await?;
+    tracing::info!(%interrupts, "/proc/interrupts");
+
+    let serial_irq = interrupts
+        .lines()
+        .find(|l| l.contains("ttyS0"))
+        .context("serial port IRQ (ttyS0) not present in /proc/interrupts")?;
+    assert!(
+        serial_irq.contains("IR-IO-APIC"),
+        "serial IRQ should route through the IR-IO-APIC chip once interrupt \
+         remapping is enabled, got: {serial_irq}"
+    );
+
+    let count_before = sum_irq_count(serial_irq);
+    cmd!(
+        sh,
+        "sh -c 'for i in $(seq 1 100); do echo ir-remap-test > /dev/ttyS0; done'"
+    )
+    .run()
+    .await?;
+    let interrupts_after = cmd!(sh, "cat /proc/interrupts").read().await?;
+    let serial_irq_after = interrupts_after
+        .lines()
+        .find(|l| l.contains("ttyS0"))
+        .context("serial port IRQ (ttyS0) disappeared from /proc/interrupts")?;
+    let count_after = sum_irq_count(serial_irq_after);
+    tracing::info!(count_before, count_after, "serial IOAPIC interrupt counts");
+    assert!(
+        count_after > count_before,
+        "serial (IOAPIC) interrupt count should increase after generating \
+         serial traffic with interrupt remapping enabled: \
+         before={count_before} after={count_after}"
+    );
+
     // 3–6. Common IOMMU validation: IOMMU groups, NVMe DMA, net, no faults.
     verify_iommu_mixed_topology(
         &sh,


### PR DESCRIPTION
Interrupt remapping is required to support PCI device assignment to L2 guests under nested virtualization: without it, the IOMMU cannot enforce interrupt isolation for nested guests and the hypervisor will refuse to enable the feature. This wires IOAPIC interrupts through the configured x86 IOMMU's interrupt-remapping table for both AMD IOMMU and Intel VT-d configurations.

To make this work, the platform IOAPIC's synthetic PCIe RID is published through the matching firmware discovery table: AMD IVRS gets a DEV_SPECIAL(IOAPIC) entry, and Intel DMAR gets an IOAPIC device scope on the DRHD that covers the IOAPIC. The hypervisor's IOAPIC routing implementation is then wrapped to remap MSI address/data through the selected IOMMU before forwarding routes, with route retranslation triggered by the relevant AMD and Intel interrupt-invalidation commands.