### PR TITLE
ci: temporarily disable tdx tests

### DIFF
--- a/.github/workflows/openvmm-ci.yaml
+++ b/.github/workflows/openvmm-ci.yaml
@@ -4371,13 +4371,12 @@ jobs:
       run: flowey.exe e 20 flowey_lib_common::cache 11
       shell: bash
   job21:
-    name: run vmm-tests [x64-windows-intel-tdx]
+    name: run vmm-tests [x64-windows-amd]
     runs-on:
     - self-hosted
-    - Windows
-    - X64
-    - TDX
-    - Baremetal
+    - 1ES.Pool=openvmm-gh-amd-westus3
+    - 1ES.ImageOverride=win-amd64
+    - JobId=job21-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
@@ -4622,9 +4621,9 @@ jobs:
     - id: flowey_lib_common__publish_test_results__6
       uses: actions/upload-artifact@v7
       with:
-        name: x64-windows-intel-tdx-vmm-tests-logs
+        name: x64-windows-amd-vmm-tests-logs
         path: ${{ env.floweyvar2 }}
-      name: 'publish test results: x64-windows-intel-tdx-vmm-tests (logs)'
+      name: 'publish test results: x64-windows-amd-vmm-tests (logs)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: 🦀 flowey rust steps
       run: |-
@@ -4638,9 +4637,9 @@ jobs:
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v7
       with:
-        name: x64-windows-intel-tdx-vmm-tests-junit-xml
+        name: x64-windows-amd-vmm-tests-junit-xml
         path: ${{ env.floweyvar1 }}
-      name: 'publish test results: x64-windows-intel-tdx-vmm-tests (JUnit XML)'
+      name: 'publish test results: x64-windows-amd-vmm-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
       run: flowey.exe e 21 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
@@ -4655,12 +4654,13 @@ jobs:
       run: flowey.exe e 21 flowey_lib_common::cache 11
       shell: bash
   job22:
-    name: run vmm-tests [x64-windows-amd]
+    name: run vmm-tests [x64-windows-amd-snp]
     runs-on:
     - self-hosted
-    - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=win-amd64
-    - JobId=job22-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
+    - Windows
+    - X64
+    - SNP
+    - Baremetal
     permissions:
       contents: read
       id-token: write
@@ -4905,9 +4905,9 @@ jobs:
     - id: flowey_lib_common__publish_test_results__6
       uses: actions/upload-artifact@v7
       with:
-        name: x64-windows-amd-vmm-tests-logs
+        name: x64-windows-amd-snp-vmm-tests-logs
         path: ${{ env.floweyvar2 }}
-      name: 'publish test results: x64-windows-amd-vmm-tests (logs)'
+      name: 'publish test results: x64-windows-amd-snp-vmm-tests (logs)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: 🦀 flowey rust steps
       run: |-
@@ -4921,9 +4921,9 @@ jobs:
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v7
       with:
-        name: x64-windows-amd-vmm-tests-junit-xml
+        name: x64-windows-amd-snp-vmm-tests-junit-xml
         path: ${{ env.floweyvar1 }}
-      name: 'publish test results: x64-windows-amd-vmm-tests (JUnit XML)'
+      name: 'publish test results: x64-windows-amd-snp-vmm-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
       run: flowey.exe e 22 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
@@ -4938,296 +4938,12 @@ jobs:
       run: flowey.exe e 22 flowey_lib_common::cache 11
       shell: bash
   job23:
-    name: run vmm-tests [x64-windows-amd-snp]
-    runs-on:
-    - self-hosted
-    - Windows
-    - X64
-    - SNP
-    - Baremetal
-    permissions:
-      contents: read
-      id-token: write
-    needs:
-    - job11
-    - job2
-    - job3
-    - job7
-    if: github.event.pull_request.draft == false
-    steps:
-    - name: 🌼📦 Download artifacts
-      uses: actions/download-artifact@v8
-      with:
-        pattern: '{_internal-flowey-bootstrap-x86_64-windows-uid-13,x64-guest_test_uefi,x64-linux-musl-pipette,x64-linux-musl-tmk_vmm,x64-linux-tpm_guest_tests,x64-openhcl-igvm,x64-openhcl-igvm-cvm,x64-openhcl-igvm-test-linux-direct,x64-tmks,x64-windows-openvmm,x64-windows-pipette,x64-windows-prep_steps,x64-windows-test_igvm_agent_rpc_server,x64-windows-tmk_vmm,x64-windows-tpm_guest_tests,x64-windows-vmgstool,x64-windows-vmgstool-dev,x64-windows-vmm-tests-archive}'
-        path: ${{ runner.temp }}/used_artifacts/
-    - run: echo "${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-windows-uid-13" >> $GITHUB_PATH
-      shell: bash
-      name: 🌼📦 Add flowey to PATH
-    - name: 🌼🛫 Initialize job
-      run: |
-        AgentTempDirNormal="${{ runner.temp }}"
-        AgentTempDirNormal=$(echo "$AgentTempDirNormal" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
-        echo "AgentTempDirNormal=$AgentTempDirNormal" >> $GITHUB_ENV
-
-        chmod +x $AgentTempDirNormal/used_artifacts/_internal-flowey-bootstrap-x86_64-windows-uid-13/flowey.exe
-
-        echo '"debug"' | flowey.exe v 23 'FLOWEY_LOG' update
-        echo "${{ runner.temp }}/work" | flowey.exe v 23 '_internal_WORKING_DIR' --is-raw-string update
-
-        cat <<'EOF' | flowey.exe v 23 'verbose' update
-        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
-        EOF
-        echo "${{ runner.temp }}\\used_artifacts\\x64-guest_test_uefi" | flowey.exe v 23 'artifact_use_from_x64-guest_test_uefi' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-pipette" | flowey.exe v 23 'artifact_use_from_x64-linux-musl-pipette' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-tmk_vmm" | flowey.exe v 23 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-tpm_guest_tests" | flowey.exe v 23 'artifact_use_from_x64-linux-tpm_guest_tests' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-openhcl-igvm" | flowey.exe v 23 'artifact_use_from_x64-openhcl-igvm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-openhcl-igvm-cvm" | flowey.exe v 23 'artifact_use_from_x64-openhcl-igvm-cvm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-openhcl-igvm-test-linux-direct" | flowey.exe v 23 'artifact_use_from_x64-openhcl-igvm-test-linux-direct' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-tmks" | flowey.exe v 23 'artifact_use_from_x64-tmks' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-openvmm" | flowey.exe v 23 'artifact_use_from_x64-windows-openvmm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-pipette" | flowey.exe v 23 'artifact_use_from_x64-windows-pipette' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-prep_steps" | flowey.exe v 23 'artifact_use_from_x64-windows-prep_steps' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-test_igvm_agent_rpc_server" | flowey.exe v 23 'artifact_use_from_x64-windows-test_igvm_agent_rpc_server' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-tmk_vmm" | flowey.exe v 23 'artifact_use_from_x64-windows-tmk_vmm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-tpm_guest_tests" | flowey.exe v 23 'artifact_use_from_x64-windows-tpm_guest_tests' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-vmgstool" | flowey.exe v 23 'artifact_use_from_x64-windows-vmgstool' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-vmgstool-dev" | flowey.exe v 23 'artifact_use_from_x64-windows-vmgstool-dev' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-vmm-tests-archive" | flowey.exe v 23 'artifact_use_from_x64-windows-vmm-tests-archive' --is-raw-string update
-      shell: bash
-    - name: create cargo-nextest cache dir
-      run: |-
-        flowey.exe e 23 flowey_lib_common::download_cargo_nextest 0
-        flowey.exe e 23 flowey_lib_common::download_cargo_nextest 1
-        flowey.exe e 23 flowey_lib_common::download_cargo_nextest 2
-        flowey.exe e 23 flowey_lib_common::download_cargo_nextest 3
-      shell: bash
-    - name: Pre-processing cache vars
-      run: |-
-        flowey.exe e 23 flowey_lib_common::cache 0
-        flowey.exe v 23 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
-        flowey.exe v 23 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
-      shell: bash
-    - id: flowey_lib_common__cache__1
-      uses: actions/cache@v5
-      with:
-        key: ${{ env.floweyvar4 }}
-        path: ${{ env.floweyvar5 }}
-      name: 'Restore cache: cargo-nextest'
-    - name: downloading cargo-nextest
-      run: |-
-        flowey.exe v 23 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
-        EOF
-        flowey.exe e 23 flowey_lib_common::cache 2
-        flowey.exe e 23 flowey_lib_common::download_cargo_nextest 4
-      shell: bash
-    - name: check if openvmm needs to be cloned
-      run: |-
-        flowey.exe e 23 flowey_lib_common::git_checkout 0
-        flowey.exe v 23 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
-        flowey.exe v 23 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__git_checkout__1
-      uses: actions/checkout@v6
-      with:
-        fetch-depth: '1'
-        path: repo0
-        persist-credentials: ${{ env.floweyvar3 }}
-      name: checkout repo openvmm
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: report cloned repo directories
-      run: |-
-        flowey.exe v 23 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
-        ${{ github.workspace }}
-        EOF
-        flowey.exe e 23 flowey_lib_common::git_checkout 3
-      shell: bash
-    - name: print system info
-      run: |-
-        flowey.exe e 23 flowey_lib_common::system_info 0
-        flowey.exe e 23 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-        flowey.exe e 23 flowey_lib_hvlite::run_cargo_nextest_run 0
-        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 8
-        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 9
-        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 12
-        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 14
-        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 15
-        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 13
-        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 3
-        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 11
-        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 4
-        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 5
-        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 6
-        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 1
-        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 2
-        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 0
-        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 7
-      shell: bash
-    - name: creating new test content dir
-      run: flowey.exe e 23 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
-      shell: bash
-    - name: create gh-release-download cache dir
-      run: flowey.exe e 23 flowey_lib_common::download_gh_release 0
-      shell: bash
-    - name: Pre-processing cache vars
-      run: |-
-        flowey.exe e 23 flowey_lib_common::cache 8
-        flowey.exe v 23 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
-        flowey.exe v 23 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
-      shell: bash
-    - id: flowey_lib_common__cache__9
-      uses: actions/cache@v5
-      with:
-        key: ${{ env.floweyvar8 }}
-        path: ${{ env.floweyvar9 }}
-      name: 'Restore cache: gh-release-download'
-    - name: download artifacts from github releases
-      run: |-
-        flowey.exe v 23 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
-        EOF
-        flowey.exe e 23 flowey_lib_common::cache 10
-        flowey.exe e 23 flowey_lib_common::download_gh_release 1
-      shell: bash
-    - name: extract azcopy from archive
-      run: flowey.exe e 23 flowey_lib_common::download_azcopy 0
-      shell: bash
-    - name: calculating required VMM tests disk images
-      run: flowey.exe e 23 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
-      shell: bash
-    - name: downloading VMM test disk images
-      run: |-
-        flowey.exe e 23 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
-        flowey.exe e 23 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
-      shell: bash
-    - name: create gh cache dir
-      run: flowey.exe e 23 flowey_lib_common::download_gh_cli 0
-      shell: bash
-    - name: Pre-processing cache vars
-      run: |-
-        flowey.exe e 23 flowey_lib_common::cache 4
-        flowey.exe v 23 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
-        flowey.exe v 23 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
-      shell: bash
-    - id: flowey_lib_common__cache__5
-      uses: actions/cache@v5
-      with:
-        key: ${{ env.floweyvar6 }}
-        path: ${{ env.floweyvar7 }}
-      name: 'Restore cache: gh-cli'
-    - name: installing gh
-      run: |-
-        flowey.exe v 23 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
-        EOF
-        flowey.exe e 23 flowey_lib_common::cache 6
-        flowey.exe e 23 flowey_lib_common::download_gh_cli 1
-        flowey.exe v 23 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
-        ${{ github.token }}
-        EOF
-      shell: bash
-    - name: setup gh cli
-      run: flowey.exe e 23 flowey_lib_common::use_gh_cli 0
-      shell: bash
-    - name: get latest completed action id
-      run: flowey.exe e 23 flowey_lib_common::gh_latest_completed_workflow_id 0
-      shell: bash
-    - name: download artifacts from github actions run
-      run: |-
-        flowey.exe e 23 flowey_lib_common::download_gh_artifact 0
-        flowey.exe e 23 flowey_lib_hvlite::download_release_igvm_files_from_gh::resolve 0
-      shell: bash
-    - name: unpack openvmm-test-initrd archives
-      run: flowey.exe e 23 flowey_lib_hvlite::resolve_openvmm_test_initrd 0
-      shell: bash
-    - name: unpack openvmm-test-linux archives
-      run: flowey.exe e 23 flowey_lib_hvlite::resolve_openvmm_test_linux_kernel 0
-      shell: bash
-    - name: unpack mu_msvm package (x64)
-      run: flowey.exe e 23 flowey_lib_hvlite::download_uefi_mu_msvm 0
-      shell: bash
-    - name: unpack openvmm-test-virtio-win archive
-      run: flowey.exe e 23 flowey_lib_hvlite::resolve_openvmm_test_virtio_win 0
-      shell: bash
-    - name: setting up vmm_tests env
-      run: |-
-        flowey.exe e 23 flowey_lib_hvlite::init_vmm_tests_env 0
-        flowey.exe e 23 flowey_lib_hvlite::run_cargo_nextest_run 1
-        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 16
-        flowey.exe e 23 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
-      shell: bash
-    - name: generate nextest command
-      run: flowey.exe e 23 flowey_lib_common::gen_cargo_nextest_run_cmd 0
-      shell: bash
-    - name: install vmm tests deps (windows)
-      run: flowey.exe e 23 flowey_lib_hvlite::install_vmm_tests_deps 0
-      shell: bash
-    - name: starting test_igvm_agent_rpc_server
-      run: |-
-        flowey.exe e 23 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
-        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 10
-      shell: bash
-    - name: running vmm_test prep_steps
-      run: flowey.exe e 23 flowey_lib_hvlite::run_prep_steps 0
-      shell: bash
-    - name: run 'vmm_tests' nextest tests
-      run: |-
-        flowey.exe e 23 flowey_lib_common::run_cargo_nextest_run 0
-        flowey.exe e 23 flowey_lib_common::run_cargo_nextest_run 1
-        flowey.exe e 23 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
-      shell: bash
-    - name: stopping test_igvm_agent_rpc_server
-      run: |-
-        flowey.exe e 23 flowey_lib_hvlite::stop_test_igvm_agent_rpc_server 0
-        flowey.exe e 23 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
-        flowey.exe e 23 flowey_lib_common::publish_test_results 4
-        flowey.exe e 23 flowey_lib_common::publish_test_results 5
-        flowey.exe v 23 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:152:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57 write-to-env github floweyvar2
-        flowey.exe v 23 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__publish_test_results__6
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-windows-amd-snp-vmm-tests-logs
-        path: ${{ env.floweyvar2 }}
-      name: 'publish test results: x64-windows-amd-snp-vmm-tests (logs)'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: 🦀 flowey rust steps
-      run: |-
-        flowey.exe e 23 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
-        flowey.exe e 23 flowey_lib_common::publish_test_results 0
-        flowey.exe e 23 flowey_lib_common::publish_test_results 1
-        flowey.exe e 23 flowey_lib_common::publish_test_results 2
-        flowey.exe v 23 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
-        flowey.exe v 23 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__publish_test_results__3
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-windows-amd-snp-vmm-tests-junit-xml
-        path: ${{ env.floweyvar1 }}
-      name: 'publish test results: x64-windows-amd-snp-vmm-tests (JUnit XML)'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: report test results to overall pipeline status
-      run: flowey.exe e 23 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
-      shell: bash
-    - name: 'validate cache entry: cargo-nextest'
-      run: flowey.exe e 23 flowey_lib_common::cache 3
-      shell: bash
-    - name: 'validate cache entry: gh-cli'
-      run: flowey.exe e 23 flowey_lib_common::cache 7
-      shell: bash
-    - name: 'validate cache entry: gh-release-download'
-      run: flowey.exe e 23 flowey_lib_common::cache 11
-      shell: bash
-  job24:
     name: run vmm-tests [x64-linux-amd-kvm]
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
     - 1ES.ImageOverride=ubuntu2404-amd64
-    - JobId=job24-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
+    - JobId=job23-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
@@ -5253,6 +4969,325 @@ jobs:
 
         chmod +x $AgentTempDirNormal/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-11/flowey
 
+        echo '"debug"' | flowey v 23 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey v 23 '_internal_WORKING_DIR' --is-raw-string update
+
+        cat <<'EOF' | flowey v 23 'verbose' update
+        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
+        EOF
+        echo "$AgentTempDirNormal/used_artifacts/x64-guest_test_uefi" | flowey v 23 'artifact_use_from_x64-guest_test_uefi' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-pipette" | flowey v 23 'artifact_use_from_x64-linux-musl-pipette' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-tmk_vmm" | flowey v 23 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-openvmm" | flowey v 23 'artifact_use_from_x64-linux-openvmm' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-openvmm_vhost" | flowey v 23 'artifact_use_from_x64-linux-openvmm_vhost' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-prep_steps" | flowey v 23 'artifact_use_from_x64-linux-prep_steps' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-vmm-tests-archive" | flowey v 23 'artifact_use_from_x64-linux-vmm-tests-archive' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-tmks" | flowey v 23 'artifact_use_from_x64-tmks' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-windows-pipette" | flowey v 23 'artifact_use_from_x64-windows-pipette' --is-raw-string update
+      shell: bash
+    - name: creating new test content dir
+      run: |-
+        flowey e 23 flowey_core::pipeline::artifact::resolve 8
+        flowey e 23 flowey_core::pipeline::artifact::resolve 2
+        flowey e 23 flowey_core::pipeline::artifact::resolve 3
+        flowey e 23 flowey_core::pipeline::artifact::resolve 4
+        flowey e 23 flowey_core::pipeline::artifact::resolve 1
+        flowey e 23 flowey_core::pipeline::artifact::resolve 0
+        flowey e 23 flowey_core::pipeline::artifact::resolve 7
+        flowey e 23 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
+      shell: bash
+    - name: checking if packages need to be installed
+      run: flowey e 23 flowey_lib_common::install_dist_pkg 0
+      shell: bash
+    - name: installing packages
+      run: flowey e 23 flowey_lib_common::install_dist_pkg 1
+      shell: bash
+    - name: create gh-release-download cache dir
+      run: flowey e 23 flowey_lib_common::download_gh_release 0
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
+        flowey e 23 flowey_lib_common::cache 8
+        flowey v 23 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
+        flowey v 23 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
+      shell: bash
+    - id: flowey_lib_common__cache__9
+      uses: actions/cache@v5
+      with:
+        key: ${{ env.floweyvar8 }}
+        path: ${{ env.floweyvar9 }}
+      name: 'Restore cache: gh-release-download'
+    - name: download artifacts from github releases
+      run: |-
+        flowey v 23 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
+        EOF
+        flowey e 23 flowey_lib_common::cache 10
+        flowey e 23 flowey_lib_common::download_gh_release 1
+      shell: bash
+    - name: extract azcopy from archive
+      run: flowey e 23 flowey_lib_common::download_azcopy 0
+      shell: bash
+    - name: calculating required VMM tests disk images
+      run: flowey e 23 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
+      shell: bash
+    - name: downloading VMM test disk images
+      run: |-
+        flowey e 23 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
+        flowey e 23 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
+      shell: bash
+    - name: create gh cache dir
+      run: flowey e 23 flowey_lib_common::download_gh_cli 0
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
+        flowey e 23 flowey_lib_common::cache 4
+        flowey v 23 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
+        flowey v 23 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
+      shell: bash
+    - id: flowey_lib_common__cache__5
+      uses: actions/cache@v5
+      with:
+        key: ${{ env.floweyvar6 }}
+        path: ${{ env.floweyvar7 }}
+      name: 'Restore cache: gh-cli'
+    - name: installing gh
+      run: |-
+        flowey v 23 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
+        EOF
+        flowey e 23 flowey_lib_common::cache 6
+        flowey e 23 flowey_lib_common::download_gh_cli 1
+        flowey v 23 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
+        ${{ github.token }}
+        EOF
+      shell: bash
+    - name: setup gh cli
+      run: flowey e 23 flowey_lib_common::use_gh_cli 0
+      shell: bash
+    - name: get latest completed action id
+      run: flowey e 23 flowey_lib_common::gh_latest_completed_workflow_id 0
+      shell: bash
+    - name: download artifacts from github actions run
+      run: |-
+        flowey e 23 flowey_lib_common::download_gh_artifact 0
+        flowey e 23 flowey_lib_hvlite::download_release_igvm_files_from_gh::resolve 0
+      shell: bash
+    - name: unpack openvmm-test-initrd archives
+      run: flowey e 23 flowey_lib_hvlite::resolve_openvmm_test_initrd 0
+      shell: bash
+    - name: unpack openvmm-test-linux archives
+      run: flowey e 23 flowey_lib_hvlite::resolve_openvmm_test_linux_kernel 0
+      shell: bash
+    - name: unpack mu_msvm package (x64)
+      run: flowey e 23 flowey_lib_hvlite::download_uefi_mu_msvm 0
+      shell: bash
+    - name: unpack openvmm-test-virtio-win archive
+      run: flowey e 23 flowey_lib_hvlite::resolve_openvmm_test_virtio_win 0
+      shell: bash
+    - name: setting up vmm_tests env
+      run: flowey e 23 flowey_lib_hvlite::init_vmm_tests_env 0
+      shell: bash
+    - name: ensure hypervisor device is accessible
+      run: flowey e 23 flowey_lib_hvlite::test_nextest_vmm_tests_archive 1
+      shell: bash
+    - name: ensure 2 MiB hugetlb pages are available
+      run: flowey e 23 flowey_lib_hvlite::test_nextest_vmm_tests_archive 2
+      shell: bash
+    - name: create cargo-nextest cache dir
+      run: |-
+        flowey e 23 flowey_lib_common::download_cargo_nextest 0
+        flowey e 23 flowey_lib_common::download_cargo_nextest 1
+        flowey e 23 flowey_lib_common::download_cargo_nextest 2
+        flowey e 23 flowey_lib_common::download_cargo_nextest 3
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
+        flowey e 23 flowey_lib_common::cache 0
+        flowey v 23 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
+        flowey v 23 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
+      shell: bash
+    - id: flowey_lib_common__cache__1
+      uses: actions/cache@v5
+      with:
+        key: ${{ env.floweyvar4 }}
+        path: ${{ env.floweyvar5 }}
+      name: 'Restore cache: cargo-nextest'
+    - name: downloading cargo-nextest
+      run: |-
+        flowey v 23 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
+        EOF
+        flowey e 23 flowey_lib_common::cache 2
+        flowey e 23 flowey_lib_common::download_cargo_nextest 4
+      shell: bash
+    - name: check if openvmm needs to be cloned
+      run: |-
+        flowey e 23 flowey_lib_common::git_checkout 0
+        flowey v 23 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
+        flowey v 23 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__git_checkout__1
+      uses: actions/checkout@v6
+      with:
+        fetch-depth: '1'
+        path: repo0
+        persist-credentials: ${{ env.floweyvar3 }}
+      name: checkout repo openvmm
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: report cloned repo directories
+      run: |-
+        flowey v 23 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        ${{ github.workspace }}
+        EOF
+        flowey e 23 flowey_lib_common::git_checkout 3
+      shell: bash
+    - name: print system info
+      run: |-
+        flowey e 23 flowey_lib_common::system_info 0
+        flowey e 23 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey e 23 flowey_lib_hvlite::run_cargo_nextest_run 0
+        flowey e 23 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
+        flowey e 23 flowey_lib_hvlite::run_cargo_nextest_run 1
+        flowey e 23 flowey_core::pipeline::artifact::resolve 6
+        flowey e 23 flowey_lib_hvlite::test_nextest_vmm_tests_archive 3
+      shell: bash
+    - name: generate nextest command
+      run: flowey e 23 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      shell: bash
+    - name: install vmm tests deps (linux)
+      run: |-
+        flowey e 23 flowey_lib_hvlite::install_vmm_tests_deps 0
+        flowey e 23 flowey_core::pipeline::artifact::resolve 5
+      shell: bash
+    - name: running vmm_test prep_steps
+      run: flowey e 23 flowey_lib_hvlite::run_prep_steps 0
+      shell: bash
+    - name: run 'vmm_tests' nextest tests
+      run: |-
+        flowey e 23 flowey_lib_common::run_cargo_nextest_run 0
+        flowey e 23 flowey_lib_common::run_cargo_nextest_run 1
+        flowey e 23 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
+        flowey e 23 flowey_lib_common::publish_test_results 4
+        flowey e 23 flowey_lib_common::publish_test_results 5
+        flowey v 23 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:152:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57 write-to-env github floweyvar2
+        flowey v 23 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__publish_test_results__6
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-linux-amd-kvm-vmm-tests-logs
+        path: ${{ env.floweyvar2 }}
+      name: 'publish test results: x64-linux-amd-kvm-vmm-tests (logs)'
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: 🦀 flowey rust steps
+      run: |-
+        flowey e 23 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
+        flowey e 23 flowey_lib_common::publish_test_results 0
+        flowey e 23 flowey_lib_common::publish_test_results 1
+        flowey e 23 flowey_lib_common::publish_test_results 2
+        flowey v 23 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
+        flowey v 23 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__publish_test_results__3
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-linux-amd-kvm-vmm-tests-junit-xml
+        path: ${{ env.floweyvar1 }}
+      name: 'publish test results: x64-linux-amd-kvm-vmm-tests (JUnit XML)'
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: report test results to overall pipeline status
+      run: flowey e 23 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
+      shell: bash
+    - name: 'validate cache entry: cargo-nextest'
+      run: flowey e 23 flowey_lib_common::cache 3
+      shell: bash
+    - name: 'validate cache entry: gh-cli'
+      run: flowey e 23 flowey_lib_common::cache 7
+      shell: bash
+    - name: 'validate cache entry: gh-release-download'
+      run: flowey e 23 flowey_lib_common::cache 11
+      shell: bash
+  job24:
+    name: run vmm-tests [x64-linux-intel-mshv]
+    runs-on:
+    - self-hosted
+    - 1ES.Pool=openvmm-gh-intel-westus3
+    - 1ES.ImageOverride=azurelinux3-amd64-dom0
+    - JobId=job24-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
+    permissions:
+      contents: read
+      id-token: write
+    needs:
+    - job2
+    - job3
+    - job9
+    if: github.event.pull_request.draft == false
+    steps:
+    - run: |
+        set -x
+        sudo tdnf install -y gcc glibc-devel
+        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.95.0 -y
+        . "$HOME/.cargo/env"
+        echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
+        rustup show
+      if: runner.os == 'Linux'
+      name: rustup (Linux)
+      shell: bash
+    - run: |
+        set -x
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
+        ./rustup-init.exe -y --default-toolchain=1.95.0
+        echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
+      if: runner.os == 'Windows' && runner.arch == 'X64'
+      name: rustup (Windows X64)
+      shell: bash
+    - run: |
+        set -x
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
+        ./rustup-init.exe -y --default-toolchain=1.95.0
+        echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
+      if: runner.os == 'Windows' && runner.arch == 'ARM64'
+      name: rustup (Windows ARM64)
+      shell: bash
+    - uses: actions/checkout@v6
+      with:
+        path: flowey_bootstrap
+    - name: Build flowey
+      run: |
+        set -x
+        CARGO_INCREMENTAL=0 cargo build -p flowey_hvlite --target x86_64-unknown-linux-gnu --profile flowey-ci
+        OutDirNormal=$(echo "${{ runner.temp }}/bootstrapped-flowey" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
+        mkdir -p "$OutDirNormal"
+        mv ./.github/workflows/openvmm-ci.yaml "$OutDirNormal/pipeline.yaml"
+        mv target/x86_64-unknown-linux-gnu/flowey-ci/flowey_hvlite "$OutDirNormal/flowey"
+      working-directory: flowey_bootstrap
+      shell: bash
+    - name: 🌼📦 Download artifacts
+      uses: actions/download-artifact@v8
+      with:
+        pattern: '{x64-guest_test_uefi,x64-linux-musl-openvmm,x64-linux-musl-openvmm_vhost,x64-linux-musl-pipette,x64-linux-musl-tmk_vmm,x64-linux-musl-vmm-tests-archive,x64-linux-prep_steps,x64-tmks,x64-windows-pipette}'
+        path: ${{ runner.temp }}/used_artifacts/
+    - run: echo "${{ runner.temp }}/bootstrapped-flowey" >> $GITHUB_PATH
+      shell: bash
+      name: 🌼📦 Add flowey to PATH
+    - name: 🌼🔎 Self-check YAML
+      run: |-
+        ESCAPED_AGENT_TEMPDIR=$(
+        cat <<'EOF' | sed 's/\\/\\\\/g'
+        ${{ runner.temp }}
+        EOF
+        )
+        flowey pipeline github --runtime $ESCAPED_AGENT_TEMPDIR/bootstrapped-flowey/pipeline.yaml --out .github/workflows/openvmm-ci.yaml ci checkin-gates --config=ci
+      shell: bash
+    - name: 🌼🛫 Initialize job
+      run: |
+        AgentTempDirNormal="${{ runner.temp }}"
+        AgentTempDirNormal=$(echo "$AgentTempDirNormal" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
+        echo "AgentTempDirNormal=$AgentTempDirNormal" >> $GITHUB_ENV
+
+        chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey
+
         echo '"debug"' | flowey v 24 'FLOWEY_LOG' update
         echo "${{ runner.temp }}/work" | flowey v 24 '_internal_WORKING_DIR' --is-raw-string update
 
@@ -5260,22 +5295,22 @@ jobs:
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
         echo "$AgentTempDirNormal/used_artifacts/x64-guest_test_uefi" | flowey v 24 'artifact_use_from_x64-guest_test_uefi' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-openvmm" | flowey v 24 'artifact_use_from_x64-linux-musl-openvmm' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-openvmm_vhost" | flowey v 24 'artifact_use_from_x64-linux-musl-openvmm_vhost' --is-raw-string update
         echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-pipette" | flowey v 24 'artifact_use_from_x64-linux-musl-pipette' --is-raw-string update
         echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-tmk_vmm" | flowey v 24 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-linux-openvmm" | flowey v 24 'artifact_use_from_x64-linux-openvmm' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-linux-openvmm_vhost" | flowey v 24 'artifact_use_from_x64-linux-openvmm_vhost' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-vmm-tests-archive" | flowey v 24 'artifact_use_from_x64-linux-musl-vmm-tests-archive' --is-raw-string update
         echo "$AgentTempDirNormal/used_artifacts/x64-linux-prep_steps" | flowey v 24 'artifact_use_from_x64-linux-prep_steps' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-linux-vmm-tests-archive" | flowey v 24 'artifact_use_from_x64-linux-vmm-tests-archive' --is-raw-string update
         echo "$AgentTempDirNormal/used_artifacts/x64-tmks" | flowey v 24 'artifact_use_from_x64-tmks' --is-raw-string update
         echo "$AgentTempDirNormal/used_artifacts/x64-windows-pipette" | flowey v 24 'artifact_use_from_x64-windows-pipette' --is-raw-string update
       shell: bash
     - name: creating new test content dir
       run: |-
         flowey e 24 flowey_core::pipeline::artifact::resolve 8
-        flowey e 24 flowey_core::pipeline::artifact::resolve 2
-        flowey e 24 flowey_core::pipeline::artifact::resolve 3
         flowey e 24 flowey_core::pipeline::artifact::resolve 4
         flowey e 24 flowey_core::pipeline::artifact::resolve 1
+        flowey e 24 flowey_core::pipeline::artifact::resolve 2
+        flowey e 24 flowey_core::pipeline::artifact::resolve 3
         flowey e 24 flowey_core::pipeline::artifact::resolve 0
         flowey e 24 flowey_core::pipeline::artifact::resolve 7
         flowey e 24 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
@@ -5373,10 +5408,7 @@ jobs:
       run: flowey e 24 flowey_lib_hvlite::init_vmm_tests_env 0
       shell: bash
     - name: ensure hypervisor device is accessible
-      run: flowey e 24 flowey_lib_hvlite::test_nextest_vmm_tests_archive 1
-      shell: bash
-    - name: ensure 2 MiB hugetlb pages are available
-      run: flowey e 24 flowey_lib_hvlite::test_nextest_vmm_tests_archive 2
+      run: flowey e 24 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
       shell: bash
     - name: create cargo-nextest cache dir
       run: |-
@@ -5431,10 +5463,9 @@ jobs:
         flowey e 24 flowey_lib_common::system_info 0
         flowey e 24 flowey_lib_hvlite::git_checkout_openvmm_repo 0
         flowey e 24 flowey_lib_hvlite::run_cargo_nextest_run 0
-        flowey e 24 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
         flowey e 24 flowey_lib_hvlite::run_cargo_nextest_run 1
-        flowey e 24 flowey_core::pipeline::artifact::resolve 6
-        flowey e 24 flowey_lib_hvlite::test_nextest_vmm_tests_archive 3
+        flowey e 24 flowey_core::pipeline::artifact::resolve 5
+        flowey e 24 flowey_lib_hvlite::test_nextest_vmm_tests_archive 1
       shell: bash
     - name: generate nextest command
       run: flowey e 24 flowey_lib_common::gen_cargo_nextest_run_cmd 0
@@ -5442,7 +5473,7 @@ jobs:
     - name: install vmm tests deps (linux)
       run: |-
         flowey e 24 flowey_lib_hvlite::install_vmm_tests_deps 0
-        flowey e 24 flowey_core::pipeline::artifact::resolve 5
+        flowey e 24 flowey_core::pipeline::artifact::resolve 6
       shell: bash
     - name: running vmm_test prep_steps
       run: flowey e 24 flowey_lib_hvlite::run_prep_steps 0
@@ -5460,9 +5491,9 @@ jobs:
     - id: flowey_lib_common__publish_test_results__6
       uses: actions/upload-artifact@v7
       with:
-        name: x64-linux-amd-kvm-vmm-tests-logs
+        name: x64-linux-intel-mshv-vmm-tests-logs
         path: ${{ env.floweyvar2 }}
-      name: 'publish test results: x64-linux-amd-kvm-vmm-tests (logs)'
+      name: 'publish test results: x64-linux-intel-mshv-vmm-tests (logs)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: 🦀 flowey rust steps
       run: |-
@@ -5476,9 +5507,9 @@ jobs:
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v7
       with:
-        name: x64-linux-amd-kvm-vmm-tests-junit-xml
+        name: x64-linux-intel-mshv-vmm-tests-junit-xml
         path: ${{ env.floweyvar1 }}
-      name: 'publish test results: x64-linux-amd-kvm-vmm-tests (JUnit XML)'
+      name: 'publish test results: x64-linux-intel-mshv-vmm-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
       run: flowey e 24 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
@@ -5493,321 +5524,6 @@ jobs:
       run: flowey e 24 flowey_lib_common::cache 11
       shell: bash
   job25:
-    name: run vmm-tests [x64-linux-intel-mshv]
-    runs-on:
-    - self-hosted
-    - 1ES.Pool=openvmm-gh-intel-westus3
-    - 1ES.ImageOverride=azurelinux3-amd64-dom0
-    - JobId=job25-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
-    permissions:
-      contents: read
-      id-token: write
-    needs:
-    - job2
-    - job3
-    - job9
-    if: github.event.pull_request.draft == false
-    steps:
-    - run: |
-        set -x
-        sudo tdnf install -y gcc glibc-devel
-        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.95.0 -y
-        . "$HOME/.cargo/env"
-        echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
-        rustup show
-      if: runner.os == 'Linux'
-      name: rustup (Linux)
-      shell: bash
-    - run: |
-        set -x
-        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.95.0
-        echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
-      if: runner.os == 'Windows' && runner.arch == 'X64'
-      name: rustup (Windows X64)
-      shell: bash
-    - run: |
-        set -x
-        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.95.0
-        echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
-      if: runner.os == 'Windows' && runner.arch == 'ARM64'
-      name: rustup (Windows ARM64)
-      shell: bash
-    - uses: actions/checkout@v6
-      with:
-        path: flowey_bootstrap
-    - name: Build flowey
-      run: |
-        set -x
-        CARGO_INCREMENTAL=0 cargo build -p flowey_hvlite --target x86_64-unknown-linux-gnu --profile flowey-ci
-        OutDirNormal=$(echo "${{ runner.temp }}/bootstrapped-flowey" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
-        mkdir -p "$OutDirNormal"
-        mv ./.github/workflows/openvmm-ci.yaml "$OutDirNormal/pipeline.yaml"
-        mv target/x86_64-unknown-linux-gnu/flowey-ci/flowey_hvlite "$OutDirNormal/flowey"
-      working-directory: flowey_bootstrap
-      shell: bash
-    - name: 🌼📦 Download artifacts
-      uses: actions/download-artifact@v8
-      with:
-        pattern: '{x64-guest_test_uefi,x64-linux-musl-openvmm,x64-linux-musl-openvmm_vhost,x64-linux-musl-pipette,x64-linux-musl-tmk_vmm,x64-linux-musl-vmm-tests-archive,x64-linux-prep_steps,x64-tmks,x64-windows-pipette}'
-        path: ${{ runner.temp }}/used_artifacts/
-    - run: echo "${{ runner.temp }}/bootstrapped-flowey" >> $GITHUB_PATH
-      shell: bash
-      name: 🌼📦 Add flowey to PATH
-    - name: 🌼🔎 Self-check YAML
-      run: |-
-        ESCAPED_AGENT_TEMPDIR=$(
-        cat <<'EOF' | sed 's/\\/\\\\/g'
-        ${{ runner.temp }}
-        EOF
-        )
-        flowey pipeline github --runtime $ESCAPED_AGENT_TEMPDIR/bootstrapped-flowey/pipeline.yaml --out .github/workflows/openvmm-ci.yaml ci checkin-gates --config=ci
-      shell: bash
-    - name: 🌼🛫 Initialize job
-      run: |
-        AgentTempDirNormal="${{ runner.temp }}"
-        AgentTempDirNormal=$(echo "$AgentTempDirNormal" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
-        echo "AgentTempDirNormal=$AgentTempDirNormal" >> $GITHUB_ENV
-
-        chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey
-
-        echo '"debug"' | flowey v 25 'FLOWEY_LOG' update
-        echo "${{ runner.temp }}/work" | flowey v 25 '_internal_WORKING_DIR' --is-raw-string update
-
-        cat <<'EOF' | flowey v 25 'verbose' update
-        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
-        EOF
-        echo "$AgentTempDirNormal/used_artifacts/x64-guest_test_uefi" | flowey v 25 'artifact_use_from_x64-guest_test_uefi' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-openvmm" | flowey v 25 'artifact_use_from_x64-linux-musl-openvmm' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-openvmm_vhost" | flowey v 25 'artifact_use_from_x64-linux-musl-openvmm_vhost' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-pipette" | flowey v 25 'artifact_use_from_x64-linux-musl-pipette' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-tmk_vmm" | flowey v 25 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-vmm-tests-archive" | flowey v 25 'artifact_use_from_x64-linux-musl-vmm-tests-archive' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-linux-prep_steps" | flowey v 25 'artifact_use_from_x64-linux-prep_steps' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-tmks" | flowey v 25 'artifact_use_from_x64-tmks' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-windows-pipette" | flowey v 25 'artifact_use_from_x64-windows-pipette' --is-raw-string update
-      shell: bash
-    - name: creating new test content dir
-      run: |-
-        flowey e 25 flowey_core::pipeline::artifact::resolve 8
-        flowey e 25 flowey_core::pipeline::artifact::resolve 4
-        flowey e 25 flowey_core::pipeline::artifact::resolve 1
-        flowey e 25 flowey_core::pipeline::artifact::resolve 2
-        flowey e 25 flowey_core::pipeline::artifact::resolve 3
-        flowey e 25 flowey_core::pipeline::artifact::resolve 0
-        flowey e 25 flowey_core::pipeline::artifact::resolve 7
-        flowey e 25 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
-      shell: bash
-    - name: checking if packages need to be installed
-      run: flowey e 25 flowey_lib_common::install_dist_pkg 0
-      shell: bash
-    - name: installing packages
-      run: flowey e 25 flowey_lib_common::install_dist_pkg 1
-      shell: bash
-    - name: create gh-release-download cache dir
-      run: flowey e 25 flowey_lib_common::download_gh_release 0
-      shell: bash
-    - name: Pre-processing cache vars
-      run: |-
-        flowey e 25 flowey_lib_common::cache 8
-        flowey v 25 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
-        flowey v 25 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
-      shell: bash
-    - id: flowey_lib_common__cache__9
-      uses: actions/cache@v5
-      with:
-        key: ${{ env.floweyvar8 }}
-        path: ${{ env.floweyvar9 }}
-      name: 'Restore cache: gh-release-download'
-    - name: download artifacts from github releases
-      run: |-
-        flowey v 25 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
-        EOF
-        flowey e 25 flowey_lib_common::cache 10
-        flowey e 25 flowey_lib_common::download_gh_release 1
-      shell: bash
-    - name: extract azcopy from archive
-      run: flowey e 25 flowey_lib_common::download_azcopy 0
-      shell: bash
-    - name: calculating required VMM tests disk images
-      run: flowey e 25 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
-      shell: bash
-    - name: downloading VMM test disk images
-      run: |-
-        flowey e 25 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
-        flowey e 25 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
-      shell: bash
-    - name: create gh cache dir
-      run: flowey e 25 flowey_lib_common::download_gh_cli 0
-      shell: bash
-    - name: Pre-processing cache vars
-      run: |-
-        flowey e 25 flowey_lib_common::cache 4
-        flowey v 25 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
-        flowey v 25 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
-      shell: bash
-    - id: flowey_lib_common__cache__5
-      uses: actions/cache@v5
-      with:
-        key: ${{ env.floweyvar6 }}
-        path: ${{ env.floweyvar7 }}
-      name: 'Restore cache: gh-cli'
-    - name: installing gh
-      run: |-
-        flowey v 25 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
-        EOF
-        flowey e 25 flowey_lib_common::cache 6
-        flowey e 25 flowey_lib_common::download_gh_cli 1
-        flowey v 25 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
-        ${{ github.token }}
-        EOF
-      shell: bash
-    - name: setup gh cli
-      run: flowey e 25 flowey_lib_common::use_gh_cli 0
-      shell: bash
-    - name: get latest completed action id
-      run: flowey e 25 flowey_lib_common::gh_latest_completed_workflow_id 0
-      shell: bash
-    - name: download artifacts from github actions run
-      run: |-
-        flowey e 25 flowey_lib_common::download_gh_artifact 0
-        flowey e 25 flowey_lib_hvlite::download_release_igvm_files_from_gh::resolve 0
-      shell: bash
-    - name: unpack openvmm-test-initrd archives
-      run: flowey e 25 flowey_lib_hvlite::resolve_openvmm_test_initrd 0
-      shell: bash
-    - name: unpack openvmm-test-linux archives
-      run: flowey e 25 flowey_lib_hvlite::resolve_openvmm_test_linux_kernel 0
-      shell: bash
-    - name: unpack mu_msvm package (x64)
-      run: flowey e 25 flowey_lib_hvlite::download_uefi_mu_msvm 0
-      shell: bash
-    - name: unpack openvmm-test-virtio-win archive
-      run: flowey e 25 flowey_lib_hvlite::resolve_openvmm_test_virtio_win 0
-      shell: bash
-    - name: setting up vmm_tests env
-      run: flowey e 25 flowey_lib_hvlite::init_vmm_tests_env 0
-      shell: bash
-    - name: ensure hypervisor device is accessible
-      run: flowey e 25 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
-      shell: bash
-    - name: create cargo-nextest cache dir
-      run: |-
-        flowey e 25 flowey_lib_common::download_cargo_nextest 0
-        flowey e 25 flowey_lib_common::download_cargo_nextest 1
-        flowey e 25 flowey_lib_common::download_cargo_nextest 2
-        flowey e 25 flowey_lib_common::download_cargo_nextest 3
-      shell: bash
-    - name: Pre-processing cache vars
-      run: |-
-        flowey e 25 flowey_lib_common::cache 0
-        flowey v 25 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
-        flowey v 25 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
-      shell: bash
-    - id: flowey_lib_common__cache__1
-      uses: actions/cache@v5
-      with:
-        key: ${{ env.floweyvar4 }}
-        path: ${{ env.floweyvar5 }}
-      name: 'Restore cache: cargo-nextest'
-    - name: downloading cargo-nextest
-      run: |-
-        flowey v 25 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
-        EOF
-        flowey e 25 flowey_lib_common::cache 2
-        flowey e 25 flowey_lib_common::download_cargo_nextest 4
-      shell: bash
-    - name: check if openvmm needs to be cloned
-      run: |-
-        flowey e 25 flowey_lib_common::git_checkout 0
-        flowey v 25 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
-        flowey v 25 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__git_checkout__1
-      uses: actions/checkout@v6
-      with:
-        fetch-depth: '1'
-        path: repo0
-        persist-credentials: ${{ env.floweyvar3 }}
-      name: checkout repo openvmm
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: report cloned repo directories
-      run: |-
-        flowey v 25 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
-        ${{ github.workspace }}
-        EOF
-        flowey e 25 flowey_lib_common::git_checkout 3
-      shell: bash
-    - name: print system info
-      run: |-
-        flowey e 25 flowey_lib_common::system_info 0
-        flowey e 25 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-        flowey e 25 flowey_lib_hvlite::run_cargo_nextest_run 0
-        flowey e 25 flowey_lib_hvlite::run_cargo_nextest_run 1
-        flowey e 25 flowey_core::pipeline::artifact::resolve 5
-        flowey e 25 flowey_lib_hvlite::test_nextest_vmm_tests_archive 1
-      shell: bash
-    - name: generate nextest command
-      run: flowey e 25 flowey_lib_common::gen_cargo_nextest_run_cmd 0
-      shell: bash
-    - name: install vmm tests deps (linux)
-      run: |-
-        flowey e 25 flowey_lib_hvlite::install_vmm_tests_deps 0
-        flowey e 25 flowey_core::pipeline::artifact::resolve 6
-      shell: bash
-    - name: running vmm_test prep_steps
-      run: flowey e 25 flowey_lib_hvlite::run_prep_steps 0
-      shell: bash
-    - name: run 'vmm_tests' nextest tests
-      run: |-
-        flowey e 25 flowey_lib_common::run_cargo_nextest_run 0
-        flowey e 25 flowey_lib_common::run_cargo_nextest_run 1
-        flowey e 25 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
-        flowey e 25 flowey_lib_common::publish_test_results 4
-        flowey e 25 flowey_lib_common::publish_test_results 5
-        flowey v 25 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:152:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57 write-to-env github floweyvar2
-        flowey v 25 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__publish_test_results__6
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-linux-intel-mshv-vmm-tests-logs
-        path: ${{ env.floweyvar2 }}
-      name: 'publish test results: x64-linux-intel-mshv-vmm-tests (logs)'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: 🦀 flowey rust steps
-      run: |-
-        flowey e 25 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
-        flowey e 25 flowey_lib_common::publish_test_results 0
-        flowey e 25 flowey_lib_common::publish_test_results 1
-        flowey e 25 flowey_lib_common::publish_test_results 2
-        flowey v 25 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
-        flowey v 25 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__publish_test_results__3
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-linux-intel-mshv-vmm-tests-junit-xml
-        path: ${{ env.floweyvar1 }}
-      name: 'publish test results: x64-linux-intel-mshv-vmm-tests (JUnit XML)'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: report test results to overall pipeline status
-      run: flowey e 25 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
-      shell: bash
-    - name: 'validate cache entry: cargo-nextest'
-      run: flowey e 25 flowey_lib_common::cache 3
-      shell: bash
-    - name: 'validate cache entry: gh-cli'
-      run: flowey e 25 flowey_lib_common::cache 7
-      shell: bash
-    - name: 'validate cache entry: gh-release-download'
-      run: flowey e 25 flowey_lib_common::cache 11
-      shell: bash
-  job26:
     name: run vmm-tests [aarch64-windows]
     runs-on:
     - self-hosted
@@ -5889,36 +5605,36 @@ jobs:
 
         chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey.exe
 
-        echo '"debug"' | flowey.exe v 26 'FLOWEY_LOG' update
-        echo "${{ runner.temp }}/work" | flowey.exe v 26 '_internal_WORKING_DIR' --is-raw-string update
+        echo '"debug"' | flowey.exe v 25 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey.exe v 25 '_internal_WORKING_DIR' --is-raw-string update
 
-        cat <<'EOF' | flowey.exe v 26 'verbose' update
+        cat <<'EOF' | flowey.exe v 25 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-guest_test_uefi" | flowey.exe v 26 'artifact_use_from_aarch64-guest_test_uefi' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-linux-musl-pipette" | flowey.exe v 26 'artifact_use_from_aarch64-linux-musl-pipette' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-linux-musl-tmk_vmm" | flowey.exe v 26 'artifact_use_from_aarch64-linux-musl-tmk_vmm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-openhcl-igvm" | flowey.exe v 26 'artifact_use_from_aarch64-openhcl-igvm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-tmks" | flowey.exe v 26 'artifact_use_from_aarch64-tmks' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-openvmm" | flowey.exe v 26 'artifact_use_from_aarch64-windows-openvmm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-pipette" | flowey.exe v 26 'artifact_use_from_aarch64-windows-pipette' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-tmk_vmm" | flowey.exe v 26 'artifact_use_from_aarch64-windows-tmk_vmm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-vmgstool" | flowey.exe v 26 'artifact_use_from_aarch64-windows-vmgstool' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-vmgstool-dev" | flowey.exe v 26 'artifact_use_from_aarch64-windows-vmgstool-dev' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-vmm-tests-archive" | flowey.exe v 26 'artifact_use_from_aarch64-windows-vmm-tests-archive' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-guest_test_uefi" | flowey.exe v 25 'artifact_use_from_aarch64-guest_test_uefi' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-linux-musl-pipette" | flowey.exe v 25 'artifact_use_from_aarch64-linux-musl-pipette' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-linux-musl-tmk_vmm" | flowey.exe v 25 'artifact_use_from_aarch64-linux-musl-tmk_vmm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-openhcl-igvm" | flowey.exe v 25 'artifact_use_from_aarch64-openhcl-igvm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-tmks" | flowey.exe v 25 'artifact_use_from_aarch64-tmks' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-openvmm" | flowey.exe v 25 'artifact_use_from_aarch64-windows-openvmm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-pipette" | flowey.exe v 25 'artifact_use_from_aarch64-windows-pipette' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-tmk_vmm" | flowey.exe v 25 'artifact_use_from_aarch64-windows-tmk_vmm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-vmgstool" | flowey.exe v 25 'artifact_use_from_aarch64-windows-vmgstool' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-vmgstool-dev" | flowey.exe v 25 'artifact_use_from_aarch64-windows-vmgstool-dev' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-vmm-tests-archive" | flowey.exe v 25 'artifact_use_from_aarch64-windows-vmm-tests-archive' --is-raw-string update
       shell: bash
     - name: create cargo-nextest cache dir
       run: |-
-        flowey.exe e 26 flowey_lib_common::download_cargo_nextest 0
-        flowey.exe e 26 flowey_lib_common::download_cargo_nextest 1
-        flowey.exe e 26 flowey_lib_common::download_cargo_nextest 2
-        flowey.exe e 26 flowey_lib_common::download_cargo_nextest 3
+        flowey.exe e 25 flowey_lib_common::download_cargo_nextest 0
+        flowey.exe e 25 flowey_lib_common::download_cargo_nextest 1
+        flowey.exe e 25 flowey_lib_common::download_cargo_nextest 2
+        flowey.exe e 25 flowey_lib_common::download_cargo_nextest 3
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey.exe e 26 flowey_lib_common::cache 0
-        flowey.exe v 26 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
-        flowey.exe v 26 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
+        flowey.exe e 25 flowey_lib_common::cache 0
+        flowey.exe v 25 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
+        flowey.exe v 25 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -5928,17 +5644,17 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
-        flowey.exe v 26 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey.exe v 25 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
-        flowey.exe e 26 flowey_lib_common::cache 2
-        flowey.exe e 26 flowey_lib_common::download_cargo_nextest 4
+        flowey.exe e 25 flowey_lib_common::cache 2
+        flowey.exe e 25 flowey_lib_common::download_cargo_nextest 4
       shell: bash
     - name: check if openvmm needs to be cloned
       run: |-
-        flowey.exe e 26 flowey_lib_common::git_checkout 0
-        flowey.exe v 26 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
-        flowey.exe v 26 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey.exe e 25 flowey_lib_common::git_checkout 0
+        flowey.exe v 25 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
+        flowey.exe v 25 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -5950,38 +5666,38 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey.exe v 26 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey.exe v 25 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
-        flowey.exe e 26 flowey_lib_common::git_checkout 3
+        flowey.exe e 25 flowey_lib_common::git_checkout 3
       shell: bash
     - name: print system info
       run: |-
-        flowey.exe e 26 flowey_lib_common::system_info 0
-        flowey.exe e 26 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-        flowey.exe e 26 flowey_lib_hvlite::run_cargo_nextest_run 0
-        flowey.exe e 26 flowey_core::pipeline::artifact::resolve 5
-        flowey.exe e 26 flowey_core::pipeline::artifact::resolve 6
-        flowey.exe e 26 flowey_core::pipeline::artifact::resolve 7
-        flowey.exe e 26 flowey_core::pipeline::artifact::resolve 8
-        flowey.exe e 26 flowey_core::pipeline::artifact::resolve 9
-        flowey.exe e 26 flowey_core::pipeline::artifact::resolve 3
-        flowey.exe e 26 flowey_core::pipeline::artifact::resolve 1
-        flowey.exe e 26 flowey_core::pipeline::artifact::resolve 2
-        flowey.exe e 26 flowey_core::pipeline::artifact::resolve 0
-        flowey.exe e 26 flowey_core::pipeline::artifact::resolve 4
+        flowey.exe e 25 flowey_lib_common::system_info 0
+        flowey.exe e 25 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey.exe e 25 flowey_lib_hvlite::run_cargo_nextest_run 0
+        flowey.exe e 25 flowey_core::pipeline::artifact::resolve 5
+        flowey.exe e 25 flowey_core::pipeline::artifact::resolve 6
+        flowey.exe e 25 flowey_core::pipeline::artifact::resolve 7
+        flowey.exe e 25 flowey_core::pipeline::artifact::resolve 8
+        flowey.exe e 25 flowey_core::pipeline::artifact::resolve 9
+        flowey.exe e 25 flowey_core::pipeline::artifact::resolve 3
+        flowey.exe e 25 flowey_core::pipeline::artifact::resolve 1
+        flowey.exe e 25 flowey_core::pipeline::artifact::resolve 2
+        flowey.exe e 25 flowey_core::pipeline::artifact::resolve 0
+        flowey.exe e 25 flowey_core::pipeline::artifact::resolve 4
       shell: bash
     - name: creating new test content dir
-      run: flowey.exe e 26 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
+      run: flowey.exe e 25 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
       shell: bash
     - name: create gh-release-download cache dir
-      run: flowey.exe e 26 flowey_lib_common::download_gh_release 0
+      run: flowey.exe e 25 flowey_lib_common::download_gh_release 0
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey.exe e 26 flowey_lib_common::cache 8
-        flowey.exe v 26 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
-        flowey.exe v 26 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
+        flowey.exe e 25 flowey_lib_common::cache 8
+        flowey.exe v 25 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
+        flowey.exe v 25 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
       shell: bash
     - id: flowey_lib_common__cache__9
       uses: actions/cache@v5
@@ -5991,31 +5707,31 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 26 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
+        flowey.exe v 25 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
         EOF
-        flowey.exe e 26 flowey_lib_common::cache 10
-        flowey.exe e 26 flowey_lib_common::download_gh_release 1
+        flowey.exe e 25 flowey_lib_common::cache 10
+        flowey.exe e 25 flowey_lib_common::download_gh_release 1
       shell: bash
     - name: extract azcopy from archive
-      run: flowey.exe e 26 flowey_lib_common::download_azcopy 0
+      run: flowey.exe e 25 flowey_lib_common::download_azcopy 0
       shell: bash
     - name: calculating required VMM tests disk images
-      run: flowey.exe e 26 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
+      run: flowey.exe e 25 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
       shell: bash
     - name: downloading VMM test disk images
       run: |-
-        flowey.exe e 26 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
-        flowey.exe e 26 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
+        flowey.exe e 25 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
+        flowey.exe e 25 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
       shell: bash
     - name: create gh cache dir
-      run: flowey.exe e 26 flowey_lib_common::download_gh_cli 0
+      run: flowey.exe e 25 flowey_lib_common::download_gh_cli 0
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey.exe e 26 flowey_lib_common::cache 4
-        flowey.exe v 26 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
-        flowey.exe v 26 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
+        flowey.exe e 25 flowey_lib_common::cache 4
+        flowey.exe v 25 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
+        flowey.exe v 25 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
@@ -6025,68 +5741,68 @@ jobs:
       name: 'Restore cache: gh-cli'
     - name: installing gh
       run: |-
-        flowey.exe v 26 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        flowey.exe v 25 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
-        flowey.exe e 26 flowey_lib_common::cache 6
-        flowey.exe e 26 flowey_lib_common::download_gh_cli 1
-        flowey.exe v 26 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
+        flowey.exe e 25 flowey_lib_common::cache 6
+        flowey.exe e 25 flowey_lib_common::download_gh_cli 1
+        flowey.exe v 25 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
         ${{ github.token }}
         EOF
       shell: bash
     - name: setup gh cli
-      run: flowey.exe e 26 flowey_lib_common::use_gh_cli 0
+      run: flowey.exe e 25 flowey_lib_common::use_gh_cli 0
       shell: bash
     - name: get latest completed action id
-      run: flowey.exe e 26 flowey_lib_common::gh_latest_completed_workflow_id 0
+      run: flowey.exe e 25 flowey_lib_common::gh_latest_completed_workflow_id 0
       shell: bash
     - name: download artifacts from github actions run
       run: |-
-        flowey.exe e 26 flowey_lib_common::download_gh_artifact 0
-        flowey.exe e 26 flowey_lib_hvlite::download_release_igvm_files_from_gh::resolve 0
+        flowey.exe e 25 flowey_lib_common::download_gh_artifact 0
+        flowey.exe e 25 flowey_lib_hvlite::download_release_igvm_files_from_gh::resolve 0
       shell: bash
     - name: unpack openvmm-test-initrd archives
-      run: flowey.exe e 26 flowey_lib_hvlite::resolve_openvmm_test_initrd 0
+      run: flowey.exe e 25 flowey_lib_hvlite::resolve_openvmm_test_initrd 0
       shell: bash
     - name: unpack openvmm-test-linux archives
-      run: flowey.exe e 26 flowey_lib_hvlite::resolve_openvmm_test_linux_kernel 0
+      run: flowey.exe e 25 flowey_lib_hvlite::resolve_openvmm_test_linux_kernel 0
       shell: bash
     - name: unpack mu_msvm package (aarch64)
-      run: flowey.exe e 26 flowey_lib_hvlite::download_uefi_mu_msvm 0
+      run: flowey.exe e 25 flowey_lib_hvlite::download_uefi_mu_msvm 0
       shell: bash
     - name: unpack openvmm-test-virtio-win archive
-      run: flowey.exe e 26 flowey_lib_hvlite::resolve_openvmm_test_virtio_win 0
+      run: flowey.exe e 25 flowey_lib_hvlite::resolve_openvmm_test_virtio_win 0
       shell: bash
     - name: setting up vmm_tests env
       run: |-
-        flowey.exe e 26 flowey_lib_hvlite::init_vmm_tests_env 0
-        flowey.exe e 26 flowey_lib_hvlite::run_cargo_nextest_run 1
-        flowey.exe e 26 flowey_core::pipeline::artifact::resolve 10
-        flowey.exe e 26 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
+        flowey.exe e 25 flowey_lib_hvlite::init_vmm_tests_env 0
+        flowey.exe e 25 flowey_lib_hvlite::run_cargo_nextest_run 1
+        flowey.exe e 25 flowey_core::pipeline::artifact::resolve 10
+        flowey.exe e 25 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
       shell: bash
     - name: generate nextest command
-      run: flowey.exe e 26 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      run: flowey.exe e 25 flowey_lib_common::gen_cargo_nextest_run_cmd 0
       shell: bash
     - name: install vmm tests deps (windows)
-      run: flowey.exe e 26 flowey_lib_hvlite::install_vmm_tests_deps 0
+      run: flowey.exe e 25 flowey_lib_hvlite::install_vmm_tests_deps 0
       shell: bash
     - name: starting test_igvm_agent_rpc_server
-      run: flowey.exe e 26 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
+      run: flowey.exe e 25 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
       shell: bash
     - name: run 'vmm_tests' nextest tests
       run: |-
-        flowey.exe e 26 flowey_lib_common::run_cargo_nextest_run 0
-        flowey.exe e 26 flowey_lib_common::run_cargo_nextest_run 1
-        flowey.exe e 26 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
+        flowey.exe e 25 flowey_lib_common::run_cargo_nextest_run 0
+        flowey.exe e 25 flowey_lib_common::run_cargo_nextest_run 1
+        flowey.exe e 25 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
       shell: bash
     - name: stopping test_igvm_agent_rpc_server
       run: |-
-        flowey.exe e 26 flowey_lib_hvlite::stop_test_igvm_agent_rpc_server 0
-        flowey.exe e 26 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
-        flowey.exe e 26 flowey_lib_common::publish_test_results 4
-        flowey.exe e 26 flowey_lib_common::publish_test_results 5
-        flowey.exe v 26 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:152:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57 write-to-env github floweyvar2
-        flowey.exe v 26 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57' write-to-env github FLOWEY_CONDITION
+        flowey.exe e 25 flowey_lib_hvlite::stop_test_igvm_agent_rpc_server 0
+        flowey.exe e 25 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
+        flowey.exe e 25 flowey_lib_common::publish_test_results 4
+        flowey.exe e 25 flowey_lib_common::publish_test_results 5
+        flowey.exe v 25 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:152:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57 write-to-env github floweyvar2
+        flowey.exe v 25 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__6
       uses: actions/upload-artifact@v7
@@ -6097,12 +5813,12 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: 🦀 flowey rust steps
       run: |-
-        flowey.exe e 26 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
-        flowey.exe e 26 flowey_lib_common::publish_test_results 0
-        flowey.exe e 26 flowey_lib_common::publish_test_results 1
-        flowey.exe e 26 flowey_lib_common::publish_test_results 2
-        flowey.exe v 26 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
-        flowey.exe v 26 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey.exe e 25 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
+        flowey.exe e 25 flowey_lib_common::publish_test_results 0
+        flowey.exe e 25 flowey_lib_common::publish_test_results 1
+        flowey.exe e 25 flowey_lib_common::publish_test_results 2
+        flowey.exe v 25 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
+        flowey.exe v 25 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v7
@@ -6112,18 +5828,18 @@ jobs:
       name: 'publish test results: aarch64-windows-vmm-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
-      run: flowey.exe e 26 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
+      run: flowey.exe e 25 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
       shell: bash
     - name: 'validate cache entry: cargo-nextest'
-      run: flowey.exe e 26 flowey_lib_common::cache 3
+      run: flowey.exe e 25 flowey_lib_common::cache 3
       shell: bash
     - name: 'validate cache entry: gh-cli'
-      run: flowey.exe e 26 flowey_lib_common::cache 7
+      run: flowey.exe e 25 flowey_lib_common::cache 7
       shell: bash
     - name: 'validate cache entry: gh-release-download'
-      run: flowey.exe e 26 flowey_lib_common::cache 11
+      run: flowey.exe e 25 flowey_lib_common::cache 11
       shell: bash
-  job27:
+  job26:
     name: test flowey local backend
     runs-on: ubuntu-latest
     permissions:
@@ -6191,12 +5907,154 @@ jobs:
 
         chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey
 
+        echo '"debug"' | flowey v 26 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey v 26 '_internal_WORKING_DIR' --is-raw-string update
+
+        cat <<'EOF' | flowey v 26 'verbose' update
+        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
+        EOF
+      shell: bash
+    - name: check if openvmm needs to be cloned
+      run: |-
+        flowey e 26 flowey_lib_common::git_checkout 0
+        flowey v 26 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar1
+        flowey v 26 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__git_checkout__1
+      uses: actions/checkout@v6
+      with:
+        fetch-depth: '1'
+        path: repo0
+        persist-credentials: ${{ env.floweyvar1 }}
+      name: checkout repo openvmm
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: report cloned repo directories
+      run: |-
+        flowey v 26 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        ${{ github.workspace }}
+        EOF
+        flowey e 26 flowey_lib_common::git_checkout 3
+      shell: bash
+    - name: print system info
+      run: |-
+        flowey e 26 flowey_lib_common::system_info 0
+        flowey e 26 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+      shell: bash
+    - name: add default cargo home to path
+      run: flowey e 26 flowey_lib_common::install_rust 0
+      shell: bash
+    - name: install Rust
+      run: flowey e 26 flowey_lib_common::install_rust 1
+      shell: bash
+    - name: detect active toolchain
+      run: |-
+        flowey e 26 flowey_lib_common::install_rust 2
+        flowey v 26 'flowey_lib_hvlite::_jobs::test_local_flowey_build_igvm:3:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
+        ${{ github.token }}
+        EOF
+      shell: bash
+    - name: test cargo xflowey build-igvm x64 --install-missing-deps
+      run: flowey e 26 flowey_lib_hvlite::_jobs::test_local_flowey_build_igvm 1
+      shell: bash
+  job27:
+    name: publish vmgstool
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
+    needs:
+    - job0
+    - job1
+    - job10
+    - job11
+    - job12
+    - job13
+    - job14
+    - job15
+    - job16
+    - job17
+    - job18
+    - job19
+    - job2
+    - job20
+    - job21
+    - job22
+    - job23
+    - job24
+    - job25
+    - job26
+    - job3
+    - job4
+    - job5
+    - job6
+    - job7
+    - job8
+    - job9
+    if: github.event.pull_request.draft == false
+    steps:
+    - name: 🌼📦 Download artifacts
+      uses: actions/download-artifact@v8
+      with:
+        pattern: '{_internal-flowey-bootstrap-x86_64-linux-uid-11,aarch64-linux-vmgstool,aarch64-windows-vmgstool,x64-linux-vmgstool,x64-windows-vmgstool}'
+        path: ${{ runner.temp }}/used_artifacts/
+    - run: echo "${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-11" >> $GITHUB_PATH
+      shell: bash
+      name: 🌼📦 Add flowey to PATH
+    - name: 🌼🛫 Initialize job
+      run: |
+        AgentTempDirNormal="${{ runner.temp }}"
+        AgentTempDirNormal=$(echo "$AgentTempDirNormal" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
+        echo "AgentTempDirNormal=$AgentTempDirNormal" >> $GITHUB_ENV
+
+        chmod +x $AgentTempDirNormal/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-11/flowey
+
         echo '"debug"' | flowey v 27 'FLOWEY_LOG' update
         echo "${{ runner.temp }}/work" | flowey v 27 '_internal_WORKING_DIR' --is-raw-string update
 
         cat <<'EOF' | flowey v 27 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
+        echo "$AgentTempDirNormal/used_artifacts/aarch64-linux-vmgstool" | flowey v 27 'artifact_use_from_aarch64-linux-vmgstool' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/aarch64-windows-vmgstool" | flowey v 27 'artifact_use_from_aarch64-windows-vmgstool' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-vmgstool" | flowey v 27 'artifact_use_from_x64-linux-vmgstool' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-windows-vmgstool" | flowey v 27 'artifact_use_from_x64-windows-vmgstool' --is-raw-string update
+      shell: bash
+    - name: create gh cache dir
+      run: flowey e 27 flowey_lib_common::download_gh_cli 0
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
+        flowey e 27 flowey_lib_common::cache 0
+        flowey v 27 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar2
+        flowey v 27 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar3
+      shell: bash
+    - id: flowey_lib_common__cache__1
+      uses: actions/cache@v5
+      with:
+        key: ${{ env.floweyvar2 }}
+        path: ${{ env.floweyvar3 }}
+      name: 'Restore cache: gh-cli'
+    - name: installing gh
+      run: |-
+        flowey v 27 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
+        EOF
+        flowey e 27 flowey_lib_common::cache 2
+        flowey e 27 flowey_lib_common::download_gh_cli 1
+        flowey v 27 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
+        ${{ github.token }}
+        EOF
+      shell: bash
+    - name: setup gh cli
+      run: |-
+        flowey e 27 flowey_lib_common::use_gh_cli 0
+        flowey e 27 flowey_core::pipeline::artifact::resolve 1
+        flowey e 27 flowey_core::pipeline::artifact::resolve 0
+        flowey e 27 flowey_core::pipeline::artifact::resolve 3
+        flowey e 27 flowey_core::pipeline::artifact::resolve 2
+      shell: bash
+    - name: enumerate vmgstool release files
+      run: flowey e 27 flowey_lib_hvlite::_jobs::publish_vmgstool_gh_release 0
       shell: bash
     - name: check if openvmm needs to be cloned
       run: |-
@@ -6224,166 +6082,23 @@ jobs:
         flowey e 27 flowey_lib_common::system_info 0
         flowey e 27 flowey_lib_hvlite::git_checkout_openvmm_repo 0
       shell: bash
-    - name: add default cargo home to path
-      run: flowey e 27 flowey_lib_common::install_rust 0
-      shell: bash
-    - name: install Rust
-      run: flowey e 27 flowey_lib_common::install_rust 1
-      shell: bash
-    - name: detect active toolchain
-      run: |-
-        flowey e 27 flowey_lib_common::install_rust 2
-        flowey v 27 'flowey_lib_hvlite::_jobs::test_local_flowey_build_igvm:3:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
-        ${{ github.token }}
-        EOF
-      shell: bash
-    - name: test cargo xflowey build-igvm x64 --install-missing-deps
-      run: flowey e 27 flowey_lib_hvlite::_jobs::test_local_flowey_build_igvm 1
-      shell: bash
-  job28:
-    name: publish vmgstool
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      id-token: write
-    needs:
-    - job0
-    - job1
-    - job10
-    - job11
-    - job12
-    - job13
-    - job14
-    - job15
-    - job16
-    - job17
-    - job18
-    - job19
-    - job2
-    - job20
-    - job21
-    - job22
-    - job23
-    - job24
-    - job25
-    - job26
-    - job27
-    - job3
-    - job4
-    - job5
-    - job6
-    - job7
-    - job8
-    - job9
-    if: github.event.pull_request.draft == false
-    steps:
-    - name: 🌼📦 Download artifacts
-      uses: actions/download-artifact@v8
-      with:
-        pattern: '{_internal-flowey-bootstrap-x86_64-linux-uid-11,aarch64-linux-vmgstool,aarch64-windows-vmgstool,x64-linux-vmgstool,x64-windows-vmgstool}'
-        path: ${{ runner.temp }}/used_artifacts/
-    - run: echo "${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-11" >> $GITHUB_PATH
-      shell: bash
-      name: 🌼📦 Add flowey to PATH
-    - name: 🌼🛫 Initialize job
-      run: |
-        AgentTempDirNormal="${{ runner.temp }}"
-        AgentTempDirNormal=$(echo "$AgentTempDirNormal" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
-        echo "AgentTempDirNormal=$AgentTempDirNormal" >> $GITHUB_ENV
-
-        chmod +x $AgentTempDirNormal/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-11/flowey
-
-        echo '"debug"' | flowey v 28 'FLOWEY_LOG' update
-        echo "${{ runner.temp }}/work" | flowey v 28 '_internal_WORKING_DIR' --is-raw-string update
-
-        cat <<'EOF' | flowey v 28 'verbose' update
-        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
-        EOF
-        echo "$AgentTempDirNormal/used_artifacts/aarch64-linux-vmgstool" | flowey v 28 'artifact_use_from_aarch64-linux-vmgstool' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/aarch64-windows-vmgstool" | flowey v 28 'artifact_use_from_aarch64-windows-vmgstool' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-linux-vmgstool" | flowey v 28 'artifact_use_from_x64-linux-vmgstool' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-windows-vmgstool" | flowey v 28 'artifact_use_from_x64-windows-vmgstool' --is-raw-string update
-      shell: bash
-    - name: create gh cache dir
-      run: flowey e 28 flowey_lib_common::download_gh_cli 0
-      shell: bash
-    - name: Pre-processing cache vars
-      run: |-
-        flowey e 28 flowey_lib_common::cache 0
-        flowey v 28 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar2
-        flowey v 28 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar3
-      shell: bash
-    - id: flowey_lib_common__cache__1
-      uses: actions/cache@v5
-      with:
-        key: ${{ env.floweyvar2 }}
-        path: ${{ env.floweyvar3 }}
-      name: 'Restore cache: gh-cli'
-    - name: installing gh
-      run: |-
-        flowey v 28 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
-        EOF
-        flowey e 28 flowey_lib_common::cache 2
-        flowey e 28 flowey_lib_common::download_gh_cli 1
-        flowey v 28 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
-        ${{ github.token }}
-        EOF
-      shell: bash
-    - name: setup gh cli
-      run: |-
-        flowey e 28 flowey_lib_common::use_gh_cli 0
-        flowey e 28 flowey_core::pipeline::artifact::resolve 1
-        flowey e 28 flowey_core::pipeline::artifact::resolve 0
-        flowey e 28 flowey_core::pipeline::artifact::resolve 3
-        flowey e 28 flowey_core::pipeline::artifact::resolve 2
-      shell: bash
-    - name: enumerate vmgstool release files
-      run: flowey e 28 flowey_lib_hvlite::_jobs::publish_vmgstool_gh_release 0
-      shell: bash
-    - name: check if openvmm needs to be cloned
-      run: |-
-        flowey e 28 flowey_lib_common::git_checkout 0
-        flowey v 28 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar1
-        flowey v 28 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__git_checkout__1
-      uses: actions/checkout@v6
-      with:
-        fetch-depth: '1'
-        path: repo0
-        persist-credentials: ${{ env.floweyvar1 }}
-      name: checkout repo openvmm
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: report cloned repo directories
-      run: |-
-        flowey v 28 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
-        ${{ github.workspace }}
-        EOF
-        flowey e 28 flowey_lib_common::git_checkout 3
-      shell: bash
-    - name: print system info
-      run: |-
-        flowey e 28 flowey_lib_common::system_info 0
-        flowey e 28 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-      shell: bash
     - name: get current commit
       run: |-
-        flowey e 28 flowey_lib_hvlite::_jobs::publish_vmgstool_gh_release 5
-        flowey e 28 flowey_lib_hvlite::_jobs::publish_vmgstool_gh_release 1
+        flowey e 27 flowey_lib_hvlite::_jobs::publish_vmgstool_gh_release 5
+        flowey e 27 flowey_lib_hvlite::_jobs::publish_vmgstool_gh_release 1
       shell: bash
     - name: get cargo crate version
       run: |-
-        flowey e 28 flowey_lib_common::get_cargo_crate_version 0
-        flowey e 28 flowey_lib_hvlite::_jobs::publish_vmgstool_gh_release 2
-        flowey e 28 flowey_lib_hvlite::_jobs::publish_vmgstool_gh_release 3
-        flowey e 28 flowey_lib_hvlite::_jobs::publish_vmgstool_gh_release 4
+        flowey e 27 flowey_lib_common::get_cargo_crate_version 0
+        flowey e 27 flowey_lib_hvlite::_jobs::publish_vmgstool_gh_release 2
+        flowey e 27 flowey_lib_hvlite::_jobs::publish_vmgstool_gh_release 3
+        flowey e 27 flowey_lib_hvlite::_jobs::publish_vmgstool_gh_release 4
       shell: bash
     - name: publish github releases
-      run: flowey e 28 flowey_lib_common::publish_gh_release 0
+      run: flowey e 27 flowey_lib_common::publish_gh_release 0
       shell: bash
     - name: 'validate cache entry: gh-cli'
-      run: flowey e 28 flowey_lib_common::cache 3
+      run: flowey e 27 flowey_lib_common::cache 3
       shell: bash
   job3:
     name: build artifacts (shared VMM tests) [linux]

--- a/.github/workflows/openvmm-pr-release.yaml
+++ b/.github/workflows/openvmm-pr-release.yaml
@@ -4144,13 +4144,12 @@ jobs:
       run: flowey.exe e 20 flowey_lib_common::cache 11
       shell: bash
   job21:
-    name: run vmm-tests [x64-windows-intel-tdx]
+    name: run vmm-tests [x64-windows-amd]
     runs-on:
     - self-hosted
-    - Windows
-    - X64
-    - TDX
-    - Baremetal
+    - 1ES.Pool=openvmm-gh-amd-westus3
+    - 1ES.ImageOverride=win-amd64
+    - JobId=job21-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
@@ -4396,9 +4395,9 @@ jobs:
     - id: flowey_lib_common__publish_test_results__6
       uses: actions/upload-artifact@v7
       with:
-        name: x64-windows-intel-tdx-vmm-tests-logs
+        name: x64-windows-amd-vmm-tests-logs
         path: ${{ env.floweyvar2 }}
-      name: 'publish test results: x64-windows-intel-tdx-vmm-tests (logs)'
+      name: 'publish test results: x64-windows-amd-vmm-tests (logs)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: 🦀 flowey rust steps
       run: |-
@@ -4412,9 +4411,9 @@ jobs:
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v7
       with:
-        name: x64-windows-intel-tdx-vmm-tests-junit-xml
+        name: x64-windows-amd-vmm-tests-junit-xml
         path: ${{ env.floweyvar1 }}
-      name: 'publish test results: x64-windows-intel-tdx-vmm-tests (JUnit XML)'
+      name: 'publish test results: x64-windows-amd-vmm-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
       run: flowey.exe e 21 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
@@ -4429,12 +4428,13 @@ jobs:
       run: flowey.exe e 21 flowey_lib_common::cache 11
       shell: bash
   job22:
-    name: run vmm-tests [x64-windows-amd]
+    name: run vmm-tests [x64-windows-amd-snp]
     runs-on:
     - self-hosted
-    - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=win-amd64
-    - JobId=job22-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
+    - Windows
+    - X64
+    - SNP
+    - Baremetal
     permissions:
       contents: read
       id-token: write
@@ -4680,9 +4680,9 @@ jobs:
     - id: flowey_lib_common__publish_test_results__6
       uses: actions/upload-artifact@v7
       with:
-        name: x64-windows-amd-vmm-tests-logs
+        name: x64-windows-amd-snp-vmm-tests-logs
         path: ${{ env.floweyvar2 }}
-      name: 'publish test results: x64-windows-amd-vmm-tests (logs)'
+      name: 'publish test results: x64-windows-amd-snp-vmm-tests (logs)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: 🦀 flowey rust steps
       run: |-
@@ -4696,9 +4696,9 @@ jobs:
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v7
       with:
-        name: x64-windows-amd-vmm-tests-junit-xml
+        name: x64-windows-amd-snp-vmm-tests-junit-xml
         path: ${{ env.floweyvar1 }}
-      name: 'publish test results: x64-windows-amd-vmm-tests (JUnit XML)'
+      name: 'publish test results: x64-windows-amd-snp-vmm-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
       run: flowey.exe e 22 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
@@ -4713,297 +4713,12 @@ jobs:
       run: flowey.exe e 22 flowey_lib_common::cache 11
       shell: bash
   job23:
-    name: run vmm-tests [x64-windows-amd-snp]
-    runs-on:
-    - self-hosted
-    - Windows
-    - X64
-    - SNP
-    - Baremetal
-    permissions:
-      contents: read
-      id-token: write
-    needs:
-    - job0
-    - job11
-    - job2
-    - job3
-    - job7
-    if: contains(github.event.pull_request.labels.*.name, 'release-ci-required') && github.event.pull_request.draft == false
-    steps:
-    - name: 🌼📦 Download artifacts
-      uses: actions/download-artifact@v8
-      with:
-        pattern: '{_internal-flowey-bootstrap-x86_64-windows-uid-6,x64-guest_test_uefi,x64-linux-musl-pipette,x64-linux-musl-tmk_vmm,x64-linux-tpm_guest_tests,x64-openhcl-igvm,x64-openhcl-igvm-cvm,x64-openhcl-igvm-test-linux-direct,x64-tmks,x64-windows-openvmm,x64-windows-pipette,x64-windows-prep_steps,x64-windows-test_igvm_agent_rpc_server,x64-windows-tmk_vmm,x64-windows-tpm_guest_tests,x64-windows-vmgstool,x64-windows-vmgstool-dev,x64-windows-vmm-tests-archive}'
-        path: ${{ runner.temp }}/used_artifacts/
-    - run: echo "${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-windows-uid-6" >> $GITHUB_PATH
-      shell: bash
-      name: 🌼📦 Add flowey to PATH
-    - name: 🌼🛫 Initialize job
-      run: |
-        AgentTempDirNormal="${{ runner.temp }}"
-        AgentTempDirNormal=$(echo "$AgentTempDirNormal" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
-        echo "AgentTempDirNormal=$AgentTempDirNormal" >> $GITHUB_ENV
-
-        chmod +x $AgentTempDirNormal/used_artifacts/_internal-flowey-bootstrap-x86_64-windows-uid-6/flowey.exe
-
-        echo '"debug"' | flowey.exe v 23 'FLOWEY_LOG' update
-        echo "${{ runner.temp }}/work" | flowey.exe v 23 '_internal_WORKING_DIR' --is-raw-string update
-
-        cat <<'EOF' | flowey.exe v 23 'verbose' update
-        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
-        EOF
-        echo "${{ runner.temp }}\\used_artifacts\\x64-guest_test_uefi" | flowey.exe v 23 'artifact_use_from_x64-guest_test_uefi' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-pipette" | flowey.exe v 23 'artifact_use_from_x64-linux-musl-pipette' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-tmk_vmm" | flowey.exe v 23 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-tpm_guest_tests" | flowey.exe v 23 'artifact_use_from_x64-linux-tpm_guest_tests' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-openhcl-igvm" | flowey.exe v 23 'artifact_use_from_x64-openhcl-igvm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-openhcl-igvm-cvm" | flowey.exe v 23 'artifact_use_from_x64-openhcl-igvm-cvm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-openhcl-igvm-test-linux-direct" | flowey.exe v 23 'artifact_use_from_x64-openhcl-igvm-test-linux-direct' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-tmks" | flowey.exe v 23 'artifact_use_from_x64-tmks' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-openvmm" | flowey.exe v 23 'artifact_use_from_x64-windows-openvmm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-pipette" | flowey.exe v 23 'artifact_use_from_x64-windows-pipette' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-prep_steps" | flowey.exe v 23 'artifact_use_from_x64-windows-prep_steps' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-test_igvm_agent_rpc_server" | flowey.exe v 23 'artifact_use_from_x64-windows-test_igvm_agent_rpc_server' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-tmk_vmm" | flowey.exe v 23 'artifact_use_from_x64-windows-tmk_vmm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-tpm_guest_tests" | flowey.exe v 23 'artifact_use_from_x64-windows-tpm_guest_tests' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-vmgstool" | flowey.exe v 23 'artifact_use_from_x64-windows-vmgstool' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-vmgstool-dev" | flowey.exe v 23 'artifact_use_from_x64-windows-vmgstool-dev' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-vmm-tests-archive" | flowey.exe v 23 'artifact_use_from_x64-windows-vmm-tests-archive' --is-raw-string update
-      shell: bash
-    - name: create cargo-nextest cache dir
-      run: |-
-        flowey.exe e 23 flowey_lib_common::download_cargo_nextest 0
-        flowey.exe e 23 flowey_lib_common::download_cargo_nextest 1
-        flowey.exe e 23 flowey_lib_common::download_cargo_nextest 2
-        flowey.exe e 23 flowey_lib_common::download_cargo_nextest 3
-      shell: bash
-    - name: Pre-processing cache vars
-      run: |-
-        flowey.exe e 23 flowey_lib_common::cache 0
-        flowey.exe v 23 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
-        flowey.exe v 23 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
-      shell: bash
-    - id: flowey_lib_common__cache__1
-      uses: actions/cache@v5
-      with:
-        key: ${{ env.floweyvar4 }}
-        path: ${{ env.floweyvar5 }}
-      name: 'Restore cache: cargo-nextest'
-    - name: downloading cargo-nextest
-      run: |-
-        flowey.exe v 23 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
-        EOF
-        flowey.exe e 23 flowey_lib_common::cache 2
-        flowey.exe e 23 flowey_lib_common::download_cargo_nextest 4
-      shell: bash
-    - name: check if openvmm needs to be cloned
-      run: |-
-        flowey.exe e 23 flowey_lib_common::git_checkout 0
-        flowey.exe v 23 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
-        flowey.exe v 23 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__git_checkout__1
-      uses: actions/checkout@v6
-      with:
-        fetch-depth: '1'
-        path: repo0
-        persist-credentials: ${{ env.floweyvar3 }}
-      name: checkout repo openvmm
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: report cloned repo directories
-      run: |-
-        flowey.exe v 23 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
-        ${{ github.workspace }}
-        EOF
-        flowey.exe e 23 flowey_lib_common::git_checkout 3
-      shell: bash
-    - name: print system info
-      run: |-
-        flowey.exe e 23 flowey_lib_common::system_info 0
-        flowey.exe e 23 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-        flowey.exe e 23 flowey_lib_hvlite::run_cargo_nextest_run 0
-        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 8
-        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 9
-        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 12
-        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 14
-        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 15
-        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 13
-        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 3
-        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 11
-        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 4
-        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 5
-        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 6
-        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 1
-        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 2
-        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 0
-        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 7
-      shell: bash
-    - name: creating new test content dir
-      run: flowey.exe e 23 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
-      shell: bash
-    - name: create gh-release-download cache dir
-      run: flowey.exe e 23 flowey_lib_common::download_gh_release 0
-      shell: bash
-    - name: Pre-processing cache vars
-      run: |-
-        flowey.exe e 23 flowey_lib_common::cache 8
-        flowey.exe v 23 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
-        flowey.exe v 23 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
-      shell: bash
-    - id: flowey_lib_common__cache__9
-      uses: actions/cache@v5
-      with:
-        key: ${{ env.floweyvar8 }}
-        path: ${{ env.floweyvar9 }}
-      name: 'Restore cache: gh-release-download'
-    - name: download artifacts from github releases
-      run: |-
-        flowey.exe v 23 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
-        EOF
-        flowey.exe e 23 flowey_lib_common::cache 10
-        flowey.exe e 23 flowey_lib_common::download_gh_release 1
-      shell: bash
-    - name: extract azcopy from archive
-      run: flowey.exe e 23 flowey_lib_common::download_azcopy 0
-      shell: bash
-    - name: calculating required VMM tests disk images
-      run: flowey.exe e 23 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
-      shell: bash
-    - name: downloading VMM test disk images
-      run: |-
-        flowey.exe e 23 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
-        flowey.exe e 23 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
-      shell: bash
-    - name: create gh cache dir
-      run: flowey.exe e 23 flowey_lib_common::download_gh_cli 0
-      shell: bash
-    - name: Pre-processing cache vars
-      run: |-
-        flowey.exe e 23 flowey_lib_common::cache 4
-        flowey.exe v 23 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
-        flowey.exe v 23 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
-      shell: bash
-    - id: flowey_lib_common__cache__5
-      uses: actions/cache@v5
-      with:
-        key: ${{ env.floweyvar6 }}
-        path: ${{ env.floweyvar7 }}
-      name: 'Restore cache: gh-cli'
-    - name: installing gh
-      run: |-
-        flowey.exe v 23 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
-        EOF
-        flowey.exe e 23 flowey_lib_common::cache 6
-        flowey.exe e 23 flowey_lib_common::download_gh_cli 1
-        flowey.exe v 23 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
-        ${{ github.token }}
-        EOF
-      shell: bash
-    - name: setup gh cli
-      run: flowey.exe e 23 flowey_lib_common::use_gh_cli 0
-      shell: bash
-    - name: get latest completed action id
-      run: flowey.exe e 23 flowey_lib_common::gh_latest_completed_workflow_id 0
-      shell: bash
-    - name: download artifacts from github actions run
-      run: |-
-        flowey.exe e 23 flowey_lib_common::download_gh_artifact 0
-        flowey.exe e 23 flowey_lib_hvlite::download_release_igvm_files_from_gh::resolve 0
-      shell: bash
-    - name: unpack openvmm-test-initrd archives
-      run: flowey.exe e 23 flowey_lib_hvlite::resolve_openvmm_test_initrd 0
-      shell: bash
-    - name: unpack openvmm-test-linux archives
-      run: flowey.exe e 23 flowey_lib_hvlite::resolve_openvmm_test_linux_kernel 0
-      shell: bash
-    - name: unpack mu_msvm package (x64)
-      run: flowey.exe e 23 flowey_lib_hvlite::download_uefi_mu_msvm 0
-      shell: bash
-    - name: unpack openvmm-test-virtio-win archive
-      run: flowey.exe e 23 flowey_lib_hvlite::resolve_openvmm_test_virtio_win 0
-      shell: bash
-    - name: setting up vmm_tests env
-      run: |-
-        flowey.exe e 23 flowey_lib_hvlite::init_vmm_tests_env 0
-        flowey.exe e 23 flowey_lib_hvlite::run_cargo_nextest_run 1
-        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 16
-        flowey.exe e 23 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
-      shell: bash
-    - name: generate nextest command
-      run: flowey.exe e 23 flowey_lib_common::gen_cargo_nextest_run_cmd 0
-      shell: bash
-    - name: install vmm tests deps (windows)
-      run: flowey.exe e 23 flowey_lib_hvlite::install_vmm_tests_deps 0
-      shell: bash
-    - name: starting test_igvm_agent_rpc_server
-      run: |-
-        flowey.exe e 23 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
-        flowey.exe e 23 flowey_core::pipeline::artifact::resolve 10
-      shell: bash
-    - name: running vmm_test prep_steps
-      run: flowey.exe e 23 flowey_lib_hvlite::run_prep_steps 0
-      shell: bash
-    - name: run 'vmm_tests' nextest tests
-      run: |-
-        flowey.exe e 23 flowey_lib_common::run_cargo_nextest_run 0
-        flowey.exe e 23 flowey_lib_common::run_cargo_nextest_run 1
-        flowey.exe e 23 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
-      shell: bash
-    - name: stopping test_igvm_agent_rpc_server
-      run: |-
-        flowey.exe e 23 flowey_lib_hvlite::stop_test_igvm_agent_rpc_server 0
-        flowey.exe e 23 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
-        flowey.exe e 23 flowey_lib_common::publish_test_results 4
-        flowey.exe e 23 flowey_lib_common::publish_test_results 5
-        flowey.exe v 23 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:152:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57 write-to-env github floweyvar2
-        flowey.exe v 23 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__publish_test_results__6
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-windows-amd-snp-vmm-tests-logs
-        path: ${{ env.floweyvar2 }}
-      name: 'publish test results: x64-windows-amd-snp-vmm-tests (logs)'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: 🦀 flowey rust steps
-      run: |-
-        flowey.exe e 23 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
-        flowey.exe e 23 flowey_lib_common::publish_test_results 0
-        flowey.exe e 23 flowey_lib_common::publish_test_results 1
-        flowey.exe e 23 flowey_lib_common::publish_test_results 2
-        flowey.exe v 23 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
-        flowey.exe v 23 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__publish_test_results__3
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-windows-amd-snp-vmm-tests-junit-xml
-        path: ${{ env.floweyvar1 }}
-      name: 'publish test results: x64-windows-amd-snp-vmm-tests (JUnit XML)'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: report test results to overall pipeline status
-      run: flowey.exe e 23 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
-      shell: bash
-    - name: 'validate cache entry: cargo-nextest'
-      run: flowey.exe e 23 flowey_lib_common::cache 3
-      shell: bash
-    - name: 'validate cache entry: gh-cli'
-      run: flowey.exe e 23 flowey_lib_common::cache 7
-      shell: bash
-    - name: 'validate cache entry: gh-release-download'
-      run: flowey.exe e 23 flowey_lib_common::cache 11
-      shell: bash
-  job24:
     name: run vmm-tests [x64-linux-amd-kvm]
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
     - 1ES.ImageOverride=ubuntu2404-amd64
-    - JobId=job24-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
+    - JobId=job23-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
@@ -5030,6 +4745,326 @@ jobs:
 
         chmod +x $AgentTempDirNormal/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-1/flowey
 
+        echo '"debug"' | flowey v 23 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey v 23 '_internal_WORKING_DIR' --is-raw-string update
+
+        cat <<'EOF' | flowey v 23 'verbose' update
+        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
+        EOF
+        echo "$AgentTempDirNormal/used_artifacts/x64-guest_test_uefi" | flowey v 23 'artifact_use_from_x64-guest_test_uefi' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-pipette" | flowey v 23 'artifact_use_from_x64-linux-musl-pipette' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-tmk_vmm" | flowey v 23 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-openvmm" | flowey v 23 'artifact_use_from_x64-linux-openvmm' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-openvmm_vhost" | flowey v 23 'artifact_use_from_x64-linux-openvmm_vhost' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-prep_steps" | flowey v 23 'artifact_use_from_x64-linux-prep_steps' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-vmm-tests-archive" | flowey v 23 'artifact_use_from_x64-linux-vmm-tests-archive' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-tmks" | flowey v 23 'artifact_use_from_x64-tmks' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-windows-pipette" | flowey v 23 'artifact_use_from_x64-windows-pipette' --is-raw-string update
+      shell: bash
+    - name: creating new test content dir
+      run: |-
+        flowey e 23 flowey_core::pipeline::artifact::resolve 8
+        flowey e 23 flowey_core::pipeline::artifact::resolve 2
+        flowey e 23 flowey_core::pipeline::artifact::resolve 3
+        flowey e 23 flowey_core::pipeline::artifact::resolve 4
+        flowey e 23 flowey_core::pipeline::artifact::resolve 1
+        flowey e 23 flowey_core::pipeline::artifact::resolve 0
+        flowey e 23 flowey_core::pipeline::artifact::resolve 7
+        flowey e 23 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
+      shell: bash
+    - name: checking if packages need to be installed
+      run: flowey e 23 flowey_lib_common::install_dist_pkg 0
+      shell: bash
+    - name: installing packages
+      run: flowey e 23 flowey_lib_common::install_dist_pkg 1
+      shell: bash
+    - name: create gh-release-download cache dir
+      run: flowey e 23 flowey_lib_common::download_gh_release 0
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
+        flowey e 23 flowey_lib_common::cache 8
+        flowey v 23 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
+        flowey v 23 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
+      shell: bash
+    - id: flowey_lib_common__cache__9
+      uses: actions/cache@v5
+      with:
+        key: ${{ env.floweyvar8 }}
+        path: ${{ env.floweyvar9 }}
+      name: 'Restore cache: gh-release-download'
+    - name: download artifacts from github releases
+      run: |-
+        flowey v 23 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
+        EOF
+        flowey e 23 flowey_lib_common::cache 10
+        flowey e 23 flowey_lib_common::download_gh_release 1
+      shell: bash
+    - name: extract azcopy from archive
+      run: flowey e 23 flowey_lib_common::download_azcopy 0
+      shell: bash
+    - name: calculating required VMM tests disk images
+      run: flowey e 23 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
+      shell: bash
+    - name: downloading VMM test disk images
+      run: |-
+        flowey e 23 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
+        flowey e 23 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
+      shell: bash
+    - name: create gh cache dir
+      run: flowey e 23 flowey_lib_common::download_gh_cli 0
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
+        flowey e 23 flowey_lib_common::cache 4
+        flowey v 23 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
+        flowey v 23 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
+      shell: bash
+    - id: flowey_lib_common__cache__5
+      uses: actions/cache@v5
+      with:
+        key: ${{ env.floweyvar6 }}
+        path: ${{ env.floweyvar7 }}
+      name: 'Restore cache: gh-cli'
+    - name: installing gh
+      run: |-
+        flowey v 23 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
+        EOF
+        flowey e 23 flowey_lib_common::cache 6
+        flowey e 23 flowey_lib_common::download_gh_cli 1
+        flowey v 23 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
+        ${{ github.token }}
+        EOF
+      shell: bash
+    - name: setup gh cli
+      run: flowey e 23 flowey_lib_common::use_gh_cli 0
+      shell: bash
+    - name: get latest completed action id
+      run: flowey e 23 flowey_lib_common::gh_latest_completed_workflow_id 0
+      shell: bash
+    - name: download artifacts from github actions run
+      run: |-
+        flowey e 23 flowey_lib_common::download_gh_artifact 0
+        flowey e 23 flowey_lib_hvlite::download_release_igvm_files_from_gh::resolve 0
+      shell: bash
+    - name: unpack openvmm-test-initrd archives
+      run: flowey e 23 flowey_lib_hvlite::resolve_openvmm_test_initrd 0
+      shell: bash
+    - name: unpack openvmm-test-linux archives
+      run: flowey e 23 flowey_lib_hvlite::resolve_openvmm_test_linux_kernel 0
+      shell: bash
+    - name: unpack mu_msvm package (x64)
+      run: flowey e 23 flowey_lib_hvlite::download_uefi_mu_msvm 0
+      shell: bash
+    - name: unpack openvmm-test-virtio-win archive
+      run: flowey e 23 flowey_lib_hvlite::resolve_openvmm_test_virtio_win 0
+      shell: bash
+    - name: setting up vmm_tests env
+      run: flowey e 23 flowey_lib_hvlite::init_vmm_tests_env 0
+      shell: bash
+    - name: ensure hypervisor device is accessible
+      run: flowey e 23 flowey_lib_hvlite::test_nextest_vmm_tests_archive 1
+      shell: bash
+    - name: ensure 2 MiB hugetlb pages are available
+      run: flowey e 23 flowey_lib_hvlite::test_nextest_vmm_tests_archive 2
+      shell: bash
+    - name: create cargo-nextest cache dir
+      run: |-
+        flowey e 23 flowey_lib_common::download_cargo_nextest 0
+        flowey e 23 flowey_lib_common::download_cargo_nextest 1
+        flowey e 23 flowey_lib_common::download_cargo_nextest 2
+        flowey e 23 flowey_lib_common::download_cargo_nextest 3
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
+        flowey e 23 flowey_lib_common::cache 0
+        flowey v 23 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
+        flowey v 23 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
+      shell: bash
+    - id: flowey_lib_common__cache__1
+      uses: actions/cache@v5
+      with:
+        key: ${{ env.floweyvar4 }}
+        path: ${{ env.floweyvar5 }}
+      name: 'Restore cache: cargo-nextest'
+    - name: downloading cargo-nextest
+      run: |-
+        flowey v 23 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
+        EOF
+        flowey e 23 flowey_lib_common::cache 2
+        flowey e 23 flowey_lib_common::download_cargo_nextest 4
+      shell: bash
+    - name: check if openvmm needs to be cloned
+      run: |-
+        flowey e 23 flowey_lib_common::git_checkout 0
+        flowey v 23 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
+        flowey v 23 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__git_checkout__1
+      uses: actions/checkout@v6
+      with:
+        fetch-depth: '1'
+        path: repo0
+        persist-credentials: ${{ env.floweyvar3 }}
+      name: checkout repo openvmm
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: report cloned repo directories
+      run: |-
+        flowey v 23 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        ${{ github.workspace }}
+        EOF
+        flowey e 23 flowey_lib_common::git_checkout 3
+      shell: bash
+    - name: print system info
+      run: |-
+        flowey e 23 flowey_lib_common::system_info 0
+        flowey e 23 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey e 23 flowey_lib_hvlite::run_cargo_nextest_run 0
+        flowey e 23 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
+        flowey e 23 flowey_lib_hvlite::run_cargo_nextest_run 1
+        flowey e 23 flowey_core::pipeline::artifact::resolve 6
+        flowey e 23 flowey_lib_hvlite::test_nextest_vmm_tests_archive 3
+      shell: bash
+    - name: generate nextest command
+      run: flowey e 23 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      shell: bash
+    - name: install vmm tests deps (linux)
+      run: |-
+        flowey e 23 flowey_lib_hvlite::install_vmm_tests_deps 0
+        flowey e 23 flowey_core::pipeline::artifact::resolve 5
+      shell: bash
+    - name: running vmm_test prep_steps
+      run: flowey e 23 flowey_lib_hvlite::run_prep_steps 0
+      shell: bash
+    - name: run 'vmm_tests' nextest tests
+      run: |-
+        flowey e 23 flowey_lib_common::run_cargo_nextest_run 0
+        flowey e 23 flowey_lib_common::run_cargo_nextest_run 1
+        flowey e 23 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
+        flowey e 23 flowey_lib_common::publish_test_results 4
+        flowey e 23 flowey_lib_common::publish_test_results 5
+        flowey v 23 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:152:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57 write-to-env github floweyvar2
+        flowey v 23 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__publish_test_results__6
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-linux-amd-kvm-vmm-tests-logs
+        path: ${{ env.floweyvar2 }}
+      name: 'publish test results: x64-linux-amd-kvm-vmm-tests (logs)'
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: 🦀 flowey rust steps
+      run: |-
+        flowey e 23 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
+        flowey e 23 flowey_lib_common::publish_test_results 0
+        flowey e 23 flowey_lib_common::publish_test_results 1
+        flowey e 23 flowey_lib_common::publish_test_results 2
+        flowey v 23 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
+        flowey v 23 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__publish_test_results__3
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-linux-amd-kvm-vmm-tests-junit-xml
+        path: ${{ env.floweyvar1 }}
+      name: 'publish test results: x64-linux-amd-kvm-vmm-tests (JUnit XML)'
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: report test results to overall pipeline status
+      run: flowey e 23 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
+      shell: bash
+    - name: 'validate cache entry: cargo-nextest'
+      run: flowey e 23 flowey_lib_common::cache 3
+      shell: bash
+    - name: 'validate cache entry: gh-cli'
+      run: flowey e 23 flowey_lib_common::cache 7
+      shell: bash
+    - name: 'validate cache entry: gh-release-download'
+      run: flowey e 23 flowey_lib_common::cache 11
+      shell: bash
+  job24:
+    name: run vmm-tests [x64-linux-intel-mshv]
+    runs-on:
+    - self-hosted
+    - 1ES.Pool=openvmm-gh-intel-westus3
+    - 1ES.ImageOverride=azurelinux3-amd64-dom0
+    - JobId=job24-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
+    permissions:
+      contents: read
+      id-token: write
+    needs:
+    - job0
+    - job2
+    - job3
+    - job9
+    if: contains(github.event.pull_request.labels.*.name, 'release-ci-required') && github.event.pull_request.draft == false
+    steps:
+    - run: |
+        set -x
+        sudo tdnf install -y gcc glibc-devel
+        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.95.0 -y
+        . "$HOME/.cargo/env"
+        echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
+        rustup show
+      if: runner.os == 'Linux'
+      name: rustup (Linux)
+      shell: bash
+    - run: |
+        set -x
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
+        ./rustup-init.exe -y --default-toolchain=1.95.0
+        echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
+      if: runner.os == 'Windows' && runner.arch == 'X64'
+      name: rustup (Windows X64)
+      shell: bash
+    - run: |
+        set -x
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
+        ./rustup-init.exe -y --default-toolchain=1.95.0
+        echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
+      if: runner.os == 'Windows' && runner.arch == 'ARM64'
+      name: rustup (Windows ARM64)
+      shell: bash
+    - uses: actions/checkout@v6
+      with:
+        path: flowey_bootstrap
+    - name: Build flowey
+      run: |
+        set -x
+        CARGO_INCREMENTAL=0 cargo build -p flowey_hvlite --target x86_64-unknown-linux-gnu --profile flowey-ci
+        OutDirNormal=$(echo "${{ runner.temp }}/bootstrapped-flowey" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
+        mkdir -p "$OutDirNormal"
+        mv ./.github/workflows/openvmm-pr-release.yaml "$OutDirNormal/pipeline.yaml"
+        mv target/x86_64-unknown-linux-gnu/flowey-ci/flowey_hvlite "$OutDirNormal/flowey"
+      working-directory: flowey_bootstrap
+      shell: bash
+    - name: 🌼📦 Download artifacts
+      uses: actions/download-artifact@v8
+      with:
+        pattern: '{x64-guest_test_uefi,x64-linux-musl-openvmm,x64-linux-musl-openvmm_vhost,x64-linux-musl-pipette,x64-linux-musl-tmk_vmm,x64-linux-musl-vmm-tests-archive,x64-linux-prep_steps,x64-tmks,x64-windows-pipette}'
+        path: ${{ runner.temp }}/used_artifacts/
+    - run: echo "${{ runner.temp }}/bootstrapped-flowey" >> $GITHUB_PATH
+      shell: bash
+      name: 🌼📦 Add flowey to PATH
+    - name: 🌼🔎 Self-check YAML
+      run: |-
+        ESCAPED_AGENT_TEMPDIR=$(
+        cat <<'EOF' | sed 's/\\/\\\\/g'
+        ${{ runner.temp }}
+        EOF
+        )
+        flowey pipeline github --runtime $ESCAPED_AGENT_TEMPDIR/bootstrapped-flowey/pipeline.yaml --out .github/workflows/openvmm-pr-release.yaml ci checkin-gates --config=pr-release
+      shell: bash
+    - name: 🌼🛫 Initialize job
+      run: |
+        AgentTempDirNormal="${{ runner.temp }}"
+        AgentTempDirNormal=$(echo "$AgentTempDirNormal" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
+        echo "AgentTempDirNormal=$AgentTempDirNormal" >> $GITHUB_ENV
+
+        chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey
+
         echo '"debug"' | flowey v 24 'FLOWEY_LOG' update
         echo "${{ runner.temp }}/work" | flowey v 24 '_internal_WORKING_DIR' --is-raw-string update
 
@@ -5037,22 +5072,22 @@ jobs:
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
         echo "$AgentTempDirNormal/used_artifacts/x64-guest_test_uefi" | flowey v 24 'artifact_use_from_x64-guest_test_uefi' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-openvmm" | flowey v 24 'artifact_use_from_x64-linux-musl-openvmm' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-openvmm_vhost" | flowey v 24 'artifact_use_from_x64-linux-musl-openvmm_vhost' --is-raw-string update
         echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-pipette" | flowey v 24 'artifact_use_from_x64-linux-musl-pipette' --is-raw-string update
         echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-tmk_vmm" | flowey v 24 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-linux-openvmm" | flowey v 24 'artifact_use_from_x64-linux-openvmm' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-linux-openvmm_vhost" | flowey v 24 'artifact_use_from_x64-linux-openvmm_vhost' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-vmm-tests-archive" | flowey v 24 'artifact_use_from_x64-linux-musl-vmm-tests-archive' --is-raw-string update
         echo "$AgentTempDirNormal/used_artifacts/x64-linux-prep_steps" | flowey v 24 'artifact_use_from_x64-linux-prep_steps' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-linux-vmm-tests-archive" | flowey v 24 'artifact_use_from_x64-linux-vmm-tests-archive' --is-raw-string update
         echo "$AgentTempDirNormal/used_artifacts/x64-tmks" | flowey v 24 'artifact_use_from_x64-tmks' --is-raw-string update
         echo "$AgentTempDirNormal/used_artifacts/x64-windows-pipette" | flowey v 24 'artifact_use_from_x64-windows-pipette' --is-raw-string update
       shell: bash
     - name: creating new test content dir
       run: |-
         flowey e 24 flowey_core::pipeline::artifact::resolve 8
-        flowey e 24 flowey_core::pipeline::artifact::resolve 2
-        flowey e 24 flowey_core::pipeline::artifact::resolve 3
         flowey e 24 flowey_core::pipeline::artifact::resolve 4
         flowey e 24 flowey_core::pipeline::artifact::resolve 1
+        flowey e 24 flowey_core::pipeline::artifact::resolve 2
+        flowey e 24 flowey_core::pipeline::artifact::resolve 3
         flowey e 24 flowey_core::pipeline::artifact::resolve 0
         flowey e 24 flowey_core::pipeline::artifact::resolve 7
         flowey e 24 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
@@ -5150,10 +5185,7 @@ jobs:
       run: flowey e 24 flowey_lib_hvlite::init_vmm_tests_env 0
       shell: bash
     - name: ensure hypervisor device is accessible
-      run: flowey e 24 flowey_lib_hvlite::test_nextest_vmm_tests_archive 1
-      shell: bash
-    - name: ensure 2 MiB hugetlb pages are available
-      run: flowey e 24 flowey_lib_hvlite::test_nextest_vmm_tests_archive 2
+      run: flowey e 24 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
       shell: bash
     - name: create cargo-nextest cache dir
       run: |-
@@ -5208,10 +5240,9 @@ jobs:
         flowey e 24 flowey_lib_common::system_info 0
         flowey e 24 flowey_lib_hvlite::git_checkout_openvmm_repo 0
         flowey e 24 flowey_lib_hvlite::run_cargo_nextest_run 0
-        flowey e 24 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
         flowey e 24 flowey_lib_hvlite::run_cargo_nextest_run 1
-        flowey e 24 flowey_core::pipeline::artifact::resolve 6
-        flowey e 24 flowey_lib_hvlite::test_nextest_vmm_tests_archive 3
+        flowey e 24 flowey_core::pipeline::artifact::resolve 5
+        flowey e 24 flowey_lib_hvlite::test_nextest_vmm_tests_archive 1
       shell: bash
     - name: generate nextest command
       run: flowey e 24 flowey_lib_common::gen_cargo_nextest_run_cmd 0
@@ -5219,7 +5250,7 @@ jobs:
     - name: install vmm tests deps (linux)
       run: |-
         flowey e 24 flowey_lib_hvlite::install_vmm_tests_deps 0
-        flowey e 24 flowey_core::pipeline::artifact::resolve 5
+        flowey e 24 flowey_core::pipeline::artifact::resolve 6
       shell: bash
     - name: running vmm_test prep_steps
       run: flowey e 24 flowey_lib_hvlite::run_prep_steps 0
@@ -5237,9 +5268,9 @@ jobs:
     - id: flowey_lib_common__publish_test_results__6
       uses: actions/upload-artifact@v7
       with:
-        name: x64-linux-amd-kvm-vmm-tests-logs
+        name: x64-linux-intel-mshv-vmm-tests-logs
         path: ${{ env.floweyvar2 }}
-      name: 'publish test results: x64-linux-amd-kvm-vmm-tests (logs)'
+      name: 'publish test results: x64-linux-intel-mshv-vmm-tests (logs)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: 🦀 flowey rust steps
       run: |-
@@ -5253,9 +5284,9 @@ jobs:
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v7
       with:
-        name: x64-linux-amd-kvm-vmm-tests-junit-xml
+        name: x64-linux-intel-mshv-vmm-tests-junit-xml
         path: ${{ env.floweyvar1 }}
-      name: 'publish test results: x64-linux-amd-kvm-vmm-tests (JUnit XML)'
+      name: 'publish test results: x64-linux-intel-mshv-vmm-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
       run: flowey e 24 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
@@ -5270,322 +5301,6 @@ jobs:
       run: flowey e 24 flowey_lib_common::cache 11
       shell: bash
   job25:
-    name: run vmm-tests [x64-linux-intel-mshv]
-    runs-on:
-    - self-hosted
-    - 1ES.Pool=openvmm-gh-intel-westus3
-    - 1ES.ImageOverride=azurelinux3-amd64-dom0
-    - JobId=job25-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
-    permissions:
-      contents: read
-      id-token: write
-    needs:
-    - job0
-    - job2
-    - job3
-    - job9
-    if: contains(github.event.pull_request.labels.*.name, 'release-ci-required') && github.event.pull_request.draft == false
-    steps:
-    - run: |
-        set -x
-        sudo tdnf install -y gcc glibc-devel
-        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.95.0 -y
-        . "$HOME/.cargo/env"
-        echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
-        rustup show
-      if: runner.os == 'Linux'
-      name: rustup (Linux)
-      shell: bash
-    - run: |
-        set -x
-        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.95.0
-        echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
-      if: runner.os == 'Windows' && runner.arch == 'X64'
-      name: rustup (Windows X64)
-      shell: bash
-    - run: |
-        set -x
-        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.95.0
-        echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
-      if: runner.os == 'Windows' && runner.arch == 'ARM64'
-      name: rustup (Windows ARM64)
-      shell: bash
-    - uses: actions/checkout@v6
-      with:
-        path: flowey_bootstrap
-    - name: Build flowey
-      run: |
-        set -x
-        CARGO_INCREMENTAL=0 cargo build -p flowey_hvlite --target x86_64-unknown-linux-gnu --profile flowey-ci
-        OutDirNormal=$(echo "${{ runner.temp }}/bootstrapped-flowey" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
-        mkdir -p "$OutDirNormal"
-        mv ./.github/workflows/openvmm-pr-release.yaml "$OutDirNormal/pipeline.yaml"
-        mv target/x86_64-unknown-linux-gnu/flowey-ci/flowey_hvlite "$OutDirNormal/flowey"
-      working-directory: flowey_bootstrap
-      shell: bash
-    - name: 🌼📦 Download artifacts
-      uses: actions/download-artifact@v8
-      with:
-        pattern: '{x64-guest_test_uefi,x64-linux-musl-openvmm,x64-linux-musl-openvmm_vhost,x64-linux-musl-pipette,x64-linux-musl-tmk_vmm,x64-linux-musl-vmm-tests-archive,x64-linux-prep_steps,x64-tmks,x64-windows-pipette}'
-        path: ${{ runner.temp }}/used_artifacts/
-    - run: echo "${{ runner.temp }}/bootstrapped-flowey" >> $GITHUB_PATH
-      shell: bash
-      name: 🌼📦 Add flowey to PATH
-    - name: 🌼🔎 Self-check YAML
-      run: |-
-        ESCAPED_AGENT_TEMPDIR=$(
-        cat <<'EOF' | sed 's/\\/\\\\/g'
-        ${{ runner.temp }}
-        EOF
-        )
-        flowey pipeline github --runtime $ESCAPED_AGENT_TEMPDIR/bootstrapped-flowey/pipeline.yaml --out .github/workflows/openvmm-pr-release.yaml ci checkin-gates --config=pr-release
-      shell: bash
-    - name: 🌼🛫 Initialize job
-      run: |
-        AgentTempDirNormal="${{ runner.temp }}"
-        AgentTempDirNormal=$(echo "$AgentTempDirNormal" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
-        echo "AgentTempDirNormal=$AgentTempDirNormal" >> $GITHUB_ENV
-
-        chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey
-
-        echo '"debug"' | flowey v 25 'FLOWEY_LOG' update
-        echo "${{ runner.temp }}/work" | flowey v 25 '_internal_WORKING_DIR' --is-raw-string update
-
-        cat <<'EOF' | flowey v 25 'verbose' update
-        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
-        EOF
-        echo "$AgentTempDirNormal/used_artifacts/x64-guest_test_uefi" | flowey v 25 'artifact_use_from_x64-guest_test_uefi' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-openvmm" | flowey v 25 'artifact_use_from_x64-linux-musl-openvmm' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-openvmm_vhost" | flowey v 25 'artifact_use_from_x64-linux-musl-openvmm_vhost' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-pipette" | flowey v 25 'artifact_use_from_x64-linux-musl-pipette' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-tmk_vmm" | flowey v 25 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-vmm-tests-archive" | flowey v 25 'artifact_use_from_x64-linux-musl-vmm-tests-archive' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-linux-prep_steps" | flowey v 25 'artifact_use_from_x64-linux-prep_steps' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-tmks" | flowey v 25 'artifact_use_from_x64-tmks' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-windows-pipette" | flowey v 25 'artifact_use_from_x64-windows-pipette' --is-raw-string update
-      shell: bash
-    - name: creating new test content dir
-      run: |-
-        flowey e 25 flowey_core::pipeline::artifact::resolve 8
-        flowey e 25 flowey_core::pipeline::artifact::resolve 4
-        flowey e 25 flowey_core::pipeline::artifact::resolve 1
-        flowey e 25 flowey_core::pipeline::artifact::resolve 2
-        flowey e 25 flowey_core::pipeline::artifact::resolve 3
-        flowey e 25 flowey_core::pipeline::artifact::resolve 0
-        flowey e 25 flowey_core::pipeline::artifact::resolve 7
-        flowey e 25 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
-      shell: bash
-    - name: checking if packages need to be installed
-      run: flowey e 25 flowey_lib_common::install_dist_pkg 0
-      shell: bash
-    - name: installing packages
-      run: flowey e 25 flowey_lib_common::install_dist_pkg 1
-      shell: bash
-    - name: create gh-release-download cache dir
-      run: flowey e 25 flowey_lib_common::download_gh_release 0
-      shell: bash
-    - name: Pre-processing cache vars
-      run: |-
-        flowey e 25 flowey_lib_common::cache 8
-        flowey v 25 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
-        flowey v 25 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
-      shell: bash
-    - id: flowey_lib_common__cache__9
-      uses: actions/cache@v5
-      with:
-        key: ${{ env.floweyvar8 }}
-        path: ${{ env.floweyvar9 }}
-      name: 'Restore cache: gh-release-download'
-    - name: download artifacts from github releases
-      run: |-
-        flowey v 25 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
-        EOF
-        flowey e 25 flowey_lib_common::cache 10
-        flowey e 25 flowey_lib_common::download_gh_release 1
-      shell: bash
-    - name: extract azcopy from archive
-      run: flowey e 25 flowey_lib_common::download_azcopy 0
-      shell: bash
-    - name: calculating required VMM tests disk images
-      run: flowey e 25 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
-      shell: bash
-    - name: downloading VMM test disk images
-      run: |-
-        flowey e 25 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
-        flowey e 25 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
-      shell: bash
-    - name: create gh cache dir
-      run: flowey e 25 flowey_lib_common::download_gh_cli 0
-      shell: bash
-    - name: Pre-processing cache vars
-      run: |-
-        flowey e 25 flowey_lib_common::cache 4
-        flowey v 25 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
-        flowey v 25 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
-      shell: bash
-    - id: flowey_lib_common__cache__5
-      uses: actions/cache@v5
-      with:
-        key: ${{ env.floweyvar6 }}
-        path: ${{ env.floweyvar7 }}
-      name: 'Restore cache: gh-cli'
-    - name: installing gh
-      run: |-
-        flowey v 25 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
-        EOF
-        flowey e 25 flowey_lib_common::cache 6
-        flowey e 25 flowey_lib_common::download_gh_cli 1
-        flowey v 25 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
-        ${{ github.token }}
-        EOF
-      shell: bash
-    - name: setup gh cli
-      run: flowey e 25 flowey_lib_common::use_gh_cli 0
-      shell: bash
-    - name: get latest completed action id
-      run: flowey e 25 flowey_lib_common::gh_latest_completed_workflow_id 0
-      shell: bash
-    - name: download artifacts from github actions run
-      run: |-
-        flowey e 25 flowey_lib_common::download_gh_artifact 0
-        flowey e 25 flowey_lib_hvlite::download_release_igvm_files_from_gh::resolve 0
-      shell: bash
-    - name: unpack openvmm-test-initrd archives
-      run: flowey e 25 flowey_lib_hvlite::resolve_openvmm_test_initrd 0
-      shell: bash
-    - name: unpack openvmm-test-linux archives
-      run: flowey e 25 flowey_lib_hvlite::resolve_openvmm_test_linux_kernel 0
-      shell: bash
-    - name: unpack mu_msvm package (x64)
-      run: flowey e 25 flowey_lib_hvlite::download_uefi_mu_msvm 0
-      shell: bash
-    - name: unpack openvmm-test-virtio-win archive
-      run: flowey e 25 flowey_lib_hvlite::resolve_openvmm_test_virtio_win 0
-      shell: bash
-    - name: setting up vmm_tests env
-      run: flowey e 25 flowey_lib_hvlite::init_vmm_tests_env 0
-      shell: bash
-    - name: ensure hypervisor device is accessible
-      run: flowey e 25 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
-      shell: bash
-    - name: create cargo-nextest cache dir
-      run: |-
-        flowey e 25 flowey_lib_common::download_cargo_nextest 0
-        flowey e 25 flowey_lib_common::download_cargo_nextest 1
-        flowey e 25 flowey_lib_common::download_cargo_nextest 2
-        flowey e 25 flowey_lib_common::download_cargo_nextest 3
-      shell: bash
-    - name: Pre-processing cache vars
-      run: |-
-        flowey e 25 flowey_lib_common::cache 0
-        flowey v 25 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
-        flowey v 25 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
-      shell: bash
-    - id: flowey_lib_common__cache__1
-      uses: actions/cache@v5
-      with:
-        key: ${{ env.floweyvar4 }}
-        path: ${{ env.floweyvar5 }}
-      name: 'Restore cache: cargo-nextest'
-    - name: downloading cargo-nextest
-      run: |-
-        flowey v 25 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
-        EOF
-        flowey e 25 flowey_lib_common::cache 2
-        flowey e 25 flowey_lib_common::download_cargo_nextest 4
-      shell: bash
-    - name: check if openvmm needs to be cloned
-      run: |-
-        flowey e 25 flowey_lib_common::git_checkout 0
-        flowey v 25 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
-        flowey v 25 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__git_checkout__1
-      uses: actions/checkout@v6
-      with:
-        fetch-depth: '1'
-        path: repo0
-        persist-credentials: ${{ env.floweyvar3 }}
-      name: checkout repo openvmm
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: report cloned repo directories
-      run: |-
-        flowey v 25 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
-        ${{ github.workspace }}
-        EOF
-        flowey e 25 flowey_lib_common::git_checkout 3
-      shell: bash
-    - name: print system info
-      run: |-
-        flowey e 25 flowey_lib_common::system_info 0
-        flowey e 25 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-        flowey e 25 flowey_lib_hvlite::run_cargo_nextest_run 0
-        flowey e 25 flowey_lib_hvlite::run_cargo_nextest_run 1
-        flowey e 25 flowey_core::pipeline::artifact::resolve 5
-        flowey e 25 flowey_lib_hvlite::test_nextest_vmm_tests_archive 1
-      shell: bash
-    - name: generate nextest command
-      run: flowey e 25 flowey_lib_common::gen_cargo_nextest_run_cmd 0
-      shell: bash
-    - name: install vmm tests deps (linux)
-      run: |-
-        flowey e 25 flowey_lib_hvlite::install_vmm_tests_deps 0
-        flowey e 25 flowey_core::pipeline::artifact::resolve 6
-      shell: bash
-    - name: running vmm_test prep_steps
-      run: flowey e 25 flowey_lib_hvlite::run_prep_steps 0
-      shell: bash
-    - name: run 'vmm_tests' nextest tests
-      run: |-
-        flowey e 25 flowey_lib_common::run_cargo_nextest_run 0
-        flowey e 25 flowey_lib_common::run_cargo_nextest_run 1
-        flowey e 25 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
-        flowey e 25 flowey_lib_common::publish_test_results 4
-        flowey e 25 flowey_lib_common::publish_test_results 5
-        flowey v 25 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:152:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57 write-to-env github floweyvar2
-        flowey v 25 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__publish_test_results__6
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-linux-intel-mshv-vmm-tests-logs
-        path: ${{ env.floweyvar2 }}
-      name: 'publish test results: x64-linux-intel-mshv-vmm-tests (logs)'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: 🦀 flowey rust steps
-      run: |-
-        flowey e 25 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
-        flowey e 25 flowey_lib_common::publish_test_results 0
-        flowey e 25 flowey_lib_common::publish_test_results 1
-        flowey e 25 flowey_lib_common::publish_test_results 2
-        flowey v 25 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
-        flowey v 25 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__publish_test_results__3
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-linux-intel-mshv-vmm-tests-junit-xml
-        path: ${{ env.floweyvar1 }}
-      name: 'publish test results: x64-linux-intel-mshv-vmm-tests (JUnit XML)'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: report test results to overall pipeline status
-      run: flowey e 25 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
-      shell: bash
-    - name: 'validate cache entry: cargo-nextest'
-      run: flowey e 25 flowey_lib_common::cache 3
-      shell: bash
-    - name: 'validate cache entry: gh-cli'
-      run: flowey e 25 flowey_lib_common::cache 7
-      shell: bash
-    - name: 'validate cache entry: gh-release-download'
-      run: flowey e 25 flowey_lib_common::cache 11
-      shell: bash
-  job26:
     name: run vmm-tests [aarch64-windows]
     runs-on:
     - self-hosted
@@ -5668,36 +5383,36 @@ jobs:
 
         chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey.exe
 
-        echo '"debug"' | flowey.exe v 26 'FLOWEY_LOG' update
-        echo "${{ runner.temp }}/work" | flowey.exe v 26 '_internal_WORKING_DIR' --is-raw-string update
+        echo '"debug"' | flowey.exe v 25 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey.exe v 25 '_internal_WORKING_DIR' --is-raw-string update
 
-        cat <<'EOF' | flowey.exe v 26 'verbose' update
+        cat <<'EOF' | flowey.exe v 25 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-guest_test_uefi" | flowey.exe v 26 'artifact_use_from_aarch64-guest_test_uefi' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-linux-musl-pipette" | flowey.exe v 26 'artifact_use_from_aarch64-linux-musl-pipette' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-linux-musl-tmk_vmm" | flowey.exe v 26 'artifact_use_from_aarch64-linux-musl-tmk_vmm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-openhcl-igvm" | flowey.exe v 26 'artifact_use_from_aarch64-openhcl-igvm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-tmks" | flowey.exe v 26 'artifact_use_from_aarch64-tmks' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-openvmm" | flowey.exe v 26 'artifact_use_from_aarch64-windows-openvmm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-pipette" | flowey.exe v 26 'artifact_use_from_aarch64-windows-pipette' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-tmk_vmm" | flowey.exe v 26 'artifact_use_from_aarch64-windows-tmk_vmm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-vmgstool" | flowey.exe v 26 'artifact_use_from_aarch64-windows-vmgstool' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-vmgstool-dev" | flowey.exe v 26 'artifact_use_from_aarch64-windows-vmgstool-dev' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-vmm-tests-archive" | flowey.exe v 26 'artifact_use_from_aarch64-windows-vmm-tests-archive' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-guest_test_uefi" | flowey.exe v 25 'artifact_use_from_aarch64-guest_test_uefi' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-linux-musl-pipette" | flowey.exe v 25 'artifact_use_from_aarch64-linux-musl-pipette' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-linux-musl-tmk_vmm" | flowey.exe v 25 'artifact_use_from_aarch64-linux-musl-tmk_vmm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-openhcl-igvm" | flowey.exe v 25 'artifact_use_from_aarch64-openhcl-igvm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-tmks" | flowey.exe v 25 'artifact_use_from_aarch64-tmks' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-openvmm" | flowey.exe v 25 'artifact_use_from_aarch64-windows-openvmm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-pipette" | flowey.exe v 25 'artifact_use_from_aarch64-windows-pipette' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-tmk_vmm" | flowey.exe v 25 'artifact_use_from_aarch64-windows-tmk_vmm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-vmgstool" | flowey.exe v 25 'artifact_use_from_aarch64-windows-vmgstool' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-vmgstool-dev" | flowey.exe v 25 'artifact_use_from_aarch64-windows-vmgstool-dev' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-vmm-tests-archive" | flowey.exe v 25 'artifact_use_from_aarch64-windows-vmm-tests-archive' --is-raw-string update
       shell: bash
     - name: create cargo-nextest cache dir
       run: |-
-        flowey.exe e 26 flowey_lib_common::download_cargo_nextest 0
-        flowey.exe e 26 flowey_lib_common::download_cargo_nextest 1
-        flowey.exe e 26 flowey_lib_common::download_cargo_nextest 2
-        flowey.exe e 26 flowey_lib_common::download_cargo_nextest 3
+        flowey.exe e 25 flowey_lib_common::download_cargo_nextest 0
+        flowey.exe e 25 flowey_lib_common::download_cargo_nextest 1
+        flowey.exe e 25 flowey_lib_common::download_cargo_nextest 2
+        flowey.exe e 25 flowey_lib_common::download_cargo_nextest 3
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey.exe e 26 flowey_lib_common::cache 0
-        flowey.exe v 26 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
-        flowey.exe v 26 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
+        flowey.exe e 25 flowey_lib_common::cache 0
+        flowey.exe v 25 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
+        flowey.exe v 25 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -5707,17 +5422,17 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
-        flowey.exe v 26 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey.exe v 25 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
-        flowey.exe e 26 flowey_lib_common::cache 2
-        flowey.exe e 26 flowey_lib_common::download_cargo_nextest 4
+        flowey.exe e 25 flowey_lib_common::cache 2
+        flowey.exe e 25 flowey_lib_common::download_cargo_nextest 4
       shell: bash
     - name: check if openvmm needs to be cloned
       run: |-
-        flowey.exe e 26 flowey_lib_common::git_checkout 0
-        flowey.exe v 26 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
-        flowey.exe v 26 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey.exe e 25 flowey_lib_common::git_checkout 0
+        flowey.exe v 25 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
+        flowey.exe v 25 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -5729,38 +5444,38 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey.exe v 26 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey.exe v 25 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
-        flowey.exe e 26 flowey_lib_common::git_checkout 3
+        flowey.exe e 25 flowey_lib_common::git_checkout 3
       shell: bash
     - name: print system info
       run: |-
-        flowey.exe e 26 flowey_lib_common::system_info 0
-        flowey.exe e 26 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-        flowey.exe e 26 flowey_lib_hvlite::run_cargo_nextest_run 0
-        flowey.exe e 26 flowey_core::pipeline::artifact::resolve 5
-        flowey.exe e 26 flowey_core::pipeline::artifact::resolve 6
-        flowey.exe e 26 flowey_core::pipeline::artifact::resolve 7
-        flowey.exe e 26 flowey_core::pipeline::artifact::resolve 8
-        flowey.exe e 26 flowey_core::pipeline::artifact::resolve 9
-        flowey.exe e 26 flowey_core::pipeline::artifact::resolve 3
-        flowey.exe e 26 flowey_core::pipeline::artifact::resolve 1
-        flowey.exe e 26 flowey_core::pipeline::artifact::resolve 2
-        flowey.exe e 26 flowey_core::pipeline::artifact::resolve 0
-        flowey.exe e 26 flowey_core::pipeline::artifact::resolve 4
+        flowey.exe e 25 flowey_lib_common::system_info 0
+        flowey.exe e 25 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey.exe e 25 flowey_lib_hvlite::run_cargo_nextest_run 0
+        flowey.exe e 25 flowey_core::pipeline::artifact::resolve 5
+        flowey.exe e 25 flowey_core::pipeline::artifact::resolve 6
+        flowey.exe e 25 flowey_core::pipeline::artifact::resolve 7
+        flowey.exe e 25 flowey_core::pipeline::artifact::resolve 8
+        flowey.exe e 25 flowey_core::pipeline::artifact::resolve 9
+        flowey.exe e 25 flowey_core::pipeline::artifact::resolve 3
+        flowey.exe e 25 flowey_core::pipeline::artifact::resolve 1
+        flowey.exe e 25 flowey_core::pipeline::artifact::resolve 2
+        flowey.exe e 25 flowey_core::pipeline::artifact::resolve 0
+        flowey.exe e 25 flowey_core::pipeline::artifact::resolve 4
       shell: bash
     - name: creating new test content dir
-      run: flowey.exe e 26 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
+      run: flowey.exe e 25 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
       shell: bash
     - name: create gh-release-download cache dir
-      run: flowey.exe e 26 flowey_lib_common::download_gh_release 0
+      run: flowey.exe e 25 flowey_lib_common::download_gh_release 0
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey.exe e 26 flowey_lib_common::cache 8
-        flowey.exe v 26 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
-        flowey.exe v 26 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
+        flowey.exe e 25 flowey_lib_common::cache 8
+        flowey.exe v 25 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
+        flowey.exe v 25 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
       shell: bash
     - id: flowey_lib_common__cache__9
       uses: actions/cache@v5
@@ -5770,31 +5485,31 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 26 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
+        flowey.exe v 25 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
         EOF
-        flowey.exe e 26 flowey_lib_common::cache 10
-        flowey.exe e 26 flowey_lib_common::download_gh_release 1
+        flowey.exe e 25 flowey_lib_common::cache 10
+        flowey.exe e 25 flowey_lib_common::download_gh_release 1
       shell: bash
     - name: extract azcopy from archive
-      run: flowey.exe e 26 flowey_lib_common::download_azcopy 0
+      run: flowey.exe e 25 flowey_lib_common::download_azcopy 0
       shell: bash
     - name: calculating required VMM tests disk images
-      run: flowey.exe e 26 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
+      run: flowey.exe e 25 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
       shell: bash
     - name: downloading VMM test disk images
       run: |-
-        flowey.exe e 26 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
-        flowey.exe e 26 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
+        flowey.exe e 25 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
+        flowey.exe e 25 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
       shell: bash
     - name: create gh cache dir
-      run: flowey.exe e 26 flowey_lib_common::download_gh_cli 0
+      run: flowey.exe e 25 flowey_lib_common::download_gh_cli 0
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey.exe e 26 flowey_lib_common::cache 4
-        flowey.exe v 26 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
-        flowey.exe v 26 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
+        flowey.exe e 25 flowey_lib_common::cache 4
+        flowey.exe v 25 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
+        flowey.exe v 25 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
@@ -5804,68 +5519,68 @@ jobs:
       name: 'Restore cache: gh-cli'
     - name: installing gh
       run: |-
-        flowey.exe v 26 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        flowey.exe v 25 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
-        flowey.exe e 26 flowey_lib_common::cache 6
-        flowey.exe e 26 flowey_lib_common::download_gh_cli 1
-        flowey.exe v 26 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
+        flowey.exe e 25 flowey_lib_common::cache 6
+        flowey.exe e 25 flowey_lib_common::download_gh_cli 1
+        flowey.exe v 25 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
         ${{ github.token }}
         EOF
       shell: bash
     - name: setup gh cli
-      run: flowey.exe e 26 flowey_lib_common::use_gh_cli 0
+      run: flowey.exe e 25 flowey_lib_common::use_gh_cli 0
       shell: bash
     - name: get latest completed action id
-      run: flowey.exe e 26 flowey_lib_common::gh_latest_completed_workflow_id 0
+      run: flowey.exe e 25 flowey_lib_common::gh_latest_completed_workflow_id 0
       shell: bash
     - name: download artifacts from github actions run
       run: |-
-        flowey.exe e 26 flowey_lib_common::download_gh_artifact 0
-        flowey.exe e 26 flowey_lib_hvlite::download_release_igvm_files_from_gh::resolve 0
+        flowey.exe e 25 flowey_lib_common::download_gh_artifact 0
+        flowey.exe e 25 flowey_lib_hvlite::download_release_igvm_files_from_gh::resolve 0
       shell: bash
     - name: unpack openvmm-test-initrd archives
-      run: flowey.exe e 26 flowey_lib_hvlite::resolve_openvmm_test_initrd 0
+      run: flowey.exe e 25 flowey_lib_hvlite::resolve_openvmm_test_initrd 0
       shell: bash
     - name: unpack openvmm-test-linux archives
-      run: flowey.exe e 26 flowey_lib_hvlite::resolve_openvmm_test_linux_kernel 0
+      run: flowey.exe e 25 flowey_lib_hvlite::resolve_openvmm_test_linux_kernel 0
       shell: bash
     - name: unpack mu_msvm package (aarch64)
-      run: flowey.exe e 26 flowey_lib_hvlite::download_uefi_mu_msvm 0
+      run: flowey.exe e 25 flowey_lib_hvlite::download_uefi_mu_msvm 0
       shell: bash
     - name: unpack openvmm-test-virtio-win archive
-      run: flowey.exe e 26 flowey_lib_hvlite::resolve_openvmm_test_virtio_win 0
+      run: flowey.exe e 25 flowey_lib_hvlite::resolve_openvmm_test_virtio_win 0
       shell: bash
     - name: setting up vmm_tests env
       run: |-
-        flowey.exe e 26 flowey_lib_hvlite::init_vmm_tests_env 0
-        flowey.exe e 26 flowey_lib_hvlite::run_cargo_nextest_run 1
-        flowey.exe e 26 flowey_core::pipeline::artifact::resolve 10
-        flowey.exe e 26 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
+        flowey.exe e 25 flowey_lib_hvlite::init_vmm_tests_env 0
+        flowey.exe e 25 flowey_lib_hvlite::run_cargo_nextest_run 1
+        flowey.exe e 25 flowey_core::pipeline::artifact::resolve 10
+        flowey.exe e 25 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
       shell: bash
     - name: generate nextest command
-      run: flowey.exe e 26 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      run: flowey.exe e 25 flowey_lib_common::gen_cargo_nextest_run_cmd 0
       shell: bash
     - name: install vmm tests deps (windows)
-      run: flowey.exe e 26 flowey_lib_hvlite::install_vmm_tests_deps 0
+      run: flowey.exe e 25 flowey_lib_hvlite::install_vmm_tests_deps 0
       shell: bash
     - name: starting test_igvm_agent_rpc_server
-      run: flowey.exe e 26 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
+      run: flowey.exe e 25 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
       shell: bash
     - name: run 'vmm_tests' nextest tests
       run: |-
-        flowey.exe e 26 flowey_lib_common::run_cargo_nextest_run 0
-        flowey.exe e 26 flowey_lib_common::run_cargo_nextest_run 1
-        flowey.exe e 26 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
+        flowey.exe e 25 flowey_lib_common::run_cargo_nextest_run 0
+        flowey.exe e 25 flowey_lib_common::run_cargo_nextest_run 1
+        flowey.exe e 25 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
       shell: bash
     - name: stopping test_igvm_agent_rpc_server
       run: |-
-        flowey.exe e 26 flowey_lib_hvlite::stop_test_igvm_agent_rpc_server 0
-        flowey.exe e 26 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
-        flowey.exe e 26 flowey_lib_common::publish_test_results 4
-        flowey.exe e 26 flowey_lib_common::publish_test_results 5
-        flowey.exe v 26 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:152:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57 write-to-env github floweyvar2
-        flowey.exe v 26 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57' write-to-env github FLOWEY_CONDITION
+        flowey.exe e 25 flowey_lib_hvlite::stop_test_igvm_agent_rpc_server 0
+        flowey.exe e 25 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
+        flowey.exe e 25 flowey_lib_common::publish_test_results 4
+        flowey.exe e 25 flowey_lib_common::publish_test_results 5
+        flowey.exe v 25 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:152:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57 write-to-env github floweyvar2
+        flowey.exe v 25 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__6
       uses: actions/upload-artifact@v7
@@ -5876,12 +5591,12 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: 🦀 flowey rust steps
       run: |-
-        flowey.exe e 26 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
-        flowey.exe e 26 flowey_lib_common::publish_test_results 0
-        flowey.exe e 26 flowey_lib_common::publish_test_results 1
-        flowey.exe e 26 flowey_lib_common::publish_test_results 2
-        flowey.exe v 26 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
-        flowey.exe v 26 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey.exe e 25 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
+        flowey.exe e 25 flowey_lib_common::publish_test_results 0
+        flowey.exe e 25 flowey_lib_common::publish_test_results 1
+        flowey.exe e 25 flowey_lib_common::publish_test_results 2
+        flowey.exe v 25 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
+        flowey.exe v 25 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v7
@@ -5891,18 +5606,18 @@ jobs:
       name: 'publish test results: aarch64-windows-vmm-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
-      run: flowey.exe e 26 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
+      run: flowey.exe e 25 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
       shell: bash
     - name: 'validate cache entry: cargo-nextest'
-      run: flowey.exe e 26 flowey_lib_common::cache 3
+      run: flowey.exe e 25 flowey_lib_common::cache 3
       shell: bash
     - name: 'validate cache entry: gh-cli'
-      run: flowey.exe e 26 flowey_lib_common::cache 7
+      run: flowey.exe e 25 flowey_lib_common::cache 7
       shell: bash
     - name: 'validate cache entry: gh-release-download'
-      run: flowey.exe e 26 flowey_lib_common::cache 11
+      run: flowey.exe e 25 flowey_lib_common::cache 11
       shell: bash
-  job27:
+  job26:
     name: test flowey local backend
     runs-on: ubuntu-latest
     permissions:
@@ -5928,18 +5643,18 @@ jobs:
 
         chmod +x $AgentTempDirNormal/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-1/flowey
 
-        echo '"debug"' | flowey v 27 'FLOWEY_LOG' update
-        echo "${{ runner.temp }}/work" | flowey v 27 '_internal_WORKING_DIR' --is-raw-string update
+        echo '"debug"' | flowey v 26 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey v 26 '_internal_WORKING_DIR' --is-raw-string update
 
-        cat <<'EOF' | flowey v 27 'verbose' update
+        cat <<'EOF' | flowey v 26 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
       shell: bash
     - name: check if openvmm needs to be cloned
       run: |-
-        flowey e 27 flowey_lib_common::git_checkout 0
-        flowey v 27 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar1
-        flowey v 27 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey e 26 flowey_lib_common::git_checkout 0
+        flowey v 26 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar1
+        flowey v 26 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -5951,31 +5666,31 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey v 27 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey v 26 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
-        flowey e 27 flowey_lib_common::git_checkout 3
+        flowey e 26 flowey_lib_common::git_checkout 3
       shell: bash
     - name: print system info
       run: |-
-        flowey e 27 flowey_lib_common::system_info 0
-        flowey e 27 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey e 26 flowey_lib_common::system_info 0
+        flowey e 26 flowey_lib_hvlite::git_checkout_openvmm_repo 0
       shell: bash
     - name: add default cargo home to path
-      run: flowey e 27 flowey_lib_common::install_rust 0
+      run: flowey e 26 flowey_lib_common::install_rust 0
       shell: bash
     - name: install Rust
-      run: flowey e 27 flowey_lib_common::install_rust 1
+      run: flowey e 26 flowey_lib_common::install_rust 1
       shell: bash
     - name: detect active toolchain
       run: |-
-        flowey e 27 flowey_lib_common::install_rust 2
-        flowey v 27 'flowey_lib_hvlite::_jobs::test_local_flowey_build_igvm:3:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
+        flowey e 26 flowey_lib_common::install_rust 2
+        flowey v 26 'flowey_lib_hvlite::_jobs::test_local_flowey_build_igvm:3:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
         ${{ github.token }}
         EOF
       shell: bash
     - name: test cargo xflowey build-igvm x64 --install-missing-deps
-      run: flowey e 27 flowey_lib_hvlite::_jobs::test_local_flowey_build_igvm 1
+      run: flowey e 26 flowey_lib_hvlite::_jobs::test_local_flowey_build_igvm 1
       shell: bash
   job3:
     name: build artifacts (shared VMM tests) [linux]

--- a/.github/workflows/openvmm-pr.yaml
+++ b/.github/workflows/openvmm-pr.yaml
@@ -4549,13 +4549,12 @@ jobs:
       run: flowey.exe e 22 flowey_lib_common::cache 11
       shell: bash
   job23:
-    name: run vmm-tests [x64-windows-intel-tdx]
+    name: run vmm-tests [x64-windows-amd]
     runs-on:
     - self-hosted
-    - Windows
-    - X64
-    - TDX
-    - Baremetal
+    - 1ES.Pool=openvmm-gh-amd-westus3
+    - 1ES.ImageOverride=win-amd64
+    - JobId=job23-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
@@ -4801,9 +4800,9 @@ jobs:
     - id: flowey_lib_common__publish_test_results__6
       uses: actions/upload-artifact@v7
       with:
-        name: x64-windows-intel-tdx-vmm-tests-logs
+        name: x64-windows-amd-vmm-tests-logs
         path: ${{ env.floweyvar2 }}
-      name: 'publish test results: x64-windows-intel-tdx-vmm-tests (logs)'
+      name: 'publish test results: x64-windows-amd-vmm-tests (logs)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: 🦀 flowey rust steps
       run: |-
@@ -4817,9 +4816,9 @@ jobs:
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v7
       with:
-        name: x64-windows-intel-tdx-vmm-tests-junit-xml
+        name: x64-windows-amd-vmm-tests-junit-xml
         path: ${{ env.floweyvar1 }}
-      name: 'publish test results: x64-windows-intel-tdx-vmm-tests (JUnit XML)'
+      name: 'publish test results: x64-windows-amd-vmm-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
       run: flowey.exe e 23 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
@@ -4834,12 +4833,13 @@ jobs:
       run: flowey.exe e 23 flowey_lib_common::cache 11
       shell: bash
   job24:
-    name: run vmm-tests [x64-windows-amd]
+    name: run vmm-tests [x64-windows-amd-snp]
     runs-on:
     - self-hosted
-    - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=win-amd64
-    - JobId=job24-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
+    - Windows
+    - X64
+    - SNP
+    - Baremetal
     permissions:
       contents: read
       id-token: write
@@ -5085,9 +5085,9 @@ jobs:
     - id: flowey_lib_common__publish_test_results__6
       uses: actions/upload-artifact@v7
       with:
-        name: x64-windows-amd-vmm-tests-logs
+        name: x64-windows-amd-snp-vmm-tests-logs
         path: ${{ env.floweyvar2 }}
-      name: 'publish test results: x64-windows-amd-vmm-tests (logs)'
+      name: 'publish test results: x64-windows-amd-snp-vmm-tests (logs)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: 🦀 flowey rust steps
       run: |-
@@ -5101,9 +5101,9 @@ jobs:
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v7
       with:
-        name: x64-windows-amd-vmm-tests-junit-xml
+        name: x64-windows-amd-snp-vmm-tests-junit-xml
         path: ${{ env.floweyvar1 }}
-      name: 'publish test results: x64-windows-amd-vmm-tests (JUnit XML)'
+      name: 'publish test results: x64-windows-amd-snp-vmm-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
       run: flowey.exe e 24 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
@@ -5118,297 +5118,12 @@ jobs:
       run: flowey.exe e 24 flowey_lib_common::cache 11
       shell: bash
   job25:
-    name: run vmm-tests [x64-windows-amd-snp]
-    runs-on:
-    - self-hosted
-    - Windows
-    - X64
-    - SNP
-    - Baremetal
-    permissions:
-      contents: read
-      id-token: write
-    needs:
-    - job0
-    - job12
-    - job2
-    - job3
-    - job7
-    if: github.event.pull_request.draft == false
-    steps:
-    - name: 🌼📦 Download artifacts
-      uses: actions/download-artifact@v8
-      with:
-        pattern: '{_internal-flowey-bootstrap-x86_64-windows-uid-6,x64-guest_test_uefi,x64-linux-musl-pipette,x64-linux-musl-tmk_vmm,x64-linux-tpm_guest_tests,x64-openhcl-igvm,x64-openhcl-igvm-cvm,x64-openhcl-igvm-test-linux-direct,x64-tmks,x64-windows-openvmm,x64-windows-pipette,x64-windows-prep_steps,x64-windows-test_igvm_agent_rpc_server,x64-windows-tmk_vmm,x64-windows-tpm_guest_tests,x64-windows-vmgstool,x64-windows-vmgstool-dev,x64-windows-vmm-tests-archive}'
-        path: ${{ runner.temp }}/used_artifacts/
-    - run: echo "${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-windows-uid-6" >> $GITHUB_PATH
-      shell: bash
-      name: 🌼📦 Add flowey to PATH
-    - name: 🌼🛫 Initialize job
-      run: |
-        AgentTempDirNormal="${{ runner.temp }}"
-        AgentTempDirNormal=$(echo "$AgentTempDirNormal" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
-        echo "AgentTempDirNormal=$AgentTempDirNormal" >> $GITHUB_ENV
-
-        chmod +x $AgentTempDirNormal/used_artifacts/_internal-flowey-bootstrap-x86_64-windows-uid-6/flowey.exe
-
-        echo '"debug"' | flowey.exe v 25 'FLOWEY_LOG' update
-        echo "${{ runner.temp }}/work" | flowey.exe v 25 '_internal_WORKING_DIR' --is-raw-string update
-
-        cat <<'EOF' | flowey.exe v 25 'verbose' update
-        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
-        EOF
-        echo "${{ runner.temp }}\\used_artifacts\\x64-guest_test_uefi" | flowey.exe v 25 'artifact_use_from_x64-guest_test_uefi' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-pipette" | flowey.exe v 25 'artifact_use_from_x64-linux-musl-pipette' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-tmk_vmm" | flowey.exe v 25 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-tpm_guest_tests" | flowey.exe v 25 'artifact_use_from_x64-linux-tpm_guest_tests' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-openhcl-igvm" | flowey.exe v 25 'artifact_use_from_x64-openhcl-igvm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-openhcl-igvm-cvm" | flowey.exe v 25 'artifact_use_from_x64-openhcl-igvm-cvm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-openhcl-igvm-test-linux-direct" | flowey.exe v 25 'artifact_use_from_x64-openhcl-igvm-test-linux-direct' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-tmks" | flowey.exe v 25 'artifact_use_from_x64-tmks' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-openvmm" | flowey.exe v 25 'artifact_use_from_x64-windows-openvmm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-pipette" | flowey.exe v 25 'artifact_use_from_x64-windows-pipette' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-prep_steps" | flowey.exe v 25 'artifact_use_from_x64-windows-prep_steps' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-test_igvm_agent_rpc_server" | flowey.exe v 25 'artifact_use_from_x64-windows-test_igvm_agent_rpc_server' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-tmk_vmm" | flowey.exe v 25 'artifact_use_from_x64-windows-tmk_vmm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-tpm_guest_tests" | flowey.exe v 25 'artifact_use_from_x64-windows-tpm_guest_tests' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-vmgstool" | flowey.exe v 25 'artifact_use_from_x64-windows-vmgstool' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-vmgstool-dev" | flowey.exe v 25 'artifact_use_from_x64-windows-vmgstool-dev' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-vmm-tests-archive" | flowey.exe v 25 'artifact_use_from_x64-windows-vmm-tests-archive' --is-raw-string update
-      shell: bash
-    - name: create cargo-nextest cache dir
-      run: |-
-        flowey.exe e 25 flowey_lib_common::download_cargo_nextest 0
-        flowey.exe e 25 flowey_lib_common::download_cargo_nextest 1
-        flowey.exe e 25 flowey_lib_common::download_cargo_nextest 2
-        flowey.exe e 25 flowey_lib_common::download_cargo_nextest 3
-      shell: bash
-    - name: Pre-processing cache vars
-      run: |-
-        flowey.exe e 25 flowey_lib_common::cache 0
-        flowey.exe v 25 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
-        flowey.exe v 25 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
-      shell: bash
-    - id: flowey_lib_common__cache__1
-      uses: actions/cache@v5
-      with:
-        key: ${{ env.floweyvar4 }}
-        path: ${{ env.floweyvar5 }}
-      name: 'Restore cache: cargo-nextest'
-    - name: downloading cargo-nextest
-      run: |-
-        flowey.exe v 25 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
-        EOF
-        flowey.exe e 25 flowey_lib_common::cache 2
-        flowey.exe e 25 flowey_lib_common::download_cargo_nextest 4
-      shell: bash
-    - name: check if openvmm needs to be cloned
-      run: |-
-        flowey.exe e 25 flowey_lib_common::git_checkout 0
-        flowey.exe v 25 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
-        flowey.exe v 25 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__git_checkout__1
-      uses: actions/checkout@v6
-      with:
-        fetch-depth: '1'
-        path: repo0
-        persist-credentials: ${{ env.floweyvar3 }}
-      name: checkout repo openvmm
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: report cloned repo directories
-      run: |-
-        flowey.exe v 25 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
-        ${{ github.workspace }}
-        EOF
-        flowey.exe e 25 flowey_lib_common::git_checkout 3
-      shell: bash
-    - name: print system info
-      run: |-
-        flowey.exe e 25 flowey_lib_common::system_info 0
-        flowey.exe e 25 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-        flowey.exe e 25 flowey_lib_hvlite::run_cargo_nextest_run 0
-        flowey.exe e 25 flowey_core::pipeline::artifact::resolve 8
-        flowey.exe e 25 flowey_core::pipeline::artifact::resolve 9
-        flowey.exe e 25 flowey_core::pipeline::artifact::resolve 12
-        flowey.exe e 25 flowey_core::pipeline::artifact::resolve 14
-        flowey.exe e 25 flowey_core::pipeline::artifact::resolve 15
-        flowey.exe e 25 flowey_core::pipeline::artifact::resolve 13
-        flowey.exe e 25 flowey_core::pipeline::artifact::resolve 3
-        flowey.exe e 25 flowey_core::pipeline::artifact::resolve 11
-        flowey.exe e 25 flowey_core::pipeline::artifact::resolve 4
-        flowey.exe e 25 flowey_core::pipeline::artifact::resolve 5
-        flowey.exe e 25 flowey_core::pipeline::artifact::resolve 6
-        flowey.exe e 25 flowey_core::pipeline::artifact::resolve 1
-        flowey.exe e 25 flowey_core::pipeline::artifact::resolve 2
-        flowey.exe e 25 flowey_core::pipeline::artifact::resolve 0
-        flowey.exe e 25 flowey_core::pipeline::artifact::resolve 7
-      shell: bash
-    - name: creating new test content dir
-      run: flowey.exe e 25 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
-      shell: bash
-    - name: create gh-release-download cache dir
-      run: flowey.exe e 25 flowey_lib_common::download_gh_release 0
-      shell: bash
-    - name: Pre-processing cache vars
-      run: |-
-        flowey.exe e 25 flowey_lib_common::cache 8
-        flowey.exe v 25 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
-        flowey.exe v 25 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
-      shell: bash
-    - id: flowey_lib_common__cache__9
-      uses: actions/cache@v5
-      with:
-        key: ${{ env.floweyvar8 }}
-        path: ${{ env.floweyvar9 }}
-      name: 'Restore cache: gh-release-download'
-    - name: download artifacts from github releases
-      run: |-
-        flowey.exe v 25 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
-        EOF
-        flowey.exe e 25 flowey_lib_common::cache 10
-        flowey.exe e 25 flowey_lib_common::download_gh_release 1
-      shell: bash
-    - name: extract azcopy from archive
-      run: flowey.exe e 25 flowey_lib_common::download_azcopy 0
-      shell: bash
-    - name: calculating required VMM tests disk images
-      run: flowey.exe e 25 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
-      shell: bash
-    - name: downloading VMM test disk images
-      run: |-
-        flowey.exe e 25 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
-        flowey.exe e 25 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
-      shell: bash
-    - name: create gh cache dir
-      run: flowey.exe e 25 flowey_lib_common::download_gh_cli 0
-      shell: bash
-    - name: Pre-processing cache vars
-      run: |-
-        flowey.exe e 25 flowey_lib_common::cache 4
-        flowey.exe v 25 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
-        flowey.exe v 25 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
-      shell: bash
-    - id: flowey_lib_common__cache__5
-      uses: actions/cache@v5
-      with:
-        key: ${{ env.floweyvar6 }}
-        path: ${{ env.floweyvar7 }}
-      name: 'Restore cache: gh-cli'
-    - name: installing gh
-      run: |-
-        flowey.exe v 25 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
-        EOF
-        flowey.exe e 25 flowey_lib_common::cache 6
-        flowey.exe e 25 flowey_lib_common::download_gh_cli 1
-        flowey.exe v 25 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
-        ${{ github.token }}
-        EOF
-      shell: bash
-    - name: setup gh cli
-      run: flowey.exe e 25 flowey_lib_common::use_gh_cli 0
-      shell: bash
-    - name: get latest completed action id
-      run: flowey.exe e 25 flowey_lib_common::gh_latest_completed_workflow_id 0
-      shell: bash
-    - name: download artifacts from github actions run
-      run: |-
-        flowey.exe e 25 flowey_lib_common::download_gh_artifact 0
-        flowey.exe e 25 flowey_lib_hvlite::download_release_igvm_files_from_gh::resolve 0
-      shell: bash
-    - name: unpack openvmm-test-initrd archives
-      run: flowey.exe e 25 flowey_lib_hvlite::resolve_openvmm_test_initrd 0
-      shell: bash
-    - name: unpack openvmm-test-linux archives
-      run: flowey.exe e 25 flowey_lib_hvlite::resolve_openvmm_test_linux_kernel 0
-      shell: bash
-    - name: unpack mu_msvm package (x64)
-      run: flowey.exe e 25 flowey_lib_hvlite::download_uefi_mu_msvm 0
-      shell: bash
-    - name: unpack openvmm-test-virtio-win archive
-      run: flowey.exe e 25 flowey_lib_hvlite::resolve_openvmm_test_virtio_win 0
-      shell: bash
-    - name: setting up vmm_tests env
-      run: |-
-        flowey.exe e 25 flowey_lib_hvlite::init_vmm_tests_env 0
-        flowey.exe e 25 flowey_lib_hvlite::run_cargo_nextest_run 1
-        flowey.exe e 25 flowey_core::pipeline::artifact::resolve 16
-        flowey.exe e 25 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
-      shell: bash
-    - name: generate nextest command
-      run: flowey.exe e 25 flowey_lib_common::gen_cargo_nextest_run_cmd 0
-      shell: bash
-    - name: install vmm tests deps (windows)
-      run: flowey.exe e 25 flowey_lib_hvlite::install_vmm_tests_deps 0
-      shell: bash
-    - name: starting test_igvm_agent_rpc_server
-      run: |-
-        flowey.exe e 25 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
-        flowey.exe e 25 flowey_core::pipeline::artifact::resolve 10
-      shell: bash
-    - name: running vmm_test prep_steps
-      run: flowey.exe e 25 flowey_lib_hvlite::run_prep_steps 0
-      shell: bash
-    - name: run 'vmm_tests' nextest tests
-      run: |-
-        flowey.exe e 25 flowey_lib_common::run_cargo_nextest_run 0
-        flowey.exe e 25 flowey_lib_common::run_cargo_nextest_run 1
-        flowey.exe e 25 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
-      shell: bash
-    - name: stopping test_igvm_agent_rpc_server
-      run: |-
-        flowey.exe e 25 flowey_lib_hvlite::stop_test_igvm_agent_rpc_server 0
-        flowey.exe e 25 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
-        flowey.exe e 25 flowey_lib_common::publish_test_results 4
-        flowey.exe e 25 flowey_lib_common::publish_test_results 5
-        flowey.exe v 25 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:152:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57 write-to-env github floweyvar2
-        flowey.exe v 25 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__publish_test_results__6
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-windows-amd-snp-vmm-tests-logs
-        path: ${{ env.floweyvar2 }}
-      name: 'publish test results: x64-windows-amd-snp-vmm-tests (logs)'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: 🦀 flowey rust steps
-      run: |-
-        flowey.exe e 25 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
-        flowey.exe e 25 flowey_lib_common::publish_test_results 0
-        flowey.exe e 25 flowey_lib_common::publish_test_results 1
-        flowey.exe e 25 flowey_lib_common::publish_test_results 2
-        flowey.exe v 25 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
-        flowey.exe v 25 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__publish_test_results__3
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-windows-amd-snp-vmm-tests-junit-xml
-        path: ${{ env.floweyvar1 }}
-      name: 'publish test results: x64-windows-amd-snp-vmm-tests (JUnit XML)'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: report test results to overall pipeline status
-      run: flowey.exe e 25 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
-      shell: bash
-    - name: 'validate cache entry: cargo-nextest'
-      run: flowey.exe e 25 flowey_lib_common::cache 3
-      shell: bash
-    - name: 'validate cache entry: gh-cli'
-      run: flowey.exe e 25 flowey_lib_common::cache 7
-      shell: bash
-    - name: 'validate cache entry: gh-release-download'
-      run: flowey.exe e 25 flowey_lib_common::cache 11
-      shell: bash
-  job26:
     name: run vmm-tests [x64-linux-amd-kvm]
     runs-on:
     - self-hosted
     - 1ES.Pool=openvmm-gh-amd-westus3
     - 1ES.ImageOverride=ubuntu2404-amd64
-    - JobId=job26-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
+    - JobId=job25-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
       id-token: write
@@ -5435,6 +5150,326 @@ jobs:
 
         chmod +x $AgentTempDirNormal/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-1/flowey
 
+        echo '"debug"' | flowey v 25 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey v 25 '_internal_WORKING_DIR' --is-raw-string update
+
+        cat <<'EOF' | flowey v 25 'verbose' update
+        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
+        EOF
+        echo "$AgentTempDirNormal/used_artifacts/x64-guest_test_uefi" | flowey v 25 'artifact_use_from_x64-guest_test_uefi' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-pipette" | flowey v 25 'artifact_use_from_x64-linux-musl-pipette' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-tmk_vmm" | flowey v 25 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-openvmm" | flowey v 25 'artifact_use_from_x64-linux-openvmm' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-openvmm_vhost" | flowey v 25 'artifact_use_from_x64-linux-openvmm_vhost' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-prep_steps" | flowey v 25 'artifact_use_from_x64-linux-prep_steps' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-vmm-tests-archive" | flowey v 25 'artifact_use_from_x64-linux-vmm-tests-archive' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-tmks" | flowey v 25 'artifact_use_from_x64-tmks' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-windows-pipette" | flowey v 25 'artifact_use_from_x64-windows-pipette' --is-raw-string update
+      shell: bash
+    - name: creating new test content dir
+      run: |-
+        flowey e 25 flowey_core::pipeline::artifact::resolve 8
+        flowey e 25 flowey_core::pipeline::artifact::resolve 2
+        flowey e 25 flowey_core::pipeline::artifact::resolve 3
+        flowey e 25 flowey_core::pipeline::artifact::resolve 4
+        flowey e 25 flowey_core::pipeline::artifact::resolve 1
+        flowey e 25 flowey_core::pipeline::artifact::resolve 0
+        flowey e 25 flowey_core::pipeline::artifact::resolve 7
+        flowey e 25 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
+      shell: bash
+    - name: checking if packages need to be installed
+      run: flowey e 25 flowey_lib_common::install_dist_pkg 0
+      shell: bash
+    - name: installing packages
+      run: flowey e 25 flowey_lib_common::install_dist_pkg 1
+      shell: bash
+    - name: create gh-release-download cache dir
+      run: flowey e 25 flowey_lib_common::download_gh_release 0
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
+        flowey e 25 flowey_lib_common::cache 8
+        flowey v 25 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
+        flowey v 25 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
+      shell: bash
+    - id: flowey_lib_common__cache__9
+      uses: actions/cache@v5
+      with:
+        key: ${{ env.floweyvar8 }}
+        path: ${{ env.floweyvar9 }}
+      name: 'Restore cache: gh-release-download'
+    - name: download artifacts from github releases
+      run: |-
+        flowey v 25 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
+        EOF
+        flowey e 25 flowey_lib_common::cache 10
+        flowey e 25 flowey_lib_common::download_gh_release 1
+      shell: bash
+    - name: extract azcopy from archive
+      run: flowey e 25 flowey_lib_common::download_azcopy 0
+      shell: bash
+    - name: calculating required VMM tests disk images
+      run: flowey e 25 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
+      shell: bash
+    - name: downloading VMM test disk images
+      run: |-
+        flowey e 25 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
+        flowey e 25 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
+      shell: bash
+    - name: create gh cache dir
+      run: flowey e 25 flowey_lib_common::download_gh_cli 0
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
+        flowey e 25 flowey_lib_common::cache 4
+        flowey v 25 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
+        flowey v 25 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
+      shell: bash
+    - id: flowey_lib_common__cache__5
+      uses: actions/cache@v5
+      with:
+        key: ${{ env.floweyvar6 }}
+        path: ${{ env.floweyvar7 }}
+      name: 'Restore cache: gh-cli'
+    - name: installing gh
+      run: |-
+        flowey v 25 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
+        EOF
+        flowey e 25 flowey_lib_common::cache 6
+        flowey e 25 flowey_lib_common::download_gh_cli 1
+        flowey v 25 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
+        ${{ github.token }}
+        EOF
+      shell: bash
+    - name: setup gh cli
+      run: flowey e 25 flowey_lib_common::use_gh_cli 0
+      shell: bash
+    - name: get latest completed action id
+      run: flowey e 25 flowey_lib_common::gh_latest_completed_workflow_id 0
+      shell: bash
+    - name: download artifacts from github actions run
+      run: |-
+        flowey e 25 flowey_lib_common::download_gh_artifact 0
+        flowey e 25 flowey_lib_hvlite::download_release_igvm_files_from_gh::resolve 0
+      shell: bash
+    - name: unpack openvmm-test-initrd archives
+      run: flowey e 25 flowey_lib_hvlite::resolve_openvmm_test_initrd 0
+      shell: bash
+    - name: unpack openvmm-test-linux archives
+      run: flowey e 25 flowey_lib_hvlite::resolve_openvmm_test_linux_kernel 0
+      shell: bash
+    - name: unpack mu_msvm package (x64)
+      run: flowey e 25 flowey_lib_hvlite::download_uefi_mu_msvm 0
+      shell: bash
+    - name: unpack openvmm-test-virtio-win archive
+      run: flowey e 25 flowey_lib_hvlite::resolve_openvmm_test_virtio_win 0
+      shell: bash
+    - name: setting up vmm_tests env
+      run: flowey e 25 flowey_lib_hvlite::init_vmm_tests_env 0
+      shell: bash
+    - name: ensure hypervisor device is accessible
+      run: flowey e 25 flowey_lib_hvlite::test_nextest_vmm_tests_archive 1
+      shell: bash
+    - name: ensure 2 MiB hugetlb pages are available
+      run: flowey e 25 flowey_lib_hvlite::test_nextest_vmm_tests_archive 2
+      shell: bash
+    - name: create cargo-nextest cache dir
+      run: |-
+        flowey e 25 flowey_lib_common::download_cargo_nextest 0
+        flowey e 25 flowey_lib_common::download_cargo_nextest 1
+        flowey e 25 flowey_lib_common::download_cargo_nextest 2
+        flowey e 25 flowey_lib_common::download_cargo_nextest 3
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
+        flowey e 25 flowey_lib_common::cache 0
+        flowey v 25 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
+        flowey v 25 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
+      shell: bash
+    - id: flowey_lib_common__cache__1
+      uses: actions/cache@v5
+      with:
+        key: ${{ env.floweyvar4 }}
+        path: ${{ env.floweyvar5 }}
+      name: 'Restore cache: cargo-nextest'
+    - name: downloading cargo-nextest
+      run: |-
+        flowey v 25 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
+        EOF
+        flowey e 25 flowey_lib_common::cache 2
+        flowey e 25 flowey_lib_common::download_cargo_nextest 4
+      shell: bash
+    - name: check if openvmm needs to be cloned
+      run: |-
+        flowey e 25 flowey_lib_common::git_checkout 0
+        flowey v 25 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
+        flowey v 25 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__git_checkout__1
+      uses: actions/checkout@v6
+      with:
+        fetch-depth: '1'
+        path: repo0
+        persist-credentials: ${{ env.floweyvar3 }}
+      name: checkout repo openvmm
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: report cloned repo directories
+      run: |-
+        flowey v 25 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        ${{ github.workspace }}
+        EOF
+        flowey e 25 flowey_lib_common::git_checkout 3
+      shell: bash
+    - name: print system info
+      run: |-
+        flowey e 25 flowey_lib_common::system_info 0
+        flowey e 25 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey e 25 flowey_lib_hvlite::run_cargo_nextest_run 0
+        flowey e 25 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
+        flowey e 25 flowey_lib_hvlite::run_cargo_nextest_run 1
+        flowey e 25 flowey_core::pipeline::artifact::resolve 6
+        flowey e 25 flowey_lib_hvlite::test_nextest_vmm_tests_archive 3
+      shell: bash
+    - name: generate nextest command
+      run: flowey e 25 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      shell: bash
+    - name: install vmm tests deps (linux)
+      run: |-
+        flowey e 25 flowey_lib_hvlite::install_vmm_tests_deps 0
+        flowey e 25 flowey_core::pipeline::artifact::resolve 5
+      shell: bash
+    - name: running vmm_test prep_steps
+      run: flowey e 25 flowey_lib_hvlite::run_prep_steps 0
+      shell: bash
+    - name: run 'vmm_tests' nextest tests
+      run: |-
+        flowey e 25 flowey_lib_common::run_cargo_nextest_run 0
+        flowey e 25 flowey_lib_common::run_cargo_nextest_run 1
+        flowey e 25 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
+        flowey e 25 flowey_lib_common::publish_test_results 4
+        flowey e 25 flowey_lib_common::publish_test_results 5
+        flowey v 25 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:152:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57 write-to-env github floweyvar2
+        flowey v 25 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__publish_test_results__6
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-linux-amd-kvm-vmm-tests-logs
+        path: ${{ env.floweyvar2 }}
+      name: 'publish test results: x64-linux-amd-kvm-vmm-tests (logs)'
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: 🦀 flowey rust steps
+      run: |-
+        flowey e 25 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
+        flowey e 25 flowey_lib_common::publish_test_results 0
+        flowey e 25 flowey_lib_common::publish_test_results 1
+        flowey e 25 flowey_lib_common::publish_test_results 2
+        flowey v 25 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
+        flowey v 25 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__publish_test_results__3
+      uses: actions/upload-artifact@v7
+      with:
+        name: x64-linux-amd-kvm-vmm-tests-junit-xml
+        path: ${{ env.floweyvar1 }}
+      name: 'publish test results: x64-linux-amd-kvm-vmm-tests (JUnit XML)'
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: report test results to overall pipeline status
+      run: flowey e 25 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
+      shell: bash
+    - name: 'validate cache entry: cargo-nextest'
+      run: flowey e 25 flowey_lib_common::cache 3
+      shell: bash
+    - name: 'validate cache entry: gh-cli'
+      run: flowey e 25 flowey_lib_common::cache 7
+      shell: bash
+    - name: 'validate cache entry: gh-release-download'
+      run: flowey e 25 flowey_lib_common::cache 11
+      shell: bash
+  job26:
+    name: run vmm-tests [x64-linux-intel-mshv]
+    runs-on:
+    - self-hosted
+    - 1ES.Pool=openvmm-gh-intel-westus3
+    - 1ES.ImageOverride=azurelinux3-amd64-dom0
+    - JobId=job26-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
+    permissions:
+      contents: read
+      id-token: write
+    needs:
+    - job0
+    - job2
+    - job3
+    - job9
+    if: github.event.pull_request.draft == false
+    steps:
+    - run: |
+        set -x
+        sudo tdnf install -y gcc glibc-devel
+        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.95.0 -y
+        . "$HOME/.cargo/env"
+        echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
+        rustup show
+      if: runner.os == 'Linux'
+      name: rustup (Linux)
+      shell: bash
+    - run: |
+        set -x
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
+        ./rustup-init.exe -y --default-toolchain=1.95.0
+        echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
+      if: runner.os == 'Windows' && runner.arch == 'X64'
+      name: rustup (Windows X64)
+      shell: bash
+    - run: |
+        set -x
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
+        ./rustup-init.exe -y --default-toolchain=1.95.0
+        echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
+      if: runner.os == 'Windows' && runner.arch == 'ARM64'
+      name: rustup (Windows ARM64)
+      shell: bash
+    - uses: actions/checkout@v6
+      with:
+        path: flowey_bootstrap
+    - name: Build flowey
+      run: |
+        set -x
+        CARGO_INCREMENTAL=0 cargo build -p flowey_hvlite --target x86_64-unknown-linux-gnu --profile flowey-ci
+        OutDirNormal=$(echo "${{ runner.temp }}/bootstrapped-flowey" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
+        mkdir -p "$OutDirNormal"
+        mv ./.github/workflows/openvmm-pr.yaml "$OutDirNormal/pipeline.yaml"
+        mv target/x86_64-unknown-linux-gnu/flowey-ci/flowey_hvlite "$OutDirNormal/flowey"
+      working-directory: flowey_bootstrap
+      shell: bash
+    - name: 🌼📦 Download artifacts
+      uses: actions/download-artifact@v8
+      with:
+        pattern: '{x64-guest_test_uefi,x64-linux-musl-openvmm,x64-linux-musl-openvmm_vhost,x64-linux-musl-pipette,x64-linux-musl-tmk_vmm,x64-linux-musl-vmm-tests-archive,x64-linux-prep_steps,x64-tmks,x64-windows-pipette}'
+        path: ${{ runner.temp }}/used_artifacts/
+    - run: echo "${{ runner.temp }}/bootstrapped-flowey" >> $GITHUB_PATH
+      shell: bash
+      name: 🌼📦 Add flowey to PATH
+    - name: 🌼🔎 Self-check YAML
+      run: |-
+        ESCAPED_AGENT_TEMPDIR=$(
+        cat <<'EOF' | sed 's/\\/\\\\/g'
+        ${{ runner.temp }}
+        EOF
+        )
+        flowey pipeline github --runtime $ESCAPED_AGENT_TEMPDIR/bootstrapped-flowey/pipeline.yaml --out .github/workflows/openvmm-pr.yaml ci checkin-gates --config=pr
+      shell: bash
+    - name: 🌼🛫 Initialize job
+      run: |
+        AgentTempDirNormal="${{ runner.temp }}"
+        AgentTempDirNormal=$(echo "$AgentTempDirNormal" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
+        echo "AgentTempDirNormal=$AgentTempDirNormal" >> $GITHUB_ENV
+
+        chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey
+
         echo '"debug"' | flowey v 26 'FLOWEY_LOG' update
         echo "${{ runner.temp }}/work" | flowey v 26 '_internal_WORKING_DIR' --is-raw-string update
 
@@ -5442,22 +5477,22 @@ jobs:
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
         echo "$AgentTempDirNormal/used_artifacts/x64-guest_test_uefi" | flowey v 26 'artifact_use_from_x64-guest_test_uefi' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-openvmm" | flowey v 26 'artifact_use_from_x64-linux-musl-openvmm' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-openvmm_vhost" | flowey v 26 'artifact_use_from_x64-linux-musl-openvmm_vhost' --is-raw-string update
         echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-pipette" | flowey v 26 'artifact_use_from_x64-linux-musl-pipette' --is-raw-string update
         echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-tmk_vmm" | flowey v 26 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-linux-openvmm" | flowey v 26 'artifact_use_from_x64-linux-openvmm' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-linux-openvmm_vhost" | flowey v 26 'artifact_use_from_x64-linux-openvmm_vhost' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-vmm-tests-archive" | flowey v 26 'artifact_use_from_x64-linux-musl-vmm-tests-archive' --is-raw-string update
         echo "$AgentTempDirNormal/used_artifacts/x64-linux-prep_steps" | flowey v 26 'artifact_use_from_x64-linux-prep_steps' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-linux-vmm-tests-archive" | flowey v 26 'artifact_use_from_x64-linux-vmm-tests-archive' --is-raw-string update
         echo "$AgentTempDirNormal/used_artifacts/x64-tmks" | flowey v 26 'artifact_use_from_x64-tmks' --is-raw-string update
         echo "$AgentTempDirNormal/used_artifacts/x64-windows-pipette" | flowey v 26 'artifact_use_from_x64-windows-pipette' --is-raw-string update
       shell: bash
     - name: creating new test content dir
       run: |-
         flowey e 26 flowey_core::pipeline::artifact::resolve 8
-        flowey e 26 flowey_core::pipeline::artifact::resolve 2
-        flowey e 26 flowey_core::pipeline::artifact::resolve 3
         flowey e 26 flowey_core::pipeline::artifact::resolve 4
         flowey e 26 flowey_core::pipeline::artifact::resolve 1
+        flowey e 26 flowey_core::pipeline::artifact::resolve 2
+        flowey e 26 flowey_core::pipeline::artifact::resolve 3
         flowey e 26 flowey_core::pipeline::artifact::resolve 0
         flowey e 26 flowey_core::pipeline::artifact::resolve 7
         flowey e 26 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
@@ -5555,10 +5590,7 @@ jobs:
       run: flowey e 26 flowey_lib_hvlite::init_vmm_tests_env 0
       shell: bash
     - name: ensure hypervisor device is accessible
-      run: flowey e 26 flowey_lib_hvlite::test_nextest_vmm_tests_archive 1
-      shell: bash
-    - name: ensure 2 MiB hugetlb pages are available
-      run: flowey e 26 flowey_lib_hvlite::test_nextest_vmm_tests_archive 2
+      run: flowey e 26 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
       shell: bash
     - name: create cargo-nextest cache dir
       run: |-
@@ -5613,10 +5645,9 @@ jobs:
         flowey e 26 flowey_lib_common::system_info 0
         flowey e 26 flowey_lib_hvlite::git_checkout_openvmm_repo 0
         flowey e 26 flowey_lib_hvlite::run_cargo_nextest_run 0
-        flowey e 26 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
         flowey e 26 flowey_lib_hvlite::run_cargo_nextest_run 1
-        flowey e 26 flowey_core::pipeline::artifact::resolve 6
-        flowey e 26 flowey_lib_hvlite::test_nextest_vmm_tests_archive 3
+        flowey e 26 flowey_core::pipeline::artifact::resolve 5
+        flowey e 26 flowey_lib_hvlite::test_nextest_vmm_tests_archive 1
       shell: bash
     - name: generate nextest command
       run: flowey e 26 flowey_lib_common::gen_cargo_nextest_run_cmd 0
@@ -5624,7 +5655,7 @@ jobs:
     - name: install vmm tests deps (linux)
       run: |-
         flowey e 26 flowey_lib_hvlite::install_vmm_tests_deps 0
-        flowey e 26 flowey_core::pipeline::artifact::resolve 5
+        flowey e 26 flowey_core::pipeline::artifact::resolve 6
       shell: bash
     - name: running vmm_test prep_steps
       run: flowey e 26 flowey_lib_hvlite::run_prep_steps 0
@@ -5642,9 +5673,9 @@ jobs:
     - id: flowey_lib_common__publish_test_results__6
       uses: actions/upload-artifact@v7
       with:
-        name: x64-linux-amd-kvm-vmm-tests-logs
+        name: x64-linux-intel-mshv-vmm-tests-logs
         path: ${{ env.floweyvar2 }}
-      name: 'publish test results: x64-linux-amd-kvm-vmm-tests (logs)'
+      name: 'publish test results: x64-linux-intel-mshv-vmm-tests (logs)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: 🦀 flowey rust steps
       run: |-
@@ -5658,9 +5689,9 @@ jobs:
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v7
       with:
-        name: x64-linux-amd-kvm-vmm-tests-junit-xml
+        name: x64-linux-intel-mshv-vmm-tests-junit-xml
         path: ${{ env.floweyvar1 }}
-      name: 'publish test results: x64-linux-amd-kvm-vmm-tests (JUnit XML)'
+      name: 'publish test results: x64-linux-intel-mshv-vmm-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
       run: flowey e 26 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
@@ -5675,322 +5706,6 @@ jobs:
       run: flowey e 26 flowey_lib_common::cache 11
       shell: bash
   job27:
-    name: run vmm-tests [x64-linux-intel-mshv]
-    runs-on:
-    - self-hosted
-    - 1ES.Pool=openvmm-gh-intel-westus3
-    - 1ES.ImageOverride=azurelinux3-amd64-dom0
-    - JobId=job27-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
-    permissions:
-      contents: read
-      id-token: write
-    needs:
-    - job0
-    - job2
-    - job3
-    - job9
-    if: github.event.pull_request.draft == false
-    steps:
-    - run: |
-        set -x
-        sudo tdnf install -y gcc glibc-devel
-        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.95.0 -y
-        . "$HOME/.cargo/env"
-        echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
-        rustup show
-      if: runner.os == 'Linux'
-      name: rustup (Linux)
-      shell: bash
-    - run: |
-        set -x
-        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.95.0
-        echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
-      if: runner.os == 'Windows' && runner.arch == 'X64'
-      name: rustup (Windows X64)
-      shell: bash
-    - run: |
-        set -x
-        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
-        ./rustup-init.exe -y --default-toolchain=1.95.0
-        echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
-      if: runner.os == 'Windows' && runner.arch == 'ARM64'
-      name: rustup (Windows ARM64)
-      shell: bash
-    - uses: actions/checkout@v6
-      with:
-        path: flowey_bootstrap
-    - name: Build flowey
-      run: |
-        set -x
-        CARGO_INCREMENTAL=0 cargo build -p flowey_hvlite --target x86_64-unknown-linux-gnu --profile flowey-ci
-        OutDirNormal=$(echo "${{ runner.temp }}/bootstrapped-flowey" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
-        mkdir -p "$OutDirNormal"
-        mv ./.github/workflows/openvmm-pr.yaml "$OutDirNormal/pipeline.yaml"
-        mv target/x86_64-unknown-linux-gnu/flowey-ci/flowey_hvlite "$OutDirNormal/flowey"
-      working-directory: flowey_bootstrap
-      shell: bash
-    - name: 🌼📦 Download artifacts
-      uses: actions/download-artifact@v8
-      with:
-        pattern: '{x64-guest_test_uefi,x64-linux-musl-openvmm,x64-linux-musl-openvmm_vhost,x64-linux-musl-pipette,x64-linux-musl-tmk_vmm,x64-linux-musl-vmm-tests-archive,x64-linux-prep_steps,x64-tmks,x64-windows-pipette}'
-        path: ${{ runner.temp }}/used_artifacts/
-    - run: echo "${{ runner.temp }}/bootstrapped-flowey" >> $GITHUB_PATH
-      shell: bash
-      name: 🌼📦 Add flowey to PATH
-    - name: 🌼🔎 Self-check YAML
-      run: |-
-        ESCAPED_AGENT_TEMPDIR=$(
-        cat <<'EOF' | sed 's/\\/\\\\/g'
-        ${{ runner.temp }}
-        EOF
-        )
-        flowey pipeline github --runtime $ESCAPED_AGENT_TEMPDIR/bootstrapped-flowey/pipeline.yaml --out .github/workflows/openvmm-pr.yaml ci checkin-gates --config=pr
-      shell: bash
-    - name: 🌼🛫 Initialize job
-      run: |
-        AgentTempDirNormal="${{ runner.temp }}"
-        AgentTempDirNormal=$(echo "$AgentTempDirNormal" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
-        echo "AgentTempDirNormal=$AgentTempDirNormal" >> $GITHUB_ENV
-
-        chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey
-
-        echo '"debug"' | flowey v 27 'FLOWEY_LOG' update
-        echo "${{ runner.temp }}/work" | flowey v 27 '_internal_WORKING_DIR' --is-raw-string update
-
-        cat <<'EOF' | flowey v 27 'verbose' update
-        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
-        EOF
-        echo "$AgentTempDirNormal/used_artifacts/x64-guest_test_uefi" | flowey v 27 'artifact_use_from_x64-guest_test_uefi' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-openvmm" | flowey v 27 'artifact_use_from_x64-linux-musl-openvmm' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-openvmm_vhost" | flowey v 27 'artifact_use_from_x64-linux-musl-openvmm_vhost' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-pipette" | flowey v 27 'artifact_use_from_x64-linux-musl-pipette' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-tmk_vmm" | flowey v 27 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-vmm-tests-archive" | flowey v 27 'artifact_use_from_x64-linux-musl-vmm-tests-archive' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-linux-prep_steps" | flowey v 27 'artifact_use_from_x64-linux-prep_steps' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-tmks" | flowey v 27 'artifact_use_from_x64-tmks' --is-raw-string update
-        echo "$AgentTempDirNormal/used_artifacts/x64-windows-pipette" | flowey v 27 'artifact_use_from_x64-windows-pipette' --is-raw-string update
-      shell: bash
-    - name: creating new test content dir
-      run: |-
-        flowey e 27 flowey_core::pipeline::artifact::resolve 8
-        flowey e 27 flowey_core::pipeline::artifact::resolve 4
-        flowey e 27 flowey_core::pipeline::artifact::resolve 1
-        flowey e 27 flowey_core::pipeline::artifact::resolve 2
-        flowey e 27 flowey_core::pipeline::artifact::resolve 3
-        flowey e 27 flowey_core::pipeline::artifact::resolve 0
-        flowey e 27 flowey_core::pipeline::artifact::resolve 7
-        flowey e 27 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
-      shell: bash
-    - name: checking if packages need to be installed
-      run: flowey e 27 flowey_lib_common::install_dist_pkg 0
-      shell: bash
-    - name: installing packages
-      run: flowey e 27 flowey_lib_common::install_dist_pkg 1
-      shell: bash
-    - name: create gh-release-download cache dir
-      run: flowey e 27 flowey_lib_common::download_gh_release 0
-      shell: bash
-    - name: Pre-processing cache vars
-      run: |-
-        flowey e 27 flowey_lib_common::cache 8
-        flowey v 27 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
-        flowey v 27 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
-      shell: bash
-    - id: flowey_lib_common__cache__9
-      uses: actions/cache@v5
-      with:
-        key: ${{ env.floweyvar8 }}
-        path: ${{ env.floweyvar9 }}
-      name: 'Restore cache: gh-release-download'
-    - name: download artifacts from github releases
-      run: |-
-        flowey v 27 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
-        EOF
-        flowey e 27 flowey_lib_common::cache 10
-        flowey e 27 flowey_lib_common::download_gh_release 1
-      shell: bash
-    - name: extract azcopy from archive
-      run: flowey e 27 flowey_lib_common::download_azcopy 0
-      shell: bash
-    - name: calculating required VMM tests disk images
-      run: flowey e 27 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
-      shell: bash
-    - name: downloading VMM test disk images
-      run: |-
-        flowey e 27 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
-        flowey e 27 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
-      shell: bash
-    - name: create gh cache dir
-      run: flowey e 27 flowey_lib_common::download_gh_cli 0
-      shell: bash
-    - name: Pre-processing cache vars
-      run: |-
-        flowey e 27 flowey_lib_common::cache 4
-        flowey v 27 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
-        flowey v 27 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
-      shell: bash
-    - id: flowey_lib_common__cache__5
-      uses: actions/cache@v5
-      with:
-        key: ${{ env.floweyvar6 }}
-        path: ${{ env.floweyvar7 }}
-      name: 'Restore cache: gh-cli'
-    - name: installing gh
-      run: |-
-        flowey v 27 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
-        EOF
-        flowey e 27 flowey_lib_common::cache 6
-        flowey e 27 flowey_lib_common::download_gh_cli 1
-        flowey v 27 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
-        ${{ github.token }}
-        EOF
-      shell: bash
-    - name: setup gh cli
-      run: flowey e 27 flowey_lib_common::use_gh_cli 0
-      shell: bash
-    - name: get latest completed action id
-      run: flowey e 27 flowey_lib_common::gh_latest_completed_workflow_id 0
-      shell: bash
-    - name: download artifacts from github actions run
-      run: |-
-        flowey e 27 flowey_lib_common::download_gh_artifact 0
-        flowey e 27 flowey_lib_hvlite::download_release_igvm_files_from_gh::resolve 0
-      shell: bash
-    - name: unpack openvmm-test-initrd archives
-      run: flowey e 27 flowey_lib_hvlite::resolve_openvmm_test_initrd 0
-      shell: bash
-    - name: unpack openvmm-test-linux archives
-      run: flowey e 27 flowey_lib_hvlite::resolve_openvmm_test_linux_kernel 0
-      shell: bash
-    - name: unpack mu_msvm package (x64)
-      run: flowey e 27 flowey_lib_hvlite::download_uefi_mu_msvm 0
-      shell: bash
-    - name: unpack openvmm-test-virtio-win archive
-      run: flowey e 27 flowey_lib_hvlite::resolve_openvmm_test_virtio_win 0
-      shell: bash
-    - name: setting up vmm_tests env
-      run: flowey e 27 flowey_lib_hvlite::init_vmm_tests_env 0
-      shell: bash
-    - name: ensure hypervisor device is accessible
-      run: flowey e 27 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
-      shell: bash
-    - name: create cargo-nextest cache dir
-      run: |-
-        flowey e 27 flowey_lib_common::download_cargo_nextest 0
-        flowey e 27 flowey_lib_common::download_cargo_nextest 1
-        flowey e 27 flowey_lib_common::download_cargo_nextest 2
-        flowey e 27 flowey_lib_common::download_cargo_nextest 3
-      shell: bash
-    - name: Pre-processing cache vars
-      run: |-
-        flowey e 27 flowey_lib_common::cache 0
-        flowey v 27 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
-        flowey v 27 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
-      shell: bash
-    - id: flowey_lib_common__cache__1
-      uses: actions/cache@v5
-      with:
-        key: ${{ env.floweyvar4 }}
-        path: ${{ env.floweyvar5 }}
-      name: 'Restore cache: cargo-nextest'
-    - name: downloading cargo-nextest
-      run: |-
-        flowey v 27 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
-        EOF
-        flowey e 27 flowey_lib_common::cache 2
-        flowey e 27 flowey_lib_common::download_cargo_nextest 4
-      shell: bash
-    - name: check if openvmm needs to be cloned
-      run: |-
-        flowey e 27 flowey_lib_common::git_checkout 0
-        flowey v 27 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
-        flowey v 27 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__git_checkout__1
-      uses: actions/checkout@v6
-      with:
-        fetch-depth: '1'
-        path: repo0
-        persist-credentials: ${{ env.floweyvar3 }}
-      name: checkout repo openvmm
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: report cloned repo directories
-      run: |-
-        flowey v 27 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
-        ${{ github.workspace }}
-        EOF
-        flowey e 27 flowey_lib_common::git_checkout 3
-      shell: bash
-    - name: print system info
-      run: |-
-        flowey e 27 flowey_lib_common::system_info 0
-        flowey e 27 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-        flowey e 27 flowey_lib_hvlite::run_cargo_nextest_run 0
-        flowey e 27 flowey_lib_hvlite::run_cargo_nextest_run 1
-        flowey e 27 flowey_core::pipeline::artifact::resolve 5
-        flowey e 27 flowey_lib_hvlite::test_nextest_vmm_tests_archive 1
-      shell: bash
-    - name: generate nextest command
-      run: flowey e 27 flowey_lib_common::gen_cargo_nextest_run_cmd 0
-      shell: bash
-    - name: install vmm tests deps (linux)
-      run: |-
-        flowey e 27 flowey_lib_hvlite::install_vmm_tests_deps 0
-        flowey e 27 flowey_core::pipeline::artifact::resolve 6
-      shell: bash
-    - name: running vmm_test prep_steps
-      run: flowey e 27 flowey_lib_hvlite::run_prep_steps 0
-      shell: bash
-    - name: run 'vmm_tests' nextest tests
-      run: |-
-        flowey e 27 flowey_lib_common::run_cargo_nextest_run 0
-        flowey e 27 flowey_lib_common::run_cargo_nextest_run 1
-        flowey e 27 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
-        flowey e 27 flowey_lib_common::publish_test_results 4
-        flowey e 27 flowey_lib_common::publish_test_results 5
-        flowey v 27 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:152:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57 write-to-env github floweyvar2
-        flowey v 27 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__publish_test_results__6
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-linux-intel-mshv-vmm-tests-logs
-        path: ${{ env.floweyvar2 }}
-      name: 'publish test results: x64-linux-intel-mshv-vmm-tests (logs)'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: 🦀 flowey rust steps
-      run: |-
-        flowey e 27 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
-        flowey e 27 flowey_lib_common::publish_test_results 0
-        flowey e 27 flowey_lib_common::publish_test_results 1
-        flowey e 27 flowey_lib_common::publish_test_results 2
-        flowey v 27 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
-        flowey v 27 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__publish_test_results__3
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-linux-intel-mshv-vmm-tests-junit-xml
-        path: ${{ env.floweyvar1 }}
-      name: 'publish test results: x64-linux-intel-mshv-vmm-tests (JUnit XML)'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: report test results to overall pipeline status
-      run: flowey e 27 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
-      shell: bash
-    - name: 'validate cache entry: cargo-nextest'
-      run: flowey e 27 flowey_lib_common::cache 3
-      shell: bash
-    - name: 'validate cache entry: gh-cli'
-      run: flowey e 27 flowey_lib_common::cache 7
-      shell: bash
-    - name: 'validate cache entry: gh-release-download'
-      run: flowey e 27 flowey_lib_common::cache 11
-      shell: bash
-  job28:
     name: run vmm-tests [aarch64-windows]
     runs-on:
     - self-hosted
@@ -6073,36 +5788,36 @@ jobs:
 
         chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey.exe
 
-        echo '"debug"' | flowey.exe v 28 'FLOWEY_LOG' update
-        echo "${{ runner.temp }}/work" | flowey.exe v 28 '_internal_WORKING_DIR' --is-raw-string update
+        echo '"debug"' | flowey.exe v 27 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey.exe v 27 '_internal_WORKING_DIR' --is-raw-string update
 
-        cat <<'EOF' | flowey.exe v 28 'verbose' update
+        cat <<'EOF' | flowey.exe v 27 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-guest_test_uefi" | flowey.exe v 28 'artifact_use_from_aarch64-guest_test_uefi' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-linux-musl-pipette" | flowey.exe v 28 'artifact_use_from_aarch64-linux-musl-pipette' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-linux-musl-tmk_vmm" | flowey.exe v 28 'artifact_use_from_aarch64-linux-musl-tmk_vmm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-openhcl-igvm" | flowey.exe v 28 'artifact_use_from_aarch64-openhcl-igvm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-tmks" | flowey.exe v 28 'artifact_use_from_aarch64-tmks' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-openvmm" | flowey.exe v 28 'artifact_use_from_aarch64-windows-openvmm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-pipette" | flowey.exe v 28 'artifact_use_from_aarch64-windows-pipette' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-tmk_vmm" | flowey.exe v 28 'artifact_use_from_aarch64-windows-tmk_vmm' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-vmgstool" | flowey.exe v 28 'artifact_use_from_aarch64-windows-vmgstool' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-vmgstool-dev" | flowey.exe v 28 'artifact_use_from_aarch64-windows-vmgstool-dev' --is-raw-string update
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-vmm-tests-archive" | flowey.exe v 28 'artifact_use_from_aarch64-windows-vmm-tests-archive' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-guest_test_uefi" | flowey.exe v 27 'artifact_use_from_aarch64-guest_test_uefi' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-linux-musl-pipette" | flowey.exe v 27 'artifact_use_from_aarch64-linux-musl-pipette' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-linux-musl-tmk_vmm" | flowey.exe v 27 'artifact_use_from_aarch64-linux-musl-tmk_vmm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-openhcl-igvm" | flowey.exe v 27 'artifact_use_from_aarch64-openhcl-igvm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-tmks" | flowey.exe v 27 'artifact_use_from_aarch64-tmks' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-openvmm" | flowey.exe v 27 'artifact_use_from_aarch64-windows-openvmm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-pipette" | flowey.exe v 27 'artifact_use_from_aarch64-windows-pipette' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-tmk_vmm" | flowey.exe v 27 'artifact_use_from_aarch64-windows-tmk_vmm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-vmgstool" | flowey.exe v 27 'artifact_use_from_aarch64-windows-vmgstool' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-vmgstool-dev" | flowey.exe v 27 'artifact_use_from_aarch64-windows-vmgstool-dev' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-vmm-tests-archive" | flowey.exe v 27 'artifact_use_from_aarch64-windows-vmm-tests-archive' --is-raw-string update
       shell: bash
     - name: create cargo-nextest cache dir
       run: |-
-        flowey.exe e 28 flowey_lib_common::download_cargo_nextest 0
-        flowey.exe e 28 flowey_lib_common::download_cargo_nextest 1
-        flowey.exe e 28 flowey_lib_common::download_cargo_nextest 2
-        flowey.exe e 28 flowey_lib_common::download_cargo_nextest 3
+        flowey.exe e 27 flowey_lib_common::download_cargo_nextest 0
+        flowey.exe e 27 flowey_lib_common::download_cargo_nextest 1
+        flowey.exe e 27 flowey_lib_common::download_cargo_nextest 2
+        flowey.exe e 27 flowey_lib_common::download_cargo_nextest 3
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey.exe e 28 flowey_lib_common::cache 0
-        flowey.exe v 28 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
-        flowey.exe v 28 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
+        flowey.exe e 27 flowey_lib_common::cache 0
+        flowey.exe v 27 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
+        flowey.exe v 27 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -6112,17 +5827,17 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
-        flowey.exe v 28 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey.exe v 27 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
-        flowey.exe e 28 flowey_lib_common::cache 2
-        flowey.exe e 28 flowey_lib_common::download_cargo_nextest 4
+        flowey.exe e 27 flowey_lib_common::cache 2
+        flowey.exe e 27 flowey_lib_common::download_cargo_nextest 4
       shell: bash
     - name: check if openvmm needs to be cloned
       run: |-
-        flowey.exe e 28 flowey_lib_common::git_checkout 0
-        flowey.exe v 28 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
-        flowey.exe v 28 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey.exe e 27 flowey_lib_common::git_checkout 0
+        flowey.exe v 27 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
+        flowey.exe v 27 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -6134,38 +5849,38 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey.exe v 28 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey.exe v 27 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
-        flowey.exe e 28 flowey_lib_common::git_checkout 3
+        flowey.exe e 27 flowey_lib_common::git_checkout 3
       shell: bash
     - name: print system info
       run: |-
-        flowey.exe e 28 flowey_lib_common::system_info 0
-        flowey.exe e 28 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-        flowey.exe e 28 flowey_lib_hvlite::run_cargo_nextest_run 0
-        flowey.exe e 28 flowey_core::pipeline::artifact::resolve 5
-        flowey.exe e 28 flowey_core::pipeline::artifact::resolve 6
-        flowey.exe e 28 flowey_core::pipeline::artifact::resolve 7
-        flowey.exe e 28 flowey_core::pipeline::artifact::resolve 8
-        flowey.exe e 28 flowey_core::pipeline::artifact::resolve 9
-        flowey.exe e 28 flowey_core::pipeline::artifact::resolve 3
-        flowey.exe e 28 flowey_core::pipeline::artifact::resolve 1
-        flowey.exe e 28 flowey_core::pipeline::artifact::resolve 2
-        flowey.exe e 28 flowey_core::pipeline::artifact::resolve 0
-        flowey.exe e 28 flowey_core::pipeline::artifact::resolve 4
+        flowey.exe e 27 flowey_lib_common::system_info 0
+        flowey.exe e 27 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey.exe e 27 flowey_lib_hvlite::run_cargo_nextest_run 0
+        flowey.exe e 27 flowey_core::pipeline::artifact::resolve 5
+        flowey.exe e 27 flowey_core::pipeline::artifact::resolve 6
+        flowey.exe e 27 flowey_core::pipeline::artifact::resolve 7
+        flowey.exe e 27 flowey_core::pipeline::artifact::resolve 8
+        flowey.exe e 27 flowey_core::pipeline::artifact::resolve 9
+        flowey.exe e 27 flowey_core::pipeline::artifact::resolve 3
+        flowey.exe e 27 flowey_core::pipeline::artifact::resolve 1
+        flowey.exe e 27 flowey_core::pipeline::artifact::resolve 2
+        flowey.exe e 27 flowey_core::pipeline::artifact::resolve 0
+        flowey.exe e 27 flowey_core::pipeline::artifact::resolve 4
       shell: bash
     - name: creating new test content dir
-      run: flowey.exe e 28 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
+      run: flowey.exe e 27 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
       shell: bash
     - name: create gh-release-download cache dir
-      run: flowey.exe e 28 flowey_lib_common::download_gh_release 0
+      run: flowey.exe e 27 flowey_lib_common::download_gh_release 0
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey.exe e 28 flowey_lib_common::cache 8
-        flowey.exe v 28 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
-        flowey.exe v 28 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
+        flowey.exe e 27 flowey_lib_common::cache 8
+        flowey.exe v 27 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
+        flowey.exe v 27 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
       shell: bash
     - id: flowey_lib_common__cache__9
       uses: actions/cache@v5
@@ -6175,31 +5890,31 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 28 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
+        flowey.exe v 27 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
         EOF
-        flowey.exe e 28 flowey_lib_common::cache 10
-        flowey.exe e 28 flowey_lib_common::download_gh_release 1
+        flowey.exe e 27 flowey_lib_common::cache 10
+        flowey.exe e 27 flowey_lib_common::download_gh_release 1
       shell: bash
     - name: extract azcopy from archive
-      run: flowey.exe e 28 flowey_lib_common::download_azcopy 0
+      run: flowey.exe e 27 flowey_lib_common::download_azcopy 0
       shell: bash
     - name: calculating required VMM tests disk images
-      run: flowey.exe e 28 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
+      run: flowey.exe e 27 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
       shell: bash
     - name: downloading VMM test disk images
       run: |-
-        flowey.exe e 28 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
-        flowey.exe e 28 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
+        flowey.exe e 27 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
+        flowey.exe e 27 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
       shell: bash
     - name: create gh cache dir
-      run: flowey.exe e 28 flowey_lib_common::download_gh_cli 0
+      run: flowey.exe e 27 flowey_lib_common::download_gh_cli 0
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey.exe e 28 flowey_lib_common::cache 4
-        flowey.exe v 28 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
-        flowey.exe v 28 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
+        flowey.exe e 27 flowey_lib_common::cache 4
+        flowey.exe v 27 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
+        flowey.exe v 27 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
@@ -6209,68 +5924,68 @@ jobs:
       name: 'Restore cache: gh-cli'
     - name: installing gh
       run: |-
-        flowey.exe v 28 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        flowey.exe v 27 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
-        flowey.exe e 28 flowey_lib_common::cache 6
-        flowey.exe e 28 flowey_lib_common::download_gh_cli 1
-        flowey.exe v 28 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
+        flowey.exe e 27 flowey_lib_common::cache 6
+        flowey.exe e 27 flowey_lib_common::download_gh_cli 1
+        flowey.exe v 27 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
         ${{ github.token }}
         EOF
       shell: bash
     - name: setup gh cli
-      run: flowey.exe e 28 flowey_lib_common::use_gh_cli 0
+      run: flowey.exe e 27 flowey_lib_common::use_gh_cli 0
       shell: bash
     - name: get latest completed action id
-      run: flowey.exe e 28 flowey_lib_common::gh_latest_completed_workflow_id 0
+      run: flowey.exe e 27 flowey_lib_common::gh_latest_completed_workflow_id 0
       shell: bash
     - name: download artifacts from github actions run
       run: |-
-        flowey.exe e 28 flowey_lib_common::download_gh_artifact 0
-        flowey.exe e 28 flowey_lib_hvlite::download_release_igvm_files_from_gh::resolve 0
+        flowey.exe e 27 flowey_lib_common::download_gh_artifact 0
+        flowey.exe e 27 flowey_lib_hvlite::download_release_igvm_files_from_gh::resolve 0
       shell: bash
     - name: unpack openvmm-test-initrd archives
-      run: flowey.exe e 28 flowey_lib_hvlite::resolve_openvmm_test_initrd 0
+      run: flowey.exe e 27 flowey_lib_hvlite::resolve_openvmm_test_initrd 0
       shell: bash
     - name: unpack openvmm-test-linux archives
-      run: flowey.exe e 28 flowey_lib_hvlite::resolve_openvmm_test_linux_kernel 0
+      run: flowey.exe e 27 flowey_lib_hvlite::resolve_openvmm_test_linux_kernel 0
       shell: bash
     - name: unpack mu_msvm package (aarch64)
-      run: flowey.exe e 28 flowey_lib_hvlite::download_uefi_mu_msvm 0
+      run: flowey.exe e 27 flowey_lib_hvlite::download_uefi_mu_msvm 0
       shell: bash
     - name: unpack openvmm-test-virtio-win archive
-      run: flowey.exe e 28 flowey_lib_hvlite::resolve_openvmm_test_virtio_win 0
+      run: flowey.exe e 27 flowey_lib_hvlite::resolve_openvmm_test_virtio_win 0
       shell: bash
     - name: setting up vmm_tests env
       run: |-
-        flowey.exe e 28 flowey_lib_hvlite::init_vmm_tests_env 0
-        flowey.exe e 28 flowey_lib_hvlite::run_cargo_nextest_run 1
-        flowey.exe e 28 flowey_core::pipeline::artifact::resolve 10
-        flowey.exe e 28 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
+        flowey.exe e 27 flowey_lib_hvlite::init_vmm_tests_env 0
+        flowey.exe e 27 flowey_lib_hvlite::run_cargo_nextest_run 1
+        flowey.exe e 27 flowey_core::pipeline::artifact::resolve 10
+        flowey.exe e 27 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
       shell: bash
     - name: generate nextest command
-      run: flowey.exe e 28 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      run: flowey.exe e 27 flowey_lib_common::gen_cargo_nextest_run_cmd 0
       shell: bash
     - name: install vmm tests deps (windows)
-      run: flowey.exe e 28 flowey_lib_hvlite::install_vmm_tests_deps 0
+      run: flowey.exe e 27 flowey_lib_hvlite::install_vmm_tests_deps 0
       shell: bash
     - name: starting test_igvm_agent_rpc_server
-      run: flowey.exe e 28 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
+      run: flowey.exe e 27 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
       shell: bash
     - name: run 'vmm_tests' nextest tests
       run: |-
-        flowey.exe e 28 flowey_lib_common::run_cargo_nextest_run 0
-        flowey.exe e 28 flowey_lib_common::run_cargo_nextest_run 1
-        flowey.exe e 28 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
+        flowey.exe e 27 flowey_lib_common::run_cargo_nextest_run 0
+        flowey.exe e 27 flowey_lib_common::run_cargo_nextest_run 1
+        flowey.exe e 27 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
       shell: bash
     - name: stopping test_igvm_agent_rpc_server
       run: |-
-        flowey.exe e 28 flowey_lib_hvlite::stop_test_igvm_agent_rpc_server 0
-        flowey.exe e 28 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
-        flowey.exe e 28 flowey_lib_common::publish_test_results 4
-        flowey.exe e 28 flowey_lib_common::publish_test_results 5
-        flowey.exe v 28 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:152:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57 write-to-env github floweyvar2
-        flowey.exe v 28 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57' write-to-env github FLOWEY_CONDITION
+        flowey.exe e 27 flowey_lib_hvlite::stop_test_igvm_agent_rpc_server 0
+        flowey.exe e 27 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
+        flowey.exe e 27 flowey_lib_common::publish_test_results 4
+        flowey.exe e 27 flowey_lib_common::publish_test_results 5
+        flowey.exe v 27 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:152:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57 write-to-env github floweyvar2
+        flowey.exe v 27 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:144:57' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__6
       uses: actions/upload-artifact@v7
@@ -6281,12 +5996,12 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: 🦀 flowey rust steps
       run: |-
-        flowey.exe e 28 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
-        flowey.exe e 28 flowey_lib_common::publish_test_results 0
-        flowey.exe e 28 flowey_lib_common::publish_test_results 1
-        flowey.exe e 28 flowey_lib_common::publish_test_results 2
-        flowey.exe v 28 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
-        flowey.exe v 28 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
+        flowey.exe e 27 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
+        flowey.exe e 27 flowey_lib_common::publish_test_results 0
+        flowey.exe e 27 flowey_lib_common::publish_test_results 1
+        flowey.exe e 27 flowey_lib_common::publish_test_results 2
+        flowey.exe v 27 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
+        flowey.exe v 27 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v7
@@ -6296,18 +6011,18 @@ jobs:
       name: 'publish test results: aarch64-windows-vmm-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
-      run: flowey.exe e 28 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
+      run: flowey.exe e 27 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
       shell: bash
     - name: 'validate cache entry: cargo-nextest'
-      run: flowey.exe e 28 flowey_lib_common::cache 3
+      run: flowey.exe e 27 flowey_lib_common::cache 3
       shell: bash
     - name: 'validate cache entry: gh-cli'
-      run: flowey.exe e 28 flowey_lib_common::cache 7
+      run: flowey.exe e 27 flowey_lib_common::cache 7
       shell: bash
     - name: 'validate cache entry: gh-release-download'
-      run: flowey.exe e 28 flowey_lib_common::cache 11
+      run: flowey.exe e 27 flowey_lib_common::cache 11
       shell: bash
-  job29:
+  job28:
     name: test flowey local backend
     runs-on: ubuntu-latest
     permissions:
@@ -6333,18 +6048,18 @@ jobs:
 
         chmod +x $AgentTempDirNormal/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-1/flowey
 
-        echo '"debug"' | flowey v 29 'FLOWEY_LOG' update
-        echo "${{ runner.temp }}/work" | flowey v 29 '_internal_WORKING_DIR' --is-raw-string update
+        echo '"debug"' | flowey v 28 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey v 28 '_internal_WORKING_DIR' --is-raw-string update
 
-        cat <<'EOF' | flowey v 29 'verbose' update
+        cat <<'EOF' | flowey v 28 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
       shell: bash
     - name: check if openvmm needs to be cloned
       run: |-
-        flowey e 29 flowey_lib_common::git_checkout 0
-        flowey v 29 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar1
-        flowey v 29 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey e 28 flowey_lib_common::git_checkout 0
+        flowey v 28 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar1
+        flowey v 28 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -6356,31 +6071,97 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey v 29 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey v 28 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
-        flowey e 29 flowey_lib_common::git_checkout 3
+        flowey e 28 flowey_lib_common::git_checkout 3
       shell: bash
     - name: print system info
       run: |-
-        flowey e 29 flowey_lib_common::system_info 0
-        flowey e 29 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey e 28 flowey_lib_common::system_info 0
+        flowey e 28 flowey_lib_hvlite::git_checkout_openvmm_repo 0
       shell: bash
     - name: add default cargo home to path
-      run: flowey e 29 flowey_lib_common::install_rust 0
+      run: flowey e 28 flowey_lib_common::install_rust 0
       shell: bash
     - name: install Rust
-      run: flowey e 29 flowey_lib_common::install_rust 1
+      run: flowey e 28 flowey_lib_common::install_rust 1
       shell: bash
     - name: detect active toolchain
       run: |-
-        flowey e 29 flowey_lib_common::install_rust 2
-        flowey v 29 'flowey_lib_hvlite::_jobs::test_local_flowey_build_igvm:3:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
+        flowey e 28 flowey_lib_common::install_rust 2
+        flowey v 28 'flowey_lib_hvlite::_jobs::test_local_flowey_build_igvm:3:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
         ${{ github.token }}
         EOF
       shell: bash
     - name: test cargo xflowey build-igvm x64 --install-missing-deps
-      run: flowey e 29 flowey_lib_hvlite::_jobs::test_local_flowey_build_igvm 1
+      run: flowey e 28 flowey_lib_hvlite::_jobs::test_local_flowey_build_igvm 1
+      shell: bash
+  job29:
+    name: openvmm checkin gates
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    needs:
+    - job0
+    - job1
+    - job10
+    - job11
+    - job12
+    - job13
+    - job14
+    - job15
+    - job16
+    - job17
+    - job18
+    - job19
+    - job2
+    - job20
+    - job21
+    - job22
+    - job23
+    - job24
+    - job25
+    - job26
+    - job27
+    - job28
+    - job3
+    - job4
+    - job5
+    - job6
+    - job7
+    - job8
+    - job9
+    if: always() && github.event.pull_request.draft == false
+    env:
+      ANY_JOBS_FAILED: ${{ contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'failure') }}
+    steps:
+    - name: 🌼📦 Download artifacts
+      uses: actions/download-artifact@v8
+      with:
+        name: _internal-flowey-bootstrap-x86_64-linux-uid-1
+        path: ${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-1/
+    - run: echo "${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-1" >> $GITHUB_PATH
+      shell: bash
+      name: 🌼📦 Add flowey to PATH
+    - name: 🌼🛫 Initialize job
+      run: |
+        AgentTempDirNormal="${{ runner.temp }}"
+        AgentTempDirNormal=$(echo "$AgentTempDirNormal" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
+        echo "AgentTempDirNormal=$AgentTempDirNormal" >> $GITHUB_ENV
+
+        chmod +x $AgentTempDirNormal/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-1/flowey
+
+        echo '"debug"' | flowey v 29 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey v 29 '_internal_WORKING_DIR' --is-raw-string update
+
+        cat <<'EOF' | flowey v 29 'verbose' update
+        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
+        EOF
+      shell: bash
+    - name: Check if any jobs failed
+      run: flowey e 29 flowey_lib_hvlite::_jobs::all_good_job 0
       shell: bash
   job3:
     name: build artifacts (shared VMM tests) [linux]
@@ -6720,73 +6501,6 @@ jobs:
         name: x64-tmks
         path: ${{ runner.temp }}/publish_artifacts/x64-tmks/
         include-hidden-files: true
-  job30:
-    name: openvmm checkin gates
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      id-token: write
-    needs:
-    - job0
-    - job1
-    - job10
-    - job11
-    - job12
-    - job13
-    - job14
-    - job15
-    - job16
-    - job17
-    - job18
-    - job19
-    - job2
-    - job20
-    - job21
-    - job22
-    - job23
-    - job24
-    - job25
-    - job26
-    - job27
-    - job28
-    - job29
-    - job3
-    - job4
-    - job5
-    - job6
-    - job7
-    - job8
-    - job9
-    if: always() && github.event.pull_request.draft == false
-    env:
-      ANY_JOBS_FAILED: ${{ contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'failure') }}
-    steps:
-    - name: 🌼📦 Download artifacts
-      uses: actions/download-artifact@v8
-      with:
-        name: _internal-flowey-bootstrap-x86_64-linux-uid-1
-        path: ${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-1/
-    - run: echo "${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-1" >> $GITHUB_PATH
-      shell: bash
-      name: 🌼📦 Add flowey to PATH
-    - name: 🌼🛫 Initialize job
-      run: |
-        AgentTempDirNormal="${{ runner.temp }}"
-        AgentTempDirNormal=$(echo "$AgentTempDirNormal" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
-        echo "AgentTempDirNormal=$AgentTempDirNormal" >> $GITHUB_ENV
-
-        chmod +x $AgentTempDirNormal/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-1/flowey
-
-        echo '"debug"' | flowey v 30 'FLOWEY_LOG' update
-        echo "${{ runner.temp }}/work" | flowey v 30 '_internal_WORKING_DIR' --is-raw-string update
-
-        cat <<'EOF' | flowey v 30 'verbose' update
-        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
-        EOF
-      shell: bash
-    - name: Check if any jobs failed
-      run: flowey e 30 flowey_lib_hvlite::_jobs::all_good_job 0
-      shell: bash
   job4:
     name: build artifacts (not for VMM tests) [aarch64-windows]
     runs-on:

--- a/flowey/flowey_hvlite/src/pipelines/checkin_gates.rs
+++ b/flowey/flowey_hvlite/src/pipelines/checkin_gates.rs
@@ -1333,7 +1333,7 @@ impl IntoPipeline for CheckinGatesCli {
                 "missing required windows-intel-mi-secure vmm_tests artifact: {missing}"
             )
         })?;
-        let vmm_tests_artifacts_windows_intel_tdx_x86 = vmm_tests_artifacts_windows_x86
+        let _vmm_tests_artifacts_windows_intel_tdx_x86 = vmm_tests_artifacts_windows_x86
             .clone()
             .finish()
             .map_err(|missing| {
@@ -1516,19 +1516,19 @@ impl IntoPipeline for CheckinGatesCli {
                 prep_steps_variants: Vec::new(),
                 hugetlb_2mb_overcommit_pages: None,
             },
-            VmmTestJobParams {
-                platform: FlowPlatform::Windows,
-                arch: FlowArch::X86_64,
-                gh_pool: gh_pools::windows_tdx_self_hosted_baremetal(),
-                ado_pool: None,
-                label: "x64-windows-intel-tdx",
-                target: CommonTriple::X86_64_WINDOWS_MSVC,
-                resolve_vmm_tests_artifacts: vmm_tests_artifacts_windows_intel_tdx_x86,
-                nextest_filter_expr: cvm_filter("tdx"),
-                test_artifacts: cvm_x64_test_artifacts.clone(),
-                prep_steps_variants: vec!["standard".into()],
-                hugetlb_2mb_overcommit_pages: None,
-            },
+            // VmmTestJobParams {
+            //     platform: FlowPlatform::Windows,
+            //     arch: FlowArch::X86_64,
+            //     gh_pool: gh_pools::windows_tdx_self_hosted_baremetal(),
+            //     ado_pool: None,
+            //     label: "x64-windows-intel-tdx",
+            //     target: CommonTriple::X86_64_WINDOWS_MSVC,
+            //     resolve_vmm_tests_artifacts: vmm_tests_artifacts_windows_intel_tdx_x86,
+            //     nextest_filter_expr: cvm_filter("tdx"),
+            //     test_artifacts: cvm_x64_test_artifacts.clone(),
+            //     prep_steps_variants: vec!["standard".into()],
+            //     hugetlb_2mb_overcommit_pages: None,
+            // },
             VmmTestJobParams {
                 platform: FlowPlatform::Windows,
                 arch: FlowArch::X86_64,


### PR DESCRIPTION
I updated the TDX runners and yet another rs_prerelease bug has caused both of them to crash. Disable the tests to unblock CI until I can get them stood up again.