### PR TITLE
Bump openssl-src to 300.6.1+3.6.3 (OpenSSL 3.6.3)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5441,9 +5441,9 @@ checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
 name = "openssl-src"
-version = "300.6.0+3.6.2"
+version = "300.6.1+3.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8e8cbfd3a4a8c8f089147fd7aaa33cf8c7450c4d09f8f80698a0cf093abeff4"
+checksum = "46eb8fb9fb3b61ce1c0f8a026c4c1a0714d3a9e138e7fbde78753ce2babc3846"
 dependencies = [
  "cc",
 ]


### PR DESCRIPTION
Updates vendored `openssl-src` from 300.6.0+3.6.2 to 300.6.1+3.6.3 (OpenSSL 3.6.2 -> 3.6.3) to resolve Component Governance alert MVS-2022-374v-6mvc. Lockfile-only change; `openssl-sys` + vendored OpenSSL 3.6.3 verified to compile locally.