### PR TITLE
guestmem: remove probe_gpn_readable/writable_range methods

### DIFF
--- a/vm/devices/storage/ide/src/drive.rs
+++ b/vm/devices/storage/ide/src/drive.rs
@@ -117,7 +117,12 @@ impl DiskDrive {
             DiskDrive::OpticalDevice(device) => device.dma_request(),
         }
     }
-    pub fn dma_transfer(&mut self, guest_memory: &GuestMemory, gpa: u64, len: usize) {
+    pub fn dma_transfer(
+        &mut self,
+        guest_memory: &GuestMemory,
+        gpa: u64,
+        len: usize,
+    ) -> Result<(), guestmem::GuestMemoryError> {
         match self {
             DiskDrive::HardDevice(device) => device.dma_transfer(guest_memory, gpa, len),
             DiskDrive::OpticalDevice(device) => device.dma_transfer(guest_memory, gpa, len),

--- a/vm/devices/storage/ide/src/drive/atapi_drive.rs
+++ b/vm/devices/storage/ide/src/drive/atapi_drive.rs
@@ -13,6 +13,7 @@ use crate::protocol::IdeCommand;
 use crate::protocol::Status;
 use guestmem::AlignedHeapMemory;
 use guestmem::GuestMemory;
+use guestmem::GuestMemoryError;
 use guestmem::ranges::PagedRange;
 use ide_resources::IdePath;
 use inspect::Inspect;
@@ -360,7 +361,12 @@ impl AtapiDrive {
         }
     }
 
-    pub fn dma_transfer(&mut self, guest_memory: &GuestMemory, gpa: u64, len: usize) {
+    pub fn dma_transfer(
+        &mut self,
+        guest_memory: &GuestMemory,
+        gpa: u64,
+        len: usize,
+    ) -> Result<(), GuestMemoryError> {
         let buffer = self.state.buffer.as_ref().unwrap();
         assert!(len <= buffer.len() as usize);
         let dma_type = *buffer.dma_type.as_ref().unwrap();
@@ -373,16 +379,14 @@ impl AtapiDrive {
         );
         let range = buffer.range();
         let buffer_ptr = &self.command_buffer.buffer[range][..len];
-        let r = match dma_type {
+        // Perform the memory access first. If the guest pointed the DMA engine
+        // at inaccessible memory, propagate the error without advancing the
+        // buffer so the caller can raise the bus master DMA error, just as real
+        // hardware would on a failed bus access.
+        match dma_type {
             DmaType::Write => guest_memory.write_from_atomic(gpa, buffer_ptr),
             DmaType::Read => guest_memory.read_to_atomic(gpa, buffer_ptr),
-        };
-        if let Err(err) = r {
-            tracelimit::error_ratelimited!(
-                error = &err as &dyn std::error::Error,
-                "dma transfer failed"
-            );
-        }
+        }?;
         if self.state.buffer.as_mut().unwrap().advance(len as u32) {
             match dma_type {
                 DmaType::Write => self.read_data_port_buffer_complete(),
@@ -394,6 +398,7 @@ impl AtapiDrive {
                 self.request_interrupt(true);
             }
         }
+        Ok(())
     }
 
     pub fn dma_advance_buffer(&mut self, len: usize) {

--- a/vm/devices/storage/ide/src/drive/hard_drive.rs
+++ b/vm/devices/storage/ide/src/drive/hard_drive.rs
@@ -17,6 +17,7 @@ use disk_backend::Disk;
 use disk_backend::DiskError;
 use guestmem::AlignedHeapMemory;
 use guestmem::GuestMemory;
+use guestmem::GuestMemoryError;
 use guestmem::ranges::PagedRange;
 use ide_resources::IdePath;
 use inspect::Inspect;
@@ -639,7 +640,12 @@ impl HardDrive {
         }
     }
 
-    pub fn dma_transfer(&mut self, guest_memory: &GuestMemory, gpa: u64, len: usize) {
+    pub fn dma_transfer(
+        &mut self,
+        guest_memory: &GuestMemory,
+        gpa: u64,
+        len: usize,
+    ) -> Result<(), GuestMemoryError> {
         let buffer = self.state.buffer.as_mut().unwrap();
         let buffer_ptr = &self.command_buffer.buffer[buffer.range()][..len];
         {
@@ -654,16 +660,15 @@ impl HardDrive {
             );
         }
 
-        let r = match buffer.dma_type.as_ref().unwrap() {
+        // Perform the memory access first. If the guest pointed the DMA engine
+        // at inaccessible memory, propagate the error without advancing the
+        // buffer so the caller can raise the bus master DMA error, just as real
+        // hardware would on a failed bus access.
+        match buffer.dma_type.as_ref().unwrap() {
             DmaType::Write => guest_memory.write_from_atomic(gpa, buffer_ptr),
             DmaType::Read => guest_memory.read_to_atomic(gpa, buffer_ptr),
-        };
-        if let Err(err) = r {
-            tracelimit::error_ratelimited!(
-                error = &err as &dyn std::error::Error,
-                "dma transfer failed"
-            );
-        }
+        }?;
+
         if buffer.advance(len as u32) {
             match buffer.dma_type.as_ref().unwrap() {
                 DmaType::Write => self.read_data_port_buffer_complete(),
@@ -673,6 +678,7 @@ impl HardDrive {
                 self.state.pending_interrupt = true;
             }
         }
+        Ok(())
     }
 
     pub fn dma_advance_buffer(&mut self, len: usize) {

--- a/vm/devices/storage/ide/src/lib.rs
+++ b/vm/devices/storage/ide/src/lib.rs
@@ -53,7 +53,6 @@ use disk_backend::Disk;
 use drive::DiskDrive;
 use drive::DriveRegister;
 use guestmem::GuestMemory;
-use guestmem::ranges::PagedRange;
 use ide_resources::IdePath;
 use inspect::Inspect;
 use inspect::InspectMut;
@@ -76,8 +75,6 @@ use thiserror::Error;
 use vmcore::device_state::ChangeDeviceState;
 use vmcore::line_interrupt::LineInterrupt;
 use zerocopy::IntoBytes;
-
-const PAGE_SIZE64: u64 = guestmem::PAGE_SIZE as u64;
 
 open_enum! {
     pub enum IdeIoPort: u16 {
@@ -745,10 +742,6 @@ impl Channel {
         write.deferred.complete();
     }
 
-    fn gpa_to_gpn(gpa: u64) -> u64 {
-        gpa / PAGE_SIZE64
-    }
-
     fn perform_dma_memory_phase(&mut self) {
         let Some(drive) = &mut self.drives[self.state.current_drive_idx] else {
             return;
@@ -761,9 +754,9 @@ impl Channel {
             return;
         }
 
-        let (dma_type, mut dma_avail) = match drive.dma_request() {
+        let mut dma_avail = match drive.dma_request() {
             Some((dma_type, avail)) if *dma_type == self.bus_master_state.dma_io_type() => {
-                (Some(*dma_type), avail as u32)
+                avail as u32
             }
             _ => {
                 // No active, appropriate DMA buffer.
@@ -818,49 +811,6 @@ impl Channel {
                     dma.transfer_bytes_left = 0x10000;
                 }
 
-                // Check that every page starting from the base address is within
-                // the guest's physical address space.
-                // This is a sanity check, the guest should not be able to program the DMA
-                // controller with an invalid page access.
-
-                let end_gpa = cur_desc_table_entry
-                    .mem_physical_base
-                    .checked_add(dma.transfer_bytes_left);
-
-                let mut r = None;
-
-                if let Some(end_gpa) = end_gpa {
-                    let start_gpn = Self::gpa_to_gpn(cur_desc_table_entry.mem_physical_base.into());
-                    let end_gpn = Self::gpa_to_gpn(end_gpa.into());
-                    let gpns: Vec<u64> = (start_gpn..=end_gpn).collect();
-
-                    if let Some(paged_range) =
-                        PagedRange::new(0, gpns.len() * PAGE_SIZE64 as usize, &gpns)
-                    {
-                        r = Some(match dma_type.unwrap() {
-                            DmaType::Read => {
-                                self.guest_memory.probe_gpn_readable_range(&paged_range)
-                            }
-                            DmaType::Write => {
-                                self.guest_memory.probe_gpn_writable_range(&paged_range)
-                            }
-                        });
-                    }
-                }
-
-                if r.is_some_and(|res| res.is_err()) || end_gpa.is_none() {
-                    // If there is an error and there is no other IO in parallel,
-                    // we need to stop the current DMA transfer and set the error bit
-                    // in the Bus Master Status register.
-                    self.bus_master_state.dma_state = None;
-                    if !drive.handle_read_dma_descriptor_error() {
-                        self.bus_master_state.dma_error = true;
-                    }
-
-                    tracelimit::error_ratelimited!("dma base address out-of-range error");
-                    return;
-                }
-
                 dma.transfer_base_addr = cur_desc_table_entry.mem_physical_base.into();
                 dma.transfer_complete = (cur_desc_table_entry.end_of_table & 0x80) != 0;
 
@@ -876,11 +826,24 @@ impl Channel {
 
             assert!(bytes_to_transfer != 0);
 
-            drive.dma_transfer(
+            if let Err(err) = drive.dma_transfer(
                 &self.guest_memory,
                 dma.transfer_base_addr,
                 bytes_to_transfer as usize,
-            );
+            ) {
+                // The guest pointed the DMA engine at memory it can't access.
+                // Stop the transfer and raise the bus master DMA error, just as
+                // real hardware would on a failed bus access.
+                self.bus_master_state.dma_state = None;
+                if !drive.handle_read_dma_descriptor_error() {
+                    self.bus_master_state.dma_error = true;
+                }
+                tracelimit::error_ratelimited!(
+                    error = &err as &dyn std::error::Error,
+                    "dma transfer memory access error"
+                );
+                return;
+            }
 
             dma_avail -= bytes_to_transfer;
             dma.transfer_base_addr += bytes_to_transfer as u64;

--- a/vm/vmcore/guestmem/fuzz/fuzz_guestmem.rs
+++ b/vm/vmcore/guestmem/fuzz/fuzz_guestmem.rs
@@ -167,16 +167,6 @@ enum GuestMemAction {
     ProbeGpaWritable {
         gpa: u64,
     },
-    ProbeGpnReadableRange {
-        offset: usize,
-        len: usize,
-        gpns: Vec<u64>,
-    },
-    ProbeGpnWritableRange {
-        offset: usize,
-        len: usize,
-        gpns: Vec<u64>,
-    },
     FillRange {
         offset: usize,
         len: usize,
@@ -274,18 +264,6 @@ fn do_fuzz(input: FuzzCase) {
             }
             GuestMemAction::ProbeGpaWritable { gpa } => {
                 _ = gm.probe_gpa_writable(gpa);
-            }
-            GuestMemAction::ProbeGpnReadableRange { offset, len, gpns } => {
-                let len = len % MAX_SIZE;
-                if let Some(range) = PagedRange::new(offset, len, &gpns) {
-                    _ = gm.probe_gpn_readable_range(&range);
-                }
-            }
-            GuestMemAction::ProbeGpnWritableRange { offset, len, gpns } => {
-                let len = len % MAX_SIZE;
-                if let Some(range) = PagedRange::new(offset, len, &gpns) {
-                    _ = gm.probe_gpn_writable_range(&range);
-                }
             }
             GuestMemAction::FillRange {
                 offset,

--- a/vm/vmcore/guestmem/src/lib.rs
+++ b/vm/vmcore/guestmem/src/lib.rs
@@ -2746,39 +2746,6 @@ mod tests {
         gm.read_plain::<[u8; PAGE_SIZE * 2]>(0).unwrap_err();
     }
 
-    #[cfg(feature = "bitmap")]
-    #[test]
-    fn test_probe_readable_range_bitmap() {
-        // `probe_gpn_readable_range` must consult the access bitmap for every
-        // page in the range.
-        let len = PAGE_SIZE * 4;
-        let mapping = SparseMapping::new(len).unwrap();
-        mapping.alloc(0, len).unwrap();
-        // Bit i corresponds to page i: pages 0 and 2 are readable, 1 and 3 not.
-        let bitmap = vec![0b0101];
-        let mapping = Arc::new(GuestMemoryMapping {
-            mapping,
-            bitmap: Some(bitmap),
-        });
-        let gm = GuestMemory::new("test", mapping);
-
-        let probe = |offset: usize, len: usize, gpns: &[u64]| {
-            let range = PagedRange::new(offset, len, gpns).unwrap();
-            gm.probe_gpn_readable_range(&range)
-        };
-
-        // Readable pages succeed, including a range starting at GPN 0.
-        probe(0, PAGE_SIZE, &[0]).unwrap();
-        probe(0, PAGE_SIZE, &[2]).unwrap();
-        probe(0, PAGE_SIZE * 2, &[0, 2]).unwrap();
-        probe(100, 500, &[0]).unwrap(); // partial page within a readable page
-
-        // Any unreadable page in the range fails.
-        probe(0, PAGE_SIZE, &[1]).unwrap_err();
-        probe(0, PAGE_SIZE * 2, &[0, 1]).unwrap_err();
-        probe(0, PAGE_SIZE * 2, &[2, 3]).unwrap_err();
-    }
-
     struct FaultingMapping {
         mapping: SparseMapping,
     }

--- a/vm/vmcore/guestmem/src/lib.rs
+++ b/vm/vmcore/guestmem/src/lib.rs
@@ -1841,35 +1841,6 @@ impl GuestMemory {
         )
     }
 
-    /// Probes whether a write to guest memory at address `gpa` would succeed.
-    fn probe_write_inner(&self, gpa: u64) -> Result<(), GuestMemoryBackingError> {
-        self.run_on_mapping(
-            AccessType::Write,
-            gpa,
-            1,
-            (),
-            |(), dest| {
-                // SAFETY: dest is guaranteed to point to a reserved VA range.
-                // We perform a volatile read followed by write of the same value
-                // to check write accessibility without modifying the actual data.
-                unsafe {
-                    let value = trycopy::try_read_volatile(dest)?;
-                    trycopy::try_write_volatile(dest, &value)
-                }
-            },
-            |()| {
-                // Fallback: use compare_exchange_fallback to probe write access
-                let mut current = 0u8;
-                self.inner.imp.compare_exchange_fallback(
-                    gpa,
-                    std::slice::from_mut(&mut current),
-                    &[0u8],
-                )?;
-                Ok(())
-            },
-        )
-    }
-
     /// Writes an object to guest memory at address `gpa`.
     ///
     /// If the object is 1, 2, 4, or 8 bytes and the address is naturally
@@ -2056,20 +2027,6 @@ impl GuestMemory {
                 )?;
             }
             Ok(())
-        })
-    }
-
-    /// Check if a given PagedRange is readable or not.
-    pub fn probe_gpn_readable_range(&self, range: &PagedRange<'_>) -> Result<(), GuestMemoryError> {
-        self.op_range(GuestMemoryOperation::Probe, range, move |addr, _r| {
-            self.read_plain_inner::<u8>(addr).map(|_| ())
-        })
-    }
-
-    /// Check if a given PagedRange is writable or not.
-    pub fn probe_gpn_writable_range(&self, range: &PagedRange<'_>) -> Result<(), GuestMemoryError> {
-        self.op_range(GuestMemoryOperation::Probe, range, move |addr, _r| {
-            self.probe_write_inner(addr)
         })
     }
 
@@ -2638,7 +2595,7 @@ mod tests {
     use crate::PAGE_SIZE64;
     use crate::PageFaultAction;
     use crate::PageFaultError;
-    use crate::ranges::PagedRange;
+
     use sparse_mmap::SparseMapping;
     use std::ptr::NonNull;
     use std::sync::Arc;
@@ -2885,108 +2842,6 @@ mod tests {
         gm.read_plain::<u16>(PAGE_SIZE64 * 3 - 1).unwrap_err();
         gm.read_plain::<u8>(PAGE_SIZE64 * 3 - 1).unwrap();
         gm.write_plain::<u8>(PAGE_SIZE64 * 3 - 1, &0).unwrap_err();
-
-        // Test probe_gpn_writable_range with FaultingMapping
-        // FaultingMapping layout (page_fault fails the first and last quarters
-        // of the mapping; for this 4-page mapping each quarter is one page):
-        // - Page 0 (address 0 to PAGE_SIZE): unmapped, fails on access
-        // - Page 1 (address PAGE_SIZE to 2*PAGE_SIZE): writable
-        // - Page 2 (address 2*PAGE_SIZE to 3*PAGE_SIZE): read-only
-        // - Page 3 (address 3*PAGE_SIZE to 4*PAGE_SIZE): unmapped, fails on access
-        // - Page 4 and beyond: out of range (the mapping is only 4 pages)
-
-        // Test 1: Probe unmapped page - should fail
-        let gpns = vec![0];
-        let range = PagedRange::new(0, PAGE_SIZE, &gpns).unwrap();
-        assert!(gm.probe_gpn_writable_range(&range).is_err());
-
-        // Test 2: Probe writable page - should succeed
-        let gpns = vec![1];
-        let range = PagedRange::new(0, PAGE_SIZE, &gpns).unwrap();
-        gm.probe_gpn_writable_range(&range).unwrap();
-
-        // Test 3: Probe read-only pages - should fail
-        let gpns = vec![2, 3];
-        let range = PagedRange::new(0, PAGE_SIZE * 2, &gpns).unwrap();
-        assert!(gm.probe_gpn_writable_range(&range).is_err());
-
-        // Test 4: Probe mixed access (writable + read-only) - should fail
-        let gpns = vec![1, 2];
-        let range = PagedRange::new(0, PAGE_SIZE * 2, &gpns).unwrap();
-        assert!(gm.probe_gpn_writable_range(&range).is_err());
-
-        // Test 5: Compare readable vs writable on read-only pages
-        let gpns = vec![2];
-        let range = PagedRange::new(0, PAGE_SIZE, &gpns).unwrap();
-        gm.probe_gpn_readable_range(&range).unwrap(); // Should succeed
-        assert!(gm.probe_gpn_writable_range(&range).is_err()); // Should fail
-
-        // Test 6: Partial page range
-        let gpns = vec![1];
-        let range = PagedRange::new(100, 500, &gpns).unwrap();
-        gm.probe_gpn_writable_range(&range).unwrap();
-
-        // Test 7: Empty range - should succeed
-        let range = PagedRange::empty();
-        gm.probe_gpn_writable_range(&range).unwrap();
-
-        // Test probe_gpn_readable_range with FaultingMapping
-
-        // Test 8: Probe unmapped page for read - should fail
-        let gpns = vec![5];
-        let range = PagedRange::new(0, PAGE_SIZE, &gpns).unwrap();
-        assert!(gm.probe_gpn_readable_range(&range).is_err());
-
-        // Test 9: Probe writable page for read - should succeed
-        let gpns = vec![1];
-        let range = PagedRange::new(0, PAGE_SIZE, &gpns).unwrap();
-        gm.probe_gpn_readable_range(&range).unwrap();
-
-        // Test 10: Probe mixed access (writable + read-only) for read - should succeed
-        let gpns = vec![1, 2];
-        let range = PagedRange::new(0, PAGE_SIZE * 2, &gpns).unwrap();
-        gm.probe_gpn_readable_range(&range).unwrap(); // Both pages are readable
-
-        // Test 11: Probe mixed access (unmapped + writable) for read - should fail
-        let gpns = vec![5, 1];
-        let range = PagedRange::new(0, PAGE_SIZE * 2, &gpns).unwrap();
-        assert!(gm.probe_gpn_readable_range(&range).is_err()); // Page 5 is unmapped
-
-        // Test 12: Probe mixed access (unmapped + read-only) for read - should fail
-        let gpns = vec![5, 2];
-        let range = PagedRange::new(0, PAGE_SIZE * 2, &gpns).unwrap();
-        assert!(gm.probe_gpn_readable_range(&range).is_err()); // Page 5 is unmapped
-
-        // Test 13: Partial page range for read on read-only pages
-        let gpns = vec![2];
-        let range = PagedRange::new(100, 500, &gpns).unwrap();
-        gm.probe_gpn_readable_range(&range).unwrap();
-
-        // Test 14: Partial page range for read on writable pages
-        let gpns = vec![1];
-        let range = PagedRange::new(200, 1000, &gpns).unwrap();
-        gm.probe_gpn_readable_range(&range).unwrap();
-
-        // Test 15: Empty range for read - should succeed
-        let range = PagedRange::empty();
-        gm.probe_gpn_readable_range(&range).unwrap();
-
-        // Test 16: Single byte read on read-only page
-        let gpns = vec![2];
-        let range = PagedRange::new(0, 1, &gpns).unwrap();
-        gm.probe_gpn_readable_range(&range).unwrap();
-
-        // Test 17: Single byte read on unmapped page
-        let gpns = vec![5];
-        let range = PagedRange::new(0, 1, &gpns).unwrap();
-        assert!(gm.probe_gpn_readable_range(&range).is_err());
-
-        // Test 18: Cross-boundary range spanning writable, read-only, and
-        // unmapped pages
-        let gpns = vec![1, 2, 3];
-        let range = PagedRange::new(PAGE_SIZE / 2, PAGE_SIZE * 2, &gpns).unwrap();
-        assert!(gm.probe_gpn_readable_range(&range).is_err()); // Page 3 is unmapped
-        assert!(gm.probe_gpn_writable_range(&range).is_err()); // Pages 2-3 not writable
     }
 
     #[cfg(feature = "bitmap")]


### PR DESCRIPTION
These methods were added for IDE to probe memory without accessing it. This is not something real hardware could ever do, and there is nothing special about IDE that requires it. And its use in IDE was a TOCTOU bug--the DMA could still fail if memory state were to change between the probe and the DMA.

Fix IDE to check the return value of the DMA itself rather than do a probe ahead of time. Remove the guestmem methods, which are only used by IDE and are easy to misuse.