### PR TITLE
ohcldiag-dev: add GUID-based VM identification

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5176,6 +5176,7 @@ dependencies = [
  "fs-err",
  "futures",
  "futures-concurrency",
+ "guid",
  "inspect",
  "kmsg",
  "mesh",

--- a/openhcl/diag_client/src/lib.rs
+++ b/openhcl/diag_client/src/lib.rs
@@ -111,6 +111,23 @@ pub mod hyperv {
         Ok(socket.convert().into_inner())
     }
 
+    fn query_vm_com_port(script: &str) -> anyhow::Result<String> {
+        let output = Command::new("powershell.exe")
+            .arg("-NoProfile")
+            .arg(script)
+            .output()
+            .context("failed to query VM com port")?;
+
+        if !output.status.success() {
+            let _ = std::io::stderr().write_all(&output.stderr);
+            anyhow::bail!(
+                "failed to query VM com port: exit status {}",
+                output.status.code().unwrap()
+            );
+        }
+        Ok(String::from_utf8(output.stdout)?)
+    }
+
     /// Opens a serial port on a Hyper-V VM.
     ///
     /// If the VM is not running, it will periodically try to connect to the
@@ -124,43 +141,13 @@ pub mod hyperv {
         port: ComPortAccessInfo<'_>,
     ) -> anyhow::Result<File> {
         let path = match port {
-            ComPortAccessInfo::NameAndPortNumber(vm, num) => {
-                let output = Command::new("powershell.exe")
-                    .arg("-NoProfile")
-                    .arg(format!(
-                        r#"$x = Get-VMComPort "{vm}" -Number {num} -ErrorAction Stop; $x.Path"#,
-                    ))
-                    .output()
-                    .context("failed to query VM com port")?;
-
-                if !output.status.success() {
-                    let _ = std::io::stderr().write_all(&output.stderr);
-                    anyhow::bail!(
-                        "failed to query VM com port: exit status {}",
-                        output.status.code().unwrap()
-                    );
-                }
-                &String::from_utf8(output.stdout)?
-            }
-            ComPortAccessInfo::IdAndPortNumber(id, num) => {
-                let output = Command::new("powershell.exe")
-                    .arg("-NoProfile")
-                    .arg(format!(
-                        r#"$x = Get-VMComPort -VMId "{id}" -Number {num} -ErrorAction Stop; $x.Path"#,
-                    ))
-                    .output()
-                    .context("failed to query VM com port")?;
-
-                if !output.status.success() {
-                    let _ = std::io::stderr().write_all(&output.stderr);
-                    anyhow::bail!(
-                        "failed to query VM com port: exit status {}",
-                        output.status.code().unwrap()
-                    );
-                }
-                &String::from_utf8(output.stdout)?
-            }
-            ComPortAccessInfo::PortPipePath(path) => path,
+            ComPortAccessInfo::NameAndPortNumber(vm, num) => query_vm_com_port(&format!(
+                r#"$x = Get-VMComPort "{vm}" -Number {num} -ErrorAction Stop; $x.Path"#,
+            ))?,
+            ComPortAccessInfo::IdAndPortNumber(id, num) => query_vm_com_port(&format!(
+                r#"$x = Get-VMComPort -VMId "{id}" -Number {num} -ErrorAction Stop; $x.Path"#,
+            ))?,
+            ComPortAccessInfo::PortPipePath(path) => path.to_owned(),
         };
 
         let path = path.trim();

--- a/openhcl/diag_client/src/lib.rs
+++ b/openhcl/diag_client/src/lib.rs
@@ -50,6 +50,8 @@ pub mod hyperv {
     pub enum ComPortAccessInfo<'a> {
         /// Access by number
         NameAndPortNumber(&'a str, u32),
+        /// Access by VM ID and port number
+        IdAndPortNumber(Guid, u32),
         /// Access through a named pipe
         PortPipePath(&'a str),
     }
@@ -127,6 +129,24 @@ pub mod hyperv {
                     .arg("-NoProfile")
                     .arg(format!(
                         r#"$x = Get-VMComPort "{vm}" -Number {num} -ErrorAction Stop; $x.Path"#,
+                    ))
+                    .output()
+                    .context("failed to query VM com port")?;
+
+                if !output.status.success() {
+                    let _ = std::io::stderr().write_all(&output.stderr);
+                    anyhow::bail!(
+                        "failed to query VM com port: exit status {}",
+                        output.status.code().unwrap()
+                    );
+                }
+                &String::from_utf8(output.stdout)?
+            }
+            ComPortAccessInfo::IdAndPortNumber(id, num) => {
+                let output = Command::new("powershell.exe")
+                    .arg("-NoProfile")
+                    .arg(format!(
+                        r#"$x = Get-VMComPort -VMId "{id}" -Number {num} -ErrorAction Stop; $x.Path"#,
                     ))
                     .output()
                     .context("failed to query VM com port")?;

--- a/openhcl/diag_client/src/lib.rs
+++ b/openhcl/diag_client/src/lib.rs
@@ -111,19 +111,28 @@ pub mod hyperv {
         Ok(socket.convert().into_inner())
     }
 
-    fn query_vm_com_port(script: &str) -> anyhow::Result<String> {
+    fn query_vm_com_port(port: ComPortAccessInfo<'_>) -> anyhow::Result<String> {
+        let script = match port {
+            ComPortAccessInfo::NameAndPortNumber(vm, num) => {
+                format!(r#"$x = Get-VMComPort "{vm}" -Number {num} -ErrorAction Stop; $x.Path"#)
+            }
+            ComPortAccessInfo::IdAndPortNumber(id, num) => {
+                format!(
+                    r#"$x = Get-VMComPort -VMId "{id}" -Number {num} -ErrorAction Stop; $x.Path"#
+                )
+            }
+            ComPortAccessInfo::PortPipePath(_) => unreachable!(),
+        };
+
         let output = Command::new("powershell.exe")
             .arg("-NoProfile")
-            .arg(script)
+            .arg(&script)
             .output()
             .context("failed to query VM com port")?;
 
         if !output.status.success() {
             let _ = std::io::stderr().write_all(&output.stderr);
-            anyhow::bail!(
-                "failed to query VM com port: exit status {}",
-                output.status.code().unwrap()
-            );
+            anyhow::bail!("failed to query VM com port: exit status {}", output.status);
         }
         Ok(String::from_utf8(output.stdout)?)
     }
@@ -141,13 +150,8 @@ pub mod hyperv {
         port: ComPortAccessInfo<'_>,
     ) -> anyhow::Result<File> {
         let path = match port {
-            ComPortAccessInfo::NameAndPortNumber(vm, num) => query_vm_com_port(&format!(
-                r#"$x = Get-VMComPort "{vm}" -Number {num} -ErrorAction Stop; $x.Path"#,
-            ))?,
-            ComPortAccessInfo::IdAndPortNumber(id, num) => query_vm_com_port(&format!(
-                r#"$x = Get-VMComPort -VMId "{id}" -Number {num} -ErrorAction Stop; $x.Path"#,
-            ))?,
             ComPortAccessInfo::PortPipePath(path) => path.to_owned(),
+            port => query_vm_com_port(port)?,
         };
 
         let path = path.trim();

--- a/openhcl/diag_client/src/lib.rs
+++ b/openhcl/diag_client/src/lib.rs
@@ -121,7 +121,7 @@ pub mod hyperv {
                     r#"$x = Get-VMComPort -VMId "{id}" -Number {num} -ErrorAction Stop; $x.Path"#
                 )
             }
-            ComPortAccessInfo::PortPipePath(_) => unreachable!(),
+            ComPortAccessInfo::PortPipePath(path) => return Ok(path.to_owned()),
         };
 
         let output = Command::new("powershell.exe")
@@ -149,10 +149,7 @@ pub mod hyperv {
         driver: &(impl Driver + ?Sized),
         port: ComPortAccessInfo<'_>,
     ) -> anyhow::Result<File> {
-        let path = match port {
-            ComPortAccessInfo::PortPipePath(path) => path.to_owned(),
-            port => query_vm_com_port(port)?,
-        };
+        let path = query_vm_com_port(port)?;
 
         let path = path.trim();
         if path.is_empty() {

--- a/openhcl/ohcldiag-dev/Cargo.toml
+++ b/openhcl/ohcldiag-dev/Cargo.toml
@@ -27,6 +27,7 @@ tracing-subscriber = { workspace = true, features = ["env-filter"] }
 unicycle.workspace = true
 
 [target.'cfg(windows)'.dependencies]
+guid.workspace = true
 pal.workspace = true
 socket2.workspace = true
 

--- a/openhcl/ohcldiag-dev/src/main.rs
+++ b/openhcl/ohcldiag-dev/src/main.rs
@@ -337,7 +337,7 @@ pub struct VmArg {
     )]
     #[cfg_attr(
         windows,
-        doc = "* NAME_OR_GUID - Either a Hyper-V VM name or GUID, or a path as in vsock:PATH"
+        doc = "* NAME_OR_GUID_OR_PATH - Either a Hyper-V VM name or GUID, or a path as in vsock:PATH"
     )]
     #[cfg_attr(not(windows), doc = "* PATH - A path as in vsock:PATH")]
     #[clap(name = "VM")]
@@ -372,8 +372,6 @@ impl FromStr for VmId {
                     return Ok(Self::HyperVId(guid));
                 }
 
-                // If the hyperv: prefix was explicitly provided, always treat as
-                // a Hyper-V name (preserving disambiguation semantics).
                 if had_prefix || !pal::windows::fs::is_unix_socket(value.as_ref()).unwrap_or(false)
                 {
                     return Ok(Self::HyperV(value.to_owned()));

--- a/openhcl/ohcldiag-dev/src/main.rs
+++ b/openhcl/ohcldiag-dev/src/main.rs
@@ -667,21 +667,19 @@ pub fn main() -> anyhow::Result<()> {
                     use diag_client::hyperv::ComPortAccessInfo;
                     use futures::AsyncBufReadExt;
 
-                    let vm_name = match &vm.id {
-                        VmId::HyperV(name) => name,
-                        #[cfg(windows)]
-                        VmId::HyperVId(_) => {
-                            anyhow::bail!(
-                                "--serial requires a VM name, not a GUID. Use a named VM instead."
-                            )
-                        }
-                        _ => anyhow::bail!("--serial is only supported for Hyper-V VMs"),
-                    };
-
                     let port_access_info = if let Some(pipe_path) = pipe_path.as_ref() {
                         ComPortAccessInfo::PortPipePath(pipe_path)
                     } else {
-                        ComPortAccessInfo::NameAndPortNumber(vm_name, 3)
+                        match &vm.id {
+                            VmId::HyperV(name) => {
+                                ComPortAccessInfo::NameAndPortNumber(name, 3)
+                            }
+                            #[cfg(windows)]
+                            VmId::HyperVId(guid) => {
+                                ComPortAccessInfo::IdAndPortNumber(*guid, 3)
+                            }
+                            _ => anyhow::bail!("--serial is only supported for Hyper-V VMs"),
+                        }
                     };
 
                     let pipe =

--- a/openhcl/ohcldiag-dev/src/main.rs
+++ b/openhcl/ohcldiag-dev/src/main.rs
@@ -342,6 +342,8 @@ pub struct VmArg {
 enum VmId {
     #[cfg(windows)]
     HyperV(String),
+    #[cfg(windows)]
+    HyperVId(guid::Guid),
     HybridVsock(PathBuf),
 }
 
@@ -353,10 +355,18 @@ impl FromStr for VmId {
             Ok(Self::HybridVsock(Path::new(s).to_owned()))
         } else {
             #[cfg(windows)]
-            if let Some(s) = s.strip_prefix("hyperv:") {
-                return Ok(Self::HyperV(s.to_owned()));
-            } else if !pal::windows::fs::is_unix_socket(s.as_ref()).unwrap_or(false) {
-                return Ok(Self::HyperV(s.to_owned()));
+            {
+                // Strip optional "hyperv:" prefix for all Hyper-V variants.
+                let s = s.strip_prefix("hyperv:").unwrap_or(s);
+
+                // Try parsing as a GUID first (with or without braces).
+                if let Ok(guid) = s.parse::<guid::Guid>() {
+                    return Ok(Self::HyperVId(guid));
+                }
+
+                if !pal::windows::fs::is_unix_socket(s.as_ref()).unwrap_or(false) {
+                    return Ok(Self::HyperV(s.to_owned()));
+                }
             }
             // Default to hybrid vsock since this is what OpenVMM supports for
             // Underhill.
@@ -475,6 +485,8 @@ fn new_client(driver: impl Driver + Spawn + Clone, input: &VmArg) -> anyhow::Res
     let client = match &input.id {
         #[cfg(windows)]
         VmId::HyperV(name) => DiagClient::from_hyperv_name(driver, name)?,
+        #[cfg(windows)]
+        VmId::HyperVId(guid) => DiagClient::from_hyperv_id(driver, *guid),
         VmId::HybridVsock(path) => DiagClient::from_hybrid_vsock(driver, path),
     };
     Ok(client)
@@ -657,6 +669,12 @@ pub fn main() -> anyhow::Result<()> {
 
                     let vm_name = match &vm.id {
                         VmId::HyperV(name) => name,
+                        #[cfg(windows)]
+                        VmId::HyperVId(_) => {
+                            anyhow::bail!(
+                                "--serial requires a VM name, not a GUID. Use a named VM instead."
+                            )
+                        }
                         _ => anyhow::bail!("--serial is only supported for Hyper-V VMs"),
                     };
 
@@ -758,6 +776,12 @@ pub fn main() -> anyhow::Result<()> {
                     #[cfg(windows)]
                     VmId::HyperV(name) => {
                         let vm_id = diag_client::hyperv::vm_id_from_name(&name)?;
+                        let stream =
+                            diag_client::hyperv::connect_vsock(&driver, vm_id, port).await?;
+                        PolledSocket::new(&driver, socket2::Socket::from(stream))?
+                    }
+                    #[cfg(windows)]
+                    VmId::HyperVId(vm_id) => {
                         let stream =
                             diag_client::hyperv::connect_vsock(&driver, vm_id, port).await?;
                         PolledSocket::new(&driver, socket2::Socket::from(stream))?
@@ -903,6 +927,13 @@ pub fn main() -> anyhow::Result<()> {
                             let vm_id = diag_client::hyperv::vm_id_from_name(name)?;
                             let stream =
                                 diag_client::hyperv::connect_vsock(&driver, vm_id, vsock_port)
+                                    .await?;
+                            PolledSocket::new(&driver, socket2::Socket::from(stream))?
+                        }
+                        #[cfg(windows)]
+                        VmId::HyperVId(ref vm_id) => {
+                            let stream =
+                                diag_client::hyperv::connect_vsock(&driver, *vm_id, vsock_port)
                                     .await?;
                             PolledSocket::new(&driver, socket2::Socket::from(stream))?
                         }

--- a/openhcl/ohcldiag-dev/src/main.rs
+++ b/openhcl/ohcldiag-dev/src/main.rs
@@ -331,7 +331,13 @@ pub struct VmArg {
     )]
     #[cfg_attr(
         windows,
-        doc = "* NAME_OR_PATH - Either a Hyper-V VM name, or a path as in vsock:PATH>"
+        doc = "* hyperv:GUID - A Hyper-V VM ID (with or without braces)
+
+    "
+    )]
+    #[cfg_attr(
+        windows,
+        doc = "* NAME_OR_GUID - Either a Hyper-V VM name or GUID, or a path as in vsock:PATH"
     )]
     #[cfg_attr(not(windows), doc = "* PATH - A path as in vsock:PATH")]
     #[clap(name = "VM")]
@@ -356,16 +362,21 @@ impl FromStr for VmId {
         } else {
             #[cfg(windows)]
             {
-                // Strip optional "hyperv:" prefix for all Hyper-V variants.
-                let s = s.strip_prefix("hyperv:").unwrap_or(s);
+                let (value, had_prefix) = match s.strip_prefix("hyperv:") {
+                    Some(rest) => (rest, true),
+                    None => (s, false),
+                };
 
                 // Try parsing as a GUID first (with or without braces).
-                if let Ok(guid) = s.parse::<guid::Guid>() {
+                if let Ok(guid) = value.parse::<guid::Guid>() {
                     return Ok(Self::HyperVId(guid));
                 }
 
-                if !pal::windows::fs::is_unix_socket(s.as_ref()).unwrap_or(false) {
-                    return Ok(Self::HyperV(s.to_owned()));
+                // If the hyperv: prefix was explicitly provided, always treat as
+                // a Hyper-V name (preserving disambiguation semantics).
+                if had_prefix || !pal::windows::fs::is_unix_socket(value.as_ref()).unwrap_or(false)
+                {
+                    return Ok(Self::HyperV(value.to_owned()));
                 }
             }
             // Default to hybrid vsock since this is what OpenVMM supports for
@@ -671,13 +682,9 @@ pub fn main() -> anyhow::Result<()> {
                         ComPortAccessInfo::PortPipePath(pipe_path)
                     } else {
                         match &vm.id {
-                            VmId::HyperV(name) => {
-                                ComPortAccessInfo::NameAndPortNumber(name, 3)
-                            }
+                            VmId::HyperV(name) => ComPortAccessInfo::NameAndPortNumber(name, 3),
                             #[cfg(windows)]
-                            VmId::HyperVId(guid) => {
-                                ComPortAccessInfo::IdAndPortNumber(*guid, 3)
-                            }
+                            VmId::HyperVId(guid) => ComPortAccessInfo::IdAndPortNumber(*guid, 3),
                             _ => anyhow::bail!("--serial is only supported for Hyper-V VMs"),
                         }
                     };

--- a/vm/devices/get/guest_emulation_transport/src/client.rs
+++ b/vm/devices/get/guest_emulation_transport/src/client.rs
@@ -211,6 +211,44 @@ impl GuestEmulationTransportClient {
             None
         };
 
+        // Log VTL2 settings receipt with byte count and hex preview for validation
+        match json.v2.r#static.vtl2_settings.as_ref() {
+            Some(settings) => {
+                let len = settings.len();
+                let preview_len = len.min(64);
+                let hex_preview: String = settings[..preview_len]
+                    .iter()
+                    .map(|b| format!("{:02x}", b))
+                    .collect::<Vec<_>>()
+                    .join(" ");
+                let content_preview = if settings.first() == Some(&b'{') {
+                    let s = String::from_utf8_lossy(settings);
+                    if s.len() > 256 {
+                        format!("{}...", &s[..256])
+                    } else {
+                        s.into_owned()
+                    }
+                } else {
+                    format!("(protobuf, {} bytes)", len)
+                };
+                tracing::info!(
+                    CVM_ALLOWED,
+                    bytes = len,
+                    hex_preview = %hex_preview,
+                    content = %content_preview,
+                    "VTL2_SETTINGS_RECEIVED: blob present, {} bytes, content: {}",
+                    len,
+                    content_preview,
+                );
+            }
+            None => {
+                tracing::warn!(
+                    CVM_ALLOWED,
+                    "VTL2_SETTINGS_RECEIVED: no vtl2_settings blob in DPS response",
+                );
+            }
+        }
+
         Ok(platform_settings::DevicePlatformSettings {
             smbios: platform_settings::Smbios {
                 serial_number: json.v1.serial_number.into(),

--- a/vm/devices/get/guest_emulation_transport/src/client.rs
+++ b/vm/devices/get/guest_emulation_transport/src/client.rs
@@ -211,44 +211,6 @@ impl GuestEmulationTransportClient {
             None
         };
 
-        // Log VTL2 settings receipt with byte count and hex preview for validation
-        match json.v2.r#static.vtl2_settings.as_ref() {
-            Some(settings) => {
-                let len = settings.len();
-                let preview_len = len.min(64);
-                let hex_preview: String = settings[..preview_len]
-                    .iter()
-                    .map(|b| format!("{:02x}", b))
-                    .collect::<Vec<_>>()
-                    .join(" ");
-                let content_preview = if settings.first() == Some(&b'{') {
-                    let s = String::from_utf8_lossy(settings);
-                    if s.len() > 256 {
-                        format!("{}...", &s[..256])
-                    } else {
-                        s.into_owned()
-                    }
-                } else {
-                    format!("(protobuf, {} bytes)", len)
-                };
-                tracing::info!(
-                    CVM_ALLOWED,
-                    bytes = len,
-                    hex_preview = %hex_preview,
-                    content = %content_preview,
-                    "VTL2_SETTINGS_RECEIVED: blob present, {} bytes, content: {}",
-                    len,
-                    content_preview,
-                );
-            }
-            None => {
-                tracing::warn!(
-                    CVM_ALLOWED,
-                    "VTL2_SETTINGS_RECEIVED: no vtl2_settings blob in DPS response",
-                );
-            }
-        }
-
         Ok(platform_settings::DevicePlatformSettings {
             smbios: platform_settings::Smbios {
                 serial_number: json.v1.serial_number.into(),


### PR DESCRIPTION
## Summary

Add support for identifying VMs by GUID in `ohcldiag-dev`, in addition to the existing name-based lookup.

## Motivation

When working with VMs programmatically or when multiple VMs share similar names, identifying by GUID is more reliable. This is especially useful for automation and tooling scenarios.

## Changes

- Add `VmId::HyperVId(Guid)` variant for GUID-based VM identification
- Parse GUIDs (with or without braces) from the `hyperv:` prefix or bare input
- Route GUID-based IDs through `DiagClient::from_hyperv_id`
- Handle GUID variant in serial, vsock, and crash dump code paths
- Add `guid` dependency to `ohcldiag-dev` (Windows only)