### PR TITLE
refactor(cmos_rtc): provide initial CMOS values via resource resolver

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2013,6 +2013,7 @@ name = "firmware_pcat"
 version = "0.0.0"
 dependencies = [
  "chipset_device",
+ "chipset_resources",
  "generation_id",
  "getrandom 0.4.2",
  "guestmem",
@@ -2025,6 +2026,7 @@ dependencies = [
  "thiserror 2.0.16",
  "tracelimit",
  "tracing",
+ "vm_resource",
  "vm_topology",
  "vmcore",
  "zerocopy",
@@ -5628,6 +5630,7 @@ dependencies = [
  "chipset_resources",
  "debug_worker",
  "disk_striped",
+ "firmware_pcat",
  "firmware_uefi",
  "guest_watchdog",
  "hyperv_ic",
@@ -5714,6 +5717,7 @@ dependencies = [
  "disk_vhdmp",
  "disklayer_ram",
  "disklayer_sqlite",
+ "firmware_pcat",
  "firmware_uefi",
  "gdma",
  "guest_crash_device",

--- a/openhcl/openvmm_hcl_resources/Cargo.toml
+++ b/openhcl/openvmm_hcl_resources/Cargo.toml
@@ -31,6 +31,7 @@ uidevices = { workspace = true, optional = true }
 chipset.workspace = true
 chipset_legacy.workspace = true
 chipset_resources.workspace = true
+firmware_pcat.workspace = true
 firmware_uefi.workspace = true
 hyperv_ic.workspace = true
 missing_dev.workspace = true

--- a/openhcl/openvmm_hcl_resources/src/lib.rs
+++ b/openhcl/openvmm_hcl_resources/src/lib.rs
@@ -33,6 +33,8 @@ vm_resource::register_static_resolvers! {
     #[cfg(guest_arch = "x86_64")]
     chipset::pm::resolver::HyperVPowerManagementResolver,
     chipset_resources::cmos_rtc_time_source::SystemTimeClockResolver,
+    #[cfg(guest_arch = "x86_64")]
+    firmware_pcat::PcatDefaultCmosValuesResolver,
     firmware_uefi::resolver::UefiDeviceResolver,
     missing_dev::resolver::MissingDevResolver,
     #[cfg(feature = "tpm")]

--- a/openhcl/underhill_core/src/worker.rs
+++ b/openhcl/underhill_core/src/worker.rs
@@ -2873,7 +2873,12 @@ async fn new_underhill_vm(
     #[cfg(guest_arch = "x86_64")]
     let deps_piix4_cmos_rtc = chipset.with_piix4_cmos_rtc.then(|| dev::Piix4CmosRtcDeps {
         time_source: PlatformResource.into_resource(),
-        initial_cmos: Some(firmware_pcat::default_cmos_values(&mem_layout)),
+        initial_cmos: Some(
+            chipset_resources::cmos_rtc_initial_values::PcatDefaultCmosValuesHandle {
+                first_ram_block_size: mem_layout.ram()[0].range.len(),
+            }
+            .into_resource(),
+        ),
         enlightened_interrupts: true, // As advertised by the PCAT BIOS.
     });
 

--- a/openvmm/openvmm_core/src/worker/dispatch.rs
+++ b/openvmm/openvmm_core/src/worker/dispatch.rs
@@ -1620,10 +1620,12 @@ impl InitializedVm {
             )));
         }
 
-        let initial_rtc_cmos = if matches!(cfg.load_mode, LoadMode::Pcat { .. }) {
-            Some(firmware_pcat::default_cmos_values(&mem_layout))
-        } else {
-            None
+        let is_pcat = matches!(cfg.load_mode, LoadMode::Pcat { .. });
+        let pcat_cmos_resource = || {
+            chipset_resources::cmos_rtc_initial_values::PcatDefaultCmosValuesHandle {
+                first_ram_block_size: mem_layout.ram()[0].range.len(),
+            }
+            .into_resource()
         };
 
         let deps_generic_cmos_rtc = (cfg.chipset.with_generic_cmos_rtc).then(|| {
@@ -1634,7 +1636,7 @@ impl InitializedVm {
                 }
                 .into_resource(),
                 century_reg_idx: 0x32, // TODO: automatically sync with FADT
-                initial_cmos: initial_rtc_cmos,
+                initial_cmos: is_pcat.then(&pcat_cmos_resource),
             }
         });
 
@@ -1744,7 +1746,7 @@ impl InitializedVm {
                     delta_milliseconds: cfg.rtc_delta_milliseconds,
                 }
                 .into_resource(),
-                initial_cmos: initial_rtc_cmos,
+                initial_cmos: is_pcat.then(&pcat_cmos_resource),
                 enlightened_interrupts: true, // As advertised by the PCAT BIOS.
             }
         });

--- a/openvmm/openvmm_resources/Cargo.toml
+++ b/openvmm/openvmm_resources/Cargo.toml
@@ -49,11 +49,11 @@ disklayer_sqlite = { workspace = true, optional = true }
 chipset.workspace = true
 chipset_legacy.workspace = true
 chipset_resources.workspace = true
+firmware_pcat.workspace = true
 firmware_uefi.workspace = true
 missing_dev.workspace = true
 guest_watchdog.workspace = true
 tpm_device = { workspace = true, optional = true, features = ["tpm"] }
-
 # Non-volatile stores
 vmcore.workspace = true
 vmgs_broker.workspace = true

--- a/openvmm/openvmm_resources/src/lib.rs
+++ b/openvmm/openvmm_resources/src/lib.rs
@@ -32,6 +32,8 @@ vm_resource::register_static_resolvers! {
     #[cfg(guest_arch = "x86_64")]
     chipset::pm::resolver::HyperVPowerManagementResolver,
     chipset_resources::cmos_rtc_time_source::SystemTimeClockResolver,
+    #[cfg(guest_arch = "x86_64")]
+    firmware_pcat::PcatDefaultCmosValuesResolver,
     firmware_uefi::resolver::UefiDeviceResolver,
     missing_dev::resolver::MissingDevResolver,
     #[cfg(feature = "tpm")]

--- a/vm/devices/chipset_resources/src/lib.rs
+++ b/vm/devices/chipset_resources/src/lib.rs
@@ -26,6 +26,23 @@ impl CanResolveTo<ResolvedCmosRtcTimeSource> for CmosRtcTimeSourceHandleKind {
     type Input<'a> = ();
 }
 
+/// Resource kind for CMOS RTC initial values.
+///
+/// Resolving a resource of this kind produces a 256-byte array of initial CMOS
+/// RAM contents.
+pub enum CmosRtcInitialValuesKind {}
+
+impl ResourceKind for CmosRtcInitialValuesKind {
+    const NAME: &'static str = "cmos_rtc_initial_values";
+}
+
+/// Resolved initial CMOS RAM values (256 bytes).
+pub struct ResolvedCmosRtcInitialValues(pub [u8; 256]);
+
+impl CanResolveTo<ResolvedCmosRtcInitialValues> for CmosRtcInitialValuesKind {
+    type Input<'a> = ();
+}
+
 pub mod cmos_rtc_time_source {
     //! Resource definitions and resolvers for CMOS RTC time sources.
 
@@ -73,6 +90,30 @@ pub mod cmos_rtc_time_source {
                 LocalClockDelta::from_millis(resource.delta_milliseconds),
             ))))
         }
+    }
+}
+
+pub mod cmos_rtc_initial_values {
+    //! Resource definitions for CMOS RTC initial values.
+
+    use super::CmosRtcInitialValuesKind;
+    use mesh::MeshPayload;
+    use vm_resource::ResourceId;
+
+    /// A handle that provides PCAT-default CMOS values computed from VM memory
+    /// topology.
+    ///
+    /// The resolver uses the first RAM block size to compute extended memory
+    /// fields in the 256-byte CMOS image, matching what the PCAT BIOS expects.
+    #[derive(MeshPayload)]
+    pub struct PcatDefaultCmosValuesHandle {
+        /// Size of the first RAM block in bytes. Used to compute the extended
+        /// memory CMOS fields.
+        pub first_ram_block_size: u64,
+    }
+
+    impl ResourceId<CmosRtcInitialValuesKind> for PcatDefaultCmosValuesHandle {
+        const ID: &'static str = "pcat_default_cmos_values";
     }
 }
 

--- a/vm/devices/firmware/firmware_pcat/Cargo.toml
+++ b/vm/devices/firmware/firmware_pcat/Cargo.toml
@@ -10,8 +10,10 @@ rust-version.workspace = true
 generation_id.workspace = true
 
 chipset_device.workspace = true
+chipset_resources.workspace = true
 guestmem.workspace = true
 memory_range.workspace = true
+vm_resource.workspace = true
 vmcore.workspace = true
 vm_topology = { workspace = true, features = ["inspect"] }
 

--- a/vm/devices/firmware/firmware_pcat/src/cmos_resolver.rs
+++ b/vm/devices/firmware/firmware_pcat/src/cmos_resolver.rs
@@ -1,0 +1,38 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Resource resolver for PCAT default CMOS values.
+//!
+//! Resolves [`PcatDefaultCmosValuesHandle`] into a 256-byte CMOS image by
+//! calling [`default_cmos_values_from_ram_size`](super::default_cmos_values_from_ram_size).
+
+use chipset_resources::CmosRtcInitialValuesKind;
+use chipset_resources::ResolvedCmosRtcInitialValues;
+use chipset_resources::cmos_rtc_initial_values::PcatDefaultCmosValuesHandle;
+use vm_resource::ResolveResource;
+use vm_resource::declare_static_resolver;
+
+/// Resolver for [`PcatDefaultCmosValuesHandle`].
+pub struct PcatDefaultCmosValuesResolver;
+
+declare_static_resolver! {
+    PcatDefaultCmosValuesResolver,
+    (CmosRtcInitialValuesKind, PcatDefaultCmosValuesHandle),
+}
+
+impl ResolveResource<CmosRtcInitialValuesKind, PcatDefaultCmosValuesHandle>
+    for PcatDefaultCmosValuesResolver
+{
+    type Output = ResolvedCmosRtcInitialValues;
+    type Error = std::convert::Infallible;
+
+    fn resolve(
+        &self,
+        resource: PcatDefaultCmosValuesHandle,
+        (): (),
+    ) -> Result<Self::Output, Self::Error> {
+        Ok(ResolvedCmosRtcInitialValues(
+            super::default_cmos_values_from_ram_size(resource.first_ram_block_size),
+        ))
+    }
+}

--- a/vm/devices/firmware/firmware_pcat/src/default_cmos_values.rs
+++ b/vm/devices/firmware/firmware_pcat/src/default_cmos_values.rs
@@ -621,6 +621,15 @@ fn set_token_value(token: u16, value: u16, cmos: &mut [u8; 256]) {
 /// By pre-initializing the CMOS values the first time the VM is booted, we
 /// prevent the BIOS from reporting an error to the user.
 pub fn default_cmos_values(mem_layout: &MemoryLayout) -> [u8; 256] {
+    default_cmos_values_from_ram_size(mem_layout.ram()[0].range.len())
+}
+
+/// Returns the default PCAT CMOS values given the size of the first RAM block.
+///
+/// This is the core computation extracted from [`default_cmos_values`] so that
+/// callers without access to a full [`MemoryLayout`] can still produce the
+/// correct initial CMOS state.
+pub fn default_cmos_values_from_ram_size(first_ram_block_size: u64) -> [u8; 256] {
     let mut cmos_data = [0; 256];
     let cmos = &mut cmos_data;
 
@@ -637,7 +646,7 @@ pub fn default_cmos_values(mem_layout: &MemoryLayout) -> [u8; 256] {
     //
     // Set base memory to 640k, and extended memory to the top of the first
     // memory block.
-    let total_extended_mem = mem_layout.ram()[0].range.len() >> 20;
+    let total_extended_mem = first_ram_block_size >> 20;
     assert_eq!(total_extended_mem & !0xFFFF, 0);
     set_token_value(Q_EXT_MEMORY_LSB, (total_extended_mem & 0xFF) as u16, cmos);
     set_token_value(

--- a/vm/devices/firmware/firmware_pcat/src/lib.rs
+++ b/vm/devices/firmware/firmware_pcat/src/lib.rs
@@ -13,10 +13,13 @@
 #![forbid(unsafe_code)]
 
 mod bios_boot_order;
+mod cmos_resolver;
 mod default_cmos_values;
 mod root_cpu_data;
 
+pub use cmos_resolver::PcatDefaultCmosValuesResolver;
 pub use default_cmos_values::default_cmos_values;
+pub use default_cmos_values::default_cmos_values_from_ram_size;
 
 use self::bios_boot_order::bios_boot_order;
 use chipset_device::ChipsetDevice;

--- a/vmm_core/vmotherboard/src/base_chipset.rs
+++ b/vmm_core/vmotherboard/src/base_chipset.rs
@@ -444,6 +444,16 @@ impl<'a> BaseChipsetBuilder<'a> {
                 .resolve(time_source, ())
                 .await
                 .map_err(BaseChipsetBuilderError::ResolveResource)?;
+            let initial_cmos = match initial_cmos {
+                Some(resource) => Some(
+                    resolver
+                        .resolve(resource, ())
+                        .await
+                        .map_err(BaseChipsetBuilderError::ResolveResource)?
+                        .0,
+                ),
+                None => None,
+            };
             builder.arc_mutex_device("rtc").add(|services| {
                 cmos_rtc::Rtc::new(
                     resolved.0,
@@ -466,6 +476,16 @@ impl<'a> BaseChipsetBuilder<'a> {
                 .resolve(time_source, ())
                 .await
                 .map_err(BaseChipsetBuilderError::ResolveResource)?;
+            let initial_cmos = match initial_cmos {
+                Some(resource) => Some(
+                    resolver
+                        .resolve(resource, ())
+                        .await
+                        .map_err(BaseChipsetBuilderError::ResolveResource)?
+                        .0,
+                ),
+                None => None,
+            };
             builder.arc_mutex_device("piix4-rtc").add(|services| {
                 // hard-coded to IRQ line 8, as per PIIX4 spec
                 let rtc_interrupt = services.new_line(IRQ_LINE_SET, "interrupt", 8);
@@ -1176,16 +1196,16 @@ pub mod options {
             pub time_source: Resource<chipset_resources::CmosRtcTimeSourceHandleKind>,
             /// Which CMOS RAM register contains the century register
             pub century_reg_idx: u8,
-            /// Initial state of CMOS RAM
-            pub initial_cmos: Option<[u8; 256]>,
+            /// Initial state of CMOS RAM, resolved at device build time.
+            pub initial_cmos: Option<Resource<chipset_resources::CmosRtcInitialValuesKind>>,
         }
 
         /// PIIX4 "flavored" MC146818A compatible RTC + CMOS device
         pub struct Piix4CmosRtcDeps {
             /// A time source resource, resolved at device build time.
             pub time_source: Resource<chipset_resources::CmosRtcTimeSourceHandleKind>,
-            /// Initial state of CMOS RAM
-            pub initial_cmos: Option<[u8; 256]>,
+            /// Initial state of CMOS RAM, resolved at device build time.
+            pub initial_cmos: Option<Resource<chipset_resources::CmosRtcInitialValuesKind>>,
             /// Whether enlightened interrupts are enabled. Needed when
             /// advertised by ACPI WAET table.
             pub enlightened_interrupts: bool,


### PR DESCRIPTION
## Summary

Introduces a resource-resolver pattern for computing initial CMOS RTC values, eliminating the ordering constraint where `MemoryLayout` must be available at config construction time.

## Changes

- Add `CmosRtcInitialValuesKind` resource kind and `PcatDefaultCmosValuesHandle` to `chipset_resources`
- Extract `default_cmos_values_from_ram_size()` from `default_cmos_values()` for use by the resolver
- Add `PcatDefaultCmosValuesResolver` in `firmware_pcat` that resolves the handle into a 256-byte CMOS image
- Change `Piix4CmosRtcDeps` and `GenericCmosRtcDeps` `initial_cmos` from `Option<[u8; 256]>` to `Option<Resource<CmosRtcInitialValuesKind>>`
- Update `base_chipset` to resolve the resource before passing to device constructors
- Update `dispatch.rs` and `worker.rs` to provide resource handles

## Motivation

This is a prerequisite for the CMOS RTC resourcification (#3306). The `VmManifestBuilder` in the openvmm path runs before `MemoryLayout` is computed, so it cannot call `default_cmos_values()` directly. By deferring computation to resolve time via a resource, the builder can provide the handle without needing the full memory topology upfront.

## Testing

- `cargo xtask fmt` passes
- `cargo clippy` clean on all modified crates
- `firmware_pcat` unit test (`test_default_cmos_values`) passes
- `chipset_legacy` unit tests pass