### PR TITLE
ci: update ado pools

### DIFF
--- a/.github/workflows/openvmm-ci.yaml
+++ b/.github/workflows/openvmm-ci.yaml
@@ -99,8 +99,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey.exe e 0 flowey_lib_common::git_checkout 0
-        flowey.exe v 0 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar1
-        flowey.exe v 0 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 0 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar1
+        flowey.exe v 0 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -259,8 +259,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 1 flowey_lib_common::git_checkout 0
-        flowey v 1 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar1
-        flowey v 1 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey v 1 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar1
+        flowey v 1 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -455,8 +455,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 10 flowey_lib_common::git_checkout 0
-        flowey v 10 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
-        flowey v 10 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey v 10 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar3
+        flowey v 10 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -786,8 +786,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 11 flowey_lib_common::git_checkout 0
-        flowey v 11 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
-        flowey v 11 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey v 11 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar3
+        flowey v 11 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -1239,8 +1239,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 12 flowey_lib_common::git_checkout 0
-        flowey v 12 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
-        flowey v 12 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey v 12 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar3
+        flowey v 12 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -1598,8 +1598,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey.exe e 13 flowey_lib_common::git_checkout 0
-        flowey.exe v 13 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar8
-        flowey.exe v 13 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 13 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar8
+        flowey.exe v 13 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -1893,8 +1893,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 14 flowey_lib_common::git_checkout 0
-        flowey v 14 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar10
-        flowey v 14 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey v 14 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar10
+        flowey v 14 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -2275,8 +2275,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 15 flowey_lib_common::git_checkout 0
-        flowey v 15 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar11
-        flowey v 15 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey v 15 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar11
+        flowey v 15 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -2669,8 +2669,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey.exe e 16 flowey_lib_common::git_checkout 0
-        flowey.exe v 16 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar8
-        flowey.exe v 16 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 16 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar8
+        flowey.exe v 16 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -2969,8 +2969,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 17 flowey_lib_common::git_checkout 0
-        flowey v 17 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar10
-        flowey v 17 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey v 17 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar10
+        flowey v 17 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -3356,8 +3356,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 18 flowey_lib_common::git_checkout 0
-        flowey v 18 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar11
-        flowey v 18 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey v 18 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar11
+        flowey v 18 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -3710,8 +3710,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey.exe e 19 flowey_lib_common::git_checkout 0
-        flowey.exe v 19 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
-        flowey.exe v 19 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 19 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar3
+        flowey.exe v 19 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -4003,8 +4003,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey.exe e 2 flowey_lib_common::git_checkout 0
-        flowey.exe v 2 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar1
-        flowey.exe v 2 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 2 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar1
+        flowey.exe v 2 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -4179,8 +4179,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey.exe e 20 flowey_lib_common::git_checkout 0
-        flowey.exe v 20 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
-        flowey.exe v 20 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 20 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar3
+        flowey.exe v 20 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -4458,8 +4458,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey.exe e 21 flowey_lib_common::git_checkout 0
-        flowey.exe v 21 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
-        flowey.exe v 21 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 21 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar3
+        flowey.exe v 21 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -4741,8 +4741,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey.exe e 22 flowey_lib_common::git_checkout 0
-        flowey.exe v 22 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
-        flowey.exe v 22 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 22 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar3
+        flowey.exe v 22 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -5025,8 +5025,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey.exe e 23 flowey_lib_common::git_checkout 0
-        flowey.exe v 23 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
-        flowey.exe v 23 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 23 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar3
+        flowey.exe v 23 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -5408,8 +5408,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 24 flowey_lib_common::git_checkout 0
-        flowey v 24 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
-        flowey v 24 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey v 24 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar3
+        flowey v 24 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -5724,8 +5724,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 25 flowey_lib_common::git_checkout 0
-        flowey v 25 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
-        flowey v 25 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey v 25 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar3
+        flowey v 25 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -5937,8 +5937,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey.exe e 26 flowey_lib_common::git_checkout 0
-        flowey.exe v 26 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
-        flowey.exe v 26 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 26 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar3
+        flowey.exe v 26 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -6201,8 +6201,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 27 flowey_lib_common::git_checkout 0
-        flowey v 27 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar1
-        flowey v 27 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey v 27 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar1
+        flowey v 27 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -6344,8 +6344,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 28 flowey_lib_common::git_checkout 0
-        flowey v 28 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar1
-        flowey v 28 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey v 28 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar1
+        flowey v 28 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -6498,8 +6498,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 3 flowey_lib_common::git_checkout 0
-        flowey v 3 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar1
-        flowey v 3 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey v 3 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar1
+        flowey v 3 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -6867,8 +6867,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey.exe e 4 flowey_lib_common::git_checkout 0
-        flowey.exe v 4 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar1
-        flowey.exe v 4 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 4 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar1
+        flowey.exe v 4 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -7094,8 +7094,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey.exe e 5 flowey_lib_common::git_checkout 0
-        flowey.exe v 5 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar1
-        flowey.exe v 5 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 5 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar1
+        flowey.exe v 5 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -7408,8 +7408,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey.exe e 6 flowey_lib_common::git_checkout 0
-        flowey.exe v 6 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar1
-        flowey.exe v 6 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 6 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar1
+        flowey.exe v 6 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -7639,8 +7639,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey.exe e 7 flowey_lib_common::git_checkout 0
-        flowey.exe v 7 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar1
-        flowey.exe v 7 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 7 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar1
+        flowey.exe v 7 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -7979,8 +7979,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 8 flowey_lib_common::git_checkout 0
-        flowey v 8 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar1
-        flowey v 8 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey v 8 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar1
+        flowey v 8 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -8356,8 +8356,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 9 flowey_lib_common::git_checkout 0
-        flowey v 9 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar1
-        flowey v 9 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey v 9 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar1
+        flowey v 9 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6

--- a/.github/workflows/openvmm-docs-ci.yaml
+++ b/.github/workflows/openvmm-docs-ci.yaml
@@ -133,8 +133,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 0 flowey_lib_common::git_checkout 0
-        flowey v 0 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar1
-        flowey v 0 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey v 0 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar1
+        flowey v 0 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -257,8 +257,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey.exe e 1 flowey_lib_common::git_checkout 0
-        flowey.exe v 1 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar1
-        flowey.exe v 1 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 1 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar1
+        flowey.exe v 1 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -420,8 +420,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 2 flowey_lib_common::git_checkout 0
-        flowey v 2 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar1
-        flowey v 2 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey v 2 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar1
+        flowey v 2 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -570,8 +570,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 3 flowey_lib_common::git_checkout 0
-        flowey v 3 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar2
-        flowey v 3 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey v 3 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar2
+        flowey v 3 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6

--- a/.github/workflows/openvmm-docs-pr.yaml
+++ b/.github/workflows/openvmm-docs-pr.yaml
@@ -141,8 +141,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 0 flowey_lib_common::git_checkout 0
-        flowey v 0 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar1
-        flowey v 0 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey v 0 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar1
+        flowey v 0 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -265,8 +265,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey.exe e 1 flowey_lib_common::git_checkout 0
-        flowey.exe v 1 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar1
-        flowey.exe v 1 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 1 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar1
+        flowey.exe v 1 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -428,8 +428,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 2 flowey_lib_common::git_checkout 0
-        flowey v 2 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar1
-        flowey v 2 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey v 2 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar1
+        flowey v 2 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6

--- a/.github/workflows/openvmm-pr-release.yaml
+++ b/.github/workflows/openvmm-pr-release.yaml
@@ -107,8 +107,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 0 flowey_lib_common::git_checkout 0
-        flowey v 0 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar1
-        flowey v 0 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey v 0 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar1
+        flowey v 0 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -321,8 +321,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey.exe e 1 flowey_lib_common::git_checkout 0
-        flowey.exe v 1 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar1
-        flowey.exe v 1 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 1 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar1
+        flowey.exe v 1 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -451,8 +451,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 10 flowey_lib_common::git_checkout 0
-        flowey v 10 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
-        flowey v 10 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey v 10 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar3
+        flowey v 10 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -716,8 +716,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 11 flowey_lib_common::git_checkout 0
-        flowey v 11 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
-        flowey v 11 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey v 11 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar3
+        flowey v 11 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -1116,8 +1116,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 12 flowey_lib_common::git_checkout 0
-        flowey v 12 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
-        flowey v 12 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey v 12 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar3
+        flowey v 12 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -1477,8 +1477,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey.exe e 13 flowey_lib_common::git_checkout 0
-        flowey.exe v 13 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar8
-        flowey.exe v 13 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 13 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar8
+        flowey.exe v 13 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -1735,8 +1735,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 14 flowey_lib_common::git_checkout 0
-        flowey v 14 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar10
-        flowey v 14 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey v 14 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar10
+        flowey v 14 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -2038,8 +2038,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 15 flowey_lib_common::git_checkout 0
-        flowey v 15 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar11
-        flowey v 15 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey v 15 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar11
+        flowey v 15 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -2434,8 +2434,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey.exe e 16 flowey_lib_common::git_checkout 0
-        flowey.exe v 16 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar8
-        flowey.exe v 16 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 16 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar8
+        flowey.exe v 16 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -2736,8 +2736,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 17 flowey_lib_common::git_checkout 0
-        flowey v 17 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar10
-        flowey v 17 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey v 17 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar10
+        flowey v 17 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -3091,8 +3091,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 18 flowey_lib_common::git_checkout 0
-        flowey v 18 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar11
-        flowey v 18 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey v 18 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar11
+        flowey v 18 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -3480,8 +3480,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey.exe e 19 flowey_lib_common::git_checkout 0
-        flowey.exe v 19 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
-        flowey.exe v 19 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 19 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar3
+        flowey.exe v 19 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -3775,8 +3775,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey.exe e 2 flowey_lib_common::git_checkout 0
-        flowey.exe v 2 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar1
-        flowey.exe v 2 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 2 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar1
+        flowey.exe v 2 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -3952,8 +3952,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey.exe e 20 flowey_lib_common::git_checkout 0
-        flowey.exe v 20 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
-        flowey.exe v 20 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 20 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar3
+        flowey.exe v 20 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -4232,8 +4232,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey.exe e 21 flowey_lib_common::git_checkout 0
-        flowey.exe v 21 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
-        flowey.exe v 21 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 21 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar3
+        flowey.exe v 21 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -4516,8 +4516,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey.exe e 22 flowey_lib_common::git_checkout 0
-        flowey.exe v 22 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
-        flowey.exe v 22 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 22 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar3
+        flowey.exe v 22 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -4801,8 +4801,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey.exe e 23 flowey_lib_common::git_checkout 0
-        flowey.exe v 23 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
-        flowey.exe v 23 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 23 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar3
+        flowey.exe v 23 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -5185,8 +5185,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 24 flowey_lib_common::git_checkout 0
-        flowey v 24 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
-        flowey v 24 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey v 24 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar3
+        flowey v 24 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -5502,8 +5502,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 25 flowey_lib_common::git_checkout 0
-        flowey v 25 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
-        flowey v 25 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey v 25 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar3
+        flowey v 25 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -5716,8 +5716,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey.exe e 26 flowey_lib_common::git_checkout 0
-        flowey.exe v 26 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
-        flowey.exe v 26 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 26 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar3
+        flowey.exe v 26 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -5938,8 +5938,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 27 flowey_lib_common::git_checkout 0
-        flowey v 27 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar1
-        flowey v 27 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey v 27 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar1
+        flowey v 27 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -6048,8 +6048,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 3 flowey_lib_common::git_checkout 0
-        flowey v 3 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar1
-        flowey v 3 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey v 3 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar1
+        flowey v 3 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -6418,8 +6418,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey.exe e 4 flowey_lib_common::git_checkout 0
-        flowey.exe v 4 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar1
-        flowey.exe v 4 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 4 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar1
+        flowey.exe v 4 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -6647,8 +6647,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey.exe e 5 flowey_lib_common::git_checkout 0
-        flowey.exe v 5 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar1
-        flowey.exe v 5 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 5 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar1
+        flowey.exe v 5 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -6963,8 +6963,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey.exe e 6 flowey_lib_common::git_checkout 0
-        flowey.exe v 6 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar1
-        flowey.exe v 6 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 6 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar1
+        flowey.exe v 6 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -7196,8 +7196,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey.exe e 7 flowey_lib_common::git_checkout 0
-        flowey.exe v 7 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar1
-        flowey.exe v 7 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 7 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar1
+        flowey.exe v 7 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -7494,8 +7494,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 8 flowey_lib_common::git_checkout 0
-        flowey v 8 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar1
-        flowey v 8 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey v 8 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar1
+        flowey v 8 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -7829,8 +7829,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 9 flowey_lib_common::git_checkout 0
-        flowey v 9 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar1
-        flowey v 9 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey v 9 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar1
+        flowey v 9 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6

--- a/.github/workflows/openvmm-pr.yaml
+++ b/.github/workflows/openvmm-pr.yaml
@@ -106,8 +106,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 0 flowey_lib_common::git_checkout 0
-        flowey v 0 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar1
-        flowey v 0 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey v 0 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar1
+        flowey v 0 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -320,8 +320,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey.exe e 1 flowey_lib_common::git_checkout 0
-        flowey.exe v 1 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar1
-        flowey.exe v 1 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 1 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar1
+        flowey.exe v 1 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -450,8 +450,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 10 flowey_lib_common::git_checkout 0
-        flowey v 10 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
-        flowey v 10 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey v 10 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar3
+        flowey v 10 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -702,8 +702,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 11 flowey_lib_common::git_checkout 0
-        flowey v 11 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar2
-        flowey v 11 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey v 11 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar2
+        flowey v 11 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -918,8 +918,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 12 flowey_lib_common::git_checkout 0
-        flowey v 12 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
-        flowey v 12 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey v 12 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar3
+        flowey v 12 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -1313,8 +1313,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 13 flowey_lib_common::git_checkout 0
-        flowey v 13 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar2
-        flowey v 13 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey v 13 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar2
+        flowey v 13 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -1521,8 +1521,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 14 flowey_lib_common::git_checkout 0
-        flowey v 14 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
-        flowey v 14 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey v 14 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar3
+        flowey v 14 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -1882,8 +1882,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey.exe e 15 flowey_lib_common::git_checkout 0
-        flowey.exe v 15 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar8
-        flowey.exe v 15 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 15 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar8
+        flowey.exe v 15 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -2140,8 +2140,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 16 flowey_lib_common::git_checkout 0
-        flowey v 16 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar10
-        flowey v 16 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey v 16 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar10
+        flowey v 16 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -2443,8 +2443,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 17 flowey_lib_common::git_checkout 0
-        flowey v 17 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar11
-        flowey v 17 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey v 17 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar11
+        flowey v 17 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -2839,8 +2839,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey.exe e 18 flowey_lib_common::git_checkout 0
-        flowey.exe v 18 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar8
-        flowey.exe v 18 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 18 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar8
+        flowey.exe v 18 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -3141,8 +3141,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 19 flowey_lib_common::git_checkout 0
-        flowey v 19 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar10
-        flowey v 19 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey v 19 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar10
+        flowey v 19 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -3500,8 +3500,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey.exe e 2 flowey_lib_common::git_checkout 0
-        flowey.exe v 2 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar1
-        flowey.exe v 2 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 2 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar1
+        flowey.exe v 2 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -3718,8 +3718,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 20 flowey_lib_common::git_checkout 0
-        flowey v 20 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar11
-        flowey v 20 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey v 20 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar11
+        flowey v 20 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -4073,8 +4073,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey.exe e 21 flowey_lib_common::git_checkout 0
-        flowey.exe v 21 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
-        flowey.exe v 21 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 21 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar3
+        flowey.exe v 21 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -4357,8 +4357,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey.exe e 22 flowey_lib_common::git_checkout 0
-        flowey.exe v 22 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
-        flowey.exe v 22 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 22 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar3
+        flowey.exe v 22 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -4637,8 +4637,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey.exe e 23 flowey_lib_common::git_checkout 0
-        flowey.exe v 23 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
-        flowey.exe v 23 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 23 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar3
+        flowey.exe v 23 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -4921,8 +4921,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey.exe e 24 flowey_lib_common::git_checkout 0
-        flowey.exe v 24 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
-        flowey.exe v 24 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 24 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar3
+        flowey.exe v 24 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -5206,8 +5206,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey.exe e 25 flowey_lib_common::git_checkout 0
-        flowey.exe v 25 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
-        flowey.exe v 25 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 25 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar3
+        flowey.exe v 25 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -5590,8 +5590,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 26 flowey_lib_common::git_checkout 0
-        flowey v 26 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
-        flowey v 26 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey v 26 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar3
+        flowey v 26 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -5907,8 +5907,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 27 flowey_lib_common::git_checkout 0
-        flowey v 27 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
-        flowey v 27 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey v 27 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar3
+        flowey v 27 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -6121,8 +6121,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey.exe e 28 flowey_lib_common::git_checkout 0
-        flowey.exe v 28 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar3
-        flowey.exe v 28 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 28 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar3
+        flowey.exe v 28 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -6343,8 +6343,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 29 flowey_lib_common::git_checkout 0
-        flowey v 29 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar1
-        flowey v 29 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey v 29 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar1
+        flowey v 29 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -6453,8 +6453,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 3 flowey_lib_common::git_checkout 0
-        flowey v 3 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar1
-        flowey v 3 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey v 3 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar1
+        flowey v 3 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -6890,8 +6890,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey.exe e 4 flowey_lib_common::git_checkout 0
-        flowey.exe v 4 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar1
-        flowey.exe v 4 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 4 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar1
+        flowey.exe v 4 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -7119,8 +7119,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey.exe e 5 flowey_lib_common::git_checkout 0
-        flowey.exe v 5 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar1
-        flowey.exe v 5 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 5 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar1
+        flowey.exe v 5 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -7435,8 +7435,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey.exe e 6 flowey_lib_common::git_checkout 0
-        flowey.exe v 6 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar1
-        flowey.exe v 6 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 6 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar1
+        flowey.exe v 6 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -7668,8 +7668,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey.exe e 7 flowey_lib_common::git_checkout 0
-        flowey.exe v 7 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar1
-        flowey.exe v 7 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 7 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar1
+        flowey.exe v 7 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -7966,8 +7966,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 8 flowey_lib_common::git_checkout 0
-        flowey v 8 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar1
-        flowey v 8 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey v 8 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar1
+        flowey v 8 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -8301,8 +8301,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 9 flowey_lib_common::git_checkout 0
-        flowey v 9 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:489:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46 write-to-env github floweyvar1
-        flowey v 9 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:490:46' write-to-env github FLOWEY_CONDITION
+        flowey v 9 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar1
+        flowey v 9 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6

--- a/ci-flowey/openvmm-pr.yaml
+++ b/ci-flowey/openvmm-pr.yaml
@@ -118,7 +118,7 @@ jobs:
     condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
   - bash: |-
       set -e
-      $FLOWEY_BIN v 0 'flowey_lib_common::git_checkout:4:flowey_lib_common/src/git_checkout.rs:402:29' --is-raw-string update --is-secret --env-source Pipeline.Workspace <<'EOF'
+      $FLOWEY_BIN v 0 'flowey_lib_common::git_checkout:4:flowey_lib_common/src/git_checkout.rs:402:29' --is-raw-string update --env-source Pipeline.Workspace <<'EOF'
       $(Pipeline.Workspace)
       EOF
       $(FLOWEY_BIN) e 0 flowey_lib_common::git_checkout 3
@@ -283,7 +283,7 @@ jobs:
     condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
   - bash: |-
       set -e
-      $FLOWEY_BIN v 15 'flowey_lib_common::git_checkout:4:flowey_lib_common/src/git_checkout.rs:402:29' --is-raw-string update --is-secret --env-source Pipeline.Workspace <<'EOF'
+      $FLOWEY_BIN v 15 'flowey_lib_common::git_checkout:4:flowey_lib_common/src/git_checkout.rs:402:29' --is-raw-string update --env-source Pipeline.Workspace <<'EOF'
       $(Pipeline.Workspace)
       EOF
       $(FLOWEY_BIN) e 15 flowey_lib_common::git_checkout 3
@@ -611,7 +611,7 @@ jobs:
     condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
   - bash: |-
       set -e
-      $FLOWEY_BIN v 14 'flowey_lib_common::git_checkout:4:flowey_lib_common/src/git_checkout.rs:402:29' --is-raw-string update --is-secret --env-source Pipeline.Workspace <<'EOF'
+      $FLOWEY_BIN v 14 'flowey_lib_common::git_checkout:4:flowey_lib_common/src/git_checkout.rs:402:29' --is-raw-string update --env-source Pipeline.Workspace <<'EOF'
       $(Pipeline.Workspace)
       EOF
       $(FLOWEY_BIN) e 14 flowey_lib_common::git_checkout 3
@@ -941,7 +941,7 @@ jobs:
     condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
   - bash: |-
       set -e
-      $FLOWEY_BIN v 13 'flowey_lib_common::git_checkout:4:flowey_lib_common/src/git_checkout.rs:402:29' --is-raw-string update --is-secret --env-source Pipeline.Workspace <<'EOF'
+      $FLOWEY_BIN v 13 'flowey_lib_common::git_checkout:4:flowey_lib_common/src/git_checkout.rs:402:29' --is-raw-string update --env-source Pipeline.Workspace <<'EOF'
       $(Pipeline.Workspace)
       EOF
       $(FLOWEY_BIN) e 13 flowey_lib_common::git_checkout 3
@@ -1184,7 +1184,7 @@ jobs:
     condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
   - bash: |-
       set -e
-      $FLOWEY_BIN v 12 'flowey_lib_common::git_checkout:4:flowey_lib_common/src/git_checkout.rs:402:29' --is-raw-string update --is-secret --env-source Pipeline.Workspace <<'EOF'
+      $FLOWEY_BIN v 12 'flowey_lib_common::git_checkout:4:flowey_lib_common/src/git_checkout.rs:402:29' --is-raw-string update --env-source Pipeline.Workspace <<'EOF'
       $(Pipeline.Workspace)
       EOF
       $(FLOWEY_BIN) e 12 flowey_lib_common::git_checkout 3
@@ -1479,7 +1479,7 @@ jobs:
     condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
   - bash: |-
       set -e
-      $FLOWEY_BIN v 11 'flowey_lib_common::git_checkout:4:flowey_lib_common/src/git_checkout.rs:402:29' --is-raw-string update --is-secret --env-source Pipeline.Workspace <<'EOF'
+      $FLOWEY_BIN v 11 'flowey_lib_common::git_checkout:4:flowey_lib_common/src/git_checkout.rs:402:29' --is-raw-string update --env-source Pipeline.Workspace <<'EOF'
       $(Pipeline.Workspace)
       EOF
       $(FLOWEY_BIN) e 11 flowey_lib_common::git_checkout 3
@@ -1832,7 +1832,7 @@ jobs:
     condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
   - bash: |-
       set -e
-      $FLOWEY_BIN v 10 'flowey_lib_common::git_checkout:4:flowey_lib_common/src/git_checkout.rs:402:29' --is-raw-string update --is-secret --env-source Pipeline.Workspace <<'EOF'
+      $FLOWEY_BIN v 10 'flowey_lib_common::git_checkout:4:flowey_lib_common/src/git_checkout.rs:402:29' --is-raw-string update --env-source Pipeline.Workspace <<'EOF'
       $(Pipeline.Workspace)
       EOF
       $(FLOWEY_BIN) e 10 flowey_lib_common::git_checkout 3
@@ -2088,7 +2088,7 @@ jobs:
     condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
   - bash: |-
       set -e
-      $FLOWEY_BIN v 9 'flowey_lib_common::git_checkout:4:flowey_lib_common/src/git_checkout.rs:402:29' --is-raw-string update --is-secret --env-source Pipeline.Workspace <<'EOF'
+      $FLOWEY_BIN v 9 'flowey_lib_common::git_checkout:4:flowey_lib_common/src/git_checkout.rs:402:29' --is-raw-string update --env-source Pipeline.Workspace <<'EOF'
       $(Pipeline.Workspace)
       EOF
       $(FLOWEY_BIN) e 9 flowey_lib_common::git_checkout 3
@@ -2440,7 +2440,7 @@ jobs:
     condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
   - bash: |-
       set -e
-      $FLOWEY_BIN v 8 'flowey_lib_common::git_checkout:4:flowey_lib_common/src/git_checkout.rs:402:29' --is-raw-string update --is-secret --env-source Pipeline.Workspace <<'EOF'
+      $FLOWEY_BIN v 8 'flowey_lib_common::git_checkout:4:flowey_lib_common/src/git_checkout.rs:402:29' --is-raw-string update --env-source Pipeline.Workspace <<'EOF'
       $(Pipeline.Workspace)
       EOF
       $(FLOWEY_BIN) e 8 flowey_lib_common::git_checkout 3
@@ -2769,7 +2769,7 @@ jobs:
     condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
   - bash: |-
       set -e
-      $FLOWEY_BIN v 7 'flowey_lib_common::git_checkout:4:flowey_lib_common/src/git_checkout.rs:402:29' --is-raw-string update --is-secret --env-source Pipeline.Workspace <<'EOF'
+      $FLOWEY_BIN v 7 'flowey_lib_common::git_checkout:4:flowey_lib_common/src/git_checkout.rs:402:29' --is-raw-string update --env-source Pipeline.Workspace <<'EOF'
       $(Pipeline.Workspace)
       EOF
       $(FLOWEY_BIN) e 7 flowey_lib_common::git_checkout 3
@@ -3060,7 +3060,7 @@ jobs:
     condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
   - bash: |-
       set -e
-      $FLOWEY_BIN v 6 'flowey_lib_common::git_checkout:4:flowey_lib_common/src/git_checkout.rs:402:29' --is-raw-string update --is-secret --env-source Pipeline.Workspace <<'EOF'
+      $FLOWEY_BIN v 6 'flowey_lib_common::git_checkout:4:flowey_lib_common/src/git_checkout.rs:402:29' --is-raw-string update --env-source Pipeline.Workspace <<'EOF'
       $(Pipeline.Workspace)
       EOF
       $(FLOWEY_BIN) e 6 flowey_lib_common::git_checkout 3
@@ -3276,7 +3276,7 @@ jobs:
     condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
   - bash: |-
       set -e
-      $FLOWEY_BIN v 5 'flowey_lib_common::git_checkout:4:flowey_lib_common/src/git_checkout.rs:402:29' --is-raw-string update --is-secret --env-source Pipeline.Workspace <<'EOF'
+      $FLOWEY_BIN v 5 'flowey_lib_common::git_checkout:4:flowey_lib_common/src/git_checkout.rs:402:29' --is-raw-string update --env-source Pipeline.Workspace <<'EOF'
       $(Pipeline.Workspace)
       EOF
       $(FLOWEY_BIN) e 5 flowey_lib_common::git_checkout 3
@@ -3562,7 +3562,7 @@ jobs:
     condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
   - bash: |-
       set -e
-      $FLOWEY_BIN v 4 'flowey_lib_common::git_checkout:4:flowey_lib_common/src/git_checkout.rs:402:29' --is-raw-string update --is-secret --env-source Pipeline.Workspace <<'EOF'
+      $FLOWEY_BIN v 4 'flowey_lib_common::git_checkout:4:flowey_lib_common/src/git_checkout.rs:402:29' --is-raw-string update --env-source Pipeline.Workspace <<'EOF'
       $(Pipeline.Workspace)
       EOF
       $(FLOWEY_BIN) e 4 flowey_lib_common::git_checkout 3
@@ -3733,7 +3733,7 @@ jobs:
     condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
   - bash: |-
       set -e
-      $FLOWEY_BIN v 3 'flowey_lib_common::git_checkout:4:flowey_lib_common/src/git_checkout.rs:402:29' --is-raw-string update --is-secret --env-source Pipeline.Workspace <<'EOF'
+      $FLOWEY_BIN v 3 'flowey_lib_common::git_checkout:4:flowey_lib_common/src/git_checkout.rs:402:29' --is-raw-string update --env-source Pipeline.Workspace <<'EOF'
       $(Pipeline.Workspace)
       EOF
       $(FLOWEY_BIN) e 3 flowey_lib_common::git_checkout 3
@@ -4060,7 +4060,7 @@ jobs:
     condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
   - bash: |-
       set -e
-      $FLOWEY_BIN v 2 'flowey_lib_common::git_checkout:4:flowey_lib_common/src/git_checkout.rs:402:29' --is-raw-string update --is-secret --env-source Pipeline.Workspace <<'EOF'
+      $FLOWEY_BIN v 2 'flowey_lib_common::git_checkout:4:flowey_lib_common/src/git_checkout.rs:402:29' --is-raw-string update --env-source Pipeline.Workspace <<'EOF'
       $(Pipeline.Workspace)
       EOF
       $(FLOWEY_BIN) e 2 flowey_lib_common::git_checkout 3
@@ -4270,7 +4270,7 @@ jobs:
     condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
   - bash: |-
       set -e
-      $FLOWEY_BIN v 19 'flowey_lib_common::git_checkout:4:flowey_lib_common/src/git_checkout.rs:402:29' --is-raw-string update --is-secret --env-source Pipeline.Workspace <<'EOF'
+      $FLOWEY_BIN v 19 'flowey_lib_common::git_checkout:4:flowey_lib_common/src/git_checkout.rs:402:29' --is-raw-string update --env-source Pipeline.Workspace <<'EOF'
       $(Pipeline.Workspace)
       EOF
       $(FLOWEY_BIN) e 19 flowey_lib_common::git_checkout 3
@@ -4567,7 +4567,7 @@ jobs:
     condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
   - bash: |-
       set -e
-      $FLOWEY_BIN v 18 'flowey_lib_common::git_checkout:4:flowey_lib_common/src/git_checkout.rs:402:29' --is-raw-string update --is-secret --env-source Pipeline.Workspace <<'EOF'
+      $FLOWEY_BIN v 18 'flowey_lib_common::git_checkout:4:flowey_lib_common/src/git_checkout.rs:402:29' --is-raw-string update --env-source Pipeline.Workspace <<'EOF'
       $(Pipeline.Workspace)
       EOF
       $(FLOWEY_BIN) e 18 flowey_lib_common::git_checkout 3
@@ -4874,7 +4874,7 @@ jobs:
     condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
   - bash: |-
       set -e
-      $FLOWEY_BIN v 17 'flowey_lib_common::git_checkout:4:flowey_lib_common/src/git_checkout.rs:402:29' --is-raw-string update --is-secret --env-source Pipeline.Workspace <<'EOF'
+      $FLOWEY_BIN v 17 'flowey_lib_common::git_checkout:4:flowey_lib_common/src/git_checkout.rs:402:29' --is-raw-string update --env-source Pipeline.Workspace <<'EOF'
       $(Pipeline.Workspace)
       EOF
       $(FLOWEY_BIN) e 17 flowey_lib_common::git_checkout 3
@@ -5174,7 +5174,7 @@ jobs:
     condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
   - bash: |-
       set -e
-      $FLOWEY_BIN v 16 'flowey_lib_common::git_checkout:4:flowey_lib_common/src/git_checkout.rs:402:29' --is-raw-string update --is-secret --env-source Pipeline.Workspace <<'EOF'
+      $FLOWEY_BIN v 16 'flowey_lib_common::git_checkout:4:flowey_lib_common/src/git_checkout.rs:402:29' --is-raw-string update --env-source Pipeline.Workspace <<'EOF'
       $(Pipeline.Workspace)
       EOF
       $(FLOWEY_BIN) e 16 flowey_lib_common::git_checkout 3
@@ -5392,7 +5392,7 @@ jobs:
     condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
   - bash: |-
       set -e
-      $FLOWEY_BIN v 1 'flowey_lib_common::git_checkout:4:flowey_lib_common/src/git_checkout.rs:402:29' --is-raw-string update --is-secret --env-source Pipeline.Workspace <<'EOF'
+      $FLOWEY_BIN v 1 'flowey_lib_common::git_checkout:4:flowey_lib_common/src/git_checkout.rs:402:29' --is-raw-string update --env-source Pipeline.Workspace <<'EOF'
       $(Pipeline.Workspace)
       EOF
       $(FLOWEY_BIN) e 1 flowey_lib_common::git_checkout 3

--- a/ci-flowey/openvmm-pr.yaml
+++ b/ci-flowey/openvmm-pr.yaml
@@ -26,7 +26,7 @@ jobs:
   pool:
     demands:
     - ImageOverride -equals ubuntu2404-amd64
-    name: openvmm-ado-amd-westus2
+    name: openvmm-ado-amd-westus2-v6
   dependsOn: []
   condition: and(succeeded(), not(canceled()))
   variables:
@@ -223,7 +223,7 @@ jobs:
   pool:
     demands:
     - ImageOverride -equals ubuntu2404-amd64
-    name: openvmm-ado-amd-westus2
+    name: openvmm-ado-amd-westus2-v6
   dependsOn:
   - job0
   condition: and(succeeded(), not(canceled()))
@@ -542,7 +542,7 @@ jobs:
   pool:
     demands:
     - ImageOverride -equals ubuntu2404-amd64
-    name: openvmm-ado-amd-westus2
+    name: openvmm-ado-amd-westus2-v6
   dependsOn:
   - job0
   condition: and(succeeded(), not(canceled()))
@@ -826,7 +826,7 @@ jobs:
   pool:
     demands:
     - ImageOverride -equals win-amd64-v2
-    name: openvmm-ado-amd-westus2
+    name: openvmm-ado-amd-westus2-v6
   dependsOn:
   - job0
   condition: and(succeeded(), not(canceled()))
@@ -1104,7 +1104,7 @@ jobs:
   pool:
     demands:
     - ImageOverride -equals ubuntu2404-amd64
-    name: openvmm-ado-amd-westus2
+    name: openvmm-ado-amd-westus2-v6
   dependsOn:
   - job0
   condition: and(succeeded(), not(canceled()))
@@ -1386,7 +1386,7 @@ jobs:
   pool:
     demands:
     - ImageOverride -equals ubuntu2404-amd64
-    name: openvmm-ado-amd-westus2
+    name: openvmm-ado-amd-westus2-v6
   dependsOn:
   - job0
   condition: and(succeeded(), not(canceled()))
@@ -1746,7 +1746,7 @@ jobs:
   pool:
     demands:
     - ImageOverride -equals ubuntu2404-amd64
-    name: openvmm-ado-amd-westus2
+    name: openvmm-ado-amd-westus2-v6
   dependsOn:
   - job0
   condition: and(succeeded(), not(canceled()))
@@ -1970,7 +1970,7 @@ jobs:
   pool:
     demands:
     - ImageOverride -equals ubuntu2404-amd64
-    name: openvmm-ado-amd-westus2
+    name: openvmm-ado-amd-westus2-v6
   dependsOn:
   - job0
   condition: and(succeeded(), not(canceled()))
@@ -2321,7 +2321,7 @@ jobs:
   pool:
     demands:
     - ImageOverride -equals ubuntu2404-amd64
-    name: openvmm-ado-amd-westus2
+    name: openvmm-ado-amd-westus2-v6
   dependsOn:
   - job0
   condition: and(succeeded(), not(canceled()))
@@ -2608,7 +2608,7 @@ jobs:
   pool:
     demands:
     - ImageOverride -equals win-amd64-v2
-    name: openvmm-ado-amd-westus2
+    name: openvmm-ado-amd-westus2-v6
   dependsOn:
   - job0
   condition: and(succeeded(), not(canceled()))
@@ -2902,7 +2902,7 @@ jobs:
   pool:
     demands:
     - ImageOverride -equals win-amd64-v2
-    name: openvmm-ado-amd-westus2
+    name: openvmm-ado-amd-westus2-v6
   dependsOn:
   - job0
   condition: and(succeeded(), not(canceled()))
@@ -3105,7 +3105,7 @@ jobs:
   pool:
     demands:
     - ImageOverride -equals win-amd64-v2
-    name: openvmm-ado-amd-westus2
+    name: openvmm-ado-amd-westus2-v6
   dependsOn:
   - job0
   condition: and(succeeded(), not(canceled()))
@@ -3394,7 +3394,7 @@ jobs:
   pool:
     demands:
     - ImageOverride -equals win-amd64-v2
-    name: openvmm-ado-amd-westus2
+    name: openvmm-ado-amd-westus2-v6
   dependsOn:
   - job0
   condition: and(succeeded(), not(canceled()))
@@ -3593,7 +3593,7 @@ jobs:
   pool:
     demands:
     - ImageOverride -equals ubuntu2404-amd64
-    name: openvmm-ado-amd-westus2
+    name: openvmm-ado-amd-westus2-v6
   dependsOn:
   - job0
   condition: and(succeeded(), not(canceled()))
@@ -3886,7 +3886,7 @@ jobs:
   pool:
     demands:
     - ImageOverride -equals win-amd64-v2
-    name: openvmm-ado-amd-westus2
+    name: openvmm-ado-amd-westus2-v6
   dependsOn:
   - job0
   condition: and(succeeded(), not(canceled()))
@@ -4058,7 +4058,7 @@ jobs:
   pool:
     demands:
     - ImageOverride -equals ubuntu2404-amd64
-    name: openvmm-ado-amd-westus2
+    name: openvmm-ado-amd-westus2-v6
   dependsOn:
   - job0
   - job2
@@ -4305,7 +4305,7 @@ jobs:
   pool:
     demands:
     - ImageOverride -equals win-amd64-v2
-    name: openvmm-ado-amd-westus2
+    name: openvmm-ado-amd-westus2-v6
   dependsOn:
   - job0
   - job11
@@ -4607,7 +4607,7 @@ jobs:
   pool:
     demands:
     - ImageOverride -equals win-amd64-v2
-    name: openvmm-ado-intel-centralus
+    name: openvmm-ado-intel-westus3-v6
   dependsOn:
   - job0
   - job12
@@ -4902,7 +4902,7 @@ jobs:
   pool:
     demands:
     - ImageOverride -equals win-amd64-v2
-    name: openvmm-ado-intel-centralus
+    name: openvmm-ado-intel-westus3-v6
   dependsOn:
   - job0
   - job11
@@ -5204,7 +5204,7 @@ jobs:
   pool:
     demands:
     - ImageOverride -equals win-amd64-v2
-    name: openvmm-ado-amd-westus2
+    name: openvmm-ado-amd-westus2-v6
   dependsOn:
   - job0
   condition: and(succeeded(), not(canceled()))

--- a/ci-flowey/openvmm-pr.yaml
+++ b/ci-flowey/openvmm-pr.yaml
@@ -116,7 +116,12 @@ jobs:
     submodules: recursive
     displayName: checkout repo openvmm
     condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
-  - bash: $(FLOWEY_BIN) e 0 flowey_lib_common::git_checkout 2
+  - bash: |-
+      set -e
+      $FLOWEY_BIN v 0 'flowey_lib_common::git_checkout:4:flowey_lib_common/src/git_checkout.rs:402:29' --is-raw-string update --is-secret --env-source Pipeline.Workspace <<'EOF'
+      $(Pipeline.Workspace)
+      EOF
+      $(FLOWEY_BIN) e 0 flowey_lib_common::git_checkout 3
     displayName: report cloned repo directories
   - bash: |-
       set -e
@@ -276,7 +281,12 @@ jobs:
     submodules: recursive
     displayName: checkout repo openvmm
     condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
-  - bash: $(FLOWEY_BIN) e 15 flowey_lib_common::git_checkout 2
+  - bash: |-
+      set -e
+      $FLOWEY_BIN v 15 'flowey_lib_common::git_checkout:4:flowey_lib_common/src/git_checkout.rs:402:29' --is-raw-string update --is-secret --env-source Pipeline.Workspace <<'EOF'
+      $(Pipeline.Workspace)
+      EOF
+      $(FLOWEY_BIN) e 15 flowey_lib_common::git_checkout 3
     displayName: report cloned repo directories
   - bash: |-
       set -e
@@ -599,7 +609,12 @@ jobs:
     submodules: recursive
     displayName: checkout repo openvmm
     condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
-  - bash: $(FLOWEY_BIN) e 14 flowey_lib_common::git_checkout 2
+  - bash: |-
+      set -e
+      $FLOWEY_BIN v 14 'flowey_lib_common::git_checkout:4:flowey_lib_common/src/git_checkout.rs:402:29' --is-raw-string update --is-secret --env-source Pipeline.Workspace <<'EOF'
+      $(Pipeline.Workspace)
+      EOF
+      $(FLOWEY_BIN) e 14 flowey_lib_common::git_checkout 3
     displayName: report cloned repo directories
   - bash: |-
       set -e
@@ -924,7 +939,12 @@ jobs:
     submodules: recursive
     displayName: checkout repo openvmm
     condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
-  - bash: $(FLOWEY_BIN) e 13 flowey_lib_common::git_checkout 2
+  - bash: |-
+      set -e
+      $FLOWEY_BIN v 13 'flowey_lib_common::git_checkout:4:flowey_lib_common/src/git_checkout.rs:402:29' --is-raw-string update --is-secret --env-source Pipeline.Workspace <<'EOF'
+      $(Pipeline.Workspace)
+      EOF
+      $(FLOWEY_BIN) e 13 flowey_lib_common::git_checkout 3
     displayName: report cloned repo directories
   - bash: |-
       set -e
@@ -1162,7 +1182,12 @@ jobs:
     submodules: recursive
     displayName: checkout repo openvmm
     condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
-  - bash: $(FLOWEY_BIN) e 12 flowey_lib_common::git_checkout 2
+  - bash: |-
+      set -e
+      $FLOWEY_BIN v 12 'flowey_lib_common::git_checkout:4:flowey_lib_common/src/git_checkout.rs:402:29' --is-raw-string update --is-secret --env-source Pipeline.Workspace <<'EOF'
+      $(Pipeline.Workspace)
+      EOF
+      $(FLOWEY_BIN) e 12 flowey_lib_common::git_checkout 3
     displayName: report cloned repo directories
   - bash: |-
       set -e
@@ -1452,7 +1477,12 @@ jobs:
     submodules: recursive
     displayName: checkout repo openvmm
     condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
-  - bash: $(FLOWEY_BIN) e 11 flowey_lib_common::git_checkout 2
+  - bash: |-
+      set -e
+      $FLOWEY_BIN v 11 'flowey_lib_common::git_checkout:4:flowey_lib_common/src/git_checkout.rs:402:29' --is-raw-string update --is-secret --env-source Pipeline.Workspace <<'EOF'
+      $(Pipeline.Workspace)
+      EOF
+      $(FLOWEY_BIN) e 11 flowey_lib_common::git_checkout 3
     displayName: report cloned repo directories
   - bash: |-
       set -e
@@ -1800,7 +1830,12 @@ jobs:
     submodules: recursive
     displayName: checkout repo openvmm
     condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
-  - bash: $(FLOWEY_BIN) e 10 flowey_lib_common::git_checkout 2
+  - bash: |-
+      set -e
+      $FLOWEY_BIN v 10 'flowey_lib_common::git_checkout:4:flowey_lib_common/src/git_checkout.rs:402:29' --is-raw-string update --is-secret --env-source Pipeline.Workspace <<'EOF'
+      $(Pipeline.Workspace)
+      EOF
+      $(FLOWEY_BIN) e 10 flowey_lib_common::git_checkout 3
     displayName: report cloned repo directories
   - bash: |-
       set -e
@@ -2051,7 +2086,12 @@ jobs:
     submodules: recursive
     displayName: checkout repo openvmm
     condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
-  - bash: $(FLOWEY_BIN) e 9 flowey_lib_common::git_checkout 2
+  - bash: |-
+      set -e
+      $FLOWEY_BIN v 9 'flowey_lib_common::git_checkout:4:flowey_lib_common/src/git_checkout.rs:402:29' --is-raw-string update --is-secret --env-source Pipeline.Workspace <<'EOF'
+      $(Pipeline.Workspace)
+      EOF
+      $(FLOWEY_BIN) e 9 flowey_lib_common::git_checkout 3
     displayName: report cloned repo directories
   - bash: |-
       set -e
@@ -2398,7 +2438,12 @@ jobs:
     submodules: recursive
     displayName: checkout repo openvmm
     condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
-  - bash: $(FLOWEY_BIN) e 8 flowey_lib_common::git_checkout 2
+  - bash: |-
+      set -e
+      $FLOWEY_BIN v 8 'flowey_lib_common::git_checkout:4:flowey_lib_common/src/git_checkout.rs:402:29' --is-raw-string update --is-secret --env-source Pipeline.Workspace <<'EOF'
+      $(Pipeline.Workspace)
+      EOF
+      $(FLOWEY_BIN) e 8 flowey_lib_common::git_checkout 3
     displayName: report cloned repo directories
   - bash: |-
       set -e
@@ -2722,7 +2767,12 @@ jobs:
     submodules: recursive
     displayName: checkout repo openvmm
     condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
-  - bash: $(FLOWEY_BIN) e 7 flowey_lib_common::git_checkout 2
+  - bash: |-
+      set -e
+      $FLOWEY_BIN v 7 'flowey_lib_common::git_checkout:4:flowey_lib_common/src/git_checkout.rs:402:29' --is-raw-string update --is-secret --env-source Pipeline.Workspace <<'EOF'
+      $(Pipeline.Workspace)
+      EOF
+      $(FLOWEY_BIN) e 7 flowey_lib_common::git_checkout 3
     displayName: report cloned repo directories
   - bash: |-
       set -e
@@ -3008,7 +3058,12 @@ jobs:
     submodules: recursive
     displayName: checkout repo openvmm
     condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
-  - bash: $(FLOWEY_BIN) e 6 flowey_lib_common::git_checkout 2
+  - bash: |-
+      set -e
+      $FLOWEY_BIN v 6 'flowey_lib_common::git_checkout:4:flowey_lib_common/src/git_checkout.rs:402:29' --is-raw-string update --is-secret --env-source Pipeline.Workspace <<'EOF'
+      $(Pipeline.Workspace)
+      EOF
+      $(FLOWEY_BIN) e 6 flowey_lib_common::git_checkout 3
     displayName: report cloned repo directories
   - bash: |-
       set -e
@@ -3219,7 +3274,12 @@ jobs:
     submodules: recursive
     displayName: checkout repo openvmm
     condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
-  - bash: $(FLOWEY_BIN) e 5 flowey_lib_common::git_checkout 2
+  - bash: |-
+      set -e
+      $FLOWEY_BIN v 5 'flowey_lib_common::git_checkout:4:flowey_lib_common/src/git_checkout.rs:402:29' --is-raw-string update --is-secret --env-source Pipeline.Workspace <<'EOF'
+      $(Pipeline.Workspace)
+      EOF
+      $(FLOWEY_BIN) e 5 flowey_lib_common::git_checkout 3
     displayName: report cloned repo directories
   - bash: |-
       set -e
@@ -3500,7 +3560,12 @@ jobs:
     submodules: recursive
     displayName: checkout repo openvmm
     condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
-  - bash: $(FLOWEY_BIN) e 4 flowey_lib_common::git_checkout 2
+  - bash: |-
+      set -e
+      $FLOWEY_BIN v 4 'flowey_lib_common::git_checkout:4:flowey_lib_common/src/git_checkout.rs:402:29' --is-raw-string update --is-secret --env-source Pipeline.Workspace <<'EOF'
+      $(Pipeline.Workspace)
+      EOF
+      $(FLOWEY_BIN) e 4 flowey_lib_common::git_checkout 3
     displayName: report cloned repo directories
   - bash: |-
       set -e
@@ -3666,7 +3731,12 @@ jobs:
     submodules: recursive
     displayName: checkout repo openvmm
     condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
-  - bash: $(FLOWEY_BIN) e 3 flowey_lib_common::git_checkout 2
+  - bash: |-
+      set -e
+      $FLOWEY_BIN v 3 'flowey_lib_common::git_checkout:4:flowey_lib_common/src/git_checkout.rs:402:29' --is-raw-string update --is-secret --env-source Pipeline.Workspace <<'EOF'
+      $(Pipeline.Workspace)
+      EOF
+      $(FLOWEY_BIN) e 3 flowey_lib_common::git_checkout 3
     displayName: report cloned repo directories
   - bash: |-
       set -e
@@ -3988,7 +4058,12 @@ jobs:
     submodules: recursive
     displayName: checkout repo openvmm
     condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
-  - bash: $(FLOWEY_BIN) e 2 flowey_lib_common::git_checkout 2
+  - bash: |-
+      set -e
+      $FLOWEY_BIN v 2 'flowey_lib_common::git_checkout:4:flowey_lib_common/src/git_checkout.rs:402:29' --is-raw-string update --is-secret --env-source Pipeline.Workspace <<'EOF'
+      $(Pipeline.Workspace)
+      EOF
+      $(FLOWEY_BIN) e 2 flowey_lib_common::git_checkout 3
     displayName: report cloned repo directories
   - bash: |-
       set -e
@@ -4193,7 +4268,12 @@ jobs:
     submodules: recursive
     displayName: checkout repo openvmm
     condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
-  - bash: $(FLOWEY_BIN) e 19 flowey_lib_common::git_checkout 2
+  - bash: |-
+      set -e
+      $FLOWEY_BIN v 19 'flowey_lib_common::git_checkout:4:flowey_lib_common/src/git_checkout.rs:402:29' --is-raw-string update --is-secret --env-source Pipeline.Workspace <<'EOF'
+      $(Pipeline.Workspace)
+      EOF
+      $(FLOWEY_BIN) e 19 flowey_lib_common::git_checkout 3
     displayName: report cloned repo directories
   - bash: |-
       set -e
@@ -4485,7 +4565,12 @@ jobs:
     submodules: recursive
     displayName: checkout repo openvmm
     condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
-  - bash: $(FLOWEY_BIN) e 18 flowey_lib_common::git_checkout 2
+  - bash: |-
+      set -e
+      $FLOWEY_BIN v 18 'flowey_lib_common::git_checkout:4:flowey_lib_common/src/git_checkout.rs:402:29' --is-raw-string update --is-secret --env-source Pipeline.Workspace <<'EOF'
+      $(Pipeline.Workspace)
+      EOF
+      $(FLOWEY_BIN) e 18 flowey_lib_common::git_checkout 3
     displayName: report cloned repo directories
   - bash: |-
       set -e
@@ -4787,7 +4872,12 @@ jobs:
     submodules: recursive
     displayName: checkout repo openvmm
     condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
-  - bash: $(FLOWEY_BIN) e 17 flowey_lib_common::git_checkout 2
+  - bash: |-
+      set -e
+      $FLOWEY_BIN v 17 'flowey_lib_common::git_checkout:4:flowey_lib_common/src/git_checkout.rs:402:29' --is-raw-string update --is-secret --env-source Pipeline.Workspace <<'EOF'
+      $(Pipeline.Workspace)
+      EOF
+      $(FLOWEY_BIN) e 17 flowey_lib_common::git_checkout 3
     displayName: report cloned repo directories
   - bash: |-
       set -e
@@ -5082,7 +5172,12 @@ jobs:
     submodules: recursive
     displayName: checkout repo openvmm
     condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
-  - bash: $(FLOWEY_BIN) e 16 flowey_lib_common::git_checkout 2
+  - bash: |-
+      set -e
+      $FLOWEY_BIN v 16 'flowey_lib_common::git_checkout:4:flowey_lib_common/src/git_checkout.rs:402:29' --is-raw-string update --is-secret --env-source Pipeline.Workspace <<'EOF'
+      $(Pipeline.Workspace)
+      EOF
+      $(FLOWEY_BIN) e 16 flowey_lib_common::git_checkout 3
     displayName: report cloned repo directories
   - bash: |-
       set -e
@@ -5295,7 +5390,12 @@ jobs:
     submodules: recursive
     displayName: checkout repo openvmm
     condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
-  - bash: $(FLOWEY_BIN) e 1 flowey_lib_common::git_checkout 2
+  - bash: |-
+      set -e
+      $FLOWEY_BIN v 1 'flowey_lib_common::git_checkout:4:flowey_lib_common/src/git_checkout.rs:402:29' --is-raw-string update --is-secret --env-source Pipeline.Workspace <<'EOF'
+      $(Pipeline.Workspace)
+      EOF
+      $(FLOWEY_BIN) e 1 flowey_lib_common::git_checkout 3
     displayName: report cloned repo directories
   - bash: |-
       set -e

--- a/flowey/flowey_core/src/node.rs
+++ b/flowey/flowey_core/src/node.rs
@@ -1896,6 +1896,10 @@ pub mod steps {
             /// `System.System.JobAttempt`
             pub const SYSTEM_JOB_ATTEMPT: AdoRuntimeVar =
                 AdoRuntimeVar::new_secret("System.JobAttempt");
+
+            /// `Pipeline.Workspace`
+            pub const PIPELINE_WORKSPACE: AdoRuntimeVar =
+                AdoRuntimeVar::new_secret("Pipeline.Workspace");
         }
 
         impl AdoRuntimeVar {

--- a/flowey/flowey_core/src/node.rs
+++ b/flowey/flowey_core/src/node.rs
@@ -1898,8 +1898,7 @@ pub mod steps {
                 AdoRuntimeVar::new_secret("System.JobAttempt");
 
             /// `Pipeline.Workspace`
-            pub const PIPELINE_WORKSPACE: AdoRuntimeVar =
-                AdoRuntimeVar::new_secret("Pipeline.Workspace");
+            pub const PIPELINE_WORKSPACE: AdoRuntimeVar = AdoRuntimeVar::new("Pipeline.Workspace");
         }
 
         impl AdoRuntimeVar {

--- a/flowey/flowey_hvlite/src/pipelines/checkin_gates.rs
+++ b/flowey/flowey_hvlite/src/pipelines/checkin_gates.rs
@@ -1152,7 +1152,7 @@ impl IntoPipeline for CheckinGatesCli {
                 platform: FlowPlatform::Windows,
                 arch: FlowArch::X86_64,
                 gh_pool: gh_pools::windows_intel_v6_1es(),
-                ado_pool: Some(ado_pools::windows_amd_1es()),
+                ado_pool: Some(ado_pools::windows_amd_v6_1es()),
                 clippy_targets: Some((
                     "x64-windows",
                     &[(target_lexicon::triple!("x86_64-pc-windows-msvc"), false)],
@@ -1166,7 +1166,7 @@ impl IntoPipeline for CheckinGatesCli {
                 platform: FlowPlatform::Linux(FlowPlatformLinuxDistro::Ubuntu),
                 arch: FlowArch::X86_64,
                 gh_pool: gh_pools::linux_intel_v6_1es(),
-                ado_pool: Some(ado_pools::linux_amd_1es()),
+                ado_pool: Some(ado_pools::linux_amd_v6_1es()),
                 clippy_targets: if quick_check_job.is_some() {
                     // quick check already ran clippy for x64-linux;
                     // still need macos cross-clippy here.
@@ -1186,7 +1186,7 @@ impl IntoPipeline for CheckinGatesCli {
                 platform: FlowPlatform::Linux(FlowPlatformLinuxDistro::Ubuntu),
                 arch: FlowArch::X86_64,
                 gh_pool: gh_pools::linux_intel_v6_1es(),
-                ado_pool: Some(ado_pools::linux_amd_1es()),
+                ado_pool: Some(ado_pools::linux_amd_v6_1es()),
                 clippy_targets: Some((
                     "x64-linux-musl, misc nostd",
                     &[(openhcl_musl_target(CommonArch::X86_64), true)],
@@ -1493,7 +1493,7 @@ impl IntoPipeline for CheckinGatesCli {
                 platform: FlowPlatform::Windows,
                 arch: FlowArch::X86_64,
                 gh_pool: gh_pools::windows_intel_v6_1es(),
-                ado_pool: Some(ado_pools::windows_intel_1es()),
+                ado_pool: Some(ado_pools::windows_intel_v6_1es()),
                 label: "x64-windows-intel",
                 target: CommonTriple::X86_64_WINDOWS_MSVC,
                 resolve_vmm_tests_artifacts: vmm_tests_artifacts_windows_intel_x86,
@@ -1506,7 +1506,7 @@ impl IntoPipeline for CheckinGatesCli {
                 platform: FlowPlatform::Windows,
                 arch: FlowArch::X86_64,
                 gh_pool: gh_pools::windows_intel_v6_1es(),
-                ado_pool: Some(ado_pools::windows_intel_1es()),
+                ado_pool: Some(ado_pools::windows_intel_v6_1es()),
                 label: "x64-windows-intel-mi-secure",
                 target: CommonTriple::X86_64_WINDOWS_MSVC,
                 resolve_vmm_tests_artifacts: vmm_tests_artifacts_windows_intel_mi_secure_x86,
@@ -1535,7 +1535,7 @@ impl IntoPipeline for CheckinGatesCli {
                 // a Windows hypervisor bug causes VMM tests to crash
                 // when running on v7, so use v6
                 gh_pool: gh_pools::windows_amd_v6_1es(),
-                ado_pool: Some(ado_pools::windows_amd_1es()),
+                ado_pool: Some(ado_pools::windows_amd_v6_1es()),
                 label: "x64-windows-amd",
                 target: CommonTriple::X86_64_WINDOWS_MSVC,
                 resolve_vmm_tests_artifacts: vmm_tests_artifacts_windows_amd_x86,
@@ -1561,7 +1561,7 @@ impl IntoPipeline for CheckinGatesCli {
                 platform: FlowPlatform::Linux(FlowPlatformLinuxDistro::Ubuntu),
                 arch: FlowArch::X86_64,
                 gh_pool: gh_pools::linux_amd_v7_1es(),
-                ado_pool: Some(ado_pools::linux_amd_1es()),
+                ado_pool: Some(ado_pools::linux_amd_v6_1es()),
                 label: "x64-linux-amd-kvm",
                 target: CommonTriple::X86_64_LINUX_GNU,
                 resolve_vmm_tests_artifacts: vmm_tests_artifacts_linux_x86,

--- a/flowey/flowey_hvlite/src/pipelines_shared/ado_pools.rs
+++ b/flowey/flowey_hvlite/src/pipelines_shared/ado_pools.rs
@@ -6,10 +6,10 @@
 use flowey::pipeline::prelude::*;
 
 use super::gh_pools::LINUX_IMAGE_AMD64;
-use super::gh_pools::WINDOWS_IMAGE_AMD64;
+use super::gh_pools::WINDOWS_IMAGE_AMD64_V2;
 
-pub const AMD_POOL_1ES: &str = "openvmm-ado-amd-westus2";
-pub const INTEL_POOL_1ES: &str = "openvmm-ado-intel-centralus";
+pub const AMD_V6_POOL_1ES: &str = "openvmm-ado-amd-westus2-v6";
+pub const INTEL_V6_POOL_1ES: &str = "openvmm-ado-intel-westus3-v6";
 pub const INTEL_TDX_POOL: &str = "openvmm-ado-intel-tdx";
 
 fn ado_pool_with_image_1es(pool: &str, image: &str) -> AdoPool {
@@ -26,22 +26,22 @@ pub fn windows_intel_tdx() -> AdoPool {
     }
 }
 
-pub fn windows_amd_1es() -> AdoPool {
-    ado_pool_with_image_1es(AMD_POOL_1ES, WINDOWS_IMAGE_AMD64)
+pub fn windows_amd_v6_1es() -> AdoPool {
+    ado_pool_with_image_1es(AMD_V6_POOL_1ES, WINDOWS_IMAGE_AMD64_V2)
 }
 
-pub fn windows_intel_1es() -> AdoPool {
-    ado_pool_with_image_1es(INTEL_POOL_1ES, WINDOWS_IMAGE_AMD64)
+pub fn windows_intel_v6_1es() -> AdoPool {
+    ado_pool_with_image_1es(INTEL_V6_POOL_1ES, WINDOWS_IMAGE_AMD64_V2)
 }
 
-pub fn linux_amd_1es() -> AdoPool {
-    ado_pool_with_image_1es(AMD_POOL_1ES, LINUX_IMAGE_AMD64)
+pub fn linux_amd_v6_1es() -> AdoPool {
+    ado_pool_with_image_1es(AMD_V6_POOL_1ES, LINUX_IMAGE_AMD64)
 }
 
 pub fn default_windows() -> AdoPool {
-    windows_amd_1es()
+    windows_amd_v6_1es()
 }
 
 pub fn default_linux() -> AdoPool {
-    linux_amd_1es()
+    linux_amd_v6_1es()
 }

--- a/flowey/flowey_hvlite/src/pipelines_shared/gh_pools.rs
+++ b/flowey/flowey_hvlite/src/pipelines_shared/gh_pools.rs
@@ -5,18 +5,22 @@
 
 use flowey::pipeline::prelude::*;
 
+// Constants in this file may be added, renamed or deleted, but the values
+// of these constants should not be changed to avoid changing the image to one
+// that may not be present in all of the pools where the constant is used
+// (in both Github and ADO).
+pub const WINDOWS_IMAGE_AMD64_V2: &str = "win-amd64-v2";
+pub const WINDOWS_IMAGE_ARM64_V2: &str = "win-arm64-v2";
+pub const LINUX_IMAGE_AMD64: &str = "ubuntu2404-amd64";
+pub const LINUX_IMAGE_ARM64: &str = "ubuntu2404-arm64";
+pub const MSHV_IMAGE_AMD64: &str = "azurelinux3-amd64-dom0";
+
 pub const AMD_V6_POOL_1ES: &str = "openvmm-gh-amd-westus3-v6";
 pub const AMD_V7_POOL_1ES: &str = "openvmm-gh-amd-westus3-v7";
 pub const INTEL_V5_POOL_1ES: &str = "openvmm-gh-intel-westus3";
 pub const INTEL_V6_POOL_1ES: &str = "openvmm-gh-intel-westus3-v6";
 pub const ARM_V5_POOL_1ES: &str = "openvmm-gh-arm-westus2";
 pub const ARM_V6_POOL_1ES: &str = "openvmm-gh-arm-westus3";
-
-pub const WINDOWS_IMAGE_AMD64: &str = "win-amd64-v2";
-pub const WINDOWS_IMAGE_ARM64: &str = "win-arm64-v2";
-pub const LINUX_IMAGE_AMD64: &str = "ubuntu2404-amd64";
-pub const LINUX_IMAGE_ARM64: &str = "ubuntu2404-arm64";
-pub const MSHV_IMAGE_AMD64: &str = "azurelinux3-amd64-dom0";
 
 fn gh_pool_with_image_1es(pool: &str, image: &str) -> GhRunner {
     GhRunner::SelfHosted(vec![
@@ -27,15 +31,15 @@ fn gh_pool_with_image_1es(pool: &str, image: &str) -> GhRunner {
 }
 
 pub fn windows_arm_v6_1es() -> GhRunner {
-    gh_pool_with_image_1es(ARM_V6_POOL_1ES, WINDOWS_IMAGE_ARM64)
+    gh_pool_with_image_1es(ARM_V6_POOL_1ES, WINDOWS_IMAGE_ARM64_V2)
 }
 
 pub fn windows_amd_v6_1es() -> GhRunner {
-    gh_pool_with_image_1es(AMD_V6_POOL_1ES, WINDOWS_IMAGE_AMD64)
+    gh_pool_with_image_1es(AMD_V6_POOL_1ES, WINDOWS_IMAGE_AMD64_V2)
 }
 
 pub fn windows_intel_v6_1es() -> GhRunner {
-    gh_pool_with_image_1es(INTEL_V6_POOL_1ES, WINDOWS_IMAGE_AMD64)
+    gh_pool_with_image_1es(INTEL_V6_POOL_1ES, WINDOWS_IMAGE_AMD64_V2)
 }
 
 pub fn linux_arm_v5_1es() -> GhRunner {

--- a/flowey/flowey_hvlite/src/pipelines_shared/gh_pools.rs
+++ b/flowey/flowey_hvlite/src/pipelines_shared/gh_pools.rs
@@ -8,7 +8,7 @@ use flowey::pipeline::prelude::*;
 // Constants in this file may be added, renamed or deleted, but the values
 // of these constants should not be changed to avoid changing the image to one
 // that may not be present in all of the pools where the constant is used
-// (in both Github and ADO).
+// (in both GitHub and ADO).
 pub const WINDOWS_IMAGE_AMD64_V2: &str = "win-amd64-v2";
 pub const WINDOWS_IMAGE_ARM64_V2: &str = "win-arm64-v2";
 pub const LINUX_IMAGE_AMD64: &str = "ubuntu2404-amd64";

--- a/flowey/flowey_lib_common/src/git_checkout.rs
+++ b/flowey/flowey_lib_common/src/git_checkout.rs
@@ -399,8 +399,11 @@ impl Node {
             did_checkouts.push(did_checkout);
         }
 
+        let workspace = ctx.get_ado_variable(AdoRuntimeVar::PIPELINE_WORKSPACE);
+
         ctx.emit_rust_step("report cloned repo directories", move |ctx| {
             did_checkouts.claim(ctx);
+            let workspace = workspace.claim(ctx);
             let mut registered_repos = registered_repos.into_iter().map(|(k, (a, b))| (k, (a, b.claim(ctx)))).collect::<BTreeMap<_, _>>();
             let checkout_repo = checkout_repo
                 .into_iter()
@@ -410,6 +413,7 @@ impl Node {
                 .collect::<Vec<_>>();
 
             move |rt| {
+                let workspace = PathBuf::from(rt.read(workspace));
                 let mut checkout_reqs = BTreeMap::<(String, bool), Vec<ClaimedWriteVar<PathBuf>>>::new();
                 for (repo_id, repo_path, persist_credentials) in checkout_repo {
                     checkout_reqs
@@ -426,13 +430,7 @@ impl Node {
 
                     let path = match repo_src {
                         RepoSource::AdoResource(_) => {
-                            // HACK: this should be using something like AGENT_WORKDIR
-                            if cfg!(windows) {
-                                Path::new(r#"D:\a\_work\1\"#)
-                            } else {
-                                Path::new("/mnt/vss/_work/1/")
-                            }
-                            .join(format!("repo{idx}"))
+                            workspace.join(format!("repo{idx}"))                          
                         },
                         RepoSource::GithubRepo{ .. } | RepoSource::GithubSelf => anyhow::bail!("repo source for ADO backend must be an `AdoResource` or `ExistingClone`"),
                         RepoSource::ExistingClone(path) => {

--- a/flowey/flowey_lib_common/src/git_checkout.rs
+++ b/flowey/flowey_lib_common/src/git_checkout.rs
@@ -430,7 +430,7 @@ impl Node {
 
                     let path = match repo_src {
                         RepoSource::AdoResource(_) => {
-                            workspace.join(format!("repo{idx}"))                          
+                            workspace.join(format!("repo{idx}"))
                         },
                         RepoSource::GithubRepo{ .. } | RepoSource::GithubSelf => anyhow::bail!("repo source for ADO backend must be an `AdoResource` or `ExistingClone`"),
                         RepoSource::ExistingClone(path) => {


### PR DESCRIPTION
Use gen2 windows images and v6 runner skus for ado.

Also includes a fix so that the ado work folder is obtained from an env var instead of hardcoded, which is necessary because Azure skus with NVMe (v6+) have a different default work folder.