### PR TITLE
vmm_tests: use a rustfmt-friendly syntax for vmm_test_with

### DIFF
--- a/Guide/src/dev_guide/tests/vmm.md
+++ b/Guide/src/dev_guide/tests/vmm.md
@@ -61,7 +61,7 @@ async fn my_test<T: PetriVmmBackend>(config: PetriVmBuilder<T>) -> anyhow::Resul
 For all variants of the test:
 
 ```rust,ignore
-#[vmm_test_with(unstable(
+#[vmm_test_with(unstable, configs(
     hyperv_openhcl_uefi_aarch64(vhd(windows_11_enterprise_aarch64)),
     hyperv_openhcl_uefi_aarch64(vhd(ubuntu_2404_server_aarch64))
     // ...

--- a/vmm_tests/vmm_test_macros/src/lib.rs
+++ b/vmm_tests/vmm_test_macros/src/lib.rs
@@ -268,11 +268,61 @@ impl ToTokens for FirmwareAndArch {
 
 impl Parse for ArgsWithOverrides {
     fn parse(input: ParseStream<'_>) -> syn::Result<Self> {
-        if input.peek(syn::token::Paren) {
-            parse_tuple_args_with_overrides(input)
-        } else {
-            parse_legacy_args_with_overrides(input)
+        // Syntax: a comma-separated list of attributes followed by a single
+        // `configs(...)` group of firmware entries, e.g.
+        //   #[vmm_test_with(openvmm, amd, configs(linux_direct_x64, ...))]
+        //   #[vmm_test_with(requires(vpci), configs(...))]
+        //
+        // By convention the vmm (if specified) comes first and `configs(...)`
+        // comes last; both are enforced below. Floating the attributes as
+        // plain idents (rather than wrapping them in a tuple) keeps the whole
+        // attribute a valid meta item, which is what lets rustfmt format it.
+        let mut overrides = ParsedOverrides::new();
+        let mut args = None;
+        let mut position = 0usize;
+
+        while !input.is_empty() {
+            let ident = input.parse::<Ident>()?;
+            match ident.to_string().as_str() {
+                "configs" => {
+                    let configs;
+                    syn::parenthesized!(configs in input);
+                    args = Some(configs.parse::<Args>()?);
+                    if !input.is_empty() {
+                        return Err(input.error("`configs(...)` must be the last argument"));
+                    }
+                    break;
+                }
+                "requires" => {
+                    let capabilities;
+                    syn::parenthesized!(capabilities in input);
+                    for capability in parse_required_capabilities(&capabilities)? {
+                        overrides.add_capability(capability.span, capability.name)?;
+                    }
+                }
+                "openvmm" | "hyperv" => {
+                    if position != 0 {
+                        return Err(Error::new(
+                            ident.span(),
+                            "the vmm must be the first argument",
+                        ));
+                    }
+                    overrides.apply_ident(&ident)?;
+                }
+                _ => overrides.apply_ident(&ident)?,
+            }
+
+            position += 1;
+            if input.is_empty() {
+                break;
+            }
+            input.parse::<Token![,]>()?;
         }
+
+        let args =
+            args.ok_or_else(|| input.error("expected a `configs(...)` group of firmware entries"))?;
+
+        Ok(overrides.finish(args))
     }
 }
 
@@ -365,26 +415,6 @@ struct RequiredCapability {
     name: &'static str,
 }
 
-enum OverrideItem {
-    Ident(Ident),
-    Requires(Vec<RequiredCapability>),
-}
-
-impl Parse for OverrideItem {
-    fn parse(input: ParseStream<'_>) -> syn::Result<Self> {
-        let ident = input.parse::<Ident>()?;
-        if ident == "requires" {
-            let capabilities;
-            syn::parenthesized!(capabilities in input);
-            Ok(OverrideItem::Requires(parse_required_capabilities(
-                &capabilities,
-            )?))
-        } else {
-            Ok(OverrideItem::Ident(ident))
-        }
-    }
-}
-
 fn parse_required_capabilities(input: ParseStream<'_>) -> syn::Result<Vec<RequiredCapability>> {
     let idents = input.parse_terminated(Ident::parse, Token![,])?;
     if idents.is_empty() {
@@ -404,56 +434,6 @@ fn parse_required_capabilities(input: ParseStream<'_>) -> syn::Result<Vec<Requir
             })
         })
         .collect()
-}
-
-fn parse_override_group(input: ParseStream<'_>) -> syn::Result<ParsedOverrides> {
-    let items = input.parse_terminated(OverrideItem::parse, Token![,])?;
-    let mut overrides = ParsedOverrides::new();
-    for item in items {
-        match item {
-            OverrideItem::Ident(ident) => overrides.apply_ident(&ident)?,
-            OverrideItem::Requires(capabilities) => {
-                for capability in capabilities {
-                    overrides.add_capability(capability.span, capability.name)?;
-                }
-            }
-        }
-    }
-    Ok(overrides)
-}
-
-fn parse_tuple_args_with_overrides(input: ParseStream<'_>) -> syn::Result<ArgsWithOverrides> {
-    let overrides;
-    syn::parenthesized!(overrides in input);
-    let overrides = parse_override_group(&overrides)?;
-
-    input.parse::<Token![,]>()?;
-
-    let args;
-    syn::parenthesized!(args in input);
-    let args = args.parse::<Args>()?;
-
-    if !input.is_empty() {
-        return Err(input.error("unexpected extra vmm_test_with arguments"));
-    }
-
-    Ok(overrides.finish(args))
-}
-
-fn parse_legacy_args_with_overrides(input: ParseStream<'_>) -> syn::Result<ArgsWithOverrides> {
-    let word = input.parse::<Ident>()?;
-    let mut overrides = ParsedOverrides::new();
-    overrides.apply_ident(&word)?;
-
-    let parens;
-    syn::parenthesized!(parens in input);
-    let args = parens.parse::<Args>()?;
-
-    if !input.is_empty() {
-        return Err(input.error("unexpected extra vmm_test_with arguments"));
-    }
-
-    Ok(overrides.finish(args))
 }
 
 impl ArgsWithOverrides {
@@ -918,26 +898,35 @@ pub fn vmm_test(
         .into()
 }
 
-/// Same options as `vmm_test`, but specify the following attributes to apply
-/// to all tests. The legacy form accepts a single attribute:
+/// Same options as `vmm_test`, but accepts test-wide attributes in addition to
+/// the firmware entries. The attributes are listed first, as plain comma-separated
+/// idents, and the firmware entries follow in a trailing `configs(...)` group:
+///
+/// ```ignore
+/// #[vmm_test_with(<attribute>,* configs(<firmware entry>,+))]
+/// ```
+///
+/// The available attributes are:
 /// - unstable: all variants of this test are unstable
 /// - noagent: don't use pipette in vtl0 for this test
 /// - amd: this test only runs on AMD-vendor hosts (skipped otherwise)
 /// - intel: this test only runs on Intel-vendor hosts (skipped otherwise)
 /// - hyperv: use hyperv as the vmm
 /// - openvmm: use openvmm as the vmm
+/// - requires(...): required capabilities (see below)
 ///
-/// example: #[vmm_test_with(noagent(linux_direct_x64, ...))]
+/// `requires(...)` lists capabilities the test needs. Petri auto-detects some
+/// capabilities, such as `vpci`, and execution environments can advertise
+/// capabilities via the `PETRI_CAPABILITIES` environment variable. When a
+/// required capability is not available, the test is skipped, so it
+/// self-excludes on any host that cannot provide it.
 ///
-/// The preferred form separates attributes from firmware entries and supports
-/// `requires(...)` for capabilities. Petri auto-detects some capabilities, such
-/// as `vpci`, and execution environments can advertise capabilities via the
-/// `PETRI_CAPABILITIES` environment variable. When a required capability is not
-/// available, the test is skipped, so it self-excludes on any host that cannot
-/// provide it.
+/// By convention the vmm (if specified) comes first and `configs(...)` comes
+/// last; both are enforced.
 ///
-/// example: #[vmm_test_with((openvmm, requires(test_disk_vfio)), (linux_direct_aarch64))]
-/// example: #[vmm_test_with((openvmm, amd), (linux_direct_x64))]
+/// example: #[vmm_test_with(noagent, configs(linux_direct_x64, ...))]
+/// example: #[vmm_test_with(openvmm, requires(test_disk_vfio), configs(linux_direct_aarch64))]
+/// example: #[vmm_test_with(openvmm, amd, configs(linux_direct_x64))]
 #[proc_macro_attribute]
 pub fn vmm_test_with(
     attr: proc_macro::TokenStream,

--- a/vmm_tests/vmm_test_macros/src/lib.rs
+++ b/vmm_tests/vmm_test_macros/src/lib.rs
@@ -288,6 +288,10 @@ impl Parse for ArgsWithOverrides {
                     let configs;
                     syn::parenthesized!(configs in input);
                     args = Some(configs.parse::<Args>()?);
+                    // Tolerate an optional trailing comma after `configs(...)`.
+                    if input.peek(Token![,]) {
+                        input.parse::<Token![,]>()?;
+                    }
                     if !input.is_empty() {
                         return Err(input.error("`configs(...)` must be the last argument"));
                     }
@@ -307,7 +311,11 @@ impl Parse for ArgsWithOverrides {
                             "the vmm must be the first argument",
                         ));
                     }
-                    overrides.apply_ident(&ident)?;
+                    overrides.vmm = Some(if ident == "openvmm" {
+                        Vmm::OpenVmm
+                    } else {
+                        Vmm::HyperV
+                    });
                 }
                 _ => overrides.apply_ident(&ident)?,
             }
@@ -372,18 +380,6 @@ impl ParsedOverrides {
                     return conflict_err();
                 }
                 self.requires_host_vendor = Some(HostVendor::Intel);
-            }
-            "hyperv" => {
-                if self.vmm.is_some() {
-                    return conflict_err();
-                }
-                self.vmm = Some(Vmm::HyperV);
-            }
-            "openvmm" => {
-                if self.vmm.is_some() {
-                    return conflict_err();
-                }
-                self.vmm = Some(Vmm::OpenVmm);
             }
             _ => return Err(Error::new(ident.span(), "unrecognized vmm test override")),
         }
@@ -903,7 +899,7 @@ pub fn vmm_test(
 /// idents, and the firmware entries follow in a trailing `configs(...)` group:
 ///
 /// ```ignore
-/// #[vmm_test_with(<attribute>,* configs(<firmware entry>,+))]
+/// #[vmm_test_with(<attribute>, ..., configs(<firmware entry>, ...))]
 /// ```
 ///
 /// The available attributes are:

--- a/vmm_tests/vmm_tests/tests/tests/aarch64_exclusive.rs
+++ b/vmm_tests/vmm_tests/tests/tests/aarch64_exclusive.rs
@@ -92,15 +92,7 @@ async fn boot_dt(config: PetriVmBuilder<OpenVmmPetriBackend>) -> Result<(), anyh
 ///
 /// The `_aarch64_tcg` name suffix opts this test into the TCG incubator
 /// pass: CI selects it via the `test(aarch64_tcg)` nextest filter.
-#[vmm_test_with(
-    (
-        openvmm,
-        requires(test_disk_vfio)
-    ),
-    (
-        linux_direct_aarch64
-    )
-)]
+#[vmm_test_with(openvmm, requires(test_disk_vfio), configs(linux_direct_aarch64))]
 async fn boot_no_vmbus_pcie_aarch64_tcg(
     config: PetriVmBuilder<OpenVmmPetriBackend>,
 ) -> anyhow::Result<()> {

--- a/vmm_tests/vmm_tests/tests/tests/multiarch.rs
+++ b/vmm_tests/vmm_tests/tests/tests/multiarch.rs
@@ -45,13 +45,16 @@ mod vmbus_relay;
 mod vmgs;
 
 /// Boot through the UEFI firmware, it will shut itself down after booting.
-#[vmm_test_with(noagent(
-    openvmm_uefi_x64(none),
-    openvmm_openhcl_uefi_x64(none),
-    openvmm_uefi_aarch64(none),
-    hyperv_openhcl_uefi_aarch64(none),
-    hyperv_openhcl_uefi_x64(none)
-))]
+#[vmm_test_with(
+    noagent,
+    configs(
+        openvmm_uefi_x64(none),
+        openvmm_openhcl_uefi_x64(none),
+        openvmm_uefi_aarch64(none),
+        hyperv_openhcl_uefi_aarch64(none),
+        hyperv_openhcl_uefi_x64(none)
+    )
+)]
 async fn frontpage<T: PetriVmmBackend>(config: PetriVmBuilder<T>) -> anyhow::Result<()> {
     let vm = config.run_without_agent().await?;
     vm.wait_for_clean_teardown().await?;
@@ -205,10 +208,13 @@ async fn boot_small<T: PetriVmmBackend>(config: PetriVmBuilder<T>) -> anyhow::Re
 }
 
 /// Basic boot test without agent
-#[vmm_test_with(noagent(
-    openvmm_pcat_x64(vhd(freebsd_13_2_x64)),
-    openvmm_pcat_x64(iso(freebsd_13_2_x64))
-))]
+#[vmm_test_with(
+    noagent,
+    configs(
+        openvmm_pcat_x64(vhd(freebsd_13_2_x64)),
+        openvmm_pcat_x64(iso(freebsd_13_2_x64))
+    )
+)]
 async fn boot_no_agent<T: PetriVmmBackend>(config: PetriVmBuilder<T>) -> anyhow::Result<()> {
     let mut vm = config.run_without_agent().await?;
     vm.send_enlightened_shutdown(ShutdownKind::Shutdown).await?;
@@ -278,8 +284,8 @@ async fn boot_single_proc<T: PetriVmmBackend>(config: PetriVmBuilder<T>) -> anyh
 }
 
 #[vmm_test_with(
-    (requires(vpci)),
-    (
+    requires(vpci),
+    configs(
         // TODO: virt_whp is missing VPCI LPI interrupt support, used by Windows (but not Linux)
         // openvmm_uefi_aarch64(vhd(windows_11_enterprise_aarch64)),
         openvmm_uefi_x64(vhd(windows_datacenter_core_2022_x64)),
@@ -300,14 +306,14 @@ async fn boot_nvme<T: PetriVmmBackend>(config: PetriVmBuilder<T>) -> anyhow::Res
 
 /// Tests NVMe boot with OpenHCL VPCI relaying enabled.
 #[vmm_test_with(
-    (requires(vpci)),
-    (
-    // TODO: aarch64 support (WHP missing ARM64 VTL2 support)
-    // openvmm_openhcl_uefi_aarch64(vhd(windows_11_enterprise_aarch64)),
-    // openvmm_openhcl_uefi_aarch64(vhd(ubuntu_2404_server_aarch64)),
-    openvmm_openhcl_uefi_x64(vhd(windows_datacenter_core_2022_x64)),
-    // TODO: Linux image is missing VPCI driver in its initrd
-    // openvmm_openhcl_uefi_x64(vhd(ubuntu_2504_server_x64))
+    requires(vpci),
+    configs(
+        // TODO: aarch64 support (WHP missing ARM64 VTL2 support)
+        // openvmm_openhcl_uefi_aarch64(vhd(windows_11_enterprise_aarch64)),
+        // openvmm_openhcl_uefi_aarch64(vhd(ubuntu_2404_server_aarch64)),
+        openvmm_openhcl_uefi_x64(vhd(windows_datacenter_core_2022_x64)),
+        // TODO: Linux image is missing VPCI driver in its initrd
+        // openvmm_openhcl_uefi_x64(vhd(ubuntu_2504_server_x64))
     )
 )]
 async fn boot_nvme_vpci_relay<T: PetriVmmBackend>(config: PetriVmBuilder<T>) -> anyhow::Result<()> {
@@ -464,21 +470,24 @@ async fn secure_boot<T: PetriVmmBackend>(config: PetriVmBuilder<T>) -> anyhow::R
 
 /// Verify that secure boot fails with a mismatched template.
 /// TODO: Allow Hyper-V VMs to load a UEFI firmware per VM, not system wide.
-#[vmm_test_with(noagent(
-    openvmm_uefi_aarch64(vhd(ubuntu_2404_server_aarch64)),
-    openvmm_uefi_x64(vhd(windows_datacenter_core_2022_x64)),
-    openvmm_uefi_x64(vhd(ubuntu_2504_server_x64)),
-    openvmm_openhcl_uefi_x64(vhd(windows_datacenter_core_2022_x64)),
-    openvmm_openhcl_uefi_x64(vhd(ubuntu_2504_server_x64)),
-    // hyperv_uefi_aarch64(vhd(windows_11_enterprise_aarch64)),
-    // hyperv_uefi_aarch64(vhd(ubuntu_2404_server_aarch64)),
-    // hyperv_uefi_x64(vhd(windows_datacenter_core_2022_x64)),
-    // hyperv_uefi_x64(vhd(ubuntu_2504_server_x64)),
-    hyperv_openhcl_uefi_aarch64(vhd(windows_11_enterprise_aarch64)),
-    hyperv_openhcl_uefi_aarch64(vhd(ubuntu_2404_server_aarch64)),
-    hyperv_openhcl_uefi_x64(vhd(windows_datacenter_core_2022_x64)),
-    hyperv_openhcl_uefi_x64(vhd(ubuntu_2504_server_x64))
-))]
+#[vmm_test_with(
+    noagent,
+    configs(
+        openvmm_uefi_aarch64(vhd(ubuntu_2404_server_aarch64)),
+        openvmm_uefi_x64(vhd(windows_datacenter_core_2022_x64)),
+        openvmm_uefi_x64(vhd(ubuntu_2504_server_x64)),
+        openvmm_openhcl_uefi_x64(vhd(windows_datacenter_core_2022_x64)),
+        openvmm_openhcl_uefi_x64(vhd(ubuntu_2504_server_x64)),
+        // hyperv_uefi_aarch64(vhd(windows_11_enterprise_aarch64)),
+        // hyperv_uefi_aarch64(vhd(ubuntu_2404_server_aarch64)),
+        // hyperv_uefi_x64(vhd(windows_datacenter_core_2022_x64)),
+        // hyperv_uefi_x64(vhd(ubuntu_2504_server_x64)),
+        hyperv_openhcl_uefi_aarch64(vhd(windows_11_enterprise_aarch64)),
+        hyperv_openhcl_uefi_aarch64(vhd(ubuntu_2404_server_aarch64)),
+        hyperv_openhcl_uefi_x64(vhd(windows_datacenter_core_2022_x64)),
+        hyperv_openhcl_uefi_x64(vhd(ubuntu_2504_server_x64))
+    )
+)]
 async fn secure_boot_mismatched_template<T: PetriVmmBackend>(
     config: PetriVmBuilder<T>,
 ) -> anyhow::Result<()> {
@@ -499,11 +508,14 @@ async fn secure_boot_mismatched_template<T: PetriVmmBackend>(
 /// Test EFI diagnostics with no boot devices.
 /// TODO:
 ///   - uefi_x64 + uefi_aarch64 trace searching support
-#[vmm_test_with(noagent(
-    hyperv_openhcl_uefi_x64(none),
-    hyperv_openhcl_uefi_aarch64(none),
-    openvmm_openhcl_uefi_x64(none)
-))]
+#[vmm_test_with(
+    noagent,
+    configs(
+        hyperv_openhcl_uefi_x64(none),
+        hyperv_openhcl_uefi_aarch64(none),
+        openvmm_openhcl_uefi_x64(none)
+    )
+)]
 async fn efi_diagnostics_no_boot<T: PetriVmmBackend>(
     config: PetriVmBuilder<T>,
 ) -> anyhow::Result<()> {
@@ -532,11 +544,14 @@ async fn efi_diagnostics_no_boot<T: PetriVmmBackend>(
 /// TODO:
 ///  - change hyperv tests to use WMI instead of env_cfg once
 ///    CI runners support it
-#[vmm_test_with(noagent(
-    openvmm_openhcl_uefi_x64(none),
-    hyperv_openhcl_uefi_x64(none),
-    hyperv_openhcl_uefi_aarch64(none)
-))]
+#[vmm_test_with(
+    noagent,
+    configs(
+        openvmm_openhcl_uefi_x64(none),
+        hyperv_openhcl_uefi_x64(none),
+        hyperv_openhcl_uefi_aarch64(none)
+    )
+)]
 async fn efi_diagnostics_info_level<T: PetriVmmBackend>(
     config: PetriVmBuilder<T>,
 ) -> anyhow::Result<()> {
@@ -575,8 +590,8 @@ async fn efi_diagnostics_info_level<T: PetriVmmBackend>(
 /// Boots OpenHCL UEFI with an NVMe device attached, then verifies
 /// whether IoMmuDxe will force bounce buffering on all DMA operations.
 #[vmm_test_with(
-    (requires(vpci)),
-    (openvmm_openhcl_uefi_x64(vhd(windows_datacenter_core_2022_x64)))
+    requires(vpci),
+    configs(openvmm_openhcl_uefi_x64(vhd(windows_datacenter_core_2022_x64)))
 )]
 async fn uefi_force_dma_bounce<T: PetriVmmBackend>(
     config: PetriVmBuilder<T>,
@@ -616,11 +631,14 @@ async fn uefi_force_dma_bounce<T: PetriVmmBackend>(
 /// Boot our guest-test UEFI image, which will run some tests,
 /// and then purposefully triple fault itself via an expiring
 /// watchdog timer.
-#[vmm_test_with(noagent(
-    openvmm_uefi_x64(guest_test_uefi_x64),
-    openvmm_uefi_aarch64(guest_test_uefi_aarch64),
-    openvmm_openhcl_uefi_x64(guest_test_uefi_x64)
-))]
+#[vmm_test_with(
+    noagent,
+    configs(
+        openvmm_uefi_x64(guest_test_uefi_x64),
+        openvmm_uefi_aarch64(guest_test_uefi_aarch64),
+        openvmm_openhcl_uefi_x64(guest_test_uefi_x64)
+    )
+)]
 async fn guest_test_uefi<T: PetriVmmBackend>(config: PetriVmBuilder<T>) -> anyhow::Result<()> {
     let vm = config
         .with_windows_secure_boot_template()

--- a/vmm_tests/vmm_tests/tests/tests/multiarch/pcie.rs
+++ b/vmm_tests/vmm_tests/tests/tests/multiarch/pcie.rs
@@ -581,7 +581,10 @@ async fn smmu_mixed_topology(config: PetriVmBuilder<OpenVmmPetriBackend>) -> any
 /// Restricted to AMD-vendor hosts: the AMD IOMMU emulator's IVHD entries
 /// surface a host-cpuid-derived AMD-Vi family/model that Linux's IOMMU
 /// driver only accepts when the boot CPU also reports as AMD.
-#[vmm_test_with((openvmm, amd), (linux_direct_x64))]
+///
+/// Runs under both Linux direct boot and UEFI (Ubuntu VHD) to verify the
+/// IVRS ACPI table is threaded through the UEFI firmware as well.
+#[vmm_test_with(openvmm, amd, configs(linux_direct_x64))]
 async fn amd_iommu_mixed_topology(
     config: PetriVmBuilder<OpenVmmPetriBackend>,
 ) -> anyhow::Result<()> {
@@ -665,7 +668,10 @@ async fn amd_iommu_mixed_topology(
 /// 3. Devices behind the IOMMU RC are in IOMMU groups
 /// 4. Devices on both RCs enumerate and function (block I/O, network interface)
 /// 5. DMA through the IOMMU works (NVMe I/O behind the IOMMU)
-#[vmm_test_with((openvmm, intel), (linux_direct_x64))]
+///
+/// Runs under both Linux direct boot and UEFI (Ubuntu VHD) to verify the
+/// DMAR ACPI table is threaded through the UEFI firmware as well.
+#[vmm_test_with(openvmm, intel, configs(linux_direct_x64))]
 async fn intel_vtd_multi_segment(
     config: PetriVmBuilder<OpenVmmPetriBackend>,
 ) -> anyhow::Result<()> {

--- a/vmm_tests/vmm_tests/tests/tests/multiarch/tpm.rs
+++ b/vmm_tests/vmm_tests/tests/tests/multiarch/tpm.rs
@@ -716,7 +716,7 @@ async fn cvm_tpm_guest_tests<T, S, U: PetriVmmBackend>(
 /// test function (`skip_hw_unseal`), they all map to
 /// `KeyReleaseFailureSkipHwUnsealing`.
 #[cfg(windows)]
-#[vmm_test_with(unstable(
+#[vmm_test_with(unstable, configs(
     hyperv_openhcl_uefi_x64[snp](vhd(ubuntu_2504_server_x64))[TEST_IGVM_AGENT_RPC_SERVER_WINDOWS_X64],
     hyperv_openhcl_uefi_x64[snp](vhd(windows_datacenter_core_2025_x64_prepped))[TEST_IGVM_AGENT_RPC_SERVER_WINDOWS_X64],
 ))]
@@ -799,7 +799,7 @@ async fn skip_hw_unseal<T, U: PetriVmmBackend>(
 /// test function (`use_hw_unseal`), they all map to
 /// `KeyReleaseFailure`.
 #[cfg(windows)]
-#[vmm_test_with(unstable(
+#[vmm_test_with(unstable, configs(
     hyperv_openhcl_uefi_x64[snp](vhd(ubuntu_2504_server_x64))[TPM_GUEST_TESTS_LINUX_X64, TEST_IGVM_AGENT_RPC_SERVER_WINDOWS_X64],
     hyperv_openhcl_uefi_x64[snp](vhd(windows_datacenter_core_2025_x64_prepped))[TPM_GUEST_TESTS_WINDOWS_X64, TEST_IGVM_AGENT_RPC_SERVER_WINDOWS_X64],
 ))]

--- a/vmm_tests/vmm_tests/tests/tests/multiarch/vmgs.rs
+++ b/vmm_tests/vmm_tests/tests/tests/multiarch/vmgs.rs
@@ -84,7 +84,7 @@ async fn clear_vmgs<T: PetriVmmBackend>(
 ///
 /// This test exists to ensure we are not getting a false positive for
 /// the `default_boot` and `clear_vmgs` test above.
-#[vmm_test_with(noagent(
+#[vmm_test_with(noagent, configs(
     openvmm_uefi_aarch64(vhd(windows_11_enterprise_aarch64))[VMGS_WITH_BOOT_ENTRY],
     openvmm_uefi_aarch64(vhd(ubuntu_2404_server_aarch64))[VMGS_WITH_BOOT_ENTRY],
     openvmm_uefi_x64(vhd(windows_datacenter_core_2022_x64))[VMGS_WITH_BOOT_ENTRY],

--- a/vmm_tests/vmm_tests/tests/tests/x86_64.rs
+++ b/vmm_tests/vmm_tests/tests/tests/x86_64.rs
@@ -115,7 +115,10 @@ fn configure_for_sidecar<T: PetriVmmBackend>(
 // into VTL2 Linux.
 //
 // Sidecar isn't supported on aarch64 yet.
-#[vmm_test_with(noagent(openvmm_openhcl_uefi_x64(none), hyperv_openhcl_uefi_x64(none)))]
+#[vmm_test_with(
+    noagent,
+    configs(openvmm_openhcl_uefi_x64(none), hyperv_openhcl_uefi_x64(none))
+)]
 async fn sidecar_aps_unused<T: PetriVmmBackend>(
     config: PetriVmBuilder<T>,
 ) -> Result<(), anyhow::Error> {

--- a/vmm_tests/vmm_tests/tests/tests/x86_64/openhcl_uefi.rs
+++ b/vmm_tests/vmm_tests/tests/tests/x86_64/openhcl_uefi.rs
@@ -324,7 +324,7 @@ async fn nvme_relay_32vp_768mb_very_heavy(
 
 /// Boot the UEFI firmware, with a VTL2 range automatically configured by
 /// OpenVMM.
-#[vmm_test_with(noagent(openvmm_openhcl_uefi_x64(none)))]
+#[vmm_test_with(noagent, configs(openvmm_openhcl_uefi_x64(none)))]
 async fn auto_vtl2_range(config: PetriVmBuilder<OpenVmmPetriBackend>) -> Result<(), anyhow::Error> {
     let vm = config
         .modify_backend(|b| {
@@ -344,7 +344,7 @@ async fn auto_vtl2_range(config: PetriVmBuilder<OpenVmmPetriBackend>) -> Result<
 /// correctly parses the device tree with memory on multiple NUMA nodes.
 /// Checks the absence of NUMA errors and confirms the kernel brought up
 /// multiple NUMA nodes with memory (not memoryless).
-#[vmm_test_with(noagent(openvmm_openhcl_uefi_x64(none)))]
+#[vmm_test_with(noagent, configs(openvmm_openhcl_uefi_x64(none)))]
 async fn no_numa_errors<T: PetriVmmBackend>(
     config: PetriVmBuilder<T>,
 ) -> Result<(), anyhow::Error> {
@@ -424,7 +424,7 @@ async fn no_numa_errors<T: PetriVmmBackend>(
 /// Boot OpenHCL with a multi-NUMA topology and force the private pool to be
 /// split across NUMA nodes via `OPENHCL_VTL2_GPA_POOL_NUMA=split`. Validates
 /// that the pool was actually allocated on multiple NUMA nodes.
-#[vmm_test_with(noagent(openvmm_openhcl_uefi_x64(none)))]
+#[vmm_test_with(noagent, configs(openvmm_openhcl_uefi_x64(none)))]
 async fn numa_private_pool_split<T: PetriVmmBackend>(
     config: PetriVmBuilder<T>,
 ) -> Result<(), anyhow::Error> {


### PR DESCRIPTION
Rustfmt refused to format the tuple-based syntax for `vmm_test_with` that we just added. Replace it with a different format, e.g.:

```rust
#[vmm_test_with(
    noagent,
    configs(
        openvmm_pcat_x64(vhd(freebsd_13_2_x64)),
        openvmm_pcat_x64(iso(freebsd_13_2_x64))
    )
)]
```

This looks nicer and formats automatically.