### PR TITLE
vmm_tests: boot UEFI NVMe across multiple root complexes

### DIFF
--- a/petri/src/vm/mod.rs
+++ b/petri/src/vm/mod.rs
@@ -169,6 +169,9 @@ pub struct PetriVmBuilder<T: PetriVmmBackend> {
     openhcl_agent_image: Option<AgentImage>,
     /// The boot device type for the VM
     boot_device_type: BootDeviceType,
+    /// Override for the PCIe root port the boot NVMe controller is placed on
+    /// when [`BootDeviceType::PcieNvme`] is used. Defaults to `s0rc0rp0`.
+    pcie_boot_port: Option<String>,
 
     // Minimal mode: skip default devices, serial, save/restore.
     minimal_mode: bool,
@@ -200,6 +203,7 @@ impl<T: PetriVmmBackend> Debug for PetriVmBuilder<T> {
             .field("agent_image", &self.agent_image)
             .field("openhcl_agent_image", &self.openhcl_agent_image)
             .field("boot_device_type", &self.boot_device_type)
+            .field("pcie_boot_port", &self.pcie_boot_port)
             .field("minimal_mode", &self.minimal_mode)
             .field("enable_serial", &self.enable_serial)
             .field("enable_screenshots", &self.enable_screenshots)
@@ -455,6 +459,7 @@ impl<T: PetriVmmBackend> PetriVmBuilder<T> {
             agent_image: artifacts.agent_image,
             openhcl_agent_image: artifacts.openhcl_agent_image,
             boot_device_type,
+            pcie_boot_port: None,
 
             minimal_mode: false,
             pipette_binary: artifacts.pipette_binary,
@@ -531,6 +536,7 @@ impl<T: PetriVmmBackend> PetriVmBuilder<T> {
             agent_image: artifacts.agent_image,
             openhcl_agent_image: artifacts.openhcl_agent_image,
             boot_device_type,
+            pcie_boot_port: None,
 
             minimal_mode: true,
             pipette_binary: artifacts.pipette_binary,
@@ -922,8 +928,12 @@ impl<T: PetriVmmBackend> PetriVmBuilder<T> {
                 BootDeviceType::NvmeViaScsi => todo!(),
                 BootDeviceType::NvmeViaNvme => todo!(),
                 BootDeviceType::PcieNvme => {
+                    let port_name = self
+                        .pcie_boot_port
+                        .clone()
+                        .unwrap_or_else(|| "s0rc0rp0".into());
                     self.config.pcie_nvme_drives.push(PcieNvmeDrive {
-                        port_name: "s0rc0rp0".into(),
+                        port_name,
                         nsid: 1,
                         drive: boot_drive,
                     });
@@ -1512,6 +1522,16 @@ impl<T: PetriVmmBackend> PetriVmBuilder<T> {
     /// This overrides the default, which is determined by the firmware type.
     pub fn with_boot_device_type(mut self, boot: BootDeviceType) -> Self {
         self.boot_device_type = boot;
+        self
+    }
+
+    /// Override the PCIe root port that the boot NVMe controller is placed on
+    /// when using [`BootDeviceType::PcieNvme`].
+    ///
+    /// The named port must exist in the PCIe topology added via the backend's
+    /// `with_pcie_root_topology`. Defaults to `s0rc0rp0`.
+    pub fn with_pcie_boot_port(mut self, port_name: &str) -> Self {
+        self.pcie_boot_port = Some(port_name.to_string());
         self
     }
 

--- a/petri/src/vm/openvmm/modify.rs
+++ b/petri/src/vm/openvmm/modify.rs
@@ -362,6 +362,12 @@ impl PetriVmConfigOpenVmm {
     /// All root ports are named according to their index within their parent
     /// using the naming scheme `sXrcYrpZ`. For example, the third root port on
     /// the fourth root complex in segment 0 would be named `s0rc3rp2`.
+    ///
+    /// This may be called multiple times to build asymmetric topologies (e.g. a
+    /// different number of root complexes per segment). Each call appends its
+    /// root complexes to segments numbered after any added by previous calls,
+    /// so the segment numbers in the `sXrcY` names continue from where the last
+    /// call left off.
     pub fn with_pcie_root_topology(
         mut self,
         segment_count: u64,
@@ -371,11 +377,26 @@ impl PetriVmConfigOpenVmm {
         const LOW_MMIO_SIZE: u64 = 64 * 1024 * 1024; // 64 MB
         const HIGH_MMIO_SIZE: u64 = 1024 * 1024 * 1024; // 1 GB
 
+        // Offset the segments and global indices added by this call so that it
+        // can be called multiple times. New segments are numbered after any
+        // existing ones, and the global index continues from the existing
+        // root complex count.
+        let segment_base = self
+            .config
+            .pcie_root_complexes
+            .iter()
+            .map(|rc| u64::from(rc.segment) + 1)
+            .max()
+            .unwrap_or(0);
+        let index_base = self.config.pcie_root_complexes.len() as u64;
+
         // Add the root complexes to the VM
-        for segment in 0..segment_count {
+        for segment_offset in 0..segment_count {
+            let segment = segment_base + segment_offset;
             let bus_count_per_rc = 256 / root_complex_per_segment;
             for rc_index_in_segment in 0..root_complex_per_segment {
-                let index = segment * root_complex_per_segment + rc_index_in_segment;
+                let index =
+                    index_base + segment_offset * root_complex_per_segment + rc_index_in_segment;
                 let name = format!("s{}rc{}", segment, rc_index_in_segment);
 
                 let start_bus = rc_index_in_segment * bus_count_per_rc;

--- a/vmm_tests/vmm_tests/tests/tests/multiarch/pcie.rs
+++ b/vmm_tests/vmm_tests/tests/tests/multiarch/pcie.rs
@@ -469,9 +469,16 @@ async fn pcie_save_restore(config: PetriVmBuilder<OpenVmmPetriBackend>) -> anyho
     Ok(())
 }
 
-/// Boot a guest through UEFI from an NVMe device on an emulated PCIe root port.
-/// Validates that UEFI's driver stack correctly enumerates and uses the NVMe
-/// device to load the guest OS.
+/// Boot a guest through UEFI from an NVMe device in an asymmetric multi-segment
+/// PCIe topology. Validates that UEFI's driver stack correctly enumerates
+/// multiple root complexes spread across multiple segments and boots from an
+/// NVMe device that is not on the first root complex.
+///
+/// Topology: five root complexes — two on segment 0 (`s0rc0`, `s0rc1`) and
+/// three on segment 1 (`s1rc0`, `s1rc1`, `s1rc2`). The boot NVMe controller is
+/// placed on the second root complex of segment 1 (`s1rc1rp0`). A second NVMe
+/// controller (with its own namespace) is placed on the first root complex
+/// (`s0rc0rp0`). The remaining root complexes are intentionally left empty.
 #[openvmm_test(
     uefi_x64(vhd(alpine_3_23_x64)),
     uefi_x64(vhd(windows_datacenter_core_2022_x64)),
@@ -483,11 +490,24 @@ async fn pcie_nvme_boot(config: PetriVmBuilder<OpenVmmPetriBackend>) -> anyhow::
     let (vm, agent) = config
         .with_boot_device_type(petri::BootDeviceType::PcieNvme)
         .with_default_boot_always_attempt(true)
-        .modify_backend(|b| b.with_pcie_root_topology(1, 1, 1))
+        // Boot from the NVMe controller on the second root complex of segment 1.
+        .with_pcie_boot_port("s1rc1rp0")
+        .modify_backend(|b| {
+            // Asymmetric topology: 2 root complexes on segment 0, then 3 root
+            // complexes on segment 1 (the second call appends to segment 1).
+            // One root port per root complex.
+            b.with_pcie_root_topology(1, 2, 1)
+                .with_pcie_root_topology(1, 3, 1)
+                // Second NVMe controller on the first root complex.
+                .with_pcie_nvme("s0rc0rp0", PCIE_NVME_SUBSYSTEM_IDS[0])
+        })
         .run()
         .await?;
 
-    // Verify the NVMe device is visible from guest
+    // Booting to a working agent already proves UEFI found and booted from the
+    // NVMe device on s1rc1. Additionally confirm both NVMe controllers (the
+    // boot device on segment 1 and the extra device on segment 0) enumerate in
+    // the guest.
     let guest_devices = parse_guest_pci_devices(os_flavor, &agent).await?;
     tracing::info!(?guest_devices, "guest devices");
 
@@ -495,7 +515,10 @@ async fn pcie_nvme_boot(config: PetriVmBuilder<OpenVmmPetriBackend>) -> anyhow::
         .iter()
         .filter(|d| d.class_code == 0x010802)
         .count();
-    assert!(nvme_count >= 1, "NVMe controller not visible in guest");
+    assert!(
+        nvme_count >= 2,
+        "expected both NVMe controllers (boot on s1rc1, extra on s0rc0) visible in guest, found {nvme_count}"
+    );
 
     agent.power_off().await?;
     vm.wait_for_clean_teardown().await?;


### PR DESCRIPTION
Extend pcie_nvme_boot to cover a richer PCIe topology: five root complexes split asymmetrically across two segments, booting from an NVMe controller that is not on the first root complex. This exercises UEFI's enumeration of multiple root complexes sharing segment numbers, which the prior single-RC topology never touched.

Supporting this, with_pcie_root_topology is now additive (successive calls append to fresh segments), and a new with_pcie_boot_port allows placing the boot NVMe controller on a port other than s0rc0rp0.