### PR TITLE
vmbus_server: send CloseReservedChannelResponse when disconnected

### DIFF
--- a/vm/devices/vmbus/vmbus_server/src/channels.rs
+++ b/vm/devices/vmbus/vmbus_server/src/channels.rs
@@ -2070,14 +2070,19 @@ impl<'a, N: 'a + Notifier> ServerWithNotifier<'a, N> {
                 ..
             } => {
                 channel.state = ChannelState::Closed;
-                if matches!(self.inner.state, ConnectionState::Connected { .. }) {
-                    let channel_id = channel.info.expect("assigned").channel_id;
-                    self.send_close_reserved_channel_response(
-                        channel_id,
-                        offer_id,
-                        reserved_state.target,
-                    );
-                } else {
+                let channel_id = channel.info.expect("assigned").channel_id;
+                // Always send the close response to the reserved channel's
+                // requested target, even while disconnected/ing. Reserved
+                // channels are independent of the connection state.
+                self.send_close_reserved_channel_response(
+                    channel_id,
+                    offer_id,
+                    reserved_state.target,
+                );
+
+                if !matches!(self.inner.state, ConnectionState::Connected { .. }) {
+                    // Re-borrow the channel after the &mut self call above.
+                    let channel = &mut self.inner.channels[offer_id];
                     // Handle closing reserved channels while disconnected/ing. Since we weren't waiting
                     // on the channel, no need to call check_disconnected, but we do need to release it.
                     if Self::client_release_channel(

--- a/vm/devices/vmbus/vmbus_server/src/channels/tests.rs
+++ b/vm/devices/vmbus/vmbus_server/src/channels/tests.rs
@@ -1713,7 +1713,8 @@ fn test_reserved_channel_close_response_after_unload() {
     env.gpadl(1, 10);
     env.c().gpadl_create_complete(offer_id1, GpadlId(10), 0);
 
-    env.open_reserved(1, 1, VMBUS_SINT.into());
+    const RESERVED_SINT: u32 = 5;
+    env.open_reserved(1, 1, RESERVED_SINT);
     env.c().open_complete(offer_id1, 0);
 
     // Unload while the reserved channel is still open.
@@ -1723,7 +1724,7 @@ fn test_reserved_channel_close_response_after_unload() {
     env.notifier.messages.clear();
 
     // Close the reserved channel while disconnected and complete the close.
-    env.close_reserved(1, 4, VMBUS_SINT.into());
+    env.close_reserved(1, 4, RESERVED_SINT);
     env.c().close_complete(offer_id1);
 
     // A CloseReservedChannelResponse should still be sent to the reserved
@@ -1736,7 +1737,7 @@ fn test_reserved_channel_close_response_after_unload() {
             offer_id1,
             ConnectionTarget {
                 vp: 4,
-                sint: VMBUS_SINT,
+                sint: RESERVED_SINT as u8,
             },
         ),
     );

--- a/vm/devices/vmbus/vmbus_server/src/channels/tests.rs
+++ b/vm/devices/vmbus/vmbus_server/src/channels/tests.rs
@@ -1698,6 +1698,50 @@ fn test_reserved_channels() {
     assert!(env.notifier.is_reset());
 }
 
+// Reserved channels are supposed to remain usable across unload. A close that
+// completes while the connection is disconnected must still deliver a
+// CloseReservedChannelResponse to the originally requested target.
+#[test]
+fn test_reserved_channel_close_response_after_unload() {
+    let mut env = TestEnv::new();
+
+    let offer_id1 = env.offer(1);
+
+    env.connect(Version::Win10, FeatureFlags::new());
+    env.c().handle_request_offers().unwrap();
+
+    env.gpadl(1, 10);
+    env.c().gpadl_create_complete(offer_id1, GpadlId(10), 0);
+
+    env.open_reserved(1, 1, VMBUS_SINT.into());
+    env.c().open_complete(offer_id1, 0);
+
+    // Unload while the reserved channel is still open.
+    env.c().handle_unload();
+    env.complete_reset();
+
+    env.notifier.messages.clear();
+
+    // Close the reserved channel while disconnected and complete the close.
+    env.close_reserved(1, 4, VMBUS_SINT.into());
+    env.c().close_complete(offer_id1);
+
+    // A CloseReservedChannelResponse should still be sent to the reserved
+    // channel's requested target, even though the connection is disconnected.
+    env.notifier.check_message_with_target(
+        OutgoingMessage::new(&protocol::CloseReservedChannelResponse {
+            channel_id: ChannelId(1),
+        }),
+        MessageTarget::ReservedChannel(
+            offer_id1,
+            ConnectionTarget {
+                vp: 4,
+                sint: VMBUS_SINT,
+            },
+        ),
+    );
+}
+
 #[test]
 fn test_disconnected_reset() {
     let mut env = TestEnv::new();


### PR DESCRIPTION
Reserved channels are independent of the VMBus connection state, which means that the `CloseReservedChannelResponse` message should be sent in response to `CloseReservedChannel` regardless of whether VMBus is still connected or not. However, this was only done when connected. This change fixes this and ensures the message is always sent to the target specified in the close message.