### PR TITLE
nvme: fused keepalive

### DIFF
--- a/openhcl/openhcl_boot/src/cmdline.rs
+++ b/openhcl/openhcl_boot/src/cmdline.rs
@@ -132,7 +132,7 @@ impl BootCommandLineOptions {
             confidential_debug: false,
             enable_vtl2_gpa_pool: Vtl2GpaPoolConfig::Heuristics(Vtl2GpaPoolLookupTable::Release), // use the release config by default
             sidecar: SidecarOptions::default(),
-            disable_nvme_keep_alive: true,
+            disable_nvme_keep_alive: false,
             vtl2_gpa_pool_numa_split: false,
         }
     }
@@ -141,9 +141,6 @@ impl BootCommandLineOptions {
 impl BootCommandLineOptions {
     /// Parse arguments from a command line.
     pub fn parse(&mut self, cmdline: &str) {
-        // Workaround for a host side issue: disable NVMe keepalive by default.
-        self.disable_nvme_keep_alive = true;
-
         let mut override_vtl2_gpa_pool: Option<Vtl2GpaPoolConfig> = None;
         for arg in cmdline.split_whitespace() {
             if arg.starts_with(OPENHCL_CONFIDENTIAL_DEBUG_ENV_VAR_NAME) {
@@ -186,8 +183,8 @@ impl BootCommandLineOptions {
                 }
             } else if arg.starts_with(DISABLE_NVME_KEEP_ALIVE) {
                 let arg = arg.split_once('=').map(|(_, arg)| arg);
-                if arg.is_some_and(|a| a == "0") {
-                    self.disable_nvme_keep_alive = false;
+                if arg.is_some_and(|a| a != "0") {
+                    self.disable_nvme_keep_alive = true;
                 }
             } else if arg.starts_with(VTL2_GPA_POOL_NUMA) {
                 if let Some((_, arg)) = arg.split_once('=') {

--- a/openhcl/underhill_core/src/nvme_manager/device.rs
+++ b/openhcl/underhill_core/src/nvme_manager/device.rs
@@ -304,7 +304,11 @@ impl VfioNvmeDriverSpawner {
             is_isolated,
             fused_keepalive_device,
         )
-        .instrument(tracing::info_span!("nvme_driver_new", pci_id))
+        .instrument(tracing::info_span!(
+            "nvme_driver_new",
+            pci_id,
+            fused_keepalive_device
+        ))
         .await
         .map_err(NvmeSpawnerError::DeviceInitFailed)
     }

--- a/openhcl/underhill_core/src/nvme_manager/device.rs
+++ b/openhcl/underhill_core/src/nvme_manager/device.rs
@@ -509,7 +509,7 @@ struct NvmeDriverManagerWorker {
     /// Whether the running environment (specifically the VTL2 memory layout) allows save/restore.
     save_restore_supported: bool,
     /// WORKAROUND: a subset of devices require "fused keepalive". This flag signals to the NVMe
-    /// driver that this devices' admin queues may be unusable after a servicing event
+    /// driver that this device's admin queues may be unusable after a servicing event
     fused_keepalive_device: bool,
     #[inspect(skip)]
     nvme_driver_spawner: Arc<dyn CreateNvmeDriver>,

--- a/openhcl/underhill_core/src/nvme_manager/device.rs
+++ b/openhcl/underhill_core/src/nvme_manager/device.rs
@@ -82,6 +82,7 @@ impl CreateNvmeDriver for VfioNvmeDriverSpawner {
         pci_id: &str,
         vp_count: u32,
         save_restore_supported: bool,
+        fused_keepalive_device: bool,
         mut saved_state: Option<&NvmeDriverSavedState>,
     ) -> Result<Box<dyn NvmeDevice>, NvmeSpawnerError> {
         // Gracefully tear down old state & reset device if a saved state is
@@ -175,6 +176,7 @@ impl CreateNvmeDriver for VfioNvmeDriverSpawner {
                 vfio_device,
                 saved_state,
                 self.is_isolated,
+                fused_keepalive_device,
             )
             .instrument(tracing::info_span!("nvme_driver_restore"))
             .await
@@ -186,6 +188,7 @@ impl CreateNvmeDriver for VfioNvmeDriverSpawner {
                 vp_count,
                 self.nvme_always_flr,
                 self.is_isolated,
+                fused_keepalive_device,
                 dma_clients,
             )
             .await?
@@ -224,6 +227,7 @@ impl VfioNvmeDriverSpawner {
         vp_count: u32,
         nvme_always_flr: bool,
         is_isolated: bool,
+        fused_keepalive_device: bool,
         dma_clients: VfioDmaClients,
     ) -> Result<nvme_driver::NvmeDriver<VfioDevice>, NvmeSpawnerError> {
         let mut last_err = None;
@@ -243,6 +247,7 @@ impl VfioNvmeDriverSpawner {
                 pci_id,
                 vp_count,
                 is_isolated,
+                fused_keepalive_device,
                 dma_clients.clone(),
             )
             .await
@@ -280,6 +285,7 @@ impl VfioNvmeDriverSpawner {
         pci_id: &str,
         vp_count: u32,
         is_isolated: bool,
+        fused_keepalive_device: bool,
         dma_clients: VfioDmaClients,
     ) -> Result<nvme_driver::NvmeDriver<VfioDevice>, NvmeSpawnerError> {
         let device = VfioDevice::new(driver_source, pci_id, dma_clients)
@@ -291,10 +297,16 @@ impl VfioNvmeDriverSpawner {
         // TODO: For now, any isolation means use bounce buffering. This
         // needs to change when we have nvme devices that support DMA to
         // confidential memory.
-        nvme_driver::NvmeDriver::new(driver_source, vp_count, device, is_isolated)
-            .instrument(tracing::info_span!("nvme_driver_new", pci_id))
-            .await
-            .map_err(NvmeSpawnerError::DeviceInitFailed)
+        nvme_driver::NvmeDriver::new(
+            driver_source,
+            vp_count,
+            device,
+            is_isolated,
+            fused_keepalive_device,
+        )
+        .instrument(tracing::info_span!("nvme_driver_new", pci_id))
+        .await
+        .map_err(NvmeSpawnerError::DeviceInitFailed)
     }
 
     fn try_update_reset_method(pci_id: &str, method: PciDeviceResetMethod, label: &str) {
@@ -334,7 +346,6 @@ enum NvmeDriverRequest {
 pub struct NvmeDriverManager {
     task: Task<()>,
     pci_id: String,
-    keepalive_compatible: bool,
     client: NvmeDriverManagerClient,
 }
 
@@ -359,18 +370,13 @@ impl NvmeDriverManager {
         &self.client
     }
 
-    /// Returns whether the underlying device is compatible with NVMe keepalive.
-    pub fn keepalive_compatible(&self) -> bool {
-        self.keepalive_compatible
-    }
-
     /// Creates the [`NvmeDriverManager`].
     pub fn new(
         driver_source: &VmTaskDriverSource,
         pci_id: &str,
         vp_count: u32,
         save_restore_supported: bool,
-        keepalive_compatible: bool,
+        fused_keepalive_device: bool,
         device: Option<Box<dyn NvmeDevice>>,
         nvme_driver_spawner: Arc<dyn CreateNvmeDriver>,
     ) -> anyhow::Result<Self> {
@@ -382,6 +388,7 @@ impl NvmeDriverManager {
             pci_id: pci_id.into(),
             vp_count,
             save_restore_supported,
+            fused_keepalive_device,
             driver: device,
             nvme_driver_spawner,
         };
@@ -389,7 +396,6 @@ impl NvmeDriverManager {
         Ok(Self {
             task,
             pci_id: pci_id.into(),
-            keepalive_compatible,
             client: NvmeDriverManagerClient {
                 pci_id: pci_id.into(),
                 sender: send,
@@ -502,6 +508,9 @@ struct NvmeDriverManagerWorker {
     vp_count: u32,
     /// Whether the running environment (specifically the VTL2 memory layout) allows save/restore.
     save_restore_supported: bool,
+    /// WORKAROUND: a subset of devices require "fused keepalive". This flag signals to the NVMe
+    /// driver that this devices' admin queues may be unusable after a servicing event
+    fused_keepalive_device: bool,
     #[inspect(skip)]
     nvme_driver_spawner: Arc<dyn CreateNvmeDriver>,
     driver: Option<Box<dyn NvmeDevice>>,
@@ -536,6 +545,7 @@ impl NvmeDriverManagerWorker {
                                     &self.pci_id,
                                     self.vp_count,
                                     self.save_restore_supported,
+                                    self.fused_keepalive_device,
                                     None,
                                 )
                                 .await?;

--- a/openhcl/underhill_core/src/nvme_manager/manager.rs
+++ b/openhcl/underhill_core/src/nvme_manager/manager.rs
@@ -5,7 +5,7 @@ use crate::nvme_manager::CreateNvmeDriver;
 use crate::nvme_manager::device::NvmeDriverManager;
 use crate::nvme_manager::device::NvmeDriverManagerClient;
 use crate::nvme_manager::device::NvmeDriverShutdownOptions;
-use crate::nvme_manager::is_nvme_keepalive_compatible;
+use crate::nvme_manager::is_nvme_fused_keepalive_device;
 use crate::nvme_manager::save_restore::NvmeManagerSavedState;
 use crate::nvme_manager::save_restore::NvmeSavedDiskConfig;
 use crate::servicing::NvmeSavedState;
@@ -302,17 +302,12 @@ impl NvmeManagerWorker {
 
         async {
             join_all(devices_to_shutdown.into_iter().map(|(pci_id, driver)| {
-                let keepalive_compatible = driver.keepalive_compatible();
                 driver
                     .shutdown(NvmeDriverShutdownOptions {
                         // nvme_keepalive is received from host but it is only valid
                         // when memory pool allocator supports save/restore.
-                        do_not_reset: nvme_keepalive
-                            && self.context.save_restore_supported
-                            && keepalive_compatible,
-                        skip_device_shutdown: nvme_keepalive
-                            && self.context.save_restore_supported
-                            && keepalive_compatible,
+                        do_not_reset: nvme_keepalive && self.context.save_restore_supported,
+                        skip_device_shutdown: nvme_keepalive && self.context.save_restore_supported,
                     })
                     .instrument(tracing::info_span!("shutdown_nvme_driver", %pci_id))
             }))
@@ -344,7 +339,7 @@ impl NvmeManagerWorker {
         // Note: `client` exists outside of the devices write lock. This is safe:
         // the mesh client will fail appropriately if shutdown comes in between inserting
         // this entry and the call to `load_driver()`.
-        let keepalive_compatible = is_nvme_keepalive_compatible(&pci_id);
+        let fused_keepalive_device = is_nvme_fused_keepalive_device(&pci_id);
         let client = {
             let mut guard = context.devices.write();
 
@@ -366,8 +361,8 @@ impl NvmeManagerWorker {
                             &context.driver_source,
                             &pci_id,
                             context.vp_count,
-                            context.save_restore_supported && keepalive_compatible,
-                            keepalive_compatible,
+                            context.save_restore_supported,
+                            fused_keepalive_device,
                             None, // No device yet,
                             context.nvme_driver_spawner.clone(),
                         )?;
@@ -427,24 +422,12 @@ impl NvmeManagerWorker {
     /// Saves NVMe device's states into buffer during servicing.
     pub async fn save(&mut self) -> anyhow::Result<NvmeManagerSavedState> {
         let mut nvme_disks: Vec<NvmeSavedDiskConfig> = Vec::new();
-        // Only save state for devices known to be keepalive-compatible.
         let mut devices_to_save: HashMap<String, NvmeDriverManagerClient> = self
             .context
             .devices
             .write()
             .iter()
-            .filter_map(|(pci_id, driver)| {
-                if driver.keepalive_compatible() {
-                    Some((pci_id.clone(), driver.client().clone()))
-                } else {
-                    tracing::info!(
-                        %pci_id,
-                        "skipping save of nvme device; \
-                         keepalive disabled for this device"
-                    );
-                    None
-                }
-            })
+            .map(|(pci_id, driver)| (pci_id.clone(), driver.client().clone()))
             .collect();
         for (pci_id, client) in devices_to_save.iter_mut() {
             nvme_disks.push(NvmeSavedDiskConfig {
@@ -469,13 +452,7 @@ impl NvmeManagerWorker {
 
         for disk in &saved_state.nvme_disks {
             let pci_id = disk.pci_id.clone();
-
-            // Read the PCI vendor/device IDs once and cache the resulting
-            // keepalive compatibility flag on the `NvmeDriverManager`. We
-            // cannot rely on saved state to determine keepalive compatibility
-            // because previous versions might save devices that are no longer
-            // considered keepalive compatible.
-            let keepalive_compatible = is_nvme_keepalive_compatible(&pci_id);
+            let fused_keepalive_device = is_nvme_fused_keepalive_device(&pci_id);
 
             let nvme_driver = self
                 .context
@@ -484,7 +461,8 @@ impl NvmeManagerWorker {
                     &self.context.driver_source,
                     &pci_id,
                     saved_state.cpu_count,
-                    save_restore_supported && keepalive_compatible,
+                    save_restore_supported,
+                    fused_keepalive_device,
                     Some(&disk.driver_state),
                 )
                 .await?;
@@ -495,8 +473,8 @@ impl NvmeManagerWorker {
                     &self.context.driver_source,
                     &pci_id,
                     self.context.vp_count,
-                    keepalive_compatible, // save_restore support is no longer guaranteed
-                    keepalive_compatible,
+                    save_restore_supported,
+                    fused_keepalive_device,
                     Some(nvme_driver),
                     self.context.nvme_driver_spawner.clone(),
                 )?,
@@ -777,6 +755,7 @@ mod tests {
             pci_id: &str,
             _vp_count: u32,
             _save_restore_supported: bool,
+            _fused_keepalive_device: bool,
             _saved_state: Option<&NvmeDriverSavedState>,
         ) -> Result<Box<dyn NvmeDevice>, NvmeSpawnerError> {
             if self.fail_create.load(Ordering::SeqCst) {

--- a/openhcl/underhill_core/src/nvme_manager/manager.rs
+++ b/openhcl/underhill_core/src/nvme_manager/manager.rs
@@ -15,6 +15,7 @@ use disk_backend::resolve::ResolveDiskParameters;
 use disk_backend::resolve::ResolvedDisk;
 use futures::StreamExt;
 use futures::future::join_all;
+use futures::future::try_join_all;
 use inspect::Inspect;
 use mesh::MeshPayload;
 use mesh::rpc::Rpc;
@@ -448,27 +449,33 @@ impl NvmeManagerWorker {
         saved_state: &NvmeManagerSavedState,
         save_restore_supported: bool,
     ) -> anyhow::Result<()> {
-        let mut restored_devices: HashMap<String, NvmeDriverManager> = HashMap::new();
-
-        for disk in &saved_state.nvme_disks {
+        let context = &self.context;
+        let created = try_join_all(saved_state.nvme_disks.iter().map(|disk| {
             let pci_id = disk.pci_id.clone();
-            let fused_keepalive_device = is_nvme_fused_keepalive_device(&pci_id);
+            async move {
+                let fused_keepalive_device = is_nvme_fused_keepalive_device(&pci_id);
 
-            let nvme_driver = self
-                .context
-                .nvme_driver_spawner
-                .create_driver(
-                    &self.context.driver_source,
-                    &pci_id,
-                    saved_state.cpu_count,
-                    save_restore_supported,
-                    fused_keepalive_device,
-                    Some(&disk.driver_state),
-                )
-                .await?;
+                let nvme_driver = context
+                    .nvme_driver_spawner
+                    .create_driver(
+                        &context.driver_source,
+                        &pci_id,
+                        saved_state.cpu_count,
+                        save_restore_supported,
+                        fused_keepalive_device,
+                        Some(&disk.driver_state),
+                    )
+                    .await?;
 
+                anyhow::Ok((pci_id, fused_keepalive_device, nvme_driver))
+            }
+        }))
+        .await?;
+
+        let mut restored_devices: HashMap<String, NvmeDriverManager> = HashMap::new();
+        for (pci_id, fused_keepalive_device, nvme_driver) in created {
             restored_devices.insert(
-                disk.pci_id.clone(),
+                pci_id.clone(),
                 NvmeDriverManager::new(
                     &self.context.driver_source,
                     &pci_id,

--- a/openhcl/underhill_core/src/nvme_manager/mod.rs
+++ b/openhcl/underhill_core/src/nvme_manager/mod.rs
@@ -68,12 +68,12 @@ pub struct NamespaceError {
 }
 
 /// PCI vendor ID, as it appears in the sysfs `vendor` file (e.g. `0x0100`),
-/// for NVMe devices that are incompatible with keepalive.
-const KEEPALIVE_INCOMPATIBLE_VENDOR_ID: &str = "0x1414";
+/// for NVMe devices that require fused keepalive device mode.
+const FUSED_DEVICE_VENDOR_ID: &str = "0x1414";
 
 /// PCI device ID, as it appears in the sysfs `device` file (e.g. `0x0100`),
-/// for NVMe devices that are incompatible with keepalive.
-const KEEPALIVE_INCOMPATIBLE_DEVICE_ID: &str = "0xb111";
+/// for NVMe devices that require fused keepalive device mode.
+const FUSED_DEVICE_DEVICE_ID: &str = "0xb111";
 
 #[derive(Debug, Error)]
 pub enum NvmeSpawnerError {
@@ -116,22 +116,22 @@ pub trait CreateNvmeDriver: Inspect + Send + Sync {
         pci_id: &str,
         vp_count: u32,
         save_restore_supported: bool,
+        fused_keepalive_device: bool,
         saved_state: Option<&nvme_driver::save_restore::NvmeDriverSavedState>,
     ) -> Result<Box<dyn NvmeDevice>, NvmeSpawnerError>;
 }
 
-/// Returns whether the given PCI device is compatible with NVMe keepalive.
-pub(crate) fn is_nvme_keepalive_compatible(pci_id: &str) -> bool {
+/// Returns whether the given PCI device requires fused keepalive device mode
+pub(crate) fn is_nvme_fused_keepalive_device(pci_id: &str) -> bool {
     match read_pci_vendor_device_ids(pci_id) {
         Ok((vendor_id, device_id)) => {
-            vendor_id != KEEPALIVE_INCOMPATIBLE_VENDOR_ID
-                || device_id != KEEPALIVE_INCOMPATIBLE_DEVICE_ID
+            vendor_id == FUSED_DEVICE_VENDOR_ID && device_id == FUSED_DEVICE_DEVICE_ID
         }
         Err(err) => {
             tracing::warn!(
                 pci_id = %pci_id,
                 error = err.as_ref() as &dyn std::error::Error,
-                "failed to read PCI vendor/device IDs; treating device as not keepalive-compatible"
+                "failed to read PCI vendor/device IDs; treating device as not a fused keepalive device"
             );
             false
         }

--- a/openhcl/underhill_core/src/nvme_manager/mod.rs
+++ b/openhcl/underhill_core/src/nvme_manager/mod.rs
@@ -131,9 +131,9 @@ pub(crate) fn is_nvme_fused_keepalive_device(pci_id: &str) -> bool {
             tracing::warn!(
                 pci_id = %pci_id,
                 error = err.as_ref() as &dyn std::error::Error,
-                "failed to read PCI vendor/device IDs; treating device as not a fused keepalive device"
+                "failed to read PCI vendor/device IDs; treating device as a fused keepalive device"
             );
-            false
+            true
         }
     }
 }

--- a/openhcl/underhill_core/src/nvme_manager/save_restore_helpers.rs
+++ b/openhcl/underhill_core/src/nvme_manager/save_restore_helpers.rs
@@ -175,6 +175,7 @@ mod tests {
         IoQueueSavedState {
             cpu,
             iv: qid as u32,
+            unmapped: false,
             queue_data: QueuePairSavedState {
                 mem_len: 0,
                 base_pfn: 0,

--- a/vm/devices/storage/disk_nvme/nvme_driver/fuzz/fuzz_nvme_driver.rs
+++ b/vm/devices/storage/disk_nvme/nvme_driver/fuzz/fuzz_nvme_driver.rs
@@ -75,8 +75,15 @@ impl FuzzNvmeDriver {
             .unwrap();
 
         let device = FuzzEmulatedDevice::new(nvme, msi_conn, mem.dma_client());
-        let mut nvme_driver =
-            NvmeDriver::new(&driver_source, cpu_count, device, false, false).await?;
+        let fused_keepalive_device: bool = u.arbitrary()?;
+        let mut nvme_driver = NvmeDriver::new(
+            &driver_source,
+            cpu_count,
+            device,
+            false,
+            fused_keepalive_device,
+        )
+        .await?;
         let namespace = nvme_driver.namespace(1).await?;
 
         Ok(Self {

--- a/vm/devices/storage/disk_nvme/nvme_driver/fuzz/fuzz_nvme_driver.rs
+++ b/vm/devices/storage/disk_nvme/nvme_driver/fuzz/fuzz_nvme_driver.rs
@@ -75,7 +75,8 @@ impl FuzzNvmeDriver {
             .unwrap();
 
         let device = FuzzEmulatedDevice::new(nvme, msi_conn, mem.dma_client());
-        let mut nvme_driver = NvmeDriver::new(&driver_source, cpu_count, device, false).await?;
+        let mut nvme_driver =
+            NvmeDriver::new(&driver_source, cpu_count, device, false, false).await?;
         let namespace = nvme_driver.namespace(1).await?;
 
         Ok(Self {

--- a/vm/devices/storage/disk_nvme/nvme_driver/src/driver.rs
+++ b/vm/devices/storage/disk_nvme/nvme_driver/src/driver.rs
@@ -613,7 +613,7 @@ impl<D: DeviceBacking> NvmeDriver<D> {
                     .with_context(|| {
                         format!(
                             "failed to create io queue {} (fused keepalive device mode)",
-                            i
+                            i + 1
                         )
                     })?;
                 if i == 0 {
@@ -1502,6 +1502,15 @@ impl<D: DeviceBacking> DriverWorkerTask<D> {
         Ok(())
     }
 
+    fn fallback_io_issuer(&self, cpu: u32) -> (usize, IoIssuer) {
+        self.io_issuers.per_cpu[..cpu as usize]
+            .iter()
+            .enumerate()
+            .rev()
+            .find_map(|(i, issuer)| issuer.get().map(|issuer| (i, issuer.clone())))
+            .expect("there must be at least one io issuer for cpu 0")
+    }
+
     async fn create_io_issuer(&mut self, state: &mut WorkerState, cpu: u32) {
         tracing::debug!(cpu, pci_id = ?self.device.id(), "issuer request");
         if self.io_issuers.per_cpu[cpu as usize].get().is_some() {
@@ -1510,8 +1519,8 @@ impl<D: DeviceBacking> DriverWorkerTask<D> {
 
         // In fused keepalive device mode, claim an unmapped queue from the pool
         // and re-target its interrupt to the requesting CPU.
-        if let Some(io_queue) = self.io.iter_mut().find(|q| q.unmapped) {
-            let iv = io_queue.iv;
+        if let Some(idx) = self.io.iter().position(|q| q.unmapped) {
+            let iv = self.io[idx].iv;
             tracing::debug!(
                 cpu,
                 iv,
@@ -1520,6 +1529,7 @@ impl<D: DeviceBacking> DriverWorkerTask<D> {
             );
             match self.device.map_interrupt(iv.into(), cpu) {
                 Ok(_interrupt) => {
+                    let io_queue = &mut self.io[idx];
                     io_queue.cpu = cpu;
                     io_queue.unmapped = false;
                     let issuer = IoIssuer {
@@ -1528,20 +1538,24 @@ impl<D: DeviceBacking> DriverWorkerTask<D> {
                     };
                     self.io_issuers.per_cpu[cpu as usize]
                         .set(issuer)
-                        .ok()
-                        .unwrap();
-                    return;
+                        .expect("issuer already set for this cpu");
                 }
                 Err(err) => {
+                    let (fallback_cpu, fallback) = self.fallback_io_issuer(cpu);
                     tracing::error!(
                         cpu,
                         iv,
+                        fallback_cpu,
                         pci_id = ?self.device.id(),
-                        error = ?err,
-                        "fused mode: failed to remap interrupt, falling back"
+                        error = err.as_ref() as &dyn std::error::Error,
+                        "fused mode: failed to re-target interrupt, sharing an existing issuer"
                     );
+                    self.io_issuers.per_cpu[cpu as usize]
+                        .set(fallback)
+                        .expect("issuer already set for this cpu");
                 }
             }
+            return;
         }
 
         if let Some(proto) = self.proto_io.remove(&cpu) {
@@ -1574,12 +1588,7 @@ impl<D: DeviceBacking> DriverWorkerTask<D> {
             Ok(issuer) => issuer,
             Err(err) => {
                 // Find a fallback queue close in index to the failed queue.
-                let (fallback_cpu, fallback) = self.io_issuers.per_cpu[..cpu as usize]
-                    .iter()
-                    .enumerate()
-                    .rev()
-                    .find_map(|(i, issuer)| issuer.get().map(|issuer| (i, issuer)))
-                    .expect("unable to find an io issuer for fallback");
+                let (fallback_cpu, fallback) = self.fallback_io_issuer(cpu);
 
                 // Log the error as informational only when there is a lack of
                 // hardware resources from the device.
@@ -1604,14 +1613,13 @@ impl<D: DeviceBacking> DriverWorkerTask<D> {
                     }
                 }
 
-                fallback.clone()
+                fallback
             }
         };
 
         self.io_issuers.per_cpu[cpu as usize]
             .set(issuer)
-            .ok()
-            .unwrap();
+            .expect("issuer already set for this cpu");
 
         // Lazily clear the drain-after-restore builder once draining is done,
         // to free the shared Arc resources.
@@ -2020,8 +2028,7 @@ pub mod save_restore {
         #[mesh(3)]
         pub queue_data: QueuePairSavedState,
         #[mesh(4)]
-        /// When `true`, interrupt has not been affinitized to a real CPU yet.
-        /// Defaults to `false` for backwards compatibility with older versions.
+        /// When `true`, the queue has not yet been affinitized to its cpu.
         pub unmapped: bool,
     }
 

--- a/vm/devices/storage/disk_nvme/nvme_driver/src/driver.rs
+++ b/vm/devices/storage/disk_nvme/nvme_driver/src/driver.rs
@@ -585,7 +585,6 @@ impl<D: DeviceBacking> NvmeDriver<D> {
                 }
             }))
         } else {
-            tracing::info!("fused keepalive device mode: skipping async event handler");
             None
         };
 

--- a/vm/devices/storage/disk_nvme/nvme_driver/src/driver.rs
+++ b/vm/devices/storage/disk_nvme/nvme_driver/src/driver.rs
@@ -1966,7 +1966,7 @@ impl<D: DeviceBacking> DriverWorkerTask<D> {
             io,
             qsize: worker_state.qsize,
             max_io_queues: worker_state.max_io_queues,
-            allow_lazy_restore: Some(false), // For now, we always restore eagerly to work around device bugs.
+            allow_lazy_restore: Some(true),
         })
     }
 }

--- a/vm/devices/storage/disk_nvme/nvme_driver/src/driver.rs
+++ b/vm/devices/storage/disk_nvme/nvme_driver/src/driver.rs
@@ -601,6 +601,11 @@ impl<D: DeviceBacking> NvmeDriver<D> {
             // Pre-create IO queues for all CPUs, all targeting CPU 0 initially.
             // Interrupts will be lazily re-mapped when a CPU first does IO.
             let num_queues = max_io_queues.min(self.io_issuers.per_cpu.len() as u16);
+            tracing::info!(
+                num_queues,
+                pci_id = ?self.device_id,
+                "fused keepalive device mode: eagerly pre-creating all io queues"
+            );
             for i in 0..num_queues {
                 let issuer = worker
                     .create_io_queue(&mut state, 0)
@@ -618,11 +623,21 @@ impl<D: DeviceBacking> NvmeDriver<D> {
                     // Mark remaining queues as unmapped — they'll be claimed lazily.
                     let io_queue = worker.io.last_mut().unwrap();
                     io_queue.unmapped = true;
+                    // `issuer` is just an `Arc<Issuer>` clone; the owning queue pair
+                    // is kept alive in `worker.io`. `Issuer` has no `Drop` side
+                    // effects, so dropping this handle here does not tear down the
+                    // queue. A fresh handle is cloned from the queue pair when the
+                    // queue is later claimed by its owning CPU in `create_io_issuer`.
+                    drop(issuer);
                 }
             }
         } else {
             // Pre-create the IO queue 1 for CPU 0. The other queues will be created
             // lazily. Numbering for I/O queues starts with 1 (0 is Admin).
+            tracing::info!(
+                pci_id = ?self.device_id,
+                "pre-creating io queue 1 for cpu 0; remaining queues created lazily"
+            );
             let issuer = worker
                 .create_io_queue(&mut state, 0)
                 .await

--- a/vm/devices/storage/disk_nvme/nvme_driver/src/driver.rs
+++ b/vm/devices/storage/disk_nvme/nvme_driver/src/driver.rs
@@ -623,12 +623,6 @@ impl<D: DeviceBacking> NvmeDriver<D> {
                     // Mark remaining queues as unmapped — they'll be claimed lazily.
                     let io_queue = worker.io.last_mut().unwrap();
                     io_queue.unmapped = true;
-                    // `issuer` is just an `Arc<Issuer>` clone; the owning queue pair
-                    // is kept alive in `worker.io`. `Issuer` has no `Drop` side
-                    // effects, so dropping this handle here does not tear down the
-                    // queue. A fresh handle is cloned from the queue pair when the
-                    // queue is later claimed by its owning CPU in `create_io_issuer`.
-                    drop(issuer);
                 }
             }
         } else {

--- a/vm/devices/storage/disk_nvme/nvme_driver/src/driver.rs
+++ b/vm/devices/storage/disk_nvme/nvme_driver/src/driver.rs
@@ -612,8 +612,9 @@ impl<D: DeviceBacking> NvmeDriver<D> {
                     .await
                     .with_context(|| {
                         format!(
-                            "failed to create io queue {} (fused keepalive device mode)",
-                            i + 1
+                            "failed to create io queue {} for fused keepalive device {}",
+                            i + 1,
+                            self.device_id
                         )
                     })?;
                 if i == 0 {
@@ -938,6 +939,20 @@ impl<D: DeviceBacking> NvmeDriver<D> {
         // phantom completions written by the device during the keepalive window.
         if let Some(diag) = admin.issuer().request_diagnostic_dump().await {
             if diag.peek_phase_match {
+                if fused_keepalive_device {
+                    panic!(
+                        "admin CQ has a completion at head after restore for fused \
+                         keepalive device {pci_id}: phantom completion from keepalive \
+                         window (cq_head={}, expected_phase={}, peek_cid={}, peek_sqid={}, \
+                         peek_status={:#x}, pending_count={})",
+                        diag.head,
+                        diag.expected_phase,
+                        diag.peek_cid,
+                        diag.peek_sqid,
+                        diag.peek_status_raw,
+                        diag.pending_count,
+                    );
+                }
                 tracing::warn!(
                     ?pci_id,
                     cq_head = diag.head,
@@ -1496,7 +1511,9 @@ impl<D: DeviceBacking> DriverWorkerTask<D> {
 
         self.io_issuers.per_cpu[cpu as usize]
             .set(issuer)
-            .expect("issuer already set for this cpu");
+            .unwrap_or_else(|_| {
+                panic!("io issuer for device {pci_id} on cpu {cpu} was already set")
+            });
         self.io.push(queue);
 
         Ok(())
@@ -1508,7 +1525,13 @@ impl<D: DeviceBacking> DriverWorkerTask<D> {
             .enumerate()
             .rev()
             .find_map(|(i, issuer)| issuer.get().map(|issuer| (i, issuer.clone())))
-            .expect("there must be at least one io issuer for cpu 0")
+            .unwrap_or_else(|| {
+                panic!(
+                    "io issuer for device {:?} on cpu {} failed to fallback. there must be at least one io issuer for cpu 0",
+                    self.device.id(),
+                    cpu
+                )
+            })
     }
 
     async fn create_io_issuer(&mut self, state: &mut WorkerState, cpu: u32) {
@@ -1538,7 +1561,13 @@ impl<D: DeviceBacking> DriverWorkerTask<D> {
                     };
                     self.io_issuers.per_cpu[cpu as usize]
                         .set(issuer)
-                        .expect("issuer already set for this cpu");
+                        .unwrap_or_else(|_| {
+                            panic!(
+                                "io issuer for device {:?} on cpu {} was already set",
+                                self.device.id(),
+                                cpu
+                            )
+                        });
                 }
                 Err(err) => {
                     let (fallback_cpu, fallback) = self.fallback_io_issuer(cpu);
@@ -1552,7 +1581,13 @@ impl<D: DeviceBacking> DriverWorkerTask<D> {
                     );
                     self.io_issuers.per_cpu[cpu as usize]
                         .set(fallback)
-                        .expect("issuer already set for this cpu");
+                        .unwrap_or_else(|_| {
+                            panic!(
+                                "io issuer for device {:?} on cpu {} was already set",
+                                self.device.id(),
+                                cpu
+                            )
+                        });
                 }
             }
             return;
@@ -1619,7 +1654,13 @@ impl<D: DeviceBacking> DriverWorkerTask<D> {
 
         self.io_issuers.per_cpu[cpu as usize]
             .set(issuer)
-            .expect("issuer already set for this cpu");
+            .unwrap_or_else(|_| {
+                panic!(
+                    "io issuer for device {:?} on cpu {} was already set",
+                    self.device.id(),
+                    cpu
+                )
+            });
 
         // Lazily clear the drain-after-restore builder once draining is done,
         // to free the shared Arc resources.

--- a/vm/devices/storage/disk_nvme/nvme_driver/src/driver.rs
+++ b/vm/devices/storage/disk_nvme/nvme_driver/src/driver.rs
@@ -84,6 +84,10 @@ pub struct NvmeDriver<D: DeviceBacking> {
     /// Keeps the controller connected (CC.EN==1) while servicing.
     nvme_keepalive: bool,
     bounce_buffer: bool,
+    /// WORKAROUND: a subset of devices require "fused keepalive". When this flag is
+    /// set, the driver must be prepared to continue normally if admin queues become
+    /// unusable after a servicing event
+    fused_keepalive_device: bool,
 }
 
 /// A container that can hold either a weak or strong reference to a value.
@@ -158,7 +162,7 @@ struct WorkerState {
     max_io_queues: u16,
     qsize: u16,
     #[inspect(skip)]
-    async_event_task: Task<()>,
+    async_event_task: Option<Task<()>>,
 }
 
 /// An error restoring from saved state.
@@ -196,6 +200,10 @@ struct IoQueue<D: DeviceBacking> {
     queue: QueuePair<NoOpAerHandler, D>,
     iv: u16,
     cpu: u32,
+    /// WORKAROUND: for fused keepalive devices, we eagerly initialize
+    /// IO queues. However, we continue to wait for an IO before mapping
+    /// the interrupt to a CPU
+    unmapped: bool,
 }
 
 impl<D: DeviceBacking> IoQueue<D> {
@@ -204,6 +212,7 @@ impl<D: DeviceBacking> IoQueue<D> {
             cpu: self.cpu,
             iv: self.iv as u32,
             queue_data: self.queue.save().await?,
+            unmapped: self.unmapped,
         })
     }
 
@@ -221,6 +230,7 @@ impl<D: DeviceBacking> IoQueue<D> {
             cpu,
             iv,
             queue_data,
+            unmapped,
         } = saved_state;
         let queue = QueuePair::restore(
             spawner,
@@ -238,6 +248,7 @@ impl<D: DeviceBacking> IoQueue<D> {
             queue,
             iv: *iv as u16,
             cpu: *cpu,
+            unmapped: *unmapped,
         })
     }
 }
@@ -271,11 +282,18 @@ impl<D: DeviceBacking> NvmeDriver<D> {
         cpu_count: u32,
         device: D,
         bounce_buffer: bool,
+        fused_keepalive_device: bool,
     ) -> anyhow::Result<Self> {
         let pci_id = device.id().to_owned();
-        let mut this = Self::new_disabled(driver_source, cpu_count, device, bounce_buffer)
-            .instrument(tracing::info_span!("nvme_new_disabled", pci_id))
-            .await?;
+        let mut this = Self::new_disabled(
+            driver_source,
+            cpu_count,
+            device,
+            bounce_buffer,
+            fused_keepalive_device,
+        )
+        .instrument(tracing::info_span!("nvme_new_disabled", pci_id))
+        .await?;
         match this
             .enable(cpu_count as u16)
             .instrument(tracing::info_span!("nvme_enable", pci_id))
@@ -300,6 +318,7 @@ impl<D: DeviceBacking> NvmeDriver<D> {
         cpu_count: u32,
         mut device: D,
         bounce_buffer: bool,
+        fused_keepalive_device: bool,
     ) -> anyhow::Result<Self> {
         let driver = driver_source.simple();
         let bar0 = Bar0(
@@ -361,6 +380,7 @@ impl<D: DeviceBacking> NvmeDriver<D> {
             namespaces: Default::default(),
             nvme_keepalive: false,
             bounce_buffer,
+            fused_keepalive_device,
         })
     }
 
@@ -384,7 +404,13 @@ impl<D: DeviceBacking> NvmeDriver<D> {
             .map_interrupt(0, 0)
             .context("failed to map interrupt 0")?;
 
-        // Start the admin queue pair.
+        // Start the admin queue pair. For fused keepalive devices, disable AER
+        // since no admin commands may be issued after initialization.
+        let aer_handler = if self.fused_keepalive_device {
+            AdminAerHandler::new_disabled()
+        } else {
+            AdminAerHandler::new()
+        };
         let admin = QueuePair::new(
             self.driver.clone(),
             worker.device.deref(),
@@ -394,7 +420,7 @@ impl<D: DeviceBacking> NvmeDriver<D> {
             interrupt0,
             worker.registers.clone(),
             self.bounce_buffer,
-            AdminAerHandler::new(),
+            aer_handler,
             DrainAfterRestoreBuilder::new_no_drain(),
         )
         .context("failed to create admin queue pair")?;
@@ -544,18 +570,24 @@ impl<D: DeviceBacking> NvmeDriver<D> {
         };
 
         // Spawn a task to handle asynchronous events.
-        let async_event_task = self.driver.spawn("nvme_async_event", {
-            let admin = admin.issuer().clone();
-            let rescan_notifiers = self.rescan_notifiers.clone();
-            async move {
-                if let Err(err) = handle_asynchronous_events(&admin, rescan_notifiers).await {
-                    tracing::error!(
-                        error = err.as_ref() as &dyn std::error::Error,
-                        "asynchronous event failure, not processing any more"
-                    );
+        // When fused_keepalive_device is set, no commands are issued on the admin queue after init.
+        let async_event_task = if !self.fused_keepalive_device {
+            Some(self.driver.spawn("nvme_async_event", {
+                let admin = admin.issuer().clone();
+                let rescan_notifiers = self.rescan_notifiers.clone();
+                async move {
+                    if let Err(err) = handle_asynchronous_events(&admin, rescan_notifiers).await {
+                        tracing::error!(
+                            error = err.as_ref() as &dyn std::error::Error,
+                            "asynchronous event failure, not processing any more"
+                        );
+                    }
                 }
-            }
-        });
+            }))
+        } else {
+            tracing::info!("fused keepalive device mode: skipping async event handler");
+            None
+        };
 
         let mut state = WorkerState {
             qsize,
@@ -565,14 +597,39 @@ impl<D: DeviceBacking> NvmeDriver<D> {
 
         self.admin = Some(admin.issuer().clone());
 
-        // Pre-create the IO queue 1 for CPU 0. The other queues will be created
-        // lazily. Numbering for I/O queues starts with 1 (0 is Admin).
-        let issuer = worker
-            .create_io_queue(&mut state, 0)
-            .await
-            .context("failed to create io queue 1")?;
+        if self.fused_keepalive_device {
+            // Pre-create IO queues for all CPUs, all targeting CPU 0 initially.
+            // Interrupts will be lazily re-mapped when a CPU first does IO.
+            let num_queues = max_io_queues.min(self.io_issuers.per_cpu.len() as u16);
+            for i in 0..num_queues {
+                let issuer = worker
+                    .create_io_queue(&mut state, 0)
+                    .await
+                    .with_context(|| {
+                        format!(
+                            "failed to create io queue {} (fused keepalive device mode)",
+                            i
+                        )
+                    })?;
+                if i == 0 {
+                    // First queue is assigned to CPU 0 immediately.
+                    self.io_issuers.per_cpu[0].set(issuer).unwrap();
+                } else {
+                    // Mark remaining queues as unmapped — they'll be claimed lazily.
+                    let io_queue = worker.io.last_mut().unwrap();
+                    io_queue.unmapped = true;
+                }
+            }
+        } else {
+            // Pre-create the IO queue 1 for CPU 0. The other queues will be created
+            // lazily. Numbering for I/O queues starts with 1 (0 is Admin).
+            let issuer = worker
+                .create_io_queue(&mut state, 0)
+                .await
+                .context("failed to create io queue 1")?;
 
-        self.io_issuers.per_cpu[0].set(issuer).unwrap();
+            self.io_issuers.per_cpu[0].set(issuer).unwrap();
+        }
         task.insert(&self.driver, "nvme_worker", state);
         task.start();
         Ok(())
@@ -599,7 +656,9 @@ impl<D: DeviceBacking> NvmeDriver<D> {
             task.stop().await;
             let (worker, state) = task.into_inner();
             if let Some(state) = state {
-                state.async_event_task.cancel().await;
+                if let Some(aen_task) = state.async_event_task {
+                    aen_task.cancel().await;
+                }
             }
             // Hold onto responses until the reset completes so that waiting IOs do
             // not think the memory is unaliased by the device.
@@ -750,6 +809,7 @@ impl<D: DeviceBacking> NvmeDriver<D> {
         mut device: D,
         saved_state: &NvmeDriverSavedState,
         bounce_buffer: bool,
+        fused_keepalive_device: bool,
     ) -> anyhow::Result<Self> {
         let pci_id = device.id().to_owned();
         let driver = driver_source.simple();
@@ -806,6 +866,7 @@ impl<D: DeviceBacking> NvmeDriver<D> {
             namespaces: Default::default(),
             nvme_keepalive: true,
             bounce_buffer,
+            fused_keepalive_device,
         };
 
         let task = &mut this.task.as_mut().unwrap();
@@ -840,6 +901,13 @@ impl<D: DeviceBacking> NvmeDriver<D> {
                     .find(|mem| mem.len() == a.mem_len && a.base_pfn == mem.pfns()[0])
                     .expect("unable to find restored mem block")
                     .to_owned();
+                // For fused keepalive devices, disable AER on restore since no
+                // admin commands may be issued after the BAR may be remapped.
+                let aer_handler = if fused_keepalive_device {
+                    AdminAerHandler::new_disabled()
+                } else {
+                    AdminAerHandler::new()
+                };
                 QueuePair::restore(
                     driver.clone(),
                     interrupt0,
@@ -848,7 +916,7 @@ impl<D: DeviceBacking> NvmeDriver<D> {
                     &pci_id,
                     a,
                     bounce_buffer,
-                    AdminAerHandler::new(),
+                    aer_handler,
                     DrainAfterRestoreBuilder::new_no_drain(), // admin queue doesn't need draining
                 )
                 .expect("failed to restore admin queue pair")
@@ -884,21 +952,27 @@ impl<D: DeviceBacking> NvmeDriver<D> {
         }
 
         // Spawn a task to handle asynchronous events.
-        let async_event_task = this.driver.spawn("nvme_async_event", {
-            let admin = admin.issuer().clone();
-            let rescan_notifiers = this.rescan_notifiers.clone();
-            async move {
-                if let Err(err) = handle_asynchronous_events(&admin, rescan_notifiers)
-                    .instrument(tracing::info_span!("async_event_handler"))
-                    .await
-                {
-                    tracing::error!(
-                        error = err.as_ref() as &dyn std::error::Error,
-                        "asynchronous event failure, not processing any more"
-                    );
+        // When fused_keepalive_device is set, no commands are issued on the admin queue after init.
+        let async_event_task = if !fused_keepalive_device {
+            Some(this.driver.spawn("nvme_async_event", {
+                let admin = admin.issuer().clone();
+                let rescan_notifiers = this.rescan_notifiers.clone();
+                async move {
+                    if let Err(err) = handle_asynchronous_events(&admin, rescan_notifiers)
+                        .instrument(tracing::info_span!("async_event_handler"))
+                        .await
+                    {
+                        tracing::error!(
+                            error = err.as_ref() as &dyn std::error::Error,
+                            "asynchronous event failure, not processing any more"
+                        );
+                    }
                 }
-            }
-        });
+            }))
+        } else {
+            tracing::info!("fused keepalive device mode: skipping async event handler on restore");
+            None
+        };
 
         let state = WorkerState {
             qsize: saved_state.worker_data.qsize,
@@ -1048,11 +1122,20 @@ impl<D: DeviceBacking> NvmeDriver<D> {
                         },
                     )?;
                     tracing::info!(qid, cpu, ?pci_id, "restoring queue: create issuer");
-                    let issuer = IoIssuer {
-                        issuer: q.queue.issuer().clone(),
-                        cpu: q.cpu,
-                    };
-                    this.io_issuers.per_cpu[q.cpu as usize].set(issuer).unwrap();
+                    if !q.unmapped {
+                        let issuer = IoIssuer {
+                            issuer: q.queue.issuer().clone(),
+                            cpu: q.cpu,
+                        };
+                        this.io_issuers.per_cpu[q.cpu as usize].set(issuer).unwrap();
+                    } else {
+                        tracing::info!(
+                            qid,
+                            cpu,
+                            ?pci_id,
+                            "restoring unmapped queue into lazy pool"
+                        );
+                    }
                     Ok(q)
                 })
                 .collect();
@@ -1147,12 +1230,28 @@ impl<D: DeviceBacking> NvmeDriver<D> {
                             drain_after_restore_template.new_draining()
                         },
                     )?;
-                    tracing::info!(qid, cpu, ?pci_id, "restoring queue: create issuer");
-                    let issuer = IoIssuer {
-                        issuer: q.queue.issuer().clone(),
-                        cpu: q.cpu,
-                    };
-                    this.io_issuers.per_cpu[q.cpu as usize].set(issuer).unwrap();
+                    tracing::info!(
+                        qid,
+                        cpu,
+                        iv = q.iv,
+                        ?pci_id,
+                        "restoring queue: create issuer"
+                    );
+                    if !q.unmapped {
+                        let issuer = IoIssuer {
+                            issuer: q.queue.issuer().clone(),
+                            cpu: q.cpu,
+                        };
+                        this.io_issuers.per_cpu[q.cpu as usize].set(issuer).unwrap();
+                    } else {
+                        tracing::info!(
+                            qid,
+                            cpu,
+                            iv = q.iv,
+                            ?pci_id,
+                            "restoring unmapped queue into lazy pool"
+                        );
+                    }
                     Ok(q)
                 })
                 .collect();
@@ -1400,6 +1499,42 @@ impl<D: DeviceBacking> DriverWorkerTask<D> {
             return;
         }
 
+        // In fused keepalive device mode, claim an unmapped queue from the pool
+        // and re-target its interrupt to the requesting CPU.
+        if let Some(io_queue) = self.io.iter_mut().find(|q| q.unmapped) {
+            let iv = io_queue.iv;
+            tracing::debug!(
+                cpu,
+                iv,
+                pci_id = ?self.device.id(),
+                "fused mode: claiming unmapped queue"
+            );
+            match self.device.map_interrupt(iv.into(), cpu) {
+                Ok(_interrupt) => {
+                    io_queue.cpu = cpu;
+                    io_queue.unmapped = false;
+                    let issuer = IoIssuer {
+                        issuer: io_queue.queue.issuer().clone(),
+                        cpu,
+                    };
+                    self.io_issuers.per_cpu[cpu as usize]
+                        .set(issuer)
+                        .ok()
+                        .unwrap();
+                    return;
+                }
+                Err(err) => {
+                    tracing::error!(
+                        cpu,
+                        iv,
+                        pci_id = ?self.device.id(),
+                        error = ?err,
+                        "fused mode: failed to remap interrupt, falling back"
+                    );
+                }
+            }
+        }
+
         if let Some(proto) = self.proto_io.remove(&cpu) {
             match self.restore_io_issuer(proto) {
                 Ok(()) => return,
@@ -1539,7 +1674,12 @@ impl<D: DeviceBacking> DriverWorkerTask<D> {
 
         // Add the queue pair before aliasing its memory with the device so
         // that it can be torn down correctly on failure.
-        let io_queue = self.io.push_mut(IoQueue { queue, iv, cpu });
+        let io_queue = self.io.push_mut(IoQueue {
+            queue,
+            iv,
+            cpu,
+            unmapped: false,
+        });
 
         let admin = self.admin.as_ref().unwrap().issuer().as_ref();
         let pci_id_str = self.device.id().to_owned();
@@ -1870,6 +2010,10 @@ pub mod save_restore {
         pub iv: u32,
         #[mesh(3)]
         pub queue_data: QueuePairSavedState,
+        #[mesh(4)]
+        /// When `true`, interrupt has not been affinitized to a real CPU yet.
+        /// Defaults to `false` for backwards compatibility with older versions.
+        pub unmapped: bool,
     }
 
     /// Save/restore state for QueueHandler task.

--- a/vm/devices/storage/disk_nvme/nvme_driver/src/driver.rs
+++ b/vm/devices/storage/disk_nvme/nvme_driver/src/driver.rs
@@ -242,6 +242,7 @@ impl<D: DeviceBacking> IoQueue<D> {
             bounce_buffer,
             NoOpAerHandler,
             drain_after_restore,
+            false,
         )?;
 
         Ok(Self {
@@ -422,6 +423,7 @@ impl<D: DeviceBacking> NvmeDriver<D> {
             self.bounce_buffer,
             aer_handler,
             DrainAfterRestoreBuilder::new_no_drain(),
+            false,
         )
         .context("failed to create admin queue pair")?;
 
@@ -927,6 +929,7 @@ impl<D: DeviceBacking> NvmeDriver<D> {
                     bounce_buffer,
                     aer_handler,
                     DrainAfterRestoreBuilder::new_no_drain(), // admin queue doesn't need draining
+                    fused_keepalive_device,
                 )
                 .expect("failed to restore admin queue pair")
             })
@@ -1720,6 +1723,7 @@ impl<D: DeviceBacking> DriverWorkerTask<D> {
             self.bounce_buffer,
             NoOpAerHandler,
             drain_after_restore,
+            false,
         )
         .map_err(|err| DeviceError::IoQueuePairCreationFailure(err, qid))?;
 

--- a/vm/devices/storage/disk_nvme/nvme_driver/src/queue_pair.rs
+++ b/vm/devices/storage/disk_nvme/nvme_driver/src/queue_pair.rs
@@ -93,11 +93,12 @@ impl PendingCommands {
     const MAX_CIDS: usize = 1 << Self::CID_KEY_BITS;
     const CID_SEQ_OFFSET: Wrapping<u16> = Wrapping(1 << Self::CID_KEY_BITS);
 
-    fn new(qid: u16) -> Self {
+    fn new(qid: u16, device_id: String) -> Self {
         Self {
             commands: Slab::new(),
             next_cid_high_bits: Wrapping(0),
             qid,
+            device_id,
         }
     }
 
@@ -132,7 +133,12 @@ impl PendingCommands {
         let command = self
             .commands
             .try_remove((cid & Self::CID_KEY_MASK) as usize)
-            .unwrap_or_else(|| panic!("completion for unknown cid: qid={}, cid={}", self.qid, cid));
+            .unwrap_or_else(|| {
+                panic!(
+                    "completion for unknown cid {cid} on qid {} for device {}",
+                    self.qid, self.device_id
+                )
+            });
         assert_eq!(
             command.command.cdw0.cid(),
             cid,
@@ -161,7 +167,11 @@ impl PendingCommands {
     }
 
     /// Restore pending commands from the saved state.
-    pub fn restore(saved_state: &PendingCommandsSavedState, qid: u16) -> anyhow::Result<Self> {
+    pub fn restore(
+        saved_state: &PendingCommandsSavedState,
+        qid: u16,
+        device_id: String,
+    ) -> anyhow::Result<Self> {
         let PendingCommandsSavedState {
             commands,
             next_cid_high_bits,
@@ -188,6 +198,7 @@ impl PendingCommands {
                 .collect::<Slab<PendingCommand>>(),
             next_cid_high_bits: Wrapping(*next_cid_high_bits),
             qid,
+            device_id,
         })
     }
 }
@@ -508,7 +519,7 @@ impl<A: AerHandler, D: DeviceBacking> QueuePair<A, D> {
                 QueueHandler {
                     sq: SubmissionQueue::new(qid, sq_entries, sq_mem_block),
                     cq: CompletionQueue::new(qid, cq_entries, cq_mem_block),
-                    commands: PendingCommands::new(qid),
+                    commands: PendingCommands::new(qid, device_id.into()),
                     stats: Default::default(),
                     drain_after_restore,
                     aer_handler,
@@ -947,6 +958,8 @@ struct PendingCommands {
     #[inspect(hex)]
     next_cid_high_bits: Wrapping<u16>,
     qid: u16,
+    #[inspect(skip)]
+    device_id: String,
 }
 
 #[derive(Inspect)]
@@ -1376,7 +1389,7 @@ impl<A: AerHandler> QueueHandler<A> {
         Ok(Self {
             sq: SubmissionQueue::restore(sq_mem_block, sq_state)?,
             cq: CompletionQueue::restore(cq_mem_block, cq_state)?,
-            commands: PendingCommands::restore(pending_cmds, sq_state.sqid)?,
+            commands: PendingCommands::restore(pending_cmds, sq_state.sqid, device_id.into())?,
             stats: Default::default(),
             // Only drain pending commands for I/O queues.
             // Admin queue is expected to have pending Async Event requests.

--- a/vm/devices/storage/disk_nvme/nvme_driver/src/queue_pair.rs
+++ b/vm/devices/storage/disk_nvme/nvme_driver/src/queue_pair.rs
@@ -404,6 +404,7 @@ impl<A: AerHandler, D: DeviceBacking> QueuePair<A, D> {
         bounce_buffer: bool,
         aer_handler: A,
         drain_after_restore: DrainAfterRestore,
+        commands_forbidden: bool,
     ) -> anyhow::Result<Self> {
         // FUTURE: Consider splitting this into several allocations, rather than
         // allocating the sum total together. This can increase the likelihood
@@ -439,6 +440,7 @@ impl<A: AerHandler, D: DeviceBacking> QueuePair<A, D> {
             bounce_buffer,
             aer_handler,
             drain_after_restore,
+            commands_forbidden,
         )
     }
 
@@ -455,6 +457,7 @@ impl<A: AerHandler, D: DeviceBacking> QueuePair<A, D> {
         bounce_buffer: bool,
         aer_handler: A,
         drain_after_restore: DrainAfterRestore,
+        commands_forbidden: bool,
     ) -> anyhow::Result<Self> {
         // MemoryBlock is either allocated or restored prior calling here.
         let sq_mem_block = mem.subblock(0, SQ_SIZE);
@@ -513,6 +516,7 @@ impl<A: AerHandler, D: DeviceBacking> QueuePair<A, D> {
                 device_id,
                 qid,
                 drain_after_restore,
+                commands_forbidden,
             )?,
             None => {
                 // Create a new one.
@@ -525,6 +529,7 @@ impl<A: AerHandler, D: DeviceBacking> QueuePair<A, D> {
                     aer_handler,
                     device_id: device_id.into(),
                     qid,
+                    commands_forbidden,
                 }
             }
         };
@@ -642,6 +647,7 @@ impl<A: AerHandler, D: DeviceBacking> QueuePair<A, D> {
         bounce_buffer: bool,
         aer_handler: A,
         drain_after_restore: DrainAfterRestore,
+        commands_forbidden: bool,
     ) -> anyhow::Result<Self> {
         let QueuePairSavedState {
             mem_len: _,  // Used to restore DMA buffer before calling this.
@@ -665,6 +671,7 @@ impl<A: AerHandler, D: DeviceBacking> QueuePair<A, D> {
             bounce_buffer,
             aer_handler,
             drain_after_restore,
+            commands_forbidden,
         )
     }
 }
@@ -1178,6 +1185,7 @@ struct QueueHandler<A: AerHandler> {
     aer_handler: A,
     device_id: String,
     qid: u16,
+    commands_forbidden: bool,
 }
 
 #[derive(Inspect, Default)]
@@ -1300,6 +1308,12 @@ impl<A: AerHandler> QueueHandler<A> {
                 },
                 Event::Command(cmd) => match cmd {
                     Cmd::Command(rpc) => {
+                        if self.commands_forbidden {
+                            panic!(
+                                "attempted to submit a command to admin queue {} for device {} after restore; the admin queue must remain idle for fused keepalive devices",
+                                self.qid, self.device_id
+                            );
+                        }
                         let (mut command, respond) = rpc.split();
                         self.commands.insert(&mut command, respond);
                         self.sq.write(command).unwrap();
@@ -1376,6 +1390,7 @@ impl<A: AerHandler> QueueHandler<A> {
         device_id: &str,
         qid: u16,
         drain_after_restore: DrainAfterRestore,
+        commands_forbidden: bool,
     ) -> anyhow::Result<Self> {
         let QueueHandlerSavedState {
             sq_state,
@@ -1397,6 +1412,7 @@ impl<A: AerHandler> QueueHandler<A> {
             aer_handler,
             device_id: device_id.into(),
             qid,
+            commands_forbidden,
         })
     }
 }

--- a/vm/devices/storage/disk_nvme/nvme_driver/src/queue_pair.rs
+++ b/vm/devices/storage/disk_nvme/nvme_driver/src/queue_pair.rs
@@ -1035,6 +1035,9 @@ pub struct AdminAerHandler {
     await_aen_cid: Option<u16>,
     send_aen: Option<Rpc<(), Result<AsynchronousEventRequestDw0, RequestError>>>, // Channel to return AENs on.
     failed_status: Option<spec::Status>, // If the failed state is reached, it will stop looping until save/restore.
+    /// When true, no AER commands will be issued. Used for fused keepalive
+    /// devices where admin commands must never be issued after initialization.
+    disabled: bool,
 }
 
 impl AdminAerHandler {
@@ -1044,6 +1047,19 @@ impl AdminAerHandler {
             await_aen_cid: None,
             send_aen: None,
             failed_status: None,
+            disabled: false,
+        }
+    }
+
+    /// Creates a handler that never issues AER commands. Used for fused
+    /// keepalive devices where the admin queue must remain idle after init.
+    pub fn new_disabled() -> Self {
+        Self {
+            last_aen: None,
+            await_aen_cid: None,
+            send_aen: None,
+            failed_status: None,
+            disabled: true,
         }
     }
 }
@@ -1090,7 +1106,7 @@ impl AerHandler for AdminAerHandler {
     }
 
     fn poll_send_aer(&self) -> bool {
-        self.await_aen_cid.is_none() && self.failed_status.is_none()
+        !self.disabled && self.await_aen_cid.is_none() && self.failed_status.is_none()
     }
 
     fn update_awaiting_cid(&mut self, cid: u16) {

--- a/vm/devices/storage/disk_nvme/nvme_driver/src/tests.rs
+++ b/vm/devices/storage/disk_nvme/nvme_driver/src/tests.rs
@@ -243,7 +243,7 @@ async fn test_nvme_ioqueue_max_mqes(driver: DefaultDriver) {
     let cap: Cap = Cap::new().with_mqes_z(max_u16);
     device.set_mock_response_u64(Some((0, cap.into())));
 
-    let driver = NvmeDriver::new(&driver_source, CPU_COUNT, device, false).await;
+    let driver = NvmeDriver::new(&driver_source, CPU_COUNT, device, false, false).await;
     assert!(driver.is_ok());
 }
 
@@ -278,7 +278,7 @@ async fn test_nvme_ioqueue_invalid_mqes(driver: DefaultDriver) {
     // Setup mock response at offset 0
     let cap: Cap = Cap::new().with_mqes_z(0);
     device.set_mock_response_u64(Some((0, cap.into())));
-    let driver = NvmeDriver::new(&driver_source, CPU_COUNT, device, false).await;
+    let driver = NvmeDriver::new(&driver_source, CPU_COUNT, device, false, false).await;
 
     assert!(driver.is_err());
 }
@@ -337,12 +337,12 @@ async fn test_nvme_driver(driver: DefaultDriver, config: NvmeTestConfig) {
 
     if fail_at_driver_create {
         fail_alloc.store(true, Ordering::SeqCst);
-        let driver_result = NvmeDriver::new(&driver_source, CPU_COUNT, device, false).await;
+        let driver_result = NvmeDriver::new(&driver_source, CPU_COUNT, device, false, false).await;
         assert!(driver_result.is_err());
         return;
     }
 
-    let mut driver = NvmeDriver::new(&driver_source, CPU_COUNT, device, false)
+    let mut driver = NvmeDriver::new(&driver_source, CPU_COUNT, device, false, false)
         .await
         .unwrap();
     let namespace = driver.namespace(1).await.unwrap();
@@ -486,7 +486,7 @@ async fn test_nvme_fault_injection(driver: DefaultDriver, fault_configuration: F
         .await
         .unwrap();
     let device = NvmeTestEmulatedDevice::new(nvme, msi_conn, dma_client.clone());
-    let mut driver = NvmeDriver::new(&driver_source, CPU_COUNT, device, false)
+    let mut driver = NvmeDriver::new(&driver_source, CPU_COUNT, device, false, false)
         .await
         .unwrap();
     let namespace = driver.namespace(1).await.unwrap();

--- a/vm/devices/storage/storage_tests/tests/scsidvd_nvme.rs
+++ b/vm/devices/storage/storage_tests/tests/scsidvd_nvme.rs
@@ -82,7 +82,7 @@ impl ScsiDvdNvmeTest {
             .unwrap();
 
         let device = EmulatedDevice::new(nvme, msi_conn, dma_client.clone());
-        let mut nvme_driver = NvmeDriver::new(&driver_source, CPU_COUNT, device, false)
+        let mut nvme_driver = NvmeDriver::new(&driver_source, CPU_COUNT, device, false, false)
             .await
             .unwrap();
         let namespace = nvme_driver.namespace(1).await.unwrap();

--- a/vmm_tests/vmm_tests/tests/tests/multiarch/openhcl_servicing.rs
+++ b/vmm_tests/vmm_tests/tests/tests/multiarch/openhcl_servicing.rs
@@ -1319,177 +1319,190 @@ async fn servicing_keepalive_slow_create_io_queue_with_inspect(
     Ok(())
 }
 
-/// Verifies NVMe fused keepalive device mode for devices with VendorID=0x1414, DeviceID=0xb111.
-///
-/// Two NVMe controllers are attached to a single VM:
-/// * A normal controller. Standard keepalive is honored — its controller is
-///   not reset across servicing, so `CREATE_IO_COMPLETION_QUEUE` must NOT be
-///   issued after servicing. The fault panics if the opcode is observed.
-/// * A fused keepalive device controller with VendorID = 0x1414 and DeviceID = 0xb111. The test
-///   forces this path via the hardware-config fault override. In fused keepalive device mode,
-///   all IO queues are pre-created at init and keepalive is still honored, so
-///   `CREATE_IO_COMPLETION_QUEUE` must NOT be issued after servicing either.
-///
-/// Keepalive is enabled VM-wide; both devices should preserve their controller
-/// state across servicing with no admin queue commands post-restore.
-#[openvmm_test(openhcl_linux_direct_x64 [LATEST_LINUX_DIRECT_TEST_X64])]
-async fn servicing_keepalive_fused_device(
+/// Boots a frontpage OpenHCL VM with two VTL2 NVMe -> VTL0 SCSI relays: one
+/// controller forced into fused keepalive mode (VendorID=0x1414/DeviceID=0xb111)
+/// and one normal controller. Verifies the fused device eagerly pre-creates its
+/// IO queues at init while the normal device creates them lazily.
+#[openvmm_test(openhcl_linux_direct_x64)]
+async fn nvme_fused_keepalive_enablement(
     config: PetriVmBuilder<OpenVmmPetriBackend>,
-    (igvm_file,): (ResolvedArtifact<impl petri_artifacts_common::tags::IsOpenhclIgvm>,),
 ) -> Result<(), anyhow::Error> {
-    let mut flags = config.default_servicing_flags();
-    flags.enable_nvme_keepalive = true;
+    const VP_COUNT: u32 = 4;
+    const MSIX_COUNT: u16 = 10;
+    const MAX_IO_QUEUES: u16 = 10;
 
-    const NORMAL_NVME_INSTANCE: Guid = guid::guid!("00000000-c05b-0000-0000-000000000001");
-    const FUSED_NVME_INSTANCE: Guid = guid::guid!("dce4ebad-182f-46c0-8d30-8446c1c62ab3");
+    const FUSED_INSTANCE: Guid = guid::guid!("dce4ebad-182f-46c0-8d30-8446c1c62ab3");
+    const NORMAL_INSTANCE: Guid = guid::guid!("00000000-c05b-0000-0000-000000000001");
+    const FUSED_NSID: u32 = KEEPALIVE_VTL2_NSID;
+    const NORMAL_NSID: u32 = KEEPALIVE_VTL2_NSID + 1;
+    const FUSED_LUN: u32 = VTL0_NVME_LUN;
+    const NORMAL_LUN: u32 = VTL0_NVME_LUN + 1;
 
-    const NORMAL_NSID: u32 = KEEPALIVE_VTL2_NSID;
-    const FUSED_NSID: u32 = KEEPALIVE_VTL2_NSID + 1;
-    const NORMAL_LUN: u32 = VTL0_NVME_LUN;
-    const FUSED_LUN: u32 = VTL0_NVME_LUN + 1;
+    let eager_count = (VP_COUNT as usize).min(MAX_IO_QUEUES as usize);
 
-    // Two independent fault start cells — one per device.
-    let mut normal_fault_updater = CellUpdater::new(false);
-    let mut fused_fault_updater = CellUpdater::new(false);
-
-    // Normal device: keepalive must be honored — fail loudly if any
-    // CREATE_IO_COMPLETION_QUEUE is observed after the fault is armed.
-    let normal_fault_config = FaultConfiguration::new(normal_fault_updater.cell())
-        .with_admin_queue_fault(
-            AdminQueueFaultConfig::new().with_submission_queue_fault(
-                CommandMatchBuilder::new()
-                    .match_cdw0_opcode(nvme_spec::AdminOpcode::CREATE_IO_COMPLETION_QUEUE.0)
-                    .build(),
-                AdminQueueFaultBehavior::Panic(
-                    "normal device received CREATE_IO_COMPLETION_QUEUE after servicing — \
-                     keepalive should have been honored for this device but the controller \
-                     was reset."
-                        .to_string(),
-                ),
-            ),
-        );
-
-    // Fused device (0x1414/0xb111): keepalive must also be honored —
-    // fail loudly if CREATE_IO_COMPLETION_QUEUE is observed after the
-    // fault is armed. In fused keepalive device mode all IO queues are pre-created at init.
-    let fused_fault_config = FaultConfiguration::new(fused_fault_updater.cell())
-        .with_admin_queue_fault(
-            AdminQueueFaultConfig::new().with_submission_queue_fault(
-                CommandMatchBuilder::new()
-                    .match_cdw0_opcode(nvme_spec::AdminOpcode::CREATE_IO_COMPLETION_QUEUE.0)
-                    .build(),
-                AdminQueueFaultBehavior::Panic(
-                    "fused keepalive device received CREATE_IO_COMPLETION_QUEUE after servicing — \
-                     keepalive should have been honored for this device but the controller \
-                     was reset."
-                        .to_string(),
-                ),
-            ),
-        )
-        .with_hardware_config_fault(
+    let run_vm = async || -> Result<PetriVm<OpenVmmPetriBackend>, anyhow::Error> {
+        let mut fused_updater = CellUpdater::new(false);
+        // Spoof the vendor and device ID for a device that requires fused keepalive
+        let fused_fault = FaultConfiguration::new(fused_updater.cell()).with_hardware_config_fault(
             HardwareConfigFaultConfig::new()
                 .with_vendor_id(0x1414)
                 .with_device_id(0xb111),
         );
 
-    let scsi_instance = Guid::new_random();
+        let mut normal_updater = CellUpdater::new(false);
+        let normal_fault = FaultConfiguration::new(normal_updater.cell());
 
-    let (mut vm, agent) = config
-        .with_vmbus_redirect(true)
-        .with_openhcl_command_line(
-            "OPENHCL_ENABLE_VTL2_GPA_POOL=512 OPENHCL_DISABLE_NVME_KEEP_ALIVE=0",
-        )
-        .modify_backend(move |b| {
-            b.with_custom_config(move |c| {
-                c.vpci_devices.push(VpciDeviceConfig {
-                    vtl: DeviceVtl::Vtl2,
-                    instance_id: FUSED_NVME_INSTANCE,
-                    resource: NvmeFaultControllerHandle {
-                        subsystem_id: Guid::new_random(),
-                        msix_count: 10,
-                        max_io_queues: 10,
-                        namespaces: vec![NamespaceDefinition {
-                            nsid: FUSED_NSID,
-                            read_only: false,
-                            disk: LayeredDiskHandle::single_layer(RamDiskLayerHandle {
-                                len: Some(DEFAULT_DISK_SIZE),
-                                sector_size: None,
-                            })
-                            .into_resource(),
-                        }],
-                        fault_config: fused_fault_config,
-                        enable_tdisp_tests: false,
-                    }
+        let nvme_device = |instance_id, nsid, fault_config| VpciDeviceConfig {
+            vtl: DeviceVtl::Vtl2,
+            instance_id,
+            resource: NvmeFaultControllerHandle {
+                subsystem_id: Guid::new_random(),
+                msix_count: MSIX_COUNT,
+                max_io_queues: MAX_IO_QUEUES,
+                namespaces: vec![NamespaceDefinition {
+                    nsid,
+                    read_only: false,
+                    disk: LayeredDiskHandle::single_layer(RamDiskLayerHandle {
+                        len: Some(DEFAULT_DISK_SIZE),
+                        sector_size: None,
+                    })
                     .into_resource(),
-                    vnode: None,
-                });
-                c.vpci_devices.push(VpciDeviceConfig {
-                    vtl: DeviceVtl::Vtl2,
-                    instance_id: NORMAL_NVME_INSTANCE,
-                    resource: NvmeFaultControllerHandle {
-                        subsystem_id: Guid::new_random(),
-                        msix_count: 10,
-                        max_io_queues: 10,
-                        namespaces: vec![NamespaceDefinition {
-                            nsid: NORMAL_NSID,
-                            read_only: false,
-                            disk: LayeredDiskHandle::single_layer(RamDiskLayerHandle {
-                                len: Some(DEFAULT_DISK_SIZE),
-                                sector_size: None,
-                            })
-                            .into_resource(),
-                        }],
-                        fault_config: normal_fault_config,
-                        enable_tdisp_tests: false,
-                    }
-                    .into_resource(),
-                    vnode: None,
-                });
+                }],
+                fault_config,
+                enable_tdisp_tests: false,
+            }
+            .into_resource(),
+            vnode: None,
+        };
+
+        let scsi_instance = Guid::new_random();
+
+        config
+            .with_vmbus_redirect(true)
+            .with_openhcl_command_line(
+                "OPENHCL_ENABLE_VTL2_GPA_POOL=512 OPENHCL_DISABLE_NVME_KEEP_ALIVE=0",
+            )
+            .with_processor_topology(ProcessorTopology {
+                vp_count: VP_COUNT,
+                ..Default::default()
             })
-        })
-        .add_vtl2_storage_controller(
-            Vtl2StorageControllerBuilder::new(ControllerType::Scsi)
-                .with_instance_id(scsi_instance)
-                .add_lun(
-                    Vtl2LunBuilder::disk()
-                        .with_location(FUSED_LUN)
-                        .with_physical_device(Vtl2StorageBackingDeviceBuilder::new(
-                            ControllerType::Nvme,
-                            FUSED_NVME_INSTANCE,
-                            FUSED_NSID,
-                        )),
-                )
-                .add_lun(
-                    Vtl2LunBuilder::disk()
-                        .with_location(NORMAL_LUN)
-                        .with_physical_device(Vtl2StorageBackingDeviceBuilder::new(
-                            ControllerType::Nvme,
-                            NORMAL_NVME_INSTANCE,
-                            NORMAL_NSID,
-                        )),
-                )
-                .build(),
-        )
-        .run()
-        .await?;
+            .modify_backend(move |b| {
+                b.with_custom_config(move |c| {
+                    c.vpci_devices
+                        .push(nvme_device(FUSED_INSTANCE, FUSED_NSID, fused_fault));
+                    c.vpci_devices
+                        .push(nvme_device(NORMAL_INSTANCE, NORMAL_NSID, normal_fault));
+                })
+            })
+            .add_vtl2_storage_controller(
+                Vtl2StorageControllerBuilder::new(ControllerType::Scsi)
+                    .with_instance_id(scsi_instance)
+                    .add_lun(
+                        Vtl2LunBuilder::disk()
+                            .with_location(FUSED_LUN)
+                            .with_physical_device(Vtl2StorageBackingDeviceBuilder::new(
+                                ControllerType::Nvme,
+                                FUSED_INSTANCE,
+                                FUSED_NSID,
+                            )),
+                    )
+                    .add_lun(
+                        Vtl2LunBuilder::disk()
+                            .with_location(NORMAL_LUN)
+                            .with_physical_device(Vtl2StorageBackingDeviceBuilder::new(
+                                ControllerType::Nvme,
+                                NORMAL_INSTANCE,
+                                NORMAL_NSID,
+                            )),
+                    )
+                    .build(),
+            )
+            .run_without_agent()
+            .await
+    };
 
-    agent.ping().await?;
+    // Returns, per VTL2 NVMe device, its fused flag and the `unmapped` state of
+    // each IO queue ordered by queue index.
+    let inspect_devices =
+        async |vm: &PetriVm<OpenVmmPetriBackend>| -> Result<Vec<(bool, Vec<bool>)>, anyhow::Error> {
+            let devices = vm.inspect_openhcl("vm/nvme/devices", None, None).await?;
+            let devices: serde_json::Value = serde_json::from_str(&format!("{}", devices.json()))?;
+            let devices = devices
+                .as_object()
+                .expect("inspect path 'vm/nvme/devices' did not yield a JSON object");
 
-    // Arm both faults BEFORE servicing so that any post-servicing
-    // CREATE_IO_COMPLETION_QUEUE triggers the panic.
-    normal_fault_updater.set(true).await;
-    fused_fault_updater.set(true).await;
+            devices
+                .values()
+                .map(|device| {
+                    let driver = &device["driver"]["driver"];
+                    let fused = driver["fused_keepalive_device"]
+                        .as_bool()
+                        .expect("'driver.driver.fused_keepalive_device' is not a JSON bool");
+                    let io = driver["io"]
+                        .as_object()
+                        .expect("'driver.driver.io' is not a JSON object");
+                    let mut entries = io
+                        .iter()
+                        .map(|(key, value)| {
+                            let index = key.parse::<u32>()?;
+                            let unmapped = value["unmapped"].as_bool().ok_or_else(|| {
+                                anyhow::anyhow!("io queue '{key}' missing bool 'unmapped' field")
+                            })?;
+                            anyhow::Ok((index, unmapped))
+                        })
+                        .collect::<Result<Vec<_>, _>>()?;
+                    entries.sort_by_key(|(index, _)| *index);
+                    Ok((
+                        fused,
+                        entries.into_iter().map(|(_, unmapped)| unmapped).collect(),
+                    ))
+                })
+                .collect()
+        };
 
-    vm.restart_openhcl(igvm_file.clone(), flags).await?;
+    let vm = run_vm().await?;
+    let devices = inspect_devices(&vm).await?;
 
-    agent.ping().await?;
+    assert_eq!(devices.len(), 2, "expected two VTL2 NVMe devices");
 
-    // If either device had received CREATE_IO_COMPLETION_QUEUE, the
-    // panic fault would have crashed the VM and failed this test. We
-    // disarm the faults defensively before tearing down.
-    normal_fault_updater.set(false).await;
-    fused_fault_updater.set(false).await;
+    let (_, fused_io) = devices
+        .iter()
+        .find(|(fused, _)| *fused)
+        .expect("expected one device in fused keepalive mode");
+    let (_, normal_io) = devices
+        .iter()
+        .find(|(fused, _)| !*fused)
+        .expect("expected one device in normal (non-fused) mode");
 
+    assert_eq!(
+        fused_io.len(),
+        eager_count,
+        "fused keepalive device should eagerly pre-create min(max_io_queues, vp_count) = \
+         {eager_count} IO queues at init, but found {}",
+        fused_io.len()
+    );
+    assert!(
+        fused_io.iter().filter(|&&unmapped| unmapped).count() >= 1,
+        "fused keepalive device should have eagerly pre-created unmapped IO queues, \
+         but all {} queues were mapped",
+        fused_io.len()
+    );
+
+    assert!(
+        !normal_io.is_empty(),
+        "the normal NVMe driver should have come up with at least one IO queue"
+    );
+    assert_eq!(
+        normal_io.iter().filter(|&&unmapped| unmapped).count(),
+        0,
+        "a normal (non-fused) device must never eagerly pre-create unmapped IO queues"
+    );
+    assert!(
+        normal_io.len() < eager_count,
+        "a normal device creates IO queues lazily, so it should have fewer than the \
+         fused eager count ({eager_count}), but found {}",
+        normal_io.len()
+    );
     Ok(())
 }
 

--- a/vmm_tests/vmm_tests/tests/tests/multiarch/openhcl_servicing.rs
+++ b/vmm_tests/vmm_tests/tests/tests/multiarch/openhcl_servicing.rs
@@ -1319,53 +1319,49 @@ async fn servicing_keepalive_slow_create_io_queue_with_inspect(
     Ok(())
 }
 
-/// Verifies the per-device NVMe keepalive gate.
+/// Verifies NVMe fused keepalive device mode for devices with VendorID=0x1414, DeviceID=0xb111.
 ///
 /// Two NVMe controllers are attached to a single VM:
-/// * A keepalive-compatible controller. Keepalive must be honored for
-///   this device — its controller is not reset across servicing, so
-///   `CREATE_IO_COMPLETION_QUEUE` must NOT be issued after servicing.
-///   The fault panics if the opcode is observed.
-/// * A keepalive-incompatible controller with VendorID = 0x1414 and DeviceID =
-///   0xb111. The test forces this path via the hardware-config fault override
-///   used by the compatibility check. Keepalive must be downgraded to
-///   reset-on-servicing for this device, so `CREATE_IO_COMPLETION_QUEUE` must
-///   be issued around servicing.
+/// * A normal controller. Standard keepalive is honored — its controller is
+///   not reset across servicing, so `CREATE_IO_COMPLETION_QUEUE` must NOT be
+///   issued after servicing. The fault panics if the opcode is observed.
+/// * A fused keepalive device controller with VendorID = 0x1414 and DeviceID = 0xb111. The test
+///   forces this path via the hardware-config fault override. In fused keepalive device mode,
+///   all IO queues are pre-created at init and keepalive is still honored, so
+///   `CREATE_IO_COMPLETION_QUEUE` must NOT be issued after servicing either.
 ///
-/// Keepalive is enabled VM-wide; the gate is expected to apply per
-/// device based on its Vendor/Device IDs.
+/// Keepalive is enabled VM-wide; both devices should preserve their controller
+/// state across servicing with no admin queue commands post-restore.
 #[openvmm_test(openhcl_linux_direct_x64 [LATEST_LINUX_DIRECT_TEST_X64])]
-async fn servicing_keepalive_per_device_gate(
+async fn servicing_keepalive_fused_device(
     config: PetriVmBuilder<OpenVmmPetriBackend>,
     (igvm_file,): (ResolvedArtifact<impl petri_artifacts_common::tags::IsOpenhclIgvm>,),
 ) -> Result<(), anyhow::Error> {
     let mut flags = config.default_servicing_flags();
     flags.enable_nvme_keepalive = true;
 
-    const WITH_KEEPALIVE_NVME_INSTANCE: Guid = guid::guid!("00000000-c05b-0000-0000-000000000001");
-    const NO_KEEPALIVE_NVME_INSTANCE: Guid = guid::guid!("dce4ebad-182f-46c0-8d30-8446c1c62ab3");
+    const NORMAL_NVME_INSTANCE: Guid = guid::guid!("00000000-c05b-0000-0000-000000000001");
+    const FUSED_NVME_INSTANCE: Guid = guid::guid!("dce4ebad-182f-46c0-8d30-8446c1c62ab3");
 
-    const WITH_KEEPALIVE_NSID: u32 = KEEPALIVE_VTL2_NSID;
-    const NO_KEEPALIVE_NSID: u32 = KEEPALIVE_VTL2_NSID + 1;
-    const WITH_KEEPALIVE_LUN: u32 = VTL0_NVME_LUN;
-    const NO_KEEPALIVE_LUN: u32 = VTL0_NVME_LUN + 1;
+    const NORMAL_NSID: u32 = KEEPALIVE_VTL2_NSID;
+    const FUSED_NSID: u32 = KEEPALIVE_VTL2_NSID + 1;
+    const NORMAL_LUN: u32 = VTL0_NVME_LUN;
+    const FUSED_LUN: u32 = VTL0_NVME_LUN + 1;
 
     // Two independent fault start cells — one per device.
-    let mut with_keepalive_fault_updater = CellUpdater::new(false);
-    let mut no_keepalive_fault_updater = CellUpdater::new(false);
+    let mut normal_fault_updater = CellUpdater::new(false);
+    let mut fused_fault_updater = CellUpdater::new(false);
 
-    let (no_keepalive_create_seen_send, no_keepalive_create_seen_recv) = mesh::oneshot::<()>();
-
-    // c05b device: keepalive must be honored — fail loudly if any
+    // Normal device: keepalive must be honored — fail loudly if any
     // CREATE_IO_COMPLETION_QUEUE is observed after the fault is armed.
-    let with_keepalive_fault_config = FaultConfiguration::new(with_keepalive_fault_updater.cell())
+    let normal_fault_config = FaultConfiguration::new(normal_fault_updater.cell())
         .with_admin_queue_fault(
             AdminQueueFaultConfig::new().with_submission_queue_fault(
                 CommandMatchBuilder::new()
                     .match_cdw0_opcode(nvme_spec::AdminOpcode::CREATE_IO_COMPLETION_QUEUE.0)
                     .build(),
                 AdminQueueFaultBehavior::Panic(
-                    "c05b device received CREATE_IO_COMPLETION_QUEUE after servicing — \
+                    "normal device received CREATE_IO_COMPLETION_QUEUE after servicing — \
                      keepalive should have been honored for this device but the controller \
                      was reset."
                         .to_string(),
@@ -1373,15 +1369,21 @@ async fn servicing_keepalive_per_device_gate(
             ),
         );
 
-    // Non c05b device: keepalive must be downgraded —
-    // verify CREATE_IO_COMPLETION_QUEUE IS issued after servicing.
-    let no_keepalive_fault_config = FaultConfiguration::new(no_keepalive_fault_updater.cell())
+    // Fused device (0x1414/0xb111): keepalive must also be honored —
+    // fail loudly if CREATE_IO_COMPLETION_QUEUE is observed after the
+    // fault is armed. In fused keepalive device mode all IO queues are pre-created at init.
+    let fused_fault_config = FaultConfiguration::new(fused_fault_updater.cell())
         .with_admin_queue_fault(
             AdminQueueFaultConfig::new().with_submission_queue_fault(
                 CommandMatchBuilder::new()
                     .match_cdw0_opcode(nvme_spec::AdminOpcode::CREATE_IO_COMPLETION_QUEUE.0)
                     .build(),
-                AdminQueueFaultBehavior::Verify(Some(no_keepalive_create_seen_send)),
+                AdminQueueFaultBehavior::Panic(
+                    "fused keepalive device received CREATE_IO_COMPLETION_QUEUE after servicing — \
+                     keepalive should have been honored for this device but the controller \
+                     was reset."
+                        .to_string(),
+                ),
             ),
         )
         .with_hardware_config_fault(
@@ -1401,13 +1403,13 @@ async fn servicing_keepalive_per_device_gate(
             b.with_custom_config(move |c| {
                 c.vpci_devices.push(VpciDeviceConfig {
                     vtl: DeviceVtl::Vtl2,
-                    instance_id: NO_KEEPALIVE_NVME_INSTANCE,
+                    instance_id: FUSED_NVME_INSTANCE,
                     resource: NvmeFaultControllerHandle {
                         subsystem_id: Guid::new_random(),
                         msix_count: 10,
                         max_io_queues: 10,
                         namespaces: vec![NamespaceDefinition {
-                            nsid: NO_KEEPALIVE_NSID,
+                            nsid: FUSED_NSID,
                             read_only: false,
                             disk: LayeredDiskHandle::single_layer(RamDiskLayerHandle {
                                 len: Some(DEFAULT_DISK_SIZE),
@@ -1415,7 +1417,7 @@ async fn servicing_keepalive_per_device_gate(
                             })
                             .into_resource(),
                         }],
-                        fault_config: no_keepalive_fault_config,
+                        fault_config: fused_fault_config,
                         enable_tdisp_tests: false,
                     }
                     .into_resource(),
@@ -1423,13 +1425,13 @@ async fn servicing_keepalive_per_device_gate(
                 });
                 c.vpci_devices.push(VpciDeviceConfig {
                     vtl: DeviceVtl::Vtl2,
-                    instance_id: WITH_KEEPALIVE_NVME_INSTANCE,
+                    instance_id: NORMAL_NVME_INSTANCE,
                     resource: NvmeFaultControllerHandle {
                         subsystem_id: Guid::new_random(),
                         msix_count: 10,
                         max_io_queues: 10,
                         namespaces: vec![NamespaceDefinition {
-                            nsid: WITH_KEEPALIVE_NSID,
+                            nsid: NORMAL_NSID,
                             read_only: false,
                             disk: LayeredDiskHandle::single_layer(RamDiskLayerHandle {
                                 len: Some(DEFAULT_DISK_SIZE),
@@ -1437,7 +1439,7 @@ async fn servicing_keepalive_per_device_gate(
                             })
                             .into_resource(),
                         }],
-                        fault_config: with_keepalive_fault_config,
+                        fault_config: normal_fault_config,
                         enable_tdisp_tests: false,
                     }
                     .into_resource(),
@@ -1450,20 +1452,20 @@ async fn servicing_keepalive_per_device_gate(
                 .with_instance_id(scsi_instance)
                 .add_lun(
                     Vtl2LunBuilder::disk()
-                        .with_location(NO_KEEPALIVE_LUN)
+                        .with_location(FUSED_LUN)
                         .with_physical_device(Vtl2StorageBackingDeviceBuilder::new(
                             ControllerType::Nvme,
-                            NO_KEEPALIVE_NVME_INSTANCE,
-                            NO_KEEPALIVE_NSID,
+                            FUSED_NVME_INSTANCE,
+                            FUSED_NSID,
                         )),
                 )
                 .add_lun(
                     Vtl2LunBuilder::disk()
-                        .with_location(WITH_KEEPALIVE_LUN)
+                        .with_location(NORMAL_LUN)
                         .with_physical_device(Vtl2StorageBackingDeviceBuilder::new(
                             ControllerType::Nvme,
-                            WITH_KEEPALIVE_NVME_INSTANCE,
-                            WITH_KEEPALIVE_NSID,
+                            NORMAL_NVME_INSTANCE,
+                            NORMAL_NSID,
                         )),
                 )
                 .build(),
@@ -1473,33 +1475,20 @@ async fn servicing_keepalive_per_device_gate(
 
     agent.ping().await?;
 
-    // Arm both faults BEFORE servicing so that the post-servicing
-    // CREATE_IO_COMPLETION_QUEUE is what each fault matches.
-    with_keepalive_fault_updater.set(true).await;
-    no_keepalive_fault_updater.set(true).await;
+    // Arm both faults BEFORE servicing so that any post-servicing
+    // CREATE_IO_COMPLETION_QUEUE triggers the panic.
+    normal_fault_updater.set(true).await;
+    fused_fault_updater.set(true).await;
 
     vm.restart_openhcl(igvm_file.clone(), flags).await?;
 
     agent.ping().await?;
 
-    // The non-c05b device must issue CREATE_IO_COMPLETION_QUEUE after
-    // servicing because its keepalive was downgraded to reset.
-    CancelContext::new()
-        .with_timeout(Duration::from_secs(60))
-        .until_cancelled(no_keepalive_create_seen_recv)
-        .await
-        .expect(
-            "non-c05b NVMe device did not issue CREATE_IO_COMPLETION_QUEUE within 60s after \
-             servicing — the per-device keepalive gate did not downgrade keepalive for this \
-             device.",
-        )
-        .expect("CREATE_IO_COMPLETION_QUEUE verification on non-c05b device failed");
-
-    // If the c05b device had received CREATE_IO_COMPLETION_QUEUE, the
+    // If either device had received CREATE_IO_COMPLETION_QUEUE, the
     // panic fault would have crashed the VM and failed this test. We
     // disarm the faults defensively before tearing down.
-    with_keepalive_fault_updater.set(false).await;
-    no_keepalive_fault_updater.set(false).await;
+    normal_fault_updater.set(false).await;
+    fused_fault_updater.set(false).await;
 
     Ok(())
 }


### PR DESCRIPTION
A subset of nvme devices in Azure cannot expect the admin completion queue to be mapped after a servicing event. For those devices, we run in keepalive "fused" mode, where we will not issue any admin commands after nvme driver initialization is complete.

We achieve this by:
1. Eagerly initializing all IO queues.
2. Never issuing AERs