### PR TITLE
openvmm_core: add DMAR/IVRS to UEFI-booted VMs

### DIFF
--- a/openvmm/openvmm_core/src/worker/dispatch.rs
+++ b/openvmm/openvmm_core/src/worker/dispatch.rs
@@ -3285,6 +3285,10 @@ impl LoadedVmInner {
                     cache_topology.is_some().then(|| acpi_builder.build_pptt()),
                     // IORT
                     acpi_builder.build_iort(),
+                    // IVRS (AMD IOMMU)
+                    acpi_builder.build_ivrs(),
+                    // DMAR (Intel VT-d)
+                    acpi_builder.build_dmar(),
                 ];
                 let acpi_tables: Vec<_> =
                     acpi_tables.iter().flatten().map(|t| t.as_ref()).collect();

--- a/vmm_tests/vmm_tests/tests/tests/multiarch/pcie.rs
+++ b/vmm_tests/vmm_tests/tests/tests/multiarch/pcie.rs
@@ -584,7 +584,11 @@ async fn smmu_mixed_topology(config: PetriVmBuilder<OpenVmmPetriBackend>) -> any
 ///
 /// Runs under both Linux direct boot and UEFI (Ubuntu VHD) to verify the
 /// IVRS ACPI table is threaded through the UEFI firmware as well.
-#[vmm_test_with(openvmm, amd, configs(linux_direct_x64))]
+#[vmm_test_with(
+    openvmm,
+    amd,
+    configs(linux_direct_x64, uefi_x64(vhd(ubuntu_2404_server_x64)))
+)]
 async fn amd_iommu_mixed_topology(
     config: PetriVmBuilder<OpenVmmPetriBackend>,
 ) -> anyhow::Result<()> {
@@ -671,7 +675,11 @@ async fn amd_iommu_mixed_topology(
 ///
 /// Runs under both Linux direct boot and UEFI (Ubuntu VHD) to verify the
 /// DMAR ACPI table is threaded through the UEFI firmware as well.
-#[vmm_test_with(openvmm, intel, configs(linux_direct_x64))]
+#[vmm_test_with(
+    openvmm,
+    intel,
+    configs(linux_direct_x64, uefi_x64(vhd(ubuntu_2404_server_x64)))
+)]
 async fn intel_vtd_multi_segment(
     config: PetriVmBuilder<OpenVmmPetriBackend>,
 ) -> anyhow::Result<()> {


### PR DESCRIPTION
UEFI firmware loading should receive the same AMD IVRS and Intel DMAR tables that direct boot paths use, so guests can discover emulated IOMMU topology consistently across firmware modes.

Thread the generated IOMMU ACPI tables into the firmware table list and extend the mixed-topology VMM tests to cover Ubuntu VHD UEFI boot for both AMD-Vi and Intel VT-d.