### PR TITLE
petri: require opt-in for unstable failures

### DIFF
--- a/Guide/src/dev_guide/tests/vmm.md
+++ b/Guide/src/dev_guide/tests/vmm.md
@@ -78,9 +78,8 @@ reported as a failure like any other test.
 To promote an unstable test to stable, remove `unstable` from the macro. This is
 a single-place change — no CI or configuration updates are required.
 
-To ignore these `unstable` tags and report unstable failures as passing when
-running locally (matching the CI behavior), set the following environment
-variable: `PETRI_IGNORE_UNSTABLE_FAILURES=1`
+To suppress failures from `unstable` tests when running locally (matching the CI
+behavior), set the following environment variable: `PETRI_IGNORE_UNSTABLE_FAILURES=1`
 
 ## Running VMM Tests (Flowey)
 

--- a/Guide/src/dev_guide/tests/vmm.md
+++ b/Guide/src/dev_guide/tests/vmm.md
@@ -72,13 +72,15 @@ async fn my_test<T: PetriVmmBackend>(config: PetriVmBuilder<T>) -> anyhow::Resul
 ```
 
 Unstable tests run in the same CI job as stable tests. When an unstable test fails
-the CI run will pass with a warning
+the CI run will pass with a warning. Outside of CI, an unstable test failure is
+reported as a failure like any other test.
 
 To promote an unstable test to stable, remove `unstable` from the macro. This is
 a single-place change — no CI or configuration updates are required.
 
-To ignore these `unstable` tags and report failures for all tests when running
-locally, set the following environment variable: `PETRI_REPORT_UNSTABLE_FAIL=1`
+To ignore these `unstable` tags and report unstable failures as passing when
+running locally (matching the CI behavior), set the following environment
+variable: `PETRI_IGNORE_UNSTABLE_FAILURES=1`
 
 ## Running VMM Tests (Flowey)
 

--- a/flowey/flowey_lib_hvlite/src/init_vmm_tests_env.rs
+++ b/flowey/flowey_lib_hvlite/src/init_vmm_tests_env.rs
@@ -150,6 +150,11 @@ impl SimpleFlowNode for Node {
 
         let virtio_win_dir = ctx.reqv(crate::resolve_openvmm_test_virtio_win::Request::Get);
 
+        // In CI, unstable test failures are non-gating and should be reported as
+        // passing (with a warning). Outside of CI, unstable test failures are
+        // reported as failures unless the user explicitly opts in.
+        let ignore_unstable_failures = !matches!(ctx.backend(), FlowBackend::Local);
+
         ctx.emit_rust_step("setting up vmm_tests env", |ctx| {
             let test_content_dir = test_content_dir.claim(ctx);
             let get_env = get_env.claim(ctx);
@@ -281,6 +286,10 @@ impl SimpleFlowNode for Node {
 
                 if reuse_prepped_vhds {
                     env.insert("PETRI_REUSE_PREPPED_VHDS".into(), "1".into());
+                }
+
+                if ignore_unstable_failures {
+                    env.insert("PETRI_IGNORE_UNSTABLE_FAILURES".into(), "1".into());
                 }
 
                 if let Some(openvmm) = openvmm {

--- a/petri/src/test.rs
+++ b/petri/src/test.rs
@@ -205,9 +205,9 @@ impl Test {
             Ok(()) => Ok(()),
             Err(err)
                 if self.test.0.unstable()
-                    && std::env::var("PETRI_REPORT_UNSTABLE_FAIL")
+                    && std::env::var("PETRI_IGNORE_UNSTABLE_FAILURES")
                         .ok()
-                        .is_none_or(|v| v.is_empty() || v == "0") =>
+                        .is_some_and(|v| !v.is_empty() && v != "0") =>
             {
                 tracing::warn!("ignoring unstable test failure: {err:#}");
                 Ok(())


### PR DESCRIPTION
Unstable VMM tests are meant to stay non-gating in CI, but that behavior is too permissive for local runs because it hides failures by default. Make the failure suppression explicit behind an environment variable, keep CI opted in automatically, and update the VMM test docs to describe the new default behavior.

Set `PETRI_IGNORE_UNSTABLE_FAILURES=1` to get the old behavior.