### PR TITLE
petri: add ARM CCA test integration

### DIFF
--- a/flowey/flowey_hvlite/src/pipelines/cca_tests.rs
+++ b/flowey/flowey_hvlite/src/pipelines/cca_tests.rs
@@ -20,6 +20,10 @@ pub struct CcaTestsCli {
     #[clap(long)]
     pub update_emu: bool,
 
+    /// Build CCA test artifacts without running the Petri test.
+    #[clap(long)]
+    pub build_only: bool,
+
     /// Verbose pipeline output
     #[clap(long)]
     pub verbose: bool,
@@ -58,6 +62,7 @@ impl IntoPipeline for CcaTestsCli {
             test_root,
             install_emu,
             update_emu,
+            build_only,
             verbose,
             update_emu_subcmds:
                 CcaTestsUpdateEmuSubCmds {
@@ -183,6 +188,7 @@ impl IntoPipeline for CcaTestsCli {
             })
             .dep_on(|ctx| flowey_lib_hvlite::_jobs::local_run_cca_test::Params {
                 test_root: test_root.clone(),
+                build_only,
                 done: ctx.new_done_handle(),
             })
             .finish();

--- a/flowey/flowey_hvlite/src/pipelines/checkin_gates.rs
+++ b/flowey/flowey_hvlite/src/pipelines/checkin_gates.rs
@@ -1442,6 +1442,13 @@ impl IntoPipeline for CheckinGatesCli {
             }
             filter
         };
+        let exclude_checkin_disabled_vmm_tests = |filter: String| {
+            // CCA has a dedicated xflowey pipeline that installs and drives the
+            // Arm emulator. Do not let broad check-in gate filters select the
+            // custom CCA Petri test binary.
+            format!("({filter}) & !binary(cca)")
+        };
+
         let cvm_x64_test_artifacts = vec![
             KnownTestArtifacts::Gen1WindowsDataCenterCore2022X64Vhd,
             KnownTestArtifacts::Gen2WindowsDataCenterCore2022X64Vhd,
@@ -1582,6 +1589,7 @@ impl IntoPipeline for CheckinGatesCli {
                 continue;
             }
 
+            let nextest_filter_expr = exclude_checkin_disabled_vmm_tests(nextest_filter_expr);
             let test_label = format!("{label}-vmm-tests");
 
             let pub_vmm_tests_results = if matches!(backend_hint, PipelineBackendHint::Local) {

--- a/flowey/flowey_lib_hvlite/src/_jobs/local_run_cca_test.rs
+++ b/flowey/flowey_lib_hvlite/src/_jobs/local_run_cca_test.rs
@@ -8,19 +8,20 @@ use crate::common::CommonPlatform;
 use crate::common::CommonProfile;
 use crate::common::CommonTriple;
 use flowey::node::prelude::*;
-use std::env;
-use std::ffi::OsStr;
-use std::thread;
-use std::time::Duration;
 
 flowey_request! {
     pub struct Params {
         pub test_root: PathBuf,
+        pub build_only: bool,
         pub done: WriteVar<SideEffect>,
     }
 }
 
 new_simple_flow_node!(struct Node);
+
+const ENV_CCA_TEST_ROOT: &str = "OPENVMM_CCA_TEST_ROOT";
+const ENV_CCA_TMK_VMM: &str = "OPENVMM_CCA_TMK_VMM";
+const ENV_CCA_SIMPLE_TMK: &str = "OPENVMM_CCA_SIMPLE_TMK";
 
 impl SimpleFlowNode for Node {
     type Request = Params;
@@ -31,58 +32,11 @@ impl SimpleFlowNode for Node {
     }
 
     fn process_request(request: Self::Request, ctx: &mut NodeCtx<'_>) -> anyhow::Result<()> {
-        let Params { test_root, done } = request;
-
-        let shrinkwrap_dir = test_root.join("shrinkwrap");
-        let venv_dir = shrinkwrap_dir.join("venv");
-        let shrinkwrap_exe = shrinkwrap_dir.join("shrinkwrap/shrinkwrap");
-        if !shrinkwrap_exe.exists() {
-            anyhow::bail!(
-                "shrinkwrap installation is missing or broken, try --install-emu or --update-emu --rebuild"
-            );
-        }
-
-        if !venv_dir.exists() {
-            anyhow::bail!(
-                "can't find shrinkwrap venv, try --install-emu or --update-emu --rebuild"
-            );
-        }
-
-        let plane0_linux_image = test_root.join("plane0-linux/arch/arm64/boot/Image");
-        if !plane0_linux_image.exists() {
-            anyhow::bail!(
-                "can't find plane0 linux image at {}, try --install-emu or --update-emu --rebuild-plane0-linux",
-                plane0_linux_image.display()
-            );
-        }
-
-        let home_dir = env::var("HOME").map(PathBuf::from).expect("HOME not set");
-        let firmware_dir = home_dir.join(".shrinkwrap/package/cca-3world");
-        let rootfs_file = firmware_dir.join("rootfs.ext2");
-        if !rootfs_file.exists() {
-            anyhow::bail!(
-                "can't find cca emulation rootfs at {}, try --install-emu or --update-emu --rebuild-rootfs",
-                rootfs_file.display()
-            );
-        }
-
-        let e2fsck_bin =
-            home_dir.join(".shrinkwrap/build/build/cca-3world/buildroot/host/sbin/e2fsck");
-        if !e2fsck_bin.exists() {
-            anyhow::bail!(
-                "can't find host e2fsck binary at {}, try --install-emu or --update-emu --rebuild",
-                e2fsck_bin.display()
-            );
-        }
-
-        let resize2fs_bin =
-            home_dir.join(".shrinkwrap/build/build/cca-3world/buildroot/host/sbin/resize2fs");
-        if !resize2fs_bin.exists() {
-            anyhow::bail!(
-                "can't find host resize2fs binary at {}, try --install-emu or --update-emu --rebuild",
-                resize2fs_bin.display()
-            );
-        }
+        let Params {
+            test_root,
+            build_only,
+            done,
+        } = request;
 
         // Generate request to build tmk_vmm
         let tmk_vmm_output = ctx.reqv(|v| crate::build_tmk_vmm::Request {
@@ -107,8 +61,9 @@ impl SimpleFlowNode for Node {
             let simple_tmk_output = simple_tmk_output.claim(ctx);
             move |rt| {
                 let tmk_vmm_output = rt.read(tmk_vmm_output);
-                let crate::build_tmk_vmm::TmkVmmOutput::LinuxBin { bin: tmk_vmm_bin, .. } =
-                    tmk_vmm_output
+                let crate::build_tmk_vmm::TmkVmmOutput::LinuxBin {
+                    bin: tmk_vmm_bin, ..
+                } = tmk_vmm_output
                 else {
                     anyhow::bail!("expect Linux tmk_vmm only");
                 };
@@ -116,143 +71,19 @@ impl SimpleFlowNode for Node {
                 let simple_tmk_output = rt.read(simple_tmk_output);
                 let simple_tmk_bin = simple_tmk_output.bin;
 
-                // fsck has the following exit_code, if we start the FVP and
-                // then kill it by force, the rootfs will left in 'dirty' status,
-                // but fsck will just clean it and finish with exit code 1, this
-                // is not an error.
-                //
-                //   0  No errors
-                //   1  Errors found and corrected (common after journal replay)
-                //   (full exit code see https://man7.org/linux/man-pages/man8/e2fsck.8.html)
-                let fsck_cmd = format!(
-                    r#"
-                    {e2fsck_bin} -fp {rootfs_file} || rc=$?
-                    [ "${{rc:-0}}" -le 1 ] || exit "$rc"
-                    "#,
-                    e2fsck_bin = e2fsck_bin.display(),
-                    rootfs_file = rootfs_file.display(),
-                );
-                flowey::shell_cmd!(rt, "bash -c {fsck_cmd}").run()?;
-                log::info!("e2fsck finished");
-
-                flowey::shell_cmd!(rt, "{resize2fs_bin} {rootfs_file} 1024M").run()?;
-                log::info!("resize rootfs to 1024M finished");
-
-                let guest_disk = firmware_dir.join("guest-disk.img");
-                let kvmtool_efi = firmware_dir.join("KVMTOOL_EFI.fd");
-                let lkvm = firmware_dir.join("lkvm");
-
-                let mnt_dir = PathBuf::from("mnt");
-                let cca_dir = mnt_dir.join("cca");
-
-                let run_sudo = |description: &str, args: &[&OsStr]| -> anyhow::Result<()> {
-                    let status = std::process::Command::new("sudo")
-                        .args(args)
-                        .status()
-                        .with_context(|| format!("failed to execute sudo command to {description}"))?;
-
-                    if !status.success() {
-                        anyhow::bail!("failed to {description}: exit status {status}");
-                    }
-
-                    Ok(())
-                };
-
-                let mut mounted = false;
-                let inject_result = (|| -> anyhow::Result<()> {
-                    run_sudo(
-                        "create guest rootfs mount directory",
-                        &[OsStr::new("mkdir"), OsStr::new("-p"), mnt_dir.as_os_str()],
-                    )?;
-                    run_sudo(
-                        "mount guest rootfs",
-                        &[OsStr::new("mount"), rootfs_file.as_os_str(), mnt_dir.as_os_str()],
-                    )?;
-                    mounted = true;
-
-                    run_sudo(
-                        "create cca directory in guest rootfs",
-                        &[OsStr::new("mkdir"), OsStr::new("-p"), cca_dir.as_os_str()],
-                    )?;
-
-                    for file in [
-                        &simple_tmk_bin,
-                        &tmk_vmm_bin,
-                        &guest_disk,
-                        &plane0_linux_image,
-                        &kvmtool_efi,
-                        &lkvm,
-                    ] {
-                        run_sudo(
-                            &format!("copy {} into guest rootfs", file.display()),
-                            &[OsStr::new("cp"), file.as_os_str(), cca_dir.as_os_str()],
-                        )?;
-                    }
-
-                    run_sudo("sync guest rootfs writes", &[OsStr::new("sync")])?;
-
-                    Ok(())
-                })();
-
-                if mounted {
-                    if let Err(err) = run_sudo(
-                        "unmount guest rootfs",
-                        &[OsStr::new("umount"), mnt_dir.as_os_str()],
-                    )
-                    .or_else(|_| {
-                        run_sudo(
-                            "lazy unmount guest rootfs",
-                            &[OsStr::new("umount"), OsStr::new("-l"), mnt_dir.as_os_str()],
-                        )
-                    }) {
-                        log::warn!("{err:#}");
-                    }
+                if build_only {
+                    log::info!("CCA test artifacts built; skipping Petri test because --build-only was specified");
+                    log::info!("tmk_vmm: {}", tmk_vmm_bin.display());
+                    log::info!("simple_tmk: {}", simple_tmk_bin.display());
+                    return Ok(());
                 }
 
-                if let Err(err) = run_sudo("sync host writes", &[OsStr::new("sync")]) {
-                    log::warn!("{err:#}");
-                }
-
-                thread::sleep(Duration::from_secs(1));
-                for _ in 0..5 {
-                    if !mnt_dir.is_dir() {
-                        break;
-                    }
-
-                    if run_sudo(
-                        "remove guest rootfs mount directory",
-                        &[OsStr::new("rmdir"), mnt_dir.as_os_str()],
-                    )
-                    .is_ok()
-                    {
-                        break;
-                    }
-
-                    thread::sleep(Duration::from_millis(500));
-                }
-
-                if mnt_dir.is_dir() {
-                    if let Err(err) = run_sudo(
-                        "force remove guest rootfs mount directory",
-                        &[OsStr::new("rm"), OsStr::new("-rf"), mnt_dir.as_os_str()],
-                    ) {
-                        log::warn!("{err:#}");
-                    }
-                }
-
-                inject_result.with_context(|| "failed to mount or inject files into guest rootfs")?;
-
-                log::info!("rootfs.ext2 updated successfully with cca firmwares, paravisor, and tests injected");
-                log::info!("launching openvmm cca tests...");
-
-                let venv_bin_path = format!("{}:{}", venv_dir.join("bin").display(), env::var("PATH").unwrap_or_default());
-                flowey::shell_cmd!(rt, "{shrinkwrap_exe} run cca-3world.yaml --rtvar ROOTFS={rootfs_file}")
-                    .env("VIRTUAL_ENV", &venv_dir)
-                    .env("PATH", &venv_bin_path)
-                    .run()
-                    .with_context(|| "failed to launch guest using shrinkwrap")?;
-
-                log::info!("openvmm cca tests finished");
+                flowey::shell_cmd!(rt, "cargo test -p vmm_tests --test cca")
+                .env(ENV_CCA_TEST_ROOT, &test_root)
+                .env(ENV_CCA_TMK_VMM, &tmk_vmm_bin)
+                .env(ENV_CCA_SIMPLE_TMK, &simple_tmk_bin)
+                .run()
+                .with_context(|| "failed to run CCA runtime Petri test")?;
 
                 Ok(())
             }

--- a/vmm_tests/petri_artifact_resolver_openvmm_known_paths/src/lib.rs
+++ b/vmm_tests/petri_artifact_resolver_openvmm_known_paths/src/lib.rs
@@ -127,10 +127,28 @@ impl petri_artifacts_core::ResolveTestArtifact for OpenvmmKnownPathsTestArtifact
             }
 
             _ if id == tmks::TMK_VMM_NATIVE => tmk_vmm_native_executable_path(),
+            _ if id == tmks::TMK_VMM_LINUX_X64 => tmk_vmm_linux_path(MachineArch::X86_64),
+            _ if id == tmks::TMK_VMM_LINUX_AARCH64 =>
+                env_path_or(OPENVMM_CCA_TMK_VMM_ENV_VAR, || {
+                    tmk_vmm_linux_path(MachineArch::Aarch64)
+                }),
             _ if id == tmks::TMK_VMM_LINUX_X64_MUSL => tmk_vmm_paravisor_path(MachineArch::X86_64),
             _ if id == tmks::TMK_VMM_LINUX_AARCH64_MUSL => tmk_vmm_paravisor_path(MachineArch::Aarch64),
             _ if id == tmks::SIMPLE_TMK_X64 => simple_tmk_path(MachineArch::X86_64),
-            _ if id == tmks::SIMPLE_TMK_AARCH64 => simple_tmk_path(MachineArch::Aarch64),
+            _ if id == tmks::SIMPLE_TMK_AARCH64 =>
+                env_path_or(OPENVMM_CCA_SIMPLE_TMK_ENV_VAR, || {
+                    simple_tmk_path(MachineArch::Aarch64)
+                }),
+
+            _ if id == cca::SHRINKWRAP => cca_shrinkwrap_path(),
+            _ if id == cca::VENV => cca_venv_path(),
+            _ if id == cca::ROOTFS => cca_package_path("rootfs.ext2", "CCA emulation rootfs"),
+            _ if id == cca::E2FSCK => cca_buildroot_host_sbin_path("e2fsck", "CCA buildroot host e2fsck"),
+            _ if id == cca::RESIZE2FS => cca_buildroot_host_sbin_path("resize2fs", "CCA buildroot host resize2fs"),
+            _ if id == cca::GUEST_DISK => cca_package_path("guest-disk.img", "CCA guest disk"),
+            _ if id == cca::PLANE0_LINUX_IMAGE => cca_plane0_linux_image_path(),
+            _ if id == cca::KVMTOOL_EFI => cca_package_path("KVMTOOL_EFI.fd", "CCA kvmtool EFI firmware"),
+            _ if id == cca::LKVM => cca_package_path("lkvm", "CCA lkvm"),
 
             _ if id == vmgstool::VMGSTOOL_NATIVE => vmgstool_native_executable_path(),
             _ if id == vmgstool::VMGSTOOL_DEV_NATIVE => vmgstool_dev_native_executable_path(),
@@ -433,6 +451,110 @@ fn virtio_win_path() -> anyhow::Result<PathBuf> {
     )
 }
 
+const OPENVMM_CCA_TEST_ROOT_ENV_VAR: &str = "OPENVMM_CCA_TEST_ROOT";
+const OPENVMM_CCA_TMK_VMM_ENV_VAR: &str = "OPENVMM_CCA_TMK_VMM";
+const OPENVMM_CCA_SIMPLE_TMK_ENV_VAR: &str = "OPENVMM_CCA_SIMPLE_TMK";
+
+fn cca_missing_command(description: &'static str) -> MissingCommand<'static> {
+    MissingCommand::XFlowey {
+        description,
+        xflowey_args: &["cca-tests", "--install-emu"],
+    }
+}
+
+fn env_path_or(
+    name: &str,
+    fallback: impl FnOnce() -> anyhow::Result<PathBuf>,
+) -> anyhow::Result<PathBuf> {
+    std::env::var_os(name)
+        .map(PathBuf::from)
+        .map(Ok)
+        .unwrap_or_else(fallback)
+}
+
+fn cca_test_root() -> PathBuf {
+    std::env::var_os(OPENVMM_CCA_TEST_ROOT_ENV_VAR)
+        .map(PathBuf::from)
+        .unwrap_or_else(|| PathBuf::from("target/cca-test"))
+}
+
+fn cca_home_dir() -> anyhow::Result<PathBuf> {
+    std::env::var_os("HOME")
+        .map(PathBuf::from)
+        .ok_or_else(|| anyhow::anyhow!("HOME is not set"))
+}
+
+fn cca_shrinkwrap_path() -> anyhow::Result<PathBuf> {
+    get_path(
+        cca_test_root().join("shrinkwrap"),
+        "shrinkwrap/shrinkwrap",
+        cca_missing_command("CCA shrinkwrap executable"),
+    )
+}
+
+fn cca_venv_path() -> anyhow::Result<PathBuf> {
+    get_path(
+        cca_test_root().join("shrinkwrap"),
+        "venv",
+        cca_missing_command("CCA shrinkwrap virtual environment"),
+    )
+}
+
+fn cca_plane0_linux_image_path() -> anyhow::Result<PathBuf> {
+    get_path(
+        cca_test_root().join("plane0-linux/arch/arm64/boot"),
+        "Image",
+        cca_missing_command("CCA Plane0 Linux image"),
+    )
+}
+
+fn cca_package_path(file_name: &'static str, description: &'static str) -> anyhow::Result<PathBuf> {
+    get_path(
+        cca_home_dir()?.join(".shrinkwrap/package/cca-3world"),
+        file_name,
+        cca_missing_command(description),
+    )
+}
+
+fn cca_buildroot_host_sbin_path(
+    file_name: &'static str,
+    description: &'static str,
+) -> anyhow::Result<PathBuf> {
+    get_path(
+        cca_home_dir()?.join(".shrinkwrap/build/build/cca-3world/buildroot/host/sbin"),
+        file_name,
+        cca_missing_command(description),
+    )
+}
+
+/// Path to the output location of the GNU/Linux tmk_vmm executable.
+fn tmk_vmm_linux_path(arch: MachineArch) -> anyhow::Result<PathBuf> {
+    let target = match arch {
+        MachineArch::X86_64 => "x86_64-unknown-linux-gnu",
+        MachineArch::Aarch64 => "aarch64-unknown-linux-gnu",
+    };
+
+    if let Some(path) = try_get_path(format!("target/{target}/debug"), "tmk_vmm")? {
+        return Ok(path);
+    }
+
+    if let Some(path) =
+        flowey_built_executable_path(format!("target/tmk_vmm/{target}/debug/deps"), "tmk_vmm")?
+    {
+        return Ok(path);
+    }
+
+    get_path(
+        format!("target/{target}/debug"),
+        "tmk_vmm",
+        MissingCommand::Build {
+            package: "tmk_vmm",
+            target: Some(target),
+        },
+    )
+}
+
+/// Path to the output location of the musl/Linux tmk_vmm executable.
 fn tmk_vmm_paravisor_path(arch: MachineArch) -> anyhow::Result<PathBuf> {
     let target = match arch {
         MachineArch::X86_64 => "x86_64-unknown-linux-musl",
@@ -458,6 +580,18 @@ fn simple_tmk_path(arch: MachineArch) -> anyhow::Result<PathBuf> {
         MachineArch::X86_64 => "x86_64-unknown-none",
         MachineArch::Aarch64 => "aarch64-minimal_rt-none",
     };
+
+    if let Some(path) = try_get_path(format!("target/{target}/debug"), "simple_tmk")? {
+        return Ok(path);
+    }
+
+    if let Some(path) = flowey_built_executable_path(
+        format!("target/simple_tmk/{target}/debug/deps"),
+        "simple_tmk",
+    )? {
+        return Ok(path);
+    }
+
     get_path(
         format!("target/{target}/debug"),
         "simple_tmk",
@@ -711,6 +845,74 @@ const VMM_TESTS_DIR_ENV_VAR: &str = "VMM_TESTS_CONTENT_DIR";
 /// Gets a path to the root of the repo.
 pub fn get_repo_root() -> anyhow::Result<PathBuf> {
     Ok(Path::new(env!("CARGO_MANIFEST_DIR")).join("../.."))
+}
+
+fn try_get_path(
+    search_path: impl AsRef<Path>,
+    file_name: impl AsRef<Path>,
+) -> anyhow::Result<Option<PathBuf>> {
+    let search_path = search_path.as_ref();
+    let file_name = file_name.as_ref();
+    if file_name.is_absolute() {
+        anyhow::bail!("{} should be a relative path", file_name.display());
+    }
+
+    if let Ok(env_dir) = std::env::var(VMM_TESTS_DIR_ENV_VAR) {
+        let full_path = Path::new(&env_dir).join(file_name);
+        if full_path.try_exists()? {
+            return Ok(Some(full_path));
+        }
+    }
+
+    let file_path = if search_path.is_absolute() {
+        search_path.to_owned()
+    } else {
+        get_repo_root()?.join(search_path)
+    };
+
+    let full_path = file_path.join(file_name);
+    Ok(full_path.try_exists()?.then_some(full_path))
+}
+
+fn flowey_built_executable_path(
+    search_path: impl AsRef<Path>,
+    binary_prefix: &str,
+) -> anyhow::Result<Option<PathBuf>> {
+    let search_path = search_path.as_ref();
+    let dir = if search_path.is_absolute() {
+        search_path.to_owned()
+    } else {
+        get_repo_root()?.join(search_path)
+    };
+
+    if !dir.is_dir() {
+        return Ok(None);
+    }
+
+    let mut candidates = Vec::new();
+    for entry in std::fs::read_dir(&dir)? {
+        let entry = entry?;
+        let path = entry.path();
+        if !path.is_file() {
+            continue;
+        }
+
+        if path.extension().is_some() {
+            continue;
+        }
+
+        let Some(file_name) = path.file_name().and_then(|name| name.to_str()) else {
+            continue;
+        };
+
+        if file_name == binary_prefix || file_name.starts_with(&format!("{binary_prefix}-")) {
+            let modified = entry.metadata()?.modified().ok();
+            candidates.push((modified, path));
+        }
+    }
+
+    candidates.sort_by_key(|(modified, _)| *modified);
+    Ok(candidates.pop().map(|(_, path)| path))
 }
 
 /// Attempts to find the given file, first checking for it relative to the test

--- a/vmm_tests/petri_artifacts_vmm_test/src/lib.rs
+++ b/vmm_tests/petri_artifacts_vmm_test/src/lib.rs
@@ -695,6 +695,32 @@ pub mod artifacts {
         }
     }
 
+    /// CCA emulation artifacts used by the CCA Petri test.
+    pub mod cca {
+        use petri_artifacts_core::declare_artifacts;
+
+        declare_artifacts! {
+            /// Arm shrinkwrap executable used to launch CCA emulation
+            SHRINKWRAP,
+            /// Python virtual environment for shrinkwrap
+            VENV,
+            /// Shrinkwrap-built CCA host rootfs image
+            ROOTFS,
+            /// Buildroot host e2fsck binary matching the CCA rootfs
+            E2FSCK,
+            /// Buildroot host resize2fs binary matching the CCA rootfs
+            RESIZE2FS,
+            /// Guest disk image passed into the Realm
+            GUEST_DISK,
+            /// Plane0 Linux kernel image
+            PLANE0_LINUX_IMAGE,
+            /// KVMTOOL EFI firmware image
+            KVMTOOL_EFI,
+            /// kvmtool binary used by the host rootfs to launch the Realm
+            LKVM,
+        }
+    }
+
     /// VmgsTool artifacts
     pub mod vmgstool {
         use petri_artifacts_common::tags::IsVmgsTool;

--- a/vmm_tests/vmm_tests/Cargo.toml
+++ b/vmm_tests/vmm_tests/Cargo.toml
@@ -14,6 +14,10 @@ harness = false
 name = "tmks"
 harness = false
 
+[[test]]
+name = "cca"
+harness = false
+
 [dev-dependencies]
 petri_artifact_resolver_openvmm_known_paths.workspace = true
 petri_artifacts_vmm_test.workspace = true

--- a/vmm_tests/vmm_tests/tests/cca.rs
+++ b/vmm_tests/vmm_tests/tests/cca.rs
@@ -1,0 +1,728 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Test entrypoint for CCA emulation tests.
+
+#![forbid(unsafe_code)]
+
+use anyhow::Context as _;
+use std::ffi::OsStr;
+use std::io::Read;
+use std::io::Write;
+use std::path::Path;
+use std::path::PathBuf;
+use std::process::Command;
+use std::process::Stdio;
+use std::sync::mpsc;
+use std::thread;
+use std::time::Duration;
+use std::time::Instant;
+
+const CCA_TEST_TIMEOUT: Duration = Duration::from_secs(20 * 60);
+const CCA_TEST_SUCCESS_MARKER: &str = "PASS";
+const CCA_PLANE0_PROMPT: &str = "sh-5.2#";
+const CCA_START_TMK_COMMAND: &str = "/root/busybox sh /root/start-tmk.sh";
+const CCA_OUTPUT_WINDOW_SIZE: usize = 64 * 1024;
+const CCA_TEST_FAILURE_MARKERS: &[&str] = &[
+    "test failed",
+    "some tests failed",
+    "[realm-launch][ERROR]",
+    "Kernel panic",
+    "panicked at",
+];
+
+struct CcaRuntimeArtifacts {
+    shrinkwrap_exe: petri::ResolvedArtifact,
+    venv_dir: petri::ResolvedArtifact,
+    rootfs_file: petri::ResolvedArtifact,
+    e2fsck_bin: petri::ResolvedArtifact,
+    resize2fs_bin: petri::ResolvedArtifact,
+    tmk_vmm_bin: petri::ResolvedArtifact,
+    simple_tmk_bin: petri::ResolvedArtifact,
+    guest_disk: petri::ResolvedArtifact,
+    plane0_linux_image: petri::ResolvedArtifact,
+    kvmtool_efi: petri::ResolvedArtifact,
+    lkvm: petri::ResolvedArtifact,
+}
+
+impl CcaRuntimeArtifacts {
+    fn validate(&self) -> anyhow::Result<()> {
+        for (name, path) in self.paths() {
+            if !path.exists() {
+                anyhow::bail!("{name} points to missing path {}", path.display());
+            }
+
+            tracing::info!(artifact = name, path = %path.display(), "resolved CCA runtime artifact");
+        }
+
+        Ok(())
+    }
+
+    fn paths(&self) -> [(&'static str, &Path); 11] {
+        [
+            ("cca::SHRINKWRAP", self.shrinkwrap_exe.get()),
+            ("cca::VENV", self.venv_dir.get()),
+            ("cca::ROOTFS", self.rootfs_file.get()),
+            ("cca::E2FSCK", self.e2fsck_bin.get()),
+            ("cca::RESIZE2FS", self.resize2fs_bin.get()),
+            ("tmks::TMK_VMM_LINUX_AARCH64", self.tmk_vmm_bin.get()),
+            ("tmks::SIMPLE_TMK_AARCH64", self.simple_tmk_bin.get()),
+            ("cca::GUEST_DISK", self.guest_disk.get()),
+            ("cca::PLANE0_LINUX_IMAGE", self.plane0_linux_image.get()),
+            ("cca::KVMTOOL_EFI", self.kvmtool_efi.get()),
+            ("cca::LKVM", self.lkvm.get()),
+        ]
+    }
+}
+
+fn resolve_cca_runtime(resolver: &petri::ArtifactResolver<'_>) -> Option<CcaRuntimeArtifacts> {
+    Some(CcaRuntimeArtifacts {
+        shrinkwrap_exe: resolver
+            .require(petri_artifacts_vmm_test::artifacts::cca::SHRINKWRAP)
+            .erase(),
+        venv_dir: resolver
+            .require(petri_artifacts_vmm_test::artifacts::cca::VENV)
+            .erase(),
+        rootfs_file: resolver
+            .require(petri_artifacts_vmm_test::artifacts::cca::ROOTFS)
+            .erase(),
+        e2fsck_bin: resolver
+            .require(petri_artifacts_vmm_test::artifacts::cca::E2FSCK)
+            .erase(),
+        resize2fs_bin: resolver
+            .require(petri_artifacts_vmm_test::artifacts::cca::RESIZE2FS)
+            .erase(),
+        tmk_vmm_bin: resolver
+            .require(petri_artifacts_vmm_test::artifacts::tmks::TMK_VMM_LINUX_AARCH64)
+            .erase(),
+        simple_tmk_bin: resolver
+            .require(petri_artifacts_vmm_test::artifacts::tmks::SIMPLE_TMK_AARCH64)
+            .erase(),
+        guest_disk: resolver
+            .require(petri_artifacts_vmm_test::artifacts::cca::GUEST_DISK)
+            .erase(),
+        plane0_linux_image: resolver
+            .require(petri_artifacts_vmm_test::artifacts::cca::PLANE0_LINUX_IMAGE)
+            .erase(),
+        kvmtool_efi: resolver
+            .require(petri_artifacts_vmm_test::artifacts::cca::KVMTOOL_EFI)
+            .erase(),
+        lkvm: resolver
+            .require(petri_artifacts_vmm_test::artifacts::cca::LKVM)
+            .erase(),
+    })
+}
+
+fn cca_runtime(
+    params: petri::PetriTestParams<'_>,
+    artifacts: CcaRuntimeArtifacts,
+) -> anyhow::Result<()> {
+    artifacts.validate()?;
+    let rootfs = prepare_cca_rootfs(&artifacts)?;
+    tracing::info!("launching openvmm cca tests...");
+
+    let venv_bin_path = format!(
+        "{}:{}",
+        artifacts.venv_dir.get().join("bin").display(),
+        std::env::var("PATH").unwrap_or_default()
+    );
+    run_shrinkwrap_cca_test(
+        artifacts.shrinkwrap_exe.get(),
+        artifacts.venv_dir.get(),
+        rootfs.path(),
+        &venv_bin_path,
+        params.logger.log_file("shrinkwrap_stdout")?,
+        params.logger.log_file("shrinkwrap_stderr")?,
+    )?;
+
+    tracing::info!("openvmm cca tests finished");
+
+    Ok(())
+}
+
+struct PreparedCcaRootfs {
+    test_dir: tempfile::TempDir,
+    rootfs_path: PathBuf,
+}
+
+impl PreparedCcaRootfs {
+    fn path(&self) -> &Path {
+        debug_assert!(self.rootfs_path.starts_with(self.test_dir.path()));
+        &self.rootfs_path
+    }
+}
+
+fn prepare_cca_rootfs(artifacts: &CcaRuntimeArtifacts) -> anyhow::Result<PreparedCcaRootfs> {
+    let test_dir = tempfile::tempdir().context("failed to create CCA runtime test directory")?;
+    let rootfs_path = test_dir.path().join("rootfs.ext2");
+    std::fs::copy(artifacts.rootfs_file.get(), &rootfs_path).with_context(|| {
+        format!(
+            "failed to copy CCA rootfs from {} to {}",
+            artifacts.rootfs_file.get().display(),
+            rootfs_path.display()
+        )
+    })?;
+    tracing::info!(
+        source = %artifacts.rootfs_file.get().display(),
+        rootfs = %rootfs_path.display(),
+        "copied CCA rootfs for test run"
+    );
+
+    fsck_rootfs(artifacts.e2fsck_bin.get(), &rootfs_path)?;
+    tracing::info!("e2fsck finished");
+
+    resize_rootfs(artifacts.resize2fs_bin.get(), &rootfs_path, "1024M")?;
+    tracing::info!("resize rootfs to 1024M finished");
+
+    let cca_files = [
+        (artifacts.simple_tmk_bin.get(), "simple_tmk"),
+        (artifacts.tmk_vmm_bin.get(), "tmk_vmm"),
+        (artifacts.guest_disk.get(), "guest-disk.img"),
+        (artifacts.plane0_linux_image.get(), "Image"),
+        (artifacts.kvmtool_efi.get(), "KVMTOOL_EFI.fd"),
+        (artifacts.lkvm.get(), "lkvm"),
+    ];
+    inject_files_into_cca_rootfs(&rootfs_path, &cca_files)?;
+
+    tracing::info!(
+        "rootfs.ext2 updated successfully with cca firmwares, paravisor, and tests injected"
+    );
+
+    Ok(PreparedCcaRootfs {
+        test_dir,
+        rootfs_path,
+    })
+}
+
+fn fsck_rootfs(e2fsck_bin: &Path, rootfs_file: &Path) -> anyhow::Result<()> {
+    let status = Command::new(e2fsck_bin)
+        .arg("-fp")
+        .arg(rootfs_file)
+        .status()
+        .with_context(|| format!("failed to execute {}", e2fsck_bin.display()))?;
+
+    // e2fsck returns 1 when filesystem errors were found and corrected,
+    // which is common after killing the FVP and leaving the rootfs dirty.
+    match status.code() {
+        Some(0 | 1) => Ok(()),
+        Some(code) => anyhow::bail!("e2fsck failed with exit code {code}"),
+        None => anyhow::bail!("e2fsck was terminated by signal"),
+    }
+}
+
+fn resize_rootfs(resize2fs_bin: &Path, rootfs_file: &Path, size: &str) -> anyhow::Result<()> {
+    let status = Command::new(resize2fs_bin)
+        .arg(rootfs_file)
+        .arg(size)
+        .status()
+        .with_context(|| format!("failed to execute {}", resize2fs_bin.display()))?;
+
+    if !status.success() {
+        anyhow::bail!("resize2fs failed with exit status {status}");
+    }
+
+    Ok(())
+}
+
+fn run_sudo(description: &str, args: &[&OsStr]) -> anyhow::Result<()> {
+    let status = Command::new("sudo")
+        .arg("-n")
+        .args(args)
+        .status()
+        .with_context(|| format!("failed to execute sudo command to {description}"))?;
+
+    if !status.success() {
+        anyhow::bail!(
+            "failed to {description}: exit status {status}; CCA tests require non-interactive sudo for rootfs mount/injection commands. Configure passwordless sudo for the required commands or run in an environment where sudo -n is allowed."
+        );
+    }
+
+    Ok(())
+}
+
+fn inject_files_into_cca_rootfs(rootfs_file: &Path, files: &[(&Path, &str)]) -> anyhow::Result<()> {
+    let mount_dir = tempfile::tempdir().context("failed to create guest rootfs mount directory")?;
+    let mnt_dir = mount_dir.path().to_path_buf();
+    let cca_dir = mnt_dir.join("cca");
+
+    let mut mounted = false;
+    let inject_result = (|| -> anyhow::Result<()> {
+        run_sudo(
+            "mount guest rootfs",
+            &[
+                OsStr::new("mount"),
+                OsStr::new("-o"),
+                OsStr::new("loop"),
+                rootfs_file.as_os_str(),
+                mnt_dir.as_os_str(),
+            ],
+        )?;
+        mounted = true;
+
+        run_sudo(
+            "create cca directory in guest rootfs",
+            &[OsStr::new("mkdir"), OsStr::new("-p"), cca_dir.as_os_str()],
+        )?;
+
+        for (file, file_name) in files {
+            let target_file = cca_dir.join(file_name);
+            run_sudo(
+                &format!(
+                    "copy {} into guest rootfs as {}",
+                    file.display(),
+                    target_file.display()
+                ),
+                &[OsStr::new("cp"), file.as_os_str(), target_file.as_os_str()],
+            )?;
+        }
+
+        run_sudo("sync guest rootfs writes", &[OsStr::new("sync")])?;
+
+        Ok(())
+    })();
+
+    if mounted {
+        if let Err(err) = run_sudo(
+            "unmount guest rootfs",
+            &[OsStr::new("umount"), mnt_dir.as_os_str()],
+        )
+        .or_else(|_| {
+            run_sudo(
+                "lazy unmount guest rootfs",
+                &[OsStr::new("umount"), OsStr::new("-l"), mnt_dir.as_os_str()],
+            )
+        }) {
+            tracing::warn!(error = err.as_ref() as &dyn std::error::Error, "{err:#}");
+        }
+    }
+
+    if let Err(err) = run_sudo("sync host writes", &[OsStr::new("sync")]) {
+        tracing::warn!(error = err.as_ref() as &dyn std::error::Error, "{err:#}");
+    }
+
+    thread::sleep(Duration::from_secs(1));
+    for _ in 0..5 {
+        if !mnt_dir.is_dir() {
+            break;
+        }
+
+        if run_sudo(
+            "remove guest rootfs mount directory",
+            &[OsStr::new("rmdir"), mnt_dir.as_os_str()],
+        )
+        .is_ok()
+        {
+            break;
+        }
+
+        thread::sleep(Duration::from_millis(500));
+    }
+
+    if mnt_dir.is_dir() {
+        if let Err(err) = run_sudo(
+            "force remove guest rootfs mount directory",
+            &[OsStr::new("rm"), OsStr::new("-rf"), mnt_dir.as_os_str()],
+        ) {
+            tracing::warn!(error = err.as_ref() as &dyn std::error::Error, "{err:#}");
+        }
+    }
+
+    inject_result.with_context(|| "failed to mount or inject files into guest rootfs")
+}
+
+fn run_shrinkwrap_cca_test(
+    shrinkwrap_exe: &Path,
+    venv_dir: &Path,
+    rootfs_file: &Path,
+    venv_bin_path: &str,
+    stdout_log: petri::PetriLogFile,
+    stderr_log: petri::PetriLogFile,
+) -> anyhow::Result<()> {
+    let mut emu = start_cca_emulator(
+        shrinkwrap_exe,
+        venv_dir,
+        rootfs_file,
+        venv_bin_path,
+        stdout_log,
+        stderr_log,
+    )?;
+
+    emu.wait_for(CCA_PLANE0_PROMPT)?;
+    emu.send_line(CCA_START_TMK_COMMAND)?;
+    emu.wait_for(CCA_TEST_SUCCESS_MARKER)?;
+    // Need to manually kill FVP processes for the petri test since shrinkwrap doesn't wait
+    // for them to exit and they can interfere with subsequent test runs if left running
+    stop_fvp_processes_for_rootfs(rootfs_file)?;
+
+    let status = emu
+        .stop()
+        .context("failed to stop shrinkwrap after CCA test completed")?;
+    tracing::info!("CCA test passed; stopped shrinkwrap process with status {status}");
+
+    Ok(())
+}
+
+fn stop_fvp_processes_for_rootfs(rootfs_file: &Path) -> anyhow::Result<()> {
+    let output = Command::new("pgrep")
+        .arg("-f")
+        .arg(rootfs_file)
+        .output()
+        .context("failed to execute pgrep for CCA FVP process")?;
+
+    match output.status.code() {
+        Some(0) => {}
+        Some(1) => {
+            tracing::warn!(rootfs = %rootfs_file.display(), "found no FVP process for CCA test rootfs");
+            return Ok(());
+        }
+        Some(code) => anyhow::bail!("pgrep for CCA FVP process failed with exit code {code}"),
+        None => anyhow::bail!("pgrep for CCA FVP process was terminated by signal"),
+    }
+
+    let stdout = String::from_utf8(output.stdout).context("pgrep output was not utf-8")?;
+    for line in stdout.lines() {
+        let pid = line
+            .parse::<u32>()
+            .with_context(|| format!("failed to parse pgrep pid `{line}`"))?;
+        tracing::info!(pid, rootfs = %rootfs_file.display(), "found CCA FVP process for test rootfs");
+        terminate_process(pid, "TERM")?;
+    }
+
+    Ok(())
+}
+
+fn terminate_process(pid: u32, signal: &str) -> anyhow::Result<()> {
+    let status = Command::new("kill")
+        .arg(format!("-{signal}"))
+        .arg(pid.to_string())
+        .status()
+        .with_context(|| format!("failed to execute kill -{signal} {pid}"))?;
+
+    match status.code() {
+        Some(0) => {
+            tracing::info!(pid, signal, "sent signal to CCA FVP process");
+            Ok(())
+        }
+        Some(1) => {
+            tracing::warn!(pid, signal, "CCA FVP process was already gone");
+            Ok(())
+        }
+        Some(code) => anyhow::bail!("kill -{signal} {pid} failed with exit code {code}"),
+        None => anyhow::bail!("kill -{signal} {pid} was terminated by signal"),
+    }
+}
+
+fn start_cca_emulator(
+    shrinkwrap_exe: &Path,
+    venv_dir: &Path,
+    rootfs_file: &Path,
+    venv_bin_path: &str,
+    stdout_log: petri::PetriLogFile,
+    stderr_log: petri::PetriLogFile,
+) -> anyhow::Result<CcaEmulator> {
+    let child = Command::new(shrinkwrap_exe)
+        .args(["run", "cca-3world.yaml", "--rtvar"])
+        .arg(format!("ROOTFS={}", rootfs_file.display()))
+        .env("VIRTUAL_ENV", venv_dir)
+        .env("PATH", venv_bin_path)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .with_context(|| "failed to launch guest using shrinkwrap")?;
+    let mut child = ChildGuard::new(child);
+
+    let stdin = child
+        .as_mut()
+        .stdin
+        .take()
+        .context("failed to capture shrinkwrap stdin")?;
+    let stdout = child
+        .as_mut()
+        .stdout
+        .take()
+        .context("failed to capture shrinkwrap stdout")?;
+    let stderr = child
+        .as_mut()
+        .stderr
+        .take()
+        .context("failed to capture shrinkwrap stderr")?;
+    let (output_send, output_recv) = mpsc::channel::<String>();
+
+    spawn_output_reader("shrinkwrap stdout", stdout, stdout_log, output_send.clone());
+    spawn_output_reader("shrinkwrap stderr", stderr, stderr_log, output_send.clone());
+    drop(output_send);
+
+    Ok(CcaEmulator {
+        child,
+        stdin,
+        output_recv,
+        output: String::new(),
+        started: Instant::now(),
+    })
+}
+
+struct ChildGuard {
+    child: Option<std::process::Child>,
+}
+
+impl ChildGuard {
+    fn new(child: std::process::Child) -> Self {
+        Self { child: Some(child) }
+    }
+
+    fn as_mut(&mut self) -> &mut std::process::Child {
+        self.child.as_mut().expect("shrinkwrap child is missing")
+    }
+
+    fn kill_and_wait(&mut self) -> anyhow::Result<std::process::ExitStatus> {
+        let Some(mut child) = self.child.take() else {
+            anyhow::bail!("shrinkwrap child is missing");
+        };
+
+        let _ = child.kill();
+        child
+            .wait()
+            .context("failed to wait for shrinkwrap process")
+    }
+}
+
+impl Drop for ChildGuard {
+    fn drop(&mut self) {
+        if let Some(mut child) = self.child.take() {
+            let _ = child.kill();
+            let _ = child.wait();
+        }
+    }
+}
+
+struct CcaEmulator {
+    child: ChildGuard,
+    stdin: std::process::ChildStdin,
+    output_recv: mpsc::Receiver<String>,
+    output: String,
+    started: Instant,
+}
+
+impl CcaEmulator {
+    fn wait_for(&mut self, marker: &str) -> anyhow::Result<()> {
+        tracing::info!(marker, "waiting for CCA emulator output");
+
+        loop {
+            if self.output.contains(marker) {
+                tracing::info!(marker, "observed CCA emulator output");
+                return Ok(());
+            }
+
+            if let Some(failure_marker) = CCA_TEST_FAILURE_MARKERS
+                .iter()
+                .find(|marker| self.output.contains(**marker))
+            {
+                anyhow::bail!(
+                    "CCA test failed after observing failure marker `{failure_marker}` while waiting for `{marker}`"
+                );
+            }
+
+            if let Some(status) = self.child.as_mut().try_wait()? {
+                anyhow::bail!(
+                    "shrinkwrap exited before CCA emulator output `{marker}` was observed: {status}"
+                );
+            }
+
+            let remaining = CCA_TEST_TIMEOUT
+                .checked_sub(self.started.elapsed())
+                .unwrap_or(Duration::ZERO);
+            if remaining.is_zero() {
+                let _ = self.child.kill_and_wait();
+                anyhow::bail!("timed out waiting for CCA emulator output `{marker}`");
+            }
+
+            match self
+                .output_recv
+                .recv_timeout(remaining.min(Duration::from_millis(500)))
+            {
+                Ok(output) => self.append_output(&output),
+                Err(mpsc::RecvTimeoutError::Timeout) => {}
+                Err(mpsc::RecvTimeoutError::Disconnected) => {
+                    let status = if let Some(status) = self.child.as_mut().try_wait()? {
+                        status
+                    } else {
+                        self.child.kill_and_wait().with_context(|| {
+                            format!(
+                                "failed to stop shrinkwrap after output ended while waiting for `{marker}`"
+                            )
+                        })?
+                    };
+                    anyhow::bail!(
+                        "shrinkwrap output ended before CCA emulator output `{marker}` was observed: {status}"
+                    );
+                }
+            }
+        }
+    }
+
+    fn append_output(&mut self, output: &str) {
+        self.output.push_str(output);
+
+        if self.output.len() <= CCA_OUTPUT_WINDOW_SIZE {
+            return;
+        }
+
+        let drain_len = self.output.len() - CCA_OUTPUT_WINDOW_SIZE;
+        let drain_to = self
+            .output
+            .char_indices()
+            .map(|(idx, _)| idx)
+            .find(|idx| *idx >= drain_len)
+            .unwrap_or(self.output.len());
+        self.output.drain(..drain_to);
+    }
+
+    fn send_line(&mut self, line: &str) -> anyhow::Result<()> {
+        tracing::info!(line, "sending CCA emulator command");
+        writeln!(self.stdin, "{line}").context("failed to write command to shrinkwrap stdin")?;
+        self.stdin
+            .flush()
+            .context("failed to flush command to shrinkwrap stdin")
+    }
+
+    fn stop(mut self) -> anyhow::Result<std::process::ExitStatus> {
+        self.child.kill_and_wait()
+    }
+}
+
+enum OutputEvent {
+    Byte(u8),
+    Eof,
+    Error(String),
+}
+
+fn spawn_output_reader(
+    stream_name: &'static str,
+    mut stream: impl Read + Send + 'static,
+    log_file: petri::PetriLogFile,
+    output_send: mpsc::Sender<String>,
+) {
+    let (byte_send, byte_recv) = mpsc::channel();
+
+    thread::spawn(move || {
+        let mut byte = [0];
+
+        loop {
+            let event = match stream.read(&mut byte) {
+                Ok(0) => OutputEvent::Eof,
+                Ok(_) => OutputEvent::Byte(byte[0]),
+                Err(err) => OutputEvent::Error(format!("failed to read {stream_name}: {err}")),
+            };
+
+            let done = matches!(event, OutputEvent::Eof | OutputEvent::Error(_));
+            if byte_send.send(event).is_err() || done {
+                break;
+            }
+        }
+    });
+
+    thread::spawn(move || {
+        let mut line = Vec::new();
+        let mut logged_len = 0;
+
+        loop {
+            match byte_recv.recv_timeout(Duration::from_millis(100)) {
+                Ok(OutputEvent::Byte(b'\n')) => {
+                    if line.ends_with(b"\r") {
+                        line.pop();
+                    }
+                    let line_was_empty = line.is_empty();
+                    write_output_line(&log_file, &output_send, &mut line, &mut logged_len);
+                    write_output_newline(&log_file, &output_send, line_was_empty);
+                }
+                Ok(OutputEvent::Byte(byte)) => {
+                    line.push(byte);
+                    write_visible_output(&line, &mut logged_len, &output_send);
+                }
+                Ok(OutputEvent::Eof) => {
+                    write_output_line(&log_file, &output_send, &mut line, &mut logged_len);
+                    break;
+                }
+                Ok(OutputEvent::Error(line)) => {
+                    log_file.write_entry(&line);
+                    let _ = output_send.send(line);
+                    break;
+                }
+                Err(mpsc::RecvTimeoutError::Timeout) => {
+                    write_visible_output(&line, &mut logged_len, &output_send);
+                }
+                Err(mpsc::RecvTimeoutError::Disconnected) => {
+                    write_output_line(&log_file, &output_send, &mut line, &mut logged_len);
+                    break;
+                }
+            }
+        }
+    });
+}
+
+fn write_output_line(
+    log_file: &petri::PetriLogFile,
+    output_send: &mpsc::Sender<String>,
+    line: &mut Vec<u8>,
+    logged_len: &mut usize,
+) {
+    if line.is_empty() {
+        return;
+    }
+
+    write_visible_output(line, logged_len, output_send);
+
+    let line_string = String::from_utf8_lossy(line).into_owned();
+    log_file.write_entry(&line_string);
+    line.clear();
+    *logged_len = 0;
+}
+
+fn write_output_newline(
+    log_file: &petri::PetriLogFile,
+    output_send: &mpsc::Sender<String>,
+    line_was_empty: bool,
+) {
+    let _ = std::io::stdout().write_all(b"\n");
+    let _ = std::io::stdout().flush();
+    let _ = output_send.send("\n".to_owned());
+
+    if line_was_empty {
+        log_file.write_entry("");
+    }
+}
+
+fn write_visible_output(line: &[u8], logged_len: &mut usize, output_send: &mpsc::Sender<String>) {
+    if *logged_len >= line.len() {
+        return;
+    }
+
+    let output = &line[*logged_len..];
+    let _ = std::io::stdout().write_all(output);
+    let _ = std::io::stdout().flush();
+    let _ = output_send.send(String::from_utf8_lossy(output).into_owned());
+    *logged_len = line.len();
+}
+
+petri::multitest!(vec![
+    petri::SimpleTest::new(
+        "cca_runtime",
+        resolve_cca_runtime,
+        cca_runtime,
+        None,
+        false,
+        petri::RemoteAccess::LocalOnly,
+    )
+    .into()
+]);
+
+fn main() {
+    petri::test_main(|name, requirements| {
+        requirements.resolve(
+            petri_artifact_resolver_openvmm_known_paths::OpenvmmKnownPathsTestArtifactResolver::new(
+                name,
+            ),
+        )
+    })
+}


### PR DESCRIPTION
Add a CCA Petri test target that prepares a temporary CCA rootfs, injects the Plane0 test artifacts, launches the shrinkwrap/FVP emulation, waits for the Plane0 shell, runs the TMK test command, and waits for the PASS marker.

Move the CCA runtime execution out of the Flowey job and into the Petri test so the flow can reuse the existing vmm_tests artifact resolver and test harness. Flowey now builds tmk_vmm and simple_tmk, passes their paths through OPENVMM_CCA_* environment variables, and invokes the CCA Petri test.

Teach the OpenVMM known-path artifact resolver about the CCA shrinkwrap artifacts and AArch64 TMK binaries, including Flowey-built output locations, so the test can be run either from xflowey or directly with cargo test.

Also add a --build-only mode to compile the CCA test artifacts without launching the Petri emulator run.

After the PASS marker is observed, force-stop the FVP emulator for the Petri test so emulator processes do not keep running and hold memory after the test completes.

e.g.
// only build the CCA test artifacts but no petri run 
cargo xflowey cca-tests --update-emu --rebuild-rootfs --build-only

// run CCA test petri test
cargo test -p vmm_tests --test cca -- --exact cca_runtime