### PR TITLE
dep-review.js: use merge-base for dependency review

### DIFF
--- a/.github/scripts/dep-review.js
+++ b/.github/scripts/dep-review.js
@@ -223,7 +223,37 @@ const DEP_REVIEW_TEAM = "openvmm-dependency-reviewers";
  */
 async function run(github, context, core) {
   const prNumber = context.payload.pull_request.number;
-  const baseSha = context.payload.pull_request.base.sha;
+  const baseTipSha = context.payload.pull_request.base.sha;
+  const headSha = context.payload.pull_request.head.sha;
+
+  // Use merge-base (base...head) as the baseline so we only review dependency
+  // deltas introduced by this PR, not unrelated changes that landed on base.
+  let baseSha = baseTipSha;
+  try {
+    const { data: compare } = await github.request(
+      "GET /repos/{owner}/{repo}/compare/{basehead}",
+      {
+        owner: context.repo.owner,
+        repo: context.repo.repo,
+        basehead: `${baseTipSha}...${headSha}`,
+      }
+    );
+    const mergeBaseSha = compare?.merge_base_commit?.sha;
+    if (mergeBaseSha) {
+      baseSha = mergeBaseSha;
+      console.log(`Using merge-base ${mergeBaseSha} for dependency diff baseline.`);
+    } else {
+      core.warning(
+        "Could not determine merge-base from compare API response; " +
+          "falling back to pull_request.base.sha."
+      );
+    }
+  } catch (e) {
+    core.warning(
+      `Failed to compute merge-base (${e.status || "unknown"}): ${e.message}. ` +
+        "Falling back to pull_request.base.sha."
+    );
+  }
 
   // Step 1: Check if Cargo.lock was modified
   let allFiles = [];

--- a/.github/scripts/dep-review.test.js
+++ b/.github/scripts/dep-review.test.js
@@ -18,6 +18,7 @@ const {
   checkContainment,
   diffContainmentViolations,
   buildPolicySummary,
+  run,
 } = require("./dep-review.js");
 
 // -- fixtures --
@@ -408,5 +409,90 @@ version = "0.0.0"
     assert.equal(newV.length, 1);
     assert.equal(newV[0].crate, "lib_a");
     assert.equal(newV[0].dep, "lib_b");
+  });
+});
+
+describe("run", () => {
+  it("uses merge-base sha for baseline file fetches", async () => {
+    const lock = `
+[[package]]
+name = "serde"
+version = "1.0.200"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+`;
+    const manifest = `
+[workspace]
+members = []
+
+[workspace.dependencies]
+`;
+
+    const calls = {
+      getContent: [],
+      compare: [],
+      requestReviewers: 0,
+      removeRequestedReviewers: 0,
+    };
+
+    const github = {
+      request: async (route, params) => {
+        calls.compare.push({ route, params });
+        return { data: { merge_base_commit: { sha: "mergebase123" } } };
+      },
+      rest: {
+        pulls: {
+          listFiles: async () => ({ data: [{ filename: "Cargo.lock" }] }),
+          requestReviewers: async () => {
+            calls.requestReviewers += 1;
+            return {};
+          },
+          removeRequestedReviewers: async () => {
+            calls.removeRequestedReviewers += 1;
+            return {};
+          },
+        },
+        repos: {
+          getContent: async ({ path, ref }) => {
+            calls.getContent.push({ path, ref });
+            const content = path === "Cargo.lock" ? lock : manifest;
+            return {
+              data: {
+                type: "file",
+                content: Buffer.from(content, "utf8").toString("base64"),
+              },
+            };
+          },
+        },
+      },
+    };
+
+    const context = {
+      repo: { owner: "microsoft", repo: "openvmm" },
+      payload: {
+        pull_request: {
+          number: 42,
+          base: { sha: "basetip999" },
+          head: { sha: "headabc999" },
+        },
+      },
+    };
+
+    const core = {
+      warning: () => {},
+      setFailed: () => {},
+    };
+
+    await run(github, context, core);
+
+    assert.equal(calls.compare.length, 1);
+    assert.equal(
+      calls.compare[0].params.basehead,
+      "basetip999...headabc999"
+    );
+
+    const lockFetches = calls.getContent.filter((c) => c.path === "Cargo.lock");
+    assert.equal(lockFetches.length, 2);
+    assert.ok(lockFetches.some((c) => c.ref === "mergebase123"));
+    assert.ok(lockFetches.some((c) => c.ref === "refs/pull/42/head"));
   });
 });


### PR DESCRIPTION
Dependency review was comparing Cargo.lock against the current tip of the base branch, which can surface dependency changes that landed on main after the branch point and were not introduced by the PR itself. That makes the check noisy and can request review for unrelated updates.

Use the PR merge-base as the baseline by resolving base...head through the compare API and diffing lockfile and manifest content from that commit. Keep a defensive fallback to pull_request.base.sha if merge-base resolution fails. Add a focused unit test that exercises run() end-to-end with mocked GitHub APIs and verifies baseline fetches use the merge-base ref.