### PR TITLE
openvmm: add SRAT generic initiator support

### DIFF
--- a/Guide/src/reference/architecture/openvmm/numa.md
+++ b/Guide/src/reference/architecture/openvmm/numa.md
@@ -21,16 +21,25 @@ Every VM has a NUMA topology — even a single-node VM (which is what
 
 ### VP assignment
 
-By default, VPs are distributed across nodes by round-robin over
-sockets: `(vp_index / vps_per_socket) % num_nodes`. This matches
-QEMU's default and works well for symmetric topologies.
+By default, VPs are distributed across nodes by round-robin over sockets:
+`(vp_index / vps_per_socket) % num_cpu_nodes`, where `num_cpu_nodes` counts only
+nodes that participate in VP assignment (CPU-less nodes are skipped). This works
+well for symmetric topologies.
 
 For asymmetric cases — AMD sub-socket NUMA boundaries, ARM clusters,
 or any layout where the socket-based formula is wrong — VPs can be
 assigned explicitly per node using the `vps=` option.
 
 Explicit VP lists must be disjoint (no VP in two nodes), complete
-(every VP assigned to exactly one node), and in range.
+(every VP assigned to exactly one node), and in range. A non-empty
+explicit list cannot be mixed with nodes that use the default
+round-robin assignment.
+
+An empty list, `vps=[]`, declares a CPU-less node (for example, a
+memory-only node or a generic-initiator target). It claims no VPs and,
+unlike a non-empty list, may be combined with default round-robin
+nodes — so you can add a CPU-less node without having to spell out the
+VP set for every other node.
 
 ### Inter-node distances
 

--- a/Guide/src/reference/openvmm/management/cli.md
+++ b/Guide/src/reference/openvmm/management/cli.md
@@ -105,7 +105,9 @@ as well as the generated CLI help (via `cargo run -- --help`).
   * `vps=<LIST>` - explicit VP indices for this node. Uses bracket syntax
     with comma-separated indices and dash ranges: `vps=[0,1]`,
     `vps=[0-3]`, `vps=[0,1,4-5]`. When omitted, VPs are assigned by
-    round-robin sockets across nodes.
+    round-robin sockets across nodes. An empty list, `vps=[]`, declares a
+    CPU-less node (e.g. a generic-initiator target); unlike a non-empty
+    list, it may be combined with nodes that omit `vps`.
 
   Examples:
 
@@ -298,6 +300,33 @@ name:
 - `acs=<mask>`: ACS capability mask requested for downstream switch ports.
   The upstream switch port does not expose ACS. Default is `0x005f`.
   Use `acs=0` to disable ACS for switch downstream ports.
+
+### Generic initiators
+
+A generic initiator is a device that originates memory accesses but has no
+CPUs of its own — for example a GPU or accelerator with its own coherent
+memory. Declaring one emits an SRAT Generic Initiator Affinity structure that
+tells the guest which NUMA node the device belongs to, so the guest can
+account for access latency and online the device's memory on the right
+proximity domain.
+
+Use `--pcie-generic-initiator` to mark the device directly behind a PCIe port
+as a generic initiator for a NUMA node:
+
+```sh
+# Create a CPU-less, memory-less NUMA node and a root port, then declare the
+# device behind the root port as a generic initiator for that node.
+--numa size=2G --numa size=0,vps=[] \
+  --pcie-root-complex rc0 --pcie-root-port rc0:rp0 \
+  --pcie-generic-initiator port=rp0,node=1
+```
+
+- Syntax: `port=<port_name>,node=<node>`.
+- `port=<port_name>` may be a root port name or a switch downstream port name
+  (e.g. `switch0-downstream-1`); it is resolved against the live topology.
+- `node=<node>` is the NUMA node the device is a generic initiator for, and
+  should typically be a CPU-less and memory-less node created via `--numa`.
+
 
 ### Attaching devices to PCIe
 

--- a/openhcl/underhill_core/src/loader/mod.rs
+++ b/openhcl/underhill_core/src/loader/mod.rs
@@ -281,6 +281,7 @@ fn load_linux(params: LoadLinuxParams<'_>) -> Result<VpContext, Error> {
         cache_topology: None,
         pcie_host_bridges: &vec![],
         slit_info: None,
+        generic_initiators: &[],
         arch: vmm_core::acpi_builder::AcpiArchConfig::X86 {
             with_ioapic: true, // openhcl always runs with ioapic
             with_pic: chipset_capabilities.with_pic,
@@ -481,6 +482,7 @@ pub fn write_uefi_config(
             cache_topology: None,
             pcie_host_bridges: &vec![],
             slit_info: None,
+            generic_initiators: &[],
             #[cfg(guest_arch = "x86_64")]
             arch: vmm_core::acpi_builder::AcpiArchConfig::X86 {
                 with_ioapic: true,

--- a/openhcl/underhill_core/src/worker.rs
+++ b/openhcl/underhill_core/src/worker.rs
@@ -2639,6 +2639,7 @@ async fn new_underhill_vm(
                 cache_topology: None,
                 pcie_host_bridges: &vec![],
                 slit_info: None,
+                generic_initiators: &[],
                 arch: vmm_core::acpi_builder::AcpiArchConfig::X86 {
                     with_ioapic: capabilities.with_ioapic,
                     with_pic: capabilities.with_pic,

--- a/openvmm/openvmm_core/src/worker/dispatch.rs
+++ b/openvmm/openvmm_core/src/worker/dispatch.rs
@@ -142,6 +142,7 @@ use vmcore::vmtime::VmTimeSource;
 use vmgs_resources::GuestStateEncryptionPolicy;
 use vmgs_resources::VmgsResource;
 use vmm_core::acpi_builder::AcpiTablesBuilder;
+use vmm_core::acpi_builder::GenericInitiator;
 use vmm_core::acpi_builder::SlitInfo;
 use vmm_core::device_builder::VpciBusConfig;
 use vmm_core::input_distributor::InputDistributor;
@@ -189,6 +190,7 @@ impl Manifest {
             pcie_root_complexes: config.pcie_root_complexes,
             pcie_devices: config.pcie_devices,
             pcie_switches: config.pcie_switches,
+            pcie_generic_initiators: config.pcie_generic_initiators,
             vpci_devices: config.vpci_devices,
             hypervisor: config.hypervisor,
             numa: config.numa,
@@ -239,6 +241,7 @@ pub struct Manifest {
     pcie_root_complexes: Vec<PcieRootComplexConfig>,
     pcie_devices: Vec<PcieDeviceConfig>,
     pcie_switches: Vec<PcieSwitchConfig>,
+    pcie_generic_initiators: Vec<openvmm_defs::config::PcieGenericInitiatorConfig>,
     vpci_devices: Vec<VpciDeviceConfig>,
     numa: NumaTopology,
     processor_topology: ProcessorTopologyConfig,
@@ -756,6 +759,11 @@ struct LoadedVmInner {
     amd_iommu_acpi_configs: Vec<vmm_core::acpi_builder::AmdIommuAcpiConfig>,
     pcie_host_bridges: Vec<PcieHostBridge>,
     pcie_root_complexes: Vec<Arc<closeable_mutex::CloseableMutex<GenericPcieRootComplex>>>,
+    /// Sources for SRAT generic-initiator entries, one per
+    /// [`PcieGenericInitiatorConfig`](openvmm_defs::config::PcieGenericInitiatorConfig).
+    /// Each holds the port's live bus-range handle, read at ACPI-build time
+    /// (after PCI resource assignment) to derive the device bus.
+    generic_initiator_sources: Vec<GenericInitiatorSource>,
     /// SMMU configurations, one per instance.
     #[cfg(guest_arch = "aarch64")]
     smmu_configs: Vec<vmm_core::acpi_builder::AcpiSmmuConfig>,
@@ -873,6 +881,28 @@ fn build_root_port_definition(rp_cfg: &PcieRootPortConfig) -> GenericPcieRootPor
     }
 }
 
+/// A source for an SRAT generic-initiator entry.
+///
+/// A generic-initiator entry declares that the device directly behind a named
+/// port (device 0, function 0 on the port's secondary bus) is a generic
+/// initiator for NUMA node `N`. This attaches passthrough device memory (e.g.
+/// an NVIDIA Grace GPU's coherent aperture) to a CPU-less NUMA node so the
+/// guest driver can online it.
+///
+/// Rather than predict the device's bus number, this holds the root port's
+/// live [`AssignedBusRange`](pci_core::bus_range::AssignedBusRange) handle —
+/// the same atomic the config-space emulator updates when bridge bus-number
+/// registers are written. The secondary bus is read from it at ACPI-build
+/// time, after PCI resource assignment has run.
+struct GenericInitiatorSource {
+    /// Shared bus-range handle of the root port the device sits behind.
+    bus_range: pci_core::bus_range::AssignedBusRange,
+    /// PCI segment of the root complex.
+    segment: u16,
+    /// Proximity domain (NUMA node) the device is a generic initiator for.
+    vnode: u32,
+}
+
 impl InitializedVm {
     /// Creates and initializes a VM using the given backend.
     async fn new(
@@ -970,6 +1000,20 @@ impl InitializedVm {
         )
         .context("invalid NUMA topology")?;
         processor_topology.set_vnodes(&vp_to_vnode);
+
+        // Validate that NUMA node references in the PCIe topology point at
+        // nodes that actually exist.
+        let num_nodes = cfg.numa.nodes.len() as u32;
+        for rc in &cfg.pcie_root_complexes {
+            if let Some(vnode) = rc.vnode
+                && vnode >= num_nodes
+            {
+                anyhow::bail!(
+                    "PCIe root complex '{}' references NUMA node {vnode} which does not exist (num_nodes={num_nodes})",
+                    rc.name
+                );
+            }
+        }
 
         let proto = hypervisor
             .new_partition(virt::ProtoPartitionConfig {
@@ -1432,6 +1476,9 @@ impl InitializedVm {
                             cache_topology: None,
                             pcie_host_bridges: &Vec::new(),
                             slit_info: pcat_slit_info.as_ref(),
+                            // PCAT BIOS is mutually exclusive with PCIe root
+                            // ports (the only source of generic initiators).
+                            generic_initiators: &[],
                             arch: vmm_core::acpi_builder::AcpiArchConfig::X86 {
                                 with_ioapic: cfg.chipset_capabilities.with_ioapic,
                                 with_pic: cfg.chipset_capabilities.with_pic,
@@ -1899,7 +1946,7 @@ impl InitializedVm {
         }
         let mut deferred_msi_conns: Vec<DeferredMsiConn> = Vec::new();
 
-        let (pcie_host_bridges, pcie_root_complexes) = {
+        let (mut pcie_host_bridges, pcie_root_complexes) = {
             let mut pcie_host_bridges = Vec::new();
             let mut pcie_root_complexes = Vec::new();
 
@@ -2022,6 +2069,9 @@ impl InitializedVm {
                     cxl,
                     vnode: rc.vnode,
                     preserve_bars: rc.preserve_bars,
+                    // A request to pin BARs (GPA = HPA) also requires the guest
+                    // to leave the firmware's boot configuration alone.
+                    preserve_boot_config: rc.preserve_bars,
                 });
 
                 pcie_root_complexes.push(root_complex.clone());
@@ -2126,6 +2176,50 @@ impl InitializedVm {
 
             let bus_id = vmotherboard::BusId::new(&switch.name);
             chipset_builder.register_weak_mutex_pcie_enumerator(bus_id, Box::new(switch_device));
+        }
+
+        // Collect SRAT generic-initiator sources from the configured
+        // generic-initiator entries, which can target any named port including
+        // switch downstream ports. This is the single place that validates and
+        // resolves each entry: we check the referenced NUMA node exists and
+        // look up the port in the live topology. We capture each port's live
+        // bus-range handle here rather than predict a bus number; the actual
+        // secondary bus is read from it at ACPI-build time, after PCI resource
+        // assignment runs. `port_info` contains every root port and switch
+        // downstream port at this point.
+        let num_nodes = cfg.numa.nodes.len() as u32;
+        let mut generic_initiator_sources = Vec::new();
+        for gi in &cfg.pcie_generic_initiators {
+            if gi.node >= num_nodes {
+                anyhow::bail!(
+                    "PCIe generic initiator port '{}' references NUMA node {} which does not exist (num_nodes={num_nodes})",
+                    gi.port_name,
+                    gi.node
+                );
+            }
+            let pi = port_info.get(gi.port_name.as_str()).with_context(|| {
+                format!(
+                    "generic initiator port '{}' not found in PCIe topology",
+                    gi.port_name
+                )
+            })?;
+
+            // A generic initiator's SRAT entry references its device by a fixed
+            // segment/bus/device/function. If the guest re-enumerates PCIe and
+            // reassigns bus numbers, that BDF would no longer point at the
+            // device and the proximity-domain association would be lost. Ask the
+            // host bridge backing this initiator's root complex to instruct the
+            // guest to preserve the firmware boot configuration (via the
+            // "Ignore PCI Boot Configurations" _DSM). Note this is distinct from
+            // `preserve_bars`, which pins host BAR addresses for the assignment
+            // algorithm — a generic initiator needs only stable bus numbers.
+            pcie_host_bridges[pi.rc_idx].preserve_boot_config = true;
+
+            generic_initiator_sources.push(GenericInitiatorSource {
+                bus_range: pi.bus_range.clone(),
+                segment: pi.segment,
+                vnode: gi.node,
+            });
         }
 
         // Register the VFIO resolver, which spawns a container manager task
@@ -2793,6 +2887,7 @@ impl InitializedVm {
                 amd_iommu_acpi_configs,
                 pcie_host_bridges,
                 pcie_root_complexes,
+                generic_initiator_sources,
                 pcie_hotplug_devices: Vec::new(),
                 #[cfg(guest_arch = "aarch64")]
                 smmu_configs,
@@ -2808,8 +2903,12 @@ impl InitializedVm {
                 .await
                 .context("loadedvm restore failed")?;
         } else {
-            this.inner.load_firmware(false).await?;
+            // Assign PCI bus numbers/BARs before building firmware so that the
+            // ACPI tables (specifically the SRAT generic-initiator entries) can
+            // read the assigned secondary bus numbers from the root ports'
+            // bridge registers.
             this.assign_pci_resources().await?;
+            this.inner.load_firmware(false).await?;
         }
 
         Ok(this)
@@ -2843,12 +2942,31 @@ impl LoadedVmInner {
             None
         };
         let slit_info = self.slit_info();
+        // Resolve each generic-initiator source to its assigned PCI bus now that
+        // PCI resource assignment has programmed the root ports' bridge
+        // bus-number registers. The device is function 0 of device 0 on the
+        // port's secondary bus.
+        let generic_initiators: Vec<GenericInitiator> = self
+            .generic_initiator_sources
+            .iter()
+            .map(|s| {
+                let (secondary_bus, _subordinate) = s.bus_range.bus_range();
+                GenericInitiator {
+                    segment: s.segment,
+                    bus: secondary_bus,
+                    device: 0,
+                    function: 0,
+                    vnode: s.vnode,
+                }
+            })
+            .collect();
         let acpi_builder = AcpiTablesBuilder {
             processor_topology: &self.processor_topology,
             mem_layout: &self.mem_layout,
             cache_topology: cache_topology.as_ref(),
             pcie_host_bridges: &self.pcie_host_bridges,
             slit_info: slit_info.as_ref(),
+            generic_initiators: &generic_initiators,
             #[cfg(guest_arch = "x86_64")]
             arch: vmm_core::acpi_builder::AcpiArchConfig::X86 {
                 with_ioapic: self.chipset_capabilities.with_ioapic,
@@ -3659,12 +3777,13 @@ impl LoadedVm {
 
         let manifest = Manifest {
             load_mode: self.inner.load_mode,
-            floppy_disks: vec![],        // TODO
-            ide_disks: vec![],           // TODO
-            pcie_root_complexes: vec![], // TODO
-            pcie_devices: vec![],        // TODO
-            pcie_switches: vec![],       // TODO
-            vpci_devices: vec![],        // TODO
+            floppy_disks: vec![],            // TODO
+            ide_disks: vec![],               // TODO
+            pcie_root_complexes: vec![],     // TODO
+            pcie_devices: vec![],            // TODO
+            pcie_switches: vec![],           // TODO
+            pcie_generic_initiators: vec![], // TODO
+            vpci_devices: vec![],            // TODO
             numa: self.inner.numa_cfg,
             processor_topology: self.inner.processor_topology.to_config(),
             chipset: self.inner.chipset_cfg,
@@ -3720,8 +3839,10 @@ impl LoadedVm {
 
         // Load again
         if reload_firmware {
-            self.inner.load_firmware(false).await?;
+            // Assign PCI resources before rebuilding firmware so the ACPI
+            // tables reflect the freshly assigned bus numbers.
             self.assign_pci_resources().await?;
+            self.inner.load_firmware(false).await?;
         }
 
         if resume {

--- a/openvmm/openvmm_core/src/worker/dispatch.rs
+++ b/openvmm/openvmm_core/src/worker/dispatch.rs
@@ -889,13 +889,13 @@ fn build_root_port_definition(rp_cfg: &PcieRootPortConfig) -> GenericPcieRootPor
 /// an NVIDIA Grace GPU's coherent aperture) to a CPU-less NUMA node so the
 /// guest driver can online it.
 ///
-/// Rather than predict the device's bus number, this holds the root port's
-/// live [`AssignedBusRange`](pci_core::bus_range::AssignedBusRange) handle —
-/// the same atomic the config-space emulator updates when bridge bus-number
-/// registers are written. The secondary bus is read from it at ACPI-build
-/// time, after PCI resource assignment has run.
+/// Rather than predict the device's bus number, this holds the port's live
+/// [`AssignedBusRange`](pci_core::bus_range::AssignedBusRange) handle — the
+/// same atomic the config-space emulator updates when bridge bus-number
+/// registers are written. The secondary bus is read from it at ACPI-build time,
+/// after PCI resource assignment has run.
 struct GenericInitiatorSource {
-    /// Shared bus-range handle of the root port the device sits behind.
+    /// Shared bus-range handle of the port the device sits behind.
     bus_range: pci_core::bus_range::AssignedBusRange,
     /// PCI segment of the root complex.
     segment: u16,

--- a/openvmm/openvmm_core/src/worker/numa.rs
+++ b/openvmm/openvmm_core/src/worker/numa.rs
@@ -14,13 +14,17 @@ use openvmm_defs::config::VpAssignment;
 ///
 /// Validation checks:
 /// - At least one node exists
-/// - All nodes use the same VP assignment mode (no mixing)
+/// - All CPU-bearing nodes use the same VP assignment mode (no mixing)
 /// - When `Explicit`, VP lists are disjoint, complete, and in range
 /// - Distance entries reference valid nodes, have values >= 10, and
 ///   self-distances are exactly 10
 ///
-/// `FromTopology` assigns VPs by `(vp_index / vps_per_socket) % num_nodes`.
-/// `Explicit` uses the specified VP-to-node assignments directly.
+/// `FromTopology` assigns VPs by round-robin over the CPU-bearing nodes.
+/// `Explicit` uses the specified VP-to-node assignments directly. `Empty`
+/// declares a CPU-less node; it claims no VPs and is compatible with either
+/// mode, so a CPU-less node can be combined with auto-assigned
+/// (`FromTopology`) nodes without forcing every other node to spell out its
+/// VP set.
 pub fn resolve_numa_vp_assignment(
     topology: &NumaTopology,
     proc_count: u32,
@@ -33,6 +37,9 @@ pub fn resolve_numa_vp_assignment(
     let mut explicit_count = 0usize;
     let mut vp_to_vnode = vec![0u32; proc_count as usize];
     let mut assigned = vec![false; proc_count as usize];
+    // Node indices eligible to receive auto-assigned VPs, i.e. the
+    // `FromTopology` nodes. CPU-less (`Empty`) nodes are not included.
+    let mut from_topology_nodes: Vec<u32> = Vec::new();
 
     for (i, node) in topology.nodes.iter().enumerate() {
         match &node.vps {
@@ -51,26 +58,32 @@ pub fn resolve_numa_vp_assignment(
                     vp_to_vnode[vp as usize] = i as u32;
                 }
             }
-            VpAssignment::FromTopology => {}
+            VpAssignment::FromTopology => from_topology_nodes.push(i as u32),
+            // CPU-less node: claims no VPs, compatible with any mode.
+            VpAssignment::Empty => {}
         }
     }
 
-    if explicit_count > 0 {
-        // All nodes must be explicit — no mixing.
+    if !from_topology_nodes.is_empty() {
+        // Some nodes request automatic VP assignment. That can't be combined
+        // with nodes that list specific VPs, since automatic assignment needs
+        // to own the full set of VPs to distribute. CPU-less nodes are fine:
+        // they claim no VPs.
         anyhow::ensure!(
-            explicit_count == num_nodes,
-            "cannot mix Explicit and FromTopology VP assignments; \
-             all nodes must use the same mode"
+            explicit_count == 0,
+            "NUMA nodes mix automatic and explicit VP assignment; \
+             give every CPU-bearing node an explicit VP list, or none of them"
         );
-        // Every VP must be assigned.
-        for (vp, &is_assigned) in assigned.iter().enumerate() {
-            anyhow::ensure!(is_assigned, "VP {vp} not assigned to any NUMA node");
+        // Assign VPs by socket round-robin across the CPU-bearing nodes only,
+        // skipping any CPU-less (Empty) nodes.
+        let n = from_topology_nodes.len() as u32;
+        for vp in 0..proc_count {
+            vp_to_vnode[vp as usize] = from_topology_nodes[((vp / vps_per_socket) % n) as usize];
         }
     } else {
-        // All FromTopology: assign by socket round-robin.
-        let num_nodes = num_nodes as u32;
-        for vp in 0..proc_count {
-            vp_to_vnode[vp as usize] = (vp / vps_per_socket) % num_nodes;
+        // All CPU-bearing nodes are explicit. Every VP must be assigned.
+        for (vp, &is_assigned) in assigned.iter().enumerate() {
+            anyhow::ensure!(is_assigned, "VP {vp} not assigned to any NUMA node");
         }
     }
 
@@ -366,7 +379,94 @@ mod tests {
             distances: Vec::new(),
         };
         let err = validate(&topo, 4).unwrap_err();
-        assert!(err.to_string().contains("cannot mix"), "{err}");
+        assert!(
+            err.to_string().contains("mix automatic and explicit"),
+            "{err}"
+        );
+    }
+
+    #[test]
+    fn empty_node_mixed_with_from_topology_accepted() {
+        // A CPU-less (Empty) node can coexist with auto-assigned nodes
+        // without forcing the others to spell out their VP sets. The empty
+        // node is skipped during round-robin assignment.
+        let topo = NumaTopology {
+            nodes: vec![
+                NumaNode {
+                    mem: mem(2 * 1024 * 1024 * 1024),
+                    vps: VpAssignment::FromTopology,
+                },
+                // CPU-less node (e.g. a generic-initiator target).
+                NumaNode {
+                    mem: None,
+                    vps: VpAssignment::Empty,
+                },
+            ],
+            distances: Vec::new(),
+        };
+        // All VPs land on node 0; node 1 (Empty) is skipped.
+        let map = resolve_numa_vp_assignment(&topo, 4, 1).unwrap();
+        assert_eq!(map, vec![0, 0, 0, 0]);
+    }
+
+    #[test]
+    fn empty_node_skipped_in_round_robin() {
+        // Two CPU-bearing FromTopology nodes with a CPU-less node between
+        // them: VPs round-robin only over the two CPU-bearing nodes (0 and 2).
+        let topo = NumaTopology {
+            nodes: vec![
+                NumaNode {
+                    mem: mem(1024 * 1024 * 1024),
+                    vps: VpAssignment::FromTopology,
+                },
+                NumaNode {
+                    mem: None,
+                    vps: VpAssignment::Empty,
+                },
+                NumaNode {
+                    mem: mem(1024 * 1024 * 1024),
+                    vps: VpAssignment::FromTopology,
+                },
+            ],
+            distances: Vec::new(),
+        };
+        let map = resolve_numa_vp_assignment(&topo, 4, 1).unwrap();
+        // Round-robin over [node 0, node 2]: 0, 2, 0, 2.
+        assert_eq!(map, vec![0, 2, 0, 2]);
+    }
+
+    #[test]
+    fn empty_node_mixed_with_explicit_accepted() {
+        // A CPU-less node can also coexist with explicit nodes.
+        let topo = NumaTopology {
+            nodes: vec![
+                NumaNode {
+                    mem: mem(1024 * 1024 * 1024),
+                    vps: VpAssignment::Explicit(vec![0, 1, 2, 3]),
+                },
+                NumaNode {
+                    mem: mem(1024 * 1024 * 1024),
+                    vps: VpAssignment::Empty,
+                },
+            ],
+            distances: Vec::new(),
+        };
+        let map = resolve_numa_vp_assignment(&topo, 4, 1).unwrap();
+        assert_eq!(map, vec![0, 0, 0, 0]);
+    }
+
+    #[test]
+    fn all_empty_nodes_with_no_vps() {
+        // Degenerate but valid: a single CPU-less node and zero VPs.
+        let topo = NumaTopology {
+            nodes: vec![NumaNode {
+                mem: mem(1024 * 1024 * 1024),
+                vps: VpAssignment::Empty,
+            }],
+            distances: Vec::new(),
+        };
+        let map = resolve_numa_vp_assignment(&topo, 0, 1).unwrap();
+        assert_eq!(map, Vec::<u32>::new());
     }
 
     #[test]

--- a/openvmm/openvmm_core/src/worker/vm_loaders/linux.rs
+++ b/openvmm/openvmm_core/src/worker/vm_loaders/linux.rs
@@ -509,9 +509,12 @@ fn build_dt(
             // SMMU is 1:1 with its RC — stream IDs are plain BDFs.
             node = node.add_u32_array(p_iommu_map, &[0, *phandle, 0, 0x10000])?;
         }
-        if bridge.preserve_bars {
-            // Tell Linux to keep firmware-assigned BAR values instead of
-            // reprogramming them. Linux checks this via of_pci_preserve_config().
+        if bridge.preserve_boot_config {
+            // Tell Linux to keep the firmware-assigned PCI boot configuration
+            // (bus numbers and BARs) instead of re-enumerating. Linux checks
+            // this via of_pci_preserve_config(). This is the device-tree
+            // equivalent of the host-bridge "Ignore PCI Boot Configurations"
+            // _DSM emitted on the ACPI path.
             node = node.add_u32(p_linux_pci_probe_only, 1)?;
         }
         root_builder = node.end_node()?;

--- a/openvmm/openvmm_defs/src/config.rs
+++ b/openvmm/openvmm_defs/src/config.rs
@@ -431,11 +431,12 @@ pub struct NumaNode {
 /// How VPs are assigned to a NUMA node.
 #[derive(Debug, MeshPayload)]
 pub enum VpAssignment {
-    /// Assign VPs to nodes by round-robining sockets: a VP with socket ID
-    /// `vp_index / vps_per_socket` belongs to node
-    /// `(vp_index / vps_per_socket) % num_nodes`. `vps_per_socket` comes
-    /// from `ProcessorTopologyConfig`; `num_nodes` is the length of
-    /// `NumaTopology.nodes`.
+    /// Assign VPs to nodes by round-robining sockets over the CPU-bearing
+    /// nodes only: a VP with socket ID `vp_index / vps_per_socket` belongs to
+    /// the `(vp_index / vps_per_socket) % num_cpu_nodes`-th `FromTopology`
+    /// node. `vps_per_socket` comes from `ProcessorTopologyConfig`;
+    /// `num_cpu_nodes` is the number of `FromTopology` nodes, so `Empty`
+    /// (CPU-less) nodes are skipped and do not affect the distribution.
     FromTopology,
     /// Explicit VP indices assigned to this node.
     Explicit(Vec<u32>),

--- a/openvmm/openvmm_defs/src/config.rs
+++ b/openvmm/openvmm_defs/src/config.rs
@@ -29,6 +29,7 @@ pub struct Config {
     pub pcie_root_complexes: Vec<PcieRootComplexConfig>,
     pub pcie_devices: Vec<PcieDeviceConfig>,
     pub pcie_switches: Vec<PcieSwitchConfig>,
+    pub pcie_generic_initiators: Vec<PcieGenericInitiatorConfig>,
     pub vpci_devices: Vec<VpciDeviceConfig>,
     pub numa: NumaTopology,
     pub processor_topology: ProcessorTopologyConfig,
@@ -253,6 +254,24 @@ pub struct PcieSwitchConfig {
     pub acs_capabilities_supported: Option<u16>,
 }
 
+/// Declares that the device directly behind a named PCIe port (a root port or
+/// a switch downstream port) is a generic initiator (GI) for the given NUMA
+/// node. Used to generate an SRAT Generic Initiator Affinity structure so the
+/// guest attaches the device's memory to that (typically CPU-less) proximity
+/// domain.
+///
+/// The port is resolved against the live topology by port name after switch
+/// downstream ports have been enumerated, so it can target devices that sit
+/// behind a switch.
+#[derive(Debug, MeshPayload)]
+pub struct PcieGenericInitiatorConfig {
+    /// Name of the PCIe port (root port or switch downstream port) behind
+    /// which the generic-initiator device resides.
+    pub port_name: String,
+    /// NUMA node the device is a generic initiator for.
+    pub node: u32,
+}
+
 #[derive(Debug, MeshPayload)]
 pub struct PcieDeviceConfig {
     pub port_name: String,
@@ -420,6 +439,11 @@ pub enum VpAssignment {
     FromTopology,
     /// Explicit VP indices assigned to this node.
     Explicit(Vec<u32>),
+    /// A CPU-less node: no VPs are assigned to it. Unlike `Explicit`, this
+    /// may be combined with `FromTopology` nodes, so a memory- or
+    /// device-only node can be declared without forcing every other node to
+    /// spell out its VP set.
+    Empty,
 }
 
 /// An inter-node distance entry for the ACPI SLIT.

--- a/openvmm/openvmm_entry/src/cli_args.rs
+++ b/openvmm/openvmm_entry/src/cli_args.rs
@@ -173,13 +173,16 @@ Options:
     vps=<LIST>               explicit VP indices (e.g. "[0,1,2,3]")
 
   VP lists use bracket syntax with comma-separated indices and dash
-  ranges: vps=[0,1] or vps=[0-3] or vps=[0,1,4-5].
+  ranges: vps=[0,1] or vps=[0-3] or vps=[0,1,4-5]. An empty list, vps=[],
+  declares a CPU-less node (e.g. a generic-initiator target); unlike a
+  non-empty list, it may be combined with nodes that omit vps.
 
 Examples:
     --numa size=2G --numa size=2G
     --numa size=2G,host_numa_node=0 --numa size=2G,host_numa_node=1
     --numa size=2G,hugepages=on,vps=[0,1] --numa size=2G,vps=[2,3]
-    --numa size=2G,vps=[0-3] --numa size=2G,vps=[4-7]"#
+    --numa size=2G,vps=[0-3] --numa size=2G,vps=[4-7]
+    --numa size=2G --numa size=0,vps=[]"#
     )]
     pub numa: Option<Vec<NumaNodeCli>>,
 
@@ -1096,6 +1099,33 @@ Options:
 "#)]
     #[clap(long, conflicts_with("pcat"))]
     pub pcie_switch: Vec<GenericPcieSwitchCli>,
+
+    /// Declare the device behind a PCIe port as an SRAT generic initiator
+    #[clap(long_help = r#"
+Declare that the device directly behind a PCIe port is a generic initiator
+(GI) for a NUMA node, generating an SRAT Generic Initiator Affinity structure.
+
+The port may be a root port or a switch downstream port, so this works for
+devices that sit behind a switch (e.g. a GPU placed under a switch shared
+with a NIC for peer-to-peer DMA). The port is resolved by name against the
+live topology after switch downstream ports are enumerated.
+
+Examples:
+    # The device behind switch downstream port sw1-downstream-0 is a generic
+    # initiator for NUMA node 1
+    --pcie-generic-initiator port=sw1-downstream-0,node=1
+
+    # Also works for a root port name
+    --pcie-generic-initiator port=rp0,node=2
+
+Syntax: port=<port_name>,node=<node>
+"#)]
+    #[clap(
+        long = "pcie-generic-initiator",
+        value_name = "port=<name>,node=<node>",
+        conflicts_with("pcat")
+    )]
+    pub pcie_generic_initiator: Vec<PcieGenericInitiatorCli>,
 
     /// Attach a PCIe remote device to a downstream port
     #[clap(long_help = r#"
@@ -3185,6 +3215,57 @@ impl FromStr for GenericPcieSwitchCli {
     }
 }
 
+/// CLI configuration mapping a PCIe port name to a generic-initiator NUMA node.
+#[derive(Clone, Debug, PartialEq)]
+pub struct PcieGenericInitiatorCli {
+    /// Name of the PCIe port (root port or switch downstream port) behind
+    /// which the generic-initiator device resides.
+    pub port_name: String,
+    /// NUMA node the device is a generic initiator for.
+    pub node: u32,
+}
+
+impl FromStr for PcieGenericInitiatorCli {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let mut port_name = None;
+        let mut node = None;
+
+        for opt in s.split(',') {
+            let mut kv = opt.split('=');
+            let key = kv.next().context("expected option name")?;
+            let value = kv.next();
+            if kv.next().is_some() {
+                anyhow::bail!("option '{key}' expects a single value")
+            }
+
+            match key {
+                "port" => {
+                    let value = value.context("port option requires a value")?;
+                    if value.is_empty() {
+                        anyhow::bail!("port option requires a value");
+                    }
+                    port_name = Some(value.to_string());
+                }
+                "node" => {
+                    let value = value.context("node option requires a value")?;
+                    node = Some(
+                        u32::from_str(value)
+                            .context("failed to parse generic initiator NUMA node")?,
+                    );
+                }
+                _ => anyhow::bail!("unexpected option: '{opt}'"),
+            }
+        }
+
+        Ok(PcieGenericInitiatorCli {
+            port_name: port_name.context("expected 'port=<name>'")?,
+            node: node.context("expected 'node=<node>'")?,
+        })
+    }
+}
+
 /// CLI configuration for a PCIe remote device.
 #[derive(Clone, Debug, PartialEq)]
 pub struct PcieRemoteCli {
@@ -4570,6 +4651,35 @@ mod tests {
         assert!(PcieRootPortCli::from_str("rc0:rp0:rp3").is_err());
         assert!(PcieRootPortCli::from_str("rc0:rp0,invalid_option").is_err());
         assert!(PcieRootPortCli::from_str("rc0:rp0,cxl=true").is_err());
+    }
+
+    #[test]
+    fn test_pcie_generic_initiator_from_str() {
+        assert_eq!(
+            PcieGenericInitiatorCli::from_str("port=rp0,node=1").unwrap(),
+            PcieGenericInitiatorCli {
+                port_name: "rp0".to_string(),
+                node: 1,
+            }
+        );
+
+        // Order should not matter.
+        assert_eq!(
+            PcieGenericInitiatorCli::from_str("node=2,port=sw0-downstream-1").unwrap(),
+            PcieGenericInitiatorCli {
+                port_name: "sw0-downstream-1".to_string(),
+                node: 2,
+            }
+        );
+
+        // Error cases
+        assert!(PcieGenericInitiatorCli::from_str("").is_err());
+        assert!(PcieGenericInitiatorCli::from_str("port=rp0").is_err());
+        assert!(PcieGenericInitiatorCli::from_str("node=1").is_err());
+        assert!(PcieGenericInitiatorCli::from_str("rp0=1").is_err());
+        assert!(PcieGenericInitiatorCli::from_str("port=,node=1").is_err());
+        assert!(PcieGenericInitiatorCli::from_str("port=rp0,node=x").is_err());
+        assert!(PcieGenericInitiatorCli::from_str("port=rp0,node=1,extra").is_err());
     }
 
     #[test]

--- a/openvmm/openvmm_entry/src/lib.rs
+++ b/openvmm/openvmm_entry/src/lib.rs
@@ -918,7 +918,14 @@ async fn vm_config_from_command_line(
     }
 
     let pcie_switches = build_switch_list(&opt.pcie_switch);
-
+    let pcie_generic_initiators = opt
+        .pcie_generic_initiator
+        .iter()
+        .map(|gi| openvmm_defs::config::PcieGenericInitiatorConfig {
+            port_name: gi.port_name.clone(),
+            node: gi.node,
+        })
+        .collect();
     #[cfg(target_os = "linux")]
     let vfio_pcie_devices: Vec<PcieDeviceConfig> = {
         use std::collections::HashMap;
@@ -1845,6 +1852,7 @@ async fn vm_config_from_command_line(
         #[cfg(not(target_os = "linux"))]
         pcie_devices,
         pcie_switches,
+        pcie_generic_initiators,
         vpci_devices,
         ide_disks: Vec::new(),
         numa: {
@@ -1864,6 +1872,7 @@ async fn vm_config_from_command_line(
                                 host_numa_node: n.host_numa_node,
                             }),
                             vps: match &n.vps {
+                                Some(vps) if vps.is_empty() => VpAssignment::Empty,
                                 Some(vps) => VpAssignment::Explicit(vps.clone()),
                                 None => VpAssignment::FromTopology,
                             },

--- a/openvmm/openvmm_entry/src/ttrpc/mod.rs
+++ b/openvmm/openvmm_entry/src/ttrpc/mod.rs
@@ -575,6 +575,7 @@ impl VmService {
             pcie_root_complexes: vec![],
             pcie_devices: vec![],
             pcie_switches: vec![],
+            pcie_generic_initiators: vec![],
             vpci_devices: vec![],
             numa: NumaTopology {
                 nodes: vec![NumaNode {

--- a/petri/src/vm/openvmm/construct.rs
+++ b/petri/src/vm/openvmm/construct.rs
@@ -613,6 +613,7 @@ impl PetriVmConfigOpenVmm {
             pcie_root_complexes: vec![],
             pcie_devices,
             pcie_switches: vec![],
+            pcie_generic_initiators: vec![],
             vpci_devices,
             vmbus_devices,
 

--- a/vm/acpi/src/ssdt.rs
+++ b/vm/acpi/src/ssdt.rs
@@ -60,9 +60,11 @@ pub struct PcieHostBridgeEntry {
     pub cxl: bool,
     /// NUMA proximity domain.
     pub vnode: Option<u32>,
-    /// When true, emit a `_DSM` method instructing the OS to preserve
-    /// firmware-assigned BAR values. Used for P2P DMA with GPA = HPA.
-    pub preserve_bars: bool,
+    /// When true, emit a `_DSM` method ("Ignore PCI Boot Configurations", PCI
+    /// Firmware Spec §4.6 function 5) instructing the guest OS to keep the
+    /// firmware-assigned PCI boot configuration (bus numbers and BARs) rather
+    /// than reprogramming it.
+    pub preserve_boot_config: bool,
 }
 
 impl Ssdt {
@@ -151,7 +153,7 @@ impl Ssdt {
             high_mmio,
             cxl,
             vnode,
-            preserve_bars,
+            preserve_boot_config,
         } = entry;
         let mut pcie = Device::new(encode_pcie_name(index).as_slice());
         if cxl {
@@ -311,18 +313,19 @@ impl Ssdt {
 
         pcie.add_object(&osc_method);
 
-        // _DSM: Device Specific Method for preserving firmware BAR assignments.
+        // _DSM: Device Specific Method for preserving the firmware PCI boot
+        // configuration (bus numbers and BARs).
         //
         // UUID {E5C937D0-3553-4D7A-9117-EA4D19C3434D} is the PCI/PCIe host
         // bridge _DSM defined in the PCI Firmware Specification §4.6.
         //
         // Function 0: returns a buffer with supported function bitmask
-        // Function 5: returns 0 to indicate firmware-assigned BAR values
-        //             should be preserved by the OS
+        // Function 5 ("Ignore PCI Boot Configurations"): returns 0 to tell the
+        //             OS to preserve the firmware-programmed configuration
         //
-        // When preserve_bars is false, no _DSM is emitted and the guest
-        // OS is free to reprogram BARs.
-        if preserve_bars {
+        // When preserve_boot_config is false, no _DSM is emitted and the guest
+        // OS is free to reprogram bus numbers and BARs.
+        if preserve_boot_config {
             let mut dsm_method = Method::new(b"_DSM");
             dsm_method.set_arg_count(4);
 
@@ -493,7 +496,7 @@ mod tests {
             high_mmio: MemoryRange::new(0x10_0000_0000..0x10_4000_0000),
             cxl: false,
             vnode,
-            preserve_bars: false,
+            preserve_boot_config: false,
         }
     }
 
@@ -566,10 +569,10 @@ mod tests {
     }
 
     #[test]
-    fn pcie_dsm_present_when_preserve_bars() {
+    fn pcie_dsm_present_when_preserve_boot_config() {
         let mut ssdt = Ssdt::new();
         ssdt.add_pcie(PcieHostBridgeEntry {
-            preserve_bars: true,
+            preserve_boot_config: true,
             ..test_pcie_entry(None)
         });
 
@@ -590,10 +593,10 @@ mod tests {
     }
 
     #[test]
-    fn pcie_dsm_absent_without_preserve_bars() {
+    fn pcie_dsm_absent_without_preserve_boot_config() {
         let mut ssdt = Ssdt::new();
         ssdt.add_pcie(PcieHostBridgeEntry {
-            preserve_bars: false,
+            preserve_boot_config: false,
             ..test_pcie_entry(None)
         });
 

--- a/vm/acpi_spec/src/srat.rs
+++ b/vm/acpi_spec/src/srat.rs
@@ -44,6 +44,16 @@ open_enum::open_enum! {
         MEMORY = 1,
         X2APIC = 2,
         GICC = 3,
+        GENERIC_INITIATOR = 5,
+    }
+}
+
+open_enum::open_enum! {
+    /// Device Handle Type for a [`SratGenericInitiator`] structure.
+    #[derive(IntoBytes, Immutable, KnownLayout, FromBytes, Unaligned)]
+    pub enum SratDeviceHandleType: u8 {
+        ACPI = 0,
+        PCI = 1,
     }
 }
 
@@ -136,6 +146,62 @@ impl SratGicc {
             flags: SRAT_APIC_ENABLED.into(),
             clock_domain: 0.into(),
             proximity_domain: vnode.into(),
+        }
+    }
+}
+
+/// SRAT Generic Initiator Affinity Structure (ACPI 6.3+, type 5).
+///
+/// Associates a non-CPU initiator (such as a PCI device) with a proximity
+/// domain. This is how a passthrough device's coherent/device memory is
+/// attached to a CPU-less NUMA node: the guest OS matches the device handle
+/// (PCI segment/bus/device/function) against the device and onlines the
+/// corresponding proximity domain.
+#[repr(C)]
+#[derive(Copy, Clone, Debug, IntoBytes, Immutable, KnownLayout, FromBytes, Unaligned)]
+pub struct SratGenericInitiator {
+    pub typ: SratType,
+    pub length: u8,
+    pub reserved1: u8,
+    pub device_handle_type: SratDeviceHandleType,
+    pub proximity_domain: u32_ne,
+    pub device_handle: [u8; 16],
+    pub flags: u32_ne,
+    pub reserved2: u32_ne,
+}
+
+const_assert_eq!(size_of::<SratGenericInitiator>(), 32);
+
+open_enum::open_enum! {
+    pub enum SratGenericInitiatorFlags: u32 {
+        ENABLED                   = 1 << 0,
+        ARCHITECTURAL_TRANSACTIONS = 1 << 1,
+    }
+}
+
+impl SratGenericInitiator {
+    /// Creates a Generic Initiator Affinity structure for a PCI device,
+    /// associating the device at `segment:bus:device.function` with the
+    /// proximity domain `vnode`.
+    pub fn new_pci(segment: u16, bus: u8, device: u8, function: u8, vnode: u32) -> Self {
+        // PCI Device Handle layout (ACPI 6.3, Table "Device Handle - PCI"):
+        //   bytes [0..2] : PCI Segment (little endian)
+        //   byte   [2]   : PCI Bus
+        //   byte   [3]   : PCI Device (bits 7:3) | Function (bits 2:0)
+        //   bytes [4..16]: reserved (zero)
+        let mut device_handle = [0u8; 16];
+        device_handle[0..2].copy_from_slice(&segment.to_le_bytes());
+        device_handle[2] = bus;
+        device_handle[3] = ((device & 0x1f) << 3) | (function & 0x7);
+        Self {
+            typ: SratType::GENERIC_INITIATOR,
+            length: size_of::<Self>() as u8,
+            reserved1: 0,
+            device_handle_type: SratDeviceHandleType::PCI,
+            proximity_domain: vnode.into(),
+            device_handle,
+            flags: SratGenericInitiatorFlags::ENABLED.0.into(),
+            reserved2: 0.into(),
         }
     }
 }

--- a/vm/vmcore/vm_topology/src/pcie.rs
+++ b/vm/vmcore/vm_topology/src/pcie.rs
@@ -37,6 +37,13 @@ pub struct PcieHostBridge {
     /// NUMA node affinity for this host bridge.
     pub vnode: Option<u32>,
     /// When true, treat non-zero BAR values found during probing as pinned
-    /// addresses. Used for P2P DMA with GPA = HPA.
+    /// addresses (input to the PCI resource assignment algorithm). Used for
+    /// P2P DMA with GPA = HPA.
     pub preserve_bars: bool,
+    /// When true, instruct the guest OS — via the host-bridge `_DSM` (and the
+    /// device-tree equivalent on ARM64) — to preserve the firmware-assigned
+    /// PCI boot configuration (bus numbers and BARs) rather than
+    /// re-enumerating. Required when something references a device by a fixed
+    /// BDF, e.g. an SRAT generic-initiator entry.
+    pub preserve_boot_config: bool,
 }

--- a/vmm_core/src/acpi_builder.rs
+++ b/vmm_core/src/acpi_builder.rs
@@ -60,6 +60,27 @@ pub struct SlitInfo {
     pub distances: Vec<(u32, u32, u8)>,
 }
 
+/// A PCI generic initiator to expose in the SRAT.
+///
+/// Associates a passthrough PCI device with a (typically CPU-less) NUMA node
+/// via an SRAT Generic Initiator Affinity structure. Guest drivers that look
+/// up a device's proximity domain by walking the SRAT (e.g. NVIDIA's
+/// coherent-memory onlining path for Grace-based GPUs) use this to attach the
+/// device's memory to a node.
+#[derive(Debug, Clone, Copy)]
+pub struct GenericInitiator {
+    /// PCI segment of the device.
+    pub segment: u16,
+    /// PCI bus number of the device.
+    pub bus: u8,
+    /// PCI device number.
+    pub device: u8,
+    /// PCI function number.
+    pub function: u8,
+    /// Proximity domain (NUMA node) this initiator is associated with.
+    pub vnode: u32,
+}
+
 /// Builder to construct a set of [`BuiltAcpiTables`]
 pub struct AcpiTablesBuilder<'a, T: AcpiTopology> {
     /// The processor topology.
@@ -81,6 +102,9 @@ pub struct AcpiTablesBuilder<'a, T: AcpiTopology> {
     ///
     /// If set, a SLIT table will be generated.
     pub slit_info: Option<&'a SlitInfo>,
+    /// PCI generic initiators to expose in the SRAT, associating passthrough
+    /// devices with (typically CPU-less) NUMA nodes.
+    pub generic_initiators: &'a [GenericInitiator],
     /// Architecture-specific ACPI configuration.
     pub arch: AcpiArchConfig,
 }
@@ -198,7 +222,7 @@ pub fn build_pcie_acpi_tables(
             high_mmio: bridge.high_mmio,
             cxl: bridge.cxl.is_some(),
             vnode: bridge.vnode,
-            preserve_bars: bridge.preserve_bars,
+            preserve_boot_config: bridge.preserve_boot_config,
         });
 
         if let Some(cxl) = &bridge.cxl {
@@ -389,6 +413,18 @@ impl<T: AcpiTopology> AcpiTablesBuilder<'_, T> {
                     range.range.start(),
                     range.range.len(),
                     range.vnode,
+                )
+                .as_bytes(),
+            );
+        }
+        for gi in self.generic_initiators {
+            srat_extra.extend_from_slice(
+                acpi_spec::srat::SratGenericInitiator::new_pci(
+                    gi.segment,
+                    gi.bus,
+                    gi.device,
+                    gi.function,
+                    gi.vnode,
                 )
                 .as_bytes(),
             );
@@ -1223,6 +1259,7 @@ mod test {
             cache_topology: None,
             pcie_host_bridges,
             slit_info: None,
+            generic_initiators: &[],
             arch: AcpiArchConfig::X86 {
                 with_ioapic: true,
                 with_pic: false,
@@ -1293,6 +1330,7 @@ mod test {
                 cxl: None,
                 vnode: None,
                 preserve_bars: false,
+                preserve_boot_config: false,
             },
             PcieHostBridge {
                 index: 1,
@@ -1305,6 +1343,7 @@ mod test {
                 cxl: None,
                 vnode: None,
                 preserve_bars: false,
+                preserve_boot_config: false,
             },
         ];
 
@@ -1365,6 +1404,7 @@ mod test {
             cache_topology: None,
             pcie_host_bridges,
             slit_info: None,
+            generic_initiators: &[],
             arch: AcpiArchConfig::Aarch64 {
                 hypervisor_vendor_identity: 0,
                 virt_timer_ppi: 20,
@@ -1404,6 +1444,7 @@ mod test {
                 cxl: None,
                 vnode: None,
                 preserve_bars: false,
+                preserve_boot_config: false,
             },
             PcieHostBridge {
                 index: 7,
@@ -1416,6 +1457,7 @@ mod test {
                 cxl: None,
                 vnode: None,
                 preserve_bars: false,
+                preserve_boot_config: false,
             },
         ];
         let builder = new_aarch64_builder(&mem, &topology, &pcie_host_bridges);
@@ -1477,6 +1519,7 @@ mod test {
             cxl: None,
             vnode: None,
             preserve_bars: false,
+            preserve_boot_config: false,
         }];
         let builder = new_builder(&mem, &topology, &pcie_host_bridges);
         assert!(builder.build_iort().is_none());
@@ -1509,6 +1552,7 @@ mod test {
             cxl: None,
             vnode: None,
             preserve_bars: false,
+            preserve_boot_config: false,
         }];
         let builder = new_aarch64_builder(&mem, &topology, &pcie_host_bridges);
 
@@ -1529,6 +1573,7 @@ mod test {
             cache_topology: None,
             pcie_host_bridges,
             slit_info: None,
+            generic_initiators: &[],
             arch: AcpiArchConfig::Aarch64 {
                 hypervisor_vendor_identity: 0,
                 virt_timer_ppi: 20,
@@ -1570,6 +1615,7 @@ mod test {
             }),
             vnode: None,
             preserve_bars: false,
+            preserve_boot_config: false,
         }];
         let builder = new_builder(&mem, &topology, &pcie_host_bridges);
 
@@ -1595,6 +1641,7 @@ mod test {
             cxl: None,
             vnode: None,
             preserve_bars: false,
+            preserve_boot_config: false,
         }];
         let builder = new_aarch64_builder_with_smmu(&mem, &topology, &pcie_host_bridges, smmu_base);
 
@@ -1673,6 +1720,7 @@ mod test {
                 cxl: None,
                 vnode: None,
                 preserve_bars: false,
+                preserve_boot_config: false,
             },
             PcieHostBridge {
                 index: 1,
@@ -1685,6 +1733,7 @@ mod test {
                 cxl: None,
                 vnode: None,
                 preserve_bars: false,
+                preserve_boot_config: false,
             },
         ];
         let builder = new_aarch64_builder_with_smmu(&mem, &topology, &pcie_host_bridges, smmu_base);
@@ -1738,6 +1787,7 @@ mod test {
             cxl: None,
             vnode: None,
             preserve_bars: false,
+            preserve_boot_config: false,
         }];
         let builder = new_aarch64_builder(&mem, &topology, &pcie_host_bridges);
 
@@ -1772,6 +1822,7 @@ mod test {
             cxl: None,
             vnode: None,
             preserve_bars: false,
+            preserve_boot_config: false,
         }];
         let builder = new_aarch64_builder_with_smmu(&mem, &topology, &pcie_host_bridges, smmu_base);
 

--- a/vmm_tests/vmm_tests/tests/tests/multiarch/numa.rs
+++ b/vmm_tests/vmm_tests/tests/tests/multiarch/numa.rs
@@ -182,7 +182,7 @@ async fn boot_numa_complex_topology(
                         // Node 3: memory-only (1 GB), no VPs
                         NumaNode {
                             mem: Some(make_mem(SIZE_1_GB)),
-                            vps: VpAssignment::Explicit(vec![]),
+                            vps: VpAssignment::Empty,
                         },
                     ],
                     distances: vec![


### PR DESCRIPTION
Some passthrough devices — such as an NVIDIA Grace GPU — originate memory accesses and expose their own coherent memory, but have no CPUs of their own. To let a guest account for access latency and online that device memory on the correct proximity domain, the firmware must emit an SRAT Generic Initiator Affinity structure that ties the device to a (typically CPU-less) NUMA node.

This adds a `--pcie-generic-initiator port=<name>,node=<node>` option that declares the device directly behind a named PCIe port — a root port or a switch downstream port, so devices behind a switch are supported — as a generic initiator for a NUMA node. The port is resolved by name against the live topology after switch downstream ports are enumerated, and its NUMA reference is validated against the configured nodes.

Because the device's PCI bus depends on bridge bus-number assignment, each entry captures the port's live bus-range handle rather than predicting a bus number. PCI resource assignment is now run before firmware load so the secondary bus can be read back when the ACPI tables are built. The SRAT encoding is extended with the type 5 structure and PCI device-handle type.

The SRAT entry references its device by a fixed segment/bus/device/function, so the guest must not re-enumerate PCIe and reassign bus numbers underneath it. To express that, the host-bridge model gains a `preserve_boot_config` flag, kept distinct from the existing `preserve_bars`: the former asks the guest to keep the firmware's PCI boot configuration (emitting the "Ignore PCI Boot Configurations" host-bridge _DSM on ACPI and `linux,pci-probe-only` on the ARM64 device tree), while the latter pins host BAR addresses as input to the resource-assignment algorithm. Declaring a generic initiator sets only the former, so it no longer implies BAR pinning; the existing `preserve_bars` CLI knob continues to set both, since pinned addresses also require the guest to leave the configuration alone.

A generic initiator's target is usually a CPU-less NUMA node. Declaring such a node previously forced every other node to spell out its VP set, because an empty VP list was treated as an explicit assignment that could not be mixed with automatic assignment. NUMA nodes now distinguish a third case — a CPU-less node that claims no VPs — which may be combined freely with automatically-assigned nodes; VP round-robin distributes over the CPU-bearing nodes and skips the CPU-less ones.