### PR TITLE
membacking: map private RAM into the IOMMU

### DIFF
--- a/openvmm/membacking/src/mapping_manager/manager.rs
+++ b/openvmm/membacking/src/mapping_manager/manager.rs
@@ -242,7 +242,8 @@ fn inspect_mappings(mappings: &Vec<Mapping>) -> impl '_ + Inspect {
                     req.respond()
                         .field("writable", mapping.params.writable)
                         .field("mapping_type", mapping.params.mapping_type)
-                        .hex("file_offset", mapping.params.file_offset);
+                        .field("backed_by_fd", mapping.params.backing.mappable().is_some())
+                        .hex("file_offset", mapping.params.backing.file_offset());
                 }),
             );
         }
@@ -254,15 +255,66 @@ struct Mapping {
     active_mappers: Vec<MapperId>,
 }
 
+/// How a guest memory mapping is backed by host memory.
+#[derive(Debug, MeshPayload, Clone)]
+pub enum MappingBacking {
+    /// Backed by a mappable OS object (shared memory or file). The mapping
+    /// manager mmaps `mappable` at `file_offset` into each VA mapper, so the
+    /// same physical pages are shared across all mappers (and shareable with
+    /// other processes via `GuestMemorySharing`).
+    File {
+        /// The OS object to map.
+        mappable: Mappable,
+        /// The file offset into `mappable`.
+        file_offset: u64,
+    },
+    /// Backed by private anonymous memory committed directly by the mapping
+    /// manager. There is no backing fd, so the memory cannot be shared with
+    /// other processes or programmed into DMA targets that require an fd; it is
+    /// exposed to DMA targets purely by host VA.
+    ///
+    /// Private memory is only valid with a single local eager mapper: lazy
+    /// mappers and remote mappers are rejected when any range is private (see
+    /// [`MappingManagerClient::new_mapper`] and
+    /// [`MappingManagerClient::new_remote_mapper`]). Committing anonymous pages
+    /// into multiple independent mappers would not share storage.
+    ///
+    /// Unlike file-backed memory, the storage *is* the VA mapping: there is no
+    /// fd holding the pages. Tearing the mapping down (via the region manager's
+    /// `remove_mappings`) decommits and zeroes the pages, so a private region
+    /// must not be transiently disabled and re-enabled — doing so would lose
+    /// guest memory. The region manager asserts against this.
+    Private {
+        /// Whether the range is eligible for Transparent Huge Pages (Linux).
+        transparent_hugepages: bool,
+    },
+}
+
+impl MappingBacking {
+    /// Returns the backing object, if this mapping is file-backed.
+    pub fn mappable(&self) -> Option<&Mappable> {
+        match self {
+            MappingBacking::File { mappable, .. } => Some(mappable),
+            MappingBacking::Private { .. } => None,
+        }
+    }
+
+    /// Returns the offset within the backing object, or 0 if there is none.
+    pub fn file_offset(&self) -> u64 {
+        match self {
+            MappingBacking::File { file_offset, .. } => *file_offset,
+            MappingBacking::Private { .. } => 0,
+        }
+    }
+}
+
 /// The mapping parameters.
 #[derive(Debug, MeshPayload, Clone)]
 pub struct MappingParams {
     /// The memory range for the mapping.
     pub range: MemoryRange,
-    /// The OS object to map.
-    pub mappable: Mappable,
-    /// The file offset into `mappable`.
-    pub file_offset: u64,
+    /// How the mapping is backed by host memory.
+    pub backing: MappingBacking,
     /// Whether to map the memory as writable.
     pub writable: bool,
     /// The type of memory being mapped.
@@ -593,7 +645,11 @@ impl MappingManagerTask {
     fn get_dma_target_mappings(&self) -> Vec<MappingParams> {
         self.mappings
             .iter()
-            .filter(|m| m.params.mapping_type == MappingType::Ram)
+            // Only file-backed RAM can be shared with other processes;
+            // private/anonymous RAM has no fd to hand out.
+            .filter(|m| {
+                m.params.mapping_type == MappingType::Ram && m.params.backing.mappable().is_some()
+            })
             .map(|m| m.params.clone())
             .collect()
     }
@@ -653,11 +709,14 @@ impl ProvideShareableRegions for DmaRegionProvider {
 
         Ok(mappings
             .into_iter()
-            .map(|m| ShareableRegion {
-                guest_address: m.range.start(),
-                size: m.range.len(),
-                file: m.mappable.inner_arc(),
-                file_offset: m.file_offset,
+            .filter_map(|m| {
+                let mappable = m.backing.mappable()?;
+                Some(ShareableRegion {
+                    guest_address: m.range.start(),
+                    size: m.range.len(),
+                    file: mappable.inner_arc(),
+                    file_offset: m.backing.file_offset(),
+                })
             })
             .collect())
     }
@@ -686,8 +745,10 @@ mod tests {
         client
             .add_mapping(MappingParams {
                 range: MemoryRange::new(0..0x100000),
-                mappable: ram,
-                file_offset: 0,
+                backing: MappingBacking::File {
+                    mappable: ram,
+                    file_offset: 0,
+                },
                 writable: true,
                 mapping_type: MappingType::Ram,
                 numa_node: None,
@@ -698,8 +759,10 @@ mod tests {
         client
             .add_mapping(MappingParams {
                 range: MemoryRange::new(0x100000..0x101000),
-                mappable: device,
-                file_offset: 0,
+                backing: MappingBacking::File {
+                    mappable: device,
+                    file_offset: 0,
+                },
                 writable: true,
                 mapping_type: MappingType::Device,
                 numa_node: None,
@@ -731,8 +794,10 @@ mod tests {
         client
             .add_mapping(MappingParams {
                 range: MemoryRange::new(0..0x1000),
-                mappable,
-                file_offset: 0,
+                backing: MappingBacking::File {
+                    mappable,
+                    file_offset: 0,
+                },
                 writable: true,
                 mapping_type: MappingType::Device,
                 numa_node: None,
@@ -755,8 +820,10 @@ mod tests {
             .into();
         let params = MappingParams {
             range: MemoryRange::new(0..0x10000),
-            mappable,
-            file_offset: 0,
+            backing: MappingBacking::File {
+                mappable,
+                file_offset: 0,
+            },
             writable: true,
             mapping_type: MappingType::Ram,
             numa_node: None,
@@ -829,8 +896,10 @@ mod tests {
             .into();
         let params = MappingParams {
             range: MemoryRange::new(0..0x1000),
-            mappable,
-            file_offset: 0,
+            backing: MappingBacking::File {
+                mappable,
+                file_offset: 0,
+            },
             writable: true,
             mapping_type: MappingType::Device,
             numa_node: None,
@@ -942,8 +1011,10 @@ mod tests {
             .into();
         let params = MappingParams {
             range: MemoryRange::new(0..0x1000),
-            mappable,
-            file_offset: 0,
+            backing: MappingBacking::File {
+                mappable,
+                file_offset: 0,
+            },
             writable: true,
             mapping_type: MappingType::Device,
             numa_node: None,
@@ -1060,8 +1131,10 @@ mod tests {
                 .into();
             task.add_mapping(MappingParams {
                 range: MemoryRange::new(start..end),
-                mappable,
-                file_offset: 0,
+                backing: MappingBacking::File {
+                    mappable,
+                    file_offset: 0,
+                },
                 writable: true,
                 mapping_type: MappingType::Ram,
                 numa_node: None,
@@ -1148,8 +1221,10 @@ mod tests {
             .into();
         let params = MappingParams {
             range: MemoryRange::new(0..0x1000),
-            mappable,
-            file_offset: 0,
+            backing: MappingBacking::File {
+                mappable,
+                file_offset: 0,
+            },
             writable: true,
             mapping_type: MappingType::Device,
             numa_node: None,
@@ -1255,8 +1330,10 @@ mod tests {
             .into();
         task.add_mapping(MappingParams {
             range: MemoryRange::new(0x20000..0x21000),
-            mappable,
-            file_offset: 0,
+            backing: MappingBacking::File {
+                mappable,
+                file_offset: 0,
+            },
             writable: true,
             mapping_type: MappingType::Device,
             numa_node: None,
@@ -1362,8 +1439,10 @@ mod tests {
         client
             .add_mapping(MappingParams {
                 range: MemoryRange::new(0..0x10000),
-                mappable,
-                file_offset: 0,
+                backing: MappingBacking::File {
+                    mappable,
+                    file_offset: 0,
+                },
                 writable: true,
                 mapping_type: MappingType::Device,
                 numa_node: None,
@@ -1410,8 +1489,10 @@ mod tests {
         client
             .add_mapping(MappingParams {
                 range: MemoryRange::new(0..0x10000),
-                mappable,
-                file_offset: 0,
+                backing: MappingBacking::File {
+                    mappable,
+                    file_offset: 0,
+                },
                 writable: true,
                 mapping_type: MappingType::Ram,
                 numa_node: None,
@@ -1446,8 +1527,10 @@ mod tests {
         client
             .add_mapping(MappingParams {
                 range: MemoryRange::new(0..0x10000),
-                mappable,
-                file_offset: 0,
+                backing: MappingBacking::File {
+                    mappable,
+                    file_offset: 0,
+                },
                 writable: true,
                 mapping_type: MappingType::Device,
                 numa_node: None,
@@ -1475,8 +1558,10 @@ mod tests {
         client
             .add_mapping(MappingParams {
                 range: MemoryRange::new(0x10000..0x11000),
-                mappable,
-                file_offset: 0,
+                backing: MappingBacking::File {
+                    mappable,
+                    file_offset: 0,
+                },
                 writable: true,
                 mapping_type: MappingType::Device,
                 numa_node: None,

--- a/openvmm/membacking/src/mapping_manager/mod.rs
+++ b/openvmm/membacking/src/mapping_manager/mod.rs
@@ -8,6 +8,7 @@ mod mappable;
 mod object_cache;
 mod va_mapper;
 
+pub use manager::MappingBacking;
 pub use manager::MappingManager;
 pub use manager::MappingManagerClient;
 pub use manager::MappingParams;

--- a/openvmm/membacking/src/mapping_manager/va_mapper.rs
+++ b/openvmm/membacking/src/mapping_manager/va_mapper.rs
@@ -28,6 +28,7 @@
 use super::manager::DmaRegionProvider;
 use super::manager::MapperId;
 use super::manager::MapperRequest;
+use super::manager::MappingBacking;
 use super::manager::MappingError;
 use super::manager::MappingParams;
 use super::manager::MappingRequest;
@@ -157,13 +158,13 @@ impl MapperTask {
                 MapperRequest::MapEager(rpc) => {
                     rpc.handle_failable_sync(|params| {
                         tracing::debug!(range = %params.range, "eager mapping received");
-                        self.map_file(params)
+                        self.map(params)
                     });
                 }
                 MapperRequest::MapLazy(params) => {
                     tracing::debug!(range = %params.range, "lazy mapping received");
                     let (range, writable) = (params.range, params.writable);
-                    match self.map_file(params) {
+                    match self.map(params) {
                         Ok(()) => self.wake_waiters(range, Some(writable)),
                         Err(e) => {
                             tracing::error!(
@@ -193,24 +194,42 @@ impl MapperTask {
         let _ = self.inner.mapping.unmap(0, self.inner.mapping.len());
     }
 
-    /// Maps a file-backed region into the VA space, applying NUMA policy where
-    /// supported.
-    fn map_file(&self, params: MappingParams) -> Result<(), MappingError> {
+    /// Establishes a mapping in the VA space, dispatching on how it is backed.
+    fn map(&self, params: MappingParams) -> Result<(), MappingError> {
         let MappingParams {
             range,
-            mappable,
+            backing,
             writable,
-            file_offset,
             numa_node,
             ..
         } = params;
+        match backing {
+            MappingBacking::File {
+                mappable,
+                file_offset,
+            } => self.map_file(range, &mappable, file_offset, writable, numa_node),
+            MappingBacking::Private {
+                transparent_hugepages,
+            } => self.map_private(range, transparent_hugepages, numa_node),
+        }
+    }
 
+    /// Maps a file-backed region into the VA space, applying NUMA policy where
+    /// supported.
+    fn map_file(
+        &self,
+        range: MemoryRange,
+        mappable: &super::mappable::Mappable,
+        file_offset: u64,
+        writable: bool,
+        numa_node: Option<u32>,
+    ) -> Result<(), MappingError> {
         let map_result = cfg_select! {
             windows => {
                 self.inner.mapping.map_file_numa(
                     range.start() as usize,
                     range.len() as usize,
-                    &mappable,
+                    mappable,
                     file_offset,
                     writable,
                     numa_node,
@@ -220,7 +239,7 @@ impl MapperTask {
                 self.inner.mapping.map_file(
                     range.start() as usize,
                     range.len() as usize,
-                    &mappable,
+                    mappable,
                     file_offset,
                     writable,
                 )
@@ -256,6 +275,45 @@ impl MapperTask {
                 assert!(numa_node.is_none(), "NUMA not supported on this platform; should have been rejected at build time");
             }
         }
+
+        Ok(())
+    }
+
+    /// Commits private anonymous memory for a range into the VA space.
+    ///
+    /// This replaces the reserved placeholder at `range` with committed
+    /// anonymous pages, optionally bound to a host NUMA node and marked
+    /// eligible for Transparent Huge Pages.
+    fn map_private(
+        &self,
+        range: MemoryRange,
+        transparent_hugepages: bool,
+        numa_node: Option<u32>,
+    ) -> Result<(), MappingError> {
+        let offset = range.start() as usize;
+        let len = range.len() as usize;
+
+        if let Err(e) = self.inner.alloc(offset, len, numa_node) {
+            return Err(MappingError::new(range, e));
+        }
+
+        // Name the range so it's identifiable in /proc/{pid}/smaps.
+        self.inner
+            .mapping
+            .set_name(offset, len, "guest-ram-private");
+
+        #[cfg(target_os = "linux")]
+        if transparent_hugepages {
+            if let Err(e) = self.inner.mapping.madvise_hugepage(offset, len) {
+                tracing::warn!(
+                    error = &e as &dyn std::error::Error,
+                    %range,
+                    "failed to mark private RAM as THP eligible"
+                );
+            }
+        }
+        #[cfg(not(target_os = "linux"))]
+        let _ = transparent_hugepages;
 
         Ok(())
     }
@@ -320,6 +378,39 @@ impl MapperInner {
         match recv.await {
             Ok(true) => Ok(()),
             Ok(false) | Err(_) => Err(NoMapping(range)),
+        }
+    }
+
+    /// Commits private anonymous memory for a range, optionally bound to a
+    /// specific host NUMA node.
+    ///
+    /// This replaces the placeholder at the given offset with committed
+    /// anonymous memory.
+    ///
+    /// Caution: on Linux, if NUMA binding fails, the allocation itself has
+    /// still succeeded — the returned error does not imply the memory is
+    /// unmapped.
+    fn alloc(
+        &self,
+        offset: usize,
+        len: usize,
+        numa_node: Option<u32>,
+    ) -> Result<(), std::io::Error> {
+        cfg_select! {
+            windows => {
+                self.mapping.alloc_numa(offset, len, numa_node)
+            }
+            target_os = "linux" => {
+                self.mapping.alloc(offset, len)?;
+                if let Some(node) = numa_node {
+                    self.mapping.mbind_at(offset, len, node)?;
+                }
+                Ok(())
+            }
+            _ => {
+                assert!(numa_node.is_none(), "NUMA not supported on this platform; should have been rejected at build time");
+                self.mapping.alloc(offset, len)
+            }
         }
     }
 }
@@ -440,55 +531,11 @@ impl VaMapper {
         self.process.as_ref()
     }
 
-    /// Allocates private anonymous memory for a range within the mapping,
-    /// optionally bound to a specific host NUMA node.
-    ///
-    /// This replaces the placeholder at the given offset with committed
-    /// anonymous memory.
-    ///
-    /// Caution: on Linux, if NUMA binding fails, the allocation itself has
-    /// still succeeded — the returned error does not imply the memory is
-    /// unmapped.
-    pub(crate) fn alloc_range(
-        &self,
-        offset: usize,
-        len: usize,
-        numa_node: Option<u32>,
-    ) -> Result<(), std::io::Error> {
-        cfg_select! {
-            windows => {
-                self.inner.mapping.alloc_numa(offset, len, numa_node)
-            }
-            target_os = "linux" => {
-                self.inner.mapping.alloc(offset, len)?;
-                if let Some(node) = numa_node {
-                    self.inner.mapping.mbind_at(offset, len, node)?;
-                }
-                Ok(())
-            }
-            _ => {
-                assert!(numa_node.is_none(), "NUMA not supported on this platform; should have been rejected at build time");
-                self.inner.mapping.alloc(offset, len)
-            }
-        }
-    }
-
-    /// Names a range within the mapping for debugging (visible in smaps).
-    pub fn set_range_name(&self, offset: usize, len: usize, name: &str) {
-        self.inner.mapping.set_name(offset, len, name);
-    }
-
-    /// Marks a range as eligible for Transparent Huge Pages.
-    #[cfg(target_os = "linux")]
-    pub(crate) fn madvise_hugepage(&self, offset: usize, len: usize) -> Result<(), std::io::Error> {
-        self.inner.mapping.madvise_hugepage(offset, len)
-    }
-
     /// Decommits a range of private RAM, releasing physical pages back to the
     /// host.
     ///
     /// The caller must ensure this is only called on ranges backed by
-    /// private anonymous memory (allocated via [`alloc_range`](Self::alloc_range)).
+    /// private anonymous memory.
     #[expect(dead_code)] // Will be used by ballooning / memory hot-remove.
     pub fn decommit(&self, offset: usize, len: usize) -> Result<(), std::io::Error> {
         assert!(

--- a/openvmm/membacking/src/memory_manager/device_memory.rs
+++ b/openvmm/membacking/src/memory_manager/device_memory.rs
@@ -113,7 +113,7 @@ impl MappedMemoryRegion for DeviceMemoryRegion {
         if let Some(handle) = &state.handle {
             if let Err(e) = block_on(handle.add_mapping(
                 new_mapping.range,
-                new_mapping.mappable.clone(),
+                Some(new_mapping.mappable.clone()),
                 new_mapping.file_offset,
                 new_mapping.writable,
                 None,
@@ -170,7 +170,7 @@ impl MappableGuestMemory for DeviceMemoryControl {
                 handle
                     .add_mapping(
                         mapping.range,
-                        mapping.mappable.clone(),
+                        Some(mapping.mappable.clone()),
                         mapping.file_offset,
                         mapping.writable,
                         None,

--- a/openvmm/membacking/src/memory_manager/device_memory.rs
+++ b/openvmm/membacking/src/memory_manager/device_memory.rs
@@ -6,6 +6,7 @@
 
 use super::DEVICE_PRIORITY;
 use crate::mapping_manager::Mappable;
+use crate::mapping_manager::MappingBacking;
 use crate::region_manager::MapParams;
 use crate::region_manager::RegionHandle;
 use crate::region_manager::RegionManagerClient;
@@ -113,8 +114,10 @@ impl MappedMemoryRegion for DeviceMemoryRegion {
         if let Some(handle) = &state.handle {
             if let Err(e) = block_on(handle.add_mapping(
                 new_mapping.range,
-                Some(new_mapping.mappable.clone()),
-                new_mapping.file_offset,
+                MappingBacking::File {
+                    mappable: new_mapping.mappable.clone(),
+                    file_offset: new_mapping.file_offset,
+                },
                 new_mapping.writable,
                 None,
             )) {
@@ -170,8 +173,10 @@ impl MappableGuestMemory for DeviceMemoryControl {
                 handle
                     .add_mapping(
                         mapping.range,
-                        Some(mapping.mappable.clone()),
-                        mapping.file_offset,
+                        MappingBacking::File {
+                            mappable: mapping.mappable.clone(),
+                            file_offset: mapping.file_offset,
+                        },
                         mapping.writable,
                         None,
                     )

--- a/openvmm/membacking/src/memory_manager/mod.rs
+++ b/openvmm/membacking/src/memory_manager/mod.rs
@@ -595,7 +595,7 @@ impl GuestMemoryBuilder {
                         region
                             .add_mapping(
                                 MemoryRange::new(0..sub_range.len()),
-                                mappable.clone(),
+                                Some(mappable.clone()),
                                 file_offset,
                                 true,
                                 backing.host_numa_node,
@@ -632,6 +632,27 @@ impl GuestMemoryBuilder {
                                 );
                             }
                         }
+
+                        // Register a backing-less mapping so private RAM still
+                        // participates in the region-driven DMA machinery: the
+                        // anonymous pages are already committed on the shared
+                        // eager VaMapper, so DMA targets can map them by host
+                        // VA even though there is no fd to mmap. Without this,
+                        // an assigned device DMAing to private RAM would take
+                        // IOMMU faults (silent DMA failure).
+                        region
+                            .add_mapping(
+                                MemoryRange::new(0..sub_range.len()),
+                                None,
+                                file_offset,
+                                true,
+                                backing.host_numa_node,
+                            )
+                            .await
+                            .map_err(|error| MemoryBuildError::RamMapping {
+                                range: *sub_range,
+                                error,
+                            })?;
                     }
 
                     region

--- a/openvmm/membacking/src/memory_manager/mod.rs
+++ b/openvmm/membacking/src/memory_manager/mod.rs
@@ -9,6 +9,7 @@ pub use device_memory::DeviceMemoryMapper;
 
 use crate::RemoteProcess;
 use crate::mapping_manager::Mappable;
+use crate::mapping_manager::MappingBacking;
 use crate::mapping_manager::MappingManager;
 use crate::mapping_manager::MappingManagerClient;
 use crate::mapping_manager::VaMapper;
@@ -146,9 +147,6 @@ pub enum MemoryBuildError {
     /// Private memory is incompatible with an existing memory backing.
     #[error("private memory is incompatible with an existing memory backing")]
     PrivateMemoryWithExistingBacking,
-    /// Failed to allocate private RAM range.
-    #[error("failed to allocate private RAM range {1}")]
-    PrivateRamAlloc(#[source] io::Error, MemoryRange),
     /// THP requires private memory mode.
     #[error("transparent huge pages requires private memory mode")]
     ThpWithoutPrivateMemory,
@@ -591,48 +589,27 @@ impl GuestMemoryBuilder {
                         .await
                         .expect("regions cannot overlap yet");
 
-                    if backing.mappable.is_none() {
-                        va_mapper
-                            .alloc_range(
-                                sub_range.start() as usize,
-                                sub_range.len() as usize,
-                                backing.host_numa_node,
-                            )
-                            .map_err(|e| MemoryBuildError::PrivateRamAlloc(e, *sub_range))?;
-                        va_mapper.set_range_name(
-                            sub_range.start() as usize,
-                            sub_range.len() as usize,
-                            "guest-ram-private",
-                        );
-
-                        #[cfg(target_os = "linux")]
-                        if backing.transparent_hugepages {
-                            if let Err(e) = va_mapper.madvise_hugepage(
-                                sub_range.start() as usize,
-                                sub_range.len() as usize,
-                            ) {
-                                tracing::warn!(
-                                    error = &e as &dyn std::error::Error,
-                                    range = %sub_range,
-                                    "failed to mark RAM as THP eligible"
-                                );
-                            }
-                        }
-                    }
-
                     // Register the mapping with the region. File-backed RAM
-                    // passes its `Mappable` so the mapping manager can mmap it.
-                    // Private/anonymous RAM passes `None`: its pages are already
-                    // committed on the shared eager VaMapper above, so there is
-                    // nothing to mmap, but it still participates in the
+                    // passes its `Mappable` so the mapping manager mmaps it.
+                    // Private/anonymous RAM passes `MappingBacking::Private`:
+                    // the mapping manager commits its anonymous pages directly
+                    // (there is no fd to mmap), but it still participates in the
                     // region-driven DMA machinery (mapped by host VA). Without
                     // this, an assigned device DMAing to private RAM would take
                     // IOMMU faults (silent DMA failure).
+                    let backing_kind = match &backing.mappable {
+                        Some(mappable) => MappingBacking::File {
+                            mappable: mappable.clone(),
+                            file_offset,
+                        },
+                        None => MappingBacking::Private {
+                            transparent_hugepages: backing.transparent_hugepages,
+                        },
+                    };
                     region
                         .add_mapping(
                             MemoryRange::new(0..sub_range.len()),
-                            backing.mappable.clone(),
-                            file_offset,
+                            backing_kind,
                             true,
                             backing.host_numa_node,
                         )

--- a/openvmm/membacking/src/memory_manager/mod.rs
+++ b/openvmm/membacking/src/memory_manager/mod.rs
@@ -67,7 +67,6 @@ struct RamBacking {
     /// Prefetch pages at build time.
     prefetch: bool,
     /// THP is enabled for this backing.
-    #[cfg_attr(not(target_os = "linux"), expect(dead_code))]
     transparent_hugepages: bool,
     /// Host NUMA node for this backing. `None` means OS default placement.
     host_numa_node: Option<u32>,

--- a/openvmm/membacking/src/memory_manager/mod.rs
+++ b/openvmm/membacking/src/memory_manager/mod.rs
@@ -591,21 +591,7 @@ impl GuestMemoryBuilder {
                         .await
                         .expect("regions cannot overlap yet");
 
-                    if let Some(ref mappable) = backing.mappable {
-                        region
-                            .add_mapping(
-                                MemoryRange::new(0..sub_range.len()),
-                                Some(mappable.clone()),
-                                file_offset,
-                                true,
-                                backing.host_numa_node,
-                            )
-                            .await
-                            .map_err(|error| MemoryBuildError::RamMapping {
-                                range: *sub_range,
-                                error,
-                            })?;
-                    } else {
+                    if backing.mappable.is_none() {
                         va_mapper
                             .alloc_range(
                                 sub_range.start() as usize,
@@ -632,28 +618,29 @@ impl GuestMemoryBuilder {
                                 );
                             }
                         }
-
-                        // Register a backing-less mapping so private RAM still
-                        // participates in the region-driven DMA machinery: the
-                        // anonymous pages are already committed on the shared
-                        // eager VaMapper, so DMA targets can map them by host
-                        // VA even though there is no fd to mmap. Without this,
-                        // an assigned device DMAing to private RAM would take
-                        // IOMMU faults (silent DMA failure).
-                        region
-                            .add_mapping(
-                                MemoryRange::new(0..sub_range.len()),
-                                None,
-                                file_offset,
-                                true,
-                                backing.host_numa_node,
-                            )
-                            .await
-                            .map_err(|error| MemoryBuildError::RamMapping {
-                                range: *sub_range,
-                                error,
-                            })?;
                     }
+
+                    // Register the mapping with the region. File-backed RAM
+                    // passes its `Mappable` so the mapping manager can mmap it.
+                    // Private/anonymous RAM passes `None`: its pages are already
+                    // committed on the shared eager VaMapper above, so there is
+                    // nothing to mmap, but it still participates in the
+                    // region-driven DMA machinery (mapped by host VA). Without
+                    // this, an assigned device DMAing to private RAM would take
+                    // IOMMU faults (silent DMA failure).
+                    region
+                        .add_mapping(
+                            MemoryRange::new(0..sub_range.len()),
+                            backing.mappable.clone(),
+                            file_offset,
+                            true,
+                            backing.host_numa_node,
+                        )
+                        .await
+                        .map_err(|error| MemoryBuildError::RamMapping {
+                            range: *sub_range,
+                            error,
+                        })?;
 
                     region
                         .map(MapParams {

--- a/openvmm/membacking/src/region_manager.rs
+++ b/openvmm/membacking/src/region_manager.rs
@@ -44,12 +44,15 @@ pub enum MappingType {
 pub struct DmaMapRequest<'a> {
     /// The guest physical address range to map.
     pub range: MemoryRange,
-    /// Host virtual address of the mapping, provided when the target was
-    /// registered with `needs_va = true`. When `None`, the implementation
-    /// should use `mappable` and `file_offset` directly.
-    pub host_va: Option<*const u8>,
-    /// The backing object (fd or handle) for the mapping.
-    pub mappable: &'a Mappable,
+    /// Host virtual address of the mapping. The region manager always maintains
+    /// an eager `VaMapper` (handing out a VA is free), so a valid, backed VA is
+    /// always provided. Targets that program the IOMMU by VA (VFIO type1,
+    /// iommufd) use this directly.
+    pub host_va: *const u8,
+    /// The backing object (fd or handle) for the mapping, when one exists.
+    /// `None` for anonymous/private RAM, which has no backing fd and is
+    /// mapped purely by host VA.
+    pub mappable: Option<&'a Mappable>,
     /// Offset within `mappable` where the mapping starts.
     pub file_offset: u64,
     /// Whether the mapping should allow writes. When `false`, the IOMMU
@@ -79,12 +82,12 @@ pub trait DmaTarget: Send + Sync {
     /// Program an IOMMU mapping.
     ///
     /// # Safety
-    /// When `request.host_va` is `Some`, the pointed-to memory must be
-    /// backed and must not be unmapped for the duration of the resulting
-    /// IOMMU mapping. The caller (the crate-internal `DmaMapper`) guarantees
-    /// this by holding an [`Arc<VaMapper>`] whose mappings are established
-    /// eagerly by the mapping manager. The IOMMU mapping will be torn down
-    /// (via `unmap_dma`) before the `VaMapper` releases the VA range.
+    /// `request.host_va` always points to backed memory that must not be
+    /// unmapped for the duration of the resulting IOMMU mapping. The caller
+    /// (the crate-internal `DmaMapper`) guarantees this by holding an
+    /// [`Arc<VaMapper>`] whose mappings are established eagerly by the mapping
+    /// manager. The IOMMU mapping will be torn down (via `unmap_dma`) before
+    /// the `VaMapper` releases the VA range.
     unsafe fn map_dma(&self, request: DmaMapRequest<'_>) -> anyhow::Result<()>;
 
     /// Remove IOMMU mappings within `range`.
@@ -100,36 +103,61 @@ pub trait DmaTarget: Send + Sync {
 
 /// Wraps a [`DmaTarget`] for use by the region manager.
 ///
-/// Holds an optional [`VaMapper`] to provide host VA pointers for IOMMU
+/// Holds the [`VaMapper`] used to provide host VA pointers for IOMMU
 /// programming. Mappings in the VaMapper are established eagerly by the
 /// mapping manager.
 struct DmaMapper {
     id: DmaMapperId,
     target: Arc<dyn DmaTarget>,
-    va_mapper: Option<Arc<VaMapper>>,
+    va_mapper: Arc<VaMapper>,
+    /// When `true`, every mapping presented to this target must have a backing
+    /// fd. Backing-less mappings (private/anonymous RAM, exposed only by host
+    /// VA) are rejected at registration and mapping-creation time, since such
+    /// a target cannot consume a VA-only mapping.
+    needs_fd: bool,
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 struct DmaMapperId(u64);
 
+/// A sub-mapping the region manager hands to a [`DmaMapper`]. The host VA is
+/// deliberately absent: it is filled in by [`DmaMapper::map_dma`] from the
+/// mapper's eager `VaMapper`.
+struct SubMapping<'a> {
+    range: MemoryRange,
+    mappable: Option<&'a Mappable>,
+    file_offset: u64,
+    writable: bool,
+    mapping_type: MappingType,
+}
+
 impl DmaMapper {
     /// Map a sub-mapping into the IOMMU.
-    fn map_dma(&self, mut request: DmaMapRequest<'_>) -> anyhow::Result<()> {
-        // Compute the host VA for type1/iommufd backends. The VaMapper
-        // is always eager, so the backing is already established.
+    fn map_dma(&self, mapping: SubMapping<'_>) -> anyhow::Result<()> {
+        // The region manager always maintains an eager VaMapper, so a host VA
+        // is always available and free to hand out (the backing is already
+        // established).
         //
-        // SAFETY: range.start() is within the VA reservation, and
-        // the eager mapper has already established the backing.
-        request.host_va = self.va_mapper.as_ref().map(|va_mapper| unsafe {
-            va_mapper
+        // SAFETY: range.start() is within the VA reservation, and the eager
+        // mapper has already established the backing.
+        let host_va = unsafe {
+            self.va_mapper
                 .as_ptr()
-                .add(request.range.start() as usize)
+                .add(mapping.range.start() as usize)
                 .cast_const()
-        });
-        // SAFETY: When host_va is Some, the VaMapper is eager and the mapping
-        // has been established. The VaMapper is held alive by this DmaMapper
-        // (via Arc). The IOMMU mapping will be torn down (via unmap_dma)
-        // before the VaMapper releases the VA range.
+        };
+        let request = DmaMapRequest {
+            range: mapping.range,
+            host_va,
+            mappable: mapping.mappable,
+            file_offset: mapping.file_offset,
+            writable: mapping.writable,
+            mapping_type: mapping.mapping_type,
+        };
+        // SAFETY: The VaMapper is eager and the mapping has been established.
+        // The VaMapper is held alive by this DmaMapper (via Arc). The IOMMU
+        // mapping will be torn down (via unmap_dma) before the VaMapper
+        // releases the VA range.
         unsafe { self.target.map_dma(request) }
     }
 
@@ -282,7 +310,11 @@ struct RegionMapping {
 #[derive(MeshPayload)]
 struct RegionMappingParams {
     range_in_region: MemoryRange,
-    mappable: Mappable,
+    /// The backing object, or `None` for anonymous/private RAM that has no
+    /// backing fd (and is therefore not mapped via the mapping manager, only
+    /// committed eagerly on the shared `VaMapper` and exposed to DMA targets
+    /// by host VA).
+    mappable: Option<Mappable>,
     file_offset: u64,
     writable: bool,
     numa_node: Option<u32>,
@@ -329,8 +361,8 @@ impl RegionManagerTask {
                         .await
                 }
                 RegionRequest::AddDmaMapper(LocalOnly(rpc)) => {
-                    let ((target, needs_va), rpc) = rpc.split();
-                    let result = self.add_dma_mapper(target, needs_va).await;
+                    let ((target, needs_fd), rpc) = rpc.split();
+                    let result = self.add_dma_mapper(target, needs_fd).await;
                     rpc.complete(result);
                 }
                 RegionRequest::RemoveDmaMapper(LocalOnly(id)) => {
@@ -376,16 +408,32 @@ impl RegionManagerTask {
     async fn add_dma_mapper(
         &mut self,
         target: Arc<dyn DmaTarget>,
-        needs_va: bool,
+        needs_fd: bool,
     ) -> anyhow::Result<DmaMapperId> {
-        // Create a VaMapper if the target needs host VAs for IOMMU programming.
-        let va_mapper = if needs_va {
-            let mapper = self.inner.mapping_manager.new_mapper(true).await?;
-            assert!(mapper.is_eager(), "DMA mapper requires an eager VaMapper");
-            Some(mapper)
-        } else {
-            None
-        };
+        // A host VA is always available and free to hand out, so always
+        // maintain an eager VaMapper for this target.
+        let va_mapper = self.inner.mapping_manager.new_mapper(true).await?;
+        assert!(
+            va_mapper.is_eager(),
+            "DMA mapper requires an eager VaMapper"
+        );
+
+        // A target that requires a backing fd cannot consume backing-less
+        // mappings (private/anonymous RAM, which is exposed only by host VA).
+        // Reject registration if any such mapping already exists.
+        if needs_fd {
+            if let Some(region) = self
+                .regions
+                .iter()
+                .find(|r| r.mappings.iter().any(|m| m.params.mappable.is_none()))
+            {
+                anyhow::bail!(
+                    "cannot register a DMA mapper that requires a backing fd: \
+                     region {} contains a mapping with no backing fd (private RAM)",
+                    region.params.range
+                );
+            }
+        }
 
         let id = DmaMapperId(self.inner.next_dma_mapper_id);
         self.inner.next_dma_mapper_id += 1;
@@ -394,6 +442,7 @@ impl RegionManagerTask {
             id,
             target,
             va_mapper,
+            needs_fd,
         };
 
         // Replay existing active sub-mappings so the new IOMMU consumer
@@ -403,10 +452,9 @@ impl RegionManagerTask {
                 for mapping in &region.mappings {
                     let range = range_within(region.params.range, mapping.params.range_in_region);
                     let writable = mapping.params.writable && region.map_params.unwrap().writable;
-                    mapper.map_dma(DmaMapRequest {
+                    mapper.map_dma(SubMapping {
                         range,
-                        host_va: None,
-                        mappable: &mapping.params.mappable,
+                        mappable: mapping.params.mappable.as_ref(),
                         file_offset: mapping.params.file_offset,
                         writable,
                         mapping_type: region.params.mapping_type,
@@ -593,6 +641,16 @@ impl RegionManagerTask {
         id: RegionId,
         params: RegionMappingParams,
     ) -> anyhow::Result<()> {
+        // A backing-less mapping (private/anonymous RAM) is exposed to DMA
+        // targets only by host VA. A target registered with `needs_fd` cannot
+        // consume it, so reject the mapping up front rather than silently
+        // skipping that target.
+        if params.mappable.is_none() && self.inner.dma_mappers.iter().any(|m| m.needs_fd) {
+            anyhow::bail!(
+                "cannot add a mapping with no backing fd: a registered DMA mapper requires one"
+            );
+        }
+
         let index = self.region_index(id);
         let region = &mut self.regions[index];
 
@@ -608,33 +666,39 @@ impl RegionManagerTask {
         if let Some(region_range) = region.active_range() {
             let range = range_within(region_range, params.range_in_region);
             let writable = params.writable && region.map_params.unwrap().writable;
-            self.inner
-                .mapping_manager
-                .add_mapping(MappingParams {
-                    range,
-                    mappable: params.mappable.clone(),
-                    file_offset: params.file_offset,
-                    writable,
-                    mapping_type: region.params.mapping_type,
-                    numa_node: params.numa_node,
-                })
-                .await?;
+            // Anonymous/private RAM has no backing fd, so there is nothing for
+            // the mapping manager to mmap — the pages are already committed on
+            // the eager VaMapper. Such mappings still drive DMA targets by VA.
+            if let Some(mappable) = &params.mappable {
+                self.inner
+                    .mapping_manager
+                    .add_mapping(MappingParams {
+                        range,
+                        mappable: mappable.clone(),
+                        file_offset: params.file_offset,
+                        writable,
+                        mapping_type: region.params.mapping_type,
+                        numa_node: params.numa_node,
+                    })
+                    .await?;
+            }
 
             for (dma_idx, dma_mapper) in self.inner.dma_mappers.iter().enumerate() {
-                if let Err(e) = dma_mapper.map_dma(DmaMapRequest {
+                if let Err(e) = dma_mapper.map_dma(SubMapping {
                     range,
-                    host_va: None,
-                    mappable: &params.mappable,
+                    mappable: params.mappable.as_ref(),
                     file_offset: params.file_offset,
                     writable,
                     mapping_type: region.params.mapping_type,
                 }) {
                     // Roll back: unmap from DMA mappers that already
-                    // succeeded, then remove the VA mapping.
+                    // succeeded, then remove the VA mapping (if any).
                     for dm in &self.inner.dma_mappers[..dma_idx] {
                         dm.unmap_dma(range);
                     }
-                    self.inner.mapping_manager.remove_mappings(range).await;
+                    if params.mappable.is_some() {
+                        self.inner.mapping_manager.remove_mappings(range).await;
+                    }
                     return Err(e);
                 }
             }
@@ -709,42 +773,46 @@ impl RegionManagerTaskInner {
         // Add the mappings for the region. On failure, roll back any
         // sub-mappings that were successfully added.
         for (mapped_count, mapping) in region.mappings.iter().enumerate() {
-            if let Err(e) = self
-                .mapping_manager
-                .add_mapping(MappingParams {
-                    range: range_within(region.params.range, mapping.params.range_in_region),
-                    mappable: mapping.params.mappable.clone(),
-                    file_offset: mapping.params.file_offset,
-                    writable: mapping.params.writable && map_params.writable,
-                    mapping_type: region.params.mapping_type,
-                    numa_node: mapping.params.numa_node,
-                })
-                .await
-            {
-                // Roll back: remove sub-mappings that were already added.
-                for prev in &region.mappings[..mapped_count] {
-                    let range = range_within(region.params.range, prev.params.range_in_region);
-                    for dma_mapper in &self.dma_mappers {
-                        dma_mapper.unmap_dma(range);
+            // Anonymous/private RAM has no backing fd, so skip the mapping
+            // manager (the pages are already committed on the eager VaMapper)
+            // but still drive the DMA targets below by host VA.
+            if let Some(mappable) = &mapping.params.mappable {
+                if let Err(e) = self
+                    .mapping_manager
+                    .add_mapping(MappingParams {
+                        range: range_within(region.params.range, mapping.params.range_in_region),
+                        mappable: mappable.clone(),
+                        file_offset: mapping.params.file_offset,
+                        writable: mapping.params.writable && map_params.writable,
+                        mapping_type: region.params.mapping_type,
+                        numa_node: mapping.params.numa_node,
+                    })
+                    .await
+                {
+                    // Roll back: remove sub-mappings that were already added.
+                    for prev in &region.mappings[..mapped_count] {
+                        let range = range_within(region.params.range, prev.params.range_in_region);
+                        for dma_mapper in &self.dma_mappers {
+                            dma_mapper.unmap_dma(range);
+                        }
                     }
+                    self.mapping_manager
+                        .remove_mappings(region.params.range)
+                        .await;
+                    return Err(e).context(format!(
+                        "failed to map {} during region enable",
+                        range_within(region.params.range, mapping.params.range_in_region),
+                    ));
                 }
-                self.mapping_manager
-                    .remove_mappings(region.params.range)
-                    .await;
-                return Err(e).context(format!(
-                    "failed to map {} during region enable",
-                    range_within(region.params.range, mapping.params.range_in_region),
-                ));
             }
 
             // Map into DMA mappers.
             let range = range_within(region.params.range, mapping.params.range_in_region);
             let writable = mapping.params.writable && map_params.writable;
             for (dma_idx, dma_mapper) in self.dma_mappers.iter().enumerate() {
-                if let Err(e) = dma_mapper.map_dma(DmaMapRequest {
+                if let Err(e) = dma_mapper.map_dma(SubMapping {
                     range,
-                    host_va: None,
-                    mappable: &mapping.params.mappable,
+                    mappable: mapping.params.mappable.as_ref(),
                     file_offset: mapping.params.file_offset,
                     writable,
                     mapping_type: region.params.mapping_type,
@@ -899,12 +967,18 @@ impl DmaMapperClient {
     ///
     /// This may only be called in the same process as the region manager.
     ///
-    /// If `needs_va` is `true`, the region manager will maintain a `VaMapper`
-    /// and pass a host VA to [`DmaTarget::map_dma`] for each sub-mapping.
-    /// Use this for backends that program the IOMMU via host VAs (VFIO type1).
+    /// A host VA is always provided to [`DmaTarget::map_dma`] (the region
+    /// manager always maintains an eager `VaMapper` — handing out a VA is
+    /// free), so targets that program the IOMMU by VA (VFIO type1, iommufd)
+    /// need no special opt-in.
     ///
-    /// If `needs_va` is `false`, no `VaMapper` is created and `host_va` will
-    /// be `None`. Use this for backends that map from the fd directly (iommufd).
+    /// If `needs_fd` is `true`, the target additionally requires every mapping
+    /// to carry a backing fd. Such a target is incompatible with backing-less
+    /// mappings (private/anonymous RAM, exposed only by host VA): registration
+    /// fails if any such mapping already exists, and subsequent attempts to
+    /// create one fail. Use this for backends that must map from an fd (e.g., a
+    /// virtio-user frontend driven via the DMA mapper rather than the shared
+    /// guest-memory infrastructure).
     ///
     /// The replay loop maps all existing active sub-mappings into the new
     /// consumer. On failure, already-mapped entries are **not** rolled back;
@@ -915,13 +989,13 @@ impl DmaMapperClient {
     pub async fn add_dma_mapper(
         &self,
         target: Arc<dyn DmaTarget>,
-        needs_va: bool,
+        needs_fd: bool,
     ) -> anyhow::Result<DmaMapperHandle> {
         let id = self
             .req_send
             .call(
                 |x| RegionRequest::AddDmaMapper(LocalOnly(x)),
-                (target, needs_va),
+                (target, needs_fd),
             )
             .await
             .unwrap()?;
@@ -979,11 +1053,16 @@ impl RegionHandle {
 
     /// Adds a mapping to the region.
     ///
+    /// `mappable` is the backing object (fd or handle) to mmap, or `None` for
+    /// anonymous/private RAM that has no backing fd. A `None` mapping is not
+    /// programmed into the mapping manager (its pages are already committed on
+    /// the eager `VaMapper`), but it still drives DMA targets by host VA.
+    ///
     /// TODO: allow this to split+overwrite existing mappings.
     pub async fn add_mapping(
         &self,
         range_in_region: MemoryRange,
-        mappable: Mappable,
+        mappable: Option<Mappable>,
         file_offset: u64,
         writable: bool,
         numa_node: Option<u32>,
@@ -1058,6 +1137,9 @@ mod tests {
     #[derive(Default)]
     struct RecordingDmaTarget {
         events: Mutex<Vec<DmaEvent>>,
+        /// Ranges for which `map_dma` was called with no backing fd
+        /// (`mappable: None`), i.e., the anonymous/private-RAM VA path.
+        backingless_maps: Mutex<Vec<MemoryRange>>,
     }
 
     #[derive(Debug, Clone, PartialEq, Eq)]
@@ -1068,6 +1150,9 @@ mod tests {
 
     impl DmaTarget for RecordingDmaTarget {
         unsafe fn map_dma(&self, request: DmaMapRequest<'_>) -> anyhow::Result<()> {
+            if request.mappable.is_none() {
+                self.backingless_maps.lock().push(request.range);
+            }
             self.events.lock().push(DmaEvent::Map(request.range));
             Ok(())
         }
@@ -1081,6 +1166,10 @@ mod tests {
     impl RecordingDmaTarget {
         fn take_events(&self) -> Vec<DmaEvent> {
             std::mem::take(&mut self.events.lock())
+        }
+
+        fn take_backingless_maps(&self) -> Vec<MemoryRange> {
+            std::mem::take(&mut self.backingless_maps.lock())
         }
     }
 
@@ -1193,7 +1282,24 @@ mod tests {
                     id,
                     RegionMappingParams {
                         range_in_region: MemoryRange::new(range_in_region),
-                        mappable: self.mappable.clone(),
+                        mappable: Some(self.mappable.clone()),
+                        file_offset: 0,
+                        writable: true,
+                        numa_node: None,
+                    },
+                )
+                .await
+                .unwrap();
+        }
+
+        /// Adds a backing-less (private/anonymous RAM) mapping.
+        async fn add_private_mapping(&mut self, id: RegionId, range_in_region: Range<u64>) {
+            self.task
+                .add_mapping(
+                    id,
+                    RegionMappingParams {
+                        range_in_region: MemoryRange::new(range_in_region),
+                        mappable: None,
                         file_offset: 0,
                         writable: true,
                         numa_node: None,
@@ -1250,6 +1356,92 @@ mod tests {
         assert_eq!(
             target.take_events(),
             vec![DmaEvent::Unmap(MemoryRange::new(0x0..0x4000))]
+        );
+    }
+
+    /// Anonymous/private RAM has no backing fd, so its region mappings carry
+    /// `mappable: None`. Such mappings must still drive DMA targets (by host
+    /// VA) — otherwise an assigned device DMAing to private RAM would take
+    /// IOMMU faults. This covers both the replay path (mapper registered after
+    /// the mapping) and the live path (mapping added to an active region).
+    #[async_test]
+    async fn test_dma_private_mapping_maps_by_va(spawn: impl Spawn) {
+        let mut t = DmaTestTask::new(&spawn);
+        let r = t.add_region(0x0..0x10000).await;
+        // Backing-less mapping present before the mapper registers (replay).
+        t.add_private_mapping(r, 0x0..0x4000).await;
+
+        let target = Arc::new(RecordingDmaTarget::default());
+        let id = t.task.add_dma_mapper(target.clone(), false).await.unwrap();
+
+        // Replay must emit a map for the private range, with no backing fd.
+        assert_eq!(
+            target.take_events(),
+            vec![DmaEvent::Map(MemoryRange::new(0x0..0x4000))]
+        );
+        assert_eq!(
+            target.take_backingless_maps(),
+            vec![MemoryRange::new(0x0..0x4000)]
+        );
+
+        // A private mapping added to an already-active region (live path)
+        // must also notify the DMA target by VA.
+        t.add_private_mapping(r, 0x8000..0xC000).await;
+        assert_eq!(
+            target.take_events(),
+            vec![DmaEvent::Map(MemoryRange::new(0x8000..0xC000))]
+        );
+        t.task.remove_dma_mapper(id);
+    }
+
+    /// A DMA target registered with `needs_fd = true` cannot coexist with
+    /// backing-less (private/anonymous RAM) mappings: registration must fail
+    /// when such a mapping already exists.
+    #[async_test]
+    async fn test_needs_fd_rejects_existing_private_mapping(spawn: impl Spawn) {
+        let mut t = DmaTestTask::new(&spawn);
+        let r = t.add_region(0x0..0x10000).await;
+        t.add_private_mapping(r, 0x0..0x4000).await;
+
+        let target = Arc::new(RecordingDmaTarget::default());
+        let result = t.task.add_dma_mapper(target.clone(), true).await;
+        assert!(
+            result.is_err(),
+            "needs_fd mapper must fail to register when private RAM exists"
+        );
+    }
+
+    /// Once a `needs_fd` target is registered, creating a new backing-less
+    /// mapping must fail (while a backed mapping continues to work).
+    #[async_test]
+    async fn test_needs_fd_rejects_new_private_mapping(spawn: impl Spawn) {
+        let mut t = DmaTestTask::new(&spawn);
+        let r = t.add_region(0x0..0x10000).await;
+        // A backed mapping is present; needs_fd registration succeeds.
+        t.add_mapping(r, 0x0..0x4000).await;
+        let target = Arc::new(RecordingDmaTarget::default());
+        let _id = t.task.add_dma_mapper(target.clone(), true).await.unwrap();
+
+        // Adding a backed mapping is still fine.
+        t.add_mapping(r, 0x4000..0x8000).await;
+
+        // Adding a backing-less mapping must now fail.
+        let result = t
+            .task
+            .add_mapping(
+                r,
+                RegionMappingParams {
+                    range_in_region: MemoryRange::new(0x8000..0xC000),
+                    mappable: None,
+                    file_offset: 0,
+                    writable: true,
+                    numa_node: None,
+                },
+            )
+            .await;
+        assert!(
+            result.is_err(),
+            "creating a private mapping must fail while a needs_fd mapper is registered"
         );
     }
 
@@ -1372,7 +1564,7 @@ mod tests {
                 r,
                 RegionMappingParams {
                     range_in_region: MemoryRange::new(0x0..0x4000),
-                    mappable: t.mappable.clone(),
+                    mappable: Some(t.mappable.clone()),
                     file_offset: 0,
                     writable: true,
                     numa_node: None,

--- a/openvmm/membacking/src/region_manager.rs
+++ b/openvmm/membacking/src/region_manager.rs
@@ -8,6 +8,7 @@
 #![expect(unsafe_code)]
 
 use crate::mapping_manager::Mappable;
+use crate::mapping_manager::MappingBacking;
 use crate::mapping_manager::MappingManagerClient;
 use crate::mapping_manager::MappingParams;
 use crate::mapping_manager::VaMapper;
@@ -44,16 +45,15 @@ pub enum MappingType {
 pub struct DmaMapRequest<'a> {
     /// The guest physical address range to map.
     pub range: MemoryRange,
-    /// Host virtual address of the mapping. The region manager always maintains
-    /// an eager `VaMapper` (handing out a VA is free), so a valid, backed VA is
-    /// always provided. Targets that program the IOMMU by VA (VFIO type1,
-    /// iommufd) use this directly.
+    /// Host virtual address of the mapping.
     pub host_va: *const u8,
     /// The backing object (fd or handle) for the mapping, when one exists.
     /// `None` for anonymous/private RAM, which has no backing fd and is
     /// mapped purely by host VA.
     pub mappable: Option<&'a Mappable>,
-    /// Offset within `mappable` where the mapping starts.
+    /// Offset within `mappable` where the mapping starts. Ignored (and always
+    /// zero) when `mappable` is `None`, since private/anonymous RAM has no
+    /// backing object to offset into.
     pub file_offset: u64,
     /// Whether the mapping should allow writes. When `false`, the IOMMU
     /// entry should be read-only.
@@ -125,8 +125,7 @@ struct DmaMapperId(u64);
 /// mapper's eager `VaMapper`.
 struct SubMapping<'a> {
     range: MemoryRange,
-    mappable: Option<&'a Mappable>,
-    file_offset: u64,
+    backing: &'a MappingBacking,
     writable: bool,
     mapping_type: MappingType,
 }
@@ -149,8 +148,8 @@ impl DmaMapper {
         let request = DmaMapRequest {
             range: mapping.range,
             host_va,
-            mappable: mapping.mappable,
-            file_offset: mapping.file_offset,
+            mappable: mapping.backing.mappable(),
+            file_offset: mapping.backing.file_offset(),
             writable: mapping.writable,
             mapping_type: mapping.mapping_type,
         };
@@ -274,7 +273,8 @@ fn inspect_mappings(req: inspect::Request<'_>, region_start: u64, mappings: &[Re
             inspect::adhoc(|req| {
                 req.respond()
                     .field("writable", mapping.params.writable)
-                    .hex("file_offset", mapping.params.file_offset);
+                    .field("backed_by_fd", mapping.params.backing.mappable().is_some())
+                    .hex("file_offset", mapping.params.backing.file_offset());
             }),
         );
     }
@@ -310,12 +310,11 @@ struct RegionMapping {
 #[derive(MeshPayload)]
 struct RegionMappingParams {
     range_in_region: MemoryRange,
-    /// The backing object, or `None` for anonymous/private RAM that has no
-    /// backing fd (and is therefore not mapped via the mapping manager, only
-    /// committed eagerly on the shared `VaMapper` and exposed to DMA targets
-    /// by host VA).
-    mappable: Option<Mappable>,
-    file_offset: u64,
+    /// How the mapping is backed by host memory. File-backed RAM carries a
+    /// [`Mappable`]; private/anonymous RAM uses [`MappingBacking::Private`],
+    /// which has no backing fd (the mapping manager commits its anonymous
+    /// pages directly and it is exposed to DMA targets only by host VA).
+    backing: MappingBacking,
     writable: bool,
     numa_node: Option<u32>,
 }
@@ -422,11 +421,11 @@ impl RegionManagerTask {
         // mappings (private/anonymous RAM, which is exposed only by host VA).
         // Reject registration if any such mapping already exists.
         if needs_fd {
-            if let Some(region) = self
-                .regions
-                .iter()
-                .find(|r| r.mappings.iter().any(|m| m.params.mappable.is_none()))
-            {
+            if let Some(region) = self.regions.iter().find(|r| {
+                r.mappings
+                    .iter()
+                    .any(|m| m.params.backing.mappable().is_none())
+            }) {
                 anyhow::bail!(
                     "cannot register a DMA mapper that requires a backing fd: \
                      region {} contains a mapping with no backing fd (private RAM)",
@@ -454,8 +453,7 @@ impl RegionManagerTask {
                     let writable = mapping.params.writable && region.map_params.unwrap().writable;
                     mapper.map_dma(SubMapping {
                         range,
-                        mappable: mapping.params.mappable.as_ref(),
-                        file_offset: mapping.params.file_offset,
+                        backing: &mapping.params.backing,
                         writable,
                         mapping_type: region.params.mapping_type,
                     })?;
@@ -597,7 +595,10 @@ impl RegionManagerTask {
                 enable = false;
             } else {
                 assert!(enable);
-                self.inner.disable_region(other_region).await;
+                // Overlay disable: a higher/equal-priority region is taking
+                // over this range, so the disabled region may be re-enabled
+                // later. This is transient.
+                self.inner.disable_region(other_region, true).await;
             }
         }
 
@@ -620,7 +621,9 @@ impl RegionManagerTask {
 
         let active_range = region.is_active.then_some(region.params.range);
         if active_range.is_some() {
-            self.inner.disable_region(region).await;
+            // A removal is a permanent teardown; keeping the region registered
+            // (remove == false) is transient, since a re-map can re-enable it.
+            self.inner.disable_region(region, !remove).await;
         }
 
         if remove {
@@ -645,7 +648,8 @@ impl RegionManagerTask {
         // targets only by host VA. A target registered with `needs_fd` cannot
         // consume it, so reject the mapping up front rather than silently
         // skipping that target.
-        if params.mappable.is_none() && self.inner.dma_mappers.iter().any(|m| m.needs_fd) {
+        if params.backing.mappable().is_none() && self.inner.dma_mappers.iter().any(|m| m.needs_fd)
+        {
             anyhow::bail!(
                 "cannot add a mapping with no backing fd: a registered DMA mapper requires one"
             );
@@ -666,39 +670,34 @@ impl RegionManagerTask {
         if let Some(region_range) = region.active_range() {
             let range = range_within(region_range, params.range_in_region);
             let writable = params.writable && region.map_params.unwrap().writable;
-            // Anonymous/private RAM has no backing fd, so there is nothing for
-            // the mapping manager to mmap — the pages are already committed on
-            // the eager VaMapper. Such mappings still drive DMA targets by VA.
-            if let Some(mappable) = &params.mappable {
-                self.inner
-                    .mapping_manager
-                    .add_mapping(MappingParams {
-                        range,
-                        mappable: mappable.clone(),
-                        file_offset: params.file_offset,
-                        writable,
-                        mapping_type: region.params.mapping_type,
-                        numa_node: params.numa_node,
-                    })
-                    .await?;
-            }
+            // Register the mapping with the mapping manager. File-backed RAM is
+            // mmap'd; private/anonymous RAM has its anonymous pages committed
+            // directly. Either way the eager VaMapper ends up with backed pages
+            // that drive the DMA targets below by host VA.
+            self.inner
+                .mapping_manager
+                .add_mapping(MappingParams {
+                    range,
+                    backing: params.backing.clone(),
+                    writable,
+                    mapping_type: region.params.mapping_type,
+                    numa_node: params.numa_node,
+                })
+                .await?;
 
             for (dma_idx, dma_mapper) in self.inner.dma_mappers.iter().enumerate() {
                 if let Err(e) = dma_mapper.map_dma(SubMapping {
                     range,
-                    mappable: params.mappable.as_ref(),
-                    file_offset: params.file_offset,
+                    backing: &params.backing,
                     writable,
                     mapping_type: region.params.mapping_type,
                 }) {
                     // Roll back: unmap from DMA mappers that already
-                    // succeeded, then remove the VA mapping (if any).
+                    // succeeded, then remove the VA mapping.
                     for dm in &self.inner.dma_mappers[..dma_idx] {
                         dm.unmap_dma(range);
                     }
-                    if params.mappable.is_some() {
-                        self.inner.mapping_manager.remove_mappings(range).await;
-                    }
+                    self.inner.mapping_manager.remove_mappings(range).await;
                     return Err(e);
                 }
             }
@@ -773,37 +772,35 @@ impl RegionManagerTaskInner {
         // Add the mappings for the region. On failure, roll back any
         // sub-mappings that were successfully added.
         for (mapped_count, mapping) in region.mappings.iter().enumerate() {
-            // Anonymous/private RAM has no backing fd, so skip the mapping
-            // manager (the pages are already committed on the eager VaMapper)
-            // but still drive the DMA targets below by host VA.
-            if let Some(mappable) = &mapping.params.mappable {
-                if let Err(e) = self
-                    .mapping_manager
-                    .add_mapping(MappingParams {
-                        range: range_within(region.params.range, mapping.params.range_in_region),
-                        mappable: mappable.clone(),
-                        file_offset: mapping.params.file_offset,
-                        writable: mapping.params.writable && map_params.writable,
-                        mapping_type: region.params.mapping_type,
-                        numa_node: mapping.params.numa_node,
-                    })
-                    .await
-                {
-                    // Roll back: remove sub-mappings that were already added.
-                    for prev in &region.mappings[..mapped_count] {
-                        let range = range_within(region.params.range, prev.params.range_in_region);
-                        for dma_mapper in &self.dma_mappers {
-                            dma_mapper.unmap_dma(range);
-                        }
+            // Register the mapping with the mapping manager. File-backed RAM is
+            // mmap'd; private/anonymous RAM has its anonymous pages committed
+            // directly. Either way the eager VaMapper ends up with backed pages
+            // that drive the DMA targets below by host VA.
+            if let Err(e) = self
+                .mapping_manager
+                .add_mapping(MappingParams {
+                    range: range_within(region.params.range, mapping.params.range_in_region),
+                    backing: mapping.params.backing.clone(),
+                    writable: mapping.params.writable && map_params.writable,
+                    mapping_type: region.params.mapping_type,
+                    numa_node: mapping.params.numa_node,
+                })
+                .await
+            {
+                // Roll back: remove sub-mappings that were already added.
+                for prev in &region.mappings[..mapped_count] {
+                    let range = range_within(region.params.range, prev.params.range_in_region);
+                    for dma_mapper in &self.dma_mappers {
+                        dma_mapper.unmap_dma(range);
                     }
-                    self.mapping_manager
-                        .remove_mappings(region.params.range)
-                        .await;
-                    return Err(e).context(format!(
-                        "failed to map {} during region enable",
-                        range_within(region.params.range, mapping.params.range_in_region),
-                    ));
                 }
+                self.mapping_manager
+                    .remove_mappings(region.params.range)
+                    .await;
+                return Err(e).context(format!(
+                    "failed to map {} during region enable",
+                    range_within(region.params.range, mapping.params.range_in_region),
+                ));
             }
 
             // Map into DMA mappers.
@@ -812,8 +809,7 @@ impl RegionManagerTaskInner {
             for (dma_idx, dma_mapper) in self.dma_mappers.iter().enumerate() {
                 if let Err(e) = dma_mapper.map_dma(SubMapping {
                     range,
-                    mappable: mapping.params.mappable.as_ref(),
-                    file_offset: mapping.params.file_offset,
+                    backing: &mapping.params.backing,
                     writable,
                     mapping_type: region.params.mapping_type,
                 }) {
@@ -853,8 +849,28 @@ impl RegionManagerTaskInner {
         Ok(())
     }
 
-    async fn disable_region(&mut self, region: &mut Region) {
+    /// Disables an active region, tearing down its mappings.
+    ///
+    /// `transient` indicates the region may later be re-enabled (an overlay
+    /// disable, or an unmap that keeps the region registered) rather than being
+    /// permanently removed. Private/anonymous RAM is backed solely by the VA
+    /// mapping itself, so tearing it down decommits and zeroes its pages — a
+    /// transient disable of such a region would silently lose guest memory.
+    /// That path is not reachable today (nothing transiently disables a RAM
+    /// region, which is the highest priority), so guard it with an assert to
+    /// turn a future regression into an immediate, located panic rather than
+    /// silent corruption.
+    async fn disable_region(&mut self, region: &mut Region, transient: bool) {
         assert!(region.is_active);
+        assert!(
+            !transient
+                || region
+                    .mappings
+                    .iter()
+                    .all(|m| m.params.backing.mappable().is_some()),
+            "transiently disabling region {} would decommit private RAM and lose its contents",
+            region.params.range,
+        );
 
         tracing::debug!(
             name = region.params.name,
@@ -1053,17 +1069,19 @@ impl RegionHandle {
 
     /// Adds a mapping to the region.
     ///
-    /// `mappable` is the backing object (fd or handle) to mmap, or `None` for
-    /// anonymous/private RAM that has no backing fd. A `None` mapping is not
-    /// programmed into the mapping manager (its pages are already committed on
-    /// the eager `VaMapper`), but it still drives DMA targets by host VA.
+    /// `backing` describes how the mapping is backed by host memory:
+    /// [`MappingBacking::File`] for file/shared-memory-backed RAM (mmap'd by
+    /// the mapping manager) or [`MappingBacking::Private`] for anonymous RAM
+    /// (whose pages the mapping manager commits directly). In both cases the
+    /// mapping manager establishes the backing on the eager `VaMapper`; private
+    /// mappings additionally drive DMA targets only by host VA, since they have
+    /// no backing fd.
     ///
     /// TODO: allow this to split+overwrite existing mappings.
     pub async fn add_mapping(
         &self,
         range_in_region: MemoryRange,
-        mappable: Option<Mappable>,
-        file_offset: u64,
+        backing: MappingBacking,
         writable: bool,
         numa_node: Option<u32>,
     ) -> Result<(), RemoteError> {
@@ -1074,8 +1092,7 @@ impl RegionHandle {
                     self.id.unwrap(),
                     RegionMappingParams {
                         range_in_region,
-                        mappable,
-                        file_offset,
+                        backing,
                         writable,
                         numa_node,
                     },
@@ -1118,6 +1135,7 @@ mod tests {
     use super::MapParams;
     use super::RegionManagerTask;
     use crate::mapping_manager::Mappable;
+    use crate::mapping_manager::MappingBacking;
     use crate::mapping_manager::MappingManager;
     use crate::region_manager::AddRegionError;
     use crate::region_manager::DmaMapRequest;
@@ -1282,8 +1300,10 @@ mod tests {
                     id,
                     RegionMappingParams {
                         range_in_region: MemoryRange::new(range_in_region),
-                        mappable: Some(self.mappable.clone()),
-                        file_offset: 0,
+                        backing: MappingBacking::File {
+                            mappable: self.mappable.clone(),
+                            file_offset: 0,
+                        },
                         writable: true,
                         numa_node: None,
                     },
@@ -1299,8 +1319,9 @@ mod tests {
                     id,
                     RegionMappingParams {
                         range_in_region: MemoryRange::new(range_in_region),
-                        mappable: None,
-                        file_offset: 0,
+                        backing: MappingBacking::Private {
+                            transparent_hugepages: false,
+                        },
                         writable: true,
                         numa_node: None,
                     },
@@ -1432,8 +1453,9 @@ mod tests {
                 r,
                 RegionMappingParams {
                     range_in_region: MemoryRange::new(0x8000..0xC000),
-                    mappable: None,
-                    file_offset: 0,
+                    backing: MappingBacking::Private {
+                        transparent_hugepages: false,
+                    },
                     writable: true,
                     numa_node: None,
                 },
@@ -1564,8 +1586,10 @@ mod tests {
                 r,
                 RegionMappingParams {
                     range_in_region: MemoryRange::new(0x0..0x4000),
-                    mappable: Some(t.mappable.clone()),
-                    file_offset: 0,
+                    backing: MappingBacking::File {
+                        mappable: t.mappable.clone(),
+                        file_offset: 0,
+                    },
                     writable: true,
                     numa_node: None,
                 },

--- a/vm/devices/pci/vfio_assigned_device/src/manager.rs
+++ b/vm/devices/pci/vfio_assigned_device/src/manager.rs
@@ -32,9 +32,7 @@ struct VfioType1DmaTarget {
 
 impl membacking::DmaTarget for VfioType1DmaTarget {
     unsafe fn map_dma(&self, request: membacking::DmaMapRequest<'_>) -> anyhow::Result<()> {
-        let vaddr = request
-            .host_va
-            .expect("VFIO type1 requires host VA (registered with needs_va=true)");
+        let vaddr = request.host_va;
         let range = request.range;
         let _span = tracing::info_span!("vfio map", %range).entered();
         // SAFETY: The caller (DmaMapper in membacking) guarantees that the
@@ -432,13 +430,14 @@ impl VfioContainerManager {
             container: container.clone(),
         });
 
-        // Register as a DMA mapper — the region manager will create a
-        // VaMapper internally (since needs_va is true) and replay all
-        // existing active sub-mappings (guest RAM + any active device
-        // BARs) into this container's IOMMU.
+        // Register as a DMA mapper. This target programs the IOMMU by host VA,
+        // so it does not require a backing fd (needs_fd = false) and is
+        // compatible with private RAM. The region manager replays all existing
+        // active sub-mappings (guest RAM + any active device BARs) into this
+        // container's IOMMU.
         let dma_handle = self
             .dma_mapper_client
-            .add_dma_mapper(dma_target, true)
+            .add_dma_mapper(dma_target, false)
             .await
             .context("failed to register VFIO container with region manager")?;
 
@@ -480,9 +479,7 @@ struct IommufdDmaTarget {
 
 impl membacking::DmaTarget for IommufdDmaTarget {
     unsafe fn map_dma(&self, request: membacking::DmaMapRequest<'_>) -> anyhow::Result<()> {
-        let vaddr = request
-            .host_va
-            .expect("iommufd IOAS map requires host VA (registered with needs_va=true)");
+        let vaddr = request.host_va;
         let range = request.range;
         let iova = range.start();
         let user_va = vaddr as u64;
@@ -595,8 +592,10 @@ impl IoasManager {
             ctx: ctx.clone(),
             ioas_id,
         });
+        // This target programs the IOMMU by host VA, so it does not require a
+        // backing fd (needs_fd = false) and is compatible with private RAM.
         let dma_handle = dma_mapper_client
-            .add_dma_mapper(dma_target, true)
+            .add_dma_mapper(dma_target, false)
             .await
             .context("failed to register iommufd IOAS with region manager")?;
 


### PR DESCRIPTION
Private anonymous guest RAM was not represented in region mappings, so it was never programmed into DMA targets. The private-memory builder committed pages directly into the eager VaMapper and skipped add_mapping, while IOMMU mappings are driven from region mappings. As a result, --private-memory with an assigned device caused DMA into private RAM to fault in the IOMMU.

Register private RAM as a region mapping without a backing fd. These mappings skip the mapping-manager mmap because the pages are already committed, but still provide the host VA used by DMA targets. This lets private RAM flow through the same DMA mapping machinery as shared RAM.