### PR TITLE
virt_whp: Make scan_irr per-VTL, add more sets

### DIFF
--- a/vmm_core/virt_whp/src/apic.rs
+++ b/vmm_core/virt_whp/src/apic.rs
@@ -78,9 +78,7 @@ impl WhpPartitionInner {
         match &self.vtlp(vtl).lapic {
             LocalApicKind::Emulated(lapic) => {
                 lapic.request_interrupt(request.address, request.data, |vp_index| {
-                    let vpref = self.vp(vp_index).unwrap();
-                    vpref.vp().scan_irr[vtl].store(true, Ordering::Relaxed);
-                    vpref.wake();
+                    self.vp(vp_index).unwrap().wake_for_apic(vtl);
                 });
             }
             LocalApicKind::Offloaded => {
@@ -163,16 +161,7 @@ impl<T: CpuIo> ApicClient for WhpApicClient<'_, T> {
     }
 
     fn wake(&mut self, vp_index: VpIndex) {
-        let vp = self
-            .partition
-            .vp(vp_index)
-            .expect("apic emulator passes valid vp index")
-            .vp();
-
-        vp.scan_irr[self.vtl].store(true, Ordering::Relaxed);
-        if let Some(waker) = &*vp.waker.read() {
-            waker.wake_by_ref();
-        }
+        self.partition.vp(vp_index).unwrap().wake_for_apic(self.vtl);
     }
 
     fn eoi(&mut self, vector: u8) {

--- a/vmm_core/virt_whp/src/apic.rs
+++ b/vmm_core/virt_whp/src/apic.rs
@@ -78,9 +78,9 @@ impl WhpPartitionInner {
         match &self.vtlp(vtl).lapic {
             LocalApicKind::Emulated(lapic) => {
                 lapic.request_interrupt(request.address, request.data, |vp_index| {
-                    self.vp(vp_index)
-                        .expect("apic emulator passes valid vp index")
-                        .wake()
+                    let vpref = self.vp(vp_index).unwrap();
+                    vpref.vp().scan_irr[vtl].store(true, Ordering::Relaxed);
+                    vpref.wake();
                 });
             }
             LocalApicKind::Offloaded => {
@@ -122,6 +122,7 @@ impl WhpPartitionInner {
 
 pub struct WhpApicClient<'a, T> {
     partition: &'a WhpPartitionInner,
+    vtl: Vtl,
     whp: whp::Processor<'a>,
     dev: &'a T,
     vmtime: &'a VmTimeAccess,
@@ -136,6 +137,7 @@ impl<'a> WhpVpRef<'a> {
     ) -> WhpApicClient<'a, T> {
         WhpApicClient {
             partition: self.partition,
+            vtl,
             whp: self.whp(vtl),
             dev,
             vmtime,
@@ -167,7 +169,7 @@ impl<T: CpuIo> ApicClient for WhpApicClient<'_, T> {
             .expect("apic emulator passes valid vp index")
             .vp();
 
-        vp.scan_irr.store(true, Ordering::Relaxed);
+        vp.scan_irr[self.vtl].store(true, Ordering::Relaxed);
         if let Some(waker) = &*vp.waker.read() {
             waker.wake_by_ref();
         }
@@ -431,7 +433,7 @@ impl WhpProcessor<'_> {
             if let Some(lapic) = &mut vtl_state.lapic {
                 let work = lapic.apic.scan(
                     &mut self.state.vmtime,
-                    self.inner.scan_irr.swap(false, Ordering::Relaxed),
+                    self.inner.scan_irr[vtl].swap(false, Ordering::Relaxed),
                 );
                 lapic.nmi_pending |= work.nmi;
                 if lapic.nmi_pending {

--- a/vmm_core/virt_whp/src/apic.rs
+++ b/vmm_core/virt_whp/src/apic.rs
@@ -416,12 +416,10 @@ impl WhpProcessor<'_> {
                 break;
             }
 
+            let scan_irr = self.vplc(vtl).scan_irr.swap(false, Ordering::Relaxed);
             let vtl_state = &mut self.state.vtls[vtl];
             if let Some(lapic) = &mut vtl_state.lapic {
-                let work = lapic.apic.scan(
-                    &mut self.state.vmtime,
-                    self.inner.scan_irr[vtl].swap(false, Ordering::Relaxed),
-                );
+                let work = lapic.apic.scan(&mut self.state.vmtime, scan_irr);
                 lapic.nmi_pending |= work.nmi;
                 if lapic.nmi_pending {
                     self.inject_nmi(vtl);

--- a/vmm_core/virt_whp/src/apic.rs
+++ b/vmm_core/virt_whp/src/apic.rs
@@ -49,9 +49,7 @@ impl WhpPartitionInner {
         match &self.vtlp(vtl).lapic {
             LocalApicKind::Emulated(apic) => {
                 apic.lint(vp_index, index, |vp_index| {
-                    self.vp(vp_index)
-                        .expect("apic emulator passes valid vp index")
-                        .wake()
+                    self.vp(vp_index).unwrap().wake_for_apic(vtl);
                 });
             }
             LocalApicKind::Offloaded => {

--- a/vmm_core/virt_whp/src/lib.rs
+++ b/vmm_core/virt_whp/src/lib.rs
@@ -399,7 +399,6 @@ struct Vplc {
     #[inspect(with = "|x| x.lock().is_some()")]
     start_vp_request: Mutex<Option<VpStartRequest>>,
     start_vp: AtomicBool,
-    #[cfg_attr(guest_arch = "aarch64", expect(dead_code))]
     scan_irr: AtomicBool,
 }
 

--- a/vmm_core/virt_whp/src/lib.rs
+++ b/vmm_core/virt_whp/src/lib.rs
@@ -31,7 +31,6 @@ use hv1_emulator::hv::GlobalHv;
 use hv1_emulator::hv::GlobalHvParams;
 use hv1_emulator::hv::ProcessorVtlHv;
 use hv1_emulator::message_queues::MessageQueues;
-use hv1_structs::VtlArray;
 use hv1_structs::VtlSet;
 use hvdef::HvDeliverabilityNotificationsRegister;
 use hvdef::HvMessage;
@@ -192,8 +191,6 @@ struct WhpVp {
     vtl2_enable: AtomicBool,
     vp_info: TargetVpInfo,
     waker: RwLock<Option<Waker>>,
-    #[cfg_attr(guest_arch = "aarch64", expect(dead_code))]
-    scan_irr: VtlArray<AtomicBool, 3>,
 }
 
 #[derive(InspectMut)]
@@ -363,7 +360,6 @@ impl WhpVp {
             vtl2_enable: vtl2_enabled.into(),
             vp_info: vp,
             waker: Default::default(),
-            scan_irr: VtlArray::from_fn(|_| AtomicBool::new(true)),
         }
     }
 }
@@ -402,8 +398,9 @@ struct Vplc {
     extint_pending: AtomicBool,
     #[inspect(with = "|x| x.lock().is_some()")]
     start_vp_request: Mutex<Option<VpStartRequest>>,
-    #[inspect(skip)]
     start_vp: AtomicBool,
+    #[cfg_attr(guest_arch = "aarch64", expect(dead_code))]
+    scan_irr: AtomicBool,
 }
 
 impl Vplc {
@@ -414,6 +411,7 @@ impl Vplc {
             extint_pending: false.into(),
             start_vp: false.into(),
             start_vp_request: Default::default(),
+            scan_irr: false.into(),
         }
     }
 
@@ -429,12 +427,14 @@ impl Vplc {
             extint_pending,
             start_vp_request,
             start_vp,
+            scan_irr,
         } = self;
         message_queues.clear();
         check_queues.store(false, Ordering::Relaxed);
         extint_pending.store(false, Ordering::Relaxed);
         *start_vp_request.lock() = None;
         start_vp.store(false, Ordering::Relaxed);
+        scan_irr.store(false, Ordering::Relaxed);
     }
 }
 
@@ -481,7 +481,7 @@ impl<'a> WhpVpRef<'a> {
 
     #[cfg(guest_arch = "x86_64")]
     fn wake_for_apic(&self, vtl: Vtl) {
-        self.vp().scan_irr[vtl].store(true, Ordering::Relaxed);
+        self.vplc(vtl).scan_irr.store(true, Ordering::Relaxed);
         self.wake();
     }
 
@@ -1816,7 +1816,6 @@ impl<'p> virt::Processor for WhpProcessor<'p> {
         // startup suspend and any prior wake request is stale. Per-VP signals
         // that are not VTL2-specific are intentionally left intact, as they may
         // carry pending VTL0 work.
-        self.inner.scan_irr[Vtl::Vtl2].store(false, Ordering::Relaxed);
         self.inner.vtl2_wake.store(false, Ordering::Relaxed);
 
         if cfg!(debug_assertions) {

--- a/vmm_core/virt_whp/src/lib.rs
+++ b/vmm_core/virt_whp/src/lib.rs
@@ -31,6 +31,7 @@ use hv1_emulator::hv::GlobalHv;
 use hv1_emulator::hv::GlobalHvParams;
 use hv1_emulator::hv::ProcessorVtlHv;
 use hv1_emulator::message_queues::MessageQueues;
+use hv1_structs::VtlArray;
 use hv1_structs::VtlSet;
 use hvdef::HvDeliverabilityNotificationsRegister;
 use hvdef::HvMessage;
@@ -192,7 +193,7 @@ struct WhpVp {
     vp_info: TargetVpInfo,
     waker: RwLock<Option<Waker>>,
     #[cfg_attr(guest_arch = "aarch64", expect(dead_code))]
-    scan_irr: AtomicBool,
+    scan_irr: VtlArray<AtomicBool, 3>,
 }
 
 #[derive(InspectMut)]
@@ -362,7 +363,7 @@ impl WhpVp {
             vtl2_enable: vtl2_enabled.into(),
             vp_info: vp,
             waker: Default::default(),
-            scan_irr: true.into(),
+            scan_irr: VtlArray::from_fn(|_| AtomicBool::new(true)),
         }
     }
 }
@@ -1809,6 +1810,7 @@ impl<'p> virt::Processor for WhpProcessor<'p> {
         // startup suspend and any prior wake request is stale. Per-VP signals
         // that are not VTL2-specific (such as `scan_irr`) are intentionally
         // left intact, as they may carry pending VTL0 work.
+        self.inner.scan_irr[Vtl::Vtl2].store(false, Ordering::Relaxed);
         self.inner.vtl2_wake.store(false, Ordering::Relaxed);
 
         if cfg!(debug_assertions) {
@@ -1914,6 +1916,7 @@ mod x86 {
     use crate::WhpPartition;
     use crate::WhpPartitionInner;
     use hvdef::Vtl;
+    use std::sync::atomic::Ordering;
     use virt::VpIndex;
     use virt::irqcon::MsiRequest;
 
@@ -1926,9 +1929,11 @@ mod x86 {
             move |vec: u32, auto_eoi| match &self.vtlp(vtl).lapic {
                 LocalApicKind::Emulated(lapic) => {
                     lapic.synic_interrupt(vp, vec as u8, auto_eoi, |vp_index| {
-                        self.vp(vp_index)
-                            .expect("apic emulator passes valid vp index")
-                            .wake()
+                        let vpref = self
+                            .vp(vp_index)
+                            .expect("apic emulator passes valid vp index");
+                        vpref.vp().scan_irr[vtl].store(true, Ordering::Relaxed);
+                        vpref.wake();
                     });
                 }
                 LocalApicKind::Offloaded => unreachable!(),

--- a/vmm_core/virt_whp/src/lib.rs
+++ b/vmm_core/virt_whp/src/lib.rs
@@ -1808,8 +1808,8 @@ impl<'p> virt::Processor for WhpProcessor<'p> {
 
         // Clear any pending VTL2 wake signal, since VTL2 is now back in
         // startup suspend and any prior wake request is stale. Per-VP signals
-        // that are not VTL2-specific (such as `scan_irr`) are intentionally
-        // left intact, as they may carry pending VTL0 work.
+        // that are not VTL2-specific are intentionally left intact, as they may
+        // carry pending VTL0 work.
         self.inner.scan_irr[Vtl::Vtl2].store(false, Ordering::Relaxed);
         self.inner.vtl2_wake.store(false, Ordering::Relaxed);
 

--- a/vmm_core/virt_whp/src/lib.rs
+++ b/vmm_core/virt_whp/src/lib.rs
@@ -479,6 +479,7 @@ impl<'a> WhpVpRef<'a> {
         }
     }
 
+    #[cfg(guest_arch = "x86_64")]
     fn wake_for_apic(&self, vtl: Vtl) {
         self.vp().scan_irr[vtl].store(true, Ordering::Relaxed);
         self.wake();

--- a/vmm_core/virt_whp/src/lib.rs
+++ b/vmm_core/virt_whp/src/lib.rs
@@ -479,6 +479,11 @@ impl<'a> WhpVpRef<'a> {
         }
     }
 
+    fn wake_for_apic(&self, vtl: Vtl) {
+        self.vp().scan_irr[vtl].store(true, Ordering::Relaxed);
+        self.wake();
+    }
+
     // Enqueues a message to be posted when the associated message slot is free.
     fn post_message(&self, vtl: Vtl, sint: u8, message: &HvMessage) {
         let request_notification = self.vplc(vtl).message_queues.enqueue_message(sint, message);
@@ -1916,7 +1921,6 @@ mod x86 {
     use crate::WhpPartition;
     use crate::WhpPartitionInner;
     use hvdef::Vtl;
-    use std::sync::atomic::Ordering;
     use virt::VpIndex;
     use virt::irqcon::MsiRequest;
 
@@ -1929,11 +1933,7 @@ mod x86 {
             move |vec: u32, auto_eoi| match &self.vtlp(vtl).lapic {
                 LocalApicKind::Emulated(lapic) => {
                     lapic.synic_interrupt(vp, vec as u8, auto_eoi, |vp_index| {
-                        let vpref = self
-                            .vp(vp_index)
-                            .expect("apic emulator passes valid vp index");
-                        vpref.vp().scan_irr[vtl].store(true, Ordering::Relaxed);
-                        vpref.wake();
+                        self.vp(vp_index).unwrap().wake_for_apic(vtl);
                     });
                 }
                 LocalApicKind::Offloaded => unreachable!(),


### PR DESCRIPTION
virt_whp's scan_irr bool is currently stored per-VP. However this can allow one VTL to accidentally steal a signal intended for another, resulting in a wake being lost. Make this be stored per-VTL (like virt_mshv_vtl).

Also add some additional places setting this bool to true, so their interrupts don't get lost either.

Hopefully will reduce vmm test flakiness, especially on openvmm + VBS.