### PR TITLE
pice: Downgrade a noisy trace

### DIFF
--- a/vm/devices/pci/pcie/src/root.rs
+++ b/vm/devices/pci/pcie/src/root.rs
@@ -664,7 +664,7 @@ impl MmioIntercept for GenericPcieRootComplex {
                 tracelimit::warn_ratelimited!(addr, "unexpected intercept at ECAM address");
             }
             DecodedEcamAccess::Unroutable => {
-                tracing::debug!(addr, "unroutable config space access");
+                tracing::trace!(addr, "unroutable config space access");
             }
             DecodedEcamAccess::InternalBus(port, cfg_offset) => {
                 check_result!(port.port.cfg_space.read_u32(cfg_offset, &mut dword_value));
@@ -739,7 +739,7 @@ impl MmioIntercept for GenericPcieRootComplex {
                 tracelimit::warn_ratelimited!(addr, "unexpected intercept at ECAM address");
             }
             DecodedEcamAccess::Unroutable => {
-                tracing::debug!(addr, "unroutable config space access");
+                tracing::trace!(addr, "unroutable config space access");
             }
             DecodedEcamAccess::InternalBus(port, cfg_offset) => {
                 check_result!(port.port.cfg_space.write_u32(cfg_offset, write_dword));


### PR DESCRIPTION
This tracing statement gets hit constantly during OS boot, as guests like to scan the entirety of a config space. Downgrade it to trace so it doesn't fill up test logs.

<img width="684" height="1160" alt="image" src="https://github.com/user-attachments/assets/bad400c3-58fd-4ee6-b846-bf94795ff813" />
