### PR TITLE
pcie: support explicit port devfn and per-port switch config

### DIFF
--- a/Guide/src/reference/openvmm/management/cli.md
+++ b/Guide/src/reference/openvmm/management/cli.md
@@ -283,6 +283,11 @@ name:
 --pcie-root-port rc0:rp0,hotplug,acs=0x005f,cxl
 ```
 
+- `addr=<dev>[.<fn>]`: places the root port at a fixed device/function on
+  its bus. `dev` is 0-31 and the optional `fn` is 0-7 (both decimal or
+  `0x`-prefixed hex). When omitted, the port is assigned the lowest
+  available devfn. Ports are assigned in order, so an explicit `addr` that
+  collides with an already-assigned port is an error.
 - `hotplug`: enables hotplug support for that root port.
 - `acs=<mask>`: sets the Access Control Services capability mask for the
   root port. The value can be decimal or hexadecimal. Default is `0x005f`.

--- a/openvmm/openvmm_core/src/worker/dispatch.rs
+++ b/openvmm/openvmm_core/src/worker/dispatch.rs
@@ -65,8 +65,8 @@ use openvmm_defs::config::HypervisorConfig;
 use openvmm_defs::config::LoadMode;
 use openvmm_defs::config::NumaTopology;
 use openvmm_defs::config::PcieDeviceConfig;
+use openvmm_defs::config::PciePortConfig;
 use openvmm_defs::config::PcieRootComplexConfig;
-use openvmm_defs::config::PcieRootPortConfig;
 use openvmm_defs::config::PcieSwitchConfig;
 use openvmm_defs::config::PmuGsivConfig;
 use openvmm_defs::config::ProcessorTopologyConfig;
@@ -89,9 +89,9 @@ use pal_async::task::Spawn;
 use pal_async::task::Task;
 use pci_core::PciInterruptPin;
 use pci_core::spec::caps::acs::DEFAULT_ACS_CAP_MASK;
+use pcie::GenericPciePortDefinition;
 use pcie::PciePortSettings;
 use pcie::root::GenericPcieRootComplex;
-use pcie::root::GenericPcieRootPortDefinition;
 use pcie::switch::GenericPcieSwitch;
 use scsi_core::ResolveScsiDeviceHandleParams;
 use scsidisk::SimpleScsiDisk;
@@ -857,7 +857,7 @@ fn convert_vtl2_config(
 ///
 /// When CXL is enabled, emit a default Flex Bus capability advertising both
 /// cache and memory support.
-fn build_root_port_settings(rp_cfg: &PcieRootPortConfig) -> PciePortSettings {
+fn build_root_port_settings(rp_cfg: &PciePortConfig) -> PciePortSettings {
     PciePortSettings {
         acs_capabilities_supported: rp_cfg
             .acs_capabilities_supported
@@ -871,11 +871,12 @@ fn build_root_port_settings(rp_cfg: &PcieRootPortConfig) -> PciePortSettings {
 }
 
 /// Converts a manifest root-port entry into the runtime root-port definition.
-fn build_root_port_definition(rp_cfg: &PcieRootPortConfig) -> GenericPcieRootPortDefinition {
+fn build_root_port_definition(rp_cfg: &PciePortConfig) -> GenericPciePortDefinition {
     let settings = build_root_port_settings(rp_cfg);
 
-    GenericPcieRootPortDefinition {
+    GenericPciePortDefinition {
         name: rp_cfg.name.as_str().into(),
+        devfn: rp_cfg.devfn,
         hotplug: rp_cfg.hotplug,
         settings,
     }
@@ -2143,18 +2144,16 @@ impl InitializedVm {
             let switch_device = chipset_builder
                 .arc_mutex_device(device_name)
                 .on_pcie_port(vmotherboard::BusId::new(&switch.parent_port))
-                .add(|_services| {
+                .try_add(|_services| {
+                    let downstream_ports = switch
+                        .ports
+                        .iter()
+                        .map(build_root_port_definition)
+                        .collect();
                     let definition = pcie::switch::GenericPcieSwitchDefinition {
                         name: switch.name.clone().into(),
-                        downstream_port_count: switch.num_downstream_ports,
-                        hotplug: switch.hotplug,
+                        downstream_ports,
                         msi_target,
-                        dsp_settings: PciePortSettings {
-                            acs_capabilities_supported: switch
-                                .acs_capabilities_supported
-                                .unwrap_or(DEFAULT_ACS_CAP_MASK),
-                            cxl_flex_bus_port_capability: None,
-                        },
                     };
                     GenericPcieSwitch::new(definition)
                 })?;

--- a/openvmm/openvmm_defs/src/config.rs
+++ b/openvmm/openvmm_defs/src/config.rs
@@ -243,8 +243,8 @@ pub struct PciePortConfig {
     /// When `None`, the port is assigned the lowest available devfn. Ports are
     /// assigned in order, so an explicit devfn that collides with a
     /// previously-assigned port (including one assigned automatically) is an
-    /// error. Only honored for root-complex root ports; switch downstream ports
-    /// are always packed sequentially.
+    /// error. Honored for both root-complex root ports and switch downstream
+    /// ports.
     pub devfn: Option<u8>,
     /// Enables PCIe hotplug capabilities for this port.
     pub hotplug: bool,

--- a/openvmm/openvmm_defs/src/config.rs
+++ b/openvmm/openvmm_defs/src/config.rs
@@ -217,7 +217,7 @@ pub struct PcieRootComplexConfig {
     pub end_bus: u8,
     pub low_mmio: PcieMmioRangeConfig,
     pub high_mmio: PcieMmioRangeConfig,
-    pub ports: Vec<PcieRootPortConfig>,
+    pub ports: Vec<PciePortConfig>,
     /// Optional CXL configuration for root-complex CXL mode.
     pub cxl: Option<RootComplexCxlConfig>,
     /// Optional IOMMU for this root complex.
@@ -231,15 +231,26 @@ pub struct PcieRootComplexConfig {
     pub preserve_bars: bool,
 }
 
+/// Configuration for a single PCIe port — either a root-complex root port or a
+/// switch downstream port.
 #[derive(Debug, MeshPayload)]
-pub struct PcieRootPortConfig {
-    /// Root-port name used for topology wiring and lookup.
+pub struct PciePortConfig {
+    /// Port name used for topology wiring and lookup.
     pub name: String,
-    /// Enables PCIe hotplug capabilities for this root port.
+    /// The device/function (`device << 3 | function`) to place this port at on
+    /// its bus.
+    ///
+    /// When `None`, the port is assigned the lowest available devfn. Ports are
+    /// assigned in order, so an explicit devfn that collides with a
+    /// previously-assigned port (including one assigned automatically) is an
+    /// error. Only honored for root-complex root ports; switch downstream ports
+    /// are always packed sequentially.
+    pub devfn: Option<u8>,
+    /// Enables PCIe hotplug capabilities for this port.
     pub hotplug: bool,
-    /// Optional ACS capability bitmask to expose on this root port.
+    /// Optional ACS capability bitmask to expose on this port.
     pub acs_capabilities_supported: Option<u16>,
-    /// Marks this root port as CXL-capable.
+    /// Marks this port as CXL-capable.
     ///
     /// Runtime port construction derives required BAR/subregion layout from
     /// this flag (currently CXL component registers for BAR0).
@@ -249,10 +260,9 @@ pub struct PcieRootPortConfig {
 #[derive(Debug, MeshPayload)]
 pub struct PcieSwitchConfig {
     pub name: String,
-    pub num_downstream_ports: u8,
     pub parent_port: String,
-    pub hotplug: bool,
-    pub acs_capabilities_supported: Option<u16>,
+    /// The downstream ports of this switch.
+    pub ports: Vec<PciePortConfig>,
 }
 
 /// Declares that the device directly behind a named PCIe port (a root port or

--- a/openvmm/openvmm_entry/src/cli_args.rs
+++ b/openvmm/openvmm_entry/src/cli_args.rs
@@ -1064,9 +1064,17 @@ Examples:
     # Attach root port rc0rp1 to root complex rc0 with hotplug support
     --pcie-root-port rc0:rc0rp1,hotplug
 
+    # Attach root port rc0rp2 at device 5, function 0
+    --pcie-root-port rc0:rc0rp2,addr=5
+
+    # Attach root port rc0rp3 at device 5, function 1
+    --pcie-root-port rc0:rc0rp3,addr=5.1
+
 Syntax: <root_complex_name>:<name>[,opt,opt=arg,...]
 
 Options:
+    `addr=<dev>[.<fn>]`            device/function to place this port at (default:
+                                   lowest available); dev 0-31, fn 0-7
     `hotplug`                      enable hotplug support for this root port
     `acs=<mask>`                   ACS capability bitmask (u16, decimal or 0x-prefixed hex)
     `cxl`                          configure this root port as CXL-capable
@@ -3095,6 +3103,7 @@ fn parse_cxl_cfmws_window_restriction_u16_bitmask(
 pub struct PcieRootPortCli {
     pub root_complex_name: String,
     pub name: String,
+    pub devfn: Option<u8>,
     pub hotplug: bool,
     pub acs_capabilities_supported: Option<u16>,
     pub cxl: bool,
@@ -3118,6 +3127,7 @@ impl FromStr for PcieRootPortCli {
             anyhow::bail!("unexpected token: '{extra}'")
         }
 
+        let mut devfn = None;
         let mut hotplug = false;
         let mut acs_capabilities_supported = None;
         let mut cxl = false;
@@ -3129,6 +3139,13 @@ impl FromStr for PcieRootPortCli {
             let value = kv.next();
 
             match key {
+                "addr" => {
+                    let value = value.context("addr option requires a value")?;
+                    if kv.next().is_some() {
+                        anyhow::bail!("addr option expects a single value")
+                    }
+                    devfn = Some(parse_pcie_addr(value)?);
+                }
                 "hotplug" => {
                     if value.is_some() {
                         anyhow::bail!("hotplug option does not take a value")
@@ -3155,11 +3172,42 @@ impl FromStr for PcieRootPortCli {
         Ok(PcieRootPortCli {
             root_complex_name: rc_name.to_string(),
             name: rp_name.to_string(),
+            devfn,
             hotplug,
             acs_capabilities_supported,
             cxl,
         })
     }
+}
+
+/// Parses a PCIe address of the form `XX[.Y]`, where `XX` is the device number
+/// (0-31) and the optional `Y` is the function number (0-7), into a devfn
+/// (`device << 3 | function`).
+fn parse_pcie_addr(s: &str) -> anyhow::Result<u8> {
+    let parse_int = |v: &str| -> anyhow::Result<u8> {
+        if let Some(hex) = v.strip_prefix("0x").or_else(|| v.strip_prefix("0X")) {
+            u8::from_str_radix(hex, 16).context("invalid hex number")
+        } else {
+            v.parse().context("invalid number")
+        }
+    };
+
+    let mut parts = s.split('.');
+    let device = parse_int(parts.next().context("expected device number")?)?;
+    let function = match parts.next() {
+        Some(f) => parse_int(f)?,
+        None => 0,
+    };
+    if parts.next().is_some() {
+        anyhow::bail!("unexpected token in addr '{s}'");
+    }
+    if device > 31 {
+        anyhow::bail!("device number {device} out of range (0-31)");
+    }
+    if function > 7 {
+        anyhow::bail!("function number {function} out of range (0-7)");
+    }
+    Ok((device << 3) | function)
 }
 
 #[derive(Clone, Debug, PartialEq)]
@@ -4599,6 +4647,7 @@ mod tests {
             PcieRootPortCli {
                 root_complex_name: "rc0".to_string(),
                 name: "rc0rp0".to_string(),
+                devfn: None,
                 hotplug: false,
                 acs_capabilities_supported: None,
                 cxl: false,
@@ -4610,6 +4659,7 @@ mod tests {
             PcieRootPortCli {
                 root_complex_name: "my_rc".to_string(),
                 name: "port2".to_string(),
+                devfn: None,
                 hotplug: false,
                 acs_capabilities_supported: None,
                 cxl: false,
@@ -4622,6 +4672,7 @@ mod tests {
             PcieRootPortCli {
                 root_complex_name: "my_rc".to_string(),
                 name: "port2".to_string(),
+                devfn: None,
                 hotplug: true,
                 acs_capabilities_supported: None,
                 cxl: false,
@@ -4633,6 +4684,7 @@ mod tests {
             PcieRootPortCli {
                 root_complex_name: "my_rc".to_string(),
                 name: "port3".to_string(),
+                devfn: None,
                 hotplug: false,
                 acs_capabilities_supported: Some(0),
                 cxl: false,
@@ -4644,6 +4696,7 @@ mod tests {
             PcieRootPortCli {
                 root_complex_name: "my_rc".to_string(),
                 name: "port3".to_string(),
+                devfn: None,
                 hotplug: false,
                 acs_capabilities_supported: Some(0x005f),
                 cxl: false,
@@ -4655,9 +4708,45 @@ mod tests {
             PcieRootPortCli {
                 root_complex_name: "my_rc".to_string(),
                 name: "port4".to_string(),
+                devfn: None,
                 hotplug: false,
                 acs_capabilities_supported: None,
                 cxl: true,
+            }
+        );
+
+        // Test addr= (device only, and device.function)
+        assert_eq!(
+            PcieRootPortCli::from_str("my_rc:port5,addr=5").unwrap(),
+            PcieRootPortCli {
+                root_complex_name: "my_rc".to_string(),
+                name: "port5".to_string(),
+                devfn: Some(5 << 3),
+                hotplug: false,
+                acs_capabilities_supported: None,
+                cxl: false,
+            }
+        );
+        assert_eq!(
+            PcieRootPortCli::from_str("my_rc:port6,addr=5.1").unwrap(),
+            PcieRootPortCli {
+                root_complex_name: "my_rc".to_string(),
+                name: "port6".to_string(),
+                devfn: Some((5 << 3) | 1),
+                hotplug: false,
+                acs_capabilities_supported: None,
+                cxl: false,
+            }
+        );
+        assert_eq!(
+            PcieRootPortCli::from_str("my_rc:port7,addr=0x1f.7").unwrap(),
+            PcieRootPortCli {
+                root_complex_name: "my_rc".to_string(),
+                name: "port7".to_string(),
+                devfn: Some(0xff),
+                hotplug: false,
+                acs_capabilities_supported: None,
+                cxl: false,
             }
         );
 
@@ -4668,6 +4757,10 @@ mod tests {
         assert!(PcieRootPortCli::from_str("rc0:rp0:rp3").is_err());
         assert!(PcieRootPortCli::from_str("rc0:rp0,invalid_option").is_err());
         assert!(PcieRootPortCli::from_str("rc0:rp0,cxl=true").is_err());
+        assert!(PcieRootPortCli::from_str("rc0:rp0,addr=32").is_err());
+        assert!(PcieRootPortCli::from_str("rc0:rp0,addr=0.8").is_err());
+        assert!(PcieRootPortCli::from_str("rc0:rp0,addr=1.2.3").is_err());
+        assert!(PcieRootPortCli::from_str("rc0:rp0,addr").is_err());
     }
 
     #[test]

--- a/openvmm/openvmm_entry/src/lib.rs
+++ b/openvmm/openvmm_entry/src/lib.rs
@@ -79,8 +79,8 @@ use openvmm_defs::config::NumaNode;
 use openvmm_defs::config::NumaTopology;
 use openvmm_defs::config::PcieDeviceConfig;
 use openvmm_defs::config::PcieMmioRangeConfig;
+use openvmm_defs::config::PciePortConfig;
 use openvmm_defs::config::PcieRootComplexConfig;
-use openvmm_defs::config::PcieRootPortConfig;
 use openvmm_defs::config::PcieSwitchConfig;
 use openvmm_defs::config::ProcessorTopologyConfig;
 use openvmm_defs::config::RootComplexCxlConfig;
@@ -211,10 +211,16 @@ fn build_switch_list(all_switches: &[cli_args::GenericPcieSwitchCli]) -> Vec<Pci
         .iter()
         .map(|switch_cli| PcieSwitchConfig {
             name: switch_cli.name.clone(),
-            num_downstream_ports: switch_cli.num_downstream_ports,
             parent_port: switch_cli.port_name.clone(),
-            hotplug: switch_cli.hotplug,
-            acs_capabilities_supported: switch_cli.acs_capabilities_supported,
+            ports: (0..switch_cli.num_downstream_ports)
+                .map(|i| PciePortConfig {
+                    name: format!("{}-downstream-{}", switch_cli.name, i),
+                    devfn: None,
+                    hotplug: switch_cli.hotplug,
+                    acs_capabilities_supported: switch_cli.acs_capabilities_supported,
+                    cxl: false,
+                })
+                .collect(),
         })
         .collect()
 }
@@ -831,12 +837,13 @@ async fn vm_config_from_command_line(
 
     let mut pcie_root_complexes = Vec::new();
     for (i, rc_cli) in opt.pcie_root_complex.iter().enumerate() {
-        let ports: Vec<PcieRootPortConfig> = opt
+        let ports: Vec<PciePortConfig> = opt
             .pcie_root_port
             .iter()
             .filter(|port_cli| port_cli.root_complex_name == rc_cli.name)
-            .map(|port_cli| PcieRootPortConfig {
+            .map(|port_cli| PciePortConfig {
                 name: port_cli.name.clone(),
+                devfn: port_cli.devfn,
                 hotplug: port_cli.hotplug,
                 acs_capabilities_supported: port_cli.acs_capabilities_supported,
                 cxl: port_cli.cxl,

--- a/petri/src/vm/openvmm/modify.rs
+++ b/petri/src/vm/openvmm/modify.rs
@@ -27,8 +27,8 @@ use openvmm_defs::config::LoadMode;
 use openvmm_defs::config::PcieDeviceConfig;
 use openvmm_defs::config::PcieIommuConfig;
 use openvmm_defs::config::PcieMmioRangeConfig;
+use openvmm_defs::config::PciePortConfig;
 use openvmm_defs::config::PcieRootComplexConfig;
-use openvmm_defs::config::PcieRootPortConfig;
 use openvmm_defs::config::PcieSwitchConfig;
 use openvmm_defs::config::VpciDeviceConfig;
 use openvmm_defs::config::Vtl2BaseAddressType;
@@ -372,8 +372,9 @@ impl PetriVmConfigOpenVmm {
                 let end_bus = start_bus + bus_count_per_rc - 1;
 
                 let ports = (0..root_ports_per_root_complex)
-                    .map(|i| PcieRootPortConfig {
+                    .map(|i| PciePortConfig {
                         name: format!("s{}rc{}rp{}", segment, rc_index_in_segment, i),
+                        devfn: None,
                         hotplug: true,
                         acs_capabilities_supported: Some(0),
                         cxl: false,
@@ -414,10 +415,16 @@ impl PetriVmConfigOpenVmm {
     ) -> Self {
         self.config.pcie_switches.push(PcieSwitchConfig {
             name: switch_name.to_string(),
-            num_downstream_ports: port_count,
             parent_port: port_name.to_string(),
-            hotplug,
-            acs_capabilities_supported: Some(0),
+            ports: (0..port_count)
+                .map(|i| PciePortConfig {
+                    name: format!("{switch_name}-downstream-{i}"),
+                    devfn: None,
+                    hotplug,
+                    acs_capabilities_supported: Some(0),
+                    cxl: false,
+                })
+                .collect(),
         });
         self
     }

--- a/vm/devices/pci/pcie/fuzz/fuzz_pcie.rs
+++ b/vm/devices/pci/pcie/fuzz/fuzz_pcie.rs
@@ -14,9 +14,9 @@ use chipset_device::pci::PciConfigSpace;
 use memory_range::MemoryRange;
 use pci_bus::GenericPciBusDevice;
 use pci_core::msi::MsiTarget;
+use pcie::GenericPciePortDefinition;
 use pcie::PciePortSettings;
 use pcie::root::GenericPcieRootComplex;
-use pcie::root::GenericPcieRootPortDefinition;
 use pcie::switch::GenericPcieSwitch;
 use pcie::switch::GenericPcieSwitchDefinition;
 use pcie::test_helpers::TestPcieMmioRegistration;
@@ -120,9 +120,10 @@ impl FuzzRootComplex {
         let hotplug = matches!(topology, Topology::Hotplug { .. });
 
         let mut register_mmio = TestPcieMmioRegistration {};
-        let port_defs: Vec<GenericPcieRootPortDefinition> = (0..NUM_PORTS)
-            .map(|i| GenericPcieRootPortDefinition {
+        let port_defs: Vec<GenericPciePortDefinition> = (0..NUM_PORTS)
+            .map(|i| GenericPciePortDefinition {
                 name: format!("rp{}", i).into(),
+                devfn: None,
                 hotplug,
                 settings: PciePortSettings::default(),
             })

--- a/vm/devices/pci/pcie/fuzz/fuzz_pcie.rs
+++ b/vm/devices/pci/pcie/fuzz/fuzz_pcie.rs
@@ -280,11 +280,17 @@ fn do_fuzz(u: &mut Unstructured<'_>) -> arbitrary::Result<()> {
         Topology::WithSwitch => {
             let switch = GenericPcieSwitch::new(GenericPcieSwitchDefinition {
                 name: "sw0".into(),
-                downstream_port_count: 2,
-                hotplug: false,
+                downstream_ports: (0..NUM_PORTS)
+                    .map(|i| GenericPciePortDefinition {
+                        name: format!("dsp{i}").into(),
+                        devfn: None,
+                        hotplug: false,
+                        settings: PciePortSettings::default(),
+                    })
+                    .collect(),
                 msi_target: MsiTarget::disconnected(),
-                dsp_settings: PciePortSettings::default(),
-            });
+            })
+            .map_err(|_| arbitrary::Error::IncorrectFormat)?;
             rc.add_pcie_device(port0_key, "sw0", Box::new(SwitchAdapter(switch)))
                 .map_err(|_| arbitrary::Error::IncorrectFormat)?;
         }

--- a/vm/devices/pci/pcie/src/lib.rs
+++ b/vm/devices/pci/pcie/src/lib.rs
@@ -7,6 +7,7 @@
 
 pub mod its;
 pub(crate) mod port;
+pub use port::GenericPciePortDefinition;
 pub use port::PciePortSettings;
 pub use port::PortBarDefinition;
 pub use port::PortBarSubregionDefinition;
@@ -35,3 +36,119 @@ const MAX_FUNCTIONS_PER_BUS: usize = 256;
 const BDF_BUS_SHIFT: u16 = 8;
 const BDF_DEVICE_SHIFT: u16 = 3;
 const BDF_DEVICE_FUNCTION_MASK: u16 = 0x00FF;
+
+/// Error assigning devfns to a set of PCIe ports on a bus.
+#[derive(Debug, thiserror::Error)]
+pub enum PortDevfnError {
+    /// An explicitly-requested devfn collided with an already-assigned port.
+    #[error("port '{name}' devfn {devfn:#x} is already in use")]
+    DevfnInUse {
+        /// Name of the port whose devfn collided.
+        name: std::sync::Arc<str>,
+        /// The conflicting devfn value.
+        devfn: u8,
+    },
+    /// No free devfn slot was available for an automatically-placed port.
+    #[error("no available devfn slot for port '{name}'")]
+    NoFreeDevfn {
+        /// Name of the port that could not be placed.
+        name: std::sync::Arc<str>,
+    },
+    /// A device has a port at a non-zero function but no function 0.
+    ///
+    /// Such a port is undiscoverable: the guest reads the multi-function bit
+    /// from function 0's header before probing functions 1-7, so a device with
+    /// no function 0 is skipped entirely.
+    #[error(
+        "device {device} has a port at a non-zero function but no function 0; \
+         the device would be undiscoverable"
+    )]
+    MissingFunctionZero {
+        /// The device number (0-31) missing function 0.
+        device: u8,
+    },
+}
+
+/// The placement of a PCIe port on its bus, as computed by
+/// [`assign_port_devfns`].
+pub(crate) struct PortPlacement {
+    /// The assigned devfn (`device << 3 | function`).
+    pub devfn: u8,
+    /// Whether this port's device hosts more than one function, and thus must
+    /// advertise the multi-function header bit. Computed from the final
+    /// assignment, so a port that is the sole function of its device is *not*
+    /// marked multi-function even when other ports exist on other devices.
+    pub multi_function: bool,
+}
+
+/// Assigns a devfn to each of `ports`, in order, returning their placements.
+///
+/// A port with an explicit [`devfn`](GenericPciePortDefinition::devfn) is placed
+/// there; a port without one takes the lowest free devfn at or above
+/// `first_device`'s devfn. Assignment happens in order, so an explicit devfn
+/// that collides with an already-assigned port (including one assigned
+/// automatically) is an error.
+///
+/// Also validates that every device with a port at a non-zero function has a
+/// function 0; otherwise the device would be undiscoverable (the guest reads
+/// the multi-function bit from function 0 before probing functions 1-7).
+pub(crate) fn assign_port_devfns(
+    ports: &[GenericPciePortDefinition],
+    first_device: u8,
+) -> Result<Vec<PortPlacement>, PortDevfnError> {
+    let start_devfn = first_device << BDF_DEVICE_SHIFT;
+    // 256-bit bitmap of devfns already assigned to a port, indexed so that the
+    // device number selects the byte and the function selects the bit.
+    let mut used = [0u8; 32];
+    let is_used = |used: &[u8; 32], devfn: u8| {
+        used[(devfn >> BDF_DEVICE_SHIFT) as usize] & (1 << (devfn & 7)) != 0
+    };
+    let set_used = |used: &mut [u8; 32], devfn: u8| {
+        used[(devfn >> BDF_DEVICE_SHIFT) as usize] |= 1 << (devfn & 7)
+    };
+
+    let mut placements = Vec::with_capacity(ports.len());
+    for def in ports {
+        let devfn = match def.devfn {
+            Some(devfn) => {
+                if is_used(&used, devfn) {
+                    return Err(PortDevfnError::DevfnInUse {
+                        name: def.name.clone(),
+                        devfn,
+                    });
+                }
+                devfn
+            }
+            None => (start_devfn..=u8::MAX)
+                .find(|d| !is_used(&used, *d))
+                .ok_or_else(|| PortDevfnError::NoFreeDevfn {
+                    name: def.name.clone(),
+                })?,
+        };
+        set_used(&mut used, devfn);
+        placements.push(PortPlacement {
+            devfn,
+            // Filled in below, once all devfns are known.
+            multi_function: false,
+        });
+    }
+
+    for (device, &functions) in used.iter().enumerate() {
+        if functions != 0 && functions & 1 == 0 {
+            return Err(PortDevfnError::MissingFunctionZero {
+                device: device as u8,
+            });
+        }
+    }
+
+    // The multi-function bit is per-device: a device must advertise it only
+    // when it hosts more than one function. The function-0 check above
+    // guarantees bit 0 is set for any populated device, so the bitmap byte is
+    // exactly 1 iff function 0 is the device's only function.
+    for placement in &mut placements {
+        let device_functions = used[(placement.devfn >> BDF_DEVICE_SHIFT) as usize];
+        placement.multi_function = device_functions > 1;
+    }
+
+    Ok(placements)
+}

--- a/vm/devices/pci/pcie/src/port.rs
+++ b/vm/devices/pci/pcie/src/port.rs
@@ -69,6 +69,25 @@ pub struct PciePortSettings {
     pub cxl_flex_bus_port_capability: Option<CxlFlexBusPortDvsecCapability>,
 }
 
+/// A description of a generic PCIe port (a root-complex root port or a switch
+/// downstream port).
+pub struct GenericPciePortDefinition {
+    /// The name of the port.
+    pub name: Arc<str>,
+    /// The device/function (`device << 3 | function`) to place this port at.
+    ///
+    /// When `None`, the port is assigned the lowest available devfn at or
+    /// above the builder's first-port device number. Ports are assigned in
+    /// order; an explicit devfn that collides with an already-assigned port
+    /// is an error. Only honored for root-complex root ports; switch
+    /// downstream ports are always packed sequentially.
+    pub devfn: Option<u8>,
+    /// Whether hotplug is enabled for this port.
+    pub hotplug: bool,
+    /// Express-level port settings (ACS, etc.).
+    pub settings: PciePortSettings,
+}
+
 /// Generic PCIe port BAR definition.
 #[derive(Clone)]
 pub struct PortBarDefinition {

--- a/vm/devices/pci/pcie/src/port.rs
+++ b/vm/devices/pci/pcie/src/port.rs
@@ -79,8 +79,8 @@ pub struct GenericPciePortDefinition {
     /// When `None`, the port is assigned the lowest available devfn at or
     /// above the builder's first-port device number. Ports are assigned in
     /// order; an explicit devfn that collides with an already-assigned port
-    /// is an error. Only honored for root-complex root ports; switch
-    /// downstream ports are always packed sequentially.
+    /// is an error. Honored for both root-complex root ports and switch
+    /// downstream ports.
     pub devfn: Option<u8>,
     /// Whether hotplug is enabled for this port.
     pub hotplug: bool,

--- a/vm/devices/pci/pcie/src/root.rs
+++ b/vm/devices/pci/pcie/src/root.rs
@@ -5,13 +5,13 @@
 
 use crate::BDF_BUS_SHIFT;
 use crate::BDF_DEVICE_FUNCTION_MASK;
-use crate::BDF_DEVICE_SHIFT;
 use crate::MAX_FUNCTIONS_PER_BUS;
 use crate::PAGE_OFFSET_MASK;
 use crate::PAGE_SHIFT;
 use crate::PAGE_SIZE64;
 use crate::ROOT_PORT_DEVICE_ID;
 use crate::VENDOR_ID;
+use crate::port::GenericPciePortDefinition;
 use crate::port::PcieDownstreamPort;
 use crate::port::PciePortSettings;
 use chipset_device::ChipsetDevice;
@@ -40,10 +40,19 @@ use zerocopy::IntoBytes;
 
 /// Error returned when a root complex configuration is invalid.
 #[derive(Debug, Error)]
-#[error("requested {port_count} root ports, but only {max} are supported")]
-pub struct InvalidRootComplexError {
-    port_count: usize,
-    max: usize,
+pub enum InvalidRootComplexError {
+    /// Too many root ports were requested for the available device/function
+    /// slots.
+    #[error("requested {port_count} root ports, but only {max} are supported")]
+    TooManyPorts {
+        /// Number of root ports requested.
+        port_count: usize,
+        /// Maximum number of root ports supported.
+        max: usize,
+    },
+    /// A root port's devfn could not be assigned.
+    #[error(transparent)]
+    Devfn(#[from] crate::PortDevfnError),
 }
 
 /// A generic PCI Express root complex emulator.
@@ -100,16 +109,6 @@ pub struct DownstreamPortInfo {
     pub bus_range: AssignedBusRange,
 }
 
-/// A description of a generic PCIe root port.
-pub struct GenericPcieRootPortDefinition {
-    /// The name of the root port.
-    pub name: Arc<str>,
-    /// Whether hotplug is enabled for this root port.
-    pub hotplug: bool,
-    /// Express-level port settings (ACS, etc.).
-    pub settings: PciePortSettings,
-}
-
 /// A flat description of a PCIe switch without hierarchy.
 pub struct GenericSwitchDefinition {
     /// The name of the switch.
@@ -161,7 +160,7 @@ pub struct GenericPcieRootComplexBuilder<'a> {
     register_mmio: &'a mut dyn RegisterMmioIntercept,
     bus_range: RangeInclusive<u8>,
     ecam_range: MemoryRange,
-    root_ports: Option<(Vec<GenericPcieRootPortDefinition>, &'a MsiTarget)>,
+    root_ports: Option<(Vec<GenericPciePortDefinition>, &'a MsiTarget)>,
     first_port_device_number: u8,
     chbcr_range: Option<MemoryRange>,
 }
@@ -174,7 +173,7 @@ impl<'a> GenericPcieRootComplexBuilder<'a> {
     /// the platform's interrupt controller.
     pub fn root_ports(
         mut self,
-        ports: Vec<GenericPcieRootPortDefinition>,
+        ports: Vec<GenericPciePortDefinition>,
         msi_target: &'a MsiTarget,
     ) -> Self {
         self.root_ports = Some((ports, msi_target));
@@ -241,42 +240,45 @@ impl<'a> GenericPcieRootComplexBuilder<'a> {
         let mut devices: Vec<(u8, BusDevice)> = Vec::new();
 
         if let Some((ports, msi_target)) = root_ports {
-            // Pack root ports into consecutive devfn values, 8 functions
-            // per device slot, mirroring the switch downstream-port pattern.
             let port_count = ports.len();
             let max = 32usize.saturating_sub(first_port_device_number as usize) * 8;
             if port_count > max {
-                return Err(InvalidRootComplexError { port_count, max });
+                return Err(InvalidRootComplexError::TooManyPorts { port_count, max });
             }
 
-            let multi_function = port_count > 1;
+            // Assign each root port a devfn (honoring explicit requests and
+            // filling the rest from `first_port_device_number`), shared with
+            // the switch downstream-port assignment.
+            let placements = crate::assign_port_devfns(&ports, first_port_device_number)?;
 
-            for (i, definition) in ports.into_iter().enumerate() {
-                let device = (i / 8) + first_port_device_number as usize;
-                let function = i % 8;
-                let devfn = ((device as u8) << BDF_DEVICE_SHIFT) | function as u8;
+            for (i, (definition, placement)) in ports.into_iter().zip(placements).enumerate() {
                 let hotplug_slot_number = if definition.hotplug {
                     Some(i as u32 + 1)
                 } else {
                     None
                 };
-                let port_msi_target = msi_target.with_devfn(devfn);
+                let port_msi_target = msi_target.with_devfn(placement.devfn);
                 let root_port = RootPort::new(
                     register_mmio,
                     definition.name.clone(),
-                    multi_function,
+                    placement.multi_function,
                     hotplug_slot_number,
                     &port_msi_target,
                     definition.settings,
                 );
                 devices.push((
-                    devfn,
+                    placement.devfn,
                     BusDevice::RootPort {
                         name: definition.name,
                         port: Box::new(root_port),
                     },
                 ));
             }
+
+            // `devices` is searched with `binary_search_by_key` on devfn, so it
+            // must be kept sorted. Explicit devfns may be assigned out of
+            // order, so sort here.
+            devices.sort_by_key(|(devfn, _)| *devfn);
         }
 
         Ok(GenericPcieRootComplex {
@@ -1052,8 +1054,9 @@ mod tests {
         port_count: u16,
     ) -> GenericPcieRootComplex {
         let port_defs = (0..port_count)
-            .map(|i| GenericPcieRootPortDefinition {
+            .map(|i| GenericPciePortDefinition {
                 name: format!("test-port-{}", i).into(),
+                devfn: None,
                 hotplug: false,
                 settings: PciePortSettings::default(),
             })
@@ -1077,8 +1080,9 @@ mod tests {
         chbcr_start: u64,
     ) -> GenericPcieRootComplex {
         let port_defs = (0..port_count)
-            .map(|i| GenericPcieRootPortDefinition {
+            .map(|i| GenericPciePortDefinition {
                 name: format!("test-port-{}", i).into(),
+                devfn: None,
                 hotplug: false,
                 settings: PciePortSettings::default(),
             })
@@ -1741,8 +1745,9 @@ mod tests {
         let rc_bus_range = AssignedBusRange::new();
         rc_bus_range.set_bus_range(start_bus, end_bus);
         let msi_conn = pci_core::msi::MsiConnection::new(rc_bus_range, 0);
-        let port_defs = vec![GenericPcieRootPortDefinition {
+        let port_defs = vec![GenericPciePortDefinition {
             name: "port-0".into(),
+            devfn: None,
             hotplug: false,
             settings: PciePortSettings::default(),
         }];
@@ -1885,11 +1890,53 @@ mod tests {
     }
 
     #[test]
+    fn test_multi_function_bit_is_per_device() {
+        // Two ports placed at explicit devfns on *distinct* devices (each the
+        // sole function of its device) must NOT advertise the multi-function
+        // bit, even though there is more than one port.
+        let mut register_mmio = TestPcieMmioRegistration {};
+        let ecam = MemoryRange::new(0..ecam_size_from_bus_numbers(0, 0));
+        let rc_bus_range = AssignedBusRange::new();
+        rc_bus_range.set_bus_range(0, 0);
+        let msi_conn = pci_core::msi::MsiConnection::new(rc_bus_range, 0);
+        let port_defs = vec![
+            GenericPciePortDefinition {
+                name: "a".into(),
+                devfn: Some(8), // device 1, function 0
+                hotplug: false,
+                settings: PciePortSettings::default(),
+            },
+            GenericPciePortDefinition {
+                name: "b".into(),
+                devfn: Some(16), // device 2, function 0
+                hotplug: false,
+                settings: PciePortSettings::default(),
+            },
+        ];
+        let mut rc = GenericPcieRootComplex::builder(&mut register_mmio, 0..=0u8, ecam)
+            .root_ports(port_defs, msi_conn.target())
+            .build()
+            .unwrap();
+
+        for devfn in [8u64, 16] {
+            let mut header: u32 = 0;
+            rc.mmio_read(devfn * 4096 + 0x0C, header.as_mut_bytes())
+                .unwrap();
+            assert_eq!(
+                header & (1 << 23),
+                0,
+                "devfn {devfn}: sole function of its device must not set the multi-function bit"
+            );
+        }
+    }
+
+    #[test]
     fn test_too_many_ports_returns_error() {
         // 257 ports starting at device 0 requires device 32, which is out of range.
-        let port_defs: Vec<GenericPcieRootPortDefinition> = (0..257)
-            .map(|i| GenericPcieRootPortDefinition {
+        let port_defs: Vec<GenericPciePortDefinition> = (0..257)
+            .map(|i| GenericPciePortDefinition {
                 name: format!("port-{}", i).into(),
+                devfn: None,
                 hotplug: false,
                 settings: PciePortSettings::default(),
             })
@@ -1906,5 +1953,105 @@ mod tests {
             result.is_err(),
             "257 ports should exceed the 256-port limit"
         );
+    }
+
+    /// Builds a root complex from explicit per-port devfn requests, returning
+    /// the assigned devfns in port-name order.
+    fn build_with_devfns(
+        ports: Vec<(&str, Option<u8>)>,
+        first_port_device_number: u8,
+    ) -> Result<Vec<(String, u8)>, InvalidRootComplexError> {
+        let port_defs: Vec<GenericPciePortDefinition> = ports
+            .into_iter()
+            .map(|(name, devfn)| GenericPciePortDefinition {
+                name: name.into(),
+                devfn,
+                hotplug: false,
+                settings: PciePortSettings::default(),
+            })
+            .collect();
+        let mut register_mmio = TestPcieMmioRegistration {};
+        let ecam = MemoryRange::new(0..ecam_size_from_bus_numbers(0, 0));
+        let rc_bus_range = AssignedBusRange::new();
+        rc_bus_range.set_bus_range(0, 0);
+        let msi_conn = pci_core::msi::MsiConnection::new(rc_bus_range, 0);
+        let rc = GenericPcieRootComplex::builder(&mut register_mmio, 0..=0u8, ecam)
+            .root_ports(port_defs, msi_conn.target())
+            .first_port_device_number(first_port_device_number)
+            .build()?;
+        Ok(rc
+            .downstream_ports()
+            .into_iter()
+            .map(|p| (p.name.to_string(), p.devfn))
+            .collect())
+    }
+
+    #[test]
+    fn test_devfn_auto_allocation() {
+        // All-None ports pack onto consecutive devfns starting at 0.
+        let ports = build_with_devfns(vec![("a", None), ("b", None), ("c", None)], 0).unwrap();
+        assert_eq!(
+            ports,
+            vec![("a".into(), 0), ("b".into(), 1), ("c".into(), 2)]
+        );
+    }
+
+    #[test]
+    fn test_devfn_auto_allocation_respects_first_device() {
+        // None ports start at the first-port device number (device 1 → devfn 8).
+        let ports = build_with_devfns(vec![("a", None), ("b", None)], 1).unwrap();
+        assert_eq!(ports, vec![("a".into(), 8), ("b".into(), 9)]);
+    }
+
+    #[test]
+    fn test_devfn_explicit_and_auto_mix() {
+        // Explicit devfn is honored; subsequent None ports skip used devfns.
+        let ports =
+            build_with_devfns(vec![("a", Some(0)), ("b", None), ("c", Some(16))], 0).unwrap();
+        // Sorted by devfn: a@0, b@1, c@16.
+        assert_eq!(
+            ports,
+            vec![("a".into(), 0), ("b".into(), 1), ("c".into(), 16)]
+        );
+    }
+
+    #[test]
+    fn test_devfn_none_then_explicit_zero_conflicts() {
+        // [None, Some(0)]: the None port takes devfn 0, so the explicit
+        // request for 0 collides and fails (allocation is in order).
+        let err = build_with_devfns(vec![("a", None), ("b", Some(0))], 0).unwrap_err();
+        assert!(matches!(
+            err,
+            InvalidRootComplexError::Devfn(crate::PortDevfnError::DevfnInUse { devfn: 0, .. })
+        ));
+    }
+
+    #[test]
+    fn test_devfn_explicit_duplicate_conflicts() {
+        let err = build_with_devfns(vec![("a", Some(5)), ("b", Some(5))], 0).unwrap_err();
+        assert!(matches!(
+            err,
+            InvalidRootComplexError::Devfn(crate::PortDevfnError::DevfnInUse { devfn: 5, .. })
+        ));
+    }
+
+    #[test]
+    fn test_devfn_nonzero_function_without_function_zero_fails() {
+        // device 5, function 1 (devfn 0x29) with no function 0 is undiscoverable.
+        let err = build_with_devfns(vec![("a", Some((5 << 3) | 1))], 0).unwrap_err();
+        assert!(matches!(
+            err,
+            InvalidRootComplexError::Devfn(crate::PortDevfnError::MissingFunctionZero {
+                device: 5
+            })
+        ));
+    }
+
+    #[test]
+    fn test_devfn_function_zero_present_allows_higher_functions() {
+        // device 5 functions 0 and 1 present: discoverable, so this is allowed.
+        let ports =
+            build_with_devfns(vec![("a", Some(5 << 3)), ("b", Some((5 << 3) | 1))], 0).unwrap();
+        assert_eq!(ports, vec![("a".into(), 40), ("b".into(), 41)]);
     }
 }

--- a/vm/devices/pci/pcie/src/switch.rs
+++ b/vm/devices/pci/pcie/src/switch.rs
@@ -11,6 +11,7 @@
 //! PCIe capabilities indicating their port type.
 
 use crate::DOWNSTREAM_SWITCH_PORT_DEVICE_ID;
+use crate::PortDevfnError;
 use crate::UPSTREAM_SWITCH_PORT_DEVICE_ID;
 use crate::VENDOR_ID;
 use crate::port::PcieDownstreamPort;
@@ -145,16 +146,31 @@ impl DownstreamSwitchPort {
 pub struct GenericPcieSwitchDefinition {
     /// The name of the switch.
     pub name: Arc<str>,
-    /// The number of downstream ports to create.
+    /// The downstream ports to create.
+    ///
+    /// Each port is assigned a devfn the same way root-complex root ports are:
+    /// an explicit [`devfn`](crate::GenericPciePortDefinition::devfn) is honored,
+    /// and the rest are packed sequentially from device 0. CXL is not supported
+    /// on switch downstream ports.
     /// TODO: implement physical slot number, link and slot stuff
-    pub downstream_port_count: u8,
-    /// Whether hotplug is enabled for this switch's downstream ports.
-    pub hotplug: bool,
+    pub downstream_ports: Vec<crate::GenericPciePortDefinition>,
     /// MSI target from the parent connection. The switch re-derives
     /// per-port targets using the upstream port's bus range.
     pub msi_target: MsiTarget,
-    /// Express-level settings for downstream switch ports.
-    pub dsp_settings: PciePortSettings,
+}
+
+/// Error returned when a switch configuration is invalid.
+#[derive(Debug, thiserror::Error)]
+pub enum InvalidSwitchError {
+    /// CXL was requested on a switch downstream port, which is not supported.
+    #[error("downstream port '{name}': CXL is not supported on switch ports")]
+    CxlUnsupported {
+        /// Name of the offending downstream port.
+        name: Arc<str>,
+    },
+    /// A downstream port's devfn could not be assigned.
+    #[error(transparent)]
+    Devfn(#[from] PortDevfnError),
 }
 
 /// A PCI Express switch emulator that implements a complete switch with upstream and downstream ports.
@@ -171,18 +187,30 @@ pub struct GenericPcieSwitch {
     name: Arc<str>,
     /// The upstream switch port that connects to the parent.
     upstream_port: UpstreamSwitchPort,
-    /// Downstream switch ports indexed by devfn.
-    #[inspect(with = "|x| inspect::iter_by_index(x).map_value(|(_, v)| v)")]
-    downstream_ports: Vec<(Arc<str>, DownstreamSwitchPort)>,
+    /// Downstream switch ports, sorted by devfn.
+    #[inspect(with = "|x| inspect::iter_by_key(x.iter().map(|(k, _, v)| (k, v)))")]
+    downstream_ports: Vec<(u8, Arc<str>, DownstreamSwitchPort)>,
 }
 
 impl GenericPcieSwitch {
     /// Constructs a new [`GenericPcieSwitch`] emulator.
-    pub fn new(definition: GenericPcieSwitchDefinition) -> Self {
+    pub fn new(definition: GenericPcieSwitchDefinition) -> Result<Self, InvalidSwitchError> {
         let upstream_port = UpstreamSwitchPort::new();
 
-        // If there are multiple downstream ports, they need the multi-function flag set
-        let multi_function = definition.downstream_port_count > 1;
+        // CXL is not supported on switch downstream ports (there is no CHBCR /
+        // component-register infrastructure behind a switch).
+        for port_def in &definition.downstream_ports {
+            if port_def.settings.cxl_flex_bus_port_capability.is_some() {
+                return Err(InvalidSwitchError::CxlUnsupported {
+                    name: port_def.name.clone(),
+                });
+            }
+        }
+
+        // Assign each downstream port a devfn, shared with the root-complex
+        // root-port assignment. Honors explicit devfns and packs the rest from
+        // device 0.
+        let placements = crate::assign_port_devfns(&definition.downstream_ports, 0)?;
 
         // Derive per-port MSI targets from the parent's target, using
         // the upstream port's bus range. When the guest programs the
@@ -192,33 +220,40 @@ impl GenericPcieSwitch {
             .msi_target
             .with_bus_range(upstream_port.cfg_space().bus_range(), 0);
 
-        let downstream_ports: Vec<(Arc<str>, DownstreamSwitchPort)> = (0..definition
-            .downstream_port_count)
-            .map(|i| {
-                let port_name: Arc<str> = format!("{}-downstream-{}", definition.name, i).into();
+        let mut downstream_ports: Vec<(u8, Arc<str>, DownstreamSwitchPort)> = definition
+            .downstream_ports
+            .into_iter()
+            .zip(placements)
+            .enumerate()
+            .map(|(i, (port_def, placement))| {
+                let port_name = port_def.name;
                 // Use the port index as the slot number for hotpluggable ports
-                let hotplug_slot_number = if definition.hotplug {
+                let hotplug_slot_number = if port_def.hotplug {
                     Some((i as u32) + 1)
                 } else {
                     None
                 };
-                let port_msi_target = switch_msi_target.with_devfn(i);
+                let port_msi_target = switch_msi_target.with_devfn(placement.devfn);
                 let port = DownstreamSwitchPort::new(
                     port_name.clone(),
-                    Some(multi_function),
+                    Some(placement.multi_function),
                     hotplug_slot_number,
                     &port_msi_target,
-                    definition.dsp_settings.clone(),
+                    port_def.settings,
                 );
-                (port_name, port)
+                (placement.devfn, port_name, port)
             })
             .collect();
 
-        Self {
+        // `downstream_ports` is searched by devfn, so keep it sorted; explicit
+        // devfns may be assigned out of order.
+        downstream_ports.sort_by_key(|(devfn, _, _)| *devfn);
+
+        Ok(Self {
             name: definition.name,
             upstream_port,
             downstream_ports,
-        }
+        })
     }
 
     /// Get the name of this switch.
@@ -235,9 +270,8 @@ impl GenericPcieSwitch {
     pub fn downstream_ports(&self) -> Vec<crate::root::DownstreamPortInfo> {
         self.downstream_ports
             .iter()
-            .enumerate()
-            .map(|(i, (name, dsp))| crate::root::DownstreamPortInfo {
-                devfn: i as u8,
+            .map(|(devfn, name, dsp)| crate::root::DownstreamPortInfo {
+                devfn: *devfn,
                 name: name.clone(),
                 bus_range: dsp.port.bus_range(),
             })
@@ -313,7 +347,10 @@ impl GenericPcieSwitch {
         cfg_offset: u16,
         value: &mut u32,
     ) -> Option<IoResult> {
-        let (_, downstream_port) = self.downstream_ports.get_mut(function as usize)?;
+        let (_, _, downstream_port) = self
+            .downstream_ports
+            .iter_mut()
+            .find(|(devfn, _, _)| *devfn == function)?;
         Some(downstream_port.port.cfg_space.read_u32(cfg_offset, value))
     }
 
@@ -324,7 +361,10 @@ impl GenericPcieSwitch {
         cfg_offset: u16,
         value: u32,
     ) -> Option<IoResult> {
-        let (_, downstream_port) = self.downstream_ports.get_mut(function as usize)?;
+        let (_, _, downstream_port) = self
+            .downstream_ports
+            .iter_mut()
+            .find(|(devfn, _, _)| *devfn == function)?;
         Some(downstream_port.port.cfg_space.write_u32(cfg_offset, value))
     }
 
@@ -336,7 +376,7 @@ impl GenericPcieSwitch {
         cfg_offset: u16,
         value: &mut u32,
     ) -> Option<IoResult> {
-        for (_, downstream_port) in self.downstream_ports.iter_mut() {
+        for (_, _, downstream_port) in self.downstream_ports.iter_mut() {
             let downstream_bus_range = downstream_port.cfg_space().assigned_bus_range();
 
             // Skip downstream ports with invalid/uninitialized bus configuration
@@ -365,7 +405,7 @@ impl GenericPcieSwitch {
         cfg_offset: u16,
         value: u32,
     ) -> Option<IoResult> {
-        for (_, downstream_port) in self.downstream_ports.iter_mut() {
+        for (_, _, downstream_port) in self.downstream_ports.iter_mut() {
             let downstream_bus_range = downstream_port.cfg_space().assigned_bus_range();
 
             // Skip downstream ports with invalid/uninitialized bus configuration
@@ -393,9 +433,10 @@ impl GenericPcieSwitch {
         name: &str,
         dev: Box<dyn GenericPciBusDevice>,
     ) -> anyhow::Result<()> {
-        let (port_name, downstream_port) = self
+        let (_, port_name, downstream_port) = self
             .downstream_ports
-            .get_mut(port_devfn as usize)
+            .iter_mut()
+            .find(|(devfn, _, _)| *devfn == port_devfn)
             .ok_or_else(|| anyhow::anyhow!("port devfn {} not found", port_devfn))?;
         downstream_port
             .port
@@ -418,7 +459,7 @@ impl ChangeDeviceState for GenericPcieSwitch {
         self.upstream_port.cfg_space.reset();
 
         // Reset all downstream port configuration spaces
-        for (_, downstream_port) in self.downstream_ports.iter_mut() {
+        for (_, _, downstream_port) in self.downstream_ports.iter_mut() {
             downstream_port.port.cfg_space.reset();
         }
     }
@@ -559,9 +600,9 @@ mod save_restore {
 
             // Save all downstream ports (already sorted by devfn in the Vec).
             let mut downstream_ports = Vec::with_capacity(self.downstream_ports.len());
-            for (i, (_, downstream_port)) in self.downstream_ports.iter_mut().enumerate() {
+            for (devfn, _, downstream_port) in self.downstream_ports.iter_mut() {
                 downstream_ports.push(state::DownstreamPortSavedState {
-                    devfn: i as u8,
+                    devfn: *devfn,
                     cfg_space: downstream_port.port.cfg_space.save()?,
                     cxl_component_registers: downstream_port
                         .port
@@ -605,8 +646,10 @@ mod save_restore {
                     )));
                 }
 
-                if let Some((_, downstream_port)) =
-                    self.downstream_ports.get_mut(port_state.devfn as usize)
+                if let Some((_, _, downstream_port)) = self
+                    .downstream_ports
+                    .iter_mut()
+                    .find(|(devfn, _, _)| *devfn == port_state.devfn)
                 {
                     downstream_port
                         .port
@@ -633,6 +676,35 @@ mod tests {
     use super::*;
     use pci_core::bus_range::AssignedBusRange;
     use pci_core::msi::MsiConnection;
+
+    /// Builds a switch definition with `downstream_port_count` uniform
+    /// downstream ports named `{name}-downstream-{i}`, mirroring the naming
+    /// convention used by the rest of the topology.
+    fn switch_def(
+        name: &str,
+        downstream_port_count: u8,
+        hotplug: bool,
+        dsp_settings: PciePortSettings,
+        msi_target: MsiTarget,
+    ) -> GenericPcieSwitchDefinition {
+        GenericPcieSwitchDefinition {
+            name: name.into(),
+            downstream_ports: (0..downstream_port_count)
+                .map(|i| crate::GenericPciePortDefinition {
+                    name: format!("{name}-downstream-{i}").into(),
+                    devfn: None,
+                    hotplug,
+                    settings: dsp_settings.clone(),
+                })
+                .collect(),
+            msi_target,
+        }
+    }
+
+    /// Builds a switch from a definition, unwrapping the (test-only) result.
+    fn build(definition: GenericPcieSwitchDefinition) -> GenericPcieSwitch {
+        GenericPcieSwitch::new(definition).unwrap()
+    }
 
     #[test]
     fn test_upstream_switch_port_creation() {
@@ -769,14 +841,13 @@ mod tests {
 
     #[test]
     fn test_switch_creation() {
-        let definition = GenericPcieSwitchDefinition {
-            name: "test-switch".into(),
-            downstream_port_count: 3,
-            hotplug: false,
-            dsp_settings: PciePortSettings::default(),
-            msi_target: MsiTarget::disconnected(),
-        };
-        let switch = GenericPcieSwitch::new(definition);
+        let switch = build(switch_def(
+            "test-switch",
+            3,
+            false,
+            PciePortSettings::default(),
+            MsiTarget::disconnected(),
+        ));
 
         assert_eq!(switch.name().as_ref(), "test-switch");
         assert_eq!(switch.downstream_ports().len(), 3);
@@ -801,14 +872,13 @@ mod tests {
         use crate::test_helpers::TestPcieEndpoint;
         use chipset_device::io::IoError;
 
-        let definition = GenericPcieSwitchDefinition {
-            name: "test-switch".into(),
-            downstream_port_count: 2,
-            hotplug: false,
-            dsp_settings: PciePortSettings::default(),
-            msi_target: MsiTarget::disconnected(),
-        };
-        let mut switch = GenericPcieSwitch::new(definition);
+        let mut switch = build(switch_def(
+            "test-switch",
+            2,
+            false,
+            PciePortSettings::default(),
+            MsiTarget::disconnected(),
+        ));
 
         let downstream_device = TestPcieEndpoint::new(
             |offset, value| match offset {
@@ -849,14 +919,13 @@ mod tests {
         use crate::test_helpers::TestPcieEndpoint;
         use chipset_device::io::IoResult;
 
-        let definition = GenericPcieSwitchDefinition {
-            name: "test-switch".into(),
-            downstream_port_count: 2,
-            hotplug: false,
-            dsp_settings: PciePortSettings::default(),
-            msi_target: MsiTarget::disconnected(),
-        };
-        let mut switch = GenericPcieSwitch::new(definition);
+        let mut switch = build(switch_def(
+            "test-switch",
+            2,
+            false,
+            PciePortSettings::default(),
+            MsiTarget::disconnected(),
+        ));
 
         // Verify that Switch implements routing functionality by testing add_pcie_device method
         // This tests that the switch can accept device connections (routing capability)
@@ -884,14 +953,13 @@ mod tests {
         use chipset_device::ChipsetDevice;
         use chipset_device::pci::PciConfigSpace;
 
-        let definition = GenericPcieSwitchDefinition {
-            name: "test-switch".into(),
-            downstream_port_count: 4,
-            hotplug: false,
-            dsp_settings: PciePortSettings::default(),
-            msi_target: MsiTarget::disconnected(),
-        };
-        let mut switch = GenericPcieSwitch::new(definition);
+        let mut switch = build(switch_def(
+            "test-switch",
+            4,
+            false,
+            PciePortSettings::default(),
+            MsiTarget::disconnected(),
+        ));
 
         // Test that it supports PCI but not other interfaces
         assert!(switch.supports_pci().is_some());
@@ -915,41 +983,38 @@ mod tests {
 
     #[test]
     fn test_switch_default() {
-        let definition = GenericPcieSwitchDefinition {
-            name: "default-switch".into(),
-            downstream_port_count: 4,
-            hotplug: false,
-            dsp_settings: PciePortSettings::default(),
-            msi_target: MsiTarget::disconnected(),
-        };
-        let switch = GenericPcieSwitch::new(definition);
+        let switch = build(switch_def(
+            "default-switch",
+            4,
+            false,
+            PciePortSettings::default(),
+            MsiTarget::disconnected(),
+        ));
         assert_eq!(switch.name().as_ref(), "default-switch");
         assert_eq!(switch.downstream_ports().len(), 4);
     }
 
     #[test]
     fn test_switch_large_downstream_port_count() {
-        let definition = GenericPcieSwitchDefinition {
-            name: "test-switch".into(),
-            downstream_port_count: 16,
-            hotplug: false,
-            dsp_settings: PciePortSettings::default(),
-            msi_target: MsiTarget::disconnected(),
-        };
-        let switch = GenericPcieSwitch::new(definition);
+        let switch = build(switch_def(
+            "test-switch",
+            16,
+            false,
+            PciePortSettings::default(),
+            MsiTarget::disconnected(),
+        ));
         assert_eq!(switch.downstream_ports().len(), 16);
     }
 
     #[test]
     fn test_switch_downstream_port_direct_access() {
-        let definition = GenericPcieSwitchDefinition {
-            name: "test-switch".into(),
-            downstream_port_count: 3,
-            hotplug: false,
-            dsp_settings: PciePortSettings::default(),
-            msi_target: MsiTarget::disconnected(),
-        };
-        let mut switch = GenericPcieSwitch::new(definition);
+        let mut switch = build(switch_def(
+            "test-switch",
+            3,
+            false,
+            PciePortSettings::default(),
+            MsiTarget::disconnected(),
+        ));
 
         // Simulate the switch's internal bus being assigned as bus 1
         let secondary_bus = 1u8;
@@ -987,14 +1052,13 @@ mod tests {
 
     #[test]
     fn test_switch_invalid_bus_range_handling() {
-        let definition = GenericPcieSwitchDefinition {
-            name: "test-switch".into(),
-            downstream_port_count: 2,
-            hotplug: false,
-            dsp_settings: PciePortSettings::default(),
-            msi_target: MsiTarget::disconnected(),
-        };
-        let mut switch = GenericPcieSwitch::new(definition);
+        let mut switch = build(switch_def(
+            "test-switch",
+            2,
+            false,
+            PciePortSettings::default(),
+            MsiTarget::disconnected(),
+        ));
 
         // Don't configure bus numbers, so the range should be 0..=0 (invalid)
         let bus_range = switch.upstream_port.cfg_space().assigned_bus_range();
@@ -1014,14 +1078,13 @@ mod tests {
 
     #[test]
     fn test_switch_downstream_port_invalid_bus_range_skipping() {
-        let definition = GenericPcieSwitchDefinition {
-            name: "test-switch".into(),
-            downstream_port_count: 2,
-            hotplug: false,
-            dsp_settings: PciePortSettings::default(),
-            msi_target: MsiTarget::disconnected(),
-        };
-        let mut switch = GenericPcieSwitch::new(definition);
+        let mut switch = build(switch_def(
+            "test-switch",
+            2,
+            false,
+            PciePortSettings::default(),
+            MsiTarget::disconnected(),
+        ));
 
         // Configure the upstream port with a valid bus range
         let secondary_bus = 1u8;
@@ -1055,19 +1118,18 @@ mod tests {
     #[test]
     fn test_switch_multi_function_bit() {
         // Test that switches with multiple downstream ports set the multi-function bit
-        let multi_port_definition = GenericPcieSwitchDefinition {
-            name: "multi-port-switch".into(),
-            downstream_port_count: 3,
-            hotplug: false,
-            dsp_settings: PciePortSettings::default(),
-            msi_target: MsiTarget::disconnected(),
-        };
-        let multi_port_switch = GenericPcieSwitch::new(multi_port_definition);
+        let multi_port_switch = build(switch_def(
+            "multi-port-switch",
+            3,
+            false,
+            PciePortSettings::default(),
+            MsiTarget::disconnected(),
+        ));
 
         // Verify each downstream port has the multi-function bit set
         for p in multi_port_switch.downstream_ports() {
             let port_num = p.devfn;
-            if let Some((_, downstream_port)) =
+            if let Some((_, _, downstream_port)) =
                 multi_port_switch.downstream_ports.get(port_num as usize)
             {
                 let mut header_type_value: u32 = 0;
@@ -1098,19 +1160,18 @@ mod tests {
         }
 
         // Test that switches with single downstream port do NOT set the multi-function bit
-        let single_port_definition = GenericPcieSwitchDefinition {
-            name: "single-port-switch".into(),
-            downstream_port_count: 1,
-            hotplug: false,
-            dsp_settings: PciePortSettings::default(),
-            msi_target: MsiTarget::disconnected(),
-        };
-        let single_port_switch = GenericPcieSwitch::new(single_port_definition);
+        let single_port_switch = build(switch_def(
+            "single-port-switch",
+            1,
+            false,
+            PciePortSettings::default(),
+            MsiTarget::disconnected(),
+        ));
 
         // Verify the single downstream port does NOT have the multi-function bit set
         for p in single_port_switch.downstream_ports() {
             let port_num = p.devfn;
-            if let Some((_, downstream_port)) =
+            if let Some((_, _, downstream_port)) =
                 single_port_switch.downstream_ports.get(port_num as usize)
             {
                 let mut header_type_value: u32 = 0;
@@ -1144,25 +1205,23 @@ mod tests {
     #[test]
     fn test_hotplug_support() {
         // Test hotplug disabled
-        let definition_no_hotplug = GenericPcieSwitchDefinition {
-            name: "test-switch-no-hotplug".into(),
-            downstream_port_count: 1,
-            hotplug: false,
-            dsp_settings: PciePortSettings::default(),
-            msi_target: MsiTarget::disconnected(),
-        };
-        let switch_no_hotplug = GenericPcieSwitch::new(definition_no_hotplug);
+        let switch_no_hotplug = build(switch_def(
+            "test-switch-no-hotplug",
+            1,
+            false,
+            PciePortSettings::default(),
+            MsiTarget::disconnected(),
+        ));
         assert_eq!(switch_no_hotplug.name().as_ref(), "test-switch-no-hotplug");
 
         // Test hotplug enabled
-        let definition_with_hotplug = GenericPcieSwitchDefinition {
-            name: "test-switch-with-hotplug".into(),
-            downstream_port_count: 1,
-            hotplug: true,
-            dsp_settings: PciePortSettings::default(),
-            msi_target: MsiTarget::disconnected(),
-        };
-        let switch_with_hotplug = GenericPcieSwitch::new(definition_with_hotplug);
+        let switch_with_hotplug = build(switch_def(
+            "test-switch-with-hotplug",
+            1,
+            true,
+            PciePortSettings::default(),
+            MsiTarget::disconnected(),
+        ));
         assert_eq!(
             switch_with_hotplug.name().as_ref(),
             "test-switch-with-hotplug"
@@ -1174,28 +1233,26 @@ mod tests {
         use vmcore::save_restore::SaveRestore;
 
         // Create a switch with 3 downstream ports
-        let definition = GenericPcieSwitchDefinition {
-            name: "test-switch".into(),
-            downstream_port_count: 3,
-            hotplug: false,
-            dsp_settings: PciePortSettings::default(),
-            msi_target: MsiTarget::disconnected(),
-        };
-        let mut switch = GenericPcieSwitch::new(definition);
+        let mut switch = build(switch_def(
+            "test-switch",
+            3,
+            false,
+            PciePortSettings::default(),
+            MsiTarget::disconnected(),
+        ));
 
         // Save the state
         let saved_state = switch.save().expect("save should succeed");
         assert_eq!(saved_state.downstream_ports.len(), 3);
 
         // Create a new switch with only 2 downstream ports
-        let definition2 = GenericPcieSwitchDefinition {
-            name: "test-switch".into(),
-            downstream_port_count: 2,
-            hotplug: false,
-            dsp_settings: PciePortSettings::default(),
-            msi_target: MsiTarget::disconnected(),
-        };
-        let mut switch2 = GenericPcieSwitch::new(definition2);
+        let mut switch2 = build(switch_def(
+            "test-switch",
+            2,
+            false,
+            PciePortSettings::default(),
+            MsiTarget::disconnected(),
+        ));
 
         // Restore should fail because port 2 doesn't exist in the new switch
         let result = switch2.restore(saved_state);
@@ -1206,14 +1263,13 @@ mod tests {
     fn test_save_restore_basic() {
         use vmcore::save_restore::SaveRestore;
 
-        let definition = GenericPcieSwitchDefinition {
-            name: "test-switch".into(),
-            downstream_port_count: 2,
-            hotplug: false,
-            dsp_settings: PciePortSettings::default(),
-            msi_target: MsiTarget::disconnected(),
-        };
-        let mut switch = GenericPcieSwitch::new(definition);
+        let mut switch = build(switch_def(
+            "test-switch",
+            2,
+            false,
+            PciePortSettings::default(),
+            MsiTarget::disconnected(),
+        ));
 
         // Save the initial state
         let saved_state = switch.save().expect("save should succeed");
@@ -1222,14 +1278,13 @@ mod tests {
         assert_eq!(saved_state.downstream_ports.len(), 2);
 
         // Restore the state to a new switch
-        let definition2 = GenericPcieSwitchDefinition {
-            name: "test-switch".into(),
-            downstream_port_count: 2,
-            hotplug: false,
-            dsp_settings: PciePortSettings::default(),
-            msi_target: MsiTarget::disconnected(),
-        };
-        let mut switch2 = GenericPcieSwitch::new(definition2);
+        let mut switch2 = build(switch_def(
+            "test-switch",
+            2,
+            false,
+            PciePortSettings::default(),
+            MsiTarget::disconnected(),
+        ));
         switch2
             .restore(saved_state)
             .expect("restore should succeed");
@@ -1239,14 +1294,13 @@ mod tests {
     fn test_save_restore_with_bus_configuration() {
         use vmcore::save_restore::SaveRestore;
 
-        let definition = GenericPcieSwitchDefinition {
-            name: "test-switch".into(),
-            downstream_port_count: 3,
-            hotplug: false,
-            dsp_settings: PciePortSettings::default(),
-            msi_target: MsiTarget::disconnected(),
-        };
-        let mut switch = GenericPcieSwitch::new(definition);
+        let mut switch = build(switch_def(
+            "test-switch",
+            3,
+            false,
+            PciePortSettings::default(),
+            MsiTarget::disconnected(),
+        ));
 
         // Configure bus numbers on the upstream port
         let secondary_bus = 5u8;
@@ -1269,14 +1323,13 @@ mod tests {
         let saved_state = switch.save().expect("save should succeed");
 
         // Create a new switch and restore the state
-        let definition2 = GenericPcieSwitchDefinition {
-            name: "test-switch".into(),
-            downstream_port_count: 3,
-            hotplug: false,
-            dsp_settings: PciePortSettings::default(),
-            msi_target: MsiTarget::disconnected(),
-        };
-        let mut switch2 = GenericPcieSwitch::new(definition2);
+        let mut switch2 = build(switch_def(
+            "test-switch",
+            3,
+            false,
+            PciePortSettings::default(),
+            MsiTarget::disconnected(),
+        ));
 
         // Verify the new switch has default bus range before restore
         let default_bus_range = switch2.upstream_port.cfg_space().assigned_bus_range();
@@ -1297,18 +1350,17 @@ mod tests {
     fn test_save_restore_downstream_port_state() {
         use vmcore::save_restore::SaveRestore;
 
-        let definition = GenericPcieSwitchDefinition {
-            name: "test-switch".into(),
-            downstream_port_count: 2,
-            hotplug: false,
-            dsp_settings: PciePortSettings::default(),
-            msi_target: MsiTarget::disconnected(),
-        };
-        let mut switch = GenericPcieSwitch::new(definition);
+        let mut switch = build(switch_def(
+            "test-switch",
+            2,
+            false,
+            PciePortSettings::default(),
+            MsiTarget::disconnected(),
+        ));
 
         // Configure bus numbers on one of the downstream ports
         // First, we need to get access to the downstream port and configure it
-        if let Some((_, downstream_port)) = switch.downstream_ports.get_mut(0) {
+        if let Some((_, _, downstream_port)) = switch.downstream_ports.get_mut(0) {
             let secondary_bus = 10u8;
             let subordinate_bus = 20u8;
             let primary_bus = 5u8;
@@ -1323,7 +1375,7 @@ mod tests {
         }
 
         // Verify the downstream port bus range is set
-        if let Some((_, downstream_port)) = switch.downstream_ports.first() {
+        if let Some((_, _, downstream_port)) = switch.downstream_ports.first() {
             let bus_range = downstream_port.cfg_space().assigned_bus_range();
             assert_eq!(*bus_range.start(), 10);
             assert_eq!(*bus_range.end(), 20);
@@ -1333,17 +1385,16 @@ mod tests {
         let saved_state = switch.save().expect("save should succeed");
 
         // Create a new switch and restore the state
-        let definition2 = GenericPcieSwitchDefinition {
-            name: "test-switch".into(),
-            downstream_port_count: 2,
-            hotplug: false,
-            dsp_settings: PciePortSettings::default(),
-            msi_target: MsiTarget::disconnected(),
-        };
-        let mut switch2 = GenericPcieSwitch::new(definition2);
+        let mut switch2 = build(switch_def(
+            "test-switch",
+            2,
+            false,
+            PciePortSettings::default(),
+            MsiTarget::disconnected(),
+        ));
 
         // Verify the new switch has default bus range on downstream port before restore
-        if let Some((_, downstream_port)) = switch2.downstream_ports.first() {
+        if let Some((_, _, downstream_port)) = switch2.downstream_ports.first() {
             let default_bus_range = downstream_port.cfg_space().assigned_bus_range();
             assert_eq!(default_bus_range, 0..=0);
         }
@@ -1354,7 +1405,7 @@ mod tests {
             .expect("restore should succeed");
 
         // Verify the downstream port bus range is restored
-        if let Some((_, downstream_port)) = switch2.downstream_ports.first() {
+        if let Some((_, _, downstream_port)) = switch2.downstream_ports.first() {
             let restored_bus_range = downstream_port.cfg_space().assigned_bus_range();
             assert_eq!(*restored_bus_range.start(), 10);
             assert_eq!(*restored_bus_range.end(), 20);
@@ -1365,14 +1416,13 @@ mod tests {
     fn test_save_restore_preserves_upstream_and_downstream_cfg_space() {
         use vmcore::save_restore::SaveRestore;
 
-        let definition = GenericPcieSwitchDefinition {
-            name: "test-switch".into(),
-            downstream_port_count: 2,
-            hotplug: false,
-            dsp_settings: PciePortSettings::default(),
-            msi_target: MsiTarget::disconnected(),
-        };
-        let mut switch = GenericPcieSwitch::new(definition);
+        let mut switch = build(switch_def(
+            "test-switch",
+            2,
+            false,
+            PciePortSettings::default(),
+            MsiTarget::disconnected(),
+        ));
 
         // Upstream primary/secondary/subordinate bus numbers.
         switch
@@ -1382,7 +1432,7 @@ mod tests {
             .unwrap();
 
         // Downstream port 1 bus range.
-        if let Some((_, downstream_port)) = switch.downstream_ports.get_mut(1) {
+        if let Some((_, _, downstream_port)) = switch.downstream_ports.get_mut(1) {
             downstream_port
                 .port
                 .cfg_space
@@ -1392,14 +1442,13 @@ mod tests {
 
         let saved_state = switch.save().expect("save should succeed");
 
-        let definition2 = GenericPcieSwitchDefinition {
-            name: "test-switch".into(),
-            downstream_port_count: 2,
-            hotplug: false,
-            dsp_settings: PciePortSettings::default(),
-            msi_target: MsiTarget::disconnected(),
-        };
-        let mut switch2 = GenericPcieSwitch::new(definition2);
+        let mut switch2 = build(switch_def(
+            "test-switch",
+            2,
+            false,
+            PciePortSettings::default(),
+            MsiTarget::disconnected(),
+        ));
 
         switch2
             .restore(saved_state)
@@ -1409,7 +1458,7 @@ mod tests {
         assert_eq!(*upstream_bus_range.start(), 0x12);
         assert_eq!(*upstream_bus_range.end(), 0x14);
 
-        if let Some((_, downstream_port)) = switch2.downstream_ports.get(1) {
+        if let Some((_, _, downstream_port)) = switch2.downstream_ports.get(1) {
             let downstream_bus_range = downstream_port.cfg_space().assigned_bus_range();
             assert_eq!(*downstream_bus_range.start(), 0x1f);
             assert_eq!(*downstream_bus_range.end(), 0x20);
@@ -1501,13 +1550,13 @@ mod tests {
             .unwrap();
 
         // Create and attach a switch behind the port
-        let switch = GenericPcieSwitch::new(GenericPcieSwitchDefinition {
-            name: "test-switch".into(),
-            downstream_port_count: 2,
-            hotplug: false,
-            dsp_settings: PciePortSettings::default(),
-            msi_target: MsiTarget::disconnected(),
-        });
+        let switch = build(switch_def(
+            "test-switch",
+            2,
+            false,
+            PciePortSettings::default(),
+            MsiTarget::disconnected(),
+        ));
 
         port.link = Some(("switch".into(), Box::new(SwitchAdapter(switch))));
 
@@ -1539,16 +1588,16 @@ mod tests {
     fn test_switch_acs_only_applies_to_dsp() {
         use pci_core::spec::caps::ExtendedCapabilityId;
 
-        let switch = GenericPcieSwitch::new(GenericPcieSwitchDefinition {
-            name: "acs-switch".into(),
-            downstream_port_count: 1,
-            hotplug: false,
-            dsp_settings: PciePortSettings {
+        let switch = build(switch_def(
+            "acs-switch",
+            1,
+            false,
+            PciePortSettings {
                 acs_capabilities_supported: 0x0001,
                 ..Default::default()
             },
-            msi_target: MsiTarget::disconnected(),
-        });
+            MsiTarget::disconnected(),
+        ));
 
         // Upstream switch ports do not expose ACS in this model.
         let mut upstream_header = 0u32;
@@ -1560,7 +1609,7 @@ mod tests {
         assert_eq!(upstream_header, 0);
 
         let mut switch = switch;
-        let (_, downstream_port) = switch
+        let (_, _, downstream_port) = switch
             .downstream_ports
             .iter_mut()
             .next()
@@ -1582,5 +1631,88 @@ mod tests {
             .read_u32(0x104, &mut caps_control)
             .unwrap();
         assert_eq!(caps_control as u16, 0x0001);
+    }
+
+    #[test]
+    fn test_switch_explicit_devfn() {
+        // A downstream port with an explicit devfn is placed there; the
+        // remaining ports fill the lowest free devfns from 0.
+        let definition = GenericPcieSwitchDefinition {
+            name: "sw".into(),
+            downstream_ports: vec![
+                crate::GenericPciePortDefinition {
+                    name: "a".into(),
+                    devfn: Some(16), // device 2, function 0
+                    hotplug: false,
+                    settings: PciePortSettings::default(),
+                },
+                crate::GenericPciePortDefinition {
+                    name: "b".into(),
+                    devfn: None,
+                    hotplug: false,
+                    settings: PciePortSettings::default(),
+                },
+            ],
+            msi_target: MsiTarget::disconnected(),
+        };
+        let switch = GenericPcieSwitch::new(definition).unwrap();
+        let mut ports: Vec<_> = switch
+            .downstream_ports()
+            .into_iter()
+            .map(|p| (p.name.to_string(), p.devfn))
+            .collect();
+        ports.sort_by_key(|(_, devfn)| *devfn);
+        assert_eq!(ports, vec![("b".into(), 0), ("a".into(), 16)]);
+    }
+
+    #[test]
+    fn test_switch_cxl_rejected() {
+        // CXL is not supported on switch downstream ports.
+        let definition = GenericPcieSwitchDefinition {
+            name: "sw".into(),
+            downstream_ports: vec![crate::GenericPciePortDefinition {
+                name: "a".into(),
+                devfn: None,
+                hotplug: false,
+                settings: PciePortSettings {
+                    cxl_flex_bus_port_capability: Some(Default::default()),
+                    ..Default::default()
+                },
+            }],
+            msi_target: MsiTarget::disconnected(),
+        };
+        assert!(matches!(
+            GenericPcieSwitch::new(definition),
+            Err(InvalidSwitchError::CxlUnsupported { .. })
+        ));
+    }
+
+    #[test]
+    fn test_switch_duplicate_devfn_rejected() {
+        let definition = GenericPcieSwitchDefinition {
+            name: "sw".into(),
+            downstream_ports: vec![
+                crate::GenericPciePortDefinition {
+                    name: "a".into(),
+                    devfn: Some(0),
+                    hotplug: false,
+                    settings: PciePortSettings::default(),
+                },
+                crate::GenericPciePortDefinition {
+                    name: "b".into(),
+                    devfn: Some(0),
+                    hotplug: false,
+                    settings: PciePortSettings::default(),
+                },
+            ],
+            msi_target: MsiTarget::disconnected(),
+        };
+        assert!(matches!(
+            GenericPcieSwitch::new(definition),
+            Err(InvalidSwitchError::Devfn(PortDevfnError::DevfnInUse {
+                devfn: 0,
+                ..
+            }))
+        ));
     }
 }

--- a/vmm_tests/vmm_tests/tests/tests/multiarch/numa.rs
+++ b/vmm_tests/vmm_tests/tests/tests/multiarch/numa.rs
@@ -10,8 +10,8 @@ use openvmm_defs::config::NumaNode;
 use openvmm_defs::config::NumaTopology;
 use openvmm_defs::config::PcieDeviceConfig;
 use openvmm_defs::config::PcieMmioRangeConfig;
+use openvmm_defs::config::PciePortConfig;
 use openvmm_defs::config::PcieRootComplexConfig;
-use openvmm_defs::config::PcieRootPortConfig;
 use openvmm_defs::config::VpAssignment;
 use petri::PetriVmBuilder;
 use petri::openvmm::OpenVmmPetriBackend;
@@ -339,8 +339,9 @@ async fn pcie_device_numa_affinity(
                         size: 1024 * 1024 * 1024,
                     },
                     cxl: None,
-                    ports: vec![PcieRootPortConfig {
+                    ports: vec![PciePortConfig {
                         name: "rp0".to_string(),
+                        devfn: None,
                         hotplug: false,
                         acs_capabilities_supported: None,
                         cxl: false,


### PR DESCRIPTION
The PCIe root-port and switch configuration was too rigid: root ports were packed onto consecutive devfns with no way to pin a port to a specific device/function, and a switch was described only by a downstream-port count, so every downstream port shared one set of settings. This made it impossible to model topologies that require a device at a fixed address, and left switch ports unable to carry per-port attributes.

Introduce an explicit `devfn` on the shared port configuration so a port can request a specific device/function on its bus; when unset, the port still takes the lowest available slot. Ports are assigned strictly in order, so an explicit request that collides with an already-placed port (including one placed automatically) is a hard error rather than a silent reshuffle. The assignment also rejects a device that has a function other than function 0 without function 0 present, since such a device is undiscoverable. This logic lives in one shared `assign_port_devfns` helper used by both the root complex and the switch, so they share identical semantics, and it returns each port's placement including whether its device is genuinely multi-function — fixing a latent bug where the multi-function header bit was set based on total port count rather than per device.

Replace the switch's `num_downstream_ports` with a list of port configurations (reusing the renamed `PciePortConfig`/`GenericPciePortDefinition` type), so downstream ports gain the same per-port attributes as root ports and honor explicit devfns. As a result, switch downstream ports can now sit on more than one device number: the switch looks ports up by their assigned devfn rather than by vector position. Switch construction is now fallible and owns its own constraints — CXL is rejected on switch ports (there is no component-register infrastructure behind a switch) instead of being checked in the VM worker.

The CLI is unchanged except for a new `addr=XX[.Y]` option on `--pcie-root-port`; `--pcie-switch` still takes `num_downstream_ports`, which now expands into a uniform list of downstream ports.