### PR TITLE
vmm_tests: add vTPM AK stability tests across reboot

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4705,7 +4705,7 @@ dependencies = [
 [[package]]
 name = "ms-tpm-20-ref"
 version = "0.0.0"
-source = "git+https://github.com/microsoft/ms-tpm-20-ref-rs.git?rev=07a121e4b46659cdfa8711740c6622728adffd65#07a121e4b46659cdfa8711740c6622728adffd65"
+source = "git+https://github.com/microsoft/ms-tpm-20-ref-rs.git?rev=9a24154df7b09cd1a0b90f25a7bf9cbb16e24c7d#9a24154df7b09cd1a0b90f25a7bf9cbb16e24c7d"
 dependencies = [
  "cc",
  "once_cell",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -527,7 +527,7 @@ constant_time_eq = "0.5"
 cms = { version = "0.3.0-pre.2", default-features = false }
 der = "0.8"
 getrandom = "0.4"
-ms-tpm-20-ref = { git = "https://github.com/microsoft/ms-tpm-20-ref-rs.git", rev = "07a121e4b46659cdfa8711740c6622728adffd65", default-features = false }
+ms-tpm-20-ref = { git = "https://github.com/microsoft/ms-tpm-20-ref-rs.git", rev = "9a24154df7b09cd1a0b90f25a7bf9cbb16e24c7d", default-features = false }
 openssl = "0.10.79"
 openssl-sys = "0.9"
 pkcs1 = "0.8.0-rc.4"

--- a/flowey/flowey_lib_hvlite/src/_jobs/cfg_versions.rs
+++ b/flowey/flowey_lib_hvlite/src/_jobs/cfg_versions.rs
@@ -32,7 +32,7 @@ pub const NODEJS: &str = "24.x";
 //      increases with each release from the respective branch.
 pub const OPENHCL_KERNEL_DEV_VERSION: &str = "6.18.0.7";
 pub const OPENHCL_KERNEL_STABLE_VERSION: &str = "6.18.0.7";
-pub const OPENVMM_DEPS: &str = "0.3.0-101";
+pub const OPENVMM_DEPS: &str = "0.3.0-110";
 pub const PROTOC: &str = "27.1";
 
 flowey_request! {

--- a/nix/openvmm_deps.nix
+++ b/nix/openvmm_deps.nix
@@ -6,17 +6,17 @@ let
          else if system == "aarch64-linux" then "aarch64"
          else "x86_64";
   hash = {
-    "aarch64" = "sha256-PQl0dupOVNnjllaAl+zwYL7sYXBUekoWDO5HnRwwUDo=";
-    "x86_64" = "sha256-0pHZ+W4dVXkk2VnDDbzrsO4m96dA79ZfRSmtT6bDkAc=";
+    "aarch64" = "sha256-ZawXPaBJcs7xwIJXBqmftNnjYSlHU2fs87ozwZu1P0w=";
+    "x86_64" = "sha256-vW0wl9jLM8BrwMvfLLb7UxNPO3jViRuR1onJWKtZrZs=";
   }.${arch};
 
 in stdenv.mkDerivation {
   pname = "openvmm-deps-${arch}";
-  version = "0.3.0-101";
+  version = "0.3.0-110";
 
   src = fetchzip {
     url =
-      "https://github.com/microsoft/openvmm-deps/releases/download/0.3.0-101/openvmm-deps.${arch}.0.3.0-101.tar.gz";
+      "https://github.com/microsoft/openvmm-deps/releases/download/0.3.0-110/openvmm-deps.${arch}.0.3.0-110.tar.gz";
     stripRoot = false;
     inherit hash;
   };

--- a/vm/devices/get/get_resources/src/lib.rs
+++ b/vm/devices/get/get_resources/src/lib.rs
@@ -302,5 +302,13 @@ pub mod ged {
         /// unsealing using the hardware key protector saved on the
         /// previous successful boot.  The VM should boot normally.
         KeyReleaseFailure,
+        /// Config for testing a host/agent-requested TPM state refresh.
+        ///
+        /// The agent's GSP RPC reports `state_refresh_request`, which
+        /// drives `refresh_tpm_seeds` in OpenHCL and causes the vTPM
+        /// seeds (and therefore the AK) to be regenerated on the next
+        /// boot.  AK cert requests are served so the guest has a valid
+        /// AK to read across boots.
+        StateRefresh,
     }
 }

--- a/vm/devices/get/test_igvm_agent_lib/src/lib.rs
+++ b/vm/devices/get/test_igvm_agent_lib/src/lib.rs
@@ -235,6 +235,20 @@ fn test_config_to_plan(test_config: &IgvmAttestTestConfig) -> IgvmAgentTestPlan 
                 ]),
             );
         }
+        IgvmAttestTestConfig::StateRefresh => {
+            // The `state_refresh_request` behavior is driven by the GSP
+            // RPC handler (see `test_igvm_agent_rpc_server`), not by the
+            // attest plan. Serve AK cert requests across boots so the
+            // guest has a valid AK to read and compare across reboots.
+            plan.insert(
+                IgvmAttestRequestType::AK_CERT_REQUEST,
+                VecDeque::from([
+                    IgvmAgentAction::RespondSuccess,
+                    IgvmAgentAction::RespondSuccess,
+                    IgvmAgentAction::AlwaysNoResponse,
+                ]),
+            );
+        }
     }
 
     plan

--- a/vm/devices/get/test_igvm_agent_rpc_server/src/main.rs
+++ b/vm/devices/get/test_igvm_agent_rpc_server/src/main.rs
@@ -32,6 +32,8 @@ enum TestConfig {
     KeyReleaseFailureSkipHwUnsealing,
     /// Test key release failure without skip_hw_unsealing signal
     KeyReleaseFailure,
+    /// Test a host/agent-requested TPM state refresh (via the GSP RPC).
+    StateRefresh,
 }
 
 impl From<TestConfig> for IgvmAttestTestConfig {
@@ -47,6 +49,7 @@ impl From<TestConfig> for IgvmAttestTestConfig {
                 IgvmAttestTestConfig::KeyReleaseFailureSkipHwUnsealing
             }
             TestConfig::KeyReleaseFailure => IgvmAttestTestConfig::KeyReleaseFailure,
+            TestConfig::StateRefresh => IgvmAttestTestConfig::StateRefresh,
         }
     }
 }

--- a/vm/devices/get/test_igvm_agent_rpc_server/src/rpc/handlers.rs
+++ b/vm/devices/get/test_igvm_agent_rpc_server/src/rpc/handlers.rs
@@ -44,6 +44,9 @@ pub unsafe extern "C" fn MIDL_user_free(ptr: *mut c_void) {
 const GSP_MAX_CLEAR_SIZE: usize = 64;
 const GSP_MAX_CIPHER_SIZE: usize = 512;
 const GSP_MAX_COUNT: usize = 2;
+/// IDL `StatusFlagStateRefreshRequest` — request a TPM state refresh.
+/// Maps to `GspExtendedStatusFlags::state_refresh_request` (bit 0).
+const STATUS_FLAG_STATE_REFRESH_REQUEST: u32 = 0x1;
 
 /// GSP clear text buffer (matches IDL GspClear)
 #[repr(C)]
@@ -219,7 +222,8 @@ pub extern "system" fn rpc_igvm_attest(
     );
 
     let vm_name_ref = vm_name_str.as_deref().unwrap_or("");
-    let payload = match igvm_agent::process_igvm_attest(vm_name_ref, report_slice) {
+    let payload = match igvm_agent::process_igvm_attest(read_guid(vm_id), vm_name_ref, report_slice)
+    {
         Ok(payload) => payload,
         Err(err) => {
             tracing::error!(?err, "igvm_agent::process_igvm_attest failed");
@@ -261,7 +265,24 @@ pub extern "system" fn rpc_igvm_attest(
 
 /// Entry point that services `RpcVmGspRequest` calls for the test agent.
 ///
-/// This function is currently disabled and will raise RPC_S_SERVER_UNAVAILABLE.
+/// By default this is disabled and raises `RPC_S_SERVER_UNAVAILABLE`, so the
+/// host falls back to its own GSP handling (the original behavior).
+///
+/// When the VM's resolved test config is `IgvmAttestTestConfig::StateRefresh`,
+/// the handler instead returns `S_OK` with `response_status_flags` carrying
+/// `StatusFlagStateRefreshRequest`. OpenHCL propagates this into
+/// `refresh_tpm_seeds`, regenerating the vTPM seeds (and the AK) on the next
+/// boot.
+///
+/// NOTE: This is a test stub that acts as the GSP authority using an *identity
+/// cipher*: the new cleartext seed is echoed back verbatim as the "encrypted"
+/// blob, and each previously-stored "encrypted" blob is echoed back verbatim as
+/// its "decrypted" seed. This is self-consistent across boots because this stub
+/// is the sole producer and consumer of those blobs. Returning real, non-empty
+/// GSP seed data is required: OpenHCL treats an empty `encrypted_gsp` as
+/// "GSP-by-key unavailable" (`no_gsp_available = encrypted_gsp.length == 0`),
+/// which would both drop the `state_refresh_request` flag from the GSP-by-key
+/// response and prevent the VMGS from being unlocked across boots.
 // SAFETY: FFI
 #[unsafe(export_name = "RpcVmGspRequest")]
 pub extern "system" fn rpc_vm_gsp_request(
@@ -271,8 +292,9 @@ pub extern "system" fn rpc_vm_gsp_request(
     request_data: *const GspRequestInfo,
     response_data: *mut GspResponseInfo,
 ) -> HRESULT {
-    // Log the request parameters before raising the exception
-    let vm_id_str = read_guid(_vm_id).map(|g| g.to_string());
+    // Log the request parameters
+    let vm_id = read_guid(_vm_id);
+    let vm_id_str = vm_id.map(|g| g.to_string());
     let vm_name_str = read_utf16(_vm_name);
 
     // Now we can safely dereference the structures since they match the IDL definitions
@@ -293,42 +315,98 @@ pub extern "system" fn rpc_vm_gsp_request(
         (0, 0, 0)
     };
 
-    let (response_encrypted_len, response_decrypted_count, response_flags) =
-        if !response_data.is_null() {
-            // SAFETY: memory access
-            let response = unsafe { &*response_data };
-            let decrypted_count = response
-                .decrypted_gsp
-                .iter()
-                .filter(|gsp| gsp.length > 0)
-                .count();
-            (
-                response.encrypted_gsp.length,
-                decrypted_count,
-                response.response_status_flags,
-            )
-        } else {
-            (0, 0, 0)
-        };
+    // Determine whether the resolved test config wants a state refresh.
+    //
+    // The GSP RPC's `VmName` is the VM's runtime GUID rather than the
+    // descriptive Hyper-V name, so the config is looked up by `VmId` (recorded
+    // by the IGVM attest path, which runs earlier in the same boot).
+    let gsp_state_refresh = vm_id
+        .as_ref()
+        .is_some_and(igvm_agent::gsp_state_refresh_requested);
 
-    tracing::warn!(
+    if !gsp_state_refresh {
+        tracing::warn!(
+            vm_id = vm_id_str.as_deref().unwrap_or("<null>"),
+            vm_name = vm_name_str.as_deref().unwrap_or("<unknown>"),
+            new_gsp_length = new_gsp_len,
+            encrypted_gsp_count = encrypted_gsp_count,
+            supported_status_flags = supported_flags,
+            "RpcVmGspRequest called but support is disabled - raising RPC_S_SERVER_UNAVAILABLE"
+        );
+
+        // Raise RPC_S_SERVER_UNAVAILABLE exception
+        // SAFETY: Make an FFI call
+        unsafe {
+            RpcRaiseException(RPC_S_SERVER_UNAVAILABLE);
+        }
+
+        // This line is never reached due to RpcRaiseException
+        unreachable!();
+    }
+
+    if request_data.is_null() {
+        tracing::error!("request_data pointer is null");
+        return E_POINTER;
+    }
+
+    if response_data.is_null() {
+        tracing::error!("response_data pointer is null");
+        return E_POINTER;
+    }
+
+    // Build a self-consistent GSP-by-key response using an identity cipher so
+    // that OpenHCL sees GSP-by-key as available, carries the state-refresh flag
+    // through the GSP-by-key response, and can unlock the VMGS across boots.
+    //
+    // A real IGVM agent encrypts the request's `new_gsp` seed and decrypts the
+    // request's stored `encrypted_gsp` blobs. Here we use an identity transform
+    // (ciphertext == cleartext), which round-trips correctly because this stub
+    // is the only entity that produces and consumes these blobs.
+    //
+    // SAFETY: The RPC runtime provides valid, correctly-sized `request_data`
+    // and `response_data` pointers (both verified non-null above) matching the
+    // IDL `GspRequestInfo` / `GspResponseInfo` layouts.
+    unsafe {
+        let request = &*request_data;
+        let response = &mut *response_data;
+
+        response.encrypted_gsp.length = 0;
+        response.encrypted_gsp.buffer = [0; GSP_MAX_CIPHER_SIZE];
+        for clear in response.decrypted_gsp.iter_mut() {
+            clear.length = 0;
+            clear.buffer = [0; GSP_MAX_CLEAR_SIZE];
+        }
+
+        // "Encrypt" the new cleartext seed: echo it back verbatim as the
+        // ciphertext blob that OpenHCL persists and replays next boot.
+        let new_gsp_copy_len = (request.new_gsp.length as usize).min(GSP_MAX_CLEAR_SIZE);
+        response.encrypted_gsp.length = new_gsp_copy_len as u32;
+        response.encrypted_gsp.buffer[..new_gsp_copy_len]
+            .copy_from_slice(&request.new_gsp.buffer[..new_gsp_copy_len]);
+
+        // "Decrypt" each previously-stored ciphertext back into its
+        // cleartext seed (identity transform).
+        for (clear, cipher) in response
+            .decrypted_gsp
+            .iter_mut()
+            .zip(request.encrypted_gsp.iter())
+        {
+            let len = (cipher.length as usize).min(GSP_MAX_CLEAR_SIZE);
+            clear.length = len as u32;
+            clear.buffer[..len].copy_from_slice(&cipher.buffer[..len]);
+        }
+
+        response.response_status_flags = STATUS_FLAG_STATE_REFRESH_REQUEST;
+    }
+
+    tracing::info!(
         vm_id = vm_id_str.as_deref().unwrap_or("<null>"),
         vm_name = vm_name_str.as_deref().unwrap_or("<unknown>"),
         new_gsp_length = new_gsp_len,
         encrypted_gsp_count = encrypted_gsp_count,
         supported_status_flags = supported_flags,
-        response_encrypted_length = response_encrypted_len,
-        response_decrypted_count = response_decrypted_count,
-        response_status_flags = response_flags,
-        "RpcVmGspRequest called but support is disabled - raising RPC_S_SERVER_UNAVAILABLE"
+        "RpcVmGspRequest returning state_refresh_request per test config"
     );
 
-    // Raise RPC_S_SERVER_UNAVAILABLE exception
-    // SAFETY: Make an FFI call
-    unsafe {
-        RpcRaiseException(RPC_S_SERVER_UNAVAILABLE);
-    }
-
-    // This line is never reached due to RpcRaiseException
-    unreachable!();
+    S_OK
 }

--- a/vm/devices/get/test_igvm_agent_rpc_server/src/rpc/igvm_agent.rs
+++ b/vm/devices/get/test_igvm_agent_rpc_server/src/rpc/igvm_agent.rs
@@ -16,6 +16,7 @@
 //! names short (≤ 15 chars) so the distinctive part is never truncated.
 
 use get_resources::ged::IgvmAttestTestConfig;
+use guid::Guid;
 use parking_lot::Mutex;
 use std::collections::HashMap;
 use std::sync::OnceLock;
@@ -42,6 +43,17 @@ struct AgentRegistry {
     default_setting: Option<IgvmAgentTestSetting>,
     /// Live per-VM agents, lazily created on first request.
     agents: HashMap<String, TestIgvmAgent>,
+    /// Maps a VM's `VmId` GUID to its resolved test config.
+    ///
+    /// The two RPC entry points receive different `VmName` values: the IGVM
+    /// attest path (`RpcIGVmAttest`) gets the descriptive Hyper-V VM name
+    /// (which [`resolve_test_config`] matches against), while the GSP path
+    /// (`RpcVmGspRequest`) only gets the VM's runtime GUID. Both paths do,
+    /// however, share the same `VmId`. The attest path runs first on every
+    /// boot (OpenHCL performs key release before requesting GSP data), so it
+    /// records the resolved config here keyed by `VmId`, allowing the GSP
+    /// path to recover it.
+    vm_id_settings: HashMap<Guid, IgvmAgentTestSetting>,
 }
 
 static REGISTRY: OnceLock<Mutex<AgentRegistry>> = OnceLock::new();
@@ -51,6 +63,7 @@ fn registry() -> &'static Mutex<AgentRegistry> {
         Mutex::new(AgentRegistry {
             default_setting: None,
             agents: HashMap::new(),
+            vm_id_settings: HashMap::new(),
         })
     })
 }
@@ -161,6 +174,30 @@ fn resolve_test_config(vm_name: &str) -> Option<IgvmAgentTestSetting> {
             "windows_datacenter_core_2025_x64_prepped_snp_use_hw_unseal",
             IgvmAttestTestConfig::KeyReleaseFailure,
         ),
+        (
+            "ubuntu_2504_server_x64_vbs_ak_pub_refresh",
+            IgvmAttestTestConfig::StateRefresh,
+        ),
+        (
+            "windows_datacenter_core_2025_x64_prepped_vbs_ak_pub_refresh",
+            IgvmAttestTestConfig::StateRefresh,
+        ),
+        (
+            "ubuntu_2504_server_x64_tdx_ak_pub_refresh",
+            IgvmAttestTestConfig::StateRefresh,
+        ),
+        (
+            "windows_datacenter_core_2025_x64_prepped_tdx_ak_pub_refresh",
+            IgvmAttestTestConfig::StateRefresh,
+        ),
+        (
+            "ubuntu_2504_server_x64_snp_ak_pub_refresh",
+            IgvmAttestTestConfig::StateRefresh,
+        ),
+        (
+            "windows_datacenter_core_2025_x64_prepped_snp_ak_pub_refresh",
+            IgvmAttestTestConfig::StateRefresh,
+        ),
     ];
 
     for &(pattern, config) in KNOWN_TEST_CONFIGS {
@@ -180,17 +217,57 @@ pub fn install_default_plan(setting: &IgvmAgentTestSetting) {
     reg.default_setting = Some(setting.clone());
 }
 
+/// Whether the resolved test config for the VM with the given `vm_id` requests
+/// that the GSP RPC report `state_refresh_request`.
+///
+/// The GSP RPC (`RpcVmGspRequest`) only receives the VM's runtime GUID, not the
+/// descriptive Hyper-V name that [`resolve_test_config`] matches against. It
+/// therefore looks up the config recorded by the IGVM attest path (keyed by
+/// `VmId`), falling back to the default setting (from CLI `--test-config`).
+/// Returns `false` (the original behavior, raising `RPC_S_SERVER_UNAVAILABLE`)
+/// unless the config is [`IgvmAttestTestConfig::StateRefresh`].
+pub fn gsp_state_refresh_requested(vm_id: &Guid) -> bool {
+    let reg = registry().lock();
+    let setting = reg
+        .vm_id_settings
+        .get(vm_id)
+        .cloned()
+        .or_else(|| reg.default_setting.clone());
+
+    matches!(
+        setting,
+        Some(IgvmAgentTestSetting::TestConfig(
+            IgvmAttestTestConfig::StateRefresh
+        ))
+    )
+}
+
 /// Process an attestation request payload for the given VM.
 ///
 /// On first contact the VM's agent is created and configured:
 /// 1. If the VM name matches a hardcoded pattern, that config is used.
 /// 2. Otherwise the default plan (if any) is installed.
-pub fn process_igvm_attest(vm_name: &str, report: &[u8]) -> TestAgentResult<Vec<u8>> {
+///
+/// The resolved config is also recorded keyed by `vm_id` so the GSP RPC path
+/// (which only sees the VM's runtime GUID, not the descriptive name) can
+/// recover it later in the same boot.
+pub fn process_igvm_attest(
+    vm_id: Option<Guid>,
+    vm_name: &str,
+    report: &[u8],
+) -> TestAgentResult<Vec<u8>> {
     let mut reg = registry().lock();
 
     // Clone the default setting before entering the entry API so the
     // borrow checker is happy.
     let default_setting = reg.default_setting.clone();
+
+    // Record the resolved config keyed by `vm_id` for the GSP RPC path.
+    if let Some(vm_id) = vm_id {
+        if let Some(setting) = resolve_test_config(vm_name).or_else(|| default_setting.clone()) {
+            reg.vm_id_settings.insert(vm_id, setting);
+        }
+    }
 
     let agent = reg.agents.entry(vm_name.to_owned()).or_insert_with(|| {
         let mut agent = TestIgvmAgent::new(vm_name);

--- a/vmm_tests/vmm_tests/tests/tests/multiarch/tpm.rs
+++ b/vmm_tests/vmm_tests/tests/tests/multiarch/tpm.rs
@@ -190,6 +190,45 @@ impl<'a> TpmGuestTests<'a> {
             _ => unreachable!(),
         }
     }
+
+    /// Read the vTPM Attestation Key public modulus (`HCLAkPub.n`) from the
+    /// attestation report's runtime claims.
+    ///
+    /// The modulus uniquely identifies the AK, so comparing it across reboots
+    /// detects whether the AK was regenerated.
+    #[cfg(windows)]
+    async fn read_ak_pub_modulus(&self) -> anyhow::Result<String> {
+        let output = self.read_report().await?;
+
+        // The report binary prints preamble lines followed by:
+        //   Runtime claims JSON:
+        //   { ...pretty-printed JSON... }
+        const MARKER: &str = "Runtime claims JSON:";
+        let json_start = output
+            .find(MARKER)
+            .map(|i| i + MARKER.len())
+            .with_context(|| format!("report output missing runtime claims JSON: {output}"))?;
+
+        // Parse the first JSON value, ignoring any trailing output.
+        let claims = serde_json::Deserializer::from_str(output[json_start..].trim_start())
+            .into_iter::<serde_json::Value>()
+            .next()
+            .context("no JSON value found after runtime claims marker")?
+            .context("failed to parse runtime claims JSON")?;
+
+        let modulus = claims
+            .get("keys")
+            .and_then(|keys| keys.as_array())
+            .context("runtime claims missing keys array")?
+            .iter()
+            .find(|key| key.get("kid").and_then(|v| v.as_str()) == Some("HCLAkPub"))
+            .context("runtime claims missing HCLAkPub key")?
+            .get("n")
+            .and_then(|n| n.as_str())
+            .context("HCLAkPub missing modulus")?;
+
+        Ok(modulus.to_string())
+    }
 }
 
 /// Basic boot tests with TPM enabled.
@@ -624,6 +663,19 @@ async fn tpm_test_platform_hierarchy_disabled(
 
 /// CVM with guest tpm tests on Hyper-V.
 ///
+/// Exercises the CVM vTPM end-to-end against the test IGVM agent RPC server:
+/// verifies the AK certificate and attestation report runtime claims, and
+/// that the vTPM Attestation Key (AK) public key is stable across a reboot.
+///
+/// AK stability: the AK is derived deterministically from the TPM
+/// endorsement-hierarchy seed. With a correct OSS ms-tpm-20-ref crypto
+/// backend (prebuilt `tpm-oss-openssl/libtpm.a` from openvmm-deps),
+/// re-deriving the AK on the next boot must produce the same public key. A
+/// previous `DfStart` (`CryptRand.c`) out-of-bounds read made the
+/// 64-bit-radix derivation non-deterministic; this guards the fix shipped via
+/// openvmm-deps. (See `ak_pub_refresh` for the contrasting case where a
+/// host-requested state refresh deliberately rotates the AK.)
+///
 /// The test requires the test_igvm_agent_rpc_server to be running.
 /// In CI, the server is started by flowey before tests run.
 /// For local development, either start the server manually or set
@@ -653,7 +705,7 @@ async fn cvm_tpm_guest_tests<T, S, U: PetriVmmBackend>(
         .with_tpm_state_persistence(true)
         .with_guest_state_lifetime(PetriGuestStateLifetime::Disk);
 
-    let (vm, agent) = config.run().await?;
+    let (mut vm, agent) = config.run().await?;
 
     let guest_binary_path = match os_flavor {
         OsFlavor::Linux => TPM_GUEST_TESTS_LINUX_GUEST_PATH,
@@ -688,6 +740,112 @@ async fn cvm_tpm_guest_tests<T, S, U: PetriVmmBackend>(
     ensure!(
         report_output.contains("\"vmUniqueId\""),
         format!("{report_output}")
+    );
+
+    // Capture the AK public modulus on this (first) boot for the stability
+    // check below.
+    let ak_pub_first = tpm_guest_tests.read_ak_pub_modulus().await?;
+    ensure!(
+        !ak_pub_first.is_empty(),
+        "AK pub modulus should not be empty on first boot"
+    );
+
+    // Reboot. With no state refresh requested, the AK must be re-derived
+    // identically.
+    agent.reboot().await?;
+    let agent = vm.wait_for_reset().await?;
+
+    // Second boot: re-send the binary and capture the AK public modulus again.
+    let host_binary_path = tpm_guest_tests_artifact.get();
+    let tpm_guest_tests =
+        TpmGuestTests::send_tpm_guest_tests(&agent, host_binary_path, guest_binary_path, os_flavor)
+            .await?;
+    let ak_pub_second = tpm_guest_tests.read_ak_pub_modulus().await?;
+
+    ensure!(
+        ak_pub_first == ak_pub_second,
+        "AK pub must remain stable across reboot, but it changed \
+         (first={ak_pub_first}, second={ak_pub_second})"
+    );
+
+    agent.power_off().await?;
+    vm.wait_for_clean_teardown().await?;
+
+    Ok(())
+}
+
+/// Verify that a host/agent-requested TPM state refresh regenerates the vTPM
+/// Attestation Key (AK) across a reboot for a normal stateful CVM.
+///
+/// The `test_igvm_agent_rpc_server` is configured (via the `StateRefresh`
+/// config, resolved by VM name in its `KNOWN_TEST_CONFIGS`) to report
+/// `state_refresh_request` in its GSP RPC response. OpenHCL propagates this
+/// into `refresh_tpm_seeds`, which regenerates the vTPM seeds (and therefore
+/// the AK) on the next boot. The test reads the AK public modulus
+/// (`HCLAkPub.n`) before and after the reboot and asserts it CHANGED.
+///
+/// This is the counterpart to the AK-stability check in `cvm_tpm_guest_tests`:
+/// together they prove the AK is deterministic across reboots by default, yet
+/// a state refresh deliberately rotates it.
+#[cfg(windows)]
+#[vmm_test(
+    hyperv_openhcl_uefi_x64[vbs](vhd(ubuntu_2504_server_x64))[TPM_GUEST_TESTS_LINUX_X64, TEST_IGVM_AGENT_RPC_SERVER_WINDOWS_X64],
+    hyperv_openhcl_uefi_x64[vbs](vhd(windows_datacenter_core_2025_x64_prepped))[TPM_GUEST_TESTS_WINDOWS_X64, TEST_IGVM_AGENT_RPC_SERVER_WINDOWS_X64],
+    hyperv_openhcl_uefi_x64[tdx](vhd(ubuntu_2504_server_x64))[TPM_GUEST_TESTS_LINUX_X64, TEST_IGVM_AGENT_RPC_SERVER_WINDOWS_X64],
+    hyperv_openhcl_uefi_x64[tdx](vhd(windows_datacenter_core_2025_x64_prepped))[TPM_GUEST_TESTS_WINDOWS_X64, TEST_IGVM_AGENT_RPC_SERVER_WINDOWS_X64],
+    hyperv_openhcl_uefi_x64[snp](vhd(ubuntu_2504_server_x64))[TPM_GUEST_TESTS_LINUX_X64, TEST_IGVM_AGENT_RPC_SERVER_WINDOWS_X64],
+    hyperv_openhcl_uefi_x64[snp](vhd(windows_datacenter_core_2025_x64_prepped))[TPM_GUEST_TESTS_WINDOWS_X64, TEST_IGVM_AGENT_RPC_SERVER_WINDOWS_X64],
+)]
+async fn ak_pub_refresh<T, S, U: PetriVmmBackend>(
+    config: PetriVmBuilder<U>,
+    extra_deps: (ResolvedArtifact<T>, ResolvedArtifact<S>),
+) -> anyhow::Result<()> {
+    let os_flavor = config.os_flavor();
+    let (tpm_guest_tests_artifact, rpc_server_artifact) = extra_deps;
+
+    let rpc_server_path = rpc_server_artifact.get();
+    let _rpc_guard = ensure_rpc_server_running(rpc_server_path)?;
+
+    let (mut vm, agent) = config
+        .with_tpm(true)
+        .with_tpm_state_persistence(true)
+        .with_guest_state_lifetime(PetriGuestStateLifetime::Disk)
+        .run()
+        .await?;
+
+    let guest_binary_path = match os_flavor {
+        OsFlavor::Linux => TPM_GUEST_TESTS_LINUX_GUEST_PATH,
+        OsFlavor::Windows => TPM_GUEST_TESTS_WINDOWS_GUEST_PATH,
+        _ => unreachable!(),
+    };
+
+    // First boot: capture the AK public modulus.
+    let host_binary_path = tpm_guest_tests_artifact.get();
+    let tpm_guest_tests =
+        TpmGuestTests::send_tpm_guest_tests(&agent, host_binary_path, guest_binary_path, os_flavor)
+            .await?;
+    let ak_pub_first = tpm_guest_tests.read_ak_pub_modulus().await?;
+    ensure!(
+        !ak_pub_first.is_empty(),
+        "AK pub modulus should not be empty on first boot"
+    );
+
+    // Reboot. The agent requests a TPM state refresh via the GSP RPC, so the
+    // vTPM seeds (and the AK) must be regenerated.
+    agent.reboot().await?;
+    let agent = vm.wait_for_reset().await?;
+
+    // Second boot: capture the AK public modulus again.
+    let host_binary_path = tpm_guest_tests_artifact.get();
+    let tpm_guest_tests =
+        TpmGuestTests::send_tpm_guest_tests(&agent, host_binary_path, guest_binary_path, os_flavor)
+            .await?;
+    let ak_pub_second = tpm_guest_tests.read_ak_pub_modulus().await?;
+
+    ensure!(
+        ak_pub_first != ak_pub_second,
+        "AK pub must change across reboot when a state refresh is requested, \
+         but it stayed the same (value={ak_pub_first})"
     );
 
     agent.power_off().await?;


### PR DESCRIPTION
This PR bumps the `openvmm-deps` that includes a fix in `libtpm.a`, which introduces non-determinism in RSA generation.
Also add vmm tests to verify the fix.