### PR TITLE
ttrpc: expand vmservice with PCIe topology, NUMA, and richer devices

### DIFF
--- a/openvmm/openvmm_entry/src/ttrpc/mod.rs
+++ b/openvmm/openvmm_entry/src/ttrpc/mod.rs
@@ -593,10 +593,10 @@ impl VmService {
             .build()
             .context("failed to build vm configuration")?;
 
-        // Build the NUMA topology. A flat `MemoryConfig.memory_mb` and an
-        // explicit `NumaConfig` are mutually exclusive (mirrors the CLI
-        // `--memory` vs `--numa` conflict). `config_mem_size` is the total
-        // guest memory reported to the `VmController`.
+        // Build the NUMA topology. A `MemoryConfig` and an explicit
+        // `NumaConfig` are mutually exclusive (mirrors the CLI `--memory` vs
+        // `--numa` conflict). `config_mem_size` is the total guest memory
+        // reported to the `VmController`.
         let (numa, config_mem_size) = if let Some(numa_config) = req_config.numa_config.take() {
             if req_config.memory_config.is_some() {
                 bail!("memory_config and numa_config are mutually exclusive");
@@ -633,14 +633,6 @@ impl VmService {
             .as_ref()
             .map(|c| c.processor_count)
             .unwrap_or(1);
-        let vps_per_socket = req_config
-            .processor_config
-            .as_ref()
-            .and_then(|c| c.vps_per_socket);
-        let enable_smt = req_config
-            .processor_config
-            .as_ref()
-            .and_then(|c| c.enable_smt);
 
         // Build the PCIe topology (root complexes, switches, and the devices
         // attached behind their ports).
@@ -665,8 +657,8 @@ impl VmService {
             chipset: chipset.chipset,
             processor_topology: ProcessorTopologyConfig {
                 proc_count: config_proc_count,
-                vps_per_socket,
-                enable_smt,
+                vps_per_socket: None,
+                enable_smt: None,
                 arch: Default::default(),
             },
             hypervisor: HypervisorConfig {
@@ -1404,6 +1396,12 @@ async fn build_pcie_device(
 #[cfg(target_os = "linux")]
 fn build_vfio_device(vfio: vmservice::VfioDevice) -> anyhow::Result<Resource<PciDeviceHandleKind>> {
     let vmservice::VfioDevice { host_pci_address } = vfio;
+    // The address is joined into a sysfs path below; reject path separators so
+    // it cannot escape `/sys/bus/pci/devices` (an absolute path or `..` would
+    // otherwise redirect the join).
+    if host_pci_address.contains('/') || host_pci_address.contains("..") {
+        anyhow::bail!("PCI address must not contain path separators");
+    }
     let sysfs_path = std::path::Path::new("/sys/bus/pci/devices").join(&host_pci_address);
     let iommu_group_link =
         std::fs::read_link(sysfs_path.join("iommu_group")).with_context(|| {

--- a/openvmm/openvmm_entry/src/ttrpc/mod.rs
+++ b/openvmm/openvmm_entry/src/ttrpc/mod.rs
@@ -23,6 +23,7 @@ use inspect::InspectionBuilder;
 use inspect_proto::InspectResponse2;
 use inspect_proto::InspectService;
 use inspect_proto::UpdateResponse2;
+use memory_range::MemoryRange;
 use mesh::CancelReason;
 use mesh::MeshPayload;
 use mesh::error::RemoteError;
@@ -36,14 +37,21 @@ use net_backend_resources::consomme::ConsommeRequest;
 use net_backend_resources::consomme::HostPort;
 use net_backend_resources::consomme::HostPortConfig;
 use net_backend_resources::consomme::HostPortProtocol;
+use net_backend_resources::mac_address::MacAddress;
 use netvsp_resources::NetvspHandle;
 use openvmm_defs::config::Config;
 use openvmm_defs::config::DeviceVtl;
 use openvmm_defs::config::HypervisorConfig;
 use openvmm_defs::config::LoadMode;
 use openvmm_defs::config::MemoryConfig;
+use openvmm_defs::config::NumaDistance;
 use openvmm_defs::config::NumaNode;
 use openvmm_defs::config::NumaTopology;
+use openvmm_defs::config::PcieDeviceConfig;
+use openvmm_defs::config::PcieMmioRangeConfig;
+use openvmm_defs::config::PciePortConfig;
+use openvmm_defs::config::PcieRootComplexConfig;
+use openvmm_defs::config::PcieSwitchConfig;
 use openvmm_defs::config::ProcessorTopologyConfig;
 use openvmm_defs::config::VirtioBus;
 use openvmm_defs::config::VmbusConfig;
@@ -72,6 +80,9 @@ use virtio_resources::VirtioPciDeviceHandle;
 use vm_manifest_builder::VmManifestBuilder;
 use vm_resource::IntoResource;
 use vm_resource::Resource;
+use vm_resource::kind::DiskHandleKind;
+use vm_resource::kind::NetEndpointHandleKind;
+use vm_resource::kind::PciDeviceHandleKind;
 use vm_resource::kind::SerialBackendHandle;
 use vm_resource::kind::VirtioDeviceHandle;
 use vm_resource::kind::VmbusDeviceHandleKind;
@@ -429,6 +440,30 @@ impl VmService {
                         let r = self.modify_resource(&vm, request);
                         self.start_rpc(response, r);
                     }
+                    vmservice::Vm::AddPcieDevice(request, response) => {
+                        let worker_rpc = vm.worker_rpc.clone();
+                        self.start_rpc(
+                            response,
+                            Ok(async move {
+                                let vmservice::AddPcieDeviceRequest { port_name, device } = request;
+                                let resource =
+                                    build_pcie_device(device.context("missing device")?).await?;
+                                worker_rpc
+                                    .call_failable(VmRpc::AddPcieDevice, (port_name, resource))
+                                    .await
+                                    .map_err(anyhow::Error::from)
+                            }),
+                        );
+                    }
+                    vmservice::Vm::RemovePcieDevice(request, response) => {
+                        let recv = vm
+                            .worker_rpc
+                            .call_failable(VmRpc::RemovePcieDevice, request.port_name);
+                        self.start_rpc(
+                            response,
+                            Ok(async move { recv.await.map_err(anyhow::Error::from) }),
+                        );
+                    }
 
                     r @ vmservice::Vm::CapabilitiesVm(_, _)
                     | r @ vmservice::Vm::PropertiesVm(_, _) => {
@@ -503,7 +538,7 @@ impl VmService {
     }
 
     async fn create_vm(&mut self, request: vmservice::CreateVmRequest) -> anyhow::Result<()> {
-        let req_config = request.config.context("missing configuration")?;
+        let mut req_config = request.config.context("missing configuration")?;
 
         if self.vm.is_some() {
             bail!("VM already created");
@@ -558,34 +593,27 @@ impl VmService {
             .build()
             .context("failed to build vm configuration")?;
 
-        // Extract memory and processor counts for the VmController.
-        let config_mem_size = req_config
-            .memory_config
-            .as_ref()
-            .context("missing memory configuration")?
-            .memory_mb
-            .checked_mul(0x100000)
-            .context("invalid memory configuration")?;
-        let config_proc_count = req_config
-            .processor_config
-            .as_ref()
-            .map(|c| c.processor_count)
-            .unwrap_or(1);
-
-        let mut config = Config {
-            // TODO: devices, other stuff
-            load_mode,
-            ide_disks: vec![],
-            floppy_disks: vec![],
-            pcie_root_complexes: vec![],
-            pcie_devices: vec![],
-            pcie_switches: vec![],
-            pcie_generic_initiators: vec![],
-            vpci_devices: vec![],
-            numa: NumaTopology {
+        // Build the NUMA topology. A flat `MemoryConfig.memory_mb` and an
+        // explicit `NumaConfig` are mutually exclusive (mirrors the CLI
+        // `--memory` vs `--numa` conflict). `config_mem_size` is the total
+        // guest memory reported to the `VmController`.
+        let (numa, config_mem_size) = if let Some(numa_config) = req_config.numa_config.take() {
+            if req_config.memory_config.is_some() {
+                bail!("memory_config and numa_config are mutually exclusive");
+            }
+            build_numa_topology(numa_config)?
+        } else {
+            let mem_size = req_config
+                .memory_config
+                .as_ref()
+                .context("missing memory configuration")?
+                .memory_mb
+                .checked_mul(0x100000)
+                .context("invalid memory configuration")?;
+            let numa = NumaTopology {
                 nodes: vec![NumaNode {
                     mem: Some(MemoryConfig {
-                        mem_size: config_mem_size,
+                        mem_size,
                         prefetch_memory: false,
                         private_memory: false,
                         transparent_hugepages: false,
@@ -596,12 +624,49 @@ impl VmService {
                     vps: VpAssignment::FromTopology,
                 }],
                 distances: vec![],
-            },
+            };
+            (numa, mem_size)
+        };
+
+        let config_proc_count = req_config
+            .processor_config
+            .as_ref()
+            .map(|c| c.processor_count)
+            .unwrap_or(1);
+        let vps_per_socket = req_config
+            .processor_config
+            .as_ref()
+            .and_then(|c| c.vps_per_socket);
+        let enable_smt = req_config
+            .processor_config
+            .as_ref()
+            .and_then(|c| c.enable_smt);
+
+        // Build the PCIe topology (root complexes, switches, and the devices
+        // attached behind their ports).
+        let (pcie_root_complexes, pcie_switches, pcie_devices) =
+            if let Some(pcie) = req_config.pcie.take() {
+                build_pcie_topology(pcie).await?
+            } else {
+                (Vec::new(), Vec::new(), Vec::new())
+            };
+
+        let mut config = Config {
+            // TODO: devices, other stuff
+            load_mode,
+            ide_disks: vec![],
+            floppy_disks: vec![],
+            pcie_root_complexes,
+            pcie_devices,
+            pcie_switches,
+            pcie_generic_initiators: vec![],
+            vpci_devices: vec![],
+            numa,
             chipset: chipset.chipset,
             processor_topology: ProcessorTopologyConfig {
                 proc_count: config_proc_count,
-                vps_per_socket: None,
-                enable_smt: None,
+                vps_per_socket,
+                enable_smt,
                 arch: Default::default(),
             },
             hypervisor: HypervisorConfig {
@@ -1068,7 +1133,7 @@ fn parse_nic_config(
         instance_id: nic.nic_id.parse().context("invalid instance ID")?,
         mac_address: nic
             .mac_address
-            .parse::<net_backend_resources::mac_address::MacAddress>()
+            .parse::<MacAddress>()
             .context("invalid mac address")?,
         endpoint,
         max_queues: None,
@@ -1098,4 +1163,435 @@ async fn make_disk_config(disk: vmservice::ScsiDisk) -> anyhow::Result<ScsiDevic
         }
         .into_resource(),
     })
+}
+
+/// Builds a [`NumaTopology`] from the proto `NumaConfig`, returning the
+/// topology and the total guest memory in bytes (summed across the nodes).
+fn build_numa_topology(numa: vmservice::NumaConfig) -> anyhow::Result<(NumaTopology, u64)> {
+    let mut total_mem = 0u64;
+    let mut nodes = Vec::new();
+    for node in numa.nodes {
+        let mem = if let Some(mem) = node.memory {
+            let mem_size = mem
+                .memory_mb
+                .checked_mul(0x100000)
+                .context("invalid node memory size")?;
+            total_mem = total_mem
+                .checked_add(mem_size)
+                .context("total memory overflow")?;
+            if mem.hugepage_size_bytes.is_some() && !mem.hugepages {
+                bail!("hugepage_size_bytes requires hugepages");
+            }
+            Some(MemoryConfig {
+                mem_size,
+                prefetch_memory: mem.prefetch,
+                private_memory: mem.private_memory,
+                transparent_hugepages: mem.transparent_hugepages,
+                hugepages: mem.hugepages,
+                hugepage_size: mem.hugepage_size_bytes,
+                host_numa_node: mem.host_numa_node,
+            })
+        } else {
+            None
+        };
+        // Absent => `FromTopology`; present-but-empty => `Empty` (CPU-less);
+        // present-and-non-empty => explicit VP indices.
+        let vps = match node.vps {
+            None => VpAssignment::FromTopology,
+            Some(vps) if vps.vp_index.is_empty() => VpAssignment::Empty,
+            Some(vps) => VpAssignment::Explicit(vps.vp_index),
+        };
+        nodes.push(NumaNode { mem, vps });
+    }
+
+    let distances = numa
+        .distances
+        .into_iter()
+        .map(|d| {
+            Ok(NumaDistance {
+                src: d.src,
+                dst: d.dst,
+                distance: d.distance.try_into().context("distance out of range")?,
+            })
+        })
+        .collect::<anyhow::Result<Vec<_>>>()?;
+
+    Ok((NumaTopology { nodes, distances }, total_mem))
+}
+
+/// Converts a proto MMIO window (a size plus an optional pinned base) into a
+/// [`PcieMmioRangeConfig`].
+fn pcie_mmio_range_config(size: u64, base: Option<u64>) -> anyhow::Result<PcieMmioRangeConfig> {
+    Ok(if let Some(base) = base {
+        let end = base
+            .checked_add(size)
+            .context("MMIO base + size overflows")?;
+        PcieMmioRangeConfig::Fixed(MemoryRange::try_new(base..end).context("invalid MMIO range")?)
+    } else {
+        PcieMmioRangeConfig::Dynamic { size }
+    })
+}
+
+/// Flattens the nested proto PCIe topology into the flat config representation:
+/// a list of root complexes (each carrying its root ports), a list of switches
+/// (each referencing its parent port), and a list of devices (each referencing
+/// the port it sits behind).
+async fn build_pcie_topology(
+    topology: vmservice::PcieTopologyConfig,
+) -> anyhow::Result<(
+    Vec<PcieRootComplexConfig>,
+    Vec<PcieSwitchConfig>,
+    Vec<PcieDeviceConfig>,
+)> {
+    let mut root_complexes = Vec::new();
+    let mut switches = Vec::new();
+    // Devices are built after the topology walk so that the (async) device
+    // construction does not need to recurse.
+    let mut pending_devices: Vec<(String, vmservice::PcieDeviceKind)> = Vec::new();
+
+    for (index, rc) in topology.root_complexes.into_iter().enumerate() {
+        let mut ports = Vec::new();
+        for root_port in rc.root_ports {
+            let port_name = root_port.name;
+            ports.push(PciePortConfig {
+                name: port_name.clone(),
+                devfn: root_port
+                    .devfn
+                    .map(|d| d.try_into().context("devfn out of range"))
+                    .transpose()?,
+                hotplug: root_port.hotplug,
+                acs_capabilities_supported: None,
+                cxl: false,
+            });
+            if let Some(attached) = root_port.attached {
+                walk_pcie_attachment(port_name, attached, &mut switches, &mut pending_devices)?;
+            }
+        }
+
+        root_complexes.push(PcieRootComplexConfig {
+            index: index as u32,
+            name: rc.name,
+            segment: rc.segment.try_into().context("segment out of range")?,
+            start_bus: rc.start_bus.try_into().context("start_bus out of range")?,
+            end_bus: rc.end_bus.try_into().context("end_bus out of range")?,
+            low_mmio: pcie_mmio_range_config(rc.low_mmio, rc.low_mmio_base)?,
+            high_mmio: pcie_mmio_range_config(rc.high_mmio, rc.high_mmio_base)?,
+            ports,
+            cxl: None,
+            iommu: None,
+            vnode: rc.node,
+            preserve_bars: rc.preserve_bars,
+        });
+    }
+
+    let mut devices = Vec::new();
+    for (port_name, device) in pending_devices {
+        let resource = build_pcie_device(device).await?;
+        devices.push(PcieDeviceConfig {
+            port_name,
+            resource,
+        });
+    }
+
+    Ok((root_complexes, switches, devices))
+}
+
+/// Walks a single proto `PcieAttachment` (the thing behind one port): either an
+/// endpoint device (queued in `pending_devices`) or a nested switch (appended
+/// to `switches`, recursing into its downstream ports).
+fn walk_pcie_attachment(
+    port_name: String,
+    attachment: vmservice::PcieAttachment,
+    switches: &mut Vec<PcieSwitchConfig>,
+    pending_devices: &mut Vec<(String, vmservice::PcieDeviceKind)>,
+) -> anyhow::Result<()> {
+    match attachment.kind.context("missing attachment kind")? {
+        vmservice::pcie_attachment::Kind::Device(device) => {
+            pending_devices.push((port_name, device));
+        }
+        vmservice::pcie_attachment::Kind::Switch(switch) => {
+            let switch_name = switch.name;
+            let ports = switch
+                .downstream_ports
+                .iter()
+                .enumerate()
+                .map(|(i, p)| {
+                    Ok(PciePortConfig {
+                        name: format!("{switch_name}-downstream-{i}"),
+                        devfn: p
+                            .devfn
+                            .map(|d| d.try_into().context("devfn out of range"))
+                            .transpose()?,
+                        hotplug: p.hotplug,
+                        acs_capabilities_supported: None,
+                        cxl: false,
+                    })
+                })
+                .collect::<anyhow::Result<_>>()?;
+            switches.push(PcieSwitchConfig {
+                name: switch_name.clone(),
+                parent_port: port_name,
+                ports,
+            });
+            for (i, downstream) in switch.downstream_ports.into_iter().enumerate() {
+                // The runtime names switch downstream ports
+                // `{switch_name}-downstream-{index}` (0-based); use that as the
+                // port name when wiring whatever is attached behind them. The
+                // proto's per-port `name` is informational for now.
+                let downstream_name = format!("{switch_name}-downstream-{i}");
+                if let Some(attached) = downstream.attached {
+                    walk_pcie_attachment(downstream_name, attached, switches, pending_devices)?;
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Builds the resource for a single endpoint PCIe device function (a virtio
+/// function, an NVMe controller, or a VFIO-assigned host device).
+async fn build_pcie_device(
+    device: vmservice::PcieDeviceKind,
+) -> anyhow::Result<Resource<PciDeviceHandleKind>> {
+    use vmservice::pcie_device_kind::Kind;
+    Ok(match device.kind.context("missing PCIe device kind")? {
+        Kind::Virtio(virtio) => {
+            let resource = build_virtio_device(virtio).await?;
+            VirtioPciDeviceHandle(resource).into_resource()
+        }
+        Kind::Nvme(nvme) => build_nvme_controller(nvme).await?,
+        Kind::Vfio(vfio) => build_vfio_device(vfio)?,
+    })
+}
+
+/// Builds a VFIO-assigned host PCI device resource from the proto `VfioDevice`.
+///
+/// Uses the legacy VFIO group/container path: the device's IOMMU group is
+/// resolved from sysfs and the corresponding `/dev/vfio/<group_id>` file is
+/// opened. The device must already be bound to `vfio-pci` on the host.
+#[cfg(target_os = "linux")]
+fn build_vfio_device(vfio: vmservice::VfioDevice) -> anyhow::Result<Resource<PciDeviceHandleKind>> {
+    let sysfs_path = std::path::Path::new("/sys/bus/pci/devices").join(&vfio.host_pci_address);
+    let iommu_group_link =
+        std::fs::read_link(sysfs_path.join("iommu_group")).with_context(|| {
+            format!(
+                "failed to read IOMMU group for {} (is it bound to vfio-pci?)",
+                vfio.host_pci_address
+            )
+        })?;
+    let group_id: u64 = iommu_group_link
+        .file_name()
+        .and_then(|s| s.to_str())
+        .context("invalid iommu_group symlink")?
+        .parse()
+        .context("failed to parse IOMMU group ID")?;
+    let group = std::fs::OpenOptions::new()
+        .read(true)
+        .write(true)
+        .open(format!("/dev/vfio/{group_id}"))
+        .with_context(|| format!("failed to open /dev/vfio/{group_id}"))?;
+    Ok(vfio_assigned_device_resources::VfioDeviceHandle {
+        pci_id: vfio.host_pci_address,
+        group,
+        bar_pt: [false; 6],
+    }
+    .into_resource())
+}
+
+#[cfg(not(target_os = "linux"))]
+fn build_vfio_device(
+    _vfio: vmservice::VfioDevice,
+) -> anyhow::Result<Resource<PciDeviceHandleKind>> {
+    anyhow::bail!("VFIO device assignment is only supported on Linux")
+}
+
+/// Builds an NVMe controller resource from the proto `NvmeConfig`.
+async fn build_nvme_controller(
+    nvme: vmservice::NvmeConfig,
+) -> anyhow::Result<Resource<PciDeviceHandleKind>> {
+    let mut namespaces = Vec::new();
+    for ns in nvme.namespaces {
+        let read_only = ns.read_only;
+        let disk =
+            build_disk_backend(ns.backend.context("missing namespace backend")?, read_only).await?;
+        namespaces.push(nvme_resources::NamespaceDefinition {
+            nsid: ns.nsid,
+            read_only,
+            disk,
+        });
+    }
+    Ok(nvme_resources::NvmeControllerHandle {
+        subsystem_id: crate::storage_builder::deterministic_guid(&nvme.controller_id),
+        msix_count: 64,
+        max_io_queues: 64,
+        namespaces,
+        requests: None,
+    }
+    .into_resource())
+}
+
+/// Builds a transport-independent virtio device function from the proto
+/// `VirtioDevice`.
+async fn build_virtio_device(
+    device: vmservice::VirtioDevice,
+) -> anyhow::Result<Resource<VirtioDeviceHandle>> {
+    use vmservice::virtio_device::Kind;
+    Ok(match device.kind.context("missing virtio device kind")? {
+        Kind::Blk(blk) => {
+            let read_only = blk.read_only;
+            let disk =
+                build_disk_backend(blk.backend.context("missing blk backend")?, read_only).await?;
+            virtio_resources::blk::VirtioBlkHandle { disk, read_only }.into_resource()
+        }
+        Kind::Net(net) => {
+            let endpoint = build_nic_backend(net.backend.context("missing net backend")?)?;
+            virtio_resources::net::VirtioNetHandle {
+                max_queues: net
+                    .max_queues
+                    .map(|q| q.try_into().context("max_queues out of range"))
+                    .transpose()?,
+                mac_address: net
+                    .mac_address
+                    .parse::<MacAddress>()
+                    .context("invalid mac address")?,
+                endpoint,
+            }
+            .into_resource()
+        }
+        Kind::Rng(_) => virtio_resources::rng::VirtioRngHandle.into_resource(),
+        Kind::Vsock(vsock) => {
+            let listener = UnixListener::bind(&vsock.socket_path).with_context(|| {
+                format!("failed to bind virtio-vsock socket: {}", vsock.socket_path)
+            })?;
+            virtio_resources::vsock::VirtioVsockHandle {
+                // The guest CID does not matter for the UDS relay; it just needs
+                // to be a non-reserved value.
+                guest_cid: 0x3,
+                base_path: vsock.socket_path,
+                listener,
+            }
+            .into_resource()
+        }
+        Kind::Console(console) => {
+            let backend =
+                build_serial_backend(console.backend.context("missing console backend")?)?;
+            virtio_resources::console::VirtioConsoleHandle { backend }.into_resource()
+        }
+        Kind::VhostUser(vhost_user) => build_vhost_user_device(vhost_user)?,
+    })
+}
+
+/// Builds a disk backend resource from the proto `DiskBackend`.
+async fn build_disk_backend(
+    backend: vmservice::DiskBackend,
+    read_only: bool,
+) -> anyhow::Result<Resource<DiskHandleKind>> {
+    match backend.kind.context("missing disk backend kind")? {
+        vmservice::disk_backend::Kind::File(file) => open_disk_type(
+            file.path.as_ref(),
+            OpenDiskOptions {
+                read_only,
+                direct: file.direct,
+            },
+        )
+        .await
+        .with_context(|| format!("failed to open {}", file.path)),
+    }
+}
+
+/// Builds a host network endpoint resource from the proto `NicBackend`.
+fn build_nic_backend(
+    backend: vmservice::NicBackend,
+) -> anyhow::Result<Resource<NetEndpointHandleKind>> {
+    use vmservice::nic_backend::Kind;
+    Ok(match backend.kind.context("missing network backend")? {
+        Kind::Consomme(consomme) => net_backend_resources::consomme::ConsommeHandle {
+            cidr: (!consomme.cidr.is_empty()).then_some(consomme.cidr),
+            ports: Vec::new(),
+            recv: None,
+        }
+        .into_resource(),
+        #[cfg(target_os = "linux")]
+        Kind::Tap(tap) => {
+            let fd = net_tap::tap::open_tap(tap.name.as_ref())
+                .with_context(|| format!("failed to open TAP device '{}'", tap.name))?;
+            net_backend_resources::tap::TapHandle { fd }.into_resource()
+        }
+        #[cfg(windows)]
+        Kind::Dio(dio) => net_backend_resources::dio::WindowsDirectIoHandle {
+            switch_port_id: net_backend_resources::dio::SwitchPortId {
+                switch: dio.switch_id.parse().context("invalid switch ID")?,
+                port: dio.port_id.parse().context("invalid port ID")?,
+            },
+        }
+        .into_resource(),
+        _ => anyhow::bail!("unsupported network backend"),
+    })
+}
+
+/// Builds a serial backend resource from the proto `SerialBackend`.
+fn build_serial_backend(
+    backend: vmservice::SerialBackend,
+) -> anyhow::Result<Resource<SerialBackendHandle>> {
+    match backend.kind.context("missing serial backend kind")? {
+        vmservice::serial_backend::Kind::Relay(relay) => {
+            let (serial_fn, action) = open_socket_backend(relay.connect);
+            serial_fn(relay.socket_path.as_ref()).with_context(|| {
+                format!("failed to {} serial socket: {}", action, relay.socket_path)
+            })
+        }
+    }
+}
+
+/// Builds a vhost-user-backed virtio device. Only supported on unix, where the
+/// backend is reached over a Unix domain socket.
+#[cfg(unix)]
+fn build_vhost_user_device(
+    vhost_user: vmservice::VhostUser,
+) -> anyhow::Result<Resource<VirtioDeviceHandle>> {
+    use vmservice::vhost_user_device::Kind;
+
+    let stream = unix_socket::UnixStream::connect(&vhost_user.socket_path).with_context(|| {
+        format!(
+            "failed to connect to vhost-user socket: {}",
+            vhost_user.socket_path
+        )
+    })?;
+    let device = vhost_user.device.context("missing vhost-user device")?;
+    let to_u16 =
+        |v: u32| -> anyhow::Result<u16> { v.try_into().context("queue value out of range") };
+    Ok(
+        match device.kind.context("missing vhost-user device kind")? {
+            Kind::Blk(blk) => virtio_resources::vhost_user::VhostUserBlkHandle {
+                socket: stream.into(),
+                num_queues: blk.num_queues.map(to_u16).transpose()?,
+                queue_size: blk.queue_size.map(to_u16).transpose()?,
+            }
+            .into_resource(),
+            Kind::Fs(fs) => virtio_resources::vhost_user::VhostUserFsHandle {
+                socket: stream.into(),
+                tag: fs.tag,
+                num_queues: fs.num_queues.map(to_u16).transpose()?,
+                queue_size: fs.queue_size.map(to_u16).transpose()?,
+            }
+            .into_resource(),
+            Kind::Other(other) => virtio_resources::vhost_user::VhostUserGenericHandle {
+                socket: stream.into(),
+                device_id: to_u16(other.device_id)?,
+                queue_sizes: other
+                    .queue_sizes
+                    .into_iter()
+                    .map(to_u16)
+                    .collect::<anyhow::Result<Vec<_>>>()?,
+            }
+            .into_resource(),
+        },
+    )
+}
+
+#[cfg(not(unix))]
+fn build_vhost_user_device(
+    _vhost_user: vmservice::VhostUser,
+) -> anyhow::Result<Resource<VirtioDeviceHandle>> {
+    anyhow::bail!("vhost-user is only supported on unix hosts")
 }

--- a/openvmm/openvmm_entry/src/ttrpc/mod.rs
+++ b/openvmm/openvmm_entry/src/ttrpc/mod.rs
@@ -1063,25 +1063,23 @@ fn open_socket_backend(
 /// validating the protocol and port ranges. The host port is always treated as
 /// a fixed port; the unbind path ignores it.
 fn parse_port_config(port: vmservice::PortConfig) -> anyhow::Result<HostPortConfig> {
-    let protocol = if port.protocol == vmservice::IpProtocol::Tcp as i32 {
+    let vmservice::PortConfig {
+        host_port,
+        guest_port,
+        protocol,
+    } = port;
+    let protocol = if protocol == vmservice::IpProtocol::Tcp as i32 {
         HostPortProtocol::Tcp
-    } else if port.protocol == vmservice::IpProtocol::Udp as i32 {
+    } else if protocol == vmservice::IpProtocol::Udp as i32 {
         HostPortProtocol::Udp
     } else {
-        anyhow::bail!("invalid protocol {}", port.protocol);
+        anyhow::bail!("invalid protocol {protocol}");
     };
     Ok(HostPortConfig {
         protocol,
         host_address: None,
-        host_port: HostPort::Fixed(
-            port.host_port
-                .try_into()
-                .context("host port out of range")?,
-        ),
-        guest_port: port
-            .guest_port
-            .try_into()
-            .context("guest port out of range")?,
+        host_port: HostPort::Fixed(host_port.try_into().context("host port out of range")?),
+        guest_port: guest_port.try_into().context("guest port out of range")?,
     })
 }
 
@@ -1168,50 +1166,62 @@ async fn make_disk_config(disk: vmservice::ScsiDisk) -> anyhow::Result<ScsiDevic
 /// Builds a [`NumaTopology`] from the proto `NumaConfig`, returning the
 /// topology and the total guest memory in bytes (summed across the nodes).
 fn build_numa_topology(numa: vmservice::NumaConfig) -> anyhow::Result<(NumaTopology, u64)> {
+    let vmservice::NumaConfig {
+        nodes: proto_nodes,
+        distances: proto_distances,
+    } = numa;
     let mut total_mem = 0u64;
     let mut nodes = Vec::new();
-    for node in numa.nodes {
-        let mem = if let Some(mem) = node.memory {
-            let mem_size = mem
-                .memory_mb
+    for node in proto_nodes {
+        let vmservice::NumaNode { memory, vps } = node;
+        let mem = if let Some(mem) = memory {
+            let vmservice::NodeMemoryConfig {
+                memory_mb,
+                host_numa_node,
+                prefetch,
+                private_memory,
+                transparent_hugepages,
+                hugepages,
+                hugepage_size_bytes,
+            } = mem;
+            let mem_size = memory_mb
                 .checked_mul(0x100000)
                 .context("invalid node memory size")?;
             total_mem = total_mem
                 .checked_add(mem_size)
                 .context("total memory overflow")?;
-            if mem.hugepage_size_bytes.is_some() && !mem.hugepages {
-                bail!("hugepage_size_bytes requires hugepages");
-            }
             Some(MemoryConfig {
                 mem_size,
-                prefetch_memory: mem.prefetch,
-                private_memory: mem.private_memory,
-                transparent_hugepages: mem.transparent_hugepages,
-                hugepages: mem.hugepages,
-                hugepage_size: mem.hugepage_size_bytes,
-                host_numa_node: mem.host_numa_node,
+                prefetch_memory: prefetch,
+                private_memory,
+                transparent_hugepages,
+                hugepages,
+                hugepage_size: hugepage_size_bytes,
+                host_numa_node,
             })
         } else {
             None
         };
         // Absent => `FromTopology`; present-but-empty => `Empty` (CPU-less);
         // present-and-non-empty => explicit VP indices.
-        let vps = match node.vps {
+        let vps = match vps {
             None => VpAssignment::FromTopology,
-            Some(vps) if vps.vp_index.is_empty() => VpAssignment::Empty,
-            Some(vps) => VpAssignment::Explicit(vps.vp_index),
+            Some(vmservice::VpAssignment { vp_index }) if vp_index.is_empty() => {
+                VpAssignment::Empty
+            }
+            Some(vmservice::VpAssignment { vp_index }) => VpAssignment::Explicit(vp_index),
         };
         nodes.push(NumaNode { mem, vps });
     }
 
-    let distances = numa
-        .distances
+    let distances = proto_distances
         .into_iter()
         .map(|d| {
+            let vmservice::NumaDistance { src, dst, distance } = d;
             Ok(NumaDistance {
-                src: d.src,
-                dst: d.dst,
-                distance: d.distance.try_into().context("distance out of range")?,
+                src,
+                dst,
+                distance: distance.try_into().context("distance out of range")?,
             })
         })
         .collect::<anyhow::Result<Vec<_>>>()?;
@@ -1243,44 +1253,64 @@ async fn build_pcie_topology(
     Vec<PcieSwitchConfig>,
     Vec<PcieDeviceConfig>,
 )> {
+    let vmservice::PcieTopologyConfig {
+        root_complexes: proto_root_complexes,
+    } = topology;
     let mut root_complexes = Vec::new();
     let mut switches = Vec::new();
     // Devices are built after the topology walk so that the (async) device
     // construction does not need to recurse.
     let mut pending_devices: Vec<(String, vmservice::PcieDeviceKind)> = Vec::new();
 
-    for (index, rc) in topology.root_complexes.into_iter().enumerate() {
+    for (index, rc) in proto_root_complexes.into_iter().enumerate() {
+        let vmservice::PcieRootComplex {
+            name,
+            segment,
+            start_bus,
+            end_bus,
+            low_mmio,
+            high_mmio,
+            low_mmio_base,
+            high_mmio_base,
+            preserve_bars,
+            node,
+            root_ports,
+        } = rc;
         let mut ports = Vec::new();
-        for root_port in rc.root_ports {
-            let port_name = root_port.name;
+        for root_port in root_ports {
+            let vmservice::PciePort {
+                name: port_name,
+                hotplug,
+                attached,
+                devfn,
+            } = root_port;
             ports.push(PciePortConfig {
                 name: port_name.clone(),
-                devfn: root_port
-                    .devfn
+                devfn: devfn
                     .map(|d| d.try_into().context("devfn out of range"))
                     .transpose()?,
-                hotplug: root_port.hotplug,
+                hotplug,
                 acs_capabilities_supported: None,
                 cxl: false,
             });
-            if let Some(attached) = root_port.attached {
+            if let Some(attached) = attached {
                 walk_pcie_attachment(port_name, attached, &mut switches, &mut pending_devices)?;
             }
         }
 
         root_complexes.push(PcieRootComplexConfig {
             index: index as u32,
-            name: rc.name,
-            segment: rc.segment.try_into().context("segment out of range")?,
-            start_bus: rc.start_bus.try_into().context("start_bus out of range")?,
-            end_bus: rc.end_bus.try_into().context("end_bus out of range")?,
-            low_mmio: pcie_mmio_range_config(rc.low_mmio, rc.low_mmio_base)?,
-            high_mmio: pcie_mmio_range_config(rc.high_mmio, rc.high_mmio_base)?,
+            name,
+            segment: segment.try_into().context("segment out of range")?,
+            start_bus: start_bus.try_into().context("start_bus out of range")?,
+            end_bus: end_bus.try_into().context("end_bus out of range")?,
+            low_mmio: pcie_mmio_range_config(low_mmio, low_mmio_base)?,
+            high_mmio: pcie_mmio_range_config(high_mmio, high_mmio_base)?,
             ports,
             cxl: None,
             iommu: None,
-            vnode: rc.node,
-            preserve_bars: rc.preserve_bars,
+            vnode: node,
+            preserve_bars,
         });
     }
 
@@ -1310,38 +1340,39 @@ fn walk_pcie_attachment(
             pending_devices.push((port_name, device));
         }
         vmservice::pcie_attachment::Kind::Switch(switch) => {
-            let switch_name = switch.name;
-            let ports = switch
-                .downstream_ports
-                .iter()
-                .enumerate()
-                .map(|(i, p)| {
-                    Ok(PciePortConfig {
-                        name: format!("{switch_name}-downstream-{i}"),
-                        devfn: p
-                            .devfn
-                            .map(|d| d.try_into().context("devfn out of range"))
-                            .transpose()?,
-                        hotplug: p.hotplug,
-                        acs_capabilities_supported: None,
-                        cxl: false,
-                    })
-                })
-                .collect::<anyhow::Result<_>>()?;
+            let vmservice::PcieSwitch {
+                name: switch_name,
+                downstream_ports,
+            } = switch;
+            let mut ports = Vec::new();
+            let mut children = Vec::new();
+            for downstream in downstream_ports {
+                let vmservice::PciePort {
+                    name: downstream_name,
+                    hotplug,
+                    attached,
+                    devfn,
+                } = downstream;
+                ports.push(PciePortConfig {
+                    name: downstream_name.clone(),
+                    devfn: devfn
+                        .map(|d| d.try_into().context("devfn out of range"))
+                        .transpose()?,
+                    hotplug,
+                    acs_capabilities_supported: None,
+                    cxl: false,
+                });
+                if let Some(attached) = attached {
+                    children.push((downstream_name, attached));
+                }
+            }
             switches.push(PcieSwitchConfig {
-                name: switch_name.clone(),
+                name: switch_name,
                 parent_port: port_name,
                 ports,
             });
-            for (i, downstream) in switch.downstream_ports.into_iter().enumerate() {
-                // The runtime names switch downstream ports
-                // `{switch_name}-downstream-{index}` (0-based); use that as the
-                // port name when wiring whatever is attached behind them. The
-                // proto's per-port `name` is informational for now.
-                let downstream_name = format!("{switch_name}-downstream-{i}");
-                if let Some(attached) = downstream.attached {
-                    walk_pcie_attachment(downstream_name, attached, switches, pending_devices)?;
-                }
+            for (downstream_name, attached) in children {
+                walk_pcie_attachment(downstream_name, attached, switches, pending_devices)?;
             }
         }
     }
@@ -1354,7 +1385,8 @@ async fn build_pcie_device(
     device: vmservice::PcieDeviceKind,
 ) -> anyhow::Result<Resource<PciDeviceHandleKind>> {
     use vmservice::pcie_device_kind::Kind;
-    Ok(match device.kind.context("missing PCIe device kind")? {
+    let vmservice::PcieDeviceKind { kind } = device;
+    Ok(match kind.context("missing PCIe device kind")? {
         Kind::Virtio(virtio) => {
             let resource = build_virtio_device(virtio).await?;
             VirtioPciDeviceHandle(resource).into_resource()
@@ -1371,13 +1403,11 @@ async fn build_pcie_device(
 /// opened. The device must already be bound to `vfio-pci` on the host.
 #[cfg(target_os = "linux")]
 fn build_vfio_device(vfio: vmservice::VfioDevice) -> anyhow::Result<Resource<PciDeviceHandleKind>> {
-    let sysfs_path = std::path::Path::new("/sys/bus/pci/devices").join(&vfio.host_pci_address);
+    let vmservice::VfioDevice { host_pci_address } = vfio;
+    let sysfs_path = std::path::Path::new("/sys/bus/pci/devices").join(&host_pci_address);
     let iommu_group_link =
         std::fs::read_link(sysfs_path.join("iommu_group")).with_context(|| {
-            format!(
-                "failed to read IOMMU group for {} (is it bound to vfio-pci?)",
-                vfio.host_pci_address
-            )
+            format!("failed to read IOMMU group for {host_pci_address} (is it bound to vfio-pci?)")
         })?;
     let group_id: u64 = iommu_group_link
         .file_name()
@@ -1391,7 +1421,7 @@ fn build_vfio_device(vfio: vmservice::VfioDevice) -> anyhow::Result<Resource<Pci
         .open(format!("/dev/vfio/{group_id}"))
         .with_context(|| format!("failed to open /dev/vfio/{group_id}"))?;
     Ok(vfio_assigned_device_resources::VfioDeviceHandle {
-        pci_id: vfio.host_pci_address,
+        pci_id: host_pci_address,
         group,
         bar_pt: [false; 6],
     }
@@ -1409,19 +1439,27 @@ fn build_vfio_device(
 async fn build_nvme_controller(
     nvme: vmservice::NvmeConfig,
 ) -> anyhow::Result<Resource<PciDeviceHandleKind>> {
+    let vmservice::NvmeConfig {
+        controller_id,
+        namespaces: proto_namespaces,
+    } = nvme;
     let mut namespaces = Vec::new();
-    for ns in nvme.namespaces {
-        let read_only = ns.read_only;
+    for ns in proto_namespaces {
+        let vmservice::NvmeNamespace {
+            nsid,
+            backend,
+            read_only,
+        } = ns;
         let disk =
-            build_disk_backend(ns.backend.context("missing namespace backend")?, read_only).await?;
+            build_disk_backend(backend.context("missing namespace backend")?, read_only).await?;
         namespaces.push(nvme_resources::NamespaceDefinition {
-            nsid: ns.nsid,
+            nsid,
             read_only,
             disk,
         });
     }
     Ok(nvme_resources::NvmeControllerHandle {
-        subsystem_id: crate::storage_builder::deterministic_guid(&nvme.controller_id),
+        subsystem_id: crate::storage_builder::deterministic_guid(&controller_id),
         msix_count: 64,
         max_io_queues: 64,
         namespaces,
@@ -1436,45 +1474,47 @@ async fn build_virtio_device(
     device: vmservice::VirtioDevice,
 ) -> anyhow::Result<Resource<VirtioDeviceHandle>> {
     use vmservice::virtio_device::Kind;
-    Ok(match device.kind.context("missing virtio device kind")? {
-        Kind::Blk(blk) => {
-            let read_only = blk.read_only;
+    let vmservice::VirtioDevice { kind } = device;
+    Ok(match kind.context("missing virtio device kind")? {
+        Kind::Blk(vmservice::VirtioBlk { backend, read_only }) => {
             let disk =
-                build_disk_backend(blk.backend.context("missing blk backend")?, read_only).await?;
+                build_disk_backend(backend.context("missing blk backend")?, read_only).await?;
             virtio_resources::blk::VirtioBlkHandle { disk, read_only }.into_resource()
         }
-        Kind::Net(net) => {
-            let endpoint = build_nic_backend(net.backend.context("missing net backend")?)?;
+        Kind::Net(vmservice::VirtioNet {
+            max_queues,
+            backend,
+            mac_address,
+        }) => {
+            let endpoint = build_nic_backend(backend.context("missing net backend")?)?;
             virtio_resources::net::VirtioNetHandle {
-                max_queues: net
-                    .max_queues
+                max_queues: max_queues
                     .map(|q| q.try_into().context("max_queues out of range"))
                     .transpose()?,
-                mac_address: net
-                    .mac_address
+                mac_address: mac_address
                     .parse::<MacAddress>()
                     .context("invalid mac address")?,
                 endpoint,
             }
             .into_resource()
         }
-        Kind::Rng(_) => virtio_resources::rng::VirtioRngHandle.into_resource(),
-        Kind::Vsock(vsock) => {
-            let listener = UnixListener::bind(&vsock.socket_path).with_context(|| {
-                format!("failed to bind virtio-vsock socket: {}", vsock.socket_path)
-            })?;
+        Kind::Rng(vmservice::VirtioRng {}) => {
+            virtio_resources::rng::VirtioRngHandle.into_resource()
+        }
+        Kind::Vsock(vmservice::VirtioVsock { socket_path }) => {
+            let listener = UnixListener::bind(&socket_path)
+                .with_context(|| format!("failed to bind virtio-vsock socket: {socket_path}"))?;
             virtio_resources::vsock::VirtioVsockHandle {
                 // The guest CID does not matter for the UDS relay; it just needs
                 // to be a non-reserved value.
                 guest_cid: 0x3,
-                base_path: vsock.socket_path,
+                base_path: socket_path,
                 listener,
             }
             .into_resource()
         }
-        Kind::Console(console) => {
-            let backend =
-                build_serial_backend(console.backend.context("missing console backend")?)?;
+        Kind::Console(vmservice::VirtioConsole { backend }) => {
+            let backend = build_serial_backend(backend.context("missing console backend")?)?;
             virtio_resources::console::VirtioConsoleHandle { backend }.into_resource()
         }
         Kind::VhostUser(vhost_user) => build_vhost_user_device(vhost_user)?,
@@ -1486,16 +1526,13 @@ async fn build_disk_backend(
     backend: vmservice::DiskBackend,
     read_only: bool,
 ) -> anyhow::Result<Resource<DiskHandleKind>> {
-    match backend.kind.context("missing disk backend kind")? {
-        vmservice::disk_backend::Kind::File(file) => open_disk_type(
-            file.path.as_ref(),
-            OpenDiskOptions {
-                read_only,
-                direct: file.direct,
-            },
-        )
-        .await
-        .with_context(|| format!("failed to open {}", file.path)),
+    let vmservice::DiskBackend { kind } = backend;
+    match kind.context("missing disk backend kind")? {
+        vmservice::disk_backend::Kind::File(vmservice::FileDisk { path, direct }) => {
+            open_disk_type(path.as_ref(), OpenDiskOptions { read_only, direct })
+                .await
+                .with_context(|| format!("failed to open {path}"))
+        }
     }
 }
 
@@ -1504,27 +1541,35 @@ fn build_nic_backend(
     backend: vmservice::NicBackend,
 ) -> anyhow::Result<Resource<NetEndpointHandleKind>> {
     use vmservice::nic_backend::Kind;
-    Ok(match backend.kind.context("missing network backend")? {
-        Kind::Consomme(consomme) => net_backend_resources::consomme::ConsommeHandle {
-            cidr: (!consomme.cidr.is_empty()).then_some(consomme.cidr),
-            ports: Vec::new(),
-            recv: None,
+    let vmservice::NicBackend { kind } = backend;
+    Ok(match kind.context("missing network backend")? {
+        Kind::Consomme(vmservice::ConsommeBackend { cidr, ports }) => {
+            net_backend_resources::consomme::ConsommeHandle {
+                cidr: (!cidr.is_empty()).then_some(cidr),
+                ports: ports
+                    .into_iter()
+                    .map(parse_port_config)
+                    .collect::<anyhow::Result<_>>()?,
+                recv: None,
+            }
+            .into_resource()
         }
-        .into_resource(),
         #[cfg(target_os = "linux")]
-        Kind::Tap(tap) => {
-            let fd = net_tap::tap::open_tap(tap.name.as_ref())
-                .with_context(|| format!("failed to open TAP device '{}'", tap.name))?;
+        Kind::Tap(vmservice::TapBackend { name }) => {
+            let fd = net_tap::tap::open_tap(name.as_ref())
+                .with_context(|| format!("failed to open TAP device '{name}'"))?;
             net_backend_resources::tap::TapHandle { fd }.into_resource()
         }
         #[cfg(windows)]
-        Kind::Dio(dio) => net_backend_resources::dio::WindowsDirectIoHandle {
-            switch_port_id: net_backend_resources::dio::SwitchPortId {
-                switch: dio.switch_id.parse().context("invalid switch ID")?,
-                port: dio.port_id.parse().context("invalid port ID")?,
-            },
+        Kind::Dio(vmservice::DioBackend { switch_id, port_id }) => {
+            net_backend_resources::dio::WindowsDirectIoHandle {
+                switch_port_id: net_backend_resources::dio::SwitchPortId {
+                    switch: switch_id.parse().context("invalid switch ID")?,
+                    port: port_id.parse().context("invalid port ID")?,
+                },
+            }
+            .into_resource()
         }
-        .into_resource(),
         _ => anyhow::bail!("unsupported network backend"),
     })
 }
@@ -1533,12 +1578,15 @@ fn build_nic_backend(
 fn build_serial_backend(
     backend: vmservice::SerialBackend,
 ) -> anyhow::Result<Resource<SerialBackendHandle>> {
-    match backend.kind.context("missing serial backend kind")? {
-        vmservice::serial_backend::Kind::Relay(relay) => {
-            let (serial_fn, action) = open_socket_backend(relay.connect);
-            serial_fn(relay.socket_path.as_ref()).with_context(|| {
-                format!("failed to {} serial socket: {}", action, relay.socket_path)
-            })
+    let vmservice::SerialBackend { kind } = backend;
+    match kind.context("missing serial backend kind")? {
+        vmservice::serial_backend::Kind::Relay(vmservice::SerialRelay {
+            socket_path,
+            connect,
+        }) => {
+            let (serial_fn, action) = open_socket_backend(connect);
+            serial_fn(socket_path.as_ref())
+                .with_context(|| format!("failed to {action} serial socket: {socket_path}"))
         }
     }
 }
@@ -1551,42 +1599,49 @@ fn build_vhost_user_device(
 ) -> anyhow::Result<Resource<VirtioDeviceHandle>> {
     use vmservice::vhost_user_device::Kind;
 
-    let stream = unix_socket::UnixStream::connect(&vhost_user.socket_path).with_context(|| {
-        format!(
-            "failed to connect to vhost-user socket: {}",
-            vhost_user.socket_path
-        )
-    })?;
-    let device = vhost_user.device.context("missing vhost-user device")?;
+    let vmservice::VhostUser {
+        socket_path,
+        device,
+    } = vhost_user;
+    let stream = unix_socket::UnixStream::connect(&socket_path)
+        .with_context(|| format!("failed to connect to vhost-user socket: {socket_path}"))?;
+    let vmservice::VhostUserDevice { kind } = device.context("missing vhost-user device")?;
     let to_u16 =
         |v: u32| -> anyhow::Result<u16> { v.try_into().context("queue value out of range") };
-    Ok(
-        match device.kind.context("missing vhost-user device kind")? {
-            Kind::Blk(blk) => virtio_resources::vhost_user::VhostUserBlkHandle {
-                socket: stream.into(),
-                num_queues: blk.num_queues.map(to_u16).transpose()?,
-                queue_size: blk.queue_size.map(to_u16).transpose()?,
-            }
-            .into_resource(),
-            Kind::Fs(fs) => virtio_resources::vhost_user::VhostUserFsHandle {
-                socket: stream.into(),
-                tag: fs.tag,
-                num_queues: fs.num_queues.map(to_u16).transpose()?,
-                queue_size: fs.queue_size.map(to_u16).transpose()?,
-            }
-            .into_resource(),
-            Kind::Other(other) => virtio_resources::vhost_user::VhostUserGenericHandle {
-                socket: stream.into(),
-                device_id: to_u16(other.device_id)?,
-                queue_sizes: other
-                    .queue_sizes
-                    .into_iter()
-                    .map(to_u16)
-                    .collect::<anyhow::Result<Vec<_>>>()?,
-            }
-            .into_resource(),
-        },
-    )
+    Ok(match kind.context("missing vhost-user device kind")? {
+        Kind::Blk(vmservice::VhostUserBlk {
+            num_queues,
+            queue_size,
+        }) => virtio_resources::vhost_user::VhostUserBlkHandle {
+            socket: stream.into(),
+            num_queues: num_queues.map(to_u16).transpose()?,
+            queue_size: queue_size.map(to_u16).transpose()?,
+        }
+        .into_resource(),
+        Kind::Fs(vmservice::VhostUserFs {
+            tag,
+            num_queues,
+            queue_size,
+        }) => virtio_resources::vhost_user::VhostUserFsHandle {
+            socket: stream.into(),
+            tag,
+            num_queues: num_queues.map(to_u16).transpose()?,
+            queue_size: queue_size.map(to_u16).transpose()?,
+        }
+        .into_resource(),
+        Kind::Other(vmservice::VhostUserGeneric {
+            device_id,
+            queue_sizes,
+        }) => virtio_resources::vhost_user::VhostUserGenericHandle {
+            socket: stream.into(),
+            device_id: to_u16(device_id)?,
+            queue_sizes: queue_sizes
+                .into_iter()
+                .map(to_u16)
+                .collect::<anyhow::Result<Vec<_>>>()?,
+        }
+        .into_resource(),
+    })
 }
 
 #[cfg(not(unix))]

--- a/openvmm/openvmm_ttrpc_vmservice/src/vmservice.proto
+++ b/openvmm/openvmm_ttrpc_vmservice/src/vmservice.proto
@@ -116,6 +116,8 @@ message PcieDeviceKind {
         VirtioDevice virtio = 1;
         // An NVMe controller.
         NvmeConfig   nvme   = 2;
+        // A host PCI device assigned to the guest via VFIO.
+        VfioDevice   vfio   = 3;
     }
 }
 
@@ -297,6 +299,13 @@ message NvmeNamespace {
     DiskBackend backend = 2;
     // Expose the namespace read-only to the guest.
     bool read_only = 3;
+}
+
+// Host PCI device assigned to the guest via Linux VFIO. Linux only. The device
+// must be bound to vfio-pci on the host before VM start.
+message VfioDevice {
+    // Host PCI address (BDF), e.g. "0000:01:00.0".
+    string host_pci_address = 1;
 }
 
 //

--- a/openvmm/openvmm_ttrpc_vmservice/src/vmservice.proto
+++ b/openvmm/openvmm_ttrpc_vmservice/src/vmservice.proto
@@ -198,6 +198,8 @@ message VirtioNet {
     optional uint32 max_queues = 1;
     // Host network backend.
     NicBackend backend = 2;
+    // MAC address for the adapter (e.g. "12-34-56-78-9A-BC").
+    string mac_address = 3;
 }
 
 // A host network backend, shared across NIC device types (virtio-net, MANA,

--- a/openvmm/openvmm_ttrpc_vmservice/src/vmservice.proto
+++ b/openvmm/openvmm_ttrpc_vmservice/src/vmservice.proto
@@ -214,15 +214,7 @@ message NicBackend {
         TapBackend      tap      = 2;
         // Built-in user-mode (consomme) network backend.
         ConsommeBackend consomme = 3;
-        // Windows kernel-mode vmswitch backend.
-        VmnicBackend    vmnic    = 4;
     }
-}
-
-// Windows kernel-mode vmswitch network backend.
-message VmnicBackend {
-    // Switch ID GUID, or "default".
-    string switch_id = 1;
 }
 
 // A virtio device backed by an external vhost-user backend process.

--- a/openvmm/openvmm_ttrpc_vmservice/src/vmservice.proto
+++ b/openvmm/openvmm_ttrpc_vmservice/src/vmservice.proto
@@ -317,8 +317,8 @@ message NumaNode {
     // Memory for this node. Absent => CPU-only / device-only node.
     optional NodeMemoryConfig memory = 1;
     // VP assignment for this node:
-    //   - absent             => VPs assigned by topology (sockets round-robined
-    //                           across CPU-bearing nodes)
+    //   - absent             => VPs assigned by topology (sockets distributed
+    //                           round-robin across CPU-bearing nodes)
     //   - present, empty     => CPU-less node (no VPs; may coexist with
     //                           topology-assigned nodes)
     //   - present, non-empty => exactly these VP indices
@@ -444,6 +444,9 @@ message VMConfig {
         UEFI uefi = 6;
     }
     WindowsOptions windows_options = 7;
+    // Field 8 was previously map<string, string> extra_data.
+    reserved 8;
+    reserved "extra_data";
     HVSocketConfig hvsocket_config = 9;
 
     // Virtual NUMA topology. Mutually exclusive with a flat

--- a/openvmm/openvmm_ttrpc_vmservice/src/vmservice.proto
+++ b/openvmm/openvmm_ttrpc_vmservice/src/vmservice.proto
@@ -90,10 +90,6 @@ message ProcessorConfig {
     uint32 processor_count = 1;
     uint32 processor_weight = 2;
     uint32 processor_limit = 3;
-
-    // Max VPs per socket. Absent => single socket / hypervisor default.
-    optional uint32 vps_per_socket = 4;
-    optional bool enable_smt = 5;
 }
 
 message DevicesConfig {
@@ -450,8 +446,8 @@ message VMConfig {
     reserved "extra_data";
     HVSocketConfig hvsocket_config = 9;
 
-    // Virtual NUMA topology. Mutually exclusive with a flat
-    // MemoryConfig.memory_mb (mirrors the CLI --memory vs --numa conflict).
+    // Virtual NUMA topology. Mutually exclusive with memory_config
+    // (mirrors the CLI --memory vs --numa conflict).
     NumaConfig numa_config = 10;
     // PCIe root complexes / ports / switches.
     PcieTopologyConfig pcie = 11;

--- a/openvmm/openvmm_ttrpc_vmservice/src/vmservice.proto
+++ b/openvmm/openvmm_ttrpc_vmservice/src/vmservice.proto
@@ -397,11 +397,12 @@ message PcieRootComplex {
     // NUMA node this root complex is associated with. Absent => none.
     optional uint32 node = 10;
     // Root ports on this complex.
-    repeated PcieRootPort root_ports = 11;
+    repeated PciePort root_ports = 11;
 }
 
-// A PCIe root port. Hosts at most one device or switch (see `attached`).
-message PcieRootPort {
+// A PCIe port: a root-complex root port or a switch downstream port. Hosts at
+// most one device or switch (see `attached`).
+message PciePort {
     // Port name, used to target runtime hot-add (AddPcieDevice).
     string name = 1;
     // Allow runtime hot-plug into this port.
@@ -409,6 +410,9 @@ message PcieRootPort {
     // What is attached behind this port. Absent => empty port (available for
     // hotplug if `hotplug` is set).
     PcieAttachment attached = 3;
+    // Device/function (`device << 3 | function`) to place this port at on its
+    // bus. Absent => lowest available devfn.
+    optional uint32 devfn = 4;
 }
 
 // A PCIe switch: a set of downstream ports, each of which may have its own
@@ -417,18 +421,7 @@ message PcieSwitch {
     // Switch name.
     string name = 1;
     // Downstream ports of this switch.
-    repeated PcieDownstreamPort downstream_ports = 2;
-}
-
-// A PCIe switch downstream port. Hosts at most one device or nested switch.
-message PcieDownstreamPort {
-    // Port name, used to target runtime hot-add (AddPcieDevice).
-    string name = 1;
-    // Allow runtime hot-plug into this port.
-    bool   hotplug = 2;
-    // What is attached behind this port. Absent => empty port (available for
-    // hotplug if `hotplug` is set).
-    PcieAttachment attached = 3;
+    repeated PciePort downstream_ports = 2;
 }
 
 // What sits behind a PCIe port: an endpoint device or a (nested) switch.

--- a/openvmm/openvmm_ttrpc_vmservice/src/vmservice.proto
+++ b/openvmm/openvmm_ttrpc_vmservice/src/vmservice.proto
@@ -317,11 +317,11 @@ message NumaNode {
     // Memory for this node. Absent => CPU-only / device-only node.
     optional NodeMemoryConfig memory = 1;
     // VP assignment for this node:
-    //   - absent             => VPs assigned by topology (sockets distributed
-    //                           round-robin across CPU-bearing nodes)
-    //   - present, empty     => CPU-less node (no VPs; may coexist with
-    //                           topology-assigned nodes)
-    //   - present, non-empty => exactly these VP indices
+    //   - absent: VPs assigned by topology (sockets distributed round-robin
+    //     across CPU-bearing nodes)
+    //   - present, empty: CPU-less node (no VPs; may coexist with
+    //     topology-assigned nodes)
+    //   - present, non-empty: exactly these VP indices
     optional VpAssignment vps = 2;
 }
 
@@ -356,8 +356,9 @@ message NumaDistance {
     uint32 src = 1;
     // Destination node index.
     uint32 dst = 2;
-    // 10 = local, 20 = default cross-node, 255 = unreachable. Range 10..=255.
-    // TBD(C): u8 in Rust; validated in the handler.
+    // 10 = local, 20 = default cross-node, 255 = unreachable. Range 10..=255
+    // (a u8 in the config); out-of-range values are rejected when the topology
+    // is realized.
     uint32 distance = 3;
 }
 

--- a/openvmm/openvmm_ttrpc_vmservice/src/vmservice.proto
+++ b/openvmm/openvmm_ttrpc_vmservice/src/vmservice.proto
@@ -44,9 +44,18 @@ service VM {
     // This includes things such as block devices, network adapters, and pci devices.
     rpc ModifyResource(ModifyResourceRequest) returns (google.protobuf.Empty);
 
+    // AddPcieDevice hot-adds a PCIe device behind a named port (a root port or
+    // switch downstream port declared in the topology).
+    rpc AddPcieDevice(AddPcieDeviceRequest) returns (google.protobuf.Empty);
+
+    // RemovePcieDevice hot-removes the PCIe device behind the named port.
+    rpc RemovePcieDevice(RemovePcieDeviceRequest) returns (google.protobuf.Empty);
+
     // Quit will shutdown the process hosting the ttrpc server.
     rpc Quit(google.protobuf.Empty) returns (google.protobuf.Empty);
 }
+
+// Note: VTL assignment is not modeled yet; all devices are assumed to be VTL0.
 
 //
 // VM lifecycle request/response
@@ -81,6 +90,10 @@ message ProcessorConfig {
     uint32 processor_count = 1;
     uint32 processor_weight = 2;
     uint32 processor_limit = 3;
+
+    // Max VPs per socket. Absent => single socket / hypervisor default.
+    optional uint32 vps_per_socket = 4;
+    optional bool enable_smt = 5;
 }
 
 message DevicesConfig {
@@ -95,13 +108,334 @@ message DevicesConfig {
     VirtioConsoleConfig virtio_console = 6;
 }
 
-message VirtioConsoleConfig {
-    // Path to a named pipe or Unix domain socket for the console backend.
+// An endpoint PCIe device function. Attached behind a port in the topology
+// (PcieAttachment), or hot-added at runtime (AddPcieDevice).
+message PcieDeviceKind {
+    oneof kind {
+        // A virtio device function.
+        VirtioDevice virtio = 1;
+        // An NVMe controller.
+        NvmeConfig   nvme   = 2;
+    }
+}
+
+// A virtio device function, independent of its transport. Today these are
+// carried over PCIe (via PcieDeviceKind.virtio); the same message can be
+// reused for a virtio-mmio transport in the future.
+message VirtioDevice {
+    oneof kind {
+        // virtio-blk block device.
+        VirtioBlk     blk        = 1;
+        // virtio-net network device.
+        VirtioNet     net        = 2;
+        // virtio-rng entropy device.
+        VirtioRng     rng        = 3;
+        // virtio-vsock socket device.
+        VirtioVsock   vsock      = 4;
+        // virtio-console serial device.
+        VirtioConsole console    = 5;
+        // A virtio device whose datapath is backed by an external vhost-user
+        // process (e.g. vhost-user-blk / vhost-user-fs).
+        VhostUser     vhost_user = 6;
+    }
+}
+
+// virtio-console serial device configuration.
+message VirtioConsole {
+    // The serial backend the console is connected to.
+    SerialBackend backend = 1;
+}
+
+// A serial backend: where a serial/console stream is connected. Modeled as a
+// oneof so more backends (stderr, file, tcp listener, terminal, ...) can be
+// added later. TBD(F): the CLI also accepts console|stderr|file|listen|tcp|term.
+message SerialBackend {
+    oneof kind {
+        // Relay the stream over a named pipe / Unix domain socket.
+        SerialRelay relay = 1;
+    }
+}
+
+// A named-pipe / Unix-domain-socket serial relay.
+message SerialRelay {
+    // Path to a named pipe or Unix domain socket.
     string socket_path = 1;
-    // When true, connect to an existing pipe/socket at socket_path as a client
-    // instead of creating a new server listener. Used when the host has already
-    // created the socket/pipe.
+    // When true, connect to an existing pipe/socket as a client instead of
+    // creating a new server listener (e.g. the host already created it).
     bool connect = 2;
+}
+
+// Disk backend shared by virtio-blk (and reusable for other disk types).
+// Covers the common, non-dev subset of DiskCliKind; richer kinds (sql, blob,
+// crypt, autocache, prwrap, ...) can be added as new oneof arms. TBD(A).
+message DiskBackend {
+    oneof kind {
+        // A file-backed disk.
+        FileDisk file = 1;
+    }
+}
+
+// A disk backed by a host file.
+message FileDisk {
+    // Path to the backing file.
+    string path = 1;
+    // Bypass the OS page cache (O_DIRECT).
+    bool   direct = 2;
+}
+
+// virtio-blk block device configuration.
+message VirtioBlk {
+    // Backing disk.
+    DiskBackend backend = 1;
+    // Expose the disk read-only to the guest.
+    bool read_only = 2;
+}
+
+// virtio-net network device configuration. An absent backend means "none"
+// (no host connectivity).
+message VirtioNet {
+    // Maximum number of queue pairs. Absent => backend/host default.
+    optional uint32 max_queues = 1;
+    // Host network backend.
+    NicBackend backend = 2;
+}
+
+// A host network backend, shared across NIC device types (virtio-net, MANA,
+// vmbus netvsp, ...).
+message NicBackend {
+    oneof kind {
+        // DirectIO backend bound to a host switch/port.
+        DioBackend      dio      = 1;
+        // Host TAP device backend.
+        TapBackend      tap      = 2;
+        // Built-in user-mode (consomme) network backend.
+        ConsommeBackend consomme = 3;
+        // Windows kernel-mode vmswitch backend.
+        VmnicBackend    vmnic    = 4;
+    }
+}
+
+// Windows kernel-mode vmswitch network backend.
+message VmnicBackend {
+    // Switch ID GUID, or "default".
+    string switch_id = 1;
+}
+
+// A virtio device backed by an external vhost-user backend process.
+message VhostUser {
+    // Unix socket path of the vhost-user backend.
+    string socket_path = 1;
+    // The vhost-user device type and its config.
+    VhostUserDevice device = 2;
+}
+
+// The concrete vhost-user device behind a VhostUser.
+message VhostUserDevice {
+    oneof kind {
+        // vhost-user-blk block device.
+        VhostUserBlk     blk   = 1;
+        // vhost-user-fs filesystem device.
+        VhostUserFs      fs    = 2;
+        // A generic vhost-user device identified by numeric virtio device ID.
+        VhostUserGeneric other = 3;
+    }
+}
+
+// vhost-user-blk device. Most config comes from the backend; only queue
+// overrides are specified here.
+message VhostUserBlk {
+    // Number of virtqueues. Absent => backend default.
+    optional uint32 num_queues = 1;
+    // Per-queue size. Absent => backend default.
+    optional uint32 queue_size = 2;
+}
+
+// vhost-user-fs filesystem device.
+message VhostUserFs {
+    // Mount tag the guest uses to mount the filesystem.
+    string tag = 1;
+    // Number of virtqueues. Absent => backend default.
+    optional uint32 num_queues = 2;
+    // Per-queue size. Absent => backend default.
+    optional uint32 queue_size = 3;
+}
+
+// A generic vhost-user device addressed by raw virtio device ID.
+message VhostUserGeneric {
+    // Numeric virtio device ID.
+    uint32 device_id = 1;
+    // Per-queue sizes, one entry per virtqueue.
+    repeated uint32 queue_sizes = 2;
+}
+
+// virtio-rng carries no config beyond the PCIe port it attaches to.
+message VirtioRng {
+}
+
+// virtio-vsock socket device configuration.
+message VirtioVsock {
+    // Unix socket base path (mirrors --virtio-vsock-path).
+    string socket_path = 1;
+}
+
+// NVMe controller. Attached behind a PCIe port in the topology, or hot-added
+// at runtime via AddPcieDevice.
+message NvmeConfig {
+    // Controller identifier.
+    string controller_id = 1;
+    // Namespaces exposed by the controller.
+    repeated NvmeNamespace namespaces = 2;
+}
+
+// A namespace within an NVMe controller.
+message NvmeNamespace {
+    // Namespace ID (1-based).
+    uint32 nsid = 1;
+    // Backing disk.
+    DiskBackend backend = 2;
+    // Expose the namespace read-only to the guest.
+    bool read_only = 3;
+}
+
+//
+// Virtual NUMA topology
+//
+// Virtual NUMA topology.
+message NumaConfig {
+    // NUMA nodes. A node's index in this list is its node ID.
+    repeated NumaNode     nodes     = 1;
+    // Inter-node distances for the ACPI SLIT. Missing pairs default to
+    // 10 (local) / 20 (cross-node).
+    repeated NumaDistance distances = 2;
+}
+
+// A single virtual NUMA node.
+message NumaNode {
+    // Memory for this node. Absent => CPU-only / device-only node.
+    optional NodeMemoryConfig memory = 1;
+    // VP assignment for this node:
+    //   - absent             => VPs assigned by topology (sockets round-robined
+    //                           across CPU-bearing nodes)
+    //   - present, empty     => CPU-less node (no VPs; may coexist with
+    //                           topology-assigned nodes)
+    //   - present, non-empty => exactly these VP indices
+    optional VpAssignment vps = 2;
+}
+
+// Explicit VP assignment for a NUMA node (see NumaNode.vps for how presence
+// and emptiness are interpreted).
+message VpAssignment {
+    // VP indices assigned to the node.
+    repeated uint32 vp_index = 1;
+}
+
+// Per-node memory allocation configuration.
+message NodeMemoryConfig {
+    // Memory size for this node, in MiB.
+    uint64 memory_mb = 1;
+    // Host physical NUMA node to bind to (Linux mbind). Absent => OS default.
+    optional uint32 host_numa_node = 2;
+    // Pre-populate (prefetch) the backing memory.
+    bool prefetch              = 3;
+    // Use private anonymous memory instead of shared file-backed memory.
+    bool private_memory        = 4;
+    // Mark the memory transparent-hugepage eligible (requires private_memory).
+    bool transparent_hugepages = 5;
+    // Allocate from explicit hugetlb pages.
+    bool hugepages             = 6;
+    // Hugetlb page size in bytes (requires hugepages). Absent => default.
+    optional uint64 hugepage_size_bytes = 7;
+}
+
+// An inter-node distance entry for the ACPI SLIT.
+message NumaDistance {
+    // Source node index.
+    uint32 src = 1;
+    // Destination node index.
+    uint32 dst = 2;
+    // 10 = local, 20 = default cross-node, 255 = unreachable. Range 10..=255.
+    // TBD(C): u8 in Rust; validated in the handler.
+    uint32 distance = 3;
+}
+
+//
+// PCIe topology
+//
+// The topology mirrors hardware: a root complex contains root ports, each port
+// has at most one thing attached behind it (a device or a switch), and a
+// switch in turn contains downstream ports that follow the same pattern. This
+// makes invalid states unrepresentable (no dangling port references, no two
+// devices on one port).
+message PcieTopologyConfig {
+    // The PCIe root complexes in the VM.
+    repeated PcieRootComplex root_complexes = 1;
+}
+
+// A PCIe root complex.
+message PcieRootComplex {
+    // Root complex name (used to reference it).
+    string name      = 1;
+    // PCI segment number (u16).
+    uint32 segment   = 2;
+    // Lowest valid bus number (u8).
+    uint32 start_bus = 3;
+    // Highest valid bus number (u8).
+    uint32 end_bus   = 4;
+    // Low (32-bit) MMIO window size, in bytes.
+    uint64 low_mmio  = 5;
+    // High (64-bit) MMIO window size, in bytes.
+    uint64 high_mmio = 6;
+    // Pin the low MMIO window base address. Absent => auto-assigned.
+    optional uint64 low_mmio_base  = 7;
+    // Pin the high MMIO window base address. Absent => auto-assigned.
+    optional uint64 high_mmio_base = 8;
+    // Keep assigned BARs pinned at their addresses.
+    bool   preserve_bars = 9;
+    // NUMA node this root complex is associated with. Absent => none.
+    optional uint32 node = 10;
+    // Root ports on this complex.
+    repeated PcieRootPort root_ports = 11;
+}
+
+// A PCIe root port. Hosts at most one device or switch (see `attached`).
+message PcieRootPort {
+    // Port name, used to target runtime hot-add (AddPcieDevice).
+    string name = 1;
+    // Allow runtime hot-plug into this port.
+    bool   hotplug = 2;
+    // What is attached behind this port. Absent => empty port (available for
+    // hotplug if `hotplug` is set).
+    PcieAttachment attached = 3;
+}
+
+// A PCIe switch: a set of downstream ports, each of which may have its own
+// device or a nested switch attached.
+message PcieSwitch {
+    // Switch name.
+    string name = 1;
+    // Downstream ports of this switch.
+    repeated PcieDownstreamPort downstream_ports = 2;
+}
+
+// A PCIe switch downstream port. Hosts at most one device or nested switch.
+message PcieDownstreamPort {
+    // Port name, used to target runtime hot-add (AddPcieDevice).
+    string name = 1;
+    // Allow runtime hot-plug into this port.
+    bool   hotplug = 2;
+    // What is attached behind this port. Absent => empty port (available for
+    // hotplug if `hotplug` is set).
+    PcieAttachment attached = 3;
+}
+
+// What sits behind a PCIe port: an endpoint device or a (nested) switch.
+message PcieAttachment {
+    oneof kind {
+        // An endpoint device.
+        PcieDeviceKind device = 1;
+        // A nested PCIe switch.
+        PcieSwitch     switch = 2;
+    }
 }
 
 message VMConfig {
@@ -114,9 +448,13 @@ message VMConfig {
         UEFI uefi = 6;
     }
     WindowsOptions windows_options = 7;
-    // Optional k:v extra data. Up to the virtstack for how to interpret this.
-    map<string, string> extra_data = 8;
     HVSocketConfig hvsocket_config = 9;
+
+    // Virtual NUMA topology. Mutually exclusive with a flat
+    // MemoryConfig.memory_mb (mirrors the CLI --memory vs --numa conflict).
+    NumaConfig numa_config = 10;
+    // PCIe root complexes / ports / switches.
+    PcieTopologyConfig pcie = 11;
 }
 
 // WindowsOptions contains virtual machine configurations that are only present on a Windows host.
@@ -283,6 +621,15 @@ message VirtioFSConfig {
     string root_path = 2;
 }
 
+message VirtioConsoleConfig {
+    // Path to a named pipe or Unix domain socket for the console backend.
+    string socket_path = 1;
+    // When true, connect to an existing pipe/socket at socket_path as a client
+    // instead of creating a new server listener. Used when the host has already
+    // created the socket/pipe.
+    bool connect = 2;
+}
+
 message ModifyMemoryRequest {
     uint64 memory_mb = 1;
 }
@@ -308,4 +655,22 @@ message ModifyResourceRequest {
         NICConfig nic_config = 7;
         WindowsPCIDevice windows_device = 8;
     }
+}
+
+//
+// PCIe device hot add/remove request/response
+//
+// Request to hot-add a PCIe device behind an existing port.
+message AddPcieDeviceRequest {
+    // Name of the PCIe port to plug the device into: a root port or switch
+    // downstream port declared in the topology.
+    string port_name = 1;
+    // The device to attach.
+    PcieDeviceKind device = 2;
+}
+
+// Request to hot-remove the PCIe device behind a port.
+message RemovePcieDeviceRequest {
+    // Name of the PCIe port whose device should be removed.
+    string port_name = 1;
 }

--- a/vmm_tests/vmm_tests/tests/tests/ttrpc.rs
+++ b/vmm_tests/vmm_tests/tests/tests/ttrpc.rs
@@ -37,9 +37,12 @@ fn test_ttrpc_interface(
     params: petri::PetriTestParams<'_>,
     [openvmm, kernel_path, initrd_path]: [ResolvedArtifact; 3],
 ) -> anyhow::Result<()> {
-    let mut socket_path = std::env::temp_dir();
-    socket_path.push(Guid::new_random().to_string());
-    let pidfile_path = std::env::temp_dir().join(format!("{}.pid", Guid::new_random()));
+    // All temporary files for this test live under a single temp directory
+    // that is cleaned up automatically when it is dropped at the end of the
+    // test.
+    let tempdir = tempfile::tempdir()?;
+    let socket_path = tempdir.path().join("ttrpc.sock");
+    let pidfile_path = tempdir.path().join("openvmm.pid");
 
     tracing::info!(socket_path = %socket_path.display(), "launching OpenVMM with ttrpc");
 
@@ -113,14 +116,19 @@ fn test_ttrpc_interface(
             &driver,
             mesh_rpc::client::UnixDialier::new(driver.clone(), ttrpc_path),
         );
+
+        // Backing files for the PCIe storage devices created on iteration 0
+        // (virtio-blk and an NVMe namespace). They are plain raw disks.
+        let nvme_disk_path = tempdir.path().join("nvme.img");
+        let blk_disk_path = tempdir.path().join("blk.img");
+        for path in [&nvme_disk_path, &blk_disk_path] {
+            std::fs::File::create(path)?.set_len(1024 * 1024)?;
+        }
+
         for i in 0..3 {
-            let mut com1_path = std::env::temp_dir();
-            com1_path.push(Guid::new_random().to_string());
-
-            let mut console_path = std::env::temp_dir();
-            console_path.push(Guid::new_random().to_string());
-
-            let virtiofs_root = std::env::temp_dir().join(Guid::new_random().to_string());
+            let com1_path = tempdir.path().join(format!("com1-{i}.sock"));
+            let console_path = tempdir.path().join(format!("console-{i}.sock"));
+            let virtiofs_root = tempdir.path().join(format!("virtiofs-{i}"));
             std::fs::create_dir_all(&virtiofs_root).unwrap();
 
             let consomme_nic_id = Guid::new_random().to_string();
@@ -141,20 +149,155 @@ fn test_ttrpc_interface(
                 None
             };
 
+            // On iteration 0, exercise the richer CreateVM surface: a NUMA
+            // topology (replacing flat memory), an explicit processor topology,
+            // and a PCIe topology with virtio + NVMe devices behind root ports
+            // and a switch, plus an empty hotplug port used below for
+            // AddPcieDevice/RemovePcieDevice. Other iterations use the simpler
+            // flat-memory configuration so the flat path stays covered too.
+            let (memory_config, numa_config, processor_config, pcie) = if i == 0 {
+                let switch = vmservice::PcieSwitch {
+                    name: "sw0".to_string(),
+                    downstream_ports: vec![
+                        vmservice::PciePort {
+                            name: "sw0-dp0".to_string(),
+                            hotplug: false,
+                            attached: Some(attachment_device(virtio_device(
+                                vmservice::virtio_device::Kind::Blk(vmservice::VirtioBlk {
+                                    backend: Some(file_disk(&blk_disk_path)),
+                                    read_only: false,
+                                }),
+                            ))),
+                            devfn: None,
+                        },
+                        vmservice::PciePort {
+                            name: "sw0-dp1".to_string(),
+                            hotplug: false,
+                            attached: None,
+                            devfn: None,
+                        },
+                    ],
+                };
+                let root_complex = vmservice::PcieRootComplex {
+                    name: "rc0".to_string(),
+                    segment: 0,
+                    start_bus: 0,
+                    end_bus: 255,
+                    low_mmio: 64 * 1024 * 1024,
+                    high_mmio: 1024 * 1024 * 1024,
+                    root_ports: vec![
+                        // virtio-rng behind a root port.
+                        pcie_root_port(
+                            "rp0",
+                            false,
+                            Some(attachment_device(virtio_device(
+                                vmservice::virtio_device::Kind::Rng(vmservice::VirtioRng {}),
+                            ))),
+                        ),
+                        // NVMe controller with a file-backed namespace.
+                        pcie_root_port(
+                            "rp1",
+                            false,
+                            Some(attachment_device(vmservice::PcieDeviceKind {
+                                kind: Some(vmservice::pcie_device_kind::Kind::Nvme(
+                                    vmservice::NvmeConfig {
+                                        controller_id: "nvme0".to_string(),
+                                        namespaces: vec![vmservice::NvmeNamespace {
+                                            nsid: 1,
+                                            backend: Some(file_disk(&nvme_disk_path)),
+                                            read_only: false,
+                                        }],
+                                    },
+                                )),
+                            })),
+                        ),
+                        // virtio-net (consomme) behind a root port.
+                        pcie_root_port(
+                            "rp2",
+                            false,
+                            Some(attachment_device(virtio_device(
+                                vmservice::virtio_device::Kind::Net(vmservice::VirtioNet {
+                                    max_queues: None,
+                                    mac_address: "00-15-5D-12-12-13".to_string(),
+                                    backend: Some(vmservice::NicBackend {
+                                        kind: Some(vmservice::nic_backend::Kind::Consomme(
+                                            vmservice::ConsommeBackend {
+                                                cidr: String::new(),
+                                                ports: vec![],
+                                            },
+                                        )),
+                                    }),
+                                }),
+                            ))),
+                        ),
+                        // A switch hosting a virtio-blk device on its first
+                        // downstream port.
+                        pcie_root_port("rp3", false, Some(attachment_switch(switch))),
+                        // Empty hotplug-capable port for AddPcieDevice.
+                        pcie_root_port("rphp", true, None),
+                    ],
+                    ..Default::default()
+                };
+                (
+                    None,
+                    Some(vmservice::NumaConfig {
+                        nodes: vec![
+                            vmservice::NumaNode {
+                                memory: Some(vmservice::NodeMemoryConfig {
+                                    memory_mb: 128,
+                                    ..Default::default()
+                                }),
+                                vps: None,
+                            },
+                            vmservice::NumaNode {
+                                memory: Some(vmservice::NodeMemoryConfig {
+                                    memory_mb: 128,
+                                    ..Default::default()
+                                }),
+                                vps: None,
+                            },
+                        ],
+                        distances: vec![vmservice::NumaDistance {
+                            src: 0,
+                            dst: 1,
+                            distance: 20,
+                        }],
+                    }),
+                    Some(vmservice::ProcessorConfig {
+                        processor_count: 2,
+                        vps_per_socket: Some(1),
+                        enable_smt: Some(false),
+                        ..Default::default()
+                    }),
+                    Some(vmservice::PcieTopologyConfig {
+                        root_complexes: vec![root_complex],
+                    }),
+                )
+            } else {
+                (
+                    Some(vmservice::MemoryConfig {
+                        memory_mb: 256,
+                        ..Default::default()
+                    }),
+                    None,
+                    Some(vmservice::ProcessorConfig {
+                        processor_count: 2,
+                        ..Default::default()
+                    }),
+                    None,
+                )
+            };
+
             client
                 .call()
                 .start(
                     vmservice::Vm::CreateVm,
                     vmservice::CreateVmRequest {
                         config: Some(vmservice::VmConfig {
-                            memory_config: Some(vmservice::MemoryConfig {
-                                memory_mb: 256,
-                                ..Default::default()
-                            }),
-                            processor_config: Some(vmservice::ProcessorConfig {
-                                processor_count: 2,
-                                ..Default::default()
-                            }),
+                            memory_config,
+                            numa_config,
+                            processor_config,
+                            pcie,
                             boot_config: Some(vmservice::vm_config::BootConfig::DirectBoot(
                                 vmservice::DirectBoot {
                                     kernel_path: kernel_path.get().to_string_lossy().to_string(),
@@ -246,6 +389,36 @@ fn test_ttrpc_interface(
                 );
             }
 
+            // On iteration 0, hot-add a virtio-rng device to the empty
+            // hotplug-capable port and then hot-remove it, exercising the
+            // AddPcieDevice/RemovePcieDevice RPCs.
+            if i == 0 {
+                client
+                    .call()
+                    .start(
+                        vmservice::Vm::AddPcieDevice,
+                        vmservice::AddPcieDeviceRequest {
+                            port_name: "rphp".to_string(),
+                            device: Some(virtio_device(vmservice::virtio_device::Kind::Rng(
+                                vmservice::VirtioRng {},
+                            ))),
+                        },
+                    )
+                    .await
+                    .unwrap();
+
+                client
+                    .call()
+                    .start(
+                        vmservice::Vm::RemovePcieDevice,
+                        vmservice::RemovePcieDeviceRequest {
+                            port_name: "rphp".to_string(),
+                        },
+                    )
+                    .await
+                    .unwrap();
+            }
+
             // Get the serial connection - either by accepting on our listener
             // (connect: true) or connecting to the VM's socket (connect: false).
             let com1 = if let Some(listener) = com1_listener {
@@ -331,15 +504,9 @@ fn test_ttrpc_interface(
                 }
                 _ => unreachable!(),
             }
-
-            // Clean up temp files from this iteration.
-            let _ = std::fs::remove_file(&com1_path);
-            let _ = std::fs::remove_file(&console_path);
-            let _ = std::fs::remove_dir_all(&virtiofs_root);
         }
 
         let exit_status = child.wait().await?;
-        let _ = std::fs::remove_file(&socket_path);
 
         // Surface the OpenVMM exit status so that abnormal exits (e.g. an abort
         // from a panic — the workspace uses `panic = 'abort'`) are visible in
@@ -359,4 +526,52 @@ fn test_ttrpc_interface(
 
         Ok(())
     })
+}
+
+/// Wraps a `PcieDeviceKind` as a device attachment behind a PCIe port.
+fn attachment_device(device: vmservice::PcieDeviceKind) -> vmservice::PcieAttachment {
+    vmservice::PcieAttachment {
+        kind: Some(vmservice::pcie_attachment::Kind::Device(device)),
+    }
+}
+
+/// Wraps a `PcieSwitch` as a switch attachment behind a PCIe port.
+fn attachment_switch(switch: vmservice::PcieSwitch) -> vmservice::PcieAttachment {
+    vmservice::PcieAttachment {
+        kind: Some(vmservice::pcie_attachment::Kind::Switch(switch)),
+    }
+}
+
+/// Builds a PCIe root port with the given name, hotplug flag, and optional
+/// attached device/switch.
+fn pcie_root_port(
+    name: &str,
+    hotplug: bool,
+    attached: Option<vmservice::PcieAttachment>,
+) -> vmservice::PciePort {
+    vmservice::PciePort {
+        name: name.to_string(),
+        hotplug,
+        attached,
+        devfn: None,
+    }
+}
+
+/// Wraps a virtio device function kind as a `PcieDeviceKind`.
+fn virtio_device(kind: vmservice::virtio_device::Kind) -> vmservice::PcieDeviceKind {
+    vmservice::PcieDeviceKind {
+        kind: Some(vmservice::pcie_device_kind::Kind::Virtio(
+            vmservice::VirtioDevice { kind: Some(kind) },
+        )),
+    }
+}
+
+/// Builds a file-backed disk backend for the given path.
+fn file_disk(path: &std::path::Path) -> vmservice::DiskBackend {
+    vmservice::DiskBackend {
+        kind: Some(vmservice::disk_backend::Kind::File(vmservice::FileDisk {
+            path: path.to_string_lossy().into(),
+            direct: false,
+        })),
+    }
 }

--- a/vmm_tests/vmm_tests/tests/tests/ttrpc.rs
+++ b/vmm_tests/vmm_tests/tests/tests/ttrpc.rs
@@ -129,7 +129,7 @@ fn test_ttrpc_interface(
             let com1_path = tempdir.path().join(format!("com1-{i}.sock"));
             let console_path = tempdir.path().join(format!("console-{i}.sock"));
             let virtiofs_root = tempdir.path().join(format!("virtiofs-{i}"));
-            std::fs::create_dir_all(&virtiofs_root).unwrap();
+            std::fs::create_dir_all(&virtiofs_root)?;
 
             let consomme_nic_id = Guid::new_random().to_string();
 
@@ -265,8 +265,6 @@ fn test_ttrpc_interface(
                     }),
                     Some(vmservice::ProcessorConfig {
                         processor_count: 2,
-                        vps_per_socket: Some(1),
-                        enable_smt: Some(false),
                         ..Default::default()
                     }),
                     Some(vmservice::PcieTopologyConfig {


### PR DESCRIPTION
The OpenVMM ttrpc `VM` service could only create a VM with a flat memory blob and a few SCSI/NIC resources — enough to test the RPC plumbing, but far short of what the CLI expresses, so anything driving OpenVMM over ttrpc fell back to command-line flags for real workloads. This grows the `vmservice` protocol and its `openvmm_entry` implementation so a controller can describe a realistic VM entirely through the API.

What's added:

- **PCIe topology that mirrors hardware.** A root complex contains named root ports; each port has at most one thing behind it — an endpoint device or a switch — and switches expose their own downstream ports recursively. This makes invalid states unrepresentable (no dangling ports, no two devices per port).
- **Hot-plug RPCs.** `AddPcieDevice` / `RemovePcieDevice` add and remove an endpoint behind a named, hotplug-enabled port at runtime.
- **Endpoint device kinds** via a `PcieDeviceKind` oneof: virtio functions, NVMe controllers, and VFIO-assigned host devices. The virtio side is a transport-independent `VirtioDevice` (blk, net, rng, vsock, console, generic vhost-user) so it can later ride a non-PCIe transport.
- **Shared backend oneofs** for disks, NICs, and serial — exposing the common cases today (file disks; consomme/tap/dio networking; socket relays) but shaped to grow new arms without breaking the wire format. `TBD` comments mark where the CLI is still richer.
- **Virtual NUMA** (`NumaConfig`), mutually exclusive with the flat `memory_config` (mirrors the CLI `--memory` vs `--numa`): per-node memory with host binding and hugepage options, explicit-or-topology VP assignment, and SLIT distances. Total guest memory is summed from the nodes, so the rest of the controller is unaffected.