### PR TITLE
virt_whp: handle deliverability notifications for correct vtl

### DIFF
--- a/vmm_core/virt_whp/src/vp.rs
+++ b/vmm_core/virt_whp/src/vp.rs
@@ -451,8 +451,7 @@ impl<'a> WhpProcessor<'a> {
             }
         }
 
-        let notifications =
-            &mut self.state.vtls[self.state.active_vtl].deliverability_notifications;
+        let notifications = &mut self.state.vtls[vtl].deliverability_notifications;
 
         notifications.set_sints(notifications.sints() & !sints);
         self.flush_messages(vtl, sints);


### PR DESCRIPTION
Found by AI: sints_deliverable(vtl, sints) receives the VTL whose SINTs became deliverable, but it clears active_vtl’s notification bits. During sidecar/VTL2 scheduling, those can differ, leaving VTL2 deliverability bits stale and preventing later queued VTL2 messages from waking/posting.

Hopefully will reduce test flakiness.