### PR TITLE
openvmm_core: validate PCIe root-complex bus ranges

### DIFF
--- a/openvmm/openvmm_core/src/worker/dispatch.rs
+++ b/openvmm/openvmm_core/src/worker/dispatch.rs
@@ -6,6 +6,7 @@ mod dump;
 mod ecam_config_access;
 mod intel_vtd_wiring;
 mod ioapic_iommu_wiring;
+mod pcie_topology;
 mod pcie_wiring;
 mod smmu_wiring;
 
@@ -25,7 +26,6 @@ use cfg_if::cfg_if;
 use chipset_device_resources::IRQ_LINE_SET;
 use chipset_resources::LEGACY_CHIPSET_PCI_BUS_NAME;
 use chipset_resources::cmos_rtc_time_source::SystemTimeClockHandle;
-use cxl_spec::pci_registers::spec::flex_bus_port_dvsec::CxlFlexBusPortDvsecCapability;
 use cxl_spec::spec::CXL_COMPONENT_REGISTERS_SIZE_BYTES;
 use debug_ptr::DebugPtr;
 use disk_backend::Disk;
@@ -69,7 +69,6 @@ use openvmm_defs::config::LoadMode;
 use openvmm_defs::config::NumaTopology;
 use openvmm_defs::config::PcieDeviceConfig;
 use openvmm_defs::config::PcieIommuConfig;
-use openvmm_defs::config::PciePortConfig;
 use openvmm_defs::config::PcieRootComplexConfig;
 use openvmm_defs::config::PcieSwitchConfig;
 use openvmm_defs::config::PmuGsivConfig;
@@ -92,9 +91,6 @@ use pal_async::local::block_with_io;
 use pal_async::task::Spawn;
 use pal_async::task::Task;
 use pci_core::PciInterruptPin;
-use pci_core::spec::caps::acs::DEFAULT_ACS_CAP_MASK;
-use pcie::GenericPciePortDefinition;
-use pcie::PciePortSettings;
 use pcie::root::GenericPcieRootComplex;
 use pcie::switch::GenericPcieSwitch;
 use scsi_core::ResolveScsiDeviceHandleParams;
@@ -918,35 +914,6 @@ fn convert_vtl2_config(
     };
 
     Ok(Some(config))
-}
-
-/// Builds root-port PCIe settings from manifest flags.
-///
-/// When CXL is enabled, emit a default Flex Bus capability advertising both
-/// cache and memory support.
-fn build_root_port_settings(rp_cfg: &PciePortConfig) -> PciePortSettings {
-    PciePortSettings {
-        acs_capabilities_supported: rp_cfg
-            .acs_capabilities_supported
-            .unwrap_or(DEFAULT_ACS_CAP_MASK),
-        cxl_flex_bus_port_capability: rp_cfg.cxl.then_some(
-            CxlFlexBusPortDvsecCapability::new()
-                .with_cache_capable(true)
-                .with_mem_capable(true),
-        ),
-    }
-}
-
-/// Converts a manifest root-port entry into the runtime root-port definition.
-fn build_root_port_definition(rp_cfg: &PciePortConfig) -> GenericPciePortDefinition {
-    let settings = build_root_port_settings(rp_cfg);
-
-    GenericPciePortDefinition {
-        name: rp_cfg.name.as_str().into(),
-        devfn: rp_cfg.devfn,
-        hotplug: rp_cfg.hotplug,
-        settings,
-    }
 }
 
 /// A source for an SRAT generic-initiator entry.
@@ -2016,6 +1983,7 @@ impl InitializedVm {
         let mut deferred_msi_conns: Vec<DeferredMsiConn> = Vec::new();
 
         let (mut pcie_host_bridges, pcie_root_complexes) = {
+            pcie_topology::validate_pcie_root_complexes(&cfg.pcie_root_complexes)?;
             let mut pcie_host_bridges = Vec::new();
             let mut pcie_root_complexes = Vec::new();
 
@@ -2114,8 +2082,11 @@ impl InitializedVm {
                     chipset_builder
                         .arc_mutex_device(device_name)
                         .try_add(|services| {
-                            let root_port_definitions =
-                                rc.ports.iter().map(build_root_port_definition).collect();
+                            let root_port_definitions = rc
+                                .ports
+                                .iter()
+                                .map(pcie_topology::build_root_port_definition)
+                                .collect();
                             GenericPcieRootComplex::builder(
                                 &mut services.register_mmio(),
                                 rc.start_bus..=rc.end_bus,
@@ -2242,7 +2213,7 @@ impl InitializedVm {
                     let downstream_ports = switch
                         .ports
                         .iter()
-                        .map(build_root_port_definition)
+                        .map(pcie_topology::build_root_port_definition)
                         .collect();
                     let definition = pcie::switch::GenericPcieSwitchDefinition {
                         name: switch.name.clone().into(),

--- a/openvmm/openvmm_core/src/worker/dispatch/pcie_topology.rs
+++ b/openvmm/openvmm_core/src/worker/dispatch/pcie_topology.rs
@@ -1,0 +1,128 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! PCIe topology construction and validation helpers.
+//!
+//! These turn the manifest's [`PcieRootComplexConfig`]/[`PciePortConfig`]
+//! entries into runtime root-port definitions and validate that the configured
+//! root complexes form a consistent bus-number topology before the VM is built.
+
+use cxl_spec::pci_registers::spec::flex_bus_port_dvsec::CxlFlexBusPortDvsecCapability;
+use openvmm_defs::config::PciePortConfig;
+use openvmm_defs::config::PcieRootComplexConfig;
+use pci_core::spec::caps::acs::DEFAULT_ACS_CAP_MASK;
+use pcie::GenericPciePortDefinition;
+use pcie::PciePortSettings;
+
+/// Builds root-port PCIe settings from manifest flags.
+///
+/// When CXL is enabled, emit a default Flex Bus capability advertising both
+/// cache and memory support.
+fn build_root_port_settings(rp_cfg: &PciePortConfig) -> PciePortSettings {
+    PciePortSettings {
+        acs_capabilities_supported: rp_cfg
+            .acs_capabilities_supported
+            .unwrap_or(DEFAULT_ACS_CAP_MASK),
+        cxl_flex_bus_port_capability: rp_cfg.cxl.then_some(
+            CxlFlexBusPortDvsecCapability::new()
+                .with_cache_capable(true)
+                .with_mem_capable(true),
+        ),
+    }
+}
+
+/// Converts a manifest root-port entry into the runtime root-port definition.
+pub(super) fn build_root_port_definition(rp_cfg: &PciePortConfig) -> GenericPciePortDefinition {
+    let settings = build_root_port_settings(rp_cfg);
+
+    GenericPciePortDefinition {
+        name: rp_cfg.name.as_str().into(),
+        devfn: rp_cfg.devfn,
+        hotplug: rp_cfg.hotplug,
+        settings,
+    }
+}
+
+/// Validates that the configured PCIe root complexes form a consistent
+/// topology: each bus range is well-formed (`start_bus <= end_bus`) and no two
+/// root complexes on the same PCI segment have overlapping bus ranges.
+pub(super) fn validate_pcie_root_complexes(
+    root_complexes: &[PcieRootComplexConfig],
+) -> anyhow::Result<()> {
+    for (index, root_complex) in root_complexes.iter().enumerate() {
+        if root_complex.start_bus > root_complex.end_bus {
+            anyhow::bail!(
+                "invalid PCIe root complex '{}': start_bus ({}) must be less than or equal to end_bus ({})",
+                root_complex.name,
+                root_complex.start_bus,
+                root_complex.end_bus,
+            );
+        }
+
+        for previous in &root_complexes[..index] {
+            if root_complex.segment == previous.segment
+                && root_complex.start_bus <= previous.end_bus
+                && previous.start_bus <= root_complex.end_bus
+            {
+                anyhow::bail!(
+                    "invalid PCIe root complex '{}': bus range {}..={} overlaps with '{}' bus range {}..={} on PCI segment {}",
+                    root_complex.name,
+                    root_complex.start_bus,
+                    root_complex.end_bus,
+                    previous.name,
+                    previous.start_bus,
+                    previous.end_bus,
+                    root_complex.segment,
+                );
+            }
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use openvmm_defs::config::PcieMmioRangeConfig;
+
+    fn rc(name: &str, segment: u16, start_bus: u8, end_bus: u8) -> PcieRootComplexConfig {
+        PcieRootComplexConfig {
+            index: 0,
+            name: name.to_string(),
+            segment,
+            start_bus,
+            end_bus,
+            low_mmio: PcieMmioRangeConfig::Dynamic { size: 0 },
+            high_mmio: PcieMmioRangeConfig::Dynamic { size: 0 },
+            ports: Vec::new(),
+            cxl: None,
+            iommu: None,
+            vnode: None,
+            preserve_bars: false,
+        }
+    }
+
+    #[test]
+    fn accepts_disjoint_ranges() {
+        let rcs = [
+            rc("rc0", 0, 0, 4),
+            rc("rc1", 0, 5, 9),
+            // Same bus range but a different segment is fine.
+            rc("rc2", 1, 0, 4),
+        ];
+        validate_pcie_root_complexes(&rcs).unwrap();
+    }
+
+    #[test]
+    fn rejects_inverted_bus_range() {
+        let rcs = [rc("rc0", 0, 4, 0)];
+        assert!(validate_pcie_root_complexes(&rcs).is_err());
+    }
+
+    #[test]
+    fn rejects_overlapping_ranges_on_same_segment() {
+        let rcs = [rc("rc0", 0, 0, 4), rc("rc1", 0, 4, 8)];
+        assert!(validate_pcie_root_complexes(&rcs).is_err());
+    }
+}


### PR DESCRIPTION
Configuring two PCIe root complexes with overlapping bus ranges on the same PCI segment previously failed only incidentally and late: enumeration got far enough to derive per-complex ECAM windows, and the failure surfaced deep in vmotherboard init as an opaque "static mmio intercept region conflict" between two ecam:0x... ranges, with nothing pointing back at the offending configuration. This adds an up-front check that rejects overlapping bus ranges with a clear error naming both root complexes and the segment.

The check also guards inverted ranges (start_bus > end_bus). The CLI value parser already rejects those, so this is a defensive backstop for configs built programmatically rather than from the command line.

The validation lands in a new dispatch/pcie_topology.rs module rather than the already-oversized dispatch.rs. The two existing config-to-topology root-port helpers (build_root_port_settings / build_root_port_definition) move there too, since they are the same kind of self-contained manifest-to-PCIe-topology logic with no dependency on worker state. Unit tests cover the accepted (disjoint, or same range on different segments) and rejected (inverted range, overlapping ranges on one segment) cases.