### PR TITLE
[2505] Deps: fix tpm dep, hardcode to current commit (#3745)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4281,7 +4281,7 @@ dependencies = [
 [[package]]
 name = "ms-tpm-20-ref"
 version = "0.1.0"
-source = "git+https://github.com/microsoft/ms-tpm-20-ref-rs.git?branch=main#5b8ca3b5b423859da441f51ec8b1610708ed53c2"
+source = "git+https://github.com/microsoft/ms-tpm-20-ref-rs.git?rev=5b8ca3b5b423859da441f51ec8b1610708ed53c2#5b8ca3b5b423859da441f51ec8b1610708ed53c2"
 dependencies = [
  "cc",
  "once_cell",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -471,7 +471,7 @@ loom = "0.7.2"
 macaddr = "1.0"
 mbrman = "0.5"
 mimalloc = { version = "0.1.39", default-features = false }
-ms-tpm-20-ref = { version = "0.1", git = "https://github.com/microsoft/ms-tpm-20-ref-rs.git", branch = "main" }
+ms-tpm-20-ref = { git = "https://github.com/microsoft/ms-tpm-20-ref-rs.git", rev = "5b8ca3b5b423859da441f51ec8b1610708ed53c2" }
 mshv-bindings = "0.3.4"
 mshv-ioctls = "0.3.4"
 nix = { version = "0.27", default-features = false }


### PR DESCRIPTION
Cherry-pick of #3745 into `release/2505`.

Pushing a new commit to the TPM repo broke consumers who were depending on it by branch label. We should instead depend on a specific pinned commit. Do that here. The lockfile change shows this was already the commit this branch was on.

Original PR: https://github.com/microsoft/openvmm/pull/3745