### PR TITLE
Deps: fix tpm dep, hardcode to current commit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4213,7 +4213,7 @@ dependencies = [
 [[package]]
 name = "ms-tpm-20-ref"
 version = "0.1.0"
-source = "git+https://github.com/microsoft/ms-tpm-20-ref-rs.git?branch=main#5b8ca3b5b423859da441f51ec8b1610708ed53c2"
+source = "git+https://github.com/microsoft/ms-tpm-20-ref-rs.git?rev=5b8ca3b5b423859da441f51ec8b1610708ed53c2#5b8ca3b5b423859da441f51ec8b1610708ed53c2"
 dependencies = [
  "cc",
  "once_cell",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -485,7 +485,7 @@ log = "0.4"
 loom = "0.7.2"
 macaddr = "1.0"
 mimalloc = { version = "0.1.39", default-features = false }
-ms-tpm-20-ref = { version = "0.1", git = "https://github.com/microsoft/ms-tpm-20-ref-rs.git", branch = "main" }
+ms-tpm-20-ref = { git = "https://github.com/microsoft/ms-tpm-20-ref-rs.git", rev = "5b8ca3b5b423859da441f51ec8b1610708ed53c2" }
 mshv-bindings = "0.6.0"
 mshv-ioctls = "0.6.0"
 nix = { version = "0.30.1", default-features = false }


### PR DESCRIPTION
Pushing a new commit to the TPM repo broke consumers who were depending on it by branch label. We should instead depend on a specific pinned commit. Do that here. The lockfile change shows this was already the commit this branch was on.