### PR TITLE
petri/logview: bump react-router to 7.15.0 to fix CVEs

### DIFF
--- a/petri/logview/package-lock.json
+++ b/petri/logview/package-lock.json
@@ -2392,9 +2392,9 @@
       }
     },
     "node_modules/react-router": {
-      "version": "7.14.0",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.14.0.tgz",
-      "integrity": "sha512-m/xR9N4LQLmAS0ZhkY2nkPA1N7gQ5TUVa5n8TgANuDTARbn1gt+zLPXEm7W0XDTbrQ2AJSJKhoa6yx1D8BcpxQ==",
+      "version": "7.15.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.15.0.tgz",
+      "integrity": "sha512-HW9vYwuM8f4yx66Izy8xfrzCM+SBJluoZcCbww9A1TySax11S5Vgw6fi3ZjMONw9J4gQwngL7PzkyIpJJpJ7RQ==",
       "license": "MIT",
       "dependencies": {
         "cookie": "^1.0.1",
@@ -2414,12 +2414,12 @@
       }
     },
     "node_modules/react-router-dom": {
-      "version": "7.14.0",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.14.0.tgz",
-      "integrity": "sha512-2G3ajSVSZMEtmTjIklRWlNvo8wICEpLihfD/0YMDxbWK2UyP5EGfnoIn9AIQGnF3G/FX0MRbHXdFcD+rL1ZreQ==",
+      "version": "7.15.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.15.0.tgz",
+      "integrity": "sha512-VcrVg64Fo8nwBvDscajG8gRTLIuTC6N50nb22l2HOOV4PTOHgoGp8mUjy9wLiHYoYTSYI36tUnXZgasSRFZorQ==",
       "license": "MIT",
       "dependencies": {
-        "react-router": "7.14.0"
+        "react-router": "7.15.0"
       },
       "engines": {
         "node": ">=20.0.0"


### PR DESCRIPTION
Bumps `react-router`/`react-router-dom` from 7.14.0 to 7.15.0 in `petri/logview` to resolve three advisories flagged against the older version:

- CVE-2026-42211
- CVE-2026-42342 (GHSA-8x6r-g9mw-2r78, DoS via unbounded path expansion in the `__manifest` endpoint) — first patched in **7.15.0**
- CVE-2026-40181

7.15.0 is within the existing `^7.12.0` range, so only `package-lock.json` changes. `npm audit` reports 0 vulnerabilities afterward, and `npm install --package-lock-only` produces no further changes (lockfile is consistent).