### PR TITLE
user_driver: fix VFIO msi-x unmap

### DIFF
--- a/vm/devices/pci/vfio_assigned_device/src/lib.rs
+++ b/vm/devices/pci/vfio_assigned_device/src/lib.rs
@@ -585,14 +585,11 @@ impl VfioAssignedPciDevice {
     }
 
     /// Tear down VFIO MSI-X eventfd mapping when the guest disables MSI-X.
+    ///
+    /// Callers must only invoke this when MSI-X is currently enabled (the
+    /// kernel returns EINVAL otherwise).
     fn msix_disable(&mut self) {
-        let count = self
-            .msix
-            .as_ref()
-            .expect("msix must be present")
-            .vector_count;
-
-        if let Err(e) = self.vfio_device.device.unmap_msix(0, count as u32) {
+        if let Err(e) = self.vfio_device.device.unmap_msix() {
             tracing::warn!(
                 error = e.as_ref() as &dyn std::error::Error,
                 pci_id = self.pci_id.as_str(),

--- a/vm/devices/user_driver/src/vfio.rs
+++ b/vm/devices/user_driver/src/vfio.rs
@@ -414,9 +414,8 @@ impl DeviceBacking for VfioDevice {
             return Ok(());
         }
 
-        let count = self.interrupts.len() as u32;
         self.device
-            .unmap_msix(0, count)
+            .unmap_msix()
             .context("failed to unmap all msix vectors")?;
 
         // Clear local bookkeeping so re-mapping works correctly later.

--- a/vm/devices/user_driver/src/vfio.rs
+++ b/vm/devices/user_driver/src/vfio.rs
@@ -410,7 +410,7 @@ impl DeviceBacking for VfioDevice {
     }
 
     fn unmap_all_interrupts(&mut self) -> anyhow::Result<()> {
-        if self.interrupts.is_empty() {
+        if self.interrupts.iter().all(|i| i.is_none()) {
             return Ok(());
         }
 

--- a/vm/devices/user_driver/vfio_sys/src/lib.rs
+++ b/vm/devices/user_driver/vfio_sys/src/lib.rs
@@ -670,22 +670,23 @@ impl Device {
         Ok(())
     }
 
-    /// Disable (unmap) a contiguous range of previously mapped MSI-X vectors.
+    /// Disable MSI-X for this device, tearing down all eventfd bindings.
     ///
-    /// This issues VFIO_DEVICE_SET_IRQS with ACTION_TRIGGER + DATA_NONE and a
-    /// non-zero count, which per VFIO semantics removes the eventfd bindings
-    /// for the specified range starting at `start`.
-    pub fn unmap_msix(&self, start: u32, count: u32) -> anyhow::Result<()> {
-        if count == 0 {
-            return Ok(());
-        }
-
+    /// VFIO does not support disabling a subset of MSI-X vectors via DATA_NONE:
+    /// per `vfio_pci_set_msi_trigger` in the kernel, the only teardown form is
+    /// ACTION_TRIGGER | DATA_NONE with `count == 0`, which disables MSI-X
+    /// entirely. (A non-zero count with DATA_NONE is instead interpreted as a
+    /// loopback signal request that fires each vector's eventfd and unmaps
+    /// nothing.) This therefore always disables all vectors, and the caller
+    /// must only invoke it when MSI-X is currently enabled — otherwise the
+    /// kernel returns EINVAL.
+    pub fn unmap_msix(&self) -> anyhow::Result<()> {
         let header = vfio_irq_set {
             argsz: size_of::<vfio_irq_set>() as u32,
             flags: VFIO_IRQ_SET_ACTION_TRIGGER | VFIO_IRQ_SET_DATA_NONE,
             index: VFIO_PCI_MSIX_IRQ_INDEX,
-            start,
-            count,
+            start: 0,
+            count: 0,
             data: Default::default(),
         };
 


### PR DESCRIPTION
The VFIO code in user_driver passes the wrong parameters the IOCTL it uses to unmap interrupts. Fix this.