### PR TITLE
virt_whp: Fix start_vp and enable_vp_vtl again

### DIFF
--- a/vmm_core/virt_whp/src/hypercalls.rs
+++ b/vmm_core/virt_whp/src/hypercalls.rs
@@ -1018,8 +1018,15 @@ mod x86 {
                 return Err(HvError::AccessDenied);
             }
 
+            if target_vtl == Vtl::Vtl2 && !target_vp.vp().vtl2_enable.load(Ordering::SeqCst) {
+                return Err(HvError::InvalidVpState);
+            }
+
             let target_vplc = target_vp.vplc(target_vtl);
-            *target_vplc.start_vp_context.lock() = Some(Box::new(*vp_context));
+            *target_vplc.start_vp_request.lock() = Some(crate::VpStartRequest {
+                operation: crate::VpStartOperation::StartVirtualProcessor,
+                context: Box::new(*vp_context),
+            });
             target_vplc.start_vp.store(true, Ordering::Release);
             target_vp.wake();
             Ok(())
@@ -1360,11 +1367,14 @@ mod x86 {
             tracing::debug!(vp_index = vp_index.index(), ?vtl, "enabling vtl");
 
             let target_vplc = target_vp.vplc(vtl);
-            *target_vplc.start_vp_context.lock() = Some(Box::new(*vp_context));
+            *target_vplc.start_vp_request.lock() = Some(crate::VpStartRequest {
+                operation: crate::VpStartOperation::EnableVpVtl,
+                context: Box::new(*vp_context),
+            });
             target_vplc.start_vp.store(true, Ordering::Release);
 
-            // Force the target VP to return from any in-progress run and
-            // wake its async future so it processes the start-VP request.
+            // Force the target VP to return from any in-progress run and wake
+            // its async future so it processes the request.
             target_vp.whp(Vtl::Vtl0).cancel_run().expect("can't fail");
             target_vp.wake();
             Ok(())

--- a/vmm_core/virt_whp/src/hypercalls.rs
+++ b/vmm_core/virt_whp/src/hypercalls.rs
@@ -1018,7 +1018,7 @@ mod x86 {
                 return Err(HvError::AccessDenied);
             }
 
-            if target_vtl == Vtl::Vtl2 && !target_vp.vp().vtl2_enable.load(Ordering::SeqCst) {
+            if target_vtl == Vtl::Vtl2 && !target_vp.vp().vtl2_enable.load(Ordering::Relaxed) {
                 return Err(HvError::InvalidVpState);
             }
 
@@ -1360,7 +1360,7 @@ mod x86 {
                 return Err(HvError::InvalidParameter);
             }
 
-            if target_vp.vp().vtl2_enable.swap(true, Ordering::SeqCst) {
+            if target_vp.vp().vtl2_enable.swap(true, Ordering::Relaxed) {
                 return Err(HvError::VtlAlreadyEnabled);
             }
 

--- a/vmm_core/virt_whp/src/lib.rs
+++ b/vmm_core/virt_whp/src/lib.rs
@@ -374,6 +374,7 @@ type InitialVpContext = hvdef::hypercall::InitialVpContextArm64;
 
 /// Which hypercall is requesting that a VP's initial VTL context be set.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(guest_arch = "aarch64", expect(dead_code))]
 enum VpStartOperation {
     /// `HvCallEnableVpVtl`: install the VTL's initial register context, but do
     /// not change the active VTL (i.e. do not start the VP running the VTL).
@@ -387,6 +388,7 @@ enum VpStartOperation {
 /// A pending `HvCallEnableVpVtl` / `HvCallStartVirtualProcessor` request for a
 /// VTL on a VP, set by the issuing VP and consumed by the target VP's run loop.
 #[derive(Debug)]
+#[cfg_attr(guest_arch = "aarch64", expect(dead_code))]
 struct VpStartRequest {
     operation: VpStartOperation,
     context: Box<InitialVpContext>,

--- a/vmm_core/virt_whp/src/lib.rs
+++ b/vmm_core/virt_whp/src/lib.rs
@@ -372,13 +372,33 @@ type InitialVpContext = hvdef::hypercall::InitialVpContextX64;
 #[cfg(guest_arch = "aarch64")]
 type InitialVpContext = hvdef::hypercall::InitialVpContextArm64;
 
+/// Which hypercall is requesting that a VP's initial VTL context be set.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum VpStartOperation {
+    /// `HvCallEnableVpVtl`: install the VTL's initial register context, but do
+    /// not change the active VTL (i.e. do not start the VP running the VTL).
+    EnableVpVtl,
+    /// `HvCallStartVirtualProcessor`: install the context and start the VP
+    /// running the target VTL. This is the only way to start a VP in a
+    /// non-zero VTL.
+    StartVirtualProcessor,
+}
+
+/// A pending `HvCallEnableVpVtl` / `HvCallStartVirtualProcessor` request for a
+/// VTL on a VP, set by the issuing VP and consumed by the target VP's run loop.
+#[derive(Debug)]
+struct VpStartRequest {
+    operation: VpStartOperation,
+    context: Box<InitialVpContext>,
+}
+
 #[derive(Debug, Inspect)]
 struct Vplc {
     message_queues: MessageQueues,
     check_queues: AtomicBool,
     extint_pending: AtomicBool,
     #[inspect(with = "|x| x.lock().is_some()")]
-    start_vp_context: Mutex<Option<Box<InitialVpContext>>>,
+    start_vp_request: Mutex<Option<VpStartRequest>>,
     #[inspect(skip)]
     start_vp: AtomicBool,
 }
@@ -390,7 +410,7 @@ impl Vplc {
             check_queues: false.into(),
             extint_pending: false.into(),
             start_vp: false.into(),
-            start_vp_context: Default::default(),
+            start_vp_request: Default::default(),
         }
     }
 
@@ -404,13 +424,13 @@ impl Vplc {
             message_queues,
             check_queues,
             extint_pending,
-            start_vp_context,
+            start_vp_request,
             start_vp,
         } = self;
         message_queues.clear();
         check_queues.store(false, Ordering::Relaxed);
         extint_pending.store(false, Ordering::Relaxed);
-        *start_vp_context.lock() = None;
+        *start_vp_request.lock() = None;
         start_vp.store(false, Ordering::Relaxed);
     }
 }
@@ -1743,10 +1763,9 @@ impl<'p> virt::Processor for WhpProcessor<'p> {
         let is_bsp = self.inner.vp_info.base.is_bsp();
         self.state.reset(false, is_bsp);
 
-        // For each enabled VTL: apply arch fixups that WHP doesn't handle
-        // and clear any pending `start_vp_context` (via `finish_reset`),
-        // then clear stale pending per-VTL VP signal flags (via
-        // `Vplc::reset`).
+        // For each enabled VTL: apply arch fixups that WHP doesn't handle (via
+        // `finish_reset`), then clear stale pending per-VTL VP signal flags,
+        // including any pending `start_vp_request` (via `Vplc::reset`).
         // VTL0 is always present.
         self.finish_reset(Vtl::Vtl0);
         self.vplc(Vtl::Vtl0).reset();
@@ -1770,28 +1789,24 @@ impl<'p> virt::Processor for WhpProcessor<'p> {
         assert_eq!(vtl, Vtl::Vtl2);
         let is_bsp = self.inner.vp_info.base.is_bsp();
 
-        // Reset per-VP VTL2-enable state on non-BSP VPs. The new VTL2 will
-        // re-issue `HvCallEnableVpVtl` on each AP to program its startup
-        // context (RIP/RSP/CR3/GDT/IDT)
-        //
-        // Leave `enabled_vtls` alone so that `state.reset` keeps `active_vtl`
-        // at VTL2 on the AP, allowing it to idle in VTL2 (in startup suspend)
-        // during the servicing window.
-        if !is_bsp {
-            self.inner.vtl2_enable.store(false, Ordering::Relaxed);
-        }
-
+        // VTL2 stays enabled across a scrub. `enabled_vtls` and `vtl2_enable`
+        // are both left set, so `state.reset` keeps `active_vtl` at VTL2 and
+        // each AP idles in VTL2 (in startup suspend) during the servicing window.
         self.state.reset(true, is_bsp);
 
-        // Scrub only resets VTL2. Reset the Vplc to clear any stale pending
-        // signals (message queue notifications, external interrupts, start-VP
-        // requests, etc.) -- the hypervisor zeroes the equivalent per-VTL
-        // activity flags during a VTL scrub.
+        // Re-apply arch register fixups that WHP doesn't handle (`finish_reset`
+        // must run after the partition-level WHP reset), then clear stale
+        // pending per-VTL VP signals -- message queue notifications, external
+        // interrupts, start-VP requests, etc. -- via `Vplc::reset`. The
+        // hypervisor zeroes the equivalent per-VTL activity flags during a VTL
+        // scrub.
         self.finish_reset(Vtl::Vtl2);
         self.vplc(Vtl::Vtl2).reset();
 
         // Clear any pending VTL2 wake signal, since VTL2 is now back in
-        // startup suspend and any prior wake request is stale.
+        // startup suspend and any prior wake request is stale. Per-VP signals
+        // that are not VTL2-specific (such as `scan_irr`) are intentionally
+        // left intact, as they may carry pending VTL0 work.
         self.inner.vtl2_wake.store(false, Ordering::Relaxed);
 
         if cfg!(debug_assertions) {

--- a/vmm_core/virt_whp/src/vp.rs
+++ b/vmm_core/virt_whp/src/vp.rs
@@ -512,7 +512,6 @@ mod x86 {
     use hvdef::HvVtlEntryReason;
     use hvdef::HvX64VpExecutionState;
     use hvdef::Vtl;
-    use hvdef::hypercall::InitialVpContextX64;
     use thiserror::Error;
     use virt::LateMapVtl0MemoryPolicy;
     use virt::VpHaltReason;

--- a/vmm_core/virt_whp/src/vp.rs
+++ b/vmm_core/virt_whp/src/vp.rs
@@ -254,19 +254,12 @@ impl<'a> WhpProcessor<'a> {
                     && self.inner.vtl2_enable.load(Ordering::SeqCst)
                 {
                     tracing::debug!("enabled vtl2");
+                    // Mark VTL2 as enabled. The VP is not made runnable in VTL2
+                    // here; that happens in `start_vp` (below) once a start
+                    // request from `enable_vp_vtl` or `start_virtual_processor`
+                    // is processed, which also installs the initial register
+                    // state and hands VTL2 control of VTL0 startup.
                     self.state.enabled_vtls.set(Vtl::Vtl2);
-                    self.set_vtl_runnable(Vtl::Vtl2, HvVtlEntryReason::INTERRUPT);
-                    // VTL2 "owns" startup suspend now, so clear the suspension state of VTL0.
-                    #[cfg(guest_arch = "x86_64")]
-                    if !matches!(self.vp.partition.hvstate, super::Hv1State::Disabled) {
-                        if let Some(lapic) = self.state.vtls.lapic(self.state.active_vtl) {
-                            lapic.startup_suspend = false;
-                        } else {
-                            self.current_whp()
-                                .set_register(whp::Register64::InternalActivityState, 0)
-                                .unwrap();
-                        }
-                    }
                 }
 
                 // Check if we need to make VTL2 runnable for forward progress.
@@ -333,9 +326,9 @@ impl<'a> WhpProcessor<'a> {
                     let vplc = self.vplc(vtl);
                     if vplc.start_vp.load(Ordering::Relaxed) {
                         vplc.start_vp.store(false, Ordering::SeqCst);
-                        let context = vplc.start_vp_context.lock().take();
-                        if let Some(context) = context {
-                            self.start_vp(vtl, context);
+                        let request = vplc.start_vp_request.lock().take();
+                        if let Some(request) = request {
+                            self.start_vp(vtl, request);
                         }
                     }
                 }
@@ -459,7 +452,6 @@ impl<'a> WhpProcessor<'a> {
 
     pub(crate) fn finish_reset(&mut self, vtl: Vtl) {
         self.finish_reset_arch(vtl);
-        *self.vplc(vtl).start_vp_context.lock() = None;
     }
 
     fn request_sint_notifications(&mut self, vtl: Vtl, sints: u16) {
@@ -1555,25 +1547,56 @@ mod x86 {
             }
         }
 
-        pub(super) fn start_vp(&mut self, vtl: Vtl, vp_context: Box<InitialVpContextX64>) {
-            // Synchronize the register state.
-            self.switch_vtl(vtl);
+        pub(super) fn start_vp(&mut self, vtl: Vtl, request: crate::VpStartRequest) {
+            let start = matches!(
+                request.operation,
+                crate::VpStartOperation::StartVirtualProcessor
+            );
 
-            tracing::debug!(vp_index = self.vp.index.index(), ?vtl, "starting vp");
+            // HvCallStartVirtualProcessor starts the VP running the target VTL,
+            // making it the active VTL. HvCallEnableVpVtl only installs the
+            // initial context (below) and does not change the active VTL.
+            if start {
+                self.switch_vtl(vtl);
+            }
+
+            tracing::debug!(
+                vp_index = self.vp.index.index(),
+                ?vtl,
+                ?request.operation,
+                "setting up vp initial context"
+            );
 
             match hv1_emulator::hypercall::set_x86_vp_context(
                 &mut self.access_state(vtl),
-                &vp_context,
+                &request.context,
             ) {
                 Ok(()) => {
-                    self.set_vtl_runnable(vtl, HvVtlEntryReason::INTERRUPT);
+                    if start {
+                        self.set_vtl_runnable(vtl, HvVtlEntryReason::INTERRUPT);
+                        if vtl == Vtl::Vtl2 {
+                            // VTL2 now owns startup control of VTL0, so clear
+                            // VTL0's startup-suspend state so it can run when
+                            // VTL2 switches to it.
+                            if !matches!(self.vp.partition.hvstate, Hv1State::Disabled) {
+                                if let Some(lapic) = self.state.vtls.lapic(Vtl::Vtl0) {
+                                    lapic.startup_suspend = false;
+                                } else {
+                                    self.vp
+                                        .whp(Vtl::Vtl0)
+                                        .set_register(whp::Register64::InternalActivityState, 0)
+                                        .unwrap();
+                                }
+                            }
+                        }
+                    }
                 }
                 Err(err) => {
                     tracelimit::warn_ratelimited!(
                         error = &err as &dyn std::error::Error,
                         vp_index = self.vp.index.index(),
                         ?vtl,
-                        "failed to start VP"
+                        "failed to set up VP initial context"
                     );
                 }
             }
@@ -1839,8 +1862,8 @@ mod aarch64 {
             let _ = vtl;
         }
 
-        pub(super) fn start_vp(&mut self, vtl: Vtl, vp_context: Box<InitialVpContext>) {
-            let _ = (vtl, vp_context);
+        pub(super) fn start_vp(&mut self, vtl: Vtl, request: crate::VpStartRequest) {
+            let _ = (vtl, request);
             todo!("TODO-aarch64")
         }
 

--- a/vmm_core/virt_whp/src/vp.rs
+++ b/vmm_core/virt_whp/src/vp.rs
@@ -1682,7 +1682,6 @@ mod x86 {
 
 #[cfg(guest_arch = "aarch64")]
 mod aarch64 {
-    use crate::InitialVpContext;
     use crate::WhpProcessor;
     use aarch64defs::EsrEl2;
     use aarch64defs::ExceptionClass;


### PR DESCRIPTION
This time the code very closely matches what we do in virt_mshv_vtl, so it should be much more correct and solid.