### PR TITLE
kernel upgrade: Update OpenHCL to use v6.18.0.7

### DIFF
--- a/flowey/flowey_lib_hvlite/src/_jobs/cfg_versions.rs
+++ b/flowey/flowey_lib_hvlite/src/_jobs/cfg_versions.rs
@@ -30,8 +30,8 @@ pub const NODEJS: &str = "24.x";
 // N.B. Kernel version numbers for dev and stable branches are not directly
 //      comparable. They originate from separate branches, and the fourth digit
 //      increases with each release from the respective branch.
-pub const OPENHCL_KERNEL_DEV_VERSION: &str = "6.18.0.6";
-pub const OPENHCL_KERNEL_STABLE_VERSION: &str = "6.18.0.6";
+pub const OPENHCL_KERNEL_DEV_VERSION: &str = "6.18.0.7";
+pub const OPENHCL_KERNEL_STABLE_VERSION: &str = "6.18.0.7";
 pub const OPENVMM_DEPS: &str = "0.3.0-101";
 pub const PROTOC: &str = "27.1";
 

--- a/nix/openhcl_kernel.nix
+++ b/nix/openhcl_kernel.nix
@@ -1,7 +1,7 @@
 { system, stdenv, fetchzip, targetArch ? null, is_dev ? false, is_cvm ? false }:
 
 let
-  version = if is_dev then "6.18.0.6" else "6.18.0.6";
+  version = if is_dev then "6.18.0.7" else "6.18.0.7";
   # Allow explicit override of architecture, otherwise derive from host system
   # Note: targetArch uses "x86_64"/"aarch64", but URLs use "x64"/"arm64"
   arch = if targetArch == "x86_64" then "x64"
@@ -18,21 +18,21 @@ let
   hashes = {
     hcl-main = {
       std = {
-        x64 = "sha256-j2ED/aSHpqQ0LFMUf0DS9Vhb/PfOoaUq0I6pt1ALIBo=";
-        arm64 = "sha256-NG4Lsf8EXiWh2h9vFjxQvtiuPOGrWxNcHfbcUxrDmBk=";
+        x64 = "sha256-OPgJGihkrdJtoZhOdRRct55exP2HY8qepUuQqnmZdKQ=";
+        arm64 = "sha256-s49kGBGhDY3muXA6FjjztoNXjfzOdtEXnHR4LLnqY+c=";
       };
       cvm = {
-        x64 = "sha256-NJE1O56L0NWmPswGz7Po2vG8E5ifR8/uT+zTB0gz5iI=";
+        x64 = "sha256-/T7D4lcl30q3GNsbZ1XdGlLxfdrlzUeJ8k3vA40xa1k=";
         arm64 = throw "openhcl-kernel: cvm arm64 variant not available";
       };
     };
     hcl-dev = {
       std = {
-        x64 = "sha256-+gGo/niYk5OUX7LuNEJAv+IVh8l6GbOghWe9sXmzJZ0=";
-        arm64 = "sha256-2te4dN1yasAQ+L/E9/RjaTOzn/uwOy0VvjHoTpLqLhQ=";
+        x64 = "sha256-PUqcTMu52LCQzemRJLaf2xcpyTuA0EHIzXHqzmSq+2A=";
+        arm64 = "sha256-B/rTpIr9ZbBbxhCt9vdoz5K01rN0bZ9E6/P4q2nrxNo=";
       };
       cvm = {
-        x64 = "sha256-GAWE3Il9aZH0rTvrYh4s5BCD07MjKuuLTi1XeAG1LBc=";
+        x64 = "sha256-L+VF1NdQhzTU1T8K8NPP66XIJeKrj15oEw0eQjpzRpg=";
         arm64 = throw "openhcl-kernel: dev cvm arm64 variant not available";
       };
     };


### PR DESCRIPTION
Upgrade kernel used in OpenHCL to 6.18.0.7 release tag.
This picks up a fix for the management VTL environment failing to negotiate protocol versions on ARM64 (UnderhillSvcTest AH2024 repros).

Kernel PRs:
https://github.com/microsoft/OHCL-Linux-Kernel/pull/146
Bug: https://microsoft.visualstudio.com/OS/_workitems/edit/62728487