### PR TITLE
serial_pl011: do not report virtual transmitter busy

### DIFF
--- a/vm/devices/serial/serial_pl011/src/lib.rs
+++ b/vm/devices/serial/serial_pl011/src/lib.rs
@@ -660,7 +660,10 @@ impl State {
             .with_cts(self.connected)
             .with_dcd(self.connected)
             .with_dsr(self.connected)
-            .with_busy(!self.tx_buffer.is_empty())
+            // This virtual UART has no shift register latency. Reporting BUSY
+            // while bytes are queued can deadlock earlycon users that spin on
+            // BUSY before the asynchronous backend poller gets scheduled.
+            .with_busy(false)
             .with_rxfe(self.rx_buffer.is_empty())
             .with_txff(self.tx_buffer.len() >= fifo_size)
             .with_rxff(self.rx_buffer.len() >= fifo_size)


### PR DESCRIPTION
## Summary

Do not report PL011 `UARTFR.BUSY` based on OpenVMM’s asynchronous serial backend queue.

The old implementation treated any queued TX byte as “UART busy”:

```rust
.with_busy(!self.tx_buffer.is_empty())
```

That is a poor fit for this virtual PL011 model. `tx_buffer` is not a hardware shift register; it is OpenVMM’s pending async write queue to the host serial backend. If the guest spins waiting for `BUSY` to clear, the vCPU can keep running while the backend poller does not get scheduled, so the queue never drains and `BUSY` never clears.

This happens with Linux PL011 early console output: after writing a byte, earlycon polls `UARTFR.BUSY` until the transmitter is idle. With `BUSY` tied to the async backend queue, early boot console output can wedge even though the virtual MMIO write itself was already accepted.

## Behavior after this change

For this virtual UART, a write to `UARTDR` is considered to leave the transmitter immediately, so `UARTFR.BUSY` is always reported clear. This models the PL011 transmitter as zero-latency, rather than trying to expose host backend scheduling through a guest-visible hardware bit.

This does **not** make the transmit FIFO look unbounded or always empty:

- `UARTFR.TXFF` still reflects whether OpenVMM’s TX buffer is full.
- `UARTFR.TXFE` still reflects whether OpenVMM’s TX buffer is empty.
- Existing TX queueing, dropping, stats, and backend drain behavior are unchanged.

So guests still see FIFO fullness/emptiness for backpressure and flush visibility; only the PL011-specific “transmitter is actively shifting bits” state stops being derived from the async backend queue.

## Testing

- `cargo clippy --all-targets -p serial_pl011`
- `cargo doc --no-deps -p serial_pl011`
- `cargo xtask fmt --fix`
