### PR TITLE
net_consomme: skip source rewriting on loopback endpoints

### DIFF
--- a/vm/devices/net/net_consomme/consomme/src/lib.rs
+++ b/vm/devices/net/net_consomme/consomme/src/lib.rs
@@ -183,7 +183,13 @@ pub struct ConsommeParams {
     /// Per-connection TCP transmit ring buffer bounds (host-to-guest).
     pub tcp_tx_buffer: TcpBufferBounds,
     /// True if this endpoint is dedicated to loopback traffic (its `client_ip`
-    /// is a loopback address), set when the [`Consomme`] instance is created.
+    /// is a loopback address).
+    ///
+    /// This is a derived field: it is computed from `client_ip` by
+    /// [`refresh_derived`](Self::refresh_derived), which runs when the
+    /// [`Consomme`] instance is created and whenever the parameters are updated
+    /// at runtime. Callers that mutate `client_ip` directly must call
+    /// `refresh_derived` to keep it in sync.
     ///
     /// Such endpoints carry localhost traffic and the guest routes loopback
     /// replies back through this adapter, so the host-source virtual address

--- a/vm/devices/net/net_consomme/consomme/src/lib.rs
+++ b/vm/devices/net/net_consomme/consomme/src/lib.rs
@@ -182,6 +182,21 @@ pub struct ConsommeParams {
     pub tcp_rx_buffer: TcpBufferBounds,
     /// Per-connection TCP transmit ring buffer bounds (host-to-guest).
     pub tcp_tx_buffer: TcpBufferBounds,
+    /// True if this endpoint is dedicated to loopback traffic, i.e. its own
+    /// client address is a loopback address.
+    ///
+    /// Such an endpoint exists specifically to carry localhost traffic between
+    /// the host and guest, and the guest is configured to route replies to
+    /// loopback source addresses back out through this adapter (for example, via
+    /// a dedicated policy-routing table). For these endpoints the local-source
+    /// virtual address rewriting must be skipped: rewriting the source to an
+    /// address outside the loopback range causes the guest's reply to miss that
+    /// routing and never reach the gateway, breaking the connection.
+    ///
+    /// This is derived from `client_ip` when the [`Consomme`] instance is
+    /// created.
+    #[inspect(display)]
+    pub is_loopback_adapter: bool,
 }
 
 /// Bounds for a per-connection TCP ring buffer.
@@ -243,6 +258,7 @@ impl ConsommeParams {
             skip_ipv6_checks: false,
             tcp_rx_buffer: DEFAULT_TCP_BUFFER_BOUNDS,
             tcp_tx_buffer: DEFAULT_TCP_BUFFER_BOUNDS,
+            is_loopback_adapter: false,
         })
     }
 
@@ -342,20 +358,6 @@ impl ConsommeParams {
             }
         }
     }
-
-    /// Returns true if this endpoint is dedicated to loopback traffic, i.e. its
-    /// own client address is a loopback address.
-    ///
-    /// Such an endpoint exists specifically to carry localhost traffic between
-    /// the host and guest, and the guest is configured to route replies to
-    /// loopback source addresses back out through this adapter (for example, via
-    /// a dedicated policy-routing table). For these endpoints the local-source
-    /// virtual address rewriting must be skipped: rewriting the source to an
-    /// address outside the loopback range causes the guest's reply to miss that
-    /// routing and never reach the gateway, breaking the connection.
-    fn is_loopback_endpoint(&self) -> bool {
-        self.client_ip.is_loopback()
-    }
 }
 
 impl ConsommeState {
@@ -410,7 +412,7 @@ impl ConsommeState {
         // the source out of the loopback range would break that return path.
         let src = match remote_addr {
             SocketAddr::V4(v4)
-                if params.is_local_address(remote_addr) && !params.is_loopback_endpoint() =>
+                if params.is_local_address(remote_addr) && !params.is_loopback_adapter =>
             {
                 let subnet_base =
                     Ipv4Addr::from(u32::from(params.gateway_ip) & u32::from(params.net_mask));
@@ -430,7 +432,7 @@ impl ConsommeState {
                 }
             }
             SocketAddr::V6(v6)
-                if params.is_local_address(remote_addr) && !params.is_loopback_endpoint() =>
+                if params.is_local_address(remote_addr) && !params.is_loopback_adapter =>
             {
                 let virtual_ip = local_addr_map.get_or_allocate_v6(
                     *v6.ip(),
@@ -725,6 +727,11 @@ fn is_routable_ipv6(addr: &std::net::Ipv6Addr) -> bool {
 impl Consomme {
     /// Creates a new consomme instance with specified state.
     pub fn new(mut params: ConsommeParams) -> Self {
+        // Derive whether this endpoint is dedicated to loopback traffic from its
+        // client address, so the host-originated source rewriting can be skipped
+        // for it (see `ConsommeParams::is_loopback_adapter`).
+        params.is_loopback_adapter = params.client_ip.is_loopback();
+
         let host_has_ipv6 = if params.skip_ipv6_checks {
             true
         } else {

--- a/vm/devices/net/net_consomme/consomme/src/lib.rs
+++ b/vm/devices/net/net_consomme/consomme/src/lib.rs
@@ -352,6 +352,17 @@ impl ConsommeParams {
             }
         }
     }
+
+    /// Recomputes fields derived from other parameters (currently
+    /// [`is_loopback_adapter`](Self::is_loopback_adapter), derived from
+    /// `client_ip`).
+    ///
+    /// Called when a [`Consomme`] instance is created and whenever the
+    /// parameters are updated at runtime, so the derived state stays in sync
+    /// with the inputs it depends on.
+    pub fn refresh_derived(&mut self) {
+        self.is_loopback_adapter = self.client_ip.is_loopback();
+    }
 }
 
 impl ConsommeState {
@@ -716,9 +727,9 @@ fn is_routable_ipv6(addr: &std::net::Ipv6Addr) -> bool {
 impl Consomme {
     /// Creates a new consomme instance with specified state.
     pub fn new(mut params: ConsommeParams) -> Self {
-        // Derive the loopback-adapter flag from the client address (see
-        // `ConsommeParams::is_loopback_adapter`).
-        params.is_loopback_adapter = params.client_ip.is_loopback();
+        // Derive parameters computed from other fields (e.g. the loopback-adapter
+        // flag) before constructing the instance.
+        params.refresh_derived();
 
         let host_has_ipv6 = if params.skip_ipv6_checks {
             true

--- a/vm/devices/net/net_consomme/consomme/src/lib.rs
+++ b/vm/devices/net/net_consomme/consomme/src/lib.rs
@@ -182,21 +182,6 @@ pub struct ConsommeParams {
     pub tcp_rx_buffer: TcpBufferBounds,
     /// Per-connection TCP transmit ring buffer bounds (host-to-guest).
     pub tcp_tx_buffer: TcpBufferBounds,
-    /// True if this endpoint is dedicated to loopback traffic (its `client_ip`
-    /// is a loopback address).
-    ///
-    /// This is a derived field: it is computed from `client_ip` by
-    /// [`refresh_derived`](Self::refresh_derived), which runs when the
-    /// [`Consomme`] instance is created and whenever the parameters are updated
-    /// at runtime. Callers that mutate `client_ip` directly must call
-    /// `refresh_derived` to keep it in sync.
-    ///
-    /// Such endpoints carry localhost traffic and the guest routes loopback
-    /// replies back through this adapter, so the host-source virtual address
-    /// rewriting must be skipped for them. Rewriting the source out of the
-    /// loopback range would break that return path.
-    #[inspect(display)]
-    pub is_loopback_adapter: bool,
 }
 
 /// Bounds for a per-connection TCP ring buffer.
@@ -258,7 +243,6 @@ impl ConsommeParams {
             skip_ipv6_checks: false,
             tcp_rx_buffer: DEFAULT_TCP_BUFFER_BOUNDS,
             tcp_tx_buffer: DEFAULT_TCP_BUFFER_BOUNDS,
-            is_loopback_adapter: false,
         })
     }
 
@@ -358,17 +342,6 @@ impl ConsommeParams {
             }
         }
     }
-
-    /// Recomputes fields derived from other parameters (currently
-    /// [`is_loopback_adapter`](Self::is_loopback_adapter), derived from
-    /// `client_ip`).
-    ///
-    /// Called when a [`Consomme`] instance is created and whenever the
-    /// parameters are updated at runtime, so the derived state stays in sync
-    /// with the inputs it depends on.
-    pub fn refresh_derived(&mut self) {
-        self.is_loopback_adapter = self.client_ip.is_loopback();
-    }
 }
 
 impl ConsommeState {
@@ -415,11 +388,17 @@ impl ConsommeState {
         // If the remote IP is loopback or matches the client IP address, replace
         // it with a unique virtual address so that the guest routes the reply
         // back through the virtual adapter and we can reverse-translate it on the
-        // outgoing path. Skipped for loopback adapters (see `is_loopback_adapter`).
+        // outgoing path.
+        //
+        // This is skipped for endpoints that are themselves dedicated to
+        // loopback traffic (their `client_ip` is a loopback address, as used by
+        // WSL's VirtioProxy localhost forwarding). The guest routes those
+        // replies back through this adapter based on the loopback source, so
+        // rewriting the source out of the loopback range would break the return
+        // path.
+        let is_loopback_adapter = params.client_ip.is_loopback();
         let src = match remote_addr {
-            SocketAddr::V4(v4)
-                if params.is_local_address(remote_addr) && !params.is_loopback_adapter =>
-            {
+            SocketAddr::V4(v4) if params.is_local_address(remote_addr) && !is_loopback_adapter => {
                 let subnet_base =
                     Ipv4Addr::from(u32::from(params.gateway_ip) & u32::from(params.net_mask));
                 let virtual_ip = local_addr_map.get_or_allocate_v4(
@@ -437,9 +416,7 @@ impl ConsommeState {
                     }
                 }
             }
-            SocketAddr::V6(v6)
-                if params.is_local_address(remote_addr) && !params.is_loopback_adapter =>
-            {
+            SocketAddr::V6(v6) if params.is_local_address(remote_addr) && !is_loopback_adapter => {
                 let virtual_ip = local_addr_map.get_or_allocate_v6(
                     *v6.ip(),
                     params.gateway_link_local_ipv6,
@@ -733,10 +710,6 @@ fn is_routable_ipv6(addr: &std::net::Ipv6Addr) -> bool {
 impl Consomme {
     /// Creates a new consomme instance with specified state.
     pub fn new(mut params: ConsommeParams) -> Self {
-        // Derive parameters computed from other fields (e.g. the loopback-adapter
-        // flag) before constructing the instance.
-        params.refresh_derived();
-
         let host_has_ipv6 = if params.skip_ipv6_checks {
             true
         } else {

--- a/vm/devices/net/net_consomme/consomme/src/lib.rs
+++ b/vm/devices/net/net_consomme/consomme/src/lib.rs
@@ -342,6 +342,20 @@ impl ConsommeParams {
             }
         }
     }
+
+    /// Returns true if this endpoint is dedicated to loopback traffic, i.e. its
+    /// own client address is a loopback address.
+    ///
+    /// Such an endpoint exists specifically to carry localhost traffic between
+    /// the host and guest, and the guest is configured to route replies to
+    /// loopback source addresses back out through this adapter (for example, via
+    /// a dedicated policy-routing table). For these endpoints the local-source
+    /// virtual address rewriting must be skipped: rewriting the source to an
+    /// address outside the loopback range causes the guest's reply to miss that
+    /// routing and never reach the gateway, breaking the connection.
+    fn is_loopback_endpoint(&self) -> bool {
+        self.client_ip.is_loopback()
+    }
 }
 
 impl ConsommeState {
@@ -389,8 +403,15 @@ impl ConsommeState {
         // it with a unique virtual address so that the guest routes the reply
         // back through the virtual adapter and we can reverse-translate it on the
         // outgoing path.
+        //
+        // This rewriting is skipped for endpoints that are themselves dedicated to
+        // loopback traffic (see `is_loopback_endpoint`): those endpoints already
+        // route loopback-sourced replies back through the adapter, and rewriting
+        // the source out of the loopback range would break that return path.
         let src = match remote_addr {
-            SocketAddr::V4(v4) if params.is_local_address(remote_addr) => {
+            SocketAddr::V4(v4)
+                if params.is_local_address(remote_addr) && !params.is_loopback_endpoint() =>
+            {
                 let subnet_base =
                     Ipv4Addr::from(u32::from(params.gateway_ip) & u32::from(params.net_mask));
                 let virtual_ip = local_addr_map.get_or_allocate_v4(
@@ -408,7 +429,9 @@ impl ConsommeState {
                     }
                 }
             }
-            SocketAddr::V6(v6) if params.is_local_address(remote_addr) => {
+            SocketAddr::V6(v6)
+                if params.is_local_address(remote_addr) && !params.is_loopback_endpoint() =>
+            {
                 let virtual_ip = local_addr_map.get_or_allocate_v6(
                     *v6.ip(),
                     params.gateway_link_local_ipv6,

--- a/vm/devices/net/net_consomme/consomme/src/lib.rs
+++ b/vm/devices/net/net_consomme/consomme/src/lib.rs
@@ -182,19 +182,13 @@ pub struct ConsommeParams {
     pub tcp_rx_buffer: TcpBufferBounds,
     /// Per-connection TCP transmit ring buffer bounds (host-to-guest).
     pub tcp_tx_buffer: TcpBufferBounds,
-    /// True if this endpoint is dedicated to loopback traffic, i.e. its own
-    /// client address is a loopback address.
+    /// True if this endpoint is dedicated to loopback traffic (its `client_ip`
+    /// is a loopback address), set when the [`Consomme`] instance is created.
     ///
-    /// Such an endpoint exists specifically to carry localhost traffic between
-    /// the host and guest, and the guest is configured to route replies to
-    /// loopback source addresses back out through this adapter (for example, via
-    /// a dedicated policy-routing table). For these endpoints the local-source
-    /// virtual address rewriting must be skipped: rewriting the source to an
-    /// address outside the loopback range causes the guest's reply to miss that
-    /// routing and never reach the gateway, breaking the connection.
-    ///
-    /// This is derived from `client_ip` when the [`Consomme`] instance is
-    /// created.
+    /// Such endpoints carry localhost traffic and the guest routes loopback
+    /// replies back through this adapter, so the host-source virtual address
+    /// rewriting must be skipped for them. Rewriting the source out of the
+    /// loopback range would break that return path.
     #[inspect(display)]
     pub is_loopback_adapter: bool,
 }
@@ -404,12 +398,7 @@ impl ConsommeState {
         // If the remote IP is loopback or matches the client IP address, replace
         // it with a unique virtual address so that the guest routes the reply
         // back through the virtual adapter and we can reverse-translate it on the
-        // outgoing path.
-        //
-        // This rewriting is skipped for endpoints that are themselves dedicated to
-        // loopback traffic (see `is_loopback_endpoint`): those endpoints already
-        // route loopback-sourced replies back through the adapter, and rewriting
-        // the source out of the loopback range would break that return path.
+        // outgoing path. Skipped for loopback adapters (see `is_loopback_adapter`).
         let src = match remote_addr {
             SocketAddr::V4(v4)
                 if params.is_local_address(remote_addr) && !params.is_loopback_adapter =>
@@ -727,9 +716,8 @@ fn is_routable_ipv6(addr: &std::net::Ipv6Addr) -> bool {
 impl Consomme {
     /// Creates a new consomme instance with specified state.
     pub fn new(mut params: ConsommeParams) -> Self {
-        // Derive whether this endpoint is dedicated to loopback traffic from its
-        // client address, so the host-originated source rewriting can be skipped
-        // for it (see `ConsommeParams::is_loopback_adapter`).
+        // Derive the loopback-adapter flag from the client address (see
+        // `ConsommeParams::is_loopback_adapter`).
         params.is_loopback_adapter = params.client_ip.is_loopback();
 
         let host_has_ipv6 = if params.skip_ipv6_checks {

--- a/vm/devices/net/net_consomme/consomme/src/tcp/tests.rs
+++ b/vm/devices/net/net_consomme/consomme/src/tcp/tests.rs
@@ -843,6 +843,92 @@ async fn test_tcp_port_forward_loopback_src_rewritten(driver: DefaultDriver) {
     );
 }
 
+/// Test that when the consomme endpoint is itself a loopback adapter (its own
+/// `client_ip` is a loopback address, as used by WSL's VirtioProxy localhost
+/// forwarding), the source IP of a forwarded loopback connection is left as
+/// loopback and is **not** rewritten to a virtual subnet address. Such adapters
+/// rely on the loopback source staying in range so the guest routes the reply
+/// back through the adapter.
+#[pal_async::async_test]
+async fn test_tcp_port_forward_loopback_adapter_src_not_rewritten(driver: DefaultDriver) {
+    let mut params = ConsommeParams::new().unwrap();
+    // Configure this endpoint as a loopback adapter.
+    params.client_ip = Ipv4Address::new(127, 0, 0, 1);
+    let mut consomme = Consomme::new(params);
+    let mut client = TestClient::new(driver.clone());
+
+    // The derived loopback-adapter flag should be set from the client IP.
+    assert!(consomme.params_mut().is_loopback_adapter);
+
+    let guest_port = 9999;
+    let received = client.received_packets.clone();
+    let client_ip = consomme.params_mut().client_ip;
+
+    // Create and bind a TCP socket on loopback.
+    let socket = Socket::new(Domain::IPV4, Type::STREAM, None).unwrap();
+    socket
+        .bind(&SocketAddrV4::new(Ipv4Addr::LOCALHOST, 0).into())
+        .unwrap();
+    let host_addr = socket.local_addr().unwrap().as_socket().unwrap();
+
+    {
+        let mut access = consomme.access(&mut client);
+        access
+            .bind_tcp_port(socket, guest_port)
+            .expect("bind should succeed");
+    }
+
+    // Connect from localhost to trigger the listener.
+    let connector = std::net::TcpStream::connect(host_addr).unwrap();
+    connector.set_nonblocking(true).unwrap();
+
+    // Poll until consomme delivers a SYN to the guest.
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+    loop {
+        std::future::poll_fn(|cx| {
+            consomme.access(&mut client).poll(cx);
+            Poll::Ready(())
+        })
+        .await;
+
+        let has_syn = received.lock().iter().any(|p| {
+            TcpTestHarness::is_tcp_packet(p)
+                .is_some_and(|t| t.control == TcpControl::Syn && t.dst_port == guest_port)
+        });
+        if has_syn {
+            break;
+        }
+        assert!(
+            std::time::Instant::now() < deadline,
+            "timed out waiting for forwarded TCP SYN"
+        );
+        pal_async::timer::PolledTimer::new(&driver)
+            .sleep(std::time::Duration::from_millis(10))
+            .await;
+    }
+
+    // Verify the source IP of the forwarded SYN is left as loopback (not
+    // rewritten to a virtual subnet address).
+    let packets = received.lock();
+    let syn_pkt = packets
+        .iter()
+        .find(|p| {
+            TcpTestHarness::is_tcp_packet(p)
+                .is_some_and(|t| t.control == TcpControl::Syn && t.dst_port == guest_port)
+        })
+        .expect("should have received a SYN");
+    let (src_ip, dst_ip, _tcp) = parse_tcp_packet(syn_pkt);
+
+    // The destination should be the (loopback) guest IP.
+    assert_eq!(dst_ip, client_ip);
+    // The source must remain loopback so the guest's reply is routed back
+    // through the loopback adapter rather than out the default interface.
+    assert!(
+        src_ip.is_loopback(),
+        "forwarded SYN source IP should remain loopback, got {src_ip}"
+    );
+}
+
 /// Test that binding the same guest port twice returns `PortAlreadyBound`.
 #[pal_async::async_test]
 async fn test_tcp_bind_duplicate_port(driver: DefaultDriver) {

--- a/vm/devices/net/net_consomme/consomme/src/tcp/tests.rs
+++ b/vm/devices/net/net_consomme/consomme/src/tcp/tests.rs
@@ -857,9 +857,6 @@ async fn test_tcp_port_forward_loopback_adapter_src_not_rewritten(driver: Defaul
     let mut consomme = Consomme::new(params);
     let mut client = TestClient::new(driver.clone());
 
-    // The derived loopback-adapter flag should be set from the client IP.
-    assert!(consomme.params_mut().is_loopback_adapter);
-
     let guest_port = 9999;
     let received = client.received_packets.clone();
     let client_ip = consomme.params_mut().client_ip;

--- a/vm/devices/net/net_consomme/src/lib.rs
+++ b/vm/devices/net/net_consomme/src/lib.rs
@@ -466,6 +466,7 @@ fn process_message(
         ConsommeMessage::UpdateState(rpc) => {
             rpc.handle_sync(|f| {
                 f(consomme.get_mut().params_mut());
+                consomme.get_mut().params_mut().refresh_derived();
                 consomme.get_mut().clear_local_addr_map();
                 consomme.update_dns_nameservers()
             });

--- a/vm/devices/net/net_consomme/src/lib.rs
+++ b/vm/devices/net/net_consomme/src/lib.rs
@@ -466,7 +466,6 @@ fn process_message(
         ConsommeMessage::UpdateState(rpc) => {
             rpc.handle_sync(|f| {
                 f(consomme.get_mut().params_mut());
-                consomme.get_mut().params_mut().refresh_derived();
                 consomme.get_mut().clear_local_addr_map();
                 consomme.update_dns_nameservers()
             });


### PR DESCRIPTION
## Summary

Fixes a regression where host-to-guest **localhost** connections hang under WSL's VirtioProxy networking mode (no SYN-ACK, handshake never completes).

## Root cause

Commit 063b4f42a (`net_consomme`: rewrite the source of host-originated connections to a per-host virtual address inside the guest subnet) is incompatible with consomme endpoints that are dedicated to loopback traffic.

WSL's VirtioProxy localhost forwarding creates a **separate** consomme adapter whose client address is `127.0.0.1`. The guest installs a dedicated policy-routing table that routes replies whose source is a loopback address back out through that adapter. The full path depends on the injected connection's source staying in the loopback range:

1. Host opens a connection to `127.0.0.1:<port>` which is injected into the guest via the loopback adapter.
2. With the new behavior, consomme rewrites the source to a virtual address in the guest subnet (e.g. `10.0.0.254`).
3. The guest service replies to that rewritten address. It no longer matches the loopback policy-routing table, so the reply is sent out the default interface with a martian source and dropped.
4. No SYN-ACK reaches the host; the connection hangs.

## Fix

Detect loopback-dedicated endpoints internally (their `client_ip` is a loopback address) and skip the local-source virtual address rewriting for them. The check is computed on demand from `client_ip` inside `translate_remote_address`, so it stays correct even when parameters are updated at runtime and adds no derived state to the caller-provided `ConsommeParams`. These endpoints exist specifically to carry localhost traffic and their replies are already routed back through the adapter without rewriting, so the reverse-translation that the rewrite enables is unnecessary for them.

Non-loopback endpoints are unaffected and continue to get the virtual-address rewriting.

## Testing

- Reproduced the hang in a WSL VirtioProxy guest with an in-guest `tcpdump`, confirming the injected SYN's source was rewritten out of the loopback range and the reply was dropped as a martian.
- With the fix, the SYN source stays `127.0.0.1`, the full TCP handshake completes, and WSL's `NetworkTests::HostToGuestLoopback` passes for all configurations.
- `consomme` unit tests: 85/85 pass.
- `cargo clippy`, `cargo doc`, and `cargo xtask fmt` clean.

