### PR TITLE
consomme: send window updates when the TCP receive window reopens

### DIFF
--- a/vm/devices/net/net_consomme/consomme/src/tcp.rs
+++ b/vm/devices/net/net_consomme/consomme/src/tcp.rs
@@ -1278,8 +1278,9 @@ impl TcpConnectionInner {
 
     /// Whether draining to the host reopened the receive window enough to
     /// re-advertise it (RFC 1122 §4.2.3.3 receiver SWS avoidance). Fires once on
-    /// the closed-to-open transition, and only once the guest can see a full
-    /// segment post-scale-truncation, so it never emits a sub-MSS update.
+    /// the closed-to-open transition, once the guest-visible (post-scale-
+    /// truncation) window reaches the reopen threshold: a full segment, or half
+    /// the window cap when the cap is smaller than one segment.
     fn should_reopen_window(&self) -> bool {
         let reopen_threshold = self.tx_mss.min(self.rx_window_cap / 2);
         self.rx_window_last_adv < reopen_threshold

--- a/vm/devices/net/net_consomme/consomme/src/tcp.rs
+++ b/vm/devices/net/net_consomme/consomme/src/tcp.rs
@@ -1268,10 +1268,12 @@ impl TcpConnectionInner {
         (self.rx_window_avail() >> self.rx_window_scale) << self.rx_window_scale
     }
 
-    /// Record the window just advertised to the guest. Tracks the post-scale
-    /// value the guest reconstructs so the reopen check stays accurate.
-    fn record_advertised_window(&mut self) {
-        self.rx_window_last_adv = self.rx_window_advertised();
+    /// Record the window just advertised to the guest. `window_len` is the
+    /// scaled value placed on the wire; the guest shifts it back up by the
+    /// window scale, so track that reconstructed value to keep the reopen
+    /// check accurate.
+    fn record_advertised_window(&mut self, window_len: u16) {
+        self.rx_window_last_adv = (window_len as usize) << self.rx_window_scale;
     }
 
     /// Whether draining to the host reopened the receive window enough to
@@ -1364,13 +1366,14 @@ impl TcpConnectionInner {
                 break;
             }
 
+            let window_len = self.rx_window_len();
             let mut tcp = TcpRepr {
                 src_port: sender.ft.dst.port(),
                 dst_port: sender.ft.src.port(),
                 control: TcpControl::None,
                 seq_number: self.tx_send,
                 ack_number: Some(self.rx_seq),
-                window_len: self.rx_window_len(),
+                window_len,
                 window_scale: None,
                 max_seg_size: None,
                 sack_permitted: false,
@@ -1455,7 +1458,7 @@ impl TcpConnectionInner {
             self.stats.tx_segment_size.add_sample(payload_len as u64);
             self.tx_send = tx_next;
             self.needs_ack = false;
-            self.record_advertised_window();
+            self.record_advertised_window(window_len);
         }
 
         assert!(self.tx_send <= tx_end);
@@ -1487,13 +1490,14 @@ impl TcpConnectionInner {
     /// shouldn't be combined with data so that they are interpreted correctly
     /// by the peer.
     fn ack(&mut self, sender: &mut Sender<'_, impl Client>) {
+        let window_len = self.rx_window_len();
         let tcp = TcpRepr {
             src_port: sender.ft.dst.port(),
             dst_port: sender.ft.src.port(),
             control: TcpControl::None,
             seq_number: self.tx_send,
             ack_number: Some(self.rx_seq),
-            window_len: self.rx_window_len(),
+            window_len,
             window_scale: None,
             max_seg_size: None,
             sack_permitted: false,
@@ -1506,7 +1510,7 @@ impl TcpConnectionInner {
 
         sender.send_packet(&tcp, None);
         self.stats.standalone_acks_tx.increment();
-        self.record_advertised_window();
+        self.record_advertised_window(window_len);
     }
 
     fn handle_listen_syn(

--- a/vm/devices/net/net_consomme/consomme/src/tcp.rs
+++ b/vm/devices/net/net_consomme/consomme/src/tcp.rs
@@ -193,6 +193,10 @@ struct TcpConnectionInner {
     rx_buffer_max: usize,
     #[inspect(with = "inspect_seq")]
     rx_seq: TcpSeqNumber,
+    /// Window last advertised to the guest, as it reconstructs it after
+    /// window-scale truncation. Used to detect a zero-window reopen.
+    #[inspect(hex)]
+    rx_window_last_adv: usize,
     #[inspect(flatten)]
     rx_assembler: assembler::Assembler,
     needs_ack: bool,
@@ -778,6 +782,7 @@ impl TcpConnection {
             rx_window_scale,
             rx_buffer_max: rx_bounds.max,
             rx_seq,
+            rx_window_last_adv: rx_bounds.initial,
             rx_assembler: assembler::Assembler::new(),
             needs_ack: false,
             is_shutdown: false,
@@ -1175,6 +1180,11 @@ impl TcpConnectionInner {
                     Poll::Pending => break,
                 }
             }
+            // Draining to the host may have reopened the window; re-advertise it
+            // so the guest resumes without waiting on its persist timer.
+            if self.should_reopen_window() {
+                self.needs_ack = true;
+            }
             // Autotune: if the host kept up (drained to empty) and the buffer
             // was at least 75% full this cycle, the guest is rx-bound. Grow
             // both the ring and the advertised window ceiling so the next ACK
@@ -1243,7 +1253,35 @@ impl TcpConnectionInner {
     }
 
     fn rx_window_len(&self) -> u16 {
-        ((self.rx_window_cap - self.rx_buffer.len()) >> self.rx_window_scale) as u16
+        (self.rx_window_avail() >> self.rx_window_scale) as u16
+    }
+
+    /// Available receive window in unscaled bytes.
+    fn rx_window_avail(&self) -> usize {
+        self.rx_window_cap - self.rx_buffer.len()
+    }
+
+    /// The receive window as the guest reconstructs it: `rx_window_avail`
+    /// rounded down to the scale quantum, since the low `rx_window_scale` bits
+    /// are not transmitted. Equals `rx_window_avail` when scaling is off.
+    fn rx_window_advertised(&self) -> usize {
+        (self.rx_window_avail() >> self.rx_window_scale) << self.rx_window_scale
+    }
+
+    /// Record the window just advertised to the guest. Tracks the post-scale
+    /// value the guest reconstructs so the reopen check stays accurate.
+    fn record_advertised_window(&mut self) {
+        self.rx_window_last_adv = self.rx_window_advertised();
+    }
+
+    /// Whether draining to the host reopened the receive window enough to
+    /// re-advertise it (RFC 1122 §4.2.3.3 receiver SWS avoidance). Fires once on
+    /// the closed-to-open transition, and only once the guest can see a full
+    /// segment post-scale-truncation, so it never emits a sub-MSS update.
+    fn should_reopen_window(&self) -> bool {
+        let reopen_threshold = self.tx_mss.min(self.rx_window_cap / 2);
+        self.rx_window_last_adv < reopen_threshold
+            && self.rx_window_advertised() >= reopen_threshold
     }
 
     fn send_next(&mut self, sender: &mut Sender<'_, impl Client>, ack_policy: AckPolicy) {
@@ -1263,6 +1301,15 @@ impl TcpConnectionInner {
         // (even with no shift) to enable window scale support.
         let window_scale = self.enable_window_scaling.then_some(self.rx_window_scale);
 
+        // RFC 7323 §2.2: the window in a SYN/SYN-ACK is not scaled even with the
+        // window_scale option present. Advertise the real window clamped to 16
+        // bits; the active-open SYN (no ACK) carries a zero window.
+        let window_len = if ack_number.is_some() {
+            self.rx_window_avail().min(u16::MAX as usize) as u16
+        } else {
+            0
+        };
+
         // Advertise the maximum possible segment size, allowing the guest
         // to truncate this to its own MTU calculation.
         let max_seg_size = u16::MAX;
@@ -1272,11 +1319,7 @@ impl TcpConnectionInner {
             control: TcpControl::Syn,
             seq_number: self.tx_send,
             ack_number,
-            window_len: if ack_number.is_some() {
-                self.rx_window_len()
-            } else {
-                0
-            },
+            window_len,
             window_scale,
             max_seg_size: Some(max_seg_size),
             sack_permitted: false,
@@ -1287,6 +1330,10 @@ impl TcpConnectionInner {
 
         sender.send_packet(&tcp, None);
         self.tx_send += 1;
+        if ack_number.is_some() {
+            // The guest reads the SYN-ACK window unscaled, so record that value.
+            self.rx_window_last_adv = window_len as usize;
+        }
     }
 
     fn send_data(&mut self, sender: &mut Sender<'_, impl Client>, ack_policy: AckPolicy) {
@@ -1408,6 +1455,7 @@ impl TcpConnectionInner {
             self.stats.tx_segment_size.add_sample(payload_len as u64);
             self.tx_send = tx_next;
             self.needs_ack = false;
+            self.record_advertised_window();
         }
 
         assert!(self.tx_send <= tx_end);
@@ -1458,6 +1506,7 @@ impl TcpConnectionInner {
 
         sender.send_packet(&tcp, None);
         self.stats.standalone_acks_tx.increment();
+        self.record_advertised_window();
     }
 
     fn handle_listen_syn(

--- a/vm/devices/net/net_consomme/consomme/src/tcp/tests.rs
+++ b/vm/devices/net/net_consomme/consomme/src/tcp/tests.rs
@@ -1884,7 +1884,7 @@ async fn test_tcp_record_advertised_window_truncates_with_scale(driver: DefaultD
     // scale-aligned to force truncation, including one just above a segment.
     for cap in [(1usize << scale) + 1, 1460, 64 << 10, (4 << 20) - 1] {
         inner.rx_window_cap = cap;
-        inner.record_advertised_window();
+        inner.record_advertised_window(inner.rx_window_len());
         let reconstructed = (inner.rx_window_len() as usize) << scale;
         assert_eq!(
             inner.rx_window_last_adv, reconstructed,
@@ -1932,7 +1932,7 @@ async fn test_tcp_should_reopen_window_waits_for_full_segment(driver: DefaultDri
         inner.should_reopen_window(),
         "reopen must fire once a full segment is advertisable"
     );
-    inner.record_advertised_window();
+    inner.record_advertised_window(inner.rx_window_len());
     assert!(
         !inner.should_reopen_window(),
         "reopen must disarm after advertising, not re-fire every poll"

--- a/vm/devices/net/net_consomme/consomme/src/tcp/tests.rs
+++ b/vm/devices/net/net_consomme/consomme/src/tcp/tests.rs
@@ -528,8 +528,9 @@ impl TcpTestHarness {
     }
 
     /// Flood guest→host data (without reading the host socket) until the
-    /// advertised receive window closes to zero. Only sends segments that fit
-    /// the current window, so nothing is dropped. Returns bytes accepted.
+    /// available receive buffer (`rx_window_avail`) reaches zero, which drives
+    /// the advertised window to zero. Only sends segments that fit the current
+    /// window, so nothing is dropped. Returns bytes accepted.
     async fn flood_guest_until_window_closed(&mut self) -> usize {
         let guest_mac = self.guest_mac;
         let gateway_mac = self.gateway_mac;

--- a/vm/devices/net/net_consomme/consomme/src/tcp/tests.rs
+++ b/vm/devices/net/net_consomme/consomme/src/tcp/tests.rs
@@ -503,19 +503,6 @@ impl TcpTestHarness {
             .inner
     }
 
-    /// Mutably borrow the established connection's inner state, for tests that
-    /// poke internal fields directly.
-    fn connection_inner_mut(&mut self) -> &mut TcpConnectionInner {
-        let ft = self.four_tuple();
-        &mut self
-            .consomme
-            .tcp
-            .connections
-            .get_mut(&ft)
-            .expect("connection should exist")
-            .inner
-    }
-
     /// Poll consomme until `cond` holds for the established connection, leaving
     /// the future pending between polls so the async reactor can run and socket
     /// readiness can fire.
@@ -1866,75 +1853,5 @@ async fn test_tcp_zero_window_reopen_sends_update(driver: DefaultDriver) {
         window_update.is_some_and(|w| w > 0),
         "consomme must proactively re-advertise a non-zero window after the \
          host drains the backlog; got {window_update:?}"
-    );
-}
-
-/// Regression: with window scaling active, the recorded "last advertised"
-/// window must be the value the guest reconstructs after `>> rx_window_scale`
-/// truncation, not the raw bytes. Tracking raw bytes would disarm the reopen
-/// check while the guest still sees a sub-segment window and stalls (sender
-/// SWS). Uses the default scale 7, which the 16 KiB (scale 0) test cannot.
-#[pal_async::async_test]
-async fn test_tcp_record_advertised_window_truncates_with_scale(driver: DefaultDriver) {
-    let mut h = TcpTestHarness::connect(driver).await;
-    let inner = h.connection_inner_mut();
-    let scale = inner.rx_window_scale;
-    assert!(scale > 0, "default config should negotiate window scaling");
-    // Empty buffer, so `rx_window_avail` tracks the cap. Use caps that are not
-    // scale-aligned to force truncation, including one just above a segment.
-    for cap in [(1usize << scale) + 1, 1460, 64 << 10, (4 << 20) - 1] {
-        inner.rx_window_cap = cap;
-        inner.record_advertised_window(inner.rx_window_len());
-        let reconstructed = (inner.rx_window_len() as usize) << scale;
-        assert_eq!(
-            inner.rx_window_last_adv, reconstructed,
-            "recorded window must equal the guest-reconstructed value (cap={cap})"
-        );
-        assert!(
-            inner.rx_window_last_adv <= inner.rx_window_avail(),
-            "recorded window must never exceed actual availability (cap={cap})"
-        );
-    }
-}
-
-/// Regression for the reopen gate under active window scaling: it must fire only
-/// once the guest can see a full segment (post-truncation), and must not keep
-/// re-arming when the window reopens to a scale-truncated sub-segment size.
-#[pal_async::async_test]
-async fn test_tcp_should_reopen_window_waits_for_full_segment(driver: DefaultDriver) {
-    let mut h = TcpTestHarness::connect(driver).await;
-    let inner = h.connection_inner_mut();
-    let scale = inner.rx_window_scale;
-    assert!(scale > 0, "default config should negotiate window scaling");
-    let mss = inner.tx_mss;
-    let quantum = 1usize << scale;
-    assert!(mss % quantum != 0, "test assumes mss is not scale-aligned");
-
-    // Occupy part of the (empty) ring so we can set `avail` independently of the
-    // window cap, keeping the reopen threshold a full segment (cap/2 >= mss).
-    let base = inner.rx_buffer.capacity() / 2;
-    inner.rx_buffer.extend_by(base);
-    // Simulate a window that just closed to zero.
-    inner.rx_window_last_adv = 0;
-
-    // Reopened to exactly one segment, but truncation drops what the guest sees
-    // below a segment (e.g. 1460 -> 1408 at scale 7): the gate must NOT fire.
-    inner.rx_window_cap = base + mss;
-    assert!(
-        !inner.should_reopen_window(),
-        "reopen must not fire while the guest would see a sub-segment window"
-    );
-
-    // Reopened to the next scale multiple at or above a segment: fire exactly
-    // once, then disarm after recording (no per-poll re-arming).
-    inner.rx_window_cap = base + mss.next_multiple_of(quantum);
-    assert!(
-        inner.should_reopen_window(),
-        "reopen must fire once a full segment is advertisable"
-    );
-    inner.record_advertised_window(inner.rx_window_len());
-    assert!(
-        !inner.should_reopen_window(),
-        "reopen must disarm after advertising, not re-fire every poll"
     );
 }

--- a/vm/devices/net/net_consomme/consomme/src/tcp/tests.rs
+++ b/vm/devices/net/net_consomme/consomme/src/tcp/tests.rs
@@ -17,6 +17,7 @@ use parking_lot::Mutex;
 use smoltcp::wire::EthernetAddress;
 use smoltcp::wire::Ipv4Address;
 use smoltcp::wire::Ipv4Repr;
+use socket2::SockRef;
 use std::io::ErrorKind;
 use std::net::Ipv4Addr;
 use std::net::Ipv6Addr;
@@ -502,6 +503,19 @@ impl TcpTestHarness {
             .inner
     }
 
+    /// Mutably borrow the established connection's inner state, for tests that
+    /// poke internal fields directly.
+    fn connection_inner_mut(&mut self) -> &mut TcpConnectionInner {
+        let ft = self.four_tuple();
+        &mut self
+            .consomme
+            .tcp
+            .connections
+            .get_mut(&ft)
+            .expect("connection should exist")
+            .inner
+    }
+
     /// Poll consomme until `cond` holds for the established connection, leaving
     /// the future pending between polls so the async reactor can run and socket
     /// readiness can fire.
@@ -524,6 +538,114 @@ impl TcpTestHarness {
             }
         })
         .await;
+    }
+
+    /// Flood guest→host data (without reading the host socket) until the
+    /// advertised receive window closes to zero. Only sends segments that fit
+    /// the current window, so nothing is dropped. Returns bytes accepted.
+    async fn flood_guest_until_window_closed(&mut self) -> usize {
+        let guest_mac = self.guest_mac;
+        let gateway_mac = self.gateway_mac;
+        let guest_ip = self.guest_ip;
+        let dst_ip = self.dst_ip;
+        let guest_port = self.guest_port;
+        let dst_port = self.dst_port;
+        let server_ack = self.server_ack;
+        let ft = self.four_tuple();
+
+        let consomme = &mut self.consomme;
+        let client = &mut self.client;
+        // Deliberately do NOT read `host_stream`: the path backs up so the
+        // receive window fills.
+        let guest_seq = &mut self.guest_seq;
+        let mut buf = vec![0u8; 1514];
+        let payload = [0x5Au8; 1400];
+        let mut total = 0usize;
+        // Safety cap so a regression can't loop forever.
+        let mut budget = 64 << 20;
+        std::future::poll_fn(move |cx| {
+            consomme.access(client).poll(cx);
+            let avail = consomme
+                .tcp
+                .connections
+                .get(&ft)
+                .expect("connection should exist")
+                .inner
+                .rx_window_avail();
+            if avail == 0 || budget == 0 {
+                return Poll::Ready(total);
+            }
+            let n = avail.min(payload.len()).min(budget);
+            let tcp = TcpRepr {
+                src_port: guest_port,
+                dst_port,
+                control: TcpControl::None,
+                seq_number: *guest_seq,
+                ack_number: Some(server_ack),
+                window_len: 64240,
+                window_scale: None,
+                max_seg_size: None,
+                sack_permitted: false,
+                sack_ranges: [None, None, None],
+                timestamp: None,
+                payload: &payload[..n],
+            };
+            let len = build_tcp_packet(&mut buf, guest_mac, gateway_mac, guest_ip, dst_ip, &tcp);
+            consomme
+                .access(client)
+                .send(&buf[..len], &ChecksumState::NONE)
+                .unwrap();
+            *guest_seq += n;
+            total += n;
+            budget -= n;
+            // Re-poll promptly to keep pushing; once the host socket buffers
+            // fill, consomme stops draining and `avail` reaches zero.
+            cx.waker().wake_by_ref();
+            Poll::Pending
+        })
+        .await
+    }
+
+    /// Drain the host socket while polling consomme, waiting for a guest-bound
+    /// ACK that advertises a non-zero receive window. Returns the advertised
+    /// window length, or `None` if no such packet appeared within a few
+    /// seconds.
+    async fn drain_host_until_window_update(&mut self) -> Option<u16> {
+        let mut timer = pal_async::timer::PolledTimer::new(self.client.driver());
+        let received = self.client.received_packets.clone();
+        let consomme = &mut self.consomme;
+        let client = &mut self.client;
+        let host_stream = &mut self.host_stream;
+        let poll = std::future::poll_fn(move |cx| {
+            consomme.access(client).poll(cx);
+            // Drain the host socket so the receive window reopens. Registers a
+            // read-readiness waker on Pending so we are re-polled as more data
+            // arrives.
+            let mut rb = [0u8; 4096];
+            loop {
+                match Pin::new(&mut *host_stream).poll_read(cx, &mut rb) {
+                    Poll::Ready(Ok(0)) => break,
+                    Poll::Ready(Ok(_)) => {}
+                    Poll::Ready(Err(e)) => panic!("host read error: {e}"),
+                    Poll::Pending => break,
+                }
+            }
+            let found = received.lock().iter().rev().find_map(|p| {
+                let t = TcpTestHarness::is_tcp_packet(p)?;
+                (t.ack_number.is_some() && t.window_len > 0).then_some(t.window_len)
+            });
+            match found {
+                Some(w) => Poll::Ready(w),
+                None => Poll::Pending,
+            }
+        });
+        let timeout = timer.sleep(std::time::Duration::from_secs(5));
+        let poll = std::pin::pin!(poll);
+        let timeout = std::pin::pin!(timeout);
+        match futures::future::select(poll, timeout).await {
+            futures::future::Either::Left((w, _)) => Some(w),
+            futures::future::Either::Right(_) => None,
+        }
     }
 }
 
@@ -1226,20 +1348,15 @@ async fn test_tcp_window_scale_activation(driver: DefaultDriver) {
         "SYN-ACK should include window_scale option when SYN had one"
     );
     let syn_ack_window_scale = syn_ack.window_scale.unwrap();
-    // The window_len in SYN-ACK is the unscaled value — it represents
-    // the actual receive window without any shift applied. Verify that
-    // the effective (scaled) window represents a valid receive buffer
-    // size (between 16KB min and 4MB max per the clamp in new_base).
-    // If the SYN-ACK window field were incorrectly pre-scaled, the
-    // effective value would be unreasonably large.
-    let effective_rx_window = (syn_ack.window_len as usize) << syn_ack_window_scale;
-    assert!(
-        (16384..=4 * 1024 * 1024).contains(&effective_rx_window),
-        "SYN-ACK effective window (unscaled={}, scale={}, effective={}) \
-         should represent a valid receive buffer size",
-        syn_ack.window_len,
-        syn_ack_window_scale,
-        effective_rx_window,
+    // RFC 7323 §2.2: the window field in a SYN/SYN-ACK is NOT scaled, even
+    // though the window_scale option is present. The guest reads window_len
+    // verbatim, so it must carry the real receive window (the 16 KiB initial
+    // cap), not a pre-shifted value. If it were pre-scaled (>> 7), the guest
+    // would see only 128 bytes and stall at connection start.
+    assert_eq!(
+        syn_ack.window_len as usize,
+        16 * 1024,
+        "SYN-ACK must advertise the unscaled receive window (scale={syn_ack_window_scale})",
     );
 
     // Now complete the handshake with an ACK that has a small window.
@@ -1706,5 +1823,118 @@ async fn test_tcp_tx_buffer_autotune_caps_at_max(driver: DefaultDriver) {
         cap,
         32 << 10,
         "tx ring must cap at the configured 32 KiB max"
+    );
+}
+
+/// Regression test: after the guest egress fills the receive window and it
+/// later reopens (host drains), consomme must send an unsolicited window-update
+/// ACK rather than waiting for the guest's zero-window probe.
+#[pal_async::async_test]
+async fn test_tcp_zero_window_reopen_sends_update(driver: DefaultDriver) {
+    let mut params = ConsommeParams::new().unwrap();
+    // Small, fixed receive window so it closes quickly and autotune can't grow
+    // it (which would mask the reopen path via its own `needs_ack`).
+    params.tcp_rx_buffer = crate::TcpBufferBounds {
+        initial: 16 << 10,
+        max: 16 << 10,
+    };
+    let mut h = TcpTestHarness::connect_with_params(driver, params).await;
+
+    // Shrink the host receive buffer so the egress path backs up after only a
+    // modest amount of data, keeping the flood bounded.
+    SockRef::from(h.host_stream.get())
+        .set_recv_buffer_size(8 << 10)
+        .unwrap();
+
+    // Flood until consomme's advertised receive window closes to zero.
+    let sent = h.flood_guest_until_window_closed().await;
+    assert_eq!(
+        h.connection_inner().rx_window_avail(),
+        0,
+        "receive window should have closed after flooding {sent} bytes"
+    );
+    assert!(
+        h.connection_inner().rx_window_last_adv < h.connection_inner().tx_mss,
+        "consomme should have advertised a (near) zero window to the guest"
+    );
+
+    // Discard the zero-window ACKs, then drain the host socket. Consomme must
+    // emit a window-update ACK on its own, without the guest probing.
+    h.clear_guest_packets();
+    let window_update = h.drain_host_until_window_update().await;
+    assert!(
+        window_update.is_some_and(|w| w > 0),
+        "consomme must proactively re-advertise a non-zero window after the \
+         host drains the backlog; got {window_update:?}"
+    );
+}
+
+/// Regression: with window scaling active, the recorded "last advertised"
+/// window must be the value the guest reconstructs after `>> rx_window_scale`
+/// truncation, not the raw bytes. Tracking raw bytes would disarm the reopen
+/// check while the guest still sees a sub-segment window and stalls (sender
+/// SWS). Uses the default scale 7, which the 16 KiB (scale 0) test cannot.
+#[pal_async::async_test]
+async fn test_tcp_record_advertised_window_truncates_with_scale(driver: DefaultDriver) {
+    let mut h = TcpTestHarness::connect(driver).await;
+    let inner = h.connection_inner_mut();
+    let scale = inner.rx_window_scale;
+    assert!(scale > 0, "default config should negotiate window scaling");
+    // Empty buffer, so `rx_window_avail` tracks the cap. Use caps that are not
+    // scale-aligned to force truncation, including one just above a segment.
+    for cap in [(1usize << scale) + 1, 1460, 64 << 10, (4 << 20) - 1] {
+        inner.rx_window_cap = cap;
+        inner.record_advertised_window();
+        let reconstructed = (inner.rx_window_len() as usize) << scale;
+        assert_eq!(
+            inner.rx_window_last_adv, reconstructed,
+            "recorded window must equal the guest-reconstructed value (cap={cap})"
+        );
+        assert!(
+            inner.rx_window_last_adv <= inner.rx_window_avail(),
+            "recorded window must never exceed actual availability (cap={cap})"
+        );
+    }
+}
+
+/// Regression for the reopen gate under active window scaling: it must fire only
+/// once the guest can see a full segment (post-truncation), and must not keep
+/// re-arming when the window reopens to a scale-truncated sub-segment size.
+#[pal_async::async_test]
+async fn test_tcp_should_reopen_window_waits_for_full_segment(driver: DefaultDriver) {
+    let mut h = TcpTestHarness::connect(driver).await;
+    let inner = h.connection_inner_mut();
+    let scale = inner.rx_window_scale;
+    assert!(scale > 0, "default config should negotiate window scaling");
+    let mss = inner.tx_mss;
+    let quantum = 1usize << scale;
+    assert!(mss % quantum != 0, "test assumes mss is not scale-aligned");
+
+    // Occupy part of the (empty) ring so we can set `avail` independently of the
+    // window cap, keeping the reopen threshold a full segment (cap/2 >= mss).
+    let base = inner.rx_buffer.capacity() / 2;
+    inner.rx_buffer.extend_by(base);
+    // Simulate a window that just closed to zero.
+    inner.rx_window_last_adv = 0;
+
+    // Reopened to exactly one segment, but truncation drops what the guest sees
+    // below a segment (e.g. 1460 -> 1408 at scale 7): the gate must NOT fire.
+    inner.rx_window_cap = base + mss;
+    assert!(
+        !inner.should_reopen_window(),
+        "reopen must not fire while the guest would see a sub-segment window"
+    );
+
+    // Reopened to the next scale multiple at or above a segment: fire exactly
+    // once, then disarm after recording (no per-poll re-arming).
+    inner.rx_window_cap = base + mss.next_multiple_of(quantum);
+    assert!(
+        inner.should_reopen_window(),
+        "reopen must fire once a full segment is advertisable"
+    );
+    inner.record_advertised_window();
+    assert!(
+        !inner.should_reopen_window(),
+        "reopen must disarm after advertising, not re-fire every poll"
     );
 }


### PR DESCRIPTION
## Problem

Under sustained guest egress, the host socket backs up, consomme's rx buffer fills, and it advertises a zero window. When the host later drained and the window reopened, nothing set `needs_ack`, so no window-update ACK was sent. The guest stalled at window 0 until its slow persist-timer zero-window probe, whose data landed out-of-window and was dropped as "bad tcp state: unacceptable segment number". This collapsed egress throughput.

Reported via WSL networking (consomme powers `wsldevicehost`): a workload's egress dropped to ~20 Mbps under load.

## Fix

- Track the window last advertised to the guest (`rx_window_last_adv`), as the guest reconstructs it after window-scale truncation.
- On host drain in `poll_socket_backend`, proactively re-advertise once a full segment of window is available (`should_reopen_window`, RFC 1122 4.2.3.3 receiver SWS avoidance), instead of waiting on the guest's persist timer.
- Fix `send_syn` to advertise the SYN-ACK window unscaled per RFC 7323 2.2 (it was scaling 16 KiB down to 128, throttling connection start).

## Tests

- `test_tcp_zero_window_reopen_sends_update` (integration, scale 0)
- `test_tcp_record_advertised_window_truncates_with_scale` (scale 7 truncation)
- `test_tcp_should_reopen_window_waits_for_full_segment` (scale 7 gate: fires once, no re-arm)
- `test_tcp_window_scale_activation` updated to require an unscaled SYN-ACK window

All verified fail-without-fix / pass-with-fix. 81 consomme tests pass; clippy and `cargo xtask fmt` clean.