### PR TITLE
Revert HvSintEnabled flag in UEFI config for aarch64

### DIFF
--- a/openhcl/underhill_core/src/loader/mod.rs
+++ b/openhcl/underhill_core/src/loader/mod.rs
@@ -688,7 +688,6 @@ pub fn write_uefi_config(
 
         flags.set_cxl_memory_enabled(platform_config.general.cxl_memory_enabled);
         flags.set_default_boot_always_attempt(platform_config.general.default_boot_always_attempt);
-        flags.set_hv_sint_enabled(platform_config.general.hv_sint_enabled);
         flags.set_force_dma_bounce_enabled(platform_config.general.force_dma_bounce_enabled);
 
         // Some settings do not depend on host config

--- a/openhcl/underhill_core/src/worker.rs
+++ b/openhcl/underhill_core/src/worker.rs
@@ -3780,7 +3780,6 @@ fn validate_isolated_configuration(dps: &DevicePlatformSettings) -> Result<(), a
         guest_state_encryption_policy: _,
         guest_state_lifetime: _,
         management_vtl_features: _,
-        hv_sint_enabled: _,
         force_dma_bounce_enabled: _,
         battery_enabled: _, // TODO: Add this to attestation later
     } = &dps.general;

--- a/openvmm/openvmm_entry/src/lib.rs
+++ b/openvmm/openvmm_entry/src/lib.rs
@@ -1439,7 +1439,6 @@ async fn vm_config_from_command_line(
                             EfiDiagnosticsLogLevelCli::Full => get_resources::ged::EfiDiagnosticsLogLevelType::Full,
                         }
                     },
-                    hv_sint_enabled: false,
                     force_dma_bounce_enabled: opt.uefi_force_dma_bounce,
                 }
                 .into_resource(),

--- a/petri/src/vm/openvmm/construct.rs
+++ b/petri/src/vm/openvmm/construct.rs
@@ -1131,7 +1131,6 @@ impl PetriVmConfigSetupCore<'_> {
                     get_resources::ged::EfiDiagnosticsLogLevelType::Full
                 }
             },
-            hv_sint_enabled: false,
             force_dma_bounce_enabled: *force_dma_bounce,
         };
 

--- a/vm/devices/get/get_protocol/src/dps_json.rs
+++ b/vm/devices/get/get_protocol/src/dps_json.rs
@@ -220,8 +220,6 @@ pub struct HclDevicePlatformSettingsV2Static {
     #[serde(default)]
     pub management_vtl_features: ManagementVtlFeatures,
     #[serde(default)]
-    pub hv_sint_enabled: bool,
-    #[serde(default)]
     pub force_dma_bounce_enabled: bool,
 }
 

--- a/vm/devices/get/get_resources/src/lib.rs
+++ b/vm/devices/get/get_resources/src/lib.rs
@@ -95,8 +95,6 @@ pub mod ged {
         pub test_gsp_by_id: bool,
         /// EFI diagnostics log level
         pub efi_diagnostics_log_level: EfiDiagnosticsLogLevelType,
-        /// Enable PPI-based SINT ACPI device for ARM64 Linux L1VH
-        pub hv_sint_enabled: bool,
         /// Force UEFI to bounce-buffer all DMA traffic.
         pub force_dma_bounce_enabled: bool,
     }

--- a/vm/devices/get/guest_emulation_device/src/lib.rs
+++ b/vm/devices/get/guest_emulation_device/src/lib.rs
@@ -161,8 +161,6 @@ pub struct GuestConfig {
     /// EFI diagnostics log level
     #[inspect(debug)]
     pub efi_diagnostics_log_level: EfiDiagnosticsLogLevelType,
-    /// Enable PPI-based SINT ACPI device for ARM64 Linux L1VH
-    pub hv_sint_enabled: bool,
     /// Force UEFI to bounce-buffer all DMA traffic.
     pub force_dma_bounce_enabled: bool,
 }
@@ -1357,7 +1355,6 @@ impl<T: RingMem + Unpin> GedChannel<T> {
                     guest_state_encryption_policy: state.config.guest_state_encryption_policy,
                     management_vtl_features: state.config.management_vtl_features,
                     efi_diagnostics_log_level: state.config.efi_diagnostics_log_level,
-                    hv_sint_enabled: state.config.hv_sint_enabled,
                     force_dma_bounce_enabled: state.config.force_dma_bounce_enabled,
                 },
                 dynamic: get_protocol::dps_json::HclDevicePlatformSettingsV2Dynamic {

--- a/vm/devices/get/guest_emulation_device/src/resolver.rs
+++ b/vm/devices/get/guest_emulation_device/src/resolver.rs
@@ -207,7 +207,6 @@ impl AsyncResolveResource<VmbusDeviceHandleKind, GuestEmulationDeviceHandle>
                         get_protocol::dps_json::EfiDiagnosticsLogLevelType::FULL
                     }
                 },
-                hv_sint_enabled: resource.hv_sint_enabled,
                 force_dma_bounce_enabled: resource.force_dma_bounce_enabled,
             },
             halt,

--- a/vm/devices/get/guest_emulation_device/src/test_utilities.rs
+++ b/vm/devices/get/guest_emulation_device/src/test_utilities.rs
@@ -262,7 +262,6 @@ pub fn create_host_channel(
         guest_state_encryption_policy: Default::default(),
         management_vtl_features: Default::default(),
         efi_diagnostics_log_level: Default::default(),
-        hv_sint_enabled: false,
         force_dma_bounce_enabled: false,
     };
 

--- a/vm/devices/get/guest_emulation_transport/src/api.rs
+++ b/vm/devices/get/guest_emulation_transport/src/api.rs
@@ -135,7 +135,6 @@ pub mod platform_settings {
         pub guest_state_encryption_policy: GuestStateEncryptionPolicy,
         #[inspect(debug)]
         pub management_vtl_features: ManagementVtlFeatures,
-        pub hv_sint_enabled: bool,
         pub force_dma_bounce_enabled: bool,
     }
 

--- a/vm/devices/get/guest_emulation_transport/src/client.rs
+++ b/vm/devices/get/guest_emulation_transport/src/client.rs
@@ -344,7 +344,6 @@ impl GuestEmulationTransportClient {
                 guest_state_lifetime: json.v2.r#static.guest_state_lifetime,
                 guest_state_encryption_policy: json.v2.r#static.guest_state_encryption_policy,
                 management_vtl_features: json.v2.r#static.management_vtl_features,
-                hv_sint_enabled: json.v2.r#static.hv_sint_enabled,
                 force_dma_bounce_enabled: json.v2.r#static.force_dma_bounce_enabled,
             },
             acpi_tables: json.v2.dynamic.acpi_tables,

--- a/vm/loader/src/uefi/config.rs
+++ b/vm/loader/src/uefi/config.rs
@@ -323,7 +323,12 @@ pub struct Flags {
     pub dhcp6_link_layer_address: bool,
     pub cxl_memory_enabled: bool,
     pub mtrrs_initialized_at_load: bool,
-    pub hv_sint_enabled: bool,
+    // The SINT-PPI UEFI feature was reverted, but its bit is retained as
+    // reserved padding so that the following flags stay ABI-aligned with the
+    // MSVM UEFI firmware, which froze this bit position rather than reclaiming
+    // it (later flags were stacked on top of it).
+    #[bits(1)]
+    _reserved_hv_sint: u64,
     pub vmbus_disabled: bool,
     pub pci_resources_pre_assigned: bool,
     pub force_dma_bounce_enabled: bool,

--- a/vm/loader/src/uefi/config.rs
+++ b/vm/loader/src/uefi/config.rs
@@ -323,12 +323,10 @@ pub struct Flags {
     pub dhcp6_link_layer_address: bool,
     pub cxl_memory_enabled: bool,
     pub mtrrs_initialized_at_load: bool,
-    // The SINT-PPI UEFI feature was reverted, but its bit is retained as
-    // reserved padding so that the following flags stay ABI-aligned with the
-    // MSVM UEFI firmware, which froze this bit position rather than reclaiming
-    // it (later flags were stacked on top of it).
+    
     #[bits(1)]
     _reserved_hv_sint: u64,
+
     pub vmbus_disabled: bool,
     pub pci_resources_pre_assigned: bool,
     pub force_dma_bounce_enabled: bool,

--- a/vm/loader/src/uefi/config.rs
+++ b/vm/loader/src/uefi/config.rs
@@ -323,10 +323,7 @@ pub struct Flags {
     pub dhcp6_link_layer_address: bool,
     pub cxl_memory_enabled: bool,
     pub mtrrs_initialized_at_load: bool,
-    
-    #[bits(1)]
-    _reserved_hv_sint: u64,
-
+    _reserved_hv_sint: bool,
     pub vmbus_disabled: bool,
     pub pci_resources_pre_assigned: bool,
     pub force_dma_bounce_enabled: bool,


### PR DESCRIPTION
This reverts the HvSintEnabled flag, which is no longer used. The bit remains in place because Hyper-V's UEFI still has it as a reserved bit.

Testing: `cargo +nightly test --lib` on all 7 affected crates.