### PR TITLE
Guide: Recommend modern versions of clang/lld

### DIFF
--- a/Guide/src/dev_guide/getting_started/cross_compile.md
+++ b/Guide/src/dev_guide/getting_started/cross_compile.md
@@ -26,20 +26,20 @@ Additional build tools must be installed as well. If your distro has LLVM 14
 available (Ubuntu 22.04 or newer):
 
 ```bash
-sudo apt install clang-tools-14 lld-14 llvm-dev
+sudo apt install clang-tools lld llvm-dev
 ```
 
 Otherwise, follow the steps at <https://apt.llvm.org/> to install a specific
 version, by adding the correct apt repos. Note that you must install
-`clang-tools-14` as default `clang-14` uses gcc style arguments, where
-`clang-cl-14` uses msvc style arguments. You can use their helper script as
+`clang-tools` as default `clang` uses gcc style arguments, where
+`clang-cl` uses msvc style arguments. You can use their helper script as
 well:
 
 ```bash
 wget https://apt.llvm.org/llvm.sh
 chmod +x llvm.sh
-sudo ./llvm.sh 14
-sudo apt install clang-tools-14
+sudo ./llvm.sh
+sudo apt install clang-tools
 ```
 
 ## Setting up the terminal environment

--- a/Guide/src/dev_guide/tests/vmm.md
+++ b/Guide/src/dev_guide/tests/vmm.md
@@ -198,7 +198,7 @@ And, for further example, to rebuild everything* and run all* the tests
 rustup target add x86_64-unknown-none
 rustup target add x86_64-unknown-uefi
 rustup target add x86_64-pc-windows-msvc
-sudo apt install clang-tools-14 lld-14
+sudo apt install clang-tools lld
 
 cargo install cargo-nextest --locked
 

--- a/build_support/setup_windows_cross.sh
+++ b/build_support/setup_windows_cross.sh
@@ -5,7 +5,7 @@
 # Validate that a tool is present.
 function check_cross_tool {
     if ! command -v "$1" >/dev/null 2>/dev/null; then
-        >&2 echo "missing $1 - Try 'sudo apt install clang-tools-14 lld-14 llvm-dev' or check the guide."
+        >&2 echo "missing $1 - Try 'sudo apt install clang-tools lld llvm-dev' or check the guide."
         false
     fi
 }


### PR DESCRIPTION
Ubuntu 26.04 dropped support for llvm-14 packages. The thing is, we were only recommending that version because, at the time this section was written, the default version of these packages was too old. That is no longer the case, so just recommend whatever modern version is distro-default.