### PR TITLE
[1.7] openhcl_boot: handle multi numa private pool fallback (#3312)

### DIFF
--- a/openhcl/openhcl_boot/src/cmdline.rs
+++ b/openhcl/openhcl_boot/src/cmdline.rs
@@ -34,6 +34,13 @@ const SIDECAR: &str = "OPENHCL_SIDECAR=";
 /// Disable NVME keep alive regardless if the host supports it.
 const DISABLE_NVME_KEEP_ALIVE: &str = "OPENHCL_DISABLE_NVME_KEEP_ALIVE=";
 
+/// Control NUMA allocation behavior for the VTL2 GPA pool.
+///
+/// * `split`: Force the pool to be split evenly across NUMA nodes, skipping
+///   the default "try node 0 first" fast path. Useful for testing multi-range
+///   pool allocation.
+const VTL2_GPA_POOL_NUMA: &str = "OPENHCL_VTL2_GPA_POOL_NUMA=";
+
 /// Lookup table to use for VTL2 GPA pool size heuristics.
 #[derive(Debug, PartialEq, Clone, Copy)]
 pub enum Vtl2GpaPoolLookupTable {
@@ -115,6 +122,9 @@ pub struct BootCommandLineOptions {
     pub enable_vtl2_gpa_pool: Vtl2GpaPoolConfig,
     pub sidecar: SidecarOptions,
     pub disable_nvme_keep_alive: bool,
+    /// When true, force the VTL2 GPA pool to be split evenly across NUMA
+    /// nodes instead of trying to allocate entirely on node 0 first.
+    pub vtl2_gpa_pool_numa_split: bool,
 }
 
 impl BootCommandLineOptions {
@@ -124,6 +134,7 @@ impl BootCommandLineOptions {
             enable_vtl2_gpa_pool: Vtl2GpaPoolConfig::Heuristics(Vtl2GpaPoolLookupTable::Release), // use the release config by default
             sidecar: SidecarOptions::default(),
             disable_nvme_keep_alive: false,
+            vtl2_gpa_pool_numa_split: false,
         }
     }
 }
@@ -175,6 +186,13 @@ impl BootCommandLineOptions {
                 let arg = arg.split_once('=').map(|(_, arg)| arg);
                 if arg.is_some_and(|a| a != "0") {
                     self.disable_nvme_keep_alive = true;
+                }
+            } else if arg.starts_with(VTL2_GPA_POOL_NUMA) {
+                if let Some((_, arg)) = arg.split_once('=') {
+                    match arg {
+                        "split" => self.vtl2_gpa_pool_numa_split = true,
+                        _ => log!("Unknown value for OPENHCL_VTL2_GPA_POOL_NUMA: {arg}"),
+                    }
                 }
             }
         }

--- a/openhcl/openhcl_boot/src/host_params/dt/mod.rs
+++ b/openhcl/openhcl_boot/src/host_params/dt/mod.rs
@@ -75,6 +75,127 @@ pub enum DtError {
     NotEnoughVtl2Mmio,
 }
 
+/// Allocate the private pool across NUMA nodes.
+///
+/// By default, tries to allocate the entire pool on NUMA node 0 (preserving
+/// previous behavior). If that fails, or if `force_numa_split` is true, the
+/// pool is split evenly across all available NUMA nodes (one range per node).
+fn allocate_private_pool(
+    address_space: &mut AddressSpaceManager,
+    vtl2_ram: &[MemoryEntry],
+    pool_size_bytes: u64,
+    force_numa_split: bool,
+    enable_vtl2_gpa_pool: crate::cmdline::Vtl2GpaPoolConfig,
+    device_dma_page_count: Option<u64>,
+    vp_count: usize,
+    mem_size: u64,
+) {
+    // Try allocating the entire pool on node 0 first. We do this to maintain
+    // compatibility with older openhcl_boot images that do not understand how
+    // to handle a split private pool, and to maintain previous behavior where
+    // the pool was completely allocated on numa node 0.
+    //
+    // Allocate from high memory downward to avoid overlapping any used ranges
+    // in low memory when openhcl's usage gets bigger, as otherwise the
+    // used_range by the bootshim could overlap the pool range chosen when
+    // servicing to a new image.
+    if !force_numa_split {
+        if let Some(pool) = address_space.allocate(
+            Some(0),
+            pool_size_bytes,
+            AllocationType::GpaPool,
+            AllocationPolicy::HighMemory,
+        ) {
+            log!("allocated VTL2 pool at {:#x?}", pool.range);
+            return;
+        }
+        log!("node 0 cannot fit full pool, splitting across NUMA nodes");
+    } else {
+        log!("forcing VTL2 pool NUMA split across nodes");
+    }
+
+    // Enumerate unique NUMA nodes from VTL2 RAM.
+    //
+    // FUTURE: Handle cases where the are CPU only or RAM only numa nodes.
+    let mut numa_nodes = off_stack!(ArrayVec<u32, MAX_NUMA_NODES>, ArrayVec::new_const());
+    for entry in vtl2_ram.iter() {
+        match numa_nodes.binary_search(&entry.vnode) {
+            Ok(_) => {}
+            Err(index) => {
+                numa_nodes.insert(index, entry.vnode);
+            }
+        }
+    }
+
+    let num_nodes = numa_nodes.len() as u64;
+    // Split the per node size to page size aligned chunks, and give the
+    // remainder to the last node.
+    let per_node_size = (pool_size_bytes / num_nodes) & !(HV_PAGE_SIZE - 1);
+    let last_node_size = pool_size_bytes - per_node_size * (num_nodes - 1);
+    let mut remaining = pool_size_bytes;
+
+    // If per-node-size is zero, we're in some strange configuration. We should
+    // have been able to allocate this from a single node, as this would mean
+    // the number of nodes is larger than the number of pages requested for the
+    // pool, so fail explicitly.
+    if per_node_size == 0 {
+        panic!(
+            "cannot split VTL2 pool of size {pool_size_bytes:#x} bytes across \
+            {num_nodes} nodes, per node size {per_node_size:#x} bytes; \
+            enable_vtl2_gpa_pool={enable_vtl2_gpa_pool:?}, \
+            device_dma_page_count={device_dma_page_count:#x?}, \
+            vp_count={vp_count}, mem_size={mem_size:#x}"
+        );
+    }
+
+    for (i, vnode) in numa_nodes.iter().enumerate() {
+        if remaining == 0 {
+            break;
+        }
+
+        let is_last = i == numa_nodes.len() - 1;
+        let alloc_size = if is_last {
+            last_node_size
+        } else {
+            per_node_size
+        };
+
+        // Make sure to allocate high memory downward, for the same reason as
+        // described in the numa 0 case.
+        match address_space.allocate(
+            Some(*vnode),
+            alloc_size,
+            AllocationType::GpaPool,
+            AllocationPolicy::HighMemory,
+        ) {
+            Some(pool) => {
+                remaining -= pool.range.len();
+                log!(
+                    "allocated VTL2 pool on node {} at {:#x?}",
+                    vnode,
+                    pool.range
+                );
+            }
+            None => {
+                let highest_numa_node = vtl2_ram.iter().map(|e| e.vnode).max().unwrap_or(0);
+                panic!(
+                    "failed to allocate VTL2 pool on node {vnode}: \
+                     need {alloc_size:#x} bytes, pool total {pool_size_bytes:#x} bytes \
+                     (enable_vtl2_gpa_pool={enable_vtl2_gpa_pool:?}, \
+                     device_dma_page_count={device_dma_page_count:#x?}, \
+                     vp_count={vp_count}, mem_size={mem_size:#x}), \
+                     highest_numa_node={highest_numa_node}"
+                );
+            }
+        }
+    }
+
+    assert_eq!(
+        remaining, 0,
+        "pool allocation arithmetic error: {remaining:#x} bytes unallocated"
+    );
+}
+
 /// Allocate VTL2 ram from the partition's memory map.
 fn allocate_vtl2_ram(
     params: &ShimParams,
@@ -575,27 +696,16 @@ fn topology_from_host_dt(
             // ranges to figure out which VTL2 memory is free to allocate from.
             let pool_size_bytes = vtl2_gpa_pool_size * HV_PAGE_SIZE;
 
-            // NOTE: For now, allocate all the private pool on NUMA node 0 to
-            // match previous behavior. Allocate from high memory downward to
-            // avoid overlapping any used ranges in low memory when openhcl's
-            // usage gets bigger, as otherwise the used_range by the bootshim
-            // could overlap the pool range chosen, when servicing to a new
-            // image.
-            match address_space.allocate(
-                Some(0),
+            allocate_private_pool(
+                address_space,
+                &vtl2_ram,
                 pool_size_bytes,
-                AllocationType::GpaPool,
-                AllocationPolicy::HighMemory,
-            ) {
-                Some(pool) => {
-                    log!("allocated VTL2 pool at {:#x?}", pool.range);
-                }
-                None => {
-                    panic!(
-                        "failed to allocate VTL2 pool of size {pool_size_bytes:#x} bytes (enable_vtl2_gpa_pool={enable_vtl2_gpa_pool:?}, device_dma_page_count={device_dma_page_count:#x?}, vp_count={vp_count}, mem_size={mem_size:#x})"
-                    );
-                }
-            };
+                options.vtl2_gpa_pool_numa_split,
+                enable_vtl2_gpa_pool,
+                device_dma_page_count,
+                vp_count,
+                mem_size,
+            );
         }
     }
 
@@ -750,22 +860,15 @@ fn topology_from_persisted_state(
     // allocated vtl2 pool. Today, we do not allocate a new/larger pool if the
     // command line arguments or host device tree changed, as that's not
     // something we expect to happen in practice.
-    let mut pool_ranges = partition_memory.iter().filter_map(|entry| {
+    let pool_ranges = partition_memory.iter().filter_map(|entry| {
         if entry.vtl_type == MemoryVtlType::VTL2_GPA_POOL {
             Some(entry.range)
         } else {
             None
         }
     });
-    let pool_range = pool_ranges.next();
-    assert!(
-        pool_ranges.next().is_none(),
-        "previous instance had multiple pool ranges"
-    );
 
-    if let Some(pool_range) = pool_range {
-        address_space_builder = address_space_builder.with_pool_range(pool_range);
-    }
+    address_space_builder = address_space_builder.with_pool_ranges(pool_ranges);
 
     // As described above, other ranges come from this current boot.
     address_space_builder = add_common_ranges(params, address_space_builder);

--- a/openhcl/openhcl_boot/src/memory.rs
+++ b/openhcl/openhcl_boot/src/memory.rs
@@ -3,7 +3,9 @@
 
 //! Address space allocator for VTL2 memory used by the bootshim.
 
+use crate::host_params::MAX_NUMA_NODES;
 use crate::host_params::MAX_VTL2_RAM_RANGES;
+use crate::single_threaded::off_stack;
 use arrayvec::ArrayVec;
 use host_fdt_parser::MemoryEntry;
 #[cfg(test)]
@@ -39,7 +41,6 @@ pub enum ReservedMemoryType {
     SidecarNode,
     /// Persistent VTL2 memory used for page allocations in usermode. This
     /// memory is persisted, both location and contents, across servicing.
-    /// Today, we only support a single range.
     Vtl2GpaPool,
     /// Page tables that are used for AP startup, on TDX.
     TdxPageTables,
@@ -138,7 +139,7 @@ pub struct AddressSpaceManagerBuilder<'a, I: Iterator<Item = MemoryRange>> {
     sidecar_image: Option<MemoryRange>,
     page_tables: Option<MemoryRange>,
     log_buffer: Option<MemoryRange>,
-    pool_range: Option<MemoryRange>,
+    pool_ranges: ArrayVec<MemoryRange, MAX_NUMA_NODES>,
 }
 
 impl<'a, I: Iterator<Item = MemoryRange>> AddressSpaceManagerBuilder<'a, I> {
@@ -171,7 +172,7 @@ impl<'a, I: Iterator<Item = MemoryRange>> AddressSpaceManagerBuilder<'a, I> {
             sidecar_image: None,
             page_tables: None,
             log_buffer: None,
-            pool_range: None,
+            pool_ranges: ArrayVec::new(),
         }
     }
 
@@ -194,8 +195,16 @@ impl<'a, I: Iterator<Item = MemoryRange>> AddressSpaceManagerBuilder<'a, I> {
     }
 
     /// Existing VTL2 GPA pool ranges, reported as type [`MemoryVtlType::VTL2_GPA_POOL`].
-    pub fn with_pool_range(mut self, pool_range: MemoryRange) -> Self {
-        self.pool_range = Some(pool_range);
+    ///
+    /// # Panics
+    ///
+    /// Panics if called more than once.
+    pub fn with_pool_ranges(mut self, pool_ranges: impl Iterator<Item = MemoryRange>) -> Self {
+        assert!(
+            self.pool_ranges.is_empty(),
+            "pool ranges already set on builder"
+        );
+        self.pool_ranges.extend(pool_ranges);
         self
     }
 
@@ -211,7 +220,7 @@ impl<'a, I: Iterator<Item = MemoryRange>> AddressSpaceManagerBuilder<'a, I> {
             sidecar_image,
             page_tables,
             log_buffer,
-            pool_range,
+            pool_ranges,
         } = self;
 
         if vtl2_ram.len() > MAX_VTL2_RAM_RANGES {
@@ -232,7 +241,9 @@ impl<'a, I: Iterator<Item = MemoryRange>> AddressSpaceManagerBuilder<'a, I> {
             persisted_state_region.split_at_offset(PAGE_SIZE_4K);
 
         // The other ranges are reserved, and must overlap with the used range.
-        let mut reserved: ArrayVec<(MemoryRange, ReservedMemoryType), 20> = ArrayVec::new();
+        const MAX_RESERVED_RANGES: usize = 20;
+        let mut reserved = off_stack!(ArrayVec<(MemoryRange, ReservedMemoryType), MAX_RESERVED_RANGES>, ArrayVec::new_const());
+        reserved.clear();
         reserved.push((persisted_header, ReservedMemoryType::PersistedStateHeader));
         reserved.push((persisted_payload, ReservedMemoryType::PersistedStatePayload));
         reserved.extend(vtl2_config.map(|r| (r, ReservedMemoryType::Vtl2Config)));
@@ -258,7 +269,11 @@ impl<'a, I: Iterator<Item = MemoryRange>> AddressSpaceManagerBuilder<'a, I> {
         );
         reserved.sort_unstable_by_key(|(r, _)| r.start());
 
-        let mut used_ranges: ArrayVec<(MemoryRange, AddressUsage), 13> = ArrayVec::new();
+        // Maximum number of used ranges is reserved ranges, plus any allocated
+        // pool ranges (one per node maximally).
+        const MAX_USED_RANGES: usize = MAX_RESERVED_RANGES + MAX_NUMA_NODES;
+        let mut used_ranges = off_stack!(ArrayVec<(MemoryRange, AddressUsage), MAX_USED_RANGES>, ArrayVec::new_const());
+        used_ranges.clear();
 
         // Construct initial used ranges by walking both the bootshim_used range
         // and all reserved ranges that overlap.
@@ -284,8 +299,8 @@ impl<'a, I: Iterator<Item = MemoryRange>> AddressSpaceManagerBuilder<'a, I> {
             }
         }
 
-        // Add any existing pool range as reserved.
-        if let Some(range) = pool_range {
+        // Add any existing pool ranges as reserved.
+        for range in pool_ranges {
             used_ranges.push((
                 range,
                 AddressUsage::Reserved(ReservedMemoryType::Vtl2GpaPool),
@@ -1025,5 +1040,210 @@ mod tests {
         }
     }
 
-    // FIXME: test pool ranges
+    // Tests for multi-NUMA pool range support in the builder.
+
+    #[test]
+    fn test_single_pool_range() {
+        let mut address_space = AddressSpaceManager::new_const();
+        let vtl2_ram = &[MemoryEntry {
+            range: MemoryRange::new(0x0..0x20000),
+            vnode: 0,
+            mem_type: MemoryMapEntryType::MEMORY,
+        }];
+
+        AddressSpaceManagerBuilder::new(
+            &mut address_space,
+            vtl2_ram,
+            MemoryRange::new(0x0..0x4000),
+            MemoryRange::new(0x0..0x2000),
+            core::iter::empty(),
+        )
+        .with_pool_ranges([MemoryRange::new(0x10000..0x18000)].into_iter())
+        .init()
+        .unwrap();
+
+        assert!(address_space.has_vtl2_pool());
+
+        // Pool range should be reserved.
+        let reserved: Vec<_> = address_space.reserved_vtl2_ranges().collect();
+        assert!(
+            reserved
+                .iter()
+                .any(|(r, t)| *r == MemoryRange::new(0x10000..0x18000)
+                    && *t == ReservedMemoryType::Vtl2GpaPool)
+        );
+    }
+
+    #[test]
+    fn test_multiple_pool_ranges() {
+        let mut address_space = AddressSpaceManager::new_const();
+        let vtl2_ram = &[
+            MemoryEntry {
+                range: MemoryRange::new(0x0..0x20000),
+                vnode: 0,
+                mem_type: MemoryMapEntryType::MEMORY,
+            },
+            MemoryEntry {
+                range: MemoryRange::new(0x100000..0x120000),
+                vnode: 1,
+                mem_type: MemoryMapEntryType::MEMORY,
+            },
+        ];
+
+        AddressSpaceManagerBuilder::new(
+            &mut address_space,
+            vtl2_ram,
+            MemoryRange::new(0x0..0x4000),
+            MemoryRange::new(0x0..0x2000),
+            core::iter::empty(),
+        )
+        .with_pool_ranges(
+            [
+                MemoryRange::new(0x10000..0x18000),
+                MemoryRange::new(0x110000..0x118000),
+            ]
+            .into_iter(),
+        )
+        .init()
+        .unwrap();
+
+        assert!(address_space.has_vtl2_pool());
+
+        // Both pool ranges should be reserved.
+        let reserved: Vec<_> = address_space
+            .reserved_vtl2_ranges()
+            .filter(|(_, t)| *t == ReservedMemoryType::Vtl2GpaPool)
+            .collect();
+        assert_eq!(reserved.len(), 2);
+        assert_eq!(reserved[0].0, MemoryRange::new(0x10000..0x18000));
+        assert_eq!(reserved[1].0, MemoryRange::new(0x110000..0x118000));
+    }
+
+    #[test]
+    fn test_allocate_pool_single_numa_node() {
+        // With a single NUMA node, pool should be allocated as one range on
+        // node 0 (regardless of force_split, since there's only one node).
+        let mut address_space = AddressSpaceManager::new_const();
+        let vtl2_ram = &[MemoryEntry {
+            range: MemoryRange::new(0x0..0x100000),
+            vnode: 0,
+            mem_type: MemoryMapEntryType::MEMORY,
+        }];
+
+        AddressSpaceManagerBuilder::new(
+            &mut address_space,
+            vtl2_ram,
+            MemoryRange::new(0x0..0x4000),
+            MemoryRange::new(0x0..0x2000),
+            core::iter::empty(),
+        )
+        .init()
+        .unwrap();
+
+        // Allocate pool on node 0.
+        let pool = address_space
+            .allocate(
+                Some(0),
+                0x10000,
+                AllocationType::GpaPool,
+                AllocationPolicy::HighMemory,
+            )
+            .unwrap();
+        assert_eq!(pool.vnode, 0);
+        assert_eq!(pool.range.len(), 0x10000);
+        assert!(address_space.has_vtl2_pool());
+    }
+
+    #[test]
+    fn test_allocate_pool_two_numa_nodes_node0_fits() {
+        // With 2 NUMA nodes and enough space on node 0, pool should be
+        // allocated entirely on node 0.
+        let mut address_space = AddressSpaceManager::new_const();
+        let vtl2_ram = &[
+            MemoryEntry {
+                range: MemoryRange::new(0x0..0x100000),
+                vnode: 0,
+                mem_type: MemoryMapEntryType::MEMORY,
+            },
+            MemoryEntry {
+                range: MemoryRange::new(0x200000..0x300000),
+                vnode: 1,
+                mem_type: MemoryMapEntryType::MEMORY,
+            },
+        ];
+
+        AddressSpaceManagerBuilder::new(
+            &mut address_space,
+            vtl2_ram,
+            MemoryRange::new(0x0..0x4000),
+            MemoryRange::new(0x0..0x2000),
+            core::iter::empty(),
+        )
+        .init()
+        .unwrap();
+
+        // Node 0 has plenty of free space, so the pool fits entirely on node 0.
+        let pool = address_space
+            .allocate(
+                Some(0),
+                0x10000,
+                AllocationType::GpaPool,
+                AllocationPolicy::HighMemory,
+            )
+            .unwrap();
+        assert_eq!(pool.vnode, 0);
+        assert_eq!(pool.range.len(), 0x10000);
+    }
+
+    #[test]
+    fn test_allocate_pool_two_numa_nodes_node0_exhausted() {
+        // Node 0 has no free space after bootshim. Pool must come from node 1.
+        let mut address_space = AddressSpaceManager::new_const();
+        let vtl2_ram = &[
+            MemoryEntry {
+                range: MemoryRange::new(0x0..0x4000),
+                vnode: 0,
+                mem_type: MemoryMapEntryType::MEMORY,
+            },
+            MemoryEntry {
+                range: MemoryRange::new(0x200000..0x300000),
+                vnode: 1,
+                mem_type: MemoryMapEntryType::MEMORY,
+            },
+        ];
+
+        AddressSpaceManagerBuilder::new(
+            &mut address_space,
+            vtl2_ram,
+            MemoryRange::new(0x0..0x4000),
+            MemoryRange::new(0x0..0x2000),
+            core::iter::empty(),
+        )
+        .init()
+        .unwrap();
+
+        // Node 0 allocation should fail (all used by bootshim).
+        assert!(
+            address_space
+                .allocate(
+                    Some(0),
+                    0x10000,
+                    AllocationType::GpaPool,
+                    AllocationPolicy::HighMemory,
+                )
+                .is_none()
+        );
+
+        // Node 1 should succeed.
+        let pool = address_space
+            .allocate(
+                Some(1),
+                0x10000,
+                AllocationType::GpaPool,
+                AllocationPolicy::HighMemory,
+            )
+            .unwrap();
+        assert_eq!(pool.vnode, 1);
+        assert_eq!(pool.range.len(), 0x10000);
+    }
 }

--- a/openvmm/openvmm_core/src/worker/dispatch.rs
+++ b/openvmm/openvmm_core/src/worker/dispatch.rs
@@ -887,8 +887,29 @@ impl InitializedVm {
         };
 
         // Choose the memory layout of the VM.
-        let mem_layout = MemoryLayout::new(cfg.memory.mem_size, &cfg.memory.mmio_gaps, vtl2_range)
-            .context("invalid memory configuration")?;
+        let mem_layout = if let Some(ref sizes) = cfg.memory.numa_mem_sizes {
+            // When numa_mem_sizes is set, distribute guest RAM across vNUMA nodes
+            // for ACPI SRAT / FDT reporting.
+            //
+            // TODO: The vNUMA nodes reported are meant for test usage only, as they
+            // are not aligned to any physical NUMA node. There is more work to do
+            // to support useful vNUMA reporting.
+            let total: u64 = sizes
+                .iter()
+                .copied()
+                .try_fold(0u64, |acc, s| acc.checked_add(s))
+                .context("numa memory sizes overflow")?;
+            anyhow::ensure!(
+                total == cfg.memory.mem_size,
+                "numa_mem_sizes total ({total:#x}) does not match mem_size ({:#x})",
+                cfg.memory.mem_size
+            );
+
+            MemoryLayout::new_with_numa(sizes, &cfg.memory.mmio_gaps, vtl2_range)
+        } else {
+            MemoryLayout::new(cfg.memory.mem_size, &cfg.memory.mmio_gaps, vtl2_range)
+        }
+        .context("invalid memory configuration")?;
 
         if mem_layout.end_of_ram_or_mmio() > 1 << physical_address_size {
             anyhow::bail!(

--- a/openvmm/openvmm_defs/src/config.rs
+++ b/openvmm/openvmm_defs/src/config.rs
@@ -274,6 +274,10 @@ pub struct MemoryConfig {
     pub mmio_gaps: Vec<MemoryRange>,
     pub prefetch_memory: bool,
     pub pcie_ecam_base: u64,
+    /// Test only: per-NUMA-node memory sizes. When set, RAM is distributed
+    /// across vNUMA nodes according to these sizes instead of assigning all RAM
+    /// to node 0. The sum must equal `mem_size`.
+    pub numa_mem_sizes: Option<Vec<u64>>,
 }
 
 #[derive(Debug, MeshPayload, Default)]

--- a/openvmm/openvmm_entry/src/cli_args.rs
+++ b/openvmm/openvmm_entry/src/cli_args.rs
@@ -49,9 +49,19 @@ pub struct Options {
         long,
         value_name = "SIZE",
         default_value = "1GB",
-        value_parser = parse_memory
+        value_parser = parse_memory,
+        conflicts_with = "numa_memory"
     )]
     pub memory: u64,
+
+    /// per-NUMA-node guest RAM sizes (comma-separated, e.g. "2G,2G").
+    /// Distributes memory across vNUMA nodes reported to the guest. Mutually
+    /// exclusive with --memory. This is for test-only usage.
+    ///
+    /// TODO: Backing pages are not pinned to any host topology, nor coordinated
+    /// with CPUs. This should change once we implement real numa support.
+    #[clap(long, value_name = "SIZES", value_parser = parse_memory, value_delimiter = ',', conflicts_with = "memory")]
+    pub numa_memory: Option<Vec<u64>>,
 
     /// use shared memory segment
     #[clap(short = 'M', long)]

--- a/openvmm/openvmm_entry/src/lib.rs
+++ b/openvmm/openvmm_entry/src/lib.rs
@@ -1393,10 +1393,18 @@ fn vm_config_from_command_line(
         vpci_devices,
         ide_disks: Vec::new(),
         memory: MemoryConfig {
-            mem_size: opt.memory,
+            mem_size: if let Some(ref sizes) = opt.numa_memory {
+                sizes
+                    .iter()
+                    .try_fold(0u64, |acc, &s| acc.checked_add(s))
+                    .context("numa memory sizes overflow")?
+            } else {
+                opt.memory
+            },
             mmio_gaps,
             prefetch_memory: opt.prefetch,
             pcie_ecam_base: DEFAULT_PCIE_ECAM_BASE,
+            numa_mem_sizes: opt.numa_memory.clone(),
         },
         processor_topology: ProcessorTopologyConfig {
             proc_count: opt.processors,

--- a/openvmm/openvmm_entry/src/ttrpc/mod.rs
+++ b/openvmm/openvmm_entry/src/ttrpc/mod.rs
@@ -473,6 +473,7 @@ impl VmService {
                 mmio_gaps: DEFAULT_MMIO_GAPS_X86.into(),
                 prefetch_memory: false,
                 pcie_ecam_base: DEFAULT_PCIE_ECAM_BASE,
+                numa_mem_sizes: None,
             },
             chipset: chipset.chipset,
             processor_topology: ProcessorTopologyConfig {

--- a/petri/src/vm/mod.rs
+++ b/petri/src/vm/mod.rs
@@ -1741,6 +1741,9 @@ pub struct MemoryConfig {
     pub dynamic_memory_range: Option<(u64, u64)>,
     /// Specifies the mmio gaps to use, either platform or custom.
     pub mmio_gaps: MmioConfig,
+    /// Per-NUMA-node memory sizes. When set, RAM is distributed across
+    /// vNUMA nodes instead of assigning all RAM to node 0.
+    pub numa_mem_sizes: Option<Vec<u64>>,
 }
 
 impl Default for MemoryConfig {
@@ -1749,6 +1752,7 @@ impl Default for MemoryConfig {
             startup_bytes: 0x1_0000_0000,
             dynamic_memory_range: None,
             mmio_gaps: MmioConfig::Platform,
+            numa_mem_sizes: None,
         }
     }
 }

--- a/petri/src/vm/openvmm/construct.rs
+++ b/petri/src/vm/openvmm/construct.rs
@@ -274,14 +274,24 @@ impl PetriVmConfigOpenVmm {
                 startup_bytes,
                 dynamic_memory_range,
                 mmio_gaps,
+                numa_mem_sizes,
             } = memory;
 
             if dynamic_memory_range.is_some() {
                 anyhow::bail!("dynamic memory not supported in OpenVMM");
             }
 
+            let mem_size = if let Some(ref sizes) = numa_mem_sizes {
+                sizes
+                    .iter()
+                    .try_fold(0u64, |acc, &s| acc.checked_add(s))
+                    .context("numa memory sizes overflow")?
+            } else {
+                startup_bytes
+            };
+
             openvmm_defs::config::MemoryConfig {
-                mem_size: startup_bytes,
+                mem_size,
                 mmio_gaps: match mmio_gaps {
                     MmioConfig::Platform => {
                         if firmware.is_openhcl() {
@@ -300,6 +310,7 @@ impl PetriVmConfigOpenVmm {
                 },
                 prefetch_memory: false,
                 pcie_ecam_base: DEFAULT_PCIE_ECAM_BASE,
+                numa_mem_sizes,
             }
         };
 

--- a/vm/vmcore/vm_topology/src/memory.rs
+++ b/vm/vmcore/vm_topology/src/memory.rs
@@ -4,6 +4,7 @@
 //! Tools to the compute guest memory layout.
 
 use memory_range::MemoryRange;
+use memory_range::subtract_ranges;
 use thiserror::Error;
 
 const PAGE_SIZE: u64 = 4096;
@@ -71,6 +72,12 @@ pub enum Error {
     /// Invalid memory size.
     #[error("invalid memory size")]
     BadSize,
+    /// Invalid per-NUMA-node memory size.
+    #[error("invalid NUMA node memory size")]
+    BadNumaSize,
+    /// Empty NUMA memory sizes.
+    #[error("empty NUMA memory sizes")]
+    EmptyNumaSizes,
     /// Invalid MMIO gap configuration.
     #[error("invalid MMIO gap configuration")]
     BadMmioGaps,
@@ -134,26 +141,78 @@ impl MemoryLayout {
         if ram_size == 0 || ram_size & (PAGE_SIZE - 1) != 0 {
             return Err(Error::BadSize);
         }
+        Self::new_with_numa(&[ram_size], gaps, vtl2_range)
+    }
+
+    /// Like [`Self::new()`], but distributes RAM across NUMA nodes according
+    /// to the per-node sizes in `numa_mem_sizes`.
+    ///
+    /// `numa_mem_sizes[i]` is the number of RAM bytes for vnode `i`.
+    /// Each size must be page-aligned and non-zero. The sum of all sizes
+    /// is the total guest RAM.
+    ///
+    /// RAM is placed sequentially around MMIO gaps, filling each node's
+    /// budget in order. When a node's budget is exhausted mid-chunk,
+    /// the chunk is split and the next node continues from that address.
+    pub fn new_with_numa(
+        numa_mem_sizes: &[u64],
+        gaps: &[MemoryRange],
+        vtl2_range: Option<MemoryRange>,
+    ) -> Result<Self, Error> {
+        if numa_mem_sizes.is_empty() {
+            return Err(Error::EmptyNumaSizes);
+        }
+
+        for &size in numa_mem_sizes {
+            if size == 0 || size & (PAGE_SIZE - 1) != 0 {
+                return Err(Error::BadNumaSize);
+            }
+        }
+
+        let ram_size: u64 = numa_mem_sizes
+            .iter()
+            .try_fold(0u64, |acc, &s| acc.checked_add(s))
+            .ok_or(Error::BadSize)?;
 
         validate_ranges(gaps)?;
+
+        let available = subtract_ranges(
+            [MemoryRange::new(0..MemoryRange::MAX_ADDRESS)],
+            gaps.iter().copied(),
+        );
+
+        // Distribute RAM across NUMA nodes, filling available ranges in order.
         let mut ram = Vec::new();
         let mut remaining = ram_size;
-        let mut remaining_gaps = gaps.iter().cloned();
-        let mut last_end = 0;
+        let mut node_idx = 0;
+        let mut node_remaining = numa_mem_sizes[0];
 
-        while remaining > 0 {
-            let (this, next_end) = if let Some(gap) = remaining_gaps.next() {
-                (remaining.min(gap.start() - last_end), gap.end())
-            } else {
-                (remaining, 0)
-            };
+        for range in available {
+            if remaining == 0 {
+                break;
+            }
+            let range_size = remaining.min(range.len());
+            let mut offset = 0;
 
-            ram.push(MemoryRangeWithNode {
-                range: MemoryRange::new(last_end..last_end + this),
-                vnode: 0,
-            });
-            remaining -= this;
-            last_end = next_end;
+            while offset < range_size {
+                if node_remaining == 0 {
+                    node_idx += 1;
+                    node_remaining = *numa_mem_sizes
+                        .get(node_idx)
+                        .expect("node budget exhausted before all RAM placed");
+                }
+
+                let piece = (range_size - offset).min(node_remaining);
+                let start = range.start() + offset;
+                ram.push(MemoryRangeWithNode {
+                    range: MemoryRange::new(start..start + piece),
+                    vnode: node_idx as u32,
+                });
+                offset += piece;
+                node_remaining -= piece;
+            }
+
+            remaining -= range_size;
         }
 
         Self::build(ram, gaps.to_vec(), vtl2_range)
@@ -460,5 +519,101 @@ mod tests {
         assert_eq!(layout.probe_address(TB + 2 * GB), None);
         assert_eq!(layout.probe_address(TB + 3 * GB), None);
         assert_eq!(layout.probe_address(4 * TB), None);
+    }
+
+    #[test]
+    fn numa_two_nodes_even_split() {
+        // 4 GB total, 2 nodes of 2 GB each, MMIO gap at 2-3 GB.
+        let mmio = &[MemoryRange::new(2 * GB..3 * GB)];
+        let layout = MemoryLayout::new_with_numa(&[2 * GB, 2 * GB], mmio, None).unwrap();
+        assert_eq!(
+            layout.ram(),
+            &[
+                MemoryRangeWithNode {
+                    range: MemoryRange::new(0..2 * GB),
+                    vnode: 0,
+                },
+                MemoryRangeWithNode {
+                    range: MemoryRange::new(3 * GB..5 * GB),
+                    vnode: 1,
+                },
+            ]
+        );
+        assert_eq!(layout.ram_size(), 4 * GB);
+    }
+
+    #[test]
+    fn numa_two_nodes_mid_chunk_split() {
+        // 4 GB total, 2 nodes of 2 GB each, MMIO gap at 3-4 GB.
+        // Node 0's 2 GB fits entirely below the gap; node 1 continues above.
+        // But the first chunk is 3 GB, so node 0 takes 2 GB and node 1
+        // takes the remaining 1 GB of that chunk, plus 1 GB above the gap.
+        let mmio = &[MemoryRange::new(3 * GB..4 * GB)];
+        let layout = MemoryLayout::new_with_numa(&[2 * GB, 2 * GB], mmio, None).unwrap();
+        assert_eq!(
+            layout.ram(),
+            &[
+                MemoryRangeWithNode {
+                    range: MemoryRange::new(0..2 * GB),
+                    vnode: 0,
+                },
+                MemoryRangeWithNode {
+                    range: MemoryRange::new(2 * GB..3 * GB),
+                    vnode: 1,
+                },
+                MemoryRangeWithNode {
+                    range: MemoryRange::new(4 * GB..5 * GB),
+                    vnode: 1,
+                },
+            ]
+        );
+        assert_eq!(layout.ram_size(), 4 * GB);
+    }
+
+    #[test]
+    fn numa_three_nodes() {
+        // 3 GB total, 3 nodes of 1 GB each, no gaps.
+        let layout = MemoryLayout::new_with_numa(&[GB, GB, GB], &[], None).unwrap();
+        assert_eq!(
+            layout.ram(),
+            &[
+                MemoryRangeWithNode {
+                    range: MemoryRange::new(0..GB),
+                    vnode: 0,
+                },
+                MemoryRangeWithNode {
+                    range: MemoryRange::new(GB..2 * GB),
+                    vnode: 1,
+                },
+                MemoryRangeWithNode {
+                    range: MemoryRange::new(2 * GB..3 * GB),
+                    vnode: 2,
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn numa_single_node_matches_new() {
+        // Single node should produce the same layout as new().
+        let mmio = &[
+            MemoryRange::new(GB..2 * GB),
+            MemoryRange::new(3 * GB..4 * GB),
+        ];
+        let layout_new = MemoryLayout::new(TB, mmio, None).unwrap();
+        let layout_numa = MemoryLayout::new_with_numa(&[TB], mmio, None).unwrap();
+        assert_eq!(layout_new.ram(), layout_numa.ram());
+    }
+
+    #[test]
+    fn numa_bad_inputs() {
+        // Empty sizes.
+        MemoryLayout::new_with_numa(&[], &[], None).unwrap_err();
+        // Non-page-aligned size.
+        MemoryLayout::new_with_numa(&[GB + 1], &[], None).unwrap_err();
+        // Zero size.
+        MemoryLayout::new_with_numa(&[0], &[], None).unwrap_err();
+        // Mixed: one valid, one zero.
+        MemoryLayout::new_with_numa(&[GB, 0], &[], None).unwrap_err();
     }
 }

--- a/vmm_tests/vmm_tests/tests/tests/multiarch/memstat.rs
+++ b/vmm_tests/vmm_tests/tests/tests/multiarch/memstat.rs
@@ -403,6 +403,7 @@ async fn idle_test<T: PetriVmmBackend>(
                 startup_bytes: 16 * (1024 * 1024 * 1024),
                 dynamic_memory_range: None,
                 mmio_gaps: petri::MmioConfig::Platform,
+                numa_mem_sizes: None,
             }
         })
         .with_openhcl_log_levels(OpenvmmLogConfig::BuiltInDefault)

--- a/vmm_tests/vmm_tests/tests/tests/multiarch/openhcl_servicing.rs
+++ b/vmm_tests/vmm_tests/tests/tests/multiarch/openhcl_servicing.rs
@@ -28,6 +28,7 @@ use nvme_resources::fault::PciFaultConfig;
 use nvme_test::command_match::CommandMatchBuilder;
 use openvmm_defs::config::DeviceVtl;
 use openvmm_defs::config::VpciDeviceConfig;
+use petri::MemoryConfig;
 use petri::OpenHclServicingFlags;
 use petri::PetriGuestStateLifetime;
 use petri::PetriVm;
@@ -149,6 +150,37 @@ async fn servicing_keepalive_no_device<T: PetriVmmBackend>(
     let flags = config.default_servicing_flags();
     openhcl_servicing_core(
         config.with_openhcl_command_line("OPENHCL_ENABLE_VTL2_GPA_POOL=512"),
+        igvm_file,
+        flags,
+        DEFAULT_SERVICING_COUNT,
+    )
+    .await
+}
+
+/// Test servicing an OpenHCL VM with a multi-NUMA pool split.
+/// The pool is split across NUMA nodes via `OPENHCL_VTL2_GPA_POOL_NUMA=split`,
+/// and pool ranges must be preserved identically across the service boundary.
+#[openvmm_test(openhcl_linux_direct_x64[LATEST_LINUX_DIRECT_TEST_X64])]
+async fn servicing_numa_private_pool<T: PetriVmmBackend>(
+    config: PetriVmBuilder<T>,
+    (igvm_file,): (ResolvedArtifact<impl petri_artifacts_common::tags::IsOpenhclIgvm>,),
+) -> anyhow::Result<()> {
+    let mut flags = config.default_servicing_flags();
+    flags.override_version_checks = true;
+    openhcl_servicing_core(
+        config
+            .with_processor_topology(ProcessorTopology {
+                vp_count: 4,
+                vps_per_socket: Some(2),
+                ..Default::default()
+            })
+            .with_memory(MemoryConfig {
+                numa_mem_sizes: Some(vec![2 * 1024 * 1024 * 1024, 2 * 1024 * 1024 * 1024]),
+                ..Default::default()
+            })
+            .with_openhcl_command_line(
+                "OPENHCL_VTL2_GPA_POOL_NUMA=split OPENHCL_ENABLE_VTL2_GPA_POOL=512 OPENHCL_DISABLE_NVME_KEEP_ALIVE=0",
+            ),
         igvm_file,
         flags,
         DEFAULT_SERVICING_COUNT,


### PR DESCRIPTION
## Pull request overview

This PR updates OpenHCL boot-time private pool allocation to support multi-NUMA systems by falling back to allocating the VTL2 GPA pool across NUMA nodes when a single-node allocation (node 0) can’t satisfy the request. It also introduces a command-line option to force NUMA-split behavior and adds VMM tests to exercise the multi-range pool behavior across boot and servicing.

**Changes:**
- Add multi-NUMA private pool allocation logic with a “try node 0 first, else split” strategy.
- Extend persisted-state handling to accept multiple VTL2 GPA pool ranges (instead of a single range).
- Add new tests covering multi-NUMA pool split boot + servicing scenarios and add a new cmdline knob to force split mode.

### Reviewed changes

Copilot reviewed 5 out of 5 changed files in this pull request and generated 3 comments.

<details>
<summary>Show a summary per file</summary>

| File | Description |
| ---- | ----------- |
| `openhcl/openhcl_boot/src/host_params/dt/mod.rs` | Implements the multi-NUMA fallback allocation behavior for the VTL2 private pool and updates persisted-state pool-range handling. |
| `openhcl/openhcl_boot/src/memory.rs` | Updates the address space builder to accept multiple existing pool ranges and adds unit tests around multi-range pool reservation/allocation behavior. |
| `openhcl/openhcl_boot/src/cmdline.rs` | Adds parsing for `OPENHCL_VTL2_GPA_POOL_NUMA=split` to force NUMA-split pool allocation. |
| `vmm_tests/vmm_tests/tests/tests/x86_64/openhcl_uefi.rs` | Adds a boot test that forces NUMA split and validates the VM reaches VTL2-ready and supports inspect. |
| `vmm_tests/vmm_tests/tests/tests/multiarch/openhcl_servicing.rs` | Adds a servicing test that forces NUMA split and validates servicing works with split pool configuration. |
</details>




