### PR TITLE
[WIP] Preserve UEFI firmware across hibernation in OpenHCL

### DIFF
--- a/openhcl/underhill_core/src/worker.rs
+++ b/openhcl/underhill_core/src/worker.rs
@@ -3679,6 +3679,7 @@ async fn new_underhill_vm(
             fatal_error_recv,
             control_send.clone(),
             get_client.clone(),
+            vmgs_client.clone(),
             env_cfg.halt_on_guest_halt,
         ),
     );
@@ -3923,6 +3924,40 @@ where
     reg_state
 }
 
+/// Power token values written to [`vmgs::FileId::HIBERNATION_TOKEN`] on a power
+/// transition, mirroring the legacy HCL `HclPowerServices` behavior. The token
+/// is written on power off and consumed/cleared on resume.
+mod hibernation_token {
+    /// VMGS backing stores at least this large can hold a firmware image
+    /// snapshot, so a hibernate writes the "firmware stored" marker.
+    pub const VMGS_FIRMWARE_THRESHOLD_BYTES: u64 = 32 * 1024 * 1024;
+    /// Written on hibernate when the VMGS is large enough to store firmware.
+    pub const FIRMWARE_STORED: u64 = u64::MAX;
+    /// Written on hibernate when the VMGS is too small to store firmware.
+    pub const HIBERNATED: u64 = 0x1;
+    /// Written on a clean power off / reset to clear any prior hibernate marker.
+    pub const NONE: u64 = 0x0;
+}
+
+/// Best-effort write of an 8-byte power token to the VMGS. Failures are logged
+/// but never block the power transition.
+async fn write_hibernation_token(vmgs_client: &vmgs_broker::VmgsClient, token: u64) {
+    if let Err(err) = vmgs_client
+        .write_file(
+            vmgs::FileId::HIBERNATION_TOKEN,
+            token.to_le_bytes().to_vec(),
+        )
+        .await
+    {
+        tracing::error!(
+            CVM_ALLOWED,
+            error = &err as &dyn std::error::Error,
+            token,
+            "failed to write hibernation power token"
+        );
+    }
+}
+
 /// Waits for halt notifications and handles them by forwarding them to the
 /// host (when appropriate).
 async fn halt_task(
@@ -3930,6 +3965,7 @@ async fn halt_task(
     mut _fatal_error_recv: mesh::Receiver<Box<dyn std::error::Error + Send + Sync>>,
     control_send: Arc<Mutex<Option<mesh::Sender<ControlRequest>>>>,
     get_client: GuestEmulationTransportClient,
+    vmgs_client: Option<vmgs_broker::VmgsClient>,
     halt_on_guest_halt: bool,
 ) {
     #[derive(Debug)]
@@ -3980,9 +4016,45 @@ async fn halt_task(
 
             // Now we can notify the host about the halt.
             match halt_request {
-                HaltRequest::PowerOff => get_client.send_power_off(),
-                HaltRequest::Reset => get_client.send_reset(),
-                HaltRequest::Hibernate => get_client.send_hibernate(),
+                HaltRequest::PowerOff => {
+                    // Clear any stale hibernate marker on a clean power off.
+                    if let Some(vmgs_client) = &vmgs_client {
+                        write_hibernation_token(vmgs_client, hibernation_token::NONE).await;
+                    }
+                    get_client.send_power_off()
+                }
+                HaltRequest::Reset => {
+                    // Clear any stale hibernate marker on reset.
+                    if let Some(vmgs_client) = &vmgs_client {
+                        write_hibernation_token(vmgs_client, hibernation_token::NONE).await;
+                    }
+                    get_client.send_reset()
+                }
+                HaltRequest::Hibernate => {
+                    // Write the power token before signaling the host, matching
+                    // the legacy HCL flow. A VMGS large enough to hold a
+                    // firmware image snapshot gets the "firmware stored" marker.
+                    if let Some(vmgs_client) = &vmgs_client {
+                        let token = match vmgs_client.device_size().await {
+                            Ok(size)
+                                if size >= hibernation_token::VMGS_FIRMWARE_THRESHOLD_BYTES =>
+                            {
+                                hibernation_token::FIRMWARE_STORED
+                            }
+                            Ok(_) => hibernation_token::HIBERNATED,
+                            Err(err) => {
+                                tracing::error!(
+                                    CVM_ALLOWED,
+                                    error = &err as &dyn std::error::Error,
+                                    "failed to query VMGS size; assuming no firmware snapshot"
+                                );
+                                hibernation_token::HIBERNATED
+                            }
+                        };
+                        write_hibernation_token(vmgs_client, token).await;
+                    }
+                    get_client.send_hibernate()
+                }
                 HaltRequest::TripleFault { vp, regs } => {
                     get_client.triple_fault(vp, TripleFaultType::UNRECOVERABLE_EXCEPTION, regs)
                 }

--- a/openhcl/underhill_core/src/worker.rs
+++ b/openhcl/underhill_core/src/worker.rs
@@ -2223,13 +2223,13 @@ async fn new_underhill_vm(
 
     // For hibernate-enabled VMs, decide at boot whether the VMGS backing store
     // is large enough to also hold a firmware image snapshot. This decision is
-    // saved and used to choose the power token value written at hibernate time
+    // saved and used to choose the hibernate token value written at hibernate time
     // (see `halt_task`), avoiding a query on the power-off path.
     //
     // If the store is large enough, the pristine UEFI firmware image is later
     // snapshotted into `vmgs::FileId::HIBERNATION_FIRMWARE` (see below, after
     // the measured VTL0 config is read). If that snapshot fails, this flag is
-    // downgraded to `false` so the power token reflects that no firmware
+    // downgraded to `false` so the hibernate token reflects that no firmware
     // was stored.
     let mut hibernation_firmware_stored = if dps.general.hibernation_enabled {
         match &vmgs_client {
@@ -2295,14 +2295,14 @@ async fn new_underhill_vm(
     //
     // - Phase 1 (normal boot): snapshot the pristine UEFI firmware image, as
     //   deposited into VTL0 guest memory, into VMGS so it can be restored later.
-    // - Phase 3 (resume boot): when the power token written at hibernate time
+    // - Phase 3 (resume boot): when the hibernate token written at hibernate time
     //   indicates a firmware image was stored, restore that saved image back
     //   into VTL0 guest memory instead, so the resumed guest sees an identical
     //   firmware binary even if the host's firmware changed in the meantime,
     //   then consume the token.
     //
     // If the operation fails (or this is not a UEFI boot), downgrade the saved
-    // flag so the next power token reflects that no firmware was stored.
+    // flag so the next hibernate token reflects that no firmware was stored.
     if hibernation_firmware_stored {
         match (
             load_kind,
@@ -2313,8 +2313,8 @@ async fn new_underhill_vm(
         ) {
             (LoadKind::Uefi, Some(uefi_info), Some(vmgs_client)) => {
                 let resuming = matches!(
-                    read_power_token(vmgs_client).await,
-                    Some(token) if token != power_token::NONE
+                    read_hibernate_token(vmgs_client).await,
+                    Some(token) if token != hibernate_token::NONE
                 );
                 let result = if resuming {
                     load_firmware_from_vmgs(gm.vtl0(), uefi_info.firmware_memory, vmgs_client).await
@@ -2326,7 +2326,7 @@ async fn new_underhill_vm(
                         if resuming {
                             // Consume the token so a later clean boot does not
                             // restore a stale firmware image.
-                            delete_power_token(vmgs_client).await;
+                            delete_hibernate_token(vmgs_client).await;
                         }
                     }
                     Err(err) => {
@@ -4018,10 +4018,10 @@ where
 /// so a hibernate writes the "firmware stored" marker.
 const VMGS_FIRMWARE_THRESHOLD_BYTES: u64 = 32 * 1024 * 1024;
 
-/// Power token values written to [`vmgs::FileId::HIBERNATION_TOKEN`] on a power
+/// Hibernate token values written to [`vmgs::FileId::HIBERNATION_TOKEN`] on a power
 /// transition, mirroring the legacy HCL `HclPowerServices` behavior. The token
 /// is written on power off and consumed/cleared on resume.
-mod power_token {
+mod hibernate_token {
     /// Written on hibernate when the VMGS is large enough to store firmware.
     pub const FIRMWARE_STORED: u64 = u64::MAX;
     /// Written on hibernate when the VMGS is too small to store firmware.
@@ -4030,9 +4030,9 @@ mod power_token {
     pub const NONE: u64 = 0x0;
 }
 
-/// Best-effort write of an 8-byte power token to the VMGS. Failures are logged
+/// Best-effort write of an 8-byte hibernate token to the VMGS. Failures are logged
 /// but never block the power transition.
-async fn write_power_token(vmgs_client: &vmgs_broker::VmgsClient, token: u64) {
+async fn write_hibernate_token(vmgs_client: &vmgs_broker::VmgsClient, token: u64) {
     if let Err(err) = vmgs_client
         .write_file(
             vmgs::FileId::HIBERNATION_TOKEN,
@@ -4044,15 +4044,15 @@ async fn write_power_token(vmgs_client: &vmgs_broker::VmgsClient, token: u64) {
             CVM_ALLOWED,
             error = &err as &dyn std::error::Error,
             token,
-            "failed to write power token"
+            "failed to write hibernate token"
         );
     }
 }
 
-/// Best-effort deletion of the power token from the VMGS, used to
+/// Best-effort deletion of the hibernate token from the VMGS, used to
 /// consume the token after a firmware image has been restored on resume.
 /// Failures are logged but never block boot.
-async fn delete_power_token(vmgs_client: &vmgs_broker::VmgsClient) {
+async fn delete_hibernate_token(vmgs_client: &vmgs_broker::VmgsClient) {
     if let Err(err) = vmgs_client
         .delete_file(vmgs::FileId::HIBERNATION_TOKEN)
         .await
@@ -4060,7 +4060,7 @@ async fn delete_power_token(vmgs_client: &vmgs_broker::VmgsClient) {
         tracing::error!(
             CVM_ALLOWED,
             error = &err as &dyn std::error::Error,
-            "failed to delete power token"
+            "failed to delete hibernate token"
         );
     }
 }
@@ -4110,10 +4110,10 @@ async fn store_firmware_to_vmgs(
     Ok(())
 }
 
-/// Reads the 8-byte little-endian power token from VMGS, returning
+/// Reads the 8-byte little-endian hibernate token from VMGS, returning
 /// `None` if it is absent or cannot be read/parsed (e.g. on a first boot before
 /// any token has been written).
-async fn read_power_token(vmgs_client: &vmgs_broker::VmgsClient) -> Option<u64> {
+async fn read_hibernate_token(vmgs_client: &vmgs_broker::VmgsClient) -> Option<u64> {
     let buf = vmgs_client
         .read_file(vmgs::FileId::HIBERNATION_TOKEN)
         .await
@@ -4214,32 +4214,32 @@ async fn halt_task(
             // Now we can notify the host about the halt.
             match halt_request {
                 HaltRequest::PowerOff => {
-                    // Write the NONE power token to clear any stale hibernate
+                    // Write the NONE hibernate token to clear any stale hibernate
                     // state on a clean power off.
                     if let Some(vmgs_client) = &vmgs_client {
-                        write_power_token(vmgs_client, power_token::NONE).await;
+                        write_hibernate_token(vmgs_client, hibernate_token::NONE).await;
                     }
                     get_client.send_power_off()
                 }
                 HaltRequest::Reset => {
-                    // Write the NONE power token to clear any stale hibernate
+                    // Write the NONE hibernate token to clear any stale hibernate
                     // state on reset.
                     if let Some(vmgs_client) = &vmgs_client {
-                        write_power_token(vmgs_client, power_token::NONE).await;
+                        write_hibernate_token(vmgs_client, hibernate_token::NONE).await;
                     }
                     get_client.send_reset()
                 }
                 HaltRequest::Hibernate => {
-                    // Write the power token before signaling the host, matching
+                    // Write the hibernate token before signaling the host, matching
                     // the legacy HCL flow. Whether the VMGS is large enough to
                     // hold a firmware image snapshot was decided at boot.
                     if let Some(vmgs_client) = &vmgs_client {
                         let token = if hibernation_firmware_stored {
-                            power_token::FIRMWARE_STORED
+                            hibernate_token::FIRMWARE_STORED
                         } else {
-                            power_token::HIBERNATED
+                            hibernate_token::HIBERNATED
                         };
-                        write_power_token(vmgs_client, token).await;
+                        write_hibernate_token(vmgs_client, token).await;
                     }
                     get_client.send_hibernate()
                 }

--- a/openhcl/underhill_core/src/worker.rs
+++ b/openhcl/underhill_core/src/worker.rs
@@ -2221,6 +2221,33 @@ async fn new_underhill_vm(
         (None, None)
     };
 
+    // For hibernate-enabled VMs, decide at boot whether the VMGS backing store
+    // is large enough to also hold a firmware image snapshot. This decision is
+    // saved and used to choose the power token value written at hibernate time
+    // (see `halt_task`), avoiding a query on the power-off path.
+    //
+    // TODO: when `hibernation_firmware_stored` is true, stash the loaded UEFI
+    // firmware image into `vmgs::FileId::HIBERNATION_FIRMWARE` so it can be
+    // restored on resume.
+    let hibernation_firmware_stored = if dps.general.hibernation_enabled {
+        match &vmgs_client {
+            Some(vmgs_client) => match vmgs_client.device_size().await {
+                Ok(size) => size >= hibernation_token::VMGS_FIRMWARE_THRESHOLD_BYTES,
+                Err(err) => {
+                    tracing::error!(
+                        CVM_ALLOWED,
+                        error = &err as &dyn std::error::Error,
+                        "failed to query VMGS size; assuming no firmware snapshot"
+                    );
+                    false
+                }
+            },
+            None => false,
+        }
+    } else {
+        false
+    };
+
     // Enable remote chipset devices.
     resolver.add_async_resolver(
         chipset_device_worker::resolver::RemoteChipsetDeviceResolver(
@@ -3680,6 +3707,7 @@ async fn new_underhill_vm(
             control_send.clone(),
             get_client.clone(),
             vmgs_client.clone(),
+            hibernation_firmware_stored,
             env_cfg.halt_on_guest_halt,
         ),
     );
@@ -3966,6 +3994,7 @@ async fn halt_task(
     control_send: Arc<Mutex<Option<mesh::Sender<ControlRequest>>>>,
     get_client: GuestEmulationTransportClient,
     vmgs_client: Option<vmgs_broker::VmgsClient>,
+    hibernation_firmware_stored: bool,
     halt_on_guest_halt: bool,
 ) {
     #[derive(Debug)]
@@ -4032,24 +4061,13 @@ async fn halt_task(
                 }
                 HaltRequest::Hibernate => {
                     // Write the power token before signaling the host, matching
-                    // the legacy HCL flow. A VMGS large enough to hold a
-                    // firmware image snapshot gets the "firmware stored" marker.
+                    // the legacy HCL flow. Whether the VMGS is large enough to
+                    // hold a firmware image snapshot was decided at boot.
                     if let Some(vmgs_client) = &vmgs_client {
-                        let token = match vmgs_client.device_size().await {
-                            Ok(size)
-                                if size >= hibernation_token::VMGS_FIRMWARE_THRESHOLD_BYTES =>
-                            {
-                                hibernation_token::FIRMWARE_STORED
-                            }
-                            Ok(_) => hibernation_token::HIBERNATED,
-                            Err(err) => {
-                                tracing::error!(
-                                    CVM_ALLOWED,
-                                    error = &err as &dyn std::error::Error,
-                                    "failed to query VMGS size; assuming no firmware snapshot"
-                                );
-                                hibernation_token::HIBERNATED
-                            }
+                        let token = if hibernation_firmware_stored {
+                            hibernation_token::FIRMWARE_STORED
+                        } else {
+                            hibernation_token::HIBERNATED
                         };
                         write_hibernation_token(vmgs_client, token).await;
                     }

--- a/openhcl/underhill_core/src/worker.rs
+++ b/openhcl/underhill_core/src/worker.rs
@@ -3995,6 +3995,12 @@ where
     reg_state
 }
 
+/// A VMGS backing store must be at least this large to store a firmware image
+/// snapshot for hibernation. This is a minimum overall size so that the
+/// firmware image fits alongside the other VMGS files, not just a tight fit of
+/// the image itself.
+const VMGS_FIRMWARE_THRESHOLD_BYTES: u64 = 32 * 1024 * 1024;
+
 /// Hibernate token values written to [`vmgs::FileId::HIBERNATION_TOKEN`] on a power
 /// transition, mirroring the legacy HCL `HclPowerServices` behavior. The token
 /// is written on power off and consumed/cleared on resume.
@@ -4061,11 +4067,17 @@ async fn store_firmware_to_vmgs(
     let len = firmware_memory.len();
 
     // The firmware image can only be stored if the VMGS backing store is large
-    // enough to hold it.
+    // enough. Require a minimum overall size so there is room for the firmware
+    // image alongside the other VMGS files, and also verify the image fits.
     let device_size = vmgs_client
         .device_size()
         .await
         .context("failed to query VMGS size")?;
+    if device_size < VMGS_FIRMWARE_THRESHOLD_BYTES {
+        anyhow::bail!(
+            "VMGS backing store ({device_size} bytes) is smaller than the minimum required to store a firmware image ({VMGS_FIRMWARE_THRESHOLD_BYTES} bytes)"
+        );
+    }
     if len > device_size {
         anyhow::bail!(
             "UEFI firmware image ({len} bytes) does not fit in VMGS backing store ({device_size} bytes)"

--- a/openhcl/underhill_core/src/worker.rs
+++ b/openhcl/underhill_core/src/worker.rs
@@ -2226,10 +2226,12 @@ async fn new_underhill_vm(
     // saved and used to choose the power token value written at hibernate time
     // (see `halt_task`), avoiding a query on the power-off path.
     //
-    // TODO: when `hibernation_firmware_stored` is true, stash the loaded UEFI
-    // firmware image into `vmgs::FileId::HIBERNATION_FIRMWARE` so it can be
-    // restored on resume.
-    let hibernation_firmware_stored = if dps.general.hibernation_enabled {
+    // If the store is large enough, the pristine UEFI firmware image is later
+    // snapshotted into `vmgs::FileId::HIBERNATION_FIRMWARE` (see below, after
+    // the measured VTL0 config is read). If that snapshot fails, this flag is
+    // downgraded to `false` so the hibernate token reflects that no firmware
+    // was stored.
+    let mut hibernation_firmware_stored = if dps.general.hibernation_enabled {
         match &vmgs_client {
             Some(vmgs_client) => match vmgs_client.device_size().await {
                 Ok(size) => size >= hibernation_token::VMGS_FIRMWARE_THRESHOLD_BYTES,
@@ -2285,6 +2287,44 @@ async fn new_underhill_vm(
             (firmware_type, Some(config), load_kind)
         }
     };
+
+    // Phase 1: For hibernate-enabled VMs whose VMGS is large enough, snapshot
+    // the pristine UEFI firmware image into VMGS *before* any dynamic config is
+    // written into the firmware region (that happens later in `load_firmware`
+    // via `write_uefi_config`). The firmware can then be restored identically
+    // on resume. The UEFI image has already been deposited into VTL0 guest
+    // memory at this point, so we read it directly. If the snapshot fails (or
+    // this is not a UEFI boot), downgrade the saved flag so the hibernate token
+    // reflects that no firmware was stored.
+    if hibernation_firmware_stored {
+        match (
+            load_kind,
+            measured_vtl0_info
+                .as_ref()
+                .and_then(|info| info.supports_uefi.as_ref()),
+            vmgs_client.as_ref(),
+        ) {
+            (LoadKind::Uefi, Some(uefi_info), Some(vmgs_client)) => {
+                if let Err(err) =
+                    snapshot_firmware_to_vmgs(gm.vtl0(), uefi_info.firmware_memory, vmgs_client)
+                        .await
+                {
+                    tracing::error!(
+                        CVM_ALLOWED,
+                        error = err.as_ref() as &dyn std::error::Error,
+                        "failed to snapshot UEFI firmware to VMGS; \
+                         hibernation will not preserve the firmware image"
+                    );
+                    hibernation_firmware_stored = false;
+                }
+            }
+            _ => {
+                // Not a UEFI boot, or no firmware region / VMGS available;
+                // nothing to snapshot.
+                hibernation_firmware_stored = false;
+            }
+        }
+    }
 
     // Only advertise extended IOAPIC on non-PCAT systems.
     #[cfg(guest_arch = "x86_64")]
@@ -3984,6 +4024,34 @@ async fn write_hibernation_token(vmgs_client: &vmgs_broker::VmgsClient, token: u
             "failed to write hibernation power token"
         );
     }
+}
+
+/// Snapshots the pristine UEFI firmware image out of VTL0 guest memory and into
+/// `vmgs::FileId::HIBERNATION_FIRMWARE` so it can be restored identically on
+/// resume from hibernation.
+///
+/// This must be called *before* any dynamic configuration is written into the
+/// firmware region (i.e. before `write_uefi_config`), so that the stored image
+/// matches the measured firmware as loaded from the IGVM file.
+async fn snapshot_firmware_to_vmgs(
+    gm: &GuestMemory,
+    firmware_memory: MemoryRange,
+    vmgs_client: &vmgs_broker::VmgsClient,
+) -> anyhow::Result<()> {
+    let len = firmware_memory.len() as usize;
+    let mut firmware = vec![0u8; len];
+    gm.read_at(firmware_memory.start(), &mut firmware)
+        .context("failed to read UEFI firmware image from VTL0 memory")?;
+    vmgs_client
+        .write_file(vmgs::FileId::HIBERNATION_FIRMWARE, firmware)
+        .await
+        .context("failed to write UEFI firmware snapshot to VMGS")?;
+    tracing::info!(
+        CVM_ALLOWED,
+        size_bytes = len,
+        "snapshotted UEFI firmware image to VMGS for hibernation"
+    );
+    Ok(())
 }
 
 /// Waits for halt notifications and handles them by forwarding them to the

--- a/openhcl/underhill_core/src/worker.rs
+++ b/openhcl/underhill_core/src/worker.rs
@@ -169,9 +169,11 @@ use vmcore::vmtime::VmTime;
 use vmcore::vmtime::VmTimeKeeper;
 use vmgs::Vmgs;
 use vmgs_broker::spawn_vmgs_broker;
+use vmgs_format::VMGS_HIBERNATION_FIRMWARE_MIN_SIZE;
 use vmgs_format::VmgsProvisioner;
 use vmgs_format::VmgsProvisioningMarker;
 use vmgs_format::VmgsProvisioningReason;
+use vmgs_format::hibernate_token;
 use vmgs_resources::VmgsFileHandle;
 use vmm_core::input_distributor::InputDistributor;
 use vmm_core::partition_unit::Halt;
@@ -2350,7 +2352,7 @@ async fn new_underhill_vm(
                                 CVM_ALLOWED,
                                 firmware_size,
                                 device_size,
-                                minimum_size = VMGS_FIRMWARE_THRESHOLD_BYTES,
+                                minimum_size = VMGS_HIBERNATION_FIRMWARE_MIN_SIZE,
                                 "VMGS backing store too small to preserve UEFI firmware across hibernation"
                             );
                             false
@@ -4043,24 +4045,6 @@ where
     reg_state
 }
 
-/// A VMGS backing store must be at least this large to store a firmware image
-/// snapshot for hibernation. This is a minimum overall size so that the
-/// firmware image fits alongside the other VMGS files, not just a tight fit of
-/// the image itself.
-const VMGS_FIRMWARE_THRESHOLD_BYTES: u64 = 32 * 1024 * 1024;
-
-/// Hibernate token values written to [`vmgs::FileId::HIBERNATION_TOKEN`] on a power
-/// transition, mirroring the legacy HCL `HclPowerServices` behavior. The token
-/// is written on power off and consumed/cleared on resume.
-mod hibernate_token {
-    /// Written on hibernate when a firmware image snapshot is stored in VMGS.
-    pub const FIRMWARE_STORED: u64 = u64::MAX;
-    /// Written on hibernate when no firmware image snapshot is stored.
-    pub const HIBERNATED: u64 = 0x1;
-    /// Written on a clean power off / reset to clear any prior hibernate state.
-    pub const NONE: u64 = 0x0;
-}
-
 /// Best-effort write of an 8-byte hibernate token to the VMGS. Failures are logged
 /// but never block the power transition.
 async fn write_hibernate_token(vmgs_client: &vmgs_broker::VmgsClient, token: u64) {
@@ -4136,14 +4120,15 @@ async fn store_firmware_to_vmgs(
         .device_size()
         .await
         .context("failed to query VMGS size")?;
-    if device_size < VMGS_FIRMWARE_THRESHOLD_BYTES || len > device_size {
+    if device_size < VMGS_HIBERNATION_FIRMWARE_MIN_SIZE || len > device_size {
         return Ok(StoreFirmwareOutcome::InsufficientSpace {
             firmware_size: len,
             device_size,
         });
     }
 
-    let mut firmware = vec![0u8; len as usize];
+    let firmware_len = usize::try_from(len).context("firmware image size does not fit in usize")?;
+    let mut firmware = vec![0u8; firmware_len];
     gm.read_at(firmware_memory.start(), &mut firmware)
         .context("failed to read UEFI firmware image from VTL0 memory")?;
     vmgs_client
@@ -4185,8 +4170,8 @@ async fn load_firmware_from_vmgs(
         .read_file(vmgs::FileId::HIBERNATION_FIRMWARE)
         .await
         .context("failed to read UEFI firmware snapshot from VMGS")?;
-    let region_len = firmware_memory.len() as usize;
-    if firmware.len() != region_len {
+    let region_len = firmware_memory.len();
+    if firmware.len() as u64 != region_len {
         anyhow::bail!(
             "stored firmware image size {} does not match firmware region size {region_len}",
             firmware.len(),

--- a/openhcl/underhill_core/src/worker.rs
+++ b/openhcl/underhill_core/src/worker.rs
@@ -2292,30 +2292,61 @@ async fn new_underhill_vm(
                     read_hibernate_token(vmgs_client).await,
                     Some(token) if token != hibernate_token::NONE
                 );
-                let result = if resuming {
-                    load_firmware_from_vmgs(gm.vtl0(), uefi_info.firmware_memory, vmgs_client).await
-                } else {
-                    store_firmware_to_vmgs(gm.vtl0(), uefi_info.firmware_memory, vmgs_client).await
-                };
-                match result {
-                    Ok(()) => {
-                        if resuming {
+                if resuming {
+                    match load_firmware_from_vmgs(gm.vtl0(), uefi_info.firmware_memory, vmgs_client)
+                        .await
+                    {
+                        Ok(()) => {
+                            tracing::info!(
+                                CVM_ALLOWED,
+                                "resuming from hibernation; restored UEFI firmware image from VMGS"
+                            );
                             // Consume the token so a later clean boot does not
                             // restore a stale firmware image.
                             delete_hibernate_token(vmgs_client).await;
+                            // The stored image remains valid for the next
+                            // hibernation.
+                            true
                         }
+                        Err(err) => {
+                            tracing::error!(
+                                CVM_ALLOWED,
+                                error = err.as_ref() as &dyn std::error::Error,
+                                "failed to restore UEFI firmware image on hibernation resume"
+                            );
+                            false
+                        }
+                    }
+                } else {
+                    match store_firmware_to_vmgs(gm.vtl0(), uefi_info.firmware_memory, vmgs_client)
+                        .await
+                    {
                         // An image is now stored in VMGS, so the next
                         // hibernation can rely on it.
-                        true
-                    }
-                    Err(err) => {
-                        tracing::error!(
-                            CVM_ALLOWED,
-                            error = err.as_ref() as &dyn std::error::Error,
-                            resuming,
-                            "failed to preserve UEFI firmware for hibernation"
-                        );
-                        false
+                        Ok(StoreFirmwareOutcome::Stored) => true,
+                        // Not having room for the firmware image is not an
+                        // error; hibernation just won't preserve the firmware.
+                        Ok(StoreFirmwareOutcome::InsufficientSpace {
+                            firmware_size,
+                            device_size,
+                        }) => {
+                            tracing::warn!(
+                                CVM_ALLOWED,
+                                firmware_size,
+                                device_size,
+                                minimum_size = VMGS_FIRMWARE_THRESHOLD_BYTES,
+                                "VMGS backing store too small to preserve UEFI firmware across hibernation"
+                            );
+                            false
+                        }
+                        Err(err) => {
+                            tracing::error!(
+                                CVM_ALLOWED,
+                                error = err.as_ref() as &dyn std::error::Error,
+                                "failed to store UEFI firmware image for hibernation"
+                            );
+                            false
+                        }
                     }
                 }
             }
@@ -4048,6 +4079,19 @@ async fn delete_hibernate_token(vmgs_client: &vmgs_broker::VmgsClient) {
     }
 }
 
+/// The result of attempting to store a firmware image into VMGS for hibernation.
+enum StoreFirmwareOutcome {
+    /// The firmware image was stored to VMGS.
+    Stored,
+    /// The VMGS backing store is too small to hold the firmware image. This is
+    /// not an error: hibernation falls back to not preserving the firmware
+    /// image across resume.
+    InsufficientSpace {
+        firmware_size: u64,
+        device_size: u64,
+    },
+}
+
 /// Stores the pristine UEFI firmware image out of VTL0 guest memory and into
 /// `vmgs::FileId::HIBERNATION_FIRMWARE` so it can be restored identically on
 /// resume from hibernation.
@@ -4057,31 +4101,29 @@ async fn delete_hibernate_token(vmgs_client: &vmgs_broker::VmgsClient) {
 /// matches the measured firmware as loaded from the IGVM file.
 ///
 /// The image is only stored if the VMGS backing store is large enough to hold
-/// it; otherwise an error is returned and the caller falls back to not
-/// preserving the firmware across hibernation.
+/// it; otherwise [`StoreFirmwareOutcome::InsufficientSpace`] is returned and the
+/// caller falls back to not preserving the firmware across hibernation. An
+/// `Err` is only returned for an actual failure to query or write VMGS.
 async fn store_firmware_to_vmgs(
     gm: &GuestMemory,
     firmware_memory: MemoryRange,
     vmgs_client: &vmgs_broker::VmgsClient,
-) -> anyhow::Result<()> {
+) -> anyhow::Result<StoreFirmwareOutcome> {
     let len = firmware_memory.len();
 
     // The firmware image can only be stored if the VMGS backing store is large
     // enough. Require a minimum overall size so there is room for the firmware
     // image alongside the other VMGS files, and also verify the image fits.
+    // Insufficient space is a normal fallback, not an error.
     let device_size = vmgs_client
         .device_size()
         .await
         .context("failed to query VMGS size")?;
-    if device_size < VMGS_FIRMWARE_THRESHOLD_BYTES {
-        anyhow::bail!(
-            "VMGS backing store ({device_size} bytes) is smaller than the minimum required to store a firmware image ({VMGS_FIRMWARE_THRESHOLD_BYTES} bytes)"
-        );
-    }
-    if len > device_size {
-        anyhow::bail!(
-            "UEFI firmware image ({len} bytes) does not fit in VMGS backing store ({device_size} bytes)"
-        );
+    if device_size < VMGS_FIRMWARE_THRESHOLD_BYTES || len > device_size {
+        return Ok(StoreFirmwareOutcome::InsufficientSpace {
+            firmware_size: len,
+            device_size,
+        });
     }
 
     let mut firmware = vec![0u8; len as usize];
@@ -4096,7 +4138,7 @@ async fn store_firmware_to_vmgs(
         size_bytes = len,
         "stored UEFI firmware image to VMGS for hibernation"
     );
-    Ok(())
+    Ok(StoreFirmwareOutcome::Stored)
 }
 
 /// Reads the 8-byte little-endian hibernate token from VMGS, returning

--- a/openhcl/underhill_core/src/worker.rs
+++ b/openhcl/underhill_core/src/worker.rs
@@ -2292,44 +2292,47 @@ async fn new_underhill_vm(
                 let resuming = matches!(token, Some(token) if token != hibernate_token::NONE);
                 if resuming {
                     // The token records whether a firmware image was actually
-                    // stored at hibernate time. If it was, a failure to restore
-                    // it is a real error. If it wasn't (e.g. the VMGS was too
-                    // small to hold the image), there is nothing to restore, so
-                    // a failure just means the file is absent and is logged as a
-                    // warning.
+                    // stored at hibernate time. Only attempt a restore when one
+                    // was stored; otherwise there is nothing in VMGS to restore
+                    // (e.g. the VMGS was too small to hold the image).
                     let firmware_expected = token == Some(hibernate_token::FIRMWARE_STORED);
-                    match load_firmware_from_vmgs(gm.vtl0(), uefi_info.firmware_memory, vmgs_client)
+                    let restored = if firmware_expected {
+                        match load_firmware_from_vmgs(
+                            gm.vtl0(),
+                            uefi_info.firmware_memory,
+                            vmgs_client,
+                        )
                         .await
-                    {
-                        Ok(()) => {
-                            tracing::info!(
-                                CVM_ALLOWED,
-                                "resuming from hibernation; restored UEFI firmware image from VMGS"
-                            );
-                            // Consume the token so a later clean boot does not
-                            // restore a stale firmware image.
-                            delete_hibernate_token(vmgs_client).await;
-                            // The stored image remains valid for the next
-                            // hibernation.
-                            true
+                        {
+                            Ok(()) => {
+                                tracing::info!(
+                                    CVM_ALLOWED,
+                                    "resuming from hibernation; restored UEFI firmware image from VMGS"
+                                );
+                                // The stored image remains valid for the next
+                                // hibernation.
+                                true
+                            }
+                            Err(err) => {
+                                tracing::error!(
+                                    CVM_ALLOWED,
+                                    error = err.as_ref() as &dyn std::error::Error,
+                                    "failed to restore UEFI firmware image on hibernation resume"
+                                );
+                                false
+                            }
                         }
-                        Err(err) if firmware_expected => {
-                            tracing::error!(
-                                CVM_ALLOWED,
-                                error = err.as_ref() as &dyn std::error::Error,
-                                "failed to restore UEFI firmware image on hibernation resume"
-                            );
-                            false
-                        }
-                        Err(err) => {
-                            tracing::warn!(
-                                CVM_ALLOWED,
-                                error = err.as_ref() as &dyn std::error::Error,
-                                "no UEFI firmware image stored in VMGS to restore on hibernation resume"
-                            );
-                            false
-                        }
-                    }
+                    } else {
+                        tracing::warn!(
+                            CVM_ALLOWED,
+                            "resuming from hibernation but no UEFI firmware image was stored in VMGS"
+                        );
+                        false
+                    };
+                    // Consume the token either way so a later clean boot does
+                    // not restore a stale firmware image.
+                    delete_hibernate_token(vmgs_client).await;
+                    restored
                 } else {
                     match store_firmware_to_vmgs(gm.vtl0(), uefi_info.firmware_memory, vmgs_client)
                         .await

--- a/openhcl/underhill_core/src/worker.rs
+++ b/openhcl/underhill_core/src/worker.rs
@@ -2221,35 +2221,6 @@ async fn new_underhill_vm(
         (None, None)
     };
 
-    // For hibernate-enabled VMs, decide at boot whether the VMGS backing store
-    // is large enough to also hold a firmware image snapshot. This decision is
-    // saved and used to choose the hibernate token value written at hibernate time
-    // (see `halt_task`), avoiding a query on the power-off path.
-    //
-    // If the store is large enough, the pristine UEFI firmware image is later
-    // snapshotted into `vmgs::FileId::HIBERNATION_FIRMWARE` (see below, after
-    // the measured VTL0 config is read). If that snapshot fails, this flag is
-    // downgraded to `false` so the hibernate token reflects that no firmware
-    // was stored.
-    let mut hibernation_firmware_stored = if dps.general.hibernation_enabled {
-        match &vmgs_client {
-            Some(vmgs_client) => match vmgs_client.device_size().await {
-                Ok(size) => size >= VMGS_FIRMWARE_THRESHOLD_BYTES,
-                Err(err) => {
-                    tracing::error!(
-                        CVM_ALLOWED,
-                        error = &err as &dyn std::error::Error,
-                        "failed to query VMGS size; assuming no firmware snapshot"
-                    );
-                    false
-                }
-            },
-            None => false,
-        }
-    } else {
-        false
-    };
-
     // Enable remote chipset devices.
     resolver.add_async_resolver(
         chipset_device_worker::resolver::RemoteChipsetDeviceResolver(
@@ -2288,22 +2259,27 @@ async fn new_underhill_vm(
         }
     };
 
-    // Hibernation firmware compatibility (OpenHCL-only). Both operations below
-    // happen *before* any dynamic config is written into the firmware region
-    // (that happens later in `load_firmware` via `write_uefi_config`), so the
-    // current dynamic config is layered on top of the pristine/restored image.
+    // Hibernation firmware compatibility (OpenHCL-only). Determine whether a
+    // firmware image snapshot will be present in VMGS for the next hibernation,
+    // and ensure the firmware region is correct for this boot. Both operations
+    // below happen *before* any dynamic config is written into the firmware
+    // region (that happens later in `load_firmware` via `write_uefi_config`), so
+    // the current dynamic config is layered on top of the pristine/restored
+    // image.
     //
-    // - Phase 1 (normal boot): snapshot the pristine UEFI firmware image, as
-    //   deposited into VTL0 guest memory, into VMGS so it can be restored later.
-    // - Phase 3 (resume boot): when the hibernate token written at hibernate time
-    //   indicates a firmware image was stored, restore that saved image back
-    //   into VTL0 guest memory instead, so the resumed guest sees an identical
-    //   firmware binary even if the host's firmware changed in the meantime,
-    //   then consume the token.
+    // - Resume boot (a non-NONE hibernate token is present): restore the
+    //   previously stored firmware image back into VTL0 guest memory, so the
+    //   resumed guest sees an identical firmware binary even if the host's
+    //   firmware changed in the meantime, then consume the token. The stored
+    //   image remains valid for the next hibernation.
+    // - Normal boot: snapshot the pristine UEFI firmware image, as deposited
+    //   into VTL0 guest memory, into VMGS so it can be restored later. This only
+    //   succeeds if the VMGS backing store is large enough to hold it.
     //
-    // If the operation fails (or this is not a UEFI boot), downgrade the saved
-    // flag so the next hibernate token reflects that no firmware was stored.
-    if hibernation_firmware_stored {
+    // `hibernation_firmware_stored` is set to `true` only once we know an image
+    // is actually stored; it drives the hibernate token written at hibernate
+    // time (see `halt_task`).
+    let hibernation_firmware_stored = if dps.general.hibernation_enabled {
         match (
             load_kind,
             measured_vtl0_info
@@ -2328,6 +2304,9 @@ async fn new_underhill_vm(
                             // restore a stale firmware image.
                             delete_hibernate_token(vmgs_client).await;
                         }
+                        // An image is now stored in VMGS, so the next
+                        // hibernation can rely on it.
+                        true
                     }
                     Err(err) => {
                         tracing::error!(
@@ -2336,17 +2315,19 @@ async fn new_underhill_vm(
                             resuming,
                             "failed to preserve UEFI firmware for hibernation"
                         );
-                        hibernation_firmware_stored = false;
+                        false
                     }
                 }
             }
             _ => {
                 // Not a UEFI boot, or no firmware region / VMGS available;
                 // nothing to snapshot or restore.
-                hibernation_firmware_stored = false;
+                false
             }
         }
-    }
+    } else {
+        false
+    };
 
     // Only advertise extended IOAPIC on non-PCAT systems.
     #[cfg(guest_arch = "x86_64")]
@@ -4014,17 +3995,13 @@ where
     reg_state
 }
 
-/// VMGS backing stores at least this large can hold a firmware image snapshot,
-/// so a hibernate writes the "firmware stored" marker.
-const VMGS_FIRMWARE_THRESHOLD_BYTES: u64 = 32 * 1024 * 1024;
-
 /// Hibernate token values written to [`vmgs::FileId::HIBERNATION_TOKEN`] on a power
 /// transition, mirroring the legacy HCL `HclPowerServices` behavior. The token
 /// is written on power off and consumed/cleared on resume.
 mod hibernate_token {
-    /// Written on hibernate when the VMGS is large enough to store firmware.
+    /// Written on hibernate when a firmware image snapshot is stored in VMGS.
     pub const FIRMWARE_STORED: u64 = u64::MAX;
-    /// Written on hibernate when the VMGS is too small to store firmware.
+    /// Written on hibernate when no firmware image snapshot is stored.
     pub const HIBERNATED: u64 = 0x1;
     /// Written on a clean power off / reset to clear any prior hibernate state.
     pub const NONE: u64 = 0x0;

--- a/openhcl/underhill_core/src/worker.rs
+++ b/openhcl/underhill_core/src/worker.rs
@@ -2288,14 +2288,21 @@ async fn new_underhill_vm(
         }
     };
 
-    // Phase 1: For hibernate-enabled VMs whose VMGS is large enough, snapshot
-    // the pristine UEFI firmware image into VMGS *before* any dynamic config is
-    // written into the firmware region (that happens later in `load_firmware`
-    // via `write_uefi_config`). The firmware can then be restored identically
-    // on resume. The UEFI image has already been deposited into VTL0 guest
-    // memory at this point, so we read it directly. If the snapshot fails (or
-    // this is not a UEFI boot), downgrade the saved flag so the hibernate token
-    // reflects that no firmware was stored.
+    // Hibernation firmware compatibility (OpenHCL-only). Both operations below
+    // happen *before* any dynamic config is written into the firmware region
+    // (that happens later in `load_firmware` via `write_uefi_config`), so the
+    // current dynamic config is layered on top of the pristine/restored image.
+    //
+    // - Phase 1 (normal boot): snapshot the pristine UEFI firmware image, as
+    //   deposited into VTL0 guest memory, into VMGS so it can be restored later.
+    // - Phase 3 (resume boot): when the power token written at hibernate time
+    //   indicates a firmware image was stored, restore that saved image back
+    //   into VTL0 guest memory instead, so the resumed guest sees an identical
+    //   firmware binary even if the host's firmware changed in the meantime,
+    //   then consume the token.
+    //
+    // If the operation fails (or this is not a UEFI boot), downgrade the saved
+    // flag so the next hibernate token reflects that no firmware was stored.
     if hibernation_firmware_stored {
         match (
             load_kind,
@@ -2305,22 +2312,39 @@ async fn new_underhill_vm(
             vmgs_client.as_ref(),
         ) {
             (LoadKind::Uefi, Some(uefi_info), Some(vmgs_client)) => {
-                if let Err(err) =
+                let resuming = matches!(
+                    read_hibernation_token(vmgs_client).await,
+                    Some(hibernation_token::FIRMWARE_STORED)
+                );
+                let result = if resuming {
+                    restore_firmware_from_vmgs(gm.vtl0(), uefi_info.firmware_memory, vmgs_client)
+                        .await
+                } else {
                     snapshot_firmware_to_vmgs(gm.vtl0(), uefi_info.firmware_memory, vmgs_client)
                         .await
-                {
-                    tracing::error!(
-                        CVM_ALLOWED,
-                        error = err.as_ref() as &dyn std::error::Error,
-                        "failed to snapshot UEFI firmware to VMGS; \
-                         hibernation will not preserve the firmware image"
-                    );
-                    hibernation_firmware_stored = false;
+                };
+                match result {
+                    Ok(()) => {
+                        if resuming {
+                            // Consume the token so a later clean boot does not
+                            // restore a stale firmware image.
+                            write_hibernation_token(vmgs_client, hibernation_token::NONE).await;
+                        }
+                    }
+                    Err(err) => {
+                        tracing::error!(
+                            CVM_ALLOWED,
+                            error = err.as_ref() as &dyn std::error::Error,
+                            resuming,
+                            "failed to preserve UEFI firmware for hibernation"
+                        );
+                        hibernation_firmware_stored = false;
+                    }
                 }
             }
             _ => {
                 // Not a UEFI boot, or no firmware region / VMGS available;
-                // nothing to snapshot.
+                // nothing to snapshot or restore.
                 hibernation_firmware_stored = false;
             }
         }
@@ -4050,6 +4074,50 @@ async fn snapshot_firmware_to_vmgs(
         CVM_ALLOWED,
         size_bytes = len,
         "snapshotted UEFI firmware image to VMGS for hibernation"
+    );
+    Ok(())
+}
+
+/// Reads the 8-byte little-endian hibernation power token from VMGS, returning
+/// `None` if it is absent or cannot be read/parsed (e.g. on a first boot before
+/// any token has been written).
+async fn read_hibernation_token(vmgs_client: &vmgs_broker::VmgsClient) -> Option<u64> {
+    let buf = vmgs_client
+        .read_file(vmgs::FileId::HIBERNATION_TOKEN)
+        .await
+        .ok()?;
+    let bytes = <[u8; 8]>::try_from(buf.as_slice()).ok()?;
+    Some(u64::from_le_bytes(bytes))
+}
+
+/// Restores a previously snapshotted UEFI firmware image from VMGS back into
+/// VTL0 guest memory. Used when resuming a hibernated guest so that the firmware
+/// binary matches what was present when the guest hibernated.
+///
+/// This must be called *before* `write_uefi_config`, so that the current
+/// dynamic config is layered on top of the restored firmware image.
+async fn restore_firmware_from_vmgs(
+    gm: &GuestMemory,
+    firmware_memory: MemoryRange,
+    vmgs_client: &vmgs_broker::VmgsClient,
+) -> anyhow::Result<()> {
+    let firmware = vmgs_client
+        .read_file(vmgs::FileId::HIBERNATION_FIRMWARE)
+        .await
+        .context("failed to read UEFI firmware snapshot from VMGS")?;
+    let region_len = firmware_memory.len() as usize;
+    if firmware.len() != region_len {
+        anyhow::bail!(
+            "stored firmware image size {} does not match firmware region size {region_len}",
+            firmware.len(),
+        );
+    }
+    gm.write_at(firmware_memory.start(), &firmware)
+        .context("failed to write UEFI firmware image into VTL0 memory")?;
+    tracing::info!(
+        CVM_ALLOWED,
+        size_bytes = region_len,
+        "restored UEFI firmware image from VMGS for hibernation resume"
     );
     Ok(())
 }

--- a/openhcl/underhill_core/src/worker.rs
+++ b/openhcl/underhill_core/src/worker.rs
@@ -3794,6 +3794,7 @@ async fn new_underhill_vm(
             control_send.clone(),
             get_client.clone(),
             vmgs_client.clone(),
+            dps.general.hibernation_enabled,
             hibernation_firmware_stored,
             env_cfg.halt_on_guest_halt,
         ),
@@ -4206,6 +4207,7 @@ async fn halt_task(
     control_send: Arc<Mutex<Option<mesh::Sender<ControlRequest>>>>,
     get_client: GuestEmulationTransportClient,
     vmgs_client: Option<vmgs_broker::VmgsClient>,
+    hibernation_enabled: bool,
     hibernation_firmware_stored: bool,
     halt_on_guest_halt: bool,
 ) {
@@ -4259,17 +4261,23 @@ async fn halt_task(
             match halt_request {
                 HaltRequest::PowerOff => {
                     // Write the NONE hibernate token to clear any stale hibernate
-                    // state on a clean power off.
-                    if let Some(vmgs_client) = &vmgs_client {
-                        write_hibernate_token(vmgs_client, hibernate_token::NONE).await;
+                    // state on a clean power off. Only relevant when hibernation
+                    // is enabled; otherwise there is no token to clear.
+                    if hibernation_enabled {
+                        if let Some(vmgs_client) = &vmgs_client {
+                            write_hibernate_token(vmgs_client, hibernate_token::NONE).await;
+                        }
                     }
                     get_client.send_power_off()
                 }
                 HaltRequest::Reset => {
                     // Write the NONE hibernate token to clear any stale hibernate
-                    // state on reset.
-                    if let Some(vmgs_client) = &vmgs_client {
-                        write_hibernate_token(vmgs_client, hibernate_token::NONE).await;
+                    // state on reset. Only relevant when hibernation is enabled;
+                    // otherwise there is no token to clear.
+                    if hibernation_enabled {
+                        if let Some(vmgs_client) = &vmgs_client {
+                            write_hibernate_token(vmgs_client, hibernate_token::NONE).await;
+                        }
                     }
                     get_client.send_reset()
                 }

--- a/openhcl/underhill_core/src/worker.rs
+++ b/openhcl/underhill_core/src/worker.rs
@@ -2234,7 +2234,7 @@ async fn new_underhill_vm(
     let mut hibernation_firmware_stored = if dps.general.hibernation_enabled {
         match &vmgs_client {
             Some(vmgs_client) => match vmgs_client.device_size().await {
-                Ok(size) => size >= hibernation_token::VMGS_FIRMWARE_THRESHOLD_BYTES,
+                Ok(size) => size >= VMGS_FIRMWARE_THRESHOLD_BYTES,
                 Err(err) => {
                     tracing::error!(
                         CVM_ALLOWED,
@@ -2317,11 +2317,9 @@ async fn new_underhill_vm(
                     Some(hibernation_token::FIRMWARE_STORED)
                 );
                 let result = if resuming {
-                    restore_firmware_from_vmgs(gm.vtl0(), uefi_info.firmware_memory, vmgs_client)
-                        .await
+                    load_firmware_from_vmgs(gm.vtl0(), uefi_info.firmware_memory, vmgs_client).await
                 } else {
-                    snapshot_firmware_to_vmgs(gm.vtl0(), uefi_info.firmware_memory, vmgs_client)
-                        .await
+                    store_firmware_to_vmgs(gm.vtl0(), uefi_info.firmware_memory, vmgs_client).await
                 };
                 match result {
                     Ok(()) => {
@@ -4016,13 +4014,14 @@ where
     reg_state
 }
 
+/// VMGS backing stores at least this large can hold a firmware image snapshot,
+/// so a hibernate writes the "firmware stored" marker.
+const VMGS_FIRMWARE_THRESHOLD_BYTES: u64 = 32 * 1024 * 1024;
+
 /// Power token values written to [`vmgs::FileId::HIBERNATION_TOKEN`] on a power
 /// transition, mirroring the legacy HCL `HclPowerServices` behavior. The token
 /// is written on power off and consumed/cleared on resume.
 mod hibernation_token {
-    /// VMGS backing stores at least this large can hold a firmware image
-    /// snapshot, so a hibernate writes the "firmware stored" marker.
-    pub const VMGS_FIRMWARE_THRESHOLD_BYTES: u64 = 32 * 1024 * 1024;
     /// Written on hibernate when the VMGS is large enough to store firmware.
     pub const FIRMWARE_STORED: u64 = u64::MAX;
     /// Written on hibernate when the VMGS is too small to store firmware.
@@ -4050,14 +4049,14 @@ async fn write_hibernation_token(vmgs_client: &vmgs_broker::VmgsClient, token: u
     }
 }
 
-/// Snapshots the pristine UEFI firmware image out of VTL0 guest memory and into
+/// Stores the pristine UEFI firmware image out of VTL0 guest memory and into
 /// `vmgs::FileId::HIBERNATION_FIRMWARE` so it can be restored identically on
 /// resume from hibernation.
 ///
 /// This must be called *before* any dynamic configuration is written into the
 /// firmware region (i.e. before `write_uefi_config`), so that the stored image
 /// matches the measured firmware as loaded from the IGVM file.
-async fn snapshot_firmware_to_vmgs(
+async fn store_firmware_to_vmgs(
     gm: &GuestMemory,
     firmware_memory: MemoryRange,
     vmgs_client: &vmgs_broker::VmgsClient,
@@ -4073,7 +4072,7 @@ async fn snapshot_firmware_to_vmgs(
     tracing::info!(
         CVM_ALLOWED,
         size_bytes = len,
-        "snapshotted UEFI firmware image to VMGS for hibernation"
+        "stored UEFI firmware image to VMGS for hibernation"
     );
     Ok(())
 }
@@ -4090,13 +4089,13 @@ async fn read_hibernation_token(vmgs_client: &vmgs_broker::VmgsClient) -> Option
     Some(u64::from_le_bytes(bytes))
 }
 
-/// Restores a previously snapshotted UEFI firmware image from VMGS back into
-/// VTL0 guest memory. Used when resuming a hibernated guest so that the firmware
-/// binary matches what was present when the guest hibernated.
+/// Loads a previously stored UEFI firmware image from VMGS back into VTL0 guest
+/// memory. Used when resuming a hibernated guest so that the firmware binary
+/// matches what was present when the guest hibernated.
 ///
 /// This must be called *before* `write_uefi_config`, so that the current
 /// dynamic config is layered on top of the restored firmware image.
-async fn restore_firmware_from_vmgs(
+async fn load_firmware_from_vmgs(
     gm: &GuestMemory,
     firmware_memory: MemoryRange,
     vmgs_client: &vmgs_broker::VmgsClient,

--- a/openhcl/underhill_core/src/worker.rs
+++ b/openhcl/underhill_core/src/worker.rs
@@ -2288,11 +2288,16 @@ async fn new_underhill_vm(
             vmgs_client.as_ref(),
         ) {
             (LoadKind::Uefi, Some(uefi_info), Some(vmgs_client)) => {
-                let resuming = matches!(
-                    read_hibernate_token(vmgs_client).await,
-                    Some(token) if token != hibernate_token::NONE
-                );
+                let token = read_hibernate_token(vmgs_client).await;
+                let resuming = matches!(token, Some(token) if token != hibernate_token::NONE);
                 if resuming {
+                    // The token records whether a firmware image was actually
+                    // stored at hibernate time. If it was, a failure to restore
+                    // it is a real error. If it wasn't (e.g. the VMGS was too
+                    // small to hold the image), there is nothing to restore, so
+                    // a failure just means the file is absent and is logged as a
+                    // warning.
+                    let firmware_expected = token == Some(hibernate_token::FIRMWARE_STORED);
                     match load_firmware_from_vmgs(gm.vtl0(), uefi_info.firmware_memory, vmgs_client)
                         .await
                     {
@@ -2308,11 +2313,19 @@ async fn new_underhill_vm(
                             // hibernation.
                             true
                         }
-                        Err(err) => {
+                        Err(err) if firmware_expected => {
                             tracing::error!(
                                 CVM_ALLOWED,
                                 error = err.as_ref() as &dyn std::error::Error,
                                 "failed to restore UEFI firmware image on hibernation resume"
+                            );
+                            false
+                        }
+                        Err(err) => {
+                            tracing::warn!(
+                                CVM_ALLOWED,
+                                error = err.as_ref() as &dyn std::error::Error,
+                                "no UEFI firmware image stored in VMGS to restore on hibernation resume"
                             );
                             false
                         }

--- a/openhcl/underhill_core/src/worker.rs
+++ b/openhcl/underhill_core/src/worker.rs
@@ -2326,7 +2326,7 @@ async fn new_underhill_vm(
                         if resuming {
                             // Consume the token so a later clean boot does not
                             // restore a stale firmware image.
-                            write_hibernation_token(vmgs_client, hibernation_token::NONE).await;
+                            delete_hibernation_token(vmgs_client).await;
                         }
                     }
                     Err(err) => {
@@ -4045,6 +4045,22 @@ async fn write_hibernation_token(vmgs_client: &vmgs_broker::VmgsClient, token: u
             error = &err as &dyn std::error::Error,
             token,
             "failed to write hibernation power token"
+        );
+    }
+}
+
+/// Best-effort deletion of the hibernation power token from the VMGS, used to
+/// consume the token after a firmware image has been restored on resume.
+/// Failures are logged but never block boot.
+async fn delete_hibernation_token(vmgs_client: &vmgs_broker::VmgsClient) {
+    if let Err(err) = vmgs_client
+        .delete_file(vmgs::FileId::HIBERNATION_TOKEN)
+        .await
+    {
+        tracing::error!(
+            CVM_ALLOWED,
+            error = &err as &dyn std::error::Error,
+            "failed to delete hibernation power token"
         );
     }
 }

--- a/openhcl/underhill_core/src/worker.rs
+++ b/openhcl/underhill_core/src/worker.rs
@@ -2314,7 +2314,7 @@ async fn new_underhill_vm(
             (LoadKind::Uefi, Some(uefi_info), Some(vmgs_client)) => {
                 let resuming = matches!(
                     read_hibernation_token(vmgs_client).await,
-                    Some(hibernation_token::FIRMWARE_STORED)
+                    Some(token) if token != hibernation_token::NONE
                 );
                 let result = if resuming {
                     load_firmware_from_vmgs(gm.vtl0(), uefi_info.firmware_memory, vmgs_client).await
@@ -4072,13 +4072,30 @@ async fn delete_hibernation_token(vmgs_client: &vmgs_broker::VmgsClient) {
 /// This must be called *before* any dynamic configuration is written into the
 /// firmware region (i.e. before `write_uefi_config`), so that the stored image
 /// matches the measured firmware as loaded from the IGVM file.
+///
+/// The image is only stored if the VMGS backing store is large enough to hold
+/// it; otherwise an error is returned and the caller falls back to not
+/// preserving the firmware across hibernation.
 async fn store_firmware_to_vmgs(
     gm: &GuestMemory,
     firmware_memory: MemoryRange,
     vmgs_client: &vmgs_broker::VmgsClient,
 ) -> anyhow::Result<()> {
-    let len = firmware_memory.len() as usize;
-    let mut firmware = vec![0u8; len];
+    let len = firmware_memory.len();
+
+    // The firmware image can only be stored if the VMGS backing store is large
+    // enough to hold it.
+    let device_size = vmgs_client
+        .device_size()
+        .await
+        .context("failed to query VMGS size")?;
+    if len > device_size {
+        anyhow::bail!(
+            "UEFI firmware image ({len} bytes) does not fit in VMGS backing store ({device_size} bytes)"
+        );
+    }
+
+    let mut firmware = vec![0u8; len as usize];
     gm.read_at(firmware_memory.start(), &mut firmware)
         .context("failed to read UEFI firmware image from VTL0 memory")?;
     vmgs_client

--- a/openhcl/underhill_core/src/worker.rs
+++ b/openhcl/underhill_core/src/worker.rs
@@ -2229,7 +2229,7 @@ async fn new_underhill_vm(
     // If the store is large enough, the pristine UEFI firmware image is later
     // snapshotted into `vmgs::FileId::HIBERNATION_FIRMWARE` (see below, after
     // the measured VTL0 config is read). If that snapshot fails, this flag is
-    // downgraded to `false` so the hibernate token reflects that no firmware
+    // downgraded to `false` so the power token reflects that no firmware
     // was stored.
     let mut hibernation_firmware_stored = if dps.general.hibernation_enabled {
         match &vmgs_client {
@@ -2302,7 +2302,7 @@ async fn new_underhill_vm(
     //   then consume the token.
     //
     // If the operation fails (or this is not a UEFI boot), downgrade the saved
-    // flag so the next hibernate token reflects that no firmware was stored.
+    // flag so the next power token reflects that no firmware was stored.
     if hibernation_firmware_stored {
         match (
             load_kind,
@@ -2313,8 +2313,8 @@ async fn new_underhill_vm(
         ) {
             (LoadKind::Uefi, Some(uefi_info), Some(vmgs_client)) => {
                 let resuming = matches!(
-                    read_hibernation_token(vmgs_client).await,
-                    Some(token) if token != hibernation_token::NONE
+                    read_power_token(vmgs_client).await,
+                    Some(token) if token != power_token::NONE
                 );
                 let result = if resuming {
                     load_firmware_from_vmgs(gm.vtl0(), uefi_info.firmware_memory, vmgs_client).await
@@ -2326,7 +2326,7 @@ async fn new_underhill_vm(
                         if resuming {
                             // Consume the token so a later clean boot does not
                             // restore a stale firmware image.
-                            delete_hibernation_token(vmgs_client).await;
+                            delete_power_token(vmgs_client).await;
                         }
                     }
                     Err(err) => {
@@ -4021,18 +4021,18 @@ const VMGS_FIRMWARE_THRESHOLD_BYTES: u64 = 32 * 1024 * 1024;
 /// Power token values written to [`vmgs::FileId::HIBERNATION_TOKEN`] on a power
 /// transition, mirroring the legacy HCL `HclPowerServices` behavior. The token
 /// is written on power off and consumed/cleared on resume.
-mod hibernation_token {
+mod power_token {
     /// Written on hibernate when the VMGS is large enough to store firmware.
     pub const FIRMWARE_STORED: u64 = u64::MAX;
     /// Written on hibernate when the VMGS is too small to store firmware.
     pub const HIBERNATED: u64 = 0x1;
-    /// Written on a clean power off / reset to clear any prior hibernate marker.
+    /// Written on a clean power off / reset to clear any prior hibernate state.
     pub const NONE: u64 = 0x0;
 }
 
 /// Best-effort write of an 8-byte power token to the VMGS. Failures are logged
 /// but never block the power transition.
-async fn write_hibernation_token(vmgs_client: &vmgs_broker::VmgsClient, token: u64) {
+async fn write_power_token(vmgs_client: &vmgs_broker::VmgsClient, token: u64) {
     if let Err(err) = vmgs_client
         .write_file(
             vmgs::FileId::HIBERNATION_TOKEN,
@@ -4044,15 +4044,15 @@ async fn write_hibernation_token(vmgs_client: &vmgs_broker::VmgsClient, token: u
             CVM_ALLOWED,
             error = &err as &dyn std::error::Error,
             token,
-            "failed to write hibernation power token"
+            "failed to write power token"
         );
     }
 }
 
-/// Best-effort deletion of the hibernation power token from the VMGS, used to
+/// Best-effort deletion of the power token from the VMGS, used to
 /// consume the token after a firmware image has been restored on resume.
 /// Failures are logged but never block boot.
-async fn delete_hibernation_token(vmgs_client: &vmgs_broker::VmgsClient) {
+async fn delete_power_token(vmgs_client: &vmgs_broker::VmgsClient) {
     if let Err(err) = vmgs_client
         .delete_file(vmgs::FileId::HIBERNATION_TOKEN)
         .await
@@ -4060,7 +4060,7 @@ async fn delete_hibernation_token(vmgs_client: &vmgs_broker::VmgsClient) {
         tracing::error!(
             CVM_ALLOWED,
             error = &err as &dyn std::error::Error,
-            "failed to delete hibernation power token"
+            "failed to delete power token"
         );
     }
 }
@@ -4110,10 +4110,10 @@ async fn store_firmware_to_vmgs(
     Ok(())
 }
 
-/// Reads the 8-byte little-endian hibernation power token from VMGS, returning
+/// Reads the 8-byte little-endian power token from VMGS, returning
 /// `None` if it is absent or cannot be read/parsed (e.g. on a first boot before
 /// any token has been written).
-async fn read_hibernation_token(vmgs_client: &vmgs_broker::VmgsClient) -> Option<u64> {
+async fn read_power_token(vmgs_client: &vmgs_broker::VmgsClient) -> Option<u64> {
     let buf = vmgs_client
         .read_file(vmgs::FileId::HIBERNATION_TOKEN)
         .await
@@ -4214,16 +4214,18 @@ async fn halt_task(
             // Now we can notify the host about the halt.
             match halt_request {
                 HaltRequest::PowerOff => {
-                    // Clear any stale hibernate marker on a clean power off.
+                    // Write the NONE power token to clear any stale hibernate
+                    // state on a clean power off.
                     if let Some(vmgs_client) = &vmgs_client {
-                        write_hibernation_token(vmgs_client, hibernation_token::NONE).await;
+                        write_power_token(vmgs_client, power_token::NONE).await;
                     }
                     get_client.send_power_off()
                 }
                 HaltRequest::Reset => {
-                    // Clear any stale hibernate marker on reset.
+                    // Write the NONE power token to clear any stale hibernate
+                    // state on reset.
                     if let Some(vmgs_client) = &vmgs_client {
-                        write_hibernation_token(vmgs_client, hibernation_token::NONE).await;
+                        write_power_token(vmgs_client, power_token::NONE).await;
                     }
                     get_client.send_reset()
                 }
@@ -4233,11 +4235,11 @@ async fn halt_task(
                     // hold a firmware image snapshot was decided at boot.
                     if let Some(vmgs_client) = &vmgs_client {
                         let token = if hibernation_firmware_stored {
-                            hibernation_token::FIRMWARE_STORED
+                            power_token::FIRMWARE_STORED
                         } else {
-                            hibernation_token::HIBERNATED
+                            power_token::HIBERNATED
                         };
-                        write_hibernation_token(vmgs_client, token).await;
+                        write_power_token(vmgs_client, token).await;
                     }
                     get_client.send_hibernate()
                 }

--- a/vm/vmgs/vmgs/src/vmgs_impl.rs
+++ b/vm/vmgs/vmgs/src/vmgs_impl.rs
@@ -641,6 +641,11 @@ impl Vmgs {
         Ok(vmgs)
     }
 
+    /// Returns the total size, in bytes, of the underlying VMGS backing store.
+    pub fn device_size(&self) -> u64 {
+        self.storage.sector_count() * self.storage.sector_size() as u64
+    }
+
     /// Get allocated and valid bytes from File Control Block for file_id.
     ///
     /// When reading data from a file, the buffer must be at least `valid_bytes` long.

--- a/vm/vmgs/vmgs_broker/src/broker.rs
+++ b/vm/vmgs/vmgs_broker/src/broker.rs
@@ -52,6 +52,7 @@ pub enum VmgsBrokerRpc {
     WriteFile(Rpc<(BrokerFileId, Vec<u8>), Result<(), VmgsBrokerError>>),
     #[cfg(feature = "encryption")]
     WriteFileEncrypted(Rpc<(BrokerFileId, Vec<u8>), Result<(), VmgsBrokerError>>),
+    DeleteFile(Rpc<BrokerFileId, Result<(), VmgsBrokerError>>),
     Save(Rpc<(), vmgs::save_restore::state::SavedVmgsState>),
 }
 
@@ -105,6 +106,15 @@ impl VmgsBrokerTask {
                 rpc.handle(async |(file_id, buf)| {
                     self.vmgs
                         .write_file_encrypted(file_id.into(), &buf)
+                        .await
+                        .map_err(Into::into)
+                })
+                .await
+            }
+            VmgsBrokerRpc::DeleteFile(rpc) => {
+                rpc.handle(async |file_id| {
+                    self.vmgs
+                        .delete_file(file_id.into())
                         .await
                         .map_err(Into::into)
                 })

--- a/vm/vmgs/vmgs_broker/src/broker.rs
+++ b/vm/vmgs/vmgs_broker/src/broker.rs
@@ -47,6 +47,7 @@ impl From<BrokerFileId> for FileId {
 pub enum VmgsBrokerRpc {
     Inspect(inspect::Deferred),
     GetFileInfo(Rpc<BrokerFileId, Result<VmgsFileInfo, VmgsBrokerError>>),
+    DeviceSize(Rpc<(), u64>),
     ReadFile(Rpc<BrokerFileId, Result<Vec<u8>, VmgsBrokerError>>),
     WriteFile(Rpc<(BrokerFileId, Vec<u8>), Result<(), VmgsBrokerError>>),
     #[cfg(feature = "encryption")]
@@ -80,6 +81,7 @@ impl VmgsBrokerTask {
             }
             VmgsBrokerRpc::GetFileInfo(rpc) => rpc
                 .handle_sync(|file_id| self.vmgs.get_file_info(file_id.into()).map_err(Into::into)),
+            VmgsBrokerRpc::DeviceSize(rpc) => rpc.handle_sync(|()| self.vmgs.device_size()),
             VmgsBrokerRpc::ReadFile(rpc) => {
                 rpc.handle(async |file_id| {
                     self.vmgs

--- a/vm/vmgs/vmgs_broker/src/client.rs
+++ b/vm/vmgs/vmgs_broker/src/client.rs
@@ -112,6 +112,16 @@ impl VmgsClient {
         Ok(())
     }
 
+    /// Deletes the specified `file_id` from the VMGS.
+    #[instrument(skip_all, fields(file_id))]
+    pub async fn delete_file(&self, file_id: FileId) -> Result<(), VmgsClientError> {
+        self.control
+            .call_failable(VmgsBrokerRpc::DeleteFile, file_id.into())
+            .await?;
+
+        Ok(())
+    }
+
     /// Save the in-memory VMGS file metadata.
     ///
     /// This saved state can be used alongside `open_from_saved` to obtain a

--- a/vm/vmgs/vmgs_broker/src/client.rs
+++ b/vm/vmgs/vmgs_broker/src/client.rs
@@ -63,6 +63,14 @@ impl VmgsClient {
         Ok(res)
     }
 
+    /// Returns the total size, in bytes, of the underlying VMGS backing store.
+    #[instrument(skip_all)]
+    pub async fn device_size(&self) -> Result<u64, VmgsClientError> {
+        let res = self.control.call(VmgsBrokerRpc::DeviceSize, ()).await?;
+
+        Ok(res)
+    }
+
     /// Reads the specified `file_id`.
     #[instrument(skip_all, fields(file_id))]
     pub async fn read_file(&self, file_id: FileId) -> Result<Vec<u8>, VmgsClientError> {

--- a/vm/vmgs/vmgs_format/src/lib.rs
+++ b/vm/vmgs/vmgs_format/src/lib.rs
@@ -53,11 +53,12 @@ open_enum! {
         GUEST_WATCHDOG = 10,
         HW_KEY_PROTECTOR = 11,
         GUEST_SECRET_KEY = 13,
-        HIBERNATION_FIRMWARE = 14,
+        HIBERNATION_TOKEN = 14,
         PLATFORM_SEED = 15,
         PROVENANCE_DOC = 16,
         TPM_NVRAM_BACKUP = 17,
         PROVISIONING_MARKER = 18,
+        HIBERNATION_FIRMWARE = 19,
 
         EXTENDED_FILE_TABLE = 63,
     }

--- a/vm/vmgs/vmgs_format/src/lib.rs
+++ b/vm/vmgs/vmgs_format/src/lib.rs
@@ -70,6 +70,25 @@ impl Display for FileId {
     }
 }
 
+/// The minimum overall VMGS backing-store size, in bytes, required before a UEFI
+/// firmware image snapshot ([`FileId::HIBERNATION_FIRMWARE`]) is stored for
+/// hibernation. This is a minimum overall size so that the firmware image fits
+/// alongside the other VMGS files, not just a tight fit of the image itself.
+pub const VMGS_HIBERNATION_FIRMWARE_MIN_SIZE: u64 = 32 * 1024 * 1024;
+
+/// Values for the 8-byte little-endian hibernate token stored in
+/// [`FileId::HIBERNATION_TOKEN`], mirroring the legacy HCL `HclPowerServices`
+/// behavior. The token is written on a power transition and consumed/cleared on
+/// resume.
+pub mod hibernate_token {
+    /// Written on hibernate when a firmware image snapshot is stored in VMGS.
+    pub const FIRMWARE_STORED: u64 = u64::MAX;
+    /// Written on hibernate when no firmware image snapshot is stored.
+    pub const HIBERNATED: u64 = 0x1;
+    /// Written on a clean power off / reset to clear any prior hibernate state.
+    pub const NONE: u64 = 0x0;
+}
+
 pub const VMGS_VERSION_2_0: u32 = 0x00020000;
 pub const VMGS_VERSION_3_0: u32 = 0x00030000;
 

--- a/vm/vmgs/vmgstool/src/main.rs
+++ b/vm/vmgs/vmgstool/src/main.rs
@@ -369,10 +369,11 @@ fn parse_file_id(file_id: &str) -> Result<FileId, std::num::ParseIntError> {
         "GUEST_WATCHDOG" => FileId::GUEST_WATCHDOG,
         "HW_KEY_PROTECTOR" => FileId::HW_KEY_PROTECTOR,
         "GUEST_SECRET_KEY" => FileId::GUEST_SECRET_KEY,
-        "HIBERNATION_FIRMWARE" => FileId::HIBERNATION_FIRMWARE,
+        "HIBERNATION_TOKEN" => FileId::HIBERNATION_TOKEN,
         "PLATFORM_SEED" => FileId::PLATFORM_SEED,
         "PROVENANCE_DOC" => FileId::PROVENANCE_DOC,
         "TPM_NVRAM_BACKUP" => FileId::TPM_NVRAM_BACKUP,
+        "HIBERNATION_FIRMWARE" => FileId::HIBERNATION_FIRMWARE,
         "EXTENDED_FILE_TABLE" => FileId::EXTENDED_FILE_TABLE,
         v => FileId(v.parse::<u32>()?),
     })


### PR DESCRIPTION
### Summary

Adds support for preserving the exact UEFI firmware image across a hibernate/resume cycle for hibernation-enabled (non-isolated) VMs in OpenHCL. This guarantees a resumed guest sees an identical firmware-provided view (ACPI/SMBIOS/memory layout) even if the host's OpenHCL/UEFI changed between the original cold boot and the resume.

### Motivation

A hibernating guest captures OS state that assumes a specific firmware-provided hardware view. If the firmware image differs after resume, that view can shift and break the resumed guest. Legacy HCL guards against this with a firmware-version "power token"; this change goes further and snapshots the actual firmware image into VMGS so the resumed guest is restored bit-for-bit.

### What it does

- **VMGS layout**: Renames `FileId` 14 as `HIBERNATION_TOKEN` (an 8-byte little-endian token) and adds `FileId` 19 `HIBERNATION_FIRMWARE` to hold the firmware image snapshot. `vmgstool` understands both names.
- **Cold boot**: Snapshots the pristine UEFI firmware image (as loaded from IGVM, before the dynamic config blob is written into VTL0) from guest RAM into the `HIBERNATION_FIRMWARE` VMGS file.
- **Hibernate**: Writes the hibernate token recording that matching VHD is in hibernated state.
- **Resume**: If the token indicates a firmware image was stored, restores it from VMGS into VTL0 guest RAM. The token is cleared on every resume so a later clean boot never restores a stale image.
- **vmgs_broker**: Adds `delete_file` to the broker/client so the halt task and boot path can manage the token concurrently with the worker.

### Behavior / logging details

- The 32 MB VMGS minimum-size gate is enforced; if the backing store is too small to hold the firmware image, hibernation simply won't preserve the firmware (logged as a **warning**, not an error).
- On resume, whether to attempt a restore is gated on the hibernate token value:
  - Token indicates a firmware image was stored → restore; a failure here is a real **error**.
  - Token indicates no image was stored → skip the restore and log a **warning**.
- The hibernate token is only written/cleared when hibernation is enabled; power off / reset clear it (to `NONE`) only in that case.

### Scope / limitations

- Targets **non-isolated** VMs. CVM/isolated support is deferred (requires additional measurement/attestation design).

### Testing

- `cargo clippy --all-targets`, `cargo doc --no-deps`, and `cargo xtask fmt` pass for the modified crates.