### PR TITLE
ci: use gen2 windows images and faster skus

### DIFF
--- a/.github/workflows/openvmm-ci.yaml
+++ b/.github/workflows/openvmm-ci.yaml
@@ -2580,7 +2580,7 @@ jobs:
     name: clippy [aarch64-windows], unit tests [aarch64-windows]
     runs-on:
     - self-hosted
-    - 1ES.Pool=openvmm-gh-arm-westus2
+    - 1ES.Pool=openvmm-gh-arm-westus3
     - 1ES.ImageOverride=win-arm64-v2
     - JobId=job16-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
@@ -2874,7 +2874,7 @@ jobs:
     name: clippy [aarch64-linux], unit tests [aarch64-linux]
     runs-on:
     - self-hosted
-    - 1ES.Pool=openvmm-gh-arm-westus2
+    - 1ES.Pool=openvmm-gh-arm-westus3
     - 1ES.ImageOverride=ubuntu2404-arm64
     - JobId=job17-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
@@ -3233,7 +3233,7 @@ jobs:
     name: clippy [aarch64-linux-musl, misc nostd], unit tests [aarch64-linux-musl]
     runs-on:
     - self-hosted
-    - 1ES.Pool=openvmm-gh-arm-westus2
+    - 1ES.Pool=openvmm-gh-arm-westus3
     - 1ES.ImageOverride=ubuntu2404-arm64
     - JobId=job18-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:

--- a/.github/workflows/openvmm-ci.yaml
+++ b/.github/workflows/openvmm-ci.yaml
@@ -2874,7 +2874,7 @@ jobs:
     name: clippy [aarch64-linux], unit tests [aarch64-linux]
     runs-on:
     - self-hosted
-    - 1ES.Pool=openvmm-gh-arm-westus3
+    - 1ES.Pool=openvmm-gh-arm-westus2
     - 1ES.ImageOverride=ubuntu2404-arm64
     - JobId=job17-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
@@ -3233,7 +3233,7 @@ jobs:
     name: clippy [aarch64-linux-musl, misc nostd], unit tests [aarch64-linux-musl]
     runs-on:
     - self-hosted
-    - 1ES.Pool=openvmm-gh-arm-westus3
+    - 1ES.Pool=openvmm-gh-arm-westus2
     - 1ES.ImageOverride=ubuntu2404-arm64
     - JobId=job18-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:

--- a/.github/workflows/openvmm-ci.yaml
+++ b/.github/workflows/openvmm-ci.yaml
@@ -1510,7 +1510,7 @@ jobs:
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=win-amd64
+    - 1ES.ImageOverride=win-amd64-test
     - JobId=job13-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
@@ -2581,7 +2581,7 @@ jobs:
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-arm-westus2
-    - 1ES.ImageOverride=win-arm64
+    - 1ES.ImageOverride=win-arm64-test
     - JobId=job16-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
@@ -3628,7 +3628,7 @@ jobs:
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-intel-westus3
-    - 1ES.ImageOverride=win-amd64
+    - 1ES.ImageOverride=win-amd64-test
     - JobId=job19-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
@@ -3911,7 +3911,7 @@ jobs:
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=win-amd64
+    - 1ES.ImageOverride=win-amd64-test
     - JobId=job2-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
@@ -4097,7 +4097,7 @@ jobs:
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-intel-westus3
-    - 1ES.ImageOverride=win-amd64
+    - 1ES.ImageOverride=win-amd64-test
     - JobId=job20-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
@@ -4659,7 +4659,7 @@ jobs:
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=win-amd64
+    - 1ES.ImageOverride=win-amd64-test
     - JobId=job22-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
@@ -6771,7 +6771,7 @@ jobs:
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=win-amd64
+    - 1ES.ImageOverride=win-amd64-test
     - JobId=job4-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
@@ -6990,7 +6990,7 @@ jobs:
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=win-amd64
+    - 1ES.ImageOverride=win-amd64-test
     - JobId=job5-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
@@ -7312,7 +7312,7 @@ jobs:
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=win-amd64
+    - 1ES.ImageOverride=win-amd64-test
     - JobId=job6-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
@@ -7535,7 +7535,7 @@ jobs:
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=win-amd64
+    - 1ES.ImageOverride=win-amd64-test
     - JobId=job7-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read

--- a/.github/workflows/openvmm-ci.yaml
+++ b/.github/workflows/openvmm-ci.yaml
@@ -356,7 +356,7 @@ jobs:
     name: build openhcl [aarch64-linux]
     runs-on:
     - self-hosted
-    - 1ES.Pool=openvmm-gh-amd-westus3
+    - 1ES.Pool=openvmm-gh-amd-westus3-v7
     - 1ES.ImageOverride=ubuntu2404-amd64
     - JobId=job10-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
@@ -675,7 +675,7 @@ jobs:
     name: build openhcl [x64-linux]
     runs-on:
     - self-hosted
-    - 1ES.Pool=openvmm-gh-amd-westus3
+    - 1ES.Pool=openvmm-gh-amd-westus3-v7
     - 1ES.ImageOverride=ubuntu2404-amd64
     - JobId=job11-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
@@ -1149,7 +1149,7 @@ jobs:
     name: build openhcl (mi-secure) [x64-linux]
     runs-on:
     - self-hosted
-    - 1ES.Pool=openvmm-gh-amd-westus3
+    - 1ES.Pool=openvmm-gh-amd-westus3-v7
     - 1ES.ImageOverride=ubuntu2404-amd64
     - JobId=job12-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
@@ -1509,7 +1509,7 @@ jobs:
     name: clippy [x64-windows], unit tests [x64-windows]
     runs-on:
     - self-hosted
-    - 1ES.Pool=openvmm-gh-amd-westus3
+    - 1ES.Pool=openvmm-gh-amd-westus3-v6
     - 1ES.ImageOverride=win-amd64-v2
     - JobId=job13-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
@@ -1803,7 +1803,7 @@ jobs:
     name: clippy [x64-linux, macos], unit tests [x64-linux]
     runs-on:
     - self-hosted
-    - 1ES.Pool=openvmm-gh-amd-westus3
+    - 1ES.Pool=openvmm-gh-amd-westus3-v7
     - 1ES.ImageOverride=ubuntu2404-amd64
     - JobId=job14-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
@@ -2186,7 +2186,7 @@ jobs:
     name: clippy [x64-linux-musl, misc nostd], unit tests [x64-linux-musl]
     runs-on:
     - self-hosted
-    - 1ES.Pool=openvmm-gh-amd-westus3
+    - 1ES.Pool=openvmm-gh-amd-westus3-v7
     - 1ES.ImageOverride=ubuntu2404-amd64
     - JobId=job15-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
@@ -3627,7 +3627,7 @@ jobs:
     name: run vmm-tests [x64-windows-intel]
     runs-on:
     - self-hosted
-    - 1ES.Pool=openvmm-gh-intel-westus3
+    - 1ES.Pool=openvmm-gh-intel-westus3-v6
     - 1ES.ImageOverride=win-amd64-v2
     - JobId=job19-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
@@ -3910,7 +3910,7 @@ jobs:
     name: build artifacts (shared VMM tests) [windows]
     runs-on:
     - self-hosted
-    - 1ES.Pool=openvmm-gh-amd-westus3
+    - 1ES.Pool=openvmm-gh-intel-westus3-v6
     - 1ES.ImageOverride=win-amd64-v2
     - JobId=job2-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
@@ -4096,7 +4096,7 @@ jobs:
     name: run vmm-tests [x64-windows-intel-mi-secure]
     runs-on:
     - self-hosted
-    - 1ES.Pool=openvmm-gh-intel-westus3
+    - 1ES.Pool=openvmm-gh-intel-westus3-v6
     - 1ES.ImageOverride=win-amd64-v2
     - JobId=job20-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
@@ -4658,7 +4658,7 @@ jobs:
     name: run vmm-tests [x64-windows-amd]
     runs-on:
     - self-hosted
-    - 1ES.Pool=openvmm-gh-amd-westus3
+    - 1ES.Pool=openvmm-gh-amd-westus3-v6
     - 1ES.ImageOverride=win-amd64-v2
     - JobId=job22-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
@@ -5225,7 +5225,7 @@ jobs:
     name: run vmm-tests [x64-linux-amd-kvm]
     runs-on:
     - self-hosted
-    - 1ES.Pool=openvmm-gh-amd-westus3
+    - 1ES.Pool=openvmm-gh-amd-westus2-v7
     - 1ES.ImageOverride=ubuntu2404-amd64
     - JobId=job24-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
@@ -6389,7 +6389,7 @@ jobs:
     name: build artifacts (shared VMM tests) [linux]
     runs-on:
     - self-hosted
-    - 1ES.Pool=openvmm-gh-amd-westus3
+    - 1ES.Pool=openvmm-gh-amd-westus3-v7
     - 1ES.ImageOverride=ubuntu2404-amd64
     - JobId=job3-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
@@ -6770,7 +6770,7 @@ jobs:
     name: build artifacts (not for VMM tests) [aarch64-windows]
     runs-on:
     - self-hosted
-    - 1ES.Pool=openvmm-gh-amd-westus3
+    - 1ES.Pool=openvmm-gh-intel-westus3-v6
     - 1ES.ImageOverride=win-amd64-v2
     - JobId=job4-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
@@ -6989,7 +6989,7 @@ jobs:
     name: build artifacts (for VMM tests) [aarch64-windows]
     runs-on:
     - self-hosted
-    - 1ES.Pool=openvmm-gh-amd-westus3
+    - 1ES.Pool=openvmm-gh-intel-westus3-v6
     - 1ES.ImageOverride=win-amd64-v2
     - JobId=job5-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
@@ -7311,7 +7311,7 @@ jobs:
     name: build artifacts (not for VMM tests) [x64-windows]
     runs-on:
     - self-hosted
-    - 1ES.Pool=openvmm-gh-amd-westus3
+    - 1ES.Pool=openvmm-gh-intel-westus3-v6
     - 1ES.ImageOverride=win-amd64-v2
     - JobId=job6-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
@@ -7534,7 +7534,7 @@ jobs:
     name: build artifacts (for VMM tests) [x64-windows]
     runs-on:
     - self-hosted
-    - 1ES.Pool=openvmm-gh-amd-westus3
+    - 1ES.Pool=openvmm-gh-intel-westus3-v6
     - 1ES.ImageOverride=win-amd64-v2
     - JobId=job7-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
@@ -7864,7 +7864,7 @@ jobs:
     name: build artifacts (for VMM tests) [aarch64-linux]
     runs-on:
     - self-hosted
-    - 1ES.Pool=openvmm-gh-amd-westus3
+    - 1ES.Pool=openvmm-gh-amd-westus3-v7
     - 1ES.ImageOverride=ubuntu2404-amd64
     - JobId=job8-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
@@ -8237,7 +8237,7 @@ jobs:
     name: build artifacts (for VMM tests) [x64-linux]
     runs-on:
     - self-hosted
-    - 1ES.Pool=openvmm-gh-amd-westus3
+    - 1ES.Pool=openvmm-gh-amd-westus3-v7
     - 1ES.ImageOverride=ubuntu2404-amd64
     - JobId=job9-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:

--- a/.github/workflows/openvmm-ci.yaml
+++ b/.github/workflows/openvmm-ci.yaml
@@ -1509,7 +1509,7 @@ jobs:
     name: clippy [x64-windows], unit tests [x64-windows]
     runs-on:
     - self-hosted
-    - 1ES.Pool=openvmm-gh-amd-westus3-v6
+    - 1ES.Pool=openvmm-gh-intel-westus3-v6
     - 1ES.ImageOverride=win-amd64-v2
     - JobId=job13-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
@@ -1803,7 +1803,7 @@ jobs:
     name: clippy [x64-linux, macos], unit tests [x64-linux]
     runs-on:
     - self-hosted
-    - 1ES.Pool=openvmm-gh-amd-westus3-v7
+    - 1ES.Pool=openvmm-gh-intel-westus3-v6
     - 1ES.ImageOverride=ubuntu2404-amd64
     - JobId=job14-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
@@ -2186,7 +2186,7 @@ jobs:
     name: clippy [x64-linux-musl, misc nostd], unit tests [x64-linux-musl]
     runs-on:
     - self-hosted
-    - 1ES.Pool=openvmm-gh-amd-westus3-v7
+    - 1ES.Pool=openvmm-gh-intel-westus3-v6
     - 1ES.ImageOverride=ubuntu2404-amd64
     - JobId=job15-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
@@ -5225,7 +5225,7 @@ jobs:
     name: run vmm-tests [x64-linux-amd-kvm]
     runs-on:
     - self-hosted
-    - 1ES.Pool=openvmm-gh-amd-westus2-v7
+    - 1ES.Pool=openvmm-gh-amd-westus3-v7
     - 1ES.ImageOverride=ubuntu2404-amd64
     - JobId=job24-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
@@ -6389,7 +6389,7 @@ jobs:
     name: build artifacts (shared VMM tests) [linux]
     runs-on:
     - self-hosted
-    - 1ES.Pool=openvmm-gh-amd-westus3-v7
+    - 1ES.Pool=openvmm-gh-intel-westus3-v6
     - 1ES.ImageOverride=ubuntu2404-amd64
     - JobId=job3-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:

--- a/.github/workflows/openvmm-ci.yaml
+++ b/.github/workflows/openvmm-ci.yaml
@@ -1510,7 +1510,7 @@ jobs:
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=win-amd64-test
+    - 1ES.ImageOverride=win-amd64-v2
     - JobId=job13-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
@@ -2581,7 +2581,7 @@ jobs:
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-arm-westus2
-    - 1ES.ImageOverride=win-arm64-test
+    - 1ES.ImageOverride=win-arm64-v2
     - JobId=job16-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
@@ -3628,7 +3628,7 @@ jobs:
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-intel-westus3
-    - 1ES.ImageOverride=win-amd64-test
+    - 1ES.ImageOverride=win-amd64-v2
     - JobId=job19-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
@@ -3911,7 +3911,7 @@ jobs:
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=win-amd64-test
+    - 1ES.ImageOverride=win-amd64-v2
     - JobId=job2-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
@@ -4097,7 +4097,7 @@ jobs:
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-intel-westus3
-    - 1ES.ImageOverride=win-amd64-test
+    - 1ES.ImageOverride=win-amd64-v2
     - JobId=job20-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
@@ -4659,7 +4659,7 @@ jobs:
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=win-amd64-test
+    - 1ES.ImageOverride=win-amd64-v2
     - JobId=job22-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
@@ -6771,7 +6771,7 @@ jobs:
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=win-amd64-test
+    - 1ES.ImageOverride=win-amd64-v2
     - JobId=job4-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
@@ -6990,7 +6990,7 @@ jobs:
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=win-amd64-test
+    - 1ES.ImageOverride=win-amd64-v2
     - JobId=job5-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
@@ -7312,7 +7312,7 @@ jobs:
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=win-amd64-test
+    - 1ES.ImageOverride=win-amd64-v2
     - JobId=job6-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
@@ -7535,7 +7535,7 @@ jobs:
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=win-amd64-test
+    - 1ES.ImageOverride=win-amd64-v2
     - JobId=job7-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read

--- a/.github/workflows/openvmm-pr-release.yaml
+++ b/.github/workflows/openvmm-pr-release.yaml
@@ -1386,7 +1386,7 @@ jobs:
     name: clippy [x64-windows], unit tests [x64-windows]
     runs-on:
     - self-hosted
-    - 1ES.Pool=openvmm-gh-amd-westus3-v6
+    - 1ES.Pool=openvmm-gh-intel-westus3-v6
     - 1ES.ImageOverride=win-amd64-v2
     - JobId=job13-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
@@ -1682,7 +1682,7 @@ jobs:
     name: clippy [macos], unit tests [x64-linux]
     runs-on:
     - self-hosted
-    - 1ES.Pool=openvmm-gh-amd-westus3-v7
+    - 1ES.Pool=openvmm-gh-intel-westus3-v6
     - 1ES.ImageOverride=ubuntu2404-amd64
     - JobId=job14-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
@@ -1991,7 +1991,7 @@ jobs:
     name: clippy [x64-linux-musl, misc nostd], unit tests [x64-linux-musl]
     runs-on:
     - self-hosted
-    - 1ES.Pool=openvmm-gh-amd-westus3-v7
+    - 1ES.Pool=openvmm-gh-intel-westus3-v6
     - 1ES.ImageOverride=ubuntu2404-amd64
     - JobId=job15-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
@@ -5001,7 +5001,7 @@ jobs:
     name: run vmm-tests [x64-linux-amd-kvm]
     runs-on:
     - self-hosted
-    - 1ES.Pool=openvmm-gh-amd-westus2-v7
+    - 1ES.Pool=openvmm-gh-amd-westus3-v7
     - 1ES.ImageOverride=ubuntu2404-amd64
     - JobId=job24-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
@@ -5981,7 +5981,7 @@ jobs:
     name: build artifacts (shared VMM tests) [linux]
     runs-on:
     - self-hosted
-    - 1ES.Pool=openvmm-gh-amd-westus3-v7
+    - 1ES.Pool=openvmm-gh-intel-westus3-v6
     - 1ES.ImageOverride=ubuntu2404-amd64
     - JobId=job3-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:

--- a/.github/workflows/openvmm-pr-release.yaml
+++ b/.github/workflows/openvmm-pr-release.yaml
@@ -2639,7 +2639,7 @@ jobs:
     name: clippy [aarch64-linux], unit tests [aarch64-linux]
     runs-on:
     - self-hosted
-    - 1ES.Pool=openvmm-gh-arm-westus3
+    - 1ES.Pool=openvmm-gh-arm-westus2
     - 1ES.ImageOverride=ubuntu2404-arm64
     - JobId=job17-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
@@ -3000,7 +3000,7 @@ jobs:
     name: clippy [aarch64-linux-musl, misc nostd], unit tests [aarch64-linux-musl]
     runs-on:
     - self-hosted
-    - 1ES.Pool=openvmm-gh-arm-westus3
+    - 1ES.Pool=openvmm-gh-arm-westus2
     - 1ES.ImageOverride=ubuntu2404-arm64
     - JobId=job18-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:

--- a/.github/workflows/openvmm-pr-release.yaml
+++ b/.github/workflows/openvmm-pr-release.yaml
@@ -1387,7 +1387,7 @@ jobs:
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=win-amd64
+    - 1ES.ImageOverride=win-amd64-test
     - JobId=job13-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
@@ -2344,7 +2344,7 @@ jobs:
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-arm-westus2
-    - 1ES.ImageOverride=win-arm64
+    - 1ES.ImageOverride=win-arm64-test
     - JobId=job16-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
@@ -3397,7 +3397,7 @@ jobs:
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-intel-westus3
-    - 1ES.ImageOverride=win-amd64
+    - 1ES.ImageOverride=win-amd64-test
     - JobId=job19-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
@@ -3681,7 +3681,7 @@ jobs:
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=win-amd64
+    - 1ES.ImageOverride=win-amd64-test
     - JobId=job2-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
@@ -3869,7 +3869,7 @@ jobs:
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-intel-westus3
-    - 1ES.ImageOverride=win-amd64
+    - 1ES.ImageOverride=win-amd64-test
     - JobId=job20-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
@@ -4433,7 +4433,7 @@ jobs:
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=win-amd64
+    - 1ES.ImageOverride=win-amd64-test
     - JobId=job22-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
@@ -6320,7 +6320,7 @@ jobs:
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=win-amd64
+    - 1ES.ImageOverride=win-amd64-test
     - JobId=job4-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
@@ -6541,7 +6541,7 @@ jobs:
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=win-amd64
+    - 1ES.ImageOverride=win-amd64-test
     - JobId=job5-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
@@ -6865,7 +6865,7 @@ jobs:
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=win-amd64
+    - 1ES.ImageOverride=win-amd64-test
     - JobId=job6-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
@@ -7090,7 +7090,7 @@ jobs:
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=win-amd64
+    - 1ES.ImageOverride=win-amd64-test
     - JobId=job7-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read

--- a/.github/workflows/openvmm-pr-release.yaml
+++ b/.github/workflows/openvmm-pr-release.yaml
@@ -1387,7 +1387,7 @@ jobs:
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=win-amd64-test
+    - 1ES.ImageOverride=win-amd64-v2
     - JobId=job13-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
@@ -2344,7 +2344,7 @@ jobs:
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-arm-westus2
-    - 1ES.ImageOverride=win-arm64-test
+    - 1ES.ImageOverride=win-arm64-v2
     - JobId=job16-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
@@ -3397,7 +3397,7 @@ jobs:
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-intel-westus3
-    - 1ES.ImageOverride=win-amd64-test
+    - 1ES.ImageOverride=win-amd64-v2
     - JobId=job19-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
@@ -3681,7 +3681,7 @@ jobs:
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=win-amd64-test
+    - 1ES.ImageOverride=win-amd64-v2
     - JobId=job2-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
@@ -3869,7 +3869,7 @@ jobs:
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-intel-westus3
-    - 1ES.ImageOverride=win-amd64-test
+    - 1ES.ImageOverride=win-amd64-v2
     - JobId=job20-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
@@ -4433,7 +4433,7 @@ jobs:
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=win-amd64-test
+    - 1ES.ImageOverride=win-amd64-v2
     - JobId=job22-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
@@ -6320,7 +6320,7 @@ jobs:
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=win-amd64-test
+    - 1ES.ImageOverride=win-amd64-v2
     - JobId=job4-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
@@ -6541,7 +6541,7 @@ jobs:
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=win-amd64-test
+    - 1ES.ImageOverride=win-amd64-v2
     - JobId=job5-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
@@ -6865,7 +6865,7 @@ jobs:
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=win-amd64-test
+    - 1ES.ImageOverride=win-amd64-v2
     - JobId=job6-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
@@ -7090,7 +7090,7 @@ jobs:
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=win-amd64-test
+    - 1ES.ImageOverride=win-amd64-v2
     - JobId=job7-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read

--- a/.github/workflows/openvmm-pr-release.yaml
+++ b/.github/workflows/openvmm-pr-release.yaml
@@ -2343,7 +2343,7 @@ jobs:
     name: clippy [aarch64-windows], unit tests [aarch64-windows]
     runs-on:
     - self-hosted
-    - 1ES.Pool=openvmm-gh-arm-westus2
+    - 1ES.Pool=openvmm-gh-arm-westus3
     - 1ES.ImageOverride=win-arm64-v2
     - JobId=job16-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
@@ -2639,7 +2639,7 @@ jobs:
     name: clippy [aarch64-linux], unit tests [aarch64-linux]
     runs-on:
     - self-hosted
-    - 1ES.Pool=openvmm-gh-arm-westus2
+    - 1ES.Pool=openvmm-gh-arm-westus3
     - 1ES.ImageOverride=ubuntu2404-arm64
     - JobId=job17-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
@@ -3000,7 +3000,7 @@ jobs:
     name: clippy [aarch64-linux-musl, misc nostd], unit tests [aarch64-linux-musl]
     runs-on:
     - self-hosted
-    - 1ES.Pool=openvmm-gh-arm-westus2
+    - 1ES.Pool=openvmm-gh-arm-westus3
     - 1ES.ImageOverride=ubuntu2404-arm64
     - JobId=job18-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:

--- a/.github/workflows/openvmm-pr-release.yaml
+++ b/.github/workflows/openvmm-pr-release.yaml
@@ -29,7 +29,7 @@ jobs:
     name: quick check [fmt, clippy x64-linux]
     runs-on:
     - self-hosted
-    - 1ES.Pool=openvmm-gh-amd-westus3
+    - 1ES.Pool=openvmm-gh-amd-westus3-v7
     - 1ES.ImageOverride=ubuntu2404-amd64
     - JobId=job0-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
@@ -407,7 +407,7 @@ jobs:
     name: build openhcl [aarch64-linux]
     runs-on:
     - self-hosted
-    - 1ES.Pool=openvmm-gh-amd-westus3
+    - 1ES.Pool=openvmm-gh-amd-westus3-v7
     - 1ES.ImageOverride=ubuntu2404-amd64
     - JobId=job10-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
@@ -660,7 +660,7 @@ jobs:
     name: build openhcl [x64-linux]
     runs-on:
     - self-hosted
-    - 1ES.Pool=openvmm-gh-amd-westus3
+    - 1ES.Pool=openvmm-gh-amd-westus3-v7
     - 1ES.ImageOverride=ubuntu2404-amd64
     - JobId=job11-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
@@ -1068,7 +1068,7 @@ jobs:
     name: build openhcl (mi-secure) [x64-linux]
     runs-on:
     - self-hosted
-    - 1ES.Pool=openvmm-gh-amd-westus3
+    - 1ES.Pool=openvmm-gh-amd-westus3-v7
     - 1ES.ImageOverride=ubuntu2404-amd64
     - JobId=job12-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
@@ -1386,7 +1386,7 @@ jobs:
     name: clippy [x64-windows], unit tests [x64-windows]
     runs-on:
     - self-hosted
-    - 1ES.Pool=openvmm-gh-amd-westus3
+    - 1ES.Pool=openvmm-gh-amd-westus3-v6
     - 1ES.ImageOverride=win-amd64-v2
     - JobId=job13-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
@@ -1682,7 +1682,7 @@ jobs:
     name: clippy [macos], unit tests [x64-linux]
     runs-on:
     - self-hosted
-    - 1ES.Pool=openvmm-gh-amd-westus3
+    - 1ES.Pool=openvmm-gh-amd-westus3-v7
     - 1ES.ImageOverride=ubuntu2404-amd64
     - JobId=job14-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
@@ -1991,7 +1991,7 @@ jobs:
     name: clippy [x64-linux-musl, misc nostd], unit tests [x64-linux-musl]
     runs-on:
     - self-hosted
-    - 1ES.Pool=openvmm-gh-amd-westus3
+    - 1ES.Pool=openvmm-gh-amd-westus3-v7
     - 1ES.ImageOverride=ubuntu2404-amd64
     - JobId=job15-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
@@ -3396,7 +3396,7 @@ jobs:
     name: run vmm-tests [x64-windows-intel]
     runs-on:
     - self-hosted
-    - 1ES.Pool=openvmm-gh-intel-westus3
+    - 1ES.Pool=openvmm-gh-intel-westus3-v6
     - 1ES.ImageOverride=win-amd64-v2
     - JobId=job19-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
@@ -3680,7 +3680,7 @@ jobs:
     name: build artifacts (shared VMM tests) [windows]
     runs-on:
     - self-hosted
-    - 1ES.Pool=openvmm-gh-amd-westus3
+    - 1ES.Pool=openvmm-gh-intel-westus3-v6
     - 1ES.ImageOverride=win-amd64-v2
     - JobId=job2-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
@@ -3868,7 +3868,7 @@ jobs:
     name: run vmm-tests [x64-windows-intel-mi-secure]
     runs-on:
     - self-hosted
-    - 1ES.Pool=openvmm-gh-intel-westus3
+    - 1ES.Pool=openvmm-gh-intel-westus3-v6
     - 1ES.ImageOverride=win-amd64-v2
     - JobId=job20-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
@@ -4432,7 +4432,7 @@ jobs:
     name: run vmm-tests [x64-windows-amd]
     runs-on:
     - self-hosted
-    - 1ES.Pool=openvmm-gh-amd-westus3
+    - 1ES.Pool=openvmm-gh-amd-westus3-v6
     - 1ES.ImageOverride=win-amd64-v2
     - JobId=job22-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
@@ -5001,7 +5001,7 @@ jobs:
     name: run vmm-tests [x64-linux-amd-kvm]
     runs-on:
     - self-hosted
-    - 1ES.Pool=openvmm-gh-amd-westus3
+    - 1ES.Pool=openvmm-gh-amd-westus2-v7
     - 1ES.ImageOverride=ubuntu2404-amd64
     - JobId=job24-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
@@ -5981,7 +5981,7 @@ jobs:
     name: build artifacts (shared VMM tests) [linux]
     runs-on:
     - self-hosted
-    - 1ES.Pool=openvmm-gh-amd-westus3
+    - 1ES.Pool=openvmm-gh-amd-westus3-v7
     - 1ES.ImageOverride=ubuntu2404-amd64
     - JobId=job3-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
@@ -6319,7 +6319,7 @@ jobs:
     name: build artifacts (not for VMM tests) [aarch64-windows]
     runs-on:
     - self-hosted
-    - 1ES.Pool=openvmm-gh-amd-westus3
+    - 1ES.Pool=openvmm-gh-intel-westus3-v6
     - 1ES.ImageOverride=win-amd64-v2
     - JobId=job4-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
@@ -6540,7 +6540,7 @@ jobs:
     name: build artifacts (for VMM tests) [aarch64-windows]
     runs-on:
     - self-hosted
-    - 1ES.Pool=openvmm-gh-amd-westus3
+    - 1ES.Pool=openvmm-gh-intel-westus3-v6
     - 1ES.ImageOverride=win-amd64-v2
     - JobId=job5-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
@@ -6864,7 +6864,7 @@ jobs:
     name: build artifacts (not for VMM tests) [x64-windows]
     runs-on:
     - self-hosted
-    - 1ES.Pool=openvmm-gh-amd-westus3
+    - 1ES.Pool=openvmm-gh-intel-westus3-v6
     - 1ES.ImageOverride=win-amd64-v2
     - JobId=job6-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
@@ -7089,7 +7089,7 @@ jobs:
     name: build artifacts (for VMM tests) [x64-windows]
     runs-on:
     - self-hosted
-    - 1ES.Pool=openvmm-gh-amd-westus3
+    - 1ES.Pool=openvmm-gh-intel-westus3-v6
     - 1ES.ImageOverride=win-amd64-v2
     - JobId=job7-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
@@ -7421,7 +7421,7 @@ jobs:
     name: build artifacts (for VMM tests) [aarch64-linux]
     runs-on:
     - self-hosted
-    - 1ES.Pool=openvmm-gh-amd-westus3
+    - 1ES.Pool=openvmm-gh-amd-westus3-v7
     - 1ES.ImageOverride=ubuntu2404-amd64
     - JobId=job8-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
@@ -7752,7 +7752,7 @@ jobs:
     name: build artifacts (for VMM tests) [x64-linux]
     runs-on:
     - self-hosted
-    - 1ES.Pool=openvmm-gh-amd-westus3
+    - 1ES.Pool=openvmm-gh-amd-westus3-v7
     - 1ES.ImageOverride=ubuntu2404-amd64
     - JobId=job9-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:

--- a/.github/workflows/openvmm-pr.yaml
+++ b/.github/workflows/openvmm-pr.yaml
@@ -1792,7 +1792,7 @@ jobs:
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=win-amd64-test
+    - 1ES.ImageOverride=win-amd64-v2
     - JobId=job15-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
@@ -2749,7 +2749,7 @@ jobs:
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-arm-westus2
-    - 1ES.ImageOverride=win-arm64-test
+    - 1ES.ImageOverride=win-arm64-v2
     - JobId=job18-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
@@ -3406,7 +3406,7 @@ jobs:
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=win-amd64-test
+    - 1ES.ImageOverride=win-amd64-v2
     - JobId=job2-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
@@ -3990,7 +3990,7 @@ jobs:
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-intel-westus3
-    - 1ES.ImageOverride=win-amd64-test
+    - 1ES.ImageOverride=win-amd64-v2
     - JobId=job21-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
@@ -4274,7 +4274,7 @@ jobs:
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-intel-westus3
-    - 1ES.ImageOverride=win-amd64-test
+    - 1ES.ImageOverride=win-amd64-v2
     - JobId=job22-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
@@ -4838,7 +4838,7 @@ jobs:
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=win-amd64-test
+    - 1ES.ImageOverride=win-amd64-v2
     - JobId=job24-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
@@ -6792,7 +6792,7 @@ jobs:
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=win-amd64-test
+    - 1ES.ImageOverride=win-amd64-v2
     - JobId=job4-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
@@ -7013,7 +7013,7 @@ jobs:
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=win-amd64-test
+    - 1ES.ImageOverride=win-amd64-v2
     - JobId=job5-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
@@ -7337,7 +7337,7 @@ jobs:
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=win-amd64-test
+    - 1ES.ImageOverride=win-amd64-v2
     - JobId=job6-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
@@ -7562,7 +7562,7 @@ jobs:
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=win-amd64-test
+    - 1ES.ImageOverride=win-amd64-v2
     - JobId=job7-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read

--- a/.github/workflows/openvmm-pr.yaml
+++ b/.github/workflows/openvmm-pr.yaml
@@ -1792,7 +1792,7 @@ jobs:
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=win-amd64
+    - 1ES.ImageOverride=win-amd64-test
     - JobId=job15-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
@@ -2749,7 +2749,7 @@ jobs:
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-arm-westus2
-    - 1ES.ImageOverride=win-arm64
+    - 1ES.ImageOverride=win-arm64-test
     - JobId=job18-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
@@ -3406,7 +3406,7 @@ jobs:
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=win-amd64
+    - 1ES.ImageOverride=win-amd64-test
     - JobId=job2-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
@@ -3990,7 +3990,7 @@ jobs:
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-intel-westus3
-    - 1ES.ImageOverride=win-amd64
+    - 1ES.ImageOverride=win-amd64-test
     - JobId=job21-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
@@ -4274,7 +4274,7 @@ jobs:
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-intel-westus3
-    - 1ES.ImageOverride=win-amd64
+    - 1ES.ImageOverride=win-amd64-test
     - JobId=job22-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
@@ -4838,7 +4838,7 @@ jobs:
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=win-amd64
+    - 1ES.ImageOverride=win-amd64-test
     - JobId=job24-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
@@ -6792,7 +6792,7 @@ jobs:
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=win-amd64
+    - 1ES.ImageOverride=win-amd64-test
     - JobId=job4-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
@@ -7013,7 +7013,7 @@ jobs:
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=win-amd64
+    - 1ES.ImageOverride=win-amd64-test
     - JobId=job5-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
@@ -7337,7 +7337,7 @@ jobs:
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=win-amd64
+    - 1ES.ImageOverride=win-amd64-test
     - JobId=job6-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
@@ -7562,7 +7562,7 @@ jobs:
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=win-amd64
+    - 1ES.ImageOverride=win-amd64-test
     - JobId=job7-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read

--- a/.github/workflows/openvmm-pr.yaml
+++ b/.github/workflows/openvmm-pr.yaml
@@ -28,7 +28,7 @@ jobs:
     name: quick check [fmt, clippy x64-linux]
     runs-on:
     - self-hosted
-    - 1ES.Pool=openvmm-gh-amd-westus3
+    - 1ES.Pool=openvmm-gh-amd-westus3-v7
     - 1ES.ImageOverride=ubuntu2404-amd64
     - JobId=job0-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
@@ -406,7 +406,7 @@ jobs:
     name: build openhcl [aarch64-linux]
     runs-on:
     - self-hosted
-    - 1ES.Pool=openvmm-gh-amd-westus3
+    - 1ES.Pool=openvmm-gh-amd-westus3-v7
     - 1ES.ImageOverride=ubuntu2404-amd64
     - JobId=job10-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
@@ -862,7 +862,7 @@ jobs:
     name: build openhcl [x64-linux]
     runs-on:
     - self-hosted
-    - 1ES.Pool=openvmm-gh-amd-westus3
+    - 1ES.Pool=openvmm-gh-amd-westus3-v7
     - 1ES.ImageOverride=ubuntu2404-amd64
     - JobId=job12-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
@@ -1473,7 +1473,7 @@ jobs:
     name: build openhcl (mi-secure) [x64-linux]
     runs-on:
     - self-hosted
-    - 1ES.Pool=openvmm-gh-amd-westus3
+    - 1ES.Pool=openvmm-gh-amd-westus3-v7
     - 1ES.ImageOverride=ubuntu2404-amd64
     - JobId=job14-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
@@ -1791,7 +1791,7 @@ jobs:
     name: clippy [x64-windows], unit tests [x64-windows]
     runs-on:
     - self-hosted
-    - 1ES.Pool=openvmm-gh-amd-westus3
+    - 1ES.Pool=openvmm-gh-amd-westus3-v6
     - 1ES.ImageOverride=win-amd64-v2
     - JobId=job15-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
@@ -2087,7 +2087,7 @@ jobs:
     name: clippy [macos], unit tests [x64-linux]
     runs-on:
     - self-hosted
-    - 1ES.Pool=openvmm-gh-amd-westus3
+    - 1ES.Pool=openvmm-gh-amd-westus3-v7
     - 1ES.ImageOverride=ubuntu2404-amd64
     - JobId=job16-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
@@ -2396,7 +2396,7 @@ jobs:
     name: clippy [x64-linux-musl, misc nostd], unit tests [x64-linux-musl]
     runs-on:
     - self-hosted
-    - 1ES.Pool=openvmm-gh-amd-westus3
+    - 1ES.Pool=openvmm-gh-amd-westus3-v7
     - 1ES.ImageOverride=ubuntu2404-amd64
     - JobId=job17-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
@@ -3405,7 +3405,7 @@ jobs:
     name: build artifacts (shared VMM tests) [windows]
     runs-on:
     - self-hosted
-    - 1ES.Pool=openvmm-gh-amd-westus3
+    - 1ES.Pool=openvmm-gh-intel-westus3-v6
     - 1ES.ImageOverride=win-amd64-v2
     - JobId=job2-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
@@ -3989,7 +3989,7 @@ jobs:
     name: run vmm-tests [x64-windows-intel]
     runs-on:
     - self-hosted
-    - 1ES.Pool=openvmm-gh-intel-westus3
+    - 1ES.Pool=openvmm-gh-intel-westus3-v6
     - 1ES.ImageOverride=win-amd64-v2
     - JobId=job21-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
@@ -4273,7 +4273,7 @@ jobs:
     name: run vmm-tests [x64-windows-intel-mi-secure]
     runs-on:
     - self-hosted
-    - 1ES.Pool=openvmm-gh-intel-westus3
+    - 1ES.Pool=openvmm-gh-intel-westus3-v6
     - 1ES.ImageOverride=win-amd64-v2
     - JobId=job22-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
@@ -4837,7 +4837,7 @@ jobs:
     name: run vmm-tests [x64-windows-amd]
     runs-on:
     - self-hosted
-    - 1ES.Pool=openvmm-gh-amd-westus3
+    - 1ES.Pool=openvmm-gh-amd-westus3-v6
     - 1ES.ImageOverride=win-amd64-v2
     - JobId=job24-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
@@ -5406,7 +5406,7 @@ jobs:
     name: run vmm-tests [x64-linux-amd-kvm]
     runs-on:
     - self-hosted
-    - 1ES.Pool=openvmm-gh-amd-westus3
+    - 1ES.Pool=openvmm-gh-amd-westus2-v7
     - 1ES.ImageOverride=ubuntu2404-amd64
     - JobId=job26-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
@@ -6386,7 +6386,7 @@ jobs:
     name: build artifacts (shared VMM tests) [linux]
     runs-on:
     - self-hosted
-    - 1ES.Pool=openvmm-gh-amd-westus3
+    - 1ES.Pool=openvmm-gh-amd-westus3-v7
     - 1ES.ImageOverride=ubuntu2404-amd64
     - JobId=job3-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
@@ -6791,7 +6791,7 @@ jobs:
     name: build artifacts (not for VMM tests) [aarch64-windows]
     runs-on:
     - self-hosted
-    - 1ES.Pool=openvmm-gh-amd-westus3
+    - 1ES.Pool=openvmm-gh-intel-westus3-v6
     - 1ES.ImageOverride=win-amd64-v2
     - JobId=job4-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
@@ -7012,7 +7012,7 @@ jobs:
     name: build artifacts (for VMM tests) [aarch64-windows]
     runs-on:
     - self-hosted
-    - 1ES.Pool=openvmm-gh-amd-westus3
+    - 1ES.Pool=openvmm-gh-intel-westus3-v6
     - 1ES.ImageOverride=win-amd64-v2
     - JobId=job5-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
@@ -7336,7 +7336,7 @@ jobs:
     name: build artifacts (not for VMM tests) [x64-windows]
     runs-on:
     - self-hosted
-    - 1ES.Pool=openvmm-gh-amd-westus3
+    - 1ES.Pool=openvmm-gh-intel-westus3-v6
     - 1ES.ImageOverride=win-amd64-v2
     - JobId=job6-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
@@ -7561,7 +7561,7 @@ jobs:
     name: build artifacts (for VMM tests) [x64-windows]
     runs-on:
     - self-hosted
-    - 1ES.Pool=openvmm-gh-amd-westus3
+    - 1ES.Pool=openvmm-gh-intel-westus3-v6
     - 1ES.ImageOverride=win-amd64-v2
     - JobId=job7-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
@@ -7893,7 +7893,7 @@ jobs:
     name: build artifacts (for VMM tests) [aarch64-linux]
     runs-on:
     - self-hosted
-    - 1ES.Pool=openvmm-gh-amd-westus3
+    - 1ES.Pool=openvmm-gh-amd-westus3-v7
     - 1ES.ImageOverride=ubuntu2404-amd64
     - JobId=job8-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
@@ -8224,7 +8224,7 @@ jobs:
     name: build artifacts (for VMM tests) [x64-linux]
     runs-on:
     - self-hosted
-    - 1ES.Pool=openvmm-gh-amd-westus3
+    - 1ES.Pool=openvmm-gh-amd-westus3-v7
     - 1ES.ImageOverride=ubuntu2404-amd64
     - JobId=job9-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:

--- a/.github/workflows/openvmm-pr.yaml
+++ b/.github/workflows/openvmm-pr.yaml
@@ -1791,7 +1791,7 @@ jobs:
     name: clippy [x64-windows], unit tests [x64-windows]
     runs-on:
     - self-hosted
-    - 1ES.Pool=openvmm-gh-amd-westus3-v6
+    - 1ES.Pool=openvmm-gh-intel-westus3-v6
     - 1ES.ImageOverride=win-amd64-v2
     - JobId=job15-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
@@ -2087,7 +2087,7 @@ jobs:
     name: clippy [macos], unit tests [x64-linux]
     runs-on:
     - self-hosted
-    - 1ES.Pool=openvmm-gh-amd-westus3-v7
+    - 1ES.Pool=openvmm-gh-intel-westus3-v6
     - 1ES.ImageOverride=ubuntu2404-amd64
     - JobId=job16-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
@@ -2396,7 +2396,7 @@ jobs:
     name: clippy [x64-linux-musl, misc nostd], unit tests [x64-linux-musl]
     runs-on:
     - self-hosted
-    - 1ES.Pool=openvmm-gh-amd-westus3-v7
+    - 1ES.Pool=openvmm-gh-intel-westus3-v6
     - 1ES.ImageOverride=ubuntu2404-amd64
     - JobId=job17-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
@@ -5406,7 +5406,7 @@ jobs:
     name: run vmm-tests [x64-linux-amd-kvm]
     runs-on:
     - self-hosted
-    - 1ES.Pool=openvmm-gh-amd-westus2-v7
+    - 1ES.Pool=openvmm-gh-amd-westus3-v7
     - 1ES.ImageOverride=ubuntu2404-amd64
     - JobId=job26-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
@@ -6386,7 +6386,7 @@ jobs:
     name: build artifacts (shared VMM tests) [linux]
     runs-on:
     - self-hosted
-    - 1ES.Pool=openvmm-gh-amd-westus3-v7
+    - 1ES.Pool=openvmm-gh-intel-westus3-v6
     - 1ES.ImageOverride=ubuntu2404-amd64
     - JobId=job3-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:

--- a/.github/workflows/openvmm-pr.yaml
+++ b/.github/workflows/openvmm-pr.yaml
@@ -2748,7 +2748,7 @@ jobs:
     name: clippy [aarch64-windows], unit tests [aarch64-windows]
     runs-on:
     - self-hosted
-    - 1ES.Pool=openvmm-gh-arm-westus2
+    - 1ES.Pool=openvmm-gh-arm-westus3
     - 1ES.ImageOverride=win-arm64-v2
     - JobId=job18-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
@@ -3044,7 +3044,7 @@ jobs:
     name: clippy [aarch64-linux], unit tests [aarch64-linux]
     runs-on:
     - self-hosted
-    - 1ES.Pool=openvmm-gh-arm-westus2
+    - 1ES.Pool=openvmm-gh-arm-westus3
     - 1ES.ImageOverride=ubuntu2404-arm64
     - JobId=job19-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
@@ -3593,7 +3593,7 @@ jobs:
     name: clippy [aarch64-linux-musl, misc nostd], unit tests [aarch64-linux-musl]
     runs-on:
     - self-hosted
-    - 1ES.Pool=openvmm-gh-arm-westus2
+    - 1ES.Pool=openvmm-gh-arm-westus3
     - 1ES.ImageOverride=ubuntu2404-arm64
     - JobId=job20-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:

--- a/.github/workflows/openvmm-pr.yaml
+++ b/.github/workflows/openvmm-pr.yaml
@@ -3044,7 +3044,7 @@ jobs:
     name: clippy [aarch64-linux], unit tests [aarch64-linux]
     runs-on:
     - self-hosted
-    - 1ES.Pool=openvmm-gh-arm-westus3
+    - 1ES.Pool=openvmm-gh-arm-westus2
     - 1ES.ImageOverride=ubuntu2404-arm64
     - JobId=job19-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
@@ -3593,7 +3593,7 @@ jobs:
     name: clippy [aarch64-linux-musl, misc nostd], unit tests [aarch64-linux-musl]
     runs-on:
     - self-hosted
-    - 1ES.Pool=openvmm-gh-arm-westus3
+    - 1ES.Pool=openvmm-gh-arm-westus2
     - 1ES.ImageOverride=ubuntu2404-arm64
     - JobId=job20-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:

--- a/ci-flowey/openvmm-pr.yaml
+++ b/ci-flowey/openvmm-pr.yaml
@@ -825,7 +825,7 @@ jobs:
   displayName: clippy [x64-windows], unit tests [x64-windows]
   pool:
     demands:
-    - ImageOverride -equals win-amd64
+    - ImageOverride -equals win-amd64-test
     name: openvmm-ado-amd-westus2
   dependsOn:
   - job0
@@ -2607,7 +2607,7 @@ jobs:
   displayName: build artifacts (for VMM tests) [x64-windows]
   pool:
     demands:
-    - ImageOverride -equals win-amd64
+    - ImageOverride -equals win-amd64-test
     name: openvmm-ado-amd-westus2
   dependsOn:
   - job0
@@ -2901,7 +2901,7 @@ jobs:
   displayName: build artifacts (not for VMM tests) [x64-windows]
   pool:
     demands:
-    - ImageOverride -equals win-amd64
+    - ImageOverride -equals win-amd64-test
     name: openvmm-ado-amd-westus2
   dependsOn:
   - job0
@@ -3104,7 +3104,7 @@ jobs:
   displayName: build artifacts (for VMM tests) [aarch64-windows]
   pool:
     demands:
-    - ImageOverride -equals win-amd64
+    - ImageOverride -equals win-amd64-test
     name: openvmm-ado-amd-westus2
   dependsOn:
   - job0
@@ -3393,7 +3393,7 @@ jobs:
   displayName: build artifacts (not for VMM tests) [aarch64-windows]
   pool:
     demands:
-    - ImageOverride -equals win-amd64
+    - ImageOverride -equals win-amd64-test
     name: openvmm-ado-amd-westus2
   dependsOn:
   - job0
@@ -3885,7 +3885,7 @@ jobs:
   displayName: build artifacts (shared VMM tests) [windows]
   pool:
     demands:
-    - ImageOverride -equals win-amd64
+    - ImageOverride -equals win-amd64-test
     name: openvmm-ado-amd-westus2
   dependsOn:
   - job0
@@ -4304,7 +4304,7 @@ jobs:
   displayName: run vmm-tests [x64-windows-amd]
   pool:
     demands:
-    - ImageOverride -equals win-amd64
+    - ImageOverride -equals win-amd64-test
     name: openvmm-ado-amd-westus2
   dependsOn:
   - job0
@@ -4606,7 +4606,7 @@ jobs:
   displayName: run vmm-tests [x64-windows-intel-mi-secure]
   pool:
     demands:
-    - ImageOverride -equals win-amd64
+    - ImageOverride -equals win-amd64-test
     name: openvmm-ado-intel-centralus
   dependsOn:
   - job0
@@ -4901,7 +4901,7 @@ jobs:
   displayName: run vmm-tests [x64-windows-intel]
   pool:
     demands:
-    - ImageOverride -equals win-amd64
+    - ImageOverride -equals win-amd64-test
     name: openvmm-ado-intel-centralus
   dependsOn:
   - job0
@@ -5203,7 +5203,7 @@ jobs:
   displayName: xtask fmt (windows)
   pool:
     demands:
-    - ImageOverride -equals win-amd64
+    - ImageOverride -equals win-amd64-test
     name: openvmm-ado-amd-westus2
   dependsOn:
   - job0

--- a/ci-flowey/openvmm-pr.yaml
+++ b/ci-flowey/openvmm-pr.yaml
@@ -825,7 +825,7 @@ jobs:
   displayName: clippy [x64-windows], unit tests [x64-windows]
   pool:
     demands:
-    - ImageOverride -equals win-amd64-test
+    - ImageOverride -equals win-amd64-v2
     name: openvmm-ado-amd-westus2
   dependsOn:
   - job0
@@ -2607,7 +2607,7 @@ jobs:
   displayName: build artifacts (for VMM tests) [x64-windows]
   pool:
     demands:
-    - ImageOverride -equals win-amd64-test
+    - ImageOverride -equals win-amd64-v2
     name: openvmm-ado-amd-westus2
   dependsOn:
   - job0
@@ -2901,7 +2901,7 @@ jobs:
   displayName: build artifacts (not for VMM tests) [x64-windows]
   pool:
     demands:
-    - ImageOverride -equals win-amd64-test
+    - ImageOverride -equals win-amd64-v2
     name: openvmm-ado-amd-westus2
   dependsOn:
   - job0
@@ -3104,7 +3104,7 @@ jobs:
   displayName: build artifacts (for VMM tests) [aarch64-windows]
   pool:
     demands:
-    - ImageOverride -equals win-amd64-test
+    - ImageOverride -equals win-amd64-v2
     name: openvmm-ado-amd-westus2
   dependsOn:
   - job0
@@ -3393,7 +3393,7 @@ jobs:
   displayName: build artifacts (not for VMM tests) [aarch64-windows]
   pool:
     demands:
-    - ImageOverride -equals win-amd64-test
+    - ImageOverride -equals win-amd64-v2
     name: openvmm-ado-amd-westus2
   dependsOn:
   - job0
@@ -3885,7 +3885,7 @@ jobs:
   displayName: build artifacts (shared VMM tests) [windows]
   pool:
     demands:
-    - ImageOverride -equals win-amd64-test
+    - ImageOverride -equals win-amd64-v2
     name: openvmm-ado-amd-westus2
   dependsOn:
   - job0
@@ -4304,7 +4304,7 @@ jobs:
   displayName: run vmm-tests [x64-windows-amd]
   pool:
     demands:
-    - ImageOverride -equals win-amd64-test
+    - ImageOverride -equals win-amd64-v2
     name: openvmm-ado-amd-westus2
   dependsOn:
   - job0
@@ -4606,7 +4606,7 @@ jobs:
   displayName: run vmm-tests [x64-windows-intel-mi-secure]
   pool:
     demands:
-    - ImageOverride -equals win-amd64-test
+    - ImageOverride -equals win-amd64-v2
     name: openvmm-ado-intel-centralus
   dependsOn:
   - job0
@@ -4901,7 +4901,7 @@ jobs:
   displayName: run vmm-tests [x64-windows-intel]
   pool:
     demands:
-    - ImageOverride -equals win-amd64-test
+    - ImageOverride -equals win-amd64-v2
     name: openvmm-ado-intel-centralus
   dependsOn:
   - job0
@@ -5203,7 +5203,7 @@ jobs:
   displayName: xtask fmt (windows)
   pool:
     demands:
-    - ImageOverride -equals win-amd64-test
+    - ImageOverride -equals win-amd64-v2
     name: openvmm-ado-amd-westus2
   dependsOn:
   - job0

--- a/flowey/flowey_hvlite/src/pipelines/checkin_gates.rs
+++ b/flowey/flowey_hvlite/src/pipelines/checkin_gates.rs
@@ -435,7 +435,7 @@ impl IntoPipeline for CheckinGatesCli {
                 FlowArch::X86_64,
                 "build artifacts (shared VMM tests) [linux]",
             )
-            .gh_set_pool(gh_pools::default_linux())
+            .gh_set_pool(gh_pools::linux_intel_v6_1es())
             .ado_set_pool(ado_pools::default_linux());
         for (
             arch,
@@ -1151,7 +1151,7 @@ impl IntoPipeline for CheckinGatesCli {
             ClippyUnitTestJobParams {
                 platform: FlowPlatform::Windows,
                 arch: FlowArch::X86_64,
-                gh_pool: gh_pools::windows_amd_v6_1es(),
+                gh_pool: gh_pools::windows_intel_v6_1es(),
                 ado_pool: Some(ado_pools::windows_amd_1es()),
                 clippy_targets: Some((
                     "x64-windows",
@@ -1165,7 +1165,7 @@ impl IntoPipeline for CheckinGatesCli {
             ClippyUnitTestJobParams {
                 platform: FlowPlatform::Linux(FlowPlatformLinuxDistro::Ubuntu),
                 arch: FlowArch::X86_64,
-                gh_pool: gh_pools::linux_amd_v7_1es(),
+                gh_pool: gh_pools::linux_intel_v6_1es(),
                 ado_pool: Some(ado_pools::linux_amd_1es()),
                 clippy_targets: if quick_check_job.is_some() {
                     // quick check already ran clippy for x64-linux;
@@ -1185,7 +1185,7 @@ impl IntoPipeline for CheckinGatesCli {
             ClippyUnitTestJobParams {
                 platform: FlowPlatform::Linux(FlowPlatformLinuxDistro::Ubuntu),
                 arch: FlowArch::X86_64,
-                gh_pool: gh_pools::linux_amd_v7_1es(),
+                gh_pool: gh_pools::linux_intel_v6_1es(),
                 ado_pool: Some(ado_pools::linux_amd_1es()),
                 clippy_targets: Some((
                     "x64-linux-musl, misc nostd",
@@ -1210,7 +1210,7 @@ impl IntoPipeline for CheckinGatesCli {
             ClippyUnitTestJobParams {
                 platform: FlowPlatform::Linux(FlowPlatformLinuxDistro::Ubuntu),
                 arch: FlowArch::Aarch64,
-                gh_pool: gh_pools::linux_arm_v6_1es(),
+                gh_pool: gh_pools::linux_arm_v5_1es(),
                 ado_pool: None,
                 clippy_targets: Some((
                     "aarch64-linux",
@@ -1224,7 +1224,7 @@ impl IntoPipeline for CheckinGatesCli {
             ClippyUnitTestJobParams {
                 platform: FlowPlatform::Linux(FlowPlatformLinuxDistro::Ubuntu),
                 arch: FlowArch::Aarch64,
-                gh_pool: gh_pools::linux_arm_v6_1es(),
+                gh_pool: gh_pools::linux_arm_v5_1es(),
                 ado_pool: None,
                 clippy_targets: Some((
                     "aarch64-linux-musl, misc nostd",
@@ -1560,8 +1560,7 @@ impl IntoPipeline for CheckinGatesCli {
             VmmTestJobParams {
                 platform: FlowPlatform::Linux(FlowPlatformLinuxDistro::Ubuntu),
                 arch: FlowArch::X86_64,
-                // use a separate pool for vmm tests to maximize quota use
-                gh_pool: gh_pools::linux_amd_v7_1es_2(),
+                gh_pool: gh_pools::linux_amd_v7_1es(),
                 ado_pool: Some(ado_pools::linux_amd_1es()),
                 label: "x64-linux-amd-kvm",
                 target: CommonTriple::X86_64_LINUX_GNU,

--- a/flowey/flowey_hvlite/src/pipelines/checkin_gates.rs
+++ b/flowey/flowey_hvlite/src/pipelines/checkin_gates.rs
@@ -1151,7 +1151,7 @@ impl IntoPipeline for CheckinGatesCli {
             ClippyUnitTestJobParams {
                 platform: FlowPlatform::Windows,
                 arch: FlowArch::X86_64,
-                gh_pool: gh_pools::windows_amd_1es(),
+                gh_pool: gh_pools::windows_amd_v6_1es(),
                 ado_pool: Some(ado_pools::windows_amd_1es()),
                 clippy_targets: Some((
                     "x64-windows",
@@ -1165,7 +1165,7 @@ impl IntoPipeline for CheckinGatesCli {
             ClippyUnitTestJobParams {
                 platform: FlowPlatform::Linux(FlowPlatformLinuxDistro::Ubuntu),
                 arch: FlowArch::X86_64,
-                gh_pool: gh_pools::linux_amd_1es(),
+                gh_pool: gh_pools::linux_amd_v7_1es(),
                 ado_pool: Some(ado_pools::linux_amd_1es()),
                 clippy_targets: if quick_check_job.is_some() {
                     // quick check already ran clippy for x64-linux;
@@ -1185,7 +1185,7 @@ impl IntoPipeline for CheckinGatesCli {
             ClippyUnitTestJobParams {
                 platform: FlowPlatform::Linux(FlowPlatformLinuxDistro::Ubuntu),
                 arch: FlowArch::X86_64,
-                gh_pool: gh_pools::linux_amd_1es(),
+                gh_pool: gh_pools::linux_amd_v7_1es(),
                 ado_pool: Some(ado_pools::linux_amd_1es()),
                 clippy_targets: Some((
                     "x64-linux-musl, misc nostd",
@@ -1196,7 +1196,7 @@ impl IntoPipeline for CheckinGatesCli {
             ClippyUnitTestJobParams {
                 platform: FlowPlatform::Windows,
                 arch: FlowArch::Aarch64,
-                gh_pool: gh_pools::windows_arm_1es(),
+                gh_pool: gh_pools::windows_arm_v6_1es(),
                 ado_pool: None,
                 clippy_targets: Some((
                     "aarch64-windows",
@@ -1210,7 +1210,7 @@ impl IntoPipeline for CheckinGatesCli {
             ClippyUnitTestJobParams {
                 platform: FlowPlatform::Linux(FlowPlatformLinuxDistro::Ubuntu),
                 arch: FlowArch::Aarch64,
-                gh_pool: gh_pools::linux_arm_1es(),
+                gh_pool: gh_pools::linux_arm_v6_1es(),
                 ado_pool: None,
                 clippy_targets: Some((
                     "aarch64-linux",
@@ -1224,7 +1224,7 @@ impl IntoPipeline for CheckinGatesCli {
             ClippyUnitTestJobParams {
                 platform: FlowPlatform::Linux(FlowPlatformLinuxDistro::Ubuntu),
                 arch: FlowArch::Aarch64,
-                gh_pool: gh_pools::linux_arm_1es(),
+                gh_pool: gh_pools::linux_arm_v6_1es(),
                 ado_pool: None,
                 clippy_targets: Some((
                     "aarch64-linux-musl, misc nostd",
@@ -1492,7 +1492,7 @@ impl IntoPipeline for CheckinGatesCli {
             VmmTestJobParams {
                 platform: FlowPlatform::Windows,
                 arch: FlowArch::X86_64,
-                gh_pool: gh_pools::windows_intel_1es(),
+                gh_pool: gh_pools::windows_intel_v6_1es(),
                 ado_pool: Some(ado_pools::windows_intel_1es()),
                 label: "x64-windows-intel",
                 target: CommonTriple::X86_64_WINDOWS_MSVC,
@@ -1505,7 +1505,7 @@ impl IntoPipeline for CheckinGatesCli {
             VmmTestJobParams {
                 platform: FlowPlatform::Windows,
                 arch: FlowArch::X86_64,
-                gh_pool: gh_pools::windows_intel_1es(),
+                gh_pool: gh_pools::windows_intel_v6_1es(),
                 ado_pool: Some(ado_pools::windows_intel_1es()),
                 label: "x64-windows-intel-mi-secure",
                 target: CommonTriple::X86_64_WINDOWS_MSVC,
@@ -1532,7 +1532,9 @@ impl IntoPipeline for CheckinGatesCli {
             VmmTestJobParams {
                 platform: FlowPlatform::Windows,
                 arch: FlowArch::X86_64,
-                gh_pool: gh_pools::windows_amd_1es(),
+                // a Windows hypervisor bug causes VMM tests to crash
+                // when running on v7, so use v6
+                gh_pool: gh_pools::windows_amd_v6_1es(),
                 ado_pool: Some(ado_pools::windows_amd_1es()),
                 label: "x64-windows-amd",
                 target: CommonTriple::X86_64_WINDOWS_MSVC,
@@ -1558,7 +1560,8 @@ impl IntoPipeline for CheckinGatesCli {
             VmmTestJobParams {
                 platform: FlowPlatform::Linux(FlowPlatformLinuxDistro::Ubuntu),
                 arch: FlowArch::X86_64,
-                gh_pool: gh_pools::linux_amd_1es(),
+                // use a separate pool for vmm tests to maximize quota use
+                gh_pool: gh_pools::linux_amd_v7_1es_2(),
                 ado_pool: Some(ado_pools::linux_amd_1es()),
                 label: "x64-linux-amd-kvm",
                 target: CommonTriple::X86_64_LINUX_GNU,
@@ -1572,7 +1575,8 @@ impl IntoPipeline for CheckinGatesCli {
             VmmTestJobParams {
                 platform: FlowPlatform::Linux(FlowPlatformLinuxDistro::AzureLinux),
                 arch: FlowArch::X86_64,
-                gh_pool: gh_pools::linux_mshv_1es(),
+                // mshv image needs to be updated to use nvme for v6+ skus
+                gh_pool: gh_pools::linux_mshv_intel_v5_1es(),
                 ado_pool: None,
                 label: "x64-linux-intel-mshv",
                 target: CommonTriple::X86_64_LINUX_MUSL,

--- a/flowey/flowey_hvlite/src/pipelines_shared/gh_pools.rs
+++ b/flowey/flowey_hvlite/src/pipelines_shared/gh_pools.rs
@@ -5,9 +5,12 @@
 
 use flowey::pipeline::prelude::*;
 
-pub const AMD_POOL_1ES: &str = "openvmm-gh-amd-westus3";
-pub const INTEL_POOL_1ES: &str = "openvmm-gh-intel-westus3";
-pub const ARM_POOL_1ES: &str = "openvmm-gh-arm-westus3";
+pub const AMD_V6_POOL_1ES: &str = "openvmm-gh-amd-westus3-v6";
+pub const AMD_V7_POOL_1ES: &str = "openvmm-gh-amd-westus3-v7";
+pub const AMD_V7_POOL_1ES_2: &str = "openvmm-gh-amd-westus2-v7";
+pub const INTEL_V5_POOL_1ES: &str = "openvmm-gh-intel-westus3";
+pub const INTEL_V6_POOL_1ES: &str = "openvmm-gh-intel-westus3-v6";
+pub const ARM_V6_POOL_1ES: &str = "openvmm-gh-arm-westus3";
 
 pub const WINDOWS_IMAGE_AMD64: &str = "win-amd64-v2";
 pub const WINDOWS_IMAGE_ARM64: &str = "win-arm64-v2";
@@ -23,28 +26,32 @@ fn gh_pool_with_image_1es(pool: &str, image: &str) -> GhRunner {
     ])
 }
 
-pub fn windows_amd_1es() -> GhRunner {
-    gh_pool_with_image_1es(AMD_POOL_1ES, WINDOWS_IMAGE_AMD64)
+pub fn windows_amd_v6_1es() -> GhRunner {
+    gh_pool_with_image_1es(AMD_V6_POOL_1ES, WINDOWS_IMAGE_AMD64)
 }
 
-pub fn windows_intel_1es() -> GhRunner {
-    gh_pool_with_image_1es(INTEL_POOL_1ES, WINDOWS_IMAGE_AMD64)
+pub fn windows_intel_v6_1es() -> GhRunner {
+    gh_pool_with_image_1es(INTEL_V6_POOL_1ES, WINDOWS_IMAGE_AMD64)
 }
 
-pub fn windows_arm_1es() -> GhRunner {
-    gh_pool_with_image_1es(ARM_POOL_1ES, WINDOWS_IMAGE_ARM64)
+pub fn windows_arm_v6_1es() -> GhRunner {
+    gh_pool_with_image_1es(ARM_V6_POOL_1ES, WINDOWS_IMAGE_ARM64)
 }
 
-pub fn linux_arm_1es() -> GhRunner {
-    gh_pool_with_image_1es(ARM_POOL_1ES, LINUX_IMAGE_ARM64)
+pub fn linux_arm_v6_1es() -> GhRunner {
+    gh_pool_with_image_1es(ARM_V6_POOL_1ES, LINUX_IMAGE_ARM64)
 }
 
-pub fn linux_amd_1es() -> GhRunner {
-    gh_pool_with_image_1es(AMD_POOL_1ES, LINUX_IMAGE_AMD64)
+pub fn linux_amd_v7_1es() -> GhRunner {
+    gh_pool_with_image_1es(AMD_V7_POOL_1ES, LINUX_IMAGE_AMD64)
 }
 
-pub fn linux_mshv_1es() -> GhRunner {
-    gh_pool_with_image_1es(INTEL_POOL_1ES, MSHV_IMAGE_AMD64)
+pub fn linux_amd_v7_1es_2() -> GhRunner {
+    gh_pool_with_image_1es(AMD_V7_POOL_1ES_2, LINUX_IMAGE_AMD64)
+}
+
+pub fn linux_mshv_intel_v5_1es() -> GhRunner {
+    gh_pool_with_image_1es(INTEL_V5_POOL_1ES, MSHV_IMAGE_AMD64)
 }
 
 pub fn windows_x64_gh() -> GhRunner {
@@ -93,9 +100,9 @@ pub fn windows_snp_self_hosted_baremetal() -> GhRunner {
 }
 
 pub fn default_windows() -> GhRunner {
-    windows_amd_1es()
+    windows_intel_v6_1es()
 }
 
 pub fn default_linux() -> GhRunner {
-    linux_amd_1es()
+    linux_amd_v7_1es()
 }

--- a/flowey/flowey_hvlite/src/pipelines_shared/gh_pools.rs
+++ b/flowey/flowey_hvlite/src/pipelines_shared/gh_pools.rs
@@ -7,9 +7,9 @@ use flowey::pipeline::prelude::*;
 
 pub const AMD_V6_POOL_1ES: &str = "openvmm-gh-amd-westus3-v6";
 pub const AMD_V7_POOL_1ES: &str = "openvmm-gh-amd-westus3-v7";
-pub const AMD_V7_POOL_1ES_2: &str = "openvmm-gh-amd-westus2-v7";
 pub const INTEL_V5_POOL_1ES: &str = "openvmm-gh-intel-westus3";
 pub const INTEL_V6_POOL_1ES: &str = "openvmm-gh-intel-westus3-v6";
+pub const ARM_V5_POOL_1ES: &str = "openvmm-gh-arm-westus2";
 pub const ARM_V6_POOL_1ES: &str = "openvmm-gh-arm-westus3";
 
 pub const WINDOWS_IMAGE_AMD64: &str = "win-amd64-v2";
@@ -26,6 +26,10 @@ fn gh_pool_with_image_1es(pool: &str, image: &str) -> GhRunner {
     ])
 }
 
+pub fn windows_arm_v6_1es() -> GhRunner {
+    gh_pool_with_image_1es(ARM_V6_POOL_1ES, WINDOWS_IMAGE_ARM64)
+}
+
 pub fn windows_amd_v6_1es() -> GhRunner {
     gh_pool_with_image_1es(AMD_V6_POOL_1ES, WINDOWS_IMAGE_AMD64)
 }
@@ -34,20 +38,16 @@ pub fn windows_intel_v6_1es() -> GhRunner {
     gh_pool_with_image_1es(INTEL_V6_POOL_1ES, WINDOWS_IMAGE_AMD64)
 }
 
-pub fn windows_arm_v6_1es() -> GhRunner {
-    gh_pool_with_image_1es(ARM_V6_POOL_1ES, WINDOWS_IMAGE_ARM64)
+pub fn linux_arm_v5_1es() -> GhRunner {
+    gh_pool_with_image_1es(ARM_V6_POOL_1ES, LINUX_IMAGE_ARM64)
 }
 
-pub fn linux_arm_v6_1es() -> GhRunner {
-    gh_pool_with_image_1es(ARM_V6_POOL_1ES, LINUX_IMAGE_ARM64)
+pub fn linux_intel_v6_1es() -> GhRunner {
+    gh_pool_with_image_1es(INTEL_V6_POOL_1ES, LINUX_IMAGE_AMD64)
 }
 
 pub fn linux_amd_v7_1es() -> GhRunner {
     gh_pool_with_image_1es(AMD_V7_POOL_1ES, LINUX_IMAGE_AMD64)
-}
-
-pub fn linux_amd_v7_1es_2() -> GhRunner {
-    gh_pool_with_image_1es(AMD_V7_POOL_1ES_2, LINUX_IMAGE_AMD64)
 }
 
 pub fn linux_mshv_intel_v5_1es() -> GhRunner {

--- a/flowey/flowey_hvlite/src/pipelines_shared/gh_pools.rs
+++ b/flowey/flowey_hvlite/src/pipelines_shared/gh_pools.rs
@@ -9,8 +9,8 @@ pub const AMD_POOL_1ES: &str = "openvmm-gh-amd-westus3";
 pub const INTEL_POOL_1ES: &str = "openvmm-gh-intel-westus3";
 pub const ARM_POOL_1ES: &str = "openvmm-gh-arm-westus2";
 
-pub const WINDOWS_IMAGE_AMD64: &str = "win-amd64";
-pub const WINDOWS_IMAGE_ARM64: &str = "win-arm64";
+pub const WINDOWS_IMAGE_AMD64: &str = "win-amd64-test";
+pub const WINDOWS_IMAGE_ARM64: &str = "win-arm64-test";
 pub const LINUX_IMAGE_AMD64: &str = "ubuntu2404-amd64";
 pub const LINUX_IMAGE_ARM64: &str = "ubuntu2404-arm64";
 pub const MSHV_IMAGE_AMD64: &str = "azurelinux3-amd64-dom0";

--- a/flowey/flowey_hvlite/src/pipelines_shared/gh_pools.rs
+++ b/flowey/flowey_hvlite/src/pipelines_shared/gh_pools.rs
@@ -9,8 +9,8 @@ pub const AMD_POOL_1ES: &str = "openvmm-gh-amd-westus3";
 pub const INTEL_POOL_1ES: &str = "openvmm-gh-intel-westus3";
 pub const ARM_POOL_1ES: &str = "openvmm-gh-arm-westus2";
 
-pub const WINDOWS_IMAGE_AMD64: &str = "win-amd64-test";
-pub const WINDOWS_IMAGE_ARM64: &str = "win-arm64-test";
+pub const WINDOWS_IMAGE_AMD64: &str = "win-amd64-v2";
+pub const WINDOWS_IMAGE_ARM64: &str = "win-arm64-v2";
 pub const LINUX_IMAGE_AMD64: &str = "ubuntu2404-amd64";
 pub const LINUX_IMAGE_ARM64: &str = "ubuntu2404-arm64";
 pub const MSHV_IMAGE_AMD64: &str = "azurelinux3-amd64-dom0";

--- a/flowey/flowey_hvlite/src/pipelines_shared/gh_pools.rs
+++ b/flowey/flowey_hvlite/src/pipelines_shared/gh_pools.rs
@@ -39,7 +39,7 @@ pub fn windows_intel_v6_1es() -> GhRunner {
 }
 
 pub fn linux_arm_v5_1es() -> GhRunner {
-    gh_pool_with_image_1es(ARM_V6_POOL_1ES, LINUX_IMAGE_ARM64)
+    gh_pool_with_image_1es(ARM_V5_POOL_1ES, LINUX_IMAGE_ARM64)
 }
 
 pub fn linux_intel_v6_1es() -> GhRunner {

--- a/flowey/flowey_hvlite/src/pipelines_shared/gh_pools.rs
+++ b/flowey/flowey_hvlite/src/pipelines_shared/gh_pools.rs
@@ -7,7 +7,7 @@ use flowey::pipeline::prelude::*;
 
 pub const AMD_POOL_1ES: &str = "openvmm-gh-amd-westus3";
 pub const INTEL_POOL_1ES: &str = "openvmm-gh-intel-westus3";
-pub const ARM_POOL_1ES: &str = "openvmm-gh-arm-westus2";
+pub const ARM_POOL_1ES: &str = "openvmm-gh-arm-westus3";
 
 pub const WINDOWS_IMAGE_AMD64: &str = "win-amd64-v2";
 pub const WINDOWS_IMAGE_ARM64: &str = "win-arm64-v2";


### PR DESCRIPTION
Use Gen2 windows images and newer SKUs (AMD v7, Intel v6 and ARM v6) where possible. Due to capacity limitations, still use ARM v5 for Linux jobs, and use Intel v6 for many of the build steps since ample quota is available for that sku and AMD v7 is limited. Continue using Intel v5 for Dom0 image until that image can be updated to support NVMe. Use AMD v6 for VMM tests instead of v7 due to a known hypervisor crash.