### PR TITLE
pipette: Robustify PipetteClient::new

### DIFF
--- a/petri/incubator/src/run.rs
+++ b/petri/incubator/src/run.rs
@@ -189,8 +189,6 @@ async fn run_via_pipette(
         .context("failed to connect to pipette")?;
 
     tracing::info!("connected to pipette");
-    client.ping().await.context("ping failed")?;
-    tracing::info!("ping OK");
 
     // Set up VFIO devices before running the guest command.
     let vfio_env = qemu::setup_vfio_devices(&client, &config.profile.devices).await?;

--- a/petri/pipette_client/src/lib.rs
+++ b/petri/pipette_client/src/lib.rs
@@ -22,6 +22,7 @@ use futures::FutureExt as _;
 use futures::StreamExt;
 use futures::io::BufReader;
 use futures_concurrency::future::TryJoin;
+use mesh::CancelContext;
 use mesh::error::RemoteError;
 use mesh::payload::Timestamp;
 use mesh::rpc::RpcError;
@@ -37,6 +38,7 @@ use shell::UnixShell;
 use shell::WindowsShell;
 use std::path::Path;
 use std::path::PathBuf;
+use std::time::Duration;
 
 /// A client to a running `pipette` instance inside a VM.
 pub struct PipetteClient {
@@ -47,6 +49,10 @@ pub struct PipetteClient {
     _diag_task: Task<()>,
 }
 
+/// Maximum time to wait for a single pipette connection attempt — the mesh
+/// handshake plus the liveness ping — to complete.
+const CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
+
 impl PipetteClient {
     /// Connects to a `pipette` instance inside a VM.
     ///
@@ -56,10 +62,29 @@ impl PipetteClient {
         spawner: impl Spawn,
         conn: impl 'static + AsyncRead + AsyncWrite + Send + Unpin,
         output_dir: &Path,
-    ) -> Result<Self, mesh::RecvError> {
+    ) -> anyhow::Result<Self> {
+        let mut ctx = CancelContext::new().with_timeout(CONNECT_TIMEOUT);
+        match ctx
+            .until_cancelled(Self::connect(spawner, conn, output_dir))
+            .await
+        {
+            Ok(result) => result,
+            Err(_) => Err(anyhow::anyhow!(
+                "timed out establishing pipette connection after {CONNECT_TIMEOUT:?}"
+            )),
+        }
+    }
+
+    async fn connect(
+        spawner: impl Spawn,
+        conn: impl 'static + AsyncRead + AsyncWrite + Send + Unpin,
+        output_dir: &Path,
+    ) -> anyhow::Result<Self> {
         let (bootstrap_send, bootstrap_recv) = mesh::oneshot::<PipetteBootstrap>();
         let mesh = PointToPointMesh::new(&spawner, conn, bootstrap_send.into());
-        let bootstrap = bootstrap_recv.await?;
+        let bootstrap = bootstrap_recv
+            .await
+            .context("failed to receive pipette bootstrap")?;
 
         let PipetteBootstrap {
             requests,
@@ -74,13 +99,27 @@ impl PipetteClient {
             recv_diag_files(output_dir.to_owned(), diag_file_recv),
         );
 
-        Ok(Self {
+        let client = Self {
             send: PipetteSender::new(requests),
             watch,
             _mesh: mesh,
             _log_task: log_task,
             _diag_task: diag_task,
-        })
+        };
+
+        // A successful mesh handshake is not, on its own, proof of a usable
+        // connection: a byte stream can deliver the guest's bootstrap to the host
+        // and then be torn down moments later — for example by the reset in a
+        // save/restore pulse, or by a TCP forward that silently drops the
+        // guest's traffic — leaving a client whose requests would never be
+        // answered. To guard against this, we confirm the agent is actually
+        // reachable with a ping, bounded by the timeout in `new`.
+        client
+            .ping()
+            .await
+            .context("pipette liveness ping failed")?;
+
+        Ok(client)
     }
 
     /// Pings the agent to check if it's alive.

--- a/petri/src/vm/hyperv/mod.rs
+++ b/petri/src/vm/hyperv/mod.rs
@@ -539,9 +539,9 @@ impl PetriVmRuntime for HyperVPetriRuntime {
                         tracing::info!(set_high_vtl, "handshaking with pipette");
                         let c = PipetteClient::new(&driver, socket, &output_dir)
                             .await
-                            .context("failed to handshake with pipette");
+                            .context("failed to connect to pipette")?;
                         tracing::info!(set_high_vtl, "completed pipette handshake");
-                        Ok(Some(c?))
+                        Ok(Some(c))
                     }
                     Err(err) => {
                         tracing::debug!(

--- a/petri/src/vm/openvmm/runtime.rs
+++ b/petri/src/vm/openvmm/runtime.rs
@@ -665,7 +665,7 @@ impl PetriVmInner {
                         Err(e) => {
                             tracing::warn!(
                                 error = e.as_ref() as &dyn std::error::Error,
-                                "pipette TCP handshake failed, retrying"
+                                "pipette TCP connection failed, retrying"
                             );
                         }
                     }

--- a/petri/src/vm/openvmm/runtime.rs
+++ b/petri/src/vm/openvmm/runtime.rs
@@ -598,8 +598,8 @@ impl PetriVmInner {
                     // that fail during the mesh handshake. Drain them and
                     // retry until we get a live connection.
                     tracing::warn!(
-                        error = &e as &dyn std::error::Error,
-                        "pipette handshake failed, retrying"
+                        error = e.as_ref() as &dyn std::error::Error,
+                        "pipette connection not live, retrying"
                     );
                 }
             }
@@ -654,26 +654,19 @@ impl PetriVmInner {
                         .set_nodelay(true)
                         .context("failed to set TCP_NODELAY")?;
                     tracing::info!("TCP connected, handshaking with pipette");
-                    // Time out the handshake — consomme's port forwarding may
-                    // drop the initial SYN to the guest if no RX buffers are
-                    // available yet, leaving the connection open but dead.
-                    // Reconnecting forces a new SYN attempt.
-                    let handshake = PipetteClient::new(
+                    match PipetteClient::new(
                         &self.resources.driver,
                         socket,
                         &self.resources.output_dir,
-                    );
-                    let mut c = CancelContext::new().with_timeout(Duration::from_secs(5));
-                    match c.until_cancelled(handshake).await {
-                        Ok(Ok(client)) => break client,
-                        Ok(Err(e)) => {
+                    )
+                    .await
+                    {
+                        Ok(client) => break client,
+                        Err(e) => {
                             tracing::warn!(
-                                error = &e as &dyn std::error::Error,
+                                error = e.as_ref() as &dyn std::error::Error,
                                 "pipette TCP handshake failed, retrying"
                             );
-                        }
-                        Err(_) => {
-                            tracing::warn!("pipette TCP handshake timed out, reconnecting");
                         }
                     }
                 }


### PR DESCRIPTION
Move additional checks and safeties into PipetteClient::new, rather than requiring all callers to repeat them. Namely we add a timeout on the whole connection sequence, and a ping after the initial handshake. This will hopefully reduce instances of dead connections appearing successful to other parts of the test infrastructure.