### PR TITLE
fuzzing: Remove mentions of nightly toolchains

### DIFF
--- a/.github/skills/fuzzing/SKILL.md
+++ b/.github/skills/fuzzing/SKILL.md
@@ -27,10 +27,10 @@ cargo xtask fuzz list
 
 ```bash
 # Continuous fuzzing (finds new crashes)
-cargo +nightly xtask fuzz run fuzz_ide
+cargo xtask fuzz run fuzz_ide
 
 # Reproduce a specific crash artifact
-cargo +nightly xtask fuzz run fuzz_ide path/to/crash-artifact
+cargo xtask fuzz run fuzz_ide path/to/crash-artifact
 ```
 
 The xtask wrapper sets `XTASK_FUZZ_REPRO=1` automatically when an artifact
@@ -39,7 +39,7 @@ path is provided, which enables `init_tracing_if_repro()` in the fuzz target.
 ## Build without running
 
 ```bash
-cargo +nightly xtask fuzz build fuzz_ide
+cargo xtask fuzz build fuzz_ide
 ```
 
 The binary lands at `target/<triple>/release/fuzz_ide` (e.g.,
@@ -121,7 +121,7 @@ Release builds have limited `frame variable` output. For full variable
 inspection, build with `--dev`:
 
 ```bash
-cargo +nightly xtask fuzz build fuzz_ide -- --dev
+cargo xtask fuzz build fuzz_ide -- --dev
 ```
 
 The debug binary lands at `target/<triple>/debug/fuzz_ide`. It's slower but
@@ -182,14 +182,14 @@ that byte value. Decode manually: `0x58` = bits 3,4,6 set = `drq`, `dsc`,
 ## Minimizing crash inputs
 
 ```bash
-cargo +nightly xtask fuzz tmin fuzz_ide path/to/crash-artifact
+cargo xtask fuzz tmin fuzz_ide path/to/crash-artifact
 ```
 
 ## Corpus management
 
 ```bash
 # Minimize the corpus (remove redundant inputs)
-cargo +nightly xtask fuzz cmin fuzz_ide
+cargo xtask fuzz cmin fuzz_ide
 ```
 
 Corpus files live in `<crate>/fuzz/corpus/<target>/`.
@@ -227,7 +227,7 @@ Run multiple fuzzers across available CPUs for extended campaigns:
 # 6-hour campaign across 112 cores, 7 fuzzers
 # Each runs with -fork=N, survives crashes/timeouts/OOMs
 nohup bash -c 'RUSTFLAGS="-Ctarget-feature=+lse,+neon" \
-  cargo +nightly xtask fuzz run fuzz_storvsp -- -- \
+  cargo xtask fuzz run fuzz_storvsp -- -- \
   -fork=20 -max_total_time=21600 \
   -ignore_crashes=1 -ignore_timeouts=1 -ignore_ooms=1 \
   -print_final_stats=1' > /tmp/fuzz_storvsp.log 2>&1 &
@@ -248,7 +248,7 @@ After the run, collect coverage on each fuzzer for gap analysis.
 
 Everything from the main prerequisites, plus:
 
-- **llvm-tools**: `rustup +nightly component add llvm-tools`
+- **llvm-tools**: `rustup component add llvm-tools`
 - **lcov** (for HTML reports): `sudo apt-get install -y lcov`
 
 ### Collecting coverage
@@ -258,13 +258,13 @@ a coverage-instrumented build and merges the results:
 
 ```bash
 # Collect coverage data only
-cargo +nightly xtask fuzz coverage fuzz_ide
+cargo xtask fuzz coverage fuzz_ide
 
 # Collect + generate HTML report (requires lcov + genhtml)
-cargo +nightly xtask fuzz coverage fuzz_ide --with-html-report
+cargo xtask fuzz coverage fuzz_ide --with-html-report
 
 # Skip rebuild, just regenerate report from existing profdata
-cargo +nightly xtask fuzz coverage fuzz_ide --with-html-report --only-report
+cargo xtask fuzz coverage fuzz_ide --with-html-report --only-report
 ```
 
 On aarch64, set `RUSTFLAGS="-Ctarget-feature=+lse,+neon"` as usual.
@@ -286,7 +286,7 @@ Use `llvm-cov report` with source path filtering:
 
 ```bash
 # Find the llvm-cov binary from nightly toolchain
-LLVM_COV=$(find $(rustc +nightly --print sysroot) -name "llvm-cov" -type f | head -1)
+LLVM_COV=$(find $(rustc --print sysroot) -name "llvm-cov" -type f | head -1)
 
 # Full per-file report, excluding third-party code
 $LLVM_COV report \
@@ -362,7 +362,7 @@ improvements should focus on primary scope first.
 
 ```bash
 # Run coverage
-cargo +nightly xtask fuzz coverage <target> --with-html-report
+cargo xtask fuzz coverage <target> --with-html-report
 
 # Open the HTML report for visual inspection
 # target/<triple>/coverage/<triple>/release/lcov_html_<target>/index.html
@@ -417,7 +417,7 @@ impl. Common issues:
 After making changes:
 
 1. Run the fuzzer for a fixed duration (e.g., 1 hour)
-2. Minimize the corpus: `cargo +nightly xtask fuzz cmin <target>`
+2. Minimize the corpus: `cargo xtask fuzz cmin <target>`
 3. Collect coverage again
 4. Compare line counts against prior coverage runs
 

--- a/.github/skills/fuzzing/SKILL.md
+++ b/.github/skills/fuzzing/SKILL.md
@@ -8,7 +8,6 @@ description: "Run, optimize, and debug OpenVMM fuzzers. Covers cargo-fuzz target
 ## Prerequisites
 
 - **Linux only** — libfuzzer-sys doesn't support Windows.
-- **Nightly toolchain**: `rustup toolchain install nightly`
 - **cargo-fuzz**: `cargo install cargo-fuzz`
 - **lldb** (for debugging): `sudo apt-get install -y lldb`
 - **aarch64 RUSTFLAGS**: On aarch64, set `RUSTFLAGS="-Ctarget-feature=+lse,+neon"` or builds fail with atomics errors. Not needed on x86_64.
@@ -285,7 +284,7 @@ of the **target crate itself** and its immediate domain dependencies.
 Use `llvm-cov report` with source path filtering:
 
 ```bash
-# Find the llvm-cov binary from nightly toolchain
+# Find the llvm-cov binary from the toolchain
 LLVM_COV=$(find $(rustc --print sysroot) -name "llvm-cov" -type f | head -1)
 
 # Full per-file report, excluding third-party code

--- a/Guide/src/dev_guide/tests/fuzzing/running.md
+++ b/Guide/src/dev_guide/tests/fuzzing/running.md
@@ -2,13 +2,11 @@
 
 ## Installing Dependencies
 
-To begin fuzzing in OpenVMM, you'll need to install `cargo-fuzz` and a nightly
-rust compiler.
+To begin fuzzing in OpenVMM, you'll need to install `cargo-fuzz`.
 
 Installation should be as simple as:
 
 ```bash
-rustup install nightly
 cargo install cargo-fuzz
 ```
 
@@ -222,9 +220,9 @@ coverage significantly faster:
 ```bash
 # rebuild the fuzzer with coverage instrumentation
 RUSTFLAGS="-C instrument-coverage" cargo fuzz build
-# set env var to rustup's llvm-preview tools
+# set env var to rustup's llvm-tools
 LLVM_TOOLS_PATH=$(dirname $(find $(rustc --print sysroot) -name 'llvm-profdata'))
-# make an output directory for corups minimation
+# make an output directory for corpus minimation
 mkdir min_corp
 # run the minimizer putting the raw cov data into coverage.profraw
 LLVM_PROFILE_FILE="coverage.profraw" ./fuzz/targets/<target-path>/release/fuzz_ide min_corp <path to input corpus directory> -merge=1
@@ -238,9 +236,9 @@ version and the tool version are in sync), and convert the coverage data into
 a report:
 
 ```bash
-# set env var to rustup's llvm-preview tools
+# set env var to rustup's llvm-tools
 LLVM_TOOLS_PATH=$(dirname $(find $(rustc --print sysroot) -name 'llvm-profdata'))
-# covert the coverage data into an lcov format
+# convert the coverage data into an lcov format
 $LLVM_TOOLS_PATH/llvm-cov export -instr-profile=coverage.profdata \
     -format=lcov \
     -object ./fuzz/targets/<target-triple>/coverage/<target-triple>/release/fuzz_ide \

--- a/Guide/src/dev_guide/tests/fuzzing/running.md
+++ b/Guide/src/dev_guide/tests/fuzzing/running.md
@@ -21,7 +21,7 @@ sudo apt-get install -y lldb
 For coverage reports, install `llvm-tools` and `lcov`:
 
 ```bash
-rustup +nightly component add llvm-tools
+rustup component add llvm-tools
 sudo apt-get install -y lcov
 ```
 
@@ -86,7 +86,7 @@ a crash is discovered.
 To just build a fuzzer without starting it:
 
 ```bash
-cargo +nightly xtask fuzz build fuzz_ide
+cargo xtask fuzz build fuzz_ide
 ```
 
 The binary lands at `target/<triple>/release/fuzz_ide`.
@@ -97,7 +97,7 @@ When LibFuzzer finds a crash, it saves the input as an artifact. Reproduce it:
 
 ```bash
 # Through xtask (sets XTASK_FUZZ_REPRO=1 automatically for tracing)
-cargo +nightly xtask fuzz run fuzz_ide path/to/crash-artifact
+cargo xtask fuzz run fuzz_ide path/to/crash-artifact
 
 # Or run the binary directly (faster for iteration)
 ./target/<triple>/release/fuzz_ide path/to/crash-artifact
@@ -109,7 +109,7 @@ XTASK_FUZZ_REPRO=1 ./target/<triple>/release/fuzz_ide path/to/crash-artifact
 ### Minimizing crash inputs
 
 ```bash
-cargo +nightly xtask fuzz tmin fuzz_ide path/to/crash-artifact
+cargo xtask fuzz tmin fuzz_ide path/to/crash-artifact
 ```
 
 ### Corpus management
@@ -120,7 +120,7 @@ Crash artifacts land in `<crate>/fuzz/artifacts/<target>/`.
 To minimize the corpus (remove redundant inputs):
 
 ```bash
-cargo +nightly xtask fuzz cmin fuzz_ide
+cargo xtask fuzz cmin fuzz_ide
 ```
 
 ### Parallel fuzzing
@@ -128,13 +128,13 @@ cargo +nightly xtask fuzz cmin fuzz_ide
 Use `-fork=N` to run N fuzzer processes in parallel across CPUs:
 
 ```bash
-cargo +nightly xtask fuzz run fuzz_ide -- -- -fork=20 -max_total_time=3600 -print_final_stats=1
+cargo xtask fuzz run fuzz_ide -- -- -fork=20 -max_total_time=3600 -print_final_stats=1
 ```
 
 To survive crashes/timeouts/OOMs during long campaigns:
 
 ```bash
-cargo +nightly xtask fuzz run fuzz_ide -- -- \
+cargo xtask fuzz run fuzz_ide -- -- \
   -fork=20 -max_total_time=21600 \
   -ignore_crashes=1 -ignore_timeouts=1 -ignore_ooms=1 \
   -print_final_stats=1
@@ -175,14 +175,14 @@ Before you begin you'll need some additional dependencies to generate an html
 report:
 
 ```bash
-rustup +nightly component add llvm-tools
+rustup component add llvm-tools
 apt install lcov
 ```
 
 To generate a report with "sane defaults", you can simply run:
 
 ```bash
-cargo +nightly xtask fuzz coverage fuzz_ide --with-html-report
+cargo xtask fuzz coverage fuzz_ide --with-html-report
 ```
 
 Simply navigate to the `html/report/dir/index.html` on your machine and inspect the coverage!
@@ -221,9 +221,9 @@ coverage significantly faster:
 
 ```bash
 # rebuild the fuzzer with coverage instrumentation
-RUSTFLAGS="-C instrument-coverage" cargo +nightly fuzz build
+RUSTFLAGS="-C instrument-coverage" cargo fuzz build
 # set env var to rustup's llvm-preview tools
-LLVM_TOOLS_PATH=$(dirname $(find $(rustc +nightly --print sysroot) -name 'llvm-profdata'))
+LLVM_TOOLS_PATH=$(dirname $(find $(rustc --print sysroot) -name 'llvm-profdata'))
 # make an output directory for corups minimation
 mkdir min_corp
 # run the minimizer putting the raw cov data into coverage.profraw
@@ -239,7 +239,7 @@ a report:
 
 ```bash
 # set env var to rustup's llvm-preview tools
-LLVM_TOOLS_PATH=$(dirname $(find $(rustc +nightly --print sysroot) -name 'llvm-profdata'))
+LLVM_TOOLS_PATH=$(dirname $(find $(rustc --print sysroot) -name 'llvm-profdata'))
 # covert the coverage data into an lcov format
 $LLVM_TOOLS_PATH/llvm-cov export -instr-profile=coverage.profdata \
     -format=lcov \

--- a/xtask/src/tasks/fuzz/html_coverage.rs
+++ b/xtask/src/tasks/fuzz/html_coverage.rs
@@ -49,9 +49,9 @@ pub(super) fn generate_html_coverage_report(
 
     let llvm_tools_dir = 'llvm_tools_dir: {
         let output = std::process::Command::new("rustc")
-            .args(["+nightly", "--print", "sysroot"])
+            .args(["--print", "sysroot"])
             .output()
-            .context("failed to run `rustc +nightly --print sysroot`")?;
+            .context("failed to run `rustc --print sysroot`")?;
         let rustc_sysroot = String::from_utf8_lossy(&output.stdout).to_string();
         let rustc_sysroot = rustc_sysroot.trim();
 
@@ -65,7 +65,7 @@ pub(super) fn generate_html_coverage_report(
         }
 
         anyhow::bail!(
-            "failed to find `llvm-tools` directory. did you run `rustup +nightly component add llvm-tools`?"
+            "failed to find `llvm-tools` directory. did you run `rustup component add llvm-tools`?"
         )
     };
 


### PR DESCRIPTION
Nearly all fuzzing related functionality is available on stable now, and for the stuff that isn't xtask will work around it with RUSTC_BOOTSTRAP.