### PR TITLE
net_consomme: address poll_message todo

### DIFF
--- a/.github/workflows/openvmm-ci.yaml
+++ b/.github/workflows/openvmm-ci.yaml
@@ -356,7 +356,7 @@ jobs:
     name: build openhcl [aarch64-linux]
     runs-on:
     - self-hosted
-    - 1ES.Pool=openvmm-gh-amd-westus3
+    - 1ES.Pool=openvmm-gh-amd-westus3-v7
     - 1ES.ImageOverride=ubuntu2404-amd64
     - JobId=job10-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
@@ -675,7 +675,7 @@ jobs:
     name: build openhcl [x64-linux]
     runs-on:
     - self-hosted
-    - 1ES.Pool=openvmm-gh-amd-westus3
+    - 1ES.Pool=openvmm-gh-amd-westus3-v7
     - 1ES.ImageOverride=ubuntu2404-amd64
     - JobId=job11-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
@@ -1149,7 +1149,7 @@ jobs:
     name: build openhcl (mi-secure) [x64-linux]
     runs-on:
     - self-hosted
-    - 1ES.Pool=openvmm-gh-amd-westus3
+    - 1ES.Pool=openvmm-gh-amd-westus3-v7
     - 1ES.ImageOverride=ubuntu2404-amd64
     - JobId=job12-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
@@ -1509,8 +1509,8 @@ jobs:
     name: clippy [x64-windows], unit tests [x64-windows]
     runs-on:
     - self-hosted
-    - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=win-amd64
+    - 1ES.Pool=openvmm-gh-intel-westus3-v6
+    - 1ES.ImageOverride=win-amd64-v2
     - JobId=job13-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
@@ -1803,7 +1803,7 @@ jobs:
     name: clippy [x64-linux, macos], unit tests [x64-linux]
     runs-on:
     - self-hosted
-    - 1ES.Pool=openvmm-gh-amd-westus3
+    - 1ES.Pool=openvmm-gh-intel-westus3-v6
     - 1ES.ImageOverride=ubuntu2404-amd64
     - JobId=job14-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
@@ -2186,7 +2186,7 @@ jobs:
     name: clippy [x64-linux-musl, misc nostd], unit tests [x64-linux-musl]
     runs-on:
     - self-hosted
-    - 1ES.Pool=openvmm-gh-amd-westus3
+    - 1ES.Pool=openvmm-gh-intel-westus3-v6
     - 1ES.ImageOverride=ubuntu2404-amd64
     - JobId=job15-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
@@ -2580,8 +2580,8 @@ jobs:
     name: clippy [aarch64-windows], unit tests [aarch64-windows]
     runs-on:
     - self-hosted
-    - 1ES.Pool=openvmm-gh-arm-westus2
-    - 1ES.ImageOverride=win-arm64
+    - 1ES.Pool=openvmm-gh-arm-westus3
+    - 1ES.ImageOverride=win-arm64-v2
     - JobId=job16-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
@@ -3627,8 +3627,8 @@ jobs:
     name: run vmm-tests [x64-windows-intel]
     runs-on:
     - self-hosted
-    - 1ES.Pool=openvmm-gh-intel-westus3
-    - 1ES.ImageOverride=win-amd64
+    - 1ES.Pool=openvmm-gh-intel-westus3-v6
+    - 1ES.ImageOverride=win-amd64-v2
     - JobId=job19-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
@@ -3910,8 +3910,8 @@ jobs:
     name: build artifacts (shared VMM tests) [windows]
     runs-on:
     - self-hosted
-    - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=win-amd64
+    - 1ES.Pool=openvmm-gh-intel-westus3-v6
+    - 1ES.ImageOverride=win-amd64-v2
     - JobId=job2-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
@@ -4096,8 +4096,8 @@ jobs:
     name: run vmm-tests [x64-windows-intel-mi-secure]
     runs-on:
     - self-hosted
-    - 1ES.Pool=openvmm-gh-intel-westus3
-    - 1ES.ImageOverride=win-amd64
+    - 1ES.Pool=openvmm-gh-intel-westus3-v6
+    - 1ES.ImageOverride=win-amd64-v2
     - JobId=job20-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
@@ -4658,8 +4658,8 @@ jobs:
     name: run vmm-tests [x64-windows-amd]
     runs-on:
     - self-hosted
-    - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=win-amd64
+    - 1ES.Pool=openvmm-gh-amd-westus3-v6
+    - 1ES.ImageOverride=win-amd64-v2
     - JobId=job22-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
@@ -5225,7 +5225,7 @@ jobs:
     name: run vmm-tests [x64-linux-amd-kvm]
     runs-on:
     - self-hosted
-    - 1ES.Pool=openvmm-gh-amd-westus3
+    - 1ES.Pool=openvmm-gh-amd-westus3-v7
     - 1ES.ImageOverride=ubuntu2404-amd64
     - JobId=job24-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
@@ -6389,7 +6389,7 @@ jobs:
     name: build artifacts (shared VMM tests) [linux]
     runs-on:
     - self-hosted
-    - 1ES.Pool=openvmm-gh-amd-westus3
+    - 1ES.Pool=openvmm-gh-intel-westus3-v6
     - 1ES.ImageOverride=ubuntu2404-amd64
     - JobId=job3-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
@@ -6770,8 +6770,8 @@ jobs:
     name: build artifacts (not for VMM tests) [aarch64-windows]
     runs-on:
     - self-hosted
-    - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=win-amd64
+    - 1ES.Pool=openvmm-gh-intel-westus3-v6
+    - 1ES.ImageOverride=win-amd64-v2
     - JobId=job4-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
@@ -6989,8 +6989,8 @@ jobs:
     name: build artifacts (for VMM tests) [aarch64-windows]
     runs-on:
     - self-hosted
-    - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=win-amd64
+    - 1ES.Pool=openvmm-gh-intel-westus3-v6
+    - 1ES.ImageOverride=win-amd64-v2
     - JobId=job5-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
@@ -7311,8 +7311,8 @@ jobs:
     name: build artifacts (not for VMM tests) [x64-windows]
     runs-on:
     - self-hosted
-    - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=win-amd64
+    - 1ES.Pool=openvmm-gh-intel-westus3-v6
+    - 1ES.ImageOverride=win-amd64-v2
     - JobId=job6-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
@@ -7534,8 +7534,8 @@ jobs:
     name: build artifacts (for VMM tests) [x64-windows]
     runs-on:
     - self-hosted
-    - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=win-amd64
+    - 1ES.Pool=openvmm-gh-intel-westus3-v6
+    - 1ES.ImageOverride=win-amd64-v2
     - JobId=job7-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
@@ -7864,7 +7864,7 @@ jobs:
     name: build artifacts (for VMM tests) [aarch64-linux]
     runs-on:
     - self-hosted
-    - 1ES.Pool=openvmm-gh-amd-westus3
+    - 1ES.Pool=openvmm-gh-amd-westus3-v7
     - 1ES.ImageOverride=ubuntu2404-amd64
     - JobId=job8-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
@@ -8237,7 +8237,7 @@ jobs:
     name: build artifacts (for VMM tests) [x64-linux]
     runs-on:
     - self-hosted
-    - 1ES.Pool=openvmm-gh-amd-westus3
+    - 1ES.Pool=openvmm-gh-amd-westus3-v7
     - 1ES.ImageOverride=ubuntu2404-amd64
     - JobId=job9-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:

--- a/.github/workflows/openvmm-pr-release.yaml
+++ b/.github/workflows/openvmm-pr-release.yaml
@@ -29,7 +29,7 @@ jobs:
     name: quick check [fmt, clippy x64-linux]
     runs-on:
     - self-hosted
-    - 1ES.Pool=openvmm-gh-amd-westus3
+    - 1ES.Pool=openvmm-gh-amd-westus3-v7
     - 1ES.ImageOverride=ubuntu2404-amd64
     - JobId=job0-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
@@ -407,7 +407,7 @@ jobs:
     name: build openhcl [aarch64-linux]
     runs-on:
     - self-hosted
-    - 1ES.Pool=openvmm-gh-amd-westus3
+    - 1ES.Pool=openvmm-gh-amd-westus3-v7
     - 1ES.ImageOverride=ubuntu2404-amd64
     - JobId=job10-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
@@ -660,7 +660,7 @@ jobs:
     name: build openhcl [x64-linux]
     runs-on:
     - self-hosted
-    - 1ES.Pool=openvmm-gh-amd-westus3
+    - 1ES.Pool=openvmm-gh-amd-westus3-v7
     - 1ES.ImageOverride=ubuntu2404-amd64
     - JobId=job11-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
@@ -1068,7 +1068,7 @@ jobs:
     name: build openhcl (mi-secure) [x64-linux]
     runs-on:
     - self-hosted
-    - 1ES.Pool=openvmm-gh-amd-westus3
+    - 1ES.Pool=openvmm-gh-amd-westus3-v7
     - 1ES.ImageOverride=ubuntu2404-amd64
     - JobId=job12-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
@@ -1386,8 +1386,8 @@ jobs:
     name: clippy [x64-windows], unit tests [x64-windows]
     runs-on:
     - self-hosted
-    - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=win-amd64
+    - 1ES.Pool=openvmm-gh-intel-westus3-v6
+    - 1ES.ImageOverride=win-amd64-v2
     - JobId=job13-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
@@ -1682,7 +1682,7 @@ jobs:
     name: clippy [macos], unit tests [x64-linux]
     runs-on:
     - self-hosted
-    - 1ES.Pool=openvmm-gh-amd-westus3
+    - 1ES.Pool=openvmm-gh-intel-westus3-v6
     - 1ES.ImageOverride=ubuntu2404-amd64
     - JobId=job14-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
@@ -1991,7 +1991,7 @@ jobs:
     name: clippy [x64-linux-musl, misc nostd], unit tests [x64-linux-musl]
     runs-on:
     - self-hosted
-    - 1ES.Pool=openvmm-gh-amd-westus3
+    - 1ES.Pool=openvmm-gh-intel-westus3-v6
     - 1ES.ImageOverride=ubuntu2404-amd64
     - JobId=job15-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
@@ -2343,8 +2343,8 @@ jobs:
     name: clippy [aarch64-windows], unit tests [aarch64-windows]
     runs-on:
     - self-hosted
-    - 1ES.Pool=openvmm-gh-arm-westus2
-    - 1ES.ImageOverride=win-arm64
+    - 1ES.Pool=openvmm-gh-arm-westus3
+    - 1ES.ImageOverride=win-arm64-v2
     - JobId=job16-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
@@ -3396,8 +3396,8 @@ jobs:
     name: run vmm-tests [x64-windows-intel]
     runs-on:
     - self-hosted
-    - 1ES.Pool=openvmm-gh-intel-westus3
-    - 1ES.ImageOverride=win-amd64
+    - 1ES.Pool=openvmm-gh-intel-westus3-v6
+    - 1ES.ImageOverride=win-amd64-v2
     - JobId=job19-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
@@ -3680,8 +3680,8 @@ jobs:
     name: build artifacts (shared VMM tests) [windows]
     runs-on:
     - self-hosted
-    - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=win-amd64
+    - 1ES.Pool=openvmm-gh-intel-westus3-v6
+    - 1ES.ImageOverride=win-amd64-v2
     - JobId=job2-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
@@ -3868,8 +3868,8 @@ jobs:
     name: run vmm-tests [x64-windows-intel-mi-secure]
     runs-on:
     - self-hosted
-    - 1ES.Pool=openvmm-gh-intel-westus3
-    - 1ES.ImageOverride=win-amd64
+    - 1ES.Pool=openvmm-gh-intel-westus3-v6
+    - 1ES.ImageOverride=win-amd64-v2
     - JobId=job20-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
@@ -4432,8 +4432,8 @@ jobs:
     name: run vmm-tests [x64-windows-amd]
     runs-on:
     - self-hosted
-    - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=win-amd64
+    - 1ES.Pool=openvmm-gh-amd-westus3-v6
+    - 1ES.ImageOverride=win-amd64-v2
     - JobId=job22-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
@@ -5001,7 +5001,7 @@ jobs:
     name: run vmm-tests [x64-linux-amd-kvm]
     runs-on:
     - self-hosted
-    - 1ES.Pool=openvmm-gh-amd-westus3
+    - 1ES.Pool=openvmm-gh-amd-westus3-v7
     - 1ES.ImageOverride=ubuntu2404-amd64
     - JobId=job24-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
@@ -5981,7 +5981,7 @@ jobs:
     name: build artifacts (shared VMM tests) [linux]
     runs-on:
     - self-hosted
-    - 1ES.Pool=openvmm-gh-amd-westus3
+    - 1ES.Pool=openvmm-gh-intel-westus3-v6
     - 1ES.ImageOverride=ubuntu2404-amd64
     - JobId=job3-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
@@ -6319,8 +6319,8 @@ jobs:
     name: build artifacts (not for VMM tests) [aarch64-windows]
     runs-on:
     - self-hosted
-    - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=win-amd64
+    - 1ES.Pool=openvmm-gh-intel-westus3-v6
+    - 1ES.ImageOverride=win-amd64-v2
     - JobId=job4-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
@@ -6540,8 +6540,8 @@ jobs:
     name: build artifacts (for VMM tests) [aarch64-windows]
     runs-on:
     - self-hosted
-    - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=win-amd64
+    - 1ES.Pool=openvmm-gh-intel-westus3-v6
+    - 1ES.ImageOverride=win-amd64-v2
     - JobId=job5-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
@@ -6864,8 +6864,8 @@ jobs:
     name: build artifacts (not for VMM tests) [x64-windows]
     runs-on:
     - self-hosted
-    - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=win-amd64
+    - 1ES.Pool=openvmm-gh-intel-westus3-v6
+    - 1ES.ImageOverride=win-amd64-v2
     - JobId=job6-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
@@ -7089,8 +7089,8 @@ jobs:
     name: build artifacts (for VMM tests) [x64-windows]
     runs-on:
     - self-hosted
-    - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=win-amd64
+    - 1ES.Pool=openvmm-gh-intel-westus3-v6
+    - 1ES.ImageOverride=win-amd64-v2
     - JobId=job7-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
@@ -7421,7 +7421,7 @@ jobs:
     name: build artifacts (for VMM tests) [aarch64-linux]
     runs-on:
     - self-hosted
-    - 1ES.Pool=openvmm-gh-amd-westus3
+    - 1ES.Pool=openvmm-gh-amd-westus3-v7
     - 1ES.ImageOverride=ubuntu2404-amd64
     - JobId=job8-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
@@ -7752,7 +7752,7 @@ jobs:
     name: build artifacts (for VMM tests) [x64-linux]
     runs-on:
     - self-hosted
-    - 1ES.Pool=openvmm-gh-amd-westus3
+    - 1ES.Pool=openvmm-gh-amd-westus3-v7
     - 1ES.ImageOverride=ubuntu2404-amd64
     - JobId=job9-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:

--- a/.github/workflows/openvmm-pr.yaml
+++ b/.github/workflows/openvmm-pr.yaml
@@ -28,7 +28,7 @@ jobs:
     name: quick check [fmt, clippy x64-linux]
     runs-on:
     - self-hosted
-    - 1ES.Pool=openvmm-gh-amd-westus3
+    - 1ES.Pool=openvmm-gh-amd-westus3-v7
     - 1ES.ImageOverride=ubuntu2404-amd64
     - JobId=job0-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
@@ -406,7 +406,7 @@ jobs:
     name: build openhcl [aarch64-linux]
     runs-on:
     - self-hosted
-    - 1ES.Pool=openvmm-gh-amd-westus3
+    - 1ES.Pool=openvmm-gh-amd-westus3-v7
     - 1ES.ImageOverride=ubuntu2404-amd64
     - JobId=job10-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
@@ -862,7 +862,7 @@ jobs:
     name: build openhcl [x64-linux]
     runs-on:
     - self-hosted
-    - 1ES.Pool=openvmm-gh-amd-westus3
+    - 1ES.Pool=openvmm-gh-amd-westus3-v7
     - 1ES.ImageOverride=ubuntu2404-amd64
     - JobId=job12-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
@@ -1473,7 +1473,7 @@ jobs:
     name: build openhcl (mi-secure) [x64-linux]
     runs-on:
     - self-hosted
-    - 1ES.Pool=openvmm-gh-amd-westus3
+    - 1ES.Pool=openvmm-gh-amd-westus3-v7
     - 1ES.ImageOverride=ubuntu2404-amd64
     - JobId=job14-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
@@ -1791,8 +1791,8 @@ jobs:
     name: clippy [x64-windows], unit tests [x64-windows]
     runs-on:
     - self-hosted
-    - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=win-amd64
+    - 1ES.Pool=openvmm-gh-intel-westus3-v6
+    - 1ES.ImageOverride=win-amd64-v2
     - JobId=job15-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
@@ -2087,7 +2087,7 @@ jobs:
     name: clippy [macos], unit tests [x64-linux]
     runs-on:
     - self-hosted
-    - 1ES.Pool=openvmm-gh-amd-westus3
+    - 1ES.Pool=openvmm-gh-intel-westus3-v6
     - 1ES.ImageOverride=ubuntu2404-amd64
     - JobId=job16-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
@@ -2396,7 +2396,7 @@ jobs:
     name: clippy [x64-linux-musl, misc nostd], unit tests [x64-linux-musl]
     runs-on:
     - self-hosted
-    - 1ES.Pool=openvmm-gh-amd-westus3
+    - 1ES.Pool=openvmm-gh-intel-westus3-v6
     - 1ES.ImageOverride=ubuntu2404-amd64
     - JobId=job17-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
@@ -2748,8 +2748,8 @@ jobs:
     name: clippy [aarch64-windows], unit tests [aarch64-windows]
     runs-on:
     - self-hosted
-    - 1ES.Pool=openvmm-gh-arm-westus2
-    - 1ES.ImageOverride=win-arm64
+    - 1ES.Pool=openvmm-gh-arm-westus3
+    - 1ES.ImageOverride=win-arm64-v2
     - JobId=job18-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
@@ -3405,8 +3405,8 @@ jobs:
     name: build artifacts (shared VMM tests) [windows]
     runs-on:
     - self-hosted
-    - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=win-amd64
+    - 1ES.Pool=openvmm-gh-intel-westus3-v6
+    - 1ES.ImageOverride=win-amd64-v2
     - JobId=job2-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
@@ -3989,8 +3989,8 @@ jobs:
     name: run vmm-tests [x64-windows-intel]
     runs-on:
     - self-hosted
-    - 1ES.Pool=openvmm-gh-intel-westus3
-    - 1ES.ImageOverride=win-amd64
+    - 1ES.Pool=openvmm-gh-intel-westus3-v6
+    - 1ES.ImageOverride=win-amd64-v2
     - JobId=job21-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
@@ -4273,8 +4273,8 @@ jobs:
     name: run vmm-tests [x64-windows-intel-mi-secure]
     runs-on:
     - self-hosted
-    - 1ES.Pool=openvmm-gh-intel-westus3
-    - 1ES.ImageOverride=win-amd64
+    - 1ES.Pool=openvmm-gh-intel-westus3-v6
+    - 1ES.ImageOverride=win-amd64-v2
     - JobId=job22-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
@@ -4837,8 +4837,8 @@ jobs:
     name: run vmm-tests [x64-windows-amd]
     runs-on:
     - self-hosted
-    - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=win-amd64
+    - 1ES.Pool=openvmm-gh-amd-westus3-v6
+    - 1ES.ImageOverride=win-amd64-v2
     - JobId=job24-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
@@ -5406,7 +5406,7 @@ jobs:
     name: run vmm-tests [x64-linux-amd-kvm]
     runs-on:
     - self-hosted
-    - 1ES.Pool=openvmm-gh-amd-westus3
+    - 1ES.Pool=openvmm-gh-amd-westus3-v7
     - 1ES.ImageOverride=ubuntu2404-amd64
     - JobId=job26-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
@@ -6386,7 +6386,7 @@ jobs:
     name: build artifacts (shared VMM tests) [linux]
     runs-on:
     - self-hosted
-    - 1ES.Pool=openvmm-gh-amd-westus3
+    - 1ES.Pool=openvmm-gh-intel-westus3-v6
     - 1ES.ImageOverride=ubuntu2404-amd64
     - JobId=job3-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
@@ -6791,8 +6791,8 @@ jobs:
     name: build artifacts (not for VMM tests) [aarch64-windows]
     runs-on:
     - self-hosted
-    - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=win-amd64
+    - 1ES.Pool=openvmm-gh-intel-westus3-v6
+    - 1ES.ImageOverride=win-amd64-v2
     - JobId=job4-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
@@ -7012,8 +7012,8 @@ jobs:
     name: build artifacts (for VMM tests) [aarch64-windows]
     runs-on:
     - self-hosted
-    - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=win-amd64
+    - 1ES.Pool=openvmm-gh-intel-westus3-v6
+    - 1ES.ImageOverride=win-amd64-v2
     - JobId=job5-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
@@ -7336,8 +7336,8 @@ jobs:
     name: build artifacts (not for VMM tests) [x64-windows]
     runs-on:
     - self-hosted
-    - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=win-amd64
+    - 1ES.Pool=openvmm-gh-intel-westus3-v6
+    - 1ES.ImageOverride=win-amd64-v2
     - JobId=job6-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
@@ -7561,8 +7561,8 @@ jobs:
     name: build artifacts (for VMM tests) [x64-windows]
     runs-on:
     - self-hosted
-    - 1ES.Pool=openvmm-gh-amd-westus3
-    - 1ES.ImageOverride=win-amd64
+    - 1ES.Pool=openvmm-gh-intel-westus3-v6
+    - 1ES.ImageOverride=win-amd64-v2
     - JobId=job7-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
       contents: read
@@ -7893,7 +7893,7 @@ jobs:
     name: build artifacts (for VMM tests) [aarch64-linux]
     runs-on:
     - self-hosted
-    - 1ES.Pool=openvmm-gh-amd-westus3
+    - 1ES.Pool=openvmm-gh-amd-westus3-v7
     - 1ES.ImageOverride=ubuntu2404-amd64
     - JobId=job8-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
@@ -8224,7 +8224,7 @@ jobs:
     name: build artifacts (for VMM tests) [x64-linux]
     runs-on:
     - self-hosted
-    - 1ES.Pool=openvmm-gh-amd-westus3
+    - 1ES.Pool=openvmm-gh-amd-westus3-v7
     - 1ES.ImageOverride=ubuntu2404-amd64
     - JobId=job9-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:

--- a/Guide/src/reference/openvmm/management/cli.md
+++ b/Guide/src/reference/openvmm/management/cli.md
@@ -283,6 +283,11 @@ name:
 --pcie-root-port rc0:rp0,hotplug,acs=0x005f,cxl
 ```
 
+- `addr=<dev>[.<fn>]`: places the root port at a fixed device/function on
+  its bus. `dev` is 0-31 and the optional `fn` is 0-7 (both decimal or
+  `0x`-prefixed hex). When omitted, the port is assigned the lowest
+  available devfn. Ports are assigned in order, so an explicit `addr` that
+  collides with an already-assigned port is an error.
 - `hotplug`: enables hotplug support for that root port.
 - `acs=<mask>`: sets the Access Control Services capability mask for the
   root port. The value can be decimal or hexadecimal. Default is `0x005f`.

--- a/ci-flowey/openvmm-pr.yaml
+++ b/ci-flowey/openvmm-pr.yaml
@@ -825,7 +825,7 @@ jobs:
   displayName: clippy [x64-windows], unit tests [x64-windows]
   pool:
     demands:
-    - ImageOverride -equals win-amd64
+    - ImageOverride -equals win-amd64-v2
     name: openvmm-ado-amd-westus2
   dependsOn:
   - job0
@@ -2607,7 +2607,7 @@ jobs:
   displayName: build artifacts (for VMM tests) [x64-windows]
   pool:
     demands:
-    - ImageOverride -equals win-amd64
+    - ImageOverride -equals win-amd64-v2
     name: openvmm-ado-amd-westus2
   dependsOn:
   - job0
@@ -2901,7 +2901,7 @@ jobs:
   displayName: build artifacts (not for VMM tests) [x64-windows]
   pool:
     demands:
-    - ImageOverride -equals win-amd64
+    - ImageOverride -equals win-amd64-v2
     name: openvmm-ado-amd-westus2
   dependsOn:
   - job0
@@ -3104,7 +3104,7 @@ jobs:
   displayName: build artifacts (for VMM tests) [aarch64-windows]
   pool:
     demands:
-    - ImageOverride -equals win-amd64
+    - ImageOverride -equals win-amd64-v2
     name: openvmm-ado-amd-westus2
   dependsOn:
   - job0
@@ -3393,7 +3393,7 @@ jobs:
   displayName: build artifacts (not for VMM tests) [aarch64-windows]
   pool:
     demands:
-    - ImageOverride -equals win-amd64
+    - ImageOverride -equals win-amd64-v2
     name: openvmm-ado-amd-westus2
   dependsOn:
   - job0
@@ -3885,7 +3885,7 @@ jobs:
   displayName: build artifacts (shared VMM tests) [windows]
   pool:
     demands:
-    - ImageOverride -equals win-amd64
+    - ImageOverride -equals win-amd64-v2
     name: openvmm-ado-amd-westus2
   dependsOn:
   - job0
@@ -4304,7 +4304,7 @@ jobs:
   displayName: run vmm-tests [x64-windows-amd]
   pool:
     demands:
-    - ImageOverride -equals win-amd64
+    - ImageOverride -equals win-amd64-v2
     name: openvmm-ado-amd-westus2
   dependsOn:
   - job0
@@ -4606,7 +4606,7 @@ jobs:
   displayName: run vmm-tests [x64-windows-intel-mi-secure]
   pool:
     demands:
-    - ImageOverride -equals win-amd64
+    - ImageOverride -equals win-amd64-v2
     name: openvmm-ado-intel-centralus
   dependsOn:
   - job0
@@ -4901,7 +4901,7 @@ jobs:
   displayName: run vmm-tests [x64-windows-intel]
   pool:
     demands:
-    - ImageOverride -equals win-amd64
+    - ImageOverride -equals win-amd64-v2
     name: openvmm-ado-intel-centralus
   dependsOn:
   - job0
@@ -5203,7 +5203,7 @@ jobs:
   displayName: xtask fmt (windows)
   pool:
     demands:
-    - ImageOverride -equals win-amd64
+    - ImageOverride -equals win-amd64-v2
     name: openvmm-ado-amd-westus2
   dependsOn:
   - job0

--- a/flowey/flowey_hvlite/src/pipelines/checkin_gates.rs
+++ b/flowey/flowey_hvlite/src/pipelines/checkin_gates.rs
@@ -435,7 +435,7 @@ impl IntoPipeline for CheckinGatesCli {
                 FlowArch::X86_64,
                 "build artifacts (shared VMM tests) [linux]",
             )
-            .gh_set_pool(gh_pools::default_linux())
+            .gh_set_pool(gh_pools::linux_intel_v6_1es())
             .ado_set_pool(ado_pools::default_linux());
         for (
             arch,
@@ -1151,7 +1151,7 @@ impl IntoPipeline for CheckinGatesCli {
             ClippyUnitTestJobParams {
                 platform: FlowPlatform::Windows,
                 arch: FlowArch::X86_64,
-                gh_pool: gh_pools::windows_amd_1es(),
+                gh_pool: gh_pools::windows_intel_v6_1es(),
                 ado_pool: Some(ado_pools::windows_amd_1es()),
                 clippy_targets: Some((
                     "x64-windows",
@@ -1165,7 +1165,7 @@ impl IntoPipeline for CheckinGatesCli {
             ClippyUnitTestJobParams {
                 platform: FlowPlatform::Linux(FlowPlatformLinuxDistro::Ubuntu),
                 arch: FlowArch::X86_64,
-                gh_pool: gh_pools::linux_amd_1es(),
+                gh_pool: gh_pools::linux_intel_v6_1es(),
                 ado_pool: Some(ado_pools::linux_amd_1es()),
                 clippy_targets: if quick_check_job.is_some() {
                     // quick check already ran clippy for x64-linux;
@@ -1185,7 +1185,7 @@ impl IntoPipeline for CheckinGatesCli {
             ClippyUnitTestJobParams {
                 platform: FlowPlatform::Linux(FlowPlatformLinuxDistro::Ubuntu),
                 arch: FlowArch::X86_64,
-                gh_pool: gh_pools::linux_amd_1es(),
+                gh_pool: gh_pools::linux_intel_v6_1es(),
                 ado_pool: Some(ado_pools::linux_amd_1es()),
                 clippy_targets: Some((
                     "x64-linux-musl, misc nostd",
@@ -1196,7 +1196,7 @@ impl IntoPipeline for CheckinGatesCli {
             ClippyUnitTestJobParams {
                 platform: FlowPlatform::Windows,
                 arch: FlowArch::Aarch64,
-                gh_pool: gh_pools::windows_arm_1es(),
+                gh_pool: gh_pools::windows_arm_v6_1es(),
                 ado_pool: None,
                 clippy_targets: Some((
                     "aarch64-windows",
@@ -1210,7 +1210,7 @@ impl IntoPipeline for CheckinGatesCli {
             ClippyUnitTestJobParams {
                 platform: FlowPlatform::Linux(FlowPlatformLinuxDistro::Ubuntu),
                 arch: FlowArch::Aarch64,
-                gh_pool: gh_pools::linux_arm_1es(),
+                gh_pool: gh_pools::linux_arm_v5_1es(),
                 ado_pool: None,
                 clippy_targets: Some((
                     "aarch64-linux",
@@ -1224,7 +1224,7 @@ impl IntoPipeline for CheckinGatesCli {
             ClippyUnitTestJobParams {
                 platform: FlowPlatform::Linux(FlowPlatformLinuxDistro::Ubuntu),
                 arch: FlowArch::Aarch64,
-                gh_pool: gh_pools::linux_arm_1es(),
+                gh_pool: gh_pools::linux_arm_v5_1es(),
                 ado_pool: None,
                 clippy_targets: Some((
                     "aarch64-linux-musl, misc nostd",
@@ -1492,7 +1492,7 @@ impl IntoPipeline for CheckinGatesCli {
             VmmTestJobParams {
                 platform: FlowPlatform::Windows,
                 arch: FlowArch::X86_64,
-                gh_pool: gh_pools::windows_intel_1es(),
+                gh_pool: gh_pools::windows_intel_v6_1es(),
                 ado_pool: Some(ado_pools::windows_intel_1es()),
                 label: "x64-windows-intel",
                 target: CommonTriple::X86_64_WINDOWS_MSVC,
@@ -1505,7 +1505,7 @@ impl IntoPipeline for CheckinGatesCli {
             VmmTestJobParams {
                 platform: FlowPlatform::Windows,
                 arch: FlowArch::X86_64,
-                gh_pool: gh_pools::windows_intel_1es(),
+                gh_pool: gh_pools::windows_intel_v6_1es(),
                 ado_pool: Some(ado_pools::windows_intel_1es()),
                 label: "x64-windows-intel-mi-secure",
                 target: CommonTriple::X86_64_WINDOWS_MSVC,
@@ -1532,7 +1532,9 @@ impl IntoPipeline for CheckinGatesCli {
             VmmTestJobParams {
                 platform: FlowPlatform::Windows,
                 arch: FlowArch::X86_64,
-                gh_pool: gh_pools::windows_amd_1es(),
+                // a Windows hypervisor bug causes VMM tests to crash
+                // when running on v7, so use v6
+                gh_pool: gh_pools::windows_amd_v6_1es(),
                 ado_pool: Some(ado_pools::windows_amd_1es()),
                 label: "x64-windows-amd",
                 target: CommonTriple::X86_64_WINDOWS_MSVC,
@@ -1558,7 +1560,7 @@ impl IntoPipeline for CheckinGatesCli {
             VmmTestJobParams {
                 platform: FlowPlatform::Linux(FlowPlatformLinuxDistro::Ubuntu),
                 arch: FlowArch::X86_64,
-                gh_pool: gh_pools::linux_amd_1es(),
+                gh_pool: gh_pools::linux_amd_v7_1es(),
                 ado_pool: Some(ado_pools::linux_amd_1es()),
                 label: "x64-linux-amd-kvm",
                 target: CommonTriple::X86_64_LINUX_GNU,
@@ -1572,7 +1574,8 @@ impl IntoPipeline for CheckinGatesCli {
             VmmTestJobParams {
                 platform: FlowPlatform::Linux(FlowPlatformLinuxDistro::AzureLinux),
                 arch: FlowArch::X86_64,
-                gh_pool: gh_pools::linux_mshv_1es(),
+                // mshv image needs to be updated to use nvme for v6+ skus
+                gh_pool: gh_pools::linux_mshv_intel_v5_1es(),
                 ado_pool: None,
                 label: "x64-linux-intel-mshv",
                 target: CommonTriple::X86_64_LINUX_MUSL,

--- a/flowey/flowey_hvlite/src/pipelines_shared/gh_pools.rs
+++ b/flowey/flowey_hvlite/src/pipelines_shared/gh_pools.rs
@@ -5,12 +5,15 @@
 
 use flowey::pipeline::prelude::*;
 
-pub const AMD_POOL_1ES: &str = "openvmm-gh-amd-westus3";
-pub const INTEL_POOL_1ES: &str = "openvmm-gh-intel-westus3";
-pub const ARM_POOL_1ES: &str = "openvmm-gh-arm-westus2";
+pub const AMD_V6_POOL_1ES: &str = "openvmm-gh-amd-westus3-v6";
+pub const AMD_V7_POOL_1ES: &str = "openvmm-gh-amd-westus3-v7";
+pub const INTEL_V5_POOL_1ES: &str = "openvmm-gh-intel-westus3";
+pub const INTEL_V6_POOL_1ES: &str = "openvmm-gh-intel-westus3-v6";
+pub const ARM_V5_POOL_1ES: &str = "openvmm-gh-arm-westus2";
+pub const ARM_V6_POOL_1ES: &str = "openvmm-gh-arm-westus3";
 
-pub const WINDOWS_IMAGE_AMD64: &str = "win-amd64";
-pub const WINDOWS_IMAGE_ARM64: &str = "win-arm64";
+pub const WINDOWS_IMAGE_AMD64: &str = "win-amd64-v2";
+pub const WINDOWS_IMAGE_ARM64: &str = "win-arm64-v2";
 pub const LINUX_IMAGE_AMD64: &str = "ubuntu2404-amd64";
 pub const LINUX_IMAGE_ARM64: &str = "ubuntu2404-arm64";
 pub const MSHV_IMAGE_AMD64: &str = "azurelinux3-amd64-dom0";
@@ -23,28 +26,32 @@ fn gh_pool_with_image_1es(pool: &str, image: &str) -> GhRunner {
     ])
 }
 
-pub fn windows_amd_1es() -> GhRunner {
-    gh_pool_with_image_1es(AMD_POOL_1ES, WINDOWS_IMAGE_AMD64)
+pub fn windows_arm_v6_1es() -> GhRunner {
+    gh_pool_with_image_1es(ARM_V6_POOL_1ES, WINDOWS_IMAGE_ARM64)
 }
 
-pub fn windows_intel_1es() -> GhRunner {
-    gh_pool_with_image_1es(INTEL_POOL_1ES, WINDOWS_IMAGE_AMD64)
+pub fn windows_amd_v6_1es() -> GhRunner {
+    gh_pool_with_image_1es(AMD_V6_POOL_1ES, WINDOWS_IMAGE_AMD64)
 }
 
-pub fn windows_arm_1es() -> GhRunner {
-    gh_pool_with_image_1es(ARM_POOL_1ES, WINDOWS_IMAGE_ARM64)
+pub fn windows_intel_v6_1es() -> GhRunner {
+    gh_pool_with_image_1es(INTEL_V6_POOL_1ES, WINDOWS_IMAGE_AMD64)
 }
 
-pub fn linux_arm_1es() -> GhRunner {
-    gh_pool_with_image_1es(ARM_POOL_1ES, LINUX_IMAGE_ARM64)
+pub fn linux_arm_v5_1es() -> GhRunner {
+    gh_pool_with_image_1es(ARM_V5_POOL_1ES, LINUX_IMAGE_ARM64)
 }
 
-pub fn linux_amd_1es() -> GhRunner {
-    gh_pool_with_image_1es(AMD_POOL_1ES, LINUX_IMAGE_AMD64)
+pub fn linux_intel_v6_1es() -> GhRunner {
+    gh_pool_with_image_1es(INTEL_V6_POOL_1ES, LINUX_IMAGE_AMD64)
 }
 
-pub fn linux_mshv_1es() -> GhRunner {
-    gh_pool_with_image_1es(INTEL_POOL_1ES, MSHV_IMAGE_AMD64)
+pub fn linux_amd_v7_1es() -> GhRunner {
+    gh_pool_with_image_1es(AMD_V7_POOL_1ES, LINUX_IMAGE_AMD64)
+}
+
+pub fn linux_mshv_intel_v5_1es() -> GhRunner {
+    gh_pool_with_image_1es(INTEL_V5_POOL_1ES, MSHV_IMAGE_AMD64)
 }
 
 pub fn windows_x64_gh() -> GhRunner {
@@ -93,9 +100,9 @@ pub fn windows_snp_self_hosted_baremetal() -> GhRunner {
 }
 
 pub fn default_windows() -> GhRunner {
-    windows_amd_1es()
+    windows_intel_v6_1es()
 }
 
 pub fn default_linux() -> GhRunner {
-    linux_amd_1es()
+    linux_amd_v7_1es()
 }

--- a/flowey/flowey_lib_hvlite/src/_jobs/cfg_versions.rs
+++ b/flowey/flowey_lib_hvlite/src/_jobs/cfg_versions.rs
@@ -30,8 +30,8 @@ pub const NODEJS: &str = "24.x";
 // N.B. Kernel version numbers for dev and stable branches are not directly
 //      comparable. They originate from separate branches, and the fourth digit
 //      increases with each release from the respective branch.
-pub const OPENHCL_KERNEL_DEV_VERSION: &str = "6.18.0.6";
-pub const OPENHCL_KERNEL_STABLE_VERSION: &str = "6.18.0.6";
+pub const OPENHCL_KERNEL_DEV_VERSION: &str = "6.18.0.7";
+pub const OPENHCL_KERNEL_STABLE_VERSION: &str = "6.18.0.7";
 pub const OPENVMM_DEPS: &str = "0.3.0-101";
 pub const PROTOC: &str = "27.1";
 

--- a/nix/openhcl_kernel.nix
+++ b/nix/openhcl_kernel.nix
@@ -1,7 +1,7 @@
 { system, stdenv, fetchzip, targetArch ? null, is_dev ? false, is_cvm ? false }:
 
 let
-  version = if is_dev then "6.18.0.6" else "6.18.0.6";
+  version = if is_dev then "6.18.0.7" else "6.18.0.7";
   # Allow explicit override of architecture, otherwise derive from host system
   # Note: targetArch uses "x86_64"/"aarch64", but URLs use "x64"/"arm64"
   arch = if targetArch == "x86_64" then "x64"
@@ -18,21 +18,21 @@ let
   hashes = {
     hcl-main = {
       std = {
-        x64 = "sha256-j2ED/aSHpqQ0LFMUf0DS9Vhb/PfOoaUq0I6pt1ALIBo=";
-        arm64 = "sha256-NG4Lsf8EXiWh2h9vFjxQvtiuPOGrWxNcHfbcUxrDmBk=";
+        x64 = "sha256-OPgJGihkrdJtoZhOdRRct55exP2HY8qepUuQqnmZdKQ=";
+        arm64 = "sha256-s49kGBGhDY3muXA6FjjztoNXjfzOdtEXnHR4LLnqY+c=";
       };
       cvm = {
-        x64 = "sha256-NJE1O56L0NWmPswGz7Po2vG8E5ifR8/uT+zTB0gz5iI=";
+        x64 = "sha256-/T7D4lcl30q3GNsbZ1XdGlLxfdrlzUeJ8k3vA40xa1k=";
         arm64 = throw "openhcl-kernel: cvm arm64 variant not available";
       };
     };
     hcl-dev = {
       std = {
-        x64 = "sha256-+gGo/niYk5OUX7LuNEJAv+IVh8l6GbOghWe9sXmzJZ0=";
-        arm64 = "sha256-2te4dN1yasAQ+L/E9/RjaTOzn/uwOy0VvjHoTpLqLhQ=";
+        x64 = "sha256-PUqcTMu52LCQzemRJLaf2xcpyTuA0EHIzXHqzmSq+2A=";
+        arm64 = "sha256-B/rTpIr9ZbBbxhCt9vdoz5K01rN0bZ9E6/P4q2nrxNo=";
       };
       cvm = {
-        x64 = "sha256-GAWE3Il9aZH0rTvrYh4s5BCD07MjKuuLTi1XeAG1LBc=";
+        x64 = "sha256-L+VF1NdQhzTU1T8K8NPP66XIJeKrj15oEw0eQjpzRpg=";
         arm64 = throw "openhcl-kernel: dev cvm arm64 variant not available";
       };
     };

--- a/openhcl/underhill_core/src/worker.rs
+++ b/openhcl/underhill_core/src/worker.rs
@@ -3416,11 +3416,9 @@ async fn new_underhill_vm(
                 vmm_core::device_builder::PciDeviceResolveContext {
                     driver_source: &driver_source,
                     resolver: &resolver,
-                    guest_memory: device_memory,
                     resource,
                     doorbell_registration: None,
                     shared_mem_mapper: None,
-                    software_iommu: false,
                 },
                 vmbus.control(),
                 &chipset_builder,
@@ -3429,6 +3427,7 @@ async fn new_underhill_vm(
                     vtom,
                     vnode: None,
                 },
+                device_memory.clone(),
                 |device_id| {
                     let device = partition
                         .new_virtual_device()

--- a/openvmm/openvmm_core/src/worker/dispatch.rs
+++ b/openvmm/openvmm_core/src/worker/dispatch.rs
@@ -65,8 +65,8 @@ use openvmm_defs::config::HypervisorConfig;
 use openvmm_defs::config::LoadMode;
 use openvmm_defs::config::NumaTopology;
 use openvmm_defs::config::PcieDeviceConfig;
+use openvmm_defs::config::PciePortConfig;
 use openvmm_defs::config::PcieRootComplexConfig;
-use openvmm_defs::config::PcieRootPortConfig;
 use openvmm_defs::config::PcieSwitchConfig;
 use openvmm_defs::config::PmuGsivConfig;
 use openvmm_defs::config::ProcessorTopologyConfig;
@@ -89,9 +89,9 @@ use pal_async::task::Spawn;
 use pal_async::task::Task;
 use pci_core::PciInterruptPin;
 use pci_core::spec::caps::acs::DEFAULT_ACS_CAP_MASK;
+use pcie::GenericPciePortDefinition;
 use pcie::PciePortSettings;
 use pcie::root::GenericPcieRootComplex;
-use pcie::root::GenericPcieRootPortDefinition;
 use pcie::switch::GenericPcieSwitch;
 use scsi_core::ResolveScsiDeviceHandleParams;
 use scsidisk::SimpleScsiDisk;
@@ -857,7 +857,7 @@ fn convert_vtl2_config(
 ///
 /// When CXL is enabled, emit a default Flex Bus capability advertising both
 /// cache and memory support.
-fn build_root_port_settings(rp_cfg: &PcieRootPortConfig) -> PciePortSettings {
+fn build_root_port_settings(rp_cfg: &PciePortConfig) -> PciePortSettings {
     PciePortSettings {
         acs_capabilities_supported: rp_cfg
             .acs_capabilities_supported
@@ -871,11 +871,12 @@ fn build_root_port_settings(rp_cfg: &PcieRootPortConfig) -> PciePortSettings {
 }
 
 /// Converts a manifest root-port entry into the runtime root-port definition.
-fn build_root_port_definition(rp_cfg: &PcieRootPortConfig) -> GenericPcieRootPortDefinition {
+fn build_root_port_definition(rp_cfg: &PciePortConfig) -> GenericPciePortDefinition {
     let settings = build_root_port_settings(rp_cfg);
 
-    GenericPcieRootPortDefinition {
+    GenericPciePortDefinition {
         name: rp_cfg.name.as_str().into(),
+        devfn: rp_cfg.devfn,
         hotplug: rp_cfg.hotplug,
         settings,
     }
@@ -2143,18 +2144,16 @@ impl InitializedVm {
             let switch_device = chipset_builder
                 .arc_mutex_device(device_name)
                 .on_pcie_port(vmotherboard::BusId::new(&switch.parent_port))
-                .add(|_services| {
+                .try_add(|_services| {
+                    let downstream_ports = switch
+                        .ports
+                        .iter()
+                        .map(build_root_port_definition)
+                        .collect();
                     let definition = pcie::switch::GenericPcieSwitchDefinition {
                         name: switch.name.clone().into(),
-                        downstream_port_count: switch.num_downstream_ports,
-                        hotplug: switch.hotplug,
+                        downstream_ports,
                         msi_target,
-                        dsp_settings: PciePortSettings {
-                            acs_capabilities_supported: switch
-                                .acs_capabilities_supported
-                                .unwrap_or(DEFAULT_ACS_CAP_MASK),
-                            cxl_flex_bus_port_capability: None,
-                        },
                     };
                     GenericPcieSwitch::new(definition)
                 })?;

--- a/openvmm/openvmm_core/src/worker/dispatch.rs
+++ b/openvmm/openvmm_core/src/worker/dispatch.rs
@@ -2001,7 +2001,7 @@ impl InitializedVm {
                 // (start_bus << 8) | devfn.
                 let rc_bus_range = pci_core::bus_range::AssignedBusRange::new();
                 rc_bus_range.set_bus_range(rc.start_bus, rc.end_bus);
-                let msi_conn = pci_core::msi::MsiConnection::new(rc_bus_range, 0);
+                let msi_conn = pci_core::msi::MsiConnection::new();
 
                 // When the AMD IOMMU is enabled for this root complex,
                 // reserve device 0 for the IOMMU RCiEP and start root
@@ -2029,7 +2029,10 @@ impl InitializedVm {
                                 rc.start_bus..=rc.end_bus,
                                 ranges.ecam_range,
                             )
-                            .root_ports(root_port_definitions, msi_conn.target())
+                            .root_ports(
+                                root_port_definitions,
+                                &msi_conn.msi_target(rc_bus_range, 0),
+                            )
                             .first_port_device_number(root_port_start_device)
                             .chbcr_range(chbcr_range)
                             .build()
@@ -2129,8 +2132,7 @@ impl InitializedVm {
             let parent_segment = parent_port_info.segment;
             let parent_rc_idx = parent_port_info.rc_idx;
 
-            let msi_conn =
-                pci_core::msi::MsiConnection::new(pci_core::bus_range::AssignedBusRange::new(), 0);
+            let msi_conn = pci_core::msi::MsiConnection::new();
 
             // Defer MSI wiring to after IOMMU setup.
             let msi_target = msi_conn.target().clone();
@@ -2341,7 +2343,7 @@ impl InitializedVm {
                     )
                 })?;
 
-                let msi_conn = pci_core::msi::MsiConnection::new(pi.bus_range.clone(), 0);
+                let msi_conn = pci_core::msi::MsiConnection::new();
 
                 let pcie_ctx =
                     pcie_wiring::build_device_wiring(pcie_wiring::PcieDeviceWiringParams {
@@ -2354,6 +2356,7 @@ impl InitializedVm {
                         },
                         guest_memory: gm,
                         bus_range: &pi.bus_range,
+                        msi: &msi_conn,
                         #[cfg(guest_arch = "aarch64")]
                         smmu: smmu_states[pi.rc_idx].as_ref(),
                     });
@@ -2362,17 +2365,15 @@ impl InitializedVm {
                     vmm_core::device_builder::PciDeviceResolveContext {
                         driver_source,
                         resolver,
-                        guest_memory: &pcie_ctx.guest_memory,
                         resource: dev_cfg.resource,
                         doorbell_registration: partition
                             .clone()
                             .into_doorbell_registration(Vtl::Vtl0),
                         shared_mem_mapper: Some(mapper),
-                        software_iommu: pcie_ctx.software_iommu,
                     },
                     chipset_builder,
                     port_name.clone(),
-                    msi_conn.target(),
+                    &pcie_ctx.dma_target,
                 )
                 .await?;
 
@@ -2571,13 +2572,11 @@ impl InitializedVm {
                         vmm_core::device_builder::PciDeviceResolveContext {
                             driver_source: &driver_source,
                             resolver: &resolver,
-                            guest_memory: &gm,
                             resource: dev_cfg.resource,
                             doorbell_registration: partition
                                 .clone()
                                 .into_doorbell_registration(vtl),
                             shared_mem_mapper: Some(&mapper),
-                            software_iommu: false,
                         },
                         vmbus.control(),
                         &chipset_builder,
@@ -2590,6 +2589,7 @@ impl InitializedVm {
                                 .transpose()
                                 .context("vpci device vnode exceeds 65535")?,
                         },
+                        gm.clone(),
                         |device_id| {
                             let hv_device = partition.new_virtual_device(
                                 match dev_cfg.vtl {
@@ -3542,7 +3542,7 @@ impl LoadedVm {
                                 .bus_range;
 
                             let segment = self.inner.pcie_host_bridges[rc_idx].segment;
-                            let msi_conn = pci_core::msi::MsiConnection::new(bus_range.clone(), 0);
+                            let msi_conn = pci_core::msi::MsiConnection::new();
 
                             let pcie_ctx = pcie_wiring::build_device_wiring(
                                 pcie_wiring::PcieDeviceWiringParams {
@@ -3555,6 +3555,7 @@ impl LoadedVm {
                                     },
                                     guest_memory: &self.inner.gm,
                                     bus_range: &bus_range,
+                                    msi: &msi_conn,
                                     #[cfg(guest_arch = "aarch64")]
                                     smmu: self.inner.smmu_shared_states[rc_idx].as_ref(),
                                 },
@@ -3569,13 +3570,11 @@ impl LoadedVm {
                                         .resolve(
                                             resource,
                                             pci_resources::ResolvePciDeviceHandleParams {
-                                                msi_target: msi_conn.target(),
+                                                dma_target: &pcie_ctx.dma_target,
                                                 register_mmio,
                                                 driver_source: &self.inner.driver_source,
-                                                guest_memory: &pcie_ctx.guest_memory,
                                                 doorbell_registration: self.inner.partition.clone().into_doorbell_registration(Vtl::Vtl0),
                                                 shared_mem_mapper: None,
-                                                software_iommu: pcie_ctx.software_iommu,
                                             },
                                         )
                                         .await

--- a/openvmm/openvmm_core/src/worker/dispatch/amd_iommu_wiring.rs
+++ b/openvmm/openvmm_core/src/worker/dispatch/amd_iommu_wiring.rs
@@ -104,9 +104,13 @@ pub(super) fn setup_amd_iommu(
 
         let iommu_bus_range = pci_core::bus_range::AssignedBusRange::new();
         iommu_bus_range.set_bus_range(hb.start_bus, hb.start_bus);
-        let iommu_msi_conn = pci_core::msi::MsiConnection::new(iommu_bus_range, 0);
+        let iommu_msi_conn = pci_core::msi::MsiConnection::new();
         let iommu_dev = builder.add(|_services| {
-            amd_iommu::AmdIommuDevice::new(gm.clone(), iommu_config, iommu_msi_conn.target())
+            amd_iommu::AmdIommuDevice::new(
+                gm.clone(),
+                iommu_config,
+                &iommu_msi_conn.msi_target(iommu_bus_range, 0),
+            )
         })?;
         if let Some(signal_msi) = partition.as_signal_msi(Vtl::Vtl0) {
             iommu_msi_conn.connect(signal_msi);

--- a/openvmm/openvmm_core/src/worker/dispatch/pcie_wiring.rs
+++ b/openvmm/openvmm_core/src/worker/dispatch/pcie_wiring.rs
@@ -16,6 +16,7 @@
 use crate::partition::HvlitePartition;
 use guestmem::GuestMemory;
 use hvdef::Vtl;
+use pci_core::dma::DmaTarget;
 use std::sync::Arc;
 use vm_topology::processor::ProcessorTopology;
 
@@ -119,27 +120,25 @@ pub(super) struct PcieDeviceWiringParams<'a> {
     pub msi_platform: PcieMsiPlatform<'a>,
     /// Raw guest memory (wrapped with IOMMU DMA translation when applicable).
     pub guest_memory: &'a GuestMemory,
-    /// The device's assigned bus range (for IOMMU stream/device ID).
+    /// The device's assigned bus range (for IOMMU stream/device ID and the
+    /// MSI/DMA requester identity).
     pub bus_range: &'a pci_core::bus_range::AssignedBusRange,
+    /// The device's MSI connection, providing the late-bound MSI backend.
+    pub msi: &'a pci_core::msi::MsiConnection,
     /// SMMU shared state if this device is behind an SMMU, or `None`.
     #[cfg(guest_arch = "aarch64")]
     pub smmu: Option<&'a Arc<smmu::SmmuSharedState>>,
 }
 
-/// The layered GuestMemory and MSI routing for a PCIe device.
+/// The layered DMA target and MSI routing for a PCIe device.
 ///
-/// Produced by [`build_device_wiring`]. Extends [`PcieMsiRouting`] with
-/// IOMMU DMA translation and a `software_iommu` flag.
+/// Produced by [`build_device_wiring`]. Pairs a [`DmaTarget`] (guest memory
+/// + MSI identity + optional IOMMU) with the wrapped [`PcieMsiRouting`].
 pub(super) struct PcieDeviceWiring {
-    /// Guest memory for the device — either the raw memory or an
-    /// IOMMU-translating wrapper.
-    pub guest_memory: GuestMemory,
+    /// DMA and MSI target for the device, including any IOMMU translation.
+    pub dma_target: DmaTarget,
     /// Wrapped MSI routing for the device.
     pub msi: PcieMsiRouting,
-    /// Whether the device is behind a software IOMMU (e.g., emulated
-    /// SMMU or AMD IOMMU) that cannot program the host IOMMU for
-    /// passthrough DMA.
-    pub software_iommu: bool,
 }
 
 impl PcieDeviceWiring {
@@ -149,11 +148,11 @@ impl PcieDeviceWiring {
     }
 }
 
-/// Build the layered GuestMemory and MSI routing for a PCIe device.
+/// Build the layered DMA target and MSI routing for a PCIe device.
 ///
 /// Calls [`PcieMsiPlatform::wrap_msi`] for MSI/IrqFd wrapping, then
 /// adds IOMMU DMA translation (SMMU on aarch64, AMD IOMMU on x86_64)
-/// to produce the device's `GuestMemory`.
+/// to produce the device's [`DmaTarget`].
 pub(super) fn build_device_wiring(params: PcieDeviceWiringParams<'_>) -> PcieDeviceWiring {
     let msi = params.msi_platform.wrap_msi();
 
@@ -166,12 +165,13 @@ pub(super) fn build_device_wiring(params: PcieDeviceWiringParams<'_>) -> PcieDev
     // availability.
     #[cfg(guest_arch = "aarch64")]
     if let Some(shared) = params.smmu {
-        let translator = shared.translator(0);
-        let translating_gm = iommu_common::TranslatingMemory::new_guest_memory(
-            "smmu-translating",
-            translator,
+        let dma_target = iommu_common::new_dma_target(
+            "smmu",
+            shared.translator(0),
             params.bus_range.clone(),
+            0,
             params.guest_memory.clone(),
+            params.msi,
         );
         let smmu_msi = msi.signal_msi.map(|inner_msi| {
             Arc::new(smmu::SmmuSignalMsi::new(shared.clone(), 0, inner_msi))
@@ -181,12 +181,11 @@ pub(super) fn build_device_wiring(params: PcieDeviceWiringParams<'_>) -> PcieDev
             .irqfd
             .map(|fd| shared.wrap_irqfd(0, fd) as Arc<dyn vmcore::irqfd::IrqFd>);
         return PcieDeviceWiring {
-            guest_memory: translating_gm,
+            dma_target,
             msi: PcieMsiRouting {
                 signal_msi: smmu_msi,
                 irqfd,
             },
-            software_iommu: true,
         };
     }
 
@@ -194,23 +193,26 @@ pub(super) fn build_device_wiring(params: PcieDeviceWiringParams<'_>) -> PcieDev
     // MSI interrupt remapping was already applied by wrap_msi().
     #[cfg(guest_arch = "x86_64")]
     if let Some(shared) = params.msi_platform.iommu {
-        let translator = shared.translator();
-        let translating_gm = iommu_common::TranslatingMemory::new_guest_memory(
-            "amd-iommu-translating",
-            translator,
-            params.bus_range.clone(),
-            params.guest_memory.clone(),
-        );
         return PcieDeviceWiring {
-            guest_memory: translating_gm,
+            dma_target: iommu_common::new_dma_target(
+                "amd-iommu",
+                shared.translator(),
+                params.bus_range.clone(),
+                0,
+                params.guest_memory.clone(),
+                params.msi,
+            ),
             msi,
-            software_iommu: true,
         };
     }
 
     PcieDeviceWiring {
-        guest_memory: params.guest_memory.clone(),
+        dma_target: DmaTarget::new(
+            params.bus_range.clone(),
+            0,
+            params.guest_memory.clone(),
+            params.msi,
+        ),
         msi,
-        software_iommu: false,
     }
 }

--- a/openvmm/openvmm_defs/src/config.rs
+++ b/openvmm/openvmm_defs/src/config.rs
@@ -217,7 +217,7 @@ pub struct PcieRootComplexConfig {
     pub end_bus: u8,
     pub low_mmio: PcieMmioRangeConfig,
     pub high_mmio: PcieMmioRangeConfig,
-    pub ports: Vec<PcieRootPortConfig>,
+    pub ports: Vec<PciePortConfig>,
     /// Optional CXL configuration for root-complex CXL mode.
     pub cxl: Option<RootComplexCxlConfig>,
     /// Optional IOMMU for this root complex.
@@ -231,15 +231,26 @@ pub struct PcieRootComplexConfig {
     pub preserve_bars: bool,
 }
 
+/// Configuration for a single PCIe port — either a root-complex root port or a
+/// switch downstream port.
 #[derive(Debug, MeshPayload)]
-pub struct PcieRootPortConfig {
-    /// Root-port name used for topology wiring and lookup.
+pub struct PciePortConfig {
+    /// Port name used for topology wiring and lookup.
     pub name: String,
-    /// Enables PCIe hotplug capabilities for this root port.
+    /// The device/function (`device << 3 | function`) to place this port at on
+    /// its bus.
+    ///
+    /// When `None`, the port is assigned the lowest available devfn. Ports are
+    /// assigned in order, so an explicit devfn that collides with a
+    /// previously-assigned port (including one assigned automatically) is an
+    /// error. Honored for both root-complex root ports and switch downstream
+    /// ports.
+    pub devfn: Option<u8>,
+    /// Enables PCIe hotplug capabilities for this port.
     pub hotplug: bool,
-    /// Optional ACS capability bitmask to expose on this root port.
+    /// Optional ACS capability bitmask to expose on this port.
     pub acs_capabilities_supported: Option<u16>,
-    /// Marks this root port as CXL-capable.
+    /// Marks this port as CXL-capable.
     ///
     /// Runtime port construction derives required BAR/subregion layout from
     /// this flag (currently CXL component registers for BAR0).
@@ -249,10 +260,9 @@ pub struct PcieRootPortConfig {
 #[derive(Debug, MeshPayload)]
 pub struct PcieSwitchConfig {
     pub name: String,
-    pub num_downstream_ports: u8,
     pub parent_port: String,
-    pub hotplug: bool,
-    pub acs_capabilities_supported: Option<u16>,
+    /// The downstream ports of this switch.
+    pub ports: Vec<PciePortConfig>,
 }
 
 /// Declares that the device directly behind a named PCIe port (a root port or

--- a/openvmm/openvmm_entry/src/cli_args.rs
+++ b/openvmm/openvmm_entry/src/cli_args.rs
@@ -1064,9 +1064,17 @@ Examples:
     # Attach root port rc0rp1 to root complex rc0 with hotplug support
     --pcie-root-port rc0:rc0rp1,hotplug
 
+    # Attach root port rc0rp2 at device 5, function 0
+    --pcie-root-port rc0:rc0rp2,addr=5
+
+    # Attach root port rc0rp3 at device 5, function 1
+    --pcie-root-port rc0:rc0rp3,addr=5.1
+
 Syntax: <root_complex_name>:<name>[,opt,opt=arg,...]
 
 Options:
+    `addr=<dev>[.<fn>]`            device/function to place this port at (default:
+                                   lowest available); dev 0-31, fn 0-7
     `hotplug`                      enable hotplug support for this root port
     `acs=<mask>`                   ACS capability bitmask (u16, decimal or 0x-prefixed hex)
     `cxl`                          configure this root port as CXL-capable
@@ -3095,6 +3103,7 @@ fn parse_cxl_cfmws_window_restriction_u16_bitmask(
 pub struct PcieRootPortCli {
     pub root_complex_name: String,
     pub name: String,
+    pub devfn: Option<u8>,
     pub hotplug: bool,
     pub acs_capabilities_supported: Option<u16>,
     pub cxl: bool,
@@ -3118,6 +3127,7 @@ impl FromStr for PcieRootPortCli {
             anyhow::bail!("unexpected token: '{extra}'")
         }
 
+        let mut devfn = None;
         let mut hotplug = false;
         let mut acs_capabilities_supported = None;
         let mut cxl = false;
@@ -3129,6 +3139,13 @@ impl FromStr for PcieRootPortCli {
             let value = kv.next();
 
             match key {
+                "addr" => {
+                    let value = value.context("addr option requires a value")?;
+                    if kv.next().is_some() {
+                        anyhow::bail!("addr option expects a single value")
+                    }
+                    devfn = Some(parse_pcie_addr(value)?);
+                }
                 "hotplug" => {
                     if value.is_some() {
                         anyhow::bail!("hotplug option does not take a value")
@@ -3155,11 +3172,42 @@ impl FromStr for PcieRootPortCli {
         Ok(PcieRootPortCli {
             root_complex_name: rc_name.to_string(),
             name: rp_name.to_string(),
+            devfn,
             hotplug,
             acs_capabilities_supported,
             cxl,
         })
     }
+}
+
+/// Parses a PCIe address of the form `XX[.Y]`, where `XX` is the device number
+/// (0-31) and the optional `Y` is the function number (0-7), into a devfn
+/// (`device << 3 | function`).
+fn parse_pcie_addr(s: &str) -> anyhow::Result<u8> {
+    let parse_int = |v: &str| -> anyhow::Result<u8> {
+        if let Some(hex) = v.strip_prefix("0x").or_else(|| v.strip_prefix("0X")) {
+            u8::from_str_radix(hex, 16).context("invalid hex number")
+        } else {
+            v.parse().context("invalid number")
+        }
+    };
+
+    let mut parts = s.split('.');
+    let device = parse_int(parts.next().context("expected device number")?)?;
+    let function = match parts.next() {
+        Some(f) => parse_int(f)?,
+        None => 0,
+    };
+    if parts.next().is_some() {
+        anyhow::bail!("unexpected token in addr '{s}'");
+    }
+    if device > 31 {
+        anyhow::bail!("device number {device} out of range (0-31)");
+    }
+    if function > 7 {
+        anyhow::bail!("function number {function} out of range (0-7)");
+    }
+    Ok((device << 3) | function)
 }
 
 #[derive(Clone, Debug, PartialEq)]
@@ -4599,6 +4647,7 @@ mod tests {
             PcieRootPortCli {
                 root_complex_name: "rc0".to_string(),
                 name: "rc0rp0".to_string(),
+                devfn: None,
                 hotplug: false,
                 acs_capabilities_supported: None,
                 cxl: false,
@@ -4610,6 +4659,7 @@ mod tests {
             PcieRootPortCli {
                 root_complex_name: "my_rc".to_string(),
                 name: "port2".to_string(),
+                devfn: None,
                 hotplug: false,
                 acs_capabilities_supported: None,
                 cxl: false,
@@ -4622,6 +4672,7 @@ mod tests {
             PcieRootPortCli {
                 root_complex_name: "my_rc".to_string(),
                 name: "port2".to_string(),
+                devfn: None,
                 hotplug: true,
                 acs_capabilities_supported: None,
                 cxl: false,
@@ -4633,6 +4684,7 @@ mod tests {
             PcieRootPortCli {
                 root_complex_name: "my_rc".to_string(),
                 name: "port3".to_string(),
+                devfn: None,
                 hotplug: false,
                 acs_capabilities_supported: Some(0),
                 cxl: false,
@@ -4644,6 +4696,7 @@ mod tests {
             PcieRootPortCli {
                 root_complex_name: "my_rc".to_string(),
                 name: "port3".to_string(),
+                devfn: None,
                 hotplug: false,
                 acs_capabilities_supported: Some(0x005f),
                 cxl: false,
@@ -4655,9 +4708,45 @@ mod tests {
             PcieRootPortCli {
                 root_complex_name: "my_rc".to_string(),
                 name: "port4".to_string(),
+                devfn: None,
                 hotplug: false,
                 acs_capabilities_supported: None,
                 cxl: true,
+            }
+        );
+
+        // Test addr= (device only, and device.function)
+        assert_eq!(
+            PcieRootPortCli::from_str("my_rc:port5,addr=5").unwrap(),
+            PcieRootPortCli {
+                root_complex_name: "my_rc".to_string(),
+                name: "port5".to_string(),
+                devfn: Some(5 << 3),
+                hotplug: false,
+                acs_capabilities_supported: None,
+                cxl: false,
+            }
+        );
+        assert_eq!(
+            PcieRootPortCli::from_str("my_rc:port6,addr=5.1").unwrap(),
+            PcieRootPortCli {
+                root_complex_name: "my_rc".to_string(),
+                name: "port6".to_string(),
+                devfn: Some((5 << 3) | 1),
+                hotplug: false,
+                acs_capabilities_supported: None,
+                cxl: false,
+            }
+        );
+        assert_eq!(
+            PcieRootPortCli::from_str("my_rc:port7,addr=0x1f.7").unwrap(),
+            PcieRootPortCli {
+                root_complex_name: "my_rc".to_string(),
+                name: "port7".to_string(),
+                devfn: Some(0xff),
+                hotplug: false,
+                acs_capabilities_supported: None,
+                cxl: false,
             }
         );
 
@@ -4668,6 +4757,10 @@ mod tests {
         assert!(PcieRootPortCli::from_str("rc0:rp0:rp3").is_err());
         assert!(PcieRootPortCli::from_str("rc0:rp0,invalid_option").is_err());
         assert!(PcieRootPortCli::from_str("rc0:rp0,cxl=true").is_err());
+        assert!(PcieRootPortCli::from_str("rc0:rp0,addr=32").is_err());
+        assert!(PcieRootPortCli::from_str("rc0:rp0,addr=0.8").is_err());
+        assert!(PcieRootPortCli::from_str("rc0:rp0,addr=1.2.3").is_err());
+        assert!(PcieRootPortCli::from_str("rc0:rp0,addr").is_err());
     }
 
     #[test]

--- a/openvmm/openvmm_entry/src/lib.rs
+++ b/openvmm/openvmm_entry/src/lib.rs
@@ -79,8 +79,8 @@ use openvmm_defs::config::NumaNode;
 use openvmm_defs::config::NumaTopology;
 use openvmm_defs::config::PcieDeviceConfig;
 use openvmm_defs::config::PcieMmioRangeConfig;
+use openvmm_defs::config::PciePortConfig;
 use openvmm_defs::config::PcieRootComplexConfig;
-use openvmm_defs::config::PcieRootPortConfig;
 use openvmm_defs::config::PcieSwitchConfig;
 use openvmm_defs::config::ProcessorTopologyConfig;
 use openvmm_defs::config::RootComplexCxlConfig;
@@ -212,10 +212,16 @@ fn build_switch_list(all_switches: &[cli_args::GenericPcieSwitchCli]) -> Vec<Pci
         .iter()
         .map(|switch_cli| PcieSwitchConfig {
             name: switch_cli.name.clone(),
-            num_downstream_ports: switch_cli.num_downstream_ports,
             parent_port: switch_cli.port_name.clone(),
-            hotplug: switch_cli.hotplug,
-            acs_capabilities_supported: switch_cli.acs_capabilities_supported,
+            ports: (0..switch_cli.num_downstream_ports)
+                .map(|i| PciePortConfig {
+                    name: format!("{}-downstream-{}", switch_cli.name, i),
+                    devfn: None,
+                    hotplug: switch_cli.hotplug,
+                    acs_capabilities_supported: switch_cli.acs_capabilities_supported,
+                    cxl: false,
+                })
+                .collect(),
         })
         .collect()
 }
@@ -832,12 +838,13 @@ async fn vm_config_from_command_line(
 
     let mut pcie_root_complexes = Vec::new();
     for (i, rc_cli) in opt.pcie_root_complex.iter().enumerate() {
-        let ports: Vec<PcieRootPortConfig> = opt
+        let ports: Vec<PciePortConfig> = opt
             .pcie_root_port
             .iter()
             .filter(|port_cli| port_cli.root_complex_name == rc_cli.name)
-            .map(|port_cli| PcieRootPortConfig {
+            .map(|port_cli| PciePortConfig {
                 name: port_cli.name.clone(),
+                devfn: port_cli.devfn,
                 hotplug: port_cli.hotplug,
                 acs_capabilities_supported: port_cli.acs_capabilities_supported,
                 cxl: port_cli.cxl,

--- a/petri/logview/package-lock.json
+++ b/petri/logview/package-lock.json
@@ -14,7 +14,7 @@
         "@tanstack/react-virtual": "^3.13.12",
         "react": "^19.2.1",
         "react-dom": "^19.2.1",
-        "react-router-dom": "7.15.0"
+        "react-router-dom": "^7.15.1"
       },
       "devDependencies": {
         "@types/react": "^19.2.7",
@@ -43,13 +43,13 @@
       }
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
-      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.28.5",
+        "@babel/helper-validator-identifier": "^7.29.7",
         "js-tokens": "^4.0.0",
         "picocolors": "^1.1.1"
       },
@@ -58,9 +58,9 @@
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.0.tgz",
-      "integrity": "sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+      "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -68,21 +68,21 @@
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
-      "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+      "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.29.0",
-        "@babel/generator": "^7.29.0",
-        "@babel/helper-compilation-targets": "^7.28.6",
-        "@babel/helper-module-transforms": "^7.28.6",
-        "@babel/helpers": "^7.28.6",
-        "@babel/parser": "^7.29.0",
-        "@babel/template": "^7.28.6",
-        "@babel/traverse": "^7.29.0",
-        "@babel/types": "^7.29.0",
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-compilation-targets": "^7.29.7",
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helpers": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "@jridgewell/remapping": "^2.3.5",
         "convert-source-map": "^2.0.0",
         "debug": "^4.1.0",
@@ -99,14 +99,14 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.29.1",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
-      "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
+      "integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.29.0",
-        "@babel/types": "^7.29.0",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "@jridgewell/gen-mapping": "^0.3.12",
         "@jridgewell/trace-mapping": "^0.3.28",
         "jsesc": "^3.0.2"
@@ -116,14 +116,14 @@
       }
     },
     "node_modules/@babel/helper-compilation-targets": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
-      "integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+      "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/compat-data": "^7.28.6",
-        "@babel/helper-validator-option": "^7.27.1",
+        "@babel/compat-data": "^7.29.7",
+        "@babel/helper-validator-option": "^7.29.7",
         "browserslist": "^4.24.0",
         "lru-cache": "^5.1.1",
         "semver": "^6.3.1"
@@ -133,9 +133,9 @@
       }
     },
     "node_modules/@babel/helper-globals": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
-      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+      "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -143,29 +143,29 @@
       }
     },
     "node_modules/@babel/helper-module-imports": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
-      "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+      "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/traverse": "^7.28.6",
-        "@babel/types": "^7.28.6"
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-module-transforms": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
-      "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+      "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-module-imports": "^7.28.6",
-        "@babel/helper-validator-identifier": "^7.28.5",
-        "@babel/traverse": "^7.28.6"
+        "@babel/helper-module-imports": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -185,9 +185,9 @@
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -195,9 +195,9 @@
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
-      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -205,9 +205,9 @@
       }
     },
     "node_modules/@babel/helper-validator-option": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
-      "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+      "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -215,27 +215,27 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.29.2",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.2.tgz",
-      "integrity": "sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+      "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/template": "^7.28.6",
-        "@babel/types": "^7.29.0"
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.29.2",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
-      "integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.29.0"
+        "@babel/types": "^7.29.7"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -277,33 +277,33 @@
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
-      "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+      "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.28.6",
-        "@babel/parser": "^7.28.6",
-        "@babel/types": "^7.28.6"
+        "@babel/code-frame": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
-      "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.7.tgz",
+      "integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.29.0",
-        "@babel/generator": "^7.29.0",
-        "@babel/helper-globals": "^7.28.0",
-        "@babel/parser": "^7.29.0",
-        "@babel/template": "^7.28.6",
-        "@babel/types": "^7.29.0",
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-globals": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "debug": "^4.3.1"
       },
       "engines": {
@@ -311,459 +311,17 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
-      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.28.5"
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
-      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "aix"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/android-arm": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
-      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/android-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
-      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/android-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
-      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
-      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/darwin-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
-      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
-      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
-      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-arm": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
-      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
-      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-ia32": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
-      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-loong64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
-      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
-      "cpu": [
-        "loong64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
-      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
-      "cpu": [
-        "mips64el"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
-      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
-      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-s390x": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
-      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
-      "cpu": [
-        "s390x"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
-      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
-      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
-      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
-      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
-      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/openharmony-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
-      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openharmony"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/sunos-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
-      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "sunos"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/win32-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
-      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/win32-ia32": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
-      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/win32-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
-      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
       }
     },
     "node_modules/@jridgewell/gen-mapping": {
@@ -1686,48 +1244,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/esbuild": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
-      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "bin": {
-        "esbuild": "bin/esbuild"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.27.7",
-        "@esbuild/android-arm": "0.27.7",
-        "@esbuild/android-arm64": "0.27.7",
-        "@esbuild/android-x64": "0.27.7",
-        "@esbuild/darwin-arm64": "0.27.7",
-        "@esbuild/darwin-x64": "0.27.7",
-        "@esbuild/freebsd-arm64": "0.27.7",
-        "@esbuild/freebsd-x64": "0.27.7",
-        "@esbuild/linux-arm": "0.27.7",
-        "@esbuild/linux-arm64": "0.27.7",
-        "@esbuild/linux-ia32": "0.27.7",
-        "@esbuild/linux-loong64": "0.27.7",
-        "@esbuild/linux-mips64el": "0.27.7",
-        "@esbuild/linux-ppc64": "0.27.7",
-        "@esbuild/linux-riscv64": "0.27.7",
-        "@esbuild/linux-s390x": "0.27.7",
-        "@esbuild/linux-x64": "0.27.7",
-        "@esbuild/netbsd-arm64": "0.27.7",
-        "@esbuild/netbsd-x64": "0.27.7",
-        "@esbuild/openbsd-arm64": "0.27.7",
-        "@esbuild/openbsd-x64": "0.27.7",
-        "@esbuild/openharmony-arm64": "0.27.7",
-        "@esbuild/sunos-x64": "0.27.7",
-        "@esbuild/win32-arm64": "0.27.7",
-        "@esbuild/win32-ia32": "0.27.7",
-        "@esbuild/win32-x64": "0.27.7"
-      }
-    },
     "node_modules/escalade": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
@@ -2392,9 +1908,9 @@
       }
     },
     "node_modules/react-router": {
-      "version": "7.15.0",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.15.0.tgz",
-      "integrity": "sha512-HW9vYwuM8f4yx66Izy8xfrzCM+SBJluoZcCbww9A1TySax11S5Vgw6fi3ZjMONw9J4gQwngL7PzkyIpJJpJ7RQ==",
+      "version": "7.18.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.18.0.tgz",
+      "integrity": "sha512-pTTGt8J+ji1NOmYnjzT+bAJy/1zD+Jp4ziO6cL7T3ZLvXKtusO7BpFqlRXitqpcPVqllsIXFHRMt+2/k3Xn6HQ==",
       "license": "MIT",
       "dependencies": {
         "cookie": "^1.0.1",
@@ -2414,12 +1930,12 @@
       }
     },
     "node_modules/react-router-dom": {
-      "version": "7.15.0",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.15.0.tgz",
-      "integrity": "sha512-VcrVg64Fo8nwBvDscajG8gRTLIuTC6N50nb22l2HOOV4PTOHgoGp8mUjy9wLiHYoYTSYI36tUnXZgasSRFZorQ==",
+      "version": "7.18.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.18.0.tgz",
+      "integrity": "sha512-Fi0yY6kgtKae/Th2xibdWK0KSdYZ4B53Gyf6wRtomOKWgpNm7H7+DyfDhncdz9FKbpS+1jmDhg3F4WoGJ+yFOA==",
       "license": "MIT",
       "dependencies": {
-        "react-router": "7.15.0"
+        "react-router": "7.18.0"
       },
       "engines": {
         "node": ">=20.0.0"
@@ -2803,9 +2319,9 @@
       "license": "MIT"
     },
     "node_modules/vite": {
-      "version": "7.3.2",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.2.tgz",
-      "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.5.tgz",
+      "integrity": "sha512-KuOaNhcnGFN2zIPGA7wRmzF+lJA1sea7rHq17aiJ++9lzY1WWG6Jpwqwe1KNbRVPIqHmr8GLYx7jbrQcN/7/ww==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2875,6 +2391,490 @@
         "yaml": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/esbuild": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.7",
+        "@esbuild/android-arm": "0.27.7",
+        "@esbuild/android-arm64": "0.27.7",
+        "@esbuild/android-x64": "0.27.7",
+        "@esbuild/darwin-arm64": "0.27.7",
+        "@esbuild/darwin-x64": "0.27.7",
+        "@esbuild/freebsd-arm64": "0.27.7",
+        "@esbuild/freebsd-x64": "0.27.7",
+        "@esbuild/linux-arm": "0.27.7",
+        "@esbuild/linux-arm64": "0.27.7",
+        "@esbuild/linux-ia32": "0.27.7",
+        "@esbuild/linux-loong64": "0.27.7",
+        "@esbuild/linux-mips64el": "0.27.7",
+        "@esbuild/linux-ppc64": "0.27.7",
+        "@esbuild/linux-riscv64": "0.27.7",
+        "@esbuild/linux-s390x": "0.27.7",
+        "@esbuild/linux-x64": "0.27.7",
+        "@esbuild/netbsd-arm64": "0.27.7",
+        "@esbuild/netbsd-x64": "0.27.7",
+        "@esbuild/openbsd-arm64": "0.27.7",
+        "@esbuild/openbsd-x64": "0.27.7",
+        "@esbuild/openharmony-arm64": "0.27.7",
+        "@esbuild/sunos-x64": "0.27.7",
+        "@esbuild/win32-arm64": "0.27.7",
+        "@esbuild/win32-ia32": "0.27.7",
+        "@esbuild/win32-x64": "0.27.7"
       }
     },
     "node_modules/vite/node_modules/fdir": {

--- a/petri/logview/package.json
+++ b/petri/logview/package.json
@@ -5,7 +5,7 @@
     "@tanstack/react-virtual": "^3.13.12",
     "react": "^19.2.1",
     "react-dom": "^19.2.1",
-    "react-router-dom": "7.15.0"
+    "react-router-dom": "7.18.0"
   },
   "devDependencies": {
     "@types/react": "^19.2.7",

--- a/petri/src/vm/openvmm/modify.rs
+++ b/petri/src/vm/openvmm/modify.rs
@@ -27,8 +27,8 @@ use openvmm_defs::config::LoadMode;
 use openvmm_defs::config::PcieDeviceConfig;
 use openvmm_defs::config::PcieIommuConfig;
 use openvmm_defs::config::PcieMmioRangeConfig;
+use openvmm_defs::config::PciePortConfig;
 use openvmm_defs::config::PcieRootComplexConfig;
-use openvmm_defs::config::PcieRootPortConfig;
 use openvmm_defs::config::PcieSwitchConfig;
 use openvmm_defs::config::VpciDeviceConfig;
 use openvmm_defs::config::Vtl2BaseAddressType;
@@ -376,8 +376,9 @@ impl PetriVmConfigOpenVmm {
                 let end_bus = start_bus + bus_count_per_rc - 1;
 
                 let ports = (0..root_ports_per_root_complex)
-                    .map(|i| PcieRootPortConfig {
+                    .map(|i| PciePortConfig {
                         name: format!("s{}rc{}rp{}", segment, rc_index_in_segment, i),
+                        devfn: None,
                         hotplug: true,
                         acs_capabilities_supported: Some(0),
                         cxl: false,
@@ -418,10 +419,16 @@ impl PetriVmConfigOpenVmm {
     ) -> Self {
         self.config.pcie_switches.push(PcieSwitchConfig {
             name: switch_name.to_string(),
-            num_downstream_ports: port_count,
             parent_port: port_name.to_string(),
-            hotplug,
-            acs_capabilities_supported: Some(0),
+            ports: (0..port_count)
+                .map(|i| PciePortConfig {
+                    name: format!("{switch_name}-downstream-{i}"),
+                    devfn: None,
+                    hotplug,
+                    acs_capabilities_supported: Some(0),
+                    cxl: false,
+                })
+                .collect(),
         });
         self
     }

--- a/vm/devices/iommu/amd_iommu/src/lib.rs
+++ b/vm/devices/iommu/amd_iommu/src/lib.rs
@@ -888,6 +888,7 @@ impl IommuSharedState {
 /// One `AmdTranslator` is shared by all PCI devices behind the same IOMMU.
 /// The requester ID (RID / BDF) is passed at each translation call and
 /// used directly as the AMD IOMMU DeviceID.
+#[derive(Clone)]
 pub struct AmdTranslator {
     /// Reference to the shared IOMMU state.
     shared: Arc<IommuSharedState>,
@@ -1664,6 +1665,7 @@ impl MmioIntercept for AmdIommuDevice {
 mod tests {
     use super::*;
     use guestmem::GuestMemory;
+    use pci_core::bus_range::AssignedBusRange;
     use spec::commands::CommandEntry;
     use spec::dte::IntCtl;
     use spec::events::EventCode;
@@ -1688,9 +1690,8 @@ mod tests {
 
     fn create_test_device() -> AmdIommuDevice {
         let guest_memory = GuestMemory::empty();
-        let msi_conn =
-            pci_core::msi::MsiConnection::new(pci_core::bus_range::AssignedBusRange::new(), 0);
-        AmdIommuDevice::new(guest_memory, test_config(), msi_conn.target())
+        let msi_conn = pci_core::msi::MsiConnection::new();
+        AmdIommuDevice::new(guest_memory, test_config(), &msi_conn.target())
     }
 
     /// Helper to read a 32-bit PCI config register.
@@ -2126,9 +2127,8 @@ mod tests {
     ///   0x2000..0x2FFF = scratch space (for COMPLETION_WAIT store data)
     fn create_test_device_with_memory() -> AmdIommuDevice {
         let guest_memory = GuestMemory::allocate(0x10000);
-        let msi_conn =
-            pci_core::msi::MsiConnection::new(pci_core::bus_range::AssignedBusRange::new(), 0);
-        AmdIommuDevice::new(guest_memory, test_config(), msi_conn.target())
+        let msi_conn = pci_core::msi::MsiConnection::new();
+        AmdIommuDevice::new(guest_memory, test_config(), &msi_conn.target())
     }
 
     /// Configure and enable the IOMMU with command buffer and event log.
@@ -2381,11 +2381,10 @@ mod tests {
         // Create device with a connected MSI controller to verify actual
         // MSI delivery (not just status bit).
         let guest_memory = GuestMemory::allocate(0x10000);
-        let msi_conn =
-            pci_core::msi::MsiConnection::new(pci_core::bus_range::AssignedBusRange::new(), 0);
+        let msi_conn = pci_core::msi::MsiConnection::new();
         let msi_controller = pci_core::test_helpers::TestPciInterruptController::new();
         msi_conn.connect(msi_controller.signal_msi());
-        let mut dev = AmdIommuDevice::new(guest_memory, test_config(), msi_conn.target());
+        let mut dev = AmdIommuDevice::new(guest_memory, test_config(), &msi_conn.target());
 
         // Enable MSI on the IOMMU's PCI config space.
         // The MSI capability is the second capability. Find its offset.
@@ -2649,9 +2648,8 @@ mod tests {
     /// page tables (1MB).
     fn create_test_device_for_translation() -> AmdIommuDevice {
         let guest_memory = GuestMemory::allocate(0x10_0000); // 1MB
-        let msi_conn =
-            pci_core::msi::MsiConnection::new(pci_core::bus_range::AssignedBusRange::new(), 0);
-        AmdIommuDevice::new(guest_memory, test_config(), msi_conn.target())
+        let msi_conn = pci_core::msi::MsiConnection::new();
+        AmdIommuDevice::new(guest_memory, test_config(), &msi_conn.target())
     }
 
     /// Set up the IOMMU with a device table at a given GPA.
@@ -4513,9 +4511,8 @@ mod tests {
     #[test]
     fn test_remap_msi_iommu_disabled() {
         let guest_memory = GuestMemory::allocate(0x10_0000);
-        let msi_conn =
-            pci_core::msi::MsiConnection::new(pci_core::bus_range::AssignedBusRange::new(), 0);
-        let dev = AmdIommuDevice::new(guest_memory, test_config(), msi_conn.target());
+        let msi_conn = pci_core::msi::MsiConnection::new();
+        let dev = AmdIommuDevice::new(guest_memory, test_config(), &msi_conn.target());
 
         // IOMMU not enabled — MSI should pass through unchanged.
         let (new_addr, new_data) = dev.remap_msi(0x10, 0xFEE0_0000, 0x30).unwrap();
@@ -4619,15 +4616,15 @@ mod tests {
     const WRAPPER_BUS: u8 = 1;
     const WRAPPER_DEVICE_ID: u16 = (WRAPPER_BUS as u16) << 8;
 
-    fn bus_range_for_device_id(device_id: u16) -> pci_core::bus_range::AssignedBusRange {
+    fn bus_range_for_device_id(device_id: u16) -> AssignedBusRange {
         assert_eq!(device_id & 0xFF, 0, "test DeviceID must be dev 0 fn 0");
         let bus = (device_id >> 8) as u8;
-        let bus_range = pci_core::bus_range::AssignedBusRange::new();
+        let bus_range = AssignedBusRange::new();
         bus_range.set_bus_range(bus, bus);
         bus_range
     }
 
-    fn wrapper_bus_range() -> pci_core::bus_range::AssignedBusRange {
+    fn wrapper_bus_range() -> AssignedBusRange {
         bus_range_for_device_id(WRAPPER_DEVICE_ID)
     }
 
@@ -4635,9 +4632,8 @@ mod tests {
     /// for testing per-device wrappers. Returns the device and shared state.
     fn setup_iommu_for_wrappers() -> AmdIommuDevice {
         let guest_memory = GuestMemory::allocate(0x10_0000); // 1MB
-        let msi_conn =
-            pci_core::msi::MsiConnection::new(pci_core::bus_range::AssignedBusRange::new(), 0);
-        let mut dev = AmdIommuDevice::new(guest_memory, test_config(), msi_conn.target());
+        let msi_conn = pci_core::msi::MsiConnection::new();
+        let mut dev = AmdIommuDevice::new(guest_memory, test_config(), &msi_conn.target());
 
         let devtab_gpa = 0x1_0000;
         setup_iommu_with_devtab(&mut dev, devtab_gpa, 512);
@@ -4698,7 +4694,7 @@ mod tests {
     /// remapping.
     fn device_context(
         shared: &Arc<IommuSharedState>,
-        bus_range: pci_core::bus_range::AssignedBusRange,
+        bus_range: AssignedBusRange,
         inner_gm: &GuestMemory,
         inner_msi: Arc<dyn SignalMsi>,
     ) -> (GuestMemory, Arc<IommuSignalMsi>) {
@@ -4763,9 +4759,8 @@ mod tests {
     #[test]
     fn test_translating_memory_passthrough() {
         let guest_memory = GuestMemory::allocate(0x10_0000);
-        let msi_conn =
-            pci_core::msi::MsiConnection::new(pci_core::bus_range::AssignedBusRange::new(), 0);
-        let mut dev = AmdIommuDevice::new(guest_memory, test_config(), msi_conn.target());
+        let msi_conn = pci_core::msi::MsiConnection::new();
+        let mut dev = AmdIommuDevice::new(guest_memory, test_config(), &msi_conn.target());
 
         let devtab_gpa = 0x1_0000;
         setup_iommu_with_devtab(&mut dev, devtab_gpa, 512);
@@ -4814,9 +4809,8 @@ mod tests {
     #[test]
     fn test_translating_memory_disabled_bypass() {
         let guest_memory = GuestMemory::allocate(0x10_0000);
-        let msi_conn =
-            pci_core::msi::MsiConnection::new(pci_core::bus_range::AssignedBusRange::new(), 0);
-        let dev = AmdIommuDevice::new(guest_memory, test_config(), msi_conn.target());
+        let msi_conn = pci_core::msi::MsiConnection::new();
+        let dev = AmdIommuDevice::new(guest_memory, test_config(), &msi_conn.target());
         // IOMMU not enabled — all accesses should pass through.
 
         let shared = dev.shared_state().clone();
@@ -4861,9 +4855,8 @@ mod tests {
     #[test]
     fn test_signal_msi_iommu_disabled() {
         let guest_memory = GuestMemory::allocate(0x10_0000);
-        let msi_conn =
-            pci_core::msi::MsiConnection::new(pci_core::bus_range::AssignedBusRange::new(), 0);
-        let dev = AmdIommuDevice::new(guest_memory, test_config(), msi_conn.target());
+        let msi_conn = pci_core::msi::MsiConnection::new();
+        let dev = AmdIommuDevice::new(guest_memory, test_config(), &msi_conn.target());
 
         let shared = dev.shared_state().clone();
         let mock_msi = MockSignalMsi::new();
@@ -4978,9 +4971,8 @@ mod tests {
         // =====================================================================
 
         let guest_memory = GuestMemory::allocate(0x20_0000); // 2MB
-        let msi_conn =
-            pci_core::msi::MsiConnection::new(pci_core::bus_range::AssignedBusRange::new(), 0);
-        let mut dev = AmdIommuDevice::new(guest_memory, test_config(), msi_conn.target());
+        let msi_conn = pci_core::msi::MsiConnection::new();
+        let mut dev = AmdIommuDevice::new(guest_memory, test_config(), &msi_conn.target());
 
         let devtab_gpa: u64 = 0x00_0000;
         let cmdbuf_gpa: u64 = 0x00_8000;
@@ -5360,9 +5352,8 @@ mod tests {
     ///              (deliberately non-contiguous GPAs)
     fn setup_iommu_two_pages() -> AmdIommuDevice {
         let guest_memory = GuestMemory::allocate(0x20_0000); // 2MB
-        let msi_conn =
-            pci_core::msi::MsiConnection::new(pci_core::bus_range::AssignedBusRange::new(), 0);
-        let mut dev = AmdIommuDevice::new(guest_memory, test_config(), msi_conn.target());
+        let msi_conn = pci_core::msi::MsiConnection::new();
+        let mut dev = AmdIommuDevice::new(guest_memory, test_config(), &msi_conn.target());
 
         let devtab_gpa = 0x1_0000;
         setup_iommu_with_devtab(&mut dev, devtab_gpa, 512);
@@ -5412,9 +5403,8 @@ mod tests {
             ],
         )
         .unwrap();
-        let msi_conn =
-            pci_core::msi::MsiConnection::new(pci_core::bus_range::AssignedBusRange::new(), 0);
-        let mut dev = AmdIommuDevice::new(guest_memory, test_config(), msi_conn.target());
+        let msi_conn = pci_core::msi::MsiConnection::new();
+        let mut dev = AmdIommuDevice::new(guest_memory, test_config(), &msi_conn.target());
 
         let devtab_gpa = 0x1000;
         setup_iommu_with_devtab(&mut dev, devtab_gpa, 512);
@@ -5787,9 +5777,8 @@ mod tests {
     #[test]
     fn test_translating_memory_3level_high_iova() {
         let guest_memory = GuestMemory::allocate(0x20_0000); // 2MB
-        let msi_conn =
-            pci_core::msi::MsiConnection::new(pci_core::bus_range::AssignedBusRange::new(), 0);
-        let mut dev = AmdIommuDevice::new(guest_memory, test_config(), msi_conn.target());
+        let msi_conn = pci_core::msi::MsiConnection::new();
+        let mut dev = AmdIommuDevice::new(guest_memory, test_config(), &msi_conn.target());
 
         let devtab_gpa = 0x1_0000;
         setup_iommu_with_devtab(&mut dev, devtab_gpa, 512);
@@ -6020,9 +6009,8 @@ mod tests {
     #[test]
     fn test_translating_memory_iova_overflow() {
         let guest_memory = GuestMemory::allocate(0x10_0000);
-        let msi_conn =
-            pci_core::msi::MsiConnection::new(pci_core::bus_range::AssignedBusRange::new(), 0);
-        let mut dev = AmdIommuDevice::new(guest_memory, test_config(), msi_conn.target());
+        let msi_conn = pci_core::msi::MsiConnection::new();
+        let mut dev = AmdIommuDevice::new(guest_memory, test_config(), &msi_conn.target());
 
         let devtab_gpa = 0x1_0000;
         setup_iommu_with_devtab(&mut dev, devtab_gpa, 512);
@@ -6137,11 +6125,10 @@ mod tests {
     #[test]
     fn test_evtlog_overflow_delivers_msi() {
         let guest_memory = GuestMemory::allocate(0x10000);
-        let msi_conn =
-            pci_core::msi::MsiConnection::new(pci_core::bus_range::AssignedBusRange::new(), 0);
+        let msi_conn = pci_core::msi::MsiConnection::new();
         let msi_controller = pci_core::test_helpers::TestPciInterruptController::new();
         msi_conn.connect(msi_controller.signal_msi());
-        let mut dev = AmdIommuDevice::new(guest_memory, test_config(), msi_conn.target());
+        let mut dev = AmdIommuDevice::new(guest_memory, test_config(), &msi_conn.target());
 
         // Enable MSI on PCI config space.
         let iommu_cap_header = pci_read(&mut dev, 0x40);
@@ -6251,9 +6238,8 @@ mod tests {
         // Place the event log within valid memory and the command buffer
         // beyond it so that reading a command entry fails.
         let guest_memory = GuestMemory::allocate(0x10000);
-        let msi_conn =
-            pci_core::msi::MsiConnection::new(pci_core::bus_range::AssignedBusRange::new(), 0);
-        let mut dev = AmdIommuDevice::new(guest_memory, test_config(), msi_conn.target());
+        let msi_conn = pci_core::msi::MsiConnection::new();
+        let mut dev = AmdIommuDevice::new(guest_memory, test_config(), &msi_conn.target());
 
         // Event log at valid GPA 0x1000.
         let evt_base = EvtLogBase::new()

--- a/vm/devices/iommu/iommu_common/src/lib.rs
+++ b/vm/devices/iommu/iommu_common/src/lib.rs
@@ -82,6 +82,18 @@ pub struct TranslationFault<E: std::error::Error + 'static> {
     pub error: E,
 }
 
+/// Error returned when a requester ID's bus falls outside the device's
+/// assigned bus range, faulting the DMA access.
+#[derive(Debug, thiserror::Error)]
+#[error(
+    "DMA requester ID {rid:#06x} bus outside assigned bus range {secondary:#04x}..={subordinate:#04x}"
+)]
+struct RidOutOfRange {
+    rid: u32,
+    secondary: u8,
+    subordinate: u8,
+}
+
 /// A [`GuestMemoryAccess`](guestmem::GuestMemoryAccess) implementation that
 /// translates IOVAs via an [`IommuTranslator`] before accessing guest memory.
 ///
@@ -94,6 +106,11 @@ pub struct TranslatingMemory<T: IommuTranslator> {
     translator: T,
     /// The device's assigned bus range, used to derive the RID.
     bus_range: AssignedBusRange,
+    /// Offset added to `(secondary_bus << 8)` to form the requester ID for
+    /// each access. For a single-function device this is just its devfn; for
+    /// SR-IOV VFs it may carry into the bus byte to address functions on
+    /// higher buses within the assigned range.
+    rid_offset: u16,
     /// The raw (untranslated) guest memory.
     inner_gm: GuestMemory,
 }
@@ -110,21 +127,51 @@ impl<T: IommuTranslator> TranslatingMemory<T> {
         bus_range: AssignedBusRange,
         inner_gm: GuestMemory,
     ) -> GuestMemory {
+        Self::new_guest_memory_for_rid_offset(label, translator, bus_range, 0, inner_gm)
+    }
+
+    /// Create a new translating `GuestMemory` for a requester-ID offset
+    /// relative to the secondary bus.
+    ///
+    /// Every access resolves the RID as `(secondary_bus << 8) + rid_offset`,
+    /// reading the secondary bus from the live `bus_range`, so the identity
+    /// tracks the bus assignment. This is the primitive for SR-IOV virtual
+    /// functions, which are constructed before the PF's bus is programmed.
+    pub fn new_guest_memory_for_rid_offset(
+        label: impl Into<std::sync::Arc<str>>,
+        translator: T,
+        bus_range: AssignedBusRange,
+        rid_offset: u16,
+        inner_gm: GuestMemory,
+    ) -> GuestMemory {
         let tm = TranslatingMemory {
             translator,
             bus_range,
+            rid_offset,
             inner_gm,
         };
         GuestMemory::new(label, tm)
     }
 
-    /// Derive the requester ID (RID) from the current bus range.
+    /// Derive the requester ID (RID) for a DMA access.
     ///
-    /// Returns `(secondary_bus as u16) << 8`. If secondary_bus is 0,
-    /// the RID is 0 — the IOMMU handles this case (translation or fault).
-    fn rid(&self) -> u16 {
-        let (secondary, _) = self.bus_range.bus_range();
-        (secondary as u16) << 8
+    /// The RID is composed as `(secondary_bus << 8) + rid_offset` against the
+    /// live bus range. [`RidOutOfRange`] is returned when the resulting bus
+    /// reaches past the subordinate bus — the access then faults rather than
+    /// translating with a device identity outside the assigned range. The
+    /// offset is non-negative, so the bus is always at least the secondary
+    /// bus.
+    fn rid(&self) -> Result<u16, RidOutOfRange> {
+        let (secondary, subordinate) = self.bus_range.bus_range();
+        let rid = ((secondary as u32) << 8) + self.rid_offset as u32;
+        if rid >> 8 > subordinate as u32 {
+            return Err(RidOutOfRange {
+                rid,
+                secondary,
+                subordinate,
+            });
+        }
+        Ok(rid as u16)
     }
 }
 
@@ -155,7 +202,9 @@ impl<T: IommuTranslator> TranslatingMemory<T> {
             let current_iova = iova + offset as u64;
             let chunk_len = chunk_size(current_iova, len - offset);
 
-            let rid = self.rid();
+            let rid = self
+                .rid()
+                .map_err(|err| GuestMemoryBackingError::other(current_iova, err))?;
             let result = self
                 .translator
                 .translate(rid, current_iova, write, |gpa| op(gpa, offset, chunk_len));
@@ -222,5 +271,186 @@ unsafe impl<T: IommuTranslator> guestmem::GuestMemoryAccess for TranslatingMemor
                 .fill_at(gpa, val, chunk_len)
                 .map_err(|e| GuestMemoryBackingError::other(addr, e))
         })
+    }
+}
+
+/// A [`DmaTargetIommu`](pci_core::dma::DmaTargetIommu) implementation that
+/// produces per-RID translating [`GuestMemory`] from any [`IommuTranslator`].
+///
+/// IOMMU backends (SMMU, AMD-Vi, …) plug into the
+/// [`DmaTarget`](pci_core::dma::DmaTarget) machinery by handing one of these
+/// their arch-specific [`IommuTranslator`]. They do not need to depend on
+/// `pci_core::dma` or construct [`GuestMemory`] for virtual functions
+/// themselves — this type performs the RID composition and `GuestMemory`
+/// construction generically.
+pub struct TranslatingDmaTarget<T: IommuTranslator + Clone> {
+    /// Debug label applied to each VF's `GuestMemory`.
+    label: std::sync::Arc<str>,
+    /// The IOMMU's arch-specific translator, cloned per derived VF.
+    translator: T,
+    /// The device's assigned bus range; the requester ID is derived as
+    /// `(secondary << 8) + rid_offset` per access.
+    bus_range: AssignedBusRange,
+    /// The raw (untranslated) guest memory.
+    inner_gm: GuestMemory,
+}
+
+impl<T: IommuTranslator + Clone> TranslatingDmaTarget<T> {
+    /// Creates a new per-RID `GuestMemory` factory.
+    ///
+    /// - `label`: debug label applied to each VF's `GuestMemory`
+    /// - `translator`: the IOMMU's arch-specific translator (cloned per VF)
+    /// - `bus_range`: the device's assigned bus range, used to derive the
+    ///   default function-0 RID
+    /// - `inner_gm`: the raw (untranslated) guest memory
+    pub fn new(
+        label: impl Into<std::sync::Arc<str>>,
+        translator: T,
+        bus_range: AssignedBusRange,
+        inner_gm: GuestMemory,
+    ) -> Self {
+        Self {
+            label: label.into(),
+            translator,
+            bus_range,
+            inner_gm,
+        }
+    }
+}
+
+impl<T: IommuTranslator + Clone> pci_core::dma::DmaTargetIommu for TranslatingDmaTarget<T> {
+    fn guest_memory_for_rid_offset(&self, rid_offset: u16) -> GuestMemory {
+        TranslatingMemory::new_guest_memory_for_rid_offset(
+            self.label.clone(),
+            self.translator.clone(),
+            self.bus_range.clone(),
+            rid_offset,
+            self.inner_gm.clone(),
+        )
+    }
+}
+
+/// Build a [`DmaTarget`](pci_core::dma::DmaTarget) backed by an IOMMU translator.
+///
+/// Builds a [`TranslatingDmaTarget`] factory over `translator`/`guest_memory`
+/// and hands it to [`DmaTarget::with_iommu`](pci_core::dma::DmaTarget::with_iommu),
+/// which derives the base function-`devfn` translating memory from it and
+/// stamps the MSI identity from `msi`. IOMMU backends (SMMU, AMD-Vi, …) call
+/// this to plug their arch-specific translator into the
+/// [`DmaTarget`](pci_core::dma::DmaTarget) machinery.
+pub fn new_dma_target<T>(
+    label: &str,
+    translator: T,
+    bus_range: AssignedBusRange,
+    devfn: u8,
+    guest_memory: GuestMemory,
+    msi: &pci_core::msi::MsiConnection,
+) -> pci_core::dma::DmaTarget
+where
+    T: IommuTranslator + Clone,
+{
+    let iommu = std::sync::Arc::new(TranslatingDmaTarget::new(
+        format!("{label}-translating"),
+        translator,
+        bus_range.clone(),
+        guest_memory,
+    ));
+    pci_core::dma::DmaTarget::with_iommu(bus_range, devfn, iommu, msi)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Identity translator: GPA == IOVA, never faults. Records nothing — the
+    /// `rid` validation happens in `TranslatingMemory` before `translate` is
+    /// ever called.
+    #[derive(Clone)]
+    struct IdentityTranslator;
+
+    #[derive(Debug, thiserror::Error)]
+    #[error("identity translator never faults")]
+    struct NeverFault;
+
+    impl IommuTranslator for IdentityTranslator {
+        type Error = NeverFault;
+
+        fn max_iova(&self) -> u64 {
+            u64::MAX
+        }
+
+        fn translate<R>(
+            &self,
+            _rid: u16,
+            iova: u64,
+            _write: bool,
+            op: impl FnOnce(u64) -> R,
+        ) -> Result<R, TranslationFault<Self::Error>> {
+            Ok(op(iova))
+        }
+    }
+
+    fn bus_range(secondary: u8, subordinate: u8) -> AssignedBusRange {
+        let r = AssignedBusRange::new();
+        r.set_bus_range(secondary, subordinate);
+        r
+    }
+
+    #[test]
+    fn rid_offset_in_range_translates() {
+        let inner = GuestMemory::allocate(0x1000);
+        let gm = TranslatingMemory::new_guest_memory_for_rid_offset(
+            "test",
+            IdentityTranslator,
+            bus_range(5, 10),
+            (2 << 8) | 0x02, // secondary 5 + offset -> bus 7 within [5, 10]
+            inner.clone(),
+        );
+
+        gm.write_at(0x100, &[0xAB, 0xCD]).unwrap();
+        let mut buf = [0u8; 2];
+        gm.read_at(0x100, &mut buf).unwrap();
+        assert_eq!(buf, [0xAB, 0xCD]);
+
+        // Identity mapping wrote through to inner GPA 0x100.
+        let mut inner_buf = [0u8; 2];
+        inner.read_at(0x100, &mut inner_buf).unwrap();
+        assert_eq!(inner_buf, [0xAB, 0xCD]);
+    }
+
+    #[test]
+    fn rid_offset_out_of_range_faults() {
+        let inner = GuestMemory::allocate(0x1000);
+        let mut buf = [0u8; 2];
+
+        // secondary 5 + offset (6 << 8) -> bus 11, above subordinate 10 ->
+        // access faults
+        let gm_above = TranslatingMemory::new_guest_memory_for_rid_offset(
+            "test",
+            IdentityTranslator,
+            bus_range(5, 10),
+            6 << 8,
+            inner.clone(),
+        );
+        assert!(gm_above.read_at(0x100, &mut buf).is_err());
+        assert!(gm_above.write_at(0x100, &[1, 2]).is_err());
+    }
+
+    #[test]
+    fn derived_rid_uses_secondary_bus_in_range() {
+        // No override: the derived RID uses the secondary bus, which is
+        // always within the range, so the access translates.
+        let inner = GuestMemory::allocate(0x1000);
+        let gm = TranslatingMemory::new_guest_memory(
+            "test",
+            IdentityTranslator,
+            bus_range(5, 10),
+            inner.clone(),
+        );
+
+        gm.write_at(0x40, &[0x11]).unwrap();
+        let mut buf = [0u8; 1];
+        gm.read_at(0x40, &mut buf).unwrap();
+        assert_eq!(buf, [0x11]);
     }
 }

--- a/vm/devices/iommu/smmu/src/shared.rs
+++ b/vm/devices/iommu/smmu/src/shared.rs
@@ -509,6 +509,7 @@ impl SmmuSharedState {
 /// One `SmmuTranslator` is shared by all PCI devices behind the same SMMU.
 /// The requester ID (RID / BDF) is passed at each translation call and
 /// combined with the `stream_id_base` to form the SMMU stream ID.
+#[derive(Clone)]
 pub struct SmmuTranslator {
     shared: Arc<SmmuSharedState>,
     /// Offset into the SMMU's stream table for this root complex.

--- a/vm/devices/net/gdma/src/resolver.rs
+++ b/vm/devices/net/gdma/src/resolver.rs
@@ -65,8 +65,8 @@ impl AsyncResolveResource<PciDeviceHandleKind, GdmaDeviceHandle> for GdmaDeviceR
 
         let device = GdmaDevice::new(
             input.driver_source,
-            input.guest_memory.clone(),
-            input.msi_target,
+            input.dma_target.guest_memory().clone(),
+            input.dma_target.msi_target(),
             vports,
             input.register_mmio,
         );

--- a/vm/devices/net/mana_driver/src/tests.rs
+++ b/vm/devices/net/mana_driver/src/tests.rs
@@ -16,7 +16,6 @@ use gdma_defs::GdmaQueueType;
 use net_backend::null::NullEndpoint;
 use pal_async::DefaultDriver;
 use pal_async::async_test;
-use pci_core::bus_range::AssignedBusRange;
 use pci_core::msi::MsiConnection;
 use std::sync::Arc;
 use test_with_tracing::test;
@@ -30,11 +29,11 @@ use vmcore::vm_task::VmTaskDriverSource;
 #[async_test]
 async fn test_gdma(driver: DefaultDriver) {
     let mem = DeviceTestMemory::new(128, false, "test_gdma");
-    let msi_conn = MsiConnection::new(AssignedBusRange::new(), 0);
+    let msi_conn = MsiConnection::new();
     let device = gdma::GdmaDevice::new(
         &VmTaskDriverSource::new(SingleDriverBackend::new(driver.clone())),
         mem.guest_memory(),
-        msi_conn.target(),
+        &msi_conn.target(),
         vec![VportConfig {
             mac_address: [1, 2, 3, 4, 5, 6].into(),
             endpoint: Box::new(NullEndpoint::new()),
@@ -168,11 +167,11 @@ async fn test_gdma(driver: DefaultDriver) {
 #[async_test]
 async fn test_gdma_save_restore(driver: DefaultDriver) {
     let mem = DeviceTestMemory::new(128, false, "test_gdma");
-    let msi_conn = MsiConnection::new(AssignedBusRange::new(), 0);
+    let msi_conn = MsiConnection::new();
     let device = gdma::GdmaDevice::new(
         &VmTaskDriverSource::new(SingleDriverBackend::new(driver.clone())),
         mem.guest_memory(),
-        msi_conn.target(),
+        &msi_conn.target(),
         vec![VportConfig {
             mac_address: [1, 2, 3, 4, 5, 6].into(),
             endpoint: Box::new(NullEndpoint::new()),
@@ -208,11 +207,11 @@ async fn test_gdma_save_restore(driver: DefaultDriver) {
 #[async_test]
 async fn test_adapter_link_speed_default(driver: DefaultDriver) {
     let mem = DeviceTestMemory::new(128, false, "test_adapter_link_speed_default");
-    let msi_conn = MsiConnection::new(AssignedBusRange::new(), 0);
+    let msi_conn = MsiConnection::new();
     let device = gdma::GdmaDevice::new(
         &VmTaskDriverSource::new(SingleDriverBackend::new(driver.clone())),
         mem.guest_memory(),
-        msi_conn.target(),
+        &msi_conn.target(),
         vec![VportConfig {
             mac_address: [1, 2, 3, 4, 5, 6].into(),
             endpoint: Box::new(NullEndpoint::new()),
@@ -256,11 +255,11 @@ async fn test_adapter_link_speed_default(driver: DefaultDriver) {
 /// and `link_speed_bps()` converts it correctly.
 async fn verify_adapter_link_speed_expected(driver: DefaultDriver, link_speed_mbps: u32) {
     let mem = DeviceTestMemory::new(128, false, "test_adapter_link_speed_expected");
-    let msi_conn = MsiConnection::new(AssignedBusRange::new(), 0);
+    let msi_conn = MsiConnection::new();
     let device = gdma::GdmaDevice::new_with_config(
         &VmTaskDriverSource::new(SingleDriverBackend::new(driver.clone())),
         mem.guest_memory(),
-        msi_conn.target(),
+        &msi_conn.target(),
         vec![VportConfig {
             mac_address: [1, 2, 3, 4, 5, 6].into(),
             endpoint: Box::new(NullEndpoint::new()),
@@ -316,11 +315,11 @@ async fn test_adapter_link_speed_expected(driver: DefaultDriver) {
 #[async_test]
 async fn test_gdma_reset_request(driver: DefaultDriver) {
     let mem = DeviceTestMemory::new(128, false, "test_gdma");
-    let msi_conn = MsiConnection::new(AssignedBusRange::new(), 0);
+    let msi_conn = MsiConnection::new();
     let device = gdma::GdmaDevice::new(
         &VmTaskDriverSource::new(SingleDriverBackend::new(driver.clone())),
         mem.guest_memory(),
-        msi_conn.target(),
+        &msi_conn.target(),
         vec![VportConfig {
             mac_address: [1, 2, 3, 4, 5, 6].into(),
             endpoint: Box::new(NullEndpoint::new()),
@@ -379,11 +378,11 @@ async fn test_gdma_reset_request(driver: DefaultDriver) {
 #[async_test]
 async fn test_gdma_reset_request_with_revoke(driver: DefaultDriver) {
     let mem = DeviceTestMemory::new(128, false, "test_gdma");
-    let msi_conn = MsiConnection::new(AssignedBusRange::new(), 0);
+    let msi_conn = MsiConnection::new();
     let device = gdma::GdmaDevice::new(
         &VmTaskDriverSource::new(SingleDriverBackend::new(driver.clone())),
         mem.guest_memory(),
-        msi_conn.target(),
+        &msi_conn.target(),
         vec![VportConfig {
             mac_address: [1, 2, 3, 4, 5, 6].into(),
             endpoint: Box::new(NullEndpoint::new()),

--- a/vm/devices/net/net_consomme/consomme/src/tcp.rs
+++ b/vm/devices/net/net_consomme/consomme/src/tcp.rs
@@ -193,6 +193,10 @@ struct TcpConnectionInner {
     rx_buffer_max: usize,
     #[inspect(with = "inspect_seq")]
     rx_seq: TcpSeqNumber,
+    /// Window last advertised to the guest, as it reconstructs it after
+    /// window-scale truncation. Used to detect a zero-window reopen.
+    #[inspect(hex)]
+    rx_window_last_adv: usize,
     #[inspect(flatten)]
     rx_assembler: assembler::Assembler,
     needs_ack: bool,
@@ -778,6 +782,7 @@ impl TcpConnection {
             rx_window_scale,
             rx_buffer_max: rx_bounds.max,
             rx_seq,
+            rx_window_last_adv: rx_bounds.initial,
             rx_assembler: assembler::Assembler::new(),
             needs_ack: false,
             is_shutdown: false,
@@ -1175,6 +1180,11 @@ impl TcpConnectionInner {
                     Poll::Pending => break,
                 }
             }
+            // Draining to the host may have reopened the window; re-advertise it
+            // so the guest resumes without waiting on its persist timer.
+            if self.should_reopen_window() {
+                self.needs_ack = true;
+            }
             // Autotune: if the host kept up (drained to empty) and the buffer
             // was at least 75% full this cycle, the guest is rx-bound. Grow
             // both the ring and the advertised window ceiling so the next ACK
@@ -1243,7 +1253,38 @@ impl TcpConnectionInner {
     }
 
     fn rx_window_len(&self) -> u16 {
-        ((self.rx_window_cap - self.rx_buffer.len()) >> self.rx_window_scale) as u16
+        (self.rx_window_avail() >> self.rx_window_scale) as u16
+    }
+
+    /// Available receive window in unscaled bytes.
+    fn rx_window_avail(&self) -> usize {
+        self.rx_window_cap - self.rx_buffer.len()
+    }
+
+    /// The receive window as the guest reconstructs it: `rx_window_avail`
+    /// rounded down to the scale quantum, since the low `rx_window_scale` bits
+    /// are not transmitted. Equals `rx_window_avail` when scaling is off.
+    fn rx_window_advertised(&self) -> usize {
+        (self.rx_window_avail() >> self.rx_window_scale) << self.rx_window_scale
+    }
+
+    /// Record the window just advertised to the guest. `window_len` is the
+    /// scaled value placed on the wire; the guest shifts it back up by the
+    /// window scale, so track that reconstructed value to keep the reopen
+    /// check accurate.
+    fn record_advertised_window(&mut self, window_len: u16) {
+        self.rx_window_last_adv = (window_len as usize) << self.rx_window_scale;
+    }
+
+    /// Whether draining to the host reopened the receive window enough to
+    /// re-advertise it (RFC 1122 §4.2.3.3 receiver SWS avoidance). Fires once on
+    /// the closed-to-open transition, once the guest-visible (post-scale-
+    /// truncation) window reaches the reopen threshold: a full segment, or half
+    /// the window cap when the cap is smaller than one segment.
+    fn should_reopen_window(&self) -> bool {
+        let reopen_threshold = self.tx_mss.min(self.rx_window_cap / 2);
+        self.rx_window_last_adv < reopen_threshold
+            && self.rx_window_advertised() >= reopen_threshold
     }
 
     fn send_next(&mut self, sender: &mut Sender<'_, impl Client>, ack_policy: AckPolicy) {
@@ -1263,6 +1304,15 @@ impl TcpConnectionInner {
         // (even with no shift) to enable window scale support.
         let window_scale = self.enable_window_scaling.then_some(self.rx_window_scale);
 
+        // RFC 7323 §2.2: the window in a SYN/SYN-ACK is not scaled even with the
+        // window_scale option present. Advertise the real window clamped to 16
+        // bits; the active-open SYN (no ACK) carries a zero window.
+        let window_len = if ack_number.is_some() {
+            self.rx_window_avail().min(u16::MAX as usize) as u16
+        } else {
+            0
+        };
+
         // Advertise the maximum possible segment size, allowing the guest
         // to truncate this to its own MTU calculation.
         let max_seg_size = u16::MAX;
@@ -1272,11 +1322,7 @@ impl TcpConnectionInner {
             control: TcpControl::Syn,
             seq_number: self.tx_send,
             ack_number,
-            window_len: if ack_number.is_some() {
-                self.rx_window_len()
-            } else {
-                0
-            },
+            window_len,
             window_scale,
             max_seg_size: Some(max_seg_size),
             sack_permitted: false,
@@ -1287,6 +1333,10 @@ impl TcpConnectionInner {
 
         sender.send_packet(&tcp, None);
         self.tx_send += 1;
+        if ack_number.is_some() {
+            // The guest reads the SYN-ACK window unscaled, so record that value.
+            self.rx_window_last_adv = window_len as usize;
+        }
     }
 
     fn send_data(&mut self, sender: &mut Sender<'_, impl Client>, ack_policy: AckPolicy) {
@@ -1317,13 +1367,14 @@ impl TcpConnectionInner {
                 break;
             }
 
+            let window_len = self.rx_window_len();
             let mut tcp = TcpRepr {
                 src_port: sender.ft.dst.port(),
                 dst_port: sender.ft.src.port(),
                 control: TcpControl::None,
                 seq_number: self.tx_send,
                 ack_number: Some(self.rx_seq),
-                window_len: self.rx_window_len(),
+                window_len,
                 window_scale: None,
                 max_seg_size: None,
                 sack_permitted: false,
@@ -1408,6 +1459,7 @@ impl TcpConnectionInner {
             self.stats.tx_segment_size.add_sample(payload_len as u64);
             self.tx_send = tx_next;
             self.needs_ack = false;
+            self.record_advertised_window(window_len);
         }
 
         assert!(self.tx_send <= tx_end);
@@ -1439,13 +1491,14 @@ impl TcpConnectionInner {
     /// shouldn't be combined with data so that they are interpreted correctly
     /// by the peer.
     fn ack(&mut self, sender: &mut Sender<'_, impl Client>) {
+        let window_len = self.rx_window_len();
         let tcp = TcpRepr {
             src_port: sender.ft.dst.port(),
             dst_port: sender.ft.src.port(),
             control: TcpControl::None,
             seq_number: self.tx_send,
             ack_number: Some(self.rx_seq),
-            window_len: self.rx_window_len(),
+            window_len,
             window_scale: None,
             max_seg_size: None,
             sack_permitted: false,
@@ -1458,6 +1511,7 @@ impl TcpConnectionInner {
 
         sender.send_packet(&tcp, None);
         self.stats.standalone_acks_tx.increment();
+        self.record_advertised_window(window_len);
     }
 
     fn handle_listen_syn(

--- a/vm/devices/net/net_consomme/consomme/src/tcp/tests.rs
+++ b/vm/devices/net/net_consomme/consomme/src/tcp/tests.rs
@@ -17,6 +17,7 @@ use parking_lot::Mutex;
 use smoltcp::wire::EthernetAddress;
 use smoltcp::wire::Ipv4Address;
 use smoltcp::wire::Ipv4Repr;
+use socket2::SockRef;
 use std::io::ErrorKind;
 use std::net::Ipv4Addr;
 use std::net::Ipv6Addr;
@@ -524,6 +525,115 @@ impl TcpTestHarness {
             }
         })
         .await;
+    }
+
+    /// Flood guest→host data (without reading the host socket) until the
+    /// available receive buffer (`rx_window_avail`) reaches zero, which drives
+    /// the advertised window to zero. Only sends segments that fit the current
+    /// window, so nothing is dropped. Returns bytes accepted.
+    async fn flood_guest_until_window_closed(&mut self) -> usize {
+        let guest_mac = self.guest_mac;
+        let gateway_mac = self.gateway_mac;
+        let guest_ip = self.guest_ip;
+        let dst_ip = self.dst_ip;
+        let guest_port = self.guest_port;
+        let dst_port = self.dst_port;
+        let server_ack = self.server_ack;
+        let ft = self.four_tuple();
+
+        let consomme = &mut self.consomme;
+        let client = &mut self.client;
+        // Deliberately do NOT read `host_stream`: the path backs up so the
+        // receive window fills.
+        let guest_seq = &mut self.guest_seq;
+        let mut buf = vec![0u8; 1514];
+        let payload = [0x5Au8; 1400];
+        let mut total = 0usize;
+        // Safety cap so a regression can't loop forever.
+        let mut budget = 64 << 20;
+        std::future::poll_fn(move |cx| {
+            consomme.access(client).poll(cx);
+            let avail = consomme
+                .tcp
+                .connections
+                .get(&ft)
+                .expect("connection should exist")
+                .inner
+                .rx_window_avail();
+            if avail == 0 || budget == 0 {
+                return Poll::Ready(total);
+            }
+            let n = avail.min(payload.len()).min(budget);
+            let tcp = TcpRepr {
+                src_port: guest_port,
+                dst_port,
+                control: TcpControl::None,
+                seq_number: *guest_seq,
+                ack_number: Some(server_ack),
+                window_len: 64240,
+                window_scale: None,
+                max_seg_size: None,
+                sack_permitted: false,
+                sack_ranges: [None, None, None],
+                timestamp: None,
+                payload: &payload[..n],
+            };
+            let len = build_tcp_packet(&mut buf, guest_mac, gateway_mac, guest_ip, dst_ip, &tcp);
+            consomme
+                .access(client)
+                .send(&buf[..len], &ChecksumState::NONE)
+                .unwrap();
+            *guest_seq += n;
+            total += n;
+            budget -= n;
+            // Re-poll promptly to keep pushing; once the host socket buffers
+            // fill, consomme stops draining and `avail` reaches zero.
+            cx.waker().wake_by_ref();
+            Poll::Pending
+        })
+        .await
+    }
+
+    /// Drain the host socket while polling consomme, waiting for a guest-bound
+    /// ACK that advertises a non-zero receive window. Returns the advertised
+    /// window length, or `None` if no such packet appeared within a few
+    /// seconds.
+    async fn drain_host_until_window_update(&mut self) -> Option<u16> {
+        let mut timer = pal_async::timer::PolledTimer::new(self.client.driver());
+        let received = self.client.received_packets.clone();
+        let consomme = &mut self.consomme;
+        let client = &mut self.client;
+        let host_stream = &mut self.host_stream;
+        let poll = std::future::poll_fn(move |cx| {
+            consomme.access(client).poll(cx);
+            // Drain the host socket so the receive window reopens. Registers a
+            // read-readiness waker on Pending so we are re-polled as more data
+            // arrives.
+            let mut rb = [0u8; 4096];
+            loop {
+                match Pin::new(&mut *host_stream).poll_read(cx, &mut rb) {
+                    Poll::Ready(Ok(0)) => break,
+                    Poll::Ready(Ok(_)) => {}
+                    Poll::Ready(Err(e)) => panic!("host read error: {e}"),
+                    Poll::Pending => break,
+                }
+            }
+            let found = received.lock().iter().rev().find_map(|p| {
+                let t = TcpTestHarness::is_tcp_packet(p)?;
+                (t.ack_number.is_some() && t.window_len > 0).then_some(t.window_len)
+            });
+            match found {
+                Some(w) => Poll::Ready(w),
+                None => Poll::Pending,
+            }
+        });
+        let timeout = timer.sleep(std::time::Duration::from_secs(5));
+        let poll = std::pin::pin!(poll);
+        let timeout = std::pin::pin!(timeout);
+        match futures::future::select(poll, timeout).await {
+            futures::future::Either::Left((w, _)) => Some(w),
+            futures::future::Either::Right(_) => None,
+        }
     }
 }
 
@@ -1226,20 +1336,15 @@ async fn test_tcp_window_scale_activation(driver: DefaultDriver) {
         "SYN-ACK should include window_scale option when SYN had one"
     );
     let syn_ack_window_scale = syn_ack.window_scale.unwrap();
-    // The window_len in SYN-ACK is the unscaled value — it represents
-    // the actual receive window without any shift applied. Verify that
-    // the effective (scaled) window represents a valid receive buffer
-    // size (between 16KB min and 4MB max per the clamp in new_base).
-    // If the SYN-ACK window field were incorrectly pre-scaled, the
-    // effective value would be unreasonably large.
-    let effective_rx_window = (syn_ack.window_len as usize) << syn_ack_window_scale;
-    assert!(
-        (16384..=4 * 1024 * 1024).contains(&effective_rx_window),
-        "SYN-ACK effective window (unscaled={}, scale={}, effective={}) \
-         should represent a valid receive buffer size",
-        syn_ack.window_len,
-        syn_ack_window_scale,
-        effective_rx_window,
+    // RFC 7323 §2.2: the window field in a SYN/SYN-ACK is NOT scaled, even
+    // though the window_scale option is present. The guest reads window_len
+    // verbatim, so it must carry the real receive window (the 16 KiB initial
+    // cap), not a pre-shifted value. If it were pre-scaled (>> 7), the guest
+    // would see only 128 bytes and stall at connection start.
+    assert_eq!(
+        syn_ack.window_len as usize,
+        16 * 1024,
+        "SYN-ACK must advertise the unscaled receive window (scale={syn_ack_window_scale})",
     );
 
     // Now complete the handshake with an ACK that has a small window.
@@ -1706,5 +1811,48 @@ async fn test_tcp_tx_buffer_autotune_caps_at_max(driver: DefaultDriver) {
         cap,
         32 << 10,
         "tx ring must cap at the configured 32 KiB max"
+    );
+}
+
+/// Regression test: after the guest egress fills the receive window and it
+/// later reopens (host drains), consomme must send an unsolicited window-update
+/// ACK rather than waiting for the guest's zero-window probe.
+#[pal_async::async_test]
+async fn test_tcp_zero_window_reopen_sends_update(driver: DefaultDriver) {
+    let mut params = ConsommeParams::new().unwrap();
+    // Small, fixed receive window so it closes quickly and autotune can't grow
+    // it (which would mask the reopen path via its own `needs_ack`).
+    params.tcp_rx_buffer = crate::TcpBufferBounds {
+        initial: 16 << 10,
+        max: 16 << 10,
+    };
+    let mut h = TcpTestHarness::connect_with_params(driver, params).await;
+
+    // Shrink the host receive buffer so the egress path backs up after only a
+    // modest amount of data, keeping the flood bounded.
+    SockRef::from(h.host_stream.get())
+        .set_recv_buffer_size(8 << 10)
+        .unwrap();
+
+    // Flood until consomme's advertised receive window closes to zero.
+    let sent = h.flood_guest_until_window_closed().await;
+    assert_eq!(
+        h.connection_inner().rx_window_avail(),
+        0,
+        "receive window should have closed after flooding {sent} bytes"
+    );
+    assert!(
+        h.connection_inner().rx_window_last_adv < h.connection_inner().tx_mss,
+        "consomme should have advertised a (near) zero window to the guest"
+    );
+
+    // Discard the zero-window ACKs, then drain the host socket. Consomme must
+    // emit a window-update ACK on its own, without the guest probing.
+    h.clear_guest_packets();
+    let window_update = h.drain_host_until_window_update().await;
+    assert!(
+        window_update.is_some_and(|w| w > 0),
+        "consomme must proactively re-advertise a non-zero window after the \
+         host drains the backlog; got {window_update:?}"
     );
 }

--- a/vm/devices/net/net_consomme/src/lib.rs
+++ b/vm/devices/net/net_consomme/src/lib.rs
@@ -136,9 +136,25 @@ impl ConsommeEndpoint {
         }
     }
 
+    pub fn new_dynamic(state: ConsommeParams) -> (Self, ConsommeControl) {
+        let consomme = Consomme::new(state);
+        let (send, recv) = mesh::channel();
+        (
+            Self {
+                endpoint_state: Arc::new(Mutex::new(Some(EndpointState {
+                    consomme,
+                    recv: Some(recv),
+                    port_recv: None,
+                    port_forwards: Vec::new(),
+                }))),
+            },
+            ConsommeControl { send },
+        )
+    }
+
     /// Creates a new endpoint with initial ports and a channel for runtime
     /// port bind/unbind requests from an external source (e.g. ttrpc server).
-    pub fn new_dynamic(
+    pub fn new_with_port_channel(
         state: ConsommeParams,
         ports: Vec<PortForwardConfig>,
         port_recv: mesh::Receiver<ConsommeRequest>,
@@ -175,9 +191,9 @@ pub enum ConsommeMessageError {
     /// Communication error with running instance.
     #[error("communication error")]
     Mesh(RpcError),
-    /// Error executing request on consomme endpoint.
-    #[error(transparent)]
-    Remote(mesh::error::RemoteError),
+    /// Error executing request on current network instance.
+    #[error("bind error")]
+    Bind(consomme::BindError),
 }
 
 /// Callback to modify network state dynamically.
@@ -198,19 +214,19 @@ impl From<HostPortProtocol> for IpProtocol {
     }
 }
 
-impl From<IpProtocol> for HostPortProtocol {
-    fn from(p: IpProtocol) -> Self {
-        match p {
-            IpProtocol::Tcp => HostPortProtocol::Tcp,
-            IpProtocol::Udp => HostPortProtocol::Udp,
-        }
-    }
+/// Configuration for unbinding a previously forwarded port.
+struct PortUnbindConfig {
+    /// The protocol that was forwarded.
+    protocol: IpProtocol,
+    /// The IP address family that was forwarded.
+    family: IpVersion,
+    /// The guest port that was forwarded.
+    guest_port: u16,
 }
 
 enum ConsommeMessage {
-    /// A port bind/unbind request (shared with cross-proc `ConsommeRequest`).
-    PortRequest(ConsommeRequest),
-    /// In-proc only: update dynamic network state.
+    BindPort(Rpc<PortForwardConfig, Result<(), consomme::BindError>>),
+    UnbindPort(Rpc<PortUnbindConfig, Result<(), consomme::BindError>>),
     UpdateState(Rpc<ConsommeParamsUpdateFn, ()>),
 }
 
@@ -222,42 +238,55 @@ impl ConsommeControl {
         ip_addr: Option<IpAddr>,
         host_port: u16,
         guest_port: u16,
-    ) -> Result<(), ConsommeMessageError> {
+    ) -> Result<u16, ConsommeMessageError> {
+        let socket = create_bound_socket(&protocol, ip_addr, host_port)
+            .map_err(|e| ConsommeMessageError::Bind(consomme::BindError::Io(e)))?;
+        let host_addr = socket_addr(&socket).map_err(ConsommeMessageError::Bind)?;
         self.send
             .call(
-                |rpc| ConsommeMessage::PortRequest(ConsommeRequest::Bind(rpc)),
-                HostPortConfig {
-                    protocol: protocol.into(),
-                    host_address: ip_addr.map(net_backend_resources::consomme::HostIpAddress::from),
-                    host_port: net_backend_resources::consomme::HostPort::Fixed(host_port),
+                ConsommeMessage::BindPort,
+                PortForwardConfig {
+                    protocol,
+                    socket,
                     guest_port,
                 },
             )
             .await
             .map_err(ConsommeMessageError::Mesh)?
-            .map_err(ConsommeMessageError::Remote)
+            .map(|()| {
+                let bound_host_port = host_addr.port();
+                tracing::info!(
+                    ?protocol,
+                    requested_host_port = host_port,
+                    bound_host_addr = %host_addr,
+                    bound_host_port,
+                    guest_port,
+                    "port forward bound"
+                );
+                bound_host_port
+            })
+            .map_err(ConsommeMessageError::Bind)
     }
 
     /// Unbinds a port and IP family previously reserved with bind_port().
     pub async fn unbind_port(
         &self,
         protocol: IpProtocol,
-        ip_addr: Option<IpAddr>,
+        family: IpVersion,
         guest_port: u16,
     ) -> Result<(), ConsommeMessageError> {
         self.send
             .call(
-                |rpc| ConsommeMessage::PortRequest(ConsommeRequest::Unbind(rpc)),
-                HostPortConfig {
-                    protocol: protocol.into(),
-                    host_address: ip_addr.map(net_backend_resources::consomme::HostIpAddress::from),
-                    host_port: net_backend_resources::consomme::HostPort::Fixed(0),
+                ConsommeMessage::UnbindPort,
+                PortUnbindConfig {
+                    protocol,
+                    family,
                     guest_port,
                 },
             )
             .await
             .map_err(ConsommeMessageError::Mesh)?
-            .map_err(ConsommeMessageError::Remote)
+            .map_err(ConsommeMessageError::Bind)
     }
 
     /// Updates dynamic network state
@@ -557,13 +586,32 @@ fn process_port_request(
     }
 }
 
-/// Handle a `ConsommeMessage` — delegates port operations to `process_port_request`.
+/// Handle an in-process `ConsommeMessage` from a `ConsommeControl`.
 fn process_message(
     consomme: &mut consomme::Access<'_, impl consomme::Client>,
     message: ConsommeMessage,
 ) {
     match message {
-        ConsommeMessage::PortRequest(request) => process_port_request(consomme, request),
+        ConsommeMessage::BindPort(rpc) => {
+            rpc.handle_sync(|bind_message| match bind_message.protocol {
+                IpProtocol::Tcp => {
+                    consomme.bind_tcp_port(bind_message.socket, bind_message.guest_port)
+                }
+                IpProtocol::Udp => {
+                    consomme.bind_udp_port(bind_message.socket, bind_message.guest_port)
+                }
+            });
+        }
+        ConsommeMessage::UnbindPort(rpc) => {
+            rpc.handle_sync(|unbind_message| match unbind_message.protocol {
+                IpProtocol::Tcp => {
+                    consomme.unbind_tcp_port(unbind_message.family, unbind_message.guest_port)
+                }
+                IpProtocol::Udp => {
+                    consomme.unbind_udp_port(unbind_message.family, unbind_message.guest_port)
+                }
+            });
+        }
         ConsommeMessage::UpdateState(rpc) => {
             rpc.handle_sync(|f| {
                 f(consomme.get_mut().params_mut());

--- a/vm/devices/net/net_consomme/src/lib.rs
+++ b/vm/devices/net/net_consomme/src/lib.rs
@@ -118,6 +118,64 @@ impl PendingRequests {
     fn is_empty(&self) -> bool {
         self.ports.is_empty() && self.state_updates.is_empty()
     }
+
+    fn buffer_control(&mut self, request: ControlRequest) {
+        match request {
+            ControlRequest::Port(request) => self.buffer_request(request),
+            ControlRequest::UpdateState(rpc) => self.state_updates.push(rpc),
+        }
+    }
+
+    /// Adds a port request, coalescing it with any existing request for the
+    /// same port.
+    fn buffer_request(&mut self, request: ConsommeRequest) {
+        let key = PortKey::for_request(&request);
+        if let Some(existing) = self.ports.remove(&key) {
+            let cancels = matches!(existing, ConsommeRequest::Bind(_))
+                && matches!(request, ConsommeRequest::Unbind(_));
+            if cancels {
+                // Unbind cancels a not-yet-applied bind; complete both as no-ops.
+                into_rpc(existing).complete(Ok(()));
+                into_rpc(request).complete(Ok(()));
+                tracing::debug!(guest_port = key.guest_port, "coalesced bind and unbind");
+                return;
+            }
+            // Newer request wins; report the older one as superseded.
+            into_rpc(existing).fail(PortRequestSuperseded);
+        }
+        self.ports.insert(key, request);
+    }
+}
+
+/// Drains all currently-available items from `recv` into `buffer`, registering a
+/// waker when nothing is ready and dropping the receiver if the channel closed.
+/// Returns whether any item was read.
+fn drain_receiver<T>(
+    recv: &mut Option<mesh::Receiver<T>>,
+    cx: &mut Context<'_>,
+    channel: &'static str,
+    mut buffer: impl FnMut(T),
+) -> bool {
+    let mut received = false;
+    loop {
+        let polled = recv.as_mut().map(|r| r.poll_recv(cx));
+        match polled {
+            Some(Poll::Ready(Ok(item))) => {
+                buffer(item);
+                received = true;
+            }
+            Some(Poll::Ready(Err(err))) => {
+                tracing::warn!(
+                    err = &err as &dyn std::error::Error,
+                    channel,
+                    "consomme request channel closed"
+                );
+                *recv = None;
+            }
+            Some(Poll::Pending) | None => break,
+        }
+    }
+    received
 }
 
 /// Coalescing key: bind/unbind for the same protocol, family, and guest port
@@ -218,69 +276,21 @@ impl ConsommeEndpoint {
     /// wakers for channels with nothing ready. Returns whether any new request
     /// was read.
     fn drain_channels(&mut self, cx: &mut Context<'_>) -> bool {
-        let mut received = false;
-        loop {
-            let polled = self.control_recv.as_mut().map(|r| r.poll_recv(cx));
-            match polled {
-                Some(Poll::Ready(Ok(request))) => {
-                    self.buffer_control(request);
-                    received = true;
-                }
-                Some(Poll::Ready(Err(err))) => {
-                    tracing::warn!(
-                        err = &err as &dyn std::error::Error,
-                        "consomme control channel closed"
-                    );
-                    self.control_recv = None;
-                }
-                Some(Poll::Pending) | None => break,
-            }
-        }
-        loop {
-            let polled = self.port_recv.as_mut().map(|r| r.poll_recv(cx));
-            match polled {
-                Some(Poll::Ready(Ok(request))) => {
-                    self.buffer_request(request);
-                    received = true;
-                }
-                Some(Poll::Ready(Err(err))) => {
-                    tracing::warn!(
-                        err = &err as &dyn std::error::Error,
-                        "consomme port request channel closed"
-                    );
-                    self.port_recv = None;
-                }
-                Some(Poll::Pending) | None => break,
-            }
-        }
+        let Self {
+            control_recv,
+            port_recv,
+            pending,
+            ..
+        } = self;
+        // Borrow each receiver and `pending` separately so the shared buffering
+        // logic can be reused for both channels without a borrow conflict.
+        let mut received = drain_receiver(control_recv, cx, "control", |request| {
+            pending.buffer_control(request)
+        });
+        received |= drain_receiver(port_recv, cx, "port request", |request| {
+            pending.buffer_request(request)
+        });
         received
-    }
-
-    fn buffer_control(&mut self, request: ControlRequest) {
-        match request {
-            ControlRequest::Port(request) => self.buffer_request(request),
-            ControlRequest::UpdateState(rpc) => self.pending.state_updates.push(rpc),
-        }
-    }
-
-    /// Adds a port request to `pending`, coalescing it with any existing request
-    /// for the same port.
-    fn buffer_request(&mut self, request: ConsommeRequest) {
-        let key = PortKey::for_request(&request);
-        if let Some(existing) = self.pending.ports.remove(&key) {
-            let cancels = matches!(existing, ConsommeRequest::Bind(_))
-                && matches!(request, ConsommeRequest::Unbind(_));
-            if cancels {
-                // Unbind cancels a not-yet-applied bind; complete both as no-ops.
-                into_rpc(existing).complete(Ok(()));
-                into_rpc(request).complete(Ok(()));
-                tracing::debug!(guest_port = key.guest_port, "coalesced bind and unbind");
-                return;
-            }
-            // Newer request wins; report the older one as superseded.
-            into_rpc(existing).fail(PortRequestSuperseded);
-        }
-        self.pending.ports.insert(key, request);
     }
 }
 
@@ -466,11 +476,12 @@ impl net_backend::Endpoint for ConsommeEndpoint {
             }
             Ok(bound)
         });
-        bind_result?;
 
         // Apply requests buffered while no queue was running (see
-        // `wait_for_endpoint_action`). No pool is needed: these operations don't
-        // indicate received packets.
+        // `wait_for_endpoint_action`). This runs regardless of whether the
+        // static port-forward binding above succeeded, so the buffered RPCs
+        // always complete here instead of stalling until some unrelated future
+        // request triggers the next restart.
         let pending = std::mem::take(&mut self.pending);
         queue.with_consomme_no_pool(|c| {
             for request in pending.ports.into_values() {
@@ -484,6 +495,8 @@ impl net_backend::Endpoint for ConsommeEndpoint {
                 });
             }
         });
+
+        bind_result?;
 
         queues.push(queue);
         Ok(())
@@ -925,18 +938,22 @@ mod tests {
     #[test]
     fn unbind_cancels_pending_bind() {
         let mut ep = endpoint();
-        ep.buffer_request(ConsommeRequest::Bind(Rpc::detached(cfg(80))));
+        ep.pending
+            .buffer_request(ConsommeRequest::Bind(Rpc::detached(cfg(80))));
         assert_eq!(ep.pending.ports.len(), 1);
         // An unbind for the same port annihilates the not-yet-applied bind.
-        ep.buffer_request(ConsommeRequest::Unbind(Rpc::detached(cfg(80))));
+        ep.pending
+            .buffer_request(ConsommeRequest::Unbind(Rpc::detached(cfg(80))));
         assert!(ep.pending.ports.is_empty());
     }
 
     #[test]
     fn newer_request_supersedes_same_port() {
         let mut ep = endpoint();
-        ep.buffer_request(ConsommeRequest::Bind(Rpc::detached(cfg(80))));
-        ep.buffer_request(ConsommeRequest::Bind(Rpc::detached(cfg(80))));
+        ep.pending
+            .buffer_request(ConsommeRequest::Bind(Rpc::detached(cfg(80))));
+        ep.pending
+            .buffer_request(ConsommeRequest::Bind(Rpc::detached(cfg(80))));
         // The two binds collapse to a single pending entry.
         assert_eq!(ep.pending.ports.len(), 1);
     }
@@ -944,8 +961,10 @@ mod tests {
     #[test]
     fn different_ports_are_independent() {
         let mut ep = endpoint();
-        ep.buffer_request(ConsommeRequest::Bind(Rpc::detached(cfg(80))));
-        ep.buffer_request(ConsommeRequest::Bind(Rpc::detached(cfg(81))));
+        ep.pending
+            .buffer_request(ConsommeRequest::Bind(Rpc::detached(cfg(80))));
+        ep.pending
+            .buffer_request(ConsommeRequest::Bind(Rpc::detached(cfg(81))));
         assert_eq!(ep.pending.ports.len(), 2);
     }
 

--- a/vm/devices/net/net_consomme/src/lib.rs
+++ b/vm/devices/net/net_consomme/src/lib.rs
@@ -118,6 +118,64 @@ impl PendingRequests {
     fn is_empty(&self) -> bool {
         self.ports.is_empty() && self.state_updates.is_empty()
     }
+
+    fn buffer_control(&mut self, request: ControlRequest) {
+        match request {
+            ControlRequest::Port(request) => self.buffer_request(request),
+            ControlRequest::UpdateState(rpc) => self.state_updates.push(rpc),
+        }
+    }
+
+    /// Adds a port request, coalescing it with any existing request for the
+    /// same port.
+    fn buffer_request(&mut self, request: ConsommeRequest) {
+        let key = PortKey::for_request(&request);
+        if let Some(existing) = self.ports.remove(&key) {
+            let cancels = matches!(existing, ConsommeRequest::Bind(_))
+                && matches!(request, ConsommeRequest::Unbind(_));
+            if cancels {
+                // Unbind cancels a not-yet-applied bind; complete both as no-ops.
+                into_rpc(existing).complete(Ok(()));
+                into_rpc(request).complete(Ok(()));
+                tracing::debug!(guest_port = key.guest_port, "coalesced bind and unbind");
+                return;
+            }
+            // Newer request wins; report the older one as superseded.
+            into_rpc(existing).fail(PortRequestSuperseded);
+        }
+        self.ports.insert(key, request);
+    }
+}
+
+/// Drains all currently-available items from `recv` into `buffer`, registering a
+/// waker when nothing is ready and dropping the receiver if the channel closed.
+/// Returns whether any item was read.
+fn drain_receiver<T>(
+    recv: &mut Option<mesh::Receiver<T>>,
+    cx: &mut Context<'_>,
+    channel: &'static str,
+    mut buffer: impl FnMut(T),
+) -> bool {
+    let mut received = false;
+    loop {
+        let polled = recv.as_mut().map(|r| r.poll_recv(cx));
+        match polled {
+            Some(Poll::Ready(Ok(item))) => {
+                buffer(item);
+                received = true;
+            }
+            Some(Poll::Ready(Err(err))) => {
+                tracing::warn!(
+                    err = &err as &dyn std::error::Error,
+                    channel,
+                    "consomme request channel closed"
+                );
+                *recv = None;
+            }
+            Some(Poll::Pending) | None => break,
+        }
+    }
+    received
 }
 
 /// Coalescing key: bind/unbind for the same protocol, family, and guest port
@@ -218,69 +276,21 @@ impl ConsommeEndpoint {
     /// wakers for channels with nothing ready. Returns whether any new request
     /// was read.
     fn drain_channels(&mut self, cx: &mut Context<'_>) -> bool {
-        let mut received = false;
-        loop {
-            let polled = self.control_recv.as_mut().map(|r| r.poll_recv(cx));
-            match polled {
-                Some(Poll::Ready(Ok(request))) => {
-                    self.buffer_control(request);
-                    received = true;
-                }
-                Some(Poll::Ready(Err(err))) => {
-                    tracing::warn!(
-                        err = &err as &dyn std::error::Error,
-                        "consomme control channel closed"
-                    );
-                    self.control_recv = None;
-                }
-                Some(Poll::Pending) | None => break,
-            }
-        }
-        loop {
-            let polled = self.port_recv.as_mut().map(|r| r.poll_recv(cx));
-            match polled {
-                Some(Poll::Ready(Ok(request))) => {
-                    self.buffer_request(request);
-                    received = true;
-                }
-                Some(Poll::Ready(Err(err))) => {
-                    tracing::warn!(
-                        err = &err as &dyn std::error::Error,
-                        "consomme port request channel closed"
-                    );
-                    self.port_recv = None;
-                }
-                Some(Poll::Pending) | None => break,
-            }
-        }
+        let Self {
+            control_recv,
+            port_recv,
+            pending,
+            ..
+        } = self;
+        // Borrow each receiver and `pending` separately so the shared buffering
+        // logic can be reused for both channels without a borrow conflict.
+        let mut received = drain_receiver(control_recv, cx, "control", |request| {
+            pending.buffer_control(request)
+        });
+        received |= drain_receiver(port_recv, cx, "port request", |request| {
+            pending.buffer_request(request)
+        });
         received
-    }
-
-    fn buffer_control(&mut self, request: ControlRequest) {
-        match request {
-            ControlRequest::Port(request) => self.buffer_request(request),
-            ControlRequest::UpdateState(rpc) => self.pending.state_updates.push(rpc),
-        }
-    }
-
-    /// Adds a port request to `pending`, coalescing it with any existing request
-    /// for the same port.
-    fn buffer_request(&mut self, request: ConsommeRequest) {
-        let key = PortKey::for_request(&request);
-        if let Some(existing) = self.pending.ports.remove(&key) {
-            let cancels = matches!(existing, ConsommeRequest::Bind(_))
-                && matches!(request, ConsommeRequest::Unbind(_));
-            if cancels {
-                // Unbind cancels a not-yet-applied bind; complete both as no-ops.
-                into_rpc(existing).complete(Ok(()));
-                into_rpc(request).complete(Ok(()));
-                tracing::debug!(guest_port = key.guest_port, "coalesced bind and unbind");
-                return;
-            }
-            // Newer request wins; report the older one as superseded.
-            into_rpc(existing).fail(PortRequestSuperseded);
-        }
-        self.pending.ports.insert(key, request);
     }
 }
 
@@ -465,11 +475,12 @@ impl net_backend::Endpoint for ConsommeEndpoint {
             }
             Ok(bound)
         });
-        bind_result?;
 
         // Apply requests buffered while no queue was running (see
-        // `wait_for_endpoint_action`). No pool is needed: these operations don't
-        // indicate received packets.
+        // `wait_for_endpoint_action`). This runs regardless of whether the
+        // static port-forward binding above succeeded, so the buffered RPCs
+        // always complete here instead of stalling until some unrelated future
+        // request triggers the next restart.
         let pending = std::mem::take(&mut self.pending);
         queue.with_consomme_no_pool(|c| {
             for request in pending.ports.into_values() {
@@ -483,6 +494,8 @@ impl net_backend::Endpoint for ConsommeEndpoint {
                 });
             }
         });
+
+        bind_result?;
 
         queues.push(queue);
         Ok(())
@@ -923,18 +936,22 @@ mod tests {
     #[test]
     fn unbind_cancels_pending_bind() {
         let mut ep = endpoint();
-        ep.buffer_request(ConsommeRequest::Bind(Rpc::detached(cfg(80))));
+        ep.pending
+            .buffer_request(ConsommeRequest::Bind(Rpc::detached(cfg(80))));
         assert_eq!(ep.pending.ports.len(), 1);
         // An unbind for the same port annihilates the not-yet-applied bind.
-        ep.buffer_request(ConsommeRequest::Unbind(Rpc::detached(cfg(80))));
+        ep.pending
+            .buffer_request(ConsommeRequest::Unbind(Rpc::detached(cfg(80))));
         assert!(ep.pending.ports.is_empty());
     }
 
     #[test]
     fn newer_request_supersedes_same_port() {
         let mut ep = endpoint();
-        ep.buffer_request(ConsommeRequest::Bind(Rpc::detached(cfg(80))));
-        ep.buffer_request(ConsommeRequest::Bind(Rpc::detached(cfg(80))));
+        ep.pending
+            .buffer_request(ConsommeRequest::Bind(Rpc::detached(cfg(80))));
+        ep.pending
+            .buffer_request(ConsommeRequest::Bind(Rpc::detached(cfg(80))));
         // The two binds collapse to a single pending entry.
         assert_eq!(ep.pending.ports.len(), 1);
     }
@@ -942,8 +959,10 @@ mod tests {
     #[test]
     fn different_ports_are_independent() {
         let mut ep = endpoint();
-        ep.buffer_request(ConsommeRequest::Bind(Rpc::detached(cfg(80))));
-        ep.buffer_request(ConsommeRequest::Bind(Rpc::detached(cfg(81))));
+        ep.pending
+            .buffer_request(ConsommeRequest::Bind(Rpc::detached(cfg(80))));
+        ep.pending
+            .buffer_request(ConsommeRequest::Bind(Rpc::detached(cfg(81))));
         assert_eq!(ep.pending.ports.len(), 2);
     }
 

--- a/vm/devices/net/net_consomme/src/lib.rs
+++ b/vm/devices/net/net_consomme/src/lib.rs
@@ -19,6 +19,7 @@ use mesh::rpc::Rpc;
 use mesh::rpc::RpcError;
 use mesh::rpc::RpcSend;
 use net_backend::BufferAccess;
+use net_backend::EndpointAction;
 use net_backend::L4Protocol;
 use net_backend::QueueConfig;
 use net_backend::RssConfig;
@@ -35,6 +36,7 @@ use net_backend_resources::consomme::HostPortConfig;
 use net_backend_resources::consomme::HostPortProtocol;
 use pal_async::driver::Driver;
 use parking_lot::Mutex;
+use std::collections::HashMap;
 use std::collections::VecDeque;
 use std::net::IpAddr;
 use std::net::Ipv4Addr;
@@ -93,6 +95,54 @@ fn socket_family(socket: &socket2::Socket) -> Result<IpVersion, consomme::BindEr
 
 pub struct ConsommeEndpoint {
     endpoint_state: Arc<Mutex<Option<EndpointState>>>,
+    /// In-proc control requests (see [`ConsommeControl`]).
+    control_recv: Option<mesh::Receiver<ControlRequest>>,
+    /// Cross-proc port bind/unbind requests (e.g. from ttrpc).
+    port_recv: Option<mesh::Receiver<ConsommeRequest>>,
+    /// Requests buffered until the next queue (re)start applies them. Coalesced
+    /// per port so the set stays bounded.
+    pending: PendingRequests,
+}
+
+/// Requests buffered while no queue owns the consomme state.
+#[derive(Default)]
+struct PendingRequests {
+    /// Bind/unbind requests, keyed by port; a newer request for a port replaces
+    /// (and completes) an older one.
+    ports: HashMap<PortKey, ConsommeRequest>,
+    /// In-proc state updates, applied in order.
+    state_updates: Vec<Rpc<ConsommeParamsUpdateFn, ()>>,
+}
+
+impl PendingRequests {
+    fn is_empty(&self) -> bool {
+        self.ports.is_empty() && self.state_updates.is_empty()
+    }
+}
+
+/// Coalescing key: bind/unbind for the same protocol, family, and guest port
+/// target the same forward.
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
+struct PortKey {
+    is_udp: bool,
+    is_ipv6: bool,
+    guest_port: u16,
+}
+
+impl PortKey {
+    fn for_request(request: &ConsommeRequest) -> Self {
+        let cfg = match request {
+            ConsommeRequest::Bind(rpc) | ConsommeRequest::Unbind(rpc) => rpc.input(),
+        };
+        Self {
+            is_udp: matches!(cfg.protocol, HostPortProtocol::Udp),
+            is_ipv6: matches!(
+                cfg.host_address,
+                Some(net_backend_resources::consomme::HostIpAddress::Ipv6(_))
+            ),
+            guest_port: cfg.guest_port,
+        }
+    }
 }
 
 /// Configuration for a port to forward from the host to the guest.
@@ -107,50 +157,130 @@ pub struct PortForwardConfig {
 
 struct EndpointState {
     consomme: Consomme,
-    recv: Option<mesh::Receiver<ConsommeMessage>>,
-    port_recv: Option<mesh::Receiver<ConsommeRequest>>,
     port_forwards: Vec<PortForwardConfig>,
 }
 
+/// Builder for a [`ConsommeEndpoint`].
+pub struct ConsommeEndpointBuilder {
+    state: ConsommeParams,
+    ports: Vec<PortForwardConfig>,
+    port_recv: Option<mesh::Receiver<ConsommeRequest>>,
+    control_recv: Option<mesh::Receiver<ControlRequest>>,
+}
+
+impl ConsommeEndpointBuilder {
+    /// Sets the ports to forward once the queue starts.
+    pub fn ports(mut self, ports: Vec<PortForwardConfig>) -> Self {
+        self.ports = ports;
+        self
+    }
+
+    /// Attaches a cross-process channel for runtime port bind/unbind requests.
+    pub fn port_requests(mut self, recv: mesh::Receiver<ConsommeRequest>) -> Self {
+        self.port_recv = Some(recv);
+        self
+    }
+
+    /// Builds the endpoint.
+    pub fn build(self) -> ConsommeEndpoint {
+        ConsommeEndpoint {
+            endpoint_state: Arc::new(Mutex::new(Some(EndpointState {
+                consomme: Consomme::new(self.state),
+                port_forwards: self.ports,
+            }))),
+            control_recv: self.control_recv,
+            port_recv: self.port_recv,
+            pending: PendingRequests::default(),
+        }
+    }
+
+    /// Builds the endpoint with an in-process [`ConsommeControl`] handle for
+    /// runtime bind/unbind and state updates.
+    pub fn build_with_control(mut self) -> (ConsommeEndpoint, ConsommeControl) {
+        let (send, recv) = mesh::channel();
+        self.control_recv = Some(recv);
+        (self.build(), ConsommeControl { send })
+    }
+}
+
 impl ConsommeEndpoint {
-    pub fn new(state: ConsommeParams) -> Self {
-        Self {
-            endpoint_state: Arc::new(Mutex::new(Some(EndpointState {
-                consomme: Consomme::new(state),
-                recv: None,
-                port_recv: None,
-                port_forwards: Vec::new(),
-            }))),
+    /// Starts building an endpoint with the given network parameters.
+    pub fn builder(state: ConsommeParams) -> ConsommeEndpointBuilder {
+        ConsommeEndpointBuilder {
+            state,
+            ports: Vec::new(),
+            port_recv: None,
+            control_recv: None,
         }
     }
 
-    /// Creates a new endpoint with ports to forward once the queue starts.
-    pub fn new_with_ports(state: ConsommeParams, ports: Vec<PortForwardConfig>) -> Self {
-        Self {
-            endpoint_state: Arc::new(Mutex::new(Some(EndpointState {
-                consomme: Consomme::new(state),
-                recv: None,
-                port_recv: None,
-                port_forwards: ports,
-            }))),
+    /// Drains available requests from both channels into `pending`, registering
+    /// wakers for channels with nothing ready. Returns whether any new request
+    /// was read.
+    fn drain_channels(&mut self, cx: &mut Context<'_>) -> bool {
+        let mut received = false;
+        loop {
+            let polled = self.control_recv.as_mut().map(|r| r.poll_recv(cx));
+            match polled {
+                Some(Poll::Ready(Ok(request))) => {
+                    self.buffer_control(request);
+                    received = true;
+                }
+                Some(Poll::Ready(Err(err))) => {
+                    tracing::warn!(
+                        err = &err as &dyn std::error::Error,
+                        "consomme control channel closed"
+                    );
+                    self.control_recv = None;
+                }
+                Some(Poll::Pending) | None => break,
+            }
+        }
+        loop {
+            let polled = self.port_recv.as_mut().map(|r| r.poll_recv(cx));
+            match polled {
+                Some(Poll::Ready(Ok(request))) => {
+                    self.buffer_request(request);
+                    received = true;
+                }
+                Some(Poll::Ready(Err(err))) => {
+                    tracing::warn!(
+                        err = &err as &dyn std::error::Error,
+                        "consomme port request channel closed"
+                    );
+                    self.port_recv = None;
+                }
+                Some(Poll::Pending) | None => break,
+            }
+        }
+        received
+    }
+
+    fn buffer_control(&mut self, request: ControlRequest) {
+        match request {
+            ControlRequest::Port(request) => self.buffer_request(request),
+            ControlRequest::UpdateState(rpc) => self.pending.state_updates.push(rpc),
         }
     }
 
-    /// Creates a new endpoint with initial ports and a channel for runtime
-    /// port bind/unbind requests from an external source (e.g. ttrpc server).
-    pub fn new_dynamic(
-        state: ConsommeParams,
-        ports: Vec<PortForwardConfig>,
-        port_recv: mesh::Receiver<ConsommeRequest>,
-    ) -> Self {
-        Self {
-            endpoint_state: Arc::new(Mutex::new(Some(EndpointState {
-                consomme: Consomme::new(state),
-                recv: None,
-                port_recv: Some(port_recv),
-                port_forwards: ports,
-            }))),
+    /// Adds a port request to `pending`, coalescing it with any existing request
+    /// for the same port.
+    fn buffer_request(&mut self, request: ConsommeRequest) {
+        let key = PortKey::for_request(&request);
+        if let Some(existing) = self.pending.ports.remove(&key) {
+            let cancels = matches!(existing, ConsommeRequest::Bind(_))
+                && matches!(request, ConsommeRequest::Unbind(_));
+            if cancels {
+                // Unbind cancels a not-yet-applied bind; complete both as no-ops.
+                into_rpc(existing).complete(Ok(()));
+                into_rpc(request).complete(Ok(()));
+                tracing::debug!(guest_port = key.guest_port, "coalesced bind and unbind");
+                return;
+            }
+            // Newer request wins; report the older one as superseded.
+            into_rpc(existing).fail(PortRequestSuperseded);
         }
+        self.pending.ports.insert(key, request);
     }
 }
 
@@ -166,7 +296,7 @@ impl InspectMut for ConsommeEndpoint {
 
 /// Provide dynamic updates during runtime.
 pub struct ConsommeControl {
-    send: mesh::Sender<ConsommeMessage>,
+    send: mesh::Sender<ControlRequest>,
 }
 
 /// Error type returned from some dynamic update functions like bind_port.
@@ -181,7 +311,7 @@ pub enum ConsommeMessageError {
 }
 
 /// Callback to modify network state dynamically.
-pub type ConsommeParamsUpdateFn = Box<dyn Fn(&mut ConsommeParams) + Send>;
+pub type ConsommeParamsUpdateFn = Box<dyn Fn(&mut ConsommeParams) + Send + Sync>;
 
 #[derive(Debug, Clone, Copy)]
 pub enum IpProtocol {
@@ -207,10 +337,12 @@ impl From<IpProtocol> for HostPortProtocol {
     }
 }
 
-enum ConsommeMessage {
-    /// A port bind/unbind request (shared with cross-proc `ConsommeRequest`).
-    PortRequest(ConsommeRequest),
-    /// In-proc only: update dynamic network state.
+/// In-proc control request. A superset of the cross-proc `ConsommeRequest` that
+/// also carries operations which can't cross a process boundary.
+enum ControlRequest {
+    /// Port bind/unbind (same as the cross-proc request).
+    Port(ConsommeRequest),
+    /// Update dynamic network state (in-proc only).
     UpdateState(Rpc<ConsommeParamsUpdateFn, ()>),
 }
 
@@ -225,7 +357,7 @@ impl ConsommeControl {
     ) -> Result<(), ConsommeMessageError> {
         self.send
             .call(
-                |rpc| ConsommeMessage::PortRequest(ConsommeRequest::Bind(rpc)),
+                |rpc| ControlRequest::Port(ConsommeRequest::Bind(rpc)),
                 HostPortConfig {
                     protocol: protocol.into(),
                     host_address: ip_addr.map(net_backend_resources::consomme::HostIpAddress::from),
@@ -247,7 +379,7 @@ impl ConsommeControl {
     ) -> Result<(), ConsommeMessageError> {
         self.send
             .call(
-                |rpc| ConsommeMessage::PortRequest(ConsommeRequest::Unbind(rpc)),
+                |rpc| ControlRequest::Port(ConsommeRequest::Unbind(rpc)),
                 HostPortConfig {
                     protocol: protocol.into(),
                     host_address: ip_addr.map(net_backend_resources::consomme::HostIpAddress::from),
@@ -266,7 +398,7 @@ impl ConsommeControl {
         f: ConsommeParamsUpdateFn,
     ) -> Result<(), ConsommeMessageError> {
         self.send
-            .call(ConsommeMessage::UpdateState, f)
+            .call(ControlRequest::UpdateState, f)
             .await
             .map_err(ConsommeMessageError::Mesh)
     }
@@ -334,6 +466,24 @@ impl net_backend::Endpoint for ConsommeEndpoint {
             Ok(bound)
         });
         bind_result?;
+
+        // Apply requests buffered while no queue was running (see
+        // `wait_for_endpoint_action`). No pool is needed: these operations don't
+        // indicate received packets.
+        let pending = std::mem::take(&mut self.pending);
+        queue.with_consomme_no_pool(|c| {
+            for request in pending.ports.into_values() {
+                process_port_request(c, request);
+            }
+            for rpc in pending.state_updates {
+                rpc.handle_sync(|f| {
+                    f(c.get_mut().params_mut());
+                    c.get_mut().clear_local_addr_map();
+                    c.update_dns_nameservers()
+                });
+            }
+        });
+
         queues.push(queue);
         Ok(())
     }
@@ -354,6 +504,18 @@ impl net_backend::Endpoint for ConsommeEndpoint {
             tso: true,
             uso: true,
         }
+    }
+
+    async fn wait_for_endpoint_action(&mut self) -> EndpointAction {
+        std::future::poll_fn(|cx| {
+            if self.drain_channels(cx) && !self.pending.is_empty() {
+                Poll::Ready(())
+            } else {
+                Poll::Pending
+            }
+        })
+        .await;
+        EndpointAction::RestartRequired
     }
 }
 
@@ -413,57 +575,6 @@ impl ConsommeQueue {
                 driver: &self.driver,
                 pool,
             }))
-    }
-
-    fn poll_message(&mut self, cx: &mut Context<'_>, pool: &mut dyn BufferAccess) {
-        // process all pending messages
-        let state = self.endpoint_state.as_mut().unwrap();
-        while let Some(recv) = &mut state.recv {
-            match recv.poll_recv(cx) {
-                Poll::Ready(Err(err)) => {
-                    tracing::warn!(
-                        err = &err as &dyn std::error::Error,
-                        "Consomme dynamic update channel failure"
-                    );
-                    state.recv = None;
-                    break;
-                }
-                Poll::Ready(Ok(message)) => process_message(
-                    &mut state.consomme.access(&mut Client {
-                        state: &mut self.state,
-                        stats: &mut self.stats,
-                        driver: &self.driver,
-                        pool,
-                    }),
-                    message,
-                ),
-                Poll::Pending => break,
-            }
-        }
-
-        // Poll cross-proc port request channel.
-        while let Some(recv) = &mut state.port_recv {
-            match recv.poll_recv(cx) {
-                Poll::Ready(Err(err)) => {
-                    tracing::warn!(
-                        err = &err as &dyn std::error::Error,
-                        "Consomme port request channel failure"
-                    );
-                    state.port_recv = None;
-                    return;
-                }
-                Poll::Ready(Ok(request)) => process_port_request(
-                    &mut state.consomme.access(&mut Client {
-                        state: &mut self.state,
-                        stats: &mut self.stats,
-                        driver: &self.driver,
-                        pool,
-                    }),
-                    request,
-                ),
-                Poll::Pending => return,
-            }
-        }
     }
 }
 
@@ -529,6 +640,18 @@ fn execute_unbind(
     result.context("failed to unbind port")
 }
 
+/// Returned to a port request superseded by a newer one for the same port.
+#[derive(Debug, Error)]
+#[error("port request superseded by a newer request for the same guest port")]
+struct PortRequestSuperseded;
+
+/// Extracts the inner RPC from a `ConsommeRequest` to complete a coalesced one.
+fn into_rpc(request: ConsommeRequest) -> mesh::rpc::FailableRpc<HostPortConfig, ()> {
+    match request {
+        ConsommeRequest::Bind(rpc) | ConsommeRequest::Unbind(rpc) => rpc,
+    }
+}
+
 /// Handle a `ConsommeRequest` (shared by both in-proc and cross-proc paths).
 fn process_port_request(
     consomme: &mut consomme::Access<'_, impl consomme::Client>,
@@ -553,23 +676,6 @@ fn process_port_request(
                     Ok(())
                 },
             );
-        }
-    }
-}
-
-/// Handle a `ConsommeMessage` — delegates port operations to `process_port_request`.
-fn process_message(
-    consomme: &mut consomme::Access<'_, impl consomme::Client>,
-    message: ConsommeMessage,
-) {
-    match message {
-        ConsommeMessage::PortRequest(request) => process_port_request(consomme, request),
-        ConsommeMessage::UpdateState(rpc) => {
-            rpc.handle_sync(|f| {
-                f(consomme.get_mut().params_mut());
-                consomme.get_mut().clear_local_addr_map();
-                consomme.update_dns_nameservers()
-            });
         }
     }
 }
@@ -648,12 +754,6 @@ impl net_backend::Queue for ConsommeQueue {
 
             self.state.tx_ready.push_back(tx_id);
         }
-
-        // TODO: handle messages asynchronously from any queue processing, since
-        // there is no guarantee the queue will be processed at all (e.g., if
-        // the guest stops processing traffic). This will probably require adding
-        // a lock around the consomme state.
-        self.poll_message(cx, pool);
 
         self.with_consomme(pool, |c| c.poll(cx));
 
@@ -799,5 +899,75 @@ impl consomme::Client for Client<'_> {
         } else {
             0
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use net_backend_resources::consomme::HostPort;
+
+    fn cfg(guest_port: u16) -> HostPortConfig {
+        HostPortConfig {
+            protocol: HostPortProtocol::Tcp,
+            host_address: None,
+            host_port: HostPort::Fixed(8080),
+            guest_port,
+        }
+    }
+
+    fn endpoint() -> ConsommeEndpoint {
+        ConsommeEndpoint::builder(ConsommeParams::new().unwrap()).build()
+    }
+
+    #[test]
+    fn unbind_cancels_pending_bind() {
+        let mut ep = endpoint();
+        ep.buffer_request(ConsommeRequest::Bind(Rpc::detached(cfg(80))));
+        assert_eq!(ep.pending.ports.len(), 1);
+        // An unbind for the same port annihilates the not-yet-applied bind.
+        ep.buffer_request(ConsommeRequest::Unbind(Rpc::detached(cfg(80))));
+        assert!(ep.pending.ports.is_empty());
+    }
+
+    #[test]
+    fn newer_request_supersedes_same_port() {
+        let mut ep = endpoint();
+        ep.buffer_request(ConsommeRequest::Bind(Rpc::detached(cfg(80))));
+        ep.buffer_request(ConsommeRequest::Bind(Rpc::detached(cfg(80))));
+        // The two binds collapse to a single pending entry.
+        assert_eq!(ep.pending.ports.len(), 1);
+    }
+
+    #[test]
+    fn different_ports_are_independent() {
+        let mut ep = endpoint();
+        ep.buffer_request(ConsommeRequest::Bind(Rpc::detached(cfg(80))));
+        ep.buffer_request(ConsommeRequest::Bind(Rpc::detached(cfg(81))));
+        assert_eq!(ep.pending.ports.len(), 2);
+    }
+
+    #[test]
+    fn drain_is_edge_triggered() {
+        use std::task::Context;
+        use std::task::Waker;
+
+        let (send, recv) = mesh::channel::<ConsommeRequest>();
+        let mut ep = ConsommeEndpoint::builder(ConsommeParams::new().unwrap())
+            .port_requests(recv)
+            .build();
+        let mut cx = Context::from_waker(Waker::noop());
+
+        // No requests yet: nothing read.
+        assert!(!ep.drain_channels(&mut cx));
+
+        // A request becomes available: read exactly once.
+        send.send(ConsommeRequest::Bind(Rpc::detached(cfg(80))));
+        assert!(ep.drain_channels(&mut cx));
+        assert_eq!(ep.pending.ports.len(), 1);
+
+        // Nothing new, even though `pending` is non-empty: no re-trigger (this
+        // is what stops the frontend's restart-coalescing loop from spinning).
+        assert!(!ep.drain_channels(&mut cx));
     }
 }

--- a/vm/devices/net/net_consomme/src/lib.rs
+++ b/vm/devices/net/net_consomme/src/lib.rs
@@ -318,6 +318,9 @@ pub enum ConsommeMessageError {
     /// Error executing request on current network instance.
     #[error("bind error")]
     Bind(consomme::BindError),
+    /// Error from a remote operation on the endpoint.
+    #[error(transparent)]
+    Remote(mesh::error::RemoteError),
 }
 
 /// Callback to modify network state dynamically.
@@ -338,14 +341,13 @@ impl From<HostPortProtocol> for IpProtocol {
     }
 }
 
-/// Configuration for unbinding a previously forwarded port.
-struct PortUnbindConfig {
-    /// The protocol that was forwarded.
-    protocol: IpProtocol,
-    /// The IP address family that was forwarded.
-    family: IpVersion,
-    /// The guest port that was forwarded.
-    guest_port: u16,
+impl From<IpProtocol> for HostPortProtocol {
+    fn from(p: IpProtocol) -> Self {
+        match p {
+            IpProtocol::Tcp => HostPortProtocol::Tcp,
+            IpProtocol::Udp => HostPortProtocol::Udp,
+        }
+    }
 }
 
 /// In-proc control request. A superset of the cross-proc `ConsommeRequest` that
@@ -693,7 +695,6 @@ fn process_port_request(
         }
     }
 }
-
 
 impl net_backend::Queue for ConsommeQueue {
     fn poll_ready(&mut self, cx: &mut Context<'_>, pool: &mut dyn BufferAccess) -> Poll<()> {

--- a/vm/devices/net/net_consomme/src/lib.rs
+++ b/vm/devices/net/net_consomme/src/lib.rs
@@ -19,6 +19,7 @@ use mesh::rpc::Rpc;
 use mesh::rpc::RpcError;
 use mesh::rpc::RpcSend;
 use net_backend::BufferAccess;
+use net_backend::EndpointAction;
 use net_backend::L4Protocol;
 use net_backend::QueueConfig;
 use net_backend::RssConfig;
@@ -35,6 +36,7 @@ use net_backend_resources::consomme::HostPortConfig;
 use net_backend_resources::consomme::HostPortProtocol;
 use pal_async::driver::Driver;
 use parking_lot::Mutex;
+use std::collections::HashMap;
 use std::collections::VecDeque;
 use std::net::IpAddr;
 use std::net::Ipv4Addr;
@@ -93,6 +95,54 @@ fn socket_family(socket: &socket2::Socket) -> Result<IpVersion, consomme::BindEr
 
 pub struct ConsommeEndpoint {
     endpoint_state: Arc<Mutex<Option<EndpointState>>>,
+    /// In-proc control requests (see [`ConsommeControl`]).
+    control_recv: Option<mesh::Receiver<ControlRequest>>,
+    /// Cross-proc port bind/unbind requests (e.g. from ttrpc).
+    port_recv: Option<mesh::Receiver<ConsommeRequest>>,
+    /// Requests buffered until the next queue (re)start applies them. Coalesced
+    /// per port so the set stays bounded.
+    pending: PendingRequests,
+}
+
+/// Requests buffered while no queue owns the consomme state.
+#[derive(Default)]
+struct PendingRequests {
+    /// Bind/unbind requests, keyed by port; a newer request for a port replaces
+    /// (and completes) an older one.
+    ports: HashMap<PortKey, ConsommeRequest>,
+    /// In-proc state updates, applied in order.
+    state_updates: Vec<Rpc<ConsommeParamsUpdateFn, ()>>,
+}
+
+impl PendingRequests {
+    fn is_empty(&self) -> bool {
+        self.ports.is_empty() && self.state_updates.is_empty()
+    }
+}
+
+/// Coalescing key: bind/unbind for the same protocol, family, and guest port
+/// target the same forward.
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
+struct PortKey {
+    is_udp: bool,
+    is_ipv6: bool,
+    guest_port: u16,
+}
+
+impl PortKey {
+    fn for_request(request: &ConsommeRequest) -> Self {
+        let cfg = match request {
+            ConsommeRequest::Bind(rpc) | ConsommeRequest::Unbind(rpc) => rpc.input(),
+        };
+        Self {
+            is_udp: matches!(cfg.protocol, HostPortProtocol::Udp),
+            is_ipv6: matches!(
+                cfg.host_address,
+                Some(net_backend_resources::consomme::HostIpAddress::Ipv6(_))
+            ),
+            guest_port: cfg.guest_port,
+        }
+    }
 }
 
 /// Configuration for a port to forward from the host to the guest.
@@ -107,66 +157,130 @@ pub struct PortForwardConfig {
 
 struct EndpointState {
     consomme: Consomme,
-    recv: Option<mesh::Receiver<ConsommeMessage>>,
-    port_recv: Option<mesh::Receiver<ConsommeRequest>>,
     port_forwards: Vec<PortForwardConfig>,
 }
 
-impl ConsommeEndpoint {
-    pub fn new(state: ConsommeParams) -> Self {
-        Self {
+/// Builder for a [`ConsommeEndpoint`].
+pub struct ConsommeEndpointBuilder {
+    state: ConsommeParams,
+    ports: Vec<PortForwardConfig>,
+    port_recv: Option<mesh::Receiver<ConsommeRequest>>,
+    control_recv: Option<mesh::Receiver<ControlRequest>>,
+}
+
+impl ConsommeEndpointBuilder {
+    /// Sets the ports to forward once the queue starts.
+    pub fn ports(mut self, ports: Vec<PortForwardConfig>) -> Self {
+        self.ports = ports;
+        self
+    }
+
+    /// Attaches a cross-process channel for runtime port bind/unbind requests.
+    pub fn port_requests(mut self, recv: mesh::Receiver<ConsommeRequest>) -> Self {
+        self.port_recv = Some(recv);
+        self
+    }
+
+    /// Builds the endpoint.
+    pub fn build(self) -> ConsommeEndpoint {
+        ConsommeEndpoint {
             endpoint_state: Arc::new(Mutex::new(Some(EndpointState {
-                consomme: Consomme::new(state),
-                recv: None,
-                port_recv: None,
-                port_forwards: Vec::new(),
+                consomme: Consomme::new(self.state),
+                port_forwards: self.ports,
             }))),
+            control_recv: self.control_recv,
+            port_recv: self.port_recv,
+            pending: PendingRequests::default(),
         }
     }
 
-    /// Creates a new endpoint with ports to forward once the queue starts.
-    pub fn new_with_ports(state: ConsommeParams, ports: Vec<PortForwardConfig>) -> Self {
-        Self {
-            endpoint_state: Arc::new(Mutex::new(Some(EndpointState {
-                consomme: Consomme::new(state),
-                recv: None,
-                port_recv: None,
-                port_forwards: ports,
-            }))),
-        }
-    }
-
-    pub fn new_dynamic(state: ConsommeParams) -> (Self, ConsommeControl) {
-        let consomme = Consomme::new(state);
+    /// Builds the endpoint with an in-process [`ConsommeControl`] handle for
+    /// runtime bind/unbind and state updates.
+    pub fn build_with_control(mut self) -> (ConsommeEndpoint, ConsommeControl) {
         let (send, recv) = mesh::channel();
-        (
-            Self {
-                endpoint_state: Arc::new(Mutex::new(Some(EndpointState {
-                    consomme,
-                    recv: Some(recv),
-                    port_recv: None,
-                    port_forwards: Vec::new(),
-                }))),
-            },
-            ConsommeControl { send },
-        )
+        self.control_recv = Some(recv);
+        (self.build(), ConsommeControl { send })
+    }
+}
+
+impl ConsommeEndpoint {
+    /// Starts building an endpoint with the given network parameters.
+    pub fn builder(state: ConsommeParams) -> ConsommeEndpointBuilder {
+        ConsommeEndpointBuilder {
+            state,
+            ports: Vec::new(),
+            port_recv: None,
+            control_recv: None,
+        }
     }
 
-    /// Creates a new endpoint with initial ports and a channel for runtime
-    /// port bind/unbind requests from an external source (e.g. ttrpc server).
-    pub fn new_with_port_channel(
-        state: ConsommeParams,
-        ports: Vec<PortForwardConfig>,
-        port_recv: mesh::Receiver<ConsommeRequest>,
-    ) -> Self {
-        Self {
-            endpoint_state: Arc::new(Mutex::new(Some(EndpointState {
-                consomme: Consomme::new(state),
-                recv: None,
-                port_recv: Some(port_recv),
-                port_forwards: ports,
-            }))),
+    /// Drains available requests from both channels into `pending`, registering
+    /// wakers for channels with nothing ready. Returns whether any new request
+    /// was read.
+    fn drain_channels(&mut self, cx: &mut Context<'_>) -> bool {
+        let mut received = false;
+        loop {
+            let polled = self.control_recv.as_mut().map(|r| r.poll_recv(cx));
+            match polled {
+                Some(Poll::Ready(Ok(request))) => {
+                    self.buffer_control(request);
+                    received = true;
+                }
+                Some(Poll::Ready(Err(err))) => {
+                    tracing::warn!(
+                        err = &err as &dyn std::error::Error,
+                        "consomme control channel closed"
+                    );
+                    self.control_recv = None;
+                }
+                Some(Poll::Pending) | None => break,
+            }
         }
+        loop {
+            let polled = self.port_recv.as_mut().map(|r| r.poll_recv(cx));
+            match polled {
+                Some(Poll::Ready(Ok(request))) => {
+                    self.buffer_request(request);
+                    received = true;
+                }
+                Some(Poll::Ready(Err(err))) => {
+                    tracing::warn!(
+                        err = &err as &dyn std::error::Error,
+                        "consomme port request channel closed"
+                    );
+                    self.port_recv = None;
+                }
+                Some(Poll::Pending) | None => break,
+            }
+        }
+        received
+    }
+
+    fn buffer_control(&mut self, request: ControlRequest) {
+        match request {
+            ControlRequest::Port(request) => self.buffer_request(request),
+            ControlRequest::UpdateState(rpc) => self.pending.state_updates.push(rpc),
+        }
+    }
+
+    /// Adds a port request to `pending`, coalescing it with any existing request
+    /// for the same port.
+    fn buffer_request(&mut self, request: ConsommeRequest) {
+        let key = PortKey::for_request(&request);
+        if let Some(existing) = self.pending.ports.remove(&key) {
+            let cancels = matches!(existing, ConsommeRequest::Bind(_))
+                && matches!(request, ConsommeRequest::Unbind(_));
+            if cancels {
+                // Unbind cancels a not-yet-applied bind; complete both as no-ops.
+                into_rpc(existing).complete(Ok(()));
+                into_rpc(request).complete(Ok(()));
+                tracing::debug!(guest_port = key.guest_port, "coalesced bind and unbind");
+                return;
+            }
+            // Newer request wins; report the older one as superseded.
+            into_rpc(existing).fail(PortRequestSuperseded);
+        }
+        self.pending.ports.insert(key, request);
     }
 }
 
@@ -182,7 +296,7 @@ impl InspectMut for ConsommeEndpoint {
 
 /// Provide dynamic updates during runtime.
 pub struct ConsommeControl {
-    send: mesh::Sender<ConsommeMessage>,
+    send: mesh::Sender<ControlRequest>,
 }
 
 /// Error type returned from some dynamic update functions like bind_port.
@@ -197,7 +311,7 @@ pub enum ConsommeMessageError {
 }
 
 /// Callback to modify network state dynamically.
-pub type ConsommeParamsUpdateFn = Box<dyn Fn(&mut ConsommeParams) + Send>;
+pub type ConsommeParamsUpdateFn = Box<dyn Fn(&mut ConsommeParams) + Send + Sync>;
 
 #[derive(Debug, Clone, Copy)]
 pub enum IpProtocol {
@@ -224,9 +338,12 @@ struct PortUnbindConfig {
     guest_port: u16,
 }
 
-enum ConsommeMessage {
-    BindPort(Rpc<PortForwardConfig, Result<(), consomme::BindError>>),
-    UnbindPort(Rpc<PortUnbindConfig, Result<(), consomme::BindError>>),
+/// In-proc control request. A superset of the cross-proc `ConsommeRequest` that
+/// also carries operations which can't cross a process boundary.
+enum ControlRequest {
+    /// Port bind/unbind (same as the cross-proc request).
+    Port(ConsommeRequest),
+    /// Update dynamic network state (in-proc only).
     UpdateState(Rpc<ConsommeParamsUpdateFn, ()>),
 }
 
@@ -238,55 +355,42 @@ impl ConsommeControl {
         ip_addr: Option<IpAddr>,
         host_port: u16,
         guest_port: u16,
-    ) -> Result<u16, ConsommeMessageError> {
-        let socket = create_bound_socket(&protocol, ip_addr, host_port)
-            .map_err(|e| ConsommeMessageError::Bind(consomme::BindError::Io(e)))?;
-        let host_addr = socket_addr(&socket).map_err(ConsommeMessageError::Bind)?;
+    ) -> Result<(), ConsommeMessageError> {
         self.send
             .call(
-                ConsommeMessage::BindPort,
-                PortForwardConfig {
-                    protocol,
-                    socket,
+                |rpc| ControlRequest::Port(ConsommeRequest::Bind(rpc)),
+                HostPortConfig {
+                    protocol: protocol.into(),
+                    host_address: ip_addr.map(net_backend_resources::consomme::HostIpAddress::from),
+                    host_port: net_backend_resources::consomme::HostPort::Fixed(host_port),
                     guest_port,
                 },
             )
             .await
             .map_err(ConsommeMessageError::Mesh)?
-            .map(|()| {
-                let bound_host_port = host_addr.port();
-                tracing::info!(
-                    ?protocol,
-                    requested_host_port = host_port,
-                    bound_host_addr = %host_addr,
-                    bound_host_port,
-                    guest_port,
-                    "port forward bound"
-                );
-                bound_host_port
-            })
-            .map_err(ConsommeMessageError::Bind)
+            .map_err(ConsommeMessageError::Remote)
     }
 
     /// Unbinds a port and IP family previously reserved with bind_port().
     pub async fn unbind_port(
         &self,
         protocol: IpProtocol,
-        family: IpVersion,
+        ip_addr: Option<IpAddr>,
         guest_port: u16,
     ) -> Result<(), ConsommeMessageError> {
         self.send
             .call(
-                ConsommeMessage::UnbindPort,
-                PortUnbindConfig {
-                    protocol,
-                    family,
+                |rpc| ControlRequest::Port(ConsommeRequest::Unbind(rpc)),
+                HostPortConfig {
+                    protocol: protocol.into(),
+                    host_address: ip_addr.map(net_backend_resources::consomme::HostIpAddress::from),
+                    host_port: net_backend_resources::consomme::HostPort::Fixed(0),
                     guest_port,
                 },
             )
             .await
             .map_err(ConsommeMessageError::Mesh)?
-            .map_err(ConsommeMessageError::Bind)
+            .map_err(ConsommeMessageError::Remote)
     }
 
     /// Updates dynamic network state
@@ -295,7 +399,7 @@ impl ConsommeControl {
         f: ConsommeParamsUpdateFn,
     ) -> Result<(), ConsommeMessageError> {
         self.send
-            .call(ConsommeMessage::UpdateState, f)
+            .call(ControlRequest::UpdateState, f)
             .await
             .map_err(ConsommeMessageError::Mesh)
     }
@@ -363,6 +467,24 @@ impl net_backend::Endpoint for ConsommeEndpoint {
             Ok(bound)
         });
         bind_result?;
+
+        // Apply requests buffered while no queue was running (see
+        // `wait_for_endpoint_action`). No pool is needed: these operations don't
+        // indicate received packets.
+        let pending = std::mem::take(&mut self.pending);
+        queue.with_consomme_no_pool(|c| {
+            for request in pending.ports.into_values() {
+                process_port_request(c, request);
+            }
+            for rpc in pending.state_updates {
+                rpc.handle_sync(|f| {
+                    f(c.get_mut().params_mut());
+                    c.get_mut().clear_local_addr_map();
+                    c.update_dns_nameservers()
+                });
+            }
+        });
+
         queues.push(queue);
         Ok(())
     }
@@ -383,6 +505,18 @@ impl net_backend::Endpoint for ConsommeEndpoint {
             tso: true,
             uso: true,
         }
+    }
+
+    async fn wait_for_endpoint_action(&mut self) -> EndpointAction {
+        std::future::poll_fn(|cx| {
+            if self.drain_channels(cx) && !self.pending.is_empty() {
+                Poll::Ready(())
+            } else {
+                Poll::Pending
+            }
+        })
+        .await;
+        EndpointAction::RestartRequired
     }
 }
 
@@ -442,57 +576,6 @@ impl ConsommeQueue {
                 driver: &self.driver,
                 pool,
             }))
-    }
-
-    fn poll_message(&mut self, cx: &mut Context<'_>, pool: &mut dyn BufferAccess) {
-        // process all pending messages
-        let state = self.endpoint_state.as_mut().unwrap();
-        while let Some(recv) = &mut state.recv {
-            match recv.poll_recv(cx) {
-                Poll::Ready(Err(err)) => {
-                    tracing::warn!(
-                        err = &err as &dyn std::error::Error,
-                        "Consomme dynamic update channel failure"
-                    );
-                    state.recv = None;
-                    break;
-                }
-                Poll::Ready(Ok(message)) => process_message(
-                    &mut state.consomme.access(&mut Client {
-                        state: &mut self.state,
-                        stats: &mut self.stats,
-                        driver: &self.driver,
-                        pool,
-                    }),
-                    message,
-                ),
-                Poll::Pending => break,
-            }
-        }
-
-        // Poll cross-proc port request channel.
-        while let Some(recv) = &mut state.port_recv {
-            match recv.poll_recv(cx) {
-                Poll::Ready(Err(err)) => {
-                    tracing::warn!(
-                        err = &err as &dyn std::error::Error,
-                        "Consomme port request channel failure"
-                    );
-                    state.port_recv = None;
-                    return;
-                }
-                Poll::Ready(Ok(request)) => process_port_request(
-                    &mut state.consomme.access(&mut Client {
-                        state: &mut self.state,
-                        stats: &mut self.stats,
-                        driver: &self.driver,
-                        pool,
-                    }),
-                    request,
-                ),
-                Poll::Pending => return,
-            }
-        }
     }
 }
 
@@ -558,6 +641,18 @@ fn execute_unbind(
     result.context("failed to unbind port")
 }
 
+/// Returned to a port request superseded by a newer one for the same port.
+#[derive(Debug, Error)]
+#[error("port request superseded by a newer request for the same guest port")]
+struct PortRequestSuperseded;
+
+/// Extracts the inner RPC from a `ConsommeRequest` to complete a coalesced one.
+fn into_rpc(request: ConsommeRequest) -> mesh::rpc::FailableRpc<HostPortConfig, ()> {
+    match request {
+        ConsommeRequest::Bind(rpc) | ConsommeRequest::Unbind(rpc) => rpc,
+    }
+}
+
 /// Handle a `ConsommeRequest` (shared by both in-proc and cross-proc paths).
 fn process_port_request(
     consomme: &mut consomme::Access<'_, impl consomme::Client>,
@@ -586,41 +681,6 @@ fn process_port_request(
     }
 }
 
-/// Handle an in-process `ConsommeMessage` from a `ConsommeControl`.
-fn process_message(
-    consomme: &mut consomme::Access<'_, impl consomme::Client>,
-    message: ConsommeMessage,
-) {
-    match message {
-        ConsommeMessage::BindPort(rpc) => {
-            rpc.handle_sync(|bind_message| match bind_message.protocol {
-                IpProtocol::Tcp => {
-                    consomme.bind_tcp_port(bind_message.socket, bind_message.guest_port)
-                }
-                IpProtocol::Udp => {
-                    consomme.bind_udp_port(bind_message.socket, bind_message.guest_port)
-                }
-            });
-        }
-        ConsommeMessage::UnbindPort(rpc) => {
-            rpc.handle_sync(|unbind_message| match unbind_message.protocol {
-                IpProtocol::Tcp => {
-                    consomme.unbind_tcp_port(unbind_message.family, unbind_message.guest_port)
-                }
-                IpProtocol::Udp => {
-                    consomme.unbind_udp_port(unbind_message.family, unbind_message.guest_port)
-                }
-            });
-        }
-        ConsommeMessage::UpdateState(rpc) => {
-            rpc.handle_sync(|f| {
-                f(consomme.get_mut().params_mut());
-                consomme.get_mut().clear_local_addr_map();
-                consomme.update_dns_nameservers()
-            });
-        }
-    }
-}
 
 impl net_backend::Queue for ConsommeQueue {
     fn poll_ready(&mut self, cx: &mut Context<'_>, pool: &mut dyn BufferAccess) -> Poll<()> {
@@ -696,12 +756,6 @@ impl net_backend::Queue for ConsommeQueue {
 
             self.state.tx_ready.push_back(tx_id);
         }
-
-        // TODO: handle messages asynchronously from any queue processing, since
-        // there is no guarantee the queue will be processed at all (e.g., if
-        // the guest stops processing traffic). This will probably require adding
-        // a lock around the consomme state.
-        self.poll_message(cx, pool);
 
         self.with_consomme(pool, |c| c.poll(cx));
 
@@ -847,5 +901,75 @@ impl consomme::Client for Client<'_> {
         } else {
             0
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use net_backend_resources::consomme::HostPort;
+
+    fn cfg(guest_port: u16) -> HostPortConfig {
+        HostPortConfig {
+            protocol: HostPortProtocol::Tcp,
+            host_address: None,
+            host_port: HostPort::Fixed(8080),
+            guest_port,
+        }
+    }
+
+    fn endpoint() -> ConsommeEndpoint {
+        ConsommeEndpoint::builder(ConsommeParams::new().unwrap()).build()
+    }
+
+    #[test]
+    fn unbind_cancels_pending_bind() {
+        let mut ep = endpoint();
+        ep.buffer_request(ConsommeRequest::Bind(Rpc::detached(cfg(80))));
+        assert_eq!(ep.pending.ports.len(), 1);
+        // An unbind for the same port annihilates the not-yet-applied bind.
+        ep.buffer_request(ConsommeRequest::Unbind(Rpc::detached(cfg(80))));
+        assert!(ep.pending.ports.is_empty());
+    }
+
+    #[test]
+    fn newer_request_supersedes_same_port() {
+        let mut ep = endpoint();
+        ep.buffer_request(ConsommeRequest::Bind(Rpc::detached(cfg(80))));
+        ep.buffer_request(ConsommeRequest::Bind(Rpc::detached(cfg(80))));
+        // The two binds collapse to a single pending entry.
+        assert_eq!(ep.pending.ports.len(), 1);
+    }
+
+    #[test]
+    fn different_ports_are_independent() {
+        let mut ep = endpoint();
+        ep.buffer_request(ConsommeRequest::Bind(Rpc::detached(cfg(80))));
+        ep.buffer_request(ConsommeRequest::Bind(Rpc::detached(cfg(81))));
+        assert_eq!(ep.pending.ports.len(), 2);
+    }
+
+    #[test]
+    fn drain_is_edge_triggered() {
+        use std::task::Context;
+        use std::task::Waker;
+
+        let (send, recv) = mesh::channel::<ConsommeRequest>();
+        let mut ep = ConsommeEndpoint::builder(ConsommeParams::new().unwrap())
+            .port_requests(recv)
+            .build();
+        let mut cx = Context::from_waker(Waker::noop());
+
+        // No requests yet: nothing read.
+        assert!(!ep.drain_channels(&mut cx));
+
+        // A request becomes available: read exactly once.
+        send.send(ConsommeRequest::Bind(Rpc::detached(cfg(80))));
+        assert!(ep.drain_channels(&mut cx));
+        assert_eq!(ep.pending.ports.len(), 1);
+
+        // Nothing new, even though `pending` is non-empty: no re-trigger (this
+        // is what stops the frontend's restart-coalescing loop from spinning).
+        assert!(!ep.drain_channels(&mut cx));
     }
 }

--- a/vm/devices/net/net_consomme/src/resolver.rs
+++ b/vm/devices/net/net_consomme/src/resolver.rs
@@ -97,7 +97,7 @@ impl ResolveResource<NetEndpointHandleKind, ConsommeHandle> for ConsommeResolver
             })
             .collect::<Result<Vec<_>, ResolveConsommeError>>()?;
         let endpoint = if let Some(port_recv) = resource.recv {
-            ConsommeEndpoint::new_dynamic(state, port_forwards, port_recv)
+            ConsommeEndpoint::new_with_port_channel(state, port_forwards, port_recv)
         } else {
             ConsommeEndpoint::new_with_ports(state, port_forwards)
         };

--- a/vm/devices/net/net_consomme/src/resolver.rs
+++ b/vm/devices/net/net_consomme/src/resolver.rs
@@ -96,11 +96,10 @@ impl ResolveResource<NetEndpointHandleKind, ConsommeHandle> for ConsommeResolver
                 })
             })
             .collect::<Result<Vec<_>, ResolveConsommeError>>()?;
-        let endpoint = if let Some(port_recv) = resource.recv {
-            ConsommeEndpoint::new_with_port_channel(state, port_forwards, port_recv)
-        } else {
-            ConsommeEndpoint::new_with_ports(state, port_forwards)
-        };
-        Ok(endpoint.into())
+        let mut builder = ConsommeEndpoint::builder(state).ports(port_forwards);
+        if let Some(port_recv) = resource.recv {
+            builder = builder.port_requests(port_recv);
+        }
+        Ok(builder.build().into())
     }
 }

--- a/vm/devices/net/net_consomme/src/resolver.rs
+++ b/vm/devices/net/net_consomme/src/resolver.rs
@@ -96,11 +96,10 @@ impl ResolveResource<NetEndpointHandleKind, ConsommeHandle> for ConsommeResolver
                 })
             })
             .collect::<Result<Vec<_>, ResolveConsommeError>>()?;
-        let endpoint = if let Some(port_recv) = resource.recv {
-            ConsommeEndpoint::new_dynamic(state, port_forwards, port_recv)
-        } else {
-            ConsommeEndpoint::new_with_ports(state, port_forwards)
-        };
-        Ok(endpoint.into())
+        let mut builder = ConsommeEndpoint::builder(state).ports(port_forwards);
+        if let Some(port_recv) = resource.recv {
+            builder = builder.port_requests(port_recv);
+        }
+        Ok(builder.build().into())
     }
 }

--- a/vm/devices/net/net_mana/src/test.rs
+++ b/vm/devices/net/net_mana/src/test.rs
@@ -24,7 +24,6 @@ use net_backend::VlanMetadata;
 use net_backend::loopback::LoopbackEndpoint;
 use pal_async::DefaultDriver;
 use pal_async::async_test;
-use pci_core::bus_range::AssignedBusRange;
 use pci_core::msi::MsiConnection;
 use std::future::poll_fn;
 use std::time::Duration;
@@ -549,11 +548,11 @@ async fn test_multi_mixed_packet(driver: DefaultDriver) {
 async fn test_vport_with_query_filter_state(driver: DefaultDriver) {
     let pages = 512; // 2MB
     let mem = DeviceTestMemory::new(pages, false, "test_vport_with_query_filter_state");
-    let msi_conn = MsiConnection::new(AssignedBusRange::new(), 0);
+    let msi_conn = MsiConnection::new();
     let device = gdma::GdmaDevice::new(
         &VmTaskDriverSource::new(SingleDriverBackend::new(driver.clone())),
         mem.guest_memory(),
-        msi_conn.target(),
+        &msi_conn.target(),
         vec![VportConfig {
             mac_address: [1, 2, 3, 4, 5, 6].into(),
             endpoint: Box::new(LoopbackEndpoint::new()),
@@ -613,11 +612,11 @@ async fn test_link_speed_default(driver: DefaultDriver) {
 
     let pages = 512; // 2MB
     let mem = DeviceTestMemory::new(pages, false, "test_link_speed_default");
-    let msi_conn = MsiConnection::new(AssignedBusRange::new(), 0);
+    let msi_conn = MsiConnection::new();
     let device = gdma::GdmaDevice::new(
         &VmTaskDriverSource::new(SingleDriverBackend::new(driver.clone())),
         mem.guest_memory(),
-        msi_conn.target(),
+        &msi_conn.target(),
         vec![VportConfig {
             mac_address: [1, 2, 3, 4, 5, 6].into(),
             endpoint: Box::new(LoopbackEndpoint::new()),
@@ -677,11 +676,11 @@ async fn verify_link_speed_expected(driver: DefaultDriver, link_speed_mbps: u32)
 
     let pages = 512;
     let mem = DeviceTestMemory::new(pages, false, "test_link_speed_expected");
-    let msi_conn = MsiConnection::new(AssignedBusRange::new(), 0);
+    let msi_conn = MsiConnection::new();
     let device = gdma::GdmaDevice::new_with_config(
         &VmTaskDriverSource::new(SingleDriverBackend::new(driver.clone())),
         mem.guest_memory(),
-        msi_conn.target(),
+        &msi_conn.target(),
         vec![VportConfig {
             mac_address: [1, 2, 3, 4, 5, 6].into(),
             endpoint: Box::new(LoopbackEndpoint::new()),
@@ -941,11 +940,11 @@ async fn test_endpoint(
     let data_to_send = pkt_builder.packet_data();
     let tx_segments = pkt_builder.segments();
 
-    let msi_conn = MsiConnection::new(AssignedBusRange::new(), 0);
+    let msi_conn = MsiConnection::new();
     let device = gdma::GdmaDevice::new(
         &VmTaskDriverSource::new(SingleDriverBackend::new(driver.clone())),
         mem.guest_memory(),
-        msi_conn.target(),
+        &msi_conn.target(),
         vec![VportConfig {
             mac_address: [1, 2, 3, 4, 5, 6].into(),
             endpoint: Box::new(LoopbackEndpoint::new()),
@@ -1115,11 +1114,11 @@ async fn new_test_queue(
 ) {
     let pages = 256;
     let mem = DeviceTestMemory::new(pages * 2, true, "test queue");
-    let msi_conn = MsiConnection::new(AssignedBusRange::new(), 0);
+    let msi_conn = MsiConnection::new();
     let device = gdma::GdmaDevice::new(
         &VmTaskDriverSource::new(SingleDriverBackend::new(driver.clone())),
         mem.guest_memory(),
-        msi_conn.target(),
+        &msi_conn.target(),
         vec![VportConfig {
             mac_address: [1, 2, 3, 4, 5, 6].into(),
             endpoint: Box::new(LoopbackEndpoint::new()),

--- a/vm/devices/pci/pci_core/src/capabilities/msi_cap.rs
+++ b/vm/devices/pci/pci_core/src/capabilities/msi_cap.rs
@@ -396,7 +396,7 @@ mod save_restore {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::bus_range::AssignedBusRange;
+
     use crate::msi::MsiConnection;
     use crate::test_helpers::TestPciInterruptController;
     use crate::test_helpers::read_cap_u32;
@@ -404,8 +404,8 @@ mod tests {
 
     #[test]
     fn msi_check() {
-        let msi_conn = MsiConnection::new(AssignedBusRange::new(), 0);
-        let mut cap = MsiCapability::new(2, true, false, msi_conn.target()); // 4 messages max, 64-bit, no masking
+        let msi_conn = MsiConnection::new();
+        let mut cap = MsiCapability::new(2, true, false, &msi_conn.target()); // 4 messages max, 64-bit, no masking
         let msi_controller = TestPciInterruptController::new();
         msi_conn.connect(msi_controller.signal_msi());
 
@@ -441,8 +441,8 @@ mod tests {
 
     #[test]
     fn msi_32bit_check() {
-        let msi_conn = MsiConnection::new(AssignedBusRange::new(), 0);
-        let mut cap = MsiCapability::new(1, false, false, msi_conn.target()); // 2 messages max, 32-bit, no masking
+        let msi_conn = MsiConnection::new();
+        let mut cap = MsiCapability::new(1, false, false, &msi_conn.target()); // 2 messages max, 32-bit, no masking
         let msi_controller = TestPciInterruptController::new();
         msi_conn.connect(msi_controller.signal_msi());
 
@@ -461,8 +461,8 @@ mod tests {
     fn test_msi_save_restore() {
         use vmcore::save_restore::SaveRestore;
 
-        let msi_conn = MsiConnection::new(AssignedBusRange::new(), 0);
-        let mut cap = MsiCapability::new(2, true, false, msi_conn.target()); // 4 messages max, 64-bit, no masking
+        let msi_conn = MsiConnection::new();
+        let mut cap = MsiCapability::new(2, true, false, &msi_conn.target()); // 4 messages max, 64-bit, no masking
         let msi_controller = TestPciInterruptController::new();
         msi_conn.connect(msi_controller.signal_msi());
 
@@ -502,8 +502,8 @@ mod tests {
     fn test_msi_save_restore_32bit_with_masking() {
         use vmcore::save_restore::SaveRestore;
 
-        let msi_conn = MsiConnection::new(AssignedBusRange::new(), 0);
-        let mut cap = MsiCapability::new(3, false, true, msi_conn.target()); // 8 messages max, 32-bit, with masking
+        let msi_conn = MsiConnection::new();
+        let mut cap = MsiCapability::new(3, false, true, &msi_conn.target()); // 8 messages max, 32-bit, with masking
         let msi_controller = TestPciInterruptController::new();
         msi_conn.connect(msi_controller.signal_msi());
 
@@ -553,8 +553,8 @@ mod tests {
     fn test_msi_save_restore_mme_clamping() {
         use vmcore::save_restore::SaveRestore;
 
-        let msi_conn = MsiConnection::new(AssignedBusRange::new(), 0);
-        let mut cap = MsiCapability::new(1, true, false, msi_conn.target()); // Only 2 messages max (MMC=1)
+        let msi_conn = MsiConnection::new();
+        let mut cap = MsiCapability::new(1, true, false, &msi_conn.target()); // Only 2 messages max (MMC=1)
         let msi_controller = TestPciInterruptController::new();
         msi_conn.connect(msi_controller.signal_msi());
 

--- a/vm/devices/pci/pci_core/src/capabilities/msix.rs
+++ b/vm/devices/pci/pci_core/src/capabilities/msix.rs
@@ -612,7 +612,6 @@ mod save_restore {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::bus_range::AssignedBusRange;
     use crate::msi::MsiConnection;
     use crate::test_helpers::TestPciInterruptController;
     use crate::test_helpers::read_cap_u32;
@@ -620,8 +619,8 @@ mod tests {
 
     #[test]
     fn msix_check() {
-        let msi_conn = MsiConnection::new(AssignedBusRange::new(), 0);
-        let (mut msix, mut cap) = MsixEmulator::new(2, 64, msi_conn.target());
+        let msi_conn = MsiConnection::new();
+        let (mut msix, mut cap) = MsixEmulator::new(2, 64, &msi_conn.target());
         let msi_controller = TestPciInterruptController::new();
         msi_conn.connect(msi_controller.signal_msi());
         // check capabilities
@@ -744,9 +743,9 @@ mod tests {
     #[test]
     fn route_set_msi_on_unmask() {
         let (irqfd, calls) = mock_irqfd(2);
-        let msi_conn = MsiConnection::new(AssignedBusRange::new(), 0);
+        let msi_conn = MsiConnection::new();
         msi_conn.connect_irqfd(irqfd);
-        let (mut msix, mut cap) = MsixEmulator::new(2, 2, msi_conn.target());
+        let (mut msix, mut cap) = MsixEmulator::new(2, 2, &msi_conn.target());
         let msi_controller = TestPciInterruptController::new();
         msi_conn.connect(msi_controller.signal_msi());
 
@@ -786,9 +785,9 @@ mod tests {
     #[test]
     fn route_mask_on_vector_mask() {
         let (irqfd, calls) = mock_irqfd(2);
-        let msi_conn = MsiConnection::new(AssignedBusRange::new(), 0);
+        let msi_conn = MsiConnection::new();
         msi_conn.connect_irqfd(irqfd);
-        let (mut msix, mut cap) = MsixEmulator::new(2, 2, msi_conn.target());
+        let (mut msix, mut cap) = MsixEmulator::new(2, 2, &msi_conn.target());
         let msi_controller = TestPciInterruptController::new();
         msi_conn.connect(msi_controller.signal_msi());
 
@@ -815,9 +814,9 @@ mod tests {
     #[test]
     fn route_global_disable_masks_all() {
         let (irqfd, calls) = mock_irqfd(2);
-        let msi_conn = MsiConnection::new(AssignedBusRange::new(), 0);
+        let msi_conn = MsiConnection::new();
         msi_conn.connect_irqfd(irqfd);
-        let (mut msix, mut cap) = MsixEmulator::new(2, 2, msi_conn.target());
+        let (mut msix, mut cap) = MsixEmulator::new(2, 2, &msi_conn.target());
         let msi_controller = TestPciInterruptController::new();
         msi_conn.connect(msi_controller.signal_msi());
 
@@ -847,9 +846,9 @@ mod tests {
     #[test]
     fn route_consume_pending_on_pba_read() {
         let (irqfd, _calls) = mock_irqfd(2);
-        let msi_conn = MsiConnection::new(AssignedBusRange::new(), 0);
+        let msi_conn = MsiConnection::new();
         msi_conn.connect_irqfd(irqfd);
-        let (msix, mut cap) = MsixEmulator::new(2, 2, msi_conn.target());
+        let (msix, mut cap) = MsixEmulator::new(2, 2, &msi_conn.target());
         let msi_controller = TestPciInterruptController::new();
         msi_conn.connect(msi_controller.signal_msi());
 
@@ -874,9 +873,9 @@ mod tests {
     #[test]
     fn route_set_msi_on_addr_data_change_while_unmasked() {
         let (irqfd, calls) = mock_irqfd(1);
-        let msi_conn = MsiConnection::new(AssignedBusRange::new(), 0);
+        let msi_conn = MsiConnection::new();
         msi_conn.connect_irqfd(irqfd);
-        let (mut msix, mut cap) = MsixEmulator::new(2, 1, msi_conn.target());
+        let (mut msix, mut cap) = MsixEmulator::new(2, 1, &msi_conn.target());
         let msi_controller = TestPciInterruptController::new();
         msi_conn.connect(msi_controller.signal_msi());
 

--- a/vm/devices/pci/pci_core/src/dma.rs
+++ b/vm/devices/pci/pci_core/src/dma.rs
@@ -1,0 +1,308 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! DMA target for PCI devices.
+//!
+//! [`DmaTarget`] bundles a device's [`GuestMemory`] (for DMA reads/writes)
+//! and [`MsiTarget`] (for MSI interrupt delivery) into a single type.
+//!
+//! In hardware, both DMA and MSI are bus-mastered transactions identified
+//! by the device's Requester ID (RID). This type ensures the two always
+//! carry a consistent device identity. For SR-IOV devices, calling
+//! [`DmaTarget::with_rid_offset`] derives both DMA and MSI targets for a
+//! specific VF in a single operation — you can't accidentally end up
+//! with mismatched identities.
+
+use crate::bus_range::AssignedBusRange;
+use crate::msi::MsiConnection;
+use crate::msi::MsiTarget;
+use guestmem::GuestMemory;
+use std::sync::Arc;
+
+/// A trait for IOMMU backends that produce per-device guest memory.
+///
+/// Implemented by SMMU (and future VT-d, AMD-Vi, etc.). The factory is
+/// shared across all devices behind the same IOMMU instance.
+pub trait DmaTargetIommu: Send + Sync + 'static {
+    /// Create a [`GuestMemory`] for a requester-ID offset relative to the
+    /// device's secondary bus.
+    ///
+    /// The RID is resolved as `(secondary << 8) + rid_offset` on each access,
+    /// so it tracks the live bus assignment. A plain `devfn` is just an
+    /// offset in `0..=0xff`; SR-IOV VFs use larger offsets that carry into
+    /// the bus byte.
+    fn guest_memory_for_rid_offset(&self, rid_offset: u16) -> GuestMemory;
+}
+
+/// Everything a PCI device needs for bus-mastered transactions: DMA
+/// memory access and MSI interrupt delivery.
+///
+/// Most devices only need [`guest_memory`](Self::guest_memory) and
+/// [`msi_target`](Self::msi_target). SR-IOV PFs additionally call
+/// [`with_rid_offset`](Self::with_rid_offset) when creating VFs.
+#[derive(Clone)]
+pub struct DmaTarget {
+    /// This target's requester-ID offset from the secondary bus. Held so
+    /// [`with_rid_offset`](Self::with_rid_offset) can derive a target at a
+    /// further offset relative to this one.
+    rid_offset: u16,
+    guest_memory: GuestMemory,
+    msi_target: MsiTarget,
+    /// When an IOMMU is present, produces per-device GuestMemory
+    /// instances with distinct stream/context table entries.
+    iommu: Option<Arc<dyn DmaTargetIommu>>,
+    /// Whether the device is behind a software IOMMU (e.g., emulated
+    /// SMMU) that cannot program the host IOMMU for passthrough DMA.
+    software_iommu: bool,
+}
+
+impl DmaTarget {
+    /// Creates a DMA target with no IOMMU.
+    ///
+    /// `bus_range` and `devfn` set the device's requester-ID identity, shared
+    /// by both the DMA and MSI sides. The MSI backend is taken (late-bound)
+    /// from `msi`. Since there is no IOMMU, all targets derived from this one
+    /// share the same guest memory; [`with_rid_offset`](Self::with_rid_offset)
+    /// only updates the MSI identity.
+    pub fn new(
+        bus_range: AssignedBusRange,
+        devfn: u8,
+        guest_memory: GuestMemory,
+        msi: &MsiConnection,
+    ) -> Self {
+        let msi_target = msi.msi_target(bus_range, devfn);
+        Self {
+            rid_offset: devfn as u16,
+            guest_memory,
+            msi_target,
+            iommu: None,
+            software_iommu: false,
+        }
+    }
+
+    /// Creates a DMA target backed by an IOMMU.
+    ///
+    /// The base (function-`devfn`) translating guest memory is derived from
+    /// `iommu`; per-VF memory is produced by
+    /// [`with_rid_offset`](Self::with_rid_offset). The MSI backend is taken
+    /// (late-bound) from `msi`.
+    pub fn with_iommu(
+        bus_range: AssignedBusRange,
+        devfn: u8,
+        iommu: Arc<dyn DmaTargetIommu>,
+        msi: &MsiConnection,
+    ) -> Self {
+        let guest_memory = iommu.guest_memory_for_rid_offset(devfn as u16);
+        let msi_target = msi.msi_target(bus_range, devfn);
+        Self {
+            rid_offset: devfn as u16,
+            guest_memory,
+            msi_target,
+            iommu: Some(iommu),
+            software_iommu: true,
+        }
+    }
+
+    /// Returns the guest memory for DMA from this device.
+    pub fn guest_memory(&self) -> &GuestMemory {
+        &self.guest_memory
+    }
+
+    /// Returns the MSI target for interrupt delivery from this device.
+    pub fn msi_target(&self) -> &MsiTarget {
+        &self.msi_target
+    }
+
+    /// Whether the device is behind a software IOMMU that cannot
+    /// program the host IOMMU for passthrough DMA.
+    pub fn software_iommu(&self) -> bool {
+        self.software_iommu
+    }
+
+    /// Derives a DMA target offset by `delta` from this one in RID space.
+    ///
+    /// This is the SR-IOV VF derivation primitive: given a PF's target, its
+    /// `i`th VF is `delta = VF_Offset + i * VF_Stride` away. Offsets stack,
+    /// so deriving from an already-derived target accumulates. Both the DMA
+    /// and MSI identity are derived in lockstep and resolved at use time as
+    /// `(secondary << 8) + offset` against the live bus assignment, so VF
+    /// targets can be derived before the bus is programmed.
+    pub fn with_rid_offset(&self, delta: u16) -> DmaTarget {
+        let rid_offset = self.rid_offset.wrapping_add(delta);
+        DmaTarget {
+            rid_offset,
+            guest_memory: match &self.iommu {
+                Some(factory) => factory.guest_memory_for_rid_offset(rid_offset),
+                None => self.guest_memory.clone(),
+            },
+            msi_target: self.msi_target.with_rid_offset(rid_offset),
+            iommu: self.iommu.clone(),
+            software_iommu: self.software_iommu,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::bus_range::AssignedBusRange;
+    use crate::msi::MsiConnection;
+    use crate::msi::SignalMsi;
+    use parking_lot::Mutex;
+    use std::sync::Arc;
+
+    /// Records the requester IDs signaled through an `MsiTarget`, so tests
+    /// can observe the MSI identity derived by `with_rid_offset`.
+    struct RecordingSignalMsi {
+        calls: Mutex<Vec<Option<u32>>>,
+    }
+
+    impl RecordingSignalMsi {
+        fn new() -> Arc<Self> {
+            Arc::new(Self {
+                calls: Mutex::new(Vec::new()),
+            })
+        }
+
+        fn pop(&self) -> Option<u32> {
+            self.calls.lock().pop().flatten()
+        }
+    }
+
+    impl SignalMsi for RecordingSignalMsi {
+        fn signal_msi(&self, devid: Option<u32>, _address: u64, _data: u32) {
+            self.calls.lock().push(devid);
+        }
+    }
+
+    /// Records the `rid_offset` passed to the IOMMU factory and hands back a
+    /// distinct `GuestMemory` for each call so tests can confirm the derived
+    /// target uses the IOMMU-provided memory.
+    struct RecordingIommu {
+        rid_offset_calls: Mutex<Vec<u16>>,
+    }
+
+    impl RecordingIommu {
+        fn new() -> Arc<Self> {
+            Arc::new(Self {
+                rid_offset_calls: Mutex::new(Vec::new()),
+            })
+        }
+    }
+
+    impl DmaTargetIommu for RecordingIommu {
+        fn guest_memory_for_rid_offset(&self, rid_offset: u16) -> GuestMemory {
+            self.rid_offset_calls.lock().push(rid_offset);
+            // A distinct, non-empty allocation marks this as IOMMU-provided.
+            GuestMemory::allocate(0x2000)
+        }
+    }
+
+    #[test]
+    fn new_has_no_iommu() {
+        let msi_conn = MsiConnection::new();
+        let target = DmaTarget::new(AssignedBusRange::new(), 0, GuestMemory::empty(), &msi_conn);
+        assert!(!target.software_iommu());
+        assert!(target.iommu.is_none());
+    }
+
+    #[test]
+    fn with_rid_offset_no_iommu_shares_memory_and_updates_msi() {
+        let bus_range = AssignedBusRange::new();
+        bus_range.set_bus_range(5, 10);
+        let msi_conn = MsiConnection::new();
+        let recorder = RecordingSignalMsi::new();
+        msi_conn.connect(recorder.clone());
+
+        let gm = GuestMemory::allocate(0x1000);
+        let target = DmaTarget::new(bus_range.clone(), 0, gm.clone(), &msi_conn);
+
+        let derived = target.with_rid_offset(0x18); // function 0x18 on the secondary bus
+
+        // No IOMMU: the guest memory is shared. Write through the original
+        // and observe it through the derived target.
+        target.guest_memory().write_at(0, &[0xAB]).unwrap();
+        let mut buf = [0u8];
+        derived.guest_memory().read_at(0, &mut buf).unwrap();
+        assert_eq!(buf[0], 0xAB);
+
+        // The MSI identity is derived from the offset: bus 5 (secondary) | offset.
+        assert!(!derived.software_iommu());
+        derived.msi_target().signal_msi(0xFEE0_0000, 0);
+        assert_eq!(recorder.pop().unwrap(), (5 << 8) | 0x18);
+    }
+
+    #[test]
+    fn with_rid_offset_stacks() {
+        let bus_range = AssignedBusRange::new();
+        bus_range.set_bus_range(5, 10);
+        let msi_conn = MsiConnection::new();
+        let recorder = RecordingSignalMsi::new();
+        msi_conn.connect(recorder.clone());
+
+        let target = DmaTarget::new(bus_range.clone(), 0, GuestMemory::empty(), &msi_conn);
+
+        // Offsets accumulate: 0x10 then 0x08 lands at 0x18.
+        let derived = target.with_rid_offset(0x10).with_rid_offset(0x08);
+        derived.msi_target().signal_msi(0xFEE0_0000, 0);
+        assert_eq!(recorder.pop().unwrap(), (5 << 8) | 0x18);
+    }
+
+    #[test]
+    fn with_rid_offset_iommu_derives_memory_and_msi_together() {
+        let bus_range = AssignedBusRange::new();
+        bus_range.set_bus_range(5, 10);
+        let msi_conn = MsiConnection::new();
+        let recorder = RecordingSignalMsi::new();
+        msi_conn.connect(recorder.clone());
+
+        let iommu = RecordingIommu::new();
+        let target = DmaTarget::with_iommu(bus_range.clone(), 0, iommu.clone(), &msi_conn);
+        assert!(target.software_iommu());
+
+        let derived = target.with_rid_offset(0x18);
+
+        // The base target asked the factory for offset 0 (devfn 0); deriving
+        // offset 0x18 asks for that offset.
+        assert_eq!(*iommu.rid_offset_calls.lock(), vec![0, 0x18]);
+        // The derived target uses the IOMMU-provided 0x2000 allocation: an
+        // access past the empty base memory succeeds.
+        derived.guest_memory().write_at(0x1500, &[0xCD]).unwrap();
+        let mut buf = [0u8];
+        derived.guest_memory().read_at(0x1500, &mut buf).unwrap();
+        assert_eq!(buf[0], 0xCD);
+        assert!(derived.software_iommu());
+
+        derived.msi_target().signal_msi(0xFEE0_0000, 0);
+        assert_eq!(recorder.pop().unwrap(), (5 << 8) | 0x18);
+    }
+
+    #[test]
+    fn with_rid_offset_iommu_cross_bus() {
+        let bus_range = AssignedBusRange::new();
+        bus_range.set_bus_range(5, 10);
+        let msi_conn = MsiConnection::new();
+        let recorder = RecordingSignalMsi::new();
+        msi_conn.connect(recorder.clone());
+
+        let iommu = RecordingIommu::new();
+        let target = DmaTarget::with_iommu(bus_range.clone(), 0, iommu.clone(), &msi_conn);
+
+        // Offset (2 << 8) | 0x0A lands on bus 7 (secondary 5 + 2), devfn 0x0A.
+        let offset: u16 = (2 << 8) | 0x0A;
+        let derived = target.with_rid_offset(offset);
+
+        // The base construction asked for offset 0 first, then the VF offset.
+        assert_eq!(*iommu.rid_offset_calls.lock(), vec![0, offset]);
+        // The derived target uses the IOMMU-provided 0x2000 allocation: an
+        // access past the empty base memory succeeds.
+        derived.guest_memory().write_at(0x1500, &[0xCD]).unwrap();
+        let mut buf = [0u8];
+        derived.guest_memory().read_at(0x1500, &mut buf).unwrap();
+        assert_eq!(buf[0], 0xCD);
+        assert!(derived.software_iommu());
+
+        derived.msi_target().signal_msi(0xFEE0_0000, 0);
+        assert_eq!(recorder.pop().unwrap(), (7 << 8) | 0x0A);
+    }
+}

--- a/vm/devices/pci/pci_core/src/lib.rs
+++ b/vm/devices/pci/pci_core/src/lib.rs
@@ -15,6 +15,7 @@ pub mod bus_range;
 pub mod capabilities;
 pub mod cfg_space_emu;
 pub mod chipset_device_ext;
+pub mod dma;
 pub mod msi;
 pub mod spec;
 

--- a/vm/devices/pci/pci_core/src/msi.rs
+++ b/vm/devices/pci/pci_core/src/msi.rs
@@ -29,7 +29,7 @@ pub trait SignalMsi: Send + Sync {
 /// where the physical device signals the event on interrupt.
 pub struct MsiRoute {
     inner: Box<dyn IrqFdRoute>,
-    default_bdf: DefaultBdf,
+    default_rid: DefaultRid,
 }
 
 impl MsiRoute {
@@ -40,10 +40,18 @@ impl MsiRoute {
         self.inner.event()
     }
 
-    /// Configures the MSI address and data for this route, using
-    /// the route's default BDF as the requester ID.
+    /// Configures the MSI address and data for this route, using the route's
+    /// default requester ID `(secondary_bus << 8) + rid_offset`.
+    ///
+    /// If the resolved bus falls outside the assigned bus range, the route is
+    /// left disabled and a ratelimited warning is emitted.
     pub fn enable(&self, address: u64, data: u32) {
-        let resolved = resolve_default_bdf(&self.default_bdf);
+        // `resolve_default_rid` emits the ratelimited warning when the
+        // resolved bus is out of range; just leave the route disabled here.
+        let Some(resolved) = resolve_default_rid(&self.default_rid) else {
+            self.inner.disable();
+            return;
+        };
         self.inner.enable(address, data, Some(resolved))
     }
 
@@ -60,8 +68,8 @@ impl MsiRoute {
     /// is left disabled and a ratelimited warning is emitted.
     pub fn enable_with_rid(&self, rid: u16, address: u64, data: u32) {
         let bus = (rid >> 8) as u8;
-        if !self.default_bdf.bus_range.contains_bus(bus) {
-            let (secondary, subordinate) = self.default_bdf.bus_range.bus_range();
+        if !self.default_rid.bus_range.contains_bus(bus) {
+            let (secondary, subordinate) = self.default_rid.bus_range.bus_range();
             tracelimit::warn_ratelimited!(
                 rid,
                 secondary,
@@ -97,33 +105,61 @@ impl SignalMsi for DisconnectedMsiTarget {
     }
 }
 
-/// Default BDF source for MSI device identification.
+/// Default requester-ID source for MSI device identification.
 ///
-/// [`MsiTarget::signal_msi`] uses this to compose the requester ID
-/// from the port's secondary bus combined with the configured `devfn`.
+/// [`MsiTarget::signal_msi`] composes the requester ID at signal time as
+/// `(secondary_bus << 8) + rid_offset`, reading the secondary bus from the
+/// live [`AssignedBusRange`]. For a single-function device `rid_offset` is
+/// just its devfn; for SR-IOV VFs it may carry into the bus byte to address
+/// functions on higher buses within the assigned range.
 #[derive(Clone, Debug)]
-struct DefaultBdf {
+struct DefaultRid {
     bus_range: AssignedBusRange,
-    devfn: u8,
+    rid_offset: u16,
 }
 
-/// Resolves a BDF from a [`DefaultBdf`] source.
-fn resolve_default_bdf(default: &DefaultBdf) -> u32 {
-    let (secondary, _) = default.bus_range.bus_range();
-    (secondary as u32) << 8 | default.devfn as u32
+/// Resolves a requester ID from a [`DefaultRid`] source, composing it as
+/// `(secondary_bus << 8) + rid_offset` against the live bus range.
+///
+/// Returns `None` when the resulting bus falls outside the assigned range
+/// (the offset reaches past the subordinate bus), in which case a ratelimited
+/// warning is emitted and the caller should drop the MSI / disable the route.
+/// The offset is non-negative, so the bus is always at least the secondary
+/// bus; only the upper bound can be exceeded.
+fn resolve_default_rid(default: &DefaultRid) -> Option<u32> {
+    let (secondary, subordinate) = default.bus_range.bus_range();
+    let rid = ((secondary as u32) << 8) + default.rid_offset as u32;
+    if rid >> 8 > subordinate as u32 {
+        tracelimit::warn_ratelimited!(
+            rid,
+            secondary,
+            subordinate,
+            "dropping MSI: rid bus outside assigned bus range"
+        );
+        return None;
+    }
+    Some(rid)
 }
 
-/// A connection between a device and an MSI target.
+/// A late-bound MSI backend slot.
+///
+/// A connection carries no device identity — it is purely the backend that
+/// MSIs are delivered to, filled in after construction via [`connect`].
+/// Identity is supplied when a target is derived via
+/// [`msi_target`](Self::msi_target), or when a
+/// [`DmaTarget`](crate::dma::DmaTarget) is built from it.
+///
+/// [`connect`]: Self::connect
 #[derive(Debug)]
 pub struct MsiConnection {
-    target: MsiTarget,
+    inner: Arc<RwLock<MsiTargetInner>>,
 }
 
 /// An MSI target that can be used to signal MSI interrupts.
 #[derive(Clone)]
 pub struct MsiTarget {
     inner: Arc<RwLock<MsiTargetInner>>,
-    default_bdf: DefaultBdf,
+    default_rid: DefaultRid,
 }
 
 impl MsiTarget {
@@ -136,9 +172,9 @@ impl MsiTarget {
                 signal_msi: Arc::new(DisconnectedMsiTarget),
                 irqfd: None,
             })),
-            default_bdf: DefaultBdf {
+            default_rid: DefaultRid {
                 bus_range: AssignedBusRange::new(),
-                devfn: 0,
+                rid_offset: 0,
             },
         }
     }
@@ -147,7 +183,7 @@ impl MsiTarget {
 impl std::fmt::Debug for MsiTarget {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("MsiTarget")
-            .field("default_bdf", &self.default_bdf)
+            .field("default_rid", &self.default_rid)
             .finish()
     }
 }
@@ -170,27 +206,24 @@ impl std::fmt::Debug for MsiTargetInner {
 }
 
 impl MsiConnection {
-    /// Creates a new disconnected MSI target connection.
+    /// Creates a new disconnected MSI connection.
     ///
-    /// `bus_range` and `devfn` configure the default BDF identity
-    /// for this connection. When a device signals an MSI via
-    /// [`MsiTarget::signal_msi`], the BDF is resolved from the bus
-    /// range's secondary bus and the given `devfn`.
-    pub fn new(bus_range: AssignedBusRange, devfn: u8) -> Self {
+    /// The connection is purely the late-bound MSI backend slot; it carries
+    /// no device identity. Callers stamp identity when they derive a target
+    /// via [`msi_target`](Self::msi_target), or by building a
+    /// [`DmaTarget`](crate::dma::DmaTarget) from it.
+    pub fn new() -> Self {
         Self {
-            target: MsiTarget {
-                inner: Arc::new(RwLock::new(MsiTargetInner {
-                    signal_msi: Arc::new(DisconnectedMsiTarget),
-                    irqfd: None,
-                })),
-                default_bdf: DefaultBdf { bus_range, devfn },
-            },
+            inner: Arc::new(RwLock::new(MsiTargetInner {
+                signal_msi: Arc::new(DisconnectedMsiTarget),
+                irqfd: None,
+            })),
         }
     }
 
     /// Updates the MSI target to which this connection signals interrupts.
     pub fn connect(&self, signal_msi: Arc<dyn SignalMsi>) {
-        let mut inner = self.target.inner.write();
+        let mut inner = self.inner.write();
         inner.signal_msi = signal_msi;
     }
 
@@ -199,13 +232,34 @@ impl MsiConnection {
     /// When present, [`MsiTarget::new_route`] can create [`MsiRoute`]
     /// instances for direct interrupt delivery.
     pub fn connect_irqfd(&self, irqfd: Arc<dyn IrqFd>) {
-        let mut inner = self.target.inner.write();
+        let mut inner = self.inner.write();
         inner.irqfd = Some(irqfd);
     }
 
-    /// Returns the MSI target for this connection.
-    pub fn target(&self) -> &MsiTarget {
-        &self.target
+    /// Derives an MSI target with the given identity, sharing this
+    /// connection's (late-bound) backend slot.
+    pub fn msi_target(&self, bus_range: AssignedBusRange, devfn: u8) -> MsiTarget {
+        MsiTarget {
+            inner: self.inner.clone(),
+            default_rid: DefaultRid {
+                bus_range,
+                rid_offset: devfn as u16,
+            },
+        }
+    }
+
+    /// Derives an MSI target with no device identity (an empty bus range).
+    ///
+    /// Use for MSI emitters that don't need a meaningful requester ID, or
+    /// that re-anchor identity themselves (e.g. PCIe switches).
+    pub fn target(&self) -> MsiTarget {
+        self.msi_target(AssignedBusRange::new(), 0)
+    }
+}
+
+impl Default for MsiConnection {
+    fn default() -> Self {
+        Self::new()
     }
 }
 
@@ -217,13 +271,7 @@ impl MsiTarget {
     /// bus range, then call `with_devfn(port_number)` to get a
     /// target that resolves to `(bus << 8) | devfn`.
     pub fn with_devfn(&self, devfn: u8) -> MsiTarget {
-        MsiTarget {
-            inner: self.inner.clone(),
-            default_bdf: DefaultBdf {
-                bus_range: self.default_bdf.bus_range.clone(),
-                devfn,
-            },
-        }
+        self.with_rid_offset(devfn as u16)
     }
 
     /// Returns a new `MsiTarget` sharing the same connection but with
@@ -234,14 +282,53 @@ impl MsiTarget {
     pub fn with_bus_range(&self, bus_range: AssignedBusRange, devfn: u8) -> MsiTarget {
         MsiTarget {
             inner: self.inner.clone(),
-            default_bdf: DefaultBdf { bus_range, devfn },
+            default_rid: DefaultRid {
+                bus_range,
+                rid_offset: devfn as u16,
+            },
+        }
+    }
+
+    /// Returns a new `MsiTarget` sharing the same connection and bus range
+    /// but with the requester-ID offset set so the target resolves to the
+    /// given absolute `rid`.
+    ///
+    /// The offset is computed against the *current* secondary bus, so call
+    /// this only once the bus range is assigned. For targets derived before
+    /// the bus is programmed (e.g. SR-IOV VFs), use
+    /// [`with_rid_offset`](Self::with_rid_offset) instead.
+    ///
+    /// The resulting bus is validated against the assigned bus range when an
+    /// MSI is signaled (see [`signal_msi`](Self::signal_msi)), not here.
+    pub fn with_rid(&self, rid: u16) -> MsiTarget {
+        let (secondary, _) = self.default_rid.bus_range.bus_range();
+        self.with_rid_offset(rid.wrapping_sub((secondary as u16) << 8))
+    }
+
+    /// Returns a new `MsiTarget` sharing the same connection and bus range
+    /// but with the requester-ID offset set to `rid_offset`.
+    ///
+    /// The RID is resolved at signal time as `(secondary_bus << 8) +
+    /// rid_offset`, so the target tracks the live bus assignment. This is the
+    /// primitive for SR-IOV VFs, which are constructed before the PF's bus is
+    /// programmed: pass the VF's RID offset (e.g. VF Offset + index × VF
+    /// Stride) and it resolves correctly once the bus range is assigned.
+    pub fn with_rid_offset(&self, rid_offset: u16) -> MsiTarget {
+        MsiTarget {
+            inner: self.inner.clone(),
+            default_rid: DefaultRid {
+                bus_range: self.default_rid.bus_range.clone(),
+                rid_offset,
+            },
         }
     }
 
     /// Signals an MSI interrupt to this target, using this target's
     /// default BDF as the requester ID.
     pub fn signal_msi(&self, address: u64, data: u32) {
-        let resolved = resolve_default_bdf(&self.default_bdf);
+        let Some(resolved) = resolve_default_rid(&self.default_rid) else {
+            return;
+        };
         let inner = self.inner.read();
         inner.signal_msi.signal_msi(Some(resolved), address, data);
     }
@@ -259,8 +346,8 @@ impl MsiTarget {
     /// dropped and a ratelimited warning is emitted.
     pub fn signal_msi_with_rid(&self, rid: u16, address: u64, data: u32) {
         let bus = (rid >> 8) as u8;
-        if !self.default_bdf.bus_range.contains_bus(bus) {
-            let (secondary, subordinate) = self.default_bdf.bus_range.bus_range();
+        if !self.default_rid.bus_range.contains_bus(bus) {
+            let (secondary, subordinate) = self.default_rid.bus_range.bus_range();
             tracelimit::warn_ratelimited!(
                 rid,
                 secondary,
@@ -286,15 +373,9 @@ impl MsiTarget {
         inner.irqfd.as_ref().map(|fd| {
             Ok(MsiRoute {
                 inner: fd.new_irqfd_route()?,
-                default_bdf: self.default_bdf.clone(),
+                default_rid: self.default_rid.clone(),
             })
         })
-    }
-
-    /// Returns the default BDF that will be used by
-    /// [`signal_msi`](Self::signal_msi) and [`MsiRoute::enable`].
-    pub fn default_bdf(&self) -> u32 {
-        resolve_default_bdf(&self.default_bdf)
     }
 
     /// Returns whether this target supports direct MSI routes.
@@ -399,14 +480,16 @@ mod tests {
     }
 
     #[test]
-    fn signal_msi_resolves_default_bdf() {
+    fn signal_msi_resolves_default_rid() {
         let bus_range = AssignedBusRange::new();
         bus_range.set_bus_range(5, 10);
-        let msi_conn = MsiConnection::new(bus_range, 0x18); // devfn = dev 3, fn 0
+        let msi_conn = MsiConnection::new();
         let recorder = RecordingSignalMsi::new();
         msi_conn.connect(recorder.clone());
 
-        msi_conn.target().signal_msi(0xFEE0_0000, 42);
+        msi_conn
+            .msi_target(bus_range, 0x18)
+            .signal_msi(0xFEE0_0000, 42);
 
         let (devid, addr, data) = recorder.pop().unwrap();
         assert_eq!(devid, Some((5 << 8) | 0x18));
@@ -418,13 +501,15 @@ mod tests {
     fn signal_msi_with_rid_accepts_bus_in_range() {
         let bus_range = AssignedBusRange::new();
         bus_range.set_bus_range(5, 10);
-        let msi_conn = MsiConnection::new(bus_range, 0);
+        let msi_conn = MsiConnection::new();
         let recorder = RecordingSignalMsi::new();
         msi_conn.connect(recorder.clone());
 
         // RID with bus=7, devfn=0x0A → within [5, 10]
         let rid: u16 = (7 << 8) | 0x0A;
-        msi_conn.target().signal_msi_with_rid(rid, 0xABCD, 99);
+        msi_conn
+            .msi_target(bus_range, 0)
+            .signal_msi_with_rid(rid, 0xABCD, 99);
 
         let (devid, addr, data) = recorder.pop().unwrap();
         assert_eq!(devid, Some(rid as u32));
@@ -436,18 +521,22 @@ mod tests {
     fn signal_msi_with_rid_drops_bus_outside_range() {
         let bus_range = AssignedBusRange::new();
         bus_range.set_bus_range(5, 10);
-        let msi_conn = MsiConnection::new(bus_range, 0);
+        let msi_conn = MsiConnection::new();
         let recorder = RecordingSignalMsi::new();
         msi_conn.connect(recorder.clone());
 
         // bus=11, above subordinate=10 → dropped
         let rid_above: u16 = 11 << 8;
-        msi_conn.target().signal_msi_with_rid(rid_above, 0xABCD, 1);
+        msi_conn
+            .msi_target(bus_range.clone(), 0)
+            .signal_msi_with_rid(rid_above, 0xABCD, 1);
         assert!(recorder.pop().is_none());
 
         // bus=4, below secondary=5 → dropped
         let rid_below: u16 = 4 << 8;
-        msi_conn.target().signal_msi_with_rid(rid_below, 0xABCD, 2);
+        msi_conn
+            .msi_target(bus_range, 0)
+            .signal_msi_with_rid(rid_below, 0xABCD, 2);
         assert!(recorder.pop().is_none());
     }
 
@@ -455,28 +544,36 @@ mod tests {
     fn signal_msi_with_rid_accepts_boundary_buses() {
         let bus_range = AssignedBusRange::new();
         bus_range.set_bus_range(5, 10);
-        let msi_conn = MsiConnection::new(bus_range, 0);
+        let msi_conn = MsiConnection::new();
         let recorder = RecordingSignalMsi::new();
         msi_conn.connect(recorder.clone());
 
         // Exactly at secondary bus (5)
-        msi_conn.target().signal_msi_with_rid(5 << 8, 0x1000, 10);
+        msi_conn
+            .msi_target(bus_range.clone(), 0)
+            .signal_msi_with_rid(5 << 8, 0x1000, 10);
         assert!(recorder.pop().is_some());
 
         // Exactly at subordinate bus (10)
-        msi_conn.target().signal_msi_with_rid(10 << 8, 0x2000, 20);
+        msi_conn
+            .msi_target(bus_range, 0)
+            .signal_msi_with_rid(10 << 8, 0x2000, 20);
         assert!(recorder.pop().is_some());
     }
 
     #[test]
-    fn route_enable_resolves_default_bdf() {
+    fn route_enable_resolves_default_rid() {
         let bus_range = AssignedBusRange::new();
         bus_range.set_bus_range(3, 8);
         let (irqfd, calls) = mock_irqfd(1);
-        let msi_conn = MsiConnection::new(bus_range, 0x10); // devfn = dev 2, fn 0
+        let msi_conn = MsiConnection::new();
         msi_conn.connect_irqfd(irqfd);
 
-        let route = msi_conn.target().new_route().unwrap().unwrap();
+        let route = msi_conn
+            .msi_target(bus_range, 0x10)
+            .new_route()
+            .unwrap()
+            .unwrap();
         route.enable(0xFEE0_0000, 55);
 
         let log = calls[0].lock();
@@ -496,10 +593,14 @@ mod tests {
         let bus_range = AssignedBusRange::new();
         bus_range.set_bus_range(5, 10);
         let (irqfd, calls) = mock_irqfd(1);
-        let msi_conn = MsiConnection::new(bus_range, 0);
+        let msi_conn = MsiConnection::new();
         msi_conn.connect_irqfd(irqfd);
 
-        let route = msi_conn.target().new_route().unwrap().unwrap();
+        let route = msi_conn
+            .msi_target(bus_range, 0)
+            .new_route()
+            .unwrap()
+            .unwrap();
         let rid: u16 = (7 << 8) | 0x0A;
         route.enable_with_rid(rid, 0xBEEF, 77);
 
@@ -520,10 +621,14 @@ mod tests {
         let bus_range = AssignedBusRange::new();
         bus_range.set_bus_range(5, 10);
         let (irqfd, calls) = mock_irqfd(1);
-        let msi_conn = MsiConnection::new(bus_range, 0);
+        let msi_conn = MsiConnection::new();
         msi_conn.connect_irqfd(irqfd);
 
-        let route = msi_conn.target().new_route().unwrap().unwrap();
+        let route = msi_conn
+            .msi_target(bus_range, 0)
+            .new_route()
+            .unwrap()
+            .unwrap();
         // bus=11, above subordinate → should disable
         let rid: u16 = 11 << 8;
         route.enable_with_rid(rid, 0xBEEF, 77);
@@ -537,11 +642,11 @@ mod tests {
     fn with_devfn_derives_target_with_new_devfn() {
         let bus_range = AssignedBusRange::new();
         bus_range.set_bus_range(2, 5);
-        let msi_conn = MsiConnection::new(bus_range, 0);
+        let msi_conn = MsiConnection::new();
         let recorder = RecordingSignalMsi::new();
         msi_conn.connect(recorder.clone());
 
-        let derived = msi_conn.target().with_devfn(0x18); // dev 3, fn 0
+        let derived = msi_conn.msi_target(bus_range, 0).with_devfn(0x18); // dev 3, fn 0
         derived.signal_msi(0x1000, 1);
 
         let (devid, _, _) = recorder.pop().unwrap();
@@ -552,13 +657,15 @@ mod tests {
     fn with_bus_range_derives_target_with_new_range() {
         let parent_range = AssignedBusRange::new();
         parent_range.set_bus_range(1, 20);
-        let msi_conn = MsiConnection::new(parent_range, 0);
+        let msi_conn = MsiConnection::new();
         let recorder = RecordingSignalMsi::new();
         msi_conn.connect(recorder.clone());
 
         let child_range = AssignedBusRange::new();
         child_range.set_bus_range(10, 15);
-        let derived = msi_conn.target().with_bus_range(child_range, 0x08);
+        let derived = msi_conn
+            .msi_target(parent_range, 0)
+            .with_bus_range(child_range, 0x08);
         derived.signal_msi(0x2000, 2);
 
         let (devid, _, _) = recorder.pop().unwrap();
@@ -568,5 +675,62 @@ mod tests {
         // Validation uses the child range, not the parent
         derived.signal_msi_with_rid(16 << 8, 0x3000, 3);
         assert!(recorder.pop().is_none()); // bus 16 > subordinate 15
+    }
+
+    #[test]
+    fn with_rid_signal_msi_accepts_bus_in_range() {
+        let bus_range = AssignedBusRange::new();
+        bus_range.set_bus_range(5, 10);
+        let msi_conn = MsiConnection::new();
+        let recorder = RecordingSignalMsi::new();
+        msi_conn.connect(recorder.clone());
+
+        // RID with bus=7 (within [5, 10]), devfn=0x0A
+        let rid: u16 = (7 << 8) | 0x0A;
+        let derived = msi_conn.msi_target(bus_range, 0).with_rid(rid);
+        derived.signal_msi(0x1000, 7);
+
+        let (devid, addr, data) = recorder.pop().unwrap();
+        assert_eq!(devid, Some(rid as u32));
+        assert_eq!(addr, 0x1000);
+        assert_eq!(data, 7);
+    }
+
+    #[test]
+    fn with_rid_signal_msi_drops_bus_outside_range() {
+        let bus_range = AssignedBusRange::new();
+        bus_range.set_bus_range(5, 10);
+        let msi_conn = MsiConnection::new();
+        let recorder = RecordingSignalMsi::new();
+        msi_conn.connect(recorder.clone());
+
+        // bus=11 > subordinate=10 → dropped
+        let derived_above = msi_conn.msi_target(bus_range.clone(), 0).with_rid(11 << 8);
+        derived_above.signal_msi(0x1000, 1);
+        assert!(recorder.pop().is_none());
+
+        // bus=4 < secondary=5 → dropped
+        let derived_below = msi_conn.msi_target(bus_range, 0).with_rid(4 << 8);
+        derived_below.signal_msi(0x2000, 2);
+        assert!(recorder.pop().is_none());
+    }
+
+    #[test]
+    fn with_rid_route_enable_disables_when_bus_outside_range() {
+        let bus_range = AssignedBusRange::new();
+        bus_range.set_bus_range(5, 10);
+        let (irqfd, calls) = mock_irqfd(1);
+        let msi_conn = MsiConnection::new();
+        msi_conn.connect_irqfd(irqfd);
+
+        // Derive a target whose override bus (11) is outside [5, 10], then
+        // enable a route from it: the route must be disabled, not enabled.
+        let derived = msi_conn.msi_target(bus_range, 0).with_rid(11 << 8);
+        let route = derived.new_route().unwrap().unwrap();
+        route.enable(0xBEEF, 77);
+
+        let log = calls[0].lock();
+        assert_eq!(log.len(), 1);
+        assert_eq!(log[0], RouteCall::Disable);
     }
 }

--- a/vm/devices/pci/pci_resources/src/lib.rs
+++ b/vm/devices/pci/pci_resources/src/lib.rs
@@ -9,9 +9,8 @@ use chipset_device::mmio::RegisterMmioIntercept;
 use chipset_device_resources::ErasedChipsetDevice;
 use chipset_device_resources::ResolvedChipsetDevice;
 use guestmem::DoorbellRegistration;
-use guestmem::GuestMemory;
 use guestmem::MemoryMapper;
-use pci_core::msi::MsiTarget;
+use pci_core::dma::DmaTarget;
 use std::sync::Arc;
 use vm_resource::CanResolveTo;
 use vm_resource::kind::PciDeviceHandleKind;
@@ -32,21 +31,14 @@ impl<T: Into<ResolvedChipsetDevice>> From<T> for ResolvedPciDevice {
 
 /// Parameters used when resolving a resource with kind [`PciDeviceHandleKind`].
 pub struct ResolvePciDeviceHandleParams<'a> {
-    /// The target for MSI interrupts.
-    pub msi_target: &'a MsiTarget,
+    /// DMA and MSI target for the device.
+    pub dma_target: &'a DmaTarget,
     /// An object with which to register MMIO regions.
     pub register_mmio: &'a mut (dyn RegisterMmioIntercept + Send),
     /// The VM's task driver source.
     pub driver_source: &'a VmTaskDriverSource,
-    /// The VM's guest memory.
-    pub guest_memory: &'a GuestMemory,
     /// An object with which to register doorbell regions.
     pub doorbell_registration: Option<Arc<dyn DoorbellRegistration>>,
     /// An object with which to register shared memory regions.
     pub shared_mem_mapper: Option<&'a dyn MemoryMapper>,
-    /// Whether the device is behind a software IOMMU (e.g., emulated SMMU)
-    /// that cannot program the host IOMMU for passthrough DMA. When `true`,
-    /// device assignment backends (e.g., VFIO) that require host IOMMU
-    /// mappings must reject the assignment.
-    pub software_iommu: bool,
 }

--- a/vm/devices/pci/pcie/fuzz/fuzz_pcie.rs
+++ b/vm/devices/pci/pcie/fuzz/fuzz_pcie.rs
@@ -128,11 +128,10 @@ impl FuzzRootComplex {
                 settings: PciePortSettings::default(),
             })
             .collect();
-        let msi_conn =
-            pci_core::msi::MsiConnection::new(pci_core::bus_range::AssignedBusRange::new(), 0);
+        let msi_conn = pci_core::msi::MsiConnection::new();
         let rc =
             GenericPcieRootComplex::builder(&mut register_mmio, START_BUS..=END_BUS, ecam_range)
-                .root_ports(port_defs, msi_conn.target())
+                .root_ports(port_defs, &msi_conn.target())
                 .build()
                 .unwrap();
         Self { rc }

--- a/vm/devices/pci/pcie/fuzz/fuzz_pcie.rs
+++ b/vm/devices/pci/pcie/fuzz/fuzz_pcie.rs
@@ -14,9 +14,9 @@ use chipset_device::pci::PciConfigSpace;
 use memory_range::MemoryRange;
 use pci_bus::GenericPciBusDevice;
 use pci_core::msi::MsiTarget;
+use pcie::GenericPciePortDefinition;
 use pcie::PciePortSettings;
 use pcie::root::GenericPcieRootComplex;
-use pcie::root::GenericPcieRootPortDefinition;
 use pcie::switch::GenericPcieSwitch;
 use pcie::switch::GenericPcieSwitchDefinition;
 use pcie::test_helpers::TestPcieMmioRegistration;
@@ -120,9 +120,10 @@ impl FuzzRootComplex {
         let hotplug = matches!(topology, Topology::Hotplug { .. });
 
         let mut register_mmio = TestPcieMmioRegistration {};
-        let port_defs: Vec<GenericPcieRootPortDefinition> = (0..NUM_PORTS)
-            .map(|i| GenericPcieRootPortDefinition {
+        let port_defs: Vec<GenericPciePortDefinition> = (0..NUM_PORTS)
+            .map(|i| GenericPciePortDefinition {
                 name: format!("rp{}", i).into(),
+                devfn: None,
                 hotplug,
                 settings: PciePortSettings::default(),
             })
@@ -279,11 +280,17 @@ fn do_fuzz(u: &mut Unstructured<'_>) -> arbitrary::Result<()> {
         Topology::WithSwitch => {
             let switch = GenericPcieSwitch::new(GenericPcieSwitchDefinition {
                 name: "sw0".into(),
-                downstream_port_count: 2,
-                hotplug: false,
+                downstream_ports: (0..NUM_PORTS)
+                    .map(|i| GenericPciePortDefinition {
+                        name: format!("dsp{i}").into(),
+                        devfn: None,
+                        hotplug: false,
+                        settings: PciePortSettings::default(),
+                    })
+                    .collect(),
                 msi_target: MsiTarget::disconnected(),
-                dsp_settings: PciePortSettings::default(),
-            });
+            })
+            .map_err(|_| arbitrary::Error::IncorrectFormat)?;
             rc.add_pcie_device(port0_key, "sw0", Box::new(SwitchAdapter(switch)))
                 .map_err(|_| arbitrary::Error::IncorrectFormat)?;
         }

--- a/vm/devices/pci/pcie/src/lib.rs
+++ b/vm/devices/pci/pcie/src/lib.rs
@@ -7,6 +7,7 @@
 
 pub mod its;
 pub(crate) mod port;
+pub use port::GenericPciePortDefinition;
 pub use port::PciePortSettings;
 pub use port::PortBarDefinition;
 pub use port::PortBarSubregionDefinition;
@@ -35,3 +36,119 @@ const MAX_FUNCTIONS_PER_BUS: usize = 256;
 const BDF_BUS_SHIFT: u16 = 8;
 const BDF_DEVICE_SHIFT: u16 = 3;
 const BDF_DEVICE_FUNCTION_MASK: u16 = 0x00FF;
+
+/// Error assigning devfns to a set of PCIe ports on a bus.
+#[derive(Debug, thiserror::Error)]
+pub enum PortDevfnError {
+    /// An explicitly-requested devfn collided with an already-assigned port.
+    #[error("port '{name}' devfn {devfn:#x} is already in use")]
+    DevfnInUse {
+        /// Name of the port whose devfn collided.
+        name: std::sync::Arc<str>,
+        /// The conflicting devfn value.
+        devfn: u8,
+    },
+    /// No free devfn slot was available for an automatically-placed port.
+    #[error("no available devfn slot for port '{name}'")]
+    NoFreeDevfn {
+        /// Name of the port that could not be placed.
+        name: std::sync::Arc<str>,
+    },
+    /// A device has a port at a non-zero function but no function 0.
+    ///
+    /// Such a port is undiscoverable: the guest reads the multi-function bit
+    /// from function 0's header before probing functions 1-7, so a device with
+    /// no function 0 is skipped entirely.
+    #[error(
+        "device {device} has a port at a non-zero function but no function 0; \
+         the device would be undiscoverable"
+    )]
+    MissingFunctionZero {
+        /// The device number (0-31) missing function 0.
+        device: u8,
+    },
+}
+
+/// The placement of a PCIe port on its bus, as computed by
+/// [`assign_port_devfns`].
+pub(crate) struct PortPlacement {
+    /// The assigned devfn (`device << 3 | function`).
+    pub devfn: u8,
+    /// Whether this port's device hosts more than one function, and thus must
+    /// advertise the multi-function header bit. Computed from the final
+    /// assignment, so a port that is the sole function of its device is *not*
+    /// marked multi-function even when other ports exist on other devices.
+    pub multi_function: bool,
+}
+
+/// Assigns a devfn to each of `ports`, in order, returning their placements.
+///
+/// A port with an explicit [`devfn`](GenericPciePortDefinition::devfn) is placed
+/// there; a port without one takes the lowest free devfn at or above
+/// `first_device`'s devfn. Assignment happens in order, so an explicit devfn
+/// that collides with an already-assigned port (including one assigned
+/// automatically) is an error.
+///
+/// Also validates that every device with a port at a non-zero function has a
+/// function 0; otherwise the device would be undiscoverable (the guest reads
+/// the multi-function bit from function 0 before probing functions 1-7).
+pub(crate) fn assign_port_devfns(
+    ports: &[GenericPciePortDefinition],
+    first_device: u8,
+) -> Result<Vec<PortPlacement>, PortDevfnError> {
+    let start_devfn = first_device << BDF_DEVICE_SHIFT;
+    // 256-bit bitmap of devfns already assigned to a port, indexed so that the
+    // device number selects the byte and the function selects the bit.
+    let mut used = [0u8; 32];
+    let is_used = |used: &[u8; 32], devfn: u8| {
+        used[(devfn >> BDF_DEVICE_SHIFT) as usize] & (1 << (devfn & 7)) != 0
+    };
+    let set_used = |used: &mut [u8; 32], devfn: u8| {
+        used[(devfn >> BDF_DEVICE_SHIFT) as usize] |= 1 << (devfn & 7)
+    };
+
+    let mut placements = Vec::with_capacity(ports.len());
+    for def in ports {
+        let devfn = match def.devfn {
+            Some(devfn) => {
+                if is_used(&used, devfn) {
+                    return Err(PortDevfnError::DevfnInUse {
+                        name: def.name.clone(),
+                        devfn,
+                    });
+                }
+                devfn
+            }
+            None => (start_devfn..=u8::MAX)
+                .find(|d| !is_used(&used, *d))
+                .ok_or_else(|| PortDevfnError::NoFreeDevfn {
+                    name: def.name.clone(),
+                })?,
+        };
+        set_used(&mut used, devfn);
+        placements.push(PortPlacement {
+            devfn,
+            // Filled in below, once all devfns are known.
+            multi_function: false,
+        });
+    }
+
+    for (device, &functions) in used.iter().enumerate() {
+        if functions != 0 && functions & 1 == 0 {
+            return Err(PortDevfnError::MissingFunctionZero {
+                device: device as u8,
+            });
+        }
+    }
+
+    // The multi-function bit is per-device: a device must advertise it only
+    // when it hosts more than one function. The function-0 check above
+    // guarantees bit 0 is set for any populated device, so the bitmap byte is
+    // exactly 1 iff function 0 is the device's only function.
+    for placement in &mut placements {
+        let device_functions = used[(placement.devfn >> BDF_DEVICE_SHIFT) as usize];
+        placement.multi_function = device_functions > 1;
+    }
+
+    Ok(placements)
+}

--- a/vm/devices/pci/pcie/src/port.rs
+++ b/vm/devices/pci/pcie/src/port.rs
@@ -981,14 +981,14 @@ mod tests {
             type0_sub_system_id: 0,
         };
 
-        let msi_conn = pci_core::msi::MsiConnection::new(AssignedBusRange::new(), 0);
+        let msi_conn = pci_core::msi::MsiConnection::new();
         let mut port = PcieDownstreamPort::new(
             "test-port",
             hardware_ids,
             DevicePortType::RootPort,
             false,
             Some(1), // Enable hotplug with slot number 1
-            msi_conn.target(),
+            &msi_conn.target(),
             PciePortSettings::default(),
             None,
             None,
@@ -1035,14 +1035,14 @@ mod tests {
             type0_sub_system_id: 0,
         };
 
-        let msi_conn = pci_core::msi::MsiConnection::new(AssignedBusRange::new(), 0);
+        let msi_conn = pci_core::msi::MsiConnection::new();
         let mut port = PcieDownstreamPort::new(
             "test-port",
             hardware_ids,
             DevicePortType::RootPort,
             false,
             None, // No hotplug
-            msi_conn.target(),
+            &msi_conn.target(),
             PciePortSettings::default(),
             None,
             None,
@@ -1130,14 +1130,14 @@ mod tests {
             type0_sub_system_id: 0,
         };
 
-        let msi_conn = pci_core::msi::MsiConnection::new(AssignedBusRange::new(), 0);
+        let msi_conn = pci_core::msi::MsiConnection::new();
         let mut port = PcieDownstreamPort::new(
             "test-port",
             hardware_ids,
             DevicePortType::RootPort,
             false,
             None,
-            msi_conn.target(),
+            &msi_conn.target(),
             PciePortSettings::default(),
             None,
             None,
@@ -1191,14 +1191,14 @@ mod tests {
             type0_sub_system_id: 0,
         };
 
-        let msi_conn = pci_core::msi::MsiConnection::new(AssignedBusRange::new(), 0);
+        let msi_conn = pci_core::msi::MsiConnection::new();
         let mut port = PcieDownstreamPort::new(
             "test-port",
             hardware_ids,
             DevicePortType::RootPort,
             false,
             None,
-            msi_conn.target(),
+            &msi_conn.target(),
             PciePortSettings::default(),
             None,
             None,

--- a/vm/devices/pci/pcie/src/port.rs
+++ b/vm/devices/pci/pcie/src/port.rs
@@ -69,6 +69,25 @@ pub struct PciePortSettings {
     pub cxl_flex_bus_port_capability: Option<CxlFlexBusPortDvsecCapability>,
 }
 
+/// A description of a generic PCIe port (a root-complex root port or a switch
+/// downstream port).
+pub struct GenericPciePortDefinition {
+    /// The name of the port.
+    pub name: Arc<str>,
+    /// The device/function (`device << 3 | function`) to place this port at.
+    ///
+    /// When `None`, the port is assigned the lowest available devfn at or
+    /// above the builder's first-port device number. Ports are assigned in
+    /// order; an explicit devfn that collides with an already-assigned port
+    /// is an error. Honored for both root-complex root ports and switch
+    /// downstream ports.
+    pub devfn: Option<u8>,
+    /// Whether hotplug is enabled for this port.
+    pub hotplug: bool,
+    /// Express-level port settings (ACS, etc.).
+    pub settings: PciePortSettings,
+}
+
 /// Generic PCIe port BAR definition.
 #[derive(Clone)]
 pub struct PortBarDefinition {

--- a/vm/devices/pci/pcie/src/root.rs
+++ b/vm/devices/pci/pcie/src/root.rs
@@ -5,13 +5,13 @@
 
 use crate::BDF_BUS_SHIFT;
 use crate::BDF_DEVICE_FUNCTION_MASK;
-use crate::BDF_DEVICE_SHIFT;
 use crate::MAX_FUNCTIONS_PER_BUS;
 use crate::PAGE_OFFSET_MASK;
 use crate::PAGE_SHIFT;
 use crate::PAGE_SIZE64;
 use crate::ROOT_PORT_DEVICE_ID;
 use crate::VENDOR_ID;
+use crate::port::GenericPciePortDefinition;
 use crate::port::PcieDownstreamPort;
 use crate::port::PciePortSettings;
 use chipset_device::ChipsetDevice;
@@ -40,10 +40,19 @@ use zerocopy::IntoBytes;
 
 /// Error returned when a root complex configuration is invalid.
 #[derive(Debug, Error)]
-#[error("requested {port_count} root ports, but only {max} are supported")]
-pub struct InvalidRootComplexError {
-    port_count: usize,
-    max: usize,
+pub enum InvalidRootComplexError {
+    /// Too many root ports were requested for the available device/function
+    /// slots.
+    #[error("requested {port_count} root ports, but only {max} are supported")]
+    TooManyPorts {
+        /// Number of root ports requested.
+        port_count: usize,
+        /// Maximum number of root ports supported.
+        max: usize,
+    },
+    /// A root port's devfn could not be assigned.
+    #[error(transparent)]
+    Devfn(#[from] crate::PortDevfnError),
 }
 
 /// A generic PCI Express root complex emulator.
@@ -100,16 +109,6 @@ pub struct DownstreamPortInfo {
     pub bus_range: AssignedBusRange,
 }
 
-/// A description of a generic PCIe root port.
-pub struct GenericPcieRootPortDefinition {
-    /// The name of the root port.
-    pub name: Arc<str>,
-    /// Whether hotplug is enabled for this root port.
-    pub hotplug: bool,
-    /// Express-level port settings (ACS, etc.).
-    pub settings: PciePortSettings,
-}
-
 /// A flat description of a PCIe switch without hierarchy.
 pub struct GenericSwitchDefinition {
     /// The name of the switch.
@@ -161,7 +160,7 @@ pub struct GenericPcieRootComplexBuilder<'a> {
     register_mmio: &'a mut dyn RegisterMmioIntercept,
     bus_range: RangeInclusive<u8>,
     ecam_range: MemoryRange,
-    root_ports: Option<(Vec<GenericPcieRootPortDefinition>, &'a MsiTarget)>,
+    root_ports: Option<(Vec<GenericPciePortDefinition>, &'a MsiTarget)>,
     first_port_device_number: u8,
     chbcr_range: Option<MemoryRange>,
 }
@@ -174,7 +173,7 @@ impl<'a> GenericPcieRootComplexBuilder<'a> {
     /// the platform's interrupt controller.
     pub fn root_ports(
         mut self,
-        ports: Vec<GenericPcieRootPortDefinition>,
+        ports: Vec<GenericPciePortDefinition>,
         msi_target: &'a MsiTarget,
     ) -> Self {
         self.root_ports = Some((ports, msi_target));
@@ -241,42 +240,45 @@ impl<'a> GenericPcieRootComplexBuilder<'a> {
         let mut devices: Vec<(u8, BusDevice)> = Vec::new();
 
         if let Some((ports, msi_target)) = root_ports {
-            // Pack root ports into consecutive devfn values, 8 functions
-            // per device slot, mirroring the switch downstream-port pattern.
             let port_count = ports.len();
             let max = 32usize.saturating_sub(first_port_device_number as usize) * 8;
             if port_count > max {
-                return Err(InvalidRootComplexError { port_count, max });
+                return Err(InvalidRootComplexError::TooManyPorts { port_count, max });
             }
 
-            let multi_function = port_count > 1;
+            // Assign each root port a devfn (honoring explicit requests and
+            // filling the rest from `first_port_device_number`), shared with
+            // the switch downstream-port assignment.
+            let placements = crate::assign_port_devfns(&ports, first_port_device_number)?;
 
-            for (i, definition) in ports.into_iter().enumerate() {
-                let device = (i / 8) + first_port_device_number as usize;
-                let function = i % 8;
-                let devfn = ((device as u8) << BDF_DEVICE_SHIFT) | function as u8;
+            for (i, (definition, placement)) in ports.into_iter().zip(placements).enumerate() {
                 let hotplug_slot_number = if definition.hotplug {
                     Some(i as u32 + 1)
                 } else {
                     None
                 };
-                let port_msi_target = msi_target.with_devfn(devfn);
+                let port_msi_target = msi_target.with_devfn(placement.devfn);
                 let root_port = RootPort::new(
                     register_mmio,
                     definition.name.clone(),
-                    multi_function,
+                    placement.multi_function,
                     hotplug_slot_number,
                     &port_msi_target,
                     definition.settings,
                 );
                 devices.push((
-                    devfn,
+                    placement.devfn,
                     BusDevice::RootPort {
                         name: definition.name,
                         port: Box::new(root_port),
                     },
                 ));
             }
+
+            // `devices` is searched with `binary_search_by_key` on devfn, so it
+            // must be kept sorted. Explicit devfns may be assigned out of
+            // order, so sort here.
+            devices.sort_by_key(|(devfn, _)| *devfn);
         }
 
         Ok(GenericPcieRootComplex {
@@ -1052,8 +1054,9 @@ mod tests {
         port_count: u16,
     ) -> GenericPcieRootComplex {
         let port_defs = (0..port_count)
-            .map(|i| GenericPcieRootPortDefinition {
+            .map(|i| GenericPciePortDefinition {
                 name: format!("test-port-{}", i).into(),
+                devfn: None,
                 hotplug: false,
                 settings: PciePortSettings::default(),
             })
@@ -1077,8 +1080,9 @@ mod tests {
         chbcr_start: u64,
     ) -> GenericPcieRootComplex {
         let port_defs = (0..port_count)
-            .map(|i| GenericPcieRootPortDefinition {
+            .map(|i| GenericPciePortDefinition {
                 name: format!("test-port-{}", i).into(),
+                devfn: None,
                 hotplug: false,
                 settings: PciePortSettings::default(),
             })
@@ -1741,8 +1745,9 @@ mod tests {
         let rc_bus_range = AssignedBusRange::new();
         rc_bus_range.set_bus_range(start_bus, end_bus);
         let msi_conn = pci_core::msi::MsiConnection::new(rc_bus_range, 0);
-        let port_defs = vec![GenericPcieRootPortDefinition {
+        let port_defs = vec![GenericPciePortDefinition {
             name: "port-0".into(),
+            devfn: None,
             hotplug: false,
             settings: PciePortSettings::default(),
         }];
@@ -1885,11 +1890,53 @@ mod tests {
     }
 
     #[test]
+    fn test_multi_function_bit_is_per_device() {
+        // Two ports placed at explicit devfns on *distinct* devices (each the
+        // sole function of its device) must NOT advertise the multi-function
+        // bit, even though there is more than one port.
+        let mut register_mmio = TestPcieMmioRegistration {};
+        let ecam = MemoryRange::new(0..ecam_size_from_bus_numbers(0, 0));
+        let rc_bus_range = AssignedBusRange::new();
+        rc_bus_range.set_bus_range(0, 0);
+        let msi_conn = pci_core::msi::MsiConnection::new(rc_bus_range, 0);
+        let port_defs = vec![
+            GenericPciePortDefinition {
+                name: "a".into(),
+                devfn: Some(8), // device 1, function 0
+                hotplug: false,
+                settings: PciePortSettings::default(),
+            },
+            GenericPciePortDefinition {
+                name: "b".into(),
+                devfn: Some(16), // device 2, function 0
+                hotplug: false,
+                settings: PciePortSettings::default(),
+            },
+        ];
+        let mut rc = GenericPcieRootComplex::builder(&mut register_mmio, 0..=0u8, ecam)
+            .root_ports(port_defs, msi_conn.target())
+            .build()
+            .unwrap();
+
+        for devfn in [8u64, 16] {
+            let mut header: u32 = 0;
+            rc.mmio_read(devfn * 4096 + 0x0C, header.as_mut_bytes())
+                .unwrap();
+            assert_eq!(
+                header & (1 << 23),
+                0,
+                "devfn {devfn}: sole function of its device must not set the multi-function bit"
+            );
+        }
+    }
+
+    #[test]
     fn test_too_many_ports_returns_error() {
         // 257 ports starting at device 0 requires device 32, which is out of range.
-        let port_defs: Vec<GenericPcieRootPortDefinition> = (0..257)
-            .map(|i| GenericPcieRootPortDefinition {
+        let port_defs: Vec<GenericPciePortDefinition> = (0..257)
+            .map(|i| GenericPciePortDefinition {
                 name: format!("port-{}", i).into(),
+                devfn: None,
                 hotplug: false,
                 settings: PciePortSettings::default(),
             })
@@ -1906,5 +1953,105 @@ mod tests {
             result.is_err(),
             "257 ports should exceed the 256-port limit"
         );
+    }
+
+    /// Builds a root complex from explicit per-port devfn requests, returning
+    /// the assigned devfns in port-name order.
+    fn build_with_devfns(
+        ports: Vec<(&str, Option<u8>)>,
+        first_port_device_number: u8,
+    ) -> Result<Vec<(String, u8)>, InvalidRootComplexError> {
+        let port_defs: Vec<GenericPciePortDefinition> = ports
+            .into_iter()
+            .map(|(name, devfn)| GenericPciePortDefinition {
+                name: name.into(),
+                devfn,
+                hotplug: false,
+                settings: PciePortSettings::default(),
+            })
+            .collect();
+        let mut register_mmio = TestPcieMmioRegistration {};
+        let ecam = MemoryRange::new(0..ecam_size_from_bus_numbers(0, 0));
+        let rc_bus_range = AssignedBusRange::new();
+        rc_bus_range.set_bus_range(0, 0);
+        let msi_conn = pci_core::msi::MsiConnection::new(rc_bus_range, 0);
+        let rc = GenericPcieRootComplex::builder(&mut register_mmio, 0..=0u8, ecam)
+            .root_ports(port_defs, msi_conn.target())
+            .first_port_device_number(first_port_device_number)
+            .build()?;
+        Ok(rc
+            .downstream_ports()
+            .into_iter()
+            .map(|p| (p.name.to_string(), p.devfn))
+            .collect())
+    }
+
+    #[test]
+    fn test_devfn_auto_allocation() {
+        // All-None ports pack onto consecutive devfns starting at 0.
+        let ports = build_with_devfns(vec![("a", None), ("b", None), ("c", None)], 0).unwrap();
+        assert_eq!(
+            ports,
+            vec![("a".into(), 0), ("b".into(), 1), ("c".into(), 2)]
+        );
+    }
+
+    #[test]
+    fn test_devfn_auto_allocation_respects_first_device() {
+        // None ports start at the first-port device number (device 1 → devfn 8).
+        let ports = build_with_devfns(vec![("a", None), ("b", None)], 1).unwrap();
+        assert_eq!(ports, vec![("a".into(), 8), ("b".into(), 9)]);
+    }
+
+    #[test]
+    fn test_devfn_explicit_and_auto_mix() {
+        // Explicit devfn is honored; subsequent None ports skip used devfns.
+        let ports =
+            build_with_devfns(vec![("a", Some(0)), ("b", None), ("c", Some(16))], 0).unwrap();
+        // Sorted by devfn: a@0, b@1, c@16.
+        assert_eq!(
+            ports,
+            vec![("a".into(), 0), ("b".into(), 1), ("c".into(), 16)]
+        );
+    }
+
+    #[test]
+    fn test_devfn_none_then_explicit_zero_conflicts() {
+        // [None, Some(0)]: the None port takes devfn 0, so the explicit
+        // request for 0 collides and fails (allocation is in order).
+        let err = build_with_devfns(vec![("a", None), ("b", Some(0))], 0).unwrap_err();
+        assert!(matches!(
+            err,
+            InvalidRootComplexError::Devfn(crate::PortDevfnError::DevfnInUse { devfn: 0, .. })
+        ));
+    }
+
+    #[test]
+    fn test_devfn_explicit_duplicate_conflicts() {
+        let err = build_with_devfns(vec![("a", Some(5)), ("b", Some(5))], 0).unwrap_err();
+        assert!(matches!(
+            err,
+            InvalidRootComplexError::Devfn(crate::PortDevfnError::DevfnInUse { devfn: 5, .. })
+        ));
+    }
+
+    #[test]
+    fn test_devfn_nonzero_function_without_function_zero_fails() {
+        // device 5, function 1 (devfn 0x29) with no function 0 is undiscoverable.
+        let err = build_with_devfns(vec![("a", Some((5 << 3) | 1))], 0).unwrap_err();
+        assert!(matches!(
+            err,
+            InvalidRootComplexError::Devfn(crate::PortDevfnError::MissingFunctionZero {
+                device: 5
+            })
+        ));
+    }
+
+    #[test]
+    fn test_devfn_function_zero_present_allows_higher_functions() {
+        // device 5 functions 0 and 1 present: discoverable, so this is allowed.
+        let ports =
+            build_with_devfns(vec![("a", Some(5 << 3)), ("b", Some((5 << 3) | 1))], 0).unwrap();
+        assert_eq!(ports, vec![("a".into(), 40), ("b".into(), 41)]);
     }
 }

--- a/vm/devices/pci/pcie/src/root.rs
+++ b/vm/devices/pci/pcie/src/root.rs
@@ -664,7 +664,7 @@ impl MmioIntercept for GenericPcieRootComplex {
                 tracelimit::warn_ratelimited!(addr, "unexpected intercept at ECAM address");
             }
             DecodedEcamAccess::Unroutable => {
-                tracing::debug!(addr, "unroutable config space access");
+                tracing::trace!(addr, "unroutable config space access");
             }
             DecodedEcamAccess::InternalBus(port, cfg_offset) => {
                 check_result!(port.port.cfg_space.read_u32(cfg_offset, &mut dword_value));
@@ -739,7 +739,7 @@ impl MmioIntercept for GenericPcieRootComplex {
                 tracelimit::warn_ratelimited!(addr, "unexpected intercept at ECAM address");
             }
             DecodedEcamAccess::Unroutable => {
-                tracing::debug!(addr, "unroutable config space access");
+                tracing::trace!(addr, "unroutable config space access");
             }
             DecodedEcamAccess::InternalBus(port, cfg_offset) => {
                 check_result!(port.port.cfg_space.write_u32(cfg_offset, write_dword));

--- a/vm/devices/pci/pcie/src/root.rs
+++ b/vm/devices/pci/pcie/src/root.rs
@@ -1066,9 +1066,9 @@ mod tests {
         let ecam = MemoryRange::new(0..ecam_size_from_bus_numbers(start_bus, end_bus));
         let rc_bus_range = AssignedBusRange::new();
         rc_bus_range.set_bus_range(start_bus, end_bus);
-        let msi_conn = pci_core::msi::MsiConnection::new(rc_bus_range, 0);
+        let msi_conn = pci_core::msi::MsiConnection::new();
         GenericPcieRootComplex::builder(&mut register_mmio, start_bus..=end_bus, ecam)
-            .root_ports(port_defs, msi_conn.target())
+            .root_ports(port_defs, &msi_conn.msi_target(rc_bus_range, 0))
             .build()
             .unwrap()
     }
@@ -1095,10 +1095,10 @@ mod tests {
         );
         let rc_bus_range = AssignedBusRange::new();
         rc_bus_range.set_bus_range(start_bus, end_bus);
-        let msi_conn = pci_core::msi::MsiConnection::new(rc_bus_range, 0);
+        let msi_conn = pci_core::msi::MsiConnection::new();
 
         GenericPcieRootComplex::builder(&mut register_mmio, start_bus..=end_bus, ecam)
-            .root_ports(port_defs, msi_conn.target())
+            .root_ports(port_defs, &msi_conn.msi_target(rc_bus_range, 0))
             .chbcr_range(Some(chbcr))
             .build()
             .unwrap()
@@ -1447,13 +1447,13 @@ mod tests {
         // Test with hotplug disabled (None)
         let root_port_no_hotplug = {
             let mut register_mmio = TestPcieMmioRegistration {};
-            let c = pci_core::msi::MsiConnection::new(AssignedBusRange::new(), 0);
+            let c = pci_core::msi::MsiConnection::new();
             RootPort::new(
                 &mut register_mmio,
                 "test-port-no-hotplug",
                 false,
                 None,
-                c.target(),
+                &c.target(),
                 PciePortSettings::default(),
             )
         };
@@ -1471,13 +1471,13 @@ mod tests {
         // Test with hotplug enabled (Some(slot_number))
         let root_port_with_hotplug = {
             let mut register_mmio = TestPcieMmioRegistration {};
-            let c = pci_core::msi::MsiConnection::new(AssignedBusRange::new(), 0);
+            let c = pci_core::msi::MsiConnection::new();
             RootPort::new(
                 &mut register_mmio,
                 "test-port-hotplug",
                 false,
                 Some(5),
-                c.target(),
+                &c.target(),
                 PciePortSettings::default(),
             )
         };
@@ -1496,13 +1496,13 @@ mod tests {
     fn test_root_port_invalid_bus_range_handling() {
         let mut root_port = {
             let mut register_mmio = TestPcieMmioRegistration {};
-            let c = pci_core::msi::MsiConnection::new(AssignedBusRange::new(), 0);
+            let c = pci_core::msi::MsiConnection::new();
             RootPort::new(
                 &mut register_mmio,
                 "test-port",
                 false,
                 None,
-                c.target(),
+                &c.target(),
                 PciePortSettings::default(),
             )
         };
@@ -1744,7 +1744,7 @@ mod tests {
         let ecam = MemoryRange::new(0..ecam_size_from_bus_numbers(start_bus, end_bus));
         let rc_bus_range = AssignedBusRange::new();
         rc_bus_range.set_bus_range(start_bus, end_bus);
-        let msi_conn = pci_core::msi::MsiConnection::new(rc_bus_range, 0);
+        let msi_conn = pci_core::msi::MsiConnection::new();
         let port_defs = vec![GenericPciePortDefinition {
             name: "port-0".into(),
             devfn: None,
@@ -1752,7 +1752,7 @@ mod tests {
             settings: PciePortSettings::default(),
         }];
         let mut rc = GenericPcieRootComplex::builder(&mut register_mmio, start_bus..=end_bus, ecam)
-            .root_ports(port_defs, msi_conn.target())
+            .root_ports(port_defs, &msi_conn.msi_target(rc_bus_range, 0))
             .first_port_device_number(1)
             .build()
             .unwrap();
@@ -1896,9 +1896,7 @@ mod tests {
         // bit, even though there is more than one port.
         let mut register_mmio = TestPcieMmioRegistration {};
         let ecam = MemoryRange::new(0..ecam_size_from_bus_numbers(0, 0));
-        let rc_bus_range = AssignedBusRange::new();
-        rc_bus_range.set_bus_range(0, 0);
-        let msi_conn = pci_core::msi::MsiConnection::new(rc_bus_range, 0);
+        let msi_conn = pci_core::msi::MsiConnection::new();
         let port_defs = vec![
             GenericPciePortDefinition {
                 name: "a".into(),
@@ -1914,7 +1912,7 @@ mod tests {
             },
         ];
         let mut rc = GenericPcieRootComplex::builder(&mut register_mmio, 0..=0u8, ecam)
-            .root_ports(port_defs, msi_conn.target())
+            .root_ports(port_defs, &msi_conn.target())
             .build()
             .unwrap();
 
@@ -1945,9 +1943,9 @@ mod tests {
         let ecam = MemoryRange::new(0..ecam_size_from_bus_numbers(0, 255));
         let rc_bus_range = AssignedBusRange::new();
         rc_bus_range.set_bus_range(0, 255);
-        let msi_conn = pci_core::msi::MsiConnection::new(rc_bus_range, 0);
+        let msi_conn = pci_core::msi::MsiConnection::new();
         let result = GenericPcieRootComplex::builder(&mut register_mmio, 0..=255u8, ecam)
-            .root_ports(port_defs, msi_conn.target())
+            .root_ports(port_defs, &msi_conn.msi_target(rc_bus_range, 0))
             .build();
         assert!(
             result.is_err(),
@@ -1972,11 +1970,9 @@ mod tests {
             .collect();
         let mut register_mmio = TestPcieMmioRegistration {};
         let ecam = MemoryRange::new(0..ecam_size_from_bus_numbers(0, 0));
-        let rc_bus_range = AssignedBusRange::new();
-        rc_bus_range.set_bus_range(0, 0);
-        let msi_conn = pci_core::msi::MsiConnection::new(rc_bus_range, 0);
+        let msi_conn = pci_core::msi::MsiConnection::new();
         let rc = GenericPcieRootComplex::builder(&mut register_mmio, 0..=0u8, ecam)
-            .root_ports(port_defs, msi_conn.target())
+            .root_ports(port_defs, &msi_conn.target())
             .first_port_device_number(first_port_device_number)
             .build()?;
         Ok(rc

--- a/vm/devices/pci/pcie/src/switch.rs
+++ b/vm/devices/pci/pcie/src/switch.rs
@@ -11,6 +11,7 @@
 //! PCIe capabilities indicating their port type.
 
 use crate::DOWNSTREAM_SWITCH_PORT_DEVICE_ID;
+use crate::PortDevfnError;
 use crate::UPSTREAM_SWITCH_PORT_DEVICE_ID;
 use crate::VENDOR_ID;
 use crate::port::PcieDownstreamPort;
@@ -145,16 +146,31 @@ impl DownstreamSwitchPort {
 pub struct GenericPcieSwitchDefinition {
     /// The name of the switch.
     pub name: Arc<str>,
-    /// The number of downstream ports to create.
+    /// The downstream ports to create.
+    ///
+    /// Each port is assigned a devfn the same way root-complex root ports are:
+    /// an explicit [`devfn`](crate::GenericPciePortDefinition::devfn) is honored,
+    /// and the rest are packed sequentially from device 0. CXL is not supported
+    /// on switch downstream ports.
     /// TODO: implement physical slot number, link and slot stuff
-    pub downstream_port_count: u8,
-    /// Whether hotplug is enabled for this switch's downstream ports.
-    pub hotplug: bool,
+    pub downstream_ports: Vec<crate::GenericPciePortDefinition>,
     /// MSI target from the parent connection. The switch re-derives
     /// per-port targets using the upstream port's bus range.
     pub msi_target: MsiTarget,
-    /// Express-level settings for downstream switch ports.
-    pub dsp_settings: PciePortSettings,
+}
+
+/// Error returned when a switch configuration is invalid.
+#[derive(Debug, thiserror::Error)]
+pub enum InvalidSwitchError {
+    /// CXL was requested on a switch downstream port, which is not supported.
+    #[error("downstream port '{name}': CXL is not supported on switch ports")]
+    CxlUnsupported {
+        /// Name of the offending downstream port.
+        name: Arc<str>,
+    },
+    /// A downstream port's devfn could not be assigned.
+    #[error(transparent)]
+    Devfn(#[from] PortDevfnError),
 }
 
 /// A PCI Express switch emulator that implements a complete switch with upstream and downstream ports.
@@ -171,18 +187,30 @@ pub struct GenericPcieSwitch {
     name: Arc<str>,
     /// The upstream switch port that connects to the parent.
     upstream_port: UpstreamSwitchPort,
-    /// Downstream switch ports indexed by devfn.
-    #[inspect(with = "|x| inspect::iter_by_index(x).map_value(|(_, v)| v)")]
-    downstream_ports: Vec<(Arc<str>, DownstreamSwitchPort)>,
+    /// Downstream switch ports, sorted by devfn.
+    #[inspect(with = "|x| inspect::iter_by_key(x.iter().map(|(k, _, v)| (k, v)))")]
+    downstream_ports: Vec<(u8, Arc<str>, DownstreamSwitchPort)>,
 }
 
 impl GenericPcieSwitch {
     /// Constructs a new [`GenericPcieSwitch`] emulator.
-    pub fn new(definition: GenericPcieSwitchDefinition) -> Self {
+    pub fn new(definition: GenericPcieSwitchDefinition) -> Result<Self, InvalidSwitchError> {
         let upstream_port = UpstreamSwitchPort::new();
 
-        // If there are multiple downstream ports, they need the multi-function flag set
-        let multi_function = definition.downstream_port_count > 1;
+        // CXL is not supported on switch downstream ports (there is no CHBCR /
+        // component-register infrastructure behind a switch).
+        for port_def in &definition.downstream_ports {
+            if port_def.settings.cxl_flex_bus_port_capability.is_some() {
+                return Err(InvalidSwitchError::CxlUnsupported {
+                    name: port_def.name.clone(),
+                });
+            }
+        }
+
+        // Assign each downstream port a devfn, shared with the root-complex
+        // root-port assignment. Honors explicit devfns and packs the rest from
+        // device 0.
+        let placements = crate::assign_port_devfns(&definition.downstream_ports, 0)?;
 
         // Derive per-port MSI targets from the parent's target, using
         // the upstream port's bus range. When the guest programs the
@@ -192,33 +220,40 @@ impl GenericPcieSwitch {
             .msi_target
             .with_bus_range(upstream_port.cfg_space().bus_range(), 0);
 
-        let downstream_ports: Vec<(Arc<str>, DownstreamSwitchPort)> = (0..definition
-            .downstream_port_count)
-            .map(|i| {
-                let port_name: Arc<str> = format!("{}-downstream-{}", definition.name, i).into();
+        let mut downstream_ports: Vec<(u8, Arc<str>, DownstreamSwitchPort)> = definition
+            .downstream_ports
+            .into_iter()
+            .zip(placements)
+            .enumerate()
+            .map(|(i, (port_def, placement))| {
+                let port_name = port_def.name;
                 // Use the port index as the slot number for hotpluggable ports
-                let hotplug_slot_number = if definition.hotplug {
+                let hotplug_slot_number = if port_def.hotplug {
                     Some((i as u32) + 1)
                 } else {
                     None
                 };
-                let port_msi_target = switch_msi_target.with_devfn(i);
+                let port_msi_target = switch_msi_target.with_devfn(placement.devfn);
                 let port = DownstreamSwitchPort::new(
                     port_name.clone(),
-                    Some(multi_function),
+                    Some(placement.multi_function),
                     hotplug_slot_number,
                     &port_msi_target,
-                    definition.dsp_settings.clone(),
+                    port_def.settings,
                 );
-                (port_name, port)
+                (placement.devfn, port_name, port)
             })
             .collect();
 
-        Self {
+        // `downstream_ports` is searched by devfn, so keep it sorted; explicit
+        // devfns may be assigned out of order.
+        downstream_ports.sort_by_key(|(devfn, _, _)| *devfn);
+
+        Ok(Self {
             name: definition.name,
             upstream_port,
             downstream_ports,
-        }
+        })
     }
 
     /// Get the name of this switch.
@@ -235,9 +270,8 @@ impl GenericPcieSwitch {
     pub fn downstream_ports(&self) -> Vec<crate::root::DownstreamPortInfo> {
         self.downstream_ports
             .iter()
-            .enumerate()
-            .map(|(i, (name, dsp))| crate::root::DownstreamPortInfo {
-                devfn: i as u8,
+            .map(|(devfn, name, dsp)| crate::root::DownstreamPortInfo {
+                devfn: *devfn,
                 name: name.clone(),
                 bus_range: dsp.port.bus_range(),
             })
@@ -313,7 +347,10 @@ impl GenericPcieSwitch {
         cfg_offset: u16,
         value: &mut u32,
     ) -> Option<IoResult> {
-        let (_, downstream_port) = self.downstream_ports.get_mut(function as usize)?;
+        let (_, _, downstream_port) = self
+            .downstream_ports
+            .iter_mut()
+            .find(|(devfn, _, _)| *devfn == function)?;
         Some(downstream_port.port.cfg_space.read_u32(cfg_offset, value))
     }
 
@@ -324,7 +361,10 @@ impl GenericPcieSwitch {
         cfg_offset: u16,
         value: u32,
     ) -> Option<IoResult> {
-        let (_, downstream_port) = self.downstream_ports.get_mut(function as usize)?;
+        let (_, _, downstream_port) = self
+            .downstream_ports
+            .iter_mut()
+            .find(|(devfn, _, _)| *devfn == function)?;
         Some(downstream_port.port.cfg_space.write_u32(cfg_offset, value))
     }
 
@@ -336,7 +376,7 @@ impl GenericPcieSwitch {
         cfg_offset: u16,
         value: &mut u32,
     ) -> Option<IoResult> {
-        for (_, downstream_port) in self.downstream_ports.iter_mut() {
+        for (_, _, downstream_port) in self.downstream_ports.iter_mut() {
             let downstream_bus_range = downstream_port.cfg_space().assigned_bus_range();
 
             // Skip downstream ports with invalid/uninitialized bus configuration
@@ -365,7 +405,7 @@ impl GenericPcieSwitch {
         cfg_offset: u16,
         value: u32,
     ) -> Option<IoResult> {
-        for (_, downstream_port) in self.downstream_ports.iter_mut() {
+        for (_, _, downstream_port) in self.downstream_ports.iter_mut() {
             let downstream_bus_range = downstream_port.cfg_space().assigned_bus_range();
 
             // Skip downstream ports with invalid/uninitialized bus configuration
@@ -393,9 +433,10 @@ impl GenericPcieSwitch {
         name: &str,
         dev: Box<dyn GenericPciBusDevice>,
     ) -> anyhow::Result<()> {
-        let (port_name, downstream_port) = self
+        let (_, port_name, downstream_port) = self
             .downstream_ports
-            .get_mut(port_devfn as usize)
+            .iter_mut()
+            .find(|(devfn, _, _)| *devfn == port_devfn)
             .ok_or_else(|| anyhow::anyhow!("port devfn {} not found", port_devfn))?;
         downstream_port
             .port
@@ -418,7 +459,7 @@ impl ChangeDeviceState for GenericPcieSwitch {
         self.upstream_port.cfg_space.reset();
 
         // Reset all downstream port configuration spaces
-        for (_, downstream_port) in self.downstream_ports.iter_mut() {
+        for (_, _, downstream_port) in self.downstream_ports.iter_mut() {
             downstream_port.port.cfg_space.reset();
         }
     }
@@ -559,9 +600,9 @@ mod save_restore {
 
             // Save all downstream ports (already sorted by devfn in the Vec).
             let mut downstream_ports = Vec::with_capacity(self.downstream_ports.len());
-            for (i, (_, downstream_port)) in self.downstream_ports.iter_mut().enumerate() {
+            for (devfn, _, downstream_port) in self.downstream_ports.iter_mut() {
                 downstream_ports.push(state::DownstreamPortSavedState {
-                    devfn: i as u8,
+                    devfn: *devfn,
                     cfg_space: downstream_port.port.cfg_space.save()?,
                     cxl_component_registers: downstream_port
                         .port
@@ -605,8 +646,10 @@ mod save_restore {
                     )));
                 }
 
-                if let Some((_, downstream_port)) =
-                    self.downstream_ports.get_mut(port_state.devfn as usize)
+                if let Some((_, _, downstream_port)) = self
+                    .downstream_ports
+                    .iter_mut()
+                    .find(|(devfn, _, _)| *devfn == port_state.devfn)
                 {
                     downstream_port
                         .port
@@ -633,6 +676,35 @@ mod tests {
     use super::*;
     use pci_core::bus_range::AssignedBusRange;
     use pci_core::msi::MsiConnection;
+
+    /// Builds a switch definition with `downstream_port_count` uniform
+    /// downstream ports named `{name}-downstream-{i}`, mirroring the naming
+    /// convention used by the rest of the topology.
+    fn switch_def(
+        name: &str,
+        downstream_port_count: u8,
+        hotplug: bool,
+        dsp_settings: PciePortSettings,
+        msi_target: MsiTarget,
+    ) -> GenericPcieSwitchDefinition {
+        GenericPcieSwitchDefinition {
+            name: name.into(),
+            downstream_ports: (0..downstream_port_count)
+                .map(|i| crate::GenericPciePortDefinition {
+                    name: format!("{name}-downstream-{i}").into(),
+                    devfn: None,
+                    hotplug,
+                    settings: dsp_settings.clone(),
+                })
+                .collect(),
+            msi_target,
+        }
+    }
+
+    /// Builds a switch from a definition, unwrapping the (test-only) result.
+    fn build(definition: GenericPcieSwitchDefinition) -> GenericPcieSwitch {
+        GenericPcieSwitch::new(definition).unwrap()
+    }
 
     #[test]
     fn test_upstream_switch_port_creation() {
@@ -769,14 +841,13 @@ mod tests {
 
     #[test]
     fn test_switch_creation() {
-        let definition = GenericPcieSwitchDefinition {
-            name: "test-switch".into(),
-            downstream_port_count: 3,
-            hotplug: false,
-            dsp_settings: PciePortSettings::default(),
-            msi_target: MsiTarget::disconnected(),
-        };
-        let switch = GenericPcieSwitch::new(definition);
+        let switch = build(switch_def(
+            "test-switch",
+            3,
+            false,
+            PciePortSettings::default(),
+            MsiTarget::disconnected(),
+        ));
 
         assert_eq!(switch.name().as_ref(), "test-switch");
         assert_eq!(switch.downstream_ports().len(), 3);
@@ -801,14 +872,13 @@ mod tests {
         use crate::test_helpers::TestPcieEndpoint;
         use chipset_device::io::IoError;
 
-        let definition = GenericPcieSwitchDefinition {
-            name: "test-switch".into(),
-            downstream_port_count: 2,
-            hotplug: false,
-            dsp_settings: PciePortSettings::default(),
-            msi_target: MsiTarget::disconnected(),
-        };
-        let mut switch = GenericPcieSwitch::new(definition);
+        let mut switch = build(switch_def(
+            "test-switch",
+            2,
+            false,
+            PciePortSettings::default(),
+            MsiTarget::disconnected(),
+        ));
 
         let downstream_device = TestPcieEndpoint::new(
             |offset, value| match offset {
@@ -849,14 +919,13 @@ mod tests {
         use crate::test_helpers::TestPcieEndpoint;
         use chipset_device::io::IoResult;
 
-        let definition = GenericPcieSwitchDefinition {
-            name: "test-switch".into(),
-            downstream_port_count: 2,
-            hotplug: false,
-            dsp_settings: PciePortSettings::default(),
-            msi_target: MsiTarget::disconnected(),
-        };
-        let mut switch = GenericPcieSwitch::new(definition);
+        let mut switch = build(switch_def(
+            "test-switch",
+            2,
+            false,
+            PciePortSettings::default(),
+            MsiTarget::disconnected(),
+        ));
 
         // Verify that Switch implements routing functionality by testing add_pcie_device method
         // This tests that the switch can accept device connections (routing capability)
@@ -884,14 +953,13 @@ mod tests {
         use chipset_device::ChipsetDevice;
         use chipset_device::pci::PciConfigSpace;
 
-        let definition = GenericPcieSwitchDefinition {
-            name: "test-switch".into(),
-            downstream_port_count: 4,
-            hotplug: false,
-            dsp_settings: PciePortSettings::default(),
-            msi_target: MsiTarget::disconnected(),
-        };
-        let mut switch = GenericPcieSwitch::new(definition);
+        let mut switch = build(switch_def(
+            "test-switch",
+            4,
+            false,
+            PciePortSettings::default(),
+            MsiTarget::disconnected(),
+        ));
 
         // Test that it supports PCI but not other interfaces
         assert!(switch.supports_pci().is_some());
@@ -915,41 +983,38 @@ mod tests {
 
     #[test]
     fn test_switch_default() {
-        let definition = GenericPcieSwitchDefinition {
-            name: "default-switch".into(),
-            downstream_port_count: 4,
-            hotplug: false,
-            dsp_settings: PciePortSettings::default(),
-            msi_target: MsiTarget::disconnected(),
-        };
-        let switch = GenericPcieSwitch::new(definition);
+        let switch = build(switch_def(
+            "default-switch",
+            4,
+            false,
+            PciePortSettings::default(),
+            MsiTarget::disconnected(),
+        ));
         assert_eq!(switch.name().as_ref(), "default-switch");
         assert_eq!(switch.downstream_ports().len(), 4);
     }
 
     #[test]
     fn test_switch_large_downstream_port_count() {
-        let definition = GenericPcieSwitchDefinition {
-            name: "test-switch".into(),
-            downstream_port_count: 16,
-            hotplug: false,
-            dsp_settings: PciePortSettings::default(),
-            msi_target: MsiTarget::disconnected(),
-        };
-        let switch = GenericPcieSwitch::new(definition);
+        let switch = build(switch_def(
+            "test-switch",
+            16,
+            false,
+            PciePortSettings::default(),
+            MsiTarget::disconnected(),
+        ));
         assert_eq!(switch.downstream_ports().len(), 16);
     }
 
     #[test]
     fn test_switch_downstream_port_direct_access() {
-        let definition = GenericPcieSwitchDefinition {
-            name: "test-switch".into(),
-            downstream_port_count: 3,
-            hotplug: false,
-            dsp_settings: PciePortSettings::default(),
-            msi_target: MsiTarget::disconnected(),
-        };
-        let mut switch = GenericPcieSwitch::new(definition);
+        let mut switch = build(switch_def(
+            "test-switch",
+            3,
+            false,
+            PciePortSettings::default(),
+            MsiTarget::disconnected(),
+        ));
 
         // Simulate the switch's internal bus being assigned as bus 1
         let secondary_bus = 1u8;
@@ -987,14 +1052,13 @@ mod tests {
 
     #[test]
     fn test_switch_invalid_bus_range_handling() {
-        let definition = GenericPcieSwitchDefinition {
-            name: "test-switch".into(),
-            downstream_port_count: 2,
-            hotplug: false,
-            dsp_settings: PciePortSettings::default(),
-            msi_target: MsiTarget::disconnected(),
-        };
-        let mut switch = GenericPcieSwitch::new(definition);
+        let mut switch = build(switch_def(
+            "test-switch",
+            2,
+            false,
+            PciePortSettings::default(),
+            MsiTarget::disconnected(),
+        ));
 
         // Don't configure bus numbers, so the range should be 0..=0 (invalid)
         let bus_range = switch.upstream_port.cfg_space().assigned_bus_range();
@@ -1014,14 +1078,13 @@ mod tests {
 
     #[test]
     fn test_switch_downstream_port_invalid_bus_range_skipping() {
-        let definition = GenericPcieSwitchDefinition {
-            name: "test-switch".into(),
-            downstream_port_count: 2,
-            hotplug: false,
-            dsp_settings: PciePortSettings::default(),
-            msi_target: MsiTarget::disconnected(),
-        };
-        let mut switch = GenericPcieSwitch::new(definition);
+        let mut switch = build(switch_def(
+            "test-switch",
+            2,
+            false,
+            PciePortSettings::default(),
+            MsiTarget::disconnected(),
+        ));
 
         // Configure the upstream port with a valid bus range
         let secondary_bus = 1u8;
@@ -1055,19 +1118,18 @@ mod tests {
     #[test]
     fn test_switch_multi_function_bit() {
         // Test that switches with multiple downstream ports set the multi-function bit
-        let multi_port_definition = GenericPcieSwitchDefinition {
-            name: "multi-port-switch".into(),
-            downstream_port_count: 3,
-            hotplug: false,
-            dsp_settings: PciePortSettings::default(),
-            msi_target: MsiTarget::disconnected(),
-        };
-        let multi_port_switch = GenericPcieSwitch::new(multi_port_definition);
+        let multi_port_switch = build(switch_def(
+            "multi-port-switch",
+            3,
+            false,
+            PciePortSettings::default(),
+            MsiTarget::disconnected(),
+        ));
 
         // Verify each downstream port has the multi-function bit set
         for p in multi_port_switch.downstream_ports() {
             let port_num = p.devfn;
-            if let Some((_, downstream_port)) =
+            if let Some((_, _, downstream_port)) =
                 multi_port_switch.downstream_ports.get(port_num as usize)
             {
                 let mut header_type_value: u32 = 0;
@@ -1098,19 +1160,18 @@ mod tests {
         }
 
         // Test that switches with single downstream port do NOT set the multi-function bit
-        let single_port_definition = GenericPcieSwitchDefinition {
-            name: "single-port-switch".into(),
-            downstream_port_count: 1,
-            hotplug: false,
-            dsp_settings: PciePortSettings::default(),
-            msi_target: MsiTarget::disconnected(),
-        };
-        let single_port_switch = GenericPcieSwitch::new(single_port_definition);
+        let single_port_switch = build(switch_def(
+            "single-port-switch",
+            1,
+            false,
+            PciePortSettings::default(),
+            MsiTarget::disconnected(),
+        ));
 
         // Verify the single downstream port does NOT have the multi-function bit set
         for p in single_port_switch.downstream_ports() {
             let port_num = p.devfn;
-            if let Some((_, downstream_port)) =
+            if let Some((_, _, downstream_port)) =
                 single_port_switch.downstream_ports.get(port_num as usize)
             {
                 let mut header_type_value: u32 = 0;
@@ -1144,25 +1205,23 @@ mod tests {
     #[test]
     fn test_hotplug_support() {
         // Test hotplug disabled
-        let definition_no_hotplug = GenericPcieSwitchDefinition {
-            name: "test-switch-no-hotplug".into(),
-            downstream_port_count: 1,
-            hotplug: false,
-            dsp_settings: PciePortSettings::default(),
-            msi_target: MsiTarget::disconnected(),
-        };
-        let switch_no_hotplug = GenericPcieSwitch::new(definition_no_hotplug);
+        let switch_no_hotplug = build(switch_def(
+            "test-switch-no-hotplug",
+            1,
+            false,
+            PciePortSettings::default(),
+            MsiTarget::disconnected(),
+        ));
         assert_eq!(switch_no_hotplug.name().as_ref(), "test-switch-no-hotplug");
 
         // Test hotplug enabled
-        let definition_with_hotplug = GenericPcieSwitchDefinition {
-            name: "test-switch-with-hotplug".into(),
-            downstream_port_count: 1,
-            hotplug: true,
-            dsp_settings: PciePortSettings::default(),
-            msi_target: MsiTarget::disconnected(),
-        };
-        let switch_with_hotplug = GenericPcieSwitch::new(definition_with_hotplug);
+        let switch_with_hotplug = build(switch_def(
+            "test-switch-with-hotplug",
+            1,
+            true,
+            PciePortSettings::default(),
+            MsiTarget::disconnected(),
+        ));
         assert_eq!(
             switch_with_hotplug.name().as_ref(),
             "test-switch-with-hotplug"
@@ -1174,28 +1233,26 @@ mod tests {
         use vmcore::save_restore::SaveRestore;
 
         // Create a switch with 3 downstream ports
-        let definition = GenericPcieSwitchDefinition {
-            name: "test-switch".into(),
-            downstream_port_count: 3,
-            hotplug: false,
-            dsp_settings: PciePortSettings::default(),
-            msi_target: MsiTarget::disconnected(),
-        };
-        let mut switch = GenericPcieSwitch::new(definition);
+        let mut switch = build(switch_def(
+            "test-switch",
+            3,
+            false,
+            PciePortSettings::default(),
+            MsiTarget::disconnected(),
+        ));
 
         // Save the state
         let saved_state = switch.save().expect("save should succeed");
         assert_eq!(saved_state.downstream_ports.len(), 3);
 
         // Create a new switch with only 2 downstream ports
-        let definition2 = GenericPcieSwitchDefinition {
-            name: "test-switch".into(),
-            downstream_port_count: 2,
-            hotplug: false,
-            dsp_settings: PciePortSettings::default(),
-            msi_target: MsiTarget::disconnected(),
-        };
-        let mut switch2 = GenericPcieSwitch::new(definition2);
+        let mut switch2 = build(switch_def(
+            "test-switch",
+            2,
+            false,
+            PciePortSettings::default(),
+            MsiTarget::disconnected(),
+        ));
 
         // Restore should fail because port 2 doesn't exist in the new switch
         let result = switch2.restore(saved_state);
@@ -1206,14 +1263,13 @@ mod tests {
     fn test_save_restore_basic() {
         use vmcore::save_restore::SaveRestore;
 
-        let definition = GenericPcieSwitchDefinition {
-            name: "test-switch".into(),
-            downstream_port_count: 2,
-            hotplug: false,
-            dsp_settings: PciePortSettings::default(),
-            msi_target: MsiTarget::disconnected(),
-        };
-        let mut switch = GenericPcieSwitch::new(definition);
+        let mut switch = build(switch_def(
+            "test-switch",
+            2,
+            false,
+            PciePortSettings::default(),
+            MsiTarget::disconnected(),
+        ));
 
         // Save the initial state
         let saved_state = switch.save().expect("save should succeed");
@@ -1222,14 +1278,13 @@ mod tests {
         assert_eq!(saved_state.downstream_ports.len(), 2);
 
         // Restore the state to a new switch
-        let definition2 = GenericPcieSwitchDefinition {
-            name: "test-switch".into(),
-            downstream_port_count: 2,
-            hotplug: false,
-            dsp_settings: PciePortSettings::default(),
-            msi_target: MsiTarget::disconnected(),
-        };
-        let mut switch2 = GenericPcieSwitch::new(definition2);
+        let mut switch2 = build(switch_def(
+            "test-switch",
+            2,
+            false,
+            PciePortSettings::default(),
+            MsiTarget::disconnected(),
+        ));
         switch2
             .restore(saved_state)
             .expect("restore should succeed");
@@ -1239,14 +1294,13 @@ mod tests {
     fn test_save_restore_with_bus_configuration() {
         use vmcore::save_restore::SaveRestore;
 
-        let definition = GenericPcieSwitchDefinition {
-            name: "test-switch".into(),
-            downstream_port_count: 3,
-            hotplug: false,
-            dsp_settings: PciePortSettings::default(),
-            msi_target: MsiTarget::disconnected(),
-        };
-        let mut switch = GenericPcieSwitch::new(definition);
+        let mut switch = build(switch_def(
+            "test-switch",
+            3,
+            false,
+            PciePortSettings::default(),
+            MsiTarget::disconnected(),
+        ));
 
         // Configure bus numbers on the upstream port
         let secondary_bus = 5u8;
@@ -1269,14 +1323,13 @@ mod tests {
         let saved_state = switch.save().expect("save should succeed");
 
         // Create a new switch and restore the state
-        let definition2 = GenericPcieSwitchDefinition {
-            name: "test-switch".into(),
-            downstream_port_count: 3,
-            hotplug: false,
-            dsp_settings: PciePortSettings::default(),
-            msi_target: MsiTarget::disconnected(),
-        };
-        let mut switch2 = GenericPcieSwitch::new(definition2);
+        let mut switch2 = build(switch_def(
+            "test-switch",
+            3,
+            false,
+            PciePortSettings::default(),
+            MsiTarget::disconnected(),
+        ));
 
         // Verify the new switch has default bus range before restore
         let default_bus_range = switch2.upstream_port.cfg_space().assigned_bus_range();
@@ -1297,18 +1350,17 @@ mod tests {
     fn test_save_restore_downstream_port_state() {
         use vmcore::save_restore::SaveRestore;
 
-        let definition = GenericPcieSwitchDefinition {
-            name: "test-switch".into(),
-            downstream_port_count: 2,
-            hotplug: false,
-            dsp_settings: PciePortSettings::default(),
-            msi_target: MsiTarget::disconnected(),
-        };
-        let mut switch = GenericPcieSwitch::new(definition);
+        let mut switch = build(switch_def(
+            "test-switch",
+            2,
+            false,
+            PciePortSettings::default(),
+            MsiTarget::disconnected(),
+        ));
 
         // Configure bus numbers on one of the downstream ports
         // First, we need to get access to the downstream port and configure it
-        if let Some((_, downstream_port)) = switch.downstream_ports.get_mut(0) {
+        if let Some((_, _, downstream_port)) = switch.downstream_ports.get_mut(0) {
             let secondary_bus = 10u8;
             let subordinate_bus = 20u8;
             let primary_bus = 5u8;
@@ -1323,7 +1375,7 @@ mod tests {
         }
 
         // Verify the downstream port bus range is set
-        if let Some((_, downstream_port)) = switch.downstream_ports.first() {
+        if let Some((_, _, downstream_port)) = switch.downstream_ports.first() {
             let bus_range = downstream_port.cfg_space().assigned_bus_range();
             assert_eq!(*bus_range.start(), 10);
             assert_eq!(*bus_range.end(), 20);
@@ -1333,17 +1385,16 @@ mod tests {
         let saved_state = switch.save().expect("save should succeed");
 
         // Create a new switch and restore the state
-        let definition2 = GenericPcieSwitchDefinition {
-            name: "test-switch".into(),
-            downstream_port_count: 2,
-            hotplug: false,
-            dsp_settings: PciePortSettings::default(),
-            msi_target: MsiTarget::disconnected(),
-        };
-        let mut switch2 = GenericPcieSwitch::new(definition2);
+        let mut switch2 = build(switch_def(
+            "test-switch",
+            2,
+            false,
+            PciePortSettings::default(),
+            MsiTarget::disconnected(),
+        ));
 
         // Verify the new switch has default bus range on downstream port before restore
-        if let Some((_, downstream_port)) = switch2.downstream_ports.first() {
+        if let Some((_, _, downstream_port)) = switch2.downstream_ports.first() {
             let default_bus_range = downstream_port.cfg_space().assigned_bus_range();
             assert_eq!(default_bus_range, 0..=0);
         }
@@ -1354,7 +1405,7 @@ mod tests {
             .expect("restore should succeed");
 
         // Verify the downstream port bus range is restored
-        if let Some((_, downstream_port)) = switch2.downstream_ports.first() {
+        if let Some((_, _, downstream_port)) = switch2.downstream_ports.first() {
             let restored_bus_range = downstream_port.cfg_space().assigned_bus_range();
             assert_eq!(*restored_bus_range.start(), 10);
             assert_eq!(*restored_bus_range.end(), 20);
@@ -1365,14 +1416,13 @@ mod tests {
     fn test_save_restore_preserves_upstream_and_downstream_cfg_space() {
         use vmcore::save_restore::SaveRestore;
 
-        let definition = GenericPcieSwitchDefinition {
-            name: "test-switch".into(),
-            downstream_port_count: 2,
-            hotplug: false,
-            dsp_settings: PciePortSettings::default(),
-            msi_target: MsiTarget::disconnected(),
-        };
-        let mut switch = GenericPcieSwitch::new(definition);
+        let mut switch = build(switch_def(
+            "test-switch",
+            2,
+            false,
+            PciePortSettings::default(),
+            MsiTarget::disconnected(),
+        ));
 
         // Upstream primary/secondary/subordinate bus numbers.
         switch
@@ -1382,7 +1432,7 @@ mod tests {
             .unwrap();
 
         // Downstream port 1 bus range.
-        if let Some((_, downstream_port)) = switch.downstream_ports.get_mut(1) {
+        if let Some((_, _, downstream_port)) = switch.downstream_ports.get_mut(1) {
             downstream_port
                 .port
                 .cfg_space
@@ -1392,14 +1442,13 @@ mod tests {
 
         let saved_state = switch.save().expect("save should succeed");
 
-        let definition2 = GenericPcieSwitchDefinition {
-            name: "test-switch".into(),
-            downstream_port_count: 2,
-            hotplug: false,
-            dsp_settings: PciePortSettings::default(),
-            msi_target: MsiTarget::disconnected(),
-        };
-        let mut switch2 = GenericPcieSwitch::new(definition2);
+        let mut switch2 = build(switch_def(
+            "test-switch",
+            2,
+            false,
+            PciePortSettings::default(),
+            MsiTarget::disconnected(),
+        ));
 
         switch2
             .restore(saved_state)
@@ -1409,7 +1458,7 @@ mod tests {
         assert_eq!(*upstream_bus_range.start(), 0x12);
         assert_eq!(*upstream_bus_range.end(), 0x14);
 
-        if let Some((_, downstream_port)) = switch2.downstream_ports.get(1) {
+        if let Some((_, _, downstream_port)) = switch2.downstream_ports.get(1) {
             let downstream_bus_range = downstream_port.cfg_space().assigned_bus_range();
             assert_eq!(*downstream_bus_range.start(), 0x1f);
             assert_eq!(*downstream_bus_range.end(), 0x20);
@@ -1501,13 +1550,13 @@ mod tests {
             .unwrap();
 
         // Create and attach a switch behind the port
-        let switch = GenericPcieSwitch::new(GenericPcieSwitchDefinition {
-            name: "test-switch".into(),
-            downstream_port_count: 2,
-            hotplug: false,
-            dsp_settings: PciePortSettings::default(),
-            msi_target: MsiTarget::disconnected(),
-        });
+        let switch = build(switch_def(
+            "test-switch",
+            2,
+            false,
+            PciePortSettings::default(),
+            MsiTarget::disconnected(),
+        ));
 
         port.link = Some(("switch".into(), Box::new(SwitchAdapter(switch))));
 
@@ -1539,16 +1588,16 @@ mod tests {
     fn test_switch_acs_only_applies_to_dsp() {
         use pci_core::spec::caps::ExtendedCapabilityId;
 
-        let switch = GenericPcieSwitch::new(GenericPcieSwitchDefinition {
-            name: "acs-switch".into(),
-            downstream_port_count: 1,
-            hotplug: false,
-            dsp_settings: PciePortSettings {
+        let switch = build(switch_def(
+            "acs-switch",
+            1,
+            false,
+            PciePortSettings {
                 acs_capabilities_supported: 0x0001,
                 ..Default::default()
             },
-            msi_target: MsiTarget::disconnected(),
-        });
+            MsiTarget::disconnected(),
+        ));
 
         // Upstream switch ports do not expose ACS in this model.
         let mut upstream_header = 0u32;
@@ -1560,7 +1609,7 @@ mod tests {
         assert_eq!(upstream_header, 0);
 
         let mut switch = switch;
-        let (_, downstream_port) = switch
+        let (_, _, downstream_port) = switch
             .downstream_ports
             .iter_mut()
             .next()
@@ -1582,5 +1631,88 @@ mod tests {
             .read_u32(0x104, &mut caps_control)
             .unwrap();
         assert_eq!(caps_control as u16, 0x0001);
+    }
+
+    #[test]
+    fn test_switch_explicit_devfn() {
+        // A downstream port with an explicit devfn is placed there; the
+        // remaining ports fill the lowest free devfns from 0.
+        let definition = GenericPcieSwitchDefinition {
+            name: "sw".into(),
+            downstream_ports: vec![
+                crate::GenericPciePortDefinition {
+                    name: "a".into(),
+                    devfn: Some(16), // device 2, function 0
+                    hotplug: false,
+                    settings: PciePortSettings::default(),
+                },
+                crate::GenericPciePortDefinition {
+                    name: "b".into(),
+                    devfn: None,
+                    hotplug: false,
+                    settings: PciePortSettings::default(),
+                },
+            ],
+            msi_target: MsiTarget::disconnected(),
+        };
+        let switch = GenericPcieSwitch::new(definition).unwrap();
+        let mut ports: Vec<_> = switch
+            .downstream_ports()
+            .into_iter()
+            .map(|p| (p.name.to_string(), p.devfn))
+            .collect();
+        ports.sort_by_key(|(_, devfn)| *devfn);
+        assert_eq!(ports, vec![("b".into(), 0), ("a".into(), 16)]);
+    }
+
+    #[test]
+    fn test_switch_cxl_rejected() {
+        // CXL is not supported on switch downstream ports.
+        let definition = GenericPcieSwitchDefinition {
+            name: "sw".into(),
+            downstream_ports: vec![crate::GenericPciePortDefinition {
+                name: "a".into(),
+                devfn: None,
+                hotplug: false,
+                settings: PciePortSettings {
+                    cxl_flex_bus_port_capability: Some(Default::default()),
+                    ..Default::default()
+                },
+            }],
+            msi_target: MsiTarget::disconnected(),
+        };
+        assert!(matches!(
+            GenericPcieSwitch::new(definition),
+            Err(InvalidSwitchError::CxlUnsupported { .. })
+        ));
+    }
+
+    #[test]
+    fn test_switch_duplicate_devfn_rejected() {
+        let definition = GenericPcieSwitchDefinition {
+            name: "sw".into(),
+            downstream_ports: vec![
+                crate::GenericPciePortDefinition {
+                    name: "a".into(),
+                    devfn: Some(0),
+                    hotplug: false,
+                    settings: PciePortSettings::default(),
+                },
+                crate::GenericPciePortDefinition {
+                    name: "b".into(),
+                    devfn: Some(0),
+                    hotplug: false,
+                    settings: PciePortSettings::default(),
+                },
+            ],
+            msi_target: MsiTarget::disconnected(),
+        };
+        assert!(matches!(
+            GenericPcieSwitch::new(definition),
+            Err(InvalidSwitchError::Devfn(PortDevfnError::DevfnInUse {
+                devfn: 0,
+                ..
+            }))
+        ));
     }
 }

--- a/vm/devices/pci/pcie/src/switch.rs
+++ b/vm/devices/pci/pcie/src/switch.rs
@@ -674,7 +674,6 @@ mod save_restore {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use pci_core::bus_range::AssignedBusRange;
     use pci_core::msi::MsiConnection;
 
     /// Builds a switch definition with `downstream_port_count` uniform
@@ -1531,14 +1530,14 @@ mod tests {
             type0_sub_system_id: 0,
         };
 
-        let msi_conn = MsiConnection::new(AssignedBusRange::new(), 0);
+        let msi_conn = MsiConnection::new();
         let mut port = PcieDownstreamPort::new(
             "root-port",
             hardware_ids,
             DevicePortType::RootPort,
             false,
             None,
-            msi_conn.target(),
+            &msi_conn.target(),
             PciePortSettings::default(),
             None,
             None,

--- a/vm/devices/pci/vfio_assigned_device/src/resolver.rs
+++ b/vm/devices/pci/vfio_assigned_device/src/resolver.rs
@@ -67,7 +67,7 @@ impl AsyncResolveResource<PciDeviceHandleKind, VfioDeviceHandle> for VfioDeviceR
             bar_pt,
         } = resource;
 
-        if input.software_iommu {
+        if input.dma_target.software_iommu() {
             anyhow::bail!(
                 "VFIO device {pci_id} is behind a software IOMMU that cannot \
                  program the host IOMMU for passthrough DMA. Place the device \
@@ -95,7 +95,7 @@ impl AsyncResolveResource<PciDeviceHandleKind, VfioDeviceHandle> for VfioDeviceR
             pci_id,
             input.driver_source,
             input.register_mmio,
-            input.msi_target,
+            input.dma_target.msi_target(),
             memory_mapper,
             bar_pt,
         )
@@ -179,7 +179,7 @@ impl AsyncResolveResource<PciDeviceHandleKind, VfioCdevDeviceHandle> for VfioCde
             cdev_binding,
             pci_id,
             input.register_mmio,
-            input.msi_target,
+            input.dma_target.msi_target(),
             memory_mapper,
             bar_pt,
         )

--- a/vm/devices/pci/vpci/src/device.rs
+++ b/vm/devices/pci/vpci/src/device.rs
@@ -1465,7 +1465,6 @@ mod tests {
     use pal_async::DefaultDriver;
     use pal_async::async_test;
     use pal_async::driver::SpawnDriver;
-    use pci_core::bus_range::AssignedBusRange;
     use pci_core::cfg_space_emu::BarMemoryKind;
     use pci_core::cfg_space_emu::ConfigSpaceType0Emulator;
     use pci_core::cfg_space_emu::DeviceBars;
@@ -1945,7 +1944,7 @@ mod tests {
 
     #[async_test]
     async fn verify_simple_capability(driver: DefaultDriver) {
-        let msi_conn = MsiConnection::new(AssignedBusRange::new(), 0);
+        let msi_conn = MsiConnection::new();
         let pci_config = HardwareIds {
             vendor_id: 0x123,
             device_id: 0x789,
@@ -1957,7 +1956,7 @@ mod tests {
             type0_sub_system_id: 0x1,
         };
         let (_msix, msix_capability) =
-            pci_core::capabilities::msix::MsixEmulator::new(0, 64, msi_conn.target());
+            pci_core::capabilities::msix::MsixEmulator::new(0, 64, &msi_conn.target());
 
         let msi_controller = TestVpciInterruptController::new();
         msi_conn.connect(msi_controller.signal_msi());

--- a/vm/devices/storage/disk_nvme/nvme_driver/fuzz/fuzz_nvme_driver.rs
+++ b/vm/devices/storage/disk_nvme/nvme_driver/fuzz/fuzz_nvme_driver.rs
@@ -18,6 +18,7 @@ use nvme_spec::nvm::DsmRange;
 use page_pool_alloc::PagePoolAllocator;
 use pal_async::DefaultDriver;
 use pci_core::bus_range::AssignedBusRange;
+use pci_core::dma::DmaTarget;
 use pci_core::msi::MsiConnection;
 use scsi_buffers::OwnedRequestBuffers;
 use std::convert::TryFrom;
@@ -48,13 +49,18 @@ impl FuzzNvmeDriver {
 
         // Nvme device and driver setup
         let driver_source = VmTaskDriverSource::new(SingleDriverBackend::new(driver));
-        let msi_conn = MsiConnection::new(AssignedBusRange::new(), 0);
+        let msi_conn = MsiConnection::new();
 
         let guid = arbitrary_guid(u)?;
+        let dma_target = DmaTarget::new(
+            AssignedBusRange::new(),
+            0,
+            mem.guest_memory().clone(),
+            &msi_conn,
+        );
         let nvme = NvmeController::new(
             &driver_source,
-            mem.guest_memory().clone(),
-            msi_conn.target(),
+            &dma_target,
             &mut ExternallyManagedMmioIntercepts,
             NvmeControllerCaps {
                 msix_count: 2,

--- a/vm/devices/storage/disk_nvme/nvme_driver/src/tests.rs
+++ b/vm/devices/storage/disk_nvme/nvme_driver/src/tests.rs
@@ -35,6 +35,7 @@ use pal_async::DefaultDriver;
 use pal_async::async_test;
 use parking_lot::Mutex;
 use pci_core::bus_range::AssignedBusRange;
+use pci_core::dma::DmaTarget;
 use pci_core::msi::MsiConnection;
 use scsi_buffers::OwnedRequestBuffers;
 use std::sync::Arc;
@@ -222,11 +223,11 @@ async fn test_nvme_ioqueue_max_mqes(driver: DefaultDriver) {
 
     // Controller Driver Setup
     let driver_source = VmTaskDriverSource::new(SingleDriverBackend::new(driver));
-    let msi_conn = MsiConnection::new(AssignedBusRange::new(), 0);
+    let msi_conn = MsiConnection::new();
+    let dma_target = DmaTarget::new(AssignedBusRange::new(), 0, guest_mem.clone(), &msi_conn);
     let nvme = nvme::NvmeController::new(
         &driver_source,
-        guest_mem,
-        msi_conn.target(),
+        &dma_target,
         &mut ExternallyManagedMmioIntercepts,
         NvmeControllerCaps {
             msix_count: MSIX_COUNT,
@@ -259,11 +260,11 @@ async fn test_nvme_ioqueue_invalid_mqes(driver: DefaultDriver) {
     let dma_client = device_test_memory.dma_client();
 
     let driver_source = VmTaskDriverSource::new(SingleDriverBackend::new(driver));
-    let msi_conn = MsiConnection::new(AssignedBusRange::new(), 0);
+    let msi_conn = MsiConnection::new();
+    let dma_target = DmaTarget::new(AssignedBusRange::new(), 0, guest_mem.clone(), &msi_conn);
     let nvme = nvme::NvmeController::new(
         &driver_source,
-        guest_mem,
-        msi_conn.target(),
+        &dma_target,
         &mut ExternallyManagedMmioIntercepts,
         NvmeControllerCaps {
             msix_count: MSIX_COUNT,
@@ -315,11 +316,11 @@ async fn test_nvme_driver(driver: DefaultDriver, config: NvmeTestConfig) {
 
     // Arrange: Create the NVMe controller and driver.
     let driver_source = VmTaskDriverSource::new(SingleDriverBackend::new(driver));
-    let msi_conn = MsiConnection::new(AssignedBusRange::new(), 0);
+    let msi_conn = MsiConnection::new();
+    let dma_target = DmaTarget::new(AssignedBusRange::new(), 0, guest_mem.clone(), &msi_conn);
     let nvme = nvme::NvmeController::new(
         &driver_source,
-        guest_mem.clone(),
-        msi_conn.target(),
+        &dma_target,
         &mut ExternallyManagedMmioIntercepts,
         NvmeControllerCaps {
             msix_count: MSIX_COUNT,
@@ -459,11 +460,11 @@ async fn test_nvme_fault_injection(driver: DefaultDriver, fault_configuration: F
 
     // Arrange: Create the NVMe controller and driver.
     let driver_source = VmTaskDriverSource::new(SingleDriverBackend::new(driver));
-    let msi_conn = MsiConnection::new(AssignedBusRange::new(), 0);
+    let msi_conn = MsiConnection::new();
     let nvme = nvme_test::NvmeFaultController::new(
         &driver_source,
         guest_mem.clone(),
-        msi_conn.target(),
+        &msi_conn.target(),
         &mut ExternallyManagedMmioIntercepts,
         nvme_test::NvmeFaultControllerCaps {
             msix_count: MSIX_COUNT,

--- a/vm/devices/storage/nvme/src/pci.rs
+++ b/vm/devices/storage/nvme/src/pci.rs
@@ -26,7 +26,6 @@ use chipset_device::pci::PciConfigSpace;
 use device_emulators::ReadWriteRequestType;
 use device_emulators::read_as_u32_chunks;
 use device_emulators::write_as_u32_chunks;
-use guestmem::GuestMemory;
 use guid::Guid;
 use inspect::Inspect;
 use inspect::InspectMut;
@@ -36,7 +35,7 @@ use pci_core::capabilities::pci_express::PciExpressCapability;
 use pci_core::cfg_space_emu::BarMemoryKind;
 use pci_core::cfg_space_emu::ConfigSpaceType0Emulator;
 use pci_core::cfg_space_emu::DeviceBars;
-use pci_core::msi::MsiTarget;
+use pci_core::dma::DmaTarget;
 use pci_core::spec::hwid::ClassCode;
 use pci_core::spec::hwid::HardwareIds;
 use pci_core::spec::hwid::ProgrammingInterface;
@@ -111,11 +110,12 @@ impl NvmeController {
     /// Creates a new NVMe controller.
     pub fn new(
         driver_source: &VmTaskDriverSource,
-        guest_memory: GuestMemory,
-        msi_target: &MsiTarget,
+        dma_target: &DmaTarget,
         register_mmio: &mut dyn RegisterMmioIntercept,
         caps: NvmeControllerCaps,
     ) -> Self {
+        let msi_target = dma_target.msi_target();
+        let guest_memory = dma_target.guest_memory().clone();
         let (msix, msix_cap) = MsixEmulator::new(4, caps.msix_count, msi_target);
         let bars = DeviceBars::new()
             .bar0(

--- a/vm/devices/storage/nvme/src/resolver.rs
+++ b/vm/devices/storage/nvme/src/resolver.rs
@@ -60,8 +60,7 @@ impl AsyncResolveResource<PciDeviceHandleKind, NvmeControllerHandle> for NvmeCon
     ) -> Result<Self::Output, Self::Error> {
         let controller = NvmeController::new(
             input.driver_source,
-            input.guest_memory.clone(),
-            input.msi_target,
+            input.dma_target,
             input.register_mmio,
             NvmeControllerCaps {
                 msix_count: resource.msix_count,

--- a/vm/devices/storage/nvme/src/tests/controller_tests.rs
+++ b/vm/devices/storage/nvme/src/tests/controller_tests.rs
@@ -20,6 +20,7 @@ use guid::Guid;
 use pal_async::DefaultDriver;
 use pal_async::async_test;
 use pci_core::bus_range::AssignedBusRange;
+use pci_core::dma::DmaTarget;
 use pci_core::msi::MsiConnection;
 use pci_core::test_helpers::TestPciInterruptController;
 use user_driver::backoff::Backoff;
@@ -35,11 +36,11 @@ fn instantiate_controller(
 ) -> NvmeController {
     let mut mmio_reg = TestNvmeMmioRegistration {};
     let vm_task_driver = &VmTaskDriverSource::new(SingleDriverBackend::new(driver));
-    let msi_conn = MsiConnection::new(AssignedBusRange::new(), 0);
+    let msi_conn = MsiConnection::new();
+    let dma_target = DmaTarget::new(AssignedBusRange::new(), 0, gm.clone(), &msi_conn);
     let controller = NvmeController::new(
         vm_task_driver,
-        gm.clone(),
-        msi_conn.target(),
+        &dma_target,
         &mut mmio_reg,
         NvmeControllerCaps {
             msix_count: 64,

--- a/vm/devices/storage/nvme_test/src/resolver.rs
+++ b/vm/devices/storage/nvme_test/src/resolver.rs
@@ -66,8 +66,8 @@ impl AsyncResolveResource<PciDeviceHandleKind, NvmeFaultControllerHandle>
 
         let controller = NvmeFaultController::new(
             input.driver_source,
-            input.guest_memory.clone(),
-            input.msi_target,
+            input.dma_target.guest_memory().clone(),
+            input.dma_target.msi_target(),
             input.register_mmio,
             NvmeFaultControllerCaps {
                 msix_count: resource.msix_count,

--- a/vm/devices/storage/nvme_test/src/tests/controller_tests.rs
+++ b/vm/devices/storage/nvme_test/src/tests/controller_tests.rs
@@ -24,7 +24,6 @@ use nvme_spec::Command;
 use nvme_spec::Completion;
 use pal_async::DefaultDriver;
 use pal_async::async_test;
-use pci_core::bus_range::AssignedBusRange;
 use pci_core::msi::MsiConnection;
 use pci_core::test_helpers::TestPciInterruptController;
 use user_driver::backoff::Backoff;
@@ -41,11 +40,11 @@ fn instantiate_controller(
 ) -> NvmeFaultController {
     let mut mmio_reg = TestNvmeMmioRegistration {};
     let vm_task_driver = &VmTaskDriverSource::new(SingleDriverBackend::new(driver));
-    let msi_conn = MsiConnection::new(AssignedBusRange::new(), 0);
+    let msi_conn = MsiConnection::new();
     let controller = NvmeFaultController::new(
         vm_task_driver,
         gm.clone(),
-        msi_conn.target(),
+        &msi_conn.target(),
         &mut mmio_reg,
         NvmeFaultControllerCaps {
             msix_count: 64,

--- a/vm/devices/storage/storage_tests/tests/scsidvd_nvme.rs
+++ b/vm/devices/storage/storage_tests/tests/scsidvd_nvme.rs
@@ -17,6 +17,7 @@ use page_pool_alloc::PagePoolAllocator;
 use pal_async::DefaultDriver;
 use pal_async::async_test;
 use pci_core::bus_range::AssignedBusRange;
+use pci_core::dma::DmaTarget;
 use pci_core::msi::MsiConnection;
 use scsi_buffers::OwnedRequestBuffers;
 use scsi_buffers::RequestBuffers;
@@ -56,11 +57,11 @@ impl ScsiDvdNvmeTest {
         let dma_client = mem.dma_client();
         let payload_mem = mem.payload_mem();
 
-        let msi_conn = MsiConnection::new(AssignedBusRange::new(), 0);
+        let msi_conn = MsiConnection::new();
+        let dma_target = DmaTarget::new(AssignedBusRange::new(), 0, guest_mem.clone(), &msi_conn);
         let nvme = NvmeController::new(
             &driver_source,
-            guest_mem.clone(),
-            msi_conn.target(),
+            &dma_target,
             &mut ExternallyManagedMmioIntercepts,
             NvmeControllerCaps {
                 msix_count: MSIX_COUNT,

--- a/vm/devices/virtio/virtio/src/resolver.rs
+++ b/vm/devices/virtio/virtio/src/resolver.rs
@@ -57,8 +57,8 @@ impl AsyncResolveResource<PciDeviceHandleKind, VirtioPciDeviceHandle> for Virtio
         let device = VirtioPciDevice::new(
             inner.0,
             &input.driver_source.simple(),
-            input.guest_memory.clone(),
-            PciInterruptModel::Msix(input.msi_target),
+            input.dma_target.guest_memory().clone(),
+            PciInterruptModel::Msix(input.dma_target.msi_target()),
             input.doorbell_registration,
             input.register_mmio,
             input.shared_mem_mapper,

--- a/vm/devices/virtio/virtio/src/tests.rs
+++ b/vm/devices/virtio/virtio/src/tests.rs
@@ -36,7 +36,6 @@ use pal_async::timer::PolledTimer;
 use pal_async::wait::PolledWait;
 use pal_event::Event;
 use parking_lot::Mutex;
-use pci_core::bus_range::AssignedBusRange;
 use pci_core::msi::MsiConnection;
 use pci_core::spec::caps::CapabilityId;
 use pci_core::spec::cfg_space;
@@ -1392,7 +1391,7 @@ impl VirtioPciTestDevice {
     ) -> Self {
         let doorbell_registration: Arc<dyn DoorbellRegistration> = test_mem.clone();
         let mem = GuestMemory::new("test", test_mem.clone());
-        let msi_conn = MsiConnection::new(AssignedBusRange::new(), 0);
+        let msi_conn = MsiConnection::new();
         let driver_source = VmTaskDriverSource::new(SingleDriverBackend::new(driver.clone()));
 
         let dev = VirtioPciDevice::new(
@@ -1411,7 +1410,7 @@ impl VirtioPciTestDevice {
             )),
             driver,
             mem.clone(),
-            PciInterruptModel::Msix(msi_conn.target()),
+            PciInterruptModel::Msix(&msi_conn.target()),
             Some(doorbell_registration),
             &mut ExternallyManagedMmioIntercepts,
             None,
@@ -2876,7 +2875,7 @@ async fn verify_enable_failure_mmio_does_not_set_driver_ok(_driver: DefaultDrive
 async fn verify_enable_failure_pci_does_not_set_driver_ok(_driver: DefaultDriver) {
     let test_mem = VirtioTestMemoryAccess::new();
     let doorbell_registration: Arc<dyn DoorbellRegistration> = test_mem.clone();
-    let msi_conn = MsiConnection::new(AssignedBusRange::new(), 0);
+    let msi_conn = MsiConnection::new();
 
     let mut dev = VirtioPciDevice::new(
         Box::new(FailingTestDevice {
@@ -2891,7 +2890,7 @@ async fn verify_enable_failure_pci_does_not_set_driver_ok(_driver: DefaultDriver
         }),
         &_driver,
         GuestMemory::empty(),
-        PciInterruptModel::Msix(msi_conn.target()),
+        PciInterruptModel::Msix(&msi_conn.target()),
         Some(doorbell_registration),
         &mut ExternallyManagedMmioIntercepts,
         None,
@@ -3714,13 +3713,13 @@ impl PciTestTransport {
     fn new(device: Box<dyn DynVirtioDevice>, driver: &DefaultDriver, num_queues: u16) -> Self {
         let test_mem = VirtioTestMemoryAccess::new();
         let doorbell_registration: Arc<dyn DoorbellRegistration> = test_mem;
-        let msi_conn = MsiConnection::new(AssignedBusRange::new(), 0);
+        let msi_conn = MsiConnection::new();
 
         let mut dev = VirtioPciDevice::new(
             device,
             driver,
             GuestMemory::empty(),
-            PciInterruptModel::Msix(msi_conn.target()),
+            PciInterruptModel::Msix(&msi_conn.target()),
             Some(doorbell_registration),
             &mut ExternallyManagedMmioIntercepts,
             None,
@@ -4228,7 +4227,7 @@ async fn pci_save_restore_incompatible_features(driver: DefaultDriver) {
     assert_ne!(saved.common.driver_feature_banks[0] & 2, 0);
 
     // Create a new device that does NOT support that device-specific feature.
-    let msi_conn = MsiConnection::new(AssignedBusRange::new(), 0);
+    let msi_conn = MsiConnection::new();
     let mut dev2 = VirtioPciDevice::new(
         Box::new(TestDevice::new(
             &driver_source,
@@ -4244,7 +4243,7 @@ async fn pci_save_restore_incompatible_features(driver: DefaultDriver) {
         )),
         &driver,
         mem,
-        PciInterruptModel::Msix(msi_conn.target()),
+        PciInterruptModel::Msix(&msi_conn.target()),
         None,
         &mut ExternallyManagedMmioIntercepts,
         None,
@@ -4262,7 +4261,7 @@ async fn pci_save_restore_incompatible_features(driver: DefaultDriver) {
 async fn pci_save_not_supported_device(_driver: DefaultDriver) {
     use vmcore::save_restore::SaveRestore;
 
-    let msi_conn = MsiConnection::new(AssignedBusRange::new(), 0);
+    let msi_conn = MsiConnection::new();
 
     // FailingTestDevice does not override supports_save_restore (default false).
     let mut dev = VirtioPciDevice::new(
@@ -4277,7 +4276,7 @@ async fn pci_save_not_supported_device(_driver: DefaultDriver) {
         }),
         &_driver,
         GuestMemory::empty(),
-        PciInterruptModel::Msix(msi_conn.target()),
+        PciInterruptModel::Msix(&msi_conn.target()),
         None,
         &mut ExternallyManagedMmioIntercepts,
         None,

--- a/vm/devices/vmbus/vmbus_server/src/channels.rs
+++ b/vm/devices/vmbus/vmbus_server/src/channels.rs
@@ -2070,14 +2070,19 @@ impl<'a, N: 'a + Notifier> ServerWithNotifier<'a, N> {
                 ..
             } => {
                 channel.state = ChannelState::Closed;
-                if matches!(self.inner.state, ConnectionState::Connected { .. }) {
-                    let channel_id = channel.info.expect("assigned").channel_id;
-                    self.send_close_reserved_channel_response(
-                        channel_id,
-                        offer_id,
-                        reserved_state.target,
-                    );
-                } else {
+                let channel_id = channel.info.expect("assigned").channel_id;
+                // Always send the close response to the reserved channel's
+                // requested target, even while disconnected/ing. Reserved
+                // channels are independent of the connection state.
+                self.send_close_reserved_channel_response(
+                    channel_id,
+                    offer_id,
+                    reserved_state.target,
+                );
+
+                if !matches!(self.inner.state, ConnectionState::Connected { .. }) {
+                    // Re-borrow the channel after the &mut self call above.
+                    let channel = &mut self.inner.channels[offer_id];
                     // Handle closing reserved channels while disconnected/ing. Since we weren't waiting
                     // on the channel, no need to call check_disconnected, but we do need to release it.
                     if Self::client_release_channel(

--- a/vm/devices/vmbus/vmbus_server/src/channels/tests.rs
+++ b/vm/devices/vmbus/vmbus_server/src/channels/tests.rs
@@ -1698,6 +1698,51 @@ fn test_reserved_channels() {
     assert!(env.notifier.is_reset());
 }
 
+// Reserved channels are supposed to remain usable across unload. A close that
+// completes while the connection is disconnected must still deliver a
+// CloseReservedChannelResponse to the originally requested target.
+#[test]
+fn test_reserved_channel_close_response_after_unload() {
+    let mut env = TestEnv::new();
+
+    let offer_id1 = env.offer(1);
+
+    env.connect(Version::Win10, FeatureFlags::new());
+    env.c().handle_request_offers().unwrap();
+
+    env.gpadl(1, 10);
+    env.c().gpadl_create_complete(offer_id1, GpadlId(10), 0);
+
+    const RESERVED_SINT: u32 = 5;
+    env.open_reserved(1, 1, RESERVED_SINT);
+    env.c().open_complete(offer_id1, 0);
+
+    // Unload while the reserved channel is still open.
+    env.c().handle_unload();
+    env.complete_reset();
+
+    env.notifier.messages.clear();
+
+    // Close the reserved channel while disconnected and complete the close.
+    env.close_reserved(1, 4, RESERVED_SINT);
+    env.c().close_complete(offer_id1);
+
+    // A CloseReservedChannelResponse should still be sent to the reserved
+    // channel's requested target, even though the connection is disconnected.
+    env.notifier.check_message_with_target(
+        OutgoingMessage::new(&protocol::CloseReservedChannelResponse {
+            channel_id: ChannelId(1),
+        }),
+        MessageTarget::ReservedChannel(
+            offer_id1,
+            ConnectionTarget {
+                vp: 4,
+                sint: RESERVED_SINT as u8,
+            },
+        ),
+    );
+}
+
 #[test]
 fn test_disconnected_reset() {
     let mut env = TestEnv::new();

--- a/vm/kvm/src/lib.rs
+++ b/vm/kvm/src/lib.rs
@@ -23,13 +23,22 @@ use std::sync::atomic::Ordering;
 use thiserror::Error;
 
 mod ioctl {
+    #[cfg(target_arch = "aarch64")]
+    use super::KvmArmRmiPopulate;
     use kvm_bindings::*;
+    #[cfg(target_arch = "x86_64")]
+    use nix::errno::Errno;
     use nix::ioctl_read;
     use nix::ioctl_readwrite;
+    use nix::ioctl_readwrite_bad;
     use nix::ioctl_write_int_bad;
     use nix::ioctl_write_ptr;
     use nix::request_code_none;
+    use nix::request_code_readwrite;
+    use std::mem::size_of;
+
     const KVMIO: u8 = 0xae;
+
     ioctl_write_int_bad!(kvm_create_vm, request_code_none!(KVMIO, 0x1));
     ioctl_write_int_bad!(kvm_check_extension, request_code_none!(KVMIO, 0x03));
     ioctl_write_int_bad!(kvm_get_vcpu_mmap_size, request_code_none!(KVMIO, 0x04));
@@ -43,6 +52,12 @@ mod ioctl {
         KVMIO,
         0x46,
         kvm_userspace_memory_region
+    );
+    ioctl_write_ptr!(
+        kvm_set_user_memory_region2,
+        KVMIO,
+        0x49,
+        kvm_userspace_memory_region2
     );
     ioctl_write_ptr!(kvm_irq_line, KVMIO, 0x61, kvm_irq_level);
     ioctl_write_ptr!(kvm_set_gsi_routing, KVMIO, 0x6a, kvm_irq_routing);
@@ -99,8 +114,125 @@ mod ioctl {
     ioctl_read!(kvm_arm_preferred_target, KVMIO, 0xaf, kvm_vcpu_init);
     ioctl_write_ptr!(kvm_ioeventfd, KVMIO, 0x79, kvm_ioeventfd);
     ioctl_write_ptr!(kvm_set_guest_debug, KVMIO, 0x9b, kvm_guest_debug);
+    ioctl_write_ptr!(
+        kvm_set_memory_attributes,
+        KVMIO,
+        0xd2,
+        kvm_memory_attributes
+    );
     ioctl_readwrite!(kvm_create_device, KVMIO, 0xe0, kvm_create_device);
     ioctl_write_ptr!(kvm_set_device_attr, KVMIO, 0xe1, kvm_device_attr);
+    ioctl_readwrite!(kvm_create_guest_memfd, KVMIO, 0xd4, kvm_create_guest_memfd);
+    #[cfg(target_arch = "aarch64")]
+    ioctl_readwrite_bad!(
+        kvm_arm_rmi_populate,
+        request_code_readwrite!(KVMIO, 0xd7, size_of::<KvmArmRmiPopulate>()),
+        KvmArmRmiPopulate
+    );
+    #[cfg(target_arch = "x86_64")]
+    ioctl_readwrite_bad!(
+        kvm_memory_encrypt_op,
+        request_code_readwrite!(KVMIO, 0xba, size_of::<libc::c_ulong>()),
+        kvm_sev_cmd
+    );
+    #[cfg(target_arch = "x86_64")]
+    /// # Safety
+    ///
+    /// `fd` must refer to a valid KVM VM file descriptor.
+    pub unsafe fn kvm_memory_encrypt_op_supported(fd: libc::c_int) -> nix::Result<()> {
+        // SAFETY: Calling the KVM_MEMORY_ENCRYPT_OP ioctl with a null argument is
+        // the documented availability probe for SEV support.
+        match unsafe {
+            libc::ioctl(
+                fd,
+                request_code_readwrite!(KVMIO, 0xba, size_of::<libc::c_ulong>()),
+                std::ptr::null_mut::<libc::c_void>(),
+            )
+        } {
+            0 => Ok(()),
+            _ => Err(Errno::last()),
+        }
+    }
+}
+
+#[cfg(target_arch = "x86_64")]
+const KVM_CAP_VM_TYPES_UAPI: u32 = 235;
+#[cfg(target_arch = "x86_64")]
+const KVM_CAP_EXIT_HYPERCALL_UAPI: u32 = 201;
+#[cfg(target_arch = "x86_64")]
+pub const KVM_HC_MAP_GPA_RANGE_UAPI: u64 = 12;
+#[cfg(target_arch = "x86_64")]
+pub const KVM_MAP_GPA_RANGE_ENCRYPTED_UAPI: u64 = 1 << 4;
+#[cfg(target_arch = "x86_64")]
+pub const KVM_MAP_GPA_RANGE_DECRYPTED_UAPI: u64 = 0 << 4;
+#[cfg(target_arch = "x86_64")]
+const KVM_X86_SNP_VM_UAPI: libc::c_int = 4;
+
+pub const KVM_MEMORY_EXIT_FLAG_PRIVATE_UAPI: u64 = 1 << 3;
+
+#[cfg(target_arch = "aarch64")]
+pub const KVM_CAP_ARM_RMI_UAPI: u32 = 249;
+#[cfg(target_arch = "aarch64")]
+pub const KVM_ARM_RMI_POPULATE_FLAGS_MEASURE_UAPI: u32 = 1 << 0;
+#[cfg(target_arch = "aarch64")]
+const KVM_VM_TYPE_ARM_IPA_SIZE_MASK_UAPI: u64 = 0xff;
+#[cfg(target_arch = "aarch64")]
+const KVM_VM_TYPE_ARM_REALM_UAPI: u64 = 1 << 30;
+
+#[cfg(target_arch = "x86_64")]
+pub const KVM_SEV_SNP_PAGE_TYPE_NORMAL_UAPI: u8 = KVM_SEV_SNP_PAGE_TYPE_NORMAL as u8;
+#[cfg(target_arch = "x86_64")]
+pub const KVM_SEV_SNP_PAGE_TYPE_ZERO_UAPI: u8 = KVM_SEV_SNP_PAGE_TYPE_ZERO as u8;
+#[cfg(target_arch = "x86_64")]
+pub const KVM_SEV_SNP_PAGE_TYPE_UNMEASURED_UAPI: u8 = KVM_SEV_SNP_PAGE_TYPE_UNMEASURED as u8;
+#[cfg(target_arch = "x86_64")]
+pub const KVM_SEV_SNP_PAGE_TYPE_SECRETS_UAPI: u8 = KVM_SEV_SNP_PAGE_TYPE_SECRETS as u8;
+#[cfg(target_arch = "x86_64")]
+pub const KVM_SEV_SNP_PAGE_TYPE_CPUID_UAPI: u8 = KVM_SEV_SNP_PAGE_TYPE_CPUID as u8;
+
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+pub enum VmType {
+    Default,
+    #[cfg(target_arch = "x86_64")]
+    Snp,
+    #[cfg(target_arch = "aarch64")]
+    Realm {
+        ipa_bits: u8,
+    },
+}
+
+#[cfg(target_arch = "x86_64")]
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+pub enum SevSnpPageType {
+    Normal,
+    Zero,
+    Unmeasured,
+    Secrets,
+    Cpuid,
+}
+
+#[cfg(target_arch = "x86_64")]
+impl SevSnpPageType {
+    pub const fn as_uapi(self) -> u8 {
+        match self {
+            SevSnpPageType::Normal => KVM_SEV_SNP_PAGE_TYPE_NORMAL_UAPI,
+            SevSnpPageType::Zero => KVM_SEV_SNP_PAGE_TYPE_ZERO_UAPI,
+            SevSnpPageType::Unmeasured => KVM_SEV_SNP_PAGE_TYPE_UNMEASURED_UAPI,
+            SevSnpPageType::Secrets => KVM_SEV_SNP_PAGE_TYPE_SECRETS_UAPI,
+            SevSnpPageType::Cpuid => KVM_SEV_SNP_PAGE_TYPE_CPUID_UAPI,
+        }
+    }
+}
+
+#[cfg(target_arch = "aarch64")]
+#[repr(C)]
+#[derive(Debug, Copy, Clone, Default, Eq, PartialEq)]
+pub struct KvmArmRmiPopulate {
+    pub base: u64,
+    pub size: u64,
+    pub source_uaddr: u64,
+    pub flags: u32,
+    pub reserved: u32,
 }
 
 #[derive(Error, Debug)]
@@ -111,8 +243,27 @@ pub enum Error {
     SignalMsi(#[source] nix::Error),
     #[error("SetMemoryRegion")]
     SetMemoryRegion(#[source] nix::Error),
+    #[error("SetMemoryAttributes")]
+    SetMemoryAttributes(#[source] nix::Error),
+    #[error("CreateGuestMemfd")]
+    CreateGuestMemfd(#[source] nix::Error),
     #[error("CreateVm")]
     CreateVm(#[source] nix::Error),
+    #[cfg(target_arch = "aarch64")]
+    #[error("ArmRmiPopulate")]
+    ArmRmiPopulate(#[source] nix::Error),
+    #[error("missing KVM capability: {0}")]
+    MissingCapability(&'static str),
+    #[error("unsupported KVM VM type: {0:?}")]
+    UnsupportedVmType(VmType),
+    #[cfg(target_arch = "x86_64")]
+    #[error("MemoryEncryptOp({command}, firmware_error={firmware_error:#x})")]
+    MemoryEncryptOp {
+        command: &'static str,
+        firmware_error: u32,
+        #[source]
+        source: nix::Error,
+    },
     #[error("EnableCap({0})")]
     EnableCap(&'static str, #[source] nix::Error),
     #[error("CreateVCpu")]
@@ -127,6 +278,14 @@ pub enum Error {
     SetSRegs(#[source] nix::Error),
     #[error("Run")]
     Run(#[source] nix::Error),
+    #[error("RunMemoryFault(flags={flags:#x}, gpa={gpa:#x}, size={size:#x})")]
+    RunMemoryFault {
+        flags: u64,
+        gpa: u64,
+        size: u64,
+        #[source]
+        source: nix::Error,
+    },
     #[error("GetVCpuMmapSize")]
     GetVCpuMmapSize(#[source] nix::Error),
     #[error("MmapVCpu")]
@@ -283,13 +442,51 @@ impl Kvm {
         unsafe { ioctl::kvm_check_extension(self.as_fd().as_raw_fd(), extension as i32) }
     }
 
-    pub fn new_vm(&self) -> Result<Partition> {
+    pub fn new_vm(&self, vm_type: VmType) -> Result<Partition> {
+        let raw_vm_type = self.raw_vm_type(vm_type)?;
+        self.new_vm_with_type(raw_vm_type)
+    }
+
+    fn raw_vm_type(&self, vm_type: VmType) -> Result<libc::c_int> {
+        match vm_type {
+            VmType::Default => Ok(self.default_vm_type()),
+            #[cfg(target_arch = "x86_64")]
+            VmType::Snp => {
+                let supported_vm_types =
+                    self.check_extension(KVM_CAP_VM_TYPES_UAPI)
+                        .map_err(Error::CheckExtension)? as u64;
+                let raw_vm_type = KVM_X86_SNP_VM_UAPI;
+                let vm_type_bit = 1_u64
+                    .checked_shl(raw_vm_type as u32)
+                    .ok_or(Error::UnsupportedVmType(vm_type))?;
+                if supported_vm_types & vm_type_bit == 0 {
+                    return Err(Error::UnsupportedVmType(vm_type));
+                }
+                Ok(raw_vm_type)
+            }
+            #[cfg(target_arch = "aarch64")]
+            VmType::Realm { ipa_bits } => Ok((KVM_VM_TYPE_ARM_REALM_UAPI
+                | ((ipa_bits as u64) & KVM_VM_TYPE_ARM_IPA_SIZE_MASK_UAPI))
+                as libc::c_int),
+        }
+    }
+
+    fn default_vm_type(&self) -> libc::c_int {
         // On ARM, can request memory isolation which we don't use.
         // For that, include the `KVM_VM_TYPE_ARM_PROTECTED` flag.
         // Use 0 as the fallback machine type, which implies 40bit
         // IPA on ARM64, and on x86_64 is the only option.
-        let vm_type = self.check_extension(KVM_CAP_ARM_VM_IPA_SIZE).unwrap_or(0);
+        #[cfg(target_arch = "aarch64")]
+        {
+            self.check_extension(KVM_CAP_ARM_VM_IPA_SIZE).unwrap_or(0)
+        }
+        #[cfg(not(target_arch = "aarch64"))]
+        {
+            0
+        }
+    }
 
+    fn new_vm_with_type(&self, vm_type: libc::c_int) -> Result<Partition> {
         // SAFETY: Calling IOCTL as documented, with no special requirements.
         let vm = unsafe {
             let fd =
@@ -362,6 +559,163 @@ pub struct Partition {
 }
 
 impl Partition {
+    #[cfg(target_arch = "x86_64")]
+    pub fn check_sev_snp_launch_extensions(&self) -> Result<()> {
+        // SAFETY: This is the documented KVM_MEMORY_ENCRYPT_OP availability
+        // probe, and does not pass any userspace data pointer to KVM.
+        unsafe { ioctl::kvm_memory_encrypt_op_supported(self.vm.as_raw_fd()) }.map_err(|err| {
+            Error::MemoryEncryptOp {
+                command: "KVM_MEMORY_ENCRYPT_OP(NULL)",
+                firmware_error: 0,
+                source: err,
+            }
+        })
+    }
+
+    #[cfg(target_arch = "x86_64")]
+    pub fn enable_hypercall_exits(&self, hypercall_mask: u64) -> Result<()> {
+        // SAFETY: Calling IOCTL as documented, with no special requirements.
+        unsafe {
+            ioctl::kvm_enable_cap(
+                self.vm.as_raw_fd(),
+                &kvm_enable_cap {
+                    cap: KVM_CAP_EXIT_HYPERCALL_UAPI,
+                    args: [hypercall_mask, 0, 0, 0],
+                    ..Default::default()
+                },
+            )
+            .map_err(|err| Error::EnableCap("exit_hypercall", err))?;
+        }
+        Ok(())
+    }
+
+    pub fn check_extension(&self, extension: u32) -> nix::Result<libc::c_int> {
+        // SAFETY: Calling IOCTL as documented, with no special requirements.
+        unsafe { ioctl::kvm_check_extension(self.vm.as_raw_fd(), extension as i32) }
+    }
+
+    #[cfg(target_arch = "aarch64")]
+    pub fn arm_rmi_populate(&self, populate: &mut KvmArmRmiPopulate) -> Result<()> {
+        // SAFETY: `populate` points to a valid KVM_ARM_RMI_POPULATE argument for
+        // the duration of the ioctl. KVM may update it to report partial progress.
+        unsafe { ioctl::kvm_arm_rmi_populate(self.vm.as_raw_fd(), populate) }
+            .map_err(Error::ArmRmiPopulate)?;
+        Ok(())
+    }
+
+    #[cfg(target_arch = "x86_64")]
+    pub fn sev_snp_init(&self, sev: BorrowedFd<'_>) -> Result<()> {
+        let mut init = kvm_sev_init::default();
+        let mut command = kvm_sev_cmd {
+            id: sev_cmd_id_KVM_SEV_INIT2,
+            data: std::ptr::from_mut(&mut init) as u64,
+            sev_fd: sev.as_raw_fd() as u32,
+            ..Default::default()
+        };
+
+        // SAFETY: `command` and its data pointer refer to stack-allocated C ABI
+        // structs that remain valid for the duration of the ioctl.
+        unsafe {
+            ioctl::kvm_memory_encrypt_op(self.vm.as_raw_fd(), &mut command).map_err(|err| {
+                Error::MemoryEncryptOp {
+                    command: "KVM_SEV_INIT2",
+                    firmware_error: command.error,
+                    source: err,
+                }
+            })?;
+        }
+        Ok(())
+    }
+
+    #[cfg(target_arch = "x86_64")]
+    fn sev_snp_cmd<T>(
+        &self,
+        sev: BorrowedFd<'_>,
+        command_name: &'static str,
+        command_id: sev_cmd_id,
+        data: &mut T,
+    ) -> Result<()> {
+        let mut command = kvm_sev_cmd {
+            id: command_id,
+            data: std::ptr::from_mut(data) as u64,
+            sev_fd: sev.as_raw_fd() as u32,
+            ..Default::default()
+        };
+
+        loop {
+            // SAFETY: `command` and its data pointer refer to stack-allocated C ABI
+            // structs that remain valid for the duration of the ioctl.
+            match unsafe { ioctl::kvm_memory_encrypt_op(self.vm.as_raw_fd(), &mut command) } {
+                Ok(_) => break,
+                Err(nix::errno::Errno::EAGAIN) => {}
+                Err(err) => {
+                    return Err(Error::MemoryEncryptOp {
+                        command: command_name,
+                        firmware_error: command.error,
+                        source: err,
+                    });
+                }
+            }
+        }
+        Ok(())
+    }
+
+    #[cfg(target_arch = "x86_64")]
+    pub fn sev_snp_launch_start(
+        &self,
+        sev: BorrowedFd<'_>,
+        data: &mut kvm_sev_snp_launch_start,
+    ) -> Result<()> {
+        self.sev_snp_cmd(
+            sev,
+            "KVM_SEV_SNP_LAUNCH_START",
+            sev_cmd_id_KVM_SEV_SNP_LAUNCH_START,
+            data,
+        )
+    }
+
+    #[cfg(target_arch = "x86_64")]
+    pub fn sev_snp_launch_update(
+        &self,
+        sev: BorrowedFd<'_>,
+        gfn_start: u64,
+        uaddr: u64,
+        len: u64,
+        page_type: SevSnpPageType,
+    ) -> Result<()> {
+        let mut update = kvm_sev_snp_launch_update {
+            gfn_start,
+            uaddr,
+            len,
+            type_: page_type.as_uapi(),
+            ..Default::default()
+        };
+
+        while update.len != 0 {
+            self.sev_snp_cmd(
+                sev,
+                "KVM_SEV_SNP_LAUNCH_UPDATE",
+                sev_cmd_id_KVM_SEV_SNP_LAUNCH_UPDATE,
+                &mut update,
+            )?;
+        }
+        Ok(())
+    }
+
+    #[cfg(target_arch = "x86_64")]
+    pub fn sev_snp_launch_finish(
+        &self,
+        sev: BorrowedFd<'_>,
+        data: &mut kvm_sev_snp_launch_finish,
+    ) -> Result<()> {
+        self.sev_snp_cmd(
+            sev,
+            "KVM_SEV_SNP_LAUNCH_FINISH",
+            sev_cmd_id_KVM_SEV_SNP_LAUNCH_FINISH,
+            data,
+        )
+    }
+
     pub fn enable_split_irqchip(&self, lines: u32) -> Result<()> {
         // TODO: We are not checking KVM_CAP_ENABLE_CAP_VM first.
         // TODO: We are not calling KVM_CHECK_EXTENSION first.
@@ -506,7 +860,14 @@ impl Partition {
         Ok(())
     }
 
-    #[expect(clippy::missing_safety_doc, clippy::undocumented_unsafe_blocks)]
+    /// Sets or clears a userspace memory slot.
+    ///
+    /// # Safety
+    ///
+    /// If `size` is nonzero, `data..data + size` must be a valid userspace
+    /// mapping for KVM to access until the slot is changed or cleared. The
+    /// caller must also ensure that `addr` and `size` satisfy KVM's memory-slot
+    /// alignment and range requirements.
     pub unsafe fn set_user_memory_region(
         &self,
         slot: u32,
@@ -522,9 +883,82 @@ impl Partition {
             memory_size: size as u64,
             userspace_addr: data as usize as u64,
         };
+        // SAFETY: the caller guarantees that any non-empty userspace range
+        // remains valid for KVM while the slot references it.
         unsafe {
             ioctl::kvm_set_user_memory_region(self.vm.as_raw_fd(), &region)
                 .map_err(Error::SetMemoryRegion)?;
+        }
+        Ok(())
+    }
+
+    /// Sets or clears a userspace memory slot with optional guestmemfd backing.
+    ///
+    /// # Safety
+    ///
+    /// If `size` is nonzero, `data..data + size` must be a valid userspace
+    /// mapping for KVM to access until the slot is changed or cleared. The
+    /// caller must ensure that `addr`, `size`, and any `guestmemfd` offset
+    /// satisfy KVM's memory-slot alignment and range requirements. If
+    /// `guest_memfd` is supplied, the file must remain open and valid for as
+    /// long as KVM may reference the slot.
+    pub unsafe fn set_user_memory_region2(
+        &self,
+        slot: u32,
+        data: *mut u8,
+        size: usize,
+        addr: u64,
+        readonly: bool,
+        guest_memfd: Option<(&File, u64)>,
+    ) -> Result<()> {
+        let (guest_memfd, guest_memfd_offset, guest_memfd_flag) = guest_memfd
+            .map(|(file, offset)| (file.as_raw_fd() as u32, offset, KVM_MEM_GUEST_MEMFD))
+            .unwrap_or((0, 0, 0));
+        let region = kvm_userspace_memory_region2 {
+            slot,
+            flags: if readonly { KVM_MEM_READONLY } else { 0 } | guest_memfd_flag,
+            guest_phys_addr: addr,
+            memory_size: size as u64,
+            userspace_addr: data as usize as u64,
+            guest_memfd_offset,
+            guest_memfd,
+            ..Default::default()
+        };
+        // SAFETY: the caller guarantees that any non-empty userspace range and
+        // optional guestmemfd backing remain valid for KVM while the slot
+        // references them.
+        unsafe {
+            ioctl::kvm_set_user_memory_region2(self.vm.as_raw_fd(), &region)
+                .map_err(Error::SetMemoryRegion)?;
+        }
+        Ok(())
+    }
+
+    pub fn create_guest_memfd(&self, size: u64) -> Result<File> {
+        let mut guest_memfd = kvm_create_guest_memfd {
+            size,
+            ..Default::default()
+        };
+        // SAFETY: `guest_memfd` is a valid C ABI struct for KVM to read.
+        let fd = unsafe {
+            ioctl::kvm_create_guest_memfd(self.vm.as_raw_fd(), &mut guest_memfd)
+                .map_err(Error::CreateGuestMemfd)?
+        };
+        // SAFETY: On success, KVM returns a new owned file descriptor.
+        Ok(unsafe { File::from_raw_fd(fd) })
+    }
+
+    pub fn set_memory_attributes(&self, addr: u64, size: u64, attributes: u64) -> Result<()> {
+        let attr = kvm_memory_attributes {
+            address: addr,
+            size,
+            attributes,
+            ..Default::default()
+        };
+        // SAFETY: `attr` is a valid C ABI struct for KVM to read.
+        unsafe {
+            ioctl::kvm_set_memory_attributes(self.vm.as_raw_fd(), &attr)
+                .map_err(Error::SetMemoryAttributes)?;
         }
         Ok(())
     }
@@ -1304,6 +1738,16 @@ impl<'a> VpRunner<'a> {
                 Ok(_) => Ok(true),
                 Err(err) => match err {
                     nix::errno::Errno::EINTR | nix::errno::Errno::EAGAIN => Ok(false),
+                    _ if self.run_data().exit_reason == KVM_EXIT_MEMORY_FAULT => {
+                        // SAFETY: KVM reported KVM_EXIT_MEMORY_FAULT, so this is the active union field.
+                        let memory_fault = unsafe { self.run_data().__bindgen_anon_1.memory_fault };
+                        Err(Error::RunMemoryFault {
+                            flags: memory_fault.flags,
+                            gpa: memory_fault.gpa,
+                            size: memory_fault.size,
+                            source: err,
+                        })
+                    }
                     _ => Err(Error::Run(err)),
                 },
             }
@@ -1443,6 +1887,18 @@ impl<'a> VpRunner<'a> {
                 }
             }
             #[cfg(target_arch = "x86_64")]
+            KVM_EXIT_HYPERCALL => {
+                // SAFETY: this is the active union field.
+                let hypercall = unsafe { &mut self.run_data().__bindgen_anon_1.hypercall };
+                Exit::Hypercall {
+                    nr: hypercall.nr,
+                    args: hypercall.args,
+                    result: &mut hypercall.ret,
+                    // SAFETY: this is the active field for KVM_EXIT_HYPERCALL.
+                    flags: unsafe { hypercall.__bindgen_anon_1.flags },
+                }
+            }
+            #[cfg(target_arch = "x86_64")]
             KVM_EXIT_X86_WRMSR => {
                 // SAFETY: this is the active union field.
                 let msr = unsafe { &mut self.run_data().__bindgen_anon_1.msr };
@@ -1465,7 +1921,6 @@ impl<'a> VpRunner<'a> {
                     error: &mut msr.error,
                 }
             }
-            #[cfg(target_arch = "aarch64")]
             KVM_EXIT_SYSTEM_EVENT => {
                 // SAFETY: this is the active union field.
                 let system_event = unsafe { &self.run_data().__bindgen_anon_1.system_event };
@@ -1535,6 +1990,13 @@ pub enum Exit<'a> {
         data: &'a [u8],
     },
     #[cfg(target_arch = "x86_64")]
+    Hypercall {
+        nr: u64,
+        args: [u64; 6],
+        result: &'a mut u64,
+        flags: u64,
+    },
+    #[cfg(target_arch = "x86_64")]
     MsrRead {
         index: u32,
         data: &'a mut u64,
@@ -1581,7 +2043,6 @@ pub enum Exit<'a> {
     Eoi {
         irq: u8,
     },
-    #[cfg(target_arch = "aarch64")]
     SystemEvent {
         event_type: u32,
         event_flags: u64,
@@ -1650,4 +2111,35 @@ pub struct DebugRegisters {
     pub db: [u64; 4],
     pub dr6: u64,
     pub dr7: u64,
+}
+
+#[cfg(all(test, target_arch = "x86_64"))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sev_snp_page_type_values_match_kvm_uapi() {
+        assert_eq!(SevSnpPageType::Normal.as_uapi(), 1);
+        assert_eq!(SevSnpPageType::Zero.as_uapi(), 3);
+        assert_eq!(SevSnpPageType::Unmeasured.as_uapi(), 4);
+        assert_eq!(SevSnpPageType::Secrets.as_uapi(), 5);
+        assert_eq!(SevSnpPageType::Cpuid.as_uapi(), 6);
+    }
+
+    #[test]
+    fn sev_snp_launch_update_uses_expected_zero_page_shape() {
+        let update = kvm_sev_snp_launch_update {
+            gfn_start: 0x1234,
+            uaddr: 0,
+            len: 0x2000,
+            type_: SevSnpPageType::Zero.as_uapi(),
+            ..Default::default()
+        };
+
+        assert_eq!(update.gfn_start, 0x1234);
+        assert_eq!(update.uaddr, 0);
+        assert_eq!(update.len, 0x2000);
+        assert_eq!(update.type_, KVM_SEV_SNP_PAGE_TYPE_ZERO_UAPI);
+        assert_eq!(update.flags, 0);
+    }
 }

--- a/vmm_core/src/device_builder.rs
+++ b/vmm_core/src/device_builder.rs
@@ -7,6 +7,7 @@ use anyhow::Context as _;
 use chipset_device_resources::ErasedChipsetDevice;
 use guestmem::DoorbellRegistration;
 use guestmem::GuestMemory;
+use pci_core::dma::DmaTarget;
 use pci_core::msi::MsiConnection;
 use pci_core::msi::SignalMsi;
 use std::sync::Arc;
@@ -28,27 +29,27 @@ pub struct PciDeviceResolveContext<'a> {
     pub driver_source: &'a VmTaskDriverSource,
     /// The resource resolver.
     pub resolver: &'a ResourceResolver,
-    /// The VM's guest memory (possibly SMMU-wrapped for PCIe devices).
-    pub guest_memory: &'a GuestMemory,
     /// The device resource to resolve.
     pub resource: Resource<PciDeviceHandleKind>,
     /// An object with which to register doorbell regions.
     pub doorbell_registration: Option<Arc<dyn DoorbellRegistration>>,
     /// An object with which to register shared memory regions.
     pub shared_mem_mapper: Option<&'a dyn guestmem::MemoryMapper>,
-    /// Whether the device is behind a software IOMMU (e.g., emulated SMMU)
-    /// that cannot program the host IOMMU for passthrough DMA. When `true`,
-    /// device assignment backends (e.g., VFIO) must reject the assignment.
-    pub software_iommu: bool,
 }
 
 /// Resolves a PCI device resource, builds the corresponding device, and builds
 /// a VPCI bus to host it.
+///
+/// VPCI devices deliver interrupts through the vmbus [`VpciInterruptMapper`]
+/// rather than a PCIe [`MsiTarget`](pci_core::msi::MsiTarget), so this builds a
+/// fresh [`DmaTarget`] pairing `guest_memory` with a locally-owned
+/// [`MsiConnection`] that is connected to the virtual device's MSI controller.
 pub async fn build_vpci_device(
     ctx: PciDeviceResolveContext<'_>,
     vmbus: &VmbusServerControl,
     chipset_builder: &ChipsetBuilder<'_>,
     bus_config: VpciBusConfig,
+    guest_memory: GuestMemory,
     new_virtual_device: impl FnOnce(u64) -> anyhow::Result<(Arc<dyn SignalMsi>, VpciInterruptMapper)>,
 ) -> anyhow::Result<()> {
     let instance_id = bus_config.instance_id;
@@ -59,9 +60,15 @@ pub async fn build_vpci_device(
         .arc_mutex_device(device_name)
         .with_external_pci();
 
-    let msi_conn = MsiConnection::new(pci_core::bus_range::AssignedBusRange::new(), 0);
+    let msi_conn = MsiConnection::new();
 
-    let device = resolve_and_add_pci_device(device_builder, ctx, msi_conn.target()).await?;
+    let dma_target = DmaTarget::new(
+        pci_core::bus_range::AssignedBusRange::new(),
+        0,
+        guest_memory,
+        &msi_conn,
+    );
+    let device = resolve_and_add_pci_device(device_builder, ctx, &dma_target).await?;
 
     {
         let device_id = (instance_id.data2 as u64) << 16 | (instance_id.data3 as u64 & 0xfff8);
@@ -102,14 +109,14 @@ pub async fn build_pcie_device(
     ctx: PciDeviceResolveContext<'_>,
     chipset_builder: &ChipsetBuilder<'_>,
     port_name: Arc<str>,
-    msi_target: &pci_core::msi::MsiTarget,
+    dma_target: &DmaTarget,
 ) -> anyhow::Result<()> {
     let dev_name = format!("pcie:{}-{}", port_name, ctx.resource.id());
     let device_builder = chipset_builder
         .arc_mutex_device(dev_name)
         .on_pcie_port(vmotherboard::BusId::new(&port_name));
 
-    resolve_and_add_pci_device(device_builder, ctx, msi_target).await?;
+    resolve_and_add_pci_device(device_builder, ctx, dma_target).await?;
 
     Ok(())
 }
@@ -119,7 +126,7 @@ pub async fn build_pcie_device(
 pub async fn resolve_and_add_pci_device(
     device_builder: ArcMutexChipsetDeviceBuilder<'_, '_, ErasedChipsetDevice>,
     ctx: PciDeviceResolveContext<'_>,
-    msi_target: &pci_core::msi::MsiTarget,
+    dma_target: &DmaTarget,
 ) -> anyhow::Result<Arc<closeable_mutex::CloseableMutex<ErasedChipsetDevice>>> {
     let device = device_builder
         .try_add_async(async |services| {
@@ -127,13 +134,11 @@ pub async fn resolve_and_add_pci_device(
                 .resolve(
                     ctx.resource,
                     pci_resources::ResolvePciDeviceHandleParams {
-                        msi_target,
+                        dma_target,
                         register_mmio: &mut services.register_mmio(),
                         driver_source: ctx.driver_source,
-                        guest_memory: ctx.guest_memory,
                         doorbell_registration: ctx.doorbell_registration,
                         shared_mem_mapper: ctx.shared_mem_mapper,
-                        software_iommu: ctx.software_iommu,
                     },
                 )
                 .await

--- a/vmm_core/virt_kvm/src/arch/aarch64/mod.rs
+++ b/vmm_core/virt_kvm/src/arch/aarch64/mod.rs
@@ -18,6 +18,7 @@ use crate::KvmRunVpError;
 use crate::gsi::GsiRouting;
 use crate::gsi::KvmIrqFdState;
 use crate::gsi::MsiRouteBuilder;
+use crate::memory::KvmMemoryBackingMode;
 use aarch64defs::SystemReg;
 use aarch64defs::Vendor;
 use aarch64defs::gic::GicV2mRegister;
@@ -239,7 +240,7 @@ impl Kvm {
         // Probe GIC version by creating a throwaway VM and attempting to
         // create a GICv3 device. If that fails, try GICv2.
         let kvm = kvm::Kvm::from(file);
-        let probe_vm = kvm.new_vm()?;
+        let probe_vm = kvm.new_vm(kvm::VmType::Default)?;
         let supports_gic_v3 = if probe_vm
             .test_create_device(kvm_device_type_KVM_DEV_TYPE_ARM_VGIC_V3)
             .is_ok()
@@ -830,6 +831,14 @@ impl virt::ProtoPartition for KvmProtoPartition<'_> {
         let partition = Arc::new(KvmPartitionInner {
             kvm: self.vm,
             memory: Default::default(),
+            memory_backing_mode: KvmMemoryBackingMode::Userspace,
+            ram_ranges: config
+                .mem_layout
+                .ram()
+                .iter()
+                .map(|range| range.range)
+                .chain(config.mem_layout.vtl2_range())
+                .collect(),
             hv1_enabled: self.config.hv_config.is_some(),
             gm: config.guest_memory.clone(),
             vps: self
@@ -1145,7 +1154,7 @@ impl virt::Hypervisor for Kvm {
             _ => 40,
         };
 
-        let vm = self.kvm.new_vm()?;
+        let vm = self.kvm.new_vm(kvm::VmType::Default)?;
 
         Ok(KvmProtoPartition {
             vm,

--- a/vmm_core/virt_kvm/src/arch/x86_64/mod.rs
+++ b/vmm_core/virt_kvm/src/arch/x86_64/mod.rs
@@ -17,6 +17,7 @@ use crate::KvmRunVpError;
 use crate::gsi::GsiRouting;
 use crate::gsi::KvmIrqFdState;
 use crate::gsi::MsiRouteBuilder;
+use crate::memory::KvmMemoryBackingMode;
 use guestmem::DoorbellRegistration;
 use guestmem::GuestMemory;
 use guestmem::GuestMemoryError;
@@ -349,7 +350,7 @@ impl virt::Hypervisor for Kvm {
             }
         }
 
-        let vm = self.kvm.new_vm()?;
+        let vm = self.kvm.new_vm(kvm::VmType::Default)?;
         vm.enable_split_irqchip(virt::irqcon::IRQ_LINES as u32)?;
         vm.enable_x2apic_api()?;
         vm.enable_unknown_msr_exits()?;
@@ -456,6 +457,14 @@ impl ProtoPartition for KvmProtoPartition<'_> {
         let partition = Arc::new(KvmPartitionInner {
             kvm: self.vm,
             memory: Default::default(),
+            memory_backing_mode: KvmMemoryBackingMode::Userspace,
+            ram_ranges: config
+                .mem_layout
+                .ram()
+                .iter()
+                .map(|range| range.range)
+                .chain(config.mem_layout.vtl2_range())
+                .collect(),
             hv1_enabled: self.config.hv_config.is_some(),
             gm: config.guest_memory.clone(),
             vps: self
@@ -1490,6 +1499,20 @@ impl<'p> Processor for KvmProcessor<'p> {
                         KvmHypercallExit::DISPATCHER.dispatch(&self.partition.gm, &mut handler);
                         *result = handler.registers.result;
                     }
+                    kvm::Exit::Hypercall {
+                        nr,
+                        args: _,
+                        result,
+                        flags,
+                    } => {
+                        // This is only reachable for hypercall exits explicitly
+                        // enabled on the VM. Later SNP support enables
+                        // KVM_HC_MAP_GPA_RANGE and handles it here.
+                        *result = 1;
+                        return Err(
+                            dev.fatal_error(KvmRunVpError::UnhandledHypercall { nr, flags }.into())
+                        );
+                    }
                     kvm::Exit::Debug {
                         exception: _,
                         pc: _,
@@ -1525,6 +1548,30 @@ impl<'p> Processor for KvmProcessor<'p> {
                     } => {
                         tracing::error!(hardware_entry_failure_reason, "VP entry failed");
                         return Err(dev.fatal_error(KvmRunVpError::InvalidVpState.into()));
+                    }
+                    kvm::Exit::SystemEvent {
+                        event_type,
+                        event_flags,
+                    } => {
+                        // KVM reports architectural shutdown/reset/crash
+                        // notifications here; SNP adds SEV termination handling.
+                        tracing::info!(event_type, event_flags, "system event");
+                        match event_type {
+                            kvm::KVM_SYSTEM_EVENT_SHUTDOWN => {
+                                return Err(VpHaltReason::PowerOff);
+                            }
+                            kvm::KVM_SYSTEM_EVENT_RESET => {
+                                return Err(VpHaltReason::Reset);
+                            }
+                            kvm::KVM_SYSTEM_EVENT_CRASH => {
+                                return Err(VpHaltReason::TripleFault { vtl: Vtl::Vtl0 });
+                            }
+                            _ => {
+                                return Err(dev.fatal_error(
+                                    KvmRunVpError::UnhandledSystemEvent(event_type).into(),
+                                ));
+                            }
+                        }
                     }
                 }
             }

--- a/vmm_core/virt_kvm/src/lib.rs
+++ b/vmm_core/virt_kvm/src/lib.rs
@@ -11,11 +11,14 @@
 
 mod arch;
 mod gsi;
+mod memory;
 
 pub use arch::Kvm;
 
 use guestmem::GuestMemory;
 use inspect::Inspect;
+use memory::KvmMemoryBackingMode;
+use memory::KvmMemoryRangeState;
 use memory_range::MemoryRange;
 use parking_lot::Mutex;
 use std::sync::Arc;
@@ -32,7 +35,6 @@ pub fn is_available() -> Result<bool, KvmError> {
 }
 
 use arch::KvmVpInner;
-use hvdef::Vtl;
 use std::sync::atomic::Ordering;
 use virt::VpIndex;
 use vmcore::vmtime::VmTimeAccess;
@@ -53,6 +55,12 @@ pub enum KvmError {
     State(#[from] Box<StateError<KvmError>>),
     #[error("invalid state while restoring: {0}")]
     InvalidState(&'static str),
+    #[error("unsupported isolation configuration: {0}")]
+    UnsupportedIsolationConfiguration(&'static str),
+    #[error("cannot resize KVM guest_memfd memory slot")]
+    CannotResizeGuestMemfdSlot,
+    #[error("private memory range is not contained in guest_memfd private memory")]
+    InvalidPrivateMemoryRange,
     #[error("misaligned gic base address")]
     Misaligned,
     #[error("host does not support GICv2 or GICv3")]
@@ -68,21 +76,6 @@ pub enum KvmError {
     #[cfg(guest_arch = "x86_64")]
     #[error("failed to compute topology cpuid")]
     TopologyCpuid(#[source] virt::x86::topology::UnknownVendor),
-}
-
-#[derive(Debug, Inspect)]
-struct KvmMemoryRange {
-    host_addr: *mut u8,
-    range: MemoryRange,
-}
-
-unsafe impl Sync for KvmMemoryRange {}
-unsafe impl Send for KvmMemoryRange {}
-
-#[derive(Debug, Default, Inspect)]
-struct KvmMemoryRangeState {
-    #[inspect(flatten, iter_by_index)]
-    ranges: Vec<Option<KvmMemoryRange>>,
 }
 
 #[derive(Inspect)]
@@ -101,6 +94,9 @@ struct KvmPartitionInner {
     #[inspect(skip)]
     kvm: kvm::Partition,
     memory: Mutex<KvmMemoryRangeState>,
+    memory_backing_mode: KvmMemoryBackingMode,
+    #[inspect(iter_by_index)]
+    ram_ranges: Vec<MemoryRange>,
     hv1_enabled: bool,
     gm: GuestMemory,
     #[inspect(skip)]
@@ -144,9 +140,11 @@ enum KvmRunVpError {
     InvalidVpState,
     #[error("failed to run VP")]
     Run(#[source] kvm::Error),
-    #[cfg_attr(guest_arch = "x86_64", expect(dead_code))]
     #[error("unhandled system event type: {0:#x}")]
     UnhandledSystemEvent(u32),
+    #[cfg(guest_arch = "x86_64")]
+    #[error("unhandled KVM hypercall: nr={nr:#x}, flags={flags:#x}")]
+    UnhandledHypercall { nr: u64, flags: u64 },
     #[cfg(guest_arch = "x86_64")]
     #[error("failed to inject an extint interrupt")]
     ExtintInterrupt(#[source] kvm::Error),
@@ -177,97 +175,5 @@ impl KvmPartitionInner {
 
         #[cfg(guest_arch = "aarch64")]
         self.kvm.vp(vp.vp_info().base.vp_index.index()).force_exit();
-    }
-
-    /// # Safety
-    ///
-    /// `data..data+size` must be and remain an allocated VA range until the
-    /// partition is destroyed or the region is unmapped.
-    unsafe fn map_region(
-        &self,
-        data: *mut u8,
-        size: usize,
-        addr: u64,
-        readonly: bool,
-    ) -> anyhow::Result<()> {
-        let mut state = self.memory.lock();
-
-        // Memory slots cannot be resized but can be moved within the guest
-        // address space. Find the existing slot if there is one.
-        let mut slot_to_use = None;
-        for (slot, range) in state.ranges.iter_mut().enumerate() {
-            match range {
-                Some(range) if range.host_addr == data => {
-                    slot_to_use = Some(slot);
-                    break;
-                }
-                Some(_) => (),
-                None => slot_to_use = Some(slot),
-            }
-        }
-        if slot_to_use.is_none() {
-            slot_to_use = Some(state.ranges.len());
-            state.ranges.push(None);
-        }
-        let slot_to_use = slot_to_use.unwrap();
-        unsafe {
-            self.kvm
-                .set_user_memory_region(slot_to_use as u32, data, size, addr, readonly)?
-        };
-        state.ranges[slot_to_use] = Some(KvmMemoryRange {
-            host_addr: data,
-            range: MemoryRange::new(addr..addr + size as u64),
-        });
-        Ok(())
-    }
-}
-
-impl virt::PartitionMemoryMapper for KvmPartition {
-    fn memory_mapper(&self, vtl: Vtl) -> Arc<dyn virt::PartitionMemoryMap> {
-        assert_eq!(vtl, Vtl::Vtl0);
-        self.inner.clone()
-    }
-}
-
-// TODO: figure out a better abstraction that works for both KVM and WHP.
-impl virt::PartitionMemoryMap for KvmPartitionInner {
-    unsafe fn map_range(
-        &self,
-        data: *mut u8,
-        size: usize,
-        addr: u64,
-        writable: bool,
-        _exec: bool,
-    ) -> anyhow::Result<()> {
-        // SAFETY: guaranteed by caller.
-        unsafe { self.map_region(data, size, addr, !writable) }
-    }
-
-    fn unmap_range(&self, addr: u64, size: u64) -> anyhow::Result<()> {
-        let range = MemoryRange::new(addr..addr + size);
-        let mut state = self.memory.lock();
-        for (slot, entry) in state.ranges.iter_mut().enumerate() {
-            let Some(kvm_range) = entry else { continue };
-            if range.contains(&kvm_range.range) {
-                // SAFETY: clearing a slot should always be safe since it removes
-                // and does not add memory references.
-                unsafe {
-                    self.kvm.set_user_memory_region(
-                        slot as u32,
-                        std::ptr::null_mut(),
-                        0,
-                        0,
-                        false,
-                    )?;
-                }
-                *entry = None;
-            } else {
-                assert!(
-                    !range.overlaps(&kvm_range.range),
-                    "can only unmap existing ranges of exact size"
-                );
-            }
-        }
-        Ok(())
     }
 }

--- a/vmm_core/virt_kvm/src/memory.rs
+++ b/vmm_core/virt_kvm/src/memory.rs
@@ -1,0 +1,501 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+use crate::KvmError;
+use crate::KvmPartition;
+use crate::KvmPartitionInner;
+use inspect::Inspect;
+use memory_range::MemoryRange;
+use std::fs::File;
+use std::sync::Arc;
+
+#[derive(Debug, Inspect)]
+pub(crate) struct KvmMemoryRange {
+    host_addr: *mut u8,
+    range: MemoryRange,
+    guest_memfd_offset: Option<u64>,
+    private_attributes_set: bool,
+}
+
+unsafe impl Sync for KvmMemoryRange {}
+unsafe impl Send for KvmMemoryRange {}
+
+#[derive(Debug, Default, Inspect)]
+pub(crate) struct KvmMemoryRangeState {
+    #[inspect(flatten, iter_by_index)]
+    pub(crate) ranges: Vec<Option<KvmMemoryRange>>,
+}
+
+#[derive(Debug, Inspect)]
+#[inspect(external_tag)]
+pub(crate) enum KvmMemoryBackingMode {
+    Userspace,
+    GuestMemfd(KvmGuestMemfdBacking),
+}
+
+#[derive(Debug, Inspect)]
+pub(crate) struct KvmGuestMemfdBacking {
+    #[inspect(skip)]
+    file: File,
+    #[inspect(iter_by_index)]
+    ranges: Vec<KvmGuestMemfdRange>,
+    initial_private: bool,
+}
+
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Inspect)]
+struct KvmGuestMemfdRange {
+    range: MemoryRange,
+    file_offset: u64,
+}
+
+#[derive(Debug)]
+enum KvmMemoryBacking<'a> {
+    Userspace,
+    GuestMemfd {
+        file: &'a File,
+        file_offset: u64,
+        initial_private: bool,
+    },
+}
+
+impl KvmMemoryBackingMode {
+    #[expect(dead_code)]
+    pub(crate) fn guest_memfd(
+        kvm: &kvm::Partition,
+        ram_ranges: impl IntoIterator<Item = MemoryRange>,
+        initial_private: bool,
+    ) -> Result<Self, KvmError> {
+        check_private_memory_extensions(kvm)?;
+
+        let mut file_size = 0u64;
+        let mut ranges = Vec::new();
+        for range in ram_ranges {
+            ranges.push(KvmGuestMemfdRange {
+                range,
+                file_offset: file_size,
+            });
+            file_size += range.len();
+        }
+
+        Ok(Self::GuestMemfd(KvmGuestMemfdBacking {
+            file: kvm.create_guest_memfd(file_size)?,
+            ranges,
+            initial_private,
+        }))
+    }
+}
+
+impl KvmPartitionInner {
+    /// # Safety
+    ///
+    /// `data..data+size` must be and remain an allocated VA range until the
+    /// partition is destroyed or the region is unmapped.
+    unsafe fn map_region(
+        &self,
+        data: *mut u8,
+        size: usize,
+        addr: u64,
+        readonly: bool,
+    ) -> anyhow::Result<()> {
+        let range = MemoryRange::new(addr..addr + size as u64);
+        let backing = self.memory_backing(range)?;
+        let mut state = self.memory.lock();
+
+        // Memory slots cannot be resized but can be moved within the guest
+        // address space. Find the existing slot if there is one.
+        let mut slot_to_use = None;
+        for (slot, range) in state.ranges.iter_mut().enumerate() {
+            match range {
+                Some(range) if range.host_addr == data => {
+                    slot_to_use = Some(slot);
+                    break;
+                }
+                Some(_) => (),
+                None => slot_to_use = Some(slot),
+            }
+        }
+        if slot_to_use.is_none() {
+            slot_to_use = Some(state.ranges.len());
+            state.ranges.push(None);
+        }
+        let slot_to_use = slot_to_use.unwrap();
+        if let Some(existing_range) = &state.ranges[slot_to_use] {
+            if existing_range.guest_memfd_offset.is_some()
+                && existing_range.range.len() != size as u64
+            {
+                return Err(KvmError::CannotResizeGuestMemfdSlot.into());
+            }
+            if existing_range.private_attributes_set {
+                self.kvm.set_memory_attributes(
+                    existing_range.range.start(),
+                    existing_range.range.len(),
+                    0,
+                )?;
+            }
+            if existing_range.guest_memfd_offset.is_some() {
+                // SAFETY: clearing a slot removes the memory reference.
+                unsafe { self.clear_slot(slot_to_use, true)? };
+                state.ranges[slot_to_use] = None;
+            }
+        }
+        let (guest_memfd_offset, private_attributes_set) = match backing {
+            KvmMemoryBacking::Userspace => {
+                // SAFETY: `map_region` requires its caller to keep
+                // `data..data+size` valid until this guest-physical range is
+                // unmapped or the partition is destroyed.
+                unsafe {
+                    self.kvm.set_user_memory_region(
+                        slot_to_use as u32,
+                        data,
+                        size,
+                        addr,
+                        readonly,
+                    )?
+                };
+                (None, false)
+            }
+            KvmMemoryBacking::GuestMemfd {
+                file,
+                file_offset,
+                initial_private,
+            } => {
+                // SAFETY: `map_region` requires its caller to keep
+                // `data..data+size` valid until this guest-physical range is
+                // unmapped or the partition is destroyed. `memory_backing`
+                // The partition owns the backing guestmemfd for at least as long
+                // as KVM references it.
+                unsafe {
+                    self.kvm.set_user_memory_region2(
+                        slot_to_use as u32,
+                        data,
+                        size,
+                        addr,
+                        readonly,
+                        Some((file, file_offset)),
+                    )?;
+                };
+                if initial_private {
+                    if let Err(err) = self.kvm.set_memory_attributes(
+                        addr,
+                        size as u64,
+                        kvm::KVM_MEMORY_ATTRIBUTE_PRIVATE as u64,
+                    ) {
+                        // SAFETY: clearing a slot removes the memory reference.
+                        unsafe { self.clear_slot(slot_to_use, true)? };
+                        state.ranges[slot_to_use] = None;
+                        return Err(err.into());
+                    }
+                }
+                (Some(file_offset), initial_private)
+            }
+        };
+        state.ranges[slot_to_use] = Some(KvmMemoryRange {
+            host_addr: data,
+            range,
+            guest_memfd_offset,
+            private_attributes_set,
+        });
+        Ok(())
+    }
+
+    fn memory_backing(&self, range: MemoryRange) -> Result<KvmMemoryBacking<'_>, KvmError> {
+        match &self.memory_backing_mode {
+            KvmMemoryBackingMode::Userspace => Ok(KvmMemoryBacking::Userspace),
+            KvmMemoryBackingMode::GuestMemfd(backing) => {
+                match classify_guest_memfd_backing(range, &backing.ranges)? {
+                    Some(file_offset) => Ok(KvmMemoryBacking::GuestMemfd {
+                        file: &backing.file,
+                        file_offset,
+                        initial_private: backing.initial_private,
+                    }),
+                    None => Ok(KvmMemoryBacking::Userspace),
+                }
+            }
+        }
+    }
+
+    /// # Safety
+    ///
+    /// The caller must ensure that clearing the target slot is valid.
+    unsafe fn clear_slot(&self, slot: usize, guest_memfd_backed: bool) -> Result<(), kvm::Error> {
+        if guest_memfd_backed {
+            // SAFETY: the caller ensures clearing this slot is valid.
+            unsafe {
+                self.kvm.set_user_memory_region2(
+                    slot as u32,
+                    std::ptr::null_mut(),
+                    0,
+                    0,
+                    false,
+                    None,
+                )
+            }
+        } else {
+            // SAFETY: the caller ensures clearing this slot is valid.
+            unsafe {
+                self.kvm
+                    .set_user_memory_region(slot as u32, std::ptr::null_mut(), 0, 0, false)
+            }
+        }
+    }
+}
+
+fn check_private_memory_extensions(kvm: &kvm::Partition) -> Result<(), KvmError> {
+    require_kvm_extension(kvm, kvm::KVM_CAP_USER_MEMORY2, "KVM_CAP_USER_MEMORY2")?;
+    require_kvm_extension(kvm, kvm::KVM_CAP_GUEST_MEMFD, "KVM_CAP_GUEST_MEMFD")?;
+    let memory_attributes = require_kvm_extension(
+        kvm,
+        kvm::KVM_CAP_MEMORY_ATTRIBUTES,
+        "KVM_CAP_MEMORY_ATTRIBUTES",
+    )?;
+    if memory_attributes as u64 & kvm::KVM_MEMORY_ATTRIBUTE_PRIVATE as u64 == 0 {
+        return Err(kvm::Error::MissingCapability(
+            "KVM_CAP_MEMORY_ATTRIBUTES(KVM_MEMORY_ATTRIBUTE_PRIVATE)",
+        )
+        .into());
+    }
+    Ok(())
+}
+
+fn require_kvm_extension(
+    kvm: &kvm::Partition,
+    extension: u32,
+    capability: &'static str,
+) -> Result<i32, KvmError> {
+    let value = kvm
+        .check_extension(extension)
+        .map_err(kvm::Error::CheckExtension)?;
+    if value == 0 {
+        return Err(kvm::Error::MissingCapability(capability).into());
+    }
+    Ok(value)
+}
+
+fn classify_guest_memfd_backing(
+    range: MemoryRange,
+    ram_ranges: &[KvmGuestMemfdRange],
+) -> Result<Option<u64>, KvmError> {
+    let mut containing_ranges = ram_ranges
+        .iter()
+        .filter(|ram_range| ram_range.range.contains(&range));
+    if let Some(ram_range) = containing_ranges.next() {
+        if containing_ranges.next().is_some() {
+            return Err(KvmError::UnsupportedIsolationConfiguration(
+                "KVM guest_memfd mappings must be contained in exactly one RAM range",
+            ));
+        }
+        return Ok(Some(
+            ram_range.file_offset + (range.start() - ram_range.range.start()),
+        ));
+    }
+
+    if ram_ranges
+        .iter()
+        .any(|ram_range| ram_range.range.overlaps(&range))
+    {
+        return Err(KvmError::UnsupportedIsolationConfiguration(
+            "KVM guest_memfd mappings must be fully contained in one RAM range",
+        ));
+    }
+
+    Ok(None)
+}
+
+impl virt::PartitionMemoryMapper for KvmPartition {
+    fn memory_mapper(&self, vtl: hvdef::Vtl) -> Arc<dyn virt::PartitionMemoryMap> {
+        assert_eq!(vtl, hvdef::Vtl::Vtl0);
+        self.inner.clone()
+    }
+}
+
+// TODO: figure out a better abstraction that works for both KVM and WHP.
+impl virt::PartitionMemoryMap for KvmPartitionInner {
+    unsafe fn map_range(
+        &self,
+        data: *mut u8,
+        size: usize,
+        addr: u64,
+        writable: bool,
+        _exec: bool,
+    ) -> anyhow::Result<()> {
+        // SAFETY: `PartitionMemoryMap::map_range` requires the caller to keep
+        // `data..data+size` valid for the lifetime of the mapping. `map_region`
+        // preserves that lifetime requirement and records the mapped range so
+        // it can be cleared on unmap.
+        unsafe { self.map_region(data, size, addr, !writable) }
+    }
+
+    fn unmap_range(&self, addr: u64, size: u64) -> anyhow::Result<()> {
+        let range = MemoryRange::new(addr..addr + size);
+        let mut state = self.memory.lock();
+        for (slot, entry) in state.ranges.iter_mut().enumerate() {
+            let Some(kvm_range) = entry else { continue };
+            if range.contains(&kvm_range.range) {
+                let guest_memfd_backed = kvm_range.guest_memfd_offset.is_some();
+                if kvm_range.private_attributes_set {
+                    self.kvm.set_memory_attributes(
+                        kvm_range.range.start(),
+                        kvm_range.range.len(),
+                        0,
+                    )?;
+                }
+                // SAFETY: clearing a slot should always be safe since it removes
+                // and does not add memory references.
+                unsafe { self.clear_slot(slot, guest_memfd_backed)? };
+                *entry = None;
+            } else {
+                assert!(
+                    !range.overlaps(&kvm_range.range),
+                    "can only unmap existing ranges of exact size"
+                );
+            }
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn range(start: u64, end: u64) -> MemoryRange {
+        MemoryRange::new(start..end)
+    }
+
+    fn guest_memfd_ranges(ranges: &[MemoryRange]) -> Vec<KvmGuestMemfdRange> {
+        let mut file_offset = 0;
+        ranges
+            .iter()
+            .map(|&range| {
+                let guest_memfd_range = KvmGuestMemfdRange { range, file_offset };
+                file_offset += range.len();
+                guest_memfd_range
+            })
+            .collect()
+    }
+
+    #[derive(Debug, Copy, Clone, Eq, PartialEq)]
+    struct KvmPrivateMemoryRange {
+        gpa: MemoryRange,
+        hva: *mut u8,
+    }
+
+    fn private_memory_range_from_slots(
+        range: MemoryRange,
+        slots: &[Option<KvmMemoryRange>],
+    ) -> Result<KvmPrivateMemoryRange, KvmError> {
+        let slot = slots
+            .iter()
+            .flatten()
+            .find(|slot| slot.range.contains(&range))
+            .ok_or(KvmError::InvalidPrivateMemoryRange)?;
+
+        if slot.guest_memfd_offset.is_none() || !slot.private_attributes_set {
+            return Err(KvmError::InvalidPrivateMemoryRange);
+        }
+
+        let offset = range.start() - slot.range.start();
+        Ok(KvmPrivateMemoryRange {
+            gpa: range,
+            hva: slot.host_addr.wrapping_add(offset as usize),
+        })
+    }
+
+    #[test]
+    fn guest_memfd_classifier_selects_contained_ram() {
+        let ram_ranges = guest_memfd_ranges(&[range(0x1000, 0x9000), range(0x1_0000, 0x2_0000)]);
+
+        assert_eq!(
+            classify_guest_memfd_backing(range(0x2000, 0x4000), &ram_ranges).unwrap(),
+            Some(0x1000)
+        );
+        assert_eq!(
+            classify_guest_memfd_backing(range(0x1_1000, 0x1_3000), &ram_ranges).unwrap(),
+            Some(0x9000)
+        );
+    }
+
+    #[test]
+    fn guest_memfd_classifier_keeps_non_ram_userspace() {
+        let ram_ranges = guest_memfd_ranges(&[range(0x1000, 0x9000), range(0x1_0000, 0x2_0000)]);
+
+        assert_eq!(
+            classify_guest_memfd_backing(range(0xa000, 0xc000), &ram_ranges).unwrap(),
+            None
+        );
+    }
+
+    #[test]
+    fn guest_memfd_classifier_rejects_partial_ram_overlap() {
+        let ram_ranges = guest_memfd_ranges(&[range(0x1000, 0x9000), range(0x1_0000, 0x2_0000)]);
+
+        assert!(matches!(
+            classify_guest_memfd_backing(range(0x8000, 0xa000), &ram_ranges),
+            Err(KvmError::UnsupportedIsolationConfiguration(_))
+        ));
+    }
+
+    #[test]
+    fn guest_memfd_classifier_does_not_merge_adjacent_ram_ranges() {
+        let ram_ranges = guest_memfd_ranges(&[range(0x1000, 0x3000), range(0x3000, 0x5000)]);
+
+        assert!(matches!(
+            classify_guest_memfd_backing(range(0x2000, 0x4000), &ram_ranges),
+            Err(KvmError::UnsupportedIsolationConfiguration(_))
+        ));
+    }
+
+    #[test]
+    fn guest_memfd_classifier_rejects_ambiguous_ram_containment() {
+        let ram_ranges = guest_memfd_ranges(&[range(0x1000, 0x5000), range(0x2000, 0x4000)]);
+
+        assert!(matches!(
+            classify_guest_memfd_backing(range(0x2000, 0x4000), &ram_ranges),
+            Err(KvmError::UnsupportedIsolationConfiguration(_))
+        ));
+    }
+
+    #[test]
+    fn private_memory_range_resolves_hva_offset() {
+        let mut backing = vec![0u8; 0x4000];
+        let host_addr = backing.as_mut_ptr();
+        let slots = [Some(KvmMemoryRange {
+            host_addr,
+            range: range(0x1000, 0x5000),
+            guest_memfd_offset: Some(0),
+            private_attributes_set: true,
+        })];
+
+        let resolved = private_memory_range_from_slots(range(0x3000, 0x5000), &slots).unwrap();
+
+        assert_eq!(resolved.gpa, range(0x3000, 0x5000));
+        assert_eq!(resolved.hva, host_addr.wrapping_add(0x2000));
+    }
+
+    #[test]
+    fn private_memory_range_rejects_non_private_or_non_guest_memfd_slots() {
+        let mut backing = vec![0u8; 0x4000];
+        let host_addr = backing.as_mut_ptr();
+        let userspace_slots = [Some(KvmMemoryRange {
+            host_addr,
+            range: range(0x1000, 0x5000),
+            guest_memfd_offset: None,
+            private_attributes_set: true,
+        })];
+        assert!(matches!(
+            private_memory_range_from_slots(range(0x1000, 0x2000), &userspace_slots),
+            Err(KvmError::InvalidPrivateMemoryRange)
+        ));
+
+        let shared_slots = [Some(KvmMemoryRange {
+            host_addr,
+            range: range(0x1000, 0x5000),
+            guest_memfd_offset: Some(0),
+            private_attributes_set: false,
+        })];
+        assert!(matches!(
+            private_memory_range_from_slots(range(0x1000, 0x2000), &shared_slots),
+            Err(KvmError::InvalidPrivateMemoryRange)
+        ));
+    }
+}

--- a/vmm_core/virt_whp/src/hypercalls.rs
+++ b/vmm_core/virt_whp/src/hypercalls.rs
@@ -1357,60 +1357,16 @@ mod x86 {
                 return Err(HvError::VtlAlreadyEnabled);
             }
 
-            let names = &[
-                whp::abi::WHvX64RegisterRip,
-                whp::abi::WHvX64RegisterRsp,
-                whp::abi::WHvX64RegisterRflags,
-                whp::abi::WHvX64RegisterCs,
-                whp::abi::WHvX64RegisterDs,
-                whp::abi::WHvX64RegisterEs,
-                whp::abi::WHvX64RegisterFs,
-                whp::abi::WHvX64RegisterGs,
-                whp::abi::WHvX64RegisterSs,
-                whp::abi::WHvX64RegisterTr,
-                whp::abi::WHvX64RegisterLdtr,
-                whp::abi::WHvX64RegisterIdtr,
-                whp::abi::WHvX64RegisterGdtr,
-                whp::abi::WHvX64RegisterEfer,
-                whp::abi::WHvX64RegisterCr0,
-                whp::abi::WHvX64RegisterCr3,
-                whp::abi::WHvX64RegisterCr4,
-                whp::abi::WHvX64RegisterPat,
-            ];
-            let values: &[HvRegisterValue] = &[
-                vp_context.rip.into(),
-                vp_context.rsp.into(),
-                vp_context.rflags.into(),
-                vp_context.cs.into(),
-                vp_context.ds.into(),
-                vp_context.es.into(),
-                vp_context.fs.into(),
-                vp_context.gs.into(),
-                vp_context.ss.into(),
-                vp_context.tr.into(),
-                vp_context.ldtr.into(),
-                vp_context.idtr.into(),
-                vp_context.gdtr.into(),
-                vp_context.efer.into(),
-                vp_context.cr0.into(),
-                vp_context.cr3.into(),
-                vp_context.cr4.into(),
-                vp_context.msr_cr_pat.into(),
-            ];
-
-            // SAFETY: HvRegisterValue and WHV_REGISTER_VALUE are the same.
-            let values =
-                unsafe { std::mem::transmute::<&[HvRegisterValue], &[WHV_REGISTER_VALUE]>(values) };
-
             tracing::debug!(vp_index = vp_index.index(), ?vtl, "enabling vtl");
 
-            target_vp
-                .whp(vtl)
-                .set_registers(names, values)
-                .map_err(|_| HvError::InvalidParameter)?;
+            let target_vplc = target_vp.vplc(vtl);
+            *target_vplc.start_vp_context.lock() = Some(Box::new(*vp_context));
+            target_vplc.start_vp.store(true, Ordering::Release);
 
-            // Force VTL0 to return now that VTL2 is enabled.
+            // Force the target VP to return from any in-progress run and
+            // wake its async future so it processes the start-VP request.
             target_vp.whp(Vtl::Vtl0).cancel_run().expect("can't fail");
+            target_vp.wake();
             Ok(())
         }
     }

--- a/vmm_tests/vmm_tests/tests/tests/multiarch/numa.rs
+++ b/vmm_tests/vmm_tests/tests/tests/multiarch/numa.rs
@@ -10,8 +10,8 @@ use openvmm_defs::config::NumaNode;
 use openvmm_defs::config::NumaTopology;
 use openvmm_defs::config::PcieDeviceConfig;
 use openvmm_defs::config::PcieMmioRangeConfig;
+use openvmm_defs::config::PciePortConfig;
 use openvmm_defs::config::PcieRootComplexConfig;
-use openvmm_defs::config::PcieRootPortConfig;
 use openvmm_defs::config::VpAssignment;
 use petri::PetriVmBuilder;
 use petri::openvmm::OpenVmmPetriBackend;
@@ -339,8 +339,9 @@ async fn pcie_device_numa_affinity(
                         size: 1024 * 1024 * 1024,
                     },
                     cxl: None,
-                    ports: vec![PcieRootPortConfig {
+                    ports: vec![PciePortConfig {
                         name: "rp0".to_string(),
+                        devfn: None,
                         hotplug: false,
                         acs_capabilities_supported: None,
                         cxl: false,

--- a/vmm_tests/vmm_tests/tests/tests/ttrpc.rs
+++ b/vmm_tests/vmm_tests/tests/tests/ttrpc.rs
@@ -13,6 +13,7 @@ use pal_async::pipe::PolledPipe;
 use pal_async::process::PolledChild;
 use pal_async::socket::PolledSocket;
 use pal_async::task::Spawn;
+use pal_async::timer::PolledTimer;
 use petri::ResolvedArtifact;
 use petri_artifacts_vmm_test::artifacts;
 use std::process::Stdio;
@@ -355,6 +356,271 @@ fn test_ttrpc_interface(
         assert!(
             !pidfile_path.exists(),
             "pidfile should be removed after exit"
+        );
+
+        Ok(())
+    })
+}
+
+petri::test!(test_ttrpc_consomme_port_forward, |resolver| {
+    // Only supported on x86_64 for now.
+    if petri_artifacts_common::tags::MachineArch::host()
+        != petri_artifacts_common::tags::MachineArch::X86_64
+    {
+        return None;
+    }
+    let openvmm = resolver.require(artifacts::OPENVMM_NATIVE);
+    let kernel = resolver.require(artifacts::loadable::LINUX_DIRECT_TEST_KERNEL_NATIVE);
+    let initrd = resolver.require(artifacts::loadable::LINUX_DIRECT_TEST_INITRD_NATIVE);
+    Some([openvmm.erase(), kernel.erase(), initrd.erase()])
+});
+
+/// End-to-end test of consomme host port forwarding driven over the ttrpc
+/// interface: boot a guest that listens on a guest port, bind a host port to it
+/// via `ModifyResource`, then connect from the host and verify the connection
+/// reaches the in-guest listener. Finally unbind and verify the host port stops
+/// accepting connections.
+fn test_ttrpc_consomme_port_forward(
+    params: petri::PetriTestParams<'_>,
+    [openvmm, kernel_path, initrd_path]: [ResolvedArtifact; 3],
+) -> anyhow::Result<()> {
+    /// Guest TCP port the in-guest `nc` listener binds to.
+    const GUEST_PORT: u16 = 8080;
+    /// Banner the guest sends to each accepted connection.
+    const BANNER: &[u8] = b"CONSOMME_OK";
+
+    let mut socket_path = std::env::temp_dir();
+    socket_path.push(Guid::new_random().to_string());
+    let pidfile_path = std::env::temp_dir().join(format!("{}.pid", Guid::new_random()));
+
+    tracing::info!(socket_path = %socket_path.display(), "launching OpenVMM with ttrpc");
+
+    let (stderr_read, stderr_write) = pal::pipe_pair()?;
+    let (stdout_read, stdout_write) = pal::pipe_pair()?;
+    let child = std::process::Command::new(openvmm)
+        .arg("--ttrpc")
+        .arg(&socket_path)
+        .arg("--pidfile")
+        .arg(&pidfile_path)
+        .stdin(Stdio::null())
+        .stdout(stdout_write)
+        .stderr(stderr_write)
+        .spawn()?;
+
+    DefaultPool::run_with(async |driver| {
+        let mut child = PolledChild::<std::process::Child>::new(&driver, child)?;
+
+        let _stderr_task = driver.spawn(
+            "stderr",
+            petri::log_task(
+                params.logger.log_file("stderr")?,
+                PolledPipe::new(&driver, stderr_read)?,
+                "openvmm stderr",
+            ),
+        );
+
+        // Wait for stdout to close (readiness signal).
+        let mut stdout = PolledPipe::new(&driver, stdout_read)?;
+        let mut buf = [0u8; 1];
+        let n = stdout
+            .read(&mut buf)
+            .await
+            .context("reading from openvmm stdout")?;
+        anyhow::ensure!(n == 0, "openvmm wrote unexpected data to stdout");
+        drop(stdout);
+
+        // Reserve a free host TCP port to forward. The listener is dropped
+        // immediately; consomme rebinds the same port number when the forward
+        // is configured.
+        let host_port = std::net::TcpListener::bind((std::net::Ipv4Addr::LOCALHOST, 0))?
+            .local_addr()?
+            .port();
+
+        let client = mesh_rpc::Client::new(
+            &driver,
+            mesh_rpc::client::UnixDialier::new(driver.clone(), socket_path.clone()),
+        );
+
+        let nic_id = Guid::new_random().to_string();
+        let mac = "00-15-5D-12-12-12".to_string();
+
+        // Bring up eth0 (consomme's DHCP assigns 10.0.0.2) and serve the banner
+        // on GUEST_PORT, re-listening after each connection so repeated probes
+        // from the host all get served.
+        let banner = std::str::from_utf8(BANNER).unwrap();
+        let kernel_cmdline = format!(
+            "console=ttyS0 rdinit=/bin/busybox panic=-1 -- \
+             sh -c \"ifconfig eth0 up; udhcpc eth0; \
+             while true; do echo {banner} | nc -l -p {GUEST_PORT}; done\""
+        );
+
+        client
+            .call()
+            .start(
+                vmservice::Vm::CreateVm,
+                vmservice::CreateVmRequest {
+                    config: Some(vmservice::VmConfig {
+                        memory_config: Some(vmservice::MemoryConfig {
+                            memory_mb: 256,
+                            ..Default::default()
+                        }),
+                        processor_config: Some(vmservice::ProcessorConfig {
+                            processor_count: 2,
+                            ..Default::default()
+                        }),
+                        boot_config: Some(vmservice::vm_config::BootConfig::DirectBoot(
+                            vmservice::DirectBoot {
+                                kernel_path: kernel_path.get().to_string_lossy().to_string(),
+                                initrd_path: initrd_path.get().to_string_lossy().to_string(),
+                                kernel_cmdline,
+                            },
+                        )),
+                        devices_config: Some(vmservice::DevicesConfig {
+                            nic_config: vec![vmservice::NicConfig {
+                                nic_id: nic_id.clone(),
+                                mac_address: mac.clone(),
+                                backend: Some(vmservice::nic_config::Backend::Consomme(
+                                    vmservice::ConsommeBackend {
+                                        cidr: String::new(),
+                                        ports: vec![],
+                                    },
+                                )),
+                                ..Default::default()
+                            }],
+                            ..Default::default()
+                        }),
+                        ..Default::default()
+                    }),
+                    log_id: String::new(),
+                },
+            )
+            .await
+            .unwrap();
+
+        client
+            .call()
+            .start(vmservice::Vm::ResumeVm, ())
+            .await
+            .unwrap();
+
+        // Build a `ModifyResource` request that binds/unbinds host_port ->
+        // GUEST_PORT depending on the modify type (Update = bind, Remove =
+        // unbind).
+        let modify_request = |modify_type: vmservice::ModifyType| vmservice::ModifyResourceRequest {
+            r#type: modify_type as i32,
+            resource: Some(vmservice::modify_resource_request::Resource::NicConfig(
+                vmservice::NicConfig {
+                    nic_id: nic_id.clone(),
+                    mac_address: mac.clone(),
+                    backend: Some(vmservice::nic_config::Backend::Consomme(
+                        vmservice::ConsommeBackend {
+                            cidr: String::new(),
+                            ports: vec![vmservice::PortConfig {
+                                host_port: host_port as u32,
+                                guest_port: GUEST_PORT as u32,
+                                protocol: vmservice::IpProtocol::Tcp as i32,
+                            }],
+                        },
+                    )),
+                    ..Default::default()
+                },
+            )),
+        };
+
+        // Bind the port. This completes once the guest NIC is up and consomme
+        // has applied the forward.
+        client
+            .call()
+            .start(
+                vmservice::Vm::ModifyResource,
+                modify_request(vmservice::ModifyType::Update),
+            )
+            .await
+            .unwrap();
+
+        // From the host, connect to the forwarded port and confirm the guest's
+        // banner comes back. Retry to absorb guest boot/DHCP/listener latency
+        // and the fact that consomme may drop the initial SYN to the guest
+        // before RX buffers exist (a reconnect forces a fresh SYN).
+        let addr = std::net::SocketAddr::from((std::net::Ipv4Addr::LOCALHOST, host_port));
+        let mut timer = PolledTimer::new(&driver);
+        let mut got_banner = false;
+        for attempt in 0..60 {
+            let probe = async {
+                let mut socket = PolledSocket::connect_tcp(&driver, addr).await?;
+                let mut buf = vec![0u8; BANNER.len()];
+                socket.read_exact(&mut buf).await?;
+                anyhow::Ok(buf)
+            };
+            match CancelContext::new()
+                .with_timeout(Duration::from_secs(5))
+                .until_cancelled(probe)
+                .await
+            {
+                Ok(Ok(buf)) if buf == BANNER => {
+                    tracing::info!(attempt, host_port, "received guest banner over forwarded port");
+                    got_banner = true;
+                    break;
+                }
+                other => {
+                    tracing::debug!(attempt, ?other, "forwarded connection not ready, retrying");
+                    timer.sleep(Duration::from_secs(1)).await;
+                }
+            }
+        }
+        assert!(
+            got_banner,
+            "did not receive guest banner over forwarded host port {host_port}"
+        );
+
+        // Unbind the port and confirm the host stops accepting connections.
+        client
+            .call()
+            .start(
+                vmservice::Vm::ModifyResource,
+                modify_request(vmservice::ModifyType::Remove),
+            )
+            .await
+            .unwrap();
+
+        let mut refused = false;
+        for attempt in 0..30 {
+            match CancelContext::new()
+                .with_timeout(Duration::from_secs(5))
+                .until_cancelled(PolledSocket::connect_tcp(&driver, addr))
+                .await
+            {
+                // Connection refused: the host port is no longer bound.
+                Ok(Err(_)) => {
+                    tracing::info!(attempt, host_port, "forwarded port refused after unbind");
+                    refused = true;
+                    break;
+                }
+                // Still accepting (or a timeout): give the unbind time to land.
+                _ => {
+                    timer.sleep(Duration::from_secs(1)).await;
+                }
+            }
+        }
+        assert!(
+            refused,
+            "forwarded host port {host_port} still accepting connections after unbind"
+        );
+
+        // Tear down the VM and quit OpenVMM.
+        client
+            .call()
+            .start(vmservice::Vm::TeardownVm, ())
+            .await
+            .unwrap();
+        let _ = client.call().start(vmservice::Vm::Quit, ()).await;
+
+        let exit_status = child.wait().await?;
+        let _ = std::fs::remove_file(&socket_path);
+        tracing::info!(?exit_status, "openvmm exited");
+        assert!(
+            exit_status.success(),
+            "openvmm exited abnormally: {exit_status:?}"
         );
 
         Ok(())

--- a/vmm_tests/vmm_tests/tests/tests/ttrpc.rs
+++ b/vmm_tests/vmm_tests/tests/tests/ttrpc.rs
@@ -391,7 +391,6 @@ fn test_ttrpc_consomme_port_forward(
 
     let mut socket_path = std::env::temp_dir();
     socket_path.push(Guid::new_random().to_string());
-    let pidfile_path = std::env::temp_dir().join(format!("{}.pid", Guid::new_random()));
 
     tracing::info!(socket_path = %socket_path.display(), "launching OpenVMM with ttrpc");
 
@@ -400,8 +399,6 @@ fn test_ttrpc_consomme_port_forward(
     let child = std::process::Command::new(openvmm)
         .arg("--ttrpc")
         .arg(&socket_path)
-        .arg("--pidfile")
-        .arg(&pidfile_path)
         .stdin(Stdio::null())
         .stdout(stdout_write)
         .stderr(stderr_write)
@@ -428,29 +425,6 @@ fn test_ttrpc_consomme_port_forward(
             .context("reading from openvmm stdout")?;
         anyhow::ensure!(n == 0, "openvmm wrote unexpected data to stdout");
         drop(stdout);
-
-        let pid_content = match std::fs::read_to_string(&pidfile_path) {
-            Ok(s) => s,
-            Err(e) => {
-                let wait_result = CancelContext::new()
-                    .with_timeout(Duration::from_secs(10))
-                    .until_cancelled(child.wait())
-                    .await;
-                match wait_result {
-                    Ok(Ok(status)) => {
-                        anyhow::bail!("openvmm exited with {status} before pidfile was created");
-                    }
-                    _ => {
-                        return Err(e).context("failed to read pidfile");
-                    }
-                }
-            }
-        };
-        assert_eq!(
-            pid_content,
-            format!("{}\n", child.get().id()),
-            "pidfile should contain the child PID"
-        );
 
         // Reserve a free host TCP port to forward. The listener is dropped
         // immediately; consomme rebinds the same port number when the forward
@@ -649,12 +623,6 @@ fn test_ttrpc_consomme_port_forward(
         assert!(
             exit_status.success(),
             "openvmm exited abnormally: {exit_status:?}"
-        );
-
-        // Verify the pidfile was cleaned up on exit.
-        assert!(
-            !pidfile_path.exists(),
-            "pidfile should be removed after exit"
         );
 
         Ok(())

--- a/vmm_tests/vmm_tests/tests/tests/ttrpc.rs
+++ b/vmm_tests/vmm_tests/tests/tests/ttrpc.rs
@@ -506,26 +506,27 @@ fn test_ttrpc_consomme_port_forward(
         // Build a `ModifyResource` request that binds/unbinds host_port ->
         // GUEST_PORT depending on the modify type (Update = bind, Remove =
         // unbind).
-        let modify_request = |modify_type: vmservice::ModifyType| vmservice::ModifyResourceRequest {
-            r#type: modify_type as i32,
-            resource: Some(vmservice::modify_resource_request::Resource::NicConfig(
-                vmservice::NicConfig {
-                    nic_id: nic_id.clone(),
-                    mac_address: mac.clone(),
-                    backend: Some(vmservice::nic_config::Backend::Consomme(
-                        vmservice::ConsommeBackend {
-                            cidr: String::new(),
-                            ports: vec![vmservice::PortConfig {
-                                host_port: host_port as u32,
-                                guest_port: GUEST_PORT as u32,
-                                protocol: vmservice::IpProtocol::Tcp as i32,
-                            }],
-                        },
-                    )),
-                    ..Default::default()
-                },
-            )),
-        };
+        let modify_request =
+            |modify_type: vmservice::ModifyType| vmservice::ModifyResourceRequest {
+                r#type: modify_type as i32,
+                resource: Some(vmservice::modify_resource_request::Resource::NicConfig(
+                    vmservice::NicConfig {
+                        nic_id: nic_id.clone(),
+                        mac_address: mac.clone(),
+                        backend: Some(vmservice::nic_config::Backend::Consomme(
+                            vmservice::ConsommeBackend {
+                                cidr: String::new(),
+                                ports: vec![vmservice::PortConfig {
+                                    host_port: host_port as u32,
+                                    guest_port: GUEST_PORT as u32,
+                                    protocol: vmservice::IpProtocol::Tcp as i32,
+                                }],
+                            },
+                        )),
+                        ..Default::default()
+                    },
+                )),
+            };
 
         // Bind the port. This completes once the guest NIC is up and consomme
         // has applied the forward.
@@ -558,7 +559,11 @@ fn test_ttrpc_consomme_port_forward(
                 .await
             {
                 Ok(Ok(buf)) if buf == BANNER => {
-                    tracing::info!(attempt, host_port, "received guest banner over forwarded port");
+                    tracing::info!(
+                        attempt,
+                        host_port,
+                        "received guest banner over forwarded port"
+                    );
                     got_banner = true;
                     break;
                 }

--- a/vmm_tests/vmm_tests/tests/tests/ttrpc.rs
+++ b/vmm_tests/vmm_tests/tests/tests/ttrpc.rs
@@ -426,13 +426,6 @@ fn test_ttrpc_consomme_port_forward(
         anyhow::ensure!(n == 0, "openvmm wrote unexpected data to stdout");
         drop(stdout);
 
-        // Reserve a free host TCP port to forward. The listener is dropped
-        // immediately; consomme rebinds the same port number when the forward
-        // is configured.
-        let host_port = std::net::TcpListener::bind((std::net::Ipv4Addr::LOCALHOST, 0))?
-            .local_addr()?
-            .port();
-
         let client = mesh_rpc::Client::new(
             &driver,
             mesh_rpc::client::UnixDialier::new(driver.clone(), socket_path.clone()),
@@ -500,11 +493,11 @@ fn test_ttrpc_consomme_port_forward(
             .await
             .unwrap();
 
-        // Build a `ModifyResource` request that binds/unbinds host_port ->
-        // GUEST_PORT depending on the modify type (Update = bind, Remove =
-        // unbind).
+        // Pick an ephemeral host port and bind it via ModifyResource. Retry
+        // with a fresh port if the bind fails..
+        let mut host_port = 0u16;
         let modify_request =
-            |modify_type: vmservice::ModifyType| vmservice::ModifyResourceRequest {
+            |port: u16, modify_type: vmservice::ModifyType| vmservice::ModifyResourceRequest {
                 r#type: modify_type as i32,
                 resource: Some(vmservice::modify_resource_request::Resource::NicConfig(
                     vmservice::NicConfig {
@@ -514,7 +507,7 @@ fn test_ttrpc_consomme_port_forward(
                             vmservice::ConsommeBackend {
                                 cidr: String::new(),
                                 ports: vec![vmservice::PortConfig {
-                                    host_port: host_port as u32,
+                                    host_port: port as u32,
                                     guest_port: GUEST_PORT as u32,
                                     protocol: vmservice::IpProtocol::Tcp as i32,
                                 }],
@@ -525,16 +518,53 @@ fn test_ttrpc_consomme_port_forward(
                 )),
             };
 
-        // Bind the port. This completes once the guest NIC is up and consomme
-        // has applied the forward.
-        client
-            .call()
-            .start(
-                vmservice::Vm::ModifyResource,
-                modify_request(vmservice::ModifyType::Update),
-            )
-            .await
-            .unwrap();
+        const MAX_PORT_ATTEMPTS: u32 = 5;
+        let mut bound = false;
+        for attempt in 0..MAX_PORT_ATTEMPTS {
+            host_port = std::net::TcpListener::bind((std::net::Ipv4Addr::LOCALHOST, 0))?
+                .local_addr()?
+                .port();
+
+            match client
+                .call()
+                .start(
+                    vmservice::Vm::ModifyResource,
+                    modify_request(host_port, vmservice::ModifyType::Update),
+                )
+                .await
+            {
+                Ok(()) => {
+                    tracing::info!(attempt, host_port, "port forward bound successfully");
+                    bound = true;
+                    break;
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        attempt,
+                        host_port,
+                        error = ?e,
+                        "ModifyResource bind failed, retrying with new port"
+                    );
+                }
+            }
+        }
+        if !bound {
+            tracing::warn!(
+                "could not bind any ephemeral port after {MAX_PORT_ATTEMPTS} attempts, \
+                 skipping test"
+            );
+            // Tear down and exit early without failing — the port conflict is
+            // environmental, not a bug.
+            client
+                .call()
+                .start(vmservice::Vm::TeardownVm, ())
+                .await
+                .unwrap();
+            let _ = client.call().start(vmservice::Vm::Quit, ()).await;
+            let _ = child.wait().await;
+            let _ = std::fs::remove_file(&socket_path);
+            return Ok(());
+        }
 
         // From the host, connect to the forwarded port and confirm the guest's
         // banner comes back. Retry to absorb guest boot/DHCP/listener latency
@@ -580,7 +610,7 @@ fn test_ttrpc_consomme_port_forward(
             .call()
             .start(
                 vmservice::Vm::ModifyResource,
-                modify_request(vmservice::ModifyType::Remove),
+                modify_request(host_port, vmservice::ModifyType::Remove),
             )
             .await
             .unwrap();

--- a/vmm_tests/vmm_tests/tests/tests/ttrpc.rs
+++ b/vmm_tests/vmm_tests/tests/tests/ttrpc.rs
@@ -429,6 +429,29 @@ fn test_ttrpc_consomme_port_forward(
         anyhow::ensure!(n == 0, "openvmm wrote unexpected data to stdout");
         drop(stdout);
 
+        let pid_content = match std::fs::read_to_string(&pidfile_path) {
+            Ok(s) => s,
+            Err(e) => {
+                let wait_result = CancelContext::new()
+                    .with_timeout(Duration::from_secs(10))
+                    .until_cancelled(child.wait())
+                    .await;
+                match wait_result {
+                    Ok(Ok(status)) => {
+                        anyhow::bail!("openvmm exited with {status} before pidfile was created");
+                    }
+                    _ => {
+                        return Err(e).context("failed to read pidfile");
+                    }
+                }
+            }
+        };
+        assert_eq!(
+            pid_content,
+            format!("{}\n", child.get().id()),
+            "pidfile should contain the child PID"
+        );
+
         // Reserve a free host TCP port to forward. The listener is dropped
         // immediately; consomme rebinds the same port number when the forward
         // is configured.
@@ -626,6 +649,12 @@ fn test_ttrpc_consomme_port_forward(
         assert!(
             exit_status.success(),
             "openvmm exited abnormally: {exit_status:?}"
+        );
+
+        // Verify the pidfile was cleaned up on exit.
+        assert!(
+            !pidfile_path.exists(),
+            "pidfile should be removed after exit"
         );
 
         Ok(())


### PR DESCRIPTION
Currently, consomme control messages are only dequeued/handled when the backend is being polled for network packets. If a guest stops driving the NIC for packets, RPC requests are never completed. 

This PR moves the handling of RPC requests from the hot path of packet processing and onto the endpoint's `wait_for_endpoint_action` function which both netvsp and virtio-net poll for. 