### PR TITLE
pci_resource_assignment: improve error message when out of MMIO space

### DIFF
--- a/vm/devices/pci/pci_resource_assignment/src/assign.rs
+++ b/vm/devices/pci/pci_resource_assignment/src/assign.rs
@@ -558,14 +558,22 @@ fn resolve_pool_base(
         return Err(AssignmentError::MmioExhaustion {
             required,
             available: aperture.len(),
+            alignment,
             aperture: aperture_name,
         });
     }
+    // After aligning the window base up to the pool's natural alignment,
+    // the usable space is what remains before the aperture end. A large
+    // alignment (e.g. a 512 GB BAR) can push the base past the end of a
+    // small window, leaving zero usable bytes. Report the actual window
+    // size and the alignment so the failure is diagnosable rather than
+    // surfacing a misleading `have 0x0`.
     let available = aperture.end().saturating_sub(base);
     if required > available {
         return Err(AssignmentError::MmioExhaustion {
             required,
-            available,
+            available: aperture.len(),
+            alignment,
             aperture: aperture_name,
         });
     }

--- a/vm/devices/pci/pci_resource_assignment/src/assign.rs
+++ b/vm/devices/pci/pci_resource_assignment/src/assign.rs
@@ -562,14 +562,14 @@ fn resolve_pool_base(
             aperture: aperture_name,
         });
     }
-    // After aligning the window base up to the pool's natural alignment,
-    // the usable space is what remains before the aperture end. A large
-    // alignment (e.g. a 512 GB BAR) can push the base past the end of a
-    // small window, leaving zero usable bytes. Report the actual window
-    // size and the alignment so the failure is diagnosable rather than
-    // surfacing a misleading `have 0x0`.
-    let available = aperture.end().saturating_sub(base);
-    if required > available {
+    // The usable space is what remains between the chosen base and the
+    // aperture end. For unconstrained pools the base is aligned up to the
+    // pool's natural alignment, so a large alignment (e.g. a 512 GB BAR)
+    // can push the base past the end of a small window, leaving zero
+    // usable bytes. Report the actual window size and the alignment so the
+    // failure is diagnosable rather than surfacing a misleading `have 0x0`.
+    let usable = aperture.end().saturating_sub(base);
+    if required > usable {
         return Err(AssignmentError::MmioExhaustion {
             required,
             available: aperture.len(),

--- a/vm/devices/pci/pci_resource_assignment/src/lib.rs
+++ b/vm/devices/pci/pci_resource_assignment/src/lib.rs
@@ -167,12 +167,19 @@ pub enum AssignmentError {
         aperture: &'static str,
     },
     /// Not enough MMIO space for all BAR allocations.
-    #[error("{aperture} MMIO exhaustion: need {required:#x} bytes, have {available:#x}")]
+    #[error(
+        "{aperture} MMIO exhaustion: need {required:#x} bytes (alignment \
+         {alignment:#x}), have {available:#x}"
+    )]
     MmioExhaustion {
         /// Total MMIO required across all devices.
         required: u64,
-        /// Total MMIO available.
+        /// Size of the MMIO aperture window.
         available: u64,
+        /// Natural alignment the pool base must satisfy. When this exceeds
+        /// the window size, aligning the base can consume the entire
+        /// aperture even though `available` is non-zero.
+        alignment: u64,
         /// Whether this was the low or high aperture.
         aperture: &'static str,
     },


### PR DESCRIPTION
The old message was confusing since it was generated with values that had already taken alignment into account.
