### PR TITLE
Deps: Update TPM, deps, and set CC_FORCE_DISABLE for OpenHCL builds

### DIFF
--- a/.github/workflows/openvmm-ci.yaml
+++ b/.github/workflows/openvmm-ci.yaml
@@ -426,40 +426,12 @@ jobs:
         echo "$AgentTempDirNormal/publish_artifacts/aarch64-openhcl-baseline" | flowey v 10 'artifact_publish_from_aarch64-openhcl-baseline' --is-raw-string update
         mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-openhcl-igvm"
         echo "$AgentTempDirNormal/publish_artifacts/aarch64-openhcl-igvm" | flowey v 10 'artifact_publish_from_aarch64-openhcl-igvm' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-openhcl-igvm-devkern"
+        echo "$AgentTempDirNormal/publish_artifacts/aarch64-openhcl-igvm-devkern" | flowey v 10 'artifact_publish_from_aarch64-openhcl-igvm-devkern' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-openhcl-igvm-devkern-extras"
+        echo "$AgentTempDirNormal/publish_artifacts/aarch64-openhcl-igvm-devkern-extras" | flowey v 10 'artifact_publish_from_aarch64-openhcl-igvm-devkern-extras' --is-raw-string update
         mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-openhcl-igvm-extras"
         echo "$AgentTempDirNormal/publish_artifacts/aarch64-openhcl-igvm-extras" | flowey v 10 'artifact_publish_from_aarch64-openhcl-igvm-extras' --is-raw-string update
-      shell: bash
-    - name: checking if packages need to be installed
-      run: flowey e 10 flowey_lib_common::install_dist_pkg 0
-      shell: bash
-    - name: installing packages
-      run: flowey e 10 flowey_lib_common::install_dist_pkg 1
-      shell: bash
-    - name: create gh-release-download cache dir
-      run: flowey e 10 flowey_lib_common::download_gh_release 0
-      shell: bash
-    - name: Pre-processing cache vars
-      run: |-
-        flowey e 10 flowey_lib_common::cache 0
-        flowey v 10 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar1
-        flowey v 10 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar2
-      shell: bash
-    - id: flowey_lib_common__cache__1
-      uses: actions/cache@v5
-      with:
-        key: ${{ env.floweyvar1 }}
-        path: ${{ env.floweyvar2 }}
-      name: 'Restore cache: gh-release-download'
-    - name: download artifacts from github releases
-      run: |-
-        flowey v 10 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
-        EOF
-        flowey e 10 flowey_lib_common::cache 2
-        flowey e 10 flowey_lib_common::download_gh_release 1
-      shell: bash
-    - name: unpack mu_msvm package (aarch64)
-      run: flowey e 10 flowey_lib_hvlite::download_uefi_mu_msvm 0
       shell: bash
     - name: add default cargo home to path
       run: flowey e 10 flowey_lib_common::install_rust 0
@@ -493,128 +465,52 @@ jobs:
         EOF
         flowey e 10 flowey_lib_common::git_checkout 3
         flowey e 10 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-      shell: bash
-    - name: set '-Dwarnings' in .cargo/config.toml
-      run: flowey e 10 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
-      shell: bash
-    - name: unpack protoc
-      run: |-
-        flowey e 10 flowey_lib_common::resolve_protoc 0
         flowey e 10 flowey_lib_hvlite::cfg_openvmm_magicpath 0
       shell: bash
-    - name: symlink protoc
-      run: |-
-        flowey e 10 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-        flowey e 10 flowey_lib_hvlite::init_cross_build 0
-        flowey e 10 flowey_lib_hvlite::run_cargo_build 2
-        flowey e 10 flowey_lib_hvlite::run_cargo_build 3
+    - name: create gh-release-download cache dir
+      run: flowey e 10 flowey_lib_common::download_gh_release 0
       shell: bash
-    - name: cargo build openhcl_boot
+    - name: Pre-processing cache vars
       run: |-
-        flowey e 10 flowey_lib_common::run_cargo_build 1
-        flowey e 10 flowey_lib_hvlite::run_cargo_build 4
+        flowey e 10 flowey_lib_common::cache 0
+        flowey v 10 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar1
+        flowey v 10 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar2
       shell: bash
-    - name: split debug symbols
+    - id: flowey_lib_common__cache__1
+      uses: actions/cache@v5
+      with:
+        key: ${{ env.floweyvar1 }}
+        path: ${{ env.floweyvar2 }}
+      name: 'Restore cache: gh-release-download'
+    - name: download artifacts from github releases
       run: |-
-        flowey e 10 flowey_lib_hvlite::run_split_debug_info 2
-        flowey e 10 flowey_lib_hvlite::run_cargo_build 5
-        flowey e 10 flowey_lib_hvlite::build_openhcl_boot 0
-      shell: bash
-    - name: extract and resolve kernel package
-      run: |-
-        flowey e 10 flowey_lib_hvlite::resolve_openhcl_kernel_package 1
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 17
+        flowey v 10 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
+        EOF
+        flowey e 10 flowey_lib_common::cache 2
+        flowey e 10 flowey_lib_common::download_gh_release 1
       shell: bash
     - name: unpack openvmm-deps archive
       run: flowey e 10 flowey_lib_hvlite::resolve_openvmm_deps 0
       shell: bash
     - name: extract Aarch64 sysroot.tar.gz
-      run: |-
-        flowey e 10 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
-        flowey e 10 flowey_lib_hvlite::init_cross_build 2
-        flowey e 10 flowey_lib_hvlite::run_cargo_build 10
-        flowey e 10 flowey_lib_hvlite::run_cargo_build 11
+      run: flowey e 10 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
       shell: bash
-    - name: cargo build openvmm_hcl
-      run: |-
-        flowey e 10 flowey_lib_common::run_cargo_build 3
-        flowey e 10 flowey_lib_hvlite::run_cargo_build 12
-        flowey e 10 flowey_lib_hvlite::build_openvmm_hcl 1
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 13
+    - name: set '-Dwarnings' in .cargo/config.toml
+      run: flowey e 10 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
       shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 10 flowey_lib_hvlite::run_split_debug_info 1
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 14
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 15
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 18
+    - name: checking if packages need to be installed
+      run: flowey e 10 flowey_lib_common::install_dist_pkg 0
       shell: bash
-    - name: building openhcl initrd
-      run: |-
-        flowey e 10 flowey_lib_hvlite::build_openhcl_initrd 1
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 19
-        flowey e 10 flowey_lib_hvlite::init_cross_build 3
+    - name: installing packages
+      run: flowey e 10 flowey_lib_common::install_dist_pkg 1
       shell: bash
-    - name: cargo build igvmfilegen
-      run: |-
-        flowey e 10 flowey_lib_common::run_cargo_build 0
-        flowey e 10 flowey_lib_hvlite::run_cargo_build 0
+    - name: unpack protoc
+      run: flowey e 10 flowey_lib_common::resolve_protoc 0
       shell: bash
-    - name: split debug symbols
+    - name: symlink protoc
       run: |-
-        flowey e 10 flowey_lib_hvlite::run_split_debug_info 4
-        flowey e 10 flowey_lib_hvlite::run_cargo_build 1
-        flowey e 10 flowey_lib_hvlite::build_igvmfilegen 0
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 20
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 21
-      shell: bash
-    - name: building igvm file
-      run: |-
-        flowey e 10 flowey_lib_hvlite::run_igvmfilegen 1
-        flowey e 10 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 2
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 6
-      shell: bash
-    - name: extract and resolve kernel package
-      run: |-
-        flowey e 10 flowey_lib_hvlite::resolve_openhcl_kernel_package 0
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 2
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 10 flowey_lib_hvlite::run_split_debug_info 0
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 3
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 4
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 7
-      shell: bash
-    - name: building openhcl initrd
-      run: |-
-        flowey e 10 flowey_lib_hvlite::build_openhcl_initrd 0
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 8
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 9
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 10
-      shell: bash
-    - name: building igvm file
-      run: |-
-        flowey e 10 flowey_lib_hvlite::run_igvmfilegen 0
-        flowey e 10 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 0
-        flowey e 10 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::publish 0
-      shell: bash
-    - name: copying OpenHCL igvm files to artifact dir
-      run: |-
-        flowey e 10 flowey_lib_common::copy_to_artifact_dir 1
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 11
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 16
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 12
-        flowey e 10 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 3
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 5
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 1
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 0
-        flowey e 10 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 1
-        flowey e 10 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe_extras::publish 0
-      shell: bash
-    - name: copying OpenHCL igvm extras to artifact dir
-      run: |-
-        flowey e 10 flowey_lib_common::copy_to_artifact_dir 0
+        flowey e 10 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
         flowey e 10 flowey_lib_hvlite::init_cross_build 1
         flowey e 10 flowey_lib_hvlite::run_cargo_build 6
         flowey e 10 flowey_lib_hvlite::run_cargo_build 7
@@ -629,9 +525,106 @@ jobs:
         flowey e 10 flowey_lib_hvlite::run_split_debug_info 3
         flowey e 10 flowey_lib_hvlite::run_cargo_build 9
         flowey e 10 flowey_lib_hvlite::build_openvmm_hcl 0
+        flowey e 10 flowey_lib_hvlite::_jobs::build_and_publish_openvmm_hcl_baseline 0
+        flowey e 10 flowey_core::pipeline::artifact::publish 0
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 3
+        flowey e 10 flowey_lib_hvlite::init_cross_build 2
+        flowey e 10 flowey_lib_hvlite::run_cargo_build 10
+        flowey e 10 flowey_lib_hvlite::run_cargo_build 11
       shell: bash
-    - name: copying openhcl build to publish dir
-      run: flowey e 10 flowey_lib_hvlite::artifact_openvmm_hcl_sizecheck::publish 0
+    - name: cargo build openvmm_hcl
+      run: |-
+        flowey e 10 flowey_lib_common::run_cargo_build 3
+        flowey e 10 flowey_lib_hvlite::run_cargo_build 12
+        flowey e 10 flowey_lib_hvlite::build_openvmm_hcl 1
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 0
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 10 flowey_lib_hvlite::run_split_debug_info 0
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 1
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 2
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 4
+      shell: bash
+    - name: extract and resolve kernel package
+      run: flowey e 10 flowey_lib_hvlite::resolve_openhcl_kernel_package 0
+      shell: bash
+    - name: building openhcl initrd
+      run: |-
+        flowey e 10 flowey_lib_hvlite::build_openhcl_initrd 0
+        flowey e 10 flowey_lib_hvlite::init_cross_build 0
+        flowey e 10 flowey_lib_hvlite::run_cargo_build 2
+        flowey e 10 flowey_lib_hvlite::run_cargo_build 3
+      shell: bash
+    - name: cargo build openhcl_boot
+      run: |-
+        flowey e 10 flowey_lib_common::run_cargo_build 1
+        flowey e 10 flowey_lib_hvlite::run_cargo_build 4
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 10 flowey_lib_hvlite::run_split_debug_info 2
+        flowey e 10 flowey_lib_hvlite::run_cargo_build 5
+        flowey e 10 flowey_lib_hvlite::build_openhcl_boot 0
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 5
+      shell: bash
+    - name: unpack mu_msvm package (aarch64)
+      run: |-
+        flowey e 10 flowey_lib_hvlite::download_uefi_mu_msvm 0
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 6
+        flowey e 10 flowey_lib_hvlite::init_cross_build 3
+      shell: bash
+    - name: cargo build igvmfilegen
+      run: |-
+        flowey e 10 flowey_lib_common::run_cargo_build 0
+        flowey e 10 flowey_lib_hvlite::run_cargo_build 0
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 10 flowey_lib_hvlite::run_split_debug_info 4
+        flowey e 10 flowey_lib_hvlite::run_cargo_build 1
+        flowey e 10 flowey_lib_hvlite::build_igvmfilegen 0
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 7
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 8
+      shell: bash
+    - name: building igvm file
+      run: |-
+        flowey e 10 flowey_lib_hvlite::run_igvmfilegen 0
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 11
+        flowey e 10 flowey_core::pipeline::artifact::publish 1
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 9
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 10
+        flowey e 10 flowey_core::pipeline::artifact::publish 2
+      shell: bash
+    - name: extract and resolve kernel package
+      run: |-
+        flowey e 10 flowey_lib_hvlite::resolve_openhcl_kernel_package 1
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 15
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 12
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 10 flowey_lib_hvlite::run_split_debug_info 1
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 13
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 14
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 16
+      shell: bash
+    - name: building openhcl initrd
+      run: |-
+        flowey e 10 flowey_lib_hvlite::build_openhcl_initrd 1
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 17
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 18
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 19
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 20
+      shell: bash
+    - name: building igvm file
+      run: |-
+        flowey e 10 flowey_lib_hvlite::run_igvmfilegen 1
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 23
+        flowey e 10 flowey_core::pipeline::artifact::publish 3
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 21
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 22
+        flowey e 10 flowey_core::pipeline::artifact::publish 4
       shell: bash
     - name: 'validate cache entry: gh-release-download'
       run: flowey e 10 flowey_lib_common::cache 3
@@ -647,6 +640,18 @@ jobs:
       with:
         name: aarch64-openhcl-igvm
         path: ${{ runner.temp }}/publish_artifacts/aarch64-openhcl-igvm/
+        include-hidden-files: true
+    - name: 🌼📦 Publish aarch64-openhcl-igvm-devkern
+      uses: actions/upload-artifact@v7
+      with:
+        name: aarch64-openhcl-igvm-devkern
+        path: ${{ runner.temp }}/publish_artifacts/aarch64-openhcl-igvm-devkern/
+        include-hidden-files: true
+    - name: 🌼📦 Publish aarch64-openhcl-igvm-devkern-extras
+      uses: actions/upload-artifact@v7
+      with:
+        name: aarch64-openhcl-igvm-devkern-extras
+        path: ${{ runner.temp }}/publish_artifacts/aarch64-openhcl-igvm-devkern-extras/
         include-hidden-files: true
     - name: 🌼📦 Publish aarch64-openhcl-igvm-extras
       uses: actions/upload-artifact@v7
@@ -736,40 +741,24 @@ jobs:
         echo "$AgentTempDirNormal/publish_artifacts/x64-openhcl-baseline" | flowey v 11 'artifact_publish_from_x64-openhcl-baseline' --is-raw-string update
         mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm"
         echo "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm" | flowey v 11 'artifact_publish_from_x64-openhcl-igvm' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-cvm"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-cvm" | flowey v 11 'artifact_publish_from_x64-openhcl-igvm-cvm' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-cvm-extras"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-cvm-extras" | flowey v 11 'artifact_publish_from_x64-openhcl-igvm-cvm-extras' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-devkern"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-devkern" | flowey v 11 'artifact_publish_from_x64-openhcl-igvm-devkern' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-devkern-extras"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-devkern-extras" | flowey v 11 'artifact_publish_from_x64-openhcl-igvm-devkern-extras' --is-raw-string update
         mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-extras"
         echo "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-extras" | flowey v 11 'artifact_publish_from_x64-openhcl-igvm-extras' --is-raw-string update
-      shell: bash
-    - name: checking if packages need to be installed
-      run: flowey e 11 flowey_lib_common::install_dist_pkg 0
-      shell: bash
-    - name: installing packages
-      run: flowey e 11 flowey_lib_common::install_dist_pkg 1
-      shell: bash
-    - name: create gh-release-download cache dir
-      run: flowey e 11 flowey_lib_common::download_gh_release 0
-      shell: bash
-    - name: Pre-processing cache vars
-      run: |-
-        flowey e 11 flowey_lib_common::cache 0
-        flowey v 11 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar1
-        flowey v 11 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar2
-      shell: bash
-    - id: flowey_lib_common__cache__1
-      uses: actions/cache@v5
-      with:
-        key: ${{ env.floweyvar1 }}
-        path: ${{ env.floweyvar2 }}
-      name: 'Restore cache: gh-release-download'
-    - name: download artifacts from github releases
-      run: |-
-        flowey v 11 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
-        EOF
-        flowey e 11 flowey_lib_common::cache 2
-        flowey e 11 flowey_lib_common::download_gh_release 1
-      shell: bash
-    - name: unpack mu_msvm package (x64)
-      run: flowey e 11 flowey_lib_hvlite::download_uefi_mu_msvm 0
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-test-linux-direct"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-test-linux-direct" | flowey v 11 'artifact_publish_from_x64-openhcl-igvm-test-linux-direct' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-test-linux-direct-devkern"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-test-linux-direct-devkern" | flowey v 11 'artifact_publish_from_x64-openhcl-igvm-test-linux-direct-devkern' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-test-linux-direct-devkern-extras"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-test-linux-direct-devkern-extras" | flowey v 11 'artifact_publish_from_x64-openhcl-igvm-test-linux-direct-devkern-extras' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-test-linux-direct-extras"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-test-linux-direct-extras" | flowey v 11 'artifact_publish_from_x64-openhcl-igvm-test-linux-direct-extras' --is-raw-string update
       shell: bash
     - name: add default cargo home to path
       run: flowey e 11 flowey_lib_common::install_rust 0
@@ -803,226 +792,52 @@ jobs:
         EOF
         flowey e 11 flowey_lib_common::git_checkout 3
         flowey e 11 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-      shell: bash
-    - name: set '-Dwarnings' in .cargo/config.toml
-      run: flowey e 11 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
-      shell: bash
-    - name: unpack protoc
-      run: |-
-        flowey e 11 flowey_lib_common::resolve_protoc 0
         flowey e 11 flowey_lib_hvlite::cfg_openvmm_magicpath 0
       shell: bash
-    - name: symlink protoc
-      run: |-
-        flowey e 11 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-        flowey e 11 flowey_lib_hvlite::init_cross_build 0
-        flowey e 11 flowey_lib_hvlite::run_cargo_build 13
-        flowey e 11 flowey_lib_hvlite::run_cargo_build 14
+    - name: create gh-release-download cache dir
+      run: flowey e 11 flowey_lib_common::download_gh_release 0
       shell: bash
-    - name: cargo build sidecar
+    - name: Pre-processing cache vars
       run: |-
-        flowey e 11 flowey_lib_common::run_cargo_build 4
-        flowey e 11 flowey_lib_hvlite::run_cargo_build 15
+        flowey e 11 flowey_lib_common::cache 0
+        flowey v 11 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar1
+        flowey v 11 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar2
       shell: bash
-    - name: split debug symbols
+    - id: flowey_lib_common__cache__1
+      uses: actions/cache@v5
+      with:
+        key: ${{ env.floweyvar1 }}
+        path: ${{ env.floweyvar2 }}
+      name: 'Restore cache: gh-release-download'
+    - name: download artifacts from github releases
       run: |-
-        flowey e 11 flowey_lib_hvlite::run_split_debug_info 7
-        flowey e 11 flowey_lib_hvlite::run_cargo_build 16
-        flowey e 11 flowey_lib_hvlite::build_sidecar 0
-        flowey e 11 flowey_lib_hvlite::init_cross_build 1
-        flowey e 11 flowey_lib_hvlite::run_cargo_build 2
-        flowey e 11 flowey_lib_hvlite::run_cargo_build 3
-      shell: bash
-    - name: cargo build openhcl_boot
-      run: |-
-        flowey e 11 flowey_lib_common::run_cargo_build 1
-        flowey e 11 flowey_lib_hvlite::run_cargo_build 4
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 11 flowey_lib_hvlite::run_split_debug_info 5
-        flowey e 11 flowey_lib_hvlite::run_cargo_build 5
-        flowey e 11 flowey_lib_hvlite::build_openhcl_boot 0
-      shell: bash
-    - name: extract and resolve kernel package
-      run: |-
-        flowey e 11 flowey_lib_hvlite::resolve_openhcl_kernel_package 2
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 28
+        flowey v 11 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
+        EOF
+        flowey e 11 flowey_lib_common::cache 2
+        flowey e 11 flowey_lib_common::download_gh_release 1
       shell: bash
     - name: unpack openvmm-deps archive
       run: flowey e 11 flowey_lib_hvlite::resolve_openvmm_deps 0
       shell: bash
     - name: extract X86_64 sysroot.tar.gz
+      run: flowey e 11 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
+      shell: bash
+    - name: set '-Dwarnings' in .cargo/config.toml
+      run: flowey e 11 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
+      shell: bash
+    - name: checking if packages need to be installed
+      run: flowey e 11 flowey_lib_common::install_dist_pkg 0
+      shell: bash
+    - name: installing packages
+      run: flowey e 11 flowey_lib_common::install_dist_pkg 1
+      shell: bash
+    - name: unpack protoc
+      run: flowey e 11 flowey_lib_common::resolve_protoc 0
+      shell: bash
+    - name: symlink protoc
       run: |-
-        flowey e 11 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
-        flowey e 11 flowey_lib_hvlite::init_cross_build 4
-        flowey e 11 flowey_lib_hvlite::run_cargo_build 10
-        flowey e 11 flowey_lib_hvlite::run_cargo_build 11
-      shell: bash
-    - name: cargo build openvmm_hcl
-      run: |-
-        flowey e 11 flowey_lib_common::run_cargo_build 3
-        flowey e 11 flowey_lib_hvlite::run_cargo_build 12
-        flowey e 11 flowey_lib_hvlite::build_openvmm_hcl 1
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 24
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 11 flowey_lib_hvlite::run_split_debug_info 4
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 25
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 26
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 29
-      shell: bash
-    - name: building openhcl initrd
-      run: |-
-        flowey e 11 flowey_lib_hvlite::build_openhcl_initrd 4
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 30
-        flowey e 11 flowey_lib_hvlite::init_cross_build 2
-      shell: bash
-    - name: cargo build igvmfilegen
-      run: |-
-        flowey e 11 flowey_lib_common::run_cargo_build 0
-        flowey e 11 flowey_lib_hvlite::run_cargo_build 0
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 11 flowey_lib_hvlite::run_split_debug_info 8
-        flowey e 11 flowey_lib_hvlite::run_cargo_build 1
-        flowey e 11 flowey_lib_hvlite::build_igvmfilegen 0
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 31
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 32
-      shell: bash
-    - name: building igvm file
-      run: |-
-        flowey e 11 flowey_lib_hvlite::run_igvmfilegen 4
-        flowey e 11 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 2
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 39
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 35
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 11 flowey_lib_hvlite::run_split_debug_info 0
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 36
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 37
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 40
-      shell: bash
-    - name: extract and resolve kernel package
-      run: flowey e 11 flowey_lib_hvlite::resolve_openhcl_kernel_package 0
-      shell: bash
-    - name: building openhcl initrd
-      run: flowey e 11 flowey_lib_hvlite::build_openhcl_initrd 0
-      shell: bash
-    - name: unpack openvmm-test-linux archives
-      run: flowey e 11 flowey_lib_hvlite::resolve_openvmm_test_linux_kernel 0
-      shell: bash
-    - name: unpack openvmm-test-initrd archives
-      run: |-
-        flowey e 11 flowey_lib_hvlite::resolve_openvmm_test_initrd 0
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 41
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 42
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 43
-      shell: bash
-    - name: building igvm file
-      run: |-
-        flowey e 11 flowey_lib_hvlite::run_igvmfilegen 0
-        flowey e 11 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 4
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 50
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 46
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 11 flowey_lib_hvlite::run_split_debug_info 1
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 47
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 48
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 51
-      shell: bash
-    - name: building openhcl initrd
-      run: |-
-        flowey e 11 flowey_lib_hvlite::build_openhcl_initrd 1
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 52
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 53
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 54
-      shell: bash
-    - name: building igvm file
-      run: |-
-        flowey e 11 flowey_lib_hvlite::run_igvmfilegen 1
-        flowey e 11 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 6
-      shell: bash
-    - name: extract and resolve kernel package
-      run: |-
-        flowey e 11 flowey_lib_hvlite::resolve_openhcl_kernel_package 1
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 17
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 13
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 11 flowey_lib_hvlite::run_split_debug_info 3
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 14
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 15
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 18
-      shell: bash
-    - name: building openhcl initrd
-      run: |-
-        flowey e 11 flowey_lib_hvlite::build_openhcl_initrd 3
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 19
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 20
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 21
-      shell: bash
-    - name: building igvm file
-      run: |-
-        flowey e 11 flowey_lib_hvlite::run_igvmfilegen 3
-        flowey e 11 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 8
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 6
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 2
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 11 flowey_lib_hvlite::run_split_debug_info 2
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 3
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 4
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 7
-      shell: bash
-    - name: building openhcl initrd
-      run: |-
-        flowey e 11 flowey_lib_hvlite::build_openhcl_initrd 2
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 8
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 9
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 10
-      shell: bash
-    - name: building igvm file
-      run: |-
-        flowey e 11 flowey_lib_hvlite::run_igvmfilegen 2
-        flowey e 11 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 0
-        flowey e 11 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::publish 0
-      shell: bash
-    - name: copying OpenHCL igvm files to artifact dir
-      run: |-
-        flowey e 11 flowey_lib_common::copy_to_artifact_dir 1
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 22
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 27
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 23
-        flowey e 11 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 3
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 38
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 34
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 33
-        flowey e 11 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 5
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 49
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 45
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 44
-        flowey e 11 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 7
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 16
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 12
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 11
-        flowey e 11 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 9
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 5
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 1
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 0
-        flowey e 11 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 1
-        flowey e 11 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe_extras::publish 0
-      shell: bash
-    - name: copying OpenHCL igvm extras to artifact dir
-      run: |-
-        flowey e 11 flowey_lib_common::copy_to_artifact_dir 0
+        flowey e 11 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
         flowey e 11 flowey_lib_hvlite::init_cross_build 3
         flowey e 11 flowey_lib_hvlite::run_cargo_build 6
         flowey e 11 flowey_lib_hvlite::run_cargo_build 7
@@ -1037,9 +852,213 @@ jobs:
         flowey e 11 flowey_lib_hvlite::run_split_debug_info 6
         flowey e 11 flowey_lib_hvlite::run_cargo_build 9
         flowey e 11 flowey_lib_hvlite::build_openvmm_hcl 0
+        flowey e 11 flowey_lib_hvlite::_jobs::build_and_publish_openvmm_hcl_baseline 0
+        flowey e 11 flowey_core::pipeline::artifact::publish 0
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 3
+        flowey e 11 flowey_lib_hvlite::init_cross_build 4
+        flowey e 11 flowey_lib_hvlite::run_cargo_build 10
+        flowey e 11 flowey_lib_hvlite::run_cargo_build 11
       shell: bash
-    - name: copying openhcl build to publish dir
-      run: flowey e 11 flowey_lib_hvlite::artifact_openvmm_hcl_sizecheck::publish 0
+    - name: cargo build openvmm_hcl
+      run: |-
+        flowey e 11 flowey_lib_common::run_cargo_build 3
+        flowey e 11 flowey_lib_hvlite::run_cargo_build 12
+        flowey e 11 flowey_lib_hvlite::build_openvmm_hcl 1
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 0
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 11 flowey_lib_hvlite::run_split_debug_info 0
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 1
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 2
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 4
+      shell: bash
+    - name: extract and resolve kernel package
+      run: flowey e 11 flowey_lib_hvlite::resolve_openhcl_kernel_package 0
+      shell: bash
+    - name: building openhcl initrd
+      run: |-
+        flowey e 11 flowey_lib_hvlite::build_openhcl_initrd 2
+        flowey e 11 flowey_lib_hvlite::init_cross_build 0
+        flowey e 11 flowey_lib_hvlite::run_cargo_build 13
+        flowey e 11 flowey_lib_hvlite::run_cargo_build 14
+      shell: bash
+    - name: cargo build sidecar
+      run: |-
+        flowey e 11 flowey_lib_common::run_cargo_build 4
+        flowey e 11 flowey_lib_hvlite::run_cargo_build 15
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 11 flowey_lib_hvlite::run_split_debug_info 7
+        flowey e 11 flowey_lib_hvlite::run_cargo_build 16
+        flowey e 11 flowey_lib_hvlite::build_sidecar 0
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 5
+        flowey e 11 flowey_lib_hvlite::init_cross_build 1
+        flowey e 11 flowey_lib_hvlite::run_cargo_build 2
+        flowey e 11 flowey_lib_hvlite::run_cargo_build 3
+      shell: bash
+    - name: cargo build openhcl_boot
+      run: |-
+        flowey e 11 flowey_lib_common::run_cargo_build 1
+        flowey e 11 flowey_lib_hvlite::run_cargo_build 4
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 11 flowey_lib_hvlite::run_split_debug_info 5
+        flowey e 11 flowey_lib_hvlite::run_cargo_build 5
+        flowey e 11 flowey_lib_hvlite::build_openhcl_boot 0
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 6
+      shell: bash
+    - name: unpack mu_msvm package (x64)
+      run: |-
+        flowey e 11 flowey_lib_hvlite::download_uefi_mu_msvm 0
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 7
+        flowey e 11 flowey_lib_hvlite::init_cross_build 2
+      shell: bash
+    - name: cargo build igvmfilegen
+      run: |-
+        flowey e 11 flowey_lib_common::run_cargo_build 0
+        flowey e 11 flowey_lib_hvlite::run_cargo_build 0
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 11 flowey_lib_hvlite::run_split_debug_info 8
+        flowey e 11 flowey_lib_hvlite::run_cargo_build 1
+        flowey e 11 flowey_lib_hvlite::build_igvmfilegen 0
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 8
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 9
+      shell: bash
+    - name: building igvm file
+      run: |-
+        flowey e 11 flowey_lib_hvlite::run_igvmfilegen 2
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 12
+        flowey e 11 flowey_core::pipeline::artifact::publish 1
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 10
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 11
+        flowey e 11 flowey_core::pipeline::artifact::publish 2
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 34
+      shell: bash
+    - name: extract and resolve kernel package
+      run: |-
+        flowey e 11 flowey_lib_hvlite::resolve_openhcl_kernel_package 2
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 28
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 25
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 11 flowey_lib_hvlite::run_split_debug_info 4
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 26
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 27
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 29
+      shell: bash
+    - name: building openhcl initrd
+      run: |-
+        flowey e 11 flowey_lib_hvlite::build_openhcl_initrd 4
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 30
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 31
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 32
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 33
+      shell: bash
+    - name: building igvm file
+      run: |-
+        flowey e 11 flowey_lib_hvlite::run_igvmfilegen 4
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 37
+        flowey e 11 flowey_core::pipeline::artifact::publish 3
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 35
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 36
+        flowey e 11 flowey_core::pipeline::artifact::publish 4
+      shell: bash
+    - name: unpack openvmm-test-linux archives
+      run: flowey e 11 flowey_lib_hvlite::resolve_openvmm_test_linux_kernel 0
+      shell: bash
+    - name: unpack openvmm-test-initrd archives
+      run: |-
+        flowey e 11 flowey_lib_hvlite::resolve_openvmm_test_initrd 0
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 41
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 38
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 11 flowey_lib_hvlite::run_split_debug_info 1
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 39
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 40
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 42
+      shell: bash
+    - name: building openhcl initrd
+      run: |-
+        flowey e 11 flowey_lib_hvlite::build_openhcl_initrd 0
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 43
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 44
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 45
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 46
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 47
+      shell: bash
+    - name: building igvm file
+      run: |-
+        flowey e 11 flowey_lib_hvlite::run_igvmfilegen 0
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 50
+        flowey e 11 flowey_core::pipeline::artifact::publish 5
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 48
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 49
+        flowey e 11 flowey_core::pipeline::artifact::publish 6
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 54
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 51
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 11 flowey_lib_hvlite::run_split_debug_info 2
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 52
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 53
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 55
+      shell: bash
+    - name: building openhcl initrd
+      run: |-
+        flowey e 11 flowey_lib_hvlite::build_openhcl_initrd 1
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 56
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 57
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 58
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 59
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 60
+      shell: bash
+    - name: building igvm file
+      run: |-
+        flowey e 11 flowey_lib_hvlite::run_igvmfilegen 1
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 63
+        flowey e 11 flowey_core::pipeline::artifact::publish 7
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 61
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 62
+        flowey e 11 flowey_core::pipeline::artifact::publish 8
+      shell: bash
+    - name: extract and resolve kernel package
+      run: |-
+        flowey e 11 flowey_lib_hvlite::resolve_openhcl_kernel_package 1
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 16
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 13
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 11 flowey_lib_hvlite::run_split_debug_info 3
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 14
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 15
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 17
+      shell: bash
+    - name: building openhcl initrd
+      run: |-
+        flowey e 11 flowey_lib_hvlite::build_openhcl_initrd 3
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 18
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 19
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 20
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 21
+      shell: bash
+    - name: building igvm file
+      run: |-
+        flowey e 11 flowey_lib_hvlite::run_igvmfilegen 3
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 24
+        flowey e 11 flowey_core::pipeline::artifact::publish 9
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 22
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 23
+        flowey e 11 flowey_core::pipeline::artifact::publish 10
       shell: bash
     - name: 'validate cache entry: gh-release-download'
       run: flowey e 11 flowey_lib_common::cache 3
@@ -1056,11 +1075,59 @@ jobs:
         name: x64-openhcl-igvm
         path: ${{ runner.temp }}/publish_artifacts/x64-openhcl-igvm/
         include-hidden-files: true
+    - name: 🌼📦 Publish x64-openhcl-igvm-cvm
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-openhcl-igvm-cvm
+        path: ${{ runner.temp }}/publish_artifacts/x64-openhcl-igvm-cvm/
+        include-hidden-files: true
+    - name: 🌼📦 Publish x64-openhcl-igvm-cvm-extras
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-openhcl-igvm-cvm-extras
+        path: ${{ runner.temp }}/publish_artifacts/x64-openhcl-igvm-cvm-extras/
+        include-hidden-files: true
+    - name: 🌼📦 Publish x64-openhcl-igvm-devkern
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-openhcl-igvm-devkern
+        path: ${{ runner.temp }}/publish_artifacts/x64-openhcl-igvm-devkern/
+        include-hidden-files: true
+    - name: 🌼📦 Publish x64-openhcl-igvm-devkern-extras
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-openhcl-igvm-devkern-extras
+        path: ${{ runner.temp }}/publish_artifacts/x64-openhcl-igvm-devkern-extras/
+        include-hidden-files: true
     - name: 🌼📦 Publish x64-openhcl-igvm-extras
       uses: actions/upload-artifact@v7
       with:
         name: x64-openhcl-igvm-extras
         path: ${{ runner.temp }}/publish_artifacts/x64-openhcl-igvm-extras/
+        include-hidden-files: true
+    - name: 🌼📦 Publish x64-openhcl-igvm-test-linux-direct
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-openhcl-igvm-test-linux-direct
+        path: ${{ runner.temp }}/publish_artifacts/x64-openhcl-igvm-test-linux-direct/
+        include-hidden-files: true
+    - name: 🌼📦 Publish x64-openhcl-igvm-test-linux-direct-devkern
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-openhcl-igvm-test-linux-direct-devkern
+        path: ${{ runner.temp }}/publish_artifacts/x64-openhcl-igvm-test-linux-direct-devkern/
+        include-hidden-files: true
+    - name: 🌼📦 Publish x64-openhcl-igvm-test-linux-direct-devkern-extras
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-openhcl-igvm-test-linux-direct-devkern-extras
+        path: ${{ runner.temp }}/publish_artifacts/x64-openhcl-igvm-test-linux-direct-devkern-extras/
+        include-hidden-files: true
+    - name: 🌼📦 Publish x64-openhcl-igvm-test-linux-direct-extras
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-openhcl-igvm-test-linux-direct-extras
+        path: ${{ runner.temp }}/publish_artifacts/x64-openhcl-igvm-test-linux-direct-extras/
         include-hidden-files: true
   job12:
     name: build openhcl (mi-secure) [x64-linux]
@@ -1142,8 +1209,51 @@ jobs:
         EOF
         mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-mi-secure-openhcl-igvm"
         echo "$AgentTempDirNormal/publish_artifacts/x64-mi-secure-openhcl-igvm" | flowey v 12 'artifact_publish_from_x64-mi-secure-openhcl-igvm' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-mi-secure-openhcl-igvm-cvm"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-mi-secure-openhcl-igvm-cvm" | flowey v 12 'artifact_publish_from_x64-mi-secure-openhcl-igvm-cvm' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-mi-secure-openhcl-igvm-cvm-extras"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-mi-secure-openhcl-igvm-cvm-extras" | flowey v 12 'artifact_publish_from_x64-mi-secure-openhcl-igvm-cvm-extras' --is-raw-string update
         mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-mi-secure-openhcl-igvm-extras"
         echo "$AgentTempDirNormal/publish_artifacts/x64-mi-secure-openhcl-igvm-extras" | flowey v 12 'artifact_publish_from_x64-mi-secure-openhcl-igvm-extras' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-mi-secure-openhcl-igvm-test-linux-direct"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-mi-secure-openhcl-igvm-test-linux-direct" | flowey v 12 'artifact_publish_from_x64-mi-secure-openhcl-igvm-test-linux-direct' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-mi-secure-openhcl-igvm-test-linux-direct-extras"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-mi-secure-openhcl-igvm-test-linux-direct-extras" | flowey v 12 'artifact_publish_from_x64-mi-secure-openhcl-igvm-test-linux-direct-extras' --is-raw-string update
+      shell: bash
+    - name: check if openvmm needs to be cloned
+      run: |-
+        flowey e 12 flowey_lib_common::git_checkout 0
+        flowey v 12 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
+        flowey v 12 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__git_checkout__1
+      uses: actions/checkout@v6
+      with:
+        fetch-depth: '1'
+        path: repo0
+        persist-credentials: ${{ env.floweyvar3 }}
+      name: checkout repo openvmm
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: report cloned repo directories
+      run: |-
+        flowey v 12 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        ${{ github.workspace }}
+        EOF
+        flowey e 12 flowey_lib_common::git_checkout 3
+        flowey e 12 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 3
+      shell: bash
+    - name: add default cargo home to path
+      run: flowey e 12 flowey_lib_common::install_rust 0
+      shell: bash
+    - name: install Rust
+      run: flowey e 12 flowey_lib_common::install_rust 1
+      shell: bash
+    - name: detect active toolchain
+      run: |-
+        flowey e 12 flowey_lib_common::install_rust 2
+        flowey e 12 flowey_lib_common::cfg_cargo_common_flags 0
+        flowey e 12 flowey_lib_hvlite::cfg_openvmm_magicpath 0
       shell: bash
     - name: create gh-release-download cache dir
       run: flowey e 12 flowey_lib_common::download_gh_release 0
@@ -1168,44 +1278,11 @@ jobs:
         flowey e 12 flowey_lib_common::cache 2
         flowey e 12 flowey_lib_common::download_gh_release 1
       shell: bash
-    - name: unpack openvmm-test-linux archives
-      run: flowey e 12 flowey_lib_hvlite::resolve_openvmm_test_linux_kernel 0
+    - name: unpack openvmm-deps archive
+      run: flowey e 12 flowey_lib_hvlite::resolve_openvmm_deps 0
       shell: bash
-    - name: unpack openvmm-test-initrd archives
-      run: flowey e 12 flowey_lib_hvlite::resolve_openvmm_test_initrd 0
-      shell: bash
-    - name: add default cargo home to path
-      run: flowey e 12 flowey_lib_common::install_rust 0
-      shell: bash
-    - name: install Rust
-      run: flowey e 12 flowey_lib_common::install_rust 1
-      shell: bash
-    - name: detect active toolchain
-      run: |-
-        flowey e 12 flowey_lib_common::install_rust 2
-        flowey e 12 flowey_lib_common::cfg_cargo_common_flags 0
-      shell: bash
-    - name: check if openvmm needs to be cloned
-      run: |-
-        flowey e 12 flowey_lib_common::git_checkout 0
-        flowey v 12 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
-        flowey v 12 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__git_checkout__1
-      uses: actions/checkout@v6
-      with:
-        fetch-depth: '1'
-        path: repo0
-        persist-credentials: ${{ env.floweyvar3 }}
-      name: checkout repo openvmm
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: report cloned repo directories
-      run: |-
-        flowey v 12 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
-        ${{ github.workspace }}
-        EOF
-        flowey e 12 flowey_lib_common::git_checkout 3
-        flowey e 12 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+    - name: extract X86_64 sysroot.tar.gz
+      run: flowey e 12 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
       shell: bash
     - name: set '-Dwarnings' in .cargo/config.toml
       run: flowey e 12 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
@@ -1217,13 +1294,35 @@ jobs:
       run: flowey e 12 flowey_lib_common::install_dist_pkg 1
       shell: bash
     - name: unpack protoc
-      run: |-
-        flowey e 12 flowey_lib_common::resolve_protoc 0
-        flowey e 12 flowey_lib_hvlite::cfg_openvmm_magicpath 0
+      run: flowey e 12 flowey_lib_common::resolve_protoc 0
       shell: bash
     - name: symlink protoc
       run: |-
         flowey e 12 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
+        flowey e 12 flowey_lib_hvlite::init_cross_build 3
+        flowey e 12 flowey_lib_hvlite::run_cargo_build 6
+        flowey e 12 flowey_lib_hvlite::run_cargo_build 7
+      shell: bash
+    - name: cargo build openvmm_hcl
+      run: |-
+        flowey e 12 flowey_lib_common::run_cargo_build 2
+        flowey e 12 flowey_lib_hvlite::run_cargo_build 8
+        flowey e 12 flowey_lib_hvlite::build_openvmm_hcl 0
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 0
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 12 flowey_lib_hvlite::run_split_debug_info 0
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 1
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 2
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 4
+      shell: bash
+    - name: extract and resolve kernel package
+      run: flowey e 12 flowey_lib_hvlite::resolve_openhcl_kernel_package 0
+      shell: bash
+    - name: building openhcl initrd
+      run: |-
+        flowey e 12 flowey_lib_hvlite::build_openhcl_initrd 0
         flowey e 12 flowey_lib_hvlite::init_cross_build 0
         flowey e 12 flowey_lib_hvlite::run_cargo_build 9
         flowey e 12 flowey_lib_hvlite::run_cargo_build 10
@@ -1238,6 +1337,7 @@ jobs:
         flowey e 12 flowey_lib_hvlite::run_split_debug_info 4
         flowey e 12 flowey_lib_hvlite::run_cargo_build 12
         flowey e 12 flowey_lib_hvlite::build_sidecar 0
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 5
         flowey e 12 flowey_lib_hvlite::init_cross_build 1
         flowey e 12 flowey_lib_hvlite::run_cargo_build 2
         flowey e 12 flowey_lib_hvlite::run_cargo_build 3
@@ -1252,40 +1352,12 @@ jobs:
         flowey e 12 flowey_lib_hvlite::run_split_debug_info 3
         flowey e 12 flowey_lib_hvlite::run_cargo_build 5
         flowey e 12 flowey_lib_hvlite::build_openhcl_boot 0
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 6
       shell: bash
-    - name: extract and resolve kernel package
+    - name: unpack mu_msvm package (x64)
       run: |-
-        flowey e 12 flowey_lib_hvlite::resolve_openhcl_kernel_package 0
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 28
-      shell: bash
-    - name: unpack openvmm-deps archive
-      run: flowey e 12 flowey_lib_hvlite::resolve_openvmm_deps 0
-      shell: bash
-    - name: extract X86_64 sysroot.tar.gz
-      run: |-
-        flowey e 12 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
-        flowey e 12 flowey_lib_hvlite::init_cross_build 3
-        flowey e 12 flowey_lib_hvlite::run_cargo_build 6
-        flowey e 12 flowey_lib_hvlite::run_cargo_build 7
-      shell: bash
-    - name: cargo build openvmm_hcl
-      run: |-
-        flowey e 12 flowey_lib_common::run_cargo_build 2
-        flowey e 12 flowey_lib_hvlite::run_cargo_build 8
-        flowey e 12 flowey_lib_hvlite::build_openvmm_hcl 0
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 24
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 12 flowey_lib_hvlite::run_split_debug_info 2
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 25
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 26
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 29
-      shell: bash
-    - name: building openhcl initrd
-      run: |-
-        flowey e 12 flowey_lib_hvlite::build_openhcl_initrd 2
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 30
+        flowey e 12 flowey_lib_hvlite::download_uefi_mu_msvm 0
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 7
         flowey e 12 flowey_lib_hvlite::init_cross_build 2
       shell: bash
     - name: cargo build igvmfilegen
@@ -1298,21 +1370,56 @@ jobs:
         flowey e 12 flowey_lib_hvlite::run_split_debug_info 5
         flowey e 12 flowey_lib_hvlite::run_cargo_build 1
         flowey e 12 flowey_lib_hvlite::build_igvmfilegen 0
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 8
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 9
+      shell: bash
+    - name: building igvm file
+      run: |-
+        flowey e 12 flowey_lib_hvlite::run_igvmfilegen 1
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 12
+        flowey e 12 flowey_core::pipeline::artifact::publish 0
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 10
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 11
+        flowey e 12 flowey_core::pipeline::artifact::publish 1
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 33
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 34
+      shell: bash
+    - name: unpack openvmm-test-linux archives
+      run: flowey e 12 flowey_lib_hvlite::resolve_openvmm_test_linux_kernel 0
+      shell: bash
+    - name: unpack openvmm-test-initrd archives
+      run: |-
+        flowey e 12 flowey_lib_hvlite::resolve_openvmm_test_initrd 0
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 28
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 25
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 12 flowey_lib_hvlite::run_split_debug_info 2
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 26
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 27
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 29
+      shell: bash
+    - name: building openhcl initrd
+      run: |-
+        flowey e 12 flowey_lib_hvlite::build_openhcl_initrd 2
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 30
         flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 31
         flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 32
       shell: bash
     - name: building igvm file
       run: |-
-        flowey e 12 flowey_lib_hvlite::run_igvmfilegen 2
-        flowey e 12 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 2
-      shell: bash
-    - name: unpack mu_msvm package (x64)
-      run: flowey e 12 flowey_lib_hvlite::download_uefi_mu_msvm 0
+        flowey e 12 flowey_lib_hvlite::run_igvmfilegen 0
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 37
+        flowey e 12 flowey_core::pipeline::artifact::publish 2
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 35
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 36
+        flowey e 12 flowey_core::pipeline::artifact::publish 3
       shell: bash
     - name: extract and resolve kernel package
       run: |-
         flowey e 12 flowey_lib_hvlite::resolve_openhcl_kernel_package 1
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 17
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 16
         flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 13
       shell: bash
     - name: split debug symbols
@@ -1320,61 +1427,24 @@ jobs:
         flowey e 12 flowey_lib_hvlite::run_split_debug_info 1
         flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 14
         flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 15
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 18
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 17
       shell: bash
     - name: building openhcl initrd
       run: |-
         flowey e 12 flowey_lib_hvlite::build_openhcl_initrd 1
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 18
         flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 19
         flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 20
         flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 21
       shell: bash
     - name: building igvm file
       run: |-
-        flowey e 12 flowey_lib_hvlite::run_igvmfilegen 1
-        flowey e 12 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 4
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 6
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 2
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 12 flowey_lib_hvlite::run_split_debug_info 0
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 3
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 4
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 7
-      shell: bash
-    - name: building openhcl initrd
-      run: |-
-        flowey e 12 flowey_lib_hvlite::build_openhcl_initrd 0
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 8
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 9
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 10
-      shell: bash
-    - name: building igvm file
-      run: |-
-        flowey e 12 flowey_lib_hvlite::run_igvmfilegen 0
-        flowey e 12 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 0
-        flowey e 12 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::publish 0
-      shell: bash
-    - name: copying OpenHCL igvm files to artifact dir
-      run: |-
-        flowey e 12 flowey_lib_common::copy_to_artifact_dir 1
+        flowey e 12 flowey_lib_hvlite::run_igvmfilegen 2
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 24
+        flowey e 12 flowey_core::pipeline::artifact::publish 4
         flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 22
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 27
         flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 23
-        flowey e 12 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 3
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 16
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 12
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 11
-        flowey e 12 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 5
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 5
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 1
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 0
-        flowey e 12 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 1
-        flowey e 12 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe_extras::publish 0
-      shell: bash
-    - name: copying OpenHCL igvm extras to artifact dir
-      run: flowey e 12 flowey_lib_common::copy_to_artifact_dir 0
+        flowey e 12 flowey_core::pipeline::artifact::publish 5
       shell: bash
     - name: 'validate cache entry: gh-release-download'
       run: flowey e 12 flowey_lib_common::cache 3
@@ -1385,11 +1455,35 @@ jobs:
         name: x64-mi-secure-openhcl-igvm
         path: ${{ runner.temp }}/publish_artifacts/x64-mi-secure-openhcl-igvm/
         include-hidden-files: true
+    - name: 🌼📦 Publish x64-mi-secure-openhcl-igvm-cvm
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-mi-secure-openhcl-igvm-cvm
+        path: ${{ runner.temp }}/publish_artifacts/x64-mi-secure-openhcl-igvm-cvm/
+        include-hidden-files: true
+    - name: 🌼📦 Publish x64-mi-secure-openhcl-igvm-cvm-extras
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-mi-secure-openhcl-igvm-cvm-extras
+        path: ${{ runner.temp }}/publish_artifacts/x64-mi-secure-openhcl-igvm-cvm-extras/
+        include-hidden-files: true
     - name: 🌼📦 Publish x64-mi-secure-openhcl-igvm-extras
       uses: actions/upload-artifact@v7
       with:
         name: x64-mi-secure-openhcl-igvm-extras
         path: ${{ runner.temp }}/publish_artifacts/x64-mi-secure-openhcl-igvm-extras/
+        include-hidden-files: true
+    - name: 🌼📦 Publish x64-mi-secure-openhcl-igvm-test-linux-direct
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-mi-secure-openhcl-igvm-test-linux-direct
+        path: ${{ runner.temp }}/publish_artifacts/x64-mi-secure-openhcl-igvm-test-linux-direct/
+        include-hidden-files: true
+    - name: 🌼📦 Publish x64-mi-secure-openhcl-igvm-test-linux-direct-extras
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-mi-secure-openhcl-igvm-test-linux-direct-extras
+        path: ${{ runner.temp }}/publish_artifacts/x64-mi-secure-openhcl-igvm-test-linux-direct-extras/
         include-hidden-files: true
   job13:
     name: clippy [x64-windows], unit tests [x64-windows]
@@ -3185,115 +3279,6 @@ jobs:
         flowey e 18 flowey_lib_common::install_rust 2
         flowey e 18 flowey_lib_common::cfg_cargo_common_flags 0
       shell: bash
-    - name: check if openvmm needs to be cloned
-      run: |-
-        flowey e 18 flowey_lib_common::git_checkout 0
-        flowey v 18 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar11
-        flowey v 18 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__git_checkout__1
-      uses: actions/checkout@v6
-      with:
-        fetch-depth: '1'
-        path: repo0
-        persist-credentials: ${{ env.floweyvar11 }}
-      name: checkout repo openvmm
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: report cloned repo directories
-      run: |-
-        flowey v 18 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
-        ${{ github.workspace }}
-        EOF
-        flowey e 18 flowey_lib_common::git_checkout 3
-        flowey e 18 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-        flowey e 18 flowey_lib_hvlite::cfg_openvmm_magicpath 0
-      shell: bash
-    - name: create gh-release-download cache dir
-      run: flowey e 18 flowey_lib_common::download_gh_release 0
-      shell: bash
-    - name: Pre-processing cache vars
-      run: |-
-        flowey e 18 flowey_lib_common::cache 4
-        flowey v 18 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar9
-        flowey v 18 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar10
-      shell: bash
-    - id: flowey_lib_common__cache__5
-      uses: actions/cache@v5
-      with:
-        key: ${{ env.floweyvar9 }}
-        path: ${{ env.floweyvar10 }}
-      name: 'Restore cache: gh-release-download'
-    - name: download artifacts from github releases
-      run: |-
-        flowey v 18 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
-        EOF
-        flowey e 18 flowey_lib_common::cache 6
-        flowey e 18 flowey_lib_common::download_gh_release 1
-      shell: bash
-    - name: unpack openvmm-deps archive
-      run: flowey e 18 flowey_lib_hvlite::resolve_openvmm_deps 0
-      shell: bash
-    - name: extract Aarch64 sysroot.tar.gz
-      run: flowey e 18 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
-      shell: bash
-    - name: checking if packages need to be installed
-      run: flowey e 18 flowey_lib_common::install_dist_pkg 0
-      shell: bash
-    - name: installing packages
-      run: flowey e 18 flowey_lib_common::install_dist_pkg 1
-      shell: bash
-    - name: set '-Dwarnings' in .cargo/config.toml
-      run: flowey e 18 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
-      shell: bash
-    - name: unpack protoc
-      run: flowey e 18 flowey_lib_common::resolve_protoc 0
-      shell: bash
-    - name: symlink protoc
-      run: |-
-        flowey e 18 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-        flowey e 18 flowey_lib_hvlite::init_cross_build 2
-      shell: bash
-    - name: cargo clippy
-      run: flowey e 18 flowey_lib_common::run_cargo_clippy 3
-      shell: bash
-    - name: cargo clippy
-      run: flowey e 18 flowey_lib_common::run_cargo_clippy 5
-      shell: bash
-    - name: cargo clippy
-      run: flowey e 18 flowey_lib_common::run_cargo_clippy 1
-      shell: bash
-    - name: cargo clippy
-      run: flowey e 18 flowey_lib_common::run_cargo_clippy 7
-      shell: bash
-    - name: cargo clippy
-      run: |-
-        flowey e 18 flowey_lib_common::run_cargo_clippy 6
-        flowey e 18 flowey_lib_hvlite::init_cross_build 0
-      shell: bash
-    - name: cargo build xtask
-      run: |-
-        flowey e 18 flowey_lib_common::run_cargo_build 0
-        flowey e 18 flowey_lib_hvlite::run_cargo_build 0
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 18 flowey_lib_hvlite::run_split_debug_info 1
-        flowey e 18 flowey_lib_hvlite::run_cargo_build 1
-        flowey e 18 flowey_lib_hvlite::build_xtask 0
-      shell: bash
-    - name: determine clippy exclusions
-      run: flowey e 18 flowey_lib_hvlite::_jobs::check_clippy 0
-      shell: bash
-    - name: cargo clippy
-      run: flowey e 18 flowey_lib_common::run_cargo_clippy 0
-      shell: bash
-    - name: cargo clippy
-      run: flowey e 18 flowey_lib_common::run_cargo_clippy 2
-      shell: bash
-    - name: cargo clippy
-      run: flowey e 18 flowey_lib_common::run_cargo_clippy 4
-      shell: bash
     - name: create cargo-nextest cache dir
       run: |-
         flowey e 18 flowey_lib_common::download_cargo_nextest 0
@@ -3328,10 +3313,78 @@ jobs:
       run: |-
         flowey e 18 flowey_lib_common::install_cargo_nextest 0
         flowey e 18 flowey_lib_hvlite::init_cross_build 3
+      shell: bash
+    - name: check if openvmm needs to be cloned
+      run: |-
+        flowey e 18 flowey_lib_common::git_checkout 0
+        flowey v 18 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar11
+        flowey v 18 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__git_checkout__1
+      uses: actions/checkout@v6
+      with:
+        fetch-depth: '1'
+        path: repo0
+        persist-credentials: ${{ env.floweyvar11 }}
+      name: checkout repo openvmm
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: report cloned repo directories
+      run: |-
+        flowey v 18 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        ${{ github.workspace }}
+        EOF
+        flowey e 18 flowey_lib_common::git_checkout 3
+        flowey e 18 flowey_lib_hvlite::git_checkout_openvmm_repo 0
         flowey e 18 flowey_lib_hvlite::run_cargo_nextest_run 0
       shell: bash
     - name: generate nextest command
       run: flowey e 18 flowey_lib_common::gen_cargo_nextest_run_cmd 1
+      shell: bash
+    - name: set '-Dwarnings' in .cargo/config.toml
+      run: flowey e 18 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
+      shell: bash
+    - name: create gh-release-download cache dir
+      run: flowey e 18 flowey_lib_common::download_gh_release 0
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
+        flowey e 18 flowey_lib_common::cache 4
+        flowey v 18 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar9
+        flowey v 18 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar10
+      shell: bash
+    - id: flowey_lib_common__cache__5
+      uses: actions/cache@v5
+      with:
+        key: ${{ env.floweyvar9 }}
+        path: ${{ env.floweyvar10 }}
+      name: 'Restore cache: gh-release-download'
+    - name: download artifacts from github releases
+      run: |-
+        flowey v 18 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
+        EOF
+        flowey e 18 flowey_lib_common::cache 6
+        flowey e 18 flowey_lib_common::download_gh_release 1
+      shell: bash
+    - name: checking if packages need to be installed
+      run: flowey e 18 flowey_lib_common::install_dist_pkg 0
+      shell: bash
+    - name: installing packages
+      run: flowey e 18 flowey_lib_common::install_dist_pkg 1
+      shell: bash
+    - name: unpack protoc
+      run: |-
+        flowey e 18 flowey_lib_common::resolve_protoc 0
+        flowey e 18 flowey_lib_hvlite::cfg_openvmm_magicpath 0
+      shell: bash
+    - name: symlink protoc
+      run: flowey e 18 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
+      shell: bash
+    - name: unpack openvmm-deps archive
+      run: flowey e 18 flowey_lib_hvlite::resolve_openvmm_deps 0
+      shell: bash
+    - name: extract Aarch64 sysroot.tar.gz
+      run: flowey e 18 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
       shell: bash
     - name: run 'unit-tests crypto (native)' nextest tests
       run: |-
@@ -3477,7 +3530,49 @@ jobs:
         flowey e 18 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
       shell: bash
     - name: run doctests for aarch64-unknown-linux-musl
-      run: flowey e 18 flowey_lib_hvlite::_jobs::build_and_run_doc_tests 0
+      run: |-
+        flowey e 18 flowey_lib_hvlite::_jobs::build_and_run_doc_tests 0
+        flowey e 18 flowey_lib_hvlite::init_cross_build 2
+      shell: bash
+    - name: cargo clippy
+      run: flowey e 18 flowey_lib_common::run_cargo_clippy 3
+      shell: bash
+    - name: cargo clippy
+      run: flowey e 18 flowey_lib_common::run_cargo_clippy 5
+      shell: bash
+    - name: cargo clippy
+      run: flowey e 18 flowey_lib_common::run_cargo_clippy 1
+      shell: bash
+    - name: cargo clippy
+      run: flowey e 18 flowey_lib_common::run_cargo_clippy 7
+      shell: bash
+    - name: cargo clippy
+      run: |-
+        flowey e 18 flowey_lib_common::run_cargo_clippy 6
+        flowey e 18 flowey_lib_hvlite::init_cross_build 0
+      shell: bash
+    - name: cargo build xtask
+      run: |-
+        flowey e 18 flowey_lib_common::run_cargo_build 0
+        flowey e 18 flowey_lib_hvlite::run_cargo_build 0
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 18 flowey_lib_hvlite::run_split_debug_info 1
+        flowey e 18 flowey_lib_hvlite::run_cargo_build 1
+        flowey e 18 flowey_lib_hvlite::build_xtask 0
+      shell: bash
+    - name: determine clippy exclusions
+      run: flowey e 18 flowey_lib_hvlite::_jobs::check_clippy 0
+      shell: bash
+    - name: cargo clippy
+      run: flowey e 18 flowey_lib_common::run_cargo_clippy 0
+      shell: bash
+    - name: cargo clippy
+      run: flowey e 18 flowey_lib_common::run_cargo_clippy 2
+      shell: bash
+    - name: cargo clippy
+      run: flowey e 18 flowey_lib_common::run_cargo_clippy 4
       shell: bash
     - name: 'validate cache entry: cargo-nextest'
       run: flowey e 18 flowey_lib_common::cache 3
@@ -3505,7 +3600,7 @@ jobs:
     - name: 🌼📦 Download artifacts
       uses: actions/download-artifact@v8
       with:
-        pattern: '{_internal-flowey-bootstrap-x86_64-windows-uid-13,x64-guest_test_uefi,x64-linux-musl-pipette,x64-linux-musl-tmk_vmm,x64-linux-tpm_guest_tests,x64-openhcl-igvm,x64-tmks,x64-windows-openvmm,x64-windows-pipette,x64-windows-prep_steps,x64-windows-test_igvm_agent_rpc_server,x64-windows-tmk_vmm,x64-windows-tpm_guest_tests,x64-windows-vmgstool,x64-windows-vmgstool-dev,x64-windows-vmm-tests-archive}'
+        pattern: '{_internal-flowey-bootstrap-x86_64-windows-uid-13,x64-guest_test_uefi,x64-linux-musl-pipette,x64-linux-musl-tmk_vmm,x64-linux-tpm_guest_tests,x64-openhcl-igvm,x64-openhcl-igvm-cvm,x64-openhcl-igvm-test-linux-direct,x64-tmks,x64-windows-openvmm,x64-windows-pipette,x64-windows-prep_steps,x64-windows-test_igvm_agent_rpc_server,x64-windows-tmk_vmm,x64-windows-tpm_guest_tests,x64-windows-vmgstool,x64-windows-vmgstool-dev,x64-windows-vmm-tests-archive}'
         path: ${{ runner.temp }}/used_artifacts/
     - run: echo "${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-windows-uid-13" >> $GITHUB_PATH
       shell: bash
@@ -3529,6 +3624,8 @@ jobs:
         echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-tmk_vmm" | flowey.exe v 19 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
         echo "${{ runner.temp }}\\used_artifacts\\x64-linux-tpm_guest_tests" | flowey.exe v 19 'artifact_use_from_x64-linux-tpm_guest_tests' --is-raw-string update
         echo "${{ runner.temp }}\\used_artifacts\\x64-openhcl-igvm" | flowey.exe v 19 'artifact_use_from_x64-openhcl-igvm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-openhcl-igvm-cvm" | flowey.exe v 19 'artifact_use_from_x64-openhcl-igvm-cvm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-openhcl-igvm-test-linux-direct" | flowey.exe v 19 'artifact_use_from_x64-openhcl-igvm-test-linux-direct' --is-raw-string update
         echo "${{ runner.temp }}\\used_artifacts\\x64-tmks" | flowey.exe v 19 'artifact_use_from_x64-tmks' --is-raw-string update
         echo "${{ runner.temp }}\\used_artifacts\\x64-windows-openvmm" | flowey.exe v 19 'artifact_use_from_x64-windows-openvmm' --is-raw-string update
         echo "${{ runner.temp }}\\used_artifacts\\x64-windows-pipette" | flowey.exe v 19 'artifact_use_from_x64-windows-pipette' --is-raw-string update
@@ -3589,24 +3686,24 @@ jobs:
         flowey.exe e 19 flowey_lib_common::git_checkout 3
         flowey.exe e 19 flowey_lib_hvlite::git_checkout_openvmm_repo 0
         flowey.exe e 19 flowey_lib_hvlite::run_cargo_nextest_run 0
+        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 8
+        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 9
+        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 12
+        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 14
+        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 15
+        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 13
+        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 3
+        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 11
+        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 4
         flowey.exe e 19 flowey_core::pipeline::artifact::resolve 5
         flowey.exe e 19 flowey_core::pipeline::artifact::resolve 6
         flowey.exe e 19 flowey_core::pipeline::artifact::resolve 1
-        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 0
-        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 9
         flowey.exe e 19 flowey_core::pipeline::artifact::resolve 2
-        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 4
-        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 11
-        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 12
-        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 10
-        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 3
-        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 8
+        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 0
+        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 7
       shell: bash
     - name: creating new test content dir
       run: flowey.exe e 19 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
-      shell: bash
-    - name: resolve OpenHCL igvm artifact
-      run: flowey.exe e 19 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::resolve 0
       shell: bash
     - name: create gh-release-download cache dir
       run: flowey.exe e 19 flowey_lib_common::download_gh_release 0
@@ -3695,7 +3792,7 @@ jobs:
       run: |-
         flowey.exe e 19 flowey_lib_hvlite::init_vmm_tests_env 0
         flowey.exe e 19 flowey_lib_hvlite::run_cargo_nextest_run 1
-        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 13
+        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 16
         flowey.exe e 19 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
       shell: bash
     - name: generate nextest command
@@ -3707,7 +3804,7 @@ jobs:
     - name: starting test_igvm_agent_rpc_server
       run: |-
         flowey.exe e 19 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
-        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 7
+        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 10
       shell: bash
     - name: running vmm_test prep_steps
       run: flowey.exe e 19 flowey_lib_hvlite::run_prep_steps 0
@@ -3964,7 +4061,7 @@ jobs:
     - name: 🌼📦 Download artifacts
       uses: actions/download-artifact@v8
       with:
-        pattern: '{_internal-flowey-bootstrap-x86_64-windows-uid-13,x64-guest_test_uefi,x64-linux-musl-pipette,x64-linux-musl-tmk_vmm,x64-linux-tpm_guest_tests,x64-mi-secure-openhcl-igvm,x64-tmks,x64-windows-openvmm,x64-windows-pipette,x64-windows-prep_steps,x64-windows-test_igvm_agent_rpc_server,x64-windows-tmk_vmm,x64-windows-tpm_guest_tests,x64-windows-vmgstool,x64-windows-vmgstool-dev,x64-windows-vmm-tests-archive}'
+        pattern: '{_internal-flowey-bootstrap-x86_64-windows-uid-13,x64-guest_test_uefi,x64-linux-musl-pipette,x64-linux-musl-tmk_vmm,x64-linux-tpm_guest_tests,x64-mi-secure-openhcl-igvm,x64-mi-secure-openhcl-igvm-cvm,x64-mi-secure-openhcl-igvm-test-linux-direct,x64-tmks,x64-windows-openvmm,x64-windows-pipette,x64-windows-prep_steps,x64-windows-test_igvm_agent_rpc_server,x64-windows-tmk_vmm,x64-windows-tpm_guest_tests,x64-windows-vmgstool,x64-windows-vmgstool-dev,x64-windows-vmm-tests-archive}'
         path: ${{ runner.temp }}/used_artifacts/
     - run: echo "${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-windows-uid-13" >> $GITHUB_PATH
       shell: bash
@@ -3988,6 +4085,8 @@ jobs:
         echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-tmk_vmm" | flowey.exe v 20 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
         echo "${{ runner.temp }}\\used_artifacts\\x64-linux-tpm_guest_tests" | flowey.exe v 20 'artifact_use_from_x64-linux-tpm_guest_tests' --is-raw-string update
         echo "${{ runner.temp }}\\used_artifacts\\x64-mi-secure-openhcl-igvm" | flowey.exe v 20 'artifact_use_from_x64-mi-secure-openhcl-igvm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-mi-secure-openhcl-igvm-cvm" | flowey.exe v 20 'artifact_use_from_x64-mi-secure-openhcl-igvm-cvm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-mi-secure-openhcl-igvm-test-linux-direct" | flowey.exe v 20 'artifact_use_from_x64-mi-secure-openhcl-igvm-test-linux-direct' --is-raw-string update
         echo "${{ runner.temp }}\\used_artifacts\\x64-tmks" | flowey.exe v 20 'artifact_use_from_x64-tmks' --is-raw-string update
         echo "${{ runner.temp }}\\used_artifacts\\x64-windows-openvmm" | flowey.exe v 20 'artifact_use_from_x64-windows-openvmm' --is-raw-string update
         echo "${{ runner.temp }}\\used_artifacts\\x64-windows-pipette" | flowey.exe v 20 'artifact_use_from_x64-windows-pipette' --is-raw-string update
@@ -4048,24 +4147,24 @@ jobs:
         flowey.exe e 20 flowey_lib_common::git_checkout 3
         flowey.exe e 20 flowey_lib_hvlite::git_checkout_openvmm_repo 0
         flowey.exe e 20 flowey_lib_hvlite::run_cargo_nextest_run 0
+        flowey.exe e 20 flowey_core::pipeline::artifact::resolve 12
+        flowey.exe e 20 flowey_core::pipeline::artifact::resolve 14
+        flowey.exe e 20 flowey_core::pipeline::artifact::resolve 15
+        flowey.exe e 20 flowey_core::pipeline::artifact::resolve 13
+        flowey.exe e 20 flowey_core::pipeline::artifact::resolve 3
+        flowey.exe e 20 flowey_core::pipeline::artifact::resolve 11
+        flowey.exe e 20 flowey_core::pipeline::artifact::resolve 4
         flowey.exe e 20 flowey_core::pipeline::artifact::resolve 5
         flowey.exe e 20 flowey_core::pipeline::artifact::resolve 6
         flowey.exe e 20 flowey_core::pipeline::artifact::resolve 1
-        flowey.exe e 20 flowey_core::pipeline::artifact::resolve 0
-        flowey.exe e 20 flowey_core::pipeline::artifact::resolve 9
         flowey.exe e 20 flowey_core::pipeline::artifact::resolve 2
-        flowey.exe e 20 flowey_core::pipeline::artifact::resolve 4
-        flowey.exe e 20 flowey_core::pipeline::artifact::resolve 11
-        flowey.exe e 20 flowey_core::pipeline::artifact::resolve 12
-        flowey.exe e 20 flowey_core::pipeline::artifact::resolve 10
-        flowey.exe e 20 flowey_core::pipeline::artifact::resolve 3
+        flowey.exe e 20 flowey_core::pipeline::artifact::resolve 0
+        flowey.exe e 20 flowey_core::pipeline::artifact::resolve 7
         flowey.exe e 20 flowey_core::pipeline::artifact::resolve 8
+        flowey.exe e 20 flowey_core::pipeline::artifact::resolve 9
       shell: bash
     - name: creating new test content dir
       run: flowey.exe e 20 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
-      shell: bash
-    - name: resolve OpenHCL igvm artifact
-      run: flowey.exe e 20 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::resolve 0
       shell: bash
     - name: create gh-release-download cache dir
       run: flowey.exe e 20 flowey_lib_common::download_gh_release 0
@@ -4154,7 +4253,7 @@ jobs:
       run: |-
         flowey.exe e 20 flowey_lib_hvlite::init_vmm_tests_env 0
         flowey.exe e 20 flowey_lib_hvlite::run_cargo_nextest_run 1
-        flowey.exe e 20 flowey_core::pipeline::artifact::resolve 13
+        flowey.exe e 20 flowey_core::pipeline::artifact::resolve 16
         flowey.exe e 20 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
       shell: bash
     - name: generate nextest command
@@ -4237,7 +4336,7 @@ jobs:
     - name: 🌼📦 Download artifacts
       uses: actions/download-artifact@v8
       with:
-        pattern: '{_internal-flowey-bootstrap-x86_64-windows-uid-13,x64-guest_test_uefi,x64-linux-musl-pipette,x64-linux-musl-tmk_vmm,x64-linux-tpm_guest_tests,x64-openhcl-igvm,x64-tmks,x64-windows-openvmm,x64-windows-pipette,x64-windows-prep_steps,x64-windows-test_igvm_agent_rpc_server,x64-windows-tmk_vmm,x64-windows-tpm_guest_tests,x64-windows-vmgstool,x64-windows-vmgstool-dev,x64-windows-vmm-tests-archive}'
+        pattern: '{_internal-flowey-bootstrap-x86_64-windows-uid-13,x64-guest_test_uefi,x64-linux-musl-pipette,x64-linux-musl-tmk_vmm,x64-linux-tpm_guest_tests,x64-openhcl-igvm,x64-openhcl-igvm-cvm,x64-openhcl-igvm-test-linux-direct,x64-tmks,x64-windows-openvmm,x64-windows-pipette,x64-windows-prep_steps,x64-windows-test_igvm_agent_rpc_server,x64-windows-tmk_vmm,x64-windows-tpm_guest_tests,x64-windows-vmgstool,x64-windows-vmgstool-dev,x64-windows-vmm-tests-archive}'
         path: ${{ runner.temp }}/used_artifacts/
     - run: echo "${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-windows-uid-13" >> $GITHUB_PATH
       shell: bash
@@ -4261,6 +4360,8 @@ jobs:
         echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-tmk_vmm" | flowey.exe v 21 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
         echo "${{ runner.temp }}\\used_artifacts\\x64-linux-tpm_guest_tests" | flowey.exe v 21 'artifact_use_from_x64-linux-tpm_guest_tests' --is-raw-string update
         echo "${{ runner.temp }}\\used_artifacts\\x64-openhcl-igvm" | flowey.exe v 21 'artifact_use_from_x64-openhcl-igvm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-openhcl-igvm-cvm" | flowey.exe v 21 'artifact_use_from_x64-openhcl-igvm-cvm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-openhcl-igvm-test-linux-direct" | flowey.exe v 21 'artifact_use_from_x64-openhcl-igvm-test-linux-direct' --is-raw-string update
         echo "${{ runner.temp }}\\used_artifacts\\x64-tmks" | flowey.exe v 21 'artifact_use_from_x64-tmks' --is-raw-string update
         echo "${{ runner.temp }}\\used_artifacts\\x64-windows-openvmm" | flowey.exe v 21 'artifact_use_from_x64-windows-openvmm' --is-raw-string update
         echo "${{ runner.temp }}\\used_artifacts\\x64-windows-pipette" | flowey.exe v 21 'artifact_use_from_x64-windows-pipette' --is-raw-string update
@@ -4321,24 +4422,24 @@ jobs:
         flowey.exe e 21 flowey_lib_common::git_checkout 3
         flowey.exe e 21 flowey_lib_hvlite::git_checkout_openvmm_repo 0
         flowey.exe e 21 flowey_lib_hvlite::run_cargo_nextest_run 0
+        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 8
+        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 9
+        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 12
+        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 14
+        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 15
+        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 13
+        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 3
+        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 11
+        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 4
         flowey.exe e 21 flowey_core::pipeline::artifact::resolve 5
         flowey.exe e 21 flowey_core::pipeline::artifact::resolve 6
         flowey.exe e 21 flowey_core::pipeline::artifact::resolve 1
-        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 0
-        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 9
         flowey.exe e 21 flowey_core::pipeline::artifact::resolve 2
-        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 4
-        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 11
-        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 12
-        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 10
-        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 3
-        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 8
+        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 0
+        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 7
       shell: bash
     - name: creating new test content dir
       run: flowey.exe e 21 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
-      shell: bash
-    - name: resolve OpenHCL igvm artifact
-      run: flowey.exe e 21 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::resolve 0
       shell: bash
     - name: create gh-release-download cache dir
       run: flowey.exe e 21 flowey_lib_common::download_gh_release 0
@@ -4427,7 +4528,7 @@ jobs:
       run: |-
         flowey.exe e 21 flowey_lib_hvlite::init_vmm_tests_env 0
         flowey.exe e 21 flowey_lib_hvlite::run_cargo_nextest_run 1
-        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 13
+        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 16
         flowey.exe e 21 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
       shell: bash
     - name: generate nextest command
@@ -4439,7 +4540,7 @@ jobs:
     - name: starting test_igvm_agent_rpc_server
       run: |-
         flowey.exe e 21 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
-        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 7
+        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 10
       shell: bash
     - name: running vmm_test prep_steps
       run: flowey.exe e 21 flowey_lib_hvlite::run_prep_steps 0
@@ -4514,7 +4615,7 @@ jobs:
     - name: 🌼📦 Download artifacts
       uses: actions/download-artifact@v8
       with:
-        pattern: '{_internal-flowey-bootstrap-x86_64-windows-uid-13,x64-guest_test_uefi,x64-linux-musl-pipette,x64-linux-musl-tmk_vmm,x64-linux-tpm_guest_tests,x64-openhcl-igvm,x64-tmks,x64-windows-openvmm,x64-windows-pipette,x64-windows-prep_steps,x64-windows-test_igvm_agent_rpc_server,x64-windows-tmk_vmm,x64-windows-tpm_guest_tests,x64-windows-vmgstool,x64-windows-vmgstool-dev,x64-windows-vmm-tests-archive}'
+        pattern: '{_internal-flowey-bootstrap-x86_64-windows-uid-13,x64-guest_test_uefi,x64-linux-musl-pipette,x64-linux-musl-tmk_vmm,x64-linux-tpm_guest_tests,x64-openhcl-igvm,x64-openhcl-igvm-cvm,x64-openhcl-igvm-test-linux-direct,x64-tmks,x64-windows-openvmm,x64-windows-pipette,x64-windows-prep_steps,x64-windows-test_igvm_agent_rpc_server,x64-windows-tmk_vmm,x64-windows-tpm_guest_tests,x64-windows-vmgstool,x64-windows-vmgstool-dev,x64-windows-vmm-tests-archive}'
         path: ${{ runner.temp }}/used_artifacts/
     - run: echo "${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-windows-uid-13" >> $GITHUB_PATH
       shell: bash
@@ -4538,6 +4639,8 @@ jobs:
         echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-tmk_vmm" | flowey.exe v 22 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
         echo "${{ runner.temp }}\\used_artifacts\\x64-linux-tpm_guest_tests" | flowey.exe v 22 'artifact_use_from_x64-linux-tpm_guest_tests' --is-raw-string update
         echo "${{ runner.temp }}\\used_artifacts\\x64-openhcl-igvm" | flowey.exe v 22 'artifact_use_from_x64-openhcl-igvm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-openhcl-igvm-cvm" | flowey.exe v 22 'artifact_use_from_x64-openhcl-igvm-cvm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-openhcl-igvm-test-linux-direct" | flowey.exe v 22 'artifact_use_from_x64-openhcl-igvm-test-linux-direct' --is-raw-string update
         echo "${{ runner.temp }}\\used_artifacts\\x64-tmks" | flowey.exe v 22 'artifact_use_from_x64-tmks' --is-raw-string update
         echo "${{ runner.temp }}\\used_artifacts\\x64-windows-openvmm" | flowey.exe v 22 'artifact_use_from_x64-windows-openvmm' --is-raw-string update
         echo "${{ runner.temp }}\\used_artifacts\\x64-windows-pipette" | flowey.exe v 22 'artifact_use_from_x64-windows-pipette' --is-raw-string update
@@ -4598,24 +4701,24 @@ jobs:
         flowey.exe e 22 flowey_lib_common::git_checkout 3
         flowey.exe e 22 flowey_lib_hvlite::git_checkout_openvmm_repo 0
         flowey.exe e 22 flowey_lib_hvlite::run_cargo_nextest_run 0
+        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 8
+        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 9
+        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 12
+        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 14
+        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 15
+        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 13
+        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 3
+        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 11
+        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 4
         flowey.exe e 22 flowey_core::pipeline::artifact::resolve 5
         flowey.exe e 22 flowey_core::pipeline::artifact::resolve 6
         flowey.exe e 22 flowey_core::pipeline::artifact::resolve 1
-        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 0
-        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 9
         flowey.exe e 22 flowey_core::pipeline::artifact::resolve 2
-        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 4
-        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 11
-        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 12
-        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 10
-        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 3
-        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 8
+        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 0
+        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 7
       shell: bash
     - name: creating new test content dir
       run: flowey.exe e 22 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
-      shell: bash
-    - name: resolve OpenHCL igvm artifact
-      run: flowey.exe e 22 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::resolve 0
       shell: bash
     - name: create gh-release-download cache dir
       run: flowey.exe e 22 flowey_lib_common::download_gh_release 0
@@ -4704,7 +4807,7 @@ jobs:
       run: |-
         flowey.exe e 22 flowey_lib_hvlite::init_vmm_tests_env 0
         flowey.exe e 22 flowey_lib_hvlite::run_cargo_nextest_run 1
-        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 13
+        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 16
         flowey.exe e 22 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
       shell: bash
     - name: generate nextest command
@@ -4716,7 +4819,7 @@ jobs:
     - name: starting test_igvm_agent_rpc_server
       run: |-
         flowey.exe e 22 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
-        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 7
+        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 10
       shell: bash
     - name: running vmm_test prep_steps
       run: flowey.exe e 22 flowey_lib_hvlite::run_prep_steps 0
@@ -4792,7 +4895,7 @@ jobs:
     - name: 🌼📦 Download artifacts
       uses: actions/download-artifact@v8
       with:
-        pattern: '{_internal-flowey-bootstrap-x86_64-windows-uid-13,x64-guest_test_uefi,x64-linux-musl-pipette,x64-linux-musl-tmk_vmm,x64-linux-tpm_guest_tests,x64-openhcl-igvm,x64-tmks,x64-windows-openvmm,x64-windows-pipette,x64-windows-prep_steps,x64-windows-test_igvm_agent_rpc_server,x64-windows-tmk_vmm,x64-windows-tpm_guest_tests,x64-windows-vmgstool,x64-windows-vmgstool-dev,x64-windows-vmm-tests-archive}'
+        pattern: '{_internal-flowey-bootstrap-x86_64-windows-uid-13,x64-guest_test_uefi,x64-linux-musl-pipette,x64-linux-musl-tmk_vmm,x64-linux-tpm_guest_tests,x64-openhcl-igvm,x64-openhcl-igvm-cvm,x64-openhcl-igvm-test-linux-direct,x64-tmks,x64-windows-openvmm,x64-windows-pipette,x64-windows-prep_steps,x64-windows-test_igvm_agent_rpc_server,x64-windows-tmk_vmm,x64-windows-tpm_guest_tests,x64-windows-vmgstool,x64-windows-vmgstool-dev,x64-windows-vmm-tests-archive}'
         path: ${{ runner.temp }}/used_artifacts/
     - run: echo "${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-windows-uid-13" >> $GITHUB_PATH
       shell: bash
@@ -4816,6 +4919,8 @@ jobs:
         echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-tmk_vmm" | flowey.exe v 23 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
         echo "${{ runner.temp }}\\used_artifacts\\x64-linux-tpm_guest_tests" | flowey.exe v 23 'artifact_use_from_x64-linux-tpm_guest_tests' --is-raw-string update
         echo "${{ runner.temp }}\\used_artifacts\\x64-openhcl-igvm" | flowey.exe v 23 'artifact_use_from_x64-openhcl-igvm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-openhcl-igvm-cvm" | flowey.exe v 23 'artifact_use_from_x64-openhcl-igvm-cvm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-openhcl-igvm-test-linux-direct" | flowey.exe v 23 'artifact_use_from_x64-openhcl-igvm-test-linux-direct' --is-raw-string update
         echo "${{ runner.temp }}\\used_artifacts\\x64-tmks" | flowey.exe v 23 'artifact_use_from_x64-tmks' --is-raw-string update
         echo "${{ runner.temp }}\\used_artifacts\\x64-windows-openvmm" | flowey.exe v 23 'artifact_use_from_x64-windows-openvmm' --is-raw-string update
         echo "${{ runner.temp }}\\used_artifacts\\x64-windows-pipette" | flowey.exe v 23 'artifact_use_from_x64-windows-pipette' --is-raw-string update
@@ -4876,24 +4981,24 @@ jobs:
         flowey.exe e 23 flowey_lib_common::git_checkout 3
         flowey.exe e 23 flowey_lib_hvlite::git_checkout_openvmm_repo 0
         flowey.exe e 23 flowey_lib_hvlite::run_cargo_nextest_run 0
+        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 8
+        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 9
+        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 12
+        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 14
+        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 15
+        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 13
+        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 3
+        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 11
+        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 4
         flowey.exe e 23 flowey_core::pipeline::artifact::resolve 5
         flowey.exe e 23 flowey_core::pipeline::artifact::resolve 6
         flowey.exe e 23 flowey_core::pipeline::artifact::resolve 1
-        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 0
-        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 9
         flowey.exe e 23 flowey_core::pipeline::artifact::resolve 2
-        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 4
-        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 11
-        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 12
-        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 10
-        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 3
-        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 8
+        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 0
+        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 7
       shell: bash
     - name: creating new test content dir
       run: flowey.exe e 23 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
-      shell: bash
-    - name: resolve OpenHCL igvm artifact
-      run: flowey.exe e 23 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::resolve 0
       shell: bash
     - name: create gh-release-download cache dir
       run: flowey.exe e 23 flowey_lib_common::download_gh_release 0
@@ -4982,7 +5087,7 @@ jobs:
       run: |-
         flowey.exe e 23 flowey_lib_hvlite::init_vmm_tests_env 0
         flowey.exe e 23 flowey_lib_hvlite::run_cargo_nextest_run 1
-        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 13
+        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 16
         flowey.exe e 23 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
       shell: bash
     - name: generate nextest command
@@ -4994,7 +5099,7 @@ jobs:
     - name: starting test_igvm_agent_rpc_server
       run: |-
         flowey.exe e 23 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
-        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 7
+        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 10
       shell: bash
     - name: running vmm_test prep_steps
       run: flowey.exe e 23 flowey_lib_hvlite::run_prep_steps 0
@@ -5099,12 +5204,12 @@ jobs:
       shell: bash
     - name: creating new test content dir
       run: |-
+        flowey e 24 flowey_core::pipeline::artifact::resolve 8
+        flowey e 24 flowey_core::pipeline::artifact::resolve 2
         flowey e 24 flowey_core::pipeline::artifact::resolve 3
         flowey e 24 flowey_core::pipeline::artifact::resolve 4
-        flowey e 24 flowey_core::pipeline::artifact::resolve 8
         flowey e 24 flowey_core::pipeline::artifact::resolve 1
         flowey e 24 flowey_core::pipeline::artifact::resolve 0
-        flowey e 24 flowey_core::pipeline::artifact::resolve 2
         flowey e 24 flowey_core::pipeline::artifact::resolve 7
         flowey e 24 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
       shell: bash
@@ -5414,12 +5519,12 @@ jobs:
       shell: bash
     - name: creating new test content dir
       run: |-
+        flowey e 25 flowey_core::pipeline::artifact::resolve 8
+        flowey e 25 flowey_core::pipeline::artifact::resolve 4
         flowey e 25 flowey_core::pipeline::artifact::resolve 1
         flowey e 25 flowey_core::pipeline::artifact::resolve 2
-        flowey e 25 flowey_core::pipeline::artifact::resolve 8
         flowey e 25 flowey_core::pipeline::artifact::resolve 3
         flowey e 25 flowey_core::pipeline::artifact::resolve 0
-        flowey e 25 flowey_core::pipeline::artifact::resolve 4
         flowey e 25 flowey_core::pipeline::artifact::resolve 7
         flowey e 25 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
       shell: bash
@@ -5776,21 +5881,19 @@ jobs:
         flowey.exe e 26 flowey_lib_common::git_checkout 3
         flowey.exe e 26 flowey_lib_hvlite::git_checkout_openvmm_repo 0
         flowey.exe e 26 flowey_lib_hvlite::run_cargo_nextest_run 0
-        flowey.exe e 26 flowey_core::pipeline::artifact::resolve 4
         flowey.exe e 26 flowey_core::pipeline::artifact::resolve 5
-        flowey.exe e 26 flowey_core::pipeline::artifact::resolve 1
-        flowey.exe e 26 flowey_core::pipeline::artifact::resolve 0
         flowey.exe e 26 flowey_core::pipeline::artifact::resolve 6
-        flowey.exe e 26 flowey_core::pipeline::artifact::resolve 2
-        flowey.exe e 26 flowey_core::pipeline::artifact::resolve 3
         flowey.exe e 26 flowey_core::pipeline::artifact::resolve 7
         flowey.exe e 26 flowey_core::pipeline::artifact::resolve 8
+        flowey.exe e 26 flowey_core::pipeline::artifact::resolve 9
+        flowey.exe e 26 flowey_core::pipeline::artifact::resolve 3
+        flowey.exe e 26 flowey_core::pipeline::artifact::resolve 1
+        flowey.exe e 26 flowey_core::pipeline::artifact::resolve 2
+        flowey.exe e 26 flowey_core::pipeline::artifact::resolve 0
+        flowey.exe e 26 flowey_core::pipeline::artifact::resolve 4
       shell: bash
     - name: creating new test content dir
       run: flowey.exe e 26 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
-      shell: bash
-    - name: resolve OpenHCL igvm artifact
-      run: flowey.exe e 26 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::resolve 0
       shell: bash
     - name: create gh-release-download cache dir
       run: flowey.exe e 26 flowey_lib_common::download_gh_release 0
@@ -5879,7 +5982,7 @@ jobs:
       run: |-
         flowey.exe e 26 flowey_lib_hvlite::init_vmm_tests_env 0
         flowey.exe e 26 flowey_lib_hvlite::run_cargo_nextest_run 1
-        flowey.exe e 26 flowey_core::pipeline::artifact::resolve 9
+        flowey.exe e 26 flowey_core::pipeline::artifact::resolve 10
         flowey.exe e 26 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
       shell: bash
     - name: generate nextest command

--- a/.github/workflows/openvmm-ci.yaml
+++ b/.github/workflows/openvmm-ci.yaml
@@ -426,12 +426,40 @@ jobs:
         echo "$AgentTempDirNormal/publish_artifacts/aarch64-openhcl-baseline" | flowey v 10 'artifact_publish_from_aarch64-openhcl-baseline' --is-raw-string update
         mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-openhcl-igvm"
         echo "$AgentTempDirNormal/publish_artifacts/aarch64-openhcl-igvm" | flowey v 10 'artifact_publish_from_aarch64-openhcl-igvm' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-openhcl-igvm-devkern"
-        echo "$AgentTempDirNormal/publish_artifacts/aarch64-openhcl-igvm-devkern" | flowey v 10 'artifact_publish_from_aarch64-openhcl-igvm-devkern' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-openhcl-igvm-devkern-extras"
-        echo "$AgentTempDirNormal/publish_artifacts/aarch64-openhcl-igvm-devkern-extras" | flowey v 10 'artifact_publish_from_aarch64-openhcl-igvm-devkern-extras' --is-raw-string update
         mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-openhcl-igvm-extras"
         echo "$AgentTempDirNormal/publish_artifacts/aarch64-openhcl-igvm-extras" | flowey v 10 'artifact_publish_from_aarch64-openhcl-igvm-extras' --is-raw-string update
+      shell: bash
+    - name: checking if packages need to be installed
+      run: flowey e 10 flowey_lib_common::install_dist_pkg 0
+      shell: bash
+    - name: installing packages
+      run: flowey e 10 flowey_lib_common::install_dist_pkg 1
+      shell: bash
+    - name: create gh-release-download cache dir
+      run: flowey e 10 flowey_lib_common::download_gh_release 0
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
+        flowey e 10 flowey_lib_common::cache 0
+        flowey v 10 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar1
+        flowey v 10 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar2
+      shell: bash
+    - id: flowey_lib_common__cache__1
+      uses: actions/cache@v5
+      with:
+        key: ${{ env.floweyvar1 }}
+        path: ${{ env.floweyvar2 }}
+      name: 'Restore cache: gh-release-download'
+    - name: download artifacts from github releases
+      run: |-
+        flowey v 10 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
+        EOF
+        flowey e 10 flowey_lib_common::cache 2
+        flowey e 10 flowey_lib_common::download_gh_release 1
+      shell: bash
+    - name: unpack mu_msvm package (aarch64)
+      run: flowey e 10 flowey_lib_hvlite::download_uefi_mu_msvm 0
       shell: bash
     - name: add default cargo home to path
       run: flowey e 10 flowey_lib_common::install_rust 0
@@ -465,89 +493,18 @@ jobs:
         EOF
         flowey e 10 flowey_lib_common::git_checkout 3
         flowey e 10 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-        flowey e 10 flowey_lib_hvlite::cfg_openvmm_magicpath 0
-      shell: bash
-    - name: create gh-release-download cache dir
-      run: flowey e 10 flowey_lib_common::download_gh_release 0
-      shell: bash
-    - name: Pre-processing cache vars
-      run: |-
-        flowey e 10 flowey_lib_common::cache 0
-        flowey v 10 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar1
-        flowey v 10 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar2
-      shell: bash
-    - id: flowey_lib_common__cache__1
-      uses: actions/cache@v5
-      with:
-        key: ${{ env.floweyvar1 }}
-        path: ${{ env.floweyvar2 }}
-      name: 'Restore cache: gh-release-download'
-    - name: download artifacts from github releases
-      run: |-
-        flowey v 10 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
-        EOF
-        flowey e 10 flowey_lib_common::cache 2
-        flowey e 10 flowey_lib_common::download_gh_release 1
-      shell: bash
-    - name: unpack openvmm-deps archive
-      run: flowey e 10 flowey_lib_hvlite::resolve_openvmm_deps 0
-      shell: bash
-    - name: extract Aarch64 sysroot.tar.gz
-      run: flowey e 10 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
       shell: bash
     - name: set '-Dwarnings' in .cargo/config.toml
       run: flowey e 10 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
       shell: bash
-    - name: checking if packages need to be installed
-      run: flowey e 10 flowey_lib_common::install_dist_pkg 0
-      shell: bash
-    - name: installing packages
-      run: flowey e 10 flowey_lib_common::install_dist_pkg 1
-      shell: bash
     - name: unpack protoc
-      run: flowey e 10 flowey_lib_common::resolve_protoc 0
+      run: |-
+        flowey e 10 flowey_lib_common::resolve_protoc 0
+        flowey e 10 flowey_lib_hvlite::cfg_openvmm_magicpath 0
       shell: bash
     - name: symlink protoc
       run: |-
         flowey e 10 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-        flowey e 10 flowey_lib_hvlite::init_cross_build 1
-      shell: bash
-    - name: cargo build openvmm_hcl
-      run: |-
-        flowey e 10 flowey_lib_common::run_cargo_build 2
-        flowey e 10 flowey_lib_hvlite::run_cargo_build 6
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 10 flowey_lib_hvlite::run_split_debug_info 3
-        flowey e 10 flowey_lib_hvlite::run_cargo_build 7
-        flowey e 10 flowey_lib_hvlite::build_openvmm_hcl 0
-        flowey e 10 flowey_lib_hvlite::_jobs::build_and_publish_openvmm_hcl_baseline 0
-        flowey e 10 flowey_core::pipeline::artifact::publish 0
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 3
-        flowey e 10 flowey_lib_hvlite::init_cross_build 2
-      shell: bash
-    - name: cargo build openvmm_hcl
-      run: |-
-        flowey e 10 flowey_lib_common::run_cargo_build 3
-        flowey e 10 flowey_lib_hvlite::run_cargo_build 8
-        flowey e 10 flowey_lib_hvlite::build_openvmm_hcl 1
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 0
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 10 flowey_lib_hvlite::run_split_debug_info 0
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 1
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 2
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 4
-      shell: bash
-    - name: extract and resolve kernel package
-      run: flowey e 10 flowey_lib_hvlite::resolve_openhcl_kernel_package 0
-      shell: bash
-    - name: building openhcl initrd
-      run: |-
-        flowey e 10 flowey_lib_hvlite::build_openhcl_initrd 0
         flowey e 10 flowey_lib_hvlite::init_cross_build 0
         flowey e 10 flowey_lib_hvlite::run_cargo_build 2
         flowey e 10 flowey_lib_hvlite::run_cargo_build 3
@@ -562,12 +519,40 @@ jobs:
         flowey e 10 flowey_lib_hvlite::run_split_debug_info 2
         flowey e 10 flowey_lib_hvlite::run_cargo_build 5
         flowey e 10 flowey_lib_hvlite::build_openhcl_boot 0
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 5
       shell: bash
-    - name: unpack mu_msvm package (aarch64)
+    - name: extract and resolve kernel package
       run: |-
-        flowey e 10 flowey_lib_hvlite::download_uefi_mu_msvm 0
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 6
+        flowey e 10 flowey_lib_hvlite::resolve_openhcl_kernel_package 1
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 17
+      shell: bash
+    - name: unpack openvmm-deps archive
+      run: flowey e 10 flowey_lib_hvlite::resolve_openvmm_deps 0
+      shell: bash
+    - name: extract Aarch64 sysroot.tar.gz
+      run: |-
+        flowey e 10 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
+        flowey e 10 flowey_lib_hvlite::init_cross_build 2
+        flowey e 10 flowey_lib_hvlite::run_cargo_build 10
+        flowey e 10 flowey_lib_hvlite::run_cargo_build 11
+      shell: bash
+    - name: cargo build openvmm_hcl
+      run: |-
+        flowey e 10 flowey_lib_common::run_cargo_build 3
+        flowey e 10 flowey_lib_hvlite::run_cargo_build 12
+        flowey e 10 flowey_lib_hvlite::build_openvmm_hcl 1
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 13
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 10 flowey_lib_hvlite::run_split_debug_info 1
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 14
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 15
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 18
+      shell: bash
+    - name: building openhcl initrd
+      run: |-
+        flowey e 10 flowey_lib_hvlite::build_openhcl_initrd 1
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 19
         flowey e 10 flowey_lib_hvlite::init_cross_build 3
       shell: bash
     - name: cargo build igvmfilegen
@@ -580,47 +565,73 @@ jobs:
         flowey e 10 flowey_lib_hvlite::run_split_debug_info 4
         flowey e 10 flowey_lib_hvlite::run_cargo_build 1
         flowey e 10 flowey_lib_hvlite::build_igvmfilegen 0
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 7
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 8
-      shell: bash
-    - name: building igvm file
-      run: |-
-        flowey e 10 flowey_lib_hvlite::run_igvmfilegen 0
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 11
-        flowey e 10 flowey_core::pipeline::artifact::publish 1
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 9
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 10
-        flowey e 10 flowey_core::pipeline::artifact::publish 2
-      shell: bash
-    - name: extract and resolve kernel package
-      run: |-
-        flowey e 10 flowey_lib_hvlite::resolve_openhcl_kernel_package 1
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 15
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 12
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 10 flowey_lib_hvlite::run_split_debug_info 1
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 13
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 14
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 16
-      shell: bash
-    - name: building openhcl initrd
-      run: |-
-        flowey e 10 flowey_lib_hvlite::build_openhcl_initrd 1
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 17
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 18
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 19
         flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 20
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 21
       shell: bash
     - name: building igvm file
       run: |-
         flowey e 10 flowey_lib_hvlite::run_igvmfilegen 1
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 23
-        flowey e 10 flowey_core::pipeline::artifact::publish 3
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 21
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 22
-        flowey e 10 flowey_core::pipeline::artifact::publish 4
+        flowey e 10 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 2
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 6
+      shell: bash
+    - name: extract and resolve kernel package
+      run: |-
+        flowey e 10 flowey_lib_hvlite::resolve_openhcl_kernel_package 0
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 2
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 10 flowey_lib_hvlite::run_split_debug_info 0
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 3
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 4
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 7
+      shell: bash
+    - name: building openhcl initrd
+      run: |-
+        flowey e 10 flowey_lib_hvlite::build_openhcl_initrd 0
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 8
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 9
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 10
+      shell: bash
+    - name: building igvm file
+      run: |-
+        flowey e 10 flowey_lib_hvlite::run_igvmfilegen 0
+        flowey e 10 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 0
+        flowey e 10 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::publish 0
+      shell: bash
+    - name: copying OpenHCL igvm files to artifact dir
+      run: |-
+        flowey e 10 flowey_lib_common::copy_to_artifact_dir 1
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 11
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 16
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 12
+        flowey e 10 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 3
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 5
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 1
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 0
+        flowey e 10 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 1
+        flowey e 10 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe_extras::publish 0
+      shell: bash
+    - name: copying OpenHCL igvm extras to artifact dir
+      run: |-
+        flowey e 10 flowey_lib_common::copy_to_artifact_dir 0
+        flowey e 10 flowey_lib_hvlite::init_cross_build 1
+        flowey e 10 flowey_lib_hvlite::run_cargo_build 6
+        flowey e 10 flowey_lib_hvlite::run_cargo_build 7
+      shell: bash
+    - name: cargo build openvmm_hcl
+      run: |-
+        flowey e 10 flowey_lib_common::run_cargo_build 2
+        flowey e 10 flowey_lib_hvlite::run_cargo_build 8
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 10 flowey_lib_hvlite::run_split_debug_info 3
+        flowey e 10 flowey_lib_hvlite::run_cargo_build 9
+        flowey e 10 flowey_lib_hvlite::build_openvmm_hcl 0
+      shell: bash
+    - name: copying openhcl build to publish dir
+      run: flowey e 10 flowey_lib_hvlite::artifact_openvmm_hcl_sizecheck::publish 0
       shell: bash
     - name: 'validate cache entry: gh-release-download'
       run: flowey e 10 flowey_lib_common::cache 3
@@ -636,18 +647,6 @@ jobs:
       with:
         name: aarch64-openhcl-igvm
         path: ${{ runner.temp }}/publish_artifacts/aarch64-openhcl-igvm/
-        include-hidden-files: true
-    - name: 🌼📦 Publish aarch64-openhcl-igvm-devkern
-      uses: actions/upload-artifact@v7
-      with:
-        name: aarch64-openhcl-igvm-devkern
-        path: ${{ runner.temp }}/publish_artifacts/aarch64-openhcl-igvm-devkern/
-        include-hidden-files: true
-    - name: 🌼📦 Publish aarch64-openhcl-igvm-devkern-extras
-      uses: actions/upload-artifact@v7
-      with:
-        name: aarch64-openhcl-igvm-devkern-extras
-        path: ${{ runner.temp }}/publish_artifacts/aarch64-openhcl-igvm-devkern-extras/
         include-hidden-files: true
     - name: 🌼📦 Publish aarch64-openhcl-igvm-extras
       uses: actions/upload-artifact@v7
@@ -737,24 +736,40 @@ jobs:
         echo "$AgentTempDirNormal/publish_artifacts/x64-openhcl-baseline" | flowey v 11 'artifact_publish_from_x64-openhcl-baseline' --is-raw-string update
         mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm"
         echo "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm" | flowey v 11 'artifact_publish_from_x64-openhcl-igvm' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-cvm"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-cvm" | flowey v 11 'artifact_publish_from_x64-openhcl-igvm-cvm' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-cvm-extras"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-cvm-extras" | flowey v 11 'artifact_publish_from_x64-openhcl-igvm-cvm-extras' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-devkern"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-devkern" | flowey v 11 'artifact_publish_from_x64-openhcl-igvm-devkern' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-devkern-extras"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-devkern-extras" | flowey v 11 'artifact_publish_from_x64-openhcl-igvm-devkern-extras' --is-raw-string update
         mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-extras"
         echo "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-extras" | flowey v 11 'artifact_publish_from_x64-openhcl-igvm-extras' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-test-linux-direct"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-test-linux-direct" | flowey v 11 'artifact_publish_from_x64-openhcl-igvm-test-linux-direct' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-test-linux-direct-devkern"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-test-linux-direct-devkern" | flowey v 11 'artifact_publish_from_x64-openhcl-igvm-test-linux-direct-devkern' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-test-linux-direct-devkern-extras"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-test-linux-direct-devkern-extras" | flowey v 11 'artifact_publish_from_x64-openhcl-igvm-test-linux-direct-devkern-extras' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-test-linux-direct-extras"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-test-linux-direct-extras" | flowey v 11 'artifact_publish_from_x64-openhcl-igvm-test-linux-direct-extras' --is-raw-string update
+      shell: bash
+    - name: checking if packages need to be installed
+      run: flowey e 11 flowey_lib_common::install_dist_pkg 0
+      shell: bash
+    - name: installing packages
+      run: flowey e 11 flowey_lib_common::install_dist_pkg 1
+      shell: bash
+    - name: create gh-release-download cache dir
+      run: flowey e 11 flowey_lib_common::download_gh_release 0
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
+        flowey e 11 flowey_lib_common::cache 0
+        flowey v 11 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar1
+        flowey v 11 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar2
+      shell: bash
+    - id: flowey_lib_common__cache__1
+      uses: actions/cache@v5
+      with:
+        key: ${{ env.floweyvar1 }}
+        path: ${{ env.floweyvar2 }}
+      name: 'Restore cache: gh-release-download'
+    - name: download artifacts from github releases
+      run: |-
+        flowey v 11 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
+        EOF
+        flowey e 11 flowey_lib_common::cache 2
+        flowey e 11 flowey_lib_common::download_gh_release 1
+      shell: bash
+    - name: unpack mu_msvm package (x64)
+      run: flowey e 11 flowey_lib_hvlite::download_uefi_mu_msvm 0
       shell: bash
     - name: add default cargo home to path
       run: flowey e 11 flowey_lib_common::install_rust 0
@@ -788,104 +803,32 @@ jobs:
         EOF
         flowey e 11 flowey_lib_common::git_checkout 3
         flowey e 11 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-        flowey e 11 flowey_lib_hvlite::cfg_openvmm_magicpath 0
-      shell: bash
-    - name: create gh-release-download cache dir
-      run: flowey e 11 flowey_lib_common::download_gh_release 0
-      shell: bash
-    - name: Pre-processing cache vars
-      run: |-
-        flowey e 11 flowey_lib_common::cache 0
-        flowey v 11 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar1
-        flowey v 11 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar2
-      shell: bash
-    - id: flowey_lib_common__cache__1
-      uses: actions/cache@v5
-      with:
-        key: ${{ env.floweyvar1 }}
-        path: ${{ env.floweyvar2 }}
-      name: 'Restore cache: gh-release-download'
-    - name: download artifacts from github releases
-      run: |-
-        flowey v 11 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
-        EOF
-        flowey e 11 flowey_lib_common::cache 2
-        flowey e 11 flowey_lib_common::download_gh_release 1
-      shell: bash
-    - name: unpack openvmm-deps archive
-      run: flowey e 11 flowey_lib_hvlite::resolve_openvmm_deps 0
-      shell: bash
-    - name: extract X86_64 sysroot.tar.gz
-      run: flowey e 11 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
       shell: bash
     - name: set '-Dwarnings' in .cargo/config.toml
       run: flowey e 11 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
       shell: bash
-    - name: checking if packages need to be installed
-      run: flowey e 11 flowey_lib_common::install_dist_pkg 0
-      shell: bash
-    - name: installing packages
-      run: flowey e 11 flowey_lib_common::install_dist_pkg 1
-      shell: bash
     - name: unpack protoc
-      run: flowey e 11 flowey_lib_common::resolve_protoc 0
+      run: |-
+        flowey e 11 flowey_lib_common::resolve_protoc 0
+        flowey e 11 flowey_lib_hvlite::cfg_openvmm_magicpath 0
       shell: bash
     - name: symlink protoc
       run: |-
         flowey e 11 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-        flowey e 11 flowey_lib_hvlite::init_cross_build 3
-      shell: bash
-    - name: cargo build openvmm_hcl
-      run: |-
-        flowey e 11 flowey_lib_common::run_cargo_build 2
-        flowey e 11 flowey_lib_hvlite::run_cargo_build 6
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 11 flowey_lib_hvlite::run_split_debug_info 6
-        flowey e 11 flowey_lib_hvlite::run_cargo_build 7
-        flowey e 11 flowey_lib_hvlite::build_openvmm_hcl 0
-        flowey e 11 flowey_lib_hvlite::_jobs::build_and_publish_openvmm_hcl_baseline 0
-        flowey e 11 flowey_core::pipeline::artifact::publish 0
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 3
-        flowey e 11 flowey_lib_hvlite::init_cross_build 4
-      shell: bash
-    - name: cargo build openvmm_hcl
-      run: |-
-        flowey e 11 flowey_lib_common::run_cargo_build 3
-        flowey e 11 flowey_lib_hvlite::run_cargo_build 8
-        flowey e 11 flowey_lib_hvlite::build_openvmm_hcl 1
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 0
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 11 flowey_lib_hvlite::run_split_debug_info 0
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 1
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 2
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 4
-      shell: bash
-    - name: extract and resolve kernel package
-      run: flowey e 11 flowey_lib_hvlite::resolve_openhcl_kernel_package 0
-      shell: bash
-    - name: building openhcl initrd
-      run: |-
-        flowey e 11 flowey_lib_hvlite::build_openhcl_initrd 2
         flowey e 11 flowey_lib_hvlite::init_cross_build 0
-        flowey e 11 flowey_lib_hvlite::run_cargo_build 9
-        flowey e 11 flowey_lib_hvlite::run_cargo_build 10
+        flowey e 11 flowey_lib_hvlite::run_cargo_build 13
+        flowey e 11 flowey_lib_hvlite::run_cargo_build 14
       shell: bash
     - name: cargo build sidecar
       run: |-
         flowey e 11 flowey_lib_common::run_cargo_build 4
-        flowey e 11 flowey_lib_hvlite::run_cargo_build 11
+        flowey e 11 flowey_lib_hvlite::run_cargo_build 15
       shell: bash
     - name: split debug symbols
       run: |-
         flowey e 11 flowey_lib_hvlite::run_split_debug_info 7
-        flowey e 11 flowey_lib_hvlite::run_cargo_build 12
+        flowey e 11 flowey_lib_hvlite::run_cargo_build 16
         flowey e 11 flowey_lib_hvlite::build_sidecar 0
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 5
         flowey e 11 flowey_lib_hvlite::init_cross_build 1
         flowey e 11 flowey_lib_hvlite::run_cargo_build 2
         flowey e 11 flowey_lib_hvlite::run_cargo_build 3
@@ -900,12 +843,40 @@ jobs:
         flowey e 11 flowey_lib_hvlite::run_split_debug_info 5
         flowey e 11 flowey_lib_hvlite::run_cargo_build 5
         flowey e 11 flowey_lib_hvlite::build_openhcl_boot 0
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 6
       shell: bash
-    - name: unpack mu_msvm package (x64)
+    - name: extract and resolve kernel package
       run: |-
-        flowey e 11 flowey_lib_hvlite::download_uefi_mu_msvm 0
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 7
+        flowey e 11 flowey_lib_hvlite::resolve_openhcl_kernel_package 2
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 28
+      shell: bash
+    - name: unpack openvmm-deps archive
+      run: flowey e 11 flowey_lib_hvlite::resolve_openvmm_deps 0
+      shell: bash
+    - name: extract X86_64 sysroot.tar.gz
+      run: |-
+        flowey e 11 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
+        flowey e 11 flowey_lib_hvlite::init_cross_build 4
+        flowey e 11 flowey_lib_hvlite::run_cargo_build 10
+        flowey e 11 flowey_lib_hvlite::run_cargo_build 11
+      shell: bash
+    - name: cargo build openvmm_hcl
+      run: |-
+        flowey e 11 flowey_lib_common::run_cargo_build 3
+        flowey e 11 flowey_lib_hvlite::run_cargo_build 12
+        flowey e 11 flowey_lib_hvlite::build_openvmm_hcl 1
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 24
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 11 flowey_lib_hvlite::run_split_debug_info 4
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 25
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 26
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 29
+      shell: bash
+    - name: building openhcl initrd
+      run: |-
+        flowey e 11 flowey_lib_hvlite::build_openhcl_initrd 4
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 30
         flowey e 11 flowey_lib_hvlite::init_cross_build 2
       shell: bash
     - name: cargo build igvmfilegen
@@ -918,48 +889,28 @@ jobs:
         flowey e 11 flowey_lib_hvlite::run_split_debug_info 8
         flowey e 11 flowey_lib_hvlite::run_cargo_build 1
         flowey e 11 flowey_lib_hvlite::build_igvmfilegen 0
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 8
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 9
-      shell: bash
-    - name: building igvm file
-      run: |-
-        flowey e 11 flowey_lib_hvlite::run_igvmfilegen 2
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 12
-        flowey e 11 flowey_core::pipeline::artifact::publish 1
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 10
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 11
-        flowey e 11 flowey_core::pipeline::artifact::publish 2
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 34
-      shell: bash
-    - name: extract and resolve kernel package
-      run: |-
-        flowey e 11 flowey_lib_hvlite::resolve_openhcl_kernel_package 2
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 28
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 25
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 11 flowey_lib_hvlite::run_split_debug_info 4
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 26
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 27
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 29
-      shell: bash
-    - name: building openhcl initrd
-      run: |-
-        flowey e 11 flowey_lib_hvlite::build_openhcl_initrd 4
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 30
         flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 31
         flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 32
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 33
       shell: bash
     - name: building igvm file
       run: |-
         flowey e 11 flowey_lib_hvlite::run_igvmfilegen 4
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 37
-        flowey e 11 flowey_core::pipeline::artifact::publish 3
+        flowey e 11 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 2
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 39
         flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 35
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 11 flowey_lib_hvlite::run_split_debug_info 0
         flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 36
-        flowey e 11 flowey_core::pipeline::artifact::publish 4
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 37
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 40
+      shell: bash
+    - name: extract and resolve kernel package
+      run: flowey e 11 flowey_lib_hvlite::resolve_openhcl_kernel_package 0
+      shell: bash
+    - name: building openhcl initrd
+      run: flowey e 11 flowey_lib_hvlite::build_openhcl_initrd 0
       shell: bash
     - name: unpack openvmm-test-linux archives
       run: flowey e 11 flowey_lib_hvlite::resolve_openvmm_test_linux_kernel 0
@@ -968,64 +919,39 @@ jobs:
       run: |-
         flowey e 11 flowey_lib_hvlite::resolve_openvmm_test_initrd 0
         flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 41
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 38
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 11 flowey_lib_hvlite::run_split_debug_info 1
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 39
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 40
         flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 42
-      shell: bash
-    - name: building openhcl initrd
-      run: |-
-        flowey e 11 flowey_lib_hvlite::build_openhcl_initrd 0
         flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 43
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 44
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 45
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 46
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 47
       shell: bash
     - name: building igvm file
       run: |-
         flowey e 11 flowey_lib_hvlite::run_igvmfilegen 0
+        flowey e 11 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 4
         flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 50
-        flowey e 11 flowey_core::pipeline::artifact::publish 5
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 48
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 49
-        flowey e 11 flowey_core::pipeline::artifact::publish 6
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 54
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 51
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 46
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 11 flowey_lib_hvlite::run_split_debug_info 2
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 52
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 53
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 55
+        flowey e 11 flowey_lib_hvlite::run_split_debug_info 1
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 47
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 48
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 51
       shell: bash
     - name: building openhcl initrd
       run: |-
         flowey e 11 flowey_lib_hvlite::build_openhcl_initrd 1
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 56
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 57
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 58
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 59
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 60
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 52
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 53
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 54
       shell: bash
     - name: building igvm file
       run: |-
         flowey e 11 flowey_lib_hvlite::run_igvmfilegen 1
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 63
-        flowey e 11 flowey_core::pipeline::artifact::publish 7
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 61
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 62
-        flowey e 11 flowey_core::pipeline::artifact::publish 8
+        flowey e 11 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 6
       shell: bash
     - name: extract and resolve kernel package
       run: |-
         flowey e 11 flowey_lib_hvlite::resolve_openhcl_kernel_package 1
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 16
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 17
         flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 13
       shell: bash
     - name: split debug symbols
@@ -1033,12 +959,11 @@ jobs:
         flowey e 11 flowey_lib_hvlite::run_split_debug_info 3
         flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 14
         flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 15
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 17
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 18
       shell: bash
     - name: building openhcl initrd
       run: |-
         flowey e 11 flowey_lib_hvlite::build_openhcl_initrd 3
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 18
         flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 19
         flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 20
         flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 21
@@ -1046,11 +971,75 @@ jobs:
     - name: building igvm file
       run: |-
         flowey e 11 flowey_lib_hvlite::run_igvmfilegen 3
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 24
-        flowey e 11 flowey_core::pipeline::artifact::publish 9
+        flowey e 11 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 8
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 6
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 2
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 11 flowey_lib_hvlite::run_split_debug_info 2
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 3
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 4
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 7
+      shell: bash
+    - name: building openhcl initrd
+      run: |-
+        flowey e 11 flowey_lib_hvlite::build_openhcl_initrd 2
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 8
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 9
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 10
+      shell: bash
+    - name: building igvm file
+      run: |-
+        flowey e 11 flowey_lib_hvlite::run_igvmfilegen 2
+        flowey e 11 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 0
+        flowey e 11 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::publish 0
+      shell: bash
+    - name: copying OpenHCL igvm files to artifact dir
+      run: |-
+        flowey e 11 flowey_lib_common::copy_to_artifact_dir 1
         flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 22
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 27
         flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 23
-        flowey e 11 flowey_core::pipeline::artifact::publish 10
+        flowey e 11 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 3
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 38
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 34
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 33
+        flowey e 11 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 5
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 49
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 45
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 44
+        flowey e 11 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 7
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 16
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 12
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 11
+        flowey e 11 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 9
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 5
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 1
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 0
+        flowey e 11 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 1
+        flowey e 11 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe_extras::publish 0
+      shell: bash
+    - name: copying OpenHCL igvm extras to artifact dir
+      run: |-
+        flowey e 11 flowey_lib_common::copy_to_artifact_dir 0
+        flowey e 11 flowey_lib_hvlite::init_cross_build 3
+        flowey e 11 flowey_lib_hvlite::run_cargo_build 6
+        flowey e 11 flowey_lib_hvlite::run_cargo_build 7
+      shell: bash
+    - name: cargo build openvmm_hcl
+      run: |-
+        flowey e 11 flowey_lib_common::run_cargo_build 2
+        flowey e 11 flowey_lib_hvlite::run_cargo_build 8
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 11 flowey_lib_hvlite::run_split_debug_info 6
+        flowey e 11 flowey_lib_hvlite::run_cargo_build 9
+        flowey e 11 flowey_lib_hvlite::build_openvmm_hcl 0
+      shell: bash
+    - name: copying openhcl build to publish dir
+      run: flowey e 11 flowey_lib_hvlite::artifact_openvmm_hcl_sizecheck::publish 0
       shell: bash
     - name: 'validate cache entry: gh-release-download'
       run: flowey e 11 flowey_lib_common::cache 3
@@ -1067,59 +1056,11 @@ jobs:
         name: x64-openhcl-igvm
         path: ${{ runner.temp }}/publish_artifacts/x64-openhcl-igvm/
         include-hidden-files: true
-    - name: 🌼📦 Publish x64-openhcl-igvm-cvm
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-openhcl-igvm-cvm
-        path: ${{ runner.temp }}/publish_artifacts/x64-openhcl-igvm-cvm/
-        include-hidden-files: true
-    - name: 🌼📦 Publish x64-openhcl-igvm-cvm-extras
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-openhcl-igvm-cvm-extras
-        path: ${{ runner.temp }}/publish_artifacts/x64-openhcl-igvm-cvm-extras/
-        include-hidden-files: true
-    - name: 🌼📦 Publish x64-openhcl-igvm-devkern
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-openhcl-igvm-devkern
-        path: ${{ runner.temp }}/publish_artifacts/x64-openhcl-igvm-devkern/
-        include-hidden-files: true
-    - name: 🌼📦 Publish x64-openhcl-igvm-devkern-extras
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-openhcl-igvm-devkern-extras
-        path: ${{ runner.temp }}/publish_artifacts/x64-openhcl-igvm-devkern-extras/
-        include-hidden-files: true
     - name: 🌼📦 Publish x64-openhcl-igvm-extras
       uses: actions/upload-artifact@v7
       with:
         name: x64-openhcl-igvm-extras
         path: ${{ runner.temp }}/publish_artifacts/x64-openhcl-igvm-extras/
-        include-hidden-files: true
-    - name: 🌼📦 Publish x64-openhcl-igvm-test-linux-direct
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-openhcl-igvm-test-linux-direct
-        path: ${{ runner.temp }}/publish_artifacts/x64-openhcl-igvm-test-linux-direct/
-        include-hidden-files: true
-    - name: 🌼📦 Publish x64-openhcl-igvm-test-linux-direct-devkern
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-openhcl-igvm-test-linux-direct-devkern
-        path: ${{ runner.temp }}/publish_artifacts/x64-openhcl-igvm-test-linux-direct-devkern/
-        include-hidden-files: true
-    - name: 🌼📦 Publish x64-openhcl-igvm-test-linux-direct-devkern-extras
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-openhcl-igvm-test-linux-direct-devkern-extras
-        path: ${{ runner.temp }}/publish_artifacts/x64-openhcl-igvm-test-linux-direct-devkern-extras/
-        include-hidden-files: true
-    - name: 🌼📦 Publish x64-openhcl-igvm-test-linux-direct-extras
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-openhcl-igvm-test-linux-direct-extras
-        path: ${{ runner.temp }}/publish_artifacts/x64-openhcl-igvm-test-linux-direct-extras/
         include-hidden-files: true
   job12:
     name: build openhcl (mi-secure) [x64-linux]
@@ -1201,51 +1142,8 @@ jobs:
         EOF
         mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-mi-secure-openhcl-igvm"
         echo "$AgentTempDirNormal/publish_artifacts/x64-mi-secure-openhcl-igvm" | flowey v 12 'artifact_publish_from_x64-mi-secure-openhcl-igvm' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-mi-secure-openhcl-igvm-cvm"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-mi-secure-openhcl-igvm-cvm" | flowey v 12 'artifact_publish_from_x64-mi-secure-openhcl-igvm-cvm' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-mi-secure-openhcl-igvm-cvm-extras"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-mi-secure-openhcl-igvm-cvm-extras" | flowey v 12 'artifact_publish_from_x64-mi-secure-openhcl-igvm-cvm-extras' --is-raw-string update
         mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-mi-secure-openhcl-igvm-extras"
         echo "$AgentTempDirNormal/publish_artifacts/x64-mi-secure-openhcl-igvm-extras" | flowey v 12 'artifact_publish_from_x64-mi-secure-openhcl-igvm-extras' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-mi-secure-openhcl-igvm-test-linux-direct"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-mi-secure-openhcl-igvm-test-linux-direct" | flowey v 12 'artifact_publish_from_x64-mi-secure-openhcl-igvm-test-linux-direct' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-mi-secure-openhcl-igvm-test-linux-direct-extras"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-mi-secure-openhcl-igvm-test-linux-direct-extras" | flowey v 12 'artifact_publish_from_x64-mi-secure-openhcl-igvm-test-linux-direct-extras' --is-raw-string update
-      shell: bash
-    - name: check if openvmm needs to be cloned
-      run: |-
-        flowey e 12 flowey_lib_common::git_checkout 0
-        flowey v 12 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
-        flowey v 12 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__git_checkout__1
-      uses: actions/checkout@v6
-      with:
-        fetch-depth: '1'
-        path: repo0
-        persist-credentials: ${{ env.floweyvar3 }}
-      name: checkout repo openvmm
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: report cloned repo directories
-      run: |-
-        flowey v 12 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
-        ${{ github.workspace }}
-        EOF
-        flowey e 12 flowey_lib_common::git_checkout 3
-        flowey e 12 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 3
-      shell: bash
-    - name: add default cargo home to path
-      run: flowey e 12 flowey_lib_common::install_rust 0
-      shell: bash
-    - name: install Rust
-      run: flowey e 12 flowey_lib_common::install_rust 1
-      shell: bash
-    - name: detect active toolchain
-      run: |-
-        flowey e 12 flowey_lib_common::install_rust 2
-        flowey e 12 flowey_lib_common::cfg_cargo_common_flags 0
-        flowey e 12 flowey_lib_hvlite::cfg_openvmm_magicpath 0
       shell: bash
     - name: create gh-release-download cache dir
       run: flowey e 12 flowey_lib_common::download_gh_release 0
@@ -1270,11 +1168,44 @@ jobs:
         flowey e 12 flowey_lib_common::cache 2
         flowey e 12 flowey_lib_common::download_gh_release 1
       shell: bash
-    - name: unpack openvmm-deps archive
-      run: flowey e 12 flowey_lib_hvlite::resolve_openvmm_deps 0
+    - name: unpack openvmm-test-linux archives
+      run: flowey e 12 flowey_lib_hvlite::resolve_openvmm_test_linux_kernel 0
       shell: bash
-    - name: extract X86_64 sysroot.tar.gz
-      run: flowey e 12 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
+    - name: unpack openvmm-test-initrd archives
+      run: flowey e 12 flowey_lib_hvlite::resolve_openvmm_test_initrd 0
+      shell: bash
+    - name: add default cargo home to path
+      run: flowey e 12 flowey_lib_common::install_rust 0
+      shell: bash
+    - name: install Rust
+      run: flowey e 12 flowey_lib_common::install_rust 1
+      shell: bash
+    - name: detect active toolchain
+      run: |-
+        flowey e 12 flowey_lib_common::install_rust 2
+        flowey e 12 flowey_lib_common::cfg_cargo_common_flags 0
+      shell: bash
+    - name: check if openvmm needs to be cloned
+      run: |-
+        flowey e 12 flowey_lib_common::git_checkout 0
+        flowey v 12 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
+        flowey v 12 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__git_checkout__1
+      uses: actions/checkout@v6
+      with:
+        fetch-depth: '1'
+        path: repo0
+        persist-credentials: ${{ env.floweyvar3 }}
+      name: checkout repo openvmm
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: report cloned repo directories
+      run: |-
+        flowey v 12 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        ${{ github.workspace }}
+        EOF
+        flowey e 12 flowey_lib_common::git_checkout 3
+        flowey e 12 flowey_lib_hvlite::git_checkout_openvmm_repo 0
       shell: bash
     - name: set '-Dwarnings' in .cargo/config.toml
       run: flowey e 12 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
@@ -1286,48 +1217,27 @@ jobs:
       run: flowey e 12 flowey_lib_common::install_dist_pkg 1
       shell: bash
     - name: unpack protoc
-      run: flowey e 12 flowey_lib_common::resolve_protoc 0
+      run: |-
+        flowey e 12 flowey_lib_common::resolve_protoc 0
+        flowey e 12 flowey_lib_hvlite::cfg_openvmm_magicpath 0
       shell: bash
     - name: symlink protoc
       run: |-
         flowey e 12 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-        flowey e 12 flowey_lib_hvlite::init_cross_build 3
-      shell: bash
-    - name: cargo build openvmm_hcl
-      run: |-
-        flowey e 12 flowey_lib_common::run_cargo_build 2
-        flowey e 12 flowey_lib_hvlite::run_cargo_build 6
-        flowey e 12 flowey_lib_hvlite::build_openvmm_hcl 0
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 0
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 12 flowey_lib_hvlite::run_split_debug_info 0
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 1
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 2
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 4
-      shell: bash
-    - name: extract and resolve kernel package
-      run: flowey e 12 flowey_lib_hvlite::resolve_openhcl_kernel_package 0
-      shell: bash
-    - name: building openhcl initrd
-      run: |-
-        flowey e 12 flowey_lib_hvlite::build_openhcl_initrd 0
         flowey e 12 flowey_lib_hvlite::init_cross_build 0
-        flowey e 12 flowey_lib_hvlite::run_cargo_build 7
-        flowey e 12 flowey_lib_hvlite::run_cargo_build 8
+        flowey e 12 flowey_lib_hvlite::run_cargo_build 9
+        flowey e 12 flowey_lib_hvlite::run_cargo_build 10
       shell: bash
     - name: cargo build sidecar
       run: |-
         flowey e 12 flowey_lib_common::run_cargo_build 3
-        flowey e 12 flowey_lib_hvlite::run_cargo_build 9
+        flowey e 12 flowey_lib_hvlite::run_cargo_build 11
       shell: bash
     - name: split debug symbols
       run: |-
         flowey e 12 flowey_lib_hvlite::run_split_debug_info 4
-        flowey e 12 flowey_lib_hvlite::run_cargo_build 10
+        flowey e 12 flowey_lib_hvlite::run_cargo_build 12
         flowey e 12 flowey_lib_hvlite::build_sidecar 0
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 5
         flowey e 12 flowey_lib_hvlite::init_cross_build 1
         flowey e 12 flowey_lib_hvlite::run_cargo_build 2
         flowey e 12 flowey_lib_hvlite::run_cargo_build 3
@@ -1342,12 +1252,40 @@ jobs:
         flowey e 12 flowey_lib_hvlite::run_split_debug_info 3
         flowey e 12 flowey_lib_hvlite::run_cargo_build 5
         flowey e 12 flowey_lib_hvlite::build_openhcl_boot 0
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 6
       shell: bash
-    - name: unpack mu_msvm package (x64)
+    - name: extract and resolve kernel package
       run: |-
-        flowey e 12 flowey_lib_hvlite::download_uefi_mu_msvm 0
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 7
+        flowey e 12 flowey_lib_hvlite::resolve_openhcl_kernel_package 0
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 28
+      shell: bash
+    - name: unpack openvmm-deps archive
+      run: flowey e 12 flowey_lib_hvlite::resolve_openvmm_deps 0
+      shell: bash
+    - name: extract X86_64 sysroot.tar.gz
+      run: |-
+        flowey e 12 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
+        flowey e 12 flowey_lib_hvlite::init_cross_build 3
+        flowey e 12 flowey_lib_hvlite::run_cargo_build 6
+        flowey e 12 flowey_lib_hvlite::run_cargo_build 7
+      shell: bash
+    - name: cargo build openvmm_hcl
+      run: |-
+        flowey e 12 flowey_lib_common::run_cargo_build 2
+        flowey e 12 flowey_lib_hvlite::run_cargo_build 8
+        flowey e 12 flowey_lib_hvlite::build_openvmm_hcl 0
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 24
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 12 flowey_lib_hvlite::run_split_debug_info 2
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 25
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 26
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 29
+      shell: bash
+    - name: building openhcl initrd
+      run: |-
+        flowey e 12 flowey_lib_hvlite::build_openhcl_initrd 2
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 30
         flowey e 12 flowey_lib_hvlite::init_cross_build 2
       shell: bash
     - name: cargo build igvmfilegen
@@ -1360,56 +1298,21 @@ jobs:
         flowey e 12 flowey_lib_hvlite::run_split_debug_info 5
         flowey e 12 flowey_lib_hvlite::run_cargo_build 1
         flowey e 12 flowey_lib_hvlite::build_igvmfilegen 0
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 8
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 9
-      shell: bash
-    - name: building igvm file
-      run: |-
-        flowey e 12 flowey_lib_hvlite::run_igvmfilegen 1
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 12
-        flowey e 12 flowey_core::pipeline::artifact::publish 0
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 10
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 11
-        flowey e 12 flowey_core::pipeline::artifact::publish 1
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 33
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 34
-      shell: bash
-    - name: unpack openvmm-test-linux archives
-      run: flowey e 12 flowey_lib_hvlite::resolve_openvmm_test_linux_kernel 0
-      shell: bash
-    - name: unpack openvmm-test-initrd archives
-      run: |-
-        flowey e 12 flowey_lib_hvlite::resolve_openvmm_test_initrd 0
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 28
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 25
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 12 flowey_lib_hvlite::run_split_debug_info 2
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 26
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 27
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 29
-      shell: bash
-    - name: building openhcl initrd
-      run: |-
-        flowey e 12 flowey_lib_hvlite::build_openhcl_initrd 2
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 30
         flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 31
         flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 32
       shell: bash
     - name: building igvm file
       run: |-
-        flowey e 12 flowey_lib_hvlite::run_igvmfilegen 0
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 37
-        flowey e 12 flowey_core::pipeline::artifact::publish 2
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 35
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 36
-        flowey e 12 flowey_core::pipeline::artifact::publish 3
+        flowey e 12 flowey_lib_hvlite::run_igvmfilegen 2
+        flowey e 12 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 2
+      shell: bash
+    - name: unpack mu_msvm package (x64)
+      run: flowey e 12 flowey_lib_hvlite::download_uefi_mu_msvm 0
       shell: bash
     - name: extract and resolve kernel package
       run: |-
         flowey e 12 flowey_lib_hvlite::resolve_openhcl_kernel_package 1
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 16
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 17
         flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 13
       shell: bash
     - name: split debug symbols
@@ -1417,24 +1320,61 @@ jobs:
         flowey e 12 flowey_lib_hvlite::run_split_debug_info 1
         flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 14
         flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 15
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 17
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 18
       shell: bash
     - name: building openhcl initrd
       run: |-
         flowey e 12 flowey_lib_hvlite::build_openhcl_initrd 1
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 18
         flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 19
         flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 20
         flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 21
       shell: bash
     - name: building igvm file
       run: |-
-        flowey e 12 flowey_lib_hvlite::run_igvmfilegen 2
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 24
-        flowey e 12 flowey_core::pipeline::artifact::publish 4
+        flowey e 12 flowey_lib_hvlite::run_igvmfilegen 1
+        flowey e 12 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 4
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 6
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 2
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 12 flowey_lib_hvlite::run_split_debug_info 0
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 3
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 4
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 7
+      shell: bash
+    - name: building openhcl initrd
+      run: |-
+        flowey e 12 flowey_lib_hvlite::build_openhcl_initrd 0
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 8
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 9
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 10
+      shell: bash
+    - name: building igvm file
+      run: |-
+        flowey e 12 flowey_lib_hvlite::run_igvmfilegen 0
+        flowey e 12 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 0
+        flowey e 12 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::publish 0
+      shell: bash
+    - name: copying OpenHCL igvm files to artifact dir
+      run: |-
+        flowey e 12 flowey_lib_common::copy_to_artifact_dir 1
         flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 22
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 27
         flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 23
-        flowey e 12 flowey_core::pipeline::artifact::publish 5
+        flowey e 12 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 3
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 16
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 12
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 11
+        flowey e 12 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 5
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 5
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 1
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 0
+        flowey e 12 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 1
+        flowey e 12 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe_extras::publish 0
+      shell: bash
+    - name: copying OpenHCL igvm extras to artifact dir
+      run: flowey e 12 flowey_lib_common::copy_to_artifact_dir 0
       shell: bash
     - name: 'validate cache entry: gh-release-download'
       run: flowey e 12 flowey_lib_common::cache 3
@@ -1445,35 +1385,11 @@ jobs:
         name: x64-mi-secure-openhcl-igvm
         path: ${{ runner.temp }}/publish_artifacts/x64-mi-secure-openhcl-igvm/
         include-hidden-files: true
-    - name: 🌼📦 Publish x64-mi-secure-openhcl-igvm-cvm
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-mi-secure-openhcl-igvm-cvm
-        path: ${{ runner.temp }}/publish_artifacts/x64-mi-secure-openhcl-igvm-cvm/
-        include-hidden-files: true
-    - name: 🌼📦 Publish x64-mi-secure-openhcl-igvm-cvm-extras
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-mi-secure-openhcl-igvm-cvm-extras
-        path: ${{ runner.temp }}/publish_artifacts/x64-mi-secure-openhcl-igvm-cvm-extras/
-        include-hidden-files: true
     - name: 🌼📦 Publish x64-mi-secure-openhcl-igvm-extras
       uses: actions/upload-artifact@v7
       with:
         name: x64-mi-secure-openhcl-igvm-extras
         path: ${{ runner.temp }}/publish_artifacts/x64-mi-secure-openhcl-igvm-extras/
-        include-hidden-files: true
-    - name: 🌼📦 Publish x64-mi-secure-openhcl-igvm-test-linux-direct
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-mi-secure-openhcl-igvm-test-linux-direct
-        path: ${{ runner.temp }}/publish_artifacts/x64-mi-secure-openhcl-igvm-test-linux-direct/
-        include-hidden-files: true
-    - name: 🌼📦 Publish x64-mi-secure-openhcl-igvm-test-linux-direct-extras
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-mi-secure-openhcl-igvm-test-linux-direct-extras
-        path: ${{ runner.temp }}/publish_artifacts/x64-mi-secure-openhcl-igvm-test-linux-direct-extras/
         include-hidden-files: true
   job13:
     name: clippy [x64-windows], unit tests [x64-windows]
@@ -3269,6 +3185,115 @@ jobs:
         flowey e 18 flowey_lib_common::install_rust 2
         flowey e 18 flowey_lib_common::cfg_cargo_common_flags 0
       shell: bash
+    - name: check if openvmm needs to be cloned
+      run: |-
+        flowey e 18 flowey_lib_common::git_checkout 0
+        flowey v 18 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar11
+        flowey v 18 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__git_checkout__1
+      uses: actions/checkout@v6
+      with:
+        fetch-depth: '1'
+        path: repo0
+        persist-credentials: ${{ env.floweyvar11 }}
+      name: checkout repo openvmm
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: report cloned repo directories
+      run: |-
+        flowey v 18 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        ${{ github.workspace }}
+        EOF
+        flowey e 18 flowey_lib_common::git_checkout 3
+        flowey e 18 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey e 18 flowey_lib_hvlite::cfg_openvmm_magicpath 0
+      shell: bash
+    - name: create gh-release-download cache dir
+      run: flowey e 18 flowey_lib_common::download_gh_release 0
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
+        flowey e 18 flowey_lib_common::cache 4
+        flowey v 18 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar9
+        flowey v 18 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar10
+      shell: bash
+    - id: flowey_lib_common__cache__5
+      uses: actions/cache@v5
+      with:
+        key: ${{ env.floweyvar9 }}
+        path: ${{ env.floweyvar10 }}
+      name: 'Restore cache: gh-release-download'
+    - name: download artifacts from github releases
+      run: |-
+        flowey v 18 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
+        EOF
+        flowey e 18 flowey_lib_common::cache 6
+        flowey e 18 flowey_lib_common::download_gh_release 1
+      shell: bash
+    - name: unpack openvmm-deps archive
+      run: flowey e 18 flowey_lib_hvlite::resolve_openvmm_deps 0
+      shell: bash
+    - name: extract Aarch64 sysroot.tar.gz
+      run: flowey e 18 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
+      shell: bash
+    - name: checking if packages need to be installed
+      run: flowey e 18 flowey_lib_common::install_dist_pkg 0
+      shell: bash
+    - name: installing packages
+      run: flowey e 18 flowey_lib_common::install_dist_pkg 1
+      shell: bash
+    - name: set '-Dwarnings' in .cargo/config.toml
+      run: flowey e 18 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
+      shell: bash
+    - name: unpack protoc
+      run: flowey e 18 flowey_lib_common::resolve_protoc 0
+      shell: bash
+    - name: symlink protoc
+      run: |-
+        flowey e 18 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
+        flowey e 18 flowey_lib_hvlite::init_cross_build 2
+      shell: bash
+    - name: cargo clippy
+      run: flowey e 18 flowey_lib_common::run_cargo_clippy 3
+      shell: bash
+    - name: cargo clippy
+      run: flowey e 18 flowey_lib_common::run_cargo_clippy 5
+      shell: bash
+    - name: cargo clippy
+      run: flowey e 18 flowey_lib_common::run_cargo_clippy 1
+      shell: bash
+    - name: cargo clippy
+      run: flowey e 18 flowey_lib_common::run_cargo_clippy 7
+      shell: bash
+    - name: cargo clippy
+      run: |-
+        flowey e 18 flowey_lib_common::run_cargo_clippy 6
+        flowey e 18 flowey_lib_hvlite::init_cross_build 0
+      shell: bash
+    - name: cargo build xtask
+      run: |-
+        flowey e 18 flowey_lib_common::run_cargo_build 0
+        flowey e 18 flowey_lib_hvlite::run_cargo_build 0
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 18 flowey_lib_hvlite::run_split_debug_info 1
+        flowey e 18 flowey_lib_hvlite::run_cargo_build 1
+        flowey e 18 flowey_lib_hvlite::build_xtask 0
+      shell: bash
+    - name: determine clippy exclusions
+      run: flowey e 18 flowey_lib_hvlite::_jobs::check_clippy 0
+      shell: bash
+    - name: cargo clippy
+      run: flowey e 18 flowey_lib_common::run_cargo_clippy 0
+      shell: bash
+    - name: cargo clippy
+      run: flowey e 18 flowey_lib_common::run_cargo_clippy 2
+      shell: bash
+    - name: cargo clippy
+      run: flowey e 18 flowey_lib_common::run_cargo_clippy 4
+      shell: bash
     - name: create cargo-nextest cache dir
       run: |-
         flowey e 18 flowey_lib_common::download_cargo_nextest 0
@@ -3303,78 +3328,10 @@ jobs:
       run: |-
         flowey e 18 flowey_lib_common::install_cargo_nextest 0
         flowey e 18 flowey_lib_hvlite::init_cross_build 3
-      shell: bash
-    - name: check if openvmm needs to be cloned
-      run: |-
-        flowey e 18 flowey_lib_common::git_checkout 0
-        flowey v 18 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar11
-        flowey v 18 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__git_checkout__1
-      uses: actions/checkout@v6
-      with:
-        fetch-depth: '1'
-        path: repo0
-        persist-credentials: ${{ env.floweyvar11 }}
-      name: checkout repo openvmm
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: report cloned repo directories
-      run: |-
-        flowey v 18 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
-        ${{ github.workspace }}
-        EOF
-        flowey e 18 flowey_lib_common::git_checkout 3
-        flowey e 18 flowey_lib_hvlite::git_checkout_openvmm_repo 0
         flowey e 18 flowey_lib_hvlite::run_cargo_nextest_run 0
       shell: bash
     - name: generate nextest command
       run: flowey e 18 flowey_lib_common::gen_cargo_nextest_run_cmd 1
-      shell: bash
-    - name: set '-Dwarnings' in .cargo/config.toml
-      run: flowey e 18 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
-      shell: bash
-    - name: create gh-release-download cache dir
-      run: flowey e 18 flowey_lib_common::download_gh_release 0
-      shell: bash
-    - name: Pre-processing cache vars
-      run: |-
-        flowey e 18 flowey_lib_common::cache 4
-        flowey v 18 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar9
-        flowey v 18 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar10
-      shell: bash
-    - id: flowey_lib_common__cache__5
-      uses: actions/cache@v5
-      with:
-        key: ${{ env.floweyvar9 }}
-        path: ${{ env.floweyvar10 }}
-      name: 'Restore cache: gh-release-download'
-    - name: download artifacts from github releases
-      run: |-
-        flowey v 18 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
-        EOF
-        flowey e 18 flowey_lib_common::cache 6
-        flowey e 18 flowey_lib_common::download_gh_release 1
-      shell: bash
-    - name: checking if packages need to be installed
-      run: flowey e 18 flowey_lib_common::install_dist_pkg 0
-      shell: bash
-    - name: installing packages
-      run: flowey e 18 flowey_lib_common::install_dist_pkg 1
-      shell: bash
-    - name: unpack protoc
-      run: |-
-        flowey e 18 flowey_lib_common::resolve_protoc 0
-        flowey e 18 flowey_lib_hvlite::cfg_openvmm_magicpath 0
-      shell: bash
-    - name: symlink protoc
-      run: flowey e 18 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-      shell: bash
-    - name: unpack openvmm-deps archive
-      run: flowey e 18 flowey_lib_hvlite::resolve_openvmm_deps 0
-      shell: bash
-    - name: extract Aarch64 sysroot.tar.gz
-      run: flowey e 18 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
       shell: bash
     - name: run 'unit-tests crypto (native)' nextest tests
       run: |-
@@ -3520,49 +3477,7 @@ jobs:
         flowey e 18 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
       shell: bash
     - name: run doctests for aarch64-unknown-linux-musl
-      run: |-
-        flowey e 18 flowey_lib_hvlite::_jobs::build_and_run_doc_tests 0
-        flowey e 18 flowey_lib_hvlite::init_cross_build 2
-      shell: bash
-    - name: cargo clippy
-      run: flowey e 18 flowey_lib_common::run_cargo_clippy 3
-      shell: bash
-    - name: cargo clippy
-      run: flowey e 18 flowey_lib_common::run_cargo_clippy 5
-      shell: bash
-    - name: cargo clippy
-      run: flowey e 18 flowey_lib_common::run_cargo_clippy 1
-      shell: bash
-    - name: cargo clippy
-      run: flowey e 18 flowey_lib_common::run_cargo_clippy 7
-      shell: bash
-    - name: cargo clippy
-      run: |-
-        flowey e 18 flowey_lib_common::run_cargo_clippy 6
-        flowey e 18 flowey_lib_hvlite::init_cross_build 0
-      shell: bash
-    - name: cargo build xtask
-      run: |-
-        flowey e 18 flowey_lib_common::run_cargo_build 0
-        flowey e 18 flowey_lib_hvlite::run_cargo_build 0
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 18 flowey_lib_hvlite::run_split_debug_info 1
-        flowey e 18 flowey_lib_hvlite::run_cargo_build 1
-        flowey e 18 flowey_lib_hvlite::build_xtask 0
-      shell: bash
-    - name: determine clippy exclusions
-      run: flowey e 18 flowey_lib_hvlite::_jobs::check_clippy 0
-      shell: bash
-    - name: cargo clippy
-      run: flowey e 18 flowey_lib_common::run_cargo_clippy 0
-      shell: bash
-    - name: cargo clippy
-      run: flowey e 18 flowey_lib_common::run_cargo_clippy 2
-      shell: bash
-    - name: cargo clippy
-      run: flowey e 18 flowey_lib_common::run_cargo_clippy 4
+      run: flowey e 18 flowey_lib_hvlite::_jobs::build_and_run_doc_tests 0
       shell: bash
     - name: 'validate cache entry: cargo-nextest'
       run: flowey e 18 flowey_lib_common::cache 3
@@ -3590,7 +3505,7 @@ jobs:
     - name: 🌼📦 Download artifacts
       uses: actions/download-artifact@v8
       with:
-        pattern: '{_internal-flowey-bootstrap-x86_64-windows-uid-13,x64-guest_test_uefi,x64-linux-musl-pipette,x64-linux-musl-tmk_vmm,x64-linux-tpm_guest_tests,x64-openhcl-igvm,x64-openhcl-igvm-cvm,x64-openhcl-igvm-test-linux-direct,x64-tmks,x64-windows-openvmm,x64-windows-pipette,x64-windows-prep_steps,x64-windows-test_igvm_agent_rpc_server,x64-windows-tmk_vmm,x64-windows-tpm_guest_tests,x64-windows-vmgstool,x64-windows-vmgstool-dev,x64-windows-vmm-tests-archive}'
+        pattern: '{_internal-flowey-bootstrap-x86_64-windows-uid-13,x64-guest_test_uefi,x64-linux-musl-pipette,x64-linux-musl-tmk_vmm,x64-linux-tpm_guest_tests,x64-openhcl-igvm,x64-tmks,x64-windows-openvmm,x64-windows-pipette,x64-windows-prep_steps,x64-windows-test_igvm_agent_rpc_server,x64-windows-tmk_vmm,x64-windows-tpm_guest_tests,x64-windows-vmgstool,x64-windows-vmgstool-dev,x64-windows-vmm-tests-archive}'
         path: ${{ runner.temp }}/used_artifacts/
     - run: echo "${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-windows-uid-13" >> $GITHUB_PATH
       shell: bash
@@ -3614,8 +3529,6 @@ jobs:
         echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-tmk_vmm" | flowey.exe v 19 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
         echo "${{ runner.temp }}\\used_artifacts\\x64-linux-tpm_guest_tests" | flowey.exe v 19 'artifact_use_from_x64-linux-tpm_guest_tests' --is-raw-string update
         echo "${{ runner.temp }}\\used_artifacts\\x64-openhcl-igvm" | flowey.exe v 19 'artifact_use_from_x64-openhcl-igvm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-openhcl-igvm-cvm" | flowey.exe v 19 'artifact_use_from_x64-openhcl-igvm-cvm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-openhcl-igvm-test-linux-direct" | flowey.exe v 19 'artifact_use_from_x64-openhcl-igvm-test-linux-direct' --is-raw-string update
         echo "${{ runner.temp }}\\used_artifacts\\x64-tmks" | flowey.exe v 19 'artifact_use_from_x64-tmks' --is-raw-string update
         echo "${{ runner.temp }}\\used_artifacts\\x64-windows-openvmm" | flowey.exe v 19 'artifact_use_from_x64-windows-openvmm' --is-raw-string update
         echo "${{ runner.temp }}\\used_artifacts\\x64-windows-pipette" | flowey.exe v 19 'artifact_use_from_x64-windows-pipette' --is-raw-string update
@@ -3676,24 +3589,24 @@ jobs:
         flowey.exe e 19 flowey_lib_common::git_checkout 3
         flowey.exe e 19 flowey_lib_hvlite::git_checkout_openvmm_repo 0
         flowey.exe e 19 flowey_lib_hvlite::run_cargo_nextest_run 0
-        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 8
-        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 9
-        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 12
-        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 14
-        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 15
-        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 13
-        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 3
-        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 11
-        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 4
         flowey.exe e 19 flowey_core::pipeline::artifact::resolve 5
         flowey.exe e 19 flowey_core::pipeline::artifact::resolve 6
         flowey.exe e 19 flowey_core::pipeline::artifact::resolve 1
-        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 2
         flowey.exe e 19 flowey_core::pipeline::artifact::resolve 0
-        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 7
+        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 9
+        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 2
+        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 4
+        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 11
+        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 12
+        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 10
+        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 3
+        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 8
       shell: bash
     - name: creating new test content dir
       run: flowey.exe e 19 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
+      shell: bash
+    - name: resolve OpenHCL igvm artifact
+      run: flowey.exe e 19 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::resolve 0
       shell: bash
     - name: create gh-release-download cache dir
       run: flowey.exe e 19 flowey_lib_common::download_gh_release 0
@@ -3782,7 +3695,7 @@ jobs:
       run: |-
         flowey.exe e 19 flowey_lib_hvlite::init_vmm_tests_env 0
         flowey.exe e 19 flowey_lib_hvlite::run_cargo_nextest_run 1
-        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 16
+        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 13
         flowey.exe e 19 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
       shell: bash
     - name: generate nextest command
@@ -3794,7 +3707,7 @@ jobs:
     - name: starting test_igvm_agent_rpc_server
       run: |-
         flowey.exe e 19 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
-        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 10
+        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 7
       shell: bash
     - name: running vmm_test prep_steps
       run: flowey.exe e 19 flowey_lib_hvlite::run_prep_steps 0
@@ -4051,7 +3964,7 @@ jobs:
     - name: 🌼📦 Download artifacts
       uses: actions/download-artifact@v8
       with:
-        pattern: '{_internal-flowey-bootstrap-x86_64-windows-uid-13,x64-guest_test_uefi,x64-linux-musl-pipette,x64-linux-musl-tmk_vmm,x64-linux-tpm_guest_tests,x64-mi-secure-openhcl-igvm,x64-mi-secure-openhcl-igvm-cvm,x64-mi-secure-openhcl-igvm-test-linux-direct,x64-tmks,x64-windows-openvmm,x64-windows-pipette,x64-windows-prep_steps,x64-windows-test_igvm_agent_rpc_server,x64-windows-tmk_vmm,x64-windows-tpm_guest_tests,x64-windows-vmgstool,x64-windows-vmgstool-dev,x64-windows-vmm-tests-archive}'
+        pattern: '{_internal-flowey-bootstrap-x86_64-windows-uid-13,x64-guest_test_uefi,x64-linux-musl-pipette,x64-linux-musl-tmk_vmm,x64-linux-tpm_guest_tests,x64-mi-secure-openhcl-igvm,x64-tmks,x64-windows-openvmm,x64-windows-pipette,x64-windows-prep_steps,x64-windows-test_igvm_agent_rpc_server,x64-windows-tmk_vmm,x64-windows-tpm_guest_tests,x64-windows-vmgstool,x64-windows-vmgstool-dev,x64-windows-vmm-tests-archive}'
         path: ${{ runner.temp }}/used_artifacts/
     - run: echo "${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-windows-uid-13" >> $GITHUB_PATH
       shell: bash
@@ -4075,8 +3988,6 @@ jobs:
         echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-tmk_vmm" | flowey.exe v 20 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
         echo "${{ runner.temp }}\\used_artifacts\\x64-linux-tpm_guest_tests" | flowey.exe v 20 'artifact_use_from_x64-linux-tpm_guest_tests' --is-raw-string update
         echo "${{ runner.temp }}\\used_artifacts\\x64-mi-secure-openhcl-igvm" | flowey.exe v 20 'artifact_use_from_x64-mi-secure-openhcl-igvm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-mi-secure-openhcl-igvm-cvm" | flowey.exe v 20 'artifact_use_from_x64-mi-secure-openhcl-igvm-cvm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-mi-secure-openhcl-igvm-test-linux-direct" | flowey.exe v 20 'artifact_use_from_x64-mi-secure-openhcl-igvm-test-linux-direct' --is-raw-string update
         echo "${{ runner.temp }}\\used_artifacts\\x64-tmks" | flowey.exe v 20 'artifact_use_from_x64-tmks' --is-raw-string update
         echo "${{ runner.temp }}\\used_artifacts\\x64-windows-openvmm" | flowey.exe v 20 'artifact_use_from_x64-windows-openvmm' --is-raw-string update
         echo "${{ runner.temp }}\\used_artifacts\\x64-windows-pipette" | flowey.exe v 20 'artifact_use_from_x64-windows-pipette' --is-raw-string update
@@ -4137,24 +4048,24 @@ jobs:
         flowey.exe e 20 flowey_lib_common::git_checkout 3
         flowey.exe e 20 flowey_lib_hvlite::git_checkout_openvmm_repo 0
         flowey.exe e 20 flowey_lib_hvlite::run_cargo_nextest_run 0
-        flowey.exe e 20 flowey_core::pipeline::artifact::resolve 12
-        flowey.exe e 20 flowey_core::pipeline::artifact::resolve 14
-        flowey.exe e 20 flowey_core::pipeline::artifact::resolve 15
-        flowey.exe e 20 flowey_core::pipeline::artifact::resolve 13
-        flowey.exe e 20 flowey_core::pipeline::artifact::resolve 3
-        flowey.exe e 20 flowey_core::pipeline::artifact::resolve 11
-        flowey.exe e 20 flowey_core::pipeline::artifact::resolve 4
         flowey.exe e 20 flowey_core::pipeline::artifact::resolve 5
         flowey.exe e 20 flowey_core::pipeline::artifact::resolve 6
         flowey.exe e 20 flowey_core::pipeline::artifact::resolve 1
-        flowey.exe e 20 flowey_core::pipeline::artifact::resolve 2
         flowey.exe e 20 flowey_core::pipeline::artifact::resolve 0
-        flowey.exe e 20 flowey_core::pipeline::artifact::resolve 7
-        flowey.exe e 20 flowey_core::pipeline::artifact::resolve 8
         flowey.exe e 20 flowey_core::pipeline::artifact::resolve 9
+        flowey.exe e 20 flowey_core::pipeline::artifact::resolve 2
+        flowey.exe e 20 flowey_core::pipeline::artifact::resolve 4
+        flowey.exe e 20 flowey_core::pipeline::artifact::resolve 11
+        flowey.exe e 20 flowey_core::pipeline::artifact::resolve 12
+        flowey.exe e 20 flowey_core::pipeline::artifact::resolve 10
+        flowey.exe e 20 flowey_core::pipeline::artifact::resolve 3
+        flowey.exe e 20 flowey_core::pipeline::artifact::resolve 8
       shell: bash
     - name: creating new test content dir
       run: flowey.exe e 20 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
+      shell: bash
+    - name: resolve OpenHCL igvm artifact
+      run: flowey.exe e 20 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::resolve 0
       shell: bash
     - name: create gh-release-download cache dir
       run: flowey.exe e 20 flowey_lib_common::download_gh_release 0
@@ -4243,7 +4154,7 @@ jobs:
       run: |-
         flowey.exe e 20 flowey_lib_hvlite::init_vmm_tests_env 0
         flowey.exe e 20 flowey_lib_hvlite::run_cargo_nextest_run 1
-        flowey.exe e 20 flowey_core::pipeline::artifact::resolve 16
+        flowey.exe e 20 flowey_core::pipeline::artifact::resolve 13
         flowey.exe e 20 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
       shell: bash
     - name: generate nextest command
@@ -4326,7 +4237,7 @@ jobs:
     - name: 🌼📦 Download artifacts
       uses: actions/download-artifact@v8
       with:
-        pattern: '{_internal-flowey-bootstrap-x86_64-windows-uid-13,x64-guest_test_uefi,x64-linux-musl-pipette,x64-linux-musl-tmk_vmm,x64-linux-tpm_guest_tests,x64-openhcl-igvm,x64-openhcl-igvm-cvm,x64-openhcl-igvm-test-linux-direct,x64-tmks,x64-windows-openvmm,x64-windows-pipette,x64-windows-prep_steps,x64-windows-test_igvm_agent_rpc_server,x64-windows-tmk_vmm,x64-windows-tpm_guest_tests,x64-windows-vmgstool,x64-windows-vmgstool-dev,x64-windows-vmm-tests-archive}'
+        pattern: '{_internal-flowey-bootstrap-x86_64-windows-uid-13,x64-guest_test_uefi,x64-linux-musl-pipette,x64-linux-musl-tmk_vmm,x64-linux-tpm_guest_tests,x64-openhcl-igvm,x64-tmks,x64-windows-openvmm,x64-windows-pipette,x64-windows-prep_steps,x64-windows-test_igvm_agent_rpc_server,x64-windows-tmk_vmm,x64-windows-tpm_guest_tests,x64-windows-vmgstool,x64-windows-vmgstool-dev,x64-windows-vmm-tests-archive}'
         path: ${{ runner.temp }}/used_artifacts/
     - run: echo "${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-windows-uid-13" >> $GITHUB_PATH
       shell: bash
@@ -4350,8 +4261,6 @@ jobs:
         echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-tmk_vmm" | flowey.exe v 21 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
         echo "${{ runner.temp }}\\used_artifacts\\x64-linux-tpm_guest_tests" | flowey.exe v 21 'artifact_use_from_x64-linux-tpm_guest_tests' --is-raw-string update
         echo "${{ runner.temp }}\\used_artifacts\\x64-openhcl-igvm" | flowey.exe v 21 'artifact_use_from_x64-openhcl-igvm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-openhcl-igvm-cvm" | flowey.exe v 21 'artifact_use_from_x64-openhcl-igvm-cvm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-openhcl-igvm-test-linux-direct" | flowey.exe v 21 'artifact_use_from_x64-openhcl-igvm-test-linux-direct' --is-raw-string update
         echo "${{ runner.temp }}\\used_artifacts\\x64-tmks" | flowey.exe v 21 'artifact_use_from_x64-tmks' --is-raw-string update
         echo "${{ runner.temp }}\\used_artifacts\\x64-windows-openvmm" | flowey.exe v 21 'artifact_use_from_x64-windows-openvmm' --is-raw-string update
         echo "${{ runner.temp }}\\used_artifacts\\x64-windows-pipette" | flowey.exe v 21 'artifact_use_from_x64-windows-pipette' --is-raw-string update
@@ -4412,24 +4321,24 @@ jobs:
         flowey.exe e 21 flowey_lib_common::git_checkout 3
         flowey.exe e 21 flowey_lib_hvlite::git_checkout_openvmm_repo 0
         flowey.exe e 21 flowey_lib_hvlite::run_cargo_nextest_run 0
-        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 8
-        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 9
-        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 12
-        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 14
-        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 15
-        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 13
-        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 3
-        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 11
-        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 4
         flowey.exe e 21 flowey_core::pipeline::artifact::resolve 5
         flowey.exe e 21 flowey_core::pipeline::artifact::resolve 6
         flowey.exe e 21 flowey_core::pipeline::artifact::resolve 1
-        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 2
         flowey.exe e 21 flowey_core::pipeline::artifact::resolve 0
-        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 7
+        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 9
+        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 2
+        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 4
+        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 11
+        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 12
+        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 10
+        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 3
+        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 8
       shell: bash
     - name: creating new test content dir
       run: flowey.exe e 21 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
+      shell: bash
+    - name: resolve OpenHCL igvm artifact
+      run: flowey.exe e 21 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::resolve 0
       shell: bash
     - name: create gh-release-download cache dir
       run: flowey.exe e 21 flowey_lib_common::download_gh_release 0
@@ -4518,7 +4427,7 @@ jobs:
       run: |-
         flowey.exe e 21 flowey_lib_hvlite::init_vmm_tests_env 0
         flowey.exe e 21 flowey_lib_hvlite::run_cargo_nextest_run 1
-        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 16
+        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 13
         flowey.exe e 21 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
       shell: bash
     - name: generate nextest command
@@ -4530,7 +4439,7 @@ jobs:
     - name: starting test_igvm_agent_rpc_server
       run: |-
         flowey.exe e 21 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
-        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 10
+        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 7
       shell: bash
     - name: running vmm_test prep_steps
       run: flowey.exe e 21 flowey_lib_hvlite::run_prep_steps 0
@@ -4605,7 +4514,7 @@ jobs:
     - name: 🌼📦 Download artifacts
       uses: actions/download-artifact@v8
       with:
-        pattern: '{_internal-flowey-bootstrap-x86_64-windows-uid-13,x64-guest_test_uefi,x64-linux-musl-pipette,x64-linux-musl-tmk_vmm,x64-linux-tpm_guest_tests,x64-openhcl-igvm,x64-openhcl-igvm-cvm,x64-openhcl-igvm-test-linux-direct,x64-tmks,x64-windows-openvmm,x64-windows-pipette,x64-windows-prep_steps,x64-windows-test_igvm_agent_rpc_server,x64-windows-tmk_vmm,x64-windows-tpm_guest_tests,x64-windows-vmgstool,x64-windows-vmgstool-dev,x64-windows-vmm-tests-archive}'
+        pattern: '{_internal-flowey-bootstrap-x86_64-windows-uid-13,x64-guest_test_uefi,x64-linux-musl-pipette,x64-linux-musl-tmk_vmm,x64-linux-tpm_guest_tests,x64-openhcl-igvm,x64-tmks,x64-windows-openvmm,x64-windows-pipette,x64-windows-prep_steps,x64-windows-test_igvm_agent_rpc_server,x64-windows-tmk_vmm,x64-windows-tpm_guest_tests,x64-windows-vmgstool,x64-windows-vmgstool-dev,x64-windows-vmm-tests-archive}'
         path: ${{ runner.temp }}/used_artifacts/
     - run: echo "${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-windows-uid-13" >> $GITHUB_PATH
       shell: bash
@@ -4629,8 +4538,6 @@ jobs:
         echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-tmk_vmm" | flowey.exe v 22 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
         echo "${{ runner.temp }}\\used_artifacts\\x64-linux-tpm_guest_tests" | flowey.exe v 22 'artifact_use_from_x64-linux-tpm_guest_tests' --is-raw-string update
         echo "${{ runner.temp }}\\used_artifacts\\x64-openhcl-igvm" | flowey.exe v 22 'artifact_use_from_x64-openhcl-igvm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-openhcl-igvm-cvm" | flowey.exe v 22 'artifact_use_from_x64-openhcl-igvm-cvm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-openhcl-igvm-test-linux-direct" | flowey.exe v 22 'artifact_use_from_x64-openhcl-igvm-test-linux-direct' --is-raw-string update
         echo "${{ runner.temp }}\\used_artifacts\\x64-tmks" | flowey.exe v 22 'artifact_use_from_x64-tmks' --is-raw-string update
         echo "${{ runner.temp }}\\used_artifacts\\x64-windows-openvmm" | flowey.exe v 22 'artifact_use_from_x64-windows-openvmm' --is-raw-string update
         echo "${{ runner.temp }}\\used_artifacts\\x64-windows-pipette" | flowey.exe v 22 'artifact_use_from_x64-windows-pipette' --is-raw-string update
@@ -4691,24 +4598,24 @@ jobs:
         flowey.exe e 22 flowey_lib_common::git_checkout 3
         flowey.exe e 22 flowey_lib_hvlite::git_checkout_openvmm_repo 0
         flowey.exe e 22 flowey_lib_hvlite::run_cargo_nextest_run 0
-        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 8
-        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 9
-        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 12
-        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 14
-        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 15
-        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 13
-        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 3
-        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 11
-        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 4
         flowey.exe e 22 flowey_core::pipeline::artifact::resolve 5
         flowey.exe e 22 flowey_core::pipeline::artifact::resolve 6
         flowey.exe e 22 flowey_core::pipeline::artifact::resolve 1
-        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 2
         flowey.exe e 22 flowey_core::pipeline::artifact::resolve 0
-        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 7
+        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 9
+        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 2
+        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 4
+        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 11
+        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 12
+        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 10
+        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 3
+        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 8
       shell: bash
     - name: creating new test content dir
       run: flowey.exe e 22 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
+      shell: bash
+    - name: resolve OpenHCL igvm artifact
+      run: flowey.exe e 22 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::resolve 0
       shell: bash
     - name: create gh-release-download cache dir
       run: flowey.exe e 22 flowey_lib_common::download_gh_release 0
@@ -4797,7 +4704,7 @@ jobs:
       run: |-
         flowey.exe e 22 flowey_lib_hvlite::init_vmm_tests_env 0
         flowey.exe e 22 flowey_lib_hvlite::run_cargo_nextest_run 1
-        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 16
+        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 13
         flowey.exe e 22 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
       shell: bash
     - name: generate nextest command
@@ -4809,7 +4716,7 @@ jobs:
     - name: starting test_igvm_agent_rpc_server
       run: |-
         flowey.exe e 22 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
-        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 10
+        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 7
       shell: bash
     - name: running vmm_test prep_steps
       run: flowey.exe e 22 flowey_lib_hvlite::run_prep_steps 0
@@ -4885,7 +4792,7 @@ jobs:
     - name: 🌼📦 Download artifacts
       uses: actions/download-artifact@v8
       with:
-        pattern: '{_internal-flowey-bootstrap-x86_64-windows-uid-13,x64-guest_test_uefi,x64-linux-musl-pipette,x64-linux-musl-tmk_vmm,x64-linux-tpm_guest_tests,x64-openhcl-igvm,x64-openhcl-igvm-cvm,x64-openhcl-igvm-test-linux-direct,x64-tmks,x64-windows-openvmm,x64-windows-pipette,x64-windows-prep_steps,x64-windows-test_igvm_agent_rpc_server,x64-windows-tmk_vmm,x64-windows-tpm_guest_tests,x64-windows-vmgstool,x64-windows-vmgstool-dev,x64-windows-vmm-tests-archive}'
+        pattern: '{_internal-flowey-bootstrap-x86_64-windows-uid-13,x64-guest_test_uefi,x64-linux-musl-pipette,x64-linux-musl-tmk_vmm,x64-linux-tpm_guest_tests,x64-openhcl-igvm,x64-tmks,x64-windows-openvmm,x64-windows-pipette,x64-windows-prep_steps,x64-windows-test_igvm_agent_rpc_server,x64-windows-tmk_vmm,x64-windows-tpm_guest_tests,x64-windows-vmgstool,x64-windows-vmgstool-dev,x64-windows-vmm-tests-archive}'
         path: ${{ runner.temp }}/used_artifacts/
     - run: echo "${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-windows-uid-13" >> $GITHUB_PATH
       shell: bash
@@ -4909,8 +4816,6 @@ jobs:
         echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-tmk_vmm" | flowey.exe v 23 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
         echo "${{ runner.temp }}\\used_artifacts\\x64-linux-tpm_guest_tests" | flowey.exe v 23 'artifact_use_from_x64-linux-tpm_guest_tests' --is-raw-string update
         echo "${{ runner.temp }}\\used_artifacts\\x64-openhcl-igvm" | flowey.exe v 23 'artifact_use_from_x64-openhcl-igvm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-openhcl-igvm-cvm" | flowey.exe v 23 'artifact_use_from_x64-openhcl-igvm-cvm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-openhcl-igvm-test-linux-direct" | flowey.exe v 23 'artifact_use_from_x64-openhcl-igvm-test-linux-direct' --is-raw-string update
         echo "${{ runner.temp }}\\used_artifacts\\x64-tmks" | flowey.exe v 23 'artifact_use_from_x64-tmks' --is-raw-string update
         echo "${{ runner.temp }}\\used_artifacts\\x64-windows-openvmm" | flowey.exe v 23 'artifact_use_from_x64-windows-openvmm' --is-raw-string update
         echo "${{ runner.temp }}\\used_artifacts\\x64-windows-pipette" | flowey.exe v 23 'artifact_use_from_x64-windows-pipette' --is-raw-string update
@@ -4971,24 +4876,24 @@ jobs:
         flowey.exe e 23 flowey_lib_common::git_checkout 3
         flowey.exe e 23 flowey_lib_hvlite::git_checkout_openvmm_repo 0
         flowey.exe e 23 flowey_lib_hvlite::run_cargo_nextest_run 0
-        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 8
-        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 9
-        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 12
-        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 14
-        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 15
-        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 13
-        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 3
-        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 11
-        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 4
         flowey.exe e 23 flowey_core::pipeline::artifact::resolve 5
         flowey.exe e 23 flowey_core::pipeline::artifact::resolve 6
         flowey.exe e 23 flowey_core::pipeline::artifact::resolve 1
-        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 2
         flowey.exe e 23 flowey_core::pipeline::artifact::resolve 0
-        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 7
+        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 9
+        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 2
+        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 4
+        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 11
+        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 12
+        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 10
+        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 3
+        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 8
       shell: bash
     - name: creating new test content dir
       run: flowey.exe e 23 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
+      shell: bash
+    - name: resolve OpenHCL igvm artifact
+      run: flowey.exe e 23 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::resolve 0
       shell: bash
     - name: create gh-release-download cache dir
       run: flowey.exe e 23 flowey_lib_common::download_gh_release 0
@@ -5077,7 +4982,7 @@ jobs:
       run: |-
         flowey.exe e 23 flowey_lib_hvlite::init_vmm_tests_env 0
         flowey.exe e 23 flowey_lib_hvlite::run_cargo_nextest_run 1
-        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 16
+        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 13
         flowey.exe e 23 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
       shell: bash
     - name: generate nextest command
@@ -5089,7 +4994,7 @@ jobs:
     - name: starting test_igvm_agent_rpc_server
       run: |-
         flowey.exe e 23 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
-        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 10
+        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 7
       shell: bash
     - name: running vmm_test prep_steps
       run: flowey.exe e 23 flowey_lib_hvlite::run_prep_steps 0
@@ -5194,12 +5099,12 @@ jobs:
       shell: bash
     - name: creating new test content dir
       run: |-
-        flowey e 24 flowey_core::pipeline::artifact::resolve 8
-        flowey e 24 flowey_core::pipeline::artifact::resolve 2
         flowey e 24 flowey_core::pipeline::artifact::resolve 3
         flowey e 24 flowey_core::pipeline::artifact::resolve 4
+        flowey e 24 flowey_core::pipeline::artifact::resolve 8
         flowey e 24 flowey_core::pipeline::artifact::resolve 1
         flowey e 24 flowey_core::pipeline::artifact::resolve 0
+        flowey e 24 flowey_core::pipeline::artifact::resolve 2
         flowey e 24 flowey_core::pipeline::artifact::resolve 7
         flowey e 24 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
       shell: bash
@@ -5509,12 +5414,12 @@ jobs:
       shell: bash
     - name: creating new test content dir
       run: |-
-        flowey e 25 flowey_core::pipeline::artifact::resolve 8
-        flowey e 25 flowey_core::pipeline::artifact::resolve 4
         flowey e 25 flowey_core::pipeline::artifact::resolve 1
         flowey e 25 flowey_core::pipeline::artifact::resolve 2
+        flowey e 25 flowey_core::pipeline::artifact::resolve 8
         flowey e 25 flowey_core::pipeline::artifact::resolve 3
         flowey e 25 flowey_core::pipeline::artifact::resolve 0
+        flowey e 25 flowey_core::pipeline::artifact::resolve 4
         flowey e 25 flowey_core::pipeline::artifact::resolve 7
         flowey e 25 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
       shell: bash
@@ -5871,19 +5776,21 @@ jobs:
         flowey.exe e 26 flowey_lib_common::git_checkout 3
         flowey.exe e 26 flowey_lib_hvlite::git_checkout_openvmm_repo 0
         flowey.exe e 26 flowey_lib_hvlite::run_cargo_nextest_run 0
+        flowey.exe e 26 flowey_core::pipeline::artifact::resolve 4
         flowey.exe e 26 flowey_core::pipeline::artifact::resolve 5
+        flowey.exe e 26 flowey_core::pipeline::artifact::resolve 1
+        flowey.exe e 26 flowey_core::pipeline::artifact::resolve 0
         flowey.exe e 26 flowey_core::pipeline::artifact::resolve 6
+        flowey.exe e 26 flowey_core::pipeline::artifact::resolve 2
+        flowey.exe e 26 flowey_core::pipeline::artifact::resolve 3
         flowey.exe e 26 flowey_core::pipeline::artifact::resolve 7
         flowey.exe e 26 flowey_core::pipeline::artifact::resolve 8
-        flowey.exe e 26 flowey_core::pipeline::artifact::resolve 9
-        flowey.exe e 26 flowey_core::pipeline::artifact::resolve 3
-        flowey.exe e 26 flowey_core::pipeline::artifact::resolve 1
-        flowey.exe e 26 flowey_core::pipeline::artifact::resolve 2
-        flowey.exe e 26 flowey_core::pipeline::artifact::resolve 0
-        flowey.exe e 26 flowey_core::pipeline::artifact::resolve 4
       shell: bash
     - name: creating new test content dir
       run: flowey.exe e 26 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
+      shell: bash
+    - name: resolve OpenHCL igvm artifact
+      run: flowey.exe e 26 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::resolve 0
       shell: bash
     - name: create gh-release-download cache dir
       run: flowey.exe e 26 flowey_lib_common::download_gh_release 0
@@ -5972,7 +5879,7 @@ jobs:
       run: |-
         flowey.exe e 26 flowey_lib_hvlite::init_vmm_tests_env 0
         flowey.exe e 26 flowey_lib_hvlite::run_cargo_nextest_run 1
-        flowey.exe e 26 flowey_core::pipeline::artifact::resolve 10
+        flowey.exe e 26 flowey_core::pipeline::artifact::resolve 9
         flowey.exe e 26 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
       shell: bash
     - name: generate nextest command

--- a/.github/workflows/openvmm-pr-release.yaml
+++ b/.github/workflows/openvmm-pr-release.yaml
@@ -433,47 +433,14 @@ jobs:
         EOF
         mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-openhcl-igvm"
         echo "$AgentTempDirNormal/publish_artifacts/aarch64-openhcl-igvm" | flowey v 10 'artifact_publish_from_aarch64-openhcl-igvm' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-openhcl-igvm-devkern"
-        echo "$AgentTempDirNormal/publish_artifacts/aarch64-openhcl-igvm-devkern" | flowey v 10 'artifact_publish_from_aarch64-openhcl-igvm-devkern' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-openhcl-igvm-devkern-extras"
-        echo "$AgentTempDirNormal/publish_artifacts/aarch64-openhcl-igvm-devkern-extras" | flowey v 10 'artifact_publish_from_aarch64-openhcl-igvm-devkern-extras' --is-raw-string update
         mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-openhcl-igvm-extras"
         echo "$AgentTempDirNormal/publish_artifacts/aarch64-openhcl-igvm-extras" | flowey v 10 'artifact_publish_from_aarch64-openhcl-igvm-extras' --is-raw-string update
       shell: bash
-    - name: check if openvmm needs to be cloned
-      run: |-
-        flowey e 10 flowey_lib_common::git_checkout 0
-        flowey v 10 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
-        flowey v 10 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+    - name: checking if packages need to be installed
+      run: flowey e 10 flowey_lib_common::install_dist_pkg 0
       shell: bash
-    - id: flowey_lib_common__git_checkout__1
-      uses: actions/checkout@v6
-      with:
-        fetch-depth: '1'
-        path: repo0
-        persist-credentials: ${{ env.floweyvar3 }}
-      name: checkout repo openvmm
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: report cloned repo directories
-      run: |-
-        flowey v 10 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
-        ${{ github.workspace }}
-        EOF
-        flowey e 10 flowey_lib_common::git_checkout 3
-        flowey e 10 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 3
-      shell: bash
-    - name: add default cargo home to path
-      run: flowey e 10 flowey_lib_common::install_rust 0
-      shell: bash
-    - name: install Rust
-      run: flowey e 10 flowey_lib_common::install_rust 1
-      shell: bash
-    - name: detect active toolchain
-      run: |-
-        flowey e 10 flowey_lib_common::install_rust 2
-        flowey e 10 flowey_lib_common::cfg_cargo_common_flags 0
-        flowey e 10 flowey_lib_hvlite::cfg_openvmm_magicpath 0
+    - name: installing packages
+      run: flowey e 10 flowey_lib_common::install_dist_pkg 1
       shell: bash
     - name: create gh-release-download cache dir
       run: flowey e 10 flowey_lib_common::download_gh_release 0
@@ -498,49 +465,53 @@ jobs:
         flowey e 10 flowey_lib_common::cache 2
         flowey e 10 flowey_lib_common::download_gh_release 1
       shell: bash
-    - name: unpack openvmm-deps archive
-      run: flowey e 10 flowey_lib_hvlite::resolve_openvmm_deps 0
+    - name: unpack mu_msvm package (aarch64)
+      run: flowey e 10 flowey_lib_hvlite::download_uefi_mu_msvm 0
       shell: bash
-    - name: extract Aarch64 sysroot.tar.gz
-      run: flowey e 10 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
+    - name: add default cargo home to path
+      run: flowey e 10 flowey_lib_common::install_rust 0
+      shell: bash
+    - name: install Rust
+      run: flowey e 10 flowey_lib_common::install_rust 1
+      shell: bash
+    - name: detect active toolchain
+      run: |-
+        flowey e 10 flowey_lib_common::install_rust 2
+        flowey e 10 flowey_lib_common::cfg_cargo_common_flags 0
+      shell: bash
+    - name: check if openvmm needs to be cloned
+      run: |-
+        flowey e 10 flowey_lib_common::git_checkout 0
+        flowey v 10 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
+        flowey v 10 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__git_checkout__1
+      uses: actions/checkout@v6
+      with:
+        fetch-depth: '1'
+        path: repo0
+        persist-credentials: ${{ env.floweyvar3 }}
+      name: checkout repo openvmm
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: report cloned repo directories
+      run: |-
+        flowey v 10 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        ${{ github.workspace }}
+        EOF
+        flowey e 10 flowey_lib_common::git_checkout 3
+        flowey e 10 flowey_lib_hvlite::git_checkout_openvmm_repo 0
       shell: bash
     - name: set '-Dwarnings' in .cargo/config.toml
       run: flowey e 10 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
       shell: bash
-    - name: checking if packages need to be installed
-      run: flowey e 10 flowey_lib_common::install_dist_pkg 0
-      shell: bash
-    - name: installing packages
-      run: flowey e 10 flowey_lib_common::install_dist_pkg 1
-      shell: bash
     - name: unpack protoc
-      run: flowey e 10 flowey_lib_common::resolve_protoc 0
+      run: |-
+        flowey e 10 flowey_lib_common::resolve_protoc 0
+        flowey e 10 flowey_lib_hvlite::cfg_openvmm_magicpath 0
       shell: bash
     - name: symlink protoc
       run: |-
         flowey e 10 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-        flowey e 10 flowey_lib_hvlite::init_cross_build 1
-      shell: bash
-    - name: cargo build openvmm_hcl
-      run: |-
-        flowey e 10 flowey_lib_common::run_cargo_build 2
-        flowey e 10 flowey_lib_hvlite::run_cargo_build 6
-        flowey e 10 flowey_lib_hvlite::build_openvmm_hcl 0
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 0
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 10 flowey_lib_hvlite::run_split_debug_info 0
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 1
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 2
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 4
-      shell: bash
-    - name: extract and resolve kernel package
-      run: flowey e 10 flowey_lib_hvlite::resolve_openhcl_kernel_package 0
-      shell: bash
-    - name: building openhcl initrd
-      run: |-
-        flowey e 10 flowey_lib_hvlite::build_openhcl_initrd 0
         flowey e 10 flowey_lib_hvlite::init_cross_build 0
         flowey e 10 flowey_lib_hvlite::run_cargo_build 2
         flowey e 10 flowey_lib_hvlite::run_cargo_build 3
@@ -555,12 +526,40 @@ jobs:
         flowey e 10 flowey_lib_hvlite::run_split_debug_info 2
         flowey e 10 flowey_lib_hvlite::run_cargo_build 5
         flowey e 10 flowey_lib_hvlite::build_openhcl_boot 0
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 5
       shell: bash
-    - name: unpack mu_msvm package (aarch64)
+    - name: extract and resolve kernel package
       run: |-
-        flowey e 10 flowey_lib_hvlite::download_uefi_mu_msvm 0
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 6
+        flowey e 10 flowey_lib_hvlite::resolve_openhcl_kernel_package 1
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 17
+      shell: bash
+    - name: unpack openvmm-deps archive
+      run: flowey e 10 flowey_lib_hvlite::resolve_openvmm_deps 0
+      shell: bash
+    - name: extract Aarch64 sysroot.tar.gz
+      run: |-
+        flowey e 10 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
+        flowey e 10 flowey_lib_hvlite::init_cross_build 1
+        flowey e 10 flowey_lib_hvlite::run_cargo_build 6
+        flowey e 10 flowey_lib_hvlite::run_cargo_build 7
+      shell: bash
+    - name: cargo build openvmm_hcl
+      run: |-
+        flowey e 10 flowey_lib_common::run_cargo_build 2
+        flowey e 10 flowey_lib_hvlite::run_cargo_build 8
+        flowey e 10 flowey_lib_hvlite::build_openvmm_hcl 0
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 13
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 10 flowey_lib_hvlite::run_split_debug_info 1
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 14
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 15
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 18
+      shell: bash
+    - name: building openhcl initrd
+      run: |-
+        flowey e 10 flowey_lib_hvlite::build_openhcl_initrd 1
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 19
         flowey e 10 flowey_lib_hvlite::init_cross_build 2
       shell: bash
     - name: cargo build igvmfilegen
@@ -573,47 +572,55 @@ jobs:
         flowey e 10 flowey_lib_hvlite::run_split_debug_info 3
         flowey e 10 flowey_lib_hvlite::run_cargo_build 1
         flowey e 10 flowey_lib_hvlite::build_igvmfilegen 0
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 7
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 8
-      shell: bash
-    - name: building igvm file
-      run: |-
-        flowey e 10 flowey_lib_hvlite::run_igvmfilegen 0
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 11
-        flowey e 10 flowey_core::pipeline::artifact::publish 0
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 9
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 10
-        flowey e 10 flowey_core::pipeline::artifact::publish 1
-      shell: bash
-    - name: extract and resolve kernel package
-      run: |-
-        flowey e 10 flowey_lib_hvlite::resolve_openhcl_kernel_package 1
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 15
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 12
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 10 flowey_lib_hvlite::run_split_debug_info 1
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 13
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 14
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 16
-      shell: bash
-    - name: building openhcl initrd
-      run: |-
-        flowey e 10 flowey_lib_hvlite::build_openhcl_initrd 1
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 17
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 18
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 19
         flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 20
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 21
       shell: bash
     - name: building igvm file
       run: |-
         flowey e 10 flowey_lib_hvlite::run_igvmfilegen 1
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 23
-        flowey e 10 flowey_core::pipeline::artifact::publish 2
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 21
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 22
-        flowey e 10 flowey_core::pipeline::artifact::publish 3
+        flowey e 10 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 2
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 6
+      shell: bash
+    - name: extract and resolve kernel package
+      run: |-
+        flowey e 10 flowey_lib_hvlite::resolve_openhcl_kernel_package 0
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 2
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 10 flowey_lib_hvlite::run_split_debug_info 0
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 3
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 4
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 7
+      shell: bash
+    - name: building openhcl initrd
+      run: |-
+        flowey e 10 flowey_lib_hvlite::build_openhcl_initrd 0
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 8
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 9
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 10
+      shell: bash
+    - name: building igvm file
+      run: |-
+        flowey e 10 flowey_lib_hvlite::run_igvmfilegen 0
+        flowey e 10 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 0
+        flowey e 10 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::publish 0
+      shell: bash
+    - name: copying OpenHCL igvm files to artifact dir
+      run: |-
+        flowey e 10 flowey_lib_common::copy_to_artifact_dir 1
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 11
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 16
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 12
+        flowey e 10 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 3
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 5
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 1
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 0
+        flowey e 10 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 1
+        flowey e 10 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe_extras::publish 0
+      shell: bash
+    - name: copying OpenHCL igvm extras to artifact dir
+      run: flowey e 10 flowey_lib_common::copy_to_artifact_dir 0
       shell: bash
     - name: 'validate cache entry: gh-release-download'
       run: flowey e 10 flowey_lib_common::cache 3
@@ -623,18 +630,6 @@ jobs:
       with:
         name: aarch64-openhcl-igvm
         path: ${{ runner.temp }}/publish_artifacts/aarch64-openhcl-igvm/
-        include-hidden-files: true
-    - name: 🌼📦 Publish aarch64-openhcl-igvm-devkern
-      uses: actions/upload-artifact@v7
-      with:
-        name: aarch64-openhcl-igvm-devkern
-        path: ${{ runner.temp }}/publish_artifacts/aarch64-openhcl-igvm-devkern/
-        include-hidden-files: true
-    - name: 🌼📦 Publish aarch64-openhcl-igvm-devkern-extras
-      uses: actions/upload-artifact@v7
-      with:
-        name: aarch64-openhcl-igvm-devkern-extras
-        path: ${{ runner.temp }}/publish_artifacts/aarch64-openhcl-igvm-devkern-extras/
         include-hidden-files: true
     - name: 🌼📦 Publish aarch64-openhcl-igvm-extras
       uses: actions/upload-artifact@v7
@@ -680,59 +675,14 @@ jobs:
         EOF
         mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm"
         echo "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm" | flowey v 11 'artifact_publish_from_x64-openhcl-igvm' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-cvm"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-cvm" | flowey v 11 'artifact_publish_from_x64-openhcl-igvm-cvm' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-cvm-extras"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-cvm-extras" | flowey v 11 'artifact_publish_from_x64-openhcl-igvm-cvm-extras' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-devkern"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-devkern" | flowey v 11 'artifact_publish_from_x64-openhcl-igvm-devkern' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-devkern-extras"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-devkern-extras" | flowey v 11 'artifact_publish_from_x64-openhcl-igvm-devkern-extras' --is-raw-string update
         mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-extras"
         echo "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-extras" | flowey v 11 'artifact_publish_from_x64-openhcl-igvm-extras' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-test-linux-direct"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-test-linux-direct" | flowey v 11 'artifact_publish_from_x64-openhcl-igvm-test-linux-direct' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-test-linux-direct-devkern"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-test-linux-direct-devkern" | flowey v 11 'artifact_publish_from_x64-openhcl-igvm-test-linux-direct-devkern' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-test-linux-direct-devkern-extras"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-test-linux-direct-devkern-extras" | flowey v 11 'artifact_publish_from_x64-openhcl-igvm-test-linux-direct-devkern-extras' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-test-linux-direct-extras"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-test-linux-direct-extras" | flowey v 11 'artifact_publish_from_x64-openhcl-igvm-test-linux-direct-extras' --is-raw-string update
       shell: bash
-    - name: check if openvmm needs to be cloned
-      run: |-
-        flowey e 11 flowey_lib_common::git_checkout 0
-        flowey v 11 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
-        flowey v 11 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+    - name: checking if packages need to be installed
+      run: flowey e 11 flowey_lib_common::install_dist_pkg 0
       shell: bash
-    - id: flowey_lib_common__git_checkout__1
-      uses: actions/checkout@v6
-      with:
-        fetch-depth: '1'
-        path: repo0
-        persist-credentials: ${{ env.floweyvar3 }}
-      name: checkout repo openvmm
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: report cloned repo directories
-      run: |-
-        flowey v 11 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
-        ${{ github.workspace }}
-        EOF
-        flowey e 11 flowey_lib_common::git_checkout 3
-        flowey e 11 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 3
-      shell: bash
-    - name: add default cargo home to path
-      run: flowey e 11 flowey_lib_common::install_rust 0
-      shell: bash
-    - name: install Rust
-      run: flowey e 11 flowey_lib_common::install_rust 1
-      shell: bash
-    - name: detect active toolchain
-      run: |-
-        flowey e 11 flowey_lib_common::install_rust 2
-        flowey e 11 flowey_lib_common::cfg_cargo_common_flags 0
-        flowey e 11 flowey_lib_hvlite::cfg_openvmm_magicpath 0
+    - name: installing packages
+      run: flowey e 11 flowey_lib_common::install_dist_pkg 1
       shell: bash
     - name: create gh-release-download cache dir
       run: flowey e 11 flowey_lib_common::download_gh_release 0
@@ -757,64 +707,67 @@ jobs:
         flowey e 11 flowey_lib_common::cache 2
         flowey e 11 flowey_lib_common::download_gh_release 1
       shell: bash
-    - name: unpack openvmm-deps archive
-      run: flowey e 11 flowey_lib_hvlite::resolve_openvmm_deps 0
+    - name: unpack mu_msvm package (x64)
+      run: flowey e 11 flowey_lib_hvlite::download_uefi_mu_msvm 0
       shell: bash
-    - name: extract X86_64 sysroot.tar.gz
-      run: flowey e 11 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
+    - name: add default cargo home to path
+      run: flowey e 11 flowey_lib_common::install_rust 0
+      shell: bash
+    - name: install Rust
+      run: flowey e 11 flowey_lib_common::install_rust 1
+      shell: bash
+    - name: detect active toolchain
+      run: |-
+        flowey e 11 flowey_lib_common::install_rust 2
+        flowey e 11 flowey_lib_common::cfg_cargo_common_flags 0
+      shell: bash
+    - name: check if openvmm needs to be cloned
+      run: |-
+        flowey e 11 flowey_lib_common::git_checkout 0
+        flowey v 11 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
+        flowey v 11 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__git_checkout__1
+      uses: actions/checkout@v6
+      with:
+        fetch-depth: '1'
+        path: repo0
+        persist-credentials: ${{ env.floweyvar3 }}
+      name: checkout repo openvmm
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: report cloned repo directories
+      run: |-
+        flowey v 11 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        ${{ github.workspace }}
+        EOF
+        flowey e 11 flowey_lib_common::git_checkout 3
+        flowey e 11 flowey_lib_hvlite::git_checkout_openvmm_repo 0
       shell: bash
     - name: set '-Dwarnings' in .cargo/config.toml
       run: flowey e 11 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
       shell: bash
-    - name: checking if packages need to be installed
-      run: flowey e 11 flowey_lib_common::install_dist_pkg 0
-      shell: bash
-    - name: installing packages
-      run: flowey e 11 flowey_lib_common::install_dist_pkg 1
-      shell: bash
     - name: unpack protoc
-      run: flowey e 11 flowey_lib_common::resolve_protoc 0
+      run: |-
+        flowey e 11 flowey_lib_common::resolve_protoc 0
+        flowey e 11 flowey_lib_hvlite::cfg_openvmm_magicpath 0
       shell: bash
     - name: symlink protoc
       run: |-
         flowey e 11 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-        flowey e 11 flowey_lib_hvlite::init_cross_build 3
-      shell: bash
-    - name: cargo build openvmm_hcl
-      run: |-
-        flowey e 11 flowey_lib_common::run_cargo_build 2
-        flowey e 11 flowey_lib_hvlite::run_cargo_build 6
-        flowey e 11 flowey_lib_hvlite::build_openvmm_hcl 0
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 0
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 11 flowey_lib_hvlite::run_split_debug_info 0
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 1
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 2
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 4
-      shell: bash
-    - name: extract and resolve kernel package
-      run: flowey e 11 flowey_lib_hvlite::resolve_openhcl_kernel_package 0
-      shell: bash
-    - name: building openhcl initrd
-      run: |-
-        flowey e 11 flowey_lib_hvlite::build_openhcl_initrd 2
         flowey e 11 flowey_lib_hvlite::init_cross_build 0
-        flowey e 11 flowey_lib_hvlite::run_cargo_build 7
-        flowey e 11 flowey_lib_hvlite::run_cargo_build 8
+        flowey e 11 flowey_lib_hvlite::run_cargo_build 9
+        flowey e 11 flowey_lib_hvlite::run_cargo_build 10
       shell: bash
     - name: cargo build sidecar
       run: |-
         flowey e 11 flowey_lib_common::run_cargo_build 3
-        flowey e 11 flowey_lib_hvlite::run_cargo_build 9
+        flowey e 11 flowey_lib_hvlite::run_cargo_build 11
       shell: bash
     - name: split debug symbols
       run: |-
         flowey e 11 flowey_lib_hvlite::run_split_debug_info 6
-        flowey e 11 flowey_lib_hvlite::run_cargo_build 10
+        flowey e 11 flowey_lib_hvlite::run_cargo_build 12
         flowey e 11 flowey_lib_hvlite::build_sidecar 0
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 5
         flowey e 11 flowey_lib_hvlite::init_cross_build 1
         flowey e 11 flowey_lib_hvlite::run_cargo_build 2
         flowey e 11 flowey_lib_hvlite::run_cargo_build 3
@@ -829,12 +782,40 @@ jobs:
         flowey e 11 flowey_lib_hvlite::run_split_debug_info 5
         flowey e 11 flowey_lib_hvlite::run_cargo_build 5
         flowey e 11 flowey_lib_hvlite::build_openhcl_boot 0
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 6
       shell: bash
-    - name: unpack mu_msvm package (x64)
+    - name: extract and resolve kernel package
       run: |-
-        flowey e 11 flowey_lib_hvlite::download_uefi_mu_msvm 0
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 7
+        flowey e 11 flowey_lib_hvlite::resolve_openhcl_kernel_package 2
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 28
+      shell: bash
+    - name: unpack openvmm-deps archive
+      run: flowey e 11 flowey_lib_hvlite::resolve_openvmm_deps 0
+      shell: bash
+    - name: extract X86_64 sysroot.tar.gz
+      run: |-
+        flowey e 11 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
+        flowey e 11 flowey_lib_hvlite::init_cross_build 3
+        flowey e 11 flowey_lib_hvlite::run_cargo_build 6
+        flowey e 11 flowey_lib_hvlite::run_cargo_build 7
+      shell: bash
+    - name: cargo build openvmm_hcl
+      run: |-
+        flowey e 11 flowey_lib_common::run_cargo_build 2
+        flowey e 11 flowey_lib_hvlite::run_cargo_build 8
+        flowey e 11 flowey_lib_hvlite::build_openvmm_hcl 0
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 24
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 11 flowey_lib_hvlite::run_split_debug_info 4
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 25
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 26
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 29
+      shell: bash
+    - name: building openhcl initrd
+      run: |-
+        flowey e 11 flowey_lib_hvlite::build_openhcl_initrd 4
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 30
         flowey e 11 flowey_lib_hvlite::init_cross_build 2
       shell: bash
     - name: cargo build igvmfilegen
@@ -847,48 +828,28 @@ jobs:
         flowey e 11 flowey_lib_hvlite::run_split_debug_info 7
         flowey e 11 flowey_lib_hvlite::run_cargo_build 1
         flowey e 11 flowey_lib_hvlite::build_igvmfilegen 0
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 8
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 9
-      shell: bash
-    - name: building igvm file
-      run: |-
-        flowey e 11 flowey_lib_hvlite::run_igvmfilegen 2
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 12
-        flowey e 11 flowey_core::pipeline::artifact::publish 0
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 10
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 11
-        flowey e 11 flowey_core::pipeline::artifact::publish 1
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 34
-      shell: bash
-    - name: extract and resolve kernel package
-      run: |-
-        flowey e 11 flowey_lib_hvlite::resolve_openhcl_kernel_package 2
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 28
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 25
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 11 flowey_lib_hvlite::run_split_debug_info 4
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 26
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 27
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 29
-      shell: bash
-    - name: building openhcl initrd
-      run: |-
-        flowey e 11 flowey_lib_hvlite::build_openhcl_initrd 4
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 30
         flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 31
         flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 32
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 33
       shell: bash
     - name: building igvm file
       run: |-
         flowey e 11 flowey_lib_hvlite::run_igvmfilegen 4
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 37
-        flowey e 11 flowey_core::pipeline::artifact::publish 2
+        flowey e 11 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 2
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 39
         flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 35
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 11 flowey_lib_hvlite::run_split_debug_info 0
         flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 36
-        flowey e 11 flowey_core::pipeline::artifact::publish 3
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 37
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 40
+      shell: bash
+    - name: extract and resolve kernel package
+      run: flowey e 11 flowey_lib_hvlite::resolve_openhcl_kernel_package 0
+      shell: bash
+    - name: building openhcl initrd
+      run: flowey e 11 flowey_lib_hvlite::build_openhcl_initrd 0
       shell: bash
     - name: unpack openvmm-test-linux archives
       run: flowey e 11 flowey_lib_hvlite::resolve_openvmm_test_linux_kernel 0
@@ -897,64 +858,39 @@ jobs:
       run: |-
         flowey e 11 flowey_lib_hvlite::resolve_openvmm_test_initrd 0
         flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 41
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 38
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 11 flowey_lib_hvlite::run_split_debug_info 1
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 39
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 40
         flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 42
-      shell: bash
-    - name: building openhcl initrd
-      run: |-
-        flowey e 11 flowey_lib_hvlite::build_openhcl_initrd 0
         flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 43
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 44
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 45
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 46
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 47
       shell: bash
     - name: building igvm file
       run: |-
         flowey e 11 flowey_lib_hvlite::run_igvmfilegen 0
+        flowey e 11 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 4
         flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 50
-        flowey e 11 flowey_core::pipeline::artifact::publish 4
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 48
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 49
-        flowey e 11 flowey_core::pipeline::artifact::publish 5
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 54
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 51
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 46
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 11 flowey_lib_hvlite::run_split_debug_info 2
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 52
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 53
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 55
+        flowey e 11 flowey_lib_hvlite::run_split_debug_info 1
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 47
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 48
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 51
       shell: bash
     - name: building openhcl initrd
       run: |-
         flowey e 11 flowey_lib_hvlite::build_openhcl_initrd 1
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 56
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 57
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 58
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 59
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 60
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 52
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 53
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 54
       shell: bash
     - name: building igvm file
       run: |-
         flowey e 11 flowey_lib_hvlite::run_igvmfilegen 1
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 63
-        flowey e 11 flowey_core::pipeline::artifact::publish 6
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 61
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 62
-        flowey e 11 flowey_core::pipeline::artifact::publish 7
+        flowey e 11 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 6
       shell: bash
     - name: extract and resolve kernel package
       run: |-
         flowey e 11 flowey_lib_hvlite::resolve_openhcl_kernel_package 1
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 16
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 17
         flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 13
       shell: bash
     - name: split debug symbols
@@ -962,12 +898,11 @@ jobs:
         flowey e 11 flowey_lib_hvlite::run_split_debug_info 3
         flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 14
         flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 15
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 17
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 18
       shell: bash
     - name: building openhcl initrd
       run: |-
         flowey e 11 flowey_lib_hvlite::build_openhcl_initrd 3
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 18
         flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 19
         flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 20
         flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 21
@@ -975,11 +910,57 @@ jobs:
     - name: building igvm file
       run: |-
         flowey e 11 flowey_lib_hvlite::run_igvmfilegen 3
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 24
-        flowey e 11 flowey_core::pipeline::artifact::publish 8
+        flowey e 11 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 8
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 6
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 2
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 11 flowey_lib_hvlite::run_split_debug_info 2
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 3
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 4
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 7
+      shell: bash
+    - name: building openhcl initrd
+      run: |-
+        flowey e 11 flowey_lib_hvlite::build_openhcl_initrd 2
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 8
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 9
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 10
+      shell: bash
+    - name: building igvm file
+      run: |-
+        flowey e 11 flowey_lib_hvlite::run_igvmfilegen 2
+        flowey e 11 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 0
+        flowey e 11 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::publish 0
+      shell: bash
+    - name: copying OpenHCL igvm files to artifact dir
+      run: |-
+        flowey e 11 flowey_lib_common::copy_to_artifact_dir 1
         flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 22
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 27
         flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 23
-        flowey e 11 flowey_core::pipeline::artifact::publish 9
+        flowey e 11 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 3
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 38
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 34
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 33
+        flowey e 11 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 5
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 49
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 45
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 44
+        flowey e 11 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 7
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 16
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 12
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 11
+        flowey e 11 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 9
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 5
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 1
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 0
+        flowey e 11 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 1
+        flowey e 11 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe_extras::publish 0
+      shell: bash
+    - name: copying OpenHCL igvm extras to artifact dir
+      run: flowey e 11 flowey_lib_common::copy_to_artifact_dir 0
       shell: bash
     - name: 'validate cache entry: gh-release-download'
       run: flowey e 11 flowey_lib_common::cache 3
@@ -990,59 +971,11 @@ jobs:
         name: x64-openhcl-igvm
         path: ${{ runner.temp }}/publish_artifacts/x64-openhcl-igvm/
         include-hidden-files: true
-    - name: 🌼📦 Publish x64-openhcl-igvm-cvm
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-openhcl-igvm-cvm
-        path: ${{ runner.temp }}/publish_artifacts/x64-openhcl-igvm-cvm/
-        include-hidden-files: true
-    - name: 🌼📦 Publish x64-openhcl-igvm-cvm-extras
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-openhcl-igvm-cvm-extras
-        path: ${{ runner.temp }}/publish_artifacts/x64-openhcl-igvm-cvm-extras/
-        include-hidden-files: true
-    - name: 🌼📦 Publish x64-openhcl-igvm-devkern
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-openhcl-igvm-devkern
-        path: ${{ runner.temp }}/publish_artifacts/x64-openhcl-igvm-devkern/
-        include-hidden-files: true
-    - name: 🌼📦 Publish x64-openhcl-igvm-devkern-extras
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-openhcl-igvm-devkern-extras
-        path: ${{ runner.temp }}/publish_artifacts/x64-openhcl-igvm-devkern-extras/
-        include-hidden-files: true
     - name: 🌼📦 Publish x64-openhcl-igvm-extras
       uses: actions/upload-artifact@v7
       with:
         name: x64-openhcl-igvm-extras
         path: ${{ runner.temp }}/publish_artifacts/x64-openhcl-igvm-extras/
-        include-hidden-files: true
-    - name: 🌼📦 Publish x64-openhcl-igvm-test-linux-direct
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-openhcl-igvm-test-linux-direct
-        path: ${{ runner.temp }}/publish_artifacts/x64-openhcl-igvm-test-linux-direct/
-        include-hidden-files: true
-    - name: 🌼📦 Publish x64-openhcl-igvm-test-linux-direct-devkern
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-openhcl-igvm-test-linux-direct-devkern
-        path: ${{ runner.temp }}/publish_artifacts/x64-openhcl-igvm-test-linux-direct-devkern/
-        include-hidden-files: true
-    - name: 🌼📦 Publish x64-openhcl-igvm-test-linux-direct-devkern-extras
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-openhcl-igvm-test-linux-direct-devkern-extras
-        path: ${{ runner.temp }}/publish_artifacts/x64-openhcl-igvm-test-linux-direct-devkern-extras/
-        include-hidden-files: true
-    - name: 🌼📦 Publish x64-openhcl-igvm-test-linux-direct-extras
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-openhcl-igvm-test-linux-direct-extras
-        path: ${{ runner.temp }}/publish_artifacts/x64-openhcl-igvm-test-linux-direct-extras/
         include-hidden-files: true
   job12:
     name: build openhcl (mi-secure) [x64-linux]
@@ -1082,51 +1015,8 @@ jobs:
         EOF
         mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-mi-secure-openhcl-igvm"
         echo "$AgentTempDirNormal/publish_artifacts/x64-mi-secure-openhcl-igvm" | flowey v 12 'artifact_publish_from_x64-mi-secure-openhcl-igvm' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-mi-secure-openhcl-igvm-cvm"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-mi-secure-openhcl-igvm-cvm" | flowey v 12 'artifact_publish_from_x64-mi-secure-openhcl-igvm-cvm' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-mi-secure-openhcl-igvm-cvm-extras"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-mi-secure-openhcl-igvm-cvm-extras" | flowey v 12 'artifact_publish_from_x64-mi-secure-openhcl-igvm-cvm-extras' --is-raw-string update
         mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-mi-secure-openhcl-igvm-extras"
         echo "$AgentTempDirNormal/publish_artifacts/x64-mi-secure-openhcl-igvm-extras" | flowey v 12 'artifact_publish_from_x64-mi-secure-openhcl-igvm-extras' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-mi-secure-openhcl-igvm-test-linux-direct"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-mi-secure-openhcl-igvm-test-linux-direct" | flowey v 12 'artifact_publish_from_x64-mi-secure-openhcl-igvm-test-linux-direct' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-mi-secure-openhcl-igvm-test-linux-direct-extras"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-mi-secure-openhcl-igvm-test-linux-direct-extras" | flowey v 12 'artifact_publish_from_x64-mi-secure-openhcl-igvm-test-linux-direct-extras' --is-raw-string update
-      shell: bash
-    - name: check if openvmm needs to be cloned
-      run: |-
-        flowey e 12 flowey_lib_common::git_checkout 0
-        flowey v 12 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
-        flowey v 12 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__git_checkout__1
-      uses: actions/checkout@v6
-      with:
-        fetch-depth: '1'
-        path: repo0
-        persist-credentials: ${{ env.floweyvar3 }}
-      name: checkout repo openvmm
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: report cloned repo directories
-      run: |-
-        flowey v 12 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
-        ${{ github.workspace }}
-        EOF
-        flowey e 12 flowey_lib_common::git_checkout 3
-        flowey e 12 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 3
-      shell: bash
-    - name: add default cargo home to path
-      run: flowey e 12 flowey_lib_common::install_rust 0
-      shell: bash
-    - name: install Rust
-      run: flowey e 12 flowey_lib_common::install_rust 1
-      shell: bash
-    - name: detect active toolchain
-      run: |-
-        flowey e 12 flowey_lib_common::install_rust 2
-        flowey e 12 flowey_lib_common::cfg_cargo_common_flags 0
-        flowey e 12 flowey_lib_hvlite::cfg_openvmm_magicpath 0
       shell: bash
     - name: create gh-release-download cache dir
       run: flowey e 12 flowey_lib_common::download_gh_release 0
@@ -1151,11 +1041,44 @@ jobs:
         flowey e 12 flowey_lib_common::cache 2
         flowey e 12 flowey_lib_common::download_gh_release 1
       shell: bash
-    - name: unpack openvmm-deps archive
-      run: flowey e 12 flowey_lib_hvlite::resolve_openvmm_deps 0
+    - name: unpack openvmm-test-linux archives
+      run: flowey e 12 flowey_lib_hvlite::resolve_openvmm_test_linux_kernel 0
       shell: bash
-    - name: extract X86_64 sysroot.tar.gz
-      run: flowey e 12 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
+    - name: unpack openvmm-test-initrd archives
+      run: flowey e 12 flowey_lib_hvlite::resolve_openvmm_test_initrd 0
+      shell: bash
+    - name: add default cargo home to path
+      run: flowey e 12 flowey_lib_common::install_rust 0
+      shell: bash
+    - name: install Rust
+      run: flowey e 12 flowey_lib_common::install_rust 1
+      shell: bash
+    - name: detect active toolchain
+      run: |-
+        flowey e 12 flowey_lib_common::install_rust 2
+        flowey e 12 flowey_lib_common::cfg_cargo_common_flags 0
+      shell: bash
+    - name: check if openvmm needs to be cloned
+      run: |-
+        flowey e 12 flowey_lib_common::git_checkout 0
+        flowey v 12 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
+        flowey v 12 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__git_checkout__1
+      uses: actions/checkout@v6
+      with:
+        fetch-depth: '1'
+        path: repo0
+        persist-credentials: ${{ env.floweyvar3 }}
+      name: checkout repo openvmm
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: report cloned repo directories
+      run: |-
+        flowey v 12 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        ${{ github.workspace }}
+        EOF
+        flowey e 12 flowey_lib_common::git_checkout 3
+        flowey e 12 flowey_lib_hvlite::git_checkout_openvmm_repo 0
       shell: bash
     - name: set '-Dwarnings' in .cargo/config.toml
       run: flowey e 12 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
@@ -1167,48 +1090,27 @@ jobs:
       run: flowey e 12 flowey_lib_common::install_dist_pkg 1
       shell: bash
     - name: unpack protoc
-      run: flowey e 12 flowey_lib_common::resolve_protoc 0
+      run: |-
+        flowey e 12 flowey_lib_common::resolve_protoc 0
+        flowey e 12 flowey_lib_hvlite::cfg_openvmm_magicpath 0
       shell: bash
     - name: symlink protoc
       run: |-
         flowey e 12 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-        flowey e 12 flowey_lib_hvlite::init_cross_build 3
-      shell: bash
-    - name: cargo build openvmm_hcl
-      run: |-
-        flowey e 12 flowey_lib_common::run_cargo_build 2
-        flowey e 12 flowey_lib_hvlite::run_cargo_build 6
-        flowey e 12 flowey_lib_hvlite::build_openvmm_hcl 0
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 0
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 12 flowey_lib_hvlite::run_split_debug_info 0
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 1
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 2
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 4
-      shell: bash
-    - name: extract and resolve kernel package
-      run: flowey e 12 flowey_lib_hvlite::resolve_openhcl_kernel_package 0
-      shell: bash
-    - name: building openhcl initrd
-      run: |-
-        flowey e 12 flowey_lib_hvlite::build_openhcl_initrd 0
         flowey e 12 flowey_lib_hvlite::init_cross_build 0
-        flowey e 12 flowey_lib_hvlite::run_cargo_build 7
-        flowey e 12 flowey_lib_hvlite::run_cargo_build 8
+        flowey e 12 flowey_lib_hvlite::run_cargo_build 9
+        flowey e 12 flowey_lib_hvlite::run_cargo_build 10
       shell: bash
     - name: cargo build sidecar
       run: |-
         flowey e 12 flowey_lib_common::run_cargo_build 3
-        flowey e 12 flowey_lib_hvlite::run_cargo_build 9
+        flowey e 12 flowey_lib_hvlite::run_cargo_build 11
       shell: bash
     - name: split debug symbols
       run: |-
         flowey e 12 flowey_lib_hvlite::run_split_debug_info 4
-        flowey e 12 flowey_lib_hvlite::run_cargo_build 10
+        flowey e 12 flowey_lib_hvlite::run_cargo_build 12
         flowey e 12 flowey_lib_hvlite::build_sidecar 0
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 5
         flowey e 12 flowey_lib_hvlite::init_cross_build 1
         flowey e 12 flowey_lib_hvlite::run_cargo_build 2
         flowey e 12 flowey_lib_hvlite::run_cargo_build 3
@@ -1223,12 +1125,40 @@ jobs:
         flowey e 12 flowey_lib_hvlite::run_split_debug_info 3
         flowey e 12 flowey_lib_hvlite::run_cargo_build 5
         flowey e 12 flowey_lib_hvlite::build_openhcl_boot 0
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 6
       shell: bash
-    - name: unpack mu_msvm package (x64)
+    - name: extract and resolve kernel package
       run: |-
-        flowey e 12 flowey_lib_hvlite::download_uefi_mu_msvm 0
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 7
+        flowey e 12 flowey_lib_hvlite::resolve_openhcl_kernel_package 0
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 28
+      shell: bash
+    - name: unpack openvmm-deps archive
+      run: flowey e 12 flowey_lib_hvlite::resolve_openvmm_deps 0
+      shell: bash
+    - name: extract X86_64 sysroot.tar.gz
+      run: |-
+        flowey e 12 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
+        flowey e 12 flowey_lib_hvlite::init_cross_build 3
+        flowey e 12 flowey_lib_hvlite::run_cargo_build 6
+        flowey e 12 flowey_lib_hvlite::run_cargo_build 7
+      shell: bash
+    - name: cargo build openvmm_hcl
+      run: |-
+        flowey e 12 flowey_lib_common::run_cargo_build 2
+        flowey e 12 flowey_lib_hvlite::run_cargo_build 8
+        flowey e 12 flowey_lib_hvlite::build_openvmm_hcl 0
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 24
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 12 flowey_lib_hvlite::run_split_debug_info 2
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 25
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 26
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 29
+      shell: bash
+    - name: building openhcl initrd
+      run: |-
+        flowey e 12 flowey_lib_hvlite::build_openhcl_initrd 2
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 30
         flowey e 12 flowey_lib_hvlite::init_cross_build 2
       shell: bash
     - name: cargo build igvmfilegen
@@ -1241,56 +1171,21 @@ jobs:
         flowey e 12 flowey_lib_hvlite::run_split_debug_info 5
         flowey e 12 flowey_lib_hvlite::run_cargo_build 1
         flowey e 12 flowey_lib_hvlite::build_igvmfilegen 0
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 8
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 9
-      shell: bash
-    - name: building igvm file
-      run: |-
-        flowey e 12 flowey_lib_hvlite::run_igvmfilegen 1
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 12
-        flowey e 12 flowey_core::pipeline::artifact::publish 0
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 10
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 11
-        flowey e 12 flowey_core::pipeline::artifact::publish 1
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 33
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 34
-      shell: bash
-    - name: unpack openvmm-test-linux archives
-      run: flowey e 12 flowey_lib_hvlite::resolve_openvmm_test_linux_kernel 0
-      shell: bash
-    - name: unpack openvmm-test-initrd archives
-      run: |-
-        flowey e 12 flowey_lib_hvlite::resolve_openvmm_test_initrd 0
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 28
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 25
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 12 flowey_lib_hvlite::run_split_debug_info 2
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 26
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 27
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 29
-      shell: bash
-    - name: building openhcl initrd
-      run: |-
-        flowey e 12 flowey_lib_hvlite::build_openhcl_initrd 2
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 30
         flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 31
         flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 32
       shell: bash
     - name: building igvm file
       run: |-
-        flowey e 12 flowey_lib_hvlite::run_igvmfilegen 0
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 37
-        flowey e 12 flowey_core::pipeline::artifact::publish 2
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 35
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 36
-        flowey e 12 flowey_core::pipeline::artifact::publish 3
+        flowey e 12 flowey_lib_hvlite::run_igvmfilegen 2
+        flowey e 12 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 2
+      shell: bash
+    - name: unpack mu_msvm package (x64)
+      run: flowey e 12 flowey_lib_hvlite::download_uefi_mu_msvm 0
       shell: bash
     - name: extract and resolve kernel package
       run: |-
         flowey e 12 flowey_lib_hvlite::resolve_openhcl_kernel_package 1
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 16
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 17
         flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 13
       shell: bash
     - name: split debug symbols
@@ -1298,24 +1193,61 @@ jobs:
         flowey e 12 flowey_lib_hvlite::run_split_debug_info 1
         flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 14
         flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 15
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 17
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 18
       shell: bash
     - name: building openhcl initrd
       run: |-
         flowey e 12 flowey_lib_hvlite::build_openhcl_initrd 1
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 18
         flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 19
         flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 20
         flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 21
       shell: bash
     - name: building igvm file
       run: |-
-        flowey e 12 flowey_lib_hvlite::run_igvmfilegen 2
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 24
-        flowey e 12 flowey_core::pipeline::artifact::publish 4
+        flowey e 12 flowey_lib_hvlite::run_igvmfilegen 1
+        flowey e 12 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 4
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 6
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 2
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 12 flowey_lib_hvlite::run_split_debug_info 0
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 3
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 4
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 7
+      shell: bash
+    - name: building openhcl initrd
+      run: |-
+        flowey e 12 flowey_lib_hvlite::build_openhcl_initrd 0
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 8
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 9
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 10
+      shell: bash
+    - name: building igvm file
+      run: |-
+        flowey e 12 flowey_lib_hvlite::run_igvmfilegen 0
+        flowey e 12 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 0
+        flowey e 12 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::publish 0
+      shell: bash
+    - name: copying OpenHCL igvm files to artifact dir
+      run: |-
+        flowey e 12 flowey_lib_common::copy_to_artifact_dir 1
         flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 22
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 27
         flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 23
-        flowey e 12 flowey_core::pipeline::artifact::publish 5
+        flowey e 12 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 3
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 16
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 12
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 11
+        flowey e 12 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 5
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 5
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 1
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 0
+        flowey e 12 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 1
+        flowey e 12 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe_extras::publish 0
+      shell: bash
+    - name: copying OpenHCL igvm extras to artifact dir
+      run: flowey e 12 flowey_lib_common::copy_to_artifact_dir 0
       shell: bash
     - name: 'validate cache entry: gh-release-download'
       run: flowey e 12 flowey_lib_common::cache 3
@@ -1326,35 +1258,11 @@ jobs:
         name: x64-mi-secure-openhcl-igvm
         path: ${{ runner.temp }}/publish_artifacts/x64-mi-secure-openhcl-igvm/
         include-hidden-files: true
-    - name: 🌼📦 Publish x64-mi-secure-openhcl-igvm-cvm
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-mi-secure-openhcl-igvm-cvm
-        path: ${{ runner.temp }}/publish_artifacts/x64-mi-secure-openhcl-igvm-cvm/
-        include-hidden-files: true
-    - name: 🌼📦 Publish x64-mi-secure-openhcl-igvm-cvm-extras
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-mi-secure-openhcl-igvm-cvm-extras
-        path: ${{ runner.temp }}/publish_artifacts/x64-mi-secure-openhcl-igvm-cvm-extras/
-        include-hidden-files: true
     - name: 🌼📦 Publish x64-mi-secure-openhcl-igvm-extras
       uses: actions/upload-artifact@v7
       with:
         name: x64-mi-secure-openhcl-igvm-extras
         path: ${{ runner.temp }}/publish_artifacts/x64-mi-secure-openhcl-igvm-extras/
-        include-hidden-files: true
-    - name: 🌼📦 Publish x64-mi-secure-openhcl-igvm-test-linux-direct
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-mi-secure-openhcl-igvm-test-linux-direct
-        path: ${{ runner.temp }}/publish_artifacts/x64-mi-secure-openhcl-igvm-test-linux-direct/
-        include-hidden-files: true
-    - name: 🌼📦 Publish x64-mi-secure-openhcl-igvm-test-linux-direct-extras
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-mi-secure-openhcl-igvm-test-linux-direct-extras
-        path: ${{ runner.temp }}/publish_artifacts/x64-mi-secure-openhcl-igvm-test-linux-direct-extras/
         include-hidden-files: true
   job13:
     name: clippy [x64-windows], unit tests [x64-windows]
@@ -3363,7 +3271,7 @@ jobs:
     - name: 🌼📦 Download artifacts
       uses: actions/download-artifact@v8
       with:
-        pattern: '{_internal-flowey-bootstrap-x86_64-windows-uid-6,x64-guest_test_uefi,x64-linux-musl-pipette,x64-linux-musl-tmk_vmm,x64-linux-tpm_guest_tests,x64-openhcl-igvm,x64-openhcl-igvm-cvm,x64-openhcl-igvm-test-linux-direct,x64-tmks,x64-windows-openvmm,x64-windows-pipette,x64-windows-prep_steps,x64-windows-test_igvm_agent_rpc_server,x64-windows-tmk_vmm,x64-windows-tpm_guest_tests,x64-windows-vmgstool,x64-windows-vmgstool-dev,x64-windows-vmm-tests-archive}'
+        pattern: '{_internal-flowey-bootstrap-x86_64-windows-uid-6,x64-guest_test_uefi,x64-linux-musl-pipette,x64-linux-musl-tmk_vmm,x64-linux-tpm_guest_tests,x64-openhcl-igvm,x64-tmks,x64-windows-openvmm,x64-windows-pipette,x64-windows-prep_steps,x64-windows-test_igvm_agent_rpc_server,x64-windows-tmk_vmm,x64-windows-tpm_guest_tests,x64-windows-vmgstool,x64-windows-vmgstool-dev,x64-windows-vmm-tests-archive}'
         path: ${{ runner.temp }}/used_artifacts/
     - run: echo "${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-windows-uid-6" >> $GITHUB_PATH
       shell: bash
@@ -3387,8 +3295,6 @@ jobs:
         echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-tmk_vmm" | flowey.exe v 19 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
         echo "${{ runner.temp }}\\used_artifacts\\x64-linux-tpm_guest_tests" | flowey.exe v 19 'artifact_use_from_x64-linux-tpm_guest_tests' --is-raw-string update
         echo "${{ runner.temp }}\\used_artifacts\\x64-openhcl-igvm" | flowey.exe v 19 'artifact_use_from_x64-openhcl-igvm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-openhcl-igvm-cvm" | flowey.exe v 19 'artifact_use_from_x64-openhcl-igvm-cvm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-openhcl-igvm-test-linux-direct" | flowey.exe v 19 'artifact_use_from_x64-openhcl-igvm-test-linux-direct' --is-raw-string update
         echo "${{ runner.temp }}\\used_artifacts\\x64-tmks" | flowey.exe v 19 'artifact_use_from_x64-tmks' --is-raw-string update
         echo "${{ runner.temp }}\\used_artifacts\\x64-windows-openvmm" | flowey.exe v 19 'artifact_use_from_x64-windows-openvmm' --is-raw-string update
         echo "${{ runner.temp }}\\used_artifacts\\x64-windows-pipette" | flowey.exe v 19 'artifact_use_from_x64-windows-pipette' --is-raw-string update
@@ -3449,24 +3355,24 @@ jobs:
         flowey.exe e 19 flowey_lib_common::git_checkout 3
         flowey.exe e 19 flowey_lib_hvlite::git_checkout_openvmm_repo 0
         flowey.exe e 19 flowey_lib_hvlite::run_cargo_nextest_run 0
-        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 8
-        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 9
-        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 12
-        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 14
-        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 15
-        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 13
-        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 3
-        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 11
-        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 4
         flowey.exe e 19 flowey_core::pipeline::artifact::resolve 5
         flowey.exe e 19 flowey_core::pipeline::artifact::resolve 6
         flowey.exe e 19 flowey_core::pipeline::artifact::resolve 1
-        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 2
         flowey.exe e 19 flowey_core::pipeline::artifact::resolve 0
-        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 7
+        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 9
+        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 2
+        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 4
+        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 11
+        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 12
+        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 10
+        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 3
+        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 8
       shell: bash
     - name: creating new test content dir
       run: flowey.exe e 19 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
+      shell: bash
+    - name: resolve OpenHCL igvm artifact
+      run: flowey.exe e 19 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::resolve 0
       shell: bash
     - name: create gh-release-download cache dir
       run: flowey.exe e 19 flowey_lib_common::download_gh_release 0
@@ -3555,7 +3461,7 @@ jobs:
       run: |-
         flowey.exe e 19 flowey_lib_hvlite::init_vmm_tests_env 0
         flowey.exe e 19 flowey_lib_hvlite::run_cargo_nextest_run 1
-        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 16
+        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 13
         flowey.exe e 19 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
       shell: bash
     - name: generate nextest command
@@ -3567,7 +3473,7 @@ jobs:
     - name: starting test_igvm_agent_rpc_server
       run: |-
         flowey.exe e 19 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
-        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 10
+        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 7
       shell: bash
     - name: running vmm_test prep_steps
       run: flowey.exe e 19 flowey_lib_hvlite::run_prep_steps 0
@@ -3827,7 +3733,7 @@ jobs:
     - name: 🌼📦 Download artifacts
       uses: actions/download-artifact@v8
       with:
-        pattern: '{_internal-flowey-bootstrap-x86_64-windows-uid-6,x64-guest_test_uefi,x64-linux-musl-pipette,x64-linux-musl-tmk_vmm,x64-linux-tpm_guest_tests,x64-mi-secure-openhcl-igvm,x64-mi-secure-openhcl-igvm-cvm,x64-mi-secure-openhcl-igvm-test-linux-direct,x64-tmks,x64-windows-openvmm,x64-windows-pipette,x64-windows-prep_steps,x64-windows-test_igvm_agent_rpc_server,x64-windows-tmk_vmm,x64-windows-tpm_guest_tests,x64-windows-vmgstool,x64-windows-vmgstool-dev,x64-windows-vmm-tests-archive}'
+        pattern: '{_internal-flowey-bootstrap-x86_64-windows-uid-6,x64-guest_test_uefi,x64-linux-musl-pipette,x64-linux-musl-tmk_vmm,x64-linux-tpm_guest_tests,x64-mi-secure-openhcl-igvm,x64-tmks,x64-windows-openvmm,x64-windows-pipette,x64-windows-prep_steps,x64-windows-test_igvm_agent_rpc_server,x64-windows-tmk_vmm,x64-windows-tpm_guest_tests,x64-windows-vmgstool,x64-windows-vmgstool-dev,x64-windows-vmm-tests-archive}'
         path: ${{ runner.temp }}/used_artifacts/
     - run: echo "${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-windows-uid-6" >> $GITHUB_PATH
       shell: bash
@@ -3851,8 +3757,6 @@ jobs:
         echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-tmk_vmm" | flowey.exe v 20 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
         echo "${{ runner.temp }}\\used_artifacts\\x64-linux-tpm_guest_tests" | flowey.exe v 20 'artifact_use_from_x64-linux-tpm_guest_tests' --is-raw-string update
         echo "${{ runner.temp }}\\used_artifacts\\x64-mi-secure-openhcl-igvm" | flowey.exe v 20 'artifact_use_from_x64-mi-secure-openhcl-igvm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-mi-secure-openhcl-igvm-cvm" | flowey.exe v 20 'artifact_use_from_x64-mi-secure-openhcl-igvm-cvm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-mi-secure-openhcl-igvm-test-linux-direct" | flowey.exe v 20 'artifact_use_from_x64-mi-secure-openhcl-igvm-test-linux-direct' --is-raw-string update
         echo "${{ runner.temp }}\\used_artifacts\\x64-tmks" | flowey.exe v 20 'artifact_use_from_x64-tmks' --is-raw-string update
         echo "${{ runner.temp }}\\used_artifacts\\x64-windows-openvmm" | flowey.exe v 20 'artifact_use_from_x64-windows-openvmm' --is-raw-string update
         echo "${{ runner.temp }}\\used_artifacts\\x64-windows-pipette" | flowey.exe v 20 'artifact_use_from_x64-windows-pipette' --is-raw-string update
@@ -3913,24 +3817,24 @@ jobs:
         flowey.exe e 20 flowey_lib_common::git_checkout 3
         flowey.exe e 20 flowey_lib_hvlite::git_checkout_openvmm_repo 0
         flowey.exe e 20 flowey_lib_hvlite::run_cargo_nextest_run 0
-        flowey.exe e 20 flowey_core::pipeline::artifact::resolve 14
-        flowey.exe e 20 flowey_core::pipeline::artifact::resolve 15
-        flowey.exe e 20 flowey_core::pipeline::artifact::resolve 13
-        flowey.exe e 20 flowey_core::pipeline::artifact::resolve 3
-        flowey.exe e 20 flowey_core::pipeline::artifact::resolve 11
-        flowey.exe e 20 flowey_core::pipeline::artifact::resolve 4
         flowey.exe e 20 flowey_core::pipeline::artifact::resolve 5
         flowey.exe e 20 flowey_core::pipeline::artifact::resolve 6
         flowey.exe e 20 flowey_core::pipeline::artifact::resolve 1
-        flowey.exe e 20 flowey_core::pipeline::artifact::resolve 2
         flowey.exe e 20 flowey_core::pipeline::artifact::resolve 0
-        flowey.exe e 20 flowey_core::pipeline::artifact::resolve 7
-        flowey.exe e 20 flowey_core::pipeline::artifact::resolve 8
         flowey.exe e 20 flowey_core::pipeline::artifact::resolve 9
+        flowey.exe e 20 flowey_core::pipeline::artifact::resolve 2
+        flowey.exe e 20 flowey_core::pipeline::artifact::resolve 4
+        flowey.exe e 20 flowey_core::pipeline::artifact::resolve 11
         flowey.exe e 20 flowey_core::pipeline::artifact::resolve 12
+        flowey.exe e 20 flowey_core::pipeline::artifact::resolve 10
+        flowey.exe e 20 flowey_core::pipeline::artifact::resolve 3
+        flowey.exe e 20 flowey_core::pipeline::artifact::resolve 8
       shell: bash
     - name: creating new test content dir
       run: flowey.exe e 20 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
+      shell: bash
+    - name: resolve OpenHCL igvm artifact
+      run: flowey.exe e 20 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::resolve 0
       shell: bash
     - name: create gh-release-download cache dir
       run: flowey.exe e 20 flowey_lib_common::download_gh_release 0
@@ -4019,7 +3923,7 @@ jobs:
       run: |-
         flowey.exe e 20 flowey_lib_hvlite::init_vmm_tests_env 0
         flowey.exe e 20 flowey_lib_hvlite::run_cargo_nextest_run 1
-        flowey.exe e 20 flowey_core::pipeline::artifact::resolve 16
+        flowey.exe e 20 flowey_core::pipeline::artifact::resolve 13
         flowey.exe e 20 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
       shell: bash
     - name: generate nextest command
@@ -4103,7 +4007,7 @@ jobs:
     - name: 🌼📦 Download artifacts
       uses: actions/download-artifact@v8
       with:
-        pattern: '{_internal-flowey-bootstrap-x86_64-windows-uid-6,x64-guest_test_uefi,x64-linux-musl-pipette,x64-linux-musl-tmk_vmm,x64-linux-tpm_guest_tests,x64-openhcl-igvm,x64-openhcl-igvm-cvm,x64-openhcl-igvm-test-linux-direct,x64-tmks,x64-windows-openvmm,x64-windows-pipette,x64-windows-prep_steps,x64-windows-test_igvm_agent_rpc_server,x64-windows-tmk_vmm,x64-windows-tpm_guest_tests,x64-windows-vmgstool,x64-windows-vmgstool-dev,x64-windows-vmm-tests-archive}'
+        pattern: '{_internal-flowey-bootstrap-x86_64-windows-uid-6,x64-guest_test_uefi,x64-linux-musl-pipette,x64-linux-musl-tmk_vmm,x64-linux-tpm_guest_tests,x64-openhcl-igvm,x64-tmks,x64-windows-openvmm,x64-windows-pipette,x64-windows-prep_steps,x64-windows-test_igvm_agent_rpc_server,x64-windows-tmk_vmm,x64-windows-tpm_guest_tests,x64-windows-vmgstool,x64-windows-vmgstool-dev,x64-windows-vmm-tests-archive}'
         path: ${{ runner.temp }}/used_artifacts/
     - run: echo "${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-windows-uid-6" >> $GITHUB_PATH
       shell: bash
@@ -4127,8 +4031,6 @@ jobs:
         echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-tmk_vmm" | flowey.exe v 21 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
         echo "${{ runner.temp }}\\used_artifacts\\x64-linux-tpm_guest_tests" | flowey.exe v 21 'artifact_use_from_x64-linux-tpm_guest_tests' --is-raw-string update
         echo "${{ runner.temp }}\\used_artifacts\\x64-openhcl-igvm" | flowey.exe v 21 'artifact_use_from_x64-openhcl-igvm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-openhcl-igvm-cvm" | flowey.exe v 21 'artifact_use_from_x64-openhcl-igvm-cvm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-openhcl-igvm-test-linux-direct" | flowey.exe v 21 'artifact_use_from_x64-openhcl-igvm-test-linux-direct' --is-raw-string update
         echo "${{ runner.temp }}\\used_artifacts\\x64-tmks" | flowey.exe v 21 'artifact_use_from_x64-tmks' --is-raw-string update
         echo "${{ runner.temp }}\\used_artifacts\\x64-windows-openvmm" | flowey.exe v 21 'artifact_use_from_x64-windows-openvmm' --is-raw-string update
         echo "${{ runner.temp }}\\used_artifacts\\x64-windows-pipette" | flowey.exe v 21 'artifact_use_from_x64-windows-pipette' --is-raw-string update
@@ -4189,24 +4091,24 @@ jobs:
         flowey.exe e 21 flowey_lib_common::git_checkout 3
         flowey.exe e 21 flowey_lib_hvlite::git_checkout_openvmm_repo 0
         flowey.exe e 21 flowey_lib_hvlite::run_cargo_nextest_run 0
-        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 8
-        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 9
-        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 12
-        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 14
-        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 15
-        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 13
-        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 3
-        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 11
-        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 4
         flowey.exe e 21 flowey_core::pipeline::artifact::resolve 5
         flowey.exe e 21 flowey_core::pipeline::artifact::resolve 6
         flowey.exe e 21 flowey_core::pipeline::artifact::resolve 1
-        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 2
         flowey.exe e 21 flowey_core::pipeline::artifact::resolve 0
-        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 7
+        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 9
+        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 2
+        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 4
+        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 11
+        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 12
+        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 10
+        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 3
+        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 8
       shell: bash
     - name: creating new test content dir
       run: flowey.exe e 21 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
+      shell: bash
+    - name: resolve OpenHCL igvm artifact
+      run: flowey.exe e 21 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::resolve 0
       shell: bash
     - name: create gh-release-download cache dir
       run: flowey.exe e 21 flowey_lib_common::download_gh_release 0
@@ -4295,7 +4197,7 @@ jobs:
       run: |-
         flowey.exe e 21 flowey_lib_hvlite::init_vmm_tests_env 0
         flowey.exe e 21 flowey_lib_hvlite::run_cargo_nextest_run 1
-        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 16
+        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 13
         flowey.exe e 21 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
       shell: bash
     - name: generate nextest command
@@ -4307,7 +4209,7 @@ jobs:
     - name: starting test_igvm_agent_rpc_server
       run: |-
         flowey.exe e 21 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
-        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 10
+        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 7
       shell: bash
     - name: running vmm_test prep_steps
       run: flowey.exe e 21 flowey_lib_hvlite::run_prep_steps 0
@@ -4383,7 +4285,7 @@ jobs:
     - name: 🌼📦 Download artifacts
       uses: actions/download-artifact@v8
       with:
-        pattern: '{_internal-flowey-bootstrap-x86_64-windows-uid-6,x64-guest_test_uefi,x64-linux-musl-pipette,x64-linux-musl-tmk_vmm,x64-linux-tpm_guest_tests,x64-openhcl-igvm,x64-openhcl-igvm-cvm,x64-openhcl-igvm-test-linux-direct,x64-tmks,x64-windows-openvmm,x64-windows-pipette,x64-windows-prep_steps,x64-windows-test_igvm_agent_rpc_server,x64-windows-tmk_vmm,x64-windows-tpm_guest_tests,x64-windows-vmgstool,x64-windows-vmgstool-dev,x64-windows-vmm-tests-archive}'
+        pattern: '{_internal-flowey-bootstrap-x86_64-windows-uid-6,x64-guest_test_uefi,x64-linux-musl-pipette,x64-linux-musl-tmk_vmm,x64-linux-tpm_guest_tests,x64-openhcl-igvm,x64-tmks,x64-windows-openvmm,x64-windows-pipette,x64-windows-prep_steps,x64-windows-test_igvm_agent_rpc_server,x64-windows-tmk_vmm,x64-windows-tpm_guest_tests,x64-windows-vmgstool,x64-windows-vmgstool-dev,x64-windows-vmm-tests-archive}'
         path: ${{ runner.temp }}/used_artifacts/
     - run: echo "${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-windows-uid-6" >> $GITHUB_PATH
       shell: bash
@@ -4407,8 +4309,6 @@ jobs:
         echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-tmk_vmm" | flowey.exe v 22 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
         echo "${{ runner.temp }}\\used_artifacts\\x64-linux-tpm_guest_tests" | flowey.exe v 22 'artifact_use_from_x64-linux-tpm_guest_tests' --is-raw-string update
         echo "${{ runner.temp }}\\used_artifacts\\x64-openhcl-igvm" | flowey.exe v 22 'artifact_use_from_x64-openhcl-igvm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-openhcl-igvm-cvm" | flowey.exe v 22 'artifact_use_from_x64-openhcl-igvm-cvm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-openhcl-igvm-test-linux-direct" | flowey.exe v 22 'artifact_use_from_x64-openhcl-igvm-test-linux-direct' --is-raw-string update
         echo "${{ runner.temp }}\\used_artifacts\\x64-tmks" | flowey.exe v 22 'artifact_use_from_x64-tmks' --is-raw-string update
         echo "${{ runner.temp }}\\used_artifacts\\x64-windows-openvmm" | flowey.exe v 22 'artifact_use_from_x64-windows-openvmm' --is-raw-string update
         echo "${{ runner.temp }}\\used_artifacts\\x64-windows-pipette" | flowey.exe v 22 'artifact_use_from_x64-windows-pipette' --is-raw-string update
@@ -4469,24 +4369,24 @@ jobs:
         flowey.exe e 22 flowey_lib_common::git_checkout 3
         flowey.exe e 22 flowey_lib_hvlite::git_checkout_openvmm_repo 0
         flowey.exe e 22 flowey_lib_hvlite::run_cargo_nextest_run 0
-        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 8
-        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 9
-        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 12
-        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 14
-        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 15
-        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 13
-        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 3
-        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 11
-        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 4
         flowey.exe e 22 flowey_core::pipeline::artifact::resolve 5
         flowey.exe e 22 flowey_core::pipeline::artifact::resolve 6
         flowey.exe e 22 flowey_core::pipeline::artifact::resolve 1
-        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 2
         flowey.exe e 22 flowey_core::pipeline::artifact::resolve 0
-        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 7
+        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 9
+        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 2
+        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 4
+        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 11
+        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 12
+        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 10
+        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 3
+        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 8
       shell: bash
     - name: creating new test content dir
       run: flowey.exe e 22 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
+      shell: bash
+    - name: resolve OpenHCL igvm artifact
+      run: flowey.exe e 22 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::resolve 0
       shell: bash
     - name: create gh-release-download cache dir
       run: flowey.exe e 22 flowey_lib_common::download_gh_release 0
@@ -4575,7 +4475,7 @@ jobs:
       run: |-
         flowey.exe e 22 flowey_lib_hvlite::init_vmm_tests_env 0
         flowey.exe e 22 flowey_lib_hvlite::run_cargo_nextest_run 1
-        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 16
+        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 13
         flowey.exe e 22 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
       shell: bash
     - name: generate nextest command
@@ -4587,7 +4487,7 @@ jobs:
     - name: starting test_igvm_agent_rpc_server
       run: |-
         flowey.exe e 22 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
-        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 10
+        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 7
       shell: bash
     - name: running vmm_test prep_steps
       run: flowey.exe e 22 flowey_lib_hvlite::run_prep_steps 0
@@ -4664,7 +4564,7 @@ jobs:
     - name: 🌼📦 Download artifacts
       uses: actions/download-artifact@v8
       with:
-        pattern: '{_internal-flowey-bootstrap-x86_64-windows-uid-6,x64-guest_test_uefi,x64-linux-musl-pipette,x64-linux-musl-tmk_vmm,x64-linux-tpm_guest_tests,x64-openhcl-igvm,x64-openhcl-igvm-cvm,x64-openhcl-igvm-test-linux-direct,x64-tmks,x64-windows-openvmm,x64-windows-pipette,x64-windows-prep_steps,x64-windows-test_igvm_agent_rpc_server,x64-windows-tmk_vmm,x64-windows-tpm_guest_tests,x64-windows-vmgstool,x64-windows-vmgstool-dev,x64-windows-vmm-tests-archive}'
+        pattern: '{_internal-flowey-bootstrap-x86_64-windows-uid-6,x64-guest_test_uefi,x64-linux-musl-pipette,x64-linux-musl-tmk_vmm,x64-linux-tpm_guest_tests,x64-openhcl-igvm,x64-tmks,x64-windows-openvmm,x64-windows-pipette,x64-windows-prep_steps,x64-windows-test_igvm_agent_rpc_server,x64-windows-tmk_vmm,x64-windows-tpm_guest_tests,x64-windows-vmgstool,x64-windows-vmgstool-dev,x64-windows-vmm-tests-archive}'
         path: ${{ runner.temp }}/used_artifacts/
     - run: echo "${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-windows-uid-6" >> $GITHUB_PATH
       shell: bash
@@ -4688,8 +4588,6 @@ jobs:
         echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-tmk_vmm" | flowey.exe v 23 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
         echo "${{ runner.temp }}\\used_artifacts\\x64-linux-tpm_guest_tests" | flowey.exe v 23 'artifact_use_from_x64-linux-tpm_guest_tests' --is-raw-string update
         echo "${{ runner.temp }}\\used_artifacts\\x64-openhcl-igvm" | flowey.exe v 23 'artifact_use_from_x64-openhcl-igvm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-openhcl-igvm-cvm" | flowey.exe v 23 'artifact_use_from_x64-openhcl-igvm-cvm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-openhcl-igvm-test-linux-direct" | flowey.exe v 23 'artifact_use_from_x64-openhcl-igvm-test-linux-direct' --is-raw-string update
         echo "${{ runner.temp }}\\used_artifacts\\x64-tmks" | flowey.exe v 23 'artifact_use_from_x64-tmks' --is-raw-string update
         echo "${{ runner.temp }}\\used_artifacts\\x64-windows-openvmm" | flowey.exe v 23 'artifact_use_from_x64-windows-openvmm' --is-raw-string update
         echo "${{ runner.temp }}\\used_artifacts\\x64-windows-pipette" | flowey.exe v 23 'artifact_use_from_x64-windows-pipette' --is-raw-string update
@@ -4750,24 +4648,24 @@ jobs:
         flowey.exe e 23 flowey_lib_common::git_checkout 3
         flowey.exe e 23 flowey_lib_hvlite::git_checkout_openvmm_repo 0
         flowey.exe e 23 flowey_lib_hvlite::run_cargo_nextest_run 0
-        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 8
-        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 9
-        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 12
-        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 14
-        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 15
-        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 13
-        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 3
-        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 11
-        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 4
         flowey.exe e 23 flowey_core::pipeline::artifact::resolve 5
         flowey.exe e 23 flowey_core::pipeline::artifact::resolve 6
         flowey.exe e 23 flowey_core::pipeline::artifact::resolve 1
-        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 2
         flowey.exe e 23 flowey_core::pipeline::artifact::resolve 0
-        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 7
+        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 9
+        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 2
+        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 4
+        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 11
+        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 12
+        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 10
+        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 3
+        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 8
       shell: bash
     - name: creating new test content dir
       run: flowey.exe e 23 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
+      shell: bash
+    - name: resolve OpenHCL igvm artifact
+      run: flowey.exe e 23 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::resolve 0
       shell: bash
     - name: create gh-release-download cache dir
       run: flowey.exe e 23 flowey_lib_common::download_gh_release 0
@@ -4856,7 +4754,7 @@ jobs:
       run: |-
         flowey.exe e 23 flowey_lib_hvlite::init_vmm_tests_env 0
         flowey.exe e 23 flowey_lib_hvlite::run_cargo_nextest_run 1
-        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 16
+        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 13
         flowey.exe e 23 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
       shell: bash
     - name: generate nextest command
@@ -4868,7 +4766,7 @@ jobs:
     - name: starting test_igvm_agent_rpc_server
       run: |-
         flowey.exe e 23 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
-        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 10
+        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 7
       shell: bash
     - name: running vmm_test prep_steps
       run: flowey.exe e 23 flowey_lib_hvlite::run_prep_steps 0
@@ -4974,12 +4872,12 @@ jobs:
       shell: bash
     - name: creating new test content dir
       run: |-
-        flowey e 24 flowey_core::pipeline::artifact::resolve 8
-        flowey e 24 flowey_core::pipeline::artifact::resolve 2
         flowey e 24 flowey_core::pipeline::artifact::resolve 3
         flowey e 24 flowey_core::pipeline::artifact::resolve 4
+        flowey e 24 flowey_core::pipeline::artifact::resolve 8
         flowey e 24 flowey_core::pipeline::artifact::resolve 1
         flowey e 24 flowey_core::pipeline::artifact::resolve 0
+        flowey e 24 flowey_core::pipeline::artifact::resolve 2
         flowey e 24 flowey_core::pipeline::artifact::resolve 7
         flowey e 24 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
       shell: bash
@@ -5290,12 +5188,12 @@ jobs:
       shell: bash
     - name: creating new test content dir
       run: |-
-        flowey e 25 flowey_core::pipeline::artifact::resolve 8
-        flowey e 25 flowey_core::pipeline::artifact::resolve 4
         flowey e 25 flowey_core::pipeline::artifact::resolve 1
         flowey e 25 flowey_core::pipeline::artifact::resolve 2
+        flowey e 25 flowey_core::pipeline::artifact::resolve 8
         flowey e 25 flowey_core::pipeline::artifact::resolve 3
         flowey e 25 flowey_core::pipeline::artifact::resolve 0
+        flowey e 25 flowey_core::pipeline::artifact::resolve 4
         flowey e 25 flowey_core::pipeline::artifact::resolve 7
         flowey e 25 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
       shell: bash
@@ -5653,19 +5551,21 @@ jobs:
         flowey.exe e 26 flowey_lib_common::git_checkout 3
         flowey.exe e 26 flowey_lib_hvlite::git_checkout_openvmm_repo 0
         flowey.exe e 26 flowey_lib_hvlite::run_cargo_nextest_run 0
+        flowey.exe e 26 flowey_core::pipeline::artifact::resolve 4
         flowey.exe e 26 flowey_core::pipeline::artifact::resolve 5
+        flowey.exe e 26 flowey_core::pipeline::artifact::resolve 1
+        flowey.exe e 26 flowey_core::pipeline::artifact::resolve 0
         flowey.exe e 26 flowey_core::pipeline::artifact::resolve 6
+        flowey.exe e 26 flowey_core::pipeline::artifact::resolve 2
+        flowey.exe e 26 flowey_core::pipeline::artifact::resolve 3
         flowey.exe e 26 flowey_core::pipeline::artifact::resolve 7
         flowey.exe e 26 flowey_core::pipeline::artifact::resolve 8
-        flowey.exe e 26 flowey_core::pipeline::artifact::resolve 9
-        flowey.exe e 26 flowey_core::pipeline::artifact::resolve 3
-        flowey.exe e 26 flowey_core::pipeline::artifact::resolve 1
-        flowey.exe e 26 flowey_core::pipeline::artifact::resolve 2
-        flowey.exe e 26 flowey_core::pipeline::artifact::resolve 0
-        flowey.exe e 26 flowey_core::pipeline::artifact::resolve 4
       shell: bash
     - name: creating new test content dir
       run: flowey.exe e 26 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
+      shell: bash
+    - name: resolve OpenHCL igvm artifact
+      run: flowey.exe e 26 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::resolve 0
       shell: bash
     - name: create gh-release-download cache dir
       run: flowey.exe e 26 flowey_lib_common::download_gh_release 0
@@ -5754,7 +5654,7 @@ jobs:
       run: |-
         flowey.exe e 26 flowey_lib_hvlite::init_vmm_tests_env 0
         flowey.exe e 26 flowey_lib_hvlite::run_cargo_nextest_run 1
-        flowey.exe e 26 flowey_core::pipeline::artifact::resolve 10
+        flowey.exe e 26 flowey_core::pipeline::artifact::resolve 9
         flowey.exe e 26 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
       shell: bash
     - name: generate nextest command

--- a/.github/workflows/openvmm-pr-release.yaml
+++ b/.github/workflows/openvmm-pr-release.yaml
@@ -433,14 +433,47 @@ jobs:
         EOF
         mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-openhcl-igvm"
         echo "$AgentTempDirNormal/publish_artifacts/aarch64-openhcl-igvm" | flowey v 10 'artifact_publish_from_aarch64-openhcl-igvm' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-openhcl-igvm-devkern"
+        echo "$AgentTempDirNormal/publish_artifacts/aarch64-openhcl-igvm-devkern" | flowey v 10 'artifact_publish_from_aarch64-openhcl-igvm-devkern' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-openhcl-igvm-devkern-extras"
+        echo "$AgentTempDirNormal/publish_artifacts/aarch64-openhcl-igvm-devkern-extras" | flowey v 10 'artifact_publish_from_aarch64-openhcl-igvm-devkern-extras' --is-raw-string update
         mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-openhcl-igvm-extras"
         echo "$AgentTempDirNormal/publish_artifacts/aarch64-openhcl-igvm-extras" | flowey v 10 'artifact_publish_from_aarch64-openhcl-igvm-extras' --is-raw-string update
       shell: bash
-    - name: checking if packages need to be installed
-      run: flowey e 10 flowey_lib_common::install_dist_pkg 0
+    - name: check if openvmm needs to be cloned
+      run: |-
+        flowey e 10 flowey_lib_common::git_checkout 0
+        flowey v 10 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
+        flowey v 10 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
-    - name: installing packages
-      run: flowey e 10 flowey_lib_common::install_dist_pkg 1
+    - id: flowey_lib_common__git_checkout__1
+      uses: actions/checkout@v6
+      with:
+        fetch-depth: '1'
+        path: repo0
+        persist-credentials: ${{ env.floweyvar3 }}
+      name: checkout repo openvmm
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: report cloned repo directories
+      run: |-
+        flowey v 10 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        ${{ github.workspace }}
+        EOF
+        flowey e 10 flowey_lib_common::git_checkout 3
+        flowey e 10 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 3
+      shell: bash
+    - name: add default cargo home to path
+      run: flowey e 10 flowey_lib_common::install_rust 0
+      shell: bash
+    - name: install Rust
+      run: flowey e 10 flowey_lib_common::install_rust 1
+      shell: bash
+    - name: detect active toolchain
+      run: |-
+        flowey e 10 flowey_lib_common::install_rust 2
+        flowey e 10 flowey_lib_common::cfg_cargo_common_flags 0
+        flowey e 10 flowey_lib_hvlite::cfg_openvmm_magicpath 0
       shell: bash
     - name: create gh-release-download cache dir
       run: flowey e 10 flowey_lib_common::download_gh_release 0
@@ -465,53 +498,51 @@ jobs:
         flowey e 10 flowey_lib_common::cache 2
         flowey e 10 flowey_lib_common::download_gh_release 1
       shell: bash
-    - name: unpack mu_msvm package (aarch64)
-      run: flowey e 10 flowey_lib_hvlite::download_uefi_mu_msvm 0
+    - name: unpack openvmm-deps archive
+      run: flowey e 10 flowey_lib_hvlite::resolve_openvmm_deps 0
       shell: bash
-    - name: add default cargo home to path
-      run: flowey e 10 flowey_lib_common::install_rust 0
-      shell: bash
-    - name: install Rust
-      run: flowey e 10 flowey_lib_common::install_rust 1
-      shell: bash
-    - name: detect active toolchain
-      run: |-
-        flowey e 10 flowey_lib_common::install_rust 2
-        flowey e 10 flowey_lib_common::cfg_cargo_common_flags 0
-      shell: bash
-    - name: check if openvmm needs to be cloned
-      run: |-
-        flowey e 10 flowey_lib_common::git_checkout 0
-        flowey v 10 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
-        flowey v 10 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__git_checkout__1
-      uses: actions/checkout@v6
-      with:
-        fetch-depth: '1'
-        path: repo0
-        persist-credentials: ${{ env.floweyvar3 }}
-      name: checkout repo openvmm
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: report cloned repo directories
-      run: |-
-        flowey v 10 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
-        ${{ github.workspace }}
-        EOF
-        flowey e 10 flowey_lib_common::git_checkout 3
-        flowey e 10 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+    - name: extract Aarch64 sysroot.tar.gz
+      run: flowey e 10 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
       shell: bash
     - name: set '-Dwarnings' in .cargo/config.toml
       run: flowey e 10 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
       shell: bash
+    - name: checking if packages need to be installed
+      run: flowey e 10 flowey_lib_common::install_dist_pkg 0
+      shell: bash
+    - name: installing packages
+      run: flowey e 10 flowey_lib_common::install_dist_pkg 1
+      shell: bash
     - name: unpack protoc
-      run: |-
-        flowey e 10 flowey_lib_common::resolve_protoc 0
-        flowey e 10 flowey_lib_hvlite::cfg_openvmm_magicpath 0
+      run: flowey e 10 flowey_lib_common::resolve_protoc 0
       shell: bash
     - name: symlink protoc
       run: |-
         flowey e 10 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
+        flowey e 10 flowey_lib_hvlite::init_cross_build 1
+        flowey e 10 flowey_lib_hvlite::run_cargo_build 6
+        flowey e 10 flowey_lib_hvlite::run_cargo_build 7
+      shell: bash
+    - name: cargo build openvmm_hcl
+      run: |-
+        flowey e 10 flowey_lib_common::run_cargo_build 2
+        flowey e 10 flowey_lib_hvlite::run_cargo_build 8
+        flowey e 10 flowey_lib_hvlite::build_openvmm_hcl 0
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 0
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 10 flowey_lib_hvlite::run_split_debug_info 0
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 1
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 2
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 4
+      shell: bash
+    - name: extract and resolve kernel package
+      run: flowey e 10 flowey_lib_hvlite::resolve_openhcl_kernel_package 0
+      shell: bash
+    - name: building openhcl initrd
+      run: |-
+        flowey e 10 flowey_lib_hvlite::build_openhcl_initrd 0
         flowey e 10 flowey_lib_hvlite::init_cross_build 0
         flowey e 10 flowey_lib_hvlite::run_cargo_build 2
         flowey e 10 flowey_lib_hvlite::run_cargo_build 3
@@ -526,40 +557,12 @@ jobs:
         flowey e 10 flowey_lib_hvlite::run_split_debug_info 2
         flowey e 10 flowey_lib_hvlite::run_cargo_build 5
         flowey e 10 flowey_lib_hvlite::build_openhcl_boot 0
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 5
       shell: bash
-    - name: extract and resolve kernel package
+    - name: unpack mu_msvm package (aarch64)
       run: |-
-        flowey e 10 flowey_lib_hvlite::resolve_openhcl_kernel_package 1
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 17
-      shell: bash
-    - name: unpack openvmm-deps archive
-      run: flowey e 10 flowey_lib_hvlite::resolve_openvmm_deps 0
-      shell: bash
-    - name: extract Aarch64 sysroot.tar.gz
-      run: |-
-        flowey e 10 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
-        flowey e 10 flowey_lib_hvlite::init_cross_build 1
-        flowey e 10 flowey_lib_hvlite::run_cargo_build 6
-        flowey e 10 flowey_lib_hvlite::run_cargo_build 7
-      shell: bash
-    - name: cargo build openvmm_hcl
-      run: |-
-        flowey e 10 flowey_lib_common::run_cargo_build 2
-        flowey e 10 flowey_lib_hvlite::run_cargo_build 8
-        flowey e 10 flowey_lib_hvlite::build_openvmm_hcl 0
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 13
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 10 flowey_lib_hvlite::run_split_debug_info 1
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 14
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 15
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 18
-      shell: bash
-    - name: building openhcl initrd
-      run: |-
-        flowey e 10 flowey_lib_hvlite::build_openhcl_initrd 1
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 19
+        flowey e 10 flowey_lib_hvlite::download_uefi_mu_msvm 0
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 6
         flowey e 10 flowey_lib_hvlite::init_cross_build 2
       shell: bash
     - name: cargo build igvmfilegen
@@ -572,55 +575,47 @@ jobs:
         flowey e 10 flowey_lib_hvlite::run_split_debug_info 3
         flowey e 10 flowey_lib_hvlite::run_cargo_build 1
         flowey e 10 flowey_lib_hvlite::build_igvmfilegen 0
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 20
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 21
-      shell: bash
-    - name: building igvm file
-      run: |-
-        flowey e 10 flowey_lib_hvlite::run_igvmfilegen 1
-        flowey e 10 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 2
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 6
-      shell: bash
-    - name: extract and resolve kernel package
-      run: |-
-        flowey e 10 flowey_lib_hvlite::resolve_openhcl_kernel_package 0
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 2
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 10 flowey_lib_hvlite::run_split_debug_info 0
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 3
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 4
         flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 7
-      shell: bash
-    - name: building openhcl initrd
-      run: |-
-        flowey e 10 flowey_lib_hvlite::build_openhcl_initrd 0
         flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 8
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 9
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 10
       shell: bash
     - name: building igvm file
       run: |-
         flowey e 10 flowey_lib_hvlite::run_igvmfilegen 0
-        flowey e 10 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 0
-        flowey e 10 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::publish 0
-      shell: bash
-    - name: copying OpenHCL igvm files to artifact dir
-      run: |-
-        flowey e 10 flowey_lib_common::copy_to_artifact_dir 1
         flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 11
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 16
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 12
-        flowey e 10 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 3
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 5
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 1
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 0
-        flowey e 10 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 1
-        flowey e 10 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe_extras::publish 0
+        flowey e 10 flowey_core::pipeline::artifact::publish 0
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 9
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 10
+        flowey e 10 flowey_core::pipeline::artifact::publish 1
       shell: bash
-    - name: copying OpenHCL igvm extras to artifact dir
-      run: flowey e 10 flowey_lib_common::copy_to_artifact_dir 0
+    - name: extract and resolve kernel package
+      run: |-
+        flowey e 10 flowey_lib_hvlite::resolve_openhcl_kernel_package 1
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 15
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 12
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 10 flowey_lib_hvlite::run_split_debug_info 1
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 13
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 14
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 16
+      shell: bash
+    - name: building openhcl initrd
+      run: |-
+        flowey e 10 flowey_lib_hvlite::build_openhcl_initrd 1
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 17
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 18
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 19
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 20
+      shell: bash
+    - name: building igvm file
+      run: |-
+        flowey e 10 flowey_lib_hvlite::run_igvmfilegen 1
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 23
+        flowey e 10 flowey_core::pipeline::artifact::publish 2
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 21
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 22
+        flowey e 10 flowey_core::pipeline::artifact::publish 3
       shell: bash
     - name: 'validate cache entry: gh-release-download'
       run: flowey e 10 flowey_lib_common::cache 3
@@ -630,6 +625,18 @@ jobs:
       with:
         name: aarch64-openhcl-igvm
         path: ${{ runner.temp }}/publish_artifacts/aarch64-openhcl-igvm/
+        include-hidden-files: true
+    - name: 🌼📦 Publish aarch64-openhcl-igvm-devkern
+      uses: actions/upload-artifact@v7
+      with:
+        name: aarch64-openhcl-igvm-devkern
+        path: ${{ runner.temp }}/publish_artifacts/aarch64-openhcl-igvm-devkern/
+        include-hidden-files: true
+    - name: 🌼📦 Publish aarch64-openhcl-igvm-devkern-extras
+      uses: actions/upload-artifact@v7
+      with:
+        name: aarch64-openhcl-igvm-devkern-extras
+        path: ${{ runner.temp }}/publish_artifacts/aarch64-openhcl-igvm-devkern-extras/
         include-hidden-files: true
     - name: 🌼📦 Publish aarch64-openhcl-igvm-extras
       uses: actions/upload-artifact@v7
@@ -675,14 +682,59 @@ jobs:
         EOF
         mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm"
         echo "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm" | flowey v 11 'artifact_publish_from_x64-openhcl-igvm' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-cvm"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-cvm" | flowey v 11 'artifact_publish_from_x64-openhcl-igvm-cvm' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-cvm-extras"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-cvm-extras" | flowey v 11 'artifact_publish_from_x64-openhcl-igvm-cvm-extras' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-devkern"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-devkern" | flowey v 11 'artifact_publish_from_x64-openhcl-igvm-devkern' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-devkern-extras"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-devkern-extras" | flowey v 11 'artifact_publish_from_x64-openhcl-igvm-devkern-extras' --is-raw-string update
         mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-extras"
         echo "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-extras" | flowey v 11 'artifact_publish_from_x64-openhcl-igvm-extras' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-test-linux-direct"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-test-linux-direct" | flowey v 11 'artifact_publish_from_x64-openhcl-igvm-test-linux-direct' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-test-linux-direct-devkern"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-test-linux-direct-devkern" | flowey v 11 'artifact_publish_from_x64-openhcl-igvm-test-linux-direct-devkern' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-test-linux-direct-devkern-extras"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-test-linux-direct-devkern-extras" | flowey v 11 'artifact_publish_from_x64-openhcl-igvm-test-linux-direct-devkern-extras' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-test-linux-direct-extras"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-test-linux-direct-extras" | flowey v 11 'artifact_publish_from_x64-openhcl-igvm-test-linux-direct-extras' --is-raw-string update
       shell: bash
-    - name: checking if packages need to be installed
-      run: flowey e 11 flowey_lib_common::install_dist_pkg 0
+    - name: check if openvmm needs to be cloned
+      run: |-
+        flowey e 11 flowey_lib_common::git_checkout 0
+        flowey v 11 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
+        flowey v 11 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
-    - name: installing packages
-      run: flowey e 11 flowey_lib_common::install_dist_pkg 1
+    - id: flowey_lib_common__git_checkout__1
+      uses: actions/checkout@v6
+      with:
+        fetch-depth: '1'
+        path: repo0
+        persist-credentials: ${{ env.floweyvar3 }}
+      name: checkout repo openvmm
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: report cloned repo directories
+      run: |-
+        flowey v 11 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        ${{ github.workspace }}
+        EOF
+        flowey e 11 flowey_lib_common::git_checkout 3
+        flowey e 11 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 3
+      shell: bash
+    - name: add default cargo home to path
+      run: flowey e 11 flowey_lib_common::install_rust 0
+      shell: bash
+    - name: install Rust
+      run: flowey e 11 flowey_lib_common::install_rust 1
+      shell: bash
+    - name: detect active toolchain
+      run: |-
+        flowey e 11 flowey_lib_common::install_rust 2
+        flowey e 11 flowey_lib_common::cfg_cargo_common_flags 0
+        flowey e 11 flowey_lib_hvlite::cfg_openvmm_magicpath 0
       shell: bash
     - name: create gh-release-download cache dir
       run: flowey e 11 flowey_lib_common::download_gh_release 0
@@ -707,53 +759,51 @@ jobs:
         flowey e 11 flowey_lib_common::cache 2
         flowey e 11 flowey_lib_common::download_gh_release 1
       shell: bash
-    - name: unpack mu_msvm package (x64)
-      run: flowey e 11 flowey_lib_hvlite::download_uefi_mu_msvm 0
+    - name: unpack openvmm-deps archive
+      run: flowey e 11 flowey_lib_hvlite::resolve_openvmm_deps 0
       shell: bash
-    - name: add default cargo home to path
-      run: flowey e 11 flowey_lib_common::install_rust 0
-      shell: bash
-    - name: install Rust
-      run: flowey e 11 flowey_lib_common::install_rust 1
-      shell: bash
-    - name: detect active toolchain
-      run: |-
-        flowey e 11 flowey_lib_common::install_rust 2
-        flowey e 11 flowey_lib_common::cfg_cargo_common_flags 0
-      shell: bash
-    - name: check if openvmm needs to be cloned
-      run: |-
-        flowey e 11 flowey_lib_common::git_checkout 0
-        flowey v 11 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
-        flowey v 11 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__git_checkout__1
-      uses: actions/checkout@v6
-      with:
-        fetch-depth: '1'
-        path: repo0
-        persist-credentials: ${{ env.floweyvar3 }}
-      name: checkout repo openvmm
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: report cloned repo directories
-      run: |-
-        flowey v 11 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
-        ${{ github.workspace }}
-        EOF
-        flowey e 11 flowey_lib_common::git_checkout 3
-        flowey e 11 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+    - name: extract X86_64 sysroot.tar.gz
+      run: flowey e 11 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
       shell: bash
     - name: set '-Dwarnings' in .cargo/config.toml
       run: flowey e 11 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
       shell: bash
+    - name: checking if packages need to be installed
+      run: flowey e 11 flowey_lib_common::install_dist_pkg 0
+      shell: bash
+    - name: installing packages
+      run: flowey e 11 flowey_lib_common::install_dist_pkg 1
+      shell: bash
     - name: unpack protoc
-      run: |-
-        flowey e 11 flowey_lib_common::resolve_protoc 0
-        flowey e 11 flowey_lib_hvlite::cfg_openvmm_magicpath 0
+      run: flowey e 11 flowey_lib_common::resolve_protoc 0
       shell: bash
     - name: symlink protoc
       run: |-
         flowey e 11 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
+        flowey e 11 flowey_lib_hvlite::init_cross_build 3
+        flowey e 11 flowey_lib_hvlite::run_cargo_build 6
+        flowey e 11 flowey_lib_hvlite::run_cargo_build 7
+      shell: bash
+    - name: cargo build openvmm_hcl
+      run: |-
+        flowey e 11 flowey_lib_common::run_cargo_build 2
+        flowey e 11 flowey_lib_hvlite::run_cargo_build 8
+        flowey e 11 flowey_lib_hvlite::build_openvmm_hcl 0
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 0
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 11 flowey_lib_hvlite::run_split_debug_info 0
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 1
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 2
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 4
+      shell: bash
+    - name: extract and resolve kernel package
+      run: flowey e 11 flowey_lib_hvlite::resolve_openhcl_kernel_package 0
+      shell: bash
+    - name: building openhcl initrd
+      run: |-
+        flowey e 11 flowey_lib_hvlite::build_openhcl_initrd 2
         flowey e 11 flowey_lib_hvlite::init_cross_build 0
         flowey e 11 flowey_lib_hvlite::run_cargo_build 9
         flowey e 11 flowey_lib_hvlite::run_cargo_build 10
@@ -768,6 +818,7 @@ jobs:
         flowey e 11 flowey_lib_hvlite::run_split_debug_info 6
         flowey e 11 flowey_lib_hvlite::run_cargo_build 12
         flowey e 11 flowey_lib_hvlite::build_sidecar 0
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 5
         flowey e 11 flowey_lib_hvlite::init_cross_build 1
         flowey e 11 flowey_lib_hvlite::run_cargo_build 2
         flowey e 11 flowey_lib_hvlite::run_cargo_build 3
@@ -782,40 +833,12 @@ jobs:
         flowey e 11 flowey_lib_hvlite::run_split_debug_info 5
         flowey e 11 flowey_lib_hvlite::run_cargo_build 5
         flowey e 11 flowey_lib_hvlite::build_openhcl_boot 0
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 6
       shell: bash
-    - name: extract and resolve kernel package
+    - name: unpack mu_msvm package (x64)
       run: |-
-        flowey e 11 flowey_lib_hvlite::resolve_openhcl_kernel_package 2
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 28
-      shell: bash
-    - name: unpack openvmm-deps archive
-      run: flowey e 11 flowey_lib_hvlite::resolve_openvmm_deps 0
-      shell: bash
-    - name: extract X86_64 sysroot.tar.gz
-      run: |-
-        flowey e 11 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
-        flowey e 11 flowey_lib_hvlite::init_cross_build 3
-        flowey e 11 flowey_lib_hvlite::run_cargo_build 6
-        flowey e 11 flowey_lib_hvlite::run_cargo_build 7
-      shell: bash
-    - name: cargo build openvmm_hcl
-      run: |-
-        flowey e 11 flowey_lib_common::run_cargo_build 2
-        flowey e 11 flowey_lib_hvlite::run_cargo_build 8
-        flowey e 11 flowey_lib_hvlite::build_openvmm_hcl 0
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 24
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 11 flowey_lib_hvlite::run_split_debug_info 4
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 25
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 26
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 29
-      shell: bash
-    - name: building openhcl initrd
-      run: |-
-        flowey e 11 flowey_lib_hvlite::build_openhcl_initrd 4
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 30
+        flowey e 11 flowey_lib_hvlite::download_uefi_mu_msvm 0
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 7
         flowey e 11 flowey_lib_hvlite::init_cross_build 2
       shell: bash
     - name: cargo build igvmfilegen
@@ -828,28 +851,48 @@ jobs:
         flowey e 11 flowey_lib_hvlite::run_split_debug_info 7
         flowey e 11 flowey_lib_hvlite::run_cargo_build 1
         flowey e 11 flowey_lib_hvlite::build_igvmfilegen 0
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 8
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 9
+      shell: bash
+    - name: building igvm file
+      run: |-
+        flowey e 11 flowey_lib_hvlite::run_igvmfilegen 2
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 12
+        flowey e 11 flowey_core::pipeline::artifact::publish 0
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 10
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 11
+        flowey e 11 flowey_core::pipeline::artifact::publish 1
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 34
+      shell: bash
+    - name: extract and resolve kernel package
+      run: |-
+        flowey e 11 flowey_lib_hvlite::resolve_openhcl_kernel_package 2
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 28
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 25
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 11 flowey_lib_hvlite::run_split_debug_info 4
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 26
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 27
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 29
+      shell: bash
+    - name: building openhcl initrd
+      run: |-
+        flowey e 11 flowey_lib_hvlite::build_openhcl_initrd 4
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 30
         flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 31
         flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 32
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 33
       shell: bash
     - name: building igvm file
       run: |-
         flowey e 11 flowey_lib_hvlite::run_igvmfilegen 4
-        flowey e 11 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 2
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 39
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 35
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 11 flowey_lib_hvlite::run_split_debug_info 0
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 36
         flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 37
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 40
-      shell: bash
-    - name: extract and resolve kernel package
-      run: flowey e 11 flowey_lib_hvlite::resolve_openhcl_kernel_package 0
-      shell: bash
-    - name: building openhcl initrd
-      run: flowey e 11 flowey_lib_hvlite::build_openhcl_initrd 0
+        flowey e 11 flowey_core::pipeline::artifact::publish 2
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 35
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 36
+        flowey e 11 flowey_core::pipeline::artifact::publish 3
       shell: bash
     - name: unpack openvmm-test-linux archives
       run: flowey e 11 flowey_lib_hvlite::resolve_openvmm_test_linux_kernel 0
@@ -858,39 +901,64 @@ jobs:
       run: |-
         flowey e 11 flowey_lib_hvlite::resolve_openvmm_test_initrd 0
         flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 41
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 42
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 43
-      shell: bash
-    - name: building igvm file
-      run: |-
-        flowey e 11 flowey_lib_hvlite::run_igvmfilegen 0
-        flowey e 11 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 4
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 50
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 46
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 38
       shell: bash
     - name: split debug symbols
       run: |-
         flowey e 11 flowey_lib_hvlite::run_split_debug_info 1
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 39
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 40
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 42
+      shell: bash
+    - name: building openhcl initrd
+      run: |-
+        flowey e 11 flowey_lib_hvlite::build_openhcl_initrd 0
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 43
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 44
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 45
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 46
         flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 47
+      shell: bash
+    - name: building igvm file
+      run: |-
+        flowey e 11 flowey_lib_hvlite::run_igvmfilegen 0
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 50
+        flowey e 11 flowey_core::pipeline::artifact::publish 4
         flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 48
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 49
+        flowey e 11 flowey_core::pipeline::artifact::publish 5
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 54
         flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 51
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 11 flowey_lib_hvlite::run_split_debug_info 2
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 52
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 53
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 55
       shell: bash
     - name: building openhcl initrd
       run: |-
         flowey e 11 flowey_lib_hvlite::build_openhcl_initrd 1
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 52
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 53
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 54
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 56
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 57
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 58
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 59
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 60
       shell: bash
     - name: building igvm file
       run: |-
         flowey e 11 flowey_lib_hvlite::run_igvmfilegen 1
-        flowey e 11 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 6
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 63
+        flowey e 11 flowey_core::pipeline::artifact::publish 6
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 61
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 62
+        flowey e 11 flowey_core::pipeline::artifact::publish 7
       shell: bash
     - name: extract and resolve kernel package
       run: |-
         flowey e 11 flowey_lib_hvlite::resolve_openhcl_kernel_package 1
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 17
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 16
         flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 13
       shell: bash
     - name: split debug symbols
@@ -898,11 +966,12 @@ jobs:
         flowey e 11 flowey_lib_hvlite::run_split_debug_info 3
         flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 14
         flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 15
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 18
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 17
       shell: bash
     - name: building openhcl initrd
       run: |-
         flowey e 11 flowey_lib_hvlite::build_openhcl_initrd 3
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 18
         flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 19
         flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 20
         flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 21
@@ -910,57 +979,11 @@ jobs:
     - name: building igvm file
       run: |-
         flowey e 11 flowey_lib_hvlite::run_igvmfilegen 3
-        flowey e 11 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 8
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 6
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 2
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 11 flowey_lib_hvlite::run_split_debug_info 2
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 3
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 4
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 7
-      shell: bash
-    - name: building openhcl initrd
-      run: |-
-        flowey e 11 flowey_lib_hvlite::build_openhcl_initrd 2
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 8
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 9
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 10
-      shell: bash
-    - name: building igvm file
-      run: |-
-        flowey e 11 flowey_lib_hvlite::run_igvmfilegen 2
-        flowey e 11 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 0
-        flowey e 11 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::publish 0
-      shell: bash
-    - name: copying OpenHCL igvm files to artifact dir
-      run: |-
-        flowey e 11 flowey_lib_common::copy_to_artifact_dir 1
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 24
+        flowey e 11 flowey_core::pipeline::artifact::publish 8
         flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 22
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 27
         flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 23
-        flowey e 11 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 3
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 38
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 34
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 33
-        flowey e 11 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 5
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 49
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 45
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 44
-        flowey e 11 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 7
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 16
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 12
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 11
-        flowey e 11 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 9
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 5
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 1
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 0
-        flowey e 11 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 1
-        flowey e 11 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe_extras::publish 0
-      shell: bash
-    - name: copying OpenHCL igvm extras to artifact dir
-      run: flowey e 11 flowey_lib_common::copy_to_artifact_dir 0
+        flowey e 11 flowey_core::pipeline::artifact::publish 9
       shell: bash
     - name: 'validate cache entry: gh-release-download'
       run: flowey e 11 flowey_lib_common::cache 3
@@ -971,11 +994,59 @@ jobs:
         name: x64-openhcl-igvm
         path: ${{ runner.temp }}/publish_artifacts/x64-openhcl-igvm/
         include-hidden-files: true
+    - name: 🌼📦 Publish x64-openhcl-igvm-cvm
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-openhcl-igvm-cvm
+        path: ${{ runner.temp }}/publish_artifacts/x64-openhcl-igvm-cvm/
+        include-hidden-files: true
+    - name: 🌼📦 Publish x64-openhcl-igvm-cvm-extras
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-openhcl-igvm-cvm-extras
+        path: ${{ runner.temp }}/publish_artifacts/x64-openhcl-igvm-cvm-extras/
+        include-hidden-files: true
+    - name: 🌼📦 Publish x64-openhcl-igvm-devkern
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-openhcl-igvm-devkern
+        path: ${{ runner.temp }}/publish_artifacts/x64-openhcl-igvm-devkern/
+        include-hidden-files: true
+    - name: 🌼📦 Publish x64-openhcl-igvm-devkern-extras
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-openhcl-igvm-devkern-extras
+        path: ${{ runner.temp }}/publish_artifacts/x64-openhcl-igvm-devkern-extras/
+        include-hidden-files: true
     - name: 🌼📦 Publish x64-openhcl-igvm-extras
       uses: actions/upload-artifact@v7
       with:
         name: x64-openhcl-igvm-extras
         path: ${{ runner.temp }}/publish_artifacts/x64-openhcl-igvm-extras/
+        include-hidden-files: true
+    - name: 🌼📦 Publish x64-openhcl-igvm-test-linux-direct
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-openhcl-igvm-test-linux-direct
+        path: ${{ runner.temp }}/publish_artifacts/x64-openhcl-igvm-test-linux-direct/
+        include-hidden-files: true
+    - name: 🌼📦 Publish x64-openhcl-igvm-test-linux-direct-devkern
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-openhcl-igvm-test-linux-direct-devkern
+        path: ${{ runner.temp }}/publish_artifacts/x64-openhcl-igvm-test-linux-direct-devkern/
+        include-hidden-files: true
+    - name: 🌼📦 Publish x64-openhcl-igvm-test-linux-direct-devkern-extras
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-openhcl-igvm-test-linux-direct-devkern-extras
+        path: ${{ runner.temp }}/publish_artifacts/x64-openhcl-igvm-test-linux-direct-devkern-extras/
+        include-hidden-files: true
+    - name: 🌼📦 Publish x64-openhcl-igvm-test-linux-direct-extras
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-openhcl-igvm-test-linux-direct-extras
+        path: ${{ runner.temp }}/publish_artifacts/x64-openhcl-igvm-test-linux-direct-extras/
         include-hidden-files: true
   job12:
     name: build openhcl (mi-secure) [x64-linux]
@@ -1015,8 +1086,51 @@ jobs:
         EOF
         mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-mi-secure-openhcl-igvm"
         echo "$AgentTempDirNormal/publish_artifacts/x64-mi-secure-openhcl-igvm" | flowey v 12 'artifact_publish_from_x64-mi-secure-openhcl-igvm' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-mi-secure-openhcl-igvm-cvm"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-mi-secure-openhcl-igvm-cvm" | flowey v 12 'artifact_publish_from_x64-mi-secure-openhcl-igvm-cvm' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-mi-secure-openhcl-igvm-cvm-extras"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-mi-secure-openhcl-igvm-cvm-extras" | flowey v 12 'artifact_publish_from_x64-mi-secure-openhcl-igvm-cvm-extras' --is-raw-string update
         mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-mi-secure-openhcl-igvm-extras"
         echo "$AgentTempDirNormal/publish_artifacts/x64-mi-secure-openhcl-igvm-extras" | flowey v 12 'artifact_publish_from_x64-mi-secure-openhcl-igvm-extras' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-mi-secure-openhcl-igvm-test-linux-direct"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-mi-secure-openhcl-igvm-test-linux-direct" | flowey v 12 'artifact_publish_from_x64-mi-secure-openhcl-igvm-test-linux-direct' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-mi-secure-openhcl-igvm-test-linux-direct-extras"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-mi-secure-openhcl-igvm-test-linux-direct-extras" | flowey v 12 'artifact_publish_from_x64-mi-secure-openhcl-igvm-test-linux-direct-extras' --is-raw-string update
+      shell: bash
+    - name: check if openvmm needs to be cloned
+      run: |-
+        flowey e 12 flowey_lib_common::git_checkout 0
+        flowey v 12 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
+        flowey v 12 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__git_checkout__1
+      uses: actions/checkout@v6
+      with:
+        fetch-depth: '1'
+        path: repo0
+        persist-credentials: ${{ env.floweyvar3 }}
+      name: checkout repo openvmm
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: report cloned repo directories
+      run: |-
+        flowey v 12 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        ${{ github.workspace }}
+        EOF
+        flowey e 12 flowey_lib_common::git_checkout 3
+        flowey e 12 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 3
+      shell: bash
+    - name: add default cargo home to path
+      run: flowey e 12 flowey_lib_common::install_rust 0
+      shell: bash
+    - name: install Rust
+      run: flowey e 12 flowey_lib_common::install_rust 1
+      shell: bash
+    - name: detect active toolchain
+      run: |-
+        flowey e 12 flowey_lib_common::install_rust 2
+        flowey e 12 flowey_lib_common::cfg_cargo_common_flags 0
+        flowey e 12 flowey_lib_hvlite::cfg_openvmm_magicpath 0
       shell: bash
     - name: create gh-release-download cache dir
       run: flowey e 12 flowey_lib_common::download_gh_release 0
@@ -1041,44 +1155,11 @@ jobs:
         flowey e 12 flowey_lib_common::cache 2
         flowey e 12 flowey_lib_common::download_gh_release 1
       shell: bash
-    - name: unpack openvmm-test-linux archives
-      run: flowey e 12 flowey_lib_hvlite::resolve_openvmm_test_linux_kernel 0
+    - name: unpack openvmm-deps archive
+      run: flowey e 12 flowey_lib_hvlite::resolve_openvmm_deps 0
       shell: bash
-    - name: unpack openvmm-test-initrd archives
-      run: flowey e 12 flowey_lib_hvlite::resolve_openvmm_test_initrd 0
-      shell: bash
-    - name: add default cargo home to path
-      run: flowey e 12 flowey_lib_common::install_rust 0
-      shell: bash
-    - name: install Rust
-      run: flowey e 12 flowey_lib_common::install_rust 1
-      shell: bash
-    - name: detect active toolchain
-      run: |-
-        flowey e 12 flowey_lib_common::install_rust 2
-        flowey e 12 flowey_lib_common::cfg_cargo_common_flags 0
-      shell: bash
-    - name: check if openvmm needs to be cloned
-      run: |-
-        flowey e 12 flowey_lib_common::git_checkout 0
-        flowey v 12 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
-        flowey v 12 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__git_checkout__1
-      uses: actions/checkout@v6
-      with:
-        fetch-depth: '1'
-        path: repo0
-        persist-credentials: ${{ env.floweyvar3 }}
-      name: checkout repo openvmm
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: report cloned repo directories
-      run: |-
-        flowey v 12 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
-        ${{ github.workspace }}
-        EOF
-        flowey e 12 flowey_lib_common::git_checkout 3
-        flowey e 12 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+    - name: extract X86_64 sysroot.tar.gz
+      run: flowey e 12 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
       shell: bash
     - name: set '-Dwarnings' in .cargo/config.toml
       run: flowey e 12 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
@@ -1090,13 +1171,35 @@ jobs:
       run: flowey e 12 flowey_lib_common::install_dist_pkg 1
       shell: bash
     - name: unpack protoc
-      run: |-
-        flowey e 12 flowey_lib_common::resolve_protoc 0
-        flowey e 12 flowey_lib_hvlite::cfg_openvmm_magicpath 0
+      run: flowey e 12 flowey_lib_common::resolve_protoc 0
       shell: bash
     - name: symlink protoc
       run: |-
         flowey e 12 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
+        flowey e 12 flowey_lib_hvlite::init_cross_build 3
+        flowey e 12 flowey_lib_hvlite::run_cargo_build 6
+        flowey e 12 flowey_lib_hvlite::run_cargo_build 7
+      shell: bash
+    - name: cargo build openvmm_hcl
+      run: |-
+        flowey e 12 flowey_lib_common::run_cargo_build 2
+        flowey e 12 flowey_lib_hvlite::run_cargo_build 8
+        flowey e 12 flowey_lib_hvlite::build_openvmm_hcl 0
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 0
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 12 flowey_lib_hvlite::run_split_debug_info 0
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 1
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 2
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 4
+      shell: bash
+    - name: extract and resolve kernel package
+      run: flowey e 12 flowey_lib_hvlite::resolve_openhcl_kernel_package 0
+      shell: bash
+    - name: building openhcl initrd
+      run: |-
+        flowey e 12 flowey_lib_hvlite::build_openhcl_initrd 0
         flowey e 12 flowey_lib_hvlite::init_cross_build 0
         flowey e 12 flowey_lib_hvlite::run_cargo_build 9
         flowey e 12 flowey_lib_hvlite::run_cargo_build 10
@@ -1111,6 +1214,7 @@ jobs:
         flowey e 12 flowey_lib_hvlite::run_split_debug_info 4
         flowey e 12 flowey_lib_hvlite::run_cargo_build 12
         flowey e 12 flowey_lib_hvlite::build_sidecar 0
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 5
         flowey e 12 flowey_lib_hvlite::init_cross_build 1
         flowey e 12 flowey_lib_hvlite::run_cargo_build 2
         flowey e 12 flowey_lib_hvlite::run_cargo_build 3
@@ -1125,40 +1229,12 @@ jobs:
         flowey e 12 flowey_lib_hvlite::run_split_debug_info 3
         flowey e 12 flowey_lib_hvlite::run_cargo_build 5
         flowey e 12 flowey_lib_hvlite::build_openhcl_boot 0
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 6
       shell: bash
-    - name: extract and resolve kernel package
+    - name: unpack mu_msvm package (x64)
       run: |-
-        flowey e 12 flowey_lib_hvlite::resolve_openhcl_kernel_package 0
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 28
-      shell: bash
-    - name: unpack openvmm-deps archive
-      run: flowey e 12 flowey_lib_hvlite::resolve_openvmm_deps 0
-      shell: bash
-    - name: extract X86_64 sysroot.tar.gz
-      run: |-
-        flowey e 12 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
-        flowey e 12 flowey_lib_hvlite::init_cross_build 3
-        flowey e 12 flowey_lib_hvlite::run_cargo_build 6
-        flowey e 12 flowey_lib_hvlite::run_cargo_build 7
-      shell: bash
-    - name: cargo build openvmm_hcl
-      run: |-
-        flowey e 12 flowey_lib_common::run_cargo_build 2
-        flowey e 12 flowey_lib_hvlite::run_cargo_build 8
-        flowey e 12 flowey_lib_hvlite::build_openvmm_hcl 0
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 24
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 12 flowey_lib_hvlite::run_split_debug_info 2
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 25
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 26
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 29
-      shell: bash
-    - name: building openhcl initrd
-      run: |-
-        flowey e 12 flowey_lib_hvlite::build_openhcl_initrd 2
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 30
+        flowey e 12 flowey_lib_hvlite::download_uefi_mu_msvm 0
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 7
         flowey e 12 flowey_lib_hvlite::init_cross_build 2
       shell: bash
     - name: cargo build igvmfilegen
@@ -1171,21 +1247,56 @@ jobs:
         flowey e 12 flowey_lib_hvlite::run_split_debug_info 5
         flowey e 12 flowey_lib_hvlite::run_cargo_build 1
         flowey e 12 flowey_lib_hvlite::build_igvmfilegen 0
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 8
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 9
+      shell: bash
+    - name: building igvm file
+      run: |-
+        flowey e 12 flowey_lib_hvlite::run_igvmfilegen 1
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 12
+        flowey e 12 flowey_core::pipeline::artifact::publish 0
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 10
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 11
+        flowey e 12 flowey_core::pipeline::artifact::publish 1
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 33
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 34
+      shell: bash
+    - name: unpack openvmm-test-linux archives
+      run: flowey e 12 flowey_lib_hvlite::resolve_openvmm_test_linux_kernel 0
+      shell: bash
+    - name: unpack openvmm-test-initrd archives
+      run: |-
+        flowey e 12 flowey_lib_hvlite::resolve_openvmm_test_initrd 0
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 28
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 25
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 12 flowey_lib_hvlite::run_split_debug_info 2
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 26
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 27
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 29
+      shell: bash
+    - name: building openhcl initrd
+      run: |-
+        flowey e 12 flowey_lib_hvlite::build_openhcl_initrd 2
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 30
         flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 31
         flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 32
       shell: bash
     - name: building igvm file
       run: |-
-        flowey e 12 flowey_lib_hvlite::run_igvmfilegen 2
-        flowey e 12 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 2
-      shell: bash
-    - name: unpack mu_msvm package (x64)
-      run: flowey e 12 flowey_lib_hvlite::download_uefi_mu_msvm 0
+        flowey e 12 flowey_lib_hvlite::run_igvmfilegen 0
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 37
+        flowey e 12 flowey_core::pipeline::artifact::publish 2
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 35
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 36
+        flowey e 12 flowey_core::pipeline::artifact::publish 3
       shell: bash
     - name: extract and resolve kernel package
       run: |-
         flowey e 12 flowey_lib_hvlite::resolve_openhcl_kernel_package 1
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 17
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 16
         flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 13
       shell: bash
     - name: split debug symbols
@@ -1193,61 +1304,24 @@ jobs:
         flowey e 12 flowey_lib_hvlite::run_split_debug_info 1
         flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 14
         flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 15
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 18
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 17
       shell: bash
     - name: building openhcl initrd
       run: |-
         flowey e 12 flowey_lib_hvlite::build_openhcl_initrd 1
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 18
         flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 19
         flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 20
         flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 21
       shell: bash
     - name: building igvm file
       run: |-
-        flowey e 12 flowey_lib_hvlite::run_igvmfilegen 1
-        flowey e 12 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 4
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 6
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 2
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 12 flowey_lib_hvlite::run_split_debug_info 0
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 3
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 4
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 7
-      shell: bash
-    - name: building openhcl initrd
-      run: |-
-        flowey e 12 flowey_lib_hvlite::build_openhcl_initrd 0
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 8
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 9
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 10
-      shell: bash
-    - name: building igvm file
-      run: |-
-        flowey e 12 flowey_lib_hvlite::run_igvmfilegen 0
-        flowey e 12 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 0
-        flowey e 12 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::publish 0
-      shell: bash
-    - name: copying OpenHCL igvm files to artifact dir
-      run: |-
-        flowey e 12 flowey_lib_common::copy_to_artifact_dir 1
+        flowey e 12 flowey_lib_hvlite::run_igvmfilegen 2
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 24
+        flowey e 12 flowey_core::pipeline::artifact::publish 4
         flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 22
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 27
         flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 23
-        flowey e 12 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 3
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 16
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 12
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 11
-        flowey e 12 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 5
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 5
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 1
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 0
-        flowey e 12 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 1
-        flowey e 12 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe_extras::publish 0
-      shell: bash
-    - name: copying OpenHCL igvm extras to artifact dir
-      run: flowey e 12 flowey_lib_common::copy_to_artifact_dir 0
+        flowey e 12 flowey_core::pipeline::artifact::publish 5
       shell: bash
     - name: 'validate cache entry: gh-release-download'
       run: flowey e 12 flowey_lib_common::cache 3
@@ -1258,11 +1332,35 @@ jobs:
         name: x64-mi-secure-openhcl-igvm
         path: ${{ runner.temp }}/publish_artifacts/x64-mi-secure-openhcl-igvm/
         include-hidden-files: true
+    - name: 🌼📦 Publish x64-mi-secure-openhcl-igvm-cvm
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-mi-secure-openhcl-igvm-cvm
+        path: ${{ runner.temp }}/publish_artifacts/x64-mi-secure-openhcl-igvm-cvm/
+        include-hidden-files: true
+    - name: 🌼📦 Publish x64-mi-secure-openhcl-igvm-cvm-extras
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-mi-secure-openhcl-igvm-cvm-extras
+        path: ${{ runner.temp }}/publish_artifacts/x64-mi-secure-openhcl-igvm-cvm-extras/
+        include-hidden-files: true
     - name: 🌼📦 Publish x64-mi-secure-openhcl-igvm-extras
       uses: actions/upload-artifact@v7
       with:
         name: x64-mi-secure-openhcl-igvm-extras
         path: ${{ runner.temp }}/publish_artifacts/x64-mi-secure-openhcl-igvm-extras/
+        include-hidden-files: true
+    - name: 🌼📦 Publish x64-mi-secure-openhcl-igvm-test-linux-direct
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-mi-secure-openhcl-igvm-test-linux-direct
+        path: ${{ runner.temp }}/publish_artifacts/x64-mi-secure-openhcl-igvm-test-linux-direct/
+        include-hidden-files: true
+    - name: 🌼📦 Publish x64-mi-secure-openhcl-igvm-test-linux-direct-extras
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-mi-secure-openhcl-igvm-test-linux-direct-extras
+        path: ${{ runner.temp }}/publish_artifacts/x64-mi-secure-openhcl-igvm-test-linux-direct-extras/
         include-hidden-files: true
   job13:
     name: clippy [x64-windows], unit tests [x64-windows]
@@ -3271,7 +3369,7 @@ jobs:
     - name: 🌼📦 Download artifacts
       uses: actions/download-artifact@v8
       with:
-        pattern: '{_internal-flowey-bootstrap-x86_64-windows-uid-6,x64-guest_test_uefi,x64-linux-musl-pipette,x64-linux-musl-tmk_vmm,x64-linux-tpm_guest_tests,x64-openhcl-igvm,x64-tmks,x64-windows-openvmm,x64-windows-pipette,x64-windows-prep_steps,x64-windows-test_igvm_agent_rpc_server,x64-windows-tmk_vmm,x64-windows-tpm_guest_tests,x64-windows-vmgstool,x64-windows-vmgstool-dev,x64-windows-vmm-tests-archive}'
+        pattern: '{_internal-flowey-bootstrap-x86_64-windows-uid-6,x64-guest_test_uefi,x64-linux-musl-pipette,x64-linux-musl-tmk_vmm,x64-linux-tpm_guest_tests,x64-openhcl-igvm,x64-openhcl-igvm-cvm,x64-openhcl-igvm-test-linux-direct,x64-tmks,x64-windows-openvmm,x64-windows-pipette,x64-windows-prep_steps,x64-windows-test_igvm_agent_rpc_server,x64-windows-tmk_vmm,x64-windows-tpm_guest_tests,x64-windows-vmgstool,x64-windows-vmgstool-dev,x64-windows-vmm-tests-archive}'
         path: ${{ runner.temp }}/used_artifacts/
     - run: echo "${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-windows-uid-6" >> $GITHUB_PATH
       shell: bash
@@ -3295,6 +3393,8 @@ jobs:
         echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-tmk_vmm" | flowey.exe v 19 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
         echo "${{ runner.temp }}\\used_artifacts\\x64-linux-tpm_guest_tests" | flowey.exe v 19 'artifact_use_from_x64-linux-tpm_guest_tests' --is-raw-string update
         echo "${{ runner.temp }}\\used_artifacts\\x64-openhcl-igvm" | flowey.exe v 19 'artifact_use_from_x64-openhcl-igvm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-openhcl-igvm-cvm" | flowey.exe v 19 'artifact_use_from_x64-openhcl-igvm-cvm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-openhcl-igvm-test-linux-direct" | flowey.exe v 19 'artifact_use_from_x64-openhcl-igvm-test-linux-direct' --is-raw-string update
         echo "${{ runner.temp }}\\used_artifacts\\x64-tmks" | flowey.exe v 19 'artifact_use_from_x64-tmks' --is-raw-string update
         echo "${{ runner.temp }}\\used_artifacts\\x64-windows-openvmm" | flowey.exe v 19 'artifact_use_from_x64-windows-openvmm' --is-raw-string update
         echo "${{ runner.temp }}\\used_artifacts\\x64-windows-pipette" | flowey.exe v 19 'artifact_use_from_x64-windows-pipette' --is-raw-string update
@@ -3355,24 +3455,24 @@ jobs:
         flowey.exe e 19 flowey_lib_common::git_checkout 3
         flowey.exe e 19 flowey_lib_hvlite::git_checkout_openvmm_repo 0
         flowey.exe e 19 flowey_lib_hvlite::run_cargo_nextest_run 0
+        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 8
+        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 9
+        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 12
+        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 14
+        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 15
+        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 13
+        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 3
+        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 11
+        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 4
         flowey.exe e 19 flowey_core::pipeline::artifact::resolve 5
         flowey.exe e 19 flowey_core::pipeline::artifact::resolve 6
         flowey.exe e 19 flowey_core::pipeline::artifact::resolve 1
-        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 0
-        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 9
         flowey.exe e 19 flowey_core::pipeline::artifact::resolve 2
-        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 4
-        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 11
-        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 12
-        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 10
-        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 3
-        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 8
+        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 0
+        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 7
       shell: bash
     - name: creating new test content dir
       run: flowey.exe e 19 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
-      shell: bash
-    - name: resolve OpenHCL igvm artifact
-      run: flowey.exe e 19 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::resolve 0
       shell: bash
     - name: create gh-release-download cache dir
       run: flowey.exe e 19 flowey_lib_common::download_gh_release 0
@@ -3461,7 +3561,7 @@ jobs:
       run: |-
         flowey.exe e 19 flowey_lib_hvlite::init_vmm_tests_env 0
         flowey.exe e 19 flowey_lib_hvlite::run_cargo_nextest_run 1
-        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 13
+        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 16
         flowey.exe e 19 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
       shell: bash
     - name: generate nextest command
@@ -3473,7 +3573,7 @@ jobs:
     - name: starting test_igvm_agent_rpc_server
       run: |-
         flowey.exe e 19 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
-        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 7
+        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 10
       shell: bash
     - name: running vmm_test prep_steps
       run: flowey.exe e 19 flowey_lib_hvlite::run_prep_steps 0
@@ -3733,7 +3833,7 @@ jobs:
     - name: 🌼📦 Download artifacts
       uses: actions/download-artifact@v8
       with:
-        pattern: '{_internal-flowey-bootstrap-x86_64-windows-uid-6,x64-guest_test_uefi,x64-linux-musl-pipette,x64-linux-musl-tmk_vmm,x64-linux-tpm_guest_tests,x64-mi-secure-openhcl-igvm,x64-tmks,x64-windows-openvmm,x64-windows-pipette,x64-windows-prep_steps,x64-windows-test_igvm_agent_rpc_server,x64-windows-tmk_vmm,x64-windows-tpm_guest_tests,x64-windows-vmgstool,x64-windows-vmgstool-dev,x64-windows-vmm-tests-archive}'
+        pattern: '{_internal-flowey-bootstrap-x86_64-windows-uid-6,x64-guest_test_uefi,x64-linux-musl-pipette,x64-linux-musl-tmk_vmm,x64-linux-tpm_guest_tests,x64-mi-secure-openhcl-igvm,x64-mi-secure-openhcl-igvm-cvm,x64-mi-secure-openhcl-igvm-test-linux-direct,x64-tmks,x64-windows-openvmm,x64-windows-pipette,x64-windows-prep_steps,x64-windows-test_igvm_agent_rpc_server,x64-windows-tmk_vmm,x64-windows-tpm_guest_tests,x64-windows-vmgstool,x64-windows-vmgstool-dev,x64-windows-vmm-tests-archive}'
         path: ${{ runner.temp }}/used_artifacts/
     - run: echo "${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-windows-uid-6" >> $GITHUB_PATH
       shell: bash
@@ -3757,6 +3857,8 @@ jobs:
         echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-tmk_vmm" | flowey.exe v 20 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
         echo "${{ runner.temp }}\\used_artifacts\\x64-linux-tpm_guest_tests" | flowey.exe v 20 'artifact_use_from_x64-linux-tpm_guest_tests' --is-raw-string update
         echo "${{ runner.temp }}\\used_artifacts\\x64-mi-secure-openhcl-igvm" | flowey.exe v 20 'artifact_use_from_x64-mi-secure-openhcl-igvm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-mi-secure-openhcl-igvm-cvm" | flowey.exe v 20 'artifact_use_from_x64-mi-secure-openhcl-igvm-cvm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-mi-secure-openhcl-igvm-test-linux-direct" | flowey.exe v 20 'artifact_use_from_x64-mi-secure-openhcl-igvm-test-linux-direct' --is-raw-string update
         echo "${{ runner.temp }}\\used_artifacts\\x64-tmks" | flowey.exe v 20 'artifact_use_from_x64-tmks' --is-raw-string update
         echo "${{ runner.temp }}\\used_artifacts\\x64-windows-openvmm" | flowey.exe v 20 'artifact_use_from_x64-windows-openvmm' --is-raw-string update
         echo "${{ runner.temp }}\\used_artifacts\\x64-windows-pipette" | flowey.exe v 20 'artifact_use_from_x64-windows-pipette' --is-raw-string update
@@ -3817,24 +3919,24 @@ jobs:
         flowey.exe e 20 flowey_lib_common::git_checkout 3
         flowey.exe e 20 flowey_lib_hvlite::git_checkout_openvmm_repo 0
         flowey.exe e 20 flowey_lib_hvlite::run_cargo_nextest_run 0
+        flowey.exe e 20 flowey_core::pipeline::artifact::resolve 14
+        flowey.exe e 20 flowey_core::pipeline::artifact::resolve 15
+        flowey.exe e 20 flowey_core::pipeline::artifact::resolve 13
+        flowey.exe e 20 flowey_core::pipeline::artifact::resolve 3
+        flowey.exe e 20 flowey_core::pipeline::artifact::resolve 11
+        flowey.exe e 20 flowey_core::pipeline::artifact::resolve 4
         flowey.exe e 20 flowey_core::pipeline::artifact::resolve 5
         flowey.exe e 20 flowey_core::pipeline::artifact::resolve 6
         flowey.exe e 20 flowey_core::pipeline::artifact::resolve 1
-        flowey.exe e 20 flowey_core::pipeline::artifact::resolve 0
-        flowey.exe e 20 flowey_core::pipeline::artifact::resolve 9
         flowey.exe e 20 flowey_core::pipeline::artifact::resolve 2
-        flowey.exe e 20 flowey_core::pipeline::artifact::resolve 4
-        flowey.exe e 20 flowey_core::pipeline::artifact::resolve 11
-        flowey.exe e 20 flowey_core::pipeline::artifact::resolve 12
-        flowey.exe e 20 flowey_core::pipeline::artifact::resolve 10
-        flowey.exe e 20 flowey_core::pipeline::artifact::resolve 3
+        flowey.exe e 20 flowey_core::pipeline::artifact::resolve 0
+        flowey.exe e 20 flowey_core::pipeline::artifact::resolve 7
         flowey.exe e 20 flowey_core::pipeline::artifact::resolve 8
+        flowey.exe e 20 flowey_core::pipeline::artifact::resolve 9
+        flowey.exe e 20 flowey_core::pipeline::artifact::resolve 12
       shell: bash
     - name: creating new test content dir
       run: flowey.exe e 20 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
-      shell: bash
-    - name: resolve OpenHCL igvm artifact
-      run: flowey.exe e 20 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::resolve 0
       shell: bash
     - name: create gh-release-download cache dir
       run: flowey.exe e 20 flowey_lib_common::download_gh_release 0
@@ -3923,7 +4025,7 @@ jobs:
       run: |-
         flowey.exe e 20 flowey_lib_hvlite::init_vmm_tests_env 0
         flowey.exe e 20 flowey_lib_hvlite::run_cargo_nextest_run 1
-        flowey.exe e 20 flowey_core::pipeline::artifact::resolve 13
+        flowey.exe e 20 flowey_core::pipeline::artifact::resolve 16
         flowey.exe e 20 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
       shell: bash
     - name: generate nextest command
@@ -4007,7 +4109,7 @@ jobs:
     - name: 🌼📦 Download artifacts
       uses: actions/download-artifact@v8
       with:
-        pattern: '{_internal-flowey-bootstrap-x86_64-windows-uid-6,x64-guest_test_uefi,x64-linux-musl-pipette,x64-linux-musl-tmk_vmm,x64-linux-tpm_guest_tests,x64-openhcl-igvm,x64-tmks,x64-windows-openvmm,x64-windows-pipette,x64-windows-prep_steps,x64-windows-test_igvm_agent_rpc_server,x64-windows-tmk_vmm,x64-windows-tpm_guest_tests,x64-windows-vmgstool,x64-windows-vmgstool-dev,x64-windows-vmm-tests-archive}'
+        pattern: '{_internal-flowey-bootstrap-x86_64-windows-uid-6,x64-guest_test_uefi,x64-linux-musl-pipette,x64-linux-musl-tmk_vmm,x64-linux-tpm_guest_tests,x64-openhcl-igvm,x64-openhcl-igvm-cvm,x64-openhcl-igvm-test-linux-direct,x64-tmks,x64-windows-openvmm,x64-windows-pipette,x64-windows-prep_steps,x64-windows-test_igvm_agent_rpc_server,x64-windows-tmk_vmm,x64-windows-tpm_guest_tests,x64-windows-vmgstool,x64-windows-vmgstool-dev,x64-windows-vmm-tests-archive}'
         path: ${{ runner.temp }}/used_artifacts/
     - run: echo "${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-windows-uid-6" >> $GITHUB_PATH
       shell: bash
@@ -4031,6 +4133,8 @@ jobs:
         echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-tmk_vmm" | flowey.exe v 21 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
         echo "${{ runner.temp }}\\used_artifacts\\x64-linux-tpm_guest_tests" | flowey.exe v 21 'artifact_use_from_x64-linux-tpm_guest_tests' --is-raw-string update
         echo "${{ runner.temp }}\\used_artifacts\\x64-openhcl-igvm" | flowey.exe v 21 'artifact_use_from_x64-openhcl-igvm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-openhcl-igvm-cvm" | flowey.exe v 21 'artifact_use_from_x64-openhcl-igvm-cvm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-openhcl-igvm-test-linux-direct" | flowey.exe v 21 'artifact_use_from_x64-openhcl-igvm-test-linux-direct' --is-raw-string update
         echo "${{ runner.temp }}\\used_artifacts\\x64-tmks" | flowey.exe v 21 'artifact_use_from_x64-tmks' --is-raw-string update
         echo "${{ runner.temp }}\\used_artifacts\\x64-windows-openvmm" | flowey.exe v 21 'artifact_use_from_x64-windows-openvmm' --is-raw-string update
         echo "${{ runner.temp }}\\used_artifacts\\x64-windows-pipette" | flowey.exe v 21 'artifact_use_from_x64-windows-pipette' --is-raw-string update
@@ -4091,24 +4195,24 @@ jobs:
         flowey.exe e 21 flowey_lib_common::git_checkout 3
         flowey.exe e 21 flowey_lib_hvlite::git_checkout_openvmm_repo 0
         flowey.exe e 21 flowey_lib_hvlite::run_cargo_nextest_run 0
+        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 8
+        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 9
+        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 12
+        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 14
+        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 15
+        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 13
+        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 3
+        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 11
+        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 4
         flowey.exe e 21 flowey_core::pipeline::artifact::resolve 5
         flowey.exe e 21 flowey_core::pipeline::artifact::resolve 6
         flowey.exe e 21 flowey_core::pipeline::artifact::resolve 1
-        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 0
-        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 9
         flowey.exe e 21 flowey_core::pipeline::artifact::resolve 2
-        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 4
-        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 11
-        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 12
-        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 10
-        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 3
-        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 8
+        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 0
+        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 7
       shell: bash
     - name: creating new test content dir
       run: flowey.exe e 21 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
-      shell: bash
-    - name: resolve OpenHCL igvm artifact
-      run: flowey.exe e 21 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::resolve 0
       shell: bash
     - name: create gh-release-download cache dir
       run: flowey.exe e 21 flowey_lib_common::download_gh_release 0
@@ -4197,7 +4301,7 @@ jobs:
       run: |-
         flowey.exe e 21 flowey_lib_hvlite::init_vmm_tests_env 0
         flowey.exe e 21 flowey_lib_hvlite::run_cargo_nextest_run 1
-        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 13
+        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 16
         flowey.exe e 21 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
       shell: bash
     - name: generate nextest command
@@ -4209,7 +4313,7 @@ jobs:
     - name: starting test_igvm_agent_rpc_server
       run: |-
         flowey.exe e 21 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
-        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 7
+        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 10
       shell: bash
     - name: running vmm_test prep_steps
       run: flowey.exe e 21 flowey_lib_hvlite::run_prep_steps 0
@@ -4285,7 +4389,7 @@ jobs:
     - name: 🌼📦 Download artifacts
       uses: actions/download-artifact@v8
       with:
-        pattern: '{_internal-flowey-bootstrap-x86_64-windows-uid-6,x64-guest_test_uefi,x64-linux-musl-pipette,x64-linux-musl-tmk_vmm,x64-linux-tpm_guest_tests,x64-openhcl-igvm,x64-tmks,x64-windows-openvmm,x64-windows-pipette,x64-windows-prep_steps,x64-windows-test_igvm_agent_rpc_server,x64-windows-tmk_vmm,x64-windows-tpm_guest_tests,x64-windows-vmgstool,x64-windows-vmgstool-dev,x64-windows-vmm-tests-archive}'
+        pattern: '{_internal-flowey-bootstrap-x86_64-windows-uid-6,x64-guest_test_uefi,x64-linux-musl-pipette,x64-linux-musl-tmk_vmm,x64-linux-tpm_guest_tests,x64-openhcl-igvm,x64-openhcl-igvm-cvm,x64-openhcl-igvm-test-linux-direct,x64-tmks,x64-windows-openvmm,x64-windows-pipette,x64-windows-prep_steps,x64-windows-test_igvm_agent_rpc_server,x64-windows-tmk_vmm,x64-windows-tpm_guest_tests,x64-windows-vmgstool,x64-windows-vmgstool-dev,x64-windows-vmm-tests-archive}'
         path: ${{ runner.temp }}/used_artifacts/
     - run: echo "${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-windows-uid-6" >> $GITHUB_PATH
       shell: bash
@@ -4309,6 +4413,8 @@ jobs:
         echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-tmk_vmm" | flowey.exe v 22 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
         echo "${{ runner.temp }}\\used_artifacts\\x64-linux-tpm_guest_tests" | flowey.exe v 22 'artifact_use_from_x64-linux-tpm_guest_tests' --is-raw-string update
         echo "${{ runner.temp }}\\used_artifacts\\x64-openhcl-igvm" | flowey.exe v 22 'artifact_use_from_x64-openhcl-igvm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-openhcl-igvm-cvm" | flowey.exe v 22 'artifact_use_from_x64-openhcl-igvm-cvm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-openhcl-igvm-test-linux-direct" | flowey.exe v 22 'artifact_use_from_x64-openhcl-igvm-test-linux-direct' --is-raw-string update
         echo "${{ runner.temp }}\\used_artifacts\\x64-tmks" | flowey.exe v 22 'artifact_use_from_x64-tmks' --is-raw-string update
         echo "${{ runner.temp }}\\used_artifacts\\x64-windows-openvmm" | flowey.exe v 22 'artifact_use_from_x64-windows-openvmm' --is-raw-string update
         echo "${{ runner.temp }}\\used_artifacts\\x64-windows-pipette" | flowey.exe v 22 'artifact_use_from_x64-windows-pipette' --is-raw-string update
@@ -4369,24 +4475,24 @@ jobs:
         flowey.exe e 22 flowey_lib_common::git_checkout 3
         flowey.exe e 22 flowey_lib_hvlite::git_checkout_openvmm_repo 0
         flowey.exe e 22 flowey_lib_hvlite::run_cargo_nextest_run 0
+        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 8
+        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 9
+        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 12
+        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 14
+        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 15
+        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 13
+        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 3
+        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 11
+        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 4
         flowey.exe e 22 flowey_core::pipeline::artifact::resolve 5
         flowey.exe e 22 flowey_core::pipeline::artifact::resolve 6
         flowey.exe e 22 flowey_core::pipeline::artifact::resolve 1
-        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 0
-        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 9
         flowey.exe e 22 flowey_core::pipeline::artifact::resolve 2
-        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 4
-        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 11
-        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 12
-        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 10
-        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 3
-        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 8
+        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 0
+        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 7
       shell: bash
     - name: creating new test content dir
       run: flowey.exe e 22 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
-      shell: bash
-    - name: resolve OpenHCL igvm artifact
-      run: flowey.exe e 22 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::resolve 0
       shell: bash
     - name: create gh-release-download cache dir
       run: flowey.exe e 22 flowey_lib_common::download_gh_release 0
@@ -4475,7 +4581,7 @@ jobs:
       run: |-
         flowey.exe e 22 flowey_lib_hvlite::init_vmm_tests_env 0
         flowey.exe e 22 flowey_lib_hvlite::run_cargo_nextest_run 1
-        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 13
+        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 16
         flowey.exe e 22 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
       shell: bash
     - name: generate nextest command
@@ -4487,7 +4593,7 @@ jobs:
     - name: starting test_igvm_agent_rpc_server
       run: |-
         flowey.exe e 22 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
-        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 7
+        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 10
       shell: bash
     - name: running vmm_test prep_steps
       run: flowey.exe e 22 flowey_lib_hvlite::run_prep_steps 0
@@ -4564,7 +4670,7 @@ jobs:
     - name: 🌼📦 Download artifacts
       uses: actions/download-artifact@v8
       with:
-        pattern: '{_internal-flowey-bootstrap-x86_64-windows-uid-6,x64-guest_test_uefi,x64-linux-musl-pipette,x64-linux-musl-tmk_vmm,x64-linux-tpm_guest_tests,x64-openhcl-igvm,x64-tmks,x64-windows-openvmm,x64-windows-pipette,x64-windows-prep_steps,x64-windows-test_igvm_agent_rpc_server,x64-windows-tmk_vmm,x64-windows-tpm_guest_tests,x64-windows-vmgstool,x64-windows-vmgstool-dev,x64-windows-vmm-tests-archive}'
+        pattern: '{_internal-flowey-bootstrap-x86_64-windows-uid-6,x64-guest_test_uefi,x64-linux-musl-pipette,x64-linux-musl-tmk_vmm,x64-linux-tpm_guest_tests,x64-openhcl-igvm,x64-openhcl-igvm-cvm,x64-openhcl-igvm-test-linux-direct,x64-tmks,x64-windows-openvmm,x64-windows-pipette,x64-windows-prep_steps,x64-windows-test_igvm_agent_rpc_server,x64-windows-tmk_vmm,x64-windows-tpm_guest_tests,x64-windows-vmgstool,x64-windows-vmgstool-dev,x64-windows-vmm-tests-archive}'
         path: ${{ runner.temp }}/used_artifacts/
     - run: echo "${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-windows-uid-6" >> $GITHUB_PATH
       shell: bash
@@ -4588,6 +4694,8 @@ jobs:
         echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-tmk_vmm" | flowey.exe v 23 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
         echo "${{ runner.temp }}\\used_artifacts\\x64-linux-tpm_guest_tests" | flowey.exe v 23 'artifact_use_from_x64-linux-tpm_guest_tests' --is-raw-string update
         echo "${{ runner.temp }}\\used_artifacts\\x64-openhcl-igvm" | flowey.exe v 23 'artifact_use_from_x64-openhcl-igvm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-openhcl-igvm-cvm" | flowey.exe v 23 'artifact_use_from_x64-openhcl-igvm-cvm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-openhcl-igvm-test-linux-direct" | flowey.exe v 23 'artifact_use_from_x64-openhcl-igvm-test-linux-direct' --is-raw-string update
         echo "${{ runner.temp }}\\used_artifacts\\x64-tmks" | flowey.exe v 23 'artifact_use_from_x64-tmks' --is-raw-string update
         echo "${{ runner.temp }}\\used_artifacts\\x64-windows-openvmm" | flowey.exe v 23 'artifact_use_from_x64-windows-openvmm' --is-raw-string update
         echo "${{ runner.temp }}\\used_artifacts\\x64-windows-pipette" | flowey.exe v 23 'artifact_use_from_x64-windows-pipette' --is-raw-string update
@@ -4648,24 +4756,24 @@ jobs:
         flowey.exe e 23 flowey_lib_common::git_checkout 3
         flowey.exe e 23 flowey_lib_hvlite::git_checkout_openvmm_repo 0
         flowey.exe e 23 flowey_lib_hvlite::run_cargo_nextest_run 0
+        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 8
+        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 9
+        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 12
+        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 14
+        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 15
+        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 13
+        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 3
+        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 11
+        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 4
         flowey.exe e 23 flowey_core::pipeline::artifact::resolve 5
         flowey.exe e 23 flowey_core::pipeline::artifact::resolve 6
         flowey.exe e 23 flowey_core::pipeline::artifact::resolve 1
-        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 0
-        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 9
         flowey.exe e 23 flowey_core::pipeline::artifact::resolve 2
-        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 4
-        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 11
-        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 12
-        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 10
-        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 3
-        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 8
+        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 0
+        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 7
       shell: bash
     - name: creating new test content dir
       run: flowey.exe e 23 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
-      shell: bash
-    - name: resolve OpenHCL igvm artifact
-      run: flowey.exe e 23 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::resolve 0
       shell: bash
     - name: create gh-release-download cache dir
       run: flowey.exe e 23 flowey_lib_common::download_gh_release 0
@@ -4754,7 +4862,7 @@ jobs:
       run: |-
         flowey.exe e 23 flowey_lib_hvlite::init_vmm_tests_env 0
         flowey.exe e 23 flowey_lib_hvlite::run_cargo_nextest_run 1
-        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 13
+        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 16
         flowey.exe e 23 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
       shell: bash
     - name: generate nextest command
@@ -4766,7 +4874,7 @@ jobs:
     - name: starting test_igvm_agent_rpc_server
       run: |-
         flowey.exe e 23 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
-        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 7
+        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 10
       shell: bash
     - name: running vmm_test prep_steps
       run: flowey.exe e 23 flowey_lib_hvlite::run_prep_steps 0
@@ -4872,12 +4980,12 @@ jobs:
       shell: bash
     - name: creating new test content dir
       run: |-
+        flowey e 24 flowey_core::pipeline::artifact::resolve 8
+        flowey e 24 flowey_core::pipeline::artifact::resolve 2
         flowey e 24 flowey_core::pipeline::artifact::resolve 3
         flowey e 24 flowey_core::pipeline::artifact::resolve 4
-        flowey e 24 flowey_core::pipeline::artifact::resolve 8
         flowey e 24 flowey_core::pipeline::artifact::resolve 1
         flowey e 24 flowey_core::pipeline::artifact::resolve 0
-        flowey e 24 flowey_core::pipeline::artifact::resolve 2
         flowey e 24 flowey_core::pipeline::artifact::resolve 7
         flowey e 24 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
       shell: bash
@@ -5188,12 +5296,12 @@ jobs:
       shell: bash
     - name: creating new test content dir
       run: |-
+        flowey e 25 flowey_core::pipeline::artifact::resolve 8
+        flowey e 25 flowey_core::pipeline::artifact::resolve 4
         flowey e 25 flowey_core::pipeline::artifact::resolve 1
         flowey e 25 flowey_core::pipeline::artifact::resolve 2
-        flowey e 25 flowey_core::pipeline::artifact::resolve 8
         flowey e 25 flowey_core::pipeline::artifact::resolve 3
         flowey e 25 flowey_core::pipeline::artifact::resolve 0
-        flowey e 25 flowey_core::pipeline::artifact::resolve 4
         flowey e 25 flowey_core::pipeline::artifact::resolve 7
         flowey e 25 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
       shell: bash
@@ -5551,21 +5659,19 @@ jobs:
         flowey.exe e 26 flowey_lib_common::git_checkout 3
         flowey.exe e 26 flowey_lib_hvlite::git_checkout_openvmm_repo 0
         flowey.exe e 26 flowey_lib_hvlite::run_cargo_nextest_run 0
-        flowey.exe e 26 flowey_core::pipeline::artifact::resolve 4
         flowey.exe e 26 flowey_core::pipeline::artifact::resolve 5
-        flowey.exe e 26 flowey_core::pipeline::artifact::resolve 1
-        flowey.exe e 26 flowey_core::pipeline::artifact::resolve 0
         flowey.exe e 26 flowey_core::pipeline::artifact::resolve 6
-        flowey.exe e 26 flowey_core::pipeline::artifact::resolve 2
-        flowey.exe e 26 flowey_core::pipeline::artifact::resolve 3
         flowey.exe e 26 flowey_core::pipeline::artifact::resolve 7
         flowey.exe e 26 flowey_core::pipeline::artifact::resolve 8
+        flowey.exe e 26 flowey_core::pipeline::artifact::resolve 9
+        flowey.exe e 26 flowey_core::pipeline::artifact::resolve 3
+        flowey.exe e 26 flowey_core::pipeline::artifact::resolve 1
+        flowey.exe e 26 flowey_core::pipeline::artifact::resolve 2
+        flowey.exe e 26 flowey_core::pipeline::artifact::resolve 0
+        flowey.exe e 26 flowey_core::pipeline::artifact::resolve 4
       shell: bash
     - name: creating new test content dir
       run: flowey.exe e 26 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
-      shell: bash
-    - name: resolve OpenHCL igvm artifact
-      run: flowey.exe e 26 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::resolve 0
       shell: bash
     - name: create gh-release-download cache dir
       run: flowey.exe e 26 flowey_lib_common::download_gh_release 0
@@ -5654,7 +5760,7 @@ jobs:
       run: |-
         flowey.exe e 26 flowey_lib_hvlite::init_vmm_tests_env 0
         flowey.exe e 26 flowey_lib_hvlite::run_cargo_nextest_run 1
-        flowey.exe e 26 flowey_core::pipeline::artifact::resolve 9
+        flowey.exe e 26 flowey_core::pipeline::artifact::resolve 10
         flowey.exe e 26 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
       shell: bash
     - name: generate nextest command

--- a/.github/workflows/openvmm-pr.yaml
+++ b/.github/workflows/openvmm-pr.yaml
@@ -432,47 +432,14 @@ jobs:
         EOF
         mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-openhcl-igvm"
         echo "$AgentTempDirNormal/publish_artifacts/aarch64-openhcl-igvm" | flowey v 10 'artifact_publish_from_aarch64-openhcl-igvm' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-openhcl-igvm-devkern"
-        echo "$AgentTempDirNormal/publish_artifacts/aarch64-openhcl-igvm-devkern" | flowey v 10 'artifact_publish_from_aarch64-openhcl-igvm-devkern' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-openhcl-igvm-devkern-extras"
-        echo "$AgentTempDirNormal/publish_artifacts/aarch64-openhcl-igvm-devkern-extras" | flowey v 10 'artifact_publish_from_aarch64-openhcl-igvm-devkern-extras' --is-raw-string update
         mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-openhcl-igvm-extras"
         echo "$AgentTempDirNormal/publish_artifacts/aarch64-openhcl-igvm-extras" | flowey v 10 'artifact_publish_from_aarch64-openhcl-igvm-extras' --is-raw-string update
       shell: bash
-    - name: check if openvmm needs to be cloned
-      run: |-
-        flowey e 10 flowey_lib_common::git_checkout 0
-        flowey v 10 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
-        flowey v 10 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+    - name: checking if packages need to be installed
+      run: flowey e 10 flowey_lib_common::install_dist_pkg 0
       shell: bash
-    - id: flowey_lib_common__git_checkout__1
-      uses: actions/checkout@v6
-      with:
-        fetch-depth: '1'
-        path: repo0
-        persist-credentials: ${{ env.floweyvar3 }}
-      name: checkout repo openvmm
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: report cloned repo directories
-      run: |-
-        flowey v 10 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
-        ${{ github.workspace }}
-        EOF
-        flowey e 10 flowey_lib_common::git_checkout 3
-        flowey e 10 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 3
-      shell: bash
-    - name: add default cargo home to path
-      run: flowey e 10 flowey_lib_common::install_rust 0
-      shell: bash
-    - name: install Rust
-      run: flowey e 10 flowey_lib_common::install_rust 1
-      shell: bash
-    - name: detect active toolchain
-      run: |-
-        flowey e 10 flowey_lib_common::install_rust 2
-        flowey e 10 flowey_lib_common::cfg_cargo_common_flags 0
-        flowey e 10 flowey_lib_hvlite::cfg_openvmm_magicpath 0
+    - name: installing packages
+      run: flowey e 10 flowey_lib_common::install_dist_pkg 1
       shell: bash
     - name: create gh-release-download cache dir
       run: flowey e 10 flowey_lib_common::download_gh_release 0
@@ -497,49 +464,53 @@ jobs:
         flowey e 10 flowey_lib_common::cache 2
         flowey e 10 flowey_lib_common::download_gh_release 1
       shell: bash
-    - name: unpack openvmm-deps archive
-      run: flowey e 10 flowey_lib_hvlite::resolve_openvmm_deps 0
+    - name: unpack mu_msvm package (aarch64)
+      run: flowey e 10 flowey_lib_hvlite::download_uefi_mu_msvm 0
       shell: bash
-    - name: extract Aarch64 sysroot.tar.gz
-      run: flowey e 10 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
+    - name: add default cargo home to path
+      run: flowey e 10 flowey_lib_common::install_rust 0
+      shell: bash
+    - name: install Rust
+      run: flowey e 10 flowey_lib_common::install_rust 1
+      shell: bash
+    - name: detect active toolchain
+      run: |-
+        flowey e 10 flowey_lib_common::install_rust 2
+        flowey e 10 flowey_lib_common::cfg_cargo_common_flags 0
+      shell: bash
+    - name: check if openvmm needs to be cloned
+      run: |-
+        flowey e 10 flowey_lib_common::git_checkout 0
+        flowey v 10 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
+        flowey v 10 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__git_checkout__1
+      uses: actions/checkout@v6
+      with:
+        fetch-depth: '1'
+        path: repo0
+        persist-credentials: ${{ env.floweyvar3 }}
+      name: checkout repo openvmm
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: report cloned repo directories
+      run: |-
+        flowey v 10 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        ${{ github.workspace }}
+        EOF
+        flowey e 10 flowey_lib_common::git_checkout 3
+        flowey e 10 flowey_lib_hvlite::git_checkout_openvmm_repo 0
       shell: bash
     - name: set '-Dwarnings' in .cargo/config.toml
       run: flowey e 10 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
       shell: bash
-    - name: checking if packages need to be installed
-      run: flowey e 10 flowey_lib_common::install_dist_pkg 0
-      shell: bash
-    - name: installing packages
-      run: flowey e 10 flowey_lib_common::install_dist_pkg 1
-      shell: bash
     - name: unpack protoc
-      run: flowey e 10 flowey_lib_common::resolve_protoc 0
+      run: |-
+        flowey e 10 flowey_lib_common::resolve_protoc 0
+        flowey e 10 flowey_lib_hvlite::cfg_openvmm_magicpath 0
       shell: bash
     - name: symlink protoc
       run: |-
         flowey e 10 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-        flowey e 10 flowey_lib_hvlite::init_cross_build 1
-      shell: bash
-    - name: cargo build openvmm_hcl
-      run: |-
-        flowey e 10 flowey_lib_common::run_cargo_build 2
-        flowey e 10 flowey_lib_hvlite::run_cargo_build 6
-        flowey e 10 flowey_lib_hvlite::build_openvmm_hcl 0
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 0
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 10 flowey_lib_hvlite::run_split_debug_info 0
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 1
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 2
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 4
-      shell: bash
-    - name: extract and resolve kernel package
-      run: flowey e 10 flowey_lib_hvlite::resolve_openhcl_kernel_package 0
-      shell: bash
-    - name: building openhcl initrd
-      run: |-
-        flowey e 10 flowey_lib_hvlite::build_openhcl_initrd 0
         flowey e 10 flowey_lib_hvlite::init_cross_build 0
         flowey e 10 flowey_lib_hvlite::run_cargo_build 2
         flowey e 10 flowey_lib_hvlite::run_cargo_build 3
@@ -554,12 +525,40 @@ jobs:
         flowey e 10 flowey_lib_hvlite::run_split_debug_info 2
         flowey e 10 flowey_lib_hvlite::run_cargo_build 5
         flowey e 10 flowey_lib_hvlite::build_openhcl_boot 0
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 5
       shell: bash
-    - name: unpack mu_msvm package (aarch64)
+    - name: extract and resolve kernel package
       run: |-
-        flowey e 10 flowey_lib_hvlite::download_uefi_mu_msvm 0
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 6
+        flowey e 10 flowey_lib_hvlite::resolve_openhcl_kernel_package 1
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 17
+      shell: bash
+    - name: unpack openvmm-deps archive
+      run: flowey e 10 flowey_lib_hvlite::resolve_openvmm_deps 0
+      shell: bash
+    - name: extract Aarch64 sysroot.tar.gz
+      run: |-
+        flowey e 10 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
+        flowey e 10 flowey_lib_hvlite::init_cross_build 1
+        flowey e 10 flowey_lib_hvlite::run_cargo_build 6
+        flowey e 10 flowey_lib_hvlite::run_cargo_build 7
+      shell: bash
+    - name: cargo build openvmm_hcl
+      run: |-
+        flowey e 10 flowey_lib_common::run_cargo_build 2
+        flowey e 10 flowey_lib_hvlite::run_cargo_build 8
+        flowey e 10 flowey_lib_hvlite::build_openvmm_hcl 0
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 13
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 10 flowey_lib_hvlite::run_split_debug_info 1
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 14
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 15
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 18
+      shell: bash
+    - name: building openhcl initrd
+      run: |-
+        flowey e 10 flowey_lib_hvlite::build_openhcl_initrd 1
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 19
         flowey e 10 flowey_lib_hvlite::init_cross_build 2
       shell: bash
     - name: cargo build igvmfilegen
@@ -572,47 +571,55 @@ jobs:
         flowey e 10 flowey_lib_hvlite::run_split_debug_info 3
         flowey e 10 flowey_lib_hvlite::run_cargo_build 1
         flowey e 10 flowey_lib_hvlite::build_igvmfilegen 0
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 7
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 8
-      shell: bash
-    - name: building igvm file
-      run: |-
-        flowey e 10 flowey_lib_hvlite::run_igvmfilegen 0
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 11
-        flowey e 10 flowey_core::pipeline::artifact::publish 0
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 9
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 10
-        flowey e 10 flowey_core::pipeline::artifact::publish 1
-      shell: bash
-    - name: extract and resolve kernel package
-      run: |-
-        flowey e 10 flowey_lib_hvlite::resolve_openhcl_kernel_package 1
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 15
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 12
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 10 flowey_lib_hvlite::run_split_debug_info 1
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 13
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 14
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 16
-      shell: bash
-    - name: building openhcl initrd
-      run: |-
-        flowey e 10 flowey_lib_hvlite::build_openhcl_initrd 1
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 17
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 18
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 19
         flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 20
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 21
       shell: bash
     - name: building igvm file
       run: |-
         flowey e 10 flowey_lib_hvlite::run_igvmfilegen 1
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 23
-        flowey e 10 flowey_core::pipeline::artifact::publish 2
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 21
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 22
-        flowey e 10 flowey_core::pipeline::artifact::publish 3
+        flowey e 10 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 2
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 6
+      shell: bash
+    - name: extract and resolve kernel package
+      run: |-
+        flowey e 10 flowey_lib_hvlite::resolve_openhcl_kernel_package 0
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 2
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 10 flowey_lib_hvlite::run_split_debug_info 0
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 3
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 4
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 7
+      shell: bash
+    - name: building openhcl initrd
+      run: |-
+        flowey e 10 flowey_lib_hvlite::build_openhcl_initrd 0
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 8
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 9
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 10
+      shell: bash
+    - name: building igvm file
+      run: |-
+        flowey e 10 flowey_lib_hvlite::run_igvmfilegen 0
+        flowey e 10 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 0
+        flowey e 10 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::publish 0
+      shell: bash
+    - name: copying OpenHCL igvm files to artifact dir
+      run: |-
+        flowey e 10 flowey_lib_common::copy_to_artifact_dir 1
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 11
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 16
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 12
+        flowey e 10 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 3
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 5
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 1
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 0
+        flowey e 10 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 1
+        flowey e 10 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe_extras::publish 0
+      shell: bash
+    - name: copying OpenHCL igvm extras to artifact dir
+      run: flowey e 10 flowey_lib_common::copy_to_artifact_dir 0
       shell: bash
     - name: 'validate cache entry: gh-release-download'
       run: flowey e 10 flowey_lib_common::cache 3
@@ -622,18 +629,6 @@ jobs:
       with:
         name: aarch64-openhcl-igvm
         path: ${{ runner.temp }}/publish_artifacts/aarch64-openhcl-igvm/
-        include-hidden-files: true
-    - name: 🌼📦 Publish aarch64-openhcl-igvm-devkern
-      uses: actions/upload-artifact@v7
-      with:
-        name: aarch64-openhcl-igvm-devkern
-        path: ${{ runner.temp }}/publish_artifacts/aarch64-openhcl-igvm-devkern/
-        include-hidden-files: true
-    - name: 🌼📦 Publish aarch64-openhcl-igvm-devkern-extras
-      uses: actions/upload-artifact@v7
-      with:
-        name: aarch64-openhcl-igvm-devkern-extras
-        path: ${{ runner.temp }}/publish_artifacts/aarch64-openhcl-igvm-devkern-extras/
         include-hidden-files: true
     - name: 🌼📦 Publish aarch64-openhcl-igvm-extras
       uses: actions/upload-artifact@v7
@@ -753,40 +748,41 @@ jobs:
       run: |-
         flowey e 11 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
         flowey e 11 flowey_lib_hvlite::init_cross_build 0
+        flowey e 11 flowey_lib_hvlite::run_cargo_build 0
+        flowey e 11 flowey_lib_hvlite::run_cargo_build 1
       shell: bash
     - name: cargo build openvmm_hcl
       run: |-
         flowey e 11 flowey_lib_common::run_cargo_build 0
-        flowey e 11 flowey_lib_hvlite::run_cargo_build 0
+        flowey e 11 flowey_lib_hvlite::run_cargo_build 2
       shell: bash
     - name: split debug symbols
       run: |-
         flowey e 11 flowey_lib_hvlite::run_split_debug_info 0
-        flowey e 11 flowey_lib_hvlite::run_cargo_build 1
+        flowey e 11 flowey_lib_hvlite::run_cargo_build 3
         flowey e 11 flowey_lib_hvlite::build_openvmm_hcl 0
-        flowey e 11 flowey_lib_hvlite::_jobs::build_and_publish_openvmm_hcl_baseline 0
       shell: bash
     - name: collect openvmm_hcl files for analysis
       run: |-
         flowey e 11 flowey_lib_hvlite::_jobs::check_openvmm_hcl_size 1
-        flowey v 11 'flowey_lib_hvlite::_jobs::check_openvmm_hcl_size:8:flowey_lib_hvlite/src/_jobs/check_openvmm_hcl_size.rs:113:27' --is-raw-string write-to-env github floweyvar1
+        flowey v 11 'flowey_lib_hvlite::_jobs::check_openvmm_hcl_size:8:flowey_lib_hvlite/src/_jobs/check_openvmm_hcl_size.rs:119:27' --is-raw-string write-to-env github floweyvar1
       shell: bash
     - id: flowey_lib_hvlite___jobs__check_openvmm_hcl_size__2
       uses: actions/upload-artifact@v7
       with:
-        name: aarch64-openhcl-baseline
+        name: aarch64_openvmm_hcl_for_size_analysis
         path: ${{ env.floweyvar1 }}
       name: publish openvmm_hcl for analysis
     - name: cargo build xtask
       run: |-
         flowey e 11 flowey_lib_hvlite::init_cross_build 1
         flowey e 11 flowey_lib_common::run_cargo_build 1
-        flowey e 11 flowey_lib_hvlite::run_cargo_build 2
+        flowey e 11 flowey_lib_hvlite::run_cargo_build 4
       shell: bash
     - name: split debug symbols
       run: |-
         flowey e 11 flowey_lib_hvlite::run_split_debug_info 1
-        flowey e 11 flowey_lib_hvlite::run_cargo_build 3
+        flowey e 11 flowey_lib_hvlite::run_cargo_build 5
         flowey e 11 flowey_lib_hvlite::build_xtask 0
       shell: bash
     - name: create gh cache dir
@@ -876,59 +872,14 @@ jobs:
         EOF
         mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm"
         echo "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm" | flowey v 12 'artifact_publish_from_x64-openhcl-igvm' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-cvm"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-cvm" | flowey v 12 'artifact_publish_from_x64-openhcl-igvm-cvm' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-cvm-extras"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-cvm-extras" | flowey v 12 'artifact_publish_from_x64-openhcl-igvm-cvm-extras' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-devkern"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-devkern" | flowey v 12 'artifact_publish_from_x64-openhcl-igvm-devkern' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-devkern-extras"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-devkern-extras" | flowey v 12 'artifact_publish_from_x64-openhcl-igvm-devkern-extras' --is-raw-string update
         mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-extras"
         echo "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-extras" | flowey v 12 'artifact_publish_from_x64-openhcl-igvm-extras' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-test-linux-direct"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-test-linux-direct" | flowey v 12 'artifact_publish_from_x64-openhcl-igvm-test-linux-direct' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-test-linux-direct-devkern"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-test-linux-direct-devkern" | flowey v 12 'artifact_publish_from_x64-openhcl-igvm-test-linux-direct-devkern' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-test-linux-direct-devkern-extras"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-test-linux-direct-devkern-extras" | flowey v 12 'artifact_publish_from_x64-openhcl-igvm-test-linux-direct-devkern-extras' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-test-linux-direct-extras"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-test-linux-direct-extras" | flowey v 12 'artifact_publish_from_x64-openhcl-igvm-test-linux-direct-extras' --is-raw-string update
       shell: bash
-    - name: check if openvmm needs to be cloned
-      run: |-
-        flowey e 12 flowey_lib_common::git_checkout 0
-        flowey v 12 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
-        flowey v 12 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+    - name: checking if packages need to be installed
+      run: flowey e 12 flowey_lib_common::install_dist_pkg 0
       shell: bash
-    - id: flowey_lib_common__git_checkout__1
-      uses: actions/checkout@v6
-      with:
-        fetch-depth: '1'
-        path: repo0
-        persist-credentials: ${{ env.floweyvar3 }}
-      name: checkout repo openvmm
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: report cloned repo directories
-      run: |-
-        flowey v 12 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
-        ${{ github.workspace }}
-        EOF
-        flowey e 12 flowey_lib_common::git_checkout 3
-        flowey e 12 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 3
-      shell: bash
-    - name: add default cargo home to path
-      run: flowey e 12 flowey_lib_common::install_rust 0
-      shell: bash
-    - name: install Rust
-      run: flowey e 12 flowey_lib_common::install_rust 1
-      shell: bash
-    - name: detect active toolchain
-      run: |-
-        flowey e 12 flowey_lib_common::install_rust 2
-        flowey e 12 flowey_lib_common::cfg_cargo_common_flags 0
-        flowey e 12 flowey_lib_hvlite::cfg_openvmm_magicpath 0
+    - name: installing packages
+      run: flowey e 12 flowey_lib_common::install_dist_pkg 1
       shell: bash
     - name: create gh-release-download cache dir
       run: flowey e 12 flowey_lib_common::download_gh_release 0
@@ -953,64 +904,67 @@ jobs:
         flowey e 12 flowey_lib_common::cache 2
         flowey e 12 flowey_lib_common::download_gh_release 1
       shell: bash
-    - name: unpack openvmm-deps archive
-      run: flowey e 12 flowey_lib_hvlite::resolve_openvmm_deps 0
+    - name: unpack mu_msvm package (x64)
+      run: flowey e 12 flowey_lib_hvlite::download_uefi_mu_msvm 0
       shell: bash
-    - name: extract X86_64 sysroot.tar.gz
-      run: flowey e 12 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
+    - name: add default cargo home to path
+      run: flowey e 12 flowey_lib_common::install_rust 0
+      shell: bash
+    - name: install Rust
+      run: flowey e 12 flowey_lib_common::install_rust 1
+      shell: bash
+    - name: detect active toolchain
+      run: |-
+        flowey e 12 flowey_lib_common::install_rust 2
+        flowey e 12 flowey_lib_common::cfg_cargo_common_flags 0
+      shell: bash
+    - name: check if openvmm needs to be cloned
+      run: |-
+        flowey e 12 flowey_lib_common::git_checkout 0
+        flowey v 12 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
+        flowey v 12 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__git_checkout__1
+      uses: actions/checkout@v6
+      with:
+        fetch-depth: '1'
+        path: repo0
+        persist-credentials: ${{ env.floweyvar3 }}
+      name: checkout repo openvmm
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: report cloned repo directories
+      run: |-
+        flowey v 12 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        ${{ github.workspace }}
+        EOF
+        flowey e 12 flowey_lib_common::git_checkout 3
+        flowey e 12 flowey_lib_hvlite::git_checkout_openvmm_repo 0
       shell: bash
     - name: set '-Dwarnings' in .cargo/config.toml
       run: flowey e 12 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
       shell: bash
-    - name: checking if packages need to be installed
-      run: flowey e 12 flowey_lib_common::install_dist_pkg 0
-      shell: bash
-    - name: installing packages
-      run: flowey e 12 flowey_lib_common::install_dist_pkg 1
-      shell: bash
     - name: unpack protoc
-      run: flowey e 12 flowey_lib_common::resolve_protoc 0
+      run: |-
+        flowey e 12 flowey_lib_common::resolve_protoc 0
+        flowey e 12 flowey_lib_hvlite::cfg_openvmm_magicpath 0
       shell: bash
     - name: symlink protoc
       run: |-
         flowey e 12 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-        flowey e 12 flowey_lib_hvlite::init_cross_build 3
-      shell: bash
-    - name: cargo build openvmm_hcl
-      run: |-
-        flowey e 12 flowey_lib_common::run_cargo_build 2
-        flowey e 12 flowey_lib_hvlite::run_cargo_build 6
-        flowey e 12 flowey_lib_hvlite::build_openvmm_hcl 0
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 0
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 12 flowey_lib_hvlite::run_split_debug_info 0
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 1
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 2
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 4
-      shell: bash
-    - name: extract and resolve kernel package
-      run: flowey e 12 flowey_lib_hvlite::resolve_openhcl_kernel_package 0
-      shell: bash
-    - name: building openhcl initrd
-      run: |-
-        flowey e 12 flowey_lib_hvlite::build_openhcl_initrd 2
         flowey e 12 flowey_lib_hvlite::init_cross_build 0
-        flowey e 12 flowey_lib_hvlite::run_cargo_build 7
-        flowey e 12 flowey_lib_hvlite::run_cargo_build 8
+        flowey e 12 flowey_lib_hvlite::run_cargo_build 9
+        flowey e 12 flowey_lib_hvlite::run_cargo_build 10
       shell: bash
     - name: cargo build sidecar
       run: |-
         flowey e 12 flowey_lib_common::run_cargo_build 3
-        flowey e 12 flowey_lib_hvlite::run_cargo_build 9
+        flowey e 12 flowey_lib_hvlite::run_cargo_build 11
       shell: bash
     - name: split debug symbols
       run: |-
         flowey e 12 flowey_lib_hvlite::run_split_debug_info 6
-        flowey e 12 flowey_lib_hvlite::run_cargo_build 10
+        flowey e 12 flowey_lib_hvlite::run_cargo_build 12
         flowey e 12 flowey_lib_hvlite::build_sidecar 0
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 5
         flowey e 12 flowey_lib_hvlite::init_cross_build 1
         flowey e 12 flowey_lib_hvlite::run_cargo_build 2
         flowey e 12 flowey_lib_hvlite::run_cargo_build 3
@@ -1025,12 +979,40 @@ jobs:
         flowey e 12 flowey_lib_hvlite::run_split_debug_info 5
         flowey e 12 flowey_lib_hvlite::run_cargo_build 5
         flowey e 12 flowey_lib_hvlite::build_openhcl_boot 0
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 6
       shell: bash
-    - name: unpack mu_msvm package (x64)
+    - name: extract and resolve kernel package
       run: |-
-        flowey e 12 flowey_lib_hvlite::download_uefi_mu_msvm 0
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 7
+        flowey e 12 flowey_lib_hvlite::resolve_openhcl_kernel_package 2
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 28
+      shell: bash
+    - name: unpack openvmm-deps archive
+      run: flowey e 12 flowey_lib_hvlite::resolve_openvmm_deps 0
+      shell: bash
+    - name: extract X86_64 sysroot.tar.gz
+      run: |-
+        flowey e 12 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
+        flowey e 12 flowey_lib_hvlite::init_cross_build 3
+        flowey e 12 flowey_lib_hvlite::run_cargo_build 6
+        flowey e 12 flowey_lib_hvlite::run_cargo_build 7
+      shell: bash
+    - name: cargo build openvmm_hcl
+      run: |-
+        flowey e 12 flowey_lib_common::run_cargo_build 2
+        flowey e 12 flowey_lib_hvlite::run_cargo_build 8
+        flowey e 12 flowey_lib_hvlite::build_openvmm_hcl 0
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 24
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 12 flowey_lib_hvlite::run_split_debug_info 4
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 25
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 26
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 29
+      shell: bash
+    - name: building openhcl initrd
+      run: |-
+        flowey e 12 flowey_lib_hvlite::build_openhcl_initrd 4
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 30
         flowey e 12 flowey_lib_hvlite::init_cross_build 2
       shell: bash
     - name: cargo build igvmfilegen
@@ -1043,48 +1025,28 @@ jobs:
         flowey e 12 flowey_lib_hvlite::run_split_debug_info 7
         flowey e 12 flowey_lib_hvlite::run_cargo_build 1
         flowey e 12 flowey_lib_hvlite::build_igvmfilegen 0
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 8
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 9
-      shell: bash
-    - name: building igvm file
-      run: |-
-        flowey e 12 flowey_lib_hvlite::run_igvmfilegen 2
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 12
-        flowey e 12 flowey_core::pipeline::artifact::publish 0
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 10
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 11
-        flowey e 12 flowey_core::pipeline::artifact::publish 1
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 34
-      shell: bash
-    - name: extract and resolve kernel package
-      run: |-
-        flowey e 12 flowey_lib_hvlite::resolve_openhcl_kernel_package 2
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 28
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 25
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 12 flowey_lib_hvlite::run_split_debug_info 4
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 26
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 27
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 29
-      shell: bash
-    - name: building openhcl initrd
-      run: |-
-        flowey e 12 flowey_lib_hvlite::build_openhcl_initrd 4
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 30
         flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 31
         flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 32
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 33
       shell: bash
     - name: building igvm file
       run: |-
         flowey e 12 flowey_lib_hvlite::run_igvmfilegen 4
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 37
-        flowey e 12 flowey_core::pipeline::artifact::publish 2
+        flowey e 12 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 2
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 39
         flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 35
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 12 flowey_lib_hvlite::run_split_debug_info 0
         flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 36
-        flowey e 12 flowey_core::pipeline::artifact::publish 3
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 37
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 40
+      shell: bash
+    - name: extract and resolve kernel package
+      run: flowey e 12 flowey_lib_hvlite::resolve_openhcl_kernel_package 0
+      shell: bash
+    - name: building openhcl initrd
+      run: flowey e 12 flowey_lib_hvlite::build_openhcl_initrd 0
       shell: bash
     - name: unpack openvmm-test-linux archives
       run: flowey e 12 flowey_lib_hvlite::resolve_openvmm_test_linux_kernel 0
@@ -1093,64 +1055,39 @@ jobs:
       run: |-
         flowey e 12 flowey_lib_hvlite::resolve_openvmm_test_initrd 0
         flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 41
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 38
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 12 flowey_lib_hvlite::run_split_debug_info 1
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 39
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 40
         flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 42
-      shell: bash
-    - name: building openhcl initrd
-      run: |-
-        flowey e 12 flowey_lib_hvlite::build_openhcl_initrd 0
         flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 43
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 44
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 45
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 46
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 47
       shell: bash
     - name: building igvm file
       run: |-
         flowey e 12 flowey_lib_hvlite::run_igvmfilegen 0
+        flowey e 12 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 4
         flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 50
-        flowey e 12 flowey_core::pipeline::artifact::publish 4
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 48
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 49
-        flowey e 12 flowey_core::pipeline::artifact::publish 5
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 54
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 51
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 46
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 12 flowey_lib_hvlite::run_split_debug_info 2
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 52
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 53
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 55
+        flowey e 12 flowey_lib_hvlite::run_split_debug_info 1
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 47
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 48
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 51
       shell: bash
     - name: building openhcl initrd
       run: |-
         flowey e 12 flowey_lib_hvlite::build_openhcl_initrd 1
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 56
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 57
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 58
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 59
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 60
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 52
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 53
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 54
       shell: bash
     - name: building igvm file
       run: |-
         flowey e 12 flowey_lib_hvlite::run_igvmfilegen 1
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 63
-        flowey e 12 flowey_core::pipeline::artifact::publish 6
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 61
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 62
-        flowey e 12 flowey_core::pipeline::artifact::publish 7
+        flowey e 12 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 6
       shell: bash
     - name: extract and resolve kernel package
       run: |-
         flowey e 12 flowey_lib_hvlite::resolve_openhcl_kernel_package 1
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 16
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 17
         flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 13
       shell: bash
     - name: split debug symbols
@@ -1158,12 +1095,11 @@ jobs:
         flowey e 12 flowey_lib_hvlite::run_split_debug_info 3
         flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 14
         flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 15
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 17
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 18
       shell: bash
     - name: building openhcl initrd
       run: |-
         flowey e 12 flowey_lib_hvlite::build_openhcl_initrd 3
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 18
         flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 19
         flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 20
         flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 21
@@ -1171,11 +1107,57 @@ jobs:
     - name: building igvm file
       run: |-
         flowey e 12 flowey_lib_hvlite::run_igvmfilegen 3
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 24
-        flowey e 12 flowey_core::pipeline::artifact::publish 8
+        flowey e 12 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 8
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 6
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 2
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 12 flowey_lib_hvlite::run_split_debug_info 2
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 3
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 4
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 7
+      shell: bash
+    - name: building openhcl initrd
+      run: |-
+        flowey e 12 flowey_lib_hvlite::build_openhcl_initrd 2
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 8
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 9
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 10
+      shell: bash
+    - name: building igvm file
+      run: |-
+        flowey e 12 flowey_lib_hvlite::run_igvmfilegen 2
+        flowey e 12 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 0
+        flowey e 12 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::publish 0
+      shell: bash
+    - name: copying OpenHCL igvm files to artifact dir
+      run: |-
+        flowey e 12 flowey_lib_common::copy_to_artifact_dir 1
         flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 22
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 27
         flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 23
-        flowey e 12 flowey_core::pipeline::artifact::publish 9
+        flowey e 12 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 3
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 38
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 34
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 33
+        flowey e 12 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 5
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 49
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 45
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 44
+        flowey e 12 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 7
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 16
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 12
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 11
+        flowey e 12 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 9
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 5
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 1
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 0
+        flowey e 12 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 1
+        flowey e 12 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe_extras::publish 0
+      shell: bash
+    - name: copying OpenHCL igvm extras to artifact dir
+      run: flowey e 12 flowey_lib_common::copy_to_artifact_dir 0
       shell: bash
     - name: 'validate cache entry: gh-release-download'
       run: flowey e 12 flowey_lib_common::cache 3
@@ -1186,59 +1168,11 @@ jobs:
         name: x64-openhcl-igvm
         path: ${{ runner.temp }}/publish_artifacts/x64-openhcl-igvm/
         include-hidden-files: true
-    - name: 🌼📦 Publish x64-openhcl-igvm-cvm
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-openhcl-igvm-cvm
-        path: ${{ runner.temp }}/publish_artifacts/x64-openhcl-igvm-cvm/
-        include-hidden-files: true
-    - name: 🌼📦 Publish x64-openhcl-igvm-cvm-extras
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-openhcl-igvm-cvm-extras
-        path: ${{ runner.temp }}/publish_artifacts/x64-openhcl-igvm-cvm-extras/
-        include-hidden-files: true
-    - name: 🌼📦 Publish x64-openhcl-igvm-devkern
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-openhcl-igvm-devkern
-        path: ${{ runner.temp }}/publish_artifacts/x64-openhcl-igvm-devkern/
-        include-hidden-files: true
-    - name: 🌼📦 Publish x64-openhcl-igvm-devkern-extras
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-openhcl-igvm-devkern-extras
-        path: ${{ runner.temp }}/publish_artifacts/x64-openhcl-igvm-devkern-extras/
-        include-hidden-files: true
     - name: 🌼📦 Publish x64-openhcl-igvm-extras
       uses: actions/upload-artifact@v7
       with:
         name: x64-openhcl-igvm-extras
         path: ${{ runner.temp }}/publish_artifacts/x64-openhcl-igvm-extras/
-        include-hidden-files: true
-    - name: 🌼📦 Publish x64-openhcl-igvm-test-linux-direct
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-openhcl-igvm-test-linux-direct
-        path: ${{ runner.temp }}/publish_artifacts/x64-openhcl-igvm-test-linux-direct/
-        include-hidden-files: true
-    - name: 🌼📦 Publish x64-openhcl-igvm-test-linux-direct-devkern
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-openhcl-igvm-test-linux-direct-devkern
-        path: ${{ runner.temp }}/publish_artifacts/x64-openhcl-igvm-test-linux-direct-devkern/
-        include-hidden-files: true
-    - name: 🌼📦 Publish x64-openhcl-igvm-test-linux-direct-devkern-extras
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-openhcl-igvm-test-linux-direct-devkern-extras
-        path: ${{ runner.temp }}/publish_artifacts/x64-openhcl-igvm-test-linux-direct-devkern-extras/
-        include-hidden-files: true
-    - name: 🌼📦 Publish x64-openhcl-igvm-test-linux-direct-extras
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-openhcl-igvm-test-linux-direct-extras
-        path: ${{ runner.temp }}/publish_artifacts/x64-openhcl-igvm-test-linux-direct-extras/
         include-hidden-files: true
   job13:
     name: verify openhcl binary size [x64]
@@ -1352,40 +1286,41 @@ jobs:
       run: |-
         flowey e 13 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
         flowey e 13 flowey_lib_hvlite::init_cross_build 1
+        flowey e 13 flowey_lib_hvlite::run_cargo_build 0
+        flowey e 13 flowey_lib_hvlite::run_cargo_build 1
       shell: bash
     - name: cargo build openvmm_hcl
       run: |-
         flowey e 13 flowey_lib_common::run_cargo_build 0
-        flowey e 13 flowey_lib_hvlite::run_cargo_build 0
+        flowey e 13 flowey_lib_hvlite::run_cargo_build 2
       shell: bash
     - name: split debug symbols
       run: |-
         flowey e 13 flowey_lib_hvlite::run_split_debug_info 1
-        flowey e 13 flowey_lib_hvlite::run_cargo_build 1
+        flowey e 13 flowey_lib_hvlite::run_cargo_build 3
         flowey e 13 flowey_lib_hvlite::build_openvmm_hcl 0
-        flowey e 13 flowey_lib_hvlite::_jobs::build_and_publish_openvmm_hcl_baseline 0
       shell: bash
     - name: collect openvmm_hcl files for analysis
       run: |-
         flowey e 13 flowey_lib_hvlite::_jobs::check_openvmm_hcl_size 1
-        flowey v 13 'flowey_lib_hvlite::_jobs::check_openvmm_hcl_size:8:flowey_lib_hvlite/src/_jobs/check_openvmm_hcl_size.rs:113:27' --is-raw-string write-to-env github floweyvar1
+        flowey v 13 'flowey_lib_hvlite::_jobs::check_openvmm_hcl_size:8:flowey_lib_hvlite/src/_jobs/check_openvmm_hcl_size.rs:119:27' --is-raw-string write-to-env github floweyvar1
       shell: bash
     - id: flowey_lib_hvlite___jobs__check_openvmm_hcl_size__2
       uses: actions/upload-artifact@v7
       with:
-        name: x64-openhcl-baseline
+        name: x86_64_openvmm_hcl_for_size_analysis
         path: ${{ env.floweyvar1 }}
       name: publish openvmm_hcl for analysis
     - name: cargo build xtask
       run: |-
         flowey e 13 flowey_lib_hvlite::init_cross_build 0
         flowey e 13 flowey_lib_common::run_cargo_build 1
-        flowey e 13 flowey_lib_hvlite::run_cargo_build 2
+        flowey e 13 flowey_lib_hvlite::run_cargo_build 4
       shell: bash
     - name: split debug symbols
       run: |-
         flowey e 13 flowey_lib_hvlite::run_split_debug_info 0
-        flowey e 13 flowey_lib_hvlite::run_cargo_build 3
+        flowey e 13 flowey_lib_hvlite::run_cargo_build 5
         flowey e 13 flowey_lib_hvlite::build_xtask 0
       shell: bash
     - name: create gh cache dir
@@ -1475,51 +1410,8 @@ jobs:
         EOF
         mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-mi-secure-openhcl-igvm"
         echo "$AgentTempDirNormal/publish_artifacts/x64-mi-secure-openhcl-igvm" | flowey v 14 'artifact_publish_from_x64-mi-secure-openhcl-igvm' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-mi-secure-openhcl-igvm-cvm"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-mi-secure-openhcl-igvm-cvm" | flowey v 14 'artifact_publish_from_x64-mi-secure-openhcl-igvm-cvm' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-mi-secure-openhcl-igvm-cvm-extras"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-mi-secure-openhcl-igvm-cvm-extras" | flowey v 14 'artifact_publish_from_x64-mi-secure-openhcl-igvm-cvm-extras' --is-raw-string update
         mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-mi-secure-openhcl-igvm-extras"
         echo "$AgentTempDirNormal/publish_artifacts/x64-mi-secure-openhcl-igvm-extras" | flowey v 14 'artifact_publish_from_x64-mi-secure-openhcl-igvm-extras' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-mi-secure-openhcl-igvm-test-linux-direct"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-mi-secure-openhcl-igvm-test-linux-direct" | flowey v 14 'artifact_publish_from_x64-mi-secure-openhcl-igvm-test-linux-direct' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-mi-secure-openhcl-igvm-test-linux-direct-extras"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-mi-secure-openhcl-igvm-test-linux-direct-extras" | flowey v 14 'artifact_publish_from_x64-mi-secure-openhcl-igvm-test-linux-direct-extras' --is-raw-string update
-      shell: bash
-    - name: check if openvmm needs to be cloned
-      run: |-
-        flowey e 14 flowey_lib_common::git_checkout 0
-        flowey v 14 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
-        flowey v 14 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__git_checkout__1
-      uses: actions/checkout@v6
-      with:
-        fetch-depth: '1'
-        path: repo0
-        persist-credentials: ${{ env.floweyvar3 }}
-      name: checkout repo openvmm
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: report cloned repo directories
-      run: |-
-        flowey v 14 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
-        ${{ github.workspace }}
-        EOF
-        flowey e 14 flowey_lib_common::git_checkout 3
-        flowey e 14 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 3
-      shell: bash
-    - name: add default cargo home to path
-      run: flowey e 14 flowey_lib_common::install_rust 0
-      shell: bash
-    - name: install Rust
-      run: flowey e 14 flowey_lib_common::install_rust 1
-      shell: bash
-    - name: detect active toolchain
-      run: |-
-        flowey e 14 flowey_lib_common::install_rust 2
-        flowey e 14 flowey_lib_common::cfg_cargo_common_flags 0
-        flowey e 14 flowey_lib_hvlite::cfg_openvmm_magicpath 0
       shell: bash
     - name: create gh-release-download cache dir
       run: flowey e 14 flowey_lib_common::download_gh_release 0
@@ -1544,11 +1436,44 @@ jobs:
         flowey e 14 flowey_lib_common::cache 2
         flowey e 14 flowey_lib_common::download_gh_release 1
       shell: bash
-    - name: unpack openvmm-deps archive
-      run: flowey e 14 flowey_lib_hvlite::resolve_openvmm_deps 0
+    - name: unpack openvmm-test-linux archives
+      run: flowey e 14 flowey_lib_hvlite::resolve_openvmm_test_linux_kernel 0
       shell: bash
-    - name: extract X86_64 sysroot.tar.gz
-      run: flowey e 14 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
+    - name: unpack openvmm-test-initrd archives
+      run: flowey e 14 flowey_lib_hvlite::resolve_openvmm_test_initrd 0
+      shell: bash
+    - name: add default cargo home to path
+      run: flowey e 14 flowey_lib_common::install_rust 0
+      shell: bash
+    - name: install Rust
+      run: flowey e 14 flowey_lib_common::install_rust 1
+      shell: bash
+    - name: detect active toolchain
+      run: |-
+        flowey e 14 flowey_lib_common::install_rust 2
+        flowey e 14 flowey_lib_common::cfg_cargo_common_flags 0
+      shell: bash
+    - name: check if openvmm needs to be cloned
+      run: |-
+        flowey e 14 flowey_lib_common::git_checkout 0
+        flowey v 14 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
+        flowey v 14 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__git_checkout__1
+      uses: actions/checkout@v6
+      with:
+        fetch-depth: '1'
+        path: repo0
+        persist-credentials: ${{ env.floweyvar3 }}
+      name: checkout repo openvmm
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: report cloned repo directories
+      run: |-
+        flowey v 14 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        ${{ github.workspace }}
+        EOF
+        flowey e 14 flowey_lib_common::git_checkout 3
+        flowey e 14 flowey_lib_hvlite::git_checkout_openvmm_repo 0
       shell: bash
     - name: set '-Dwarnings' in .cargo/config.toml
       run: flowey e 14 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
@@ -1560,48 +1485,27 @@ jobs:
       run: flowey e 14 flowey_lib_common::install_dist_pkg 1
       shell: bash
     - name: unpack protoc
-      run: flowey e 14 flowey_lib_common::resolve_protoc 0
+      run: |-
+        flowey e 14 flowey_lib_common::resolve_protoc 0
+        flowey e 14 flowey_lib_hvlite::cfg_openvmm_magicpath 0
       shell: bash
     - name: symlink protoc
       run: |-
         flowey e 14 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-        flowey e 14 flowey_lib_hvlite::init_cross_build 3
-      shell: bash
-    - name: cargo build openvmm_hcl
-      run: |-
-        flowey e 14 flowey_lib_common::run_cargo_build 2
-        flowey e 14 flowey_lib_hvlite::run_cargo_build 6
-        flowey e 14 flowey_lib_hvlite::build_openvmm_hcl 0
-        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 0
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 14 flowey_lib_hvlite::run_split_debug_info 0
-        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 1
-        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 2
-        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 4
-      shell: bash
-    - name: extract and resolve kernel package
-      run: flowey e 14 flowey_lib_hvlite::resolve_openhcl_kernel_package 0
-      shell: bash
-    - name: building openhcl initrd
-      run: |-
-        flowey e 14 flowey_lib_hvlite::build_openhcl_initrd 0
         flowey e 14 flowey_lib_hvlite::init_cross_build 0
-        flowey e 14 flowey_lib_hvlite::run_cargo_build 7
-        flowey e 14 flowey_lib_hvlite::run_cargo_build 8
+        flowey e 14 flowey_lib_hvlite::run_cargo_build 9
+        flowey e 14 flowey_lib_hvlite::run_cargo_build 10
       shell: bash
     - name: cargo build sidecar
       run: |-
         flowey e 14 flowey_lib_common::run_cargo_build 3
-        flowey e 14 flowey_lib_hvlite::run_cargo_build 9
+        flowey e 14 flowey_lib_hvlite::run_cargo_build 11
       shell: bash
     - name: split debug symbols
       run: |-
         flowey e 14 flowey_lib_hvlite::run_split_debug_info 4
-        flowey e 14 flowey_lib_hvlite::run_cargo_build 10
+        flowey e 14 flowey_lib_hvlite::run_cargo_build 12
         flowey e 14 flowey_lib_hvlite::build_sidecar 0
-        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 5
         flowey e 14 flowey_lib_hvlite::init_cross_build 1
         flowey e 14 flowey_lib_hvlite::run_cargo_build 2
         flowey e 14 flowey_lib_hvlite::run_cargo_build 3
@@ -1616,12 +1520,40 @@ jobs:
         flowey e 14 flowey_lib_hvlite::run_split_debug_info 3
         flowey e 14 flowey_lib_hvlite::run_cargo_build 5
         flowey e 14 flowey_lib_hvlite::build_openhcl_boot 0
-        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 6
       shell: bash
-    - name: unpack mu_msvm package (x64)
+    - name: extract and resolve kernel package
       run: |-
-        flowey e 14 flowey_lib_hvlite::download_uefi_mu_msvm 0
-        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 7
+        flowey e 14 flowey_lib_hvlite::resolve_openhcl_kernel_package 0
+        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 28
+      shell: bash
+    - name: unpack openvmm-deps archive
+      run: flowey e 14 flowey_lib_hvlite::resolve_openvmm_deps 0
+      shell: bash
+    - name: extract X86_64 sysroot.tar.gz
+      run: |-
+        flowey e 14 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
+        flowey e 14 flowey_lib_hvlite::init_cross_build 3
+        flowey e 14 flowey_lib_hvlite::run_cargo_build 6
+        flowey e 14 flowey_lib_hvlite::run_cargo_build 7
+      shell: bash
+    - name: cargo build openvmm_hcl
+      run: |-
+        flowey e 14 flowey_lib_common::run_cargo_build 2
+        flowey e 14 flowey_lib_hvlite::run_cargo_build 8
+        flowey e 14 flowey_lib_hvlite::build_openvmm_hcl 0
+        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 24
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 14 flowey_lib_hvlite::run_split_debug_info 2
+        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 25
+        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 26
+        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 29
+      shell: bash
+    - name: building openhcl initrd
+      run: |-
+        flowey e 14 flowey_lib_hvlite::build_openhcl_initrd 2
+        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 30
         flowey e 14 flowey_lib_hvlite::init_cross_build 2
       shell: bash
     - name: cargo build igvmfilegen
@@ -1634,56 +1566,21 @@ jobs:
         flowey e 14 flowey_lib_hvlite::run_split_debug_info 5
         flowey e 14 flowey_lib_hvlite::run_cargo_build 1
         flowey e 14 flowey_lib_hvlite::build_igvmfilegen 0
-        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 8
-        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 9
-      shell: bash
-    - name: building igvm file
-      run: |-
-        flowey e 14 flowey_lib_hvlite::run_igvmfilegen 1
-        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 12
-        flowey e 14 flowey_core::pipeline::artifact::publish 0
-        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 10
-        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 11
-        flowey e 14 flowey_core::pipeline::artifact::publish 1
-        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 33
-        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 34
-      shell: bash
-    - name: unpack openvmm-test-linux archives
-      run: flowey e 14 flowey_lib_hvlite::resolve_openvmm_test_linux_kernel 0
-      shell: bash
-    - name: unpack openvmm-test-initrd archives
-      run: |-
-        flowey e 14 flowey_lib_hvlite::resolve_openvmm_test_initrd 0
-        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 28
-        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 25
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 14 flowey_lib_hvlite::run_split_debug_info 2
-        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 26
-        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 27
-        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 29
-      shell: bash
-    - name: building openhcl initrd
-      run: |-
-        flowey e 14 flowey_lib_hvlite::build_openhcl_initrd 2
-        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 30
         flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 31
         flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 32
       shell: bash
     - name: building igvm file
       run: |-
-        flowey e 14 flowey_lib_hvlite::run_igvmfilegen 0
-        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 37
-        flowey e 14 flowey_core::pipeline::artifact::publish 2
-        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 35
-        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 36
-        flowey e 14 flowey_core::pipeline::artifact::publish 3
+        flowey e 14 flowey_lib_hvlite::run_igvmfilegen 2
+        flowey e 14 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 2
+      shell: bash
+    - name: unpack mu_msvm package (x64)
+      run: flowey e 14 flowey_lib_hvlite::download_uefi_mu_msvm 0
       shell: bash
     - name: extract and resolve kernel package
       run: |-
         flowey e 14 flowey_lib_hvlite::resolve_openhcl_kernel_package 1
-        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 16
+        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 17
         flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 13
       shell: bash
     - name: split debug symbols
@@ -1691,24 +1588,61 @@ jobs:
         flowey e 14 flowey_lib_hvlite::run_split_debug_info 1
         flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 14
         flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 15
-        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 17
+        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 18
       shell: bash
     - name: building openhcl initrd
       run: |-
         flowey e 14 flowey_lib_hvlite::build_openhcl_initrd 1
-        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 18
         flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 19
         flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 20
         flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 21
       shell: bash
     - name: building igvm file
       run: |-
-        flowey e 14 flowey_lib_hvlite::run_igvmfilegen 2
-        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 24
-        flowey e 14 flowey_core::pipeline::artifact::publish 4
+        flowey e 14 flowey_lib_hvlite::run_igvmfilegen 1
+        flowey e 14 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 4
+        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 6
+        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 2
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 14 flowey_lib_hvlite::run_split_debug_info 0
+        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 3
+        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 4
+        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 7
+      shell: bash
+    - name: building openhcl initrd
+      run: |-
+        flowey e 14 flowey_lib_hvlite::build_openhcl_initrd 0
+        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 8
+        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 9
+        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 10
+      shell: bash
+    - name: building igvm file
+      run: |-
+        flowey e 14 flowey_lib_hvlite::run_igvmfilegen 0
+        flowey e 14 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 0
+        flowey e 14 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::publish 0
+      shell: bash
+    - name: copying OpenHCL igvm files to artifact dir
+      run: |-
+        flowey e 14 flowey_lib_common::copy_to_artifact_dir 1
         flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 22
+        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 27
         flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 23
-        flowey e 14 flowey_core::pipeline::artifact::publish 5
+        flowey e 14 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 3
+        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 16
+        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 12
+        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 11
+        flowey e 14 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 5
+        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 5
+        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 1
+        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 0
+        flowey e 14 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 1
+        flowey e 14 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe_extras::publish 0
+      shell: bash
+    - name: copying OpenHCL igvm extras to artifact dir
+      run: flowey e 14 flowey_lib_common::copy_to_artifact_dir 0
       shell: bash
     - name: 'validate cache entry: gh-release-download'
       run: flowey e 14 flowey_lib_common::cache 3
@@ -1719,35 +1653,11 @@ jobs:
         name: x64-mi-secure-openhcl-igvm
         path: ${{ runner.temp }}/publish_artifacts/x64-mi-secure-openhcl-igvm/
         include-hidden-files: true
-    - name: 🌼📦 Publish x64-mi-secure-openhcl-igvm-cvm
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-mi-secure-openhcl-igvm-cvm
-        path: ${{ runner.temp }}/publish_artifacts/x64-mi-secure-openhcl-igvm-cvm/
-        include-hidden-files: true
-    - name: 🌼📦 Publish x64-mi-secure-openhcl-igvm-cvm-extras
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-mi-secure-openhcl-igvm-cvm-extras
-        path: ${{ runner.temp }}/publish_artifacts/x64-mi-secure-openhcl-igvm-cvm-extras/
-        include-hidden-files: true
     - name: 🌼📦 Publish x64-mi-secure-openhcl-igvm-extras
       uses: actions/upload-artifact@v7
       with:
         name: x64-mi-secure-openhcl-igvm-extras
         path: ${{ runner.temp }}/publish_artifacts/x64-mi-secure-openhcl-igvm-extras/
-        include-hidden-files: true
-    - name: 🌼📦 Publish x64-mi-secure-openhcl-igvm-test-linux-direct
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-mi-secure-openhcl-igvm-test-linux-direct
-        path: ${{ runner.temp }}/publish_artifacts/x64-mi-secure-openhcl-igvm-test-linux-direct/
-        include-hidden-files: true
-    - name: 🌼📦 Publish x64-mi-secure-openhcl-igvm-test-linux-direct-extras
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-mi-secure-openhcl-igvm-test-linux-direct-extras
-        path: ${{ runner.temp }}/publish_artifacts/x64-mi-secure-openhcl-igvm-test-linux-direct-extras/
         include-hidden-files: true
   job15:
     name: clippy [x64-windows], unit tests [x64-windows]
@@ -3619,6 +3529,115 @@ jobs:
         flowey e 20 flowey_lib_common::install_rust 2
         flowey e 20 flowey_lib_common::cfg_cargo_common_flags 0
       shell: bash
+    - name: check if openvmm needs to be cloned
+      run: |-
+        flowey e 20 flowey_lib_common::git_checkout 0
+        flowey v 20 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar11
+        flowey v 20 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__git_checkout__1
+      uses: actions/checkout@v6
+      with:
+        fetch-depth: '1'
+        path: repo0
+        persist-credentials: ${{ env.floweyvar11 }}
+      name: checkout repo openvmm
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: report cloned repo directories
+      run: |-
+        flowey v 20 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        ${{ github.workspace }}
+        EOF
+        flowey e 20 flowey_lib_common::git_checkout 3
+        flowey e 20 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey e 20 flowey_lib_hvlite::cfg_openvmm_magicpath 0
+      shell: bash
+    - name: create gh-release-download cache dir
+      run: flowey e 20 flowey_lib_common::download_gh_release 0
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
+        flowey e 20 flowey_lib_common::cache 4
+        flowey v 20 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar9
+        flowey v 20 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar10
+      shell: bash
+    - id: flowey_lib_common__cache__5
+      uses: actions/cache@v5
+      with:
+        key: ${{ env.floweyvar9 }}
+        path: ${{ env.floweyvar10 }}
+      name: 'Restore cache: gh-release-download'
+    - name: download artifacts from github releases
+      run: |-
+        flowey v 20 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
+        EOF
+        flowey e 20 flowey_lib_common::cache 6
+        flowey e 20 flowey_lib_common::download_gh_release 1
+      shell: bash
+    - name: unpack openvmm-deps archive
+      run: flowey e 20 flowey_lib_hvlite::resolve_openvmm_deps 0
+      shell: bash
+    - name: extract Aarch64 sysroot.tar.gz
+      run: flowey e 20 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
+      shell: bash
+    - name: checking if packages need to be installed
+      run: flowey e 20 flowey_lib_common::install_dist_pkg 0
+      shell: bash
+    - name: installing packages
+      run: flowey e 20 flowey_lib_common::install_dist_pkg 1
+      shell: bash
+    - name: set '-Dwarnings' in .cargo/config.toml
+      run: flowey e 20 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
+      shell: bash
+    - name: unpack protoc
+      run: flowey e 20 flowey_lib_common::resolve_protoc 0
+      shell: bash
+    - name: symlink protoc
+      run: |-
+        flowey e 20 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
+        flowey e 20 flowey_lib_hvlite::init_cross_build 2
+      shell: bash
+    - name: cargo clippy
+      run: flowey e 20 flowey_lib_common::run_cargo_clippy 3
+      shell: bash
+    - name: cargo clippy
+      run: flowey e 20 flowey_lib_common::run_cargo_clippy 5
+      shell: bash
+    - name: cargo clippy
+      run: flowey e 20 flowey_lib_common::run_cargo_clippy 1
+      shell: bash
+    - name: cargo clippy
+      run: flowey e 20 flowey_lib_common::run_cargo_clippy 7
+      shell: bash
+    - name: cargo clippy
+      run: |-
+        flowey e 20 flowey_lib_common::run_cargo_clippy 6
+        flowey e 20 flowey_lib_hvlite::init_cross_build 0
+      shell: bash
+    - name: cargo build xtask
+      run: |-
+        flowey e 20 flowey_lib_common::run_cargo_build 0
+        flowey e 20 flowey_lib_hvlite::run_cargo_build 0
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 20 flowey_lib_hvlite::run_split_debug_info 1
+        flowey e 20 flowey_lib_hvlite::run_cargo_build 1
+        flowey e 20 flowey_lib_hvlite::build_xtask 0
+      shell: bash
+    - name: determine clippy exclusions
+      run: flowey e 20 flowey_lib_hvlite::_jobs::check_clippy 0
+      shell: bash
+    - name: cargo clippy
+      run: flowey e 20 flowey_lib_common::run_cargo_clippy 0
+      shell: bash
+    - name: cargo clippy
+      run: flowey e 20 flowey_lib_common::run_cargo_clippy 2
+      shell: bash
+    - name: cargo clippy
+      run: flowey e 20 flowey_lib_common::run_cargo_clippy 4
+      shell: bash
     - name: create cargo-nextest cache dir
       run: |-
         flowey e 20 flowey_lib_common::download_cargo_nextest 0
@@ -3653,78 +3672,10 @@ jobs:
       run: |-
         flowey e 20 flowey_lib_common::install_cargo_nextest 0
         flowey e 20 flowey_lib_hvlite::init_cross_build 3
-      shell: bash
-    - name: check if openvmm needs to be cloned
-      run: |-
-        flowey e 20 flowey_lib_common::git_checkout 0
-        flowey v 20 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar11
-        flowey v 20 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__git_checkout__1
-      uses: actions/checkout@v6
-      with:
-        fetch-depth: '1'
-        path: repo0
-        persist-credentials: ${{ env.floweyvar11 }}
-      name: checkout repo openvmm
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: report cloned repo directories
-      run: |-
-        flowey v 20 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
-        ${{ github.workspace }}
-        EOF
-        flowey e 20 flowey_lib_common::git_checkout 3
-        flowey e 20 flowey_lib_hvlite::git_checkout_openvmm_repo 0
         flowey e 20 flowey_lib_hvlite::run_cargo_nextest_run 0
       shell: bash
     - name: generate nextest command
       run: flowey e 20 flowey_lib_common::gen_cargo_nextest_run_cmd 1
-      shell: bash
-    - name: set '-Dwarnings' in .cargo/config.toml
-      run: flowey e 20 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
-      shell: bash
-    - name: create gh-release-download cache dir
-      run: flowey e 20 flowey_lib_common::download_gh_release 0
-      shell: bash
-    - name: Pre-processing cache vars
-      run: |-
-        flowey e 20 flowey_lib_common::cache 4
-        flowey v 20 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar9
-        flowey v 20 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar10
-      shell: bash
-    - id: flowey_lib_common__cache__5
-      uses: actions/cache@v5
-      with:
-        key: ${{ env.floweyvar9 }}
-        path: ${{ env.floweyvar10 }}
-      name: 'Restore cache: gh-release-download'
-    - name: download artifacts from github releases
-      run: |-
-        flowey v 20 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
-        EOF
-        flowey e 20 flowey_lib_common::cache 6
-        flowey e 20 flowey_lib_common::download_gh_release 1
-      shell: bash
-    - name: checking if packages need to be installed
-      run: flowey e 20 flowey_lib_common::install_dist_pkg 0
-      shell: bash
-    - name: installing packages
-      run: flowey e 20 flowey_lib_common::install_dist_pkg 1
-      shell: bash
-    - name: unpack protoc
-      run: |-
-        flowey e 20 flowey_lib_common::resolve_protoc 0
-        flowey e 20 flowey_lib_hvlite::cfg_openvmm_magicpath 0
-      shell: bash
-    - name: symlink protoc
-      run: flowey e 20 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-      shell: bash
-    - name: unpack openvmm-deps archive
-      run: flowey e 20 flowey_lib_hvlite::resolve_openvmm_deps 0
-      shell: bash
-    - name: extract Aarch64 sysroot.tar.gz
-      run: flowey e 20 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
       shell: bash
     - name: run 'unit-tests crypto (native)' nextest tests
       run: |-
@@ -3870,49 +3821,7 @@ jobs:
         flowey e 20 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
       shell: bash
     - name: run doctests for aarch64-unknown-linux-musl
-      run: |-
-        flowey e 20 flowey_lib_hvlite::_jobs::build_and_run_doc_tests 0
-        flowey e 20 flowey_lib_hvlite::init_cross_build 2
-      shell: bash
-    - name: cargo clippy
-      run: flowey e 20 flowey_lib_common::run_cargo_clippy 3
-      shell: bash
-    - name: cargo clippy
-      run: flowey e 20 flowey_lib_common::run_cargo_clippy 5
-      shell: bash
-    - name: cargo clippy
-      run: flowey e 20 flowey_lib_common::run_cargo_clippy 1
-      shell: bash
-    - name: cargo clippy
-      run: flowey e 20 flowey_lib_common::run_cargo_clippy 7
-      shell: bash
-    - name: cargo clippy
-      run: |-
-        flowey e 20 flowey_lib_common::run_cargo_clippy 6
-        flowey e 20 flowey_lib_hvlite::init_cross_build 0
-      shell: bash
-    - name: cargo build xtask
-      run: |-
-        flowey e 20 flowey_lib_common::run_cargo_build 0
-        flowey e 20 flowey_lib_hvlite::run_cargo_build 0
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 20 flowey_lib_hvlite::run_split_debug_info 1
-        flowey e 20 flowey_lib_hvlite::run_cargo_build 1
-        flowey e 20 flowey_lib_hvlite::build_xtask 0
-      shell: bash
-    - name: determine clippy exclusions
-      run: flowey e 20 flowey_lib_hvlite::_jobs::check_clippy 0
-      shell: bash
-    - name: cargo clippy
-      run: flowey e 20 flowey_lib_common::run_cargo_clippy 0
-      shell: bash
-    - name: cargo clippy
-      run: flowey e 20 flowey_lib_common::run_cargo_clippy 2
-      shell: bash
-    - name: cargo clippy
-      run: flowey e 20 flowey_lib_common::run_cargo_clippy 4
+      run: flowey e 20 flowey_lib_hvlite::_jobs::build_and_run_doc_tests 0
       shell: bash
     - name: 'validate cache entry: cargo-nextest'
       run: flowey e 20 flowey_lib_common::cache 3
@@ -3941,7 +3850,7 @@ jobs:
     - name: 🌼📦 Download artifacts
       uses: actions/download-artifact@v8
       with:
-        pattern: '{_internal-flowey-bootstrap-x86_64-windows-uid-6,x64-guest_test_uefi,x64-linux-musl-pipette,x64-linux-musl-tmk_vmm,x64-linux-tpm_guest_tests,x64-openhcl-igvm,x64-openhcl-igvm-cvm,x64-openhcl-igvm-test-linux-direct,x64-tmks,x64-windows-openvmm,x64-windows-pipette,x64-windows-prep_steps,x64-windows-test_igvm_agent_rpc_server,x64-windows-tmk_vmm,x64-windows-tpm_guest_tests,x64-windows-vmgstool,x64-windows-vmgstool-dev,x64-windows-vmm-tests-archive}'
+        pattern: '{_internal-flowey-bootstrap-x86_64-windows-uid-6,x64-guest_test_uefi,x64-linux-musl-pipette,x64-linux-musl-tmk_vmm,x64-linux-tpm_guest_tests,x64-openhcl-igvm,x64-tmks,x64-windows-openvmm,x64-windows-pipette,x64-windows-prep_steps,x64-windows-test_igvm_agent_rpc_server,x64-windows-tmk_vmm,x64-windows-tpm_guest_tests,x64-windows-vmgstool,x64-windows-vmgstool-dev,x64-windows-vmm-tests-archive}'
         path: ${{ runner.temp }}/used_artifacts/
     - run: echo "${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-windows-uid-6" >> $GITHUB_PATH
       shell: bash
@@ -3965,8 +3874,6 @@ jobs:
         echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-tmk_vmm" | flowey.exe v 21 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
         echo "${{ runner.temp }}\\used_artifacts\\x64-linux-tpm_guest_tests" | flowey.exe v 21 'artifact_use_from_x64-linux-tpm_guest_tests' --is-raw-string update
         echo "${{ runner.temp }}\\used_artifacts\\x64-openhcl-igvm" | flowey.exe v 21 'artifact_use_from_x64-openhcl-igvm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-openhcl-igvm-cvm" | flowey.exe v 21 'artifact_use_from_x64-openhcl-igvm-cvm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-openhcl-igvm-test-linux-direct" | flowey.exe v 21 'artifact_use_from_x64-openhcl-igvm-test-linux-direct' --is-raw-string update
         echo "${{ runner.temp }}\\used_artifacts\\x64-tmks" | flowey.exe v 21 'artifact_use_from_x64-tmks' --is-raw-string update
         echo "${{ runner.temp }}\\used_artifacts\\x64-windows-openvmm" | flowey.exe v 21 'artifact_use_from_x64-windows-openvmm' --is-raw-string update
         echo "${{ runner.temp }}\\used_artifacts\\x64-windows-pipette" | flowey.exe v 21 'artifact_use_from_x64-windows-pipette' --is-raw-string update
@@ -4027,24 +3934,24 @@ jobs:
         flowey.exe e 21 flowey_lib_common::git_checkout 3
         flowey.exe e 21 flowey_lib_hvlite::git_checkout_openvmm_repo 0
         flowey.exe e 21 flowey_lib_hvlite::run_cargo_nextest_run 0
-        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 8
-        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 9
-        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 12
-        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 14
-        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 15
-        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 13
-        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 3
-        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 11
-        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 4
         flowey.exe e 21 flowey_core::pipeline::artifact::resolve 5
         flowey.exe e 21 flowey_core::pipeline::artifact::resolve 6
         flowey.exe e 21 flowey_core::pipeline::artifact::resolve 1
-        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 2
         flowey.exe e 21 flowey_core::pipeline::artifact::resolve 0
-        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 7
+        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 9
+        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 2
+        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 4
+        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 11
+        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 12
+        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 10
+        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 3
+        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 8
       shell: bash
     - name: creating new test content dir
       run: flowey.exe e 21 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
+      shell: bash
+    - name: resolve OpenHCL igvm artifact
+      run: flowey.exe e 21 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::resolve 0
       shell: bash
     - name: create gh-release-download cache dir
       run: flowey.exe e 21 flowey_lib_common::download_gh_release 0
@@ -4133,7 +4040,7 @@ jobs:
       run: |-
         flowey.exe e 21 flowey_lib_hvlite::init_vmm_tests_env 0
         flowey.exe e 21 flowey_lib_hvlite::run_cargo_nextest_run 1
-        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 16
+        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 13
         flowey.exe e 21 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
       shell: bash
     - name: generate nextest command
@@ -4145,7 +4052,7 @@ jobs:
     - name: starting test_igvm_agent_rpc_server
       run: |-
         flowey.exe e 21 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
-        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 10
+        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 7
       shell: bash
     - name: running vmm_test prep_steps
       run: flowey.exe e 21 flowey_lib_hvlite::run_prep_steps 0
@@ -4221,7 +4128,7 @@ jobs:
     - name: 🌼📦 Download artifacts
       uses: actions/download-artifact@v8
       with:
-        pattern: '{_internal-flowey-bootstrap-x86_64-windows-uid-6,x64-guest_test_uefi,x64-linux-musl-pipette,x64-linux-musl-tmk_vmm,x64-linux-tpm_guest_tests,x64-mi-secure-openhcl-igvm,x64-mi-secure-openhcl-igvm-cvm,x64-mi-secure-openhcl-igvm-test-linux-direct,x64-tmks,x64-windows-openvmm,x64-windows-pipette,x64-windows-prep_steps,x64-windows-test_igvm_agent_rpc_server,x64-windows-tmk_vmm,x64-windows-tpm_guest_tests,x64-windows-vmgstool,x64-windows-vmgstool-dev,x64-windows-vmm-tests-archive}'
+        pattern: '{_internal-flowey-bootstrap-x86_64-windows-uid-6,x64-guest_test_uefi,x64-linux-musl-pipette,x64-linux-musl-tmk_vmm,x64-linux-tpm_guest_tests,x64-mi-secure-openhcl-igvm,x64-tmks,x64-windows-openvmm,x64-windows-pipette,x64-windows-prep_steps,x64-windows-test_igvm_agent_rpc_server,x64-windows-tmk_vmm,x64-windows-tpm_guest_tests,x64-windows-vmgstool,x64-windows-vmgstool-dev,x64-windows-vmm-tests-archive}'
         path: ${{ runner.temp }}/used_artifacts/
     - run: echo "${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-windows-uid-6" >> $GITHUB_PATH
       shell: bash
@@ -4245,8 +4152,6 @@ jobs:
         echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-tmk_vmm" | flowey.exe v 22 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
         echo "${{ runner.temp }}\\used_artifacts\\x64-linux-tpm_guest_tests" | flowey.exe v 22 'artifact_use_from_x64-linux-tpm_guest_tests' --is-raw-string update
         echo "${{ runner.temp }}\\used_artifacts\\x64-mi-secure-openhcl-igvm" | flowey.exe v 22 'artifact_use_from_x64-mi-secure-openhcl-igvm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-mi-secure-openhcl-igvm-cvm" | flowey.exe v 22 'artifact_use_from_x64-mi-secure-openhcl-igvm-cvm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-mi-secure-openhcl-igvm-test-linux-direct" | flowey.exe v 22 'artifact_use_from_x64-mi-secure-openhcl-igvm-test-linux-direct' --is-raw-string update
         echo "${{ runner.temp }}\\used_artifacts\\x64-tmks" | flowey.exe v 22 'artifact_use_from_x64-tmks' --is-raw-string update
         echo "${{ runner.temp }}\\used_artifacts\\x64-windows-openvmm" | flowey.exe v 22 'artifact_use_from_x64-windows-openvmm' --is-raw-string update
         echo "${{ runner.temp }}\\used_artifacts\\x64-windows-pipette" | flowey.exe v 22 'artifact_use_from_x64-windows-pipette' --is-raw-string update
@@ -4307,24 +4212,24 @@ jobs:
         flowey.exe e 22 flowey_lib_common::git_checkout 3
         flowey.exe e 22 flowey_lib_hvlite::git_checkout_openvmm_repo 0
         flowey.exe e 22 flowey_lib_hvlite::run_cargo_nextest_run 0
-        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 14
-        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 15
-        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 13
-        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 3
-        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 11
-        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 4
         flowey.exe e 22 flowey_core::pipeline::artifact::resolve 5
         flowey.exe e 22 flowey_core::pipeline::artifact::resolve 6
         flowey.exe e 22 flowey_core::pipeline::artifact::resolve 1
-        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 2
         flowey.exe e 22 flowey_core::pipeline::artifact::resolve 0
-        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 7
-        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 8
         flowey.exe e 22 flowey_core::pipeline::artifact::resolve 9
+        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 2
+        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 4
+        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 11
         flowey.exe e 22 flowey_core::pipeline::artifact::resolve 12
+        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 10
+        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 3
+        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 8
       shell: bash
     - name: creating new test content dir
       run: flowey.exe e 22 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
+      shell: bash
+    - name: resolve OpenHCL igvm artifact
+      run: flowey.exe e 22 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::resolve 0
       shell: bash
     - name: create gh-release-download cache dir
       run: flowey.exe e 22 flowey_lib_common::download_gh_release 0
@@ -4413,7 +4318,7 @@ jobs:
       run: |-
         flowey.exe e 22 flowey_lib_hvlite::init_vmm_tests_env 0
         flowey.exe e 22 flowey_lib_hvlite::run_cargo_nextest_run 1
-        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 16
+        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 13
         flowey.exe e 22 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
       shell: bash
     - name: generate nextest command
@@ -4497,7 +4402,7 @@ jobs:
     - name: 🌼📦 Download artifacts
       uses: actions/download-artifact@v8
       with:
-        pattern: '{_internal-flowey-bootstrap-x86_64-windows-uid-6,x64-guest_test_uefi,x64-linux-musl-pipette,x64-linux-musl-tmk_vmm,x64-linux-tpm_guest_tests,x64-openhcl-igvm,x64-openhcl-igvm-cvm,x64-openhcl-igvm-test-linux-direct,x64-tmks,x64-windows-openvmm,x64-windows-pipette,x64-windows-prep_steps,x64-windows-test_igvm_agent_rpc_server,x64-windows-tmk_vmm,x64-windows-tpm_guest_tests,x64-windows-vmgstool,x64-windows-vmgstool-dev,x64-windows-vmm-tests-archive}'
+        pattern: '{_internal-flowey-bootstrap-x86_64-windows-uid-6,x64-guest_test_uefi,x64-linux-musl-pipette,x64-linux-musl-tmk_vmm,x64-linux-tpm_guest_tests,x64-openhcl-igvm,x64-tmks,x64-windows-openvmm,x64-windows-pipette,x64-windows-prep_steps,x64-windows-test_igvm_agent_rpc_server,x64-windows-tmk_vmm,x64-windows-tpm_guest_tests,x64-windows-vmgstool,x64-windows-vmgstool-dev,x64-windows-vmm-tests-archive}'
         path: ${{ runner.temp }}/used_artifacts/
     - run: echo "${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-windows-uid-6" >> $GITHUB_PATH
       shell: bash
@@ -4521,8 +4426,6 @@ jobs:
         echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-tmk_vmm" | flowey.exe v 23 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
         echo "${{ runner.temp }}\\used_artifacts\\x64-linux-tpm_guest_tests" | flowey.exe v 23 'artifact_use_from_x64-linux-tpm_guest_tests' --is-raw-string update
         echo "${{ runner.temp }}\\used_artifacts\\x64-openhcl-igvm" | flowey.exe v 23 'artifact_use_from_x64-openhcl-igvm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-openhcl-igvm-cvm" | flowey.exe v 23 'artifact_use_from_x64-openhcl-igvm-cvm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-openhcl-igvm-test-linux-direct" | flowey.exe v 23 'artifact_use_from_x64-openhcl-igvm-test-linux-direct' --is-raw-string update
         echo "${{ runner.temp }}\\used_artifacts\\x64-tmks" | flowey.exe v 23 'artifact_use_from_x64-tmks' --is-raw-string update
         echo "${{ runner.temp }}\\used_artifacts\\x64-windows-openvmm" | flowey.exe v 23 'artifact_use_from_x64-windows-openvmm' --is-raw-string update
         echo "${{ runner.temp }}\\used_artifacts\\x64-windows-pipette" | flowey.exe v 23 'artifact_use_from_x64-windows-pipette' --is-raw-string update
@@ -4583,24 +4486,24 @@ jobs:
         flowey.exe e 23 flowey_lib_common::git_checkout 3
         flowey.exe e 23 flowey_lib_hvlite::git_checkout_openvmm_repo 0
         flowey.exe e 23 flowey_lib_hvlite::run_cargo_nextest_run 0
-        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 8
-        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 9
-        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 12
-        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 14
-        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 15
-        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 13
-        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 3
-        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 11
-        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 4
         flowey.exe e 23 flowey_core::pipeline::artifact::resolve 5
         flowey.exe e 23 flowey_core::pipeline::artifact::resolve 6
         flowey.exe e 23 flowey_core::pipeline::artifact::resolve 1
-        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 2
         flowey.exe e 23 flowey_core::pipeline::artifact::resolve 0
-        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 7
+        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 9
+        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 2
+        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 4
+        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 11
+        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 12
+        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 10
+        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 3
+        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 8
       shell: bash
     - name: creating new test content dir
       run: flowey.exe e 23 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
+      shell: bash
+    - name: resolve OpenHCL igvm artifact
+      run: flowey.exe e 23 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::resolve 0
       shell: bash
     - name: create gh-release-download cache dir
       run: flowey.exe e 23 flowey_lib_common::download_gh_release 0
@@ -4689,7 +4592,7 @@ jobs:
       run: |-
         flowey.exe e 23 flowey_lib_hvlite::init_vmm_tests_env 0
         flowey.exe e 23 flowey_lib_hvlite::run_cargo_nextest_run 1
-        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 16
+        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 13
         flowey.exe e 23 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
       shell: bash
     - name: generate nextest command
@@ -4701,7 +4604,7 @@ jobs:
     - name: starting test_igvm_agent_rpc_server
       run: |-
         flowey.exe e 23 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
-        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 10
+        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 7
       shell: bash
     - name: running vmm_test prep_steps
       run: flowey.exe e 23 flowey_lib_hvlite::run_prep_steps 0
@@ -4777,7 +4680,7 @@ jobs:
     - name: 🌼📦 Download artifacts
       uses: actions/download-artifact@v8
       with:
-        pattern: '{_internal-flowey-bootstrap-x86_64-windows-uid-6,x64-guest_test_uefi,x64-linux-musl-pipette,x64-linux-musl-tmk_vmm,x64-linux-tpm_guest_tests,x64-openhcl-igvm,x64-openhcl-igvm-cvm,x64-openhcl-igvm-test-linux-direct,x64-tmks,x64-windows-openvmm,x64-windows-pipette,x64-windows-prep_steps,x64-windows-test_igvm_agent_rpc_server,x64-windows-tmk_vmm,x64-windows-tpm_guest_tests,x64-windows-vmgstool,x64-windows-vmgstool-dev,x64-windows-vmm-tests-archive}'
+        pattern: '{_internal-flowey-bootstrap-x86_64-windows-uid-6,x64-guest_test_uefi,x64-linux-musl-pipette,x64-linux-musl-tmk_vmm,x64-linux-tpm_guest_tests,x64-openhcl-igvm,x64-tmks,x64-windows-openvmm,x64-windows-pipette,x64-windows-prep_steps,x64-windows-test_igvm_agent_rpc_server,x64-windows-tmk_vmm,x64-windows-tpm_guest_tests,x64-windows-vmgstool,x64-windows-vmgstool-dev,x64-windows-vmm-tests-archive}'
         path: ${{ runner.temp }}/used_artifacts/
     - run: echo "${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-windows-uid-6" >> $GITHUB_PATH
       shell: bash
@@ -4801,8 +4704,6 @@ jobs:
         echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-tmk_vmm" | flowey.exe v 24 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
         echo "${{ runner.temp }}\\used_artifacts\\x64-linux-tpm_guest_tests" | flowey.exe v 24 'artifact_use_from_x64-linux-tpm_guest_tests' --is-raw-string update
         echo "${{ runner.temp }}\\used_artifacts\\x64-openhcl-igvm" | flowey.exe v 24 'artifact_use_from_x64-openhcl-igvm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-openhcl-igvm-cvm" | flowey.exe v 24 'artifact_use_from_x64-openhcl-igvm-cvm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-openhcl-igvm-test-linux-direct" | flowey.exe v 24 'artifact_use_from_x64-openhcl-igvm-test-linux-direct' --is-raw-string update
         echo "${{ runner.temp }}\\used_artifacts\\x64-tmks" | flowey.exe v 24 'artifact_use_from_x64-tmks' --is-raw-string update
         echo "${{ runner.temp }}\\used_artifacts\\x64-windows-openvmm" | flowey.exe v 24 'artifact_use_from_x64-windows-openvmm' --is-raw-string update
         echo "${{ runner.temp }}\\used_artifacts\\x64-windows-pipette" | flowey.exe v 24 'artifact_use_from_x64-windows-pipette' --is-raw-string update
@@ -4863,24 +4764,24 @@ jobs:
         flowey.exe e 24 flowey_lib_common::git_checkout 3
         flowey.exe e 24 flowey_lib_hvlite::git_checkout_openvmm_repo 0
         flowey.exe e 24 flowey_lib_hvlite::run_cargo_nextest_run 0
-        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 8
-        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 9
-        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 12
-        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 14
-        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 15
-        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 13
-        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 3
-        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 11
-        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 4
         flowey.exe e 24 flowey_core::pipeline::artifact::resolve 5
         flowey.exe e 24 flowey_core::pipeline::artifact::resolve 6
         flowey.exe e 24 flowey_core::pipeline::artifact::resolve 1
-        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 2
         flowey.exe e 24 flowey_core::pipeline::artifact::resolve 0
-        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 7
+        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 9
+        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 2
+        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 4
+        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 11
+        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 12
+        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 10
+        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 3
+        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 8
       shell: bash
     - name: creating new test content dir
       run: flowey.exe e 24 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
+      shell: bash
+    - name: resolve OpenHCL igvm artifact
+      run: flowey.exe e 24 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::resolve 0
       shell: bash
     - name: create gh-release-download cache dir
       run: flowey.exe e 24 flowey_lib_common::download_gh_release 0
@@ -4969,7 +4870,7 @@ jobs:
       run: |-
         flowey.exe e 24 flowey_lib_hvlite::init_vmm_tests_env 0
         flowey.exe e 24 flowey_lib_hvlite::run_cargo_nextest_run 1
-        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 16
+        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 13
         flowey.exe e 24 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
       shell: bash
     - name: generate nextest command
@@ -4981,7 +4882,7 @@ jobs:
     - name: starting test_igvm_agent_rpc_server
       run: |-
         flowey.exe e 24 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
-        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 10
+        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 7
       shell: bash
     - name: running vmm_test prep_steps
       run: flowey.exe e 24 flowey_lib_hvlite::run_prep_steps 0
@@ -5058,7 +4959,7 @@ jobs:
     - name: 🌼📦 Download artifacts
       uses: actions/download-artifact@v8
       with:
-        pattern: '{_internal-flowey-bootstrap-x86_64-windows-uid-6,x64-guest_test_uefi,x64-linux-musl-pipette,x64-linux-musl-tmk_vmm,x64-linux-tpm_guest_tests,x64-openhcl-igvm,x64-openhcl-igvm-cvm,x64-openhcl-igvm-test-linux-direct,x64-tmks,x64-windows-openvmm,x64-windows-pipette,x64-windows-prep_steps,x64-windows-test_igvm_agent_rpc_server,x64-windows-tmk_vmm,x64-windows-tpm_guest_tests,x64-windows-vmgstool,x64-windows-vmgstool-dev,x64-windows-vmm-tests-archive}'
+        pattern: '{_internal-flowey-bootstrap-x86_64-windows-uid-6,x64-guest_test_uefi,x64-linux-musl-pipette,x64-linux-musl-tmk_vmm,x64-linux-tpm_guest_tests,x64-openhcl-igvm,x64-tmks,x64-windows-openvmm,x64-windows-pipette,x64-windows-prep_steps,x64-windows-test_igvm_agent_rpc_server,x64-windows-tmk_vmm,x64-windows-tpm_guest_tests,x64-windows-vmgstool,x64-windows-vmgstool-dev,x64-windows-vmm-tests-archive}'
         path: ${{ runner.temp }}/used_artifacts/
     - run: echo "${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-windows-uid-6" >> $GITHUB_PATH
       shell: bash
@@ -5082,8 +4983,6 @@ jobs:
         echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-tmk_vmm" | flowey.exe v 25 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
         echo "${{ runner.temp }}\\used_artifacts\\x64-linux-tpm_guest_tests" | flowey.exe v 25 'artifact_use_from_x64-linux-tpm_guest_tests' --is-raw-string update
         echo "${{ runner.temp }}\\used_artifacts\\x64-openhcl-igvm" | flowey.exe v 25 'artifact_use_from_x64-openhcl-igvm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-openhcl-igvm-cvm" | flowey.exe v 25 'artifact_use_from_x64-openhcl-igvm-cvm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-openhcl-igvm-test-linux-direct" | flowey.exe v 25 'artifact_use_from_x64-openhcl-igvm-test-linux-direct' --is-raw-string update
         echo "${{ runner.temp }}\\used_artifacts\\x64-tmks" | flowey.exe v 25 'artifact_use_from_x64-tmks' --is-raw-string update
         echo "${{ runner.temp }}\\used_artifacts\\x64-windows-openvmm" | flowey.exe v 25 'artifact_use_from_x64-windows-openvmm' --is-raw-string update
         echo "${{ runner.temp }}\\used_artifacts\\x64-windows-pipette" | flowey.exe v 25 'artifact_use_from_x64-windows-pipette' --is-raw-string update
@@ -5144,24 +5043,24 @@ jobs:
         flowey.exe e 25 flowey_lib_common::git_checkout 3
         flowey.exe e 25 flowey_lib_hvlite::git_checkout_openvmm_repo 0
         flowey.exe e 25 flowey_lib_hvlite::run_cargo_nextest_run 0
-        flowey.exe e 25 flowey_core::pipeline::artifact::resolve 8
-        flowey.exe e 25 flowey_core::pipeline::artifact::resolve 9
-        flowey.exe e 25 flowey_core::pipeline::artifact::resolve 12
-        flowey.exe e 25 flowey_core::pipeline::artifact::resolve 14
-        flowey.exe e 25 flowey_core::pipeline::artifact::resolve 15
-        flowey.exe e 25 flowey_core::pipeline::artifact::resolve 13
-        flowey.exe e 25 flowey_core::pipeline::artifact::resolve 3
-        flowey.exe e 25 flowey_core::pipeline::artifact::resolve 11
-        flowey.exe e 25 flowey_core::pipeline::artifact::resolve 4
         flowey.exe e 25 flowey_core::pipeline::artifact::resolve 5
         flowey.exe e 25 flowey_core::pipeline::artifact::resolve 6
         flowey.exe e 25 flowey_core::pipeline::artifact::resolve 1
-        flowey.exe e 25 flowey_core::pipeline::artifact::resolve 2
         flowey.exe e 25 flowey_core::pipeline::artifact::resolve 0
-        flowey.exe e 25 flowey_core::pipeline::artifact::resolve 7
+        flowey.exe e 25 flowey_core::pipeline::artifact::resolve 9
+        flowey.exe e 25 flowey_core::pipeline::artifact::resolve 2
+        flowey.exe e 25 flowey_core::pipeline::artifact::resolve 4
+        flowey.exe e 25 flowey_core::pipeline::artifact::resolve 11
+        flowey.exe e 25 flowey_core::pipeline::artifact::resolve 12
+        flowey.exe e 25 flowey_core::pipeline::artifact::resolve 10
+        flowey.exe e 25 flowey_core::pipeline::artifact::resolve 3
+        flowey.exe e 25 flowey_core::pipeline::artifact::resolve 8
       shell: bash
     - name: creating new test content dir
       run: flowey.exe e 25 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
+      shell: bash
+    - name: resolve OpenHCL igvm artifact
+      run: flowey.exe e 25 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::resolve 0
       shell: bash
     - name: create gh-release-download cache dir
       run: flowey.exe e 25 flowey_lib_common::download_gh_release 0
@@ -5250,7 +5149,7 @@ jobs:
       run: |-
         flowey.exe e 25 flowey_lib_hvlite::init_vmm_tests_env 0
         flowey.exe e 25 flowey_lib_hvlite::run_cargo_nextest_run 1
-        flowey.exe e 25 flowey_core::pipeline::artifact::resolve 16
+        flowey.exe e 25 flowey_core::pipeline::artifact::resolve 13
         flowey.exe e 25 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
       shell: bash
     - name: generate nextest command
@@ -5262,7 +5161,7 @@ jobs:
     - name: starting test_igvm_agent_rpc_server
       run: |-
         flowey.exe e 25 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
-        flowey.exe e 25 flowey_core::pipeline::artifact::resolve 10
+        flowey.exe e 25 flowey_core::pipeline::artifact::resolve 7
       shell: bash
     - name: running vmm_test prep_steps
       run: flowey.exe e 25 flowey_lib_hvlite::run_prep_steps 0
@@ -5368,12 +5267,12 @@ jobs:
       shell: bash
     - name: creating new test content dir
       run: |-
-        flowey e 26 flowey_core::pipeline::artifact::resolve 8
-        flowey e 26 flowey_core::pipeline::artifact::resolve 2
         flowey e 26 flowey_core::pipeline::artifact::resolve 3
         flowey e 26 flowey_core::pipeline::artifact::resolve 4
+        flowey e 26 flowey_core::pipeline::artifact::resolve 8
         flowey e 26 flowey_core::pipeline::artifact::resolve 1
         flowey e 26 flowey_core::pipeline::artifact::resolve 0
+        flowey e 26 flowey_core::pipeline::artifact::resolve 2
         flowey e 26 flowey_core::pipeline::artifact::resolve 7
         flowey e 26 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
       shell: bash
@@ -5684,12 +5583,12 @@ jobs:
       shell: bash
     - name: creating new test content dir
       run: |-
-        flowey e 27 flowey_core::pipeline::artifact::resolve 8
-        flowey e 27 flowey_core::pipeline::artifact::resolve 4
         flowey e 27 flowey_core::pipeline::artifact::resolve 1
         flowey e 27 flowey_core::pipeline::artifact::resolve 2
+        flowey e 27 flowey_core::pipeline::artifact::resolve 8
         flowey e 27 flowey_core::pipeline::artifact::resolve 3
         flowey e 27 flowey_core::pipeline::artifact::resolve 0
+        flowey e 27 flowey_core::pipeline::artifact::resolve 4
         flowey e 27 flowey_core::pipeline::artifact::resolve 7
         flowey e 27 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
       shell: bash
@@ -6047,19 +5946,21 @@ jobs:
         flowey.exe e 28 flowey_lib_common::git_checkout 3
         flowey.exe e 28 flowey_lib_hvlite::git_checkout_openvmm_repo 0
         flowey.exe e 28 flowey_lib_hvlite::run_cargo_nextest_run 0
+        flowey.exe e 28 flowey_core::pipeline::artifact::resolve 4
         flowey.exe e 28 flowey_core::pipeline::artifact::resolve 5
+        flowey.exe e 28 flowey_core::pipeline::artifact::resolve 1
+        flowey.exe e 28 flowey_core::pipeline::artifact::resolve 0
         flowey.exe e 28 flowey_core::pipeline::artifact::resolve 6
+        flowey.exe e 28 flowey_core::pipeline::artifact::resolve 2
+        flowey.exe e 28 flowey_core::pipeline::artifact::resolve 3
         flowey.exe e 28 flowey_core::pipeline::artifact::resolve 7
         flowey.exe e 28 flowey_core::pipeline::artifact::resolve 8
-        flowey.exe e 28 flowey_core::pipeline::artifact::resolve 9
-        flowey.exe e 28 flowey_core::pipeline::artifact::resolve 3
-        flowey.exe e 28 flowey_core::pipeline::artifact::resolve 1
-        flowey.exe e 28 flowey_core::pipeline::artifact::resolve 2
-        flowey.exe e 28 flowey_core::pipeline::artifact::resolve 0
-        flowey.exe e 28 flowey_core::pipeline::artifact::resolve 4
       shell: bash
     - name: creating new test content dir
       run: flowey.exe e 28 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
+      shell: bash
+    - name: resolve OpenHCL igvm artifact
+      run: flowey.exe e 28 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::resolve 0
       shell: bash
     - name: create gh-release-download cache dir
       run: flowey.exe e 28 flowey_lib_common::download_gh_release 0
@@ -6148,7 +6049,7 @@ jobs:
       run: |-
         flowey.exe e 28 flowey_lib_hvlite::init_vmm_tests_env 0
         flowey.exe e 28 flowey_lib_hvlite::run_cargo_nextest_run 1
-        flowey.exe e 28 flowey_core::pipeline::artifact::resolve 10
+        flowey.exe e 28 flowey_core::pipeline::artifact::resolve 9
         flowey.exe e 28 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
       shell: bash
     - name: generate nextest command

--- a/.github/workflows/openvmm-pr.yaml
+++ b/.github/workflows/openvmm-pr.yaml
@@ -432,14 +432,47 @@ jobs:
         EOF
         mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-openhcl-igvm"
         echo "$AgentTempDirNormal/publish_artifacts/aarch64-openhcl-igvm" | flowey v 10 'artifact_publish_from_aarch64-openhcl-igvm' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-openhcl-igvm-devkern"
+        echo "$AgentTempDirNormal/publish_artifacts/aarch64-openhcl-igvm-devkern" | flowey v 10 'artifact_publish_from_aarch64-openhcl-igvm-devkern' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-openhcl-igvm-devkern-extras"
+        echo "$AgentTempDirNormal/publish_artifacts/aarch64-openhcl-igvm-devkern-extras" | flowey v 10 'artifact_publish_from_aarch64-openhcl-igvm-devkern-extras' --is-raw-string update
         mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-openhcl-igvm-extras"
         echo "$AgentTempDirNormal/publish_artifacts/aarch64-openhcl-igvm-extras" | flowey v 10 'artifact_publish_from_aarch64-openhcl-igvm-extras' --is-raw-string update
       shell: bash
-    - name: checking if packages need to be installed
-      run: flowey e 10 flowey_lib_common::install_dist_pkg 0
+    - name: check if openvmm needs to be cloned
+      run: |-
+        flowey e 10 flowey_lib_common::git_checkout 0
+        flowey v 10 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
+        flowey v 10 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
-    - name: installing packages
-      run: flowey e 10 flowey_lib_common::install_dist_pkg 1
+    - id: flowey_lib_common__git_checkout__1
+      uses: actions/checkout@v6
+      with:
+        fetch-depth: '1'
+        path: repo0
+        persist-credentials: ${{ env.floweyvar3 }}
+      name: checkout repo openvmm
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: report cloned repo directories
+      run: |-
+        flowey v 10 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        ${{ github.workspace }}
+        EOF
+        flowey e 10 flowey_lib_common::git_checkout 3
+        flowey e 10 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 3
+      shell: bash
+    - name: add default cargo home to path
+      run: flowey e 10 flowey_lib_common::install_rust 0
+      shell: bash
+    - name: install Rust
+      run: flowey e 10 flowey_lib_common::install_rust 1
+      shell: bash
+    - name: detect active toolchain
+      run: |-
+        flowey e 10 flowey_lib_common::install_rust 2
+        flowey e 10 flowey_lib_common::cfg_cargo_common_flags 0
+        flowey e 10 flowey_lib_hvlite::cfg_openvmm_magicpath 0
       shell: bash
     - name: create gh-release-download cache dir
       run: flowey e 10 flowey_lib_common::download_gh_release 0
@@ -464,53 +497,51 @@ jobs:
         flowey e 10 flowey_lib_common::cache 2
         flowey e 10 flowey_lib_common::download_gh_release 1
       shell: bash
-    - name: unpack mu_msvm package (aarch64)
-      run: flowey e 10 flowey_lib_hvlite::download_uefi_mu_msvm 0
+    - name: unpack openvmm-deps archive
+      run: flowey e 10 flowey_lib_hvlite::resolve_openvmm_deps 0
       shell: bash
-    - name: add default cargo home to path
-      run: flowey e 10 flowey_lib_common::install_rust 0
-      shell: bash
-    - name: install Rust
-      run: flowey e 10 flowey_lib_common::install_rust 1
-      shell: bash
-    - name: detect active toolchain
-      run: |-
-        flowey e 10 flowey_lib_common::install_rust 2
-        flowey e 10 flowey_lib_common::cfg_cargo_common_flags 0
-      shell: bash
-    - name: check if openvmm needs to be cloned
-      run: |-
-        flowey e 10 flowey_lib_common::git_checkout 0
-        flowey v 10 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
-        flowey v 10 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__git_checkout__1
-      uses: actions/checkout@v6
-      with:
-        fetch-depth: '1'
-        path: repo0
-        persist-credentials: ${{ env.floweyvar3 }}
-      name: checkout repo openvmm
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: report cloned repo directories
-      run: |-
-        flowey v 10 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
-        ${{ github.workspace }}
-        EOF
-        flowey e 10 flowey_lib_common::git_checkout 3
-        flowey e 10 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+    - name: extract Aarch64 sysroot.tar.gz
+      run: flowey e 10 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
       shell: bash
     - name: set '-Dwarnings' in .cargo/config.toml
       run: flowey e 10 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
       shell: bash
+    - name: checking if packages need to be installed
+      run: flowey e 10 flowey_lib_common::install_dist_pkg 0
+      shell: bash
+    - name: installing packages
+      run: flowey e 10 flowey_lib_common::install_dist_pkg 1
+      shell: bash
     - name: unpack protoc
-      run: |-
-        flowey e 10 flowey_lib_common::resolve_protoc 0
-        flowey e 10 flowey_lib_hvlite::cfg_openvmm_magicpath 0
+      run: flowey e 10 flowey_lib_common::resolve_protoc 0
       shell: bash
     - name: symlink protoc
       run: |-
         flowey e 10 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
+        flowey e 10 flowey_lib_hvlite::init_cross_build 1
+        flowey e 10 flowey_lib_hvlite::run_cargo_build 6
+        flowey e 10 flowey_lib_hvlite::run_cargo_build 7
+      shell: bash
+    - name: cargo build openvmm_hcl
+      run: |-
+        flowey e 10 flowey_lib_common::run_cargo_build 2
+        flowey e 10 flowey_lib_hvlite::run_cargo_build 8
+        flowey e 10 flowey_lib_hvlite::build_openvmm_hcl 0
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 0
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 10 flowey_lib_hvlite::run_split_debug_info 0
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 1
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 2
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 4
+      shell: bash
+    - name: extract and resolve kernel package
+      run: flowey e 10 flowey_lib_hvlite::resolve_openhcl_kernel_package 0
+      shell: bash
+    - name: building openhcl initrd
+      run: |-
+        flowey e 10 flowey_lib_hvlite::build_openhcl_initrd 0
         flowey e 10 flowey_lib_hvlite::init_cross_build 0
         flowey e 10 flowey_lib_hvlite::run_cargo_build 2
         flowey e 10 flowey_lib_hvlite::run_cargo_build 3
@@ -525,40 +556,12 @@ jobs:
         flowey e 10 flowey_lib_hvlite::run_split_debug_info 2
         flowey e 10 flowey_lib_hvlite::run_cargo_build 5
         flowey e 10 flowey_lib_hvlite::build_openhcl_boot 0
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 5
       shell: bash
-    - name: extract and resolve kernel package
+    - name: unpack mu_msvm package (aarch64)
       run: |-
-        flowey e 10 flowey_lib_hvlite::resolve_openhcl_kernel_package 1
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 17
-      shell: bash
-    - name: unpack openvmm-deps archive
-      run: flowey e 10 flowey_lib_hvlite::resolve_openvmm_deps 0
-      shell: bash
-    - name: extract Aarch64 sysroot.tar.gz
-      run: |-
-        flowey e 10 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
-        flowey e 10 flowey_lib_hvlite::init_cross_build 1
-        flowey e 10 flowey_lib_hvlite::run_cargo_build 6
-        flowey e 10 flowey_lib_hvlite::run_cargo_build 7
-      shell: bash
-    - name: cargo build openvmm_hcl
-      run: |-
-        flowey e 10 flowey_lib_common::run_cargo_build 2
-        flowey e 10 flowey_lib_hvlite::run_cargo_build 8
-        flowey e 10 flowey_lib_hvlite::build_openvmm_hcl 0
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 13
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 10 flowey_lib_hvlite::run_split_debug_info 1
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 14
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 15
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 18
-      shell: bash
-    - name: building openhcl initrd
-      run: |-
-        flowey e 10 flowey_lib_hvlite::build_openhcl_initrd 1
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 19
+        flowey e 10 flowey_lib_hvlite::download_uefi_mu_msvm 0
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 6
         flowey e 10 flowey_lib_hvlite::init_cross_build 2
       shell: bash
     - name: cargo build igvmfilegen
@@ -571,55 +574,47 @@ jobs:
         flowey e 10 flowey_lib_hvlite::run_split_debug_info 3
         flowey e 10 flowey_lib_hvlite::run_cargo_build 1
         flowey e 10 flowey_lib_hvlite::build_igvmfilegen 0
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 20
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 21
-      shell: bash
-    - name: building igvm file
-      run: |-
-        flowey e 10 flowey_lib_hvlite::run_igvmfilegen 1
-        flowey e 10 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 2
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 6
-      shell: bash
-    - name: extract and resolve kernel package
-      run: |-
-        flowey e 10 flowey_lib_hvlite::resolve_openhcl_kernel_package 0
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 2
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 10 flowey_lib_hvlite::run_split_debug_info 0
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 3
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 4
         flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 7
-      shell: bash
-    - name: building openhcl initrd
-      run: |-
-        flowey e 10 flowey_lib_hvlite::build_openhcl_initrd 0
         flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 8
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 9
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 10
       shell: bash
     - name: building igvm file
       run: |-
         flowey e 10 flowey_lib_hvlite::run_igvmfilegen 0
-        flowey e 10 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 0
-        flowey e 10 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::publish 0
-      shell: bash
-    - name: copying OpenHCL igvm files to artifact dir
-      run: |-
-        flowey e 10 flowey_lib_common::copy_to_artifact_dir 1
         flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 11
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 16
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 12
-        flowey e 10 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 3
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 5
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 1
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 0
-        flowey e 10 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 1
-        flowey e 10 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe_extras::publish 0
+        flowey e 10 flowey_core::pipeline::artifact::publish 0
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 9
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 10
+        flowey e 10 flowey_core::pipeline::artifact::publish 1
       shell: bash
-    - name: copying OpenHCL igvm extras to artifact dir
-      run: flowey e 10 flowey_lib_common::copy_to_artifact_dir 0
+    - name: extract and resolve kernel package
+      run: |-
+        flowey e 10 flowey_lib_hvlite::resolve_openhcl_kernel_package 1
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 15
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 12
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 10 flowey_lib_hvlite::run_split_debug_info 1
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 13
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 14
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 16
+      shell: bash
+    - name: building openhcl initrd
+      run: |-
+        flowey e 10 flowey_lib_hvlite::build_openhcl_initrd 1
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 17
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 18
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 19
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 20
+      shell: bash
+    - name: building igvm file
+      run: |-
+        flowey e 10 flowey_lib_hvlite::run_igvmfilegen 1
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 23
+        flowey e 10 flowey_core::pipeline::artifact::publish 2
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 21
+        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 22
+        flowey e 10 flowey_core::pipeline::artifact::publish 3
       shell: bash
     - name: 'validate cache entry: gh-release-download'
       run: flowey e 10 flowey_lib_common::cache 3
@@ -629,6 +624,18 @@ jobs:
       with:
         name: aarch64-openhcl-igvm
         path: ${{ runner.temp }}/publish_artifacts/aarch64-openhcl-igvm/
+        include-hidden-files: true
+    - name: 🌼📦 Publish aarch64-openhcl-igvm-devkern
+      uses: actions/upload-artifact@v7
+      with:
+        name: aarch64-openhcl-igvm-devkern
+        path: ${{ runner.temp }}/publish_artifacts/aarch64-openhcl-igvm-devkern/
+        include-hidden-files: true
+    - name: 🌼📦 Publish aarch64-openhcl-igvm-devkern-extras
+      uses: actions/upload-artifact@v7
+      with:
+        name: aarch64-openhcl-igvm-devkern-extras
+        path: ${{ runner.temp }}/publish_artifacts/aarch64-openhcl-igvm-devkern-extras/
         include-hidden-files: true
     - name: 🌼📦 Publish aarch64-openhcl-igvm-extras
       uses: actions/upload-artifact@v7
@@ -761,16 +768,17 @@ jobs:
         flowey e 11 flowey_lib_hvlite::run_split_debug_info 0
         flowey e 11 flowey_lib_hvlite::run_cargo_build 3
         flowey e 11 flowey_lib_hvlite::build_openvmm_hcl 0
+        flowey e 11 flowey_lib_hvlite::_jobs::build_and_publish_openvmm_hcl_baseline 0
       shell: bash
     - name: collect openvmm_hcl files for analysis
       run: |-
         flowey e 11 flowey_lib_hvlite::_jobs::check_openvmm_hcl_size 1
-        flowey v 11 'flowey_lib_hvlite::_jobs::check_openvmm_hcl_size:8:flowey_lib_hvlite/src/_jobs/check_openvmm_hcl_size.rs:119:27' --is-raw-string write-to-env github floweyvar1
+        flowey v 11 'flowey_lib_hvlite::_jobs::check_openvmm_hcl_size:8:flowey_lib_hvlite/src/_jobs/check_openvmm_hcl_size.rs:113:27' --is-raw-string write-to-env github floweyvar1
       shell: bash
     - id: flowey_lib_hvlite___jobs__check_openvmm_hcl_size__2
       uses: actions/upload-artifact@v7
       with:
-        name: aarch64_openvmm_hcl_for_size_analysis
+        name: aarch64-openhcl-baseline
         path: ${{ env.floweyvar1 }}
       name: publish openvmm_hcl for analysis
     - name: cargo build xtask
@@ -872,14 +880,59 @@ jobs:
         EOF
         mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm"
         echo "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm" | flowey v 12 'artifact_publish_from_x64-openhcl-igvm' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-cvm"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-cvm" | flowey v 12 'artifact_publish_from_x64-openhcl-igvm-cvm' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-cvm-extras"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-cvm-extras" | flowey v 12 'artifact_publish_from_x64-openhcl-igvm-cvm-extras' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-devkern"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-devkern" | flowey v 12 'artifact_publish_from_x64-openhcl-igvm-devkern' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-devkern-extras"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-devkern-extras" | flowey v 12 'artifact_publish_from_x64-openhcl-igvm-devkern-extras' --is-raw-string update
         mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-extras"
         echo "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-extras" | flowey v 12 'artifact_publish_from_x64-openhcl-igvm-extras' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-test-linux-direct"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-test-linux-direct" | flowey v 12 'artifact_publish_from_x64-openhcl-igvm-test-linux-direct' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-test-linux-direct-devkern"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-test-linux-direct-devkern" | flowey v 12 'artifact_publish_from_x64-openhcl-igvm-test-linux-direct-devkern' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-test-linux-direct-devkern-extras"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-test-linux-direct-devkern-extras" | flowey v 12 'artifact_publish_from_x64-openhcl-igvm-test-linux-direct-devkern-extras' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-test-linux-direct-extras"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-test-linux-direct-extras" | flowey v 12 'artifact_publish_from_x64-openhcl-igvm-test-linux-direct-extras' --is-raw-string update
       shell: bash
-    - name: checking if packages need to be installed
-      run: flowey e 12 flowey_lib_common::install_dist_pkg 0
+    - name: check if openvmm needs to be cloned
+      run: |-
+        flowey e 12 flowey_lib_common::git_checkout 0
+        flowey v 12 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
+        flowey v 12 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
-    - name: installing packages
-      run: flowey e 12 flowey_lib_common::install_dist_pkg 1
+    - id: flowey_lib_common__git_checkout__1
+      uses: actions/checkout@v6
+      with:
+        fetch-depth: '1'
+        path: repo0
+        persist-credentials: ${{ env.floweyvar3 }}
+      name: checkout repo openvmm
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: report cloned repo directories
+      run: |-
+        flowey v 12 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        ${{ github.workspace }}
+        EOF
+        flowey e 12 flowey_lib_common::git_checkout 3
+        flowey e 12 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 3
+      shell: bash
+    - name: add default cargo home to path
+      run: flowey e 12 flowey_lib_common::install_rust 0
+      shell: bash
+    - name: install Rust
+      run: flowey e 12 flowey_lib_common::install_rust 1
+      shell: bash
+    - name: detect active toolchain
+      run: |-
+        flowey e 12 flowey_lib_common::install_rust 2
+        flowey e 12 flowey_lib_common::cfg_cargo_common_flags 0
+        flowey e 12 flowey_lib_hvlite::cfg_openvmm_magicpath 0
       shell: bash
     - name: create gh-release-download cache dir
       run: flowey e 12 flowey_lib_common::download_gh_release 0
@@ -904,53 +957,51 @@ jobs:
         flowey e 12 flowey_lib_common::cache 2
         flowey e 12 flowey_lib_common::download_gh_release 1
       shell: bash
-    - name: unpack mu_msvm package (x64)
-      run: flowey e 12 flowey_lib_hvlite::download_uefi_mu_msvm 0
+    - name: unpack openvmm-deps archive
+      run: flowey e 12 flowey_lib_hvlite::resolve_openvmm_deps 0
       shell: bash
-    - name: add default cargo home to path
-      run: flowey e 12 flowey_lib_common::install_rust 0
-      shell: bash
-    - name: install Rust
-      run: flowey e 12 flowey_lib_common::install_rust 1
-      shell: bash
-    - name: detect active toolchain
-      run: |-
-        flowey e 12 flowey_lib_common::install_rust 2
-        flowey e 12 flowey_lib_common::cfg_cargo_common_flags 0
-      shell: bash
-    - name: check if openvmm needs to be cloned
-      run: |-
-        flowey e 12 flowey_lib_common::git_checkout 0
-        flowey v 12 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
-        flowey v 12 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__git_checkout__1
-      uses: actions/checkout@v6
-      with:
-        fetch-depth: '1'
-        path: repo0
-        persist-credentials: ${{ env.floweyvar3 }}
-      name: checkout repo openvmm
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: report cloned repo directories
-      run: |-
-        flowey v 12 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
-        ${{ github.workspace }}
-        EOF
-        flowey e 12 flowey_lib_common::git_checkout 3
-        flowey e 12 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+    - name: extract X86_64 sysroot.tar.gz
+      run: flowey e 12 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
       shell: bash
     - name: set '-Dwarnings' in .cargo/config.toml
       run: flowey e 12 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
       shell: bash
+    - name: checking if packages need to be installed
+      run: flowey e 12 flowey_lib_common::install_dist_pkg 0
+      shell: bash
+    - name: installing packages
+      run: flowey e 12 flowey_lib_common::install_dist_pkg 1
+      shell: bash
     - name: unpack protoc
-      run: |-
-        flowey e 12 flowey_lib_common::resolve_protoc 0
-        flowey e 12 flowey_lib_hvlite::cfg_openvmm_magicpath 0
+      run: flowey e 12 flowey_lib_common::resolve_protoc 0
       shell: bash
     - name: symlink protoc
       run: |-
         flowey e 12 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
+        flowey e 12 flowey_lib_hvlite::init_cross_build 3
+        flowey e 12 flowey_lib_hvlite::run_cargo_build 6
+        flowey e 12 flowey_lib_hvlite::run_cargo_build 7
+      shell: bash
+    - name: cargo build openvmm_hcl
+      run: |-
+        flowey e 12 flowey_lib_common::run_cargo_build 2
+        flowey e 12 flowey_lib_hvlite::run_cargo_build 8
+        flowey e 12 flowey_lib_hvlite::build_openvmm_hcl 0
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 0
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 12 flowey_lib_hvlite::run_split_debug_info 0
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 1
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 2
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 4
+      shell: bash
+    - name: extract and resolve kernel package
+      run: flowey e 12 flowey_lib_hvlite::resolve_openhcl_kernel_package 0
+      shell: bash
+    - name: building openhcl initrd
+      run: |-
+        flowey e 12 flowey_lib_hvlite::build_openhcl_initrd 2
         flowey e 12 flowey_lib_hvlite::init_cross_build 0
         flowey e 12 flowey_lib_hvlite::run_cargo_build 9
         flowey e 12 flowey_lib_hvlite::run_cargo_build 10
@@ -965,6 +1016,7 @@ jobs:
         flowey e 12 flowey_lib_hvlite::run_split_debug_info 6
         flowey e 12 flowey_lib_hvlite::run_cargo_build 12
         flowey e 12 flowey_lib_hvlite::build_sidecar 0
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 5
         flowey e 12 flowey_lib_hvlite::init_cross_build 1
         flowey e 12 flowey_lib_hvlite::run_cargo_build 2
         flowey e 12 flowey_lib_hvlite::run_cargo_build 3
@@ -979,40 +1031,12 @@ jobs:
         flowey e 12 flowey_lib_hvlite::run_split_debug_info 5
         flowey e 12 flowey_lib_hvlite::run_cargo_build 5
         flowey e 12 flowey_lib_hvlite::build_openhcl_boot 0
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 6
       shell: bash
-    - name: extract and resolve kernel package
+    - name: unpack mu_msvm package (x64)
       run: |-
-        flowey e 12 flowey_lib_hvlite::resolve_openhcl_kernel_package 2
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 28
-      shell: bash
-    - name: unpack openvmm-deps archive
-      run: flowey e 12 flowey_lib_hvlite::resolve_openvmm_deps 0
-      shell: bash
-    - name: extract X86_64 sysroot.tar.gz
-      run: |-
-        flowey e 12 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
-        flowey e 12 flowey_lib_hvlite::init_cross_build 3
-        flowey e 12 flowey_lib_hvlite::run_cargo_build 6
-        flowey e 12 flowey_lib_hvlite::run_cargo_build 7
-      shell: bash
-    - name: cargo build openvmm_hcl
-      run: |-
-        flowey e 12 flowey_lib_common::run_cargo_build 2
-        flowey e 12 flowey_lib_hvlite::run_cargo_build 8
-        flowey e 12 flowey_lib_hvlite::build_openvmm_hcl 0
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 24
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 12 flowey_lib_hvlite::run_split_debug_info 4
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 25
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 26
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 29
-      shell: bash
-    - name: building openhcl initrd
-      run: |-
-        flowey e 12 flowey_lib_hvlite::build_openhcl_initrd 4
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 30
+        flowey e 12 flowey_lib_hvlite::download_uefi_mu_msvm 0
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 7
         flowey e 12 flowey_lib_hvlite::init_cross_build 2
       shell: bash
     - name: cargo build igvmfilegen
@@ -1025,28 +1049,48 @@ jobs:
         flowey e 12 flowey_lib_hvlite::run_split_debug_info 7
         flowey e 12 flowey_lib_hvlite::run_cargo_build 1
         flowey e 12 flowey_lib_hvlite::build_igvmfilegen 0
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 8
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 9
+      shell: bash
+    - name: building igvm file
+      run: |-
+        flowey e 12 flowey_lib_hvlite::run_igvmfilegen 2
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 12
+        flowey e 12 flowey_core::pipeline::artifact::publish 0
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 10
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 11
+        flowey e 12 flowey_core::pipeline::artifact::publish 1
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 34
+      shell: bash
+    - name: extract and resolve kernel package
+      run: |-
+        flowey e 12 flowey_lib_hvlite::resolve_openhcl_kernel_package 2
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 28
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 25
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 12 flowey_lib_hvlite::run_split_debug_info 4
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 26
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 27
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 29
+      shell: bash
+    - name: building openhcl initrd
+      run: |-
+        flowey e 12 flowey_lib_hvlite::build_openhcl_initrd 4
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 30
         flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 31
         flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 32
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 33
       shell: bash
     - name: building igvm file
       run: |-
         flowey e 12 flowey_lib_hvlite::run_igvmfilegen 4
-        flowey e 12 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 2
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 39
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 35
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 12 flowey_lib_hvlite::run_split_debug_info 0
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 36
         flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 37
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 40
-      shell: bash
-    - name: extract and resolve kernel package
-      run: flowey e 12 flowey_lib_hvlite::resolve_openhcl_kernel_package 0
-      shell: bash
-    - name: building openhcl initrd
-      run: flowey e 12 flowey_lib_hvlite::build_openhcl_initrd 0
+        flowey e 12 flowey_core::pipeline::artifact::publish 2
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 35
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 36
+        flowey e 12 flowey_core::pipeline::artifact::publish 3
       shell: bash
     - name: unpack openvmm-test-linux archives
       run: flowey e 12 flowey_lib_hvlite::resolve_openvmm_test_linux_kernel 0
@@ -1055,39 +1099,64 @@ jobs:
       run: |-
         flowey e 12 flowey_lib_hvlite::resolve_openvmm_test_initrd 0
         flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 41
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 42
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 43
-      shell: bash
-    - name: building igvm file
-      run: |-
-        flowey e 12 flowey_lib_hvlite::run_igvmfilegen 0
-        flowey e 12 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 4
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 50
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 46
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 38
       shell: bash
     - name: split debug symbols
       run: |-
         flowey e 12 flowey_lib_hvlite::run_split_debug_info 1
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 39
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 40
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 42
+      shell: bash
+    - name: building openhcl initrd
+      run: |-
+        flowey e 12 flowey_lib_hvlite::build_openhcl_initrd 0
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 43
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 44
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 45
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 46
         flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 47
+      shell: bash
+    - name: building igvm file
+      run: |-
+        flowey e 12 flowey_lib_hvlite::run_igvmfilegen 0
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 50
+        flowey e 12 flowey_core::pipeline::artifact::publish 4
         flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 48
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 49
+        flowey e 12 flowey_core::pipeline::artifact::publish 5
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 54
         flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 51
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 12 flowey_lib_hvlite::run_split_debug_info 2
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 52
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 53
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 55
       shell: bash
     - name: building openhcl initrd
       run: |-
         flowey e 12 flowey_lib_hvlite::build_openhcl_initrd 1
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 52
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 53
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 54
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 56
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 57
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 58
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 59
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 60
       shell: bash
     - name: building igvm file
       run: |-
         flowey e 12 flowey_lib_hvlite::run_igvmfilegen 1
-        flowey e 12 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 6
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 63
+        flowey e 12 flowey_core::pipeline::artifact::publish 6
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 61
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 62
+        flowey e 12 flowey_core::pipeline::artifact::publish 7
       shell: bash
     - name: extract and resolve kernel package
       run: |-
         flowey e 12 flowey_lib_hvlite::resolve_openhcl_kernel_package 1
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 17
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 16
         flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 13
       shell: bash
     - name: split debug symbols
@@ -1095,11 +1164,12 @@ jobs:
         flowey e 12 flowey_lib_hvlite::run_split_debug_info 3
         flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 14
         flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 15
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 18
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 17
       shell: bash
     - name: building openhcl initrd
       run: |-
         flowey e 12 flowey_lib_hvlite::build_openhcl_initrd 3
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 18
         flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 19
         flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 20
         flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 21
@@ -1107,57 +1177,11 @@ jobs:
     - name: building igvm file
       run: |-
         flowey e 12 flowey_lib_hvlite::run_igvmfilegen 3
-        flowey e 12 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 8
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 6
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 2
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 12 flowey_lib_hvlite::run_split_debug_info 2
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 3
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 4
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 7
-      shell: bash
-    - name: building openhcl initrd
-      run: |-
-        flowey e 12 flowey_lib_hvlite::build_openhcl_initrd 2
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 8
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 9
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 10
-      shell: bash
-    - name: building igvm file
-      run: |-
-        flowey e 12 flowey_lib_hvlite::run_igvmfilegen 2
-        flowey e 12 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 0
-        flowey e 12 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::publish 0
-      shell: bash
-    - name: copying OpenHCL igvm files to artifact dir
-      run: |-
-        flowey e 12 flowey_lib_common::copy_to_artifact_dir 1
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 24
+        flowey e 12 flowey_core::pipeline::artifact::publish 8
         flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 22
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 27
         flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 23
-        flowey e 12 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 3
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 38
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 34
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 33
-        flowey e 12 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 5
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 49
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 45
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 44
-        flowey e 12 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 7
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 16
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 12
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 11
-        flowey e 12 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 9
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 5
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 1
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 0
-        flowey e 12 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 1
-        flowey e 12 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe_extras::publish 0
-      shell: bash
-    - name: copying OpenHCL igvm extras to artifact dir
-      run: flowey e 12 flowey_lib_common::copy_to_artifact_dir 0
+        flowey e 12 flowey_core::pipeline::artifact::publish 9
       shell: bash
     - name: 'validate cache entry: gh-release-download'
       run: flowey e 12 flowey_lib_common::cache 3
@@ -1168,11 +1192,59 @@ jobs:
         name: x64-openhcl-igvm
         path: ${{ runner.temp }}/publish_artifacts/x64-openhcl-igvm/
         include-hidden-files: true
+    - name: 🌼📦 Publish x64-openhcl-igvm-cvm
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-openhcl-igvm-cvm
+        path: ${{ runner.temp }}/publish_artifacts/x64-openhcl-igvm-cvm/
+        include-hidden-files: true
+    - name: 🌼📦 Publish x64-openhcl-igvm-cvm-extras
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-openhcl-igvm-cvm-extras
+        path: ${{ runner.temp }}/publish_artifacts/x64-openhcl-igvm-cvm-extras/
+        include-hidden-files: true
+    - name: 🌼📦 Publish x64-openhcl-igvm-devkern
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-openhcl-igvm-devkern
+        path: ${{ runner.temp }}/publish_artifacts/x64-openhcl-igvm-devkern/
+        include-hidden-files: true
+    - name: 🌼📦 Publish x64-openhcl-igvm-devkern-extras
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-openhcl-igvm-devkern-extras
+        path: ${{ runner.temp }}/publish_artifacts/x64-openhcl-igvm-devkern-extras/
+        include-hidden-files: true
     - name: 🌼📦 Publish x64-openhcl-igvm-extras
       uses: actions/upload-artifact@v7
       with:
         name: x64-openhcl-igvm-extras
         path: ${{ runner.temp }}/publish_artifacts/x64-openhcl-igvm-extras/
+        include-hidden-files: true
+    - name: 🌼📦 Publish x64-openhcl-igvm-test-linux-direct
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-openhcl-igvm-test-linux-direct
+        path: ${{ runner.temp }}/publish_artifacts/x64-openhcl-igvm-test-linux-direct/
+        include-hidden-files: true
+    - name: 🌼📦 Publish x64-openhcl-igvm-test-linux-direct-devkern
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-openhcl-igvm-test-linux-direct-devkern
+        path: ${{ runner.temp }}/publish_artifacts/x64-openhcl-igvm-test-linux-direct-devkern/
+        include-hidden-files: true
+    - name: 🌼📦 Publish x64-openhcl-igvm-test-linux-direct-devkern-extras
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-openhcl-igvm-test-linux-direct-devkern-extras
+        path: ${{ runner.temp }}/publish_artifacts/x64-openhcl-igvm-test-linux-direct-devkern-extras/
+        include-hidden-files: true
+    - name: 🌼📦 Publish x64-openhcl-igvm-test-linux-direct-extras
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-openhcl-igvm-test-linux-direct-extras
+        path: ${{ runner.temp }}/publish_artifacts/x64-openhcl-igvm-test-linux-direct-extras/
         include-hidden-files: true
   job13:
     name: verify openhcl binary size [x64]
@@ -1299,16 +1371,17 @@ jobs:
         flowey e 13 flowey_lib_hvlite::run_split_debug_info 1
         flowey e 13 flowey_lib_hvlite::run_cargo_build 3
         flowey e 13 flowey_lib_hvlite::build_openvmm_hcl 0
+        flowey e 13 flowey_lib_hvlite::_jobs::build_and_publish_openvmm_hcl_baseline 0
       shell: bash
     - name: collect openvmm_hcl files for analysis
       run: |-
         flowey e 13 flowey_lib_hvlite::_jobs::check_openvmm_hcl_size 1
-        flowey v 13 'flowey_lib_hvlite::_jobs::check_openvmm_hcl_size:8:flowey_lib_hvlite/src/_jobs/check_openvmm_hcl_size.rs:119:27' --is-raw-string write-to-env github floweyvar1
+        flowey v 13 'flowey_lib_hvlite::_jobs::check_openvmm_hcl_size:8:flowey_lib_hvlite/src/_jobs/check_openvmm_hcl_size.rs:113:27' --is-raw-string write-to-env github floweyvar1
       shell: bash
     - id: flowey_lib_hvlite___jobs__check_openvmm_hcl_size__2
       uses: actions/upload-artifact@v7
       with:
-        name: x86_64_openvmm_hcl_for_size_analysis
+        name: x64-openhcl-baseline
         path: ${{ env.floweyvar1 }}
       name: publish openvmm_hcl for analysis
     - name: cargo build xtask
@@ -1410,8 +1483,51 @@ jobs:
         EOF
         mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-mi-secure-openhcl-igvm"
         echo "$AgentTempDirNormal/publish_artifacts/x64-mi-secure-openhcl-igvm" | flowey v 14 'artifact_publish_from_x64-mi-secure-openhcl-igvm' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-mi-secure-openhcl-igvm-cvm"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-mi-secure-openhcl-igvm-cvm" | flowey v 14 'artifact_publish_from_x64-mi-secure-openhcl-igvm-cvm' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-mi-secure-openhcl-igvm-cvm-extras"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-mi-secure-openhcl-igvm-cvm-extras" | flowey v 14 'artifact_publish_from_x64-mi-secure-openhcl-igvm-cvm-extras' --is-raw-string update
         mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-mi-secure-openhcl-igvm-extras"
         echo "$AgentTempDirNormal/publish_artifacts/x64-mi-secure-openhcl-igvm-extras" | flowey v 14 'artifact_publish_from_x64-mi-secure-openhcl-igvm-extras' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-mi-secure-openhcl-igvm-test-linux-direct"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-mi-secure-openhcl-igvm-test-linux-direct" | flowey v 14 'artifact_publish_from_x64-mi-secure-openhcl-igvm-test-linux-direct' --is-raw-string update
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-mi-secure-openhcl-igvm-test-linux-direct-extras"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-mi-secure-openhcl-igvm-test-linux-direct-extras" | flowey v 14 'artifact_publish_from_x64-mi-secure-openhcl-igvm-test-linux-direct-extras' --is-raw-string update
+      shell: bash
+    - name: check if openvmm needs to be cloned
+      run: |-
+        flowey e 14 flowey_lib_common::git_checkout 0
+        flowey v 14 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
+        flowey v 14 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__git_checkout__1
+      uses: actions/checkout@v6
+      with:
+        fetch-depth: '1'
+        path: repo0
+        persist-credentials: ${{ env.floweyvar3 }}
+      name: checkout repo openvmm
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: report cloned repo directories
+      run: |-
+        flowey v 14 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        ${{ github.workspace }}
+        EOF
+        flowey e 14 flowey_lib_common::git_checkout 3
+        flowey e 14 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 3
+      shell: bash
+    - name: add default cargo home to path
+      run: flowey e 14 flowey_lib_common::install_rust 0
+      shell: bash
+    - name: install Rust
+      run: flowey e 14 flowey_lib_common::install_rust 1
+      shell: bash
+    - name: detect active toolchain
+      run: |-
+        flowey e 14 flowey_lib_common::install_rust 2
+        flowey e 14 flowey_lib_common::cfg_cargo_common_flags 0
+        flowey e 14 flowey_lib_hvlite::cfg_openvmm_magicpath 0
       shell: bash
     - name: create gh-release-download cache dir
       run: flowey e 14 flowey_lib_common::download_gh_release 0
@@ -1436,44 +1552,11 @@ jobs:
         flowey e 14 flowey_lib_common::cache 2
         flowey e 14 flowey_lib_common::download_gh_release 1
       shell: bash
-    - name: unpack openvmm-test-linux archives
-      run: flowey e 14 flowey_lib_hvlite::resolve_openvmm_test_linux_kernel 0
+    - name: unpack openvmm-deps archive
+      run: flowey e 14 flowey_lib_hvlite::resolve_openvmm_deps 0
       shell: bash
-    - name: unpack openvmm-test-initrd archives
-      run: flowey e 14 flowey_lib_hvlite::resolve_openvmm_test_initrd 0
-      shell: bash
-    - name: add default cargo home to path
-      run: flowey e 14 flowey_lib_common::install_rust 0
-      shell: bash
-    - name: install Rust
-      run: flowey e 14 flowey_lib_common::install_rust 1
-      shell: bash
-    - name: detect active toolchain
-      run: |-
-        flowey e 14 flowey_lib_common::install_rust 2
-        flowey e 14 flowey_lib_common::cfg_cargo_common_flags 0
-      shell: bash
-    - name: check if openvmm needs to be cloned
-      run: |-
-        flowey e 14 flowey_lib_common::git_checkout 0
-        flowey v 14 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
-        flowey v 14 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__git_checkout__1
-      uses: actions/checkout@v6
-      with:
-        fetch-depth: '1'
-        path: repo0
-        persist-credentials: ${{ env.floweyvar3 }}
-      name: checkout repo openvmm
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: report cloned repo directories
-      run: |-
-        flowey v 14 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
-        ${{ github.workspace }}
-        EOF
-        flowey e 14 flowey_lib_common::git_checkout 3
-        flowey e 14 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+    - name: extract X86_64 sysroot.tar.gz
+      run: flowey e 14 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
       shell: bash
     - name: set '-Dwarnings' in .cargo/config.toml
       run: flowey e 14 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
@@ -1485,13 +1568,35 @@ jobs:
       run: flowey e 14 flowey_lib_common::install_dist_pkg 1
       shell: bash
     - name: unpack protoc
-      run: |-
-        flowey e 14 flowey_lib_common::resolve_protoc 0
-        flowey e 14 flowey_lib_hvlite::cfg_openvmm_magicpath 0
+      run: flowey e 14 flowey_lib_common::resolve_protoc 0
       shell: bash
     - name: symlink protoc
       run: |-
         flowey e 14 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
+        flowey e 14 flowey_lib_hvlite::init_cross_build 3
+        flowey e 14 flowey_lib_hvlite::run_cargo_build 6
+        flowey e 14 flowey_lib_hvlite::run_cargo_build 7
+      shell: bash
+    - name: cargo build openvmm_hcl
+      run: |-
+        flowey e 14 flowey_lib_common::run_cargo_build 2
+        flowey e 14 flowey_lib_hvlite::run_cargo_build 8
+        flowey e 14 flowey_lib_hvlite::build_openvmm_hcl 0
+        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 0
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 14 flowey_lib_hvlite::run_split_debug_info 0
+        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 1
+        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 2
+        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 4
+      shell: bash
+    - name: extract and resolve kernel package
+      run: flowey e 14 flowey_lib_hvlite::resolve_openhcl_kernel_package 0
+      shell: bash
+    - name: building openhcl initrd
+      run: |-
+        flowey e 14 flowey_lib_hvlite::build_openhcl_initrd 0
         flowey e 14 flowey_lib_hvlite::init_cross_build 0
         flowey e 14 flowey_lib_hvlite::run_cargo_build 9
         flowey e 14 flowey_lib_hvlite::run_cargo_build 10
@@ -1506,6 +1611,7 @@ jobs:
         flowey e 14 flowey_lib_hvlite::run_split_debug_info 4
         flowey e 14 flowey_lib_hvlite::run_cargo_build 12
         flowey e 14 flowey_lib_hvlite::build_sidecar 0
+        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 5
         flowey e 14 flowey_lib_hvlite::init_cross_build 1
         flowey e 14 flowey_lib_hvlite::run_cargo_build 2
         flowey e 14 flowey_lib_hvlite::run_cargo_build 3
@@ -1520,40 +1626,12 @@ jobs:
         flowey e 14 flowey_lib_hvlite::run_split_debug_info 3
         flowey e 14 flowey_lib_hvlite::run_cargo_build 5
         flowey e 14 flowey_lib_hvlite::build_openhcl_boot 0
+        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 6
       shell: bash
-    - name: extract and resolve kernel package
+    - name: unpack mu_msvm package (x64)
       run: |-
-        flowey e 14 flowey_lib_hvlite::resolve_openhcl_kernel_package 0
-        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 28
-      shell: bash
-    - name: unpack openvmm-deps archive
-      run: flowey e 14 flowey_lib_hvlite::resolve_openvmm_deps 0
-      shell: bash
-    - name: extract X86_64 sysroot.tar.gz
-      run: |-
-        flowey e 14 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
-        flowey e 14 flowey_lib_hvlite::init_cross_build 3
-        flowey e 14 flowey_lib_hvlite::run_cargo_build 6
-        flowey e 14 flowey_lib_hvlite::run_cargo_build 7
-      shell: bash
-    - name: cargo build openvmm_hcl
-      run: |-
-        flowey e 14 flowey_lib_common::run_cargo_build 2
-        flowey e 14 flowey_lib_hvlite::run_cargo_build 8
-        flowey e 14 flowey_lib_hvlite::build_openvmm_hcl 0
-        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 24
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 14 flowey_lib_hvlite::run_split_debug_info 2
-        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 25
-        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 26
-        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 29
-      shell: bash
-    - name: building openhcl initrd
-      run: |-
-        flowey e 14 flowey_lib_hvlite::build_openhcl_initrd 2
-        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 30
+        flowey e 14 flowey_lib_hvlite::download_uefi_mu_msvm 0
+        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 7
         flowey e 14 flowey_lib_hvlite::init_cross_build 2
       shell: bash
     - name: cargo build igvmfilegen
@@ -1566,21 +1644,56 @@ jobs:
         flowey e 14 flowey_lib_hvlite::run_split_debug_info 5
         flowey e 14 flowey_lib_hvlite::run_cargo_build 1
         flowey e 14 flowey_lib_hvlite::build_igvmfilegen 0
+        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 8
+        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 9
+      shell: bash
+    - name: building igvm file
+      run: |-
+        flowey e 14 flowey_lib_hvlite::run_igvmfilegen 1
+        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 12
+        flowey e 14 flowey_core::pipeline::artifact::publish 0
+        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 10
+        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 11
+        flowey e 14 flowey_core::pipeline::artifact::publish 1
+        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 33
+        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 34
+      shell: bash
+    - name: unpack openvmm-test-linux archives
+      run: flowey e 14 flowey_lib_hvlite::resolve_openvmm_test_linux_kernel 0
+      shell: bash
+    - name: unpack openvmm-test-initrd archives
+      run: |-
+        flowey e 14 flowey_lib_hvlite::resolve_openvmm_test_initrd 0
+        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 28
+        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 25
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 14 flowey_lib_hvlite::run_split_debug_info 2
+        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 26
+        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 27
+        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 29
+      shell: bash
+    - name: building openhcl initrd
+      run: |-
+        flowey e 14 flowey_lib_hvlite::build_openhcl_initrd 2
+        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 30
         flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 31
         flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 32
       shell: bash
     - name: building igvm file
       run: |-
-        flowey e 14 flowey_lib_hvlite::run_igvmfilegen 2
-        flowey e 14 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 2
-      shell: bash
-    - name: unpack mu_msvm package (x64)
-      run: flowey e 14 flowey_lib_hvlite::download_uefi_mu_msvm 0
+        flowey e 14 flowey_lib_hvlite::run_igvmfilegen 0
+        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 37
+        flowey e 14 flowey_core::pipeline::artifact::publish 2
+        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 35
+        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 36
+        flowey e 14 flowey_core::pipeline::artifact::publish 3
       shell: bash
     - name: extract and resolve kernel package
       run: |-
         flowey e 14 flowey_lib_hvlite::resolve_openhcl_kernel_package 1
-        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 17
+        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 16
         flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 13
       shell: bash
     - name: split debug symbols
@@ -1588,61 +1701,24 @@ jobs:
         flowey e 14 flowey_lib_hvlite::run_split_debug_info 1
         flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 14
         flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 15
-        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 18
+        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 17
       shell: bash
     - name: building openhcl initrd
       run: |-
         flowey e 14 flowey_lib_hvlite::build_openhcl_initrd 1
+        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 18
         flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 19
         flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 20
         flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 21
       shell: bash
     - name: building igvm file
       run: |-
-        flowey e 14 flowey_lib_hvlite::run_igvmfilegen 1
-        flowey e 14 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 4
-        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 6
-        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 2
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 14 flowey_lib_hvlite::run_split_debug_info 0
-        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 3
-        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 4
-        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 7
-      shell: bash
-    - name: building openhcl initrd
-      run: |-
-        flowey e 14 flowey_lib_hvlite::build_openhcl_initrd 0
-        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 8
-        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 9
-        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 10
-      shell: bash
-    - name: building igvm file
-      run: |-
-        flowey e 14 flowey_lib_hvlite::run_igvmfilegen 0
-        flowey e 14 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 0
-        flowey e 14 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::publish 0
-      shell: bash
-    - name: copying OpenHCL igvm files to artifact dir
-      run: |-
-        flowey e 14 flowey_lib_common::copy_to_artifact_dir 1
+        flowey e 14 flowey_lib_hvlite::run_igvmfilegen 2
+        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 24
+        flowey e 14 flowey_core::pipeline::artifact::publish 4
         flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 22
-        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 27
         flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 23
-        flowey e 14 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 3
-        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 16
-        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 12
-        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 11
-        flowey e 14 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 5
-        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 5
-        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 1
-        flowey e 14 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 0
-        flowey e 14 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 1
-        flowey e 14 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe_extras::publish 0
-      shell: bash
-    - name: copying OpenHCL igvm extras to artifact dir
-      run: flowey e 14 flowey_lib_common::copy_to_artifact_dir 0
+        flowey e 14 flowey_core::pipeline::artifact::publish 5
       shell: bash
     - name: 'validate cache entry: gh-release-download'
       run: flowey e 14 flowey_lib_common::cache 3
@@ -1653,11 +1729,35 @@ jobs:
         name: x64-mi-secure-openhcl-igvm
         path: ${{ runner.temp }}/publish_artifacts/x64-mi-secure-openhcl-igvm/
         include-hidden-files: true
+    - name: 🌼📦 Publish x64-mi-secure-openhcl-igvm-cvm
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-mi-secure-openhcl-igvm-cvm
+        path: ${{ runner.temp }}/publish_artifacts/x64-mi-secure-openhcl-igvm-cvm/
+        include-hidden-files: true
+    - name: 🌼📦 Publish x64-mi-secure-openhcl-igvm-cvm-extras
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-mi-secure-openhcl-igvm-cvm-extras
+        path: ${{ runner.temp }}/publish_artifacts/x64-mi-secure-openhcl-igvm-cvm-extras/
+        include-hidden-files: true
     - name: 🌼📦 Publish x64-mi-secure-openhcl-igvm-extras
       uses: actions/upload-artifact@v7
       with:
         name: x64-mi-secure-openhcl-igvm-extras
         path: ${{ runner.temp }}/publish_artifacts/x64-mi-secure-openhcl-igvm-extras/
+        include-hidden-files: true
+    - name: 🌼📦 Publish x64-mi-secure-openhcl-igvm-test-linux-direct
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-mi-secure-openhcl-igvm-test-linux-direct
+        path: ${{ runner.temp }}/publish_artifacts/x64-mi-secure-openhcl-igvm-test-linux-direct/
+        include-hidden-files: true
+    - name: 🌼📦 Publish x64-mi-secure-openhcl-igvm-test-linux-direct-extras
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-mi-secure-openhcl-igvm-test-linux-direct-extras
+        path: ${{ runner.temp }}/publish_artifacts/x64-mi-secure-openhcl-igvm-test-linux-direct-extras/
         include-hidden-files: true
   job15:
     name: clippy [x64-windows], unit tests [x64-windows]
@@ -3529,115 +3629,6 @@ jobs:
         flowey e 20 flowey_lib_common::install_rust 2
         flowey e 20 flowey_lib_common::cfg_cargo_common_flags 0
       shell: bash
-    - name: check if openvmm needs to be cloned
-      run: |-
-        flowey e 20 flowey_lib_common::git_checkout 0
-        flowey v 20 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar11
-        flowey v 20 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__git_checkout__1
-      uses: actions/checkout@v6
-      with:
-        fetch-depth: '1'
-        path: repo0
-        persist-credentials: ${{ env.floweyvar11 }}
-      name: checkout repo openvmm
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: report cloned repo directories
-      run: |-
-        flowey v 20 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
-        ${{ github.workspace }}
-        EOF
-        flowey e 20 flowey_lib_common::git_checkout 3
-        flowey e 20 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-        flowey e 20 flowey_lib_hvlite::cfg_openvmm_magicpath 0
-      shell: bash
-    - name: create gh-release-download cache dir
-      run: flowey e 20 flowey_lib_common::download_gh_release 0
-      shell: bash
-    - name: Pre-processing cache vars
-      run: |-
-        flowey e 20 flowey_lib_common::cache 4
-        flowey v 20 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar9
-        flowey v 20 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar10
-      shell: bash
-    - id: flowey_lib_common__cache__5
-      uses: actions/cache@v5
-      with:
-        key: ${{ env.floweyvar9 }}
-        path: ${{ env.floweyvar10 }}
-      name: 'Restore cache: gh-release-download'
-    - name: download artifacts from github releases
-      run: |-
-        flowey v 20 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
-        EOF
-        flowey e 20 flowey_lib_common::cache 6
-        flowey e 20 flowey_lib_common::download_gh_release 1
-      shell: bash
-    - name: unpack openvmm-deps archive
-      run: flowey e 20 flowey_lib_hvlite::resolve_openvmm_deps 0
-      shell: bash
-    - name: extract Aarch64 sysroot.tar.gz
-      run: flowey e 20 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
-      shell: bash
-    - name: checking if packages need to be installed
-      run: flowey e 20 flowey_lib_common::install_dist_pkg 0
-      shell: bash
-    - name: installing packages
-      run: flowey e 20 flowey_lib_common::install_dist_pkg 1
-      shell: bash
-    - name: set '-Dwarnings' in .cargo/config.toml
-      run: flowey e 20 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
-      shell: bash
-    - name: unpack protoc
-      run: flowey e 20 flowey_lib_common::resolve_protoc 0
-      shell: bash
-    - name: symlink protoc
-      run: |-
-        flowey e 20 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-        flowey e 20 flowey_lib_hvlite::init_cross_build 2
-      shell: bash
-    - name: cargo clippy
-      run: flowey e 20 flowey_lib_common::run_cargo_clippy 3
-      shell: bash
-    - name: cargo clippy
-      run: flowey e 20 flowey_lib_common::run_cargo_clippy 5
-      shell: bash
-    - name: cargo clippy
-      run: flowey e 20 flowey_lib_common::run_cargo_clippy 1
-      shell: bash
-    - name: cargo clippy
-      run: flowey e 20 flowey_lib_common::run_cargo_clippy 7
-      shell: bash
-    - name: cargo clippy
-      run: |-
-        flowey e 20 flowey_lib_common::run_cargo_clippy 6
-        flowey e 20 flowey_lib_hvlite::init_cross_build 0
-      shell: bash
-    - name: cargo build xtask
-      run: |-
-        flowey e 20 flowey_lib_common::run_cargo_build 0
-        flowey e 20 flowey_lib_hvlite::run_cargo_build 0
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 20 flowey_lib_hvlite::run_split_debug_info 1
-        flowey e 20 flowey_lib_hvlite::run_cargo_build 1
-        flowey e 20 flowey_lib_hvlite::build_xtask 0
-      shell: bash
-    - name: determine clippy exclusions
-      run: flowey e 20 flowey_lib_hvlite::_jobs::check_clippy 0
-      shell: bash
-    - name: cargo clippy
-      run: flowey e 20 flowey_lib_common::run_cargo_clippy 0
-      shell: bash
-    - name: cargo clippy
-      run: flowey e 20 flowey_lib_common::run_cargo_clippy 2
-      shell: bash
-    - name: cargo clippy
-      run: flowey e 20 flowey_lib_common::run_cargo_clippy 4
-      shell: bash
     - name: create cargo-nextest cache dir
       run: |-
         flowey e 20 flowey_lib_common::download_cargo_nextest 0
@@ -3672,10 +3663,78 @@ jobs:
       run: |-
         flowey e 20 flowey_lib_common::install_cargo_nextest 0
         flowey e 20 flowey_lib_hvlite::init_cross_build 3
+      shell: bash
+    - name: check if openvmm needs to be cloned
+      run: |-
+        flowey e 20 flowey_lib_common::git_checkout 0
+        flowey v 20 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar11
+        flowey v 20 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__git_checkout__1
+      uses: actions/checkout@v6
+      with:
+        fetch-depth: '1'
+        path: repo0
+        persist-credentials: ${{ env.floweyvar11 }}
+      name: checkout repo openvmm
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: report cloned repo directories
+      run: |-
+        flowey v 20 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        ${{ github.workspace }}
+        EOF
+        flowey e 20 flowey_lib_common::git_checkout 3
+        flowey e 20 flowey_lib_hvlite::git_checkout_openvmm_repo 0
         flowey e 20 flowey_lib_hvlite::run_cargo_nextest_run 0
       shell: bash
     - name: generate nextest command
       run: flowey e 20 flowey_lib_common::gen_cargo_nextest_run_cmd 1
+      shell: bash
+    - name: set '-Dwarnings' in .cargo/config.toml
+      run: flowey e 20 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
+      shell: bash
+    - name: create gh-release-download cache dir
+      run: flowey e 20 flowey_lib_common::download_gh_release 0
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
+        flowey e 20 flowey_lib_common::cache 4
+        flowey v 20 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar9
+        flowey v 20 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar10
+      shell: bash
+    - id: flowey_lib_common__cache__5
+      uses: actions/cache@v5
+      with:
+        key: ${{ env.floweyvar9 }}
+        path: ${{ env.floweyvar10 }}
+      name: 'Restore cache: gh-release-download'
+    - name: download artifacts from github releases
+      run: |-
+        flowey v 20 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
+        EOF
+        flowey e 20 flowey_lib_common::cache 6
+        flowey e 20 flowey_lib_common::download_gh_release 1
+      shell: bash
+    - name: checking if packages need to be installed
+      run: flowey e 20 flowey_lib_common::install_dist_pkg 0
+      shell: bash
+    - name: installing packages
+      run: flowey e 20 flowey_lib_common::install_dist_pkg 1
+      shell: bash
+    - name: unpack protoc
+      run: |-
+        flowey e 20 flowey_lib_common::resolve_protoc 0
+        flowey e 20 flowey_lib_hvlite::cfg_openvmm_magicpath 0
+      shell: bash
+    - name: symlink protoc
+      run: flowey e 20 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
+      shell: bash
+    - name: unpack openvmm-deps archive
+      run: flowey e 20 flowey_lib_hvlite::resolve_openvmm_deps 0
+      shell: bash
+    - name: extract Aarch64 sysroot.tar.gz
+      run: flowey e 20 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
       shell: bash
     - name: run 'unit-tests crypto (native)' nextest tests
       run: |-
@@ -3821,7 +3880,49 @@ jobs:
         flowey e 20 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
       shell: bash
     - name: run doctests for aarch64-unknown-linux-musl
-      run: flowey e 20 flowey_lib_hvlite::_jobs::build_and_run_doc_tests 0
+      run: |-
+        flowey e 20 flowey_lib_hvlite::_jobs::build_and_run_doc_tests 0
+        flowey e 20 flowey_lib_hvlite::init_cross_build 2
+      shell: bash
+    - name: cargo clippy
+      run: flowey e 20 flowey_lib_common::run_cargo_clippy 3
+      shell: bash
+    - name: cargo clippy
+      run: flowey e 20 flowey_lib_common::run_cargo_clippy 5
+      shell: bash
+    - name: cargo clippy
+      run: flowey e 20 flowey_lib_common::run_cargo_clippy 1
+      shell: bash
+    - name: cargo clippy
+      run: flowey e 20 flowey_lib_common::run_cargo_clippy 7
+      shell: bash
+    - name: cargo clippy
+      run: |-
+        flowey e 20 flowey_lib_common::run_cargo_clippy 6
+        flowey e 20 flowey_lib_hvlite::init_cross_build 0
+      shell: bash
+    - name: cargo build xtask
+      run: |-
+        flowey e 20 flowey_lib_common::run_cargo_build 0
+        flowey e 20 flowey_lib_hvlite::run_cargo_build 0
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 20 flowey_lib_hvlite::run_split_debug_info 1
+        flowey e 20 flowey_lib_hvlite::run_cargo_build 1
+        flowey e 20 flowey_lib_hvlite::build_xtask 0
+      shell: bash
+    - name: determine clippy exclusions
+      run: flowey e 20 flowey_lib_hvlite::_jobs::check_clippy 0
+      shell: bash
+    - name: cargo clippy
+      run: flowey e 20 flowey_lib_common::run_cargo_clippy 0
+      shell: bash
+    - name: cargo clippy
+      run: flowey e 20 flowey_lib_common::run_cargo_clippy 2
+      shell: bash
+    - name: cargo clippy
+      run: flowey e 20 flowey_lib_common::run_cargo_clippy 4
       shell: bash
     - name: 'validate cache entry: cargo-nextest'
       run: flowey e 20 flowey_lib_common::cache 3
@@ -3850,7 +3951,7 @@ jobs:
     - name: 🌼📦 Download artifacts
       uses: actions/download-artifact@v8
       with:
-        pattern: '{_internal-flowey-bootstrap-x86_64-windows-uid-6,x64-guest_test_uefi,x64-linux-musl-pipette,x64-linux-musl-tmk_vmm,x64-linux-tpm_guest_tests,x64-openhcl-igvm,x64-tmks,x64-windows-openvmm,x64-windows-pipette,x64-windows-prep_steps,x64-windows-test_igvm_agent_rpc_server,x64-windows-tmk_vmm,x64-windows-tpm_guest_tests,x64-windows-vmgstool,x64-windows-vmgstool-dev,x64-windows-vmm-tests-archive}'
+        pattern: '{_internal-flowey-bootstrap-x86_64-windows-uid-6,x64-guest_test_uefi,x64-linux-musl-pipette,x64-linux-musl-tmk_vmm,x64-linux-tpm_guest_tests,x64-openhcl-igvm,x64-openhcl-igvm-cvm,x64-openhcl-igvm-test-linux-direct,x64-tmks,x64-windows-openvmm,x64-windows-pipette,x64-windows-prep_steps,x64-windows-test_igvm_agent_rpc_server,x64-windows-tmk_vmm,x64-windows-tpm_guest_tests,x64-windows-vmgstool,x64-windows-vmgstool-dev,x64-windows-vmm-tests-archive}'
         path: ${{ runner.temp }}/used_artifacts/
     - run: echo "${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-windows-uid-6" >> $GITHUB_PATH
       shell: bash
@@ -3874,6 +3975,8 @@ jobs:
         echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-tmk_vmm" | flowey.exe v 21 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
         echo "${{ runner.temp }}\\used_artifacts\\x64-linux-tpm_guest_tests" | flowey.exe v 21 'artifact_use_from_x64-linux-tpm_guest_tests' --is-raw-string update
         echo "${{ runner.temp }}\\used_artifacts\\x64-openhcl-igvm" | flowey.exe v 21 'artifact_use_from_x64-openhcl-igvm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-openhcl-igvm-cvm" | flowey.exe v 21 'artifact_use_from_x64-openhcl-igvm-cvm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-openhcl-igvm-test-linux-direct" | flowey.exe v 21 'artifact_use_from_x64-openhcl-igvm-test-linux-direct' --is-raw-string update
         echo "${{ runner.temp }}\\used_artifacts\\x64-tmks" | flowey.exe v 21 'artifact_use_from_x64-tmks' --is-raw-string update
         echo "${{ runner.temp }}\\used_artifacts\\x64-windows-openvmm" | flowey.exe v 21 'artifact_use_from_x64-windows-openvmm' --is-raw-string update
         echo "${{ runner.temp }}\\used_artifacts\\x64-windows-pipette" | flowey.exe v 21 'artifact_use_from_x64-windows-pipette' --is-raw-string update
@@ -3934,24 +4037,24 @@ jobs:
         flowey.exe e 21 flowey_lib_common::git_checkout 3
         flowey.exe e 21 flowey_lib_hvlite::git_checkout_openvmm_repo 0
         flowey.exe e 21 flowey_lib_hvlite::run_cargo_nextest_run 0
+        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 8
+        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 9
+        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 12
+        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 14
+        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 15
+        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 13
+        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 3
+        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 11
+        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 4
         flowey.exe e 21 flowey_core::pipeline::artifact::resolve 5
         flowey.exe e 21 flowey_core::pipeline::artifact::resolve 6
         flowey.exe e 21 flowey_core::pipeline::artifact::resolve 1
-        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 0
-        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 9
         flowey.exe e 21 flowey_core::pipeline::artifact::resolve 2
-        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 4
-        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 11
-        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 12
-        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 10
-        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 3
-        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 8
+        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 0
+        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 7
       shell: bash
     - name: creating new test content dir
       run: flowey.exe e 21 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
-      shell: bash
-    - name: resolve OpenHCL igvm artifact
-      run: flowey.exe e 21 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::resolve 0
       shell: bash
     - name: create gh-release-download cache dir
       run: flowey.exe e 21 flowey_lib_common::download_gh_release 0
@@ -4040,7 +4143,7 @@ jobs:
       run: |-
         flowey.exe e 21 flowey_lib_hvlite::init_vmm_tests_env 0
         flowey.exe e 21 flowey_lib_hvlite::run_cargo_nextest_run 1
-        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 13
+        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 16
         flowey.exe e 21 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
       shell: bash
     - name: generate nextest command
@@ -4052,7 +4155,7 @@ jobs:
     - name: starting test_igvm_agent_rpc_server
       run: |-
         flowey.exe e 21 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
-        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 7
+        flowey.exe e 21 flowey_core::pipeline::artifact::resolve 10
       shell: bash
     - name: running vmm_test prep_steps
       run: flowey.exe e 21 flowey_lib_hvlite::run_prep_steps 0
@@ -4128,7 +4231,7 @@ jobs:
     - name: 🌼📦 Download artifacts
       uses: actions/download-artifact@v8
       with:
-        pattern: '{_internal-flowey-bootstrap-x86_64-windows-uid-6,x64-guest_test_uefi,x64-linux-musl-pipette,x64-linux-musl-tmk_vmm,x64-linux-tpm_guest_tests,x64-mi-secure-openhcl-igvm,x64-tmks,x64-windows-openvmm,x64-windows-pipette,x64-windows-prep_steps,x64-windows-test_igvm_agent_rpc_server,x64-windows-tmk_vmm,x64-windows-tpm_guest_tests,x64-windows-vmgstool,x64-windows-vmgstool-dev,x64-windows-vmm-tests-archive}'
+        pattern: '{_internal-flowey-bootstrap-x86_64-windows-uid-6,x64-guest_test_uefi,x64-linux-musl-pipette,x64-linux-musl-tmk_vmm,x64-linux-tpm_guest_tests,x64-mi-secure-openhcl-igvm,x64-mi-secure-openhcl-igvm-cvm,x64-mi-secure-openhcl-igvm-test-linux-direct,x64-tmks,x64-windows-openvmm,x64-windows-pipette,x64-windows-prep_steps,x64-windows-test_igvm_agent_rpc_server,x64-windows-tmk_vmm,x64-windows-tpm_guest_tests,x64-windows-vmgstool,x64-windows-vmgstool-dev,x64-windows-vmm-tests-archive}'
         path: ${{ runner.temp }}/used_artifacts/
     - run: echo "${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-windows-uid-6" >> $GITHUB_PATH
       shell: bash
@@ -4152,6 +4255,8 @@ jobs:
         echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-tmk_vmm" | flowey.exe v 22 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
         echo "${{ runner.temp }}\\used_artifacts\\x64-linux-tpm_guest_tests" | flowey.exe v 22 'artifact_use_from_x64-linux-tpm_guest_tests' --is-raw-string update
         echo "${{ runner.temp }}\\used_artifacts\\x64-mi-secure-openhcl-igvm" | flowey.exe v 22 'artifact_use_from_x64-mi-secure-openhcl-igvm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-mi-secure-openhcl-igvm-cvm" | flowey.exe v 22 'artifact_use_from_x64-mi-secure-openhcl-igvm-cvm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-mi-secure-openhcl-igvm-test-linux-direct" | flowey.exe v 22 'artifact_use_from_x64-mi-secure-openhcl-igvm-test-linux-direct' --is-raw-string update
         echo "${{ runner.temp }}\\used_artifacts\\x64-tmks" | flowey.exe v 22 'artifact_use_from_x64-tmks' --is-raw-string update
         echo "${{ runner.temp }}\\used_artifacts\\x64-windows-openvmm" | flowey.exe v 22 'artifact_use_from_x64-windows-openvmm' --is-raw-string update
         echo "${{ runner.temp }}\\used_artifacts\\x64-windows-pipette" | flowey.exe v 22 'artifact_use_from_x64-windows-pipette' --is-raw-string update
@@ -4212,24 +4317,24 @@ jobs:
         flowey.exe e 22 flowey_lib_common::git_checkout 3
         flowey.exe e 22 flowey_lib_hvlite::git_checkout_openvmm_repo 0
         flowey.exe e 22 flowey_lib_hvlite::run_cargo_nextest_run 0
+        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 14
+        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 15
+        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 13
+        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 3
+        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 11
+        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 4
         flowey.exe e 22 flowey_core::pipeline::artifact::resolve 5
         flowey.exe e 22 flowey_core::pipeline::artifact::resolve 6
         flowey.exe e 22 flowey_core::pipeline::artifact::resolve 1
-        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 0
-        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 9
         flowey.exe e 22 flowey_core::pipeline::artifact::resolve 2
-        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 4
-        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 11
-        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 12
-        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 10
-        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 3
+        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 0
+        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 7
         flowey.exe e 22 flowey_core::pipeline::artifact::resolve 8
+        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 9
+        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 12
       shell: bash
     - name: creating new test content dir
       run: flowey.exe e 22 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
-      shell: bash
-    - name: resolve OpenHCL igvm artifact
-      run: flowey.exe e 22 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::resolve 0
       shell: bash
     - name: create gh-release-download cache dir
       run: flowey.exe e 22 flowey_lib_common::download_gh_release 0
@@ -4318,7 +4423,7 @@ jobs:
       run: |-
         flowey.exe e 22 flowey_lib_hvlite::init_vmm_tests_env 0
         flowey.exe e 22 flowey_lib_hvlite::run_cargo_nextest_run 1
-        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 13
+        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 16
         flowey.exe e 22 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
       shell: bash
     - name: generate nextest command
@@ -4402,7 +4507,7 @@ jobs:
     - name: 🌼📦 Download artifacts
       uses: actions/download-artifact@v8
       with:
-        pattern: '{_internal-flowey-bootstrap-x86_64-windows-uid-6,x64-guest_test_uefi,x64-linux-musl-pipette,x64-linux-musl-tmk_vmm,x64-linux-tpm_guest_tests,x64-openhcl-igvm,x64-tmks,x64-windows-openvmm,x64-windows-pipette,x64-windows-prep_steps,x64-windows-test_igvm_agent_rpc_server,x64-windows-tmk_vmm,x64-windows-tpm_guest_tests,x64-windows-vmgstool,x64-windows-vmgstool-dev,x64-windows-vmm-tests-archive}'
+        pattern: '{_internal-flowey-bootstrap-x86_64-windows-uid-6,x64-guest_test_uefi,x64-linux-musl-pipette,x64-linux-musl-tmk_vmm,x64-linux-tpm_guest_tests,x64-openhcl-igvm,x64-openhcl-igvm-cvm,x64-openhcl-igvm-test-linux-direct,x64-tmks,x64-windows-openvmm,x64-windows-pipette,x64-windows-prep_steps,x64-windows-test_igvm_agent_rpc_server,x64-windows-tmk_vmm,x64-windows-tpm_guest_tests,x64-windows-vmgstool,x64-windows-vmgstool-dev,x64-windows-vmm-tests-archive}'
         path: ${{ runner.temp }}/used_artifacts/
     - run: echo "${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-windows-uid-6" >> $GITHUB_PATH
       shell: bash
@@ -4426,6 +4531,8 @@ jobs:
         echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-tmk_vmm" | flowey.exe v 23 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
         echo "${{ runner.temp }}\\used_artifacts\\x64-linux-tpm_guest_tests" | flowey.exe v 23 'artifact_use_from_x64-linux-tpm_guest_tests' --is-raw-string update
         echo "${{ runner.temp }}\\used_artifacts\\x64-openhcl-igvm" | flowey.exe v 23 'artifact_use_from_x64-openhcl-igvm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-openhcl-igvm-cvm" | flowey.exe v 23 'artifact_use_from_x64-openhcl-igvm-cvm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-openhcl-igvm-test-linux-direct" | flowey.exe v 23 'artifact_use_from_x64-openhcl-igvm-test-linux-direct' --is-raw-string update
         echo "${{ runner.temp }}\\used_artifacts\\x64-tmks" | flowey.exe v 23 'artifact_use_from_x64-tmks' --is-raw-string update
         echo "${{ runner.temp }}\\used_artifacts\\x64-windows-openvmm" | flowey.exe v 23 'artifact_use_from_x64-windows-openvmm' --is-raw-string update
         echo "${{ runner.temp }}\\used_artifacts\\x64-windows-pipette" | flowey.exe v 23 'artifact_use_from_x64-windows-pipette' --is-raw-string update
@@ -4486,24 +4593,24 @@ jobs:
         flowey.exe e 23 flowey_lib_common::git_checkout 3
         flowey.exe e 23 flowey_lib_hvlite::git_checkout_openvmm_repo 0
         flowey.exe e 23 flowey_lib_hvlite::run_cargo_nextest_run 0
+        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 8
+        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 9
+        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 12
+        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 14
+        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 15
+        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 13
+        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 3
+        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 11
+        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 4
         flowey.exe e 23 flowey_core::pipeline::artifact::resolve 5
         flowey.exe e 23 flowey_core::pipeline::artifact::resolve 6
         flowey.exe e 23 flowey_core::pipeline::artifact::resolve 1
-        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 0
-        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 9
         flowey.exe e 23 flowey_core::pipeline::artifact::resolve 2
-        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 4
-        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 11
-        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 12
-        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 10
-        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 3
-        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 8
+        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 0
+        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 7
       shell: bash
     - name: creating new test content dir
       run: flowey.exe e 23 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
-      shell: bash
-    - name: resolve OpenHCL igvm artifact
-      run: flowey.exe e 23 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::resolve 0
       shell: bash
     - name: create gh-release-download cache dir
       run: flowey.exe e 23 flowey_lib_common::download_gh_release 0
@@ -4592,7 +4699,7 @@ jobs:
       run: |-
         flowey.exe e 23 flowey_lib_hvlite::init_vmm_tests_env 0
         flowey.exe e 23 flowey_lib_hvlite::run_cargo_nextest_run 1
-        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 13
+        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 16
         flowey.exe e 23 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
       shell: bash
     - name: generate nextest command
@@ -4604,7 +4711,7 @@ jobs:
     - name: starting test_igvm_agent_rpc_server
       run: |-
         flowey.exe e 23 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
-        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 7
+        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 10
       shell: bash
     - name: running vmm_test prep_steps
       run: flowey.exe e 23 flowey_lib_hvlite::run_prep_steps 0
@@ -4680,7 +4787,7 @@ jobs:
     - name: 🌼📦 Download artifacts
       uses: actions/download-artifact@v8
       with:
-        pattern: '{_internal-flowey-bootstrap-x86_64-windows-uid-6,x64-guest_test_uefi,x64-linux-musl-pipette,x64-linux-musl-tmk_vmm,x64-linux-tpm_guest_tests,x64-openhcl-igvm,x64-tmks,x64-windows-openvmm,x64-windows-pipette,x64-windows-prep_steps,x64-windows-test_igvm_agent_rpc_server,x64-windows-tmk_vmm,x64-windows-tpm_guest_tests,x64-windows-vmgstool,x64-windows-vmgstool-dev,x64-windows-vmm-tests-archive}'
+        pattern: '{_internal-flowey-bootstrap-x86_64-windows-uid-6,x64-guest_test_uefi,x64-linux-musl-pipette,x64-linux-musl-tmk_vmm,x64-linux-tpm_guest_tests,x64-openhcl-igvm,x64-openhcl-igvm-cvm,x64-openhcl-igvm-test-linux-direct,x64-tmks,x64-windows-openvmm,x64-windows-pipette,x64-windows-prep_steps,x64-windows-test_igvm_agent_rpc_server,x64-windows-tmk_vmm,x64-windows-tpm_guest_tests,x64-windows-vmgstool,x64-windows-vmgstool-dev,x64-windows-vmm-tests-archive}'
         path: ${{ runner.temp }}/used_artifacts/
     - run: echo "${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-windows-uid-6" >> $GITHUB_PATH
       shell: bash
@@ -4704,6 +4811,8 @@ jobs:
         echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-tmk_vmm" | flowey.exe v 24 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
         echo "${{ runner.temp }}\\used_artifacts\\x64-linux-tpm_guest_tests" | flowey.exe v 24 'artifact_use_from_x64-linux-tpm_guest_tests' --is-raw-string update
         echo "${{ runner.temp }}\\used_artifacts\\x64-openhcl-igvm" | flowey.exe v 24 'artifact_use_from_x64-openhcl-igvm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-openhcl-igvm-cvm" | flowey.exe v 24 'artifact_use_from_x64-openhcl-igvm-cvm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-openhcl-igvm-test-linux-direct" | flowey.exe v 24 'artifact_use_from_x64-openhcl-igvm-test-linux-direct' --is-raw-string update
         echo "${{ runner.temp }}\\used_artifacts\\x64-tmks" | flowey.exe v 24 'artifact_use_from_x64-tmks' --is-raw-string update
         echo "${{ runner.temp }}\\used_artifacts\\x64-windows-openvmm" | flowey.exe v 24 'artifact_use_from_x64-windows-openvmm' --is-raw-string update
         echo "${{ runner.temp }}\\used_artifacts\\x64-windows-pipette" | flowey.exe v 24 'artifact_use_from_x64-windows-pipette' --is-raw-string update
@@ -4764,24 +4873,24 @@ jobs:
         flowey.exe e 24 flowey_lib_common::git_checkout 3
         flowey.exe e 24 flowey_lib_hvlite::git_checkout_openvmm_repo 0
         flowey.exe e 24 flowey_lib_hvlite::run_cargo_nextest_run 0
+        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 8
+        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 9
+        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 12
+        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 14
+        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 15
+        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 13
+        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 3
+        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 11
+        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 4
         flowey.exe e 24 flowey_core::pipeline::artifact::resolve 5
         flowey.exe e 24 flowey_core::pipeline::artifact::resolve 6
         flowey.exe e 24 flowey_core::pipeline::artifact::resolve 1
-        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 0
-        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 9
         flowey.exe e 24 flowey_core::pipeline::artifact::resolve 2
-        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 4
-        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 11
-        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 12
-        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 10
-        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 3
-        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 8
+        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 0
+        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 7
       shell: bash
     - name: creating new test content dir
       run: flowey.exe e 24 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
-      shell: bash
-    - name: resolve OpenHCL igvm artifact
-      run: flowey.exe e 24 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::resolve 0
       shell: bash
     - name: create gh-release-download cache dir
       run: flowey.exe e 24 flowey_lib_common::download_gh_release 0
@@ -4870,7 +4979,7 @@ jobs:
       run: |-
         flowey.exe e 24 flowey_lib_hvlite::init_vmm_tests_env 0
         flowey.exe e 24 flowey_lib_hvlite::run_cargo_nextest_run 1
-        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 13
+        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 16
         flowey.exe e 24 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
       shell: bash
     - name: generate nextest command
@@ -4882,7 +4991,7 @@ jobs:
     - name: starting test_igvm_agent_rpc_server
       run: |-
         flowey.exe e 24 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
-        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 7
+        flowey.exe e 24 flowey_core::pipeline::artifact::resolve 10
       shell: bash
     - name: running vmm_test prep_steps
       run: flowey.exe e 24 flowey_lib_hvlite::run_prep_steps 0
@@ -4959,7 +5068,7 @@ jobs:
     - name: 🌼📦 Download artifacts
       uses: actions/download-artifact@v8
       with:
-        pattern: '{_internal-flowey-bootstrap-x86_64-windows-uid-6,x64-guest_test_uefi,x64-linux-musl-pipette,x64-linux-musl-tmk_vmm,x64-linux-tpm_guest_tests,x64-openhcl-igvm,x64-tmks,x64-windows-openvmm,x64-windows-pipette,x64-windows-prep_steps,x64-windows-test_igvm_agent_rpc_server,x64-windows-tmk_vmm,x64-windows-tpm_guest_tests,x64-windows-vmgstool,x64-windows-vmgstool-dev,x64-windows-vmm-tests-archive}'
+        pattern: '{_internal-flowey-bootstrap-x86_64-windows-uid-6,x64-guest_test_uefi,x64-linux-musl-pipette,x64-linux-musl-tmk_vmm,x64-linux-tpm_guest_tests,x64-openhcl-igvm,x64-openhcl-igvm-cvm,x64-openhcl-igvm-test-linux-direct,x64-tmks,x64-windows-openvmm,x64-windows-pipette,x64-windows-prep_steps,x64-windows-test_igvm_agent_rpc_server,x64-windows-tmk_vmm,x64-windows-tpm_guest_tests,x64-windows-vmgstool,x64-windows-vmgstool-dev,x64-windows-vmm-tests-archive}'
         path: ${{ runner.temp }}/used_artifacts/
     - run: echo "${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-windows-uid-6" >> $GITHUB_PATH
       shell: bash
@@ -4983,6 +5092,8 @@ jobs:
         echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-tmk_vmm" | flowey.exe v 25 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
         echo "${{ runner.temp }}\\used_artifacts\\x64-linux-tpm_guest_tests" | flowey.exe v 25 'artifact_use_from_x64-linux-tpm_guest_tests' --is-raw-string update
         echo "${{ runner.temp }}\\used_artifacts\\x64-openhcl-igvm" | flowey.exe v 25 'artifact_use_from_x64-openhcl-igvm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-openhcl-igvm-cvm" | flowey.exe v 25 'artifact_use_from_x64-openhcl-igvm-cvm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-openhcl-igvm-test-linux-direct" | flowey.exe v 25 'artifact_use_from_x64-openhcl-igvm-test-linux-direct' --is-raw-string update
         echo "${{ runner.temp }}\\used_artifacts\\x64-tmks" | flowey.exe v 25 'artifact_use_from_x64-tmks' --is-raw-string update
         echo "${{ runner.temp }}\\used_artifacts\\x64-windows-openvmm" | flowey.exe v 25 'artifact_use_from_x64-windows-openvmm' --is-raw-string update
         echo "${{ runner.temp }}\\used_artifacts\\x64-windows-pipette" | flowey.exe v 25 'artifact_use_from_x64-windows-pipette' --is-raw-string update
@@ -5043,24 +5154,24 @@ jobs:
         flowey.exe e 25 flowey_lib_common::git_checkout 3
         flowey.exe e 25 flowey_lib_hvlite::git_checkout_openvmm_repo 0
         flowey.exe e 25 flowey_lib_hvlite::run_cargo_nextest_run 0
+        flowey.exe e 25 flowey_core::pipeline::artifact::resolve 8
+        flowey.exe e 25 flowey_core::pipeline::artifact::resolve 9
+        flowey.exe e 25 flowey_core::pipeline::artifact::resolve 12
+        flowey.exe e 25 flowey_core::pipeline::artifact::resolve 14
+        flowey.exe e 25 flowey_core::pipeline::artifact::resolve 15
+        flowey.exe e 25 flowey_core::pipeline::artifact::resolve 13
+        flowey.exe e 25 flowey_core::pipeline::artifact::resolve 3
+        flowey.exe e 25 flowey_core::pipeline::artifact::resolve 11
+        flowey.exe e 25 flowey_core::pipeline::artifact::resolve 4
         flowey.exe e 25 flowey_core::pipeline::artifact::resolve 5
         flowey.exe e 25 flowey_core::pipeline::artifact::resolve 6
         flowey.exe e 25 flowey_core::pipeline::artifact::resolve 1
-        flowey.exe e 25 flowey_core::pipeline::artifact::resolve 0
-        flowey.exe e 25 flowey_core::pipeline::artifact::resolve 9
         flowey.exe e 25 flowey_core::pipeline::artifact::resolve 2
-        flowey.exe e 25 flowey_core::pipeline::artifact::resolve 4
-        flowey.exe e 25 flowey_core::pipeline::artifact::resolve 11
-        flowey.exe e 25 flowey_core::pipeline::artifact::resolve 12
-        flowey.exe e 25 flowey_core::pipeline::artifact::resolve 10
-        flowey.exe e 25 flowey_core::pipeline::artifact::resolve 3
-        flowey.exe e 25 flowey_core::pipeline::artifact::resolve 8
+        flowey.exe e 25 flowey_core::pipeline::artifact::resolve 0
+        flowey.exe e 25 flowey_core::pipeline::artifact::resolve 7
       shell: bash
     - name: creating new test content dir
       run: flowey.exe e 25 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
-      shell: bash
-    - name: resolve OpenHCL igvm artifact
-      run: flowey.exe e 25 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::resolve 0
       shell: bash
     - name: create gh-release-download cache dir
       run: flowey.exe e 25 flowey_lib_common::download_gh_release 0
@@ -5149,7 +5260,7 @@ jobs:
       run: |-
         flowey.exe e 25 flowey_lib_hvlite::init_vmm_tests_env 0
         flowey.exe e 25 flowey_lib_hvlite::run_cargo_nextest_run 1
-        flowey.exe e 25 flowey_core::pipeline::artifact::resolve 13
+        flowey.exe e 25 flowey_core::pipeline::artifact::resolve 16
         flowey.exe e 25 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
       shell: bash
     - name: generate nextest command
@@ -5161,7 +5272,7 @@ jobs:
     - name: starting test_igvm_agent_rpc_server
       run: |-
         flowey.exe e 25 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
-        flowey.exe e 25 flowey_core::pipeline::artifact::resolve 7
+        flowey.exe e 25 flowey_core::pipeline::artifact::resolve 10
       shell: bash
     - name: running vmm_test prep_steps
       run: flowey.exe e 25 flowey_lib_hvlite::run_prep_steps 0
@@ -5267,12 +5378,12 @@ jobs:
       shell: bash
     - name: creating new test content dir
       run: |-
+        flowey e 26 flowey_core::pipeline::artifact::resolve 8
+        flowey e 26 flowey_core::pipeline::artifact::resolve 2
         flowey e 26 flowey_core::pipeline::artifact::resolve 3
         flowey e 26 flowey_core::pipeline::artifact::resolve 4
-        flowey e 26 flowey_core::pipeline::artifact::resolve 8
         flowey e 26 flowey_core::pipeline::artifact::resolve 1
         flowey e 26 flowey_core::pipeline::artifact::resolve 0
-        flowey e 26 flowey_core::pipeline::artifact::resolve 2
         flowey e 26 flowey_core::pipeline::artifact::resolve 7
         flowey e 26 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
       shell: bash
@@ -5583,12 +5694,12 @@ jobs:
       shell: bash
     - name: creating new test content dir
       run: |-
+        flowey e 27 flowey_core::pipeline::artifact::resolve 8
+        flowey e 27 flowey_core::pipeline::artifact::resolve 4
         flowey e 27 flowey_core::pipeline::artifact::resolve 1
         flowey e 27 flowey_core::pipeline::artifact::resolve 2
-        flowey e 27 flowey_core::pipeline::artifact::resolve 8
         flowey e 27 flowey_core::pipeline::artifact::resolve 3
         flowey e 27 flowey_core::pipeline::artifact::resolve 0
-        flowey e 27 flowey_core::pipeline::artifact::resolve 4
         flowey e 27 flowey_core::pipeline::artifact::resolve 7
         flowey e 27 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
       shell: bash
@@ -5946,21 +6057,19 @@ jobs:
         flowey.exe e 28 flowey_lib_common::git_checkout 3
         flowey.exe e 28 flowey_lib_hvlite::git_checkout_openvmm_repo 0
         flowey.exe e 28 flowey_lib_hvlite::run_cargo_nextest_run 0
-        flowey.exe e 28 flowey_core::pipeline::artifact::resolve 4
         flowey.exe e 28 flowey_core::pipeline::artifact::resolve 5
-        flowey.exe e 28 flowey_core::pipeline::artifact::resolve 1
-        flowey.exe e 28 flowey_core::pipeline::artifact::resolve 0
         flowey.exe e 28 flowey_core::pipeline::artifact::resolve 6
-        flowey.exe e 28 flowey_core::pipeline::artifact::resolve 2
-        flowey.exe e 28 flowey_core::pipeline::artifact::resolve 3
         flowey.exe e 28 flowey_core::pipeline::artifact::resolve 7
         flowey.exe e 28 flowey_core::pipeline::artifact::resolve 8
+        flowey.exe e 28 flowey_core::pipeline::artifact::resolve 9
+        flowey.exe e 28 flowey_core::pipeline::artifact::resolve 3
+        flowey.exe e 28 flowey_core::pipeline::artifact::resolve 1
+        flowey.exe e 28 flowey_core::pipeline::artifact::resolve 2
+        flowey.exe e 28 flowey_core::pipeline::artifact::resolve 0
+        flowey.exe e 28 flowey_core::pipeline::artifact::resolve 4
       shell: bash
     - name: creating new test content dir
       run: flowey.exe e 28 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
-      shell: bash
-    - name: resolve OpenHCL igvm artifact
-      run: flowey.exe e 28 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::resolve 0
       shell: bash
     - name: create gh-release-download cache dir
       run: flowey.exe e 28 flowey_lib_common::download_gh_release 0
@@ -6049,7 +6158,7 @@ jobs:
       run: |-
         flowey.exe e 28 flowey_lib_hvlite::init_vmm_tests_env 0
         flowey.exe e 28 flowey_lib_hvlite::run_cargo_nextest_run 1
-        flowey.exe e 28 flowey_core::pipeline::artifact::resolve 9
+        flowey.exe e 28 flowey_core::pipeline::artifact::resolve 10
         flowey.exe e 28 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
       shell: bash
     - name: generate nextest command

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1882,7 +1882,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4657,7 +4657,7 @@ dependencies = [
 [[package]]
 name = "ms-tpm-20-ref"
 version = "0.0.0"
-source = "git+https://github.com/microsoft/ms-tpm-20-ref-rs.git?rev=e0bba1e46d9cdc8630f3693e5e91f8a3be4fad7b#e0bba1e46d9cdc8630f3693e5e91f8a3be4fad7b"
+source = "git+https://github.com/microsoft/ms-tpm-20-ref-rs.git?rev=07a121e4b46659cdfa8711740c6622728adffd65#07a121e4b46659cdfa8711740c6622728adffd65"
 dependencies = [
  "cc",
  "once_cell",
@@ -6860,7 +6860,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.9.4",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7864,7 +7864,7 @@ dependencies = [
  "getrandom 0.3.3",
  "once_cell",
  "rustix 1.0.8",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -10858,7 +10858,7 @@ version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0978bf7171b3d90bac376700cb56d606feb40f251a475a5d6634613564460b22"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1882,7 +1882,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6860,7 +6860,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.9.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7864,7 +7864,7 @@ dependencies = [
  "getrandom 0.3.3",
  "once_cell",
  "rustix 1.0.8",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -10858,7 +10858,7 @@ version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0978bf7171b3d90bac376700cb56d606feb40f251a475a5d6634613564460b22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -524,7 +524,7 @@ constant_time_eq = "0.5"
 cms = { version = "0.3.0-pre.2", default-features = false }
 der = "0.8"
 getrandom = "0.4"
-ms-tpm-20-ref = { git = "https://github.com/microsoft/ms-tpm-20-ref-rs.git", rev = "e0bba1e46d9cdc8630f3693e5e91f8a3be4fad7b", default-features = false }
+ms-tpm-20-ref = { git = "https://github.com/microsoft/ms-tpm-20-ref-rs.git", rev = "07a121e4b46659cdfa8711740c6622728adffd65", default-features = false }
 openssl = "0.10.79"
 openssl-sys = "0.9"
 pkcs1 = "0.8.0-rc.4"

--- a/ci-flowey/openvmm-pr.yaml
+++ b/ci-flowey/openvmm-pr.yaml
@@ -1129,45 +1129,9 @@ jobs:
       EOF
       mkdir -p "$(AgentTempDirNormal)/publish_artifacts/x64-mi-secure-openhcl-igvm"
       echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/x64-mi-secure-openhcl-igvm" | $FLOWEY_BIN v 12 'artifact_publish_from_x64-mi-secure-openhcl-igvm' --is-raw-string update
-      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/x64-mi-secure-openhcl-igvm-cvm"
-      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/x64-mi-secure-openhcl-igvm-cvm" | $FLOWEY_BIN v 12 'artifact_publish_from_x64-mi-secure-openhcl-igvm-cvm' --is-raw-string update
-      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/x64-mi-secure-openhcl-igvm-cvm-extras"
-      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/x64-mi-secure-openhcl-igvm-cvm-extras" | $FLOWEY_BIN v 12 'artifact_publish_from_x64-mi-secure-openhcl-igvm-cvm-extras' --is-raw-string update
       mkdir -p "$(AgentTempDirNormal)/publish_artifacts/x64-mi-secure-openhcl-igvm-extras"
       echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/x64-mi-secure-openhcl-igvm-extras" | $FLOWEY_BIN v 12 'artifact_publish_from_x64-mi-secure-openhcl-igvm-extras' --is-raw-string update
-      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/x64-mi-secure-openhcl-igvm-test-linux-direct"
-      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/x64-mi-secure-openhcl-igvm-test-linux-direct" | $FLOWEY_BIN v 12 'artifact_publish_from_x64-mi-secure-openhcl-igvm-test-linux-direct' --is-raw-string update
-      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/x64-mi-secure-openhcl-igvm-test-linux-direct-extras"
-      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/x64-mi-secure-openhcl-igvm-test-linux-direct-extras" | $FLOWEY_BIN v 12 'artifact_publish_from_x64-mi-secure-openhcl-igvm-test-linux-direct-extras' --is-raw-string update
     displayName: 🌼🛫 Initialize job
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 12 flowey_lib_common::git_checkout 0
-      $FLOWEY_BIN v 12 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:319:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46 write-to-env ado floweyvar3
-      $FLOWEY_BIN v 12 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46' write-to-env ado FLOWEY_CONDITION
-    displayName: check if openvmm needs to be cloned
-  - checkout: self
-    path: repo0
-    fetchTags: false
-    fetchDepth: 1
-    persistCredentials: $(floweyvar3)
-    submodules: recursive
-    displayName: checkout repo openvmm
-    condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 12 flowey_lib_common::git_checkout 2
-      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 3
-    displayName: report cloned repo directories
-  - bash: $(FLOWEY_BIN) e 12 flowey_lib_common::install_rust 0
-    displayName: install Rust
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 12 flowey_lib_common::install_rust 1
-      $(FLOWEY_BIN) e 12 flowey_lib_common::cfg_cargo_common_flags 0
-      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::cfg_openvmm_magicpath 0
-    displayName: detect active toolchain
   - bash: $(FLOWEY_BIN) e 12 flowey_lib_common::download_gh_release 0
     displayName: create gh-release-download cache dir
   - bash: |-
@@ -1191,57 +1155,64 @@ jobs:
     displayName: map ADO hitvar to flowey
   - bash: $(FLOWEY_BIN) e 12 flowey_lib_common::download_gh_release 1
     displayName: download artifacts from github releases
-  - bash: $(FLOWEY_BIN) e 12 flowey_lib_hvlite::resolve_openvmm_deps 0
-    displayName: unpack openvmm-deps archive
-  - bash: $(FLOWEY_BIN) e 12 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
-    displayName: extract X86_64 sysroot.tar.gz
+  - bash: $(FLOWEY_BIN) e 12 flowey_lib_hvlite::resolve_openvmm_test_linux_kernel 0
+    displayName: unpack openvmm-test-linux archives
+  - bash: $(FLOWEY_BIN) e 12 flowey_lib_hvlite::resolve_openvmm_test_initrd 0
+    displayName: unpack openvmm-test-initrd archives
+  - bash: $(FLOWEY_BIN) e 12 flowey_lib_common::install_rust 0
+    displayName: install Rust
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 12 flowey_lib_common::install_rust 1
+      $(FLOWEY_BIN) e 12 flowey_lib_common::cfg_cargo_common_flags 0
+    displayName: detect active toolchain
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 12 flowey_lib_common::git_checkout 0
+      $FLOWEY_BIN v 12 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:319:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46 write-to-env ado floweyvar3
+      $FLOWEY_BIN v 12 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46' write-to-env ado FLOWEY_CONDITION
+    displayName: check if openvmm needs to be cloned
+  - checkout: self
+    path: repo0
+    fetchTags: false
+    fetchDepth: 1
+    persistCredentials: $(floweyvar3)
+    submodules: recursive
+    displayName: checkout repo openvmm
+    condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 12 flowey_lib_common::git_checkout 2
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+    displayName: report cloned repo directories
   - bash: $(FLOWEY_BIN) e 12 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
     displayName: set '-Dwarnings' in .cargo/config.toml
   - bash: $(FLOWEY_BIN) e 12 flowey_lib_common::install_dist_pkg 0
     displayName: checking if packages need to be installed
   - bash: $(FLOWEY_BIN) e 12 flowey_lib_common::install_dist_pkg 1
     displayName: installing packages
-  - bash: $(FLOWEY_BIN) e 12 flowey_lib_common::resolve_protoc 0
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 12 flowey_lib_common::resolve_protoc 0
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::cfg_openvmm_magicpath 0
     displayName: unpack protoc
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 12 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::init_cross_build 3
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::init_cross_build 0
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::run_cargo_build 9
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::run_cargo_build 10
     displayName: symlink protoc
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 12 flowey_lib_common::run_cargo_build 2
-      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::run_cargo_build 6
-      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openvmm_hcl 0
-      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 0
-    displayName: cargo build openvmm_hcl
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::run_split_debug_info 0
-      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 1
-      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 2
-      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 4
-    displayName: split debug symbols
-  - bash: $(FLOWEY_BIN) e 12 flowey_lib_hvlite::resolve_openhcl_kernel_package 0
-    displayName: extract and resolve kernel package
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openhcl_initrd 0
-      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::init_cross_build 0
-      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::run_cargo_build 7
-      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::run_cargo_build 8
-    displayName: building openhcl initrd
-  - bash: |-
-      set -e
       $(FLOWEY_BIN) e 12 flowey_lib_common::run_cargo_build 3
-      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::run_cargo_build 9
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::run_cargo_build 11
     displayName: cargo build sidecar
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 12 flowey_lib_hvlite::run_split_debug_info 4
-      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::run_cargo_build 10
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::run_cargo_build 12
       $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_sidecar 0
-      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 5
       $(FLOWEY_BIN) e 12 flowey_lib_hvlite::init_cross_build 1
       $(FLOWEY_BIN) e 12 flowey_lib_hvlite::run_cargo_build 2
       $(FLOWEY_BIN) e 12 flowey_lib_hvlite::run_cargo_build 3
@@ -1256,14 +1227,41 @@ jobs:
       $(FLOWEY_BIN) e 12 flowey_lib_hvlite::run_split_debug_info 3
       $(FLOWEY_BIN) e 12 flowey_lib_hvlite::run_cargo_build 5
       $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openhcl_boot 0
-      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 6
     displayName: split debug symbols
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::download_uefi_mu_msvm 0
-      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 7
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::resolve_openhcl_kernel_package 0
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 28
+    displayName: extract and resolve kernel package
+  - bash: $(FLOWEY_BIN) e 12 flowey_lib_hvlite::resolve_openvmm_deps 0
+    displayName: unpack openvmm-deps archive
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::init_cross_build 3
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::run_cargo_build 6
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::run_cargo_build 7
+    displayName: extract X86_64 sysroot.tar.gz
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 12 flowey_lib_common::run_cargo_build 2
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::run_cargo_build 8
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openvmm_hcl 0
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 24
+    displayName: cargo build openvmm_hcl
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::run_split_debug_info 2
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 25
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 26
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 29
+    displayName: split debug symbols
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openhcl_initrd 2
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 30
       $(FLOWEY_BIN) e 12 flowey_lib_hvlite::init_cross_build 2
-    displayName: unpack mu_msvm package (x64)
+    displayName: building openhcl initrd
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 12 flowey_lib_common::run_cargo_build 0
@@ -1274,55 +1272,20 @@ jobs:
       $(FLOWEY_BIN) e 12 flowey_lib_hvlite::run_split_debug_info 5
       $(FLOWEY_BIN) e 12 flowey_lib_hvlite::run_cargo_build 1
       $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_igvmfilegen 0
-      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 8
-      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 9
-    displayName: split debug symbols
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::run_igvmfilegen 1
-      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 12
-      $(FLOWEY_BIN) e 12 flowey_core::pipeline::artifact::publish 0
-      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 10
-      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 11
-      $(FLOWEY_BIN) e 12 flowey_core::pipeline::artifact::publish 1
-      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 33
-      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 34
-    displayName: building igvm file
-  - bash: $(FLOWEY_BIN) e 12 flowey_lib_hvlite::resolve_openvmm_test_linux_kernel 0
-    displayName: unpack openvmm-test-linux archives
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::resolve_openvmm_test_initrd 0
-      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 28
-      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 25
-    displayName: unpack openvmm-test-initrd archives
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::run_split_debug_info 2
-      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 26
-      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 27
-      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 29
-    displayName: split debug symbols
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openhcl_initrd 2
-      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 30
       $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 31
       $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 32
-    displayName: building openhcl initrd
+    displayName: split debug symbols
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::run_igvmfilegen 0
-      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 37
-      $(FLOWEY_BIN) e 12 flowey_core::pipeline::artifact::publish 2
-      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 35
-      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 36
-      $(FLOWEY_BIN) e 12 flowey_core::pipeline::artifact::publish 3
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::run_igvmfilegen 2
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 2
     displayName: building igvm file
+  - bash: $(FLOWEY_BIN) e 12 flowey_lib_hvlite::download_uefi_mu_msvm 0
+    displayName: unpack mu_msvm package (x64)
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 12 flowey_lib_hvlite::resolve_openhcl_kernel_package 1
-      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 16
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 17
       $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 13
     displayName: extract and resolve kernel package
   - bash: |-
@@ -1330,45 +1293,69 @@ jobs:
       $(FLOWEY_BIN) e 12 flowey_lib_hvlite::run_split_debug_info 1
       $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 14
       $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 15
-      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 17
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 18
     displayName: split debug symbols
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openhcl_initrd 1
-      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 18
       $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 19
       $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 20
       $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 21
     displayName: building openhcl initrd
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::run_igvmfilegen 2
-      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 24
-      $(FLOWEY_BIN) e 12 flowey_core::pipeline::artifact::publish 4
-      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 22
-      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 23
-      $(FLOWEY_BIN) e 12 flowey_core::pipeline::artifact::publish 5
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::run_igvmfilegen 1
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 4
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 6
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 2
     displayName: building igvm file
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::run_split_debug_info 0
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 3
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 4
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 7
+    displayName: split debug symbols
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openhcl_initrd 0
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 8
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 9
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 10
+    displayName: building openhcl initrd
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::run_igvmfilegen 0
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 0
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::publish 0
+    displayName: building igvm file
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 12 flowey_lib_common::copy_to_artifact_dir 1
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 22
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 27
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 23
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 3
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 16
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 12
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 11
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 5
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 5
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 1
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 0
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 1
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe_extras::publish 0
+    displayName: copying OpenHCL igvm files to artifact dir
+  - bash: $(FLOWEY_BIN) e 12 flowey_lib_common::copy_to_artifact_dir 0
+    displayName: copying OpenHCL igvm extras to artifact dir
   - bash: $(FLOWEY_BIN) e 12 flowey_lib_common::cache 3
     displayName: 'validate cache entry: gh-release-download'
   - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/x64-mi-secure-openhcl-igvm
     displayName: 🌼📦 Publish x64-mi-secure-openhcl-igvm
     artifact: x64-mi-secure-openhcl-igvm
-  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/x64-mi-secure-openhcl-igvm-cvm
-    displayName: 🌼📦 Publish x64-mi-secure-openhcl-igvm-cvm
-    artifact: x64-mi-secure-openhcl-igvm-cvm
-  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/x64-mi-secure-openhcl-igvm-cvm-extras
-    displayName: 🌼📦 Publish x64-mi-secure-openhcl-igvm-cvm-extras
-    artifact: x64-mi-secure-openhcl-igvm-cvm-extras
   - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/x64-mi-secure-openhcl-igvm-extras
     displayName: 🌼📦 Publish x64-mi-secure-openhcl-igvm-extras
     artifact: x64-mi-secure-openhcl-igvm-extras
-  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/x64-mi-secure-openhcl-igvm-test-linux-direct
-    displayName: 🌼📦 Publish x64-mi-secure-openhcl-igvm-test-linux-direct
-    artifact: x64-mi-secure-openhcl-igvm-test-linux-direct
-  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/x64-mi-secure-openhcl-igvm-test-linux-direct-extras
-    displayName: 🌼📦 Publish x64-mi-secure-openhcl-igvm-test-linux-direct-extras
-    artifact: x64-mi-secure-openhcl-igvm-test-linux-direct-extras
 - job: job11
   displayName: build openhcl [x64-linux]
   pool:
@@ -1407,53 +1394,13 @@ jobs:
       EOF
       mkdir -p "$(AgentTempDirNormal)/publish_artifacts/x64-openhcl-igvm"
       echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/x64-openhcl-igvm" | $FLOWEY_BIN v 11 'artifact_publish_from_x64-openhcl-igvm' --is-raw-string update
-      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/x64-openhcl-igvm-cvm"
-      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/x64-openhcl-igvm-cvm" | $FLOWEY_BIN v 11 'artifact_publish_from_x64-openhcl-igvm-cvm' --is-raw-string update
-      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/x64-openhcl-igvm-cvm-extras"
-      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/x64-openhcl-igvm-cvm-extras" | $FLOWEY_BIN v 11 'artifact_publish_from_x64-openhcl-igvm-cvm-extras' --is-raw-string update
-      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/x64-openhcl-igvm-devkern"
-      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/x64-openhcl-igvm-devkern" | $FLOWEY_BIN v 11 'artifact_publish_from_x64-openhcl-igvm-devkern' --is-raw-string update
-      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/x64-openhcl-igvm-devkern-extras"
-      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/x64-openhcl-igvm-devkern-extras" | $FLOWEY_BIN v 11 'artifact_publish_from_x64-openhcl-igvm-devkern-extras' --is-raw-string update
       mkdir -p "$(AgentTempDirNormal)/publish_artifacts/x64-openhcl-igvm-extras"
       echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/x64-openhcl-igvm-extras" | $FLOWEY_BIN v 11 'artifact_publish_from_x64-openhcl-igvm-extras' --is-raw-string update
-      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/x64-openhcl-igvm-test-linux-direct"
-      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/x64-openhcl-igvm-test-linux-direct" | $FLOWEY_BIN v 11 'artifact_publish_from_x64-openhcl-igvm-test-linux-direct' --is-raw-string update
-      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/x64-openhcl-igvm-test-linux-direct-devkern"
-      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/x64-openhcl-igvm-test-linux-direct-devkern" | $FLOWEY_BIN v 11 'artifact_publish_from_x64-openhcl-igvm-test-linux-direct-devkern' --is-raw-string update
-      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/x64-openhcl-igvm-test-linux-direct-devkern-extras"
-      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/x64-openhcl-igvm-test-linux-direct-devkern-extras" | $FLOWEY_BIN v 11 'artifact_publish_from_x64-openhcl-igvm-test-linux-direct-devkern-extras' --is-raw-string update
-      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/x64-openhcl-igvm-test-linux-direct-extras"
-      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/x64-openhcl-igvm-test-linux-direct-extras" | $FLOWEY_BIN v 11 'artifact_publish_from_x64-openhcl-igvm-test-linux-direct-extras' --is-raw-string update
     displayName: 🌼🛫 Initialize job
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 11 flowey_lib_common::git_checkout 0
-      $FLOWEY_BIN v 11 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:319:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46 write-to-env ado floweyvar3
-      $FLOWEY_BIN v 11 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46' write-to-env ado FLOWEY_CONDITION
-    displayName: check if openvmm needs to be cloned
-  - checkout: self
-    path: repo0
-    fetchTags: false
-    fetchDepth: 1
-    persistCredentials: $(floweyvar3)
-    submodules: recursive
-    displayName: checkout repo openvmm
-    condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 11 flowey_lib_common::git_checkout 2
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 3
-    displayName: report cloned repo directories
-  - bash: $(FLOWEY_BIN) e 11 flowey_lib_common::install_rust 0
-    displayName: install Rust
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 11 flowey_lib_common::install_rust 1
-      $(FLOWEY_BIN) e 11 flowey_lib_common::cfg_cargo_common_flags 0
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::cfg_openvmm_magicpath 0
-    displayName: detect active toolchain
+  - bash: $(FLOWEY_BIN) e 11 flowey_lib_common::install_dist_pkg 0
+    displayName: checking if packages need to be installed
+  - bash: $(FLOWEY_BIN) e 11 flowey_lib_common::install_dist_pkg 1
+    displayName: installing packages
   - bash: $(FLOWEY_BIN) e 11 flowey_lib_common::download_gh_release 0
     displayName: create gh-release-download cache dir
   - bash: |-
@@ -1477,57 +1424,58 @@ jobs:
     displayName: map ADO hitvar to flowey
   - bash: $(FLOWEY_BIN) e 11 flowey_lib_common::download_gh_release 1
     displayName: download artifacts from github releases
-  - bash: $(FLOWEY_BIN) e 11 flowey_lib_hvlite::resolve_openvmm_deps 0
-    displayName: unpack openvmm-deps archive
-  - bash: $(FLOWEY_BIN) e 11 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
-    displayName: extract X86_64 sysroot.tar.gz
+  - bash: $(FLOWEY_BIN) e 11 flowey_lib_hvlite::download_uefi_mu_msvm 0
+    displayName: unpack mu_msvm package (x64)
+  - bash: $(FLOWEY_BIN) e 11 flowey_lib_common::install_rust 0
+    displayName: install Rust
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 11 flowey_lib_common::install_rust 1
+      $(FLOWEY_BIN) e 11 flowey_lib_common::cfg_cargo_common_flags 0
+    displayName: detect active toolchain
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 11 flowey_lib_common::git_checkout 0
+      $FLOWEY_BIN v 11 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:319:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46 write-to-env ado floweyvar3
+      $FLOWEY_BIN v 11 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46' write-to-env ado FLOWEY_CONDITION
+    displayName: check if openvmm needs to be cloned
+  - checkout: self
+    path: repo0
+    fetchTags: false
+    fetchDepth: 1
+    persistCredentials: $(floweyvar3)
+    submodules: recursive
+    displayName: checkout repo openvmm
+    condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 11 flowey_lib_common::git_checkout 2
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+    displayName: report cloned repo directories
   - bash: $(FLOWEY_BIN) e 11 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
     displayName: set '-Dwarnings' in .cargo/config.toml
-  - bash: $(FLOWEY_BIN) e 11 flowey_lib_common::install_dist_pkg 0
-    displayName: checking if packages need to be installed
-  - bash: $(FLOWEY_BIN) e 11 flowey_lib_common::install_dist_pkg 1
-    displayName: installing packages
-  - bash: $(FLOWEY_BIN) e 11 flowey_lib_common::resolve_protoc 0
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 11 flowey_lib_common::resolve_protoc 0
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::cfg_openvmm_magicpath 0
     displayName: unpack protoc
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 11 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::init_cross_build 3
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::init_cross_build 0
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::run_cargo_build 9
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::run_cargo_build 10
     displayName: symlink protoc
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 11 flowey_lib_common::run_cargo_build 2
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::run_cargo_build 6
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openvmm_hcl 0
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 0
-    displayName: cargo build openvmm_hcl
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::run_split_debug_info 0
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 1
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 2
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 4
-    displayName: split debug symbols
-  - bash: $(FLOWEY_BIN) e 11 flowey_lib_hvlite::resolve_openhcl_kernel_package 0
-    displayName: extract and resolve kernel package
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_initrd 2
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::init_cross_build 0
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::run_cargo_build 7
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::run_cargo_build 8
-    displayName: building openhcl initrd
-  - bash: |-
-      set -e
       $(FLOWEY_BIN) e 11 flowey_lib_common::run_cargo_build 3
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::run_cargo_build 9
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::run_cargo_build 11
     displayName: cargo build sidecar
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 11 flowey_lib_hvlite::run_split_debug_info 6
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::run_cargo_build 10
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::run_cargo_build 12
       $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_sidecar 0
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 5
       $(FLOWEY_BIN) e 11 flowey_lib_hvlite::init_cross_build 1
       $(FLOWEY_BIN) e 11 flowey_lib_hvlite::run_cargo_build 2
       $(FLOWEY_BIN) e 11 flowey_lib_hvlite::run_cargo_build 3
@@ -1542,14 +1490,41 @@ jobs:
       $(FLOWEY_BIN) e 11 flowey_lib_hvlite::run_split_debug_info 5
       $(FLOWEY_BIN) e 11 flowey_lib_hvlite::run_cargo_build 5
       $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_boot 0
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 6
     displayName: split debug symbols
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::download_uefi_mu_msvm 0
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 7
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::resolve_openhcl_kernel_package 2
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 28
+    displayName: extract and resolve kernel package
+  - bash: $(FLOWEY_BIN) e 11 flowey_lib_hvlite::resolve_openvmm_deps 0
+    displayName: unpack openvmm-deps archive
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::init_cross_build 3
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::run_cargo_build 6
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::run_cargo_build 7
+    displayName: extract X86_64 sysroot.tar.gz
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 11 flowey_lib_common::run_cargo_build 2
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::run_cargo_build 8
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openvmm_hcl 0
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 24
+    displayName: cargo build openvmm_hcl
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::run_split_debug_info 4
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 25
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 26
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 29
+    displayName: split debug symbols
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_initrd 4
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 30
       $(FLOWEY_BIN) e 11 flowey_lib_hvlite::init_cross_build 2
-    displayName: unpack mu_msvm package (x64)
+    displayName: building openhcl initrd
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 11 flowey_lib_common::run_cargo_build 0
@@ -1560,113 +1535,66 @@ jobs:
       $(FLOWEY_BIN) e 11 flowey_lib_hvlite::run_split_debug_info 7
       $(FLOWEY_BIN) e 11 flowey_lib_hvlite::run_cargo_build 1
       $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_igvmfilegen 0
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 8
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 9
-    displayName: split debug symbols
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::run_igvmfilegen 2
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 12
-      $(FLOWEY_BIN) e 11 flowey_core::pipeline::artifact::publish 0
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 10
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 11
-      $(FLOWEY_BIN) e 11 flowey_core::pipeline::artifact::publish 1
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 34
-    displayName: building igvm file
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::resolve_openhcl_kernel_package 2
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 28
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 25
-    displayName: extract and resolve kernel package
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::run_split_debug_info 4
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 26
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 27
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 29
-    displayName: split debug symbols
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_initrd 4
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 30
       $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 31
       $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 32
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 33
-    displayName: building openhcl initrd
+    displayName: split debug symbols
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 11 flowey_lib_hvlite::run_igvmfilegen 4
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 37
-      $(FLOWEY_BIN) e 11 flowey_core::pipeline::artifact::publish 2
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 2
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 39
       $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 35
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 36
-      $(FLOWEY_BIN) e 11 flowey_core::pipeline::artifact::publish 3
     displayName: building igvm file
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::run_split_debug_info 0
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 36
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 37
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 40
+    displayName: split debug symbols
+  - bash: $(FLOWEY_BIN) e 11 flowey_lib_hvlite::resolve_openhcl_kernel_package 0
+    displayName: extract and resolve kernel package
+  - bash: $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_initrd 0
+    displayName: building openhcl initrd
   - bash: $(FLOWEY_BIN) e 11 flowey_lib_hvlite::resolve_openvmm_test_linux_kernel 0
     displayName: unpack openvmm-test-linux archives
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 11 flowey_lib_hvlite::resolve_openvmm_test_initrd 0
       $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 41
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 38
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 42
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 43
     displayName: unpack openvmm-test-initrd archives
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::run_split_debug_info 1
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 39
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 40
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 42
-    displayName: split debug symbols
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_initrd 0
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 43
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 44
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 45
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 46
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 47
-    displayName: building openhcl initrd
-  - bash: |-
-      set -e
       $(FLOWEY_BIN) e 11 flowey_lib_hvlite::run_igvmfilegen 0
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 4
       $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 50
-      $(FLOWEY_BIN) e 11 flowey_core::pipeline::artifact::publish 4
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 48
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 49
-      $(FLOWEY_BIN) e 11 flowey_core::pipeline::artifact::publish 5
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 54
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 51
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 46
     displayName: building igvm file
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::run_split_debug_info 2
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 52
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 53
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 55
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::run_split_debug_info 1
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 47
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 48
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 51
     displayName: split debug symbols
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_initrd 1
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 56
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 57
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 58
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 59
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 60
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 52
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 53
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 54
     displayName: building openhcl initrd
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 11 flowey_lib_hvlite::run_igvmfilegen 1
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 63
-      $(FLOWEY_BIN) e 11 flowey_core::pipeline::artifact::publish 6
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 61
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 62
-      $(FLOWEY_BIN) e 11 flowey_core::pipeline::artifact::publish 7
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 6
     displayName: building igvm file
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 11 flowey_lib_hvlite::resolve_openhcl_kernel_package 1
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 16
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 17
       $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 13
     displayName: extract and resolve kernel package
   - bash: |-
@@ -1674,12 +1602,11 @@ jobs:
       $(FLOWEY_BIN) e 11 flowey_lib_hvlite::run_split_debug_info 3
       $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 14
       $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 15
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 17
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 18
     displayName: split debug symbols
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_initrd 3
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 18
       $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 19
       $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 20
       $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 21
@@ -1687,44 +1614,65 @@ jobs:
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 11 flowey_lib_hvlite::run_igvmfilegen 3
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 24
-      $(FLOWEY_BIN) e 11 flowey_core::pipeline::artifact::publish 8
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 22
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 23
-      $(FLOWEY_BIN) e 11 flowey_core::pipeline::artifact::publish 9
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 8
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 6
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 2
     displayName: building igvm file
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::run_split_debug_info 2
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 3
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 4
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 7
+    displayName: split debug symbols
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_initrd 2
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 8
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 9
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 10
+    displayName: building openhcl initrd
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::run_igvmfilegen 2
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 0
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::publish 0
+    displayName: building igvm file
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 11 flowey_lib_common::copy_to_artifact_dir 1
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 22
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 27
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 23
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 3
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 38
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 34
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 33
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 5
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 49
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 45
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 44
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 7
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 16
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 12
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 11
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 9
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 5
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 1
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 0
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 1
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe_extras::publish 0
+    displayName: copying OpenHCL igvm files to artifact dir
+  - bash: $(FLOWEY_BIN) e 11 flowey_lib_common::copy_to_artifact_dir 0
+    displayName: copying OpenHCL igvm extras to artifact dir
   - bash: $(FLOWEY_BIN) e 11 flowey_lib_common::cache 3
     displayName: 'validate cache entry: gh-release-download'
   - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/x64-openhcl-igvm
     displayName: 🌼📦 Publish x64-openhcl-igvm
     artifact: x64-openhcl-igvm
-  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/x64-openhcl-igvm-cvm
-    displayName: 🌼📦 Publish x64-openhcl-igvm-cvm
-    artifact: x64-openhcl-igvm-cvm
-  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/x64-openhcl-igvm-cvm-extras
-    displayName: 🌼📦 Publish x64-openhcl-igvm-cvm-extras
-    artifact: x64-openhcl-igvm-cvm-extras
-  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/x64-openhcl-igvm-devkern
-    displayName: 🌼📦 Publish x64-openhcl-igvm-devkern
-    artifact: x64-openhcl-igvm-devkern
-  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/x64-openhcl-igvm-devkern-extras
-    displayName: 🌼📦 Publish x64-openhcl-igvm-devkern-extras
-    artifact: x64-openhcl-igvm-devkern-extras
   - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/x64-openhcl-igvm-extras
     displayName: 🌼📦 Publish x64-openhcl-igvm-extras
     artifact: x64-openhcl-igvm-extras
-  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/x64-openhcl-igvm-test-linux-direct
-    displayName: 🌼📦 Publish x64-openhcl-igvm-test-linux-direct
-    artifact: x64-openhcl-igvm-test-linux-direct
-  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/x64-openhcl-igvm-test-linux-direct-devkern
-    displayName: 🌼📦 Publish x64-openhcl-igvm-test-linux-direct-devkern
-    artifact: x64-openhcl-igvm-test-linux-direct-devkern
-  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/x64-openhcl-igvm-test-linux-direct-devkern-extras
-    displayName: 🌼📦 Publish x64-openhcl-igvm-test-linux-direct-devkern-extras
-    artifact: x64-openhcl-igvm-test-linux-direct-devkern-extras
-  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/x64-openhcl-igvm-test-linux-direct-extras
-    displayName: 🌼📦 Publish x64-openhcl-igvm-test-linux-direct-extras
-    artifact: x64-openhcl-igvm-test-linux-direct-extras
 - job: job10
   displayName: build openhcl [aarch64-linux]
   pool:
@@ -1763,41 +1711,13 @@ jobs:
       EOF
       mkdir -p "$(AgentTempDirNormal)/publish_artifacts/aarch64-openhcl-igvm"
       echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-openhcl-igvm" | $FLOWEY_BIN v 10 'artifact_publish_from_aarch64-openhcl-igvm' --is-raw-string update
-      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/aarch64-openhcl-igvm-devkern"
-      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-openhcl-igvm-devkern" | $FLOWEY_BIN v 10 'artifact_publish_from_aarch64-openhcl-igvm-devkern' --is-raw-string update
-      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/aarch64-openhcl-igvm-devkern-extras"
-      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-openhcl-igvm-devkern-extras" | $FLOWEY_BIN v 10 'artifact_publish_from_aarch64-openhcl-igvm-devkern-extras' --is-raw-string update
       mkdir -p "$(AgentTempDirNormal)/publish_artifacts/aarch64-openhcl-igvm-extras"
       echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-openhcl-igvm-extras" | $FLOWEY_BIN v 10 'artifact_publish_from_aarch64-openhcl-igvm-extras' --is-raw-string update
     displayName: 🌼🛫 Initialize job
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 10 flowey_lib_common::git_checkout 0
-      $FLOWEY_BIN v 10 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:319:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46 write-to-env ado floweyvar3
-      $FLOWEY_BIN v 10 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46' write-to-env ado FLOWEY_CONDITION
-    displayName: check if openvmm needs to be cloned
-  - checkout: self
-    path: repo0
-    fetchTags: false
-    fetchDepth: 1
-    persistCredentials: $(floweyvar3)
-    submodules: recursive
-    displayName: checkout repo openvmm
-    condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 10 flowey_lib_common::git_checkout 2
-      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 3
-    displayName: report cloned repo directories
-  - bash: $(FLOWEY_BIN) e 10 flowey_lib_common::install_rust 0
-    displayName: install Rust
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 10 flowey_lib_common::install_rust 1
-      $(FLOWEY_BIN) e 10 flowey_lib_common::cfg_cargo_common_flags 0
-      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::cfg_openvmm_magicpath 0
-    displayName: detect active toolchain
+  - bash: $(FLOWEY_BIN) e 10 flowey_lib_common::install_dist_pkg 0
+    displayName: checking if packages need to be installed
+  - bash: $(FLOWEY_BIN) e 10 flowey_lib_common::install_dist_pkg 1
+    displayName: installing packages
   - bash: $(FLOWEY_BIN) e 10 flowey_lib_common::download_gh_release 0
     displayName: create gh-release-download cache dir
   - bash: |-
@@ -1821,46 +1741,48 @@ jobs:
     displayName: map ADO hitvar to flowey
   - bash: $(FLOWEY_BIN) e 10 flowey_lib_common::download_gh_release 1
     displayName: download artifacts from github releases
-  - bash: $(FLOWEY_BIN) e 10 flowey_lib_hvlite::resolve_openvmm_deps 0
-    displayName: unpack openvmm-deps archive
-  - bash: $(FLOWEY_BIN) e 10 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
-    displayName: extract Aarch64 sysroot.tar.gz
+  - bash: $(FLOWEY_BIN) e 10 flowey_lib_hvlite::download_uefi_mu_msvm 0
+    displayName: unpack mu_msvm package (aarch64)
+  - bash: $(FLOWEY_BIN) e 10 flowey_lib_common::install_rust 0
+    displayName: install Rust
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 10 flowey_lib_common::install_rust 1
+      $(FLOWEY_BIN) e 10 flowey_lib_common::cfg_cargo_common_flags 0
+    displayName: detect active toolchain
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 10 flowey_lib_common::git_checkout 0
+      $FLOWEY_BIN v 10 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:319:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46 write-to-env ado floweyvar3
+      $FLOWEY_BIN v 10 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46' write-to-env ado FLOWEY_CONDITION
+    displayName: check if openvmm needs to be cloned
+  - checkout: self
+    path: repo0
+    fetchTags: false
+    fetchDepth: 1
+    persistCredentials: $(floweyvar3)
+    submodules: recursive
+    displayName: checkout repo openvmm
+    condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 10 flowey_lib_common::git_checkout 2
+      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+    displayName: report cloned repo directories
   - bash: $(FLOWEY_BIN) e 10 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
     displayName: set '-Dwarnings' in .cargo/config.toml
-  - bash: $(FLOWEY_BIN) e 10 flowey_lib_common::install_dist_pkg 0
-    displayName: checking if packages need to be installed
-  - bash: $(FLOWEY_BIN) e 10 flowey_lib_common::install_dist_pkg 1
-    displayName: installing packages
-  - bash: $(FLOWEY_BIN) e 10 flowey_lib_common::resolve_protoc 0
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 10 flowey_lib_common::resolve_protoc 0
+      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::cfg_openvmm_magicpath 0
     displayName: unpack protoc
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 10 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::init_cross_build 1
-    displayName: symlink protoc
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 10 flowey_lib_common::run_cargo_build 2
-      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::run_cargo_build 6
-      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_openvmm_hcl 0
-      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 0
-    displayName: cargo build openvmm_hcl
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::run_split_debug_info 0
-      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 1
-      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 2
-      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 4
-    displayName: split debug symbols
-  - bash: $(FLOWEY_BIN) e 10 flowey_lib_hvlite::resolve_openhcl_kernel_package 0
-    displayName: extract and resolve kernel package
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_openhcl_initrd 0
       $(FLOWEY_BIN) e 10 flowey_lib_hvlite::init_cross_build 0
       $(FLOWEY_BIN) e 10 flowey_lib_hvlite::run_cargo_build 2
       $(FLOWEY_BIN) e 10 flowey_lib_hvlite::run_cargo_build 3
-    displayName: building openhcl initrd
+    displayName: symlink protoc
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 10 flowey_lib_common::run_cargo_build 1
@@ -1871,14 +1793,41 @@ jobs:
       $(FLOWEY_BIN) e 10 flowey_lib_hvlite::run_split_debug_info 2
       $(FLOWEY_BIN) e 10 flowey_lib_hvlite::run_cargo_build 5
       $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_openhcl_boot 0
-      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 5
     displayName: split debug symbols
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::download_uefi_mu_msvm 0
-      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 6
+      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::resolve_openhcl_kernel_package 1
+      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 17
+    displayName: extract and resolve kernel package
+  - bash: $(FLOWEY_BIN) e 10 flowey_lib_hvlite::resolve_openvmm_deps 0
+    displayName: unpack openvmm-deps archive
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
+      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::init_cross_build 1
+      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::run_cargo_build 6
+      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::run_cargo_build 7
+    displayName: extract Aarch64 sysroot.tar.gz
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 10 flowey_lib_common::run_cargo_build 2
+      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::run_cargo_build 8
+      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_openvmm_hcl 0
+      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 13
+    displayName: cargo build openvmm_hcl
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::run_split_debug_info 1
+      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 14
+      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 15
+      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 18
+    displayName: split debug symbols
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_openhcl_initrd 1
+      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 19
       $(FLOWEY_BIN) e 10 flowey_lib_hvlite::init_cross_build 2
-    displayName: unpack mu_msvm package (aarch64)
+    displayName: building openhcl initrd
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 10 flowey_lib_common::run_cargo_build 0
@@ -1889,59 +1838,60 @@ jobs:
       $(FLOWEY_BIN) e 10 flowey_lib_hvlite::run_split_debug_info 3
       $(FLOWEY_BIN) e 10 flowey_lib_hvlite::run_cargo_build 1
       $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_igvmfilegen 0
-      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 7
-      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 8
-    displayName: split debug symbols
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::run_igvmfilegen 0
-      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 11
-      $(FLOWEY_BIN) e 10 flowey_core::pipeline::artifact::publish 0
-      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 9
-      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 10
-      $(FLOWEY_BIN) e 10 flowey_core::pipeline::artifact::publish 1
-    displayName: building igvm file
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::resolve_openhcl_kernel_package 1
-      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 15
-      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 12
-    displayName: extract and resolve kernel package
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::run_split_debug_info 1
-      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 13
-      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 14
-      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 16
-    displayName: split debug symbols
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_openhcl_initrd 1
-      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 17
-      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 18
-      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 19
       $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 20
-    displayName: building openhcl initrd
+      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 21
+    displayName: split debug symbols
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 10 flowey_lib_hvlite::run_igvmfilegen 1
-      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 23
-      $(FLOWEY_BIN) e 10 flowey_core::pipeline::artifact::publish 2
-      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 21
-      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 22
-      $(FLOWEY_BIN) e 10 flowey_core::pipeline::artifact::publish 3
+      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 2
+      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 6
     displayName: building igvm file
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::resolve_openhcl_kernel_package 0
+      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 2
+    displayName: extract and resolve kernel package
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::run_split_debug_info 0
+      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 3
+      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 4
+      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 7
+    displayName: split debug symbols
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_openhcl_initrd 0
+      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 8
+      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 9
+      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 10
+    displayName: building openhcl initrd
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::run_igvmfilegen 0
+      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 0
+      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::publish 0
+    displayName: building igvm file
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 10 flowey_lib_common::copy_to_artifact_dir 1
+      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 11
+      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 16
+      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 12
+      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 3
+      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 5
+      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 1
+      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 0
+      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 1
+      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe_extras::publish 0
+    displayName: copying OpenHCL igvm files to artifact dir
+  - bash: $(FLOWEY_BIN) e 10 flowey_lib_common::copy_to_artifact_dir 0
+    displayName: copying OpenHCL igvm extras to artifact dir
   - bash: $(FLOWEY_BIN) e 10 flowey_lib_common::cache 3
     displayName: 'validate cache entry: gh-release-download'
   - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-openhcl-igvm
     displayName: 🌼📦 Publish aarch64-openhcl-igvm
     artifact: aarch64-openhcl-igvm
-  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-openhcl-igvm-devkern
-    displayName: 🌼📦 Publish aarch64-openhcl-igvm-devkern
-    artifact: aarch64-openhcl-igvm-devkern
-  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-openhcl-igvm-devkern-extras
-    displayName: 🌼📦 Publish aarch64-openhcl-igvm-devkern-extras
-    artifact: aarch64-openhcl-igvm-devkern-extras
   - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-openhcl-igvm-extras
     displayName: 🌼📦 Publish aarch64-openhcl-igvm-extras
     artifact: aarch64-openhcl-igvm-extras
@@ -4162,12 +4112,12 @@ jobs:
       $(FLOWEY_BIN) e 19 flowey_lib_common::git_checkout 2
       $(FLOWEY_BIN) e 19 flowey_lib_hvlite::git_checkout_openvmm_repo 0
       $(FLOWEY_BIN) e 19 flowey_lib_hvlite::run_cargo_nextest_run 0
-      $(FLOWEY_BIN) e 19 flowey_core::pipeline::artifact::resolve 8
-      $(FLOWEY_BIN) e 19 flowey_core::pipeline::artifact::resolve 2
       $(FLOWEY_BIN) e 19 flowey_core::pipeline::artifact::resolve 3
       $(FLOWEY_BIN) e 19 flowey_core::pipeline::artifact::resolve 4
+      $(FLOWEY_BIN) e 19 flowey_core::pipeline::artifact::resolve 8
       $(FLOWEY_BIN) e 19 flowey_core::pipeline::artifact::resolve 1
       $(FLOWEY_BIN) e 19 flowey_core::pipeline::artifact::resolve 0
+      $(FLOWEY_BIN) e 19 flowey_core::pipeline::artifact::resolve 2
       $(FLOWEY_BIN) e 19 flowey_core::pipeline::artifact::resolve 7
     displayName: report cloned repo directories
   - bash: $(FLOWEY_BIN) e 19 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
@@ -4310,16 +4260,6 @@ jobs:
       artifact: x64-openhcl-igvm
       path: $(FLOWEY_TEMP_DIR)/used_artifacts/x64-openhcl-igvm
   - task: DownloadPipelineArtifact@2
-    displayName: 🌼📦 Download x64-openhcl-igvm-cvm
-    inputs:
-      artifact: x64-openhcl-igvm-cvm
-      path: $(FLOWEY_TEMP_DIR)/used_artifacts/x64-openhcl-igvm-cvm
-  - task: DownloadPipelineArtifact@2
-    displayName: 🌼📦 Download x64-openhcl-igvm-test-linux-direct
-    inputs:
-      artifact: x64-openhcl-igvm-test-linux-direct
-      path: $(FLOWEY_TEMP_DIR)/used_artifacts/x64-openhcl-igvm-test-linux-direct
-  - task: DownloadPipelineArtifact@2
     displayName: 🌼📦 Download x64-tmks
     inputs:
       artifact: x64-tmks
@@ -4392,8 +4332,6 @@ jobs:
       echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-linux-musl-tmk_vmm" | $FLOWEY_BIN v 18 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
       echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-linux-tpm_guest_tests" | $FLOWEY_BIN v 18 'artifact_use_from_x64-linux-tpm_guest_tests' --is-raw-string update
       echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-openhcl-igvm" | $FLOWEY_BIN v 18 'artifact_use_from_x64-openhcl-igvm' --is-raw-string update
-      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-openhcl-igvm-cvm" | $FLOWEY_BIN v 18 'artifact_use_from_x64-openhcl-igvm-cvm' --is-raw-string update
-      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-openhcl-igvm-test-linux-direct" | $FLOWEY_BIN v 18 'artifact_use_from_x64-openhcl-igvm-test-linux-direct' --is-raw-string update
       echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-tmks" | $FLOWEY_BIN v 18 'artifact_use_from_x64-tmks' --is-raw-string update
       echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-openvmm" | $FLOWEY_BIN v 18 'artifact_use_from_x64-windows-openvmm' --is-raw-string update
       echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-pipette" | $FLOWEY_BIN v 18 'artifact_use_from_x64-windows-pipette' --is-raw-string update
@@ -4452,24 +4390,23 @@ jobs:
       $(FLOWEY_BIN) e 18 flowey_lib_common::git_checkout 2
       $(FLOWEY_BIN) e 18 flowey_lib_hvlite::git_checkout_openvmm_repo 0
       $(FLOWEY_BIN) e 18 flowey_lib_hvlite::run_cargo_nextest_run 0
-      $(FLOWEY_BIN) e 18 flowey_core::pipeline::artifact::resolve 8
-      $(FLOWEY_BIN) e 18 flowey_core::pipeline::artifact::resolve 9
-      $(FLOWEY_BIN) e 18 flowey_core::pipeline::artifact::resolve 12
-      $(FLOWEY_BIN) e 18 flowey_core::pipeline::artifact::resolve 14
-      $(FLOWEY_BIN) e 18 flowey_core::pipeline::artifact::resolve 15
-      $(FLOWEY_BIN) e 18 flowey_core::pipeline::artifact::resolve 13
-      $(FLOWEY_BIN) e 18 flowey_core::pipeline::artifact::resolve 3
-      $(FLOWEY_BIN) e 18 flowey_core::pipeline::artifact::resolve 11
-      $(FLOWEY_BIN) e 18 flowey_core::pipeline::artifact::resolve 4
       $(FLOWEY_BIN) e 18 flowey_core::pipeline::artifact::resolve 5
       $(FLOWEY_BIN) e 18 flowey_core::pipeline::artifact::resolve 6
       $(FLOWEY_BIN) e 18 flowey_core::pipeline::artifact::resolve 1
-      $(FLOWEY_BIN) e 18 flowey_core::pipeline::artifact::resolve 2
       $(FLOWEY_BIN) e 18 flowey_core::pipeline::artifact::resolve 0
-      $(FLOWEY_BIN) e 18 flowey_core::pipeline::artifact::resolve 7
+      $(FLOWEY_BIN) e 18 flowey_core::pipeline::artifact::resolve 9
+      $(FLOWEY_BIN) e 18 flowey_core::pipeline::artifact::resolve 2
+      $(FLOWEY_BIN) e 18 flowey_core::pipeline::artifact::resolve 4
+      $(FLOWEY_BIN) e 18 flowey_core::pipeline::artifact::resolve 11
+      $(FLOWEY_BIN) e 18 flowey_core::pipeline::artifact::resolve 12
+      $(FLOWEY_BIN) e 18 flowey_core::pipeline::artifact::resolve 10
+      $(FLOWEY_BIN) e 18 flowey_core::pipeline::artifact::resolve 3
+      $(FLOWEY_BIN) e 18 flowey_core::pipeline::artifact::resolve 8
     displayName: report cloned repo directories
   - bash: $(FLOWEY_BIN) e 18 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
     displayName: creating new test content dir
+  - bash: $(FLOWEY_BIN) e 18 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::resolve 0
+    displayName: resolve OpenHCL igvm artifact
   - bash: $(FLOWEY_BIN) e 18 flowey_lib_common::download_gh_release 0
     displayName: create gh-release-download cache dir
   - bash: |-
@@ -4514,7 +4451,7 @@ jobs:
       set -e
       $(FLOWEY_BIN) e 18 flowey_lib_hvlite::init_vmm_tests_env 0
       $(FLOWEY_BIN) e 18 flowey_lib_hvlite::run_cargo_nextest_run 1
-      $(FLOWEY_BIN) e 18 flowey_core::pipeline::artifact::resolve 16
+      $(FLOWEY_BIN) e 18 flowey_core::pipeline::artifact::resolve 13
       $(FLOWEY_BIN) e 18 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
     displayName: setting up vmm_tests env
   - bash: $(FLOWEY_BIN) e 18 flowey_lib_common::gen_cargo_nextest_run_cmd 0
@@ -4524,7 +4461,7 @@ jobs:
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 18 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
-      $(FLOWEY_BIN) e 18 flowey_core::pipeline::artifact::resolve 10
+      $(FLOWEY_BIN) e 18 flowey_core::pipeline::artifact::resolve 7
     displayName: starting test_igvm_agent_rpc_server
   - bash: $(FLOWEY_BIN) e 18 flowey_lib_hvlite::run_prep_steps 0
     displayName: running vmm_test prep_steps
@@ -4610,16 +4547,6 @@ jobs:
       artifact: x64-mi-secure-openhcl-igvm
       path: $(FLOWEY_TEMP_DIR)/used_artifacts/x64-mi-secure-openhcl-igvm
   - task: DownloadPipelineArtifact@2
-    displayName: 🌼📦 Download x64-mi-secure-openhcl-igvm-cvm
-    inputs:
-      artifact: x64-mi-secure-openhcl-igvm-cvm
-      path: $(FLOWEY_TEMP_DIR)/used_artifacts/x64-mi-secure-openhcl-igvm-cvm
-  - task: DownloadPipelineArtifact@2
-    displayName: 🌼📦 Download x64-mi-secure-openhcl-igvm-test-linux-direct
-    inputs:
-      artifact: x64-mi-secure-openhcl-igvm-test-linux-direct
-      path: $(FLOWEY_TEMP_DIR)/used_artifacts/x64-mi-secure-openhcl-igvm-test-linux-direct
-  - task: DownloadPipelineArtifact@2
     displayName: 🌼📦 Download x64-tmks
     inputs:
       artifact: x64-tmks
@@ -4692,8 +4619,6 @@ jobs:
       echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-linux-musl-tmk_vmm" | $FLOWEY_BIN v 17 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
       echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-linux-tpm_guest_tests" | $FLOWEY_BIN v 17 'artifact_use_from_x64-linux-tpm_guest_tests' --is-raw-string update
       echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-mi-secure-openhcl-igvm" | $FLOWEY_BIN v 17 'artifact_use_from_x64-mi-secure-openhcl-igvm' --is-raw-string update
-      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-mi-secure-openhcl-igvm-cvm" | $FLOWEY_BIN v 17 'artifact_use_from_x64-mi-secure-openhcl-igvm-cvm' --is-raw-string update
-      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-mi-secure-openhcl-igvm-test-linux-direct" | $FLOWEY_BIN v 17 'artifact_use_from_x64-mi-secure-openhcl-igvm-test-linux-direct' --is-raw-string update
       echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-tmks" | $FLOWEY_BIN v 17 'artifact_use_from_x64-tmks' --is-raw-string update
       echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-openvmm" | $FLOWEY_BIN v 17 'artifact_use_from_x64-windows-openvmm' --is-raw-string update
       echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-pipette" | $FLOWEY_BIN v 17 'artifact_use_from_x64-windows-pipette' --is-raw-string update
@@ -4752,24 +4677,23 @@ jobs:
       $(FLOWEY_BIN) e 17 flowey_lib_common::git_checkout 2
       $(FLOWEY_BIN) e 17 flowey_lib_hvlite::git_checkout_openvmm_repo 0
       $(FLOWEY_BIN) e 17 flowey_lib_hvlite::run_cargo_nextest_run 0
-      $(FLOWEY_BIN) e 17 flowey_core::pipeline::artifact::resolve 14
-      $(FLOWEY_BIN) e 17 flowey_core::pipeline::artifact::resolve 15
-      $(FLOWEY_BIN) e 17 flowey_core::pipeline::artifact::resolve 13
-      $(FLOWEY_BIN) e 17 flowey_core::pipeline::artifact::resolve 3
-      $(FLOWEY_BIN) e 17 flowey_core::pipeline::artifact::resolve 11
-      $(FLOWEY_BIN) e 17 flowey_core::pipeline::artifact::resolve 4
       $(FLOWEY_BIN) e 17 flowey_core::pipeline::artifact::resolve 5
       $(FLOWEY_BIN) e 17 flowey_core::pipeline::artifact::resolve 6
       $(FLOWEY_BIN) e 17 flowey_core::pipeline::artifact::resolve 1
-      $(FLOWEY_BIN) e 17 flowey_core::pipeline::artifact::resolve 2
       $(FLOWEY_BIN) e 17 flowey_core::pipeline::artifact::resolve 0
-      $(FLOWEY_BIN) e 17 flowey_core::pipeline::artifact::resolve 7
-      $(FLOWEY_BIN) e 17 flowey_core::pipeline::artifact::resolve 8
       $(FLOWEY_BIN) e 17 flowey_core::pipeline::artifact::resolve 9
+      $(FLOWEY_BIN) e 17 flowey_core::pipeline::artifact::resolve 2
+      $(FLOWEY_BIN) e 17 flowey_core::pipeline::artifact::resolve 4
+      $(FLOWEY_BIN) e 17 flowey_core::pipeline::artifact::resolve 11
       $(FLOWEY_BIN) e 17 flowey_core::pipeline::artifact::resolve 12
+      $(FLOWEY_BIN) e 17 flowey_core::pipeline::artifact::resolve 10
+      $(FLOWEY_BIN) e 17 flowey_core::pipeline::artifact::resolve 3
+      $(FLOWEY_BIN) e 17 flowey_core::pipeline::artifact::resolve 8
     displayName: report cloned repo directories
   - bash: $(FLOWEY_BIN) e 17 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
     displayName: creating new test content dir
+  - bash: $(FLOWEY_BIN) e 17 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::resolve 0
+    displayName: resolve OpenHCL igvm artifact
   - bash: $(FLOWEY_BIN) e 17 flowey_lib_common::download_gh_release 0
     displayName: create gh-release-download cache dir
   - bash: |-
@@ -4814,7 +4738,7 @@ jobs:
       set -e
       $(FLOWEY_BIN) e 17 flowey_lib_hvlite::init_vmm_tests_env 0
       $(FLOWEY_BIN) e 17 flowey_lib_hvlite::run_cargo_nextest_run 1
-      $(FLOWEY_BIN) e 17 flowey_core::pipeline::artifact::resolve 16
+      $(FLOWEY_BIN) e 17 flowey_core::pipeline::artifact::resolve 13
       $(FLOWEY_BIN) e 17 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
     displayName: setting up vmm_tests env
   - bash: $(FLOWEY_BIN) e 17 flowey_lib_common::gen_cargo_nextest_run_cmd 0
@@ -4827,13 +4751,18 @@ jobs:
       set -e
       $(FLOWEY_BIN) e 17 flowey_lib_common::run_cargo_nextest_run 0
       $(FLOWEY_BIN) e 17 flowey_lib_common::run_cargo_nextest_run 1
+      $(FLOWEY_BIN) e 17 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
+    displayName: run 'vmm_tests' nextest tests
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 17 flowey_lib_hvlite::stop_test_igvm_agent_rpc_server 0
       $(FLOWEY_BIN) e 17 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
       $(FLOWEY_BIN) e 17 flowey_lib_common::publish_test_results 1
       $(FLOWEY_BIN) e 17 flowey_lib_common::ado_task_publish_test_results 0
       $(FLOWEY_BIN) e 17 flowey_lib_common::publish_test_results 0
       $FLOWEY_BIN v 17 'flowey_lib_common::ado_task_publish_test_results:0:flowey_lib_common/src/ado_task_publish_test_results.rs:57:45' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env ado floweyvar1
       $FLOWEY_BIN v 17 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env ado FLOWEY_CONDITION
-    displayName: run 'vmm_tests' nextest tests
+    displayName: stopping test_igvm_agent_rpc_server
   - task: PublishTestResults@2
     inputs:
       testResultsFormat: JUnit
@@ -4846,10 +4775,7 @@ jobs:
       $(FLOWEY_BIN) e 17 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
       $(FLOWEY_BIN) e 17 flowey_lib_common::publish_test_results 2
       $(FLOWEY_BIN) e 17 flowey_lib_common::publish_test_results 3
-      $(FLOWEY_BIN) e 17 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
-      $(FLOWEY_BIN) e 17 flowey_lib_hvlite::stop_test_igvm_agent_rpc_server 0
-    displayName: stopping test_igvm_agent_rpc_server
-  - bash: $(FLOWEY_BIN) e 17 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
+      $(FLOWEY_BIN) e 17 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
     displayName: report test results to overall pipeline status
   - bash: $(FLOWEY_BIN) e 17 flowey_lib_common::cache 3
     displayName: 'validate cache entry: cargo-nextest'
@@ -4902,16 +4828,6 @@ jobs:
     inputs:
       artifact: x64-openhcl-igvm
       path: $(FLOWEY_TEMP_DIR)/used_artifacts/x64-openhcl-igvm
-  - task: DownloadPipelineArtifact@2
-    displayName: 🌼📦 Download x64-openhcl-igvm-cvm
-    inputs:
-      artifact: x64-openhcl-igvm-cvm
-      path: $(FLOWEY_TEMP_DIR)/used_artifacts/x64-openhcl-igvm-cvm
-  - task: DownloadPipelineArtifact@2
-    displayName: 🌼📦 Download x64-openhcl-igvm-test-linux-direct
-    inputs:
-      artifact: x64-openhcl-igvm-test-linux-direct
-      path: $(FLOWEY_TEMP_DIR)/used_artifacts/x64-openhcl-igvm-test-linux-direct
   - task: DownloadPipelineArtifact@2
     displayName: 🌼📦 Download x64-tmks
     inputs:
@@ -4985,8 +4901,6 @@ jobs:
       echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-linux-musl-tmk_vmm" | $FLOWEY_BIN v 16 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
       echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-linux-tpm_guest_tests" | $FLOWEY_BIN v 16 'artifact_use_from_x64-linux-tpm_guest_tests' --is-raw-string update
       echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-openhcl-igvm" | $FLOWEY_BIN v 16 'artifact_use_from_x64-openhcl-igvm' --is-raw-string update
-      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-openhcl-igvm-cvm" | $FLOWEY_BIN v 16 'artifact_use_from_x64-openhcl-igvm-cvm' --is-raw-string update
-      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-openhcl-igvm-test-linux-direct" | $FLOWEY_BIN v 16 'artifact_use_from_x64-openhcl-igvm-test-linux-direct' --is-raw-string update
       echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-tmks" | $FLOWEY_BIN v 16 'artifact_use_from_x64-tmks' --is-raw-string update
       echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-openvmm" | $FLOWEY_BIN v 16 'artifact_use_from_x64-windows-openvmm' --is-raw-string update
       echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-pipette" | $FLOWEY_BIN v 16 'artifact_use_from_x64-windows-pipette' --is-raw-string update
@@ -5045,24 +4959,23 @@ jobs:
       $(FLOWEY_BIN) e 16 flowey_lib_common::git_checkout 2
       $(FLOWEY_BIN) e 16 flowey_lib_hvlite::git_checkout_openvmm_repo 0
       $(FLOWEY_BIN) e 16 flowey_lib_hvlite::run_cargo_nextest_run 0
-      $(FLOWEY_BIN) e 16 flowey_core::pipeline::artifact::resolve 8
-      $(FLOWEY_BIN) e 16 flowey_core::pipeline::artifact::resolve 9
-      $(FLOWEY_BIN) e 16 flowey_core::pipeline::artifact::resolve 12
-      $(FLOWEY_BIN) e 16 flowey_core::pipeline::artifact::resolve 14
-      $(FLOWEY_BIN) e 16 flowey_core::pipeline::artifact::resolve 15
-      $(FLOWEY_BIN) e 16 flowey_core::pipeline::artifact::resolve 13
-      $(FLOWEY_BIN) e 16 flowey_core::pipeline::artifact::resolve 3
-      $(FLOWEY_BIN) e 16 flowey_core::pipeline::artifact::resolve 11
-      $(FLOWEY_BIN) e 16 flowey_core::pipeline::artifact::resolve 4
       $(FLOWEY_BIN) e 16 flowey_core::pipeline::artifact::resolve 5
       $(FLOWEY_BIN) e 16 flowey_core::pipeline::artifact::resolve 6
       $(FLOWEY_BIN) e 16 flowey_core::pipeline::artifact::resolve 1
-      $(FLOWEY_BIN) e 16 flowey_core::pipeline::artifact::resolve 2
       $(FLOWEY_BIN) e 16 flowey_core::pipeline::artifact::resolve 0
-      $(FLOWEY_BIN) e 16 flowey_core::pipeline::artifact::resolve 7
+      $(FLOWEY_BIN) e 16 flowey_core::pipeline::artifact::resolve 9
+      $(FLOWEY_BIN) e 16 flowey_core::pipeline::artifact::resolve 2
+      $(FLOWEY_BIN) e 16 flowey_core::pipeline::artifact::resolve 4
+      $(FLOWEY_BIN) e 16 flowey_core::pipeline::artifact::resolve 11
+      $(FLOWEY_BIN) e 16 flowey_core::pipeline::artifact::resolve 12
+      $(FLOWEY_BIN) e 16 flowey_core::pipeline::artifact::resolve 10
+      $(FLOWEY_BIN) e 16 flowey_core::pipeline::artifact::resolve 3
+      $(FLOWEY_BIN) e 16 flowey_core::pipeline::artifact::resolve 8
     displayName: report cloned repo directories
   - bash: $(FLOWEY_BIN) e 16 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
     displayName: creating new test content dir
+  - bash: $(FLOWEY_BIN) e 16 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::resolve 0
+    displayName: resolve OpenHCL igvm artifact
   - bash: $(FLOWEY_BIN) e 16 flowey_lib_common::download_gh_release 0
     displayName: create gh-release-download cache dir
   - bash: |-
@@ -5107,7 +5020,7 @@ jobs:
       set -e
       $(FLOWEY_BIN) e 16 flowey_lib_hvlite::init_vmm_tests_env 0
       $(FLOWEY_BIN) e 16 flowey_lib_hvlite::run_cargo_nextest_run 1
-      $(FLOWEY_BIN) e 16 flowey_core::pipeline::artifact::resolve 16
+      $(FLOWEY_BIN) e 16 flowey_core::pipeline::artifact::resolve 13
       $(FLOWEY_BIN) e 16 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
     displayName: setting up vmm_tests env
   - bash: $(FLOWEY_BIN) e 16 flowey_lib_common::gen_cargo_nextest_run_cmd 0
@@ -5117,7 +5030,7 @@ jobs:
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 16 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
-      $(FLOWEY_BIN) e 16 flowey_core::pipeline::artifact::resolve 10
+      $(FLOWEY_BIN) e 16 flowey_core::pipeline::artifact::resolve 7
     displayName: starting test_igvm_agent_rpc_server
   - bash: $(FLOWEY_BIN) e 16 flowey_lib_hvlite::run_prep_steps 0
     displayName: running vmm_test prep_steps

--- a/ci-flowey/openvmm-pr.yaml
+++ b/ci-flowey/openvmm-pr.yaml
@@ -1129,9 +1129,45 @@ jobs:
       EOF
       mkdir -p "$(AgentTempDirNormal)/publish_artifacts/x64-mi-secure-openhcl-igvm"
       echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/x64-mi-secure-openhcl-igvm" | $FLOWEY_BIN v 12 'artifact_publish_from_x64-mi-secure-openhcl-igvm' --is-raw-string update
+      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/x64-mi-secure-openhcl-igvm-cvm"
+      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/x64-mi-secure-openhcl-igvm-cvm" | $FLOWEY_BIN v 12 'artifact_publish_from_x64-mi-secure-openhcl-igvm-cvm' --is-raw-string update
+      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/x64-mi-secure-openhcl-igvm-cvm-extras"
+      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/x64-mi-secure-openhcl-igvm-cvm-extras" | $FLOWEY_BIN v 12 'artifact_publish_from_x64-mi-secure-openhcl-igvm-cvm-extras' --is-raw-string update
       mkdir -p "$(AgentTempDirNormal)/publish_artifacts/x64-mi-secure-openhcl-igvm-extras"
       echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/x64-mi-secure-openhcl-igvm-extras" | $FLOWEY_BIN v 12 'artifact_publish_from_x64-mi-secure-openhcl-igvm-extras' --is-raw-string update
+      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/x64-mi-secure-openhcl-igvm-test-linux-direct"
+      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/x64-mi-secure-openhcl-igvm-test-linux-direct" | $FLOWEY_BIN v 12 'artifact_publish_from_x64-mi-secure-openhcl-igvm-test-linux-direct' --is-raw-string update
+      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/x64-mi-secure-openhcl-igvm-test-linux-direct-extras"
+      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/x64-mi-secure-openhcl-igvm-test-linux-direct-extras" | $FLOWEY_BIN v 12 'artifact_publish_from_x64-mi-secure-openhcl-igvm-test-linux-direct-extras' --is-raw-string update
     displayName: 🌼🛫 Initialize job
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 12 flowey_lib_common::git_checkout 0
+      $FLOWEY_BIN v 12 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:319:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46 write-to-env ado floweyvar3
+      $FLOWEY_BIN v 12 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46' write-to-env ado FLOWEY_CONDITION
+    displayName: check if openvmm needs to be cloned
+  - checkout: self
+    path: repo0
+    fetchTags: false
+    fetchDepth: 1
+    persistCredentials: $(floweyvar3)
+    submodules: recursive
+    displayName: checkout repo openvmm
+    condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 12 flowey_lib_common::git_checkout 2
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 3
+    displayName: report cloned repo directories
+  - bash: $(FLOWEY_BIN) e 12 flowey_lib_common::install_rust 0
+    displayName: install Rust
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 12 flowey_lib_common::install_rust 1
+      $(FLOWEY_BIN) e 12 flowey_lib_common::cfg_cargo_common_flags 0
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::cfg_openvmm_magicpath 0
+    displayName: detect active toolchain
   - bash: $(FLOWEY_BIN) e 12 flowey_lib_common::download_gh_release 0
     displayName: create gh-release-download cache dir
   - bash: |-
@@ -1155,54 +1191,48 @@ jobs:
     displayName: map ADO hitvar to flowey
   - bash: $(FLOWEY_BIN) e 12 flowey_lib_common::download_gh_release 1
     displayName: download artifacts from github releases
-  - bash: $(FLOWEY_BIN) e 12 flowey_lib_hvlite::resolve_openvmm_test_linux_kernel 0
-    displayName: unpack openvmm-test-linux archives
-  - bash: $(FLOWEY_BIN) e 12 flowey_lib_hvlite::resolve_openvmm_test_initrd 0
-    displayName: unpack openvmm-test-initrd archives
-  - bash: $(FLOWEY_BIN) e 12 flowey_lib_common::install_rust 0
-    displayName: install Rust
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 12 flowey_lib_common::install_rust 1
-      $(FLOWEY_BIN) e 12 flowey_lib_common::cfg_cargo_common_flags 0
-    displayName: detect active toolchain
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 12 flowey_lib_common::git_checkout 0
-      $FLOWEY_BIN v 12 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:319:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46 write-to-env ado floweyvar3
-      $FLOWEY_BIN v 12 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46' write-to-env ado FLOWEY_CONDITION
-    displayName: check if openvmm needs to be cloned
-  - checkout: self
-    path: repo0
-    fetchTags: false
-    fetchDepth: 1
-    persistCredentials: $(floweyvar3)
-    submodules: recursive
-    displayName: checkout repo openvmm
-    condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 12 flowey_lib_common::git_checkout 2
-      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-    displayName: report cloned repo directories
+  - bash: $(FLOWEY_BIN) e 12 flowey_lib_hvlite::resolve_openvmm_deps 0
+    displayName: unpack openvmm-deps archive
+  - bash: $(FLOWEY_BIN) e 12 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
+    displayName: extract X86_64 sysroot.tar.gz
   - bash: $(FLOWEY_BIN) e 12 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
     displayName: set '-Dwarnings' in .cargo/config.toml
   - bash: $(FLOWEY_BIN) e 12 flowey_lib_common::install_dist_pkg 0
     displayName: checking if packages need to be installed
   - bash: $(FLOWEY_BIN) e 12 flowey_lib_common::install_dist_pkg 1
     displayName: installing packages
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 12 flowey_lib_common::resolve_protoc 0
-      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::cfg_openvmm_magicpath 0
+  - bash: $(FLOWEY_BIN) e 12 flowey_lib_common::resolve_protoc 0
     displayName: unpack protoc
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 12 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::init_cross_build 3
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::run_cargo_build 6
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::run_cargo_build 7
+    displayName: symlink protoc
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 12 flowey_lib_common::run_cargo_build 2
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::run_cargo_build 8
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openvmm_hcl 0
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 0
+    displayName: cargo build openvmm_hcl
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::run_split_debug_info 0
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 1
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 2
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 4
+    displayName: split debug symbols
+  - bash: $(FLOWEY_BIN) e 12 flowey_lib_hvlite::resolve_openhcl_kernel_package 0
+    displayName: extract and resolve kernel package
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openhcl_initrd 0
       $(FLOWEY_BIN) e 12 flowey_lib_hvlite::init_cross_build 0
       $(FLOWEY_BIN) e 12 flowey_lib_hvlite::run_cargo_build 9
       $(FLOWEY_BIN) e 12 flowey_lib_hvlite::run_cargo_build 10
-    displayName: symlink protoc
+    displayName: building openhcl initrd
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 12 flowey_lib_common::run_cargo_build 3
@@ -1213,6 +1243,7 @@ jobs:
       $(FLOWEY_BIN) e 12 flowey_lib_hvlite::run_split_debug_info 4
       $(FLOWEY_BIN) e 12 flowey_lib_hvlite::run_cargo_build 12
       $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_sidecar 0
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 5
       $(FLOWEY_BIN) e 12 flowey_lib_hvlite::init_cross_build 1
       $(FLOWEY_BIN) e 12 flowey_lib_hvlite::run_cargo_build 2
       $(FLOWEY_BIN) e 12 flowey_lib_hvlite::run_cargo_build 3
@@ -1227,41 +1258,14 @@ jobs:
       $(FLOWEY_BIN) e 12 flowey_lib_hvlite::run_split_debug_info 3
       $(FLOWEY_BIN) e 12 flowey_lib_hvlite::run_cargo_build 5
       $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openhcl_boot 0
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 6
     displayName: split debug symbols
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::resolve_openhcl_kernel_package 0
-      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 28
-    displayName: extract and resolve kernel package
-  - bash: $(FLOWEY_BIN) e 12 flowey_lib_hvlite::resolve_openvmm_deps 0
-    displayName: unpack openvmm-deps archive
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
-      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::init_cross_build 3
-      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::run_cargo_build 6
-      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::run_cargo_build 7
-    displayName: extract X86_64 sysroot.tar.gz
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 12 flowey_lib_common::run_cargo_build 2
-      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::run_cargo_build 8
-      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openvmm_hcl 0
-      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 24
-    displayName: cargo build openvmm_hcl
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::run_split_debug_info 2
-      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 25
-      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 26
-      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 29
-    displayName: split debug symbols
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openhcl_initrd 2
-      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 30
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::download_uefi_mu_msvm 0
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 7
       $(FLOWEY_BIN) e 12 flowey_lib_hvlite::init_cross_build 2
-    displayName: building openhcl initrd
+    displayName: unpack mu_msvm package (x64)
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 12 flowey_lib_common::run_cargo_build 0
@@ -1272,20 +1276,55 @@ jobs:
       $(FLOWEY_BIN) e 12 flowey_lib_hvlite::run_split_debug_info 5
       $(FLOWEY_BIN) e 12 flowey_lib_hvlite::run_cargo_build 1
       $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_igvmfilegen 0
-      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 31
-      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 32
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 8
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 9
     displayName: split debug symbols
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::run_igvmfilegen 2
-      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 2
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::run_igvmfilegen 1
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 12
+      $(FLOWEY_BIN) e 12 flowey_core::pipeline::artifact::publish 0
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 10
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 11
+      $(FLOWEY_BIN) e 12 flowey_core::pipeline::artifact::publish 1
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 33
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 34
     displayName: building igvm file
-  - bash: $(FLOWEY_BIN) e 12 flowey_lib_hvlite::download_uefi_mu_msvm 0
-    displayName: unpack mu_msvm package (x64)
+  - bash: $(FLOWEY_BIN) e 12 flowey_lib_hvlite::resolve_openvmm_test_linux_kernel 0
+    displayName: unpack openvmm-test-linux archives
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::resolve_openvmm_test_initrd 0
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 28
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 25
+    displayName: unpack openvmm-test-initrd archives
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::run_split_debug_info 2
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 26
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 27
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 29
+    displayName: split debug symbols
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openhcl_initrd 2
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 30
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 31
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 32
+    displayName: building openhcl initrd
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::run_igvmfilegen 0
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 37
+      $(FLOWEY_BIN) e 12 flowey_core::pipeline::artifact::publish 2
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 35
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 36
+      $(FLOWEY_BIN) e 12 flowey_core::pipeline::artifact::publish 3
+    displayName: building igvm file
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 12 flowey_lib_hvlite::resolve_openhcl_kernel_package 1
-      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 17
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 16
       $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 13
     displayName: extract and resolve kernel package
   - bash: |-
@@ -1293,69 +1332,45 @@ jobs:
       $(FLOWEY_BIN) e 12 flowey_lib_hvlite::run_split_debug_info 1
       $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 14
       $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 15
-      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 18
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 17
     displayName: split debug symbols
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openhcl_initrd 1
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 18
       $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 19
       $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 20
       $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 21
     displayName: building openhcl initrd
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::run_igvmfilegen 1
-      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 4
-      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 6
-      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 2
-    displayName: building igvm file
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::run_split_debug_info 0
-      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 3
-      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 4
-      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 7
-    displayName: split debug symbols
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openhcl_initrd 0
-      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 8
-      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 9
-      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 10
-    displayName: building openhcl initrd
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::run_igvmfilegen 0
-      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 0
-      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::publish 0
-    displayName: building igvm file
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 12 flowey_lib_common::copy_to_artifact_dir 1
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::run_igvmfilegen 2
+      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 24
+      $(FLOWEY_BIN) e 12 flowey_core::pipeline::artifact::publish 4
       $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 22
-      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 27
       $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 23
-      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 3
-      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 16
-      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 12
-      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 11
-      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 5
-      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 5
-      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 1
-      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 0
-      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 1
-      $(FLOWEY_BIN) e 12 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe_extras::publish 0
-    displayName: copying OpenHCL igvm files to artifact dir
-  - bash: $(FLOWEY_BIN) e 12 flowey_lib_common::copy_to_artifact_dir 0
-    displayName: copying OpenHCL igvm extras to artifact dir
+      $(FLOWEY_BIN) e 12 flowey_core::pipeline::artifact::publish 5
+    displayName: building igvm file
   - bash: $(FLOWEY_BIN) e 12 flowey_lib_common::cache 3
     displayName: 'validate cache entry: gh-release-download'
   - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/x64-mi-secure-openhcl-igvm
     displayName: 🌼📦 Publish x64-mi-secure-openhcl-igvm
     artifact: x64-mi-secure-openhcl-igvm
+  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/x64-mi-secure-openhcl-igvm-cvm
+    displayName: 🌼📦 Publish x64-mi-secure-openhcl-igvm-cvm
+    artifact: x64-mi-secure-openhcl-igvm-cvm
+  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/x64-mi-secure-openhcl-igvm-cvm-extras
+    displayName: 🌼📦 Publish x64-mi-secure-openhcl-igvm-cvm-extras
+    artifact: x64-mi-secure-openhcl-igvm-cvm-extras
   - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/x64-mi-secure-openhcl-igvm-extras
     displayName: 🌼📦 Publish x64-mi-secure-openhcl-igvm-extras
     artifact: x64-mi-secure-openhcl-igvm-extras
+  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/x64-mi-secure-openhcl-igvm-test-linux-direct
+    displayName: 🌼📦 Publish x64-mi-secure-openhcl-igvm-test-linux-direct
+    artifact: x64-mi-secure-openhcl-igvm-test-linux-direct
+  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/x64-mi-secure-openhcl-igvm-test-linux-direct-extras
+    displayName: 🌼📦 Publish x64-mi-secure-openhcl-igvm-test-linux-direct-extras
+    artifact: x64-mi-secure-openhcl-igvm-test-linux-direct-extras
 - job: job11
   displayName: build openhcl [x64-linux]
   pool:
@@ -1394,13 +1409,53 @@ jobs:
       EOF
       mkdir -p "$(AgentTempDirNormal)/publish_artifacts/x64-openhcl-igvm"
       echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/x64-openhcl-igvm" | $FLOWEY_BIN v 11 'artifact_publish_from_x64-openhcl-igvm' --is-raw-string update
+      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/x64-openhcl-igvm-cvm"
+      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/x64-openhcl-igvm-cvm" | $FLOWEY_BIN v 11 'artifact_publish_from_x64-openhcl-igvm-cvm' --is-raw-string update
+      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/x64-openhcl-igvm-cvm-extras"
+      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/x64-openhcl-igvm-cvm-extras" | $FLOWEY_BIN v 11 'artifact_publish_from_x64-openhcl-igvm-cvm-extras' --is-raw-string update
+      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/x64-openhcl-igvm-devkern"
+      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/x64-openhcl-igvm-devkern" | $FLOWEY_BIN v 11 'artifact_publish_from_x64-openhcl-igvm-devkern' --is-raw-string update
+      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/x64-openhcl-igvm-devkern-extras"
+      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/x64-openhcl-igvm-devkern-extras" | $FLOWEY_BIN v 11 'artifact_publish_from_x64-openhcl-igvm-devkern-extras' --is-raw-string update
       mkdir -p "$(AgentTempDirNormal)/publish_artifacts/x64-openhcl-igvm-extras"
       echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/x64-openhcl-igvm-extras" | $FLOWEY_BIN v 11 'artifact_publish_from_x64-openhcl-igvm-extras' --is-raw-string update
+      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/x64-openhcl-igvm-test-linux-direct"
+      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/x64-openhcl-igvm-test-linux-direct" | $FLOWEY_BIN v 11 'artifact_publish_from_x64-openhcl-igvm-test-linux-direct' --is-raw-string update
+      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/x64-openhcl-igvm-test-linux-direct-devkern"
+      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/x64-openhcl-igvm-test-linux-direct-devkern" | $FLOWEY_BIN v 11 'artifact_publish_from_x64-openhcl-igvm-test-linux-direct-devkern' --is-raw-string update
+      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/x64-openhcl-igvm-test-linux-direct-devkern-extras"
+      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/x64-openhcl-igvm-test-linux-direct-devkern-extras" | $FLOWEY_BIN v 11 'artifact_publish_from_x64-openhcl-igvm-test-linux-direct-devkern-extras' --is-raw-string update
+      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/x64-openhcl-igvm-test-linux-direct-extras"
+      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/x64-openhcl-igvm-test-linux-direct-extras" | $FLOWEY_BIN v 11 'artifact_publish_from_x64-openhcl-igvm-test-linux-direct-extras' --is-raw-string update
     displayName: 🌼🛫 Initialize job
-  - bash: $(FLOWEY_BIN) e 11 flowey_lib_common::install_dist_pkg 0
-    displayName: checking if packages need to be installed
-  - bash: $(FLOWEY_BIN) e 11 flowey_lib_common::install_dist_pkg 1
-    displayName: installing packages
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 11 flowey_lib_common::git_checkout 0
+      $FLOWEY_BIN v 11 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:319:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46 write-to-env ado floweyvar3
+      $FLOWEY_BIN v 11 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46' write-to-env ado FLOWEY_CONDITION
+    displayName: check if openvmm needs to be cloned
+  - checkout: self
+    path: repo0
+    fetchTags: false
+    fetchDepth: 1
+    persistCredentials: $(floweyvar3)
+    submodules: recursive
+    displayName: checkout repo openvmm
+    condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 11 flowey_lib_common::git_checkout 2
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 3
+    displayName: report cloned repo directories
+  - bash: $(FLOWEY_BIN) e 11 flowey_lib_common::install_rust 0
+    displayName: install Rust
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 11 flowey_lib_common::install_rust 1
+      $(FLOWEY_BIN) e 11 flowey_lib_common::cfg_cargo_common_flags 0
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::cfg_openvmm_magicpath 0
+    displayName: detect active toolchain
   - bash: $(FLOWEY_BIN) e 11 flowey_lib_common::download_gh_release 0
     displayName: create gh-release-download cache dir
   - bash: |-
@@ -1424,48 +1479,48 @@ jobs:
     displayName: map ADO hitvar to flowey
   - bash: $(FLOWEY_BIN) e 11 flowey_lib_common::download_gh_release 1
     displayName: download artifacts from github releases
-  - bash: $(FLOWEY_BIN) e 11 flowey_lib_hvlite::download_uefi_mu_msvm 0
-    displayName: unpack mu_msvm package (x64)
-  - bash: $(FLOWEY_BIN) e 11 flowey_lib_common::install_rust 0
-    displayName: install Rust
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 11 flowey_lib_common::install_rust 1
-      $(FLOWEY_BIN) e 11 flowey_lib_common::cfg_cargo_common_flags 0
-    displayName: detect active toolchain
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 11 flowey_lib_common::git_checkout 0
-      $FLOWEY_BIN v 11 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:319:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46 write-to-env ado floweyvar3
-      $FLOWEY_BIN v 11 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46' write-to-env ado FLOWEY_CONDITION
-    displayName: check if openvmm needs to be cloned
-  - checkout: self
-    path: repo0
-    fetchTags: false
-    fetchDepth: 1
-    persistCredentials: $(floweyvar3)
-    submodules: recursive
-    displayName: checkout repo openvmm
-    condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 11 flowey_lib_common::git_checkout 2
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-    displayName: report cloned repo directories
+  - bash: $(FLOWEY_BIN) e 11 flowey_lib_hvlite::resolve_openvmm_deps 0
+    displayName: unpack openvmm-deps archive
+  - bash: $(FLOWEY_BIN) e 11 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
+    displayName: extract X86_64 sysroot.tar.gz
   - bash: $(FLOWEY_BIN) e 11 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
     displayName: set '-Dwarnings' in .cargo/config.toml
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 11 flowey_lib_common::resolve_protoc 0
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::cfg_openvmm_magicpath 0
+  - bash: $(FLOWEY_BIN) e 11 flowey_lib_common::install_dist_pkg 0
+    displayName: checking if packages need to be installed
+  - bash: $(FLOWEY_BIN) e 11 flowey_lib_common::install_dist_pkg 1
+    displayName: installing packages
+  - bash: $(FLOWEY_BIN) e 11 flowey_lib_common::resolve_protoc 0
     displayName: unpack protoc
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 11 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::init_cross_build 3
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::run_cargo_build 6
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::run_cargo_build 7
+    displayName: symlink protoc
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 11 flowey_lib_common::run_cargo_build 2
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::run_cargo_build 8
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openvmm_hcl 0
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 0
+    displayName: cargo build openvmm_hcl
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::run_split_debug_info 0
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 1
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 2
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 4
+    displayName: split debug symbols
+  - bash: $(FLOWEY_BIN) e 11 flowey_lib_hvlite::resolve_openhcl_kernel_package 0
+    displayName: extract and resolve kernel package
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_initrd 2
       $(FLOWEY_BIN) e 11 flowey_lib_hvlite::init_cross_build 0
       $(FLOWEY_BIN) e 11 flowey_lib_hvlite::run_cargo_build 9
       $(FLOWEY_BIN) e 11 flowey_lib_hvlite::run_cargo_build 10
-    displayName: symlink protoc
+    displayName: building openhcl initrd
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 11 flowey_lib_common::run_cargo_build 3
@@ -1476,6 +1531,7 @@ jobs:
       $(FLOWEY_BIN) e 11 flowey_lib_hvlite::run_split_debug_info 6
       $(FLOWEY_BIN) e 11 flowey_lib_hvlite::run_cargo_build 12
       $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_sidecar 0
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 5
       $(FLOWEY_BIN) e 11 flowey_lib_hvlite::init_cross_build 1
       $(FLOWEY_BIN) e 11 flowey_lib_hvlite::run_cargo_build 2
       $(FLOWEY_BIN) e 11 flowey_lib_hvlite::run_cargo_build 3
@@ -1490,41 +1546,14 @@ jobs:
       $(FLOWEY_BIN) e 11 flowey_lib_hvlite::run_split_debug_info 5
       $(FLOWEY_BIN) e 11 flowey_lib_hvlite::run_cargo_build 5
       $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_boot 0
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 6
     displayName: split debug symbols
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::resolve_openhcl_kernel_package 2
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 28
-    displayName: extract and resolve kernel package
-  - bash: $(FLOWEY_BIN) e 11 flowey_lib_hvlite::resolve_openvmm_deps 0
-    displayName: unpack openvmm-deps archive
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::init_cross_build 3
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::run_cargo_build 6
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::run_cargo_build 7
-    displayName: extract X86_64 sysroot.tar.gz
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 11 flowey_lib_common::run_cargo_build 2
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::run_cargo_build 8
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openvmm_hcl 0
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 24
-    displayName: cargo build openvmm_hcl
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::run_split_debug_info 4
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 25
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 26
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 29
-    displayName: split debug symbols
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_initrd 4
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 30
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::download_uefi_mu_msvm 0
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 7
       $(FLOWEY_BIN) e 11 flowey_lib_hvlite::init_cross_build 2
-    displayName: building openhcl initrd
+    displayName: unpack mu_msvm package (x64)
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 11 flowey_lib_common::run_cargo_build 0
@@ -1535,66 +1564,113 @@ jobs:
       $(FLOWEY_BIN) e 11 flowey_lib_hvlite::run_split_debug_info 7
       $(FLOWEY_BIN) e 11 flowey_lib_hvlite::run_cargo_build 1
       $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_igvmfilegen 0
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 31
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 32
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 8
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 9
     displayName: split debug symbols
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::run_igvmfilegen 4
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 2
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 39
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 35
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::run_igvmfilegen 2
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 12
+      $(FLOWEY_BIN) e 11 flowey_core::pipeline::artifact::publish 0
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 10
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 11
+      $(FLOWEY_BIN) e 11 flowey_core::pipeline::artifact::publish 1
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 34
     displayName: building igvm file
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::run_split_debug_info 0
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 36
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 37
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 40
-    displayName: split debug symbols
-  - bash: $(FLOWEY_BIN) e 11 flowey_lib_hvlite::resolve_openhcl_kernel_package 0
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::resolve_openhcl_kernel_package 2
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 28
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 25
     displayName: extract and resolve kernel package
-  - bash: $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_initrd 0
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::run_split_debug_info 4
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 26
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 27
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 29
+    displayName: split debug symbols
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_initrd 4
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 30
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 31
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 32
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 33
     displayName: building openhcl initrd
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::run_igvmfilegen 4
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 37
+      $(FLOWEY_BIN) e 11 flowey_core::pipeline::artifact::publish 2
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 35
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 36
+      $(FLOWEY_BIN) e 11 flowey_core::pipeline::artifact::publish 3
+    displayName: building igvm file
   - bash: $(FLOWEY_BIN) e 11 flowey_lib_hvlite::resolve_openvmm_test_linux_kernel 0
     displayName: unpack openvmm-test-linux archives
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 11 flowey_lib_hvlite::resolve_openvmm_test_initrd 0
       $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 41
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 42
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 43
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 38
     displayName: unpack openvmm-test-initrd archives
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::run_igvmfilegen 0
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 4
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 50
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::run_split_debug_info 1
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 39
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 40
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 42
+    displayName: split debug symbols
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_initrd 0
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 43
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 44
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 45
       $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 46
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 47
+    displayName: building openhcl initrd
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::run_igvmfilegen 0
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 50
+      $(FLOWEY_BIN) e 11 flowey_core::pipeline::artifact::publish 4
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 48
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 49
+      $(FLOWEY_BIN) e 11 flowey_core::pipeline::artifact::publish 5
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 54
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 51
     displayName: building igvm file
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::run_split_debug_info 1
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 47
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 48
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 51
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::run_split_debug_info 2
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 52
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 53
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 55
     displayName: split debug symbols
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_initrd 1
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 52
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 53
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 54
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 56
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 57
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 58
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 59
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 60
     displayName: building openhcl initrd
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 11 flowey_lib_hvlite::run_igvmfilegen 1
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 6
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 63
+      $(FLOWEY_BIN) e 11 flowey_core::pipeline::artifact::publish 6
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 61
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 62
+      $(FLOWEY_BIN) e 11 flowey_core::pipeline::artifact::publish 7
     displayName: building igvm file
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 11 flowey_lib_hvlite::resolve_openhcl_kernel_package 1
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 17
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 16
       $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 13
     displayName: extract and resolve kernel package
   - bash: |-
@@ -1602,11 +1678,12 @@ jobs:
       $(FLOWEY_BIN) e 11 flowey_lib_hvlite::run_split_debug_info 3
       $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 14
       $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 15
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 18
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 17
     displayName: split debug symbols
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_initrd 3
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 18
       $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 19
       $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 20
       $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 21
@@ -1614,65 +1691,44 @@ jobs:
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 11 flowey_lib_hvlite::run_igvmfilegen 3
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 8
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 6
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 2
-    displayName: building igvm file
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::run_split_debug_info 2
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 3
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 4
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 7
-    displayName: split debug symbols
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_initrd 2
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 8
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 9
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 10
-    displayName: building openhcl initrd
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::run_igvmfilegen 2
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 0
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::publish 0
-    displayName: building igvm file
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 11 flowey_lib_common::copy_to_artifact_dir 1
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 24
+      $(FLOWEY_BIN) e 11 flowey_core::pipeline::artifact::publish 8
       $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 22
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 27
       $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 23
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 3
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 38
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 34
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 33
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 5
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 49
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 45
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 44
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 7
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 16
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 12
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 11
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 9
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 5
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 1
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 0
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 1
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe_extras::publish 0
-    displayName: copying OpenHCL igvm files to artifact dir
-  - bash: $(FLOWEY_BIN) e 11 flowey_lib_common::copy_to_artifact_dir 0
-    displayName: copying OpenHCL igvm extras to artifact dir
+      $(FLOWEY_BIN) e 11 flowey_core::pipeline::artifact::publish 9
+    displayName: building igvm file
   - bash: $(FLOWEY_BIN) e 11 flowey_lib_common::cache 3
     displayName: 'validate cache entry: gh-release-download'
   - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/x64-openhcl-igvm
     displayName: 🌼📦 Publish x64-openhcl-igvm
     artifact: x64-openhcl-igvm
+  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/x64-openhcl-igvm-cvm
+    displayName: 🌼📦 Publish x64-openhcl-igvm-cvm
+    artifact: x64-openhcl-igvm-cvm
+  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/x64-openhcl-igvm-cvm-extras
+    displayName: 🌼📦 Publish x64-openhcl-igvm-cvm-extras
+    artifact: x64-openhcl-igvm-cvm-extras
+  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/x64-openhcl-igvm-devkern
+    displayName: 🌼📦 Publish x64-openhcl-igvm-devkern
+    artifact: x64-openhcl-igvm-devkern
+  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/x64-openhcl-igvm-devkern-extras
+    displayName: 🌼📦 Publish x64-openhcl-igvm-devkern-extras
+    artifact: x64-openhcl-igvm-devkern-extras
   - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/x64-openhcl-igvm-extras
     displayName: 🌼📦 Publish x64-openhcl-igvm-extras
     artifact: x64-openhcl-igvm-extras
+  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/x64-openhcl-igvm-test-linux-direct
+    displayName: 🌼📦 Publish x64-openhcl-igvm-test-linux-direct
+    artifact: x64-openhcl-igvm-test-linux-direct
+  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/x64-openhcl-igvm-test-linux-direct-devkern
+    displayName: 🌼📦 Publish x64-openhcl-igvm-test-linux-direct-devkern
+    artifact: x64-openhcl-igvm-test-linux-direct-devkern
+  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/x64-openhcl-igvm-test-linux-direct-devkern-extras
+    displayName: 🌼📦 Publish x64-openhcl-igvm-test-linux-direct-devkern-extras
+    artifact: x64-openhcl-igvm-test-linux-direct-devkern-extras
+  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/x64-openhcl-igvm-test-linux-direct-extras
+    displayName: 🌼📦 Publish x64-openhcl-igvm-test-linux-direct-extras
+    artifact: x64-openhcl-igvm-test-linux-direct-extras
 - job: job10
   displayName: build openhcl [aarch64-linux]
   pool:
@@ -1711,13 +1767,41 @@ jobs:
       EOF
       mkdir -p "$(AgentTempDirNormal)/publish_artifacts/aarch64-openhcl-igvm"
       echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-openhcl-igvm" | $FLOWEY_BIN v 10 'artifact_publish_from_aarch64-openhcl-igvm' --is-raw-string update
+      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/aarch64-openhcl-igvm-devkern"
+      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-openhcl-igvm-devkern" | $FLOWEY_BIN v 10 'artifact_publish_from_aarch64-openhcl-igvm-devkern' --is-raw-string update
+      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/aarch64-openhcl-igvm-devkern-extras"
+      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-openhcl-igvm-devkern-extras" | $FLOWEY_BIN v 10 'artifact_publish_from_aarch64-openhcl-igvm-devkern-extras' --is-raw-string update
       mkdir -p "$(AgentTempDirNormal)/publish_artifacts/aarch64-openhcl-igvm-extras"
       echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-openhcl-igvm-extras" | $FLOWEY_BIN v 10 'artifact_publish_from_aarch64-openhcl-igvm-extras' --is-raw-string update
     displayName: 🌼🛫 Initialize job
-  - bash: $(FLOWEY_BIN) e 10 flowey_lib_common::install_dist_pkg 0
-    displayName: checking if packages need to be installed
-  - bash: $(FLOWEY_BIN) e 10 flowey_lib_common::install_dist_pkg 1
-    displayName: installing packages
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 10 flowey_lib_common::git_checkout 0
+      $FLOWEY_BIN v 10 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:319:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46 write-to-env ado floweyvar3
+      $FLOWEY_BIN v 10 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46' write-to-env ado FLOWEY_CONDITION
+    displayName: check if openvmm needs to be cloned
+  - checkout: self
+    path: repo0
+    fetchTags: false
+    fetchDepth: 1
+    persistCredentials: $(floweyvar3)
+    submodules: recursive
+    displayName: checkout repo openvmm
+    condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 10 flowey_lib_common::git_checkout 2
+      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 3
+    displayName: report cloned repo directories
+  - bash: $(FLOWEY_BIN) e 10 flowey_lib_common::install_rust 0
+    displayName: install Rust
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 10 flowey_lib_common::install_rust 1
+      $(FLOWEY_BIN) e 10 flowey_lib_common::cfg_cargo_common_flags 0
+      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::cfg_openvmm_magicpath 0
+    displayName: detect active toolchain
   - bash: $(FLOWEY_BIN) e 10 flowey_lib_common::download_gh_release 0
     displayName: create gh-release-download cache dir
   - bash: |-
@@ -1741,48 +1825,48 @@ jobs:
     displayName: map ADO hitvar to flowey
   - bash: $(FLOWEY_BIN) e 10 flowey_lib_common::download_gh_release 1
     displayName: download artifacts from github releases
-  - bash: $(FLOWEY_BIN) e 10 flowey_lib_hvlite::download_uefi_mu_msvm 0
-    displayName: unpack mu_msvm package (aarch64)
-  - bash: $(FLOWEY_BIN) e 10 flowey_lib_common::install_rust 0
-    displayName: install Rust
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 10 flowey_lib_common::install_rust 1
-      $(FLOWEY_BIN) e 10 flowey_lib_common::cfg_cargo_common_flags 0
-    displayName: detect active toolchain
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 10 flowey_lib_common::git_checkout 0
-      $FLOWEY_BIN v 10 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:319:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46 write-to-env ado floweyvar3
-      $FLOWEY_BIN v 10 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46' write-to-env ado FLOWEY_CONDITION
-    displayName: check if openvmm needs to be cloned
-  - checkout: self
-    path: repo0
-    fetchTags: false
-    fetchDepth: 1
-    persistCredentials: $(floweyvar3)
-    submodules: recursive
-    displayName: checkout repo openvmm
-    condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 10 flowey_lib_common::git_checkout 2
-      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-    displayName: report cloned repo directories
+  - bash: $(FLOWEY_BIN) e 10 flowey_lib_hvlite::resolve_openvmm_deps 0
+    displayName: unpack openvmm-deps archive
+  - bash: $(FLOWEY_BIN) e 10 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
+    displayName: extract Aarch64 sysroot.tar.gz
   - bash: $(FLOWEY_BIN) e 10 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
     displayName: set '-Dwarnings' in .cargo/config.toml
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 10 flowey_lib_common::resolve_protoc 0
-      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::cfg_openvmm_magicpath 0
+  - bash: $(FLOWEY_BIN) e 10 flowey_lib_common::install_dist_pkg 0
+    displayName: checking if packages need to be installed
+  - bash: $(FLOWEY_BIN) e 10 flowey_lib_common::install_dist_pkg 1
+    displayName: installing packages
+  - bash: $(FLOWEY_BIN) e 10 flowey_lib_common::resolve_protoc 0
     displayName: unpack protoc
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 10 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
+      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::init_cross_build 1
+      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::run_cargo_build 6
+      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::run_cargo_build 7
+    displayName: symlink protoc
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 10 flowey_lib_common::run_cargo_build 2
+      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::run_cargo_build 8
+      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_openvmm_hcl 0
+      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 0
+    displayName: cargo build openvmm_hcl
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::run_split_debug_info 0
+      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 1
+      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 2
+      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 4
+    displayName: split debug symbols
+  - bash: $(FLOWEY_BIN) e 10 flowey_lib_hvlite::resolve_openhcl_kernel_package 0
+    displayName: extract and resolve kernel package
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_openhcl_initrd 0
       $(FLOWEY_BIN) e 10 flowey_lib_hvlite::init_cross_build 0
       $(FLOWEY_BIN) e 10 flowey_lib_hvlite::run_cargo_build 2
       $(FLOWEY_BIN) e 10 flowey_lib_hvlite::run_cargo_build 3
-    displayName: symlink protoc
+    displayName: building openhcl initrd
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 10 flowey_lib_common::run_cargo_build 1
@@ -1793,41 +1877,14 @@ jobs:
       $(FLOWEY_BIN) e 10 flowey_lib_hvlite::run_split_debug_info 2
       $(FLOWEY_BIN) e 10 flowey_lib_hvlite::run_cargo_build 5
       $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_openhcl_boot 0
+      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 5
     displayName: split debug symbols
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::resolve_openhcl_kernel_package 1
-      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 17
-    displayName: extract and resolve kernel package
-  - bash: $(FLOWEY_BIN) e 10 flowey_lib_hvlite::resolve_openvmm_deps 0
-    displayName: unpack openvmm-deps archive
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
-      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::init_cross_build 1
-      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::run_cargo_build 6
-      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::run_cargo_build 7
-    displayName: extract Aarch64 sysroot.tar.gz
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 10 flowey_lib_common::run_cargo_build 2
-      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::run_cargo_build 8
-      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_openvmm_hcl 0
-      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 13
-    displayName: cargo build openvmm_hcl
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::run_split_debug_info 1
-      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 14
-      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 15
-      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 18
-    displayName: split debug symbols
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_openhcl_initrd 1
-      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 19
+      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::download_uefi_mu_msvm 0
+      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 6
       $(FLOWEY_BIN) e 10 flowey_lib_hvlite::init_cross_build 2
-    displayName: building openhcl initrd
+    displayName: unpack mu_msvm package (aarch64)
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 10 flowey_lib_common::run_cargo_build 0
@@ -1838,60 +1895,59 @@ jobs:
       $(FLOWEY_BIN) e 10 flowey_lib_hvlite::run_split_debug_info 3
       $(FLOWEY_BIN) e 10 flowey_lib_hvlite::run_cargo_build 1
       $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_igvmfilegen 0
-      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 20
-      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 21
-    displayName: split debug symbols
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::run_igvmfilegen 1
-      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 2
-      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 6
-    displayName: building igvm file
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::resolve_openhcl_kernel_package 0
-      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 2
-    displayName: extract and resolve kernel package
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::run_split_debug_info 0
-      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 3
-      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 4
       $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 7
-    displayName: split debug symbols
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_openhcl_initrd 0
       $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 8
-      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 9
-      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 10
-    displayName: building openhcl initrd
+    displayName: split debug symbols
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 10 flowey_lib_hvlite::run_igvmfilegen 0
-      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 0
-      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::publish 0
+      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 11
+      $(FLOWEY_BIN) e 10 flowey_core::pipeline::artifact::publish 0
+      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 9
+      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 10
+      $(FLOWEY_BIN) e 10 flowey_core::pipeline::artifact::publish 1
     displayName: building igvm file
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 10 flowey_lib_common::copy_to_artifact_dir 1
-      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 11
-      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 16
+      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::resolve_openhcl_kernel_package 1
+      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 15
       $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 12
-      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 3
-      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 5
-      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 1
-      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 0
-      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 1
-      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe_extras::publish 0
-    displayName: copying OpenHCL igvm files to artifact dir
-  - bash: $(FLOWEY_BIN) e 10 flowey_lib_common::copy_to_artifact_dir 0
-    displayName: copying OpenHCL igvm extras to artifact dir
+    displayName: extract and resolve kernel package
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::run_split_debug_info 1
+      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 13
+      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 14
+      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 16
+    displayName: split debug symbols
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_openhcl_initrd 1
+      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 17
+      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 18
+      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 19
+      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 20
+    displayName: building openhcl initrd
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::run_igvmfilegen 1
+      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 23
+      $(FLOWEY_BIN) e 10 flowey_core::pipeline::artifact::publish 2
+      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 21
+      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 22
+      $(FLOWEY_BIN) e 10 flowey_core::pipeline::artifact::publish 3
+    displayName: building igvm file
   - bash: $(FLOWEY_BIN) e 10 flowey_lib_common::cache 3
     displayName: 'validate cache entry: gh-release-download'
   - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-openhcl-igvm
     displayName: 🌼📦 Publish aarch64-openhcl-igvm
     artifact: aarch64-openhcl-igvm
+  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-openhcl-igvm-devkern
+    displayName: 🌼📦 Publish aarch64-openhcl-igvm-devkern
+    artifact: aarch64-openhcl-igvm-devkern
+  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-openhcl-igvm-devkern-extras
+    displayName: 🌼📦 Publish aarch64-openhcl-igvm-devkern-extras
+    artifact: aarch64-openhcl-igvm-devkern-extras
   - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-openhcl-igvm-extras
     displayName: 🌼📦 Publish aarch64-openhcl-igvm-extras
     artifact: aarch64-openhcl-igvm-extras
@@ -4112,12 +4168,12 @@ jobs:
       $(FLOWEY_BIN) e 19 flowey_lib_common::git_checkout 2
       $(FLOWEY_BIN) e 19 flowey_lib_hvlite::git_checkout_openvmm_repo 0
       $(FLOWEY_BIN) e 19 flowey_lib_hvlite::run_cargo_nextest_run 0
+      $(FLOWEY_BIN) e 19 flowey_core::pipeline::artifact::resolve 8
+      $(FLOWEY_BIN) e 19 flowey_core::pipeline::artifact::resolve 2
       $(FLOWEY_BIN) e 19 flowey_core::pipeline::artifact::resolve 3
       $(FLOWEY_BIN) e 19 flowey_core::pipeline::artifact::resolve 4
-      $(FLOWEY_BIN) e 19 flowey_core::pipeline::artifact::resolve 8
       $(FLOWEY_BIN) e 19 flowey_core::pipeline::artifact::resolve 1
       $(FLOWEY_BIN) e 19 flowey_core::pipeline::artifact::resolve 0
-      $(FLOWEY_BIN) e 19 flowey_core::pipeline::artifact::resolve 2
       $(FLOWEY_BIN) e 19 flowey_core::pipeline::artifact::resolve 7
     displayName: report cloned repo directories
   - bash: $(FLOWEY_BIN) e 19 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
@@ -4260,6 +4316,16 @@ jobs:
       artifact: x64-openhcl-igvm
       path: $(FLOWEY_TEMP_DIR)/used_artifacts/x64-openhcl-igvm
   - task: DownloadPipelineArtifact@2
+    displayName: 🌼📦 Download x64-openhcl-igvm-cvm
+    inputs:
+      artifact: x64-openhcl-igvm-cvm
+      path: $(FLOWEY_TEMP_DIR)/used_artifacts/x64-openhcl-igvm-cvm
+  - task: DownloadPipelineArtifact@2
+    displayName: 🌼📦 Download x64-openhcl-igvm-test-linux-direct
+    inputs:
+      artifact: x64-openhcl-igvm-test-linux-direct
+      path: $(FLOWEY_TEMP_DIR)/used_artifacts/x64-openhcl-igvm-test-linux-direct
+  - task: DownloadPipelineArtifact@2
     displayName: 🌼📦 Download x64-tmks
     inputs:
       artifact: x64-tmks
@@ -4332,6 +4398,8 @@ jobs:
       echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-linux-musl-tmk_vmm" | $FLOWEY_BIN v 18 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
       echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-linux-tpm_guest_tests" | $FLOWEY_BIN v 18 'artifact_use_from_x64-linux-tpm_guest_tests' --is-raw-string update
       echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-openhcl-igvm" | $FLOWEY_BIN v 18 'artifact_use_from_x64-openhcl-igvm' --is-raw-string update
+      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-openhcl-igvm-cvm" | $FLOWEY_BIN v 18 'artifact_use_from_x64-openhcl-igvm-cvm' --is-raw-string update
+      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-openhcl-igvm-test-linux-direct" | $FLOWEY_BIN v 18 'artifact_use_from_x64-openhcl-igvm-test-linux-direct' --is-raw-string update
       echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-tmks" | $FLOWEY_BIN v 18 'artifact_use_from_x64-tmks' --is-raw-string update
       echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-openvmm" | $FLOWEY_BIN v 18 'artifact_use_from_x64-windows-openvmm' --is-raw-string update
       echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-pipette" | $FLOWEY_BIN v 18 'artifact_use_from_x64-windows-pipette' --is-raw-string update
@@ -4390,23 +4458,24 @@ jobs:
       $(FLOWEY_BIN) e 18 flowey_lib_common::git_checkout 2
       $(FLOWEY_BIN) e 18 flowey_lib_hvlite::git_checkout_openvmm_repo 0
       $(FLOWEY_BIN) e 18 flowey_lib_hvlite::run_cargo_nextest_run 0
+      $(FLOWEY_BIN) e 18 flowey_core::pipeline::artifact::resolve 8
+      $(FLOWEY_BIN) e 18 flowey_core::pipeline::artifact::resolve 9
+      $(FLOWEY_BIN) e 18 flowey_core::pipeline::artifact::resolve 12
+      $(FLOWEY_BIN) e 18 flowey_core::pipeline::artifact::resolve 14
+      $(FLOWEY_BIN) e 18 flowey_core::pipeline::artifact::resolve 15
+      $(FLOWEY_BIN) e 18 flowey_core::pipeline::artifact::resolve 13
+      $(FLOWEY_BIN) e 18 flowey_core::pipeline::artifact::resolve 3
+      $(FLOWEY_BIN) e 18 flowey_core::pipeline::artifact::resolve 11
+      $(FLOWEY_BIN) e 18 flowey_core::pipeline::artifact::resolve 4
       $(FLOWEY_BIN) e 18 flowey_core::pipeline::artifact::resolve 5
       $(FLOWEY_BIN) e 18 flowey_core::pipeline::artifact::resolve 6
       $(FLOWEY_BIN) e 18 flowey_core::pipeline::artifact::resolve 1
-      $(FLOWEY_BIN) e 18 flowey_core::pipeline::artifact::resolve 0
-      $(FLOWEY_BIN) e 18 flowey_core::pipeline::artifact::resolve 9
       $(FLOWEY_BIN) e 18 flowey_core::pipeline::artifact::resolve 2
-      $(FLOWEY_BIN) e 18 flowey_core::pipeline::artifact::resolve 4
-      $(FLOWEY_BIN) e 18 flowey_core::pipeline::artifact::resolve 11
-      $(FLOWEY_BIN) e 18 flowey_core::pipeline::artifact::resolve 12
-      $(FLOWEY_BIN) e 18 flowey_core::pipeline::artifact::resolve 10
-      $(FLOWEY_BIN) e 18 flowey_core::pipeline::artifact::resolve 3
-      $(FLOWEY_BIN) e 18 flowey_core::pipeline::artifact::resolve 8
+      $(FLOWEY_BIN) e 18 flowey_core::pipeline::artifact::resolve 0
+      $(FLOWEY_BIN) e 18 flowey_core::pipeline::artifact::resolve 7
     displayName: report cloned repo directories
   - bash: $(FLOWEY_BIN) e 18 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
     displayName: creating new test content dir
-  - bash: $(FLOWEY_BIN) e 18 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::resolve 0
-    displayName: resolve OpenHCL igvm artifact
   - bash: $(FLOWEY_BIN) e 18 flowey_lib_common::download_gh_release 0
     displayName: create gh-release-download cache dir
   - bash: |-
@@ -4451,7 +4520,7 @@ jobs:
       set -e
       $(FLOWEY_BIN) e 18 flowey_lib_hvlite::init_vmm_tests_env 0
       $(FLOWEY_BIN) e 18 flowey_lib_hvlite::run_cargo_nextest_run 1
-      $(FLOWEY_BIN) e 18 flowey_core::pipeline::artifact::resolve 13
+      $(FLOWEY_BIN) e 18 flowey_core::pipeline::artifact::resolve 16
       $(FLOWEY_BIN) e 18 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
     displayName: setting up vmm_tests env
   - bash: $(FLOWEY_BIN) e 18 flowey_lib_common::gen_cargo_nextest_run_cmd 0
@@ -4461,7 +4530,7 @@ jobs:
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 18 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
-      $(FLOWEY_BIN) e 18 flowey_core::pipeline::artifact::resolve 7
+      $(FLOWEY_BIN) e 18 flowey_core::pipeline::artifact::resolve 10
     displayName: starting test_igvm_agent_rpc_server
   - bash: $(FLOWEY_BIN) e 18 flowey_lib_hvlite::run_prep_steps 0
     displayName: running vmm_test prep_steps
@@ -4547,6 +4616,16 @@ jobs:
       artifact: x64-mi-secure-openhcl-igvm
       path: $(FLOWEY_TEMP_DIR)/used_artifacts/x64-mi-secure-openhcl-igvm
   - task: DownloadPipelineArtifact@2
+    displayName: 🌼📦 Download x64-mi-secure-openhcl-igvm-cvm
+    inputs:
+      artifact: x64-mi-secure-openhcl-igvm-cvm
+      path: $(FLOWEY_TEMP_DIR)/used_artifacts/x64-mi-secure-openhcl-igvm-cvm
+  - task: DownloadPipelineArtifact@2
+    displayName: 🌼📦 Download x64-mi-secure-openhcl-igvm-test-linux-direct
+    inputs:
+      artifact: x64-mi-secure-openhcl-igvm-test-linux-direct
+      path: $(FLOWEY_TEMP_DIR)/used_artifacts/x64-mi-secure-openhcl-igvm-test-linux-direct
+  - task: DownloadPipelineArtifact@2
     displayName: 🌼📦 Download x64-tmks
     inputs:
       artifact: x64-tmks
@@ -4619,6 +4698,8 @@ jobs:
       echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-linux-musl-tmk_vmm" | $FLOWEY_BIN v 17 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
       echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-linux-tpm_guest_tests" | $FLOWEY_BIN v 17 'artifact_use_from_x64-linux-tpm_guest_tests' --is-raw-string update
       echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-mi-secure-openhcl-igvm" | $FLOWEY_BIN v 17 'artifact_use_from_x64-mi-secure-openhcl-igvm' --is-raw-string update
+      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-mi-secure-openhcl-igvm-cvm" | $FLOWEY_BIN v 17 'artifact_use_from_x64-mi-secure-openhcl-igvm-cvm' --is-raw-string update
+      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-mi-secure-openhcl-igvm-test-linux-direct" | $FLOWEY_BIN v 17 'artifact_use_from_x64-mi-secure-openhcl-igvm-test-linux-direct' --is-raw-string update
       echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-tmks" | $FLOWEY_BIN v 17 'artifact_use_from_x64-tmks' --is-raw-string update
       echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-openvmm" | $FLOWEY_BIN v 17 'artifact_use_from_x64-windows-openvmm' --is-raw-string update
       echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-pipette" | $FLOWEY_BIN v 17 'artifact_use_from_x64-windows-pipette' --is-raw-string update
@@ -4677,23 +4758,24 @@ jobs:
       $(FLOWEY_BIN) e 17 flowey_lib_common::git_checkout 2
       $(FLOWEY_BIN) e 17 flowey_lib_hvlite::git_checkout_openvmm_repo 0
       $(FLOWEY_BIN) e 17 flowey_lib_hvlite::run_cargo_nextest_run 0
+      $(FLOWEY_BIN) e 17 flowey_core::pipeline::artifact::resolve 14
+      $(FLOWEY_BIN) e 17 flowey_core::pipeline::artifact::resolve 15
+      $(FLOWEY_BIN) e 17 flowey_core::pipeline::artifact::resolve 13
+      $(FLOWEY_BIN) e 17 flowey_core::pipeline::artifact::resolve 3
+      $(FLOWEY_BIN) e 17 flowey_core::pipeline::artifact::resolve 11
+      $(FLOWEY_BIN) e 17 flowey_core::pipeline::artifact::resolve 4
       $(FLOWEY_BIN) e 17 flowey_core::pipeline::artifact::resolve 5
       $(FLOWEY_BIN) e 17 flowey_core::pipeline::artifact::resolve 6
       $(FLOWEY_BIN) e 17 flowey_core::pipeline::artifact::resolve 1
-      $(FLOWEY_BIN) e 17 flowey_core::pipeline::artifact::resolve 0
-      $(FLOWEY_BIN) e 17 flowey_core::pipeline::artifact::resolve 9
       $(FLOWEY_BIN) e 17 flowey_core::pipeline::artifact::resolve 2
-      $(FLOWEY_BIN) e 17 flowey_core::pipeline::artifact::resolve 4
-      $(FLOWEY_BIN) e 17 flowey_core::pipeline::artifact::resolve 11
-      $(FLOWEY_BIN) e 17 flowey_core::pipeline::artifact::resolve 12
-      $(FLOWEY_BIN) e 17 flowey_core::pipeline::artifact::resolve 10
-      $(FLOWEY_BIN) e 17 flowey_core::pipeline::artifact::resolve 3
+      $(FLOWEY_BIN) e 17 flowey_core::pipeline::artifact::resolve 0
+      $(FLOWEY_BIN) e 17 flowey_core::pipeline::artifact::resolve 7
       $(FLOWEY_BIN) e 17 flowey_core::pipeline::artifact::resolve 8
+      $(FLOWEY_BIN) e 17 flowey_core::pipeline::artifact::resolve 9
+      $(FLOWEY_BIN) e 17 flowey_core::pipeline::artifact::resolve 12
     displayName: report cloned repo directories
   - bash: $(FLOWEY_BIN) e 17 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
     displayName: creating new test content dir
-  - bash: $(FLOWEY_BIN) e 17 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::resolve 0
-    displayName: resolve OpenHCL igvm artifact
   - bash: $(FLOWEY_BIN) e 17 flowey_lib_common::download_gh_release 0
     displayName: create gh-release-download cache dir
   - bash: |-
@@ -4738,7 +4820,7 @@ jobs:
       set -e
       $(FLOWEY_BIN) e 17 flowey_lib_hvlite::init_vmm_tests_env 0
       $(FLOWEY_BIN) e 17 flowey_lib_hvlite::run_cargo_nextest_run 1
-      $(FLOWEY_BIN) e 17 flowey_core::pipeline::artifact::resolve 13
+      $(FLOWEY_BIN) e 17 flowey_core::pipeline::artifact::resolve 16
       $(FLOWEY_BIN) e 17 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
     displayName: setting up vmm_tests env
   - bash: $(FLOWEY_BIN) e 17 flowey_lib_common::gen_cargo_nextest_run_cmd 0
@@ -4751,18 +4833,13 @@ jobs:
       set -e
       $(FLOWEY_BIN) e 17 flowey_lib_common::run_cargo_nextest_run 0
       $(FLOWEY_BIN) e 17 flowey_lib_common::run_cargo_nextest_run 1
-      $(FLOWEY_BIN) e 17 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
-    displayName: run 'vmm_tests' nextest tests
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 17 flowey_lib_hvlite::stop_test_igvm_agent_rpc_server 0
       $(FLOWEY_BIN) e 17 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
       $(FLOWEY_BIN) e 17 flowey_lib_common::publish_test_results 1
       $(FLOWEY_BIN) e 17 flowey_lib_common::ado_task_publish_test_results 0
       $(FLOWEY_BIN) e 17 flowey_lib_common::publish_test_results 0
       $FLOWEY_BIN v 17 'flowey_lib_common::ado_task_publish_test_results:0:flowey_lib_common/src/ado_task_publish_test_results.rs:57:45' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env ado floweyvar1
       $FLOWEY_BIN v 17 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env ado FLOWEY_CONDITION
-    displayName: stopping test_igvm_agent_rpc_server
+    displayName: run 'vmm_tests' nextest tests
   - task: PublishTestResults@2
     inputs:
       testResultsFormat: JUnit
@@ -4775,7 +4852,10 @@ jobs:
       $(FLOWEY_BIN) e 17 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
       $(FLOWEY_BIN) e 17 flowey_lib_common::publish_test_results 2
       $(FLOWEY_BIN) e 17 flowey_lib_common::publish_test_results 3
-      $(FLOWEY_BIN) e 17 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
+      $(FLOWEY_BIN) e 17 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
+      $(FLOWEY_BIN) e 17 flowey_lib_hvlite::stop_test_igvm_agent_rpc_server 0
+    displayName: stopping test_igvm_agent_rpc_server
+  - bash: $(FLOWEY_BIN) e 17 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
     displayName: report test results to overall pipeline status
   - bash: $(FLOWEY_BIN) e 17 flowey_lib_common::cache 3
     displayName: 'validate cache entry: cargo-nextest'
@@ -4828,6 +4908,16 @@ jobs:
     inputs:
       artifact: x64-openhcl-igvm
       path: $(FLOWEY_TEMP_DIR)/used_artifacts/x64-openhcl-igvm
+  - task: DownloadPipelineArtifact@2
+    displayName: 🌼📦 Download x64-openhcl-igvm-cvm
+    inputs:
+      artifact: x64-openhcl-igvm-cvm
+      path: $(FLOWEY_TEMP_DIR)/used_artifacts/x64-openhcl-igvm-cvm
+  - task: DownloadPipelineArtifact@2
+    displayName: 🌼📦 Download x64-openhcl-igvm-test-linux-direct
+    inputs:
+      artifact: x64-openhcl-igvm-test-linux-direct
+      path: $(FLOWEY_TEMP_DIR)/used_artifacts/x64-openhcl-igvm-test-linux-direct
   - task: DownloadPipelineArtifact@2
     displayName: 🌼📦 Download x64-tmks
     inputs:
@@ -4901,6 +4991,8 @@ jobs:
       echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-linux-musl-tmk_vmm" | $FLOWEY_BIN v 16 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
       echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-linux-tpm_guest_tests" | $FLOWEY_BIN v 16 'artifact_use_from_x64-linux-tpm_guest_tests' --is-raw-string update
       echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-openhcl-igvm" | $FLOWEY_BIN v 16 'artifact_use_from_x64-openhcl-igvm' --is-raw-string update
+      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-openhcl-igvm-cvm" | $FLOWEY_BIN v 16 'artifact_use_from_x64-openhcl-igvm-cvm' --is-raw-string update
+      echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-openhcl-igvm-test-linux-direct" | $FLOWEY_BIN v 16 'artifact_use_from_x64-openhcl-igvm-test-linux-direct' --is-raw-string update
       echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-tmks" | $FLOWEY_BIN v 16 'artifact_use_from_x64-tmks' --is-raw-string update
       echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-openvmm" | $FLOWEY_BIN v 16 'artifact_use_from_x64-windows-openvmm' --is-raw-string update
       echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-windows-pipette" | $FLOWEY_BIN v 16 'artifact_use_from_x64-windows-pipette' --is-raw-string update
@@ -4959,23 +5051,24 @@ jobs:
       $(FLOWEY_BIN) e 16 flowey_lib_common::git_checkout 2
       $(FLOWEY_BIN) e 16 flowey_lib_hvlite::git_checkout_openvmm_repo 0
       $(FLOWEY_BIN) e 16 flowey_lib_hvlite::run_cargo_nextest_run 0
+      $(FLOWEY_BIN) e 16 flowey_core::pipeline::artifact::resolve 8
+      $(FLOWEY_BIN) e 16 flowey_core::pipeline::artifact::resolve 9
+      $(FLOWEY_BIN) e 16 flowey_core::pipeline::artifact::resolve 12
+      $(FLOWEY_BIN) e 16 flowey_core::pipeline::artifact::resolve 14
+      $(FLOWEY_BIN) e 16 flowey_core::pipeline::artifact::resolve 15
+      $(FLOWEY_BIN) e 16 flowey_core::pipeline::artifact::resolve 13
+      $(FLOWEY_BIN) e 16 flowey_core::pipeline::artifact::resolve 3
+      $(FLOWEY_BIN) e 16 flowey_core::pipeline::artifact::resolve 11
+      $(FLOWEY_BIN) e 16 flowey_core::pipeline::artifact::resolve 4
       $(FLOWEY_BIN) e 16 flowey_core::pipeline::artifact::resolve 5
       $(FLOWEY_BIN) e 16 flowey_core::pipeline::artifact::resolve 6
       $(FLOWEY_BIN) e 16 flowey_core::pipeline::artifact::resolve 1
-      $(FLOWEY_BIN) e 16 flowey_core::pipeline::artifact::resolve 0
-      $(FLOWEY_BIN) e 16 flowey_core::pipeline::artifact::resolve 9
       $(FLOWEY_BIN) e 16 flowey_core::pipeline::artifact::resolve 2
-      $(FLOWEY_BIN) e 16 flowey_core::pipeline::artifact::resolve 4
-      $(FLOWEY_BIN) e 16 flowey_core::pipeline::artifact::resolve 11
-      $(FLOWEY_BIN) e 16 flowey_core::pipeline::artifact::resolve 12
-      $(FLOWEY_BIN) e 16 flowey_core::pipeline::artifact::resolve 10
-      $(FLOWEY_BIN) e 16 flowey_core::pipeline::artifact::resolve 3
-      $(FLOWEY_BIN) e 16 flowey_core::pipeline::artifact::resolve 8
+      $(FLOWEY_BIN) e 16 flowey_core::pipeline::artifact::resolve 0
+      $(FLOWEY_BIN) e 16 flowey_core::pipeline::artifact::resolve 7
     displayName: report cloned repo directories
   - bash: $(FLOWEY_BIN) e 16 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
     displayName: creating new test content dir
-  - bash: $(FLOWEY_BIN) e 16 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::resolve 0
-    displayName: resolve OpenHCL igvm artifact
   - bash: $(FLOWEY_BIN) e 16 flowey_lib_common::download_gh_release 0
     displayName: create gh-release-download cache dir
   - bash: |-
@@ -5020,7 +5113,7 @@ jobs:
       set -e
       $(FLOWEY_BIN) e 16 flowey_lib_hvlite::init_vmm_tests_env 0
       $(FLOWEY_BIN) e 16 flowey_lib_hvlite::run_cargo_nextest_run 1
-      $(FLOWEY_BIN) e 16 flowey_core::pipeline::artifact::resolve 13
+      $(FLOWEY_BIN) e 16 flowey_core::pipeline::artifact::resolve 16
       $(FLOWEY_BIN) e 16 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
     displayName: setting up vmm_tests env
   - bash: $(FLOWEY_BIN) e 16 flowey_lib_common::gen_cargo_nextest_run_cmd 0
@@ -5030,7 +5123,7 @@ jobs:
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 16 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
-      $(FLOWEY_BIN) e 16 flowey_core::pipeline::artifact::resolve 7
+      $(FLOWEY_BIN) e 16 flowey_core::pipeline::artifact::resolve 10
     displayName: starting test_igvm_agent_rpc_server
   - bash: $(FLOWEY_BIN) e 16 flowey_lib_hvlite::run_prep_steps 0
     displayName: running vmm_test prep_steps

--- a/flowey/flowey_lib_hvlite/src/_jobs/cfg_versions.rs
+++ b/flowey/flowey_lib_hvlite/src/_jobs/cfg_versions.rs
@@ -32,7 +32,7 @@ pub const NODEJS: &str = "24.x";
 //      increases with each release from the respective branch.
 pub const OPENHCL_KERNEL_DEV_VERSION: &str = "6.18.0.6";
 pub const OPENHCL_KERNEL_STABLE_VERSION: &str = "6.18.0.6";
-pub const OPENVMM_DEPS: &str = "0.3.0-94";
+pub const OPENVMM_DEPS: &str = "0.3.0-101";
 pub const PROTOC: &str = "27.1";
 
 flowey_request! {

--- a/flowey/flowey_lib_hvlite/src/build_openhcl_boot.rs
+++ b/flowey/flowey_lib_hvlite/src/build_openhcl_boot.rs
@@ -94,8 +94,7 @@ impl FlowNode for Node {
                 extra_env: Some(ReadVar::from_static(
                     [
                         ("RUSTC_BOOTSTRAP".to_string(), "1".to_string()),
-                        // TODO: Soon
-                        //("CC_FORCE_DISABLE".to_string(), "1".to_string()),
+                        ("CC_FORCE_DISABLE".to_string(), "1".to_string()),
                     ]
                     .into_iter()
                     .collect(),

--- a/flowey/flowey_lib_hvlite/src/build_openvmm_hcl.rs
+++ b/flowey/flowey_lib_hvlite/src/build_openvmm_hcl.rs
@@ -144,12 +144,11 @@ impl FlowNode for Node {
             // Forbid cc-rs from compiling anything for the openvmm_hcl build.
             // Every C library it links comes prebuilt out of the openvmm-deps
             // sdk sysroot, so a build script reaching for cc-rs is a bug.
-            // TODO: Soon
-            // let extra_env = Some(ReadVar::from_static(
-            //     [("CC_FORCE_DISABLE".to_string(), "1".to_string())]
-            //         .into_iter()
-            //         .collect(),
-            // ));
+            let extra_env = Some(ReadVar::from_static(
+                [("CC_FORCE_DISABLE".to_string(), "1".to_string())]
+                    .into_iter()
+                    .collect(),
+            ));
 
             let output = ctx.reqv(|v| crate::run_cargo_build::Request {
                 crate_name: "openvmm_hcl".into(),
@@ -167,7 +166,7 @@ impl FlowNode for Node {
                 features: CargoFeatureSet::Specific(features),
                 target,
                 no_split_dbg_info,
-                extra_env: None,
+                extra_env,
                 pre_build_deps,
                 output: v,
             });

--- a/flowey/flowey_lib_hvlite/src/build_sidecar.rs
+++ b/flowey/flowey_lib_hvlite/src/build_sidecar.rs
@@ -86,8 +86,7 @@ impl FlowNode for Node {
                     [
                         ("RUSTC_BOOTSTRAP".to_string(), "1".to_string()),
                         // Forbid cc-rs from compiling anything
-                        // TODO: Soon
-                        // ("CC_FORCE_DISABLE".to_string(), "1".to_string()),
+                        ("CC_FORCE_DISABLE".to_string(), "1".to_string()),
                     ]
                     .into_iter()
                     .collect(),

--- a/nix/openvmm_deps.nix
+++ b/nix/openvmm_deps.nix
@@ -6,17 +6,17 @@ let
          else if system == "aarch64-linux" then "aarch64"
          else "x86_64";
   hash = {
-    "aarch64" = "sha256-Ikl2JQC/e0lp2plADR8yrIe/asS+D4/BgiSE3yJHHFE=";
-    "x86_64" = "sha256-/q2WYRiSaejBnlTg0fods2ES0bgxza5MDvTKr6LEi8A=";
+    "aarch64" = "sha256-PQl0dupOVNnjllaAl+zwYL7sYXBUekoWDO5HnRwwUDo=";
+    "x86_64" = "sha256-0pHZ+W4dVXkk2VnDDbzrsO4m96dA79ZfRSmtT6bDkAc=";
   }.${arch};
 
 in stdenv.mkDerivation {
   pname = "openvmm-deps-${arch}";
-  version = "0.3.0-94";
+  version = "0.3.0-101";
 
   src = fetchzip {
     url =
-      "https://github.com/microsoft/openvmm-deps/releases/download/0.3.0-94/openvmm-deps.${arch}.0.3.0-94.tar.gz";
+      "https://github.com/microsoft/openvmm-deps/releases/download/0.3.0-101/openvmm-deps.${arch}.0.3.0-101.tar.gz";
     stripRoot = false;
     inherit hash;
   };


### PR DESCRIPTION
Setting CC_FORCE_DISABLE allows us to be certain that any C dependencies are prebuilt and coming in through openvmm-deps, instead of being built on demand. Update the TPM and the deps packages to get the last piece that makes this possible.