### PR TITLE
firmware_uefi: vendor openssl for fuzzers

### DIFF
--- a/vm/devices/firmware/firmware_uefi/fuzz/Cargo.toml
+++ b/vm/devices/firmware/firmware_uefi/fuzz/Cargo.toml
@@ -20,7 +20,7 @@ arbitrary = { workspace = true, features = ["derive"] }
 [target.'cfg(all(target_os = "linux", target_env = "gnu"))'.dependencies]
 firmware_uefi = { workspace = true, features = ["auth-var-verify-crypto", "fuzzing"] }
 libfuzzer-sys.workspace = true
-openssl.workspace = true
+openssl = { workspace = true, features = ["vendored"] }
 
 [package.metadata.xtask.unused-deps]
 # required for the xtask_fuzz macro, but unused_deps doesn't know that


### PR DESCRIPTION
## Problem
Pipeline `[flowey] HvLite OneFuzz submission` fails on `release/1.7.2511`. The `fuzz_firmware_uefi_diagnostics` target links the system OpenSSL via `openssl-sys`, but the OneFuzz CI Linux agents no longer ship `pkg-config`/`libssl-dev`, so the build fails:

> Could not find openssl via pkg-config: The pkg-config command could not be found.

## Fix
Enable the `vendored` feature on the fuzz crate's `openssl` dependency so `openssl-sys` builds OpenSSL from source. This matches the behavior already on `main` and removes the dependency on system OpenSSL packages.