### PR TITLE
flowey: allow partial endorsements for custom IGVM builds

### DIFF
--- a/flowey/flowey_lib_hvlite/src/_jobs/local_build_igvm.rs
+++ b/flowey/flowey_lib_hvlite/src/_jobs/local_build_igvm.rs
@@ -303,9 +303,15 @@ impl SimpleFlowNode for Node {
                     igvm_vbs_json,
                 }) = openhcl_igvm.endorsements()
                 {
-                    fs_err::copy(igvm_tdx_json, output_dir.join("openhcl-tdx.json"))?;
-                    fs_err::copy(igvm_snp_json, output_dir.join("openhcl-snp.json"))?;
-                    fs_err::copy(igvm_vbs_json, output_dir.join("openhcl-vbs.json"))?;
+                    if let Some(igvm_tdx_json) = igvm_tdx_json {
+                        fs_err::copy(igvm_tdx_json, output_dir.join("openhcl-tdx.json"))?;
+                    }
+                    if let Some(igvm_snp_json) = igvm_snp_json {
+                        fs_err::copy(igvm_snp_json, output_dir.join("openhcl-snp.json"))?;
+                    }
+                    if let Some(igvm_vbs_json) = igvm_vbs_json {
+                        fs_err::copy(igvm_vbs_json, output_dir.join("openhcl-vbs.json"))?;
+                    }
                 }
                 for e in fs_err::read_dir(output_dir)? {
                     let e = e?;

--- a/flowey/flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs
+++ b/flowey/flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs
@@ -80,12 +80,27 @@ pub enum OpenhclIgvmOutput {
 pub enum OpenhclIgvmEndorsements {
     X64 {
         #[serde(rename = "openhcl-tdx.json")]
-        igvm_tdx_json: PathBuf,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        igvm_tdx_json: Option<PathBuf>,
         #[serde(rename = "openhcl-snp.json")]
-        igvm_snp_json: PathBuf,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        igvm_snp_json: Option<PathBuf>,
         #[serde(rename = "openhcl-vbs.json")]
-        igvm_vbs_json: PathBuf,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        igvm_vbs_json: Option<PathBuf>,
     },
+}
+
+impl OpenhclIgvmEndorsements {
+    fn is_complete(&self) -> bool {
+        match self {
+            OpenhclIgvmEndorsements::X64 {
+                igvm_tdx_json,
+                igvm_snp_json,
+                igvm_vbs_json,
+            } => igvm_tdx_json.is_some() && igvm_snp_json.is_some() && igvm_vbs_json.is_some(),
+        }
+    }
 }
 
 impl Artifact for OpenhclIgvmOutput {}
@@ -140,19 +155,16 @@ impl OpenhclIgvmOutput {
             igvm_snp_json,
             igvm_vbs_json,
         } = igvm;
-        let mut endorsements = match (igvm_tdx_json, igvm_snp_json, igvm_vbs_json) {
-            (Some(igvm_tdx_json), Some(igvm_snp_json), Some(igvm_vbs_json)) => {
+        let mut endorsements =
+            if igvm_tdx_json.is_some() || igvm_snp_json.is_some() || igvm_vbs_json.is_some() {
                 Some(OpenhclIgvmEndorsements::X64 {
                     igvm_tdx_json,
                     igvm_snp_json,
                     igvm_vbs_json,
                 })
-            }
-            (None, None, None) => None,
-            _ => {
-                panic!("incomplete endorsements")
-            }
-        };
+            } else {
+                None
+            };
         match recipe {
             None => OpenhclIgvmOutput::LocalOnlyCustom {
                 igvm_bin,
@@ -170,11 +182,17 @@ impl OpenhclIgvmOutput {
                     }
                     OpenhclIgvmRecipe::X64Cvm => OpenhclIgvmOutput::X64Cvm {
                         igvm_bin,
-                        endorsements: endorsements.take().expect("missing endorsements"),
+                        endorsements: endorsements
+                            .take()
+                            .filter(OpenhclIgvmEndorsements::is_complete)
+                            .expect("missing endorsements"),
                     },
                     OpenhclIgvmRecipe::X64CvmDevkern => OpenhclIgvmOutput::X64CvmDevkern {
                         igvm_bin,
-                        endorsements: endorsements.take().expect("missing endorsements"),
+                        endorsements: endorsements
+                            .take()
+                            .filter(OpenhclIgvmEndorsements::is_complete)
+                            .expect("missing endorsements"),
                     },
                     OpenhclIgvmRecipe::Aarch64 => OpenhclIgvmOutput::Aarch64 { igvm_bin },
                     OpenhclIgvmRecipe::Aarch64Devkern => {


### PR DESCRIPTION
The following local custom IGVM build regressed:

  cargo xflowey build-igvm x64 --override-manifest \
      ROOT/vm/loader/manifests/uefi-x64.json

That manifest can generate TDX and SNP endorsement files without VBS. The typed OpenHCL IGVM artifact conversion treated that as incomplete and panicked before local build-igvm could copy the generated outputs.

Allow local custom IGVM artifacts to carry partial endorsement paths and copy only the files that exist. Keep named CVM recipes strict by still requiring the complete endorsement set.