### PR TITLE
cca: Instruction Abort and testing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7431,6 +7431,7 @@ dependencies = [
  "minimal_rt_build",
  "tmk_core",
  "tmk_macros",
+ "tmk_protocol",
  "x86defs",
 ]
 
@@ -8017,6 +8018,7 @@ dependencies = [
 name = "tmk_protocol"
 version = "0.0.0"
 dependencies = [
+ "bitfield-struct 0.11.0",
  "zerocopy",
 ]
 

--- a/flowey/flowey_lib_hvlite/src/_jobs/local_install_cca_emu.rs
+++ b/flowey/flowey_lib_hvlite/src/_jobs/local_install_cca_emu.rs
@@ -16,7 +16,7 @@ use std::thread;
 const SHRINKWRAP_REPO: &str = "https://git.gitlab.arm.com/tooling/shrinkwrap.git";
 // The guest Linux kernel (with cca/plane driver) hasn't been upstreamed yet, fetch it from our private repo
 const PLANE0_LINUX_REPO: &str = "https://github.com/jiong-microsoft/OHCL-Linux-Kernel.git";
-const PLANE0_LINUX_BRANCH: &str = "cca-dev";
+const PLANE0_LINUX_BRANCH: &str = "cca-dev-ben";
 // A few config information needed when building Linux kernel
 const CCA_CONFIGS: &[&str] = &["CONFIG_VIRT_DRIVERS", "CONFIG_ARM_CCA_GUEST"];
 const NINEP_CONFIGS: &[&str] = &[

--- a/flowey/flowey_lib_hvlite/src/_jobs/local_install_cca_emu.rs
+++ b/flowey/flowey_lib_hvlite/src/_jobs/local_install_cca_emu.rs
@@ -16,7 +16,7 @@ use std::thread;
 const SHRINKWRAP_REPO: &str = "https://git.gitlab.arm.com/tooling/shrinkwrap.git";
 // The guest Linux kernel (with cca/plane driver) hasn't been upstreamed yet, fetch it from our private repo
 const PLANE0_LINUX_REPO: &str = "https://github.com/jiong-microsoft/OHCL-Linux-Kernel.git";
-const PLANE0_LINUX_BRANCH: &str = "cca-dev-ben";
+const PLANE0_LINUX_BRANCH: &str = "cca-dev";
 // A few config information needed when building Linux kernel
 const CCA_CONFIGS: &[&str] = &["CONFIG_VIRT_DRIVERS", "CONFIG_ARM_CCA_GUEST"];
 const NINEP_CONFIGS: &[&str] = &[

--- a/openhcl/hcl/src/ioctl.rs
+++ b/openhcl/hcl/src/ioctl.rs
@@ -376,6 +376,7 @@ pub(crate) mod ioctls {
     const MSHV_VTL_RSI_SYSREG_READ: u16 = 0x42;
     const MSHV_VTL_RSI_SYSREG_WRITE: u16 = 0x43;
     const MSHV_VTL_RSI_SET_MEM_PERM: u16 = 0x44;
+    const MSHV_VTL_RSI_GET_IPA_STATE: u16 = 0x45;
 
     #[repr(C)]
     #[derive(Copy, Clone)]
@@ -615,6 +616,14 @@ pub(crate) mod ioctls {
         MSHV_IOCTL,
         MSHV_VTL_RSI_SYSREG_READ,
         cca::mshv_rsi_sysreg_rw
+    );
+
+    // CCA: Get the RIPAS state of an ipa
+    ioctl_read!(
+        hcl_rsi_ipa_state_read,
+        MSHV_IOCTL,
+        MSHV_VTL_RSI_GET_IPA_STATE,
+        cca::mshv_rsi_get_ipa_state
     );
 
     // CCA: Assign the address described by `mshv_rsi_set_mem_perm`

--- a/openhcl/hcl/src/ioctl.rs
+++ b/openhcl/hcl/src/ioctl.rs
@@ -619,7 +619,7 @@ pub(crate) mod ioctls {
     );
 
     // CCA: Get the RIPAS state of an ipa
-    ioctl_read!(
+    ioctl_readwrite!(
         hcl_rsi_ipa_state_read,
         MSHV_IOCTL,
         MSHV_VTL_RSI_GET_IPA_STATE,

--- a/openhcl/hcl/src/ioctl/cca.rs
+++ b/openhcl/hcl/src/ioctl/cca.rs
@@ -220,7 +220,9 @@ impl ProcessorRunner<'_, Cca> {
         vtl: GuestVtl,
         state: &mut mshv_rsi_get_ipa_state,
     ) -> Result<(), Error> {
-        self.hcl.rsi_get_ipa_state(vtl, state).map_err(|_| Error::InvalidRegisterValue)
+        self.hcl
+            .rsi_get_ipa_state(vtl, state)
+            .map_err(|_| Error::InvalidRegisterValue)
     }
 
     /// Update the address of the `plane_run` structure in `mshv_vtl_run.context`.
@@ -490,12 +492,17 @@ impl MshvVtl {
     }
 
     /// Get the ipa RIPAS state
-    pub fn rsi_get_ipa_state(&self, vtl: GuestVtl, plane_state: &mut mshv_rsi_get_ipa_state) -> Result<(), HvError> {
+    pub fn rsi_get_ipa_state(
+        &self,
+        vtl: GuestVtl,
+        plane_state: &mut mshv_rsi_get_ipa_state,
+    ) -> Result<(), HvError> {
         let _plane = match vtl {
             GuestVtl::Vtl0 => 1,
-            _ => return Err(HvError::InvalidVtlState)
+            _ => return Err(HvError::InvalidVtlState),
         };
 
+        // SAFETY: Calling hcl_rsi_ipa_state_read ioctl with the correct arguments.
         unsafe {
             hcl_rsi_ipa_state_read(self.file.as_raw_fd(), plane_state)
                 .map_err(|_| HvError::InvalidVpState)?;
@@ -537,7 +544,11 @@ impl Hcl {
     }
 
     /// getting ipa RIPAS state
-    pub fn rsi_get_ipa_state(&self, vtl: GuestVtl, plane_state: &mut mshv_rsi_get_ipa_state) -> Result<(), HvError> {
+    pub fn rsi_get_ipa_state(
+        &self,
+        vtl: GuestVtl,
+        plane_state: &mut mshv_rsi_get_ipa_state,
+    ) -> Result<(), HvError> {
         self.mshv_vtl.rsi_get_ipa_state(vtl, plane_state)
     }
 }

--- a/openhcl/hcl/src/ioctl/cca.rs
+++ b/openhcl/hcl/src/ioctl/cca.rs
@@ -35,6 +35,13 @@ use memory_range::MemoryRange;
 use sidecar_client::SidecarVp;
 use user_driver::memory::MemoryBlock;
 
+#[derive(Debug, Error)]
+#[expect(missing_docs)]
+pub enum GetIpaStateError {
+    #[error("RSI IPA state read ioctl failed")]
+    Ioctl(#[source] nix::Error),
+}
+
 /// CCA: Structure mirroring the data returned by RMM in the RSI_REALM_CONFIG call.
 #[repr(C, align(0x1000))]
 #[derive(Clone, Copy, Default)]
@@ -71,12 +78,15 @@ pub struct mshv_rsi_set_mem_perm {
     pub top_addr: u64,
 }
 
-/// CCA:
+/// CCA: Structure used by the hcl_rsi_ipa_state_read ioctl.
+/// Caller sets fipa to the faulting IPA. On return the state
+/// contains the corresponding RIPAS state.
 #[repr(C)]
 #[derive(Clone, Copy, Default)]
-#[expect(missing_docs)]
 pub struct mshv_rsi_get_ipa_state {
+    /// Faulting ipa to have its state queried
     pub fipa: u64,
+    /// RIPAS state returned for fipa
     pub state: u64,
 }
 
@@ -215,14 +225,8 @@ impl ProcessorRunner<'_, Cca> {
     }
 
     /// Get the ipa ripas state from the RMM
-    pub fn cca_ipa_state_read(
-        &self,
-        vtl: GuestVtl,
-        state: &mut mshv_rsi_get_ipa_state,
-    ) -> Result<(), Error> {
-        self.hcl
-            .rsi_get_ipa_state(vtl, state)
-            .map_err(|_| Error::InvalidRegisterValue)
+    pub fn cca_ipa_state_read(&self, fipa: u64) -> Result<Option<u64>, GetIpaStateError> {
+        self.hcl.rsi_get_ipa_state(fipa)
     }
 
     /// Update the address of the `plane_run` structure in `mshv_vtl_run.context`.
@@ -492,23 +496,23 @@ impl MshvVtl {
     }
 
     /// Get the ipa RIPAS state
-    pub fn rsi_get_ipa_state(
-        &self,
-        vtl: GuestVtl,
-        plane_state: &mut mshv_rsi_get_ipa_state,
-    ) -> Result<(), HvError> {
-        let _plane = match vtl {
-            GuestVtl::Vtl0 => 1,
-            _ => return Err(HvError::InvalidVtlState),
+    pub fn rsi_get_ipa_state(&self, fipa: u64) -> Result<Option<u64>, GetIpaStateError> {
+        let mut plane_state = mshv_rsi_get_ipa_state {
+            fipa,
+            state: u64::MAX,
         };
 
         // SAFETY: Calling hcl_rsi_ipa_state_read ioctl with the correct arguments.
         unsafe {
-            hcl_rsi_ipa_state_read(self.file.as_raw_fd(), plane_state)
-                .map_err(|_| HvError::InvalidVpState)?;
+            hcl_rsi_ipa_state_read(self.file.as_raw_fd(), &mut plane_state)
+                .map_err(GetIpaStateError::Ioctl)?;
         }
 
-        Ok(())
+        if plane_state.state >= u8::MAX as u64 {
+            return Ok(None);
+        }
+
+        Ok(Some(plane_state.state))
     }
 }
 
@@ -544,11 +548,7 @@ impl Hcl {
     }
 
     /// getting ipa RIPAS state
-    pub fn rsi_get_ipa_state(
-        &self,
-        vtl: GuestVtl,
-        plane_state: &mut mshv_rsi_get_ipa_state,
-    ) -> Result<(), HvError> {
-        self.mshv_vtl.rsi_get_ipa_state(vtl, plane_state)
+    pub fn rsi_get_ipa_state(&self, fipa: u64) -> Result<Option<u64>, GetIpaStateError> {
+        self.mshv_vtl.rsi_get_ipa_state(fipa)
     }
 }

--- a/openhcl/hcl/src/ioctl/cca.rs
+++ b/openhcl/hcl/src/ioctl/cca.rs
@@ -16,6 +16,7 @@ use crate::ioctl::GetRegError;
 use crate::ioctl::HvError;
 use crate::ioctl::SetRegError;
 use crate::ioctl::ioctls::hcl_realm_config;
+use crate::ioctl::ioctls::hcl_rsi_ipa_state_read;
 use crate::ioctl::ioctls::hcl_rsi_set_mem_perm;
 use crate::ioctl::ioctls::hcl_rsi_sysreg_read;
 use crate::ioctl::ioctls::hcl_rsi_sysreg_write;
@@ -68,6 +69,15 @@ pub struct mshv_rsi_set_mem_perm {
     pub _pad: [u8; 7],
     pub base_addr: u64,
     pub top_addr: u64,
+}
+
+/// CCA:
+#[repr(C)]
+#[derive(Clone, Copy, Default)]
+#[expect(missing_docs)]
+pub struct mshv_rsi_get_ipa_state {
+    pub fipa: u64,
+    pub state: u64,
 }
 
 /// SystemReg is following encoding used by MSR/MRS which is different with
@@ -202,6 +212,15 @@ impl ProcessorRunner<'_, Cca> {
     ) -> Result<(), GetRegError> {
         self.hcl
             .rsi_sysreg_read(vtl, encode_rsi_sysreg(name), value)
+    }
+
+    /// Get the ipa ripas state from the RMM
+    pub fn cca_ipa_state_read(
+        &self,
+        vtl: GuestVtl,
+        state: &mut mshv_rsi_get_ipa_state,
+    ) -> Result<(), Error> {
+        self.hcl.rsi_get_ipa_state(vtl, state).map_err(|_| Error::InvalidRegisterValue)
     }
 
     /// Update the address of the `plane_run` structure in `mshv_vtl_run.context`.
@@ -469,6 +488,21 @@ impl MshvVtl {
         }
         Ok(())
     }
+
+    /// Get the ipa RIPAS state
+    pub fn rsi_get_ipa_state(&self, vtl: GuestVtl, plane_state: &mut mshv_rsi_get_ipa_state) -> Result<(), HvError> {
+        let _plane = match vtl {
+            GuestVtl::Vtl0 => 1,
+            _ => return Err(HvError::InvalidVtlState)
+        };
+
+        unsafe {
+            hcl_rsi_ipa_state_read(self.file.as_raw_fd(), plane_state)
+                .map_err(|_| HvError::InvalidVpState)?;
+        }
+
+        Ok(())
+    }
 }
 
 impl Hcl {
@@ -500,5 +534,10 @@ impl Hcl {
     /// setting memory permissions
     pub fn rsi_set_mem_perm(&self, vtl: GuestVtl, range: MemoryRange) -> Result<(), HvError> {
         self.mshv_vtl.rsi_set_mem_perm(vtl, &range)
+    }
+
+    /// getting ipa RIPAS state
+    pub fn rsi_get_ipa_state(&self, vtl: GuestVtl, plane_state: &mut mshv_rsi_get_ipa_state) -> Result<(), HvError> {
+        self.mshv_vtl.rsi_get_ipa_state(vtl, plane_state)
     }
 }

--- a/openhcl/virt_mshv_vtl/src/processor/cca/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/cca/mod.rs
@@ -25,7 +25,7 @@ use aarch64defs::SystemReg;
 use aarch64defs::rsi::cca_rsi_plane_exit;
 use hcl::GuestVtl;
 use hcl::ioctl::cca::Cca;
-use hcl::ioctl::cca::mshv_rsi_get_ipa_state;
+use hcl::ioctl::cca::GetIpaStateError;
 use hcl::ioctl::register;
 use hv1_emulator::hv::ProcessorVtlHv;
 use hv1_emulator::synic::ProcessorSynic;
@@ -396,17 +396,18 @@ impl BackingPrivate for CcaBacked {
                             let far = cca_exit.far_el2();
                             let hpfar = cca_exit.hpfar_el2();
                             let fipa = (hpfar.fipa() << 12) | (far & 0xfff);
-                            let mut plane_state = mshv_rsi_get_ipa_state {
-                                fipa,
-                                state: u64::MAX,
+
+                            let plane_state = match this.ipa_state_read(fipa) {
+                                Ok(state) => state,
+                                Err(e) => {
+                                    tracing::warn!(
+                                        error = ?e,
+                                        fipa,
+                                        "failed to read IPA state; state will be u8::MAX which is unavailable"
+                                    );
+                                    None
+                                }
                             };
-                            if let Err(e) = this.ipa_state_read(GuestVtl::Vtl0, &mut plane_state) {
-                                tracing::warn!(
-                                    error = ?e,
-                                    fipa,
-                                    "failed to read IPA state; state will be u8::MAX which is unavailable"
-                                );
-                            }
 
                             return Err(dev.fatal_error(
                                 CcaUnsupportedExit::InstructionAbort {
@@ -414,7 +415,7 @@ impl BackingPrivate for CcaBacked {
                                     elr_el2: cca_exit.elr_el2(),
                                     far_el2: cca_exit.far_el2(),
                                     fipa,
-                                    fipa_state: plane_state.state as u8,
+                                    fipa_state: plane_state.map_or(u8::MAX, |state| state as u8),
                                     ifsc: iss.ifsc().0,
                                     reason,
                                     far_not_valid: iss.fnv(),
@@ -523,14 +524,8 @@ impl UhProcessor<'_, CcaBacked> {
         self.runner.cca_sysreg_read(vtl, reg, val)
     }
 
-    fn ipa_state_read(
-        &self,
-        vtl: GuestVtl,
-        state: &mut mshv_rsi_get_ipa_state,
-    ) -> Result<(), Error> {
-        self.runner
-            .cca_ipa_state_read(vtl, state)
-            .map_err(Error::Hcl)
+    fn ipa_state_read(&self, fipa: u64) -> Result<Option<u64>, GetIpaStateError> {
+        self.runner.cca_ipa_state_read(fipa)
     }
 
     fn set_plane_enter(&mut self) {

--- a/openhcl/virt_mshv_vtl/src/processor/cca/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/cca/mod.rs
@@ -17,11 +17,15 @@ use crate::UhCvmVpState;
 use crate::UhPartitionInner;
 use crate::processor::InterceptMessageState;
 use aarch64defs::EsrEl2;
+use aarch64defs::FaultStatusCode;
+use aarch64defs::HpfarEl2;
 use aarch64defs::IssDataAbort;
+use aarch64defs::IssInstructionAbort;
 use aarch64defs::SystemReg;
 use aarch64defs::rsi::cca_rsi_plane_exit;
 use hcl::GuestVtl;
 use hcl::ioctl::cca::Cca;
+use hcl::ioctl::cca::mshv_rsi_get_ipa_state;
 use hcl::ioctl::register;
 use hv1_emulator::hv::ProcessorVtlHv;
 use hv1_emulator::synic::ProcessorSynic;
@@ -49,9 +53,116 @@ enum CcaUnsupportedExit {
     ExceptionClass { exception_class: u8, esr_el2: u64 },
     #[error("CCA data abort with invalid instruction syndrome in ESR_EL2 {0:#x}")]
     InvalidDataAbortIss(u64),
+    #[error(
+        "CCA instruction abort: ESR_EL2 {esr_el2:#x}, ELR_EL2 {elr_el2:#x}, FAR_EL2 {far_el2:#x},
+        FIPA {fipa:#x}, FIPA RIPAS state {fipa_state:#x}, IFSC {ifsc:#x}, reason {reason:?}, FNV {far_not_valid}"
+    )]
+    InstructionAbort {
+        esr_el2: u64,
+        elr_el2: u64,
+        far_el2: u64,
+        fipa: u64,
+        fipa_state: u8,
+        ifsc: u8,
+        reason: InstructionAbortReason,
+        far_not_valid: bool,
+    },
 }
 
 const AARCH64_ZERO_REGISTER_INDEX: u8 = 31;
+
+#[derive(Debug, Clone, Copy)]
+enum InstructionAbortReason {
+    AddressSizeFaultLevel0,
+    AddressSizeFaultLevel1,
+    AddressSizeFaultLevel2,
+    AddressSizeFaultLevel3,
+    TranslationFaultLevel0,
+    TranslationFaultLevel1,
+    TranslationFaultLevel2,
+    TranslationFaultLevel3,
+    AccessFlagFaultLevel0,
+    AccessFlagFaultLevel1,
+    AccessFlagFaultLevel2,
+    AccessFlagFaultLevel3,
+    PermissionFaultLevel0,
+    PermissionFaultLevel1,
+    PermissionFaultLevel2,
+    PermissionFaultLevel3,
+    SynchronousExternalAbort,
+    SyncTagCheckFault,
+    SynchronousExternalAbortOnTableWalkLevelNeg1,
+    SynchronousExternalAbortOnTableWalkLevel0,
+    SynchronousExternalAbortOnTableWalkLevel1,
+    SynchronousExternalAbortOnTableWalkLevel2,
+    SynchronousExternalAbortOnTableWalkLevel3,
+    EccParity,
+    EccParityOnTableWalkLevelNeg1,
+    EccParityOnTableWalkLevel0,
+    EccParityOnTableWalkLevel1,
+    EccParityOnTableWalkLevel2,
+    EccParityOnTableWalkLevel3,
+    GranuleProtectionFaultLevelNeg1,
+    GranuleProtectionFaultLevel0,
+    GranuleProtectionFaultLevel1,
+    GranuleProtectionFaultLevel2,
+    GranuleProtectionFaultLevel3,
+    AddressSizeFaultLevelNeg1,
+    TranslationFaultLevelNeg1,
+    TlbConflictAbort,
+    UnsupportedHardwareUpdateFault,
+    Unknown,
+}
+
+impl From<FaultStatusCode> for InstructionAbortReason {
+    fn from(value: FaultStatusCode) -> Self {
+        match value {
+            FaultStatusCode::ADDRESS_SIZE_FAULT_LEVEL0 => Self::AddressSizeFaultLevel0,
+            FaultStatusCode::ADDRESS_SIZE_FAULT_LEVEL1 => Self::AddressSizeFaultLevel1,
+            FaultStatusCode::ADDRESS_SIZE_FAULT_LEVEL2 => Self::AddressSizeFaultLevel2,
+            FaultStatusCode::ADDRESS_SIZE_FAULT_LEVEL3 => Self::AddressSizeFaultLevel3,
+            FaultStatusCode::TRANSLATION_FAULT_LEVEL0 => Self::TranslationFaultLevel0,
+            FaultStatusCode::TRANSLATION_FAULT_LEVEL1 => Self::TranslationFaultLevel1,
+            FaultStatusCode::TRANSLATION_FAULT_LEVEL2 => Self::TranslationFaultLevel2,
+            FaultStatusCode::TRANSLATION_FAULT_LEVEL3 => Self::TranslationFaultLevel3,
+            FaultStatusCode::ACCESS_FLAG_FAULT_LEVEL0 => Self::AccessFlagFaultLevel0,
+            FaultStatusCode::ACCESS_FLAG_FAULT_LEVEL1 => Self::AccessFlagFaultLevel1,
+            FaultStatusCode::ACCESS_FLAG_FAULT_LEVEL2 => Self::AccessFlagFaultLevel2,
+            FaultStatusCode::ACCESS_FLAG_FAULT_LEVEL3 => Self::AccessFlagFaultLevel3,
+            FaultStatusCode::PERMISSION_FAULT_LEVEL0 => Self::PermissionFaultLevel0,
+            FaultStatusCode::PERMISSION_FAULT_LEVEL1 => Self::PermissionFaultLevel1,
+            FaultStatusCode::PERMISSION_FAULT_LEVEL2 => Self::PermissionFaultLevel2,
+            FaultStatusCode::PERMISSION_FAULT_LEVEL3 => Self::PermissionFaultLevel3,
+            FaultStatusCode::SYNCHRONOUS_EXTERNAL_ABORT => Self::SynchronousExternalAbort,
+            FaultStatusCode::SYNC_TAG_CHECK_FAULT => Self::SyncTagCheckFault,
+            FaultStatusCode::SEA_TTW_LEVEL_NEG1 => {
+                Self::SynchronousExternalAbortOnTableWalkLevelNeg1
+            }
+            FaultStatusCode::SEA_TTW_LEVEL0 => Self::SynchronousExternalAbortOnTableWalkLevel0,
+            FaultStatusCode::SEA_TTW_LEVEL1 => Self::SynchronousExternalAbortOnTableWalkLevel1,
+            FaultStatusCode::SEA_TTW_LEVEL2 => Self::SynchronousExternalAbortOnTableWalkLevel2,
+            FaultStatusCode::SEA_TTW_LEVEL3 => Self::SynchronousExternalAbortOnTableWalkLevel3,
+            FaultStatusCode::ECC_PARITY => Self::EccParity,
+            FaultStatusCode::ECC_PARITY_TTW_LEVEL_NEG1 => Self::EccParityOnTableWalkLevelNeg1,
+            FaultStatusCode::ECC_PARITY_TTW_LEVEL0 => Self::EccParityOnTableWalkLevel0,
+            FaultStatusCode::ECC_PARITY_TTW_LEVEL1 => Self::EccParityOnTableWalkLevel1,
+            FaultStatusCode::ECC_PARITY_TTW_LEVEL2 => Self::EccParityOnTableWalkLevel2,
+            FaultStatusCode::ECC_PARITY_TTW_LEVEL3 => Self::EccParityOnTableWalkLevel3,
+            FaultStatusCode::GRANULE_PROTECTION_FAULT_LEVEL_NEG => {
+                Self::GranuleProtectionFaultLevelNeg1
+            }
+            FaultStatusCode::GRANULE_PROTECTION_FAULT_LEVEL0 => Self::GranuleProtectionFaultLevel0,
+            FaultStatusCode::GRANULE_PROTECTION_FAULT_LEVEL1 => Self::GranuleProtectionFaultLevel1,
+            FaultStatusCode::GRANULE_PROTECTION_FAULT_LEVEL2 => Self::GranuleProtectionFaultLevel2,
+            FaultStatusCode::GRANULE_PROTECTION_FAULT_LEVEL3 => Self::GranuleProtectionFaultLevel3,
+            FaultStatusCode::ADDRESS_SIZE_FAULT_LEVEL_NEG1 => Self::AddressSizeFaultLevelNeg1,
+            FaultStatusCode::TRANSLATION_FAULT_LEVEL_NEG1 => Self::TranslationFaultLevelNeg1,
+            FaultStatusCode::TLB_CONFLICT_ABORT => Self::TlbConflictAbort,
+            FaultStatusCode::UNSUPPORTED_HW_UPDATE_FAULT => Self::UnsupportedHardwareUpdateFault,
+            _ => Self::Unknown,
+        }
+    }
+}
 
 // For use with Hyper-V synthetic interrupt controller allocated by paravisor.
 enum UhDirectOverlay {
@@ -167,6 +278,14 @@ impl<'a> CcaExit<'a> {
 
     fn far_el2(&self) -> u64 {
         self.0.far_el2
+    }
+
+    fn hpfar_el2(&self) -> HpfarEl2 {
+        self.0.hpfar_el2.into()
+    }
+
+    fn elr_el2(&self) -> u64 {
+        self.0.elr_el2
     }
 
     fn gpr_or_zero_register(&self, index: u8) -> Option<u64> {
@@ -345,7 +464,45 @@ impl BackingPrivate for CcaBacked {
                         }
                         ExceptionClass::InstructionAbort => {
                             // Handle instruction abort
-                            todo!();
+                            let iss = IssInstructionAbort::from_bits(esr_el2.iss());
+
+                            if iss.fnv() {
+                                tracing::warn!("CCA InstructionAbort: FAR_EL2 is not valid");
+                                return Err(dev.fatal_error(CcaUnsupportedExit::ExitReason(0).into()));
+                            }
+
+                            let far = cca_exit.far_el2();
+                            let hpfar = cca_exit.hpfar_el2();
+                            let fipa = (hpfar.fipa() << 12) | (far & 0xfff);
+                            let mut plane_state = mshv_rsi_get_ipa_state{ fipa, state: u64::MAX};
+                            let _ = this.ipa_state_read(GuestVtl::Vtl0, &mut plane_state).map_err(|_| Error::Hcl);
+
+                            let reason = InstructionAbortReason::from(iss.ifsc());
+                            tracing::warn!(
+                                esr_el2 = cca_exit.0.esr_el2,
+                                elr_el2 = cca_exit.elr_el2(),
+                                far_el2 = cca_exit.far_el2(),
+                                fipa = fipa,
+                                fipa_state = plane_state.state as u8,
+                                ifsc = iss.ifsc().0,
+                                ?reason,
+                                far_not_valid = iss.fnv(),
+                                "CCA instruction abort"
+                            );
+                            return Err(dev.fatal_error(
+                                CcaUnsupportedExit::InstructionAbort {
+                                    esr_el2: cca_exit.0.esr_el2,
+                                    elr_el2: cca_exit.elr_el2(),
+                                    far_el2: cca_exit.far_el2(),
+                                    fipa: fipa,
+                                    fipa_state: plane_state.state as u8,
+                                    ifsc: iss.ifsc().0,
+                                    reason,
+                                    far_not_valid: iss.fnv(),
+                                }
+                                .into(),
+                            ));
+
                         }
                         ExceptionClass::SimdAccess => {
                             this.runner.cca_plane_no_trap_simd();
@@ -446,6 +603,14 @@ impl UhProcessor<'_, CcaBacked> {
         val: &mut u64,
     ) -> Result<(), register::GetRegError> {
         self.runner.cca_sysreg_read(vtl, reg, val)
+    }
+
+    fn ipa_state_read(
+        &self,
+        vtl: GuestVtl,
+        state: &mut mshv_rsi_get_ipa_state,
+    ) -> Result<(), Error> {
+        self.runner.cca_ipa_state_read(vtl, state).map_err(Error::Hcl)
     }
 
     fn set_plane_enter(&mut self) {

--- a/openhcl/virt_mshv_vtl/src/processor/cca/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/cca/mod.rs
@@ -17,8 +17,8 @@ use crate::UhCvmVpState;
 use crate::UhPartitionInner;
 use crate::processor::InterceptMessageState;
 use aarch64defs::EsrEl2;
-use aarch64defs::FaultStatusCode;
 use aarch64defs::HpfarEl2;
+use aarch64defs::InstructionAbortReason;
 use aarch64defs::IssDataAbort;
 use aarch64defs::IssInstructionAbort;
 use aarch64defs::SystemReg;
@@ -70,99 +70,6 @@ enum CcaUnsupportedExit {
 }
 
 const AARCH64_ZERO_REGISTER_INDEX: u8 = 31;
-
-#[derive(Debug, Clone, Copy)]
-enum InstructionAbortReason {
-    AddressSizeFaultLevel0,
-    AddressSizeFaultLevel1,
-    AddressSizeFaultLevel2,
-    AddressSizeFaultLevel3,
-    TranslationFaultLevel0,
-    TranslationFaultLevel1,
-    TranslationFaultLevel2,
-    TranslationFaultLevel3,
-    AccessFlagFaultLevel0,
-    AccessFlagFaultLevel1,
-    AccessFlagFaultLevel2,
-    AccessFlagFaultLevel3,
-    PermissionFaultLevel0,
-    PermissionFaultLevel1,
-    PermissionFaultLevel2,
-    PermissionFaultLevel3,
-    SynchronousExternalAbort,
-    SyncTagCheckFault,
-    SynchronousExternalAbortOnTableWalkLevelNeg1,
-    SynchronousExternalAbortOnTableWalkLevel0,
-    SynchronousExternalAbortOnTableWalkLevel1,
-    SynchronousExternalAbortOnTableWalkLevel2,
-    SynchronousExternalAbortOnTableWalkLevel3,
-    EccParity,
-    EccParityOnTableWalkLevelNeg1,
-    EccParityOnTableWalkLevel0,
-    EccParityOnTableWalkLevel1,
-    EccParityOnTableWalkLevel2,
-    EccParityOnTableWalkLevel3,
-    GranuleProtectionFaultLevelNeg1,
-    GranuleProtectionFaultLevel0,
-    GranuleProtectionFaultLevel1,
-    GranuleProtectionFaultLevel2,
-    GranuleProtectionFaultLevel3,
-    AddressSizeFaultLevelNeg1,
-    TranslationFaultLevelNeg1,
-    TlbConflictAbort,
-    UnsupportedHardwareUpdateFault,
-    Unknown,
-}
-
-impl From<FaultStatusCode> for InstructionAbortReason {
-    fn from(value: FaultStatusCode) -> Self {
-        match value {
-            FaultStatusCode::ADDRESS_SIZE_FAULT_LEVEL0 => Self::AddressSizeFaultLevel0,
-            FaultStatusCode::ADDRESS_SIZE_FAULT_LEVEL1 => Self::AddressSizeFaultLevel1,
-            FaultStatusCode::ADDRESS_SIZE_FAULT_LEVEL2 => Self::AddressSizeFaultLevel2,
-            FaultStatusCode::ADDRESS_SIZE_FAULT_LEVEL3 => Self::AddressSizeFaultLevel3,
-            FaultStatusCode::TRANSLATION_FAULT_LEVEL0 => Self::TranslationFaultLevel0,
-            FaultStatusCode::TRANSLATION_FAULT_LEVEL1 => Self::TranslationFaultLevel1,
-            FaultStatusCode::TRANSLATION_FAULT_LEVEL2 => Self::TranslationFaultLevel2,
-            FaultStatusCode::TRANSLATION_FAULT_LEVEL3 => Self::TranslationFaultLevel3,
-            FaultStatusCode::ACCESS_FLAG_FAULT_LEVEL0 => Self::AccessFlagFaultLevel0,
-            FaultStatusCode::ACCESS_FLAG_FAULT_LEVEL1 => Self::AccessFlagFaultLevel1,
-            FaultStatusCode::ACCESS_FLAG_FAULT_LEVEL2 => Self::AccessFlagFaultLevel2,
-            FaultStatusCode::ACCESS_FLAG_FAULT_LEVEL3 => Self::AccessFlagFaultLevel3,
-            FaultStatusCode::PERMISSION_FAULT_LEVEL0 => Self::PermissionFaultLevel0,
-            FaultStatusCode::PERMISSION_FAULT_LEVEL1 => Self::PermissionFaultLevel1,
-            FaultStatusCode::PERMISSION_FAULT_LEVEL2 => Self::PermissionFaultLevel2,
-            FaultStatusCode::PERMISSION_FAULT_LEVEL3 => Self::PermissionFaultLevel3,
-            FaultStatusCode::SYNCHRONOUS_EXTERNAL_ABORT => Self::SynchronousExternalAbort,
-            FaultStatusCode::SYNC_TAG_CHECK_FAULT => Self::SyncTagCheckFault,
-            FaultStatusCode::SEA_TTW_LEVEL_NEG1 => {
-                Self::SynchronousExternalAbortOnTableWalkLevelNeg1
-            }
-            FaultStatusCode::SEA_TTW_LEVEL0 => Self::SynchronousExternalAbortOnTableWalkLevel0,
-            FaultStatusCode::SEA_TTW_LEVEL1 => Self::SynchronousExternalAbortOnTableWalkLevel1,
-            FaultStatusCode::SEA_TTW_LEVEL2 => Self::SynchronousExternalAbortOnTableWalkLevel2,
-            FaultStatusCode::SEA_TTW_LEVEL3 => Self::SynchronousExternalAbortOnTableWalkLevel3,
-            FaultStatusCode::ECC_PARITY => Self::EccParity,
-            FaultStatusCode::ECC_PARITY_TTW_LEVEL_NEG1 => Self::EccParityOnTableWalkLevelNeg1,
-            FaultStatusCode::ECC_PARITY_TTW_LEVEL0 => Self::EccParityOnTableWalkLevel0,
-            FaultStatusCode::ECC_PARITY_TTW_LEVEL1 => Self::EccParityOnTableWalkLevel1,
-            FaultStatusCode::ECC_PARITY_TTW_LEVEL2 => Self::EccParityOnTableWalkLevel2,
-            FaultStatusCode::ECC_PARITY_TTW_LEVEL3 => Self::EccParityOnTableWalkLevel3,
-            FaultStatusCode::GRANULE_PROTECTION_FAULT_LEVEL_NEG => {
-                Self::GranuleProtectionFaultLevelNeg1
-            }
-            FaultStatusCode::GRANULE_PROTECTION_FAULT_LEVEL0 => Self::GranuleProtectionFaultLevel0,
-            FaultStatusCode::GRANULE_PROTECTION_FAULT_LEVEL1 => Self::GranuleProtectionFaultLevel1,
-            FaultStatusCode::GRANULE_PROTECTION_FAULT_LEVEL2 => Self::GranuleProtectionFaultLevel2,
-            FaultStatusCode::GRANULE_PROTECTION_FAULT_LEVEL3 => Self::GranuleProtectionFaultLevel3,
-            FaultStatusCode::ADDRESS_SIZE_FAULT_LEVEL_NEG1 => Self::AddressSizeFaultLevelNeg1,
-            FaultStatusCode::TRANSLATION_FAULT_LEVEL_NEG1 => Self::TranslationFaultLevelNeg1,
-            FaultStatusCode::TLB_CONFLICT_ABORT => Self::TlbConflictAbort,
-            FaultStatusCode::UNSUPPORTED_HW_UPDATE_FAULT => Self::UnsupportedHardwareUpdateFault,
-            _ => Self::Unknown,
-        }
-    }
-}
 
 // For use with Hyper-V synthetic interrupt controller allocated by paravisor.
 enum UhDirectOverlay {
@@ -485,17 +392,7 @@ impl BackingPrivate for CcaBacked {
                                 .map_err(|_| Error::Hcl);
 
                             let reason = InstructionAbortReason::from(iss.ifsc());
-                            tracing::warn!(
-                                esr_el2 = cca_exit.0.esr_el2,
-                                elr_el2 = cca_exit.elr_el2(),
-                                far_el2 = cca_exit.far_el2(),
-                                fipa = fipa,
-                                fipa_state = plane_state.state as u8,
-                                ifsc = iss.ifsc().0,
-                                ?reason,
-                                far_not_valid = iss.fnv(),
-                                "CCA instruction abort"
-                            );
+
                             return Err(dev.fatal_error(
                                 CcaUnsupportedExit::InstructionAbort {
                                     esr_el2: cca_exit.0.esr_el2,

--- a/openhcl/virt_mshv_vtl/src/processor/cca/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/cca/mod.rs
@@ -468,14 +468,21 @@ impl BackingPrivate for CcaBacked {
 
                             if iss.fnv() {
                                 tracing::warn!("CCA InstructionAbort: FAR_EL2 is not valid");
-                                return Err(dev.fatal_error(CcaUnsupportedExit::ExitReason(0).into()));
+                                return Err(
+                                    dev.fatal_error(CcaUnsupportedExit::ExitReason(0).into())
+                                );
                             }
 
                             let far = cca_exit.far_el2();
                             let hpfar = cca_exit.hpfar_el2();
                             let fipa = (hpfar.fipa() << 12) | (far & 0xfff);
-                            let mut plane_state = mshv_rsi_get_ipa_state{ fipa, state: u64::MAX};
-                            let _ = this.ipa_state_read(GuestVtl::Vtl0, &mut plane_state).map_err(|_| Error::Hcl);
+                            let mut plane_state = mshv_rsi_get_ipa_state {
+                                fipa,
+                                state: u64::MAX,
+                            };
+                            let _ = this
+                                .ipa_state_read(GuestVtl::Vtl0, &mut plane_state)
+                                .map_err(|_| Error::Hcl);
 
                             let reason = InstructionAbortReason::from(iss.ifsc());
                             tracing::warn!(
@@ -494,7 +501,7 @@ impl BackingPrivate for CcaBacked {
                                     esr_el2: cca_exit.0.esr_el2,
                                     elr_el2: cca_exit.elr_el2(),
                                     far_el2: cca_exit.far_el2(),
-                                    fipa: fipa,
+                                    fipa,
                                     fipa_state: plane_state.state as u8,
                                     ifsc: iss.ifsc().0,
                                     reason,
@@ -502,7 +509,6 @@ impl BackingPrivate for CcaBacked {
                                 }
                                 .into(),
                             ));
-
                         }
                         ExceptionClass::SimdAccess => {
                             this.runner.cca_plane_no_trap_simd();
@@ -610,7 +616,9 @@ impl UhProcessor<'_, CcaBacked> {
         vtl: GuestVtl,
         state: &mut mshv_rsi_get_ipa_state,
     ) -> Result<(), Error> {
-        self.runner.cca_ipa_state_read(vtl, state).map_err(Error::Hcl)
+        self.runner
+            .cca_ipa_state_read(vtl, state)
+            .map_err(Error::Hcl)
     }
 
     fn set_plane_enter(&mut self) {

--- a/openhcl/virt_mshv_vtl/src/processor/cca/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/cca/mod.rs
@@ -373,11 +373,24 @@ impl BackingPrivate for CcaBacked {
                             // Handle instruction abort
                             let iss = IssInstructionAbort::from_bits(esr_el2.iss());
 
+                            let reason = InstructionAbortReason::from(iss.ifsc());
+
                             if iss.fnv() {
                                 tracing::warn!("CCA InstructionAbort: FAR_EL2 is not valid");
-                                return Err(
-                                    dev.fatal_error(CcaUnsupportedExit::ExitReason(0).into())
-                                );
+
+                                return Err(dev.fatal_error(
+                                    CcaUnsupportedExit::InstructionAbort {
+                                        esr_el2: cca_exit.0.esr_el2,
+                                        elr_el2: cca_exit.elr_el2(),
+                                        far_el2: cca_exit.far_el2(),
+                                        fipa: 0,
+                                        fipa_state: u8::MAX,
+                                        ifsc: iss.ifsc().0,
+                                        reason,
+                                        far_not_valid: iss.fnv(),
+                                    }
+                                    .into(),
+                                ));
                             }
 
                             let far = cca_exit.far_el2();
@@ -387,11 +400,13 @@ impl BackingPrivate for CcaBacked {
                                 fipa,
                                 state: u64::MAX,
                             };
-                            let _ = this
-                                .ipa_state_read(GuestVtl::Vtl0, &mut plane_state)
-                                .map_err(|_| Error::Hcl);
-
-                            let reason = InstructionAbortReason::from(iss.ifsc());
+                            if let Err(e) = this.ipa_state_read(GuestVtl::Vtl0, &mut plane_state) {
+                                tracing::warn!(
+                                    error = ?e,
+                                    fipa,
+                                    "failed to read IPA state; state will be u8::MAX which is unavailable"
+                                );
+                            }
 
                             return Err(dev.fatal_error(
                                 CcaUnsupportedExit::InstructionAbort {

--- a/tmk/simple_tmk/Cargo.toml
+++ b/tmk/simple_tmk/Cargo.toml
@@ -8,6 +8,7 @@ edition.workspace = true
 
 [dependencies]
 tmk_core.workspace = true
+tmk_protocol.workspace = true
 tmk_macros.workspace = true
 
 [target.'cfg(target_arch = "x86_64")'.dependencies]

--- a/tmk/simple_tmk/src/aarch64/mod.rs
+++ b/tmk/simple_tmk/src/aarch64/mod.rs
@@ -24,7 +24,7 @@ unsafe extern "C" {
     fn instruction_abort_outside_par_entry() -> !;
 }
 
-#[tmk_test(expected_failure)]
+#[tmk_test(expected_failure, linux_only)]
 fn instruction_abort_outside_par(_: TestContext<'_>) {
     log!("instruction_abort_outside_par");
 
@@ -47,7 +47,7 @@ unsafe extern "C" {
     fn instruction_abort_ripas_empty_entry() -> !;
 }
 
-#[tmk_test(expected_failure)]
+#[tmk_test(expected_failure, linux_only)]
 fn instruction_abort_ripas_empty(_: TestContext<'_>) {
     log!("instruction_abort_ripas_empty");
 
@@ -71,7 +71,7 @@ unsafe extern "C" {
     fn instruction_abort_permissions_enabled_entry() -> !;
 }
 
-#[tmk_test(expected_failure)]
+#[tmk_test(expected_failure, linux_only)]
 fn instruction_abort_permissions_enabled(_: TestContext<'_>) {
     log!("instruction_abort_permissions_enabled");
 

--- a/tmk/simple_tmk/src/aarch64/mod.rs
+++ b/tmk/simple_tmk/src/aarch64/mod.rs
@@ -8,6 +8,7 @@
 )]
 
 use crate::prelude::*;
+use tmk_protocol as _;
 
 core::arch::global_asm! {
     ".global instruction_abort_outside_par_entry",

--- a/tmk/simple_tmk/src/aarch64/mod.rs
+++ b/tmk/simple_tmk/src/aarch64/mod.rs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+//! aarch64 specific tests.
+
 #![cfg(target_arch = "aarch64")]
 #![allow(
     unsafe_code,

--- a/tmk/simple_tmk/src/aarch64/mod.rs
+++ b/tmk/simple_tmk/src/aarch64/mod.rs
@@ -1,0 +1,70 @@
+
+#![cfg(target_arch = "aarch64")]
+
+#![allow(unsafe_code)]
+
+use crate::prelude::*;
+
+core::arch::global_asm! {
+    ".global instruction_abort_outside_par_entry",
+    "instruction_abort_outside_par_entry:",
+    "movz x16, #0x0000",
+    "movk x16, #0x0000, lsl #16",
+    "movk x16, #0xffff, lsl #32",
+    "movk x16, #0x0000, lsl #48",
+    "br x16",
+}
+
+unsafe extern "C" {
+    fn instruction_abort_outside_par_entry() -> !;
+}
+
+#[tmk_test(expected_failure)]
+fn instruction_abort_outside_par(_: TestContext<'_>) {
+    log!("instruction_abort_outside_par");
+
+    unsafe {
+        instruction_abort_outside_par_entry();
+    }
+}
+
+core::arch::global_asm! {
+    ".global instruction_abort_ripas_empty_entry",
+    "instruction_abort_ripas_empty_entry:",
+    "movz x16, #0x0000",
+    "br x16",
+}
+
+unsafe extern "C" {
+    fn instruction_abort_ripas_empty_entry() -> !;
+}
+
+#[tmk_test(expected_failure)]
+fn instruction_abort_ripas_empty(_: TestContext<'_>) {
+    log!("instruction_abort_ripas_empty");
+
+    unsafe {
+        instruction_abort_ripas_empty_entry();
+    }
+}
+
+core::arch::global_asm! {
+    ".global instruction_abort_permissions_enabled_entry",
+    "instruction_abort_permissions_enabled_entry:",
+    "movz x16, #0xf000",
+    "movk x16, #0x847f, lsl #16",
+    "br x16",
+}
+
+unsafe extern "C" {
+    fn instruction_abort_permissions_enabled_entry() -> !;
+}
+
+#[tmk_test(expected_failure)]
+fn instruction_abort_permissions_enabled(_: TestContext<'_>) {
+    log!("instruction_abort_permissions_enabled");
+
+    unsafe {
+        instruction_abort_permissions_enabled_entry();
+    }
+}

--- a/tmk/simple_tmk/src/aarch64/mod.rs
+++ b/tmk/simple_tmk/src/aarch64/mod.rs
@@ -1,7 +1,11 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 #![cfg(target_arch = "aarch64")]
-
-#![allow(unsafe_code)]
+#![allow(
+    unsafe_code,
+    reason = "global_asm! required for AArch64 trampoline code"
+)]
 
 use crate::prelude::*;
 
@@ -23,6 +27,9 @@ unsafe extern "C" {
 fn instruction_abort_outside_par(_: TestContext<'_>) {
     log!("instruction_abort_outside_par");
 
+    // SAFETY: This test intentionally jumps to an assembly entry point that
+    // triggers an instruction abort. The symbol is defined in this module via
+    // `global_asm!` and is declared `-> !`, so it is not expected to return.
     unsafe {
         instruction_abort_outside_par_entry();
     }
@@ -43,6 +50,9 @@ unsafe extern "C" {
 fn instruction_abort_ripas_empty(_: TestContext<'_>) {
     log!("instruction_abort_ripas_empty");
 
+    // SAFETY: This test intentionally transfers control to an assembly entry
+    // point that executes from an address chosen to provoke the expected
+    // instruction abort. The entry point is defined above and never returns.
     unsafe {
         instruction_abort_ripas_empty_entry();
     }
@@ -64,6 +74,9 @@ unsafe extern "C" {
 fn instruction_abort_permissions_enabled(_: TestContext<'_>) {
     log!("instruction_abort_permissions_enabled");
 
+    // SAFETY: This test intentionally calls an assembly entry point that jumps
+    // to an address expected to fault under the configured permissions. The
+    // entry point is defined in this module and is declared `-> !`.
     unsafe {
         instruction_abort_permissions_enabled_entry();
     }

--- a/tmk/simple_tmk/src/main.rs
+++ b/tmk/simple_tmk/src/main.rs
@@ -11,6 +11,7 @@ mod prelude;
 
 mod common;
 mod x86_64;
+mod aarch64;
 
 #[cfg(not(minimal_rt))]
 fn main() {

--- a/tmk/simple_tmk/src/main.rs
+++ b/tmk/simple_tmk/src/main.rs
@@ -9,9 +9,9 @@
 
 mod prelude;
 
+mod aarch64;
 mod common;
 mod x86_64;
-mod aarch64;
 
 #[cfg(not(minimal_rt))]
 fn main() {

--- a/tmk/tmk_core/src/lib.rs
+++ b/tmk/tmk_core/src/lib.rs
@@ -12,6 +12,7 @@ pub mod x86_64;
 
 #[cfg(target_arch = "aarch64")]
 use aarch64 as arch;
+use tmk_protocol::TestFlags64;
 #[cfg(target_arch = "x86_64")]
 use x86_64 as arch;
 
@@ -20,9 +21,6 @@ use core::marker::PhantomData;
 use core::ptr::null_mut;
 use core::sync::atomic::AtomicPtr;
 use core::sync::atomic::Ordering::Relaxed;
-
-/// The test is expected to fail.
-pub const TEST_FLAG_EXPECTED_FAILURE: u64 = tmk_protocol::TEST_FLAG_EXPECTED_FAILURE;
 
 /// A TMK test context, passed to each test function.
 pub struct TestContext<'scope> {
@@ -184,7 +182,7 @@ pub struct TestDescriptor {
     /// The test entry point.
     pub entrypoint: for<'scope> fn(TestContext<'scope>),
     /// Test flag - expected failure or not
-    pub flags: u64,
+    pub flags: TestFlags64,
 }
 
 #[cfg_attr(minimal_rt, panic_handler)]

--- a/tmk/tmk_core/src/lib.rs
+++ b/tmk/tmk_core/src/lib.rs
@@ -21,6 +21,9 @@ use core::ptr::null_mut;
 use core::sync::atomic::AtomicPtr;
 use core::sync::atomic::Ordering::Relaxed;
 
+/// The test is expected to fail.
+pub const TEST_FLAG_EXPECTED_FAILURE: u64 = tmk_protocol::TEST_FLAG_EXPECTED_FAILURE;
+
 /// A TMK test context, passed to each test function.
 pub struct TestContext<'scope> {
     /// The BSP VP's scope.
@@ -144,6 +147,9 @@ unsafe extern "C" {
 #[macro_export]
 macro_rules! define_tmk_test {
     ($name:expr, $func:ident) => {
+        $crate::define_tmk_test!($name, $func, 0);
+    };
+    ($name:expr, $func:ident, $flags:expr) => {
         const _: () = {
             // Strip the crate name from the module path.
             const NAME: &[u8] = const {
@@ -162,6 +168,7 @@ macro_rules! define_tmk_test {
             static TEST: $crate::TestDescriptor = $crate::TestDescriptor {
                 name: NAME,
                 entrypoint: $func,
+                flags: $flags,
             };
         };
     };
@@ -176,6 +183,8 @@ pub struct TestDescriptor {
     pub name: &'static [u8],
     /// The test entry point.
     pub entrypoint: for<'scope> fn(TestContext<'scope>),
+    /// Test flag - expected failure or not
+    pub flags: u64,
 }
 
 #[cfg_attr(minimal_rt, panic_handler)]

--- a/tmk/tmk_core/src/lib.rs
+++ b/tmk/tmk_core/src/lib.rs
@@ -144,9 +144,6 @@ unsafe extern "C" {
 #[doc(hidden)]
 #[macro_export]
 macro_rules! define_tmk_test {
-    ($name:expr, $func:ident) => {
-        $crate::define_tmk_test!($name, $func, 0);
-    };
     ($name:expr, $func:ident, $flags:expr) => {
         const _: () = {
             // Strip the crate name from the module path.
@@ -181,7 +178,7 @@ pub struct TestDescriptor {
     pub name: &'static [u8],
     /// The test entry point.
     pub entrypoint: for<'scope> fn(TestContext<'scope>),
-    /// Test flag - expected failure or not
+    /// Test flags
     pub flags: TestFlags64,
 }
 

--- a/tmk/tmk_macros/src/lib.rs
+++ b/tmk/tmk_macros/src/lib.rs
@@ -13,12 +13,27 @@ use quote::quote;
 ///
 /// This macro is used to define a test in the TMK.
 #[proc_macro_attribute]
-pub fn tmk_test(_attr: TokenStream, item: TokenStream) -> TokenStream {
+pub fn tmk_test(attr: TokenStream, item: TokenStream) -> TokenStream {
     let item = syn::parse_macro_input!(item as syn::ItemFn);
     let name = item.sig.ident.to_string();
     let func = &item.sig.ident;
+
+    let flags = match attr.to_string().as_str() {
+        "" => quote! { 0 },
+        "expected_failure" => quote! { ::tmk_core::TEST_FLAG_EXPECTED_FAILURE },
+        attr => {
+            let msg = format!("unsupported tmk_test option: {attr}");
+            return quote! {
+                compile_error!(#msg);
+                #item
+            }
+            .into_token_stream()
+            .into();
+        }
+    };
+
     quote! {
-        ::tmk_core::define_tmk_test!(#name, #func);
+        ::tmk_core::define_tmk_test!(#name, #func, #flags);
         #item
     }
     .into_token_stream()

--- a/tmk/tmk_macros/src/lib.rs
+++ b/tmk/tmk_macros/src/lib.rs
@@ -8,6 +8,7 @@
 use proc_macro::TokenStream;
 use quote::ToTokens;
 use quote::quote;
+use syn::parse::Parser;
 
 /// `tmk_test` procedural attribute macro.
 ///
@@ -18,20 +19,39 @@ pub fn tmk_test(attr: TokenStream, item: TokenStream) -> TokenStream {
     let name = item.sig.ident.to_string();
     let func = &item.sig.ident;
 
-    let flags = match attr.to_string().as_str() {
-        "" => quote! { ::tmk_protocol::TestFlags64::new() },
-        "expected_failure" => {
-            quote! { ::tmk_protocol::TestFlags64::new().with_expected_failure(true) }
+    let mut expected_failure = false;
+    let mut linux_only = false;
+
+    let parser = syn::meta::parser(|meta| {
+        if meta.path.is_ident("expected_failure") {
+            expected_failure = true;
+            Ok(())
+        } else if meta.path.is_ident("linux_only") {
+            linux_only = true;
+            Ok(())
+        } else {
+            let ident = meta
+                .path
+                .get_ident()
+                .map_or_else(|| "<unknown>".to_string(), |exp| exp.to_string());
+
+            Err(meta.error(format!("unsupported tmk_test option: {ident}")))
         }
-        attr => {
-            let msg = format!("unsupported tmk_test option: {attr}");
-            return quote! {
-                compile_error!(#msg);
-                #item
-            }
-            .into_token_stream()
-            .into();
+    });
+
+    if let Err(err) = parser.parse(attr) {
+        let compile_err = err.to_compile_error();
+        return quote! {
+            #compile_err
+            #item
         }
+        .into();
+    }
+
+    let flags = quote! {
+        ::tmk_protocol::TestFlags64::new()
+            .with_expected_failure(#expected_failure)
+            .with_linux_only(#linux_only)
     };
 
     quote! {

--- a/tmk/tmk_macros/src/lib.rs
+++ b/tmk/tmk_macros/src/lib.rs
@@ -19,8 +19,10 @@ pub fn tmk_test(attr: TokenStream, item: TokenStream) -> TokenStream {
     let func = &item.sig.ident;
 
     let flags = match attr.to_string().as_str() {
-        "" => quote! { 0 },
-        "expected_failure" => quote! { ::tmk_core::TEST_FLAG_EXPECTED_FAILURE },
+        "" => quote! { ::tmk_protocol::TestFlags64::new() },
+        "expected_failure" => {
+            quote! { ::tmk_protocol::TestFlags64::new().with_expected_failure(true) }
+        }
         attr => {
             let msg = format!("unsupported tmk_test option: {attr}");
             return quote! {

--- a/tmk/tmk_protocol/Cargo.toml
+++ b/tmk/tmk_protocol/Cargo.toml
@@ -8,6 +8,7 @@ edition.workspace = true
 
 [dependencies]
 zerocopy.workspace = true
+bitfield-struct.workspace = true
 
 [lints]
 workspace = true

--- a/tmk/tmk_protocol/src/lib.rs
+++ b/tmk/tmk_protocol/src/lib.rs
@@ -6,13 +6,12 @@
 #![no_std]
 #![forbid(unsafe_code)]
 
+use bitfield_struct::bitfield;
 use zerocopy::FromBytes;
 use zerocopy::Immutable;
 use zerocopy::IntoBytes;
+use zerocopy::KnownLayout;
 use zerocopy::TryFromBytes;
-
-/// The test is expected to fail.
-pub const TEST_FLAG_EXPECTED_FAILURE: u64 = 1 << 0;
 
 /// Start input from the VMM to the TMK.
 #[repr(C)]
@@ -22,6 +21,17 @@ pub struct StartInput {
     pub command: u64,
     /// The test index.
     pub test_index: u64,
+}
+
+/// Test metadata flags.
+#[bitfield(u64)]
+#[derive(IntoBytes, Immutable, KnownLayout, FromBytes)]
+pub struct TestFlags64 {
+    #[bits(1)]
+    pub expected_failure: bool,
+
+    #[bits(63)]
+    reserved: u64,
 }
 
 /// A 64-bit TMK test descriptor.
@@ -35,7 +45,7 @@ pub struct TestDescriptor64 {
     /// The test entry point.
     pub entrypoint: u64,
     /// Test metadata flags.
-    pub flags: u64,
+    pub flags: TestFlags64,
 }
 
 /// TMK command.

--- a/tmk/tmk_protocol/src/lib.rs
+++ b/tmk/tmk_protocol/src/lib.rs
@@ -29,8 +29,9 @@ pub struct StartInput {
 pub struct TestFlags64 {
     #[bits(1)]
     pub expected_failure: bool,
-
-    #[bits(63)]
+    #[bits(1)]
+    pub linux_only: bool,
+    #[bits(62)]
     reserved: u64,
 }
 

--- a/tmk/tmk_protocol/src/lib.rs
+++ b/tmk/tmk_protocol/src/lib.rs
@@ -11,6 +11,9 @@ use zerocopy::Immutable;
 use zerocopy::IntoBytes;
 use zerocopy::TryFromBytes;
 
+/// The test is expected to fail.
+pub const TEST_FLAG_EXPECTED_FAILURE: u64 = 1 << 0;
+
 /// Start input from the VMM to the TMK.
 #[repr(C)]
 #[derive(Debug, IntoBytes, Immutable)]
@@ -31,6 +34,8 @@ pub struct TestDescriptor64 {
     pub name_len: u64,
     /// The test entry point.
     pub entrypoint: u64,
+    /// Test metadata flags.
+    pub flags: u64,
 }
 
 /// TMK command.

--- a/tmk/tmk_vmm/src/load.rs
+++ b/tmk/tmk_vmm/src/load.rs
@@ -229,7 +229,7 @@ pub fn enumerate_tests(tmk: &File) -> anyhow::Result<Vec<TestInfo>> {
         tests.push(TestInfo {
             name: name.to_string(),
             index: i as u64,
-            expected_failure: t.flags & tmk_protocol::TEST_FLAG_EXPECTED_FAILURE != 0,
+            expected_failure: t.flags.expected_failure(),
         });
     }
 

--- a/tmk/tmk_vmm/src/load.rs
+++ b/tmk/tmk_vmm/src/load.rs
@@ -176,6 +176,7 @@ struct LoadInfo {
 pub struct TestInfo {
     pub name: String,
     pub index: u64,
+    pub expected_failure: bool,
 }
 
 /// Enumerate the tests from a TMK binary.
@@ -228,6 +229,7 @@ pub fn enumerate_tests(tmk: &File) -> anyhow::Result<Vec<TestInfo>> {
         tests.push(TestInfo {
             name: name.to_string(),
             index: i as u64,
+            expected_failure: t.flags & tmk_protocol::TEST_FLAG_EXPECTED_FAILURE != 0,
         });
     }
 

--- a/tmk/tmk_vmm/src/load.rs
+++ b/tmk/tmk_vmm/src/load.rs
@@ -177,6 +177,7 @@ pub struct TestInfo {
     pub name: String,
     pub index: u64,
     pub expected_failure: bool,
+    pub linux_only: bool,
 }
 
 /// Enumerate the tests from a TMK binary.
@@ -230,6 +231,7 @@ pub fn enumerate_tests(tmk: &File) -> anyhow::Result<Vec<TestInfo>> {
             name: name.to_string(),
             index: i as u64,
             expected_failure: t.flags.expected_failure(),
+            linux_only: t.flags.linux_only(),
         });
     }
 

--- a/tmk/tmk_vmm/src/run.rs
+++ b/tmk/tmk_vmm/src/run.rs
@@ -276,6 +276,11 @@ impl CommonState {
         for test in &tests {
             tracing::info!(target: "test", name = test.name, "test started");
 
+            if test.linux_only && !cfg!(target_os = "linux") {
+                tracing::info!(target: "test", name = test.name, "test skipped, incompatible os");
+                continue;
+            }
+
             let mut vmtime_keeper = VmTimeKeeper::new(&self.driver, VmTime::from_100ns(0));
             let vmtime_source = vmtime_keeper.builder().build(&self.driver).await.unwrap();
             let mut ctx = RunContext {

--- a/tmk/tmk_vmm/src/run.rs
+++ b/tmk/tmk_vmm/src/run.rs
@@ -291,19 +291,40 @@ impl CommonState {
 
             vmtime_keeper.stop().await;
 
-            match r {
-                TestResult::Passed => {
+            match (r, test.expected_failure) {
+                (TestResult::Passed, false) => {
                     tracing::info!(target: "test", name = test.name, "test passed");
                 }
-                TestResult::Failed => {
+                (TestResult::Passed, true) => {
+                    tracing::error!(
+                        target: "test",
+                        name = test.name,
+                        expected_failure = true,
+                        "test unexpectedly passed"
+                    );
+                    success = false;
+                }
+                (TestResult::Failed, false) => {
                     tracing::error!(target: "test", name = test.name, reason = "explicit failure", "test failed");
                     success = false;
                 }
-                TestResult::Faulted {
-                    vp_index,
-                    reason,
-                    regs,
-                } => {
+                (TestResult::Failed, true) => {
+                    tracing::info!(
+                        target: "test",
+                        name = test.name,
+                        expected_failure = true,
+                        reason = "explicit failure",
+                        "test passed"
+                    );
+                }
+                (
+                    TestResult::Faulted {
+                        vp_index,
+                        reason,
+                        regs,
+                    },
+                    false,
+                ) => {
                     tracing::error!(
                         target: "test",
                         name = test.name,
@@ -313,6 +334,24 @@ impl CommonState {
                         "test failed"
                     );
                     success = false;
+                }
+                (
+                    TestResult::Faulted {
+                        vp_index,
+                        reason,
+                        regs,
+                    },
+                    true,
+                ) => {
+                    tracing::info!(
+                        target: "test",
+                        name = test.name,
+                        expected_failure = true,
+                        vp_index = vp_index.index(),
+                        reason,
+                        regs = format_args!("{:#x?}", regs),
+                        "test passed"
+                    );
                 }
             }
         }

--- a/vm/aarch64/aarch64defs/src/lib.rs
+++ b/vm/aarch64/aarch64defs/src/lib.rs
@@ -961,3 +961,96 @@ impl Display for Vendor {
         }
     }
 }
+
+#[derive(Debug, Clone, Copy)]
+pub enum InstructionAbortReason {
+    AddressSizeFaultLevel0,
+    AddressSizeFaultLevel1,
+    AddressSizeFaultLevel2,
+    AddressSizeFaultLevel3,
+    TranslationFaultLevel0,
+    TranslationFaultLevel1,
+    TranslationFaultLevel2,
+    TranslationFaultLevel3,
+    AccessFlagFaultLevel0,
+    AccessFlagFaultLevel1,
+    AccessFlagFaultLevel2,
+    AccessFlagFaultLevel3,
+    PermissionFaultLevel0,
+    PermissionFaultLevel1,
+    PermissionFaultLevel2,
+    PermissionFaultLevel3,
+    SynchronousExternalAbort,
+    SyncTagCheckFault,
+    SynchronousExternalAbortOnTableWalkLevelNeg1,
+    SynchronousExternalAbortOnTableWalkLevel0,
+    SynchronousExternalAbortOnTableWalkLevel1,
+    SynchronousExternalAbortOnTableWalkLevel2,
+    SynchronousExternalAbortOnTableWalkLevel3,
+    EccParity,
+    EccParityOnTableWalkLevelNeg1,
+    EccParityOnTableWalkLevel0,
+    EccParityOnTableWalkLevel1,
+    EccParityOnTableWalkLevel2,
+    EccParityOnTableWalkLevel3,
+    GranuleProtectionFaultLevelNeg1,
+    GranuleProtectionFaultLevel0,
+    GranuleProtectionFaultLevel1,
+    GranuleProtectionFaultLevel2,
+    GranuleProtectionFaultLevel3,
+    AddressSizeFaultLevelNeg1,
+    TranslationFaultLevelNeg1,
+    TlbConflictAbort,
+    UnsupportedHardwareUpdateFault,
+    Unknown,
+}
+
+impl From<FaultStatusCode> for InstructionAbortReason {
+    fn from(value: FaultStatusCode) -> Self {
+        match value {
+            FaultStatusCode::ADDRESS_SIZE_FAULT_LEVEL0 => Self::AddressSizeFaultLevel0,
+            FaultStatusCode::ADDRESS_SIZE_FAULT_LEVEL1 => Self::AddressSizeFaultLevel1,
+            FaultStatusCode::ADDRESS_SIZE_FAULT_LEVEL2 => Self::AddressSizeFaultLevel2,
+            FaultStatusCode::ADDRESS_SIZE_FAULT_LEVEL3 => Self::AddressSizeFaultLevel3,
+            FaultStatusCode::TRANSLATION_FAULT_LEVEL0 => Self::TranslationFaultLevel0,
+            FaultStatusCode::TRANSLATION_FAULT_LEVEL1 => Self::TranslationFaultLevel1,
+            FaultStatusCode::TRANSLATION_FAULT_LEVEL2 => Self::TranslationFaultLevel2,
+            FaultStatusCode::TRANSLATION_FAULT_LEVEL3 => Self::TranslationFaultLevel3,
+            FaultStatusCode::ACCESS_FLAG_FAULT_LEVEL0 => Self::AccessFlagFaultLevel0,
+            FaultStatusCode::ACCESS_FLAG_FAULT_LEVEL1 => Self::AccessFlagFaultLevel1,
+            FaultStatusCode::ACCESS_FLAG_FAULT_LEVEL2 => Self::AccessFlagFaultLevel2,
+            FaultStatusCode::ACCESS_FLAG_FAULT_LEVEL3 => Self::AccessFlagFaultLevel3,
+            FaultStatusCode::PERMISSION_FAULT_LEVEL0 => Self::PermissionFaultLevel0,
+            FaultStatusCode::PERMISSION_FAULT_LEVEL1 => Self::PermissionFaultLevel1,
+            FaultStatusCode::PERMISSION_FAULT_LEVEL2 => Self::PermissionFaultLevel2,
+            FaultStatusCode::PERMISSION_FAULT_LEVEL3 => Self::PermissionFaultLevel3,
+            FaultStatusCode::SYNCHRONOUS_EXTERNAL_ABORT => Self::SynchronousExternalAbort,
+            FaultStatusCode::SYNC_TAG_CHECK_FAULT => Self::SyncTagCheckFault,
+            FaultStatusCode::SEA_TTW_LEVEL_NEG1 => {
+                Self::SynchronousExternalAbortOnTableWalkLevelNeg1
+            }
+            FaultStatusCode::SEA_TTW_LEVEL0 => Self::SynchronousExternalAbortOnTableWalkLevel0,
+            FaultStatusCode::SEA_TTW_LEVEL1 => Self::SynchronousExternalAbortOnTableWalkLevel1,
+            FaultStatusCode::SEA_TTW_LEVEL2 => Self::SynchronousExternalAbortOnTableWalkLevel2,
+            FaultStatusCode::SEA_TTW_LEVEL3 => Self::SynchronousExternalAbortOnTableWalkLevel3,
+            FaultStatusCode::ECC_PARITY => Self::EccParity,
+            FaultStatusCode::ECC_PARITY_TTW_LEVEL_NEG1 => Self::EccParityOnTableWalkLevelNeg1,
+            FaultStatusCode::ECC_PARITY_TTW_LEVEL0 => Self::EccParityOnTableWalkLevel0,
+            FaultStatusCode::ECC_PARITY_TTW_LEVEL1 => Self::EccParityOnTableWalkLevel1,
+            FaultStatusCode::ECC_PARITY_TTW_LEVEL2 => Self::EccParityOnTableWalkLevel2,
+            FaultStatusCode::ECC_PARITY_TTW_LEVEL3 => Self::EccParityOnTableWalkLevel3,
+            FaultStatusCode::GRANULE_PROTECTION_FAULT_LEVEL_NEG => {
+                Self::GranuleProtectionFaultLevelNeg1
+            }
+            FaultStatusCode::GRANULE_PROTECTION_FAULT_LEVEL0 => Self::GranuleProtectionFaultLevel0,
+            FaultStatusCode::GRANULE_PROTECTION_FAULT_LEVEL1 => Self::GranuleProtectionFaultLevel1,
+            FaultStatusCode::GRANULE_PROTECTION_FAULT_LEVEL2 => Self::GranuleProtectionFaultLevel2,
+            FaultStatusCode::GRANULE_PROTECTION_FAULT_LEVEL3 => Self::GranuleProtectionFaultLevel3,
+            FaultStatusCode::ADDRESS_SIZE_FAULT_LEVEL_NEG1 => Self::AddressSizeFaultLevelNeg1,
+            FaultStatusCode::TRANSLATION_FAULT_LEVEL_NEG1 => Self::TranslationFaultLevelNeg1,
+            FaultStatusCode::TLB_CONFLICT_ABORT => Self::TlbConflictAbort,
+            FaultStatusCode::UNSUPPORTED_HW_UPDATE_FAULT => Self::UnsupportedHardwareUpdateFault,
+            _ => Self::Unknown,
+        }
+    }
+}

--- a/vm/aarch64/aarch64defs/src/lib.rs
+++ b/vm/aarch64/aarch64defs/src/lib.rs
@@ -352,7 +352,6 @@ impl FaultStatusCode {
     const fn into_bits(self) -> u32 {
         self.0 as u32
     }
-
 }
 
 #[bitfield(u32)]

--- a/vm/aarch64/aarch64defs/src/lib.rs
+++ b/vm/aarch64/aarch64defs/src/lib.rs
@@ -181,6 +181,19 @@ pub struct SctlrEl1 {
     pub tidcp: bool,
 }
 
+/// aarch64 HPFAR_EL2
+#[bitfield(u64)]
+#[derive(PartialEq, Eq)]
+pub struct HpfarEl2 {
+    #[bits(4)]
+    pub res0: u8,
+    #[bits(44)]
+    pub fipa: u64,
+    #[bits(15)]
+    pub res1: u32,
+    pub ns: bool,
+}
+
 open_enum! {
     pub enum ExceptionClass: u8 {
         UNKNOWN = 0b000000,
@@ -322,7 +335,7 @@ open_enum! {
         /// Valid only for instruction fault.
         GRANULE_PROTECTION_FAULT_LEVEL2 = 0b100110,
         /// Valid only for instruction fault.
-        GRANULE_PROTECTION_FAULT_LEVE3 = 0b100111,
+        GRANULE_PROTECTION_FAULT_LEVEL3 = 0b100111,
         ADDRESS_SIZE_FAULT_LEVEL_NEG1 = 0b101001,
         TRANSLATION_FAULT_LEVEL_NEG1 = 0b101011,
         TLB_CONFLICT_ABORT = 0b110000,
@@ -339,6 +352,7 @@ impl FaultStatusCode {
     const fn into_bits(self) -> u32 {
         self.0 as u32
     }
+
 }
 
 #[bitfield(u32)]


### PR DESCRIPTION
- unit test added that causes an Instruction Abort by fetching from an address outside the PAR
- unit test added that causes an Instruction Abort by fetching from an address with state RIPAS_EMPTY
- unit test added that causes an Instruction Abort by fetching from an address with no permissions
- added a HpfarEl2 structure in order to retrieve the fipa more conveniently. Added the getter function in CcaExit.
- added ioctl in openVMM and kernel to get ipa state - hcl_rsi_ipa_state_read
- adding a new location where the AArch64 tests can be placed: tmk/simple_tmk/src/aarch64. Keeping architecture specific code and tests grouped together
- adding Instruction abort handling, displaying to the user the error reason with additional useful information about the plane exit
- implementation for #[tmk_test(expected_failure)] macro. Tests marked as expected failures now pass when they fail or fault. Allows representation of intentional failure cases.
- implementation for #[tmk_test(linux_only)] macro. Tests marked as linux_only will be skipped in the paravisor if the paravisor target_os != linux.