### PR TITLE
virt_mshv_vtl: Tweak startup tracing

### DIFF
--- a/openhcl/virt_mshv_vtl/src/processor/mshv/x64.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/mshv/x64.rs
@@ -204,6 +204,7 @@ impl BackingPrivate for HypervisorBackedX86 {
                 Err(err) => {
                     tracelimit::warn_ratelimited!(
                         error = &err as &dyn std::error::Error,
+                        vp = this.vp_index().index(),
                         "unable to set internal activity register, falling back to deferred init"
                     );
                     true

--- a/openhcl/virt_mshv_vtl/src/processor/mshv/x64.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/mshv/x64.rs
@@ -202,7 +202,7 @@ impl BackingPrivate for HypervisorBackedX86 {
             this.backing.deferred_init = match this.set_vtl0_startup_suspend(true) {
                 Ok(()) => false,
                 Err(err) => {
-                    tracing::warn!(
+                    tracelimit::warn_ratelimited!(
                         error = &err as &dyn std::error::Error,
                         "unable to set internal activity register, falling back to deferred init"
                     );
@@ -227,7 +227,7 @@ impl BackingPrivate for HypervisorBackedX86 {
 
     fn pre_run_vp(this: &mut UhProcessor<'_, Self>) {
         if std::mem::take(&mut this.backing.deferred_init) {
-            tracelimit::info_ratelimited!(
+            tracing::debug!(
                 vp = this.vp_index().index(),
                 "sending deferred INIT to set startup suspend"
             );


### PR DESCRIPTION
Each of these warnings would result in an info coming along later too, there's no need for that. Rate limit the warnings in case they're hitting on all cpu cores, and lower the info to a debug.