### PR TITLE
fix(vmbus_relay): enable interrupt relay by default for message redirection

### DIFF
--- a/vm/devices/vmbus/vmbus_relay/src/lib.rs
+++ b/vm/devices/vmbus/vmbus_relay/src/lib.rs
@@ -271,8 +271,8 @@ struct RelayChannelTask {
 impl RelayChannelTask {
     /// Relay open channel request from VTL0 to Host, responding with Open Result
     async fn handle_open_channel(&mut self, open_request: &OpenRequest) -> Result<()> {
-        // If the guest uses the channel bitmap, the host can't send interrupts
-        // directly and they must be relayed.
+        // With VMBus message redirection, host interrupts target VTL2 and must
+        // be relayed to VTL0. This is always the case when a relay is active.
         let redirect_interrupt = self.channel.use_interrupt_relay.load(Ordering::SeqCst);
         let (incoming_event, notify) = if redirect_interrupt {
             let event = Event::new();
@@ -580,7 +580,7 @@ impl RelayTask {
             channels: HashMap::new(),
             channel_workers: FuturesUnordered::new(),
             intercept_channels: HashMap::new(),
-            use_interrupt_relay: Arc::new(AtomicBool::new(false)),
+            use_interrupt_relay: Arc::new(AtomicBool::new(true)),
             server_response_send,
             hvsock_relay,
             running: false,


### PR DESCRIPTION
When VMBus message redirection is active, host-to-guest interrupts target VTL2 instead of VTL0. The relay must forward these interrupts to VTL0, but use_interrupt_relay defaulted to false and was only set to true when the guest sent a ModifyConnection with use_interrupt_page=true.

Modern guests (VMBus Copper version) negotiate with all feature flags false, so the interrupt page is never set, leaving relay channels without interrupt forwarding.

This caused RNDIS timeout failures on the NIC: the host wrote data to the ring buffer and signaled the guest, but the signal went to VTL2 and was never forwarded to VTL0.

The relay only exists when message redirection is active, so interrupt forwarding is always required. Default use_interrupt_relay to true.