### PR TITLE
pci_core: introduce DmaTarget to bundle DMA memory and MSI identity

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8776,7 +8776,6 @@ dependencies = [
  "pal_async",
  "pal_uring",
  "parking_lot",
- "pci_core",
  "profiler_worker",
  "safe_intrinsics",
  "scsi_buffers",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8776,6 +8776,7 @@ dependencies = [
  "pal_async",
  "pal_uring",
  "parking_lot",
+ "pci_core",
  "profiler_worker",
  "safe_intrinsics",
  "scsi_buffers",

--- a/openhcl/underhill_core/Cargo.toml
+++ b/openhcl/underhill_core/Cargo.toml
@@ -83,6 +83,7 @@ netvsp.workspace = true
 nvme_driver.workspace = true
 nvme_resources.workspace = true
 openhcl_dma_manager.workspace = true
+pci_core.workspace = true
 scsi_core.workspace = true
 scsidisk.workspace = true
 scsidisk_resources.workspace = true

--- a/openhcl/underhill_core/Cargo.toml
+++ b/openhcl/underhill_core/Cargo.toml
@@ -83,7 +83,6 @@ netvsp.workspace = true
 nvme_driver.workspace = true
 nvme_resources.workspace = true
 openhcl_dma_manager.workspace = true
-pci_core.workspace = true
 scsi_core.workspace = true
 scsidisk.workspace = true
 scsidisk_resources.workspace = true

--- a/openhcl/underhill_core/src/worker.rs
+++ b/openhcl/underhill_core/src/worker.rs
@@ -3416,10 +3416,6 @@ async fn new_underhill_vm(
                 vmm_core::device_builder::PciDeviceResolveContext {
                     driver_source: &driver_source,
                     resolver: &resolver,
-                    dma_target: &pci_core::dma::DmaTarget::new(
-                        device_memory.clone(),
-                        pci_core::msi::MsiTarget::disconnected(),
-                    ),
                     resource,
                     doorbell_registration: None,
                     shared_mem_mapper: None,
@@ -3431,6 +3427,7 @@ async fn new_underhill_vm(
                     vtom,
                     vnode: None,
                 },
+                device_memory.clone(),
                 |device_id| {
                     let device = partition
                         .new_virtual_device()

--- a/openhcl/underhill_core/src/worker.rs
+++ b/openhcl/underhill_core/src/worker.rs
@@ -3416,11 +3416,13 @@ async fn new_underhill_vm(
                 vmm_core::device_builder::PciDeviceResolveContext {
                     driver_source: &driver_source,
                     resolver: &resolver,
-                    guest_memory: device_memory,
+                    dma_target: &pci_core::dma::DmaTarget::new(
+                        device_memory.clone(),
+                        pci_core::msi::MsiTarget::disconnected(),
+                    ),
                     resource,
                     doorbell_registration: None,
                     shared_mem_mapper: None,
-                    software_iommu: false,
                 },
                 vmbus.control(),
                 &chipset_builder,

--- a/openvmm/openvmm_core/src/worker/dispatch.rs
+++ b/openvmm/openvmm_core/src/worker/dispatch.rs
@@ -2001,7 +2001,7 @@ impl InitializedVm {
                 // (start_bus << 8) | devfn.
                 let rc_bus_range = pci_core::bus_range::AssignedBusRange::new();
                 rc_bus_range.set_bus_range(rc.start_bus, rc.end_bus);
-                let msi_conn = pci_core::msi::MsiConnection::new(rc_bus_range, 0);
+                let msi_conn = pci_core::msi::MsiConnection::new();
 
                 // When the AMD IOMMU is enabled for this root complex,
                 // reserve device 0 for the IOMMU RCiEP and start root
@@ -2029,7 +2029,10 @@ impl InitializedVm {
                                 rc.start_bus..=rc.end_bus,
                                 ranges.ecam_range,
                             )
-                            .root_ports(root_port_definitions, msi_conn.target())
+                            .root_ports(
+                                root_port_definitions,
+                                &msi_conn.msi_target(rc_bus_range, 0),
+                            )
                             .first_port_device_number(root_port_start_device)
                             .chbcr_range(chbcr_range)
                             .build()
@@ -2129,8 +2132,7 @@ impl InitializedVm {
             let parent_segment = parent_port_info.segment;
             let parent_rc_idx = parent_port_info.rc_idx;
 
-            let msi_conn =
-                pci_core::msi::MsiConnection::new(pci_core::bus_range::AssignedBusRange::new(), 0);
+            let msi_conn = pci_core::msi::MsiConnection::new();
 
             // Defer MSI wiring to after IOMMU setup.
             let msi_target = msi_conn.target().clone();
@@ -2341,7 +2343,7 @@ impl InitializedVm {
                     )
                 })?;
 
-                let msi_conn = pci_core::msi::MsiConnection::new(pi.bus_range.clone(), 0);
+                let msi_conn = pci_core::msi::MsiConnection::new();
 
                 let pcie_ctx =
                     pcie_wiring::build_device_wiring(pcie_wiring::PcieDeviceWiringParams {
@@ -2354,7 +2356,7 @@ impl InitializedVm {
                         },
                         guest_memory: gm,
                         bus_range: &pi.bus_range,
-                        msi_target: msi_conn.target().clone(),
+                        msi: &msi_conn,
                         #[cfg(guest_arch = "aarch64")]
                         smmu: smmu_states[pi.rc_idx].as_ref(),
                     });
@@ -3540,7 +3542,7 @@ impl LoadedVm {
                                 .bus_range;
 
                             let segment = self.inner.pcie_host_bridges[rc_idx].segment;
-                            let msi_conn = pci_core::msi::MsiConnection::new(bus_range.clone(), 0);
+                            let msi_conn = pci_core::msi::MsiConnection::new();
 
                             let pcie_ctx = pcie_wiring::build_device_wiring(
                                 pcie_wiring::PcieDeviceWiringParams {
@@ -3553,7 +3555,7 @@ impl LoadedVm {
                                     },
                                     guest_memory: &self.inner.gm,
                                     bus_range: &bus_range,
-                                    msi_target: msi_conn.target().clone(),
+                                    msi: &msi_conn,
                                     #[cfg(guest_arch = "aarch64")]
                                     smmu: self.inner.smmu_shared_states[rc_idx].as_ref(),
                                 },

--- a/openvmm/openvmm_core/src/worker/dispatch.rs
+++ b/openvmm/openvmm_core/src/worker/dispatch.rs
@@ -2354,6 +2354,7 @@ impl InitializedVm {
                         },
                         guest_memory: gm,
                         bus_range: &pi.bus_range,
+                        msi_target: msi_conn.target().clone(),
                         #[cfg(guest_arch = "aarch64")]
                         smmu: smmu_states[pi.rc_idx].as_ref(),
                     });
@@ -2362,17 +2363,15 @@ impl InitializedVm {
                     vmm_core::device_builder::PciDeviceResolveContext {
                         driver_source,
                         resolver,
-                        guest_memory: &pcie_ctx.guest_memory,
+                        dma_target: &pcie_ctx.dma_target,
                         resource: dev_cfg.resource,
                         doorbell_registration: partition
                             .clone()
                             .into_doorbell_registration(Vtl::Vtl0),
                         shared_mem_mapper: Some(mapper),
-                        software_iommu: pcie_ctx.software_iommu,
                     },
                     chipset_builder,
                     port_name.clone(),
-                    msi_conn.target(),
                 )
                 .await?;
 
@@ -2571,13 +2570,15 @@ impl InitializedVm {
                         vmm_core::device_builder::PciDeviceResolveContext {
                             driver_source: &driver_source,
                             resolver: &resolver,
-                            guest_memory: &gm,
+                            dma_target: &pci_core::dma::DmaTarget::new(
+                                gm.clone(),
+                                pci_core::msi::MsiTarget::disconnected(),
+                            ),
                             resource: dev_cfg.resource,
                             doorbell_registration: partition
                                 .clone()
                                 .into_doorbell_registration(vtl),
                             shared_mem_mapper: Some(&mapper),
-                            software_iommu: false,
                         },
                         vmbus.control(),
                         &chipset_builder,
@@ -3555,6 +3556,7 @@ impl LoadedVm {
                                     },
                                     guest_memory: &self.inner.gm,
                                     bus_range: &bus_range,
+                                    msi_target: msi_conn.target().clone(),
                                     #[cfg(guest_arch = "aarch64")]
                                     smmu: self.inner.smmu_shared_states[rc_idx].as_ref(),
                                 },
@@ -3569,13 +3571,11 @@ impl LoadedVm {
                                         .resolve(
                                             resource,
                                             pci_resources::ResolvePciDeviceHandleParams {
-                                                msi_target: msi_conn.target(),
+                                                dma_target: &pcie_ctx.dma_target,
                                                 register_mmio,
                                                 driver_source: &self.inner.driver_source,
-                                                guest_memory: &pcie_ctx.guest_memory,
                                                 doorbell_registration: self.inner.partition.clone().into_doorbell_registration(Vtl::Vtl0),
                                                 shared_mem_mapper: None,
-                                                software_iommu: pcie_ctx.software_iommu,
                                             },
                                         )
                                         .await

--- a/openvmm/openvmm_core/src/worker/dispatch.rs
+++ b/openvmm/openvmm_core/src/worker/dispatch.rs
@@ -2363,7 +2363,6 @@ impl InitializedVm {
                     vmm_core::device_builder::PciDeviceResolveContext {
                         driver_source,
                         resolver,
-                        dma_target: &pcie_ctx.dma_target,
                         resource: dev_cfg.resource,
                         doorbell_registration: partition
                             .clone()
@@ -2372,6 +2371,7 @@ impl InitializedVm {
                     },
                     chipset_builder,
                     port_name.clone(),
+                    &pcie_ctx.dma_target,
                 )
                 .await?;
 
@@ -2570,10 +2570,6 @@ impl InitializedVm {
                         vmm_core::device_builder::PciDeviceResolveContext {
                             driver_source: &driver_source,
                             resolver: &resolver,
-                            dma_target: &pci_core::dma::DmaTarget::new(
-                                gm.clone(),
-                                pci_core::msi::MsiTarget::disconnected(),
-                            ),
                             resource: dev_cfg.resource,
                             doorbell_registration: partition
                                 .clone()
@@ -2591,6 +2587,7 @@ impl InitializedVm {
                                 .transpose()
                                 .context("vpci device vnode exceeds 65535")?,
                         },
+                        gm.clone(),
                         |device_id| {
                             let hv_device = partition.new_virtual_device(
                                 match dev_cfg.vtl {

--- a/openvmm/openvmm_core/src/worker/dispatch/amd_iommu_wiring.rs
+++ b/openvmm/openvmm_core/src/worker/dispatch/amd_iommu_wiring.rs
@@ -104,9 +104,13 @@ pub(super) fn setup_amd_iommu(
 
         let iommu_bus_range = pci_core::bus_range::AssignedBusRange::new();
         iommu_bus_range.set_bus_range(hb.start_bus, hb.start_bus);
-        let iommu_msi_conn = pci_core::msi::MsiConnection::new(iommu_bus_range, 0);
+        let iommu_msi_conn = pci_core::msi::MsiConnection::new();
         let iommu_dev = builder.add(|_services| {
-            amd_iommu::AmdIommuDevice::new(gm.clone(), iommu_config, iommu_msi_conn.target())
+            amd_iommu::AmdIommuDevice::new(
+                gm.clone(),
+                iommu_config,
+                &iommu_msi_conn.msi_target(iommu_bus_range, 0),
+            )
         })?;
         if let Some(signal_msi) = partition.as_signal_msi(Vtl::Vtl0) {
             iommu_msi_conn.connect(signal_msi);

--- a/openvmm/openvmm_core/src/worker/dispatch/pcie_wiring.rs
+++ b/openvmm/openvmm_core/src/worker/dispatch/pcie_wiring.rs
@@ -120,10 +120,11 @@ pub(super) struct PcieDeviceWiringParams<'a> {
     pub msi_platform: PcieMsiPlatform<'a>,
     /// Raw guest memory (wrapped with IOMMU DMA translation when applicable).
     pub guest_memory: &'a GuestMemory,
-    /// The device's assigned bus range (for IOMMU stream/device ID).
+    /// The device's assigned bus range (for IOMMU stream/device ID and the
+    /// MSI/DMA requester identity).
     pub bus_range: &'a pci_core::bus_range::AssignedBusRange,
-    /// The MSI target derived from the device's [`MsiConnection`].
-    pub msi_target: pci_core::msi::MsiTarget,
+    /// The device's MSI connection, providing the late-bound MSI backend.
+    pub msi: &'a pci_core::msi::MsiConnection,
     /// SMMU shared state if this device is behind an SMMU, or `None`.
     #[cfg(guest_arch = "aarch64")]
     pub smmu: Option<&'a Arc<smmu::SmmuSharedState>>,
@@ -168,8 +169,9 @@ pub(super) fn build_device_wiring(params: PcieDeviceWiringParams<'_>) -> PcieDev
             "smmu",
             shared.translator(0),
             params.bus_range.clone(),
+            0,
             params.guest_memory.clone(),
-            params.msi_target,
+            params.msi,
         );
         let smmu_msi = msi.signal_msi.map(|inner_msi| {
             Arc::new(smmu::SmmuSignalMsi::new(shared.clone(), 0, inner_msi))
@@ -196,15 +198,21 @@ pub(super) fn build_device_wiring(params: PcieDeviceWiringParams<'_>) -> PcieDev
                 "amd-iommu",
                 shared.translator(),
                 params.bus_range.clone(),
+                0,
                 params.guest_memory.clone(),
-                params.msi_target,
+                params.msi,
             ),
             msi,
         };
     }
 
     PcieDeviceWiring {
-        dma_target: DmaTarget::new(params.guest_memory.clone(), params.msi_target),
+        dma_target: DmaTarget::new(
+            params.bus_range.clone(),
+            0,
+            params.guest_memory.clone(),
+            params.msi,
+        ),
         msi,
     }
 }

--- a/openvmm/openvmm_core/src/worker/dispatch/pcie_wiring.rs
+++ b/openvmm/openvmm_core/src/worker/dispatch/pcie_wiring.rs
@@ -164,19 +164,13 @@ pub(super) fn build_device_wiring(params: PcieDeviceWiringParams<'_>) -> PcieDev
     // availability.
     #[cfg(guest_arch = "aarch64")]
     if let Some(shared) = params.smmu {
-        let translating_gm = iommu_common::TranslatingMemory::new_guest_memory(
-            "smmu-translating",
+        let dma_target = iommu_common::new_dma_target(
+            "smmu",
             shared.translator(0),
             params.bus_range.clone(),
             params.guest_memory.clone(),
+            params.msi_target,
         );
-        let iommu = Arc::new(iommu_common::TranslatingDmaTarget::new(
-            "smmu-translating-vf",
-            shared.translator(0),
-            params.bus_range.clone(),
-            params.guest_memory.clone(),
-        ));
-        let dma_target = DmaTarget::with_iommu(translating_gm, params.msi_target, iommu);
         let smmu_msi = msi.signal_msi.map(|inner_msi| {
             Arc::new(smmu::SmmuSignalMsi::new(shared.clone(), 0, inner_msi))
                 as Arc<dyn pci_core::msi::SignalMsi>
@@ -197,20 +191,14 @@ pub(super) fn build_device_wiring(params: PcieDeviceWiringParams<'_>) -> PcieDev
     // MSI interrupt remapping was already applied by wrap_msi().
     #[cfg(guest_arch = "x86_64")]
     if let Some(shared) = params.msi_platform.iommu {
-        let translating_gm = iommu_common::TranslatingMemory::new_guest_memory(
-            "amd-iommu-translating",
-            shared.translator(),
-            params.bus_range.clone(),
-            params.guest_memory.clone(),
-        );
-        let iommu = Arc::new(iommu_common::TranslatingDmaTarget::new(
-            "amd-iommu-translating-vf",
-            shared.translator(),
-            params.bus_range.clone(),
-            params.guest_memory.clone(),
-        ));
         return PcieDeviceWiring {
-            dma_target: DmaTarget::with_iommu(translating_gm, params.msi_target, iommu),
+            dma_target: iommu_common::new_dma_target(
+                "amd-iommu",
+                shared.translator(),
+                params.bus_range.clone(),
+                params.guest_memory.clone(),
+                params.msi_target,
+            ),
             msi,
         };
     }

--- a/openvmm/openvmm_core/src/worker/dispatch/pcie_wiring.rs
+++ b/openvmm/openvmm_core/src/worker/dispatch/pcie_wiring.rs
@@ -16,6 +16,7 @@
 use crate::partition::HvlitePartition;
 use guestmem::GuestMemory;
 use hvdef::Vtl;
+use pci_core::dma::DmaTarget;
 use std::sync::Arc;
 use vm_topology::processor::ProcessorTopology;
 
@@ -121,25 +122,22 @@ pub(super) struct PcieDeviceWiringParams<'a> {
     pub guest_memory: &'a GuestMemory,
     /// The device's assigned bus range (for IOMMU stream/device ID).
     pub bus_range: &'a pci_core::bus_range::AssignedBusRange,
+    /// The MSI target derived from the device's [`MsiConnection`].
+    pub msi_target: pci_core::msi::MsiTarget,
     /// SMMU shared state if this device is behind an SMMU, or `None`.
     #[cfg(guest_arch = "aarch64")]
     pub smmu: Option<&'a Arc<smmu::SmmuSharedState>>,
 }
 
-/// The layered GuestMemory and MSI routing for a PCIe device.
+/// The layered DMA target and MSI routing for a PCIe device.
 ///
-/// Produced by [`build_device_wiring`]. Extends [`PcieMsiRouting`] with
-/// IOMMU DMA translation and a `software_iommu` flag.
+/// Produced by [`build_device_wiring`]. Pairs a [`DmaTarget`] (guest memory
+/// + MSI identity + optional IOMMU) with the wrapped [`PcieMsiRouting`].
 pub(super) struct PcieDeviceWiring {
-    /// Guest memory for the device — either the raw memory or an
-    /// IOMMU-translating wrapper.
-    pub guest_memory: GuestMemory,
+    /// DMA and MSI target for the device, including any IOMMU translation.
+    pub dma_target: DmaTarget,
     /// Wrapped MSI routing for the device.
     pub msi: PcieMsiRouting,
-    /// Whether the device is behind a software IOMMU (e.g., emulated
-    /// SMMU or AMD IOMMU) that cannot program the host IOMMU for
-    /// passthrough DMA.
-    pub software_iommu: bool,
 }
 
 impl PcieDeviceWiring {
@@ -149,11 +147,11 @@ impl PcieDeviceWiring {
     }
 }
 
-/// Build the layered GuestMemory and MSI routing for a PCIe device.
+/// Build the layered DMA target and MSI routing for a PCIe device.
 ///
 /// Calls [`PcieMsiPlatform::wrap_msi`] for MSI/IrqFd wrapping, then
 /// adds IOMMU DMA translation (SMMU on aarch64, AMD IOMMU on x86_64)
-/// to produce the device's `GuestMemory`.
+/// to produce the device's [`DmaTarget`].
 pub(super) fn build_device_wiring(params: PcieDeviceWiringParams<'_>) -> PcieDeviceWiring {
     let msi = params.msi_platform.wrap_msi();
 
@@ -166,13 +164,19 @@ pub(super) fn build_device_wiring(params: PcieDeviceWiringParams<'_>) -> PcieDev
     // availability.
     #[cfg(guest_arch = "aarch64")]
     if let Some(shared) = params.smmu {
-        let translator = shared.translator(0);
         let translating_gm = iommu_common::TranslatingMemory::new_guest_memory(
             "smmu-translating",
-            translator,
+            shared.translator(0),
             params.bus_range.clone(),
             params.guest_memory.clone(),
         );
+        let iommu = Arc::new(iommu_common::TranslatingDmaTarget::new(
+            "smmu-translating-vf",
+            shared.translator(0),
+            params.bus_range.clone(),
+            params.guest_memory.clone(),
+        ));
+        let dma_target = DmaTarget::with_iommu(translating_gm, params.msi_target, iommu);
         let smmu_msi = msi.signal_msi.map(|inner_msi| {
             Arc::new(smmu::SmmuSignalMsi::new(shared.clone(), 0, inner_msi))
                 as Arc<dyn pci_core::msi::SignalMsi>
@@ -181,12 +185,11 @@ pub(super) fn build_device_wiring(params: PcieDeviceWiringParams<'_>) -> PcieDev
             .irqfd
             .map(|fd| shared.wrap_irqfd(0, fd) as Arc<dyn vmcore::irqfd::IrqFd>);
         return PcieDeviceWiring {
-            guest_memory: translating_gm,
+            dma_target,
             msi: PcieMsiRouting {
                 signal_msi: smmu_msi,
                 irqfd,
             },
-            software_iommu: true,
         };
     }
 
@@ -194,23 +197,26 @@ pub(super) fn build_device_wiring(params: PcieDeviceWiringParams<'_>) -> PcieDev
     // MSI interrupt remapping was already applied by wrap_msi().
     #[cfg(guest_arch = "x86_64")]
     if let Some(shared) = params.msi_platform.iommu {
-        let translator = shared.translator();
         let translating_gm = iommu_common::TranslatingMemory::new_guest_memory(
             "amd-iommu-translating",
-            translator,
+            shared.translator(),
             params.bus_range.clone(),
             params.guest_memory.clone(),
         );
+        let iommu = Arc::new(iommu_common::TranslatingDmaTarget::new(
+            "amd-iommu-translating-vf",
+            shared.translator(),
+            params.bus_range.clone(),
+            params.guest_memory.clone(),
+        ));
         return PcieDeviceWiring {
-            guest_memory: translating_gm,
+            dma_target: DmaTarget::with_iommu(translating_gm, params.msi_target, iommu),
             msi,
-            software_iommu: true,
         };
     }
 
     PcieDeviceWiring {
-        guest_memory: params.guest_memory.clone(),
+        dma_target: DmaTarget::new(params.guest_memory.clone(), params.msi_target),
         msi,
-        software_iommu: false,
     }
 }

--- a/vm/devices/iommu/amd_iommu/src/lib.rs
+++ b/vm/devices/iommu/amd_iommu/src/lib.rs
@@ -888,6 +888,7 @@ impl IommuSharedState {
 /// One `AmdTranslator` is shared by all PCI devices behind the same IOMMU.
 /// The requester ID (RID / BDF) is passed at each translation call and
 /// used directly as the AMD IOMMU DeviceID.
+#[derive(Clone)]
 pub struct AmdTranslator {
     /// Reference to the shared IOMMU state.
     shared: Arc<IommuSharedState>,
@@ -1664,6 +1665,7 @@ impl MmioIntercept for AmdIommuDevice {
 mod tests {
     use super::*;
     use guestmem::GuestMemory;
+    use pci_core::bus_range::AssignedBusRange;
     use spec::commands::CommandEntry;
     use spec::dte::IntCtl;
     use spec::events::EventCode;
@@ -1688,8 +1690,7 @@ mod tests {
 
     fn create_test_device() -> AmdIommuDevice {
         let guest_memory = GuestMemory::empty();
-        let msi_conn =
-            pci_core::msi::MsiConnection::new(pci_core::bus_range::AssignedBusRange::new(), 0);
+        let msi_conn = pci_core::msi::MsiConnection::new(AssignedBusRange::new(), 0);
         AmdIommuDevice::new(guest_memory, test_config(), msi_conn.target())
     }
 
@@ -2126,8 +2127,7 @@ mod tests {
     ///   0x2000..0x2FFF = scratch space (for COMPLETION_WAIT store data)
     fn create_test_device_with_memory() -> AmdIommuDevice {
         let guest_memory = GuestMemory::allocate(0x10000);
-        let msi_conn =
-            pci_core::msi::MsiConnection::new(pci_core::bus_range::AssignedBusRange::new(), 0);
+        let msi_conn = pci_core::msi::MsiConnection::new(AssignedBusRange::new(), 0);
         AmdIommuDevice::new(guest_memory, test_config(), msi_conn.target())
     }
 
@@ -2381,8 +2381,7 @@ mod tests {
         // Create device with a connected MSI controller to verify actual
         // MSI delivery (not just status bit).
         let guest_memory = GuestMemory::allocate(0x10000);
-        let msi_conn =
-            pci_core::msi::MsiConnection::new(pci_core::bus_range::AssignedBusRange::new(), 0);
+        let msi_conn = pci_core::msi::MsiConnection::new(AssignedBusRange::new(), 0);
         let msi_controller = pci_core::test_helpers::TestPciInterruptController::new();
         msi_conn.connect(msi_controller.signal_msi());
         let mut dev = AmdIommuDevice::new(guest_memory, test_config(), msi_conn.target());
@@ -2649,8 +2648,7 @@ mod tests {
     /// page tables (1MB).
     fn create_test_device_for_translation() -> AmdIommuDevice {
         let guest_memory = GuestMemory::allocate(0x10_0000); // 1MB
-        let msi_conn =
-            pci_core::msi::MsiConnection::new(pci_core::bus_range::AssignedBusRange::new(), 0);
+        let msi_conn = pci_core::msi::MsiConnection::new(AssignedBusRange::new(), 0);
         AmdIommuDevice::new(guest_memory, test_config(), msi_conn.target())
     }
 
@@ -4513,8 +4511,7 @@ mod tests {
     #[test]
     fn test_remap_msi_iommu_disabled() {
         let guest_memory = GuestMemory::allocate(0x10_0000);
-        let msi_conn =
-            pci_core::msi::MsiConnection::new(pci_core::bus_range::AssignedBusRange::new(), 0);
+        let msi_conn = pci_core::msi::MsiConnection::new(AssignedBusRange::new(), 0);
         let dev = AmdIommuDevice::new(guest_memory, test_config(), msi_conn.target());
 
         // IOMMU not enabled — MSI should pass through unchanged.
@@ -4619,15 +4616,15 @@ mod tests {
     const WRAPPER_BUS: u8 = 1;
     const WRAPPER_DEVICE_ID: u16 = (WRAPPER_BUS as u16) << 8;
 
-    fn bus_range_for_device_id(device_id: u16) -> pci_core::bus_range::AssignedBusRange {
+    fn bus_range_for_device_id(device_id: u16) -> AssignedBusRange {
         assert_eq!(device_id & 0xFF, 0, "test DeviceID must be dev 0 fn 0");
         let bus = (device_id >> 8) as u8;
-        let bus_range = pci_core::bus_range::AssignedBusRange::new();
+        let bus_range = AssignedBusRange::new();
         bus_range.set_bus_range(bus, bus);
         bus_range
     }
 
-    fn wrapper_bus_range() -> pci_core::bus_range::AssignedBusRange {
+    fn wrapper_bus_range() -> AssignedBusRange {
         bus_range_for_device_id(WRAPPER_DEVICE_ID)
     }
 
@@ -4635,8 +4632,7 @@ mod tests {
     /// for testing per-device wrappers. Returns the device and shared state.
     fn setup_iommu_for_wrappers() -> AmdIommuDevice {
         let guest_memory = GuestMemory::allocate(0x10_0000); // 1MB
-        let msi_conn =
-            pci_core::msi::MsiConnection::new(pci_core::bus_range::AssignedBusRange::new(), 0);
+        let msi_conn = pci_core::msi::MsiConnection::new(AssignedBusRange::new(), 0);
         let mut dev = AmdIommuDevice::new(guest_memory, test_config(), msi_conn.target());
 
         let devtab_gpa = 0x1_0000;
@@ -4698,7 +4694,7 @@ mod tests {
     /// remapping.
     fn device_context(
         shared: &Arc<IommuSharedState>,
-        bus_range: pci_core::bus_range::AssignedBusRange,
+        bus_range: AssignedBusRange,
         inner_gm: &GuestMemory,
         inner_msi: Arc<dyn SignalMsi>,
     ) -> (GuestMemory, Arc<IommuSignalMsi>) {
@@ -4763,8 +4759,7 @@ mod tests {
     #[test]
     fn test_translating_memory_passthrough() {
         let guest_memory = GuestMemory::allocate(0x10_0000);
-        let msi_conn =
-            pci_core::msi::MsiConnection::new(pci_core::bus_range::AssignedBusRange::new(), 0);
+        let msi_conn = pci_core::msi::MsiConnection::new(AssignedBusRange::new(), 0);
         let mut dev = AmdIommuDevice::new(guest_memory, test_config(), msi_conn.target());
 
         let devtab_gpa = 0x1_0000;
@@ -4814,8 +4809,7 @@ mod tests {
     #[test]
     fn test_translating_memory_disabled_bypass() {
         let guest_memory = GuestMemory::allocate(0x10_0000);
-        let msi_conn =
-            pci_core::msi::MsiConnection::new(pci_core::bus_range::AssignedBusRange::new(), 0);
+        let msi_conn = pci_core::msi::MsiConnection::new(AssignedBusRange::new(), 0);
         let dev = AmdIommuDevice::new(guest_memory, test_config(), msi_conn.target());
         // IOMMU not enabled — all accesses should pass through.
 
@@ -4861,8 +4855,7 @@ mod tests {
     #[test]
     fn test_signal_msi_iommu_disabled() {
         let guest_memory = GuestMemory::allocate(0x10_0000);
-        let msi_conn =
-            pci_core::msi::MsiConnection::new(pci_core::bus_range::AssignedBusRange::new(), 0);
+        let msi_conn = pci_core::msi::MsiConnection::new(AssignedBusRange::new(), 0);
         let dev = AmdIommuDevice::new(guest_memory, test_config(), msi_conn.target());
 
         let shared = dev.shared_state().clone();
@@ -4978,8 +4971,7 @@ mod tests {
         // =====================================================================
 
         let guest_memory = GuestMemory::allocate(0x20_0000); // 2MB
-        let msi_conn =
-            pci_core::msi::MsiConnection::new(pci_core::bus_range::AssignedBusRange::new(), 0);
+        let msi_conn = pci_core::msi::MsiConnection::new(AssignedBusRange::new(), 0);
         let mut dev = AmdIommuDevice::new(guest_memory, test_config(), msi_conn.target());
 
         let devtab_gpa: u64 = 0x00_0000;
@@ -5360,8 +5352,7 @@ mod tests {
     ///              (deliberately non-contiguous GPAs)
     fn setup_iommu_two_pages() -> AmdIommuDevice {
         let guest_memory = GuestMemory::allocate(0x20_0000); // 2MB
-        let msi_conn =
-            pci_core::msi::MsiConnection::new(pci_core::bus_range::AssignedBusRange::new(), 0);
+        let msi_conn = pci_core::msi::MsiConnection::new(AssignedBusRange::new(), 0);
         let mut dev = AmdIommuDevice::new(guest_memory, test_config(), msi_conn.target());
 
         let devtab_gpa = 0x1_0000;
@@ -5412,8 +5403,7 @@ mod tests {
             ],
         )
         .unwrap();
-        let msi_conn =
-            pci_core::msi::MsiConnection::new(pci_core::bus_range::AssignedBusRange::new(), 0);
+        let msi_conn = pci_core::msi::MsiConnection::new(AssignedBusRange::new(), 0);
         let mut dev = AmdIommuDevice::new(guest_memory, test_config(), msi_conn.target());
 
         let devtab_gpa = 0x1000;
@@ -5787,8 +5777,7 @@ mod tests {
     #[test]
     fn test_translating_memory_3level_high_iova() {
         let guest_memory = GuestMemory::allocate(0x20_0000); // 2MB
-        let msi_conn =
-            pci_core::msi::MsiConnection::new(pci_core::bus_range::AssignedBusRange::new(), 0);
+        let msi_conn = pci_core::msi::MsiConnection::new(AssignedBusRange::new(), 0);
         let mut dev = AmdIommuDevice::new(guest_memory, test_config(), msi_conn.target());
 
         let devtab_gpa = 0x1_0000;
@@ -6020,8 +6009,7 @@ mod tests {
     #[test]
     fn test_translating_memory_iova_overflow() {
         let guest_memory = GuestMemory::allocate(0x10_0000);
-        let msi_conn =
-            pci_core::msi::MsiConnection::new(pci_core::bus_range::AssignedBusRange::new(), 0);
+        let msi_conn = pci_core::msi::MsiConnection::new(AssignedBusRange::new(), 0);
         let mut dev = AmdIommuDevice::new(guest_memory, test_config(), msi_conn.target());
 
         let devtab_gpa = 0x1_0000;
@@ -6137,8 +6125,7 @@ mod tests {
     #[test]
     fn test_evtlog_overflow_delivers_msi() {
         let guest_memory = GuestMemory::allocate(0x10000);
-        let msi_conn =
-            pci_core::msi::MsiConnection::new(pci_core::bus_range::AssignedBusRange::new(), 0);
+        let msi_conn = pci_core::msi::MsiConnection::new(AssignedBusRange::new(), 0);
         let msi_controller = pci_core::test_helpers::TestPciInterruptController::new();
         msi_conn.connect(msi_controller.signal_msi());
         let mut dev = AmdIommuDevice::new(guest_memory, test_config(), msi_conn.target());
@@ -6251,8 +6238,7 @@ mod tests {
         // Place the event log within valid memory and the command buffer
         // beyond it so that reading a command entry fails.
         let guest_memory = GuestMemory::allocate(0x10000);
-        let msi_conn =
-            pci_core::msi::MsiConnection::new(pci_core::bus_range::AssignedBusRange::new(), 0);
+        let msi_conn = pci_core::msi::MsiConnection::new(AssignedBusRange::new(), 0);
         let mut dev = AmdIommuDevice::new(guest_memory, test_config(), msi_conn.target());
 
         // Event log at valid GPA 0x1000.

--- a/vm/devices/iommu/amd_iommu/src/lib.rs
+++ b/vm/devices/iommu/amd_iommu/src/lib.rs
@@ -1690,8 +1690,8 @@ mod tests {
 
     fn create_test_device() -> AmdIommuDevice {
         let guest_memory = GuestMemory::empty();
-        let msi_conn = pci_core::msi::MsiConnection::new(AssignedBusRange::new(), 0);
-        AmdIommuDevice::new(guest_memory, test_config(), msi_conn.target())
+        let msi_conn = pci_core::msi::MsiConnection::new();
+        AmdIommuDevice::new(guest_memory, test_config(), &msi_conn.target())
     }
 
     /// Helper to read a 32-bit PCI config register.
@@ -2127,8 +2127,8 @@ mod tests {
     ///   0x2000..0x2FFF = scratch space (for COMPLETION_WAIT store data)
     fn create_test_device_with_memory() -> AmdIommuDevice {
         let guest_memory = GuestMemory::allocate(0x10000);
-        let msi_conn = pci_core::msi::MsiConnection::new(AssignedBusRange::new(), 0);
-        AmdIommuDevice::new(guest_memory, test_config(), msi_conn.target())
+        let msi_conn = pci_core::msi::MsiConnection::new();
+        AmdIommuDevice::new(guest_memory, test_config(), &msi_conn.target())
     }
 
     /// Configure and enable the IOMMU with command buffer and event log.
@@ -2381,10 +2381,10 @@ mod tests {
         // Create device with a connected MSI controller to verify actual
         // MSI delivery (not just status bit).
         let guest_memory = GuestMemory::allocate(0x10000);
-        let msi_conn = pci_core::msi::MsiConnection::new(AssignedBusRange::new(), 0);
+        let msi_conn = pci_core::msi::MsiConnection::new();
         let msi_controller = pci_core::test_helpers::TestPciInterruptController::new();
         msi_conn.connect(msi_controller.signal_msi());
-        let mut dev = AmdIommuDevice::new(guest_memory, test_config(), msi_conn.target());
+        let mut dev = AmdIommuDevice::new(guest_memory, test_config(), &msi_conn.target());
 
         // Enable MSI on the IOMMU's PCI config space.
         // The MSI capability is the second capability. Find its offset.
@@ -2648,8 +2648,8 @@ mod tests {
     /// page tables (1MB).
     fn create_test_device_for_translation() -> AmdIommuDevice {
         let guest_memory = GuestMemory::allocate(0x10_0000); // 1MB
-        let msi_conn = pci_core::msi::MsiConnection::new(AssignedBusRange::new(), 0);
-        AmdIommuDevice::new(guest_memory, test_config(), msi_conn.target())
+        let msi_conn = pci_core::msi::MsiConnection::new();
+        AmdIommuDevice::new(guest_memory, test_config(), &msi_conn.target())
     }
 
     /// Set up the IOMMU with a device table at a given GPA.
@@ -4511,8 +4511,8 @@ mod tests {
     #[test]
     fn test_remap_msi_iommu_disabled() {
         let guest_memory = GuestMemory::allocate(0x10_0000);
-        let msi_conn = pci_core::msi::MsiConnection::new(AssignedBusRange::new(), 0);
-        let dev = AmdIommuDevice::new(guest_memory, test_config(), msi_conn.target());
+        let msi_conn = pci_core::msi::MsiConnection::new();
+        let dev = AmdIommuDevice::new(guest_memory, test_config(), &msi_conn.target());
 
         // IOMMU not enabled — MSI should pass through unchanged.
         let (new_addr, new_data) = dev.remap_msi(0x10, 0xFEE0_0000, 0x30).unwrap();
@@ -4632,8 +4632,8 @@ mod tests {
     /// for testing per-device wrappers. Returns the device and shared state.
     fn setup_iommu_for_wrappers() -> AmdIommuDevice {
         let guest_memory = GuestMemory::allocate(0x10_0000); // 1MB
-        let msi_conn = pci_core::msi::MsiConnection::new(AssignedBusRange::new(), 0);
-        let mut dev = AmdIommuDevice::new(guest_memory, test_config(), msi_conn.target());
+        let msi_conn = pci_core::msi::MsiConnection::new();
+        let mut dev = AmdIommuDevice::new(guest_memory, test_config(), &msi_conn.target());
 
         let devtab_gpa = 0x1_0000;
         setup_iommu_with_devtab(&mut dev, devtab_gpa, 512);
@@ -4759,8 +4759,8 @@ mod tests {
     #[test]
     fn test_translating_memory_passthrough() {
         let guest_memory = GuestMemory::allocate(0x10_0000);
-        let msi_conn = pci_core::msi::MsiConnection::new(AssignedBusRange::new(), 0);
-        let mut dev = AmdIommuDevice::new(guest_memory, test_config(), msi_conn.target());
+        let msi_conn = pci_core::msi::MsiConnection::new();
+        let mut dev = AmdIommuDevice::new(guest_memory, test_config(), &msi_conn.target());
 
         let devtab_gpa = 0x1_0000;
         setup_iommu_with_devtab(&mut dev, devtab_gpa, 512);
@@ -4809,8 +4809,8 @@ mod tests {
     #[test]
     fn test_translating_memory_disabled_bypass() {
         let guest_memory = GuestMemory::allocate(0x10_0000);
-        let msi_conn = pci_core::msi::MsiConnection::new(AssignedBusRange::new(), 0);
-        let dev = AmdIommuDevice::new(guest_memory, test_config(), msi_conn.target());
+        let msi_conn = pci_core::msi::MsiConnection::new();
+        let dev = AmdIommuDevice::new(guest_memory, test_config(), &msi_conn.target());
         // IOMMU not enabled — all accesses should pass through.
 
         let shared = dev.shared_state().clone();
@@ -4855,8 +4855,8 @@ mod tests {
     #[test]
     fn test_signal_msi_iommu_disabled() {
         let guest_memory = GuestMemory::allocate(0x10_0000);
-        let msi_conn = pci_core::msi::MsiConnection::new(AssignedBusRange::new(), 0);
-        let dev = AmdIommuDevice::new(guest_memory, test_config(), msi_conn.target());
+        let msi_conn = pci_core::msi::MsiConnection::new();
+        let dev = AmdIommuDevice::new(guest_memory, test_config(), &msi_conn.target());
 
         let shared = dev.shared_state().clone();
         let mock_msi = MockSignalMsi::new();
@@ -4971,8 +4971,8 @@ mod tests {
         // =====================================================================
 
         let guest_memory = GuestMemory::allocate(0x20_0000); // 2MB
-        let msi_conn = pci_core::msi::MsiConnection::new(AssignedBusRange::new(), 0);
-        let mut dev = AmdIommuDevice::new(guest_memory, test_config(), msi_conn.target());
+        let msi_conn = pci_core::msi::MsiConnection::new();
+        let mut dev = AmdIommuDevice::new(guest_memory, test_config(), &msi_conn.target());
 
         let devtab_gpa: u64 = 0x00_0000;
         let cmdbuf_gpa: u64 = 0x00_8000;
@@ -5352,8 +5352,8 @@ mod tests {
     ///              (deliberately non-contiguous GPAs)
     fn setup_iommu_two_pages() -> AmdIommuDevice {
         let guest_memory = GuestMemory::allocate(0x20_0000); // 2MB
-        let msi_conn = pci_core::msi::MsiConnection::new(AssignedBusRange::new(), 0);
-        let mut dev = AmdIommuDevice::new(guest_memory, test_config(), msi_conn.target());
+        let msi_conn = pci_core::msi::MsiConnection::new();
+        let mut dev = AmdIommuDevice::new(guest_memory, test_config(), &msi_conn.target());
 
         let devtab_gpa = 0x1_0000;
         setup_iommu_with_devtab(&mut dev, devtab_gpa, 512);
@@ -5403,8 +5403,8 @@ mod tests {
             ],
         )
         .unwrap();
-        let msi_conn = pci_core::msi::MsiConnection::new(AssignedBusRange::new(), 0);
-        let mut dev = AmdIommuDevice::new(guest_memory, test_config(), msi_conn.target());
+        let msi_conn = pci_core::msi::MsiConnection::new();
+        let mut dev = AmdIommuDevice::new(guest_memory, test_config(), &msi_conn.target());
 
         let devtab_gpa = 0x1000;
         setup_iommu_with_devtab(&mut dev, devtab_gpa, 512);
@@ -5777,8 +5777,8 @@ mod tests {
     #[test]
     fn test_translating_memory_3level_high_iova() {
         let guest_memory = GuestMemory::allocate(0x20_0000); // 2MB
-        let msi_conn = pci_core::msi::MsiConnection::new(AssignedBusRange::new(), 0);
-        let mut dev = AmdIommuDevice::new(guest_memory, test_config(), msi_conn.target());
+        let msi_conn = pci_core::msi::MsiConnection::new();
+        let mut dev = AmdIommuDevice::new(guest_memory, test_config(), &msi_conn.target());
 
         let devtab_gpa = 0x1_0000;
         setup_iommu_with_devtab(&mut dev, devtab_gpa, 512);
@@ -6009,8 +6009,8 @@ mod tests {
     #[test]
     fn test_translating_memory_iova_overflow() {
         let guest_memory = GuestMemory::allocate(0x10_0000);
-        let msi_conn = pci_core::msi::MsiConnection::new(AssignedBusRange::new(), 0);
-        let mut dev = AmdIommuDevice::new(guest_memory, test_config(), msi_conn.target());
+        let msi_conn = pci_core::msi::MsiConnection::new();
+        let mut dev = AmdIommuDevice::new(guest_memory, test_config(), &msi_conn.target());
 
         let devtab_gpa = 0x1_0000;
         setup_iommu_with_devtab(&mut dev, devtab_gpa, 512);
@@ -6125,10 +6125,10 @@ mod tests {
     #[test]
     fn test_evtlog_overflow_delivers_msi() {
         let guest_memory = GuestMemory::allocate(0x10000);
-        let msi_conn = pci_core::msi::MsiConnection::new(AssignedBusRange::new(), 0);
+        let msi_conn = pci_core::msi::MsiConnection::new();
         let msi_controller = pci_core::test_helpers::TestPciInterruptController::new();
         msi_conn.connect(msi_controller.signal_msi());
-        let mut dev = AmdIommuDevice::new(guest_memory, test_config(), msi_conn.target());
+        let mut dev = AmdIommuDevice::new(guest_memory, test_config(), &msi_conn.target());
 
         // Enable MSI on PCI config space.
         let iommu_cap_header = pci_read(&mut dev, 0x40);
@@ -6238,8 +6238,8 @@ mod tests {
         // Place the event log within valid memory and the command buffer
         // beyond it so that reading a command entry fails.
         let guest_memory = GuestMemory::allocate(0x10000);
-        let msi_conn = pci_core::msi::MsiConnection::new(AssignedBusRange::new(), 0);
-        let mut dev = AmdIommuDevice::new(guest_memory, test_config(), msi_conn.target());
+        let msi_conn = pci_core::msi::MsiConnection::new();
+        let mut dev = AmdIommuDevice::new(guest_memory, test_config(), &msi_conn.target());
 
         // Event log at valid GPA 0x1000.
         let evt_base = EvtLogBase::new()

--- a/vm/devices/iommu/iommu_common/src/lib.rs
+++ b/vm/devices/iommu/iommu_common/src/lib.rs
@@ -89,7 +89,7 @@ pub struct TranslationFault<E: std::error::Error + 'static> {
     "DMA requester ID {rid:#06x} bus outside assigned bus range {secondary:#04x}..={subordinate:#04x}"
 )]
 struct RidOutOfRange {
-    rid: u16,
+    rid: u32,
     secondary: u8,
     subordinate: u8,
 }
@@ -166,7 +166,7 @@ impl<T: IommuTranslator> TranslatingMemory<T> {
         let rid = ((secondary as u32) << 8) + self.rid_offset as u32;
         if rid >> 8 > subordinate as u32 {
             return Err(RidOutOfRange {
-                rid: rid as u16,
+                rid,
                 secondary,
                 subordinate,
             });

--- a/vm/devices/iommu/iommu_common/src/lib.rs
+++ b/vm/devices/iommu/iommu_common/src/lib.rs
@@ -82,6 +82,22 @@ pub struct TranslationFault<E: std::error::Error + 'static> {
     pub error: E,
 }
 
+/// Error returned when a fixed requester ID override falls outside the
+/// device's assigned bus range.
+///
+/// Produced by [`TranslatingMemory`] when a per-VF `rid_override`'s bus is not
+/// within the assigned `(secondary, subordinate)` range, so the DMA access
+/// faults instead of translating with an out-of-range device identity.
+#[derive(Debug, thiserror::Error)]
+#[error(
+    "DMA requester ID {rid:#06x} bus outside assigned bus range {secondary:#04x}..={subordinate:#04x}"
+)]
+struct RidOutOfRange {
+    rid: u16,
+    secondary: u8,
+    subordinate: u8,
+}
+
 /// A [`GuestMemoryAccess`](guestmem::GuestMemoryAccess) implementation that
 /// translates IOVAs via an [`IommuTranslator`] before accessing guest memory.
 ///
@@ -94,6 +110,11 @@ pub struct TranslatingMemory<T: IommuTranslator> {
     translator: T,
     /// The device's assigned bus range, used to derive the RID.
     bus_range: AssignedBusRange,
+    /// Optional fixed requester ID. When `Some`, this RID is used for every
+    /// access instead of deriving it from `bus_range`. Used for SR-IOV
+    /// virtual functions, which share the PF's bus range but need a
+    /// per-function RID.
+    rid_override: Option<u16>,
     /// The raw (untranslated) guest memory.
     inner_gm: GuestMemory,
 }
@@ -113,18 +134,57 @@ impl<T: IommuTranslator> TranslatingMemory<T> {
         let tm = TranslatingMemory {
             translator,
             bus_range,
+            rid_override: None,
             inner_gm,
         };
         GuestMemory::new(label, tm)
     }
 
-    /// Derive the requester ID (RID) from the current bus range.
+    /// Create a new translating `GuestMemory` for a specific requester ID.
     ///
-    /// Returns `(secondary_bus as u16) << 8`. If secondary_bus is 0,
-    /// the RID is 0 — the IOMMU handles this case (translation or fault).
-    fn rid(&self) -> u16 {
+    /// Like [`new_guest_memory`](Self::new_guest_memory), but every access
+    /// uses the given `rid` (`(bus << 8) | devfn`) instead of deriving it
+    /// from `bus_range`. Used for SR-IOV virtual functions, which share the
+    /// PF's bus range but each need a distinct RID.
+    pub fn new_guest_memory_for_rid(
+        label: impl Into<std::sync::Arc<str>>,
+        translator: T,
+        bus_range: AssignedBusRange,
+        rid: u16,
+        inner_gm: GuestMemory,
+    ) -> GuestMemory {
+        let tm = TranslatingMemory {
+            translator,
+            bus_range,
+            rid_override: Some(rid),
+            inner_gm,
+        };
+        GuestMemory::new(label, tm)
+    }
+
+    /// Derive the requester ID (RID) for a DMA access.
+    ///
+    /// When a fixed `rid_override` is set (SR-IOV VFs), its bus is validated
+    /// against the assigned bus range and [`RidOutOfRange`] is returned if it
+    /// falls outside — the access then faults rather than translating with a
+    /// device identity outside the device's assigned range. Otherwise the RID
+    /// is derived as `(secondary_bus as u16) << 8`; the secondary bus is
+    /// always in range.
+    fn rid(&self) -> Result<u16, RidOutOfRange> {
+        if let Some(rid) = self.rid_override {
+            let bus = (rid >> 8) as u8;
+            if !self.bus_range.contains_bus(bus) {
+                let (secondary, subordinate) = self.bus_range.bus_range();
+                return Err(RidOutOfRange {
+                    rid,
+                    secondary,
+                    subordinate,
+                });
+            }
+            return Ok(rid);
+        }
         let (secondary, _) = self.bus_range.bus_range();
-        (secondary as u16) << 8
+        Ok((secondary as u16) << 8)
     }
 }
 
@@ -155,7 +215,9 @@ impl<T: IommuTranslator> TranslatingMemory<T> {
             let current_iova = iova + offset as u64;
             let chunk_len = chunk_size(current_iova, len - offset);
 
-            let rid = self.rid();
+            let rid = self
+                .rid()
+                .map_err(|err| GuestMemoryBackingError::other(current_iova, err))?;
             let result = self
                 .translator
                 .translate(rid, current_iova, write, |gpa| op(gpa, offset, chunk_len));
@@ -222,5 +284,174 @@ unsafe impl<T: IommuTranslator> guestmem::GuestMemoryAccess for TranslatingMemor
                 .fill_at(gpa, val, chunk_len)
                 .map_err(|e| GuestMemoryBackingError::other(addr, e))
         })
+    }
+}
+
+/// A [`DmaTargetIommu`](pci_core::dma::DmaTargetIommu) implementation that
+/// produces per-RID translating [`GuestMemory`] from any [`IommuTranslator`].
+///
+/// IOMMU backends (SMMU, AMD-Vi, …) plug into the
+/// [`DmaTarget`](pci_core::dma::DmaTarget) machinery by handing one of these
+/// their arch-specific [`IommuTranslator`]. They do not need to depend on
+/// `pci_core::dma` or construct [`GuestMemory`] for virtual functions
+/// themselves — this type performs the RID composition and `GuestMemory`
+/// construction generically.
+pub struct TranslatingDmaTarget<T: IommuTranslator + Clone> {
+    /// Debug label applied to each VF's `GuestMemory`.
+    label: std::sync::Arc<str>,
+    /// The IOMMU's arch-specific translator, cloned per derived VF.
+    translator: T,
+    /// The device's assigned bus range, used to derive the default
+    /// function-0 RID in [`guest_memory_for_devfn`](Self::guest_memory_for_devfn).
+    bus_range: AssignedBusRange,
+    /// The raw (untranslated) guest memory.
+    inner_gm: GuestMemory,
+}
+
+impl<T: IommuTranslator + Clone> TranslatingDmaTarget<T> {
+    /// Creates a new per-RID `GuestMemory` factory.
+    ///
+    /// - `label`: debug label applied to each VF's `GuestMemory`
+    /// - `translator`: the IOMMU's arch-specific translator (cloned per VF)
+    /// - `bus_range`: the device's assigned bus range, used to derive the
+    ///   default function-0 RID
+    /// - `inner_gm`: the raw (untranslated) guest memory
+    pub fn new(
+        label: impl Into<std::sync::Arc<str>>,
+        translator: T,
+        bus_range: AssignedBusRange,
+        inner_gm: GuestMemory,
+    ) -> Self {
+        Self {
+            label: label.into(),
+            translator,
+            bus_range,
+            inner_gm,
+        }
+    }
+}
+
+impl<T: IommuTranslator + Clone> pci_core::dma::DmaTargetIommu for TranslatingDmaTarget<T> {
+    fn guest_memory_for_devfn(&self, devfn: u8) -> GuestMemory {
+        // Compose the RID from the bus range's secondary bus + the given devfn.
+        let (secondary, _) = self.bus_range.bus_range();
+        let rid = (secondary as u16) << 8 | devfn as u16;
+        self.guest_memory_for_rid(rid)
+    }
+
+    fn guest_memory_for_rid(&self, rid: u16) -> GuestMemory {
+        TranslatingMemory::new_guest_memory_for_rid(
+            self.label.clone(),
+            self.translator.clone(),
+            self.bus_range.clone(),
+            rid,
+            self.inner_gm.clone(),
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Identity translator: GPA == IOVA, never faults. Records nothing — the
+    /// `rid` validation happens in `TranslatingMemory` before `translate` is
+    /// ever called.
+    #[derive(Clone)]
+    struct IdentityTranslator;
+
+    #[derive(Debug, thiserror::Error)]
+    #[error("identity translator never faults")]
+    struct NeverFault;
+
+    impl IommuTranslator for IdentityTranslator {
+        type Error = NeverFault;
+
+        fn max_iova(&self) -> u64 {
+            u64::MAX
+        }
+
+        fn translate<R>(
+            &self,
+            _rid: u16,
+            iova: u64,
+            _write: bool,
+            op: impl FnOnce(u64) -> R,
+        ) -> Result<R, TranslationFault<Self::Error>> {
+            Ok(op(iova))
+        }
+    }
+
+    fn bus_range(secondary: u8, subordinate: u8) -> AssignedBusRange {
+        let r = AssignedBusRange::new();
+        r.set_bus_range(secondary, subordinate);
+        r
+    }
+
+    #[test]
+    fn rid_override_in_range_translates() {
+        let inner = GuestMemory::allocate(0x1000);
+        let gm = TranslatingMemory::new_guest_memory_for_rid(
+            "test",
+            IdentityTranslator,
+            bus_range(5, 10),
+            (7 << 8) | 0x02, // bus 7 within [5, 10]
+            inner.clone(),
+        );
+
+        gm.write_at(0x100, &[0xAB, 0xCD]).unwrap();
+        let mut buf = [0u8; 2];
+        gm.read_at(0x100, &mut buf).unwrap();
+        assert_eq!(buf, [0xAB, 0xCD]);
+
+        // Identity mapping wrote through to inner GPA 0x100.
+        let mut inner_buf = [0u8; 2];
+        inner.read_at(0x100, &mut inner_buf).unwrap();
+        assert_eq!(inner_buf, [0xAB, 0xCD]);
+    }
+
+    #[test]
+    fn rid_override_out_of_range_faults() {
+        let inner = GuestMemory::allocate(0x1000);
+        let mut buf = [0u8; 2];
+
+        // bus 11, above subordinate 10 → access faults
+        let gm_above = TranslatingMemory::new_guest_memory_for_rid(
+            "test",
+            IdentityTranslator,
+            bus_range(5, 10),
+            11 << 8,
+            inner.clone(),
+        );
+        assert!(gm_above.read_at(0x100, &mut buf).is_err());
+        assert!(gm_above.write_at(0x100, &[1, 2]).is_err());
+
+        // bus 4, below secondary 5 → access faults
+        let gm_below = TranslatingMemory::new_guest_memory_for_rid(
+            "test",
+            IdentityTranslator,
+            bus_range(5, 10),
+            4 << 8,
+            inner.clone(),
+        );
+        assert!(gm_below.read_at(0x100, &mut buf).is_err());
+    }
+
+    #[test]
+    fn derived_rid_uses_secondary_bus_in_range() {
+        // No override: the derived RID uses the secondary bus, which is
+        // always within the range, so the access translates.
+        let inner = GuestMemory::allocate(0x1000);
+        let gm = TranslatingMemory::new_guest_memory(
+            "test",
+            IdentityTranslator,
+            bus_range(5, 10),
+            inner.clone(),
+        );
+
+        gm.write_at(0x40, &[0x11]).unwrap();
+        let mut buf = [0u8; 1];
+        gm.read_at(0x40, &mut buf).unwrap();
+        assert_eq!(buf, [0x11]);
     }
 }

--- a/vm/devices/iommu/iommu_common/src/lib.rs
+++ b/vm/devices/iommu/iommu_common/src/lib.rs
@@ -82,12 +82,8 @@ pub struct TranslationFault<E: std::error::Error + 'static> {
     pub error: E,
 }
 
-/// Error returned when a fixed requester ID override falls outside the
-/// device's assigned bus range.
-///
-/// Produced by [`TranslatingMemory`] when a per-VF `rid_override`'s bus is not
-/// within the assigned `(secondary, subordinate)` range, so the DMA access
-/// faults instead of translating with an out-of-range device identity.
+/// Error returned when a requester ID's bus falls outside the device's
+/// assigned bus range, faulting the DMA access.
 #[derive(Debug, thiserror::Error)]
 #[error(
     "DMA requester ID {rid:#06x} bus outside assigned bus range {secondary:#04x}..={subordinate:#04x}"
@@ -110,11 +106,11 @@ pub struct TranslatingMemory<T: IommuTranslator> {
     translator: T,
     /// The device's assigned bus range, used to derive the RID.
     bus_range: AssignedBusRange,
-    /// Optional fixed requester ID. When `Some`, this RID is used for every
-    /// access instead of deriving it from `bus_range`. Used for SR-IOV
-    /// virtual functions, which share the PF's bus range but need a
-    /// per-function RID.
-    rid_override: Option<u16>,
+    /// Offset added to `(secondary_bus << 8)` to form the requester ID for
+    /// each access. For a single-function device this is just its devfn; for
+    /// SR-IOV VFs it may carry into the bus byte to address functions on
+    /// higher buses within the assigned range.
+    rid_offset: u16,
     /// The raw (untranslated) guest memory.
     inner_gm: GuestMemory,
 }
@@ -131,32 +127,27 @@ impl<T: IommuTranslator> TranslatingMemory<T> {
         bus_range: AssignedBusRange,
         inner_gm: GuestMemory,
     ) -> GuestMemory {
-        let tm = TranslatingMemory {
-            translator,
-            bus_range,
-            rid_override: None,
-            inner_gm,
-        };
-        GuestMemory::new(label, tm)
+        Self::new_guest_memory_for_rid_offset(label, translator, bus_range, 0, inner_gm)
     }
 
-    /// Create a new translating `GuestMemory` for a specific requester ID.
+    /// Create a new translating `GuestMemory` for a requester-ID offset
+    /// relative to the secondary bus.
     ///
-    /// Like [`new_guest_memory`](Self::new_guest_memory), but every access
-    /// uses the given `rid` (`(bus << 8) | devfn`) instead of deriving it
-    /// from `bus_range`. Used for SR-IOV virtual functions, which share the
-    /// PF's bus range but each need a distinct RID.
-    pub fn new_guest_memory_for_rid(
+    /// Every access resolves the RID as `(secondary_bus << 8) + rid_offset`,
+    /// reading the secondary bus from the live `bus_range`, so the identity
+    /// tracks the bus assignment. This is the primitive for SR-IOV virtual
+    /// functions, which are constructed before the PF's bus is programmed.
+    pub fn new_guest_memory_for_rid_offset(
         label: impl Into<std::sync::Arc<str>>,
         translator: T,
         bus_range: AssignedBusRange,
-        rid: u16,
+        rid_offset: u16,
         inner_gm: GuestMemory,
     ) -> GuestMemory {
         let tm = TranslatingMemory {
             translator,
             bus_range,
-            rid_override: Some(rid),
+            rid_offset,
             inner_gm,
         };
         GuestMemory::new(label, tm)
@@ -164,27 +155,23 @@ impl<T: IommuTranslator> TranslatingMemory<T> {
 
     /// Derive the requester ID (RID) for a DMA access.
     ///
-    /// When a fixed `rid_override` is set (SR-IOV VFs), its bus is validated
-    /// against the assigned bus range and [`RidOutOfRange`] is returned if it
-    /// falls outside — the access then faults rather than translating with a
-    /// device identity outside the device's assigned range. Otherwise the RID
-    /// is derived as `(secondary_bus as u16) << 8`; the secondary bus is
-    /// always in range.
+    /// The RID is composed as `(secondary_bus << 8) + rid_offset` against the
+    /// live bus range. [`RidOutOfRange`] is returned when the resulting bus
+    /// reaches past the subordinate bus — the access then faults rather than
+    /// translating with a device identity outside the assigned range. The
+    /// offset is non-negative, so the bus is always at least the secondary
+    /// bus.
     fn rid(&self) -> Result<u16, RidOutOfRange> {
-        if let Some(rid) = self.rid_override {
-            let bus = (rid >> 8) as u8;
-            if !self.bus_range.contains_bus(bus) {
-                let (secondary, subordinate) = self.bus_range.bus_range();
-                return Err(RidOutOfRange {
-                    rid,
-                    secondary,
-                    subordinate,
-                });
-            }
-            return Ok(rid);
+        let (secondary, subordinate) = self.bus_range.bus_range();
+        let rid = ((secondary as u32) << 8) + self.rid_offset as u32;
+        if rid >> 8 > subordinate as u32 {
+            return Err(RidOutOfRange {
+                rid: rid as u16,
+                secondary,
+                subordinate,
+            });
         }
-        let (secondary, _) = self.bus_range.bus_range();
-        Ok((secondary as u16) << 8)
+        Ok(rid as u16)
     }
 }
 
@@ -301,8 +288,8 @@ pub struct TranslatingDmaTarget<T: IommuTranslator + Clone> {
     label: std::sync::Arc<str>,
     /// The IOMMU's arch-specific translator, cloned per derived VF.
     translator: T,
-    /// The device's assigned bus range, used to derive the default
-    /// function-0 RID in [`guest_memory_for_devfn`](Self::guest_memory_for_devfn).
+    /// The device's assigned bus range; the requester ID is derived as
+    /// `(secondary << 8) + rid_offset` per access.
     bus_range: AssignedBusRange,
     /// The raw (untranslated) guest memory.
     inner_gm: GuestMemory,
@@ -332,19 +319,12 @@ impl<T: IommuTranslator + Clone> TranslatingDmaTarget<T> {
 }
 
 impl<T: IommuTranslator + Clone> pci_core::dma::DmaTargetIommu for TranslatingDmaTarget<T> {
-    fn guest_memory_for_devfn(&self, devfn: u8) -> GuestMemory {
-        // Compose the RID from the bus range's secondary bus + the given devfn.
-        let (secondary, _) = self.bus_range.bus_range();
-        let rid = (secondary as u16) << 8 | devfn as u16;
-        self.guest_memory_for_rid(rid)
-    }
-
-    fn guest_memory_for_rid(&self, rid: u16) -> GuestMemory {
-        TranslatingMemory::new_guest_memory_for_rid(
+    fn guest_memory_for_rid_offset(&self, rid_offset: u16) -> GuestMemory {
+        TranslatingMemory::new_guest_memory_for_rid_offset(
             self.label.clone(),
             self.translator.clone(),
             self.bus_range.clone(),
-            rid,
+            rid_offset,
             self.inner_gm.clone(),
         )
     }
@@ -352,35 +332,30 @@ impl<T: IommuTranslator + Clone> pci_core::dma::DmaTargetIommu for TranslatingDm
 
 /// Build a [`DmaTarget`](pci_core::dma::DmaTarget) backed by an IOMMU translator.
 ///
-/// Wraps `guest_memory` with a function-0 translating [`GuestMemory`] (whose RID
-/// is derived dynamically from `bus_range` on each access) and a
-/// [`TranslatingDmaTarget`] factory for per-VF derivation, then bundles both
-/// with `msi_target`. IOMMU backends (SMMU, AMD-Vi, …) call this to plug their
-/// arch-specific translator into the [`DmaTarget`](pci_core::dma::DmaTarget)
-/// machinery without re-implementing the two-part construction.
+/// Builds a [`TranslatingDmaTarget`] factory over `translator`/`guest_memory`
+/// and hands it to [`DmaTarget::with_iommu`](pci_core::dma::DmaTarget::with_iommu),
+/// which derives the base function-`devfn` translating memory from it and
+/// stamps the MSI identity from `msi`. IOMMU backends (SMMU, AMD-Vi, …) call
+/// this to plug their arch-specific translator into the
+/// [`DmaTarget`](pci_core::dma::DmaTarget) machinery.
 pub fn new_dma_target<T>(
     label: &str,
     translator: T,
     bus_range: AssignedBusRange,
+    devfn: u8,
     guest_memory: GuestMemory,
-    msi_target: pci_core::msi::MsiTarget,
+    msi: &pci_core::msi::MsiConnection,
 ) -> pci_core::dma::DmaTarget
 where
     T: IommuTranslator + Clone,
 {
-    let translating_gm = TranslatingMemory::new_guest_memory(
-        format!("{label}-translating"),
-        translator.clone(),
-        bus_range.clone(),
-        guest_memory.clone(),
-    );
     let iommu = std::sync::Arc::new(TranslatingDmaTarget::new(
-        format!("{label}-translating-vf"),
+        format!("{label}-translating"),
         translator,
-        bus_range,
+        bus_range.clone(),
         guest_memory,
     ));
-    pci_core::dma::DmaTarget::with_iommu(translating_gm, msi_target, iommu)
+    pci_core::dma::DmaTarget::with_iommu(bus_range, devfn, iommu, msi)
 }
 
 #[cfg(test)]
@@ -422,13 +397,13 @@ mod tests {
     }
 
     #[test]
-    fn rid_override_in_range_translates() {
+    fn rid_offset_in_range_translates() {
         let inner = GuestMemory::allocate(0x1000);
-        let gm = TranslatingMemory::new_guest_memory_for_rid(
+        let gm = TranslatingMemory::new_guest_memory_for_rid_offset(
             "test",
             IdentityTranslator,
             bus_range(5, 10),
-            (7 << 8) | 0x02, // bus 7 within [5, 10]
+            (2 << 8) | 0x02, // secondary 5 + offset -> bus 7 within [5, 10]
             inner.clone(),
         );
 
@@ -444,30 +419,21 @@ mod tests {
     }
 
     #[test]
-    fn rid_override_out_of_range_faults() {
+    fn rid_offset_out_of_range_faults() {
         let inner = GuestMemory::allocate(0x1000);
         let mut buf = [0u8; 2];
 
-        // bus 11, above subordinate 10 → access faults
-        let gm_above = TranslatingMemory::new_guest_memory_for_rid(
+        // secondary 5 + offset (6 << 8) -> bus 11, above subordinate 10 ->
+        // access faults
+        let gm_above = TranslatingMemory::new_guest_memory_for_rid_offset(
             "test",
             IdentityTranslator,
             bus_range(5, 10),
-            11 << 8,
+            6 << 8,
             inner.clone(),
         );
         assert!(gm_above.read_at(0x100, &mut buf).is_err());
         assert!(gm_above.write_at(0x100, &[1, 2]).is_err());
-
-        // bus 4, below secondary 5 → access faults
-        let gm_below = TranslatingMemory::new_guest_memory_for_rid(
-            "test",
-            IdentityTranslator,
-            bus_range(5, 10),
-            4 << 8,
-            inner.clone(),
-        );
-        assert!(gm_below.read_at(0x100, &mut buf).is_err());
     }
 
     #[test]

--- a/vm/devices/iommu/iommu_common/src/lib.rs
+++ b/vm/devices/iommu/iommu_common/src/lib.rs
@@ -350,6 +350,39 @@ impl<T: IommuTranslator + Clone> pci_core::dma::DmaTargetIommu for TranslatingDm
     }
 }
 
+/// Build a [`DmaTarget`](pci_core::dma::DmaTarget) backed by an IOMMU translator.
+///
+/// Wraps `guest_memory` with a function-0 translating [`GuestMemory`] (whose RID
+/// is derived dynamically from `bus_range` on each access) and a
+/// [`TranslatingDmaTarget`] factory for per-VF derivation, then bundles both
+/// with `msi_target`. IOMMU backends (SMMU, AMD-Vi, …) call this to plug their
+/// arch-specific translator into the [`DmaTarget`](pci_core::dma::DmaTarget)
+/// machinery without re-implementing the two-part construction.
+pub fn new_dma_target<T>(
+    label: &str,
+    translator: T,
+    bus_range: AssignedBusRange,
+    guest_memory: GuestMemory,
+    msi_target: pci_core::msi::MsiTarget,
+) -> pci_core::dma::DmaTarget
+where
+    T: IommuTranslator + Clone,
+{
+    let translating_gm = TranslatingMemory::new_guest_memory(
+        format!("{label}-translating"),
+        translator.clone(),
+        bus_range.clone(),
+        guest_memory.clone(),
+    );
+    let iommu = std::sync::Arc::new(TranslatingDmaTarget::new(
+        format!("{label}-translating-vf"),
+        translator,
+        bus_range,
+        guest_memory,
+    ));
+    pci_core::dma::DmaTarget::with_iommu(translating_gm, msi_target, iommu)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/vm/devices/iommu/smmu/src/shared.rs
+++ b/vm/devices/iommu/smmu/src/shared.rs
@@ -509,6 +509,7 @@ impl SmmuSharedState {
 /// One `SmmuTranslator` is shared by all PCI devices behind the same SMMU.
 /// The requester ID (RID / BDF) is passed at each translation call and
 /// combined with the `stream_id_base` to form the SMMU stream ID.
+#[derive(Clone)]
 pub struct SmmuTranslator {
     shared: Arc<SmmuSharedState>,
     /// Offset into the SMMU's stream table for this root complex.

--- a/vm/devices/net/gdma/src/resolver.rs
+++ b/vm/devices/net/gdma/src/resolver.rs
@@ -65,8 +65,8 @@ impl AsyncResolveResource<PciDeviceHandleKind, GdmaDeviceHandle> for GdmaDeviceR
 
         let device = GdmaDevice::new(
             input.driver_source,
-            input.guest_memory.clone(),
-            input.msi_target,
+            input.dma_target.guest_memory().clone(),
+            input.dma_target.msi_target(),
             vports,
             input.register_mmio,
         );

--- a/vm/devices/net/mana_driver/src/tests.rs
+++ b/vm/devices/net/mana_driver/src/tests.rs
@@ -16,7 +16,6 @@ use gdma_defs::GdmaQueueType;
 use net_backend::null::NullEndpoint;
 use pal_async::DefaultDriver;
 use pal_async::async_test;
-use pci_core::bus_range::AssignedBusRange;
 use pci_core::msi::MsiConnection;
 use std::sync::Arc;
 use test_with_tracing::test;
@@ -30,11 +29,11 @@ use vmcore::vm_task::VmTaskDriverSource;
 #[async_test]
 async fn test_gdma(driver: DefaultDriver) {
     let mem = DeviceTestMemory::new(128, false, "test_gdma");
-    let msi_conn = MsiConnection::new(AssignedBusRange::new(), 0);
+    let msi_conn = MsiConnection::new();
     let device = gdma::GdmaDevice::new(
         &VmTaskDriverSource::new(SingleDriverBackend::new(driver.clone())),
         mem.guest_memory(),
-        msi_conn.target(),
+        &msi_conn.target(),
         vec![VportConfig {
             mac_address: [1, 2, 3, 4, 5, 6].into(),
             endpoint: Box::new(NullEndpoint::new()),
@@ -168,11 +167,11 @@ async fn test_gdma(driver: DefaultDriver) {
 #[async_test]
 async fn test_gdma_save_restore(driver: DefaultDriver) {
     let mem = DeviceTestMemory::new(128, false, "test_gdma");
-    let msi_conn = MsiConnection::new(AssignedBusRange::new(), 0);
+    let msi_conn = MsiConnection::new();
     let device = gdma::GdmaDevice::new(
         &VmTaskDriverSource::new(SingleDriverBackend::new(driver.clone())),
         mem.guest_memory(),
-        msi_conn.target(),
+        &msi_conn.target(),
         vec![VportConfig {
             mac_address: [1, 2, 3, 4, 5, 6].into(),
             endpoint: Box::new(NullEndpoint::new()),
@@ -208,11 +207,11 @@ async fn test_gdma_save_restore(driver: DefaultDriver) {
 #[async_test]
 async fn test_adapter_link_speed_default(driver: DefaultDriver) {
     let mem = DeviceTestMemory::new(128, false, "test_adapter_link_speed_default");
-    let msi_conn = MsiConnection::new(AssignedBusRange::new(), 0);
+    let msi_conn = MsiConnection::new();
     let device = gdma::GdmaDevice::new(
         &VmTaskDriverSource::new(SingleDriverBackend::new(driver.clone())),
         mem.guest_memory(),
-        msi_conn.target(),
+        &msi_conn.target(),
         vec![VportConfig {
             mac_address: [1, 2, 3, 4, 5, 6].into(),
             endpoint: Box::new(NullEndpoint::new()),
@@ -256,11 +255,11 @@ async fn test_adapter_link_speed_default(driver: DefaultDriver) {
 /// and `link_speed_bps()` converts it correctly.
 async fn verify_adapter_link_speed_expected(driver: DefaultDriver, link_speed_mbps: u32) {
     let mem = DeviceTestMemory::new(128, false, "test_adapter_link_speed_expected");
-    let msi_conn = MsiConnection::new(AssignedBusRange::new(), 0);
+    let msi_conn = MsiConnection::new();
     let device = gdma::GdmaDevice::new_with_config(
         &VmTaskDriverSource::new(SingleDriverBackend::new(driver.clone())),
         mem.guest_memory(),
-        msi_conn.target(),
+        &msi_conn.target(),
         vec![VportConfig {
             mac_address: [1, 2, 3, 4, 5, 6].into(),
             endpoint: Box::new(NullEndpoint::new()),
@@ -316,11 +315,11 @@ async fn test_adapter_link_speed_expected(driver: DefaultDriver) {
 #[async_test]
 async fn test_gdma_reset_request(driver: DefaultDriver) {
     let mem = DeviceTestMemory::new(128, false, "test_gdma");
-    let msi_conn = MsiConnection::new(AssignedBusRange::new(), 0);
+    let msi_conn = MsiConnection::new();
     let device = gdma::GdmaDevice::new(
         &VmTaskDriverSource::new(SingleDriverBackend::new(driver.clone())),
         mem.guest_memory(),
-        msi_conn.target(),
+        &msi_conn.target(),
         vec![VportConfig {
             mac_address: [1, 2, 3, 4, 5, 6].into(),
             endpoint: Box::new(NullEndpoint::new()),
@@ -379,11 +378,11 @@ async fn test_gdma_reset_request(driver: DefaultDriver) {
 #[async_test]
 async fn test_gdma_reset_request_with_revoke(driver: DefaultDriver) {
     let mem = DeviceTestMemory::new(128, false, "test_gdma");
-    let msi_conn = MsiConnection::new(AssignedBusRange::new(), 0);
+    let msi_conn = MsiConnection::new();
     let device = gdma::GdmaDevice::new(
         &VmTaskDriverSource::new(SingleDriverBackend::new(driver.clone())),
         mem.guest_memory(),
-        msi_conn.target(),
+        &msi_conn.target(),
         vec![VportConfig {
             mac_address: [1, 2, 3, 4, 5, 6].into(),
             endpoint: Box::new(NullEndpoint::new()),

--- a/vm/devices/net/net_mana/src/test.rs
+++ b/vm/devices/net/net_mana/src/test.rs
@@ -24,7 +24,6 @@ use net_backend::VlanMetadata;
 use net_backend::loopback::LoopbackEndpoint;
 use pal_async::DefaultDriver;
 use pal_async::async_test;
-use pci_core::bus_range::AssignedBusRange;
 use pci_core::msi::MsiConnection;
 use std::future::poll_fn;
 use std::time::Duration;
@@ -549,11 +548,11 @@ async fn test_multi_mixed_packet(driver: DefaultDriver) {
 async fn test_vport_with_query_filter_state(driver: DefaultDriver) {
     let pages = 512; // 2MB
     let mem = DeviceTestMemory::new(pages, false, "test_vport_with_query_filter_state");
-    let msi_conn = MsiConnection::new(AssignedBusRange::new(), 0);
+    let msi_conn = MsiConnection::new();
     let device = gdma::GdmaDevice::new(
         &VmTaskDriverSource::new(SingleDriverBackend::new(driver.clone())),
         mem.guest_memory(),
-        msi_conn.target(),
+        &msi_conn.target(),
         vec![VportConfig {
             mac_address: [1, 2, 3, 4, 5, 6].into(),
             endpoint: Box::new(LoopbackEndpoint::new()),
@@ -613,11 +612,11 @@ async fn test_link_speed_default(driver: DefaultDriver) {
 
     let pages = 512; // 2MB
     let mem = DeviceTestMemory::new(pages, false, "test_link_speed_default");
-    let msi_conn = MsiConnection::new(AssignedBusRange::new(), 0);
+    let msi_conn = MsiConnection::new();
     let device = gdma::GdmaDevice::new(
         &VmTaskDriverSource::new(SingleDriverBackend::new(driver.clone())),
         mem.guest_memory(),
-        msi_conn.target(),
+        &msi_conn.target(),
         vec![VportConfig {
             mac_address: [1, 2, 3, 4, 5, 6].into(),
             endpoint: Box::new(LoopbackEndpoint::new()),
@@ -677,11 +676,11 @@ async fn verify_link_speed_expected(driver: DefaultDriver, link_speed_mbps: u32)
 
     let pages = 512;
     let mem = DeviceTestMemory::new(pages, false, "test_link_speed_expected");
-    let msi_conn = MsiConnection::new(AssignedBusRange::new(), 0);
+    let msi_conn = MsiConnection::new();
     let device = gdma::GdmaDevice::new_with_config(
         &VmTaskDriverSource::new(SingleDriverBackend::new(driver.clone())),
         mem.guest_memory(),
-        msi_conn.target(),
+        &msi_conn.target(),
         vec![VportConfig {
             mac_address: [1, 2, 3, 4, 5, 6].into(),
             endpoint: Box::new(LoopbackEndpoint::new()),
@@ -941,11 +940,11 @@ async fn test_endpoint(
     let data_to_send = pkt_builder.packet_data();
     let tx_segments = pkt_builder.segments();
 
-    let msi_conn = MsiConnection::new(AssignedBusRange::new(), 0);
+    let msi_conn = MsiConnection::new();
     let device = gdma::GdmaDevice::new(
         &VmTaskDriverSource::new(SingleDriverBackend::new(driver.clone())),
         mem.guest_memory(),
-        msi_conn.target(),
+        &msi_conn.target(),
         vec![VportConfig {
             mac_address: [1, 2, 3, 4, 5, 6].into(),
             endpoint: Box::new(LoopbackEndpoint::new()),
@@ -1115,11 +1114,11 @@ async fn new_test_queue(
 ) {
     let pages = 256;
     let mem = DeviceTestMemory::new(pages * 2, true, "test queue");
-    let msi_conn = MsiConnection::new(AssignedBusRange::new(), 0);
+    let msi_conn = MsiConnection::new();
     let device = gdma::GdmaDevice::new(
         &VmTaskDriverSource::new(SingleDriverBackend::new(driver.clone())),
         mem.guest_memory(),
-        msi_conn.target(),
+        &msi_conn.target(),
         vec![VportConfig {
             mac_address: [1, 2, 3, 4, 5, 6].into(),
             endpoint: Box::new(LoopbackEndpoint::new()),

--- a/vm/devices/pci/pci_core/src/capabilities/msi_cap.rs
+++ b/vm/devices/pci/pci_core/src/capabilities/msi_cap.rs
@@ -396,7 +396,7 @@ mod save_restore {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::bus_range::AssignedBusRange;
+
     use crate::msi::MsiConnection;
     use crate::test_helpers::TestPciInterruptController;
     use crate::test_helpers::read_cap_u32;
@@ -404,8 +404,8 @@ mod tests {
 
     #[test]
     fn msi_check() {
-        let msi_conn = MsiConnection::new(AssignedBusRange::new(), 0);
-        let mut cap = MsiCapability::new(2, true, false, msi_conn.target()); // 4 messages max, 64-bit, no masking
+        let msi_conn = MsiConnection::new();
+        let mut cap = MsiCapability::new(2, true, false, &msi_conn.target()); // 4 messages max, 64-bit, no masking
         let msi_controller = TestPciInterruptController::new();
         msi_conn.connect(msi_controller.signal_msi());
 
@@ -441,8 +441,8 @@ mod tests {
 
     #[test]
     fn msi_32bit_check() {
-        let msi_conn = MsiConnection::new(AssignedBusRange::new(), 0);
-        let mut cap = MsiCapability::new(1, false, false, msi_conn.target()); // 2 messages max, 32-bit, no masking
+        let msi_conn = MsiConnection::new();
+        let mut cap = MsiCapability::new(1, false, false, &msi_conn.target()); // 2 messages max, 32-bit, no masking
         let msi_controller = TestPciInterruptController::new();
         msi_conn.connect(msi_controller.signal_msi());
 
@@ -461,8 +461,8 @@ mod tests {
     fn test_msi_save_restore() {
         use vmcore::save_restore::SaveRestore;
 
-        let msi_conn = MsiConnection::new(AssignedBusRange::new(), 0);
-        let mut cap = MsiCapability::new(2, true, false, msi_conn.target()); // 4 messages max, 64-bit, no masking
+        let msi_conn = MsiConnection::new();
+        let mut cap = MsiCapability::new(2, true, false, &msi_conn.target()); // 4 messages max, 64-bit, no masking
         let msi_controller = TestPciInterruptController::new();
         msi_conn.connect(msi_controller.signal_msi());
 
@@ -502,8 +502,8 @@ mod tests {
     fn test_msi_save_restore_32bit_with_masking() {
         use vmcore::save_restore::SaveRestore;
 
-        let msi_conn = MsiConnection::new(AssignedBusRange::new(), 0);
-        let mut cap = MsiCapability::new(3, false, true, msi_conn.target()); // 8 messages max, 32-bit, with masking
+        let msi_conn = MsiConnection::new();
+        let mut cap = MsiCapability::new(3, false, true, &msi_conn.target()); // 8 messages max, 32-bit, with masking
         let msi_controller = TestPciInterruptController::new();
         msi_conn.connect(msi_controller.signal_msi());
 
@@ -553,8 +553,8 @@ mod tests {
     fn test_msi_save_restore_mme_clamping() {
         use vmcore::save_restore::SaveRestore;
 
-        let msi_conn = MsiConnection::new(AssignedBusRange::new(), 0);
-        let mut cap = MsiCapability::new(1, true, false, msi_conn.target()); // Only 2 messages max (MMC=1)
+        let msi_conn = MsiConnection::new();
+        let mut cap = MsiCapability::new(1, true, false, &msi_conn.target()); // Only 2 messages max (MMC=1)
         let msi_controller = TestPciInterruptController::new();
         msi_conn.connect(msi_controller.signal_msi());
 

--- a/vm/devices/pci/pci_core/src/capabilities/msix.rs
+++ b/vm/devices/pci/pci_core/src/capabilities/msix.rs
@@ -612,7 +612,6 @@ mod save_restore {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::bus_range::AssignedBusRange;
     use crate::msi::MsiConnection;
     use crate::test_helpers::TestPciInterruptController;
     use crate::test_helpers::read_cap_u32;
@@ -620,8 +619,8 @@ mod tests {
 
     #[test]
     fn msix_check() {
-        let msi_conn = MsiConnection::new(AssignedBusRange::new(), 0);
-        let (mut msix, mut cap) = MsixEmulator::new(2, 64, msi_conn.target());
+        let msi_conn = MsiConnection::new();
+        let (mut msix, mut cap) = MsixEmulator::new(2, 64, &msi_conn.target());
         let msi_controller = TestPciInterruptController::new();
         msi_conn.connect(msi_controller.signal_msi());
         // check capabilities
@@ -744,9 +743,9 @@ mod tests {
     #[test]
     fn route_set_msi_on_unmask() {
         let (irqfd, calls) = mock_irqfd(2);
-        let msi_conn = MsiConnection::new(AssignedBusRange::new(), 0);
+        let msi_conn = MsiConnection::new();
         msi_conn.connect_irqfd(irqfd);
-        let (mut msix, mut cap) = MsixEmulator::new(2, 2, msi_conn.target());
+        let (mut msix, mut cap) = MsixEmulator::new(2, 2, &msi_conn.target());
         let msi_controller = TestPciInterruptController::new();
         msi_conn.connect(msi_controller.signal_msi());
 
@@ -786,9 +785,9 @@ mod tests {
     #[test]
     fn route_mask_on_vector_mask() {
         let (irqfd, calls) = mock_irqfd(2);
-        let msi_conn = MsiConnection::new(AssignedBusRange::new(), 0);
+        let msi_conn = MsiConnection::new();
         msi_conn.connect_irqfd(irqfd);
-        let (mut msix, mut cap) = MsixEmulator::new(2, 2, msi_conn.target());
+        let (mut msix, mut cap) = MsixEmulator::new(2, 2, &msi_conn.target());
         let msi_controller = TestPciInterruptController::new();
         msi_conn.connect(msi_controller.signal_msi());
 
@@ -815,9 +814,9 @@ mod tests {
     #[test]
     fn route_global_disable_masks_all() {
         let (irqfd, calls) = mock_irqfd(2);
-        let msi_conn = MsiConnection::new(AssignedBusRange::new(), 0);
+        let msi_conn = MsiConnection::new();
         msi_conn.connect_irqfd(irqfd);
-        let (mut msix, mut cap) = MsixEmulator::new(2, 2, msi_conn.target());
+        let (mut msix, mut cap) = MsixEmulator::new(2, 2, &msi_conn.target());
         let msi_controller = TestPciInterruptController::new();
         msi_conn.connect(msi_controller.signal_msi());
 
@@ -847,9 +846,9 @@ mod tests {
     #[test]
     fn route_consume_pending_on_pba_read() {
         let (irqfd, _calls) = mock_irqfd(2);
-        let msi_conn = MsiConnection::new(AssignedBusRange::new(), 0);
+        let msi_conn = MsiConnection::new();
         msi_conn.connect_irqfd(irqfd);
-        let (msix, mut cap) = MsixEmulator::new(2, 2, msi_conn.target());
+        let (msix, mut cap) = MsixEmulator::new(2, 2, &msi_conn.target());
         let msi_controller = TestPciInterruptController::new();
         msi_conn.connect(msi_controller.signal_msi());
 
@@ -874,9 +873,9 @@ mod tests {
     #[test]
     fn route_set_msi_on_addr_data_change_while_unmasked() {
         let (irqfd, calls) = mock_irqfd(1);
-        let msi_conn = MsiConnection::new(AssignedBusRange::new(), 0);
+        let msi_conn = MsiConnection::new();
         msi_conn.connect_irqfd(irqfd);
-        let (mut msix, mut cap) = MsixEmulator::new(2, 1, msi_conn.target());
+        let (mut msix, mut cap) = MsixEmulator::new(2, 1, &msi_conn.target());
         let msi_controller = TestPciInterruptController::new();
         msi_conn.connect(msi_controller.signal_msi());
 

--- a/vm/devices/pci/pci_core/src/dma.rs
+++ b/vm/devices/pci/pci_core/src/dma.rs
@@ -9,10 +9,12 @@
 //! In hardware, both DMA and MSI are bus-mastered transactions identified
 //! by the device's Requester ID (RID). This type ensures the two always
 //! carry a consistent device identity. For SR-IOV devices, calling
-//! [`DmaTarget::with_devfn`] derives both DMA and MSI targets for a
+//! [`DmaTarget::with_rid_offset`] derives both DMA and MSI targets for a
 //! specific VF in a single operation — you can't accidentally end up
 //! with mismatched identities.
 
+use crate::bus_range::AssignedBusRange;
+use crate::msi::MsiConnection;
 use crate::msi::MsiTarget;
 use guestmem::GuestMemory;
 use std::sync::Arc;
@@ -22,20 +24,14 @@ use std::sync::Arc;
 /// Implemented by SMMU (and future VT-d, AMD-Vi, etc.). The factory is
 /// shared across all devices behind the same IOMMU instance.
 pub trait DmaTargetIommu: Send + Sync + 'static {
-    /// Create a [`GuestMemory`] whose DMA translations use the IOMMU
-    /// context for the given device/function number.
+    /// Create a [`GuestMemory`] for a requester-ID offset relative to the
+    /// device's secondary bus.
     ///
-    /// The implementation composes the full Requester ID from its own
-    /// bus range and the given `devfn`.
-    fn guest_memory_for_devfn(&self, devfn: u8) -> GuestMemory;
-
-    /// Create a [`GuestMemory`] for a specific Requester ID.
-    ///
-    /// `rid` is `(bus << 8) | devfn`. Use this when VFs span multiple
-    /// bus numbers and the caller has computed the full RID from
-    /// config space (e.g., from VF Offset / VF Stride and the
-    /// assigned secondary bus).
-    fn guest_memory_for_rid(&self, rid: u16) -> GuestMemory;
+    /// The RID is resolved as `(secondary << 8) + rid_offset` on each access,
+    /// so it tracks the live bus assignment. A plain `devfn` is just an
+    /// offset in `0..=0xff`; SR-IOV VFs use larger offsets that carry into
+    /// the bus byte.
+    fn guest_memory_for_rid_offset(&self, rid_offset: u16) -> GuestMemory;
 }
 
 /// Everything a PCI device needs for bus-mastered transactions: DMA
@@ -43,9 +39,13 @@ pub trait DmaTargetIommu: Send + Sync + 'static {
 ///
 /// Most devices only need [`guest_memory`](Self::guest_memory) and
 /// [`msi_target`](Self::msi_target). SR-IOV PFs additionally call
-/// [`with_devfn`](Self::with_devfn) when creating VFs.
+/// [`with_rid_offset`](Self::with_rid_offset) when creating VFs.
 #[derive(Clone)]
 pub struct DmaTarget {
+    /// This target's requester-ID offset from the secondary bus. Held so
+    /// [`with_rid_offset`](Self::with_rid_offset) can derive a target at a
+    /// further offset relative to this one.
+    rid_offset: u16,
     guest_memory: GuestMemory,
     msi_target: MsiTarget,
     /// When an IOMMU is present, produces per-device GuestMemory
@@ -59,10 +59,19 @@ pub struct DmaTarget {
 impl DmaTarget {
     /// Creates a DMA target with no IOMMU.
     ///
-    /// All functions share the same guest memory, and `with_devfn`
+    /// `bus_range` and `devfn` set the device's requester-ID identity, shared
+    /// by both the DMA and MSI sides. The MSI backend is taken (late-bound)
+    /// from `msi`. All functions share the same guest memory; `with_devfn`
     /// only updates the MSI identity.
-    pub fn new(guest_memory: GuestMemory, msi_target: MsiTarget) -> Self {
+    pub fn new(
+        bus_range: AssignedBusRange,
+        devfn: u8,
+        guest_memory: GuestMemory,
+        msi: &MsiConnection,
+    ) -> Self {
+        let msi_target = msi.msi_target(bus_range, devfn);
         Self {
+            rid_offset: devfn as u16,
             guest_memory,
             msi_target,
             iommu: None,
@@ -72,14 +81,20 @@ impl DmaTarget {
 
     /// Creates a DMA target backed by an IOMMU.
     ///
-    /// `guest_memory` is the default (function 0) DMA translation.
-    /// `iommu` produces per-device translations for `with_devfn`.
+    /// The base (function-`devfn`) translating guest memory is derived from
+    /// `iommu`; per-VF memory is produced by
+    /// [`with_rid_offset`](Self::with_rid_offset). The MSI backend is taken
+    /// (late-bound) from `msi`.
     pub fn with_iommu(
-        guest_memory: GuestMemory,
-        msi_target: MsiTarget,
+        bus_range: AssignedBusRange,
+        devfn: u8,
         iommu: Arc<dyn DmaTargetIommu>,
+        msi: &MsiConnection,
     ) -> Self {
+        let guest_memory = iommu.guest_memory_for_rid_offset(devfn as u16);
+        let msi_target = msi.msi_target(bus_range, devfn);
         Self {
+            rid_offset: devfn as u16,
             guest_memory,
             msi_target,
             iommu: Some(iommu),
@@ -103,45 +118,23 @@ impl DmaTarget {
         self.software_iommu
     }
 
-    /// Derives a DMA target for a different device function.
+    /// Derives a DMA target offset by `delta` from this one in RID space.
     ///
-    /// `devfn` is the device/function number within the port's bus.
-    /// Both DMA and MSI identity are updated atomically:
-    /// - When an IOMMU is present, the returned target's guest memory
-    ///   uses a different stream/context table entry. The IOMMU
-    ///   implementation composes the full RID from its bus range
-    ///   and the given `devfn`.
-    /// - The MSI target is derived via [`MsiTarget::with_devfn`].
-    ///
-    /// When no IOMMU is present, only the MSI identity changes; the
-    /// guest memory is shared (cloned).
-    pub fn with_devfn(&self, devfn: u8) -> DmaTarget {
+    /// This is the SR-IOV VF derivation primitive: given a PF's target, its
+    /// `i`th VF is `delta = VF_Offset + i * VF_Stride` away. Offsets stack,
+    /// so deriving from an already-derived target accumulates. Both the DMA
+    /// and MSI identity are derived in lockstep and resolved at use time as
+    /// `(secondary << 8) + offset` against the live bus assignment, so VF
+    /// targets can be derived before the bus is programmed.
+    pub fn with_rid_offset(&self, delta: u16) -> DmaTarget {
+        let rid_offset = self.rid_offset.wrapping_add(delta);
         DmaTarget {
+            rid_offset,
             guest_memory: match &self.iommu {
-                Some(factory) => factory.guest_memory_for_devfn(devfn),
+                Some(factory) => factory.guest_memory_for_rid_offset(rid_offset),
                 None => self.guest_memory.clone(),
             },
-            msi_target: self.msi_target.with_devfn(devfn),
-            iommu: self.iommu.clone(),
-            software_iommu: self.software_iommu,
-        }
-    }
-
-    /// Derives a DMA target for a specific Requester ID.
-    ///
-    /// `rid` is `(bus << 8) | devfn`. Use this when VFs span
-    /// multiple bus numbers and the device has computed the full RID
-    /// from config space assignments (secondary bus + VF Offset +
-    /// VF Stride).
-    ///
-    /// Both DMA and MSI identity are updated atomically.
-    pub fn with_rid(&self, rid: u16) -> DmaTarget {
-        DmaTarget {
-            guest_memory: match &self.iommu {
-                Some(factory) => factory.guest_memory_for_rid(rid),
-                None => self.guest_memory.clone(),
-            },
-            msi_target: self.msi_target.with_rid(rid),
+            msi_target: self.msi_target.with_rid_offset(rid_offset),
             iommu: self.iommu.clone(),
             software_iommu: self.software_iommu,
         }
@@ -158,7 +151,7 @@ mod tests {
     use std::sync::Arc;
 
     /// Records the requester IDs signaled through an `MsiTarget`, so tests
-    /// can observe the MSI identity derived by `with_devfn` / `with_rid`.
+    /// can observe the MSI identity derived by `with_rid_offset`.
     struct RecordingSignalMsi {
         calls: Mutex<Vec<Option<u32>>>,
     }
@@ -181,55 +174,49 @@ mod tests {
         }
     }
 
-    /// Records the `devfn` / `rid` passed to the IOMMU factory and hands
-    /// back a distinct `GuestMemory` for each call so tests can confirm the
-    /// derived target uses the IOMMU-provided memory.
+    /// Records the `rid_offset` passed to the IOMMU factory and hands back a
+    /// distinct `GuestMemory` for each call so tests can confirm the derived
+    /// target uses the IOMMU-provided memory.
     struct RecordingIommu {
-        devfn_calls: Mutex<Vec<u8>>,
-        rid_calls: Mutex<Vec<u16>>,
+        rid_offset_calls: Mutex<Vec<u16>>,
     }
 
     impl RecordingIommu {
         fn new() -> Arc<Self> {
             Arc::new(Self {
-                devfn_calls: Mutex::new(Vec::new()),
-                rid_calls: Mutex::new(Vec::new()),
+                rid_offset_calls: Mutex::new(Vec::new()),
             })
         }
     }
 
     impl DmaTargetIommu for RecordingIommu {
-        fn guest_memory_for_devfn(&self, devfn: u8) -> GuestMemory {
-            self.devfn_calls.lock().push(devfn);
+        fn guest_memory_for_rid_offset(&self, rid_offset: u16) -> GuestMemory {
+            self.rid_offset_calls.lock().push(rid_offset);
             // A distinct, non-empty allocation marks this as IOMMU-provided.
-            GuestMemory::allocate(0x2000)
-        }
-
-        fn guest_memory_for_rid(&self, rid: u16) -> GuestMemory {
-            self.rid_calls.lock().push(rid);
             GuestMemory::allocate(0x2000)
         }
     }
 
     #[test]
     fn new_has_no_iommu() {
-        let target = DmaTarget::new(GuestMemory::empty(), MsiTarget::disconnected());
+        let msi_conn = MsiConnection::new();
+        let target = DmaTarget::new(AssignedBusRange::new(), 0, GuestMemory::empty(), &msi_conn);
         assert!(!target.software_iommu());
         assert!(target.iommu.is_none());
     }
 
     #[test]
-    fn with_devfn_no_iommu_shares_memory_and_updates_msi() {
+    fn with_rid_offset_no_iommu_shares_memory_and_updates_msi() {
         let bus_range = AssignedBusRange::new();
         bus_range.set_bus_range(5, 10);
-        let msi_conn = MsiConnection::new(bus_range, 0);
+        let msi_conn = MsiConnection::new();
         let recorder = RecordingSignalMsi::new();
         msi_conn.connect(recorder.clone());
 
         let gm = GuestMemory::allocate(0x1000);
-        let target = DmaTarget::new(gm.clone(), msi_conn.target().clone());
+        let target = DmaTarget::new(bus_range.clone(), 0, gm.clone(), &msi_conn);
 
-        let derived = target.with_devfn(0x18); // dev 3, fn 0
+        let derived = target.with_rid_offset(0x18); // function 0x18 on the secondary bus
 
         // No IOMMU: the guest memory is shared. Write through the original
         // and observe it through the derived target.
@@ -238,34 +225,47 @@ mod tests {
         derived.guest_memory().read_at(0, &mut buf).unwrap();
         assert_eq!(buf[0], 0xAB);
 
-        // The MSI identity is derived from the devfn: bus 5 (secondary) | devfn.
+        // The MSI identity is derived from the offset: bus 5 (secondary) | offset.
         assert!(!derived.software_iommu());
         derived.msi_target().signal_msi(0xFEE0_0000, 0);
         assert_eq!(recorder.pop().unwrap(), (5 << 8) | 0x18);
     }
 
     #[test]
-    fn with_devfn_iommu_derives_memory_and_msi_together() {
+    fn with_rid_offset_stacks() {
         let bus_range = AssignedBusRange::new();
         bus_range.set_bus_range(5, 10);
-        let msi_conn = MsiConnection::new(bus_range, 0);
+        let msi_conn = MsiConnection::new();
+        let recorder = RecordingSignalMsi::new();
+        msi_conn.connect(recorder.clone());
+
+        let target = DmaTarget::new(bus_range.clone(), 0, GuestMemory::empty(), &msi_conn);
+
+        // Offsets accumulate: 0x10 then 0x08 lands at 0x18.
+        let derived = target.with_rid_offset(0x10).with_rid_offset(0x08);
+        derived.msi_target().signal_msi(0xFEE0_0000, 0);
+        assert_eq!(recorder.pop().unwrap(), (5 << 8) | 0x18);
+    }
+
+    #[test]
+    fn with_rid_offset_iommu_derives_memory_and_msi_together() {
+        let bus_range = AssignedBusRange::new();
+        bus_range.set_bus_range(5, 10);
+        let msi_conn = MsiConnection::new();
         let recorder = RecordingSignalMsi::new();
         msi_conn.connect(recorder.clone());
 
         let iommu = RecordingIommu::new();
-        let target = DmaTarget::with_iommu(
-            GuestMemory::empty(),
-            msi_conn.target().clone(),
-            iommu.clone(),
-        );
+        let target = DmaTarget::with_iommu(bus_range.clone(), 0, iommu.clone(), &msi_conn);
         assert!(target.software_iommu());
 
-        let derived = target.with_devfn(0x18);
+        let derived = target.with_rid_offset(0x18);
 
-        // The IOMMU factory was asked for the same devfn used for MSI.
-        assert_eq!(*iommu.devfn_calls.lock(), vec![0x18]);
-        // The derived target uses the IOMMU-provided 0x2000 allocation, not
-        // the empty base memory: an access past the (empty) base succeeds.
+        // The base target asked the factory for offset 0 (devfn 0); deriving
+        // offset 0x18 asks for that offset.
+        assert_eq!(*iommu.rid_offset_calls.lock(), vec![0, 0x18]);
+        // The derived target uses the IOMMU-provided 0x2000 allocation: an
+        // access past the empty base memory succeeds.
         derived.guest_memory().write_at(0x1500, &[0xCD]).unwrap();
         let mut buf = [0u8];
         derived.guest_memory().read_at(0x1500, &mut buf).unwrap();
@@ -277,27 +277,24 @@ mod tests {
     }
 
     #[test]
-    fn with_rid_iommu_derives_memory_and_msi_together() {
+    fn with_rid_offset_iommu_cross_bus() {
         let bus_range = AssignedBusRange::new();
         bus_range.set_bus_range(5, 10);
-        let msi_conn = MsiConnection::new(bus_range, 0);
+        let msi_conn = MsiConnection::new();
         let recorder = RecordingSignalMsi::new();
         msi_conn.connect(recorder.clone());
 
         let iommu = RecordingIommu::new();
-        let target = DmaTarget::with_iommu(
-            GuestMemory::empty(),
-            msi_conn.target().clone(),
-            iommu.clone(),
-        );
+        let target = DmaTarget::with_iommu(bus_range.clone(), 0, iommu.clone(), &msi_conn);
 
-        let rid: u16 = (7 << 8) | 0x0A; // bus 7 (within [5, 10]), devfn 0x0A
-        let derived = target.with_rid(rid);
+        // Offset (2 << 8) | 0x0A lands on bus 7 (secondary 5 + 2), devfn 0x0A.
+        let offset: u16 = (2 << 8) | 0x0A;
+        let derived = target.with_rid_offset(offset);
 
-        // The IOMMU factory was asked for the same RID used for MSI.
-        assert_eq!(*iommu.rid_calls.lock(), vec![rid]);
-        // The derived target uses the IOMMU-provided 0x2000 allocation, not
-        // the empty base memory: an access past the (empty) base succeeds.
+        // The base construction asked for offset 0 first, then the VF offset.
+        assert_eq!(*iommu.rid_offset_calls.lock(), vec![0, offset]);
+        // The derived target uses the IOMMU-provided 0x2000 allocation: an
+        // access past the empty base memory succeeds.
         derived.guest_memory().write_at(0x1500, &[0xCD]).unwrap();
         let mut buf = [0u8];
         derived.guest_memory().read_at(0x1500, &mut buf).unwrap();
@@ -305,6 +302,6 @@ mod tests {
         assert!(derived.software_iommu());
 
         derived.msi_target().signal_msi(0xFEE0_0000, 0);
-        assert_eq!(recorder.pop().unwrap(), rid as u32);
+        assert_eq!(recorder.pop().unwrap(), (7 << 8) | 0x0A);
     }
 }

--- a/vm/devices/pci/pci_core/src/dma.rs
+++ b/vm/devices/pci/pci_core/src/dma.rs
@@ -61,7 +61,8 @@ impl DmaTarget {
     ///
     /// `bus_range` and `devfn` set the device's requester-ID identity, shared
     /// by both the DMA and MSI sides. The MSI backend is taken (late-bound)
-    /// from `msi`. All functions share the same guest memory; `with_devfn`
+    /// from `msi`. Since there is no IOMMU, all targets derived from this one
+    /// share the same guest memory; [`with_rid_offset`](Self::with_rid_offset)
     /// only updates the MSI identity.
     pub fn new(
         bus_range: AssignedBusRange,

--- a/vm/devices/pci/pci_core/src/dma.rs
+++ b/vm/devices/pci/pci_core/src/dma.rs
@@ -1,0 +1,149 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! DMA target for PCI devices.
+//!
+//! [`DmaTarget`] bundles a device's [`GuestMemory`] (for DMA reads/writes)
+//! and [`MsiTarget`] (for MSI interrupt delivery) into a single type.
+//!
+//! In hardware, both DMA and MSI are bus-mastered transactions identified
+//! by the device's Requester ID (RID). This type ensures the two always
+//! carry a consistent device identity. For SR-IOV devices, calling
+//! [`DmaTarget::with_devfn`] derives both DMA and MSI targets for a
+//! specific VF in a single operation — you can't accidentally end up
+//! with mismatched identities.
+
+use crate::msi::MsiTarget;
+use guestmem::GuestMemory;
+use std::sync::Arc;
+
+/// A trait for IOMMU backends that produce per-device guest memory.
+///
+/// Implemented by SMMU (and future VT-d, AMD-Vi, etc.). The factory is
+/// shared across all devices behind the same IOMMU instance.
+pub trait DmaTargetIommu: Send + Sync + 'static {
+    /// Create a [`GuestMemory`] whose DMA translations use the IOMMU
+    /// context for the given device/function number.
+    ///
+    /// The implementation composes the full Requester ID from its own
+    /// bus range and the given `devfn`.
+    fn guest_memory_for_devfn(&self, devfn: u8) -> GuestMemory;
+
+    /// Create a [`GuestMemory`] for a specific Requester ID.
+    ///
+    /// `rid` is `(bus << 8) | devfn`. Use this when VFs span multiple
+    /// bus numbers and the caller has computed the full RID from
+    /// config space (e.g., from VF Offset / VF Stride and the
+    /// assigned secondary bus).
+    fn guest_memory_for_rid(&self, rid: u16) -> GuestMemory;
+}
+
+/// Everything a PCI device needs for bus-mastered transactions: DMA
+/// memory access and MSI interrupt delivery.
+///
+/// Most devices only need [`guest_memory`](Self::guest_memory) and
+/// [`msi_target`](Self::msi_target). SR-IOV PFs additionally call
+/// [`with_devfn`](Self::with_devfn) when creating VFs.
+#[derive(Clone)]
+pub struct DmaTarget {
+    guest_memory: GuestMemory,
+    msi_target: MsiTarget,
+    /// When an IOMMU is present, produces per-device GuestMemory
+    /// instances with distinct stream/context table entries.
+    iommu: Option<Arc<dyn DmaTargetIommu>>,
+    /// Whether the device is behind a software IOMMU (e.g., emulated
+    /// SMMU) that cannot program the host IOMMU for passthrough DMA.
+    software_iommu: bool,
+}
+
+impl DmaTarget {
+    /// Creates a DMA target with no IOMMU.
+    ///
+    /// All functions share the same guest memory, and `with_devfn`
+    /// only updates the MSI identity.
+    pub fn new(guest_memory: GuestMemory, msi_target: MsiTarget) -> Self {
+        Self {
+            guest_memory,
+            msi_target,
+            iommu: None,
+            software_iommu: false,
+        }
+    }
+
+    /// Creates a DMA target backed by an IOMMU.
+    ///
+    /// `guest_memory` is the default (function 0) DMA translation.
+    /// `iommu` produces per-device translations for `with_devfn`.
+    pub fn with_iommu(
+        guest_memory: GuestMemory,
+        msi_target: MsiTarget,
+        iommu: Arc<dyn DmaTargetIommu>,
+    ) -> Self {
+        Self {
+            guest_memory,
+            msi_target,
+            iommu: Some(iommu),
+            software_iommu: true,
+        }
+    }
+
+    /// Returns the guest memory for DMA from this device.
+    pub fn guest_memory(&self) -> &GuestMemory {
+        &self.guest_memory
+    }
+
+    /// Returns the MSI target for interrupt delivery from this device.
+    pub fn msi_target(&self) -> &MsiTarget {
+        &self.msi_target
+    }
+
+    /// Whether the device is behind a software IOMMU that cannot
+    /// program the host IOMMU for passthrough DMA.
+    pub fn software_iommu(&self) -> bool {
+        self.software_iommu
+    }
+
+    /// Derives a DMA target for a different device function.
+    ///
+    /// `devfn` is the device/function number within the port's bus.
+    /// Both DMA and MSI identity are updated atomically:
+    /// - When an IOMMU is present, the returned target's guest memory
+    ///   uses a different stream/context table entry. The IOMMU
+    ///   implementation composes the full RID from its bus range
+    ///   and the given `devfn`.
+    /// - The MSI target is derived via [`MsiTarget::with_devfn`].
+    ///
+    /// When no IOMMU is present, only the MSI identity changes; the
+    /// guest memory is shared (cloned).
+    pub fn with_devfn(&self, devfn: u8) -> DmaTarget {
+        DmaTarget {
+            guest_memory: match &self.iommu {
+                Some(factory) => factory.guest_memory_for_devfn(devfn),
+                None => self.guest_memory.clone(),
+            },
+            msi_target: self.msi_target.with_devfn(devfn),
+            iommu: self.iommu.clone(),
+            software_iommu: self.software_iommu,
+        }
+    }
+
+    /// Derives a DMA target for a specific Requester ID.
+    ///
+    /// `rid` is `(bus << 8) | devfn`. Use this when VFs span
+    /// multiple bus numbers and the device has computed the full RID
+    /// from config space assignments (secondary bus + VF Offset +
+    /// VF Stride).
+    ///
+    /// Both DMA and MSI identity are updated atomically.
+    pub fn with_rid(&self, rid: u16) -> DmaTarget {
+        DmaTarget {
+            guest_memory: match &self.iommu {
+                Some(factory) => factory.guest_memory_for_rid(rid),
+                None => self.guest_memory.clone(),
+            },
+            msi_target: self.msi_target.with_rid(rid),
+            iommu: self.iommu.clone(),
+            software_iommu: self.software_iommu,
+        }
+    }
+}

--- a/vm/devices/pci/pci_core/src/dma.rs
+++ b/vm/devices/pci/pci_core/src/dma.rs
@@ -147,3 +147,164 @@ impl DmaTarget {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::bus_range::AssignedBusRange;
+    use crate::msi::MsiConnection;
+    use crate::msi::SignalMsi;
+    use parking_lot::Mutex;
+    use std::sync::Arc;
+
+    /// Records the requester IDs signaled through an `MsiTarget`, so tests
+    /// can observe the MSI identity derived by `with_devfn` / `with_rid`.
+    struct RecordingSignalMsi {
+        calls: Mutex<Vec<Option<u32>>>,
+    }
+
+    impl RecordingSignalMsi {
+        fn new() -> Arc<Self> {
+            Arc::new(Self {
+                calls: Mutex::new(Vec::new()),
+            })
+        }
+
+        fn pop(&self) -> Option<u32> {
+            self.calls.lock().pop().flatten()
+        }
+    }
+
+    impl SignalMsi for RecordingSignalMsi {
+        fn signal_msi(&self, devid: Option<u32>, _address: u64, _data: u32) {
+            self.calls.lock().push(devid);
+        }
+    }
+
+    /// Records the `devfn` / `rid` passed to the IOMMU factory and hands
+    /// back a distinct `GuestMemory` for each call so tests can confirm the
+    /// derived target uses the IOMMU-provided memory.
+    struct RecordingIommu {
+        devfn_calls: Mutex<Vec<u8>>,
+        rid_calls: Mutex<Vec<u16>>,
+    }
+
+    impl RecordingIommu {
+        fn new() -> Arc<Self> {
+            Arc::new(Self {
+                devfn_calls: Mutex::new(Vec::new()),
+                rid_calls: Mutex::new(Vec::new()),
+            })
+        }
+    }
+
+    impl DmaTargetIommu for RecordingIommu {
+        fn guest_memory_for_devfn(&self, devfn: u8) -> GuestMemory {
+            self.devfn_calls.lock().push(devfn);
+            // A distinct, non-empty allocation marks this as IOMMU-provided.
+            GuestMemory::allocate(0x2000)
+        }
+
+        fn guest_memory_for_rid(&self, rid: u16) -> GuestMemory {
+            self.rid_calls.lock().push(rid);
+            GuestMemory::allocate(0x2000)
+        }
+    }
+
+    #[test]
+    fn new_has_no_iommu() {
+        let target = DmaTarget::new(GuestMemory::empty(), MsiTarget::disconnected());
+        assert!(!target.software_iommu());
+        assert!(target.iommu.is_none());
+    }
+
+    #[test]
+    fn with_devfn_no_iommu_shares_memory_and_updates_msi() {
+        let bus_range = AssignedBusRange::new();
+        bus_range.set_bus_range(5, 10);
+        let msi_conn = MsiConnection::new(bus_range, 0);
+        let recorder = RecordingSignalMsi::new();
+        msi_conn.connect(recorder.clone());
+
+        let gm = GuestMemory::allocate(0x1000);
+        let target = DmaTarget::new(gm.clone(), msi_conn.target().clone());
+
+        let derived = target.with_devfn(0x18); // dev 3, fn 0
+
+        // No IOMMU: the guest memory is shared. Write through the original
+        // and observe it through the derived target.
+        target.guest_memory().write_at(0, &[0xAB]).unwrap();
+        let mut buf = [0u8];
+        derived.guest_memory().read_at(0, &mut buf).unwrap();
+        assert_eq!(buf[0], 0xAB);
+
+        // The MSI identity is derived from the devfn: bus 5 (secondary) | devfn.
+        assert!(!derived.software_iommu());
+        derived.msi_target().signal_msi(0xFEE0_0000, 0);
+        assert_eq!(recorder.pop().unwrap(), (5 << 8) | 0x18);
+    }
+
+    #[test]
+    fn with_devfn_iommu_derives_memory_and_msi_together() {
+        let bus_range = AssignedBusRange::new();
+        bus_range.set_bus_range(5, 10);
+        let msi_conn = MsiConnection::new(bus_range, 0);
+        let recorder = RecordingSignalMsi::new();
+        msi_conn.connect(recorder.clone());
+
+        let iommu = RecordingIommu::new();
+        let target = DmaTarget::with_iommu(
+            GuestMemory::empty(),
+            msi_conn.target().clone(),
+            iommu.clone(),
+        );
+        assert!(target.software_iommu());
+
+        let derived = target.with_devfn(0x18);
+
+        // The IOMMU factory was asked for the same devfn used for MSI.
+        assert_eq!(*iommu.devfn_calls.lock(), vec![0x18]);
+        // The derived target uses the IOMMU-provided 0x2000 allocation, not
+        // the empty base memory: an access past the (empty) base succeeds.
+        derived.guest_memory().write_at(0x1500, &[0xCD]).unwrap();
+        let mut buf = [0u8];
+        derived.guest_memory().read_at(0x1500, &mut buf).unwrap();
+        assert_eq!(buf[0], 0xCD);
+        assert!(derived.software_iommu());
+
+        derived.msi_target().signal_msi(0xFEE0_0000, 0);
+        assert_eq!(recorder.pop().unwrap(), (5 << 8) | 0x18);
+    }
+
+    #[test]
+    fn with_rid_iommu_derives_memory_and_msi_together() {
+        let bus_range = AssignedBusRange::new();
+        bus_range.set_bus_range(5, 10);
+        let msi_conn = MsiConnection::new(bus_range, 0);
+        let recorder = RecordingSignalMsi::new();
+        msi_conn.connect(recorder.clone());
+
+        let iommu = RecordingIommu::new();
+        let target = DmaTarget::with_iommu(
+            GuestMemory::empty(),
+            msi_conn.target().clone(),
+            iommu.clone(),
+        );
+
+        let rid: u16 = (7 << 8) | 0x0A; // bus 7 (within [5, 10]), devfn 0x0A
+        let derived = target.with_rid(rid);
+
+        // The IOMMU factory was asked for the same RID used for MSI.
+        assert_eq!(*iommu.rid_calls.lock(), vec![rid]);
+        // The derived target uses the IOMMU-provided 0x2000 allocation, not
+        // the empty base memory: an access past the (empty) base succeeds.
+        derived.guest_memory().write_at(0x1500, &[0xCD]).unwrap();
+        let mut buf = [0u8];
+        derived.guest_memory().read_at(0x1500, &mut buf).unwrap();
+        assert_eq!(buf[0], 0xCD);
+        assert!(derived.software_iommu());
+
+        derived.msi_target().signal_msi(0xFEE0_0000, 0);
+        assert_eq!(recorder.pop().unwrap(), rid as u32);
+    }
+}

--- a/vm/devices/pci/pci_core/src/lib.rs
+++ b/vm/devices/pci/pci_core/src/lib.rs
@@ -15,6 +15,7 @@ pub mod bus_range;
 pub mod capabilities;
 pub mod cfg_space_emu;
 pub mod chipset_device_ext;
+pub mod dma;
 pub mod msi;
 pub mod spec;
 

--- a/vm/devices/pci/pci_core/src/msi.rs
+++ b/vm/devices/pci/pci_core/src/msi.rs
@@ -29,7 +29,7 @@ pub trait SignalMsi: Send + Sync {
 /// where the physical device signals the event on interrupt.
 pub struct MsiRoute {
     inner: Box<dyn IrqFdRoute>,
-    default_bdf: DefaultBdf,
+    default_rid: DefaultRid,
 }
 
 impl MsiRoute {
@@ -46,9 +46,9 @@ impl MsiRoute {
     /// If the resolved bus falls outside the assigned bus range, the route is
     /// left disabled and a ratelimited warning is emitted.
     pub fn enable(&self, address: u64, data: u32) {
-        // `resolve_default_bdf` emits the ratelimited warning when the
+        // `resolve_default_rid` emits the ratelimited warning when the
         // resolved bus is out of range; just leave the route disabled here.
-        let Some(resolved) = resolve_default_bdf(&self.default_bdf) else {
+        let Some(resolved) = resolve_default_rid(&self.default_rid) else {
             self.inner.disable();
             return;
         };
@@ -68,8 +68,8 @@ impl MsiRoute {
     /// is left disabled and a ratelimited warning is emitted.
     pub fn enable_with_rid(&self, rid: u16, address: u64, data: u32) {
         let bus = (rid >> 8) as u8;
-        if !self.default_bdf.bus_range.contains_bus(bus) {
-            let (secondary, subordinate) = self.default_bdf.bus_range.bus_range();
+        if !self.default_rid.bus_range.contains_bus(bus) {
+            let (secondary, subordinate) = self.default_rid.bus_range.bus_range();
             tracelimit::warn_ratelimited!(
                 rid,
                 secondary,
@@ -113,12 +113,12 @@ impl SignalMsi for DisconnectedMsiTarget {
 /// just its devfn; for SR-IOV VFs it may carry into the bus byte to address
 /// functions on higher buses within the assigned range.
 #[derive(Clone, Debug)]
-struct DefaultBdf {
+struct DefaultRid {
     bus_range: AssignedBusRange,
     rid_offset: u16,
 }
 
-/// Resolves a requester ID from a [`DefaultBdf`] source, composing it as
+/// Resolves a requester ID from a [`DefaultRid`] source, composing it as
 /// `(secondary_bus << 8) + rid_offset` against the live bus range.
 ///
 /// Returns `None` when the resulting bus falls outside the assigned range
@@ -126,7 +126,7 @@ struct DefaultBdf {
 /// warning is emitted and the caller should drop the MSI / disable the route.
 /// The offset is non-negative, so the bus is always at least the secondary
 /// bus; only the upper bound can be exceeded.
-fn resolve_default_bdf(default: &DefaultBdf) -> Option<u32> {
+fn resolve_default_rid(default: &DefaultRid) -> Option<u32> {
     let (secondary, subordinate) = default.bus_range.bus_range();
     let rid = ((secondary as u32) << 8) + default.rid_offset as u32;
     if rid >> 8 > subordinate as u32 {
@@ -159,7 +159,7 @@ pub struct MsiConnection {
 #[derive(Clone)]
 pub struct MsiTarget {
     inner: Arc<RwLock<MsiTargetInner>>,
-    default_bdf: DefaultBdf,
+    default_rid: DefaultRid,
 }
 
 impl MsiTarget {
@@ -172,7 +172,7 @@ impl MsiTarget {
                 signal_msi: Arc::new(DisconnectedMsiTarget),
                 irqfd: None,
             })),
-            default_bdf: DefaultBdf {
+            default_rid: DefaultRid {
                 bus_range: AssignedBusRange::new(),
                 rid_offset: 0,
             },
@@ -183,7 +183,7 @@ impl MsiTarget {
 impl std::fmt::Debug for MsiTarget {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("MsiTarget")
-            .field("default_bdf", &self.default_bdf)
+            .field("default_rid", &self.default_rid)
             .finish()
     }
 }
@@ -241,7 +241,7 @@ impl MsiConnection {
     pub fn msi_target(&self, bus_range: AssignedBusRange, devfn: u8) -> MsiTarget {
         MsiTarget {
             inner: self.inner.clone(),
-            default_bdf: DefaultBdf {
+            default_rid: DefaultRid {
                 bus_range,
                 rid_offset: devfn as u16,
             },
@@ -282,7 +282,7 @@ impl MsiTarget {
     pub fn with_bus_range(&self, bus_range: AssignedBusRange, devfn: u8) -> MsiTarget {
         MsiTarget {
             inner: self.inner.clone(),
-            default_bdf: DefaultBdf {
+            default_rid: DefaultRid {
                 bus_range,
                 rid_offset: devfn as u16,
             },
@@ -301,7 +301,7 @@ impl MsiTarget {
     /// The resulting bus is validated against the assigned bus range when an
     /// MSI is signaled (see [`signal_msi`](Self::signal_msi)), not here.
     pub fn with_rid(&self, rid: u16) -> MsiTarget {
-        let (secondary, _) = self.default_bdf.bus_range.bus_range();
+        let (secondary, _) = self.default_rid.bus_range.bus_range();
         self.with_rid_offset(rid.wrapping_sub((secondary as u16) << 8))
     }
 
@@ -316,8 +316,8 @@ impl MsiTarget {
     pub fn with_rid_offset(&self, rid_offset: u16) -> MsiTarget {
         MsiTarget {
             inner: self.inner.clone(),
-            default_bdf: DefaultBdf {
-                bus_range: self.default_bdf.bus_range.clone(),
+            default_rid: DefaultRid {
+                bus_range: self.default_rid.bus_range.clone(),
                 rid_offset,
             },
         }
@@ -326,7 +326,7 @@ impl MsiTarget {
     /// Signals an MSI interrupt to this target, using this target's
     /// default BDF as the requester ID.
     pub fn signal_msi(&self, address: u64, data: u32) {
-        let Some(resolved) = resolve_default_bdf(&self.default_bdf) else {
+        let Some(resolved) = resolve_default_rid(&self.default_rid) else {
             return;
         };
         let inner = self.inner.read();
@@ -346,8 +346,8 @@ impl MsiTarget {
     /// dropped and a ratelimited warning is emitted.
     pub fn signal_msi_with_rid(&self, rid: u16, address: u64, data: u32) {
         let bus = (rid >> 8) as u8;
-        if !self.default_bdf.bus_range.contains_bus(bus) {
-            let (secondary, subordinate) = self.default_bdf.bus_range.bus_range();
+        if !self.default_rid.bus_range.contains_bus(bus) {
+            let (secondary, subordinate) = self.default_rid.bus_range.bus_range();
             tracelimit::warn_ratelimited!(
                 rid,
                 secondary,
@@ -373,7 +373,7 @@ impl MsiTarget {
         inner.irqfd.as_ref().map(|fd| {
             Ok(MsiRoute {
                 inner: fd.new_irqfd_route()?,
-                default_bdf: self.default_bdf.clone(),
+                default_rid: self.default_rid.clone(),
             })
         })
     }
@@ -480,7 +480,7 @@ mod tests {
     }
 
     #[test]
-    fn signal_msi_resolves_default_bdf() {
+    fn signal_msi_resolves_default_rid() {
         let bus_range = AssignedBusRange::new();
         bus_range.set_bus_range(5, 10);
         let msi_conn = MsiConnection::new();
@@ -562,7 +562,7 @@ mod tests {
     }
 
     #[test]
-    fn route_enable_resolves_default_bdf() {
+    fn route_enable_resolves_default_rid() {
         let bus_range = AssignedBusRange::new();
         bus_range.set_bus_range(3, 8);
         let (irqfd, calls) = mock_irqfd(1);

--- a/vm/devices/pci/pci_core/src/msi.rs
+++ b/vm/devices/pci/pci_core/src/msi.rs
@@ -46,6 +46,8 @@ impl MsiRoute {
     /// If the resolved bus falls outside the assigned bus range, the route is
     /// left disabled and a ratelimited warning is emitted.
     pub fn enable(&self, address: u64, data: u32) {
+        // `resolve_default_bdf` emits the ratelimited warning when the
+        // resolved bus is out of range; just leave the route disabled here.
         let Some(resolved) = resolve_default_bdf(&self.default_bdf) else {
             self.inner.disable();
             return;

--- a/vm/devices/pci/pci_core/src/msi.rs
+++ b/vm/devices/pci/pci_core/src/msi.rs
@@ -42,8 +42,15 @@ impl MsiRoute {
 
     /// Configures the MSI address and data for this route, using
     /// the route's default BDF as the requester ID.
+    ///
+    /// If the route's BDF carries an explicit bus override that falls
+    /// outside the assigned bus range, the route is left disabled and a
+    /// ratelimited warning is emitted.
     pub fn enable(&self, address: u64, data: u32) {
-        let resolved = resolve_default_bdf(&self.default_bdf);
+        let Some(resolved) = resolve_default_bdf(&self.default_bdf) else {
+            self.inner.disable();
+            return;
+        };
         self.inner.enable(address, data, Some(resolved))
     }
 
@@ -100,17 +107,43 @@ impl SignalMsi for DisconnectedMsiTarget {
 /// Default BDF source for MSI device identification.
 ///
 /// [`MsiTarget::signal_msi`] uses this to compose the requester ID
-/// from the port's secondary bus combined with the configured `devfn`.
+/// from the port's secondary bus (or explicit bus override) combined
+/// with the configured `devfn`.
 #[derive(Clone, Debug)]
 struct DefaultBdf {
     bus_range: AssignedBusRange,
     devfn: u8,
+    /// When set, overrides the bus portion of the RID instead of
+    /// using `bus_range.secondary`. Used by [`MsiTarget::with_rid`]
+    /// for VFs that span multiple bus numbers.
+    bus_override: Option<u8>,
 }
 
-/// Resolves a BDF from a [`DefaultBdf`] source.
-fn resolve_default_bdf(default: &DefaultBdf) -> u32 {
-    let (secondary, _) = default.bus_range.bus_range();
-    (secondary as u32) << 8 | default.devfn as u32
+/// Resolves a BDF from a [`DefaultBdf`] source, validating an explicit
+/// `bus_override` against the assigned bus range.
+///
+/// Returns `None` when the override bus falls outside the assigned range, in
+/// which case a ratelimited warning is emitted and the caller should drop the
+/// MSI / disable the route. The derived (non-override) bus is the range's
+/// secondary bus and is therefore always in range.
+fn resolve_default_bdf(default: &DefaultBdf) -> Option<u32> {
+    let bus = if let Some(bus) = default.bus_override {
+        if !default.bus_range.contains_bus(bus) {
+            let (secondary, subordinate) = default.bus_range.bus_range();
+            tracelimit::warn_ratelimited!(
+                bus,
+                secondary,
+                subordinate,
+                "dropping MSI: rid bus override outside assigned bus range"
+            );
+            return None;
+        }
+        bus
+    } else {
+        let (secondary, _) = default.bus_range.bus_range();
+        secondary
+    };
+    Some((bus as u32) << 8 | default.devfn as u32)
 }
 
 /// A connection between a device and an MSI target.
@@ -139,6 +172,7 @@ impl MsiTarget {
             default_bdf: DefaultBdf {
                 bus_range: AssignedBusRange::new(),
                 devfn: 0,
+                bus_override: None,
             },
         }
     }
@@ -183,7 +217,11 @@ impl MsiConnection {
                     signal_msi: Arc::new(DisconnectedMsiTarget),
                     irqfd: None,
                 })),
-                default_bdf: DefaultBdf { bus_range, devfn },
+                default_bdf: DefaultBdf {
+                    bus_range,
+                    devfn,
+                    bus_override: None,
+                },
             },
         }
     }
@@ -222,6 +260,7 @@ impl MsiTarget {
             default_bdf: DefaultBdf {
                 bus_range: self.default_bdf.bus_range.clone(),
                 devfn,
+                bus_override: None,
             },
         }
     }
@@ -234,14 +273,43 @@ impl MsiTarget {
     pub fn with_bus_range(&self, bus_range: AssignedBusRange, devfn: u8) -> MsiTarget {
         MsiTarget {
             inner: self.inner.clone(),
-            default_bdf: DefaultBdf { bus_range, devfn },
+            default_bdf: DefaultBdf {
+                bus_range,
+                devfn,
+                bus_override: None,
+            },
+        }
+    }
+
+    /// Returns a new `MsiTarget` sharing the same connection and bus
+    /// range but with the default RID set to the given value.
+    ///
+    /// The RID is a 16-bit value: `(bus << 8) | devfn`. Unlike
+    /// [`with_devfn`](Self::with_devfn), this sets an explicit bus
+    /// number rather than deriving it from the bus range's secondary
+    /// bus. Use this for SR-IOV VFs that may span multiple bus
+    /// numbers within the port's assigned range.
+    ///
+    /// The bus is validated against the assigned bus range when an MSI is
+    /// signaled (see [`signal_msi`](Self::signal_msi)), not here, because
+    /// the range may not be programmed yet when the target is derived.
+    pub fn with_rid(&self, rid: u16) -> MsiTarget {
+        MsiTarget {
+            inner: self.inner.clone(),
+            default_bdf: DefaultBdf {
+                bus_range: self.default_bdf.bus_range.clone(),
+                devfn: rid as u8,
+                bus_override: Some((rid >> 8) as u8),
+            },
         }
     }
 
     /// Signals an MSI interrupt to this target, using this target's
     /// default BDF as the requester ID.
     pub fn signal_msi(&self, address: u64, data: u32) {
-        let resolved = resolve_default_bdf(&self.default_bdf);
+        let Some(resolved) = resolve_default_bdf(&self.default_bdf) else {
+            return;
+        };
         let inner = self.inner.read();
         inner.signal_msi.signal_msi(Some(resolved), address, data);
     }
@@ -289,12 +357,6 @@ impl MsiTarget {
                 default_bdf: self.default_bdf.clone(),
             })
         })
-    }
-
-    /// Returns the default BDF that will be used by
-    /// [`signal_msi`](Self::signal_msi) and [`MsiRoute::enable`].
-    pub fn default_bdf(&self) -> u32 {
-        resolve_default_bdf(&self.default_bdf)
     }
 
     /// Returns whether this target supports direct MSI routes.
@@ -568,5 +630,62 @@ mod tests {
         // Validation uses the child range, not the parent
         derived.signal_msi_with_rid(16 << 8, 0x3000, 3);
         assert!(recorder.pop().is_none()); // bus 16 > subordinate 15
+    }
+
+    #[test]
+    fn with_rid_signal_msi_accepts_bus_in_range() {
+        let bus_range = AssignedBusRange::new();
+        bus_range.set_bus_range(5, 10);
+        let msi_conn = MsiConnection::new(bus_range, 0);
+        let recorder = RecordingSignalMsi::new();
+        msi_conn.connect(recorder.clone());
+
+        // RID with bus=7 (within [5, 10]), devfn=0x0A
+        let rid: u16 = (7 << 8) | 0x0A;
+        let derived = msi_conn.target().with_rid(rid);
+        derived.signal_msi(0x1000, 7);
+
+        let (devid, addr, data) = recorder.pop().unwrap();
+        assert_eq!(devid, Some(rid as u32));
+        assert_eq!(addr, 0x1000);
+        assert_eq!(data, 7);
+    }
+
+    #[test]
+    fn with_rid_signal_msi_drops_bus_outside_range() {
+        let bus_range = AssignedBusRange::new();
+        bus_range.set_bus_range(5, 10);
+        let msi_conn = MsiConnection::new(bus_range, 0);
+        let recorder = RecordingSignalMsi::new();
+        msi_conn.connect(recorder.clone());
+
+        // bus=11 > subordinate=10 → dropped
+        let derived_above = msi_conn.target().with_rid(11 << 8);
+        derived_above.signal_msi(0x1000, 1);
+        assert!(recorder.pop().is_none());
+
+        // bus=4 < secondary=5 → dropped
+        let derived_below = msi_conn.target().with_rid(4 << 8);
+        derived_below.signal_msi(0x2000, 2);
+        assert!(recorder.pop().is_none());
+    }
+
+    #[test]
+    fn with_rid_route_enable_disables_when_bus_outside_range() {
+        let bus_range = AssignedBusRange::new();
+        bus_range.set_bus_range(5, 10);
+        let (irqfd, calls) = mock_irqfd(1);
+        let msi_conn = MsiConnection::new(bus_range, 0);
+        msi_conn.connect_irqfd(irqfd);
+
+        // Derive a target whose override bus (11) is outside [5, 10], then
+        // enable a route from it: the route must be disabled, not enabled.
+        let derived = msi_conn.target().with_rid(11 << 8);
+        let route = derived.new_route().unwrap().unwrap();
+        route.enable(0xBEEF, 77);
+
+        let log = calls[0].lock();
+        assert_eq!(log.len(), 1);
+        assert_eq!(log[0], RouteCall::Disable);
     }
 }

--- a/vm/devices/pci/pci_core/src/msi.rs
+++ b/vm/devices/pci/pci_core/src/msi.rs
@@ -40,12 +40,11 @@ impl MsiRoute {
         self.inner.event()
     }
 
-    /// Configures the MSI address and data for this route, using
-    /// the route's default BDF as the requester ID.
+    /// Configures the MSI address and data for this route, using the route's
+    /// default requester ID `(secondary_bus << 8) + rid_offset`.
     ///
-    /// If the route's BDF carries an explicit bus override that falls
-    /// outside the assigned bus range, the route is left disabled and a
-    /// ratelimited warning is emitted.
+    /// If the resolved bus falls outside the assigned bus range, the route is
+    /// left disabled and a ratelimited warning is emitted.
     pub fn enable(&self, address: u64, data: u32) {
         let Some(resolved) = resolve_default_bdf(&self.default_bdf) else {
             self.inner.disable();
@@ -104,52 +103,54 @@ impl SignalMsi for DisconnectedMsiTarget {
     }
 }
 
-/// Default BDF source for MSI device identification.
+/// Default requester-ID source for MSI device identification.
 ///
-/// [`MsiTarget::signal_msi`] uses this to compose the requester ID
-/// from the port's secondary bus (or explicit bus override) combined
-/// with the configured `devfn`.
+/// [`MsiTarget::signal_msi`] composes the requester ID at signal time as
+/// `(secondary_bus << 8) + rid_offset`, reading the secondary bus from the
+/// live [`AssignedBusRange`]. For a single-function device `rid_offset` is
+/// just its devfn; for SR-IOV VFs it may carry into the bus byte to address
+/// functions on higher buses within the assigned range.
 #[derive(Clone, Debug)]
 struct DefaultBdf {
     bus_range: AssignedBusRange,
-    devfn: u8,
-    /// When set, overrides the bus portion of the RID instead of
-    /// using `bus_range.secondary`. Used by [`MsiTarget::with_rid`]
-    /// for VFs that span multiple bus numbers.
-    bus_override: Option<u8>,
+    rid_offset: u16,
 }
 
-/// Resolves a BDF from a [`DefaultBdf`] source, validating an explicit
-/// `bus_override` against the assigned bus range.
+/// Resolves a requester ID from a [`DefaultBdf`] source, composing it as
+/// `(secondary_bus << 8) + rid_offset` against the live bus range.
 ///
-/// Returns `None` when the override bus falls outside the assigned range, in
-/// which case a ratelimited warning is emitted and the caller should drop the
-/// MSI / disable the route. The derived (non-override) bus is the range's
-/// secondary bus and is therefore always in range.
+/// Returns `None` when the resulting bus falls outside the assigned range
+/// (the offset reaches past the subordinate bus), in which case a ratelimited
+/// warning is emitted and the caller should drop the MSI / disable the route.
+/// The offset is non-negative, so the bus is always at least the secondary
+/// bus; only the upper bound can be exceeded.
 fn resolve_default_bdf(default: &DefaultBdf) -> Option<u32> {
-    let bus = if let Some(bus) = default.bus_override {
-        if !default.bus_range.contains_bus(bus) {
-            let (secondary, subordinate) = default.bus_range.bus_range();
-            tracelimit::warn_ratelimited!(
-                bus,
-                secondary,
-                subordinate,
-                "dropping MSI: rid bus override outside assigned bus range"
-            );
-            return None;
-        }
-        bus
-    } else {
-        let (secondary, _) = default.bus_range.bus_range();
-        secondary
-    };
-    Some((bus as u32) << 8 | default.devfn as u32)
+    let (secondary, subordinate) = default.bus_range.bus_range();
+    let rid = ((secondary as u32) << 8) + default.rid_offset as u32;
+    if rid >> 8 > subordinate as u32 {
+        tracelimit::warn_ratelimited!(
+            rid,
+            secondary,
+            subordinate,
+            "dropping MSI: rid bus outside assigned bus range"
+        );
+        return None;
+    }
+    Some(rid)
 }
 
-/// A connection between a device and an MSI target.
+/// A late-bound MSI backend slot.
+///
+/// A connection carries no device identity — it is purely the backend that
+/// MSIs are delivered to, filled in after construction via [`connect`].
+/// Identity is supplied when a target is derived via
+/// [`msi_target`](Self::msi_target), or when a
+/// [`DmaTarget`](crate::dma::DmaTarget) is built from it.
+///
+/// [`connect`]: Self::connect
 #[derive(Debug)]
 pub struct MsiConnection {
-    target: MsiTarget,
+    inner: Arc<RwLock<MsiTargetInner>>,
 }
 
 /// An MSI target that can be used to signal MSI interrupts.
@@ -171,8 +172,7 @@ impl MsiTarget {
             })),
             default_bdf: DefaultBdf {
                 bus_range: AssignedBusRange::new(),
-                devfn: 0,
-                bus_override: None,
+                rid_offset: 0,
             },
         }
     }
@@ -204,31 +204,24 @@ impl std::fmt::Debug for MsiTargetInner {
 }
 
 impl MsiConnection {
-    /// Creates a new disconnected MSI target connection.
+    /// Creates a new disconnected MSI connection.
     ///
-    /// `bus_range` and `devfn` configure the default BDF identity
-    /// for this connection. When a device signals an MSI via
-    /// [`MsiTarget::signal_msi`], the BDF is resolved from the bus
-    /// range's secondary bus and the given `devfn`.
-    pub fn new(bus_range: AssignedBusRange, devfn: u8) -> Self {
+    /// The connection is purely the late-bound MSI backend slot; it carries
+    /// no device identity. Callers stamp identity when they derive a target
+    /// via [`msi_target`](Self::msi_target), or by building a
+    /// [`DmaTarget`](crate::dma::DmaTarget) from it.
+    pub fn new() -> Self {
         Self {
-            target: MsiTarget {
-                inner: Arc::new(RwLock::new(MsiTargetInner {
-                    signal_msi: Arc::new(DisconnectedMsiTarget),
-                    irqfd: None,
-                })),
-                default_bdf: DefaultBdf {
-                    bus_range,
-                    devfn,
-                    bus_override: None,
-                },
-            },
+            inner: Arc::new(RwLock::new(MsiTargetInner {
+                signal_msi: Arc::new(DisconnectedMsiTarget),
+                irqfd: None,
+            })),
         }
     }
 
     /// Updates the MSI target to which this connection signals interrupts.
     pub fn connect(&self, signal_msi: Arc<dyn SignalMsi>) {
-        let mut inner = self.target.inner.write();
+        let mut inner = self.inner.write();
         inner.signal_msi = signal_msi;
     }
 
@@ -237,13 +230,34 @@ impl MsiConnection {
     /// When present, [`MsiTarget::new_route`] can create [`MsiRoute`]
     /// instances for direct interrupt delivery.
     pub fn connect_irqfd(&self, irqfd: Arc<dyn IrqFd>) {
-        let mut inner = self.target.inner.write();
+        let mut inner = self.inner.write();
         inner.irqfd = Some(irqfd);
     }
 
-    /// Returns the MSI target for this connection.
-    pub fn target(&self) -> &MsiTarget {
-        &self.target
+    /// Derives an MSI target with the given identity, sharing this
+    /// connection's (late-bound) backend slot.
+    pub fn msi_target(&self, bus_range: AssignedBusRange, devfn: u8) -> MsiTarget {
+        MsiTarget {
+            inner: self.inner.clone(),
+            default_bdf: DefaultBdf {
+                bus_range,
+                rid_offset: devfn as u16,
+            },
+        }
+    }
+
+    /// Derives an MSI target with no device identity (an empty bus range).
+    ///
+    /// Use for MSI emitters that don't need a meaningful requester ID, or
+    /// that re-anchor identity themselves (e.g. PCIe switches).
+    pub fn target(&self) -> MsiTarget {
+        self.msi_target(AssignedBusRange::new(), 0)
+    }
+}
+
+impl Default for MsiConnection {
+    fn default() -> Self {
+        Self::new()
     }
 }
 
@@ -255,14 +269,7 @@ impl MsiTarget {
     /// bus range, then call `with_devfn(port_number)` to get a
     /// target that resolves to `(bus << 8) | devfn`.
     pub fn with_devfn(&self, devfn: u8) -> MsiTarget {
-        MsiTarget {
-            inner: self.inner.clone(),
-            default_bdf: DefaultBdf {
-                bus_range: self.default_bdf.bus_range.clone(),
-                devfn,
-                bus_override: None,
-            },
-        }
+        self.with_rid_offset(devfn as u16)
     }
 
     /// Returns a new `MsiTarget` sharing the same connection but with
@@ -275,31 +282,41 @@ impl MsiTarget {
             inner: self.inner.clone(),
             default_bdf: DefaultBdf {
                 bus_range,
-                devfn,
-                bus_override: None,
+                rid_offset: devfn as u16,
             },
         }
     }
 
-    /// Returns a new `MsiTarget` sharing the same connection and bus
-    /// range but with the default RID set to the given value.
+    /// Returns a new `MsiTarget` sharing the same connection and bus range
+    /// but with the requester-ID offset set so the target resolves to the
+    /// given absolute `rid`.
     ///
-    /// The RID is a 16-bit value: `(bus << 8) | devfn`. Unlike
-    /// [`with_devfn`](Self::with_devfn), this sets an explicit bus
-    /// number rather than deriving it from the bus range's secondary
-    /// bus. Use this for SR-IOV VFs that may span multiple bus
-    /// numbers within the port's assigned range.
+    /// The offset is computed against the *current* secondary bus, so call
+    /// this only once the bus range is assigned. For targets derived before
+    /// the bus is programmed (e.g. SR-IOV VFs), use
+    /// [`with_rid_offset`](Self::with_rid_offset) instead.
     ///
-    /// The bus is validated against the assigned bus range when an MSI is
-    /// signaled (see [`signal_msi`](Self::signal_msi)), not here, because
-    /// the range may not be programmed yet when the target is derived.
+    /// The resulting bus is validated against the assigned bus range when an
+    /// MSI is signaled (see [`signal_msi`](Self::signal_msi)), not here.
     pub fn with_rid(&self, rid: u16) -> MsiTarget {
+        let (secondary, _) = self.default_bdf.bus_range.bus_range();
+        self.with_rid_offset(rid.wrapping_sub((secondary as u16) << 8))
+    }
+
+    /// Returns a new `MsiTarget` sharing the same connection and bus range
+    /// but with the requester-ID offset set to `rid_offset`.
+    ///
+    /// The RID is resolved at signal time as `(secondary_bus << 8) +
+    /// rid_offset`, so the target tracks the live bus assignment. This is the
+    /// primitive for SR-IOV VFs, which are constructed before the PF's bus is
+    /// programmed: pass the VF's RID offset (e.g. VF Offset + index × VF
+    /// Stride) and it resolves correctly once the bus range is assigned.
+    pub fn with_rid_offset(&self, rid_offset: u16) -> MsiTarget {
         MsiTarget {
             inner: self.inner.clone(),
             default_bdf: DefaultBdf {
                 bus_range: self.default_bdf.bus_range.clone(),
-                devfn: rid as u8,
-                bus_override: Some((rid >> 8) as u8),
+                rid_offset,
             },
         }
     }
@@ -464,11 +481,13 @@ mod tests {
     fn signal_msi_resolves_default_bdf() {
         let bus_range = AssignedBusRange::new();
         bus_range.set_bus_range(5, 10);
-        let msi_conn = MsiConnection::new(bus_range, 0x18); // devfn = dev 3, fn 0
+        let msi_conn = MsiConnection::new();
         let recorder = RecordingSignalMsi::new();
         msi_conn.connect(recorder.clone());
 
-        msi_conn.target().signal_msi(0xFEE0_0000, 42);
+        msi_conn
+            .msi_target(bus_range, 0x18)
+            .signal_msi(0xFEE0_0000, 42);
 
         let (devid, addr, data) = recorder.pop().unwrap();
         assert_eq!(devid, Some((5 << 8) | 0x18));
@@ -480,13 +499,15 @@ mod tests {
     fn signal_msi_with_rid_accepts_bus_in_range() {
         let bus_range = AssignedBusRange::new();
         bus_range.set_bus_range(5, 10);
-        let msi_conn = MsiConnection::new(bus_range, 0);
+        let msi_conn = MsiConnection::new();
         let recorder = RecordingSignalMsi::new();
         msi_conn.connect(recorder.clone());
 
         // RID with bus=7, devfn=0x0A → within [5, 10]
         let rid: u16 = (7 << 8) | 0x0A;
-        msi_conn.target().signal_msi_with_rid(rid, 0xABCD, 99);
+        msi_conn
+            .msi_target(bus_range, 0)
+            .signal_msi_with_rid(rid, 0xABCD, 99);
 
         let (devid, addr, data) = recorder.pop().unwrap();
         assert_eq!(devid, Some(rid as u32));
@@ -498,18 +519,22 @@ mod tests {
     fn signal_msi_with_rid_drops_bus_outside_range() {
         let bus_range = AssignedBusRange::new();
         bus_range.set_bus_range(5, 10);
-        let msi_conn = MsiConnection::new(bus_range, 0);
+        let msi_conn = MsiConnection::new();
         let recorder = RecordingSignalMsi::new();
         msi_conn.connect(recorder.clone());
 
         // bus=11, above subordinate=10 → dropped
         let rid_above: u16 = 11 << 8;
-        msi_conn.target().signal_msi_with_rid(rid_above, 0xABCD, 1);
+        msi_conn
+            .msi_target(bus_range.clone(), 0)
+            .signal_msi_with_rid(rid_above, 0xABCD, 1);
         assert!(recorder.pop().is_none());
 
         // bus=4, below secondary=5 → dropped
         let rid_below: u16 = 4 << 8;
-        msi_conn.target().signal_msi_with_rid(rid_below, 0xABCD, 2);
+        msi_conn
+            .msi_target(bus_range, 0)
+            .signal_msi_with_rid(rid_below, 0xABCD, 2);
         assert!(recorder.pop().is_none());
     }
 
@@ -517,16 +542,20 @@ mod tests {
     fn signal_msi_with_rid_accepts_boundary_buses() {
         let bus_range = AssignedBusRange::new();
         bus_range.set_bus_range(5, 10);
-        let msi_conn = MsiConnection::new(bus_range, 0);
+        let msi_conn = MsiConnection::new();
         let recorder = RecordingSignalMsi::new();
         msi_conn.connect(recorder.clone());
 
         // Exactly at secondary bus (5)
-        msi_conn.target().signal_msi_with_rid(5 << 8, 0x1000, 10);
+        msi_conn
+            .msi_target(bus_range.clone(), 0)
+            .signal_msi_with_rid(5 << 8, 0x1000, 10);
         assert!(recorder.pop().is_some());
 
         // Exactly at subordinate bus (10)
-        msi_conn.target().signal_msi_with_rid(10 << 8, 0x2000, 20);
+        msi_conn
+            .msi_target(bus_range, 0)
+            .signal_msi_with_rid(10 << 8, 0x2000, 20);
         assert!(recorder.pop().is_some());
     }
 
@@ -535,10 +564,14 @@ mod tests {
         let bus_range = AssignedBusRange::new();
         bus_range.set_bus_range(3, 8);
         let (irqfd, calls) = mock_irqfd(1);
-        let msi_conn = MsiConnection::new(bus_range, 0x10); // devfn = dev 2, fn 0
+        let msi_conn = MsiConnection::new();
         msi_conn.connect_irqfd(irqfd);
 
-        let route = msi_conn.target().new_route().unwrap().unwrap();
+        let route = msi_conn
+            .msi_target(bus_range, 0x10)
+            .new_route()
+            .unwrap()
+            .unwrap();
         route.enable(0xFEE0_0000, 55);
 
         let log = calls[0].lock();
@@ -558,10 +591,14 @@ mod tests {
         let bus_range = AssignedBusRange::new();
         bus_range.set_bus_range(5, 10);
         let (irqfd, calls) = mock_irqfd(1);
-        let msi_conn = MsiConnection::new(bus_range, 0);
+        let msi_conn = MsiConnection::new();
         msi_conn.connect_irqfd(irqfd);
 
-        let route = msi_conn.target().new_route().unwrap().unwrap();
+        let route = msi_conn
+            .msi_target(bus_range, 0)
+            .new_route()
+            .unwrap()
+            .unwrap();
         let rid: u16 = (7 << 8) | 0x0A;
         route.enable_with_rid(rid, 0xBEEF, 77);
 
@@ -582,10 +619,14 @@ mod tests {
         let bus_range = AssignedBusRange::new();
         bus_range.set_bus_range(5, 10);
         let (irqfd, calls) = mock_irqfd(1);
-        let msi_conn = MsiConnection::new(bus_range, 0);
+        let msi_conn = MsiConnection::new();
         msi_conn.connect_irqfd(irqfd);
 
-        let route = msi_conn.target().new_route().unwrap().unwrap();
+        let route = msi_conn
+            .msi_target(bus_range, 0)
+            .new_route()
+            .unwrap()
+            .unwrap();
         // bus=11, above subordinate → should disable
         let rid: u16 = 11 << 8;
         route.enable_with_rid(rid, 0xBEEF, 77);
@@ -599,11 +640,11 @@ mod tests {
     fn with_devfn_derives_target_with_new_devfn() {
         let bus_range = AssignedBusRange::new();
         bus_range.set_bus_range(2, 5);
-        let msi_conn = MsiConnection::new(bus_range, 0);
+        let msi_conn = MsiConnection::new();
         let recorder = RecordingSignalMsi::new();
         msi_conn.connect(recorder.clone());
 
-        let derived = msi_conn.target().with_devfn(0x18); // dev 3, fn 0
+        let derived = msi_conn.msi_target(bus_range, 0).with_devfn(0x18); // dev 3, fn 0
         derived.signal_msi(0x1000, 1);
 
         let (devid, _, _) = recorder.pop().unwrap();
@@ -614,13 +655,15 @@ mod tests {
     fn with_bus_range_derives_target_with_new_range() {
         let parent_range = AssignedBusRange::new();
         parent_range.set_bus_range(1, 20);
-        let msi_conn = MsiConnection::new(parent_range, 0);
+        let msi_conn = MsiConnection::new();
         let recorder = RecordingSignalMsi::new();
         msi_conn.connect(recorder.clone());
 
         let child_range = AssignedBusRange::new();
         child_range.set_bus_range(10, 15);
-        let derived = msi_conn.target().with_bus_range(child_range, 0x08);
+        let derived = msi_conn
+            .msi_target(parent_range, 0)
+            .with_bus_range(child_range, 0x08);
         derived.signal_msi(0x2000, 2);
 
         let (devid, _, _) = recorder.pop().unwrap();
@@ -636,13 +679,13 @@ mod tests {
     fn with_rid_signal_msi_accepts_bus_in_range() {
         let bus_range = AssignedBusRange::new();
         bus_range.set_bus_range(5, 10);
-        let msi_conn = MsiConnection::new(bus_range, 0);
+        let msi_conn = MsiConnection::new();
         let recorder = RecordingSignalMsi::new();
         msi_conn.connect(recorder.clone());
 
         // RID with bus=7 (within [5, 10]), devfn=0x0A
         let rid: u16 = (7 << 8) | 0x0A;
-        let derived = msi_conn.target().with_rid(rid);
+        let derived = msi_conn.msi_target(bus_range, 0).with_rid(rid);
         derived.signal_msi(0x1000, 7);
 
         let (devid, addr, data) = recorder.pop().unwrap();
@@ -655,17 +698,17 @@ mod tests {
     fn with_rid_signal_msi_drops_bus_outside_range() {
         let bus_range = AssignedBusRange::new();
         bus_range.set_bus_range(5, 10);
-        let msi_conn = MsiConnection::new(bus_range, 0);
+        let msi_conn = MsiConnection::new();
         let recorder = RecordingSignalMsi::new();
         msi_conn.connect(recorder.clone());
 
         // bus=11 > subordinate=10 → dropped
-        let derived_above = msi_conn.target().with_rid(11 << 8);
+        let derived_above = msi_conn.msi_target(bus_range.clone(), 0).with_rid(11 << 8);
         derived_above.signal_msi(0x1000, 1);
         assert!(recorder.pop().is_none());
 
         // bus=4 < secondary=5 → dropped
-        let derived_below = msi_conn.target().with_rid(4 << 8);
+        let derived_below = msi_conn.msi_target(bus_range, 0).with_rid(4 << 8);
         derived_below.signal_msi(0x2000, 2);
         assert!(recorder.pop().is_none());
     }
@@ -675,12 +718,12 @@ mod tests {
         let bus_range = AssignedBusRange::new();
         bus_range.set_bus_range(5, 10);
         let (irqfd, calls) = mock_irqfd(1);
-        let msi_conn = MsiConnection::new(bus_range, 0);
+        let msi_conn = MsiConnection::new();
         msi_conn.connect_irqfd(irqfd);
 
         // Derive a target whose override bus (11) is outside [5, 10], then
         // enable a route from it: the route must be disabled, not enabled.
-        let derived = msi_conn.target().with_rid(11 << 8);
+        let derived = msi_conn.msi_target(bus_range, 0).with_rid(11 << 8);
         let route = derived.new_route().unwrap().unwrap();
         route.enable(0xBEEF, 77);
 

--- a/vm/devices/pci/pci_resources/src/lib.rs
+++ b/vm/devices/pci/pci_resources/src/lib.rs
@@ -9,9 +9,8 @@ use chipset_device::mmio::RegisterMmioIntercept;
 use chipset_device_resources::ErasedChipsetDevice;
 use chipset_device_resources::ResolvedChipsetDevice;
 use guestmem::DoorbellRegistration;
-use guestmem::GuestMemory;
 use guestmem::MemoryMapper;
-use pci_core::msi::MsiTarget;
+use pci_core::dma::DmaTarget;
 use std::sync::Arc;
 use vm_resource::CanResolveTo;
 use vm_resource::kind::PciDeviceHandleKind;
@@ -32,21 +31,14 @@ impl<T: Into<ResolvedChipsetDevice>> From<T> for ResolvedPciDevice {
 
 /// Parameters used when resolving a resource with kind [`PciDeviceHandleKind`].
 pub struct ResolvePciDeviceHandleParams<'a> {
-    /// The target for MSI interrupts.
-    pub msi_target: &'a MsiTarget,
+    /// DMA and MSI target for the device.
+    pub dma_target: &'a DmaTarget,
     /// An object with which to register MMIO regions.
     pub register_mmio: &'a mut (dyn RegisterMmioIntercept + Send),
     /// The VM's task driver source.
     pub driver_source: &'a VmTaskDriverSource,
-    /// The VM's guest memory.
-    pub guest_memory: &'a GuestMemory,
     /// An object with which to register doorbell regions.
     pub doorbell_registration: Option<Arc<dyn DoorbellRegistration>>,
     /// An object with which to register shared memory regions.
     pub shared_mem_mapper: Option<&'a dyn MemoryMapper>,
-    /// Whether the device is behind a software IOMMU (e.g., emulated SMMU)
-    /// that cannot program the host IOMMU for passthrough DMA. When `true`,
-    /// device assignment backends (e.g., VFIO) that require host IOMMU
-    /// mappings must reject the assignment.
-    pub software_iommu: bool,
 }

--- a/vm/devices/pci/pcie/fuzz/fuzz_pcie.rs
+++ b/vm/devices/pci/pcie/fuzz/fuzz_pcie.rs
@@ -128,11 +128,10 @@ impl FuzzRootComplex {
                 settings: PciePortSettings::default(),
             })
             .collect();
-        let msi_conn =
-            pci_core::msi::MsiConnection::new(pci_core::bus_range::AssignedBusRange::new(), 0);
+        let msi_conn = pci_core::msi::MsiConnection::new();
         let rc =
             GenericPcieRootComplex::builder(&mut register_mmio, START_BUS..=END_BUS, ecam_range)
-                .root_ports(port_defs, msi_conn.target())
+                .root_ports(port_defs, &msi_conn.target())
                 .build()
                 .unwrap();
         Self { rc }

--- a/vm/devices/pci/pcie/src/port.rs
+++ b/vm/devices/pci/pcie/src/port.rs
@@ -981,14 +981,14 @@ mod tests {
             type0_sub_system_id: 0,
         };
 
-        let msi_conn = pci_core::msi::MsiConnection::new(AssignedBusRange::new(), 0);
+        let msi_conn = pci_core::msi::MsiConnection::new();
         let mut port = PcieDownstreamPort::new(
             "test-port",
             hardware_ids,
             DevicePortType::RootPort,
             false,
             Some(1), // Enable hotplug with slot number 1
-            msi_conn.target(),
+            &msi_conn.target(),
             PciePortSettings::default(),
             None,
             None,
@@ -1035,14 +1035,14 @@ mod tests {
             type0_sub_system_id: 0,
         };
 
-        let msi_conn = pci_core::msi::MsiConnection::new(AssignedBusRange::new(), 0);
+        let msi_conn = pci_core::msi::MsiConnection::new();
         let mut port = PcieDownstreamPort::new(
             "test-port",
             hardware_ids,
             DevicePortType::RootPort,
             false,
             None, // No hotplug
-            msi_conn.target(),
+            &msi_conn.target(),
             PciePortSettings::default(),
             None,
             None,
@@ -1130,14 +1130,14 @@ mod tests {
             type0_sub_system_id: 0,
         };
 
-        let msi_conn = pci_core::msi::MsiConnection::new(AssignedBusRange::new(), 0);
+        let msi_conn = pci_core::msi::MsiConnection::new();
         let mut port = PcieDownstreamPort::new(
             "test-port",
             hardware_ids,
             DevicePortType::RootPort,
             false,
             None,
-            msi_conn.target(),
+            &msi_conn.target(),
             PciePortSettings::default(),
             None,
             None,
@@ -1191,14 +1191,14 @@ mod tests {
             type0_sub_system_id: 0,
         };
 
-        let msi_conn = pci_core::msi::MsiConnection::new(AssignedBusRange::new(), 0);
+        let msi_conn = pci_core::msi::MsiConnection::new();
         let mut port = PcieDownstreamPort::new(
             "test-port",
             hardware_ids,
             DevicePortType::RootPort,
             false,
             None,
-            msi_conn.target(),
+            &msi_conn.target(),
             PciePortSettings::default(),
             None,
             None,

--- a/vm/devices/pci/pcie/src/root.rs
+++ b/vm/devices/pci/pcie/src/root.rs
@@ -1066,9 +1066,9 @@ mod tests {
         let ecam = MemoryRange::new(0..ecam_size_from_bus_numbers(start_bus, end_bus));
         let rc_bus_range = AssignedBusRange::new();
         rc_bus_range.set_bus_range(start_bus, end_bus);
-        let msi_conn = pci_core::msi::MsiConnection::new(rc_bus_range, 0);
+        let msi_conn = pci_core::msi::MsiConnection::new();
         GenericPcieRootComplex::builder(&mut register_mmio, start_bus..=end_bus, ecam)
-            .root_ports(port_defs, msi_conn.target())
+            .root_ports(port_defs, &msi_conn.msi_target(rc_bus_range, 0))
             .build()
             .unwrap()
     }
@@ -1095,10 +1095,10 @@ mod tests {
         );
         let rc_bus_range = AssignedBusRange::new();
         rc_bus_range.set_bus_range(start_bus, end_bus);
-        let msi_conn = pci_core::msi::MsiConnection::new(rc_bus_range, 0);
+        let msi_conn = pci_core::msi::MsiConnection::new();
 
         GenericPcieRootComplex::builder(&mut register_mmio, start_bus..=end_bus, ecam)
-            .root_ports(port_defs, msi_conn.target())
+            .root_ports(port_defs, &msi_conn.msi_target(rc_bus_range, 0))
             .chbcr_range(Some(chbcr))
             .build()
             .unwrap()
@@ -1447,13 +1447,13 @@ mod tests {
         // Test with hotplug disabled (None)
         let root_port_no_hotplug = {
             let mut register_mmio = TestPcieMmioRegistration {};
-            let c = pci_core::msi::MsiConnection::new(AssignedBusRange::new(), 0);
+            let c = pci_core::msi::MsiConnection::new();
             RootPort::new(
                 &mut register_mmio,
                 "test-port-no-hotplug",
                 false,
                 None,
-                c.target(),
+                &c.target(),
                 PciePortSettings::default(),
             )
         };
@@ -1471,13 +1471,13 @@ mod tests {
         // Test with hotplug enabled (Some(slot_number))
         let root_port_with_hotplug = {
             let mut register_mmio = TestPcieMmioRegistration {};
-            let c = pci_core::msi::MsiConnection::new(AssignedBusRange::new(), 0);
+            let c = pci_core::msi::MsiConnection::new();
             RootPort::new(
                 &mut register_mmio,
                 "test-port-hotplug",
                 false,
                 Some(5),
-                c.target(),
+                &c.target(),
                 PciePortSettings::default(),
             )
         };
@@ -1496,13 +1496,13 @@ mod tests {
     fn test_root_port_invalid_bus_range_handling() {
         let mut root_port = {
             let mut register_mmio = TestPcieMmioRegistration {};
-            let c = pci_core::msi::MsiConnection::new(AssignedBusRange::new(), 0);
+            let c = pci_core::msi::MsiConnection::new();
             RootPort::new(
                 &mut register_mmio,
                 "test-port",
                 false,
                 None,
-                c.target(),
+                &c.target(),
                 PciePortSettings::default(),
             )
         };
@@ -1744,7 +1744,7 @@ mod tests {
         let ecam = MemoryRange::new(0..ecam_size_from_bus_numbers(start_bus, end_bus));
         let rc_bus_range = AssignedBusRange::new();
         rc_bus_range.set_bus_range(start_bus, end_bus);
-        let msi_conn = pci_core::msi::MsiConnection::new(rc_bus_range, 0);
+        let msi_conn = pci_core::msi::MsiConnection::new();
         let port_defs = vec![GenericPciePortDefinition {
             name: "port-0".into(),
             devfn: None,
@@ -1752,7 +1752,7 @@ mod tests {
             settings: PciePortSettings::default(),
         }];
         let mut rc = GenericPcieRootComplex::builder(&mut register_mmio, start_bus..=end_bus, ecam)
-            .root_ports(port_defs, msi_conn.target())
+            .root_ports(port_defs, &msi_conn.msi_target(rc_bus_range, 0))
             .first_port_device_number(1)
             .build()
             .unwrap();
@@ -1896,9 +1896,7 @@ mod tests {
         // bit, even though there is more than one port.
         let mut register_mmio = TestPcieMmioRegistration {};
         let ecam = MemoryRange::new(0..ecam_size_from_bus_numbers(0, 0));
-        let rc_bus_range = AssignedBusRange::new();
-        rc_bus_range.set_bus_range(0, 0);
-        let msi_conn = pci_core::msi::MsiConnection::new(rc_bus_range, 0);
+        let msi_conn = pci_core::msi::MsiConnection::new();
         let port_defs = vec![
             GenericPciePortDefinition {
                 name: "a".into(),
@@ -1914,7 +1912,7 @@ mod tests {
             },
         ];
         let mut rc = GenericPcieRootComplex::builder(&mut register_mmio, 0..=0u8, ecam)
-            .root_ports(port_defs, msi_conn.target())
+            .root_ports(port_defs, &msi_conn.target())
             .build()
             .unwrap();
 
@@ -1945,9 +1943,9 @@ mod tests {
         let ecam = MemoryRange::new(0..ecam_size_from_bus_numbers(0, 255));
         let rc_bus_range = AssignedBusRange::new();
         rc_bus_range.set_bus_range(0, 255);
-        let msi_conn = pci_core::msi::MsiConnection::new(rc_bus_range, 0);
+        let msi_conn = pci_core::msi::MsiConnection::new();
         let result = GenericPcieRootComplex::builder(&mut register_mmio, 0..=255u8, ecam)
-            .root_ports(port_defs, msi_conn.target())
+            .root_ports(port_defs, &msi_conn.msi_target(rc_bus_range, 0))
             .build();
         assert!(
             result.is_err(),
@@ -1972,11 +1970,9 @@ mod tests {
             .collect();
         let mut register_mmio = TestPcieMmioRegistration {};
         let ecam = MemoryRange::new(0..ecam_size_from_bus_numbers(0, 0));
-        let rc_bus_range = AssignedBusRange::new();
-        rc_bus_range.set_bus_range(0, 0);
-        let msi_conn = pci_core::msi::MsiConnection::new(rc_bus_range, 0);
+        let msi_conn = pci_core::msi::MsiConnection::new();
         let rc = GenericPcieRootComplex::builder(&mut register_mmio, 0..=0u8, ecam)
-            .root_ports(port_defs, msi_conn.target())
+            .root_ports(port_defs, &msi_conn.target())
             .first_port_device_number(first_port_device_number)
             .build()?;
         Ok(rc

--- a/vm/devices/pci/pcie/src/switch.rs
+++ b/vm/devices/pci/pcie/src/switch.rs
@@ -674,7 +674,6 @@ mod save_restore {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use pci_core::bus_range::AssignedBusRange;
     use pci_core::msi::MsiConnection;
 
     /// Builds a switch definition with `downstream_port_count` uniform
@@ -1531,14 +1530,14 @@ mod tests {
             type0_sub_system_id: 0,
         };
 
-        let msi_conn = MsiConnection::new(AssignedBusRange::new(), 0);
+        let msi_conn = MsiConnection::new();
         let mut port = PcieDownstreamPort::new(
             "root-port",
             hardware_ids,
             DevicePortType::RootPort,
             false,
             None,
-            msi_conn.target(),
+            &msi_conn.target(),
             PciePortSettings::default(),
             None,
             None,

--- a/vm/devices/pci/vfio_assigned_device/src/resolver.rs
+++ b/vm/devices/pci/vfio_assigned_device/src/resolver.rs
@@ -67,7 +67,7 @@ impl AsyncResolveResource<PciDeviceHandleKind, VfioDeviceHandle> for VfioDeviceR
             bar_pt,
         } = resource;
 
-        if input.software_iommu {
+        if input.dma_target.software_iommu() {
             anyhow::bail!(
                 "VFIO device {pci_id} is behind a software IOMMU that cannot \
                  program the host IOMMU for passthrough DMA. Place the device \
@@ -95,7 +95,7 @@ impl AsyncResolveResource<PciDeviceHandleKind, VfioDeviceHandle> for VfioDeviceR
             pci_id,
             input.driver_source,
             input.register_mmio,
-            input.msi_target,
+            input.dma_target.msi_target(),
             memory_mapper,
             bar_pt,
         )
@@ -179,7 +179,7 @@ impl AsyncResolveResource<PciDeviceHandleKind, VfioCdevDeviceHandle> for VfioCde
             cdev_binding,
             pci_id,
             input.register_mmio,
-            input.msi_target,
+            input.dma_target.msi_target(),
             memory_mapper,
             bar_pt,
         )

--- a/vm/devices/pci/vpci/src/device.rs
+++ b/vm/devices/pci/vpci/src/device.rs
@@ -1465,7 +1465,6 @@ mod tests {
     use pal_async::DefaultDriver;
     use pal_async::async_test;
     use pal_async::driver::SpawnDriver;
-    use pci_core::bus_range::AssignedBusRange;
     use pci_core::cfg_space_emu::BarMemoryKind;
     use pci_core::cfg_space_emu::ConfigSpaceType0Emulator;
     use pci_core::cfg_space_emu::DeviceBars;
@@ -1945,7 +1944,7 @@ mod tests {
 
     #[async_test]
     async fn verify_simple_capability(driver: DefaultDriver) {
-        let msi_conn = MsiConnection::new(AssignedBusRange::new(), 0);
+        let msi_conn = MsiConnection::new();
         let pci_config = HardwareIds {
             vendor_id: 0x123,
             device_id: 0x789,
@@ -1957,7 +1956,7 @@ mod tests {
             type0_sub_system_id: 0x1,
         };
         let (_msix, msix_capability) =
-            pci_core::capabilities::msix::MsixEmulator::new(0, 64, msi_conn.target());
+            pci_core::capabilities::msix::MsixEmulator::new(0, 64, &msi_conn.target());
 
         let msi_controller = TestVpciInterruptController::new();
         msi_conn.connect(msi_controller.signal_msi());

--- a/vm/devices/storage/disk_nvme/nvme_driver/fuzz/fuzz_nvme_driver.rs
+++ b/vm/devices/storage/disk_nvme/nvme_driver/fuzz/fuzz_nvme_driver.rs
@@ -49,10 +49,15 @@ impl FuzzNvmeDriver {
 
         // Nvme device and driver setup
         let driver_source = VmTaskDriverSource::new(SingleDriverBackend::new(driver));
-        let msi_conn = MsiConnection::new(AssignedBusRange::new(), 0);
+        let msi_conn = MsiConnection::new();
 
         let guid = arbitrary_guid(u)?;
-        let dma_target = DmaTarget::new(mem.guest_memory().clone(), msi_conn.target().clone());
+        let dma_target = DmaTarget::new(
+            AssignedBusRange::new(),
+            0,
+            mem.guest_memory().clone(),
+            &msi_conn,
+        );
         let nvme = NvmeController::new(
             &driver_source,
             &dma_target,

--- a/vm/devices/storage/disk_nvme/nvme_driver/fuzz/fuzz_nvme_driver.rs
+++ b/vm/devices/storage/disk_nvme/nvme_driver/fuzz/fuzz_nvme_driver.rs
@@ -18,6 +18,7 @@ use nvme_spec::nvm::DsmRange;
 use page_pool_alloc::PagePoolAllocator;
 use pal_async::DefaultDriver;
 use pci_core::bus_range::AssignedBusRange;
+use pci_core::dma::DmaTarget;
 use pci_core::msi::MsiConnection;
 use scsi_buffers::OwnedRequestBuffers;
 use std::convert::TryFrom;
@@ -51,10 +52,10 @@ impl FuzzNvmeDriver {
         let msi_conn = MsiConnection::new(AssignedBusRange::new(), 0);
 
         let guid = arbitrary_guid(u)?;
+        let dma_target = DmaTarget::new(mem.guest_memory().clone(), msi_conn.target().clone());
         let nvme = NvmeController::new(
             &driver_source,
-            mem.guest_memory().clone(),
-            msi_conn.target(),
+            &dma_target,
             &mut ExternallyManagedMmioIntercepts,
             NvmeControllerCaps {
                 msix_count: 2,

--- a/vm/devices/storage/disk_nvme/nvme_driver/src/tests.rs
+++ b/vm/devices/storage/disk_nvme/nvme_driver/src/tests.rs
@@ -223,8 +223,8 @@ async fn test_nvme_ioqueue_max_mqes(driver: DefaultDriver) {
 
     // Controller Driver Setup
     let driver_source = VmTaskDriverSource::new(SingleDriverBackend::new(driver));
-    let msi_conn = MsiConnection::new(AssignedBusRange::new(), 0);
-    let dma_target = DmaTarget::new(guest_mem.clone(), msi_conn.target().clone());
+    let msi_conn = MsiConnection::new();
+    let dma_target = DmaTarget::new(AssignedBusRange::new(), 0, guest_mem.clone(), &msi_conn);
     let nvme = nvme::NvmeController::new(
         &driver_source,
         &dma_target,
@@ -260,8 +260,8 @@ async fn test_nvme_ioqueue_invalid_mqes(driver: DefaultDriver) {
     let dma_client = device_test_memory.dma_client();
 
     let driver_source = VmTaskDriverSource::new(SingleDriverBackend::new(driver));
-    let msi_conn = MsiConnection::new(AssignedBusRange::new(), 0);
-    let dma_target = DmaTarget::new(guest_mem.clone(), msi_conn.target().clone());
+    let msi_conn = MsiConnection::new();
+    let dma_target = DmaTarget::new(AssignedBusRange::new(), 0, guest_mem.clone(), &msi_conn);
     let nvme = nvme::NvmeController::new(
         &driver_source,
         &dma_target,
@@ -316,8 +316,8 @@ async fn test_nvme_driver(driver: DefaultDriver, config: NvmeTestConfig) {
 
     // Arrange: Create the NVMe controller and driver.
     let driver_source = VmTaskDriverSource::new(SingleDriverBackend::new(driver));
-    let msi_conn = MsiConnection::new(AssignedBusRange::new(), 0);
-    let dma_target = DmaTarget::new(guest_mem.clone(), msi_conn.target().clone());
+    let msi_conn = MsiConnection::new();
+    let dma_target = DmaTarget::new(AssignedBusRange::new(), 0, guest_mem.clone(), &msi_conn);
     let nvme = nvme::NvmeController::new(
         &driver_source,
         &dma_target,
@@ -460,11 +460,11 @@ async fn test_nvme_fault_injection(driver: DefaultDriver, fault_configuration: F
 
     // Arrange: Create the NVMe controller and driver.
     let driver_source = VmTaskDriverSource::new(SingleDriverBackend::new(driver));
-    let msi_conn = MsiConnection::new(AssignedBusRange::new(), 0);
+    let msi_conn = MsiConnection::new();
     let nvme = nvme_test::NvmeFaultController::new(
         &driver_source,
         guest_mem.clone(),
-        msi_conn.target(),
+        &msi_conn.target(),
         &mut ExternallyManagedMmioIntercepts,
         nvme_test::NvmeFaultControllerCaps {
             msix_count: MSIX_COUNT,

--- a/vm/devices/storage/disk_nvme/nvme_driver/src/tests.rs
+++ b/vm/devices/storage/disk_nvme/nvme_driver/src/tests.rs
@@ -35,6 +35,7 @@ use pal_async::DefaultDriver;
 use pal_async::async_test;
 use parking_lot::Mutex;
 use pci_core::bus_range::AssignedBusRange;
+use pci_core::dma::DmaTarget;
 use pci_core::msi::MsiConnection;
 use scsi_buffers::OwnedRequestBuffers;
 use std::sync::Arc;
@@ -223,10 +224,10 @@ async fn test_nvme_ioqueue_max_mqes(driver: DefaultDriver) {
     // Controller Driver Setup
     let driver_source = VmTaskDriverSource::new(SingleDriverBackend::new(driver));
     let msi_conn = MsiConnection::new(AssignedBusRange::new(), 0);
+    let dma_target = DmaTarget::new(guest_mem.clone(), msi_conn.target().clone());
     let nvme = nvme::NvmeController::new(
         &driver_source,
-        guest_mem,
-        msi_conn.target(),
+        &dma_target,
         &mut ExternallyManagedMmioIntercepts,
         NvmeControllerCaps {
             msix_count: MSIX_COUNT,
@@ -260,10 +261,10 @@ async fn test_nvme_ioqueue_invalid_mqes(driver: DefaultDriver) {
 
     let driver_source = VmTaskDriverSource::new(SingleDriverBackend::new(driver));
     let msi_conn = MsiConnection::new(AssignedBusRange::new(), 0);
+    let dma_target = DmaTarget::new(guest_mem.clone(), msi_conn.target().clone());
     let nvme = nvme::NvmeController::new(
         &driver_source,
-        guest_mem,
-        msi_conn.target(),
+        &dma_target,
         &mut ExternallyManagedMmioIntercepts,
         NvmeControllerCaps {
             msix_count: MSIX_COUNT,
@@ -316,10 +317,10 @@ async fn test_nvme_driver(driver: DefaultDriver, config: NvmeTestConfig) {
     // Arrange: Create the NVMe controller and driver.
     let driver_source = VmTaskDriverSource::new(SingleDriverBackend::new(driver));
     let msi_conn = MsiConnection::new(AssignedBusRange::new(), 0);
+    let dma_target = DmaTarget::new(guest_mem.clone(), msi_conn.target().clone());
     let nvme = nvme::NvmeController::new(
         &driver_source,
-        guest_mem.clone(),
-        msi_conn.target(),
+        &dma_target,
         &mut ExternallyManagedMmioIntercepts,
         NvmeControllerCaps {
             msix_count: MSIX_COUNT,

--- a/vm/devices/storage/nvme/src/pci.rs
+++ b/vm/devices/storage/nvme/src/pci.rs
@@ -26,7 +26,6 @@ use chipset_device::pci::PciConfigSpace;
 use device_emulators::ReadWriteRequestType;
 use device_emulators::read_as_u32_chunks;
 use device_emulators::write_as_u32_chunks;
-use guestmem::GuestMemory;
 use guid::Guid;
 use inspect::Inspect;
 use inspect::InspectMut;
@@ -36,7 +35,7 @@ use pci_core::capabilities::pci_express::PciExpressCapability;
 use pci_core::cfg_space_emu::BarMemoryKind;
 use pci_core::cfg_space_emu::ConfigSpaceType0Emulator;
 use pci_core::cfg_space_emu::DeviceBars;
-use pci_core::msi::MsiTarget;
+use pci_core::dma::DmaTarget;
 use pci_core::spec::hwid::ClassCode;
 use pci_core::spec::hwid::HardwareIds;
 use pci_core::spec::hwid::ProgrammingInterface;
@@ -111,11 +110,12 @@ impl NvmeController {
     /// Creates a new NVMe controller.
     pub fn new(
         driver_source: &VmTaskDriverSource,
-        guest_memory: GuestMemory,
-        msi_target: &MsiTarget,
+        dma_target: &DmaTarget,
         register_mmio: &mut dyn RegisterMmioIntercept,
         caps: NvmeControllerCaps,
     ) -> Self {
+        let msi_target = dma_target.msi_target();
+        let guest_memory = dma_target.guest_memory().clone();
         let (msix, msix_cap) = MsixEmulator::new(4, caps.msix_count, msi_target);
         let bars = DeviceBars::new()
             .bar0(

--- a/vm/devices/storage/nvme/src/resolver.rs
+++ b/vm/devices/storage/nvme/src/resolver.rs
@@ -60,8 +60,7 @@ impl AsyncResolveResource<PciDeviceHandleKind, NvmeControllerHandle> for NvmeCon
     ) -> Result<Self::Output, Self::Error> {
         let controller = NvmeController::new(
             input.driver_source,
-            input.guest_memory.clone(),
-            input.msi_target,
+            input.dma_target,
             input.register_mmio,
             NvmeControllerCaps {
                 msix_count: resource.msix_count,

--- a/vm/devices/storage/nvme/src/tests/controller_tests.rs
+++ b/vm/devices/storage/nvme/src/tests/controller_tests.rs
@@ -20,6 +20,7 @@ use guid::Guid;
 use pal_async::DefaultDriver;
 use pal_async::async_test;
 use pci_core::bus_range::AssignedBusRange;
+use pci_core::dma::DmaTarget;
 use pci_core::msi::MsiConnection;
 use pci_core::test_helpers::TestPciInterruptController;
 use user_driver::backoff::Backoff;
@@ -36,10 +37,10 @@ fn instantiate_controller(
     let mut mmio_reg = TestNvmeMmioRegistration {};
     let vm_task_driver = &VmTaskDriverSource::new(SingleDriverBackend::new(driver));
     let msi_conn = MsiConnection::new(AssignedBusRange::new(), 0);
+    let dma_target = DmaTarget::new(gm.clone(), msi_conn.target().clone());
     let controller = NvmeController::new(
         vm_task_driver,
-        gm.clone(),
-        msi_conn.target(),
+        &dma_target,
         &mut mmio_reg,
         NvmeControllerCaps {
             msix_count: 64,

--- a/vm/devices/storage/nvme/src/tests/controller_tests.rs
+++ b/vm/devices/storage/nvme/src/tests/controller_tests.rs
@@ -36,8 +36,8 @@ fn instantiate_controller(
 ) -> NvmeController {
     let mut mmio_reg = TestNvmeMmioRegistration {};
     let vm_task_driver = &VmTaskDriverSource::new(SingleDriverBackend::new(driver));
-    let msi_conn = MsiConnection::new(AssignedBusRange::new(), 0);
-    let dma_target = DmaTarget::new(gm.clone(), msi_conn.target().clone());
+    let msi_conn = MsiConnection::new();
+    let dma_target = DmaTarget::new(AssignedBusRange::new(), 0, gm.clone(), &msi_conn);
     let controller = NvmeController::new(
         vm_task_driver,
         &dma_target,

--- a/vm/devices/storage/nvme_test/src/resolver.rs
+++ b/vm/devices/storage/nvme_test/src/resolver.rs
@@ -66,8 +66,8 @@ impl AsyncResolveResource<PciDeviceHandleKind, NvmeFaultControllerHandle>
 
         let controller = NvmeFaultController::new(
             input.driver_source,
-            input.guest_memory.clone(),
-            input.msi_target,
+            input.dma_target.guest_memory().clone(),
+            input.dma_target.msi_target(),
             input.register_mmio,
             NvmeFaultControllerCaps {
                 msix_count: resource.msix_count,

--- a/vm/devices/storage/nvme_test/src/tests/controller_tests.rs
+++ b/vm/devices/storage/nvme_test/src/tests/controller_tests.rs
@@ -24,7 +24,6 @@ use nvme_spec::Command;
 use nvme_spec::Completion;
 use pal_async::DefaultDriver;
 use pal_async::async_test;
-use pci_core::bus_range::AssignedBusRange;
 use pci_core::msi::MsiConnection;
 use pci_core::test_helpers::TestPciInterruptController;
 use user_driver::backoff::Backoff;
@@ -41,11 +40,11 @@ fn instantiate_controller(
 ) -> NvmeFaultController {
     let mut mmio_reg = TestNvmeMmioRegistration {};
     let vm_task_driver = &VmTaskDriverSource::new(SingleDriverBackend::new(driver));
-    let msi_conn = MsiConnection::new(AssignedBusRange::new(), 0);
+    let msi_conn = MsiConnection::new();
     let controller = NvmeFaultController::new(
         vm_task_driver,
         gm.clone(),
-        msi_conn.target(),
+        &msi_conn.target(),
         &mut mmio_reg,
         NvmeFaultControllerCaps {
             msix_count: 64,

--- a/vm/devices/storage/storage_tests/tests/scsidvd_nvme.rs
+++ b/vm/devices/storage/storage_tests/tests/scsidvd_nvme.rs
@@ -17,6 +17,7 @@ use page_pool_alloc::PagePoolAllocator;
 use pal_async::DefaultDriver;
 use pal_async::async_test;
 use pci_core::bus_range::AssignedBusRange;
+use pci_core::dma::DmaTarget;
 use pci_core::msi::MsiConnection;
 use scsi_buffers::OwnedRequestBuffers;
 use scsi_buffers::RequestBuffers;
@@ -57,10 +58,10 @@ impl ScsiDvdNvmeTest {
         let payload_mem = mem.payload_mem();
 
         let msi_conn = MsiConnection::new(AssignedBusRange::new(), 0);
+        let dma_target = DmaTarget::new(guest_mem.clone(), msi_conn.target().clone());
         let nvme = NvmeController::new(
             &driver_source,
-            guest_mem.clone(),
-            msi_conn.target(),
+            &dma_target,
             &mut ExternallyManagedMmioIntercepts,
             NvmeControllerCaps {
                 msix_count: MSIX_COUNT,

--- a/vm/devices/storage/storage_tests/tests/scsidvd_nvme.rs
+++ b/vm/devices/storage/storage_tests/tests/scsidvd_nvme.rs
@@ -57,8 +57,8 @@ impl ScsiDvdNvmeTest {
         let dma_client = mem.dma_client();
         let payload_mem = mem.payload_mem();
 
-        let msi_conn = MsiConnection::new(AssignedBusRange::new(), 0);
-        let dma_target = DmaTarget::new(guest_mem.clone(), msi_conn.target().clone());
+        let msi_conn = MsiConnection::new();
+        let dma_target = DmaTarget::new(AssignedBusRange::new(), 0, guest_mem.clone(), &msi_conn);
         let nvme = NvmeController::new(
             &driver_source,
             &dma_target,

--- a/vm/devices/virtio/virtio/src/resolver.rs
+++ b/vm/devices/virtio/virtio/src/resolver.rs
@@ -57,8 +57,8 @@ impl AsyncResolveResource<PciDeviceHandleKind, VirtioPciDeviceHandle> for Virtio
         let device = VirtioPciDevice::new(
             inner.0,
             &input.driver_source.simple(),
-            input.guest_memory.clone(),
-            PciInterruptModel::Msix(input.msi_target),
+            input.dma_target.guest_memory().clone(),
+            PciInterruptModel::Msix(input.dma_target.msi_target()),
             input.doorbell_registration,
             input.register_mmio,
             input.shared_mem_mapper,

--- a/vm/devices/virtio/virtio/src/tests.rs
+++ b/vm/devices/virtio/virtio/src/tests.rs
@@ -36,7 +36,6 @@ use pal_async::timer::PolledTimer;
 use pal_async::wait::PolledWait;
 use pal_event::Event;
 use parking_lot::Mutex;
-use pci_core::bus_range::AssignedBusRange;
 use pci_core::msi::MsiConnection;
 use pci_core::spec::caps::CapabilityId;
 use pci_core::spec::cfg_space;
@@ -1392,7 +1391,7 @@ impl VirtioPciTestDevice {
     ) -> Self {
         let doorbell_registration: Arc<dyn DoorbellRegistration> = test_mem.clone();
         let mem = GuestMemory::new("test", test_mem.clone());
-        let msi_conn = MsiConnection::new(AssignedBusRange::new(), 0);
+        let msi_conn = MsiConnection::new();
         let driver_source = VmTaskDriverSource::new(SingleDriverBackend::new(driver.clone()));
 
         let dev = VirtioPciDevice::new(
@@ -1411,7 +1410,7 @@ impl VirtioPciTestDevice {
             )),
             driver,
             mem.clone(),
-            PciInterruptModel::Msix(msi_conn.target()),
+            PciInterruptModel::Msix(&msi_conn.target()),
             Some(doorbell_registration),
             &mut ExternallyManagedMmioIntercepts,
             None,
@@ -2876,7 +2875,7 @@ async fn verify_enable_failure_mmio_does_not_set_driver_ok(_driver: DefaultDrive
 async fn verify_enable_failure_pci_does_not_set_driver_ok(_driver: DefaultDriver) {
     let test_mem = VirtioTestMemoryAccess::new();
     let doorbell_registration: Arc<dyn DoorbellRegistration> = test_mem.clone();
-    let msi_conn = MsiConnection::new(AssignedBusRange::new(), 0);
+    let msi_conn = MsiConnection::new();
 
     let mut dev = VirtioPciDevice::new(
         Box::new(FailingTestDevice {
@@ -2891,7 +2890,7 @@ async fn verify_enable_failure_pci_does_not_set_driver_ok(_driver: DefaultDriver
         }),
         &_driver,
         GuestMemory::empty(),
-        PciInterruptModel::Msix(msi_conn.target()),
+        PciInterruptModel::Msix(&msi_conn.target()),
         Some(doorbell_registration),
         &mut ExternallyManagedMmioIntercepts,
         None,
@@ -3714,13 +3713,13 @@ impl PciTestTransport {
     fn new(device: Box<dyn DynVirtioDevice>, driver: &DefaultDriver, num_queues: u16) -> Self {
         let test_mem = VirtioTestMemoryAccess::new();
         let doorbell_registration: Arc<dyn DoorbellRegistration> = test_mem;
-        let msi_conn = MsiConnection::new(AssignedBusRange::new(), 0);
+        let msi_conn = MsiConnection::new();
 
         let mut dev = VirtioPciDevice::new(
             device,
             driver,
             GuestMemory::empty(),
-            PciInterruptModel::Msix(msi_conn.target()),
+            PciInterruptModel::Msix(&msi_conn.target()),
             Some(doorbell_registration),
             &mut ExternallyManagedMmioIntercepts,
             None,
@@ -4228,7 +4227,7 @@ async fn pci_save_restore_incompatible_features(driver: DefaultDriver) {
     assert_ne!(saved.common.driver_feature_banks[0] & 2, 0);
 
     // Create a new device that does NOT support that device-specific feature.
-    let msi_conn = MsiConnection::new(AssignedBusRange::new(), 0);
+    let msi_conn = MsiConnection::new();
     let mut dev2 = VirtioPciDevice::new(
         Box::new(TestDevice::new(
             &driver_source,
@@ -4244,7 +4243,7 @@ async fn pci_save_restore_incompatible_features(driver: DefaultDriver) {
         )),
         &driver,
         mem,
-        PciInterruptModel::Msix(msi_conn.target()),
+        PciInterruptModel::Msix(&msi_conn.target()),
         None,
         &mut ExternallyManagedMmioIntercepts,
         None,
@@ -4262,7 +4261,7 @@ async fn pci_save_restore_incompatible_features(driver: DefaultDriver) {
 async fn pci_save_not_supported_device(_driver: DefaultDriver) {
     use vmcore::save_restore::SaveRestore;
 
-    let msi_conn = MsiConnection::new(AssignedBusRange::new(), 0);
+    let msi_conn = MsiConnection::new();
 
     // FailingTestDevice does not override supports_save_restore (default false).
     let mut dev = VirtioPciDevice::new(
@@ -4277,7 +4276,7 @@ async fn pci_save_not_supported_device(_driver: DefaultDriver) {
         }),
         &_driver,
         GuestMemory::empty(),
-        PciInterruptModel::Msix(msi_conn.target()),
+        PciInterruptModel::Msix(&msi_conn.target()),
         None,
         &mut ExternallyManagedMmioIntercepts,
         None,

--- a/vmm_core/src/device_builder.rs
+++ b/vmm_core/src/device_builder.rs
@@ -60,9 +60,14 @@ pub async fn build_vpci_device(
         .arc_mutex_device(device_name)
         .with_external_pci();
 
-    let msi_conn = MsiConnection::new(pci_core::bus_range::AssignedBusRange::new(), 0);
+    let msi_conn = MsiConnection::new();
 
-    let dma_target = DmaTarget::new(guest_memory, msi_conn.target().clone());
+    let dma_target = DmaTarget::new(
+        pci_core::bus_range::AssignedBusRange::new(),
+        0,
+        guest_memory,
+        &msi_conn,
+    );
     let device = resolve_and_add_pci_device(device_builder, ctx, &dma_target).await?;
 
     {

--- a/vmm_core/src/device_builder.rs
+++ b/vmm_core/src/device_builder.rs
@@ -6,6 +6,7 @@
 use anyhow::Context as _;
 use chipset_device_resources::ErasedChipsetDevice;
 use guestmem::DoorbellRegistration;
+use guestmem::GuestMemory;
 use pci_core::dma::DmaTarget;
 use pci_core::msi::MsiConnection;
 use pci_core::msi::SignalMsi;
@@ -28,8 +29,6 @@ pub struct PciDeviceResolveContext<'a> {
     pub driver_source: &'a VmTaskDriverSource,
     /// The resource resolver.
     pub resolver: &'a ResourceResolver,
-    /// DMA and MSI target for the device.
-    pub dma_target: &'a DmaTarget,
     /// The device resource to resolve.
     pub resource: Resource<PciDeviceHandleKind>,
     /// An object with which to register doorbell regions.
@@ -40,11 +39,17 @@ pub struct PciDeviceResolveContext<'a> {
 
 /// Resolves a PCI device resource, builds the corresponding device, and builds
 /// a VPCI bus to host it.
+///
+/// VPCI devices deliver interrupts through the vmbus [`VpciInterruptMapper`]
+/// rather than a PCIe [`MsiTarget`](pci_core::msi::MsiTarget), so this builds a
+/// fresh [`DmaTarget`] pairing `guest_memory` with a locally-owned
+/// [`MsiConnection`] that is connected to the virtual device's MSI controller.
 pub async fn build_vpci_device(
     ctx: PciDeviceResolveContext<'_>,
     vmbus: &VmbusServerControl,
     chipset_builder: &ChipsetBuilder<'_>,
     bus_config: VpciBusConfig,
+    guest_memory: GuestMemory,
     new_virtual_device: impl FnOnce(u64) -> anyhow::Result<(Arc<dyn SignalMsi>, VpciInterruptMapper)>,
 ) -> anyhow::Result<()> {
     let instance_id = bus_config.instance_id;
@@ -57,10 +62,7 @@ pub async fn build_vpci_device(
 
     let msi_conn = MsiConnection::new(pci_core::bus_range::AssignedBusRange::new(), 0);
 
-    let dma_target = DmaTarget::new(
-        ctx.dma_target.guest_memory().clone(),
-        msi_conn.target().clone(),
-    );
+    let dma_target = DmaTarget::new(guest_memory, msi_conn.target().clone());
     let device = resolve_and_add_pci_device(device_builder, ctx, &dma_target).await?;
 
     {
@@ -102,13 +104,13 @@ pub async fn build_pcie_device(
     ctx: PciDeviceResolveContext<'_>,
     chipset_builder: &ChipsetBuilder<'_>,
     port_name: Arc<str>,
+    dma_target: &DmaTarget,
 ) -> anyhow::Result<()> {
     let dev_name = format!("pcie:{}-{}", port_name, ctx.resource.id());
     let device_builder = chipset_builder
         .arc_mutex_device(dev_name)
         .on_pcie_port(vmotherboard::BusId::new(&port_name));
 
-    let dma_target = ctx.dma_target;
     resolve_and_add_pci_device(device_builder, ctx, dma_target).await?;
 
     Ok(())

--- a/vmm_core/src/device_builder.rs
+++ b/vmm_core/src/device_builder.rs
@@ -6,7 +6,7 @@
 use anyhow::Context as _;
 use chipset_device_resources::ErasedChipsetDevice;
 use guestmem::DoorbellRegistration;
-use guestmem::GuestMemory;
+use pci_core::dma::DmaTarget;
 use pci_core::msi::MsiConnection;
 use pci_core::msi::SignalMsi;
 use std::sync::Arc;
@@ -28,18 +28,14 @@ pub struct PciDeviceResolveContext<'a> {
     pub driver_source: &'a VmTaskDriverSource,
     /// The resource resolver.
     pub resolver: &'a ResourceResolver,
-    /// The VM's guest memory (possibly SMMU-wrapped for PCIe devices).
-    pub guest_memory: &'a GuestMemory,
+    /// DMA and MSI target for the device.
+    pub dma_target: &'a DmaTarget,
     /// The device resource to resolve.
     pub resource: Resource<PciDeviceHandleKind>,
     /// An object with which to register doorbell regions.
     pub doorbell_registration: Option<Arc<dyn DoorbellRegistration>>,
     /// An object with which to register shared memory regions.
     pub shared_mem_mapper: Option<&'a dyn guestmem::MemoryMapper>,
-    /// Whether the device is behind a software IOMMU (e.g., emulated SMMU)
-    /// that cannot program the host IOMMU for passthrough DMA. When `true`,
-    /// device assignment backends (e.g., VFIO) must reject the assignment.
-    pub software_iommu: bool,
 }
 
 /// Resolves a PCI device resource, builds the corresponding device, and builds
@@ -61,7 +57,11 @@ pub async fn build_vpci_device(
 
     let msi_conn = MsiConnection::new(pci_core::bus_range::AssignedBusRange::new(), 0);
 
-    let device = resolve_and_add_pci_device(device_builder, ctx, msi_conn.target()).await?;
+    let dma_target = DmaTarget::new(
+        ctx.dma_target.guest_memory().clone(),
+        msi_conn.target().clone(),
+    );
+    let device = resolve_and_add_pci_device(device_builder, ctx, &dma_target).await?;
 
     {
         let device_id = (instance_id.data2 as u64) << 16 | (instance_id.data3 as u64 & 0xfff8);
@@ -102,14 +102,14 @@ pub async fn build_pcie_device(
     ctx: PciDeviceResolveContext<'_>,
     chipset_builder: &ChipsetBuilder<'_>,
     port_name: Arc<str>,
-    msi_target: &pci_core::msi::MsiTarget,
 ) -> anyhow::Result<()> {
     let dev_name = format!("pcie:{}-{}", port_name, ctx.resource.id());
     let device_builder = chipset_builder
         .arc_mutex_device(dev_name)
         .on_pcie_port(vmotherboard::BusId::new(&port_name));
 
-    resolve_and_add_pci_device(device_builder, ctx, msi_target).await?;
+    let dma_target = ctx.dma_target;
+    resolve_and_add_pci_device(device_builder, ctx, dma_target).await?;
 
     Ok(())
 }
@@ -119,7 +119,7 @@ pub async fn build_pcie_device(
 pub async fn resolve_and_add_pci_device(
     device_builder: ArcMutexChipsetDeviceBuilder<'_, '_, ErasedChipsetDevice>,
     ctx: PciDeviceResolveContext<'_>,
-    msi_target: &pci_core::msi::MsiTarget,
+    dma_target: &DmaTarget,
 ) -> anyhow::Result<Arc<closeable_mutex::CloseableMutex<ErasedChipsetDevice>>> {
     let device = device_builder
         .try_add_async(async |services| {
@@ -127,13 +127,11 @@ pub async fn resolve_and_add_pci_device(
                 .resolve(
                     ctx.resource,
                     pci_resources::ResolvePciDeviceHandleParams {
-                        msi_target,
+                        dma_target,
                         register_mmio: &mut services.register_mmio(),
                         driver_source: ctx.driver_source,
-                        guest_memory: ctx.guest_memory,
                         doorbell_registration: ctx.doorbell_registration,
                         shared_mem_mapper: ctx.shared_mem_mapper,
-                        software_iommu: ctx.software_iommu,
                     },
                 )
                 .await


### PR DESCRIPTION
PCI bus-mastered transactions—DMA reads/writes and MSI interrupts—are both identified by a device's Requester ID. Today those two concerns are plumbed through device construction separately, as a GuestMemory and an MsiTarget, which makes it easy to hand a device a DMA path and an MSI path that disagree on identity and leaves no single place to derive a per-function identity for SR-IOV virtual functions.

This introduces DmaTarget in pci_core, bundling a device's GuestMemory, its MsiTarget, and an optional IOMMU factory into one value. The `new` and `with_iommu` constructors set both the DMA and MSI identity for a function from the same devfn, and `with_rid_offset` derives a new target at a Requester-ID offset (for SR-IOV VFs) with both identities moving in lockstep, so the two cannot drift apart. When an IOMMU is present the factory—implemented by iommu_common's TranslatingDmaTarget over the shared IommuTranslator—produces per-RID translating GuestMemory, and the SMMU and AMD IOMMU wiring both flow through it.

DmaTarget is threaded through the PCIe device wiring, the device resolvers, and device_builder, replacing the separate guest_memory and software_iommu plumbing. This is groundwork for NVMe SR-IOV, where each virtual function needs a distinct, consistent DMA and MSI identity.
