### PR TITLE
kernel upgrade: Update OpenHCL to use v6.18.37.1

### DIFF
--- a/flowey/flowey_lib_hvlite/src/_jobs/cfg_versions.rs
+++ b/flowey/flowey_lib_hvlite/src/_jobs/cfg_versions.rs
@@ -30,8 +30,8 @@ pub const NODEJS: &str = "24.x";
 // N.B. Kernel version numbers for dev and stable branches are not directly
 //      comparable. They originate from separate branches, and the fourth digit
 //      increases with each release from the respective branch.
-pub const OPENHCL_KERNEL_DEV_VERSION: &str = "6.18.0.7";
-pub const OPENHCL_KERNEL_STABLE_VERSION: &str = "6.18.0.7";
+pub const OPENHCL_KERNEL_DEV_VERSION: &str = "6.18.37.1";
+pub const OPENHCL_KERNEL_STABLE_VERSION: &str = "6.18.37.1";
 pub const OPENVMM_DEPS: &str = "0.3.0-110";
 pub const PROTOC: &str = "27.1";
 

--- a/nix/openhcl_kernel.nix
+++ b/nix/openhcl_kernel.nix
@@ -1,7 +1,7 @@
 { system, stdenv, fetchzip, targetArch ? null, is_dev ? false, is_cvm ? false }:
 
 let
-  version = if is_dev then "6.18.0.7" else "6.18.0.7";
+  version = if is_dev then "6.18.37.1" else "6.18.37.1";
   # Allow explicit override of architecture, otherwise derive from host system
   # Note: targetArch uses "x86_64"/"aarch64", but URLs use "x64"/"arm64"
   arch = if targetArch == "x86_64" then "x64"
@@ -18,21 +18,21 @@ let
   hashes = {
     hcl-main = {
       std = {
-        x64 = "sha256-OPgJGihkrdJtoZhOdRRct55exP2HY8qepUuQqnmZdKQ=";
-        arm64 = "sha256-s49kGBGhDY3muXA6FjjztoNXjfzOdtEXnHR4LLnqY+c=";
+        x64 = "sha256-SJc25+RhTYM+yDSWElP2EcTE4g+0J/4MNBnaxhlKRT8=";
+        arm64 = "sha256-ckLUOpDwvGibLeqRZqYRfS4djEJGY1ULYf0Xtxm69lw=";
       };
       cvm = {
-        x64 = "sha256-/T7D4lcl30q3GNsbZ1XdGlLxfdrlzUeJ8k3vA40xa1k=";
+        x64 = "sha256-4GHCrJVWziPwdsDih0SISzWcaQ8+l04CNCtrKl+PrcU=";
         arm64 = throw "openhcl-kernel: cvm arm64 variant not available";
       };
     };
     hcl-dev = {
       std = {
-        x64 = "sha256-PUqcTMu52LCQzemRJLaf2xcpyTuA0EHIzXHqzmSq+2A=";
-        arm64 = "sha256-B/rTpIr9ZbBbxhCt9vdoz5K01rN0bZ9E6/P4q2nrxNo=";
+        x64 = "sha256-IBAkddaHIJScFoNDmteysHUDm28x5JGV+rX+f+lFqQE=";
+        arm64 = "sha256-CjC5lXRAYx3xJCwOojYud1ga52dlyTM68SHHKqYbSdA=";
       };
       cvm = {
-        x64 = "sha256-L+VF1NdQhzTU1T8K8NPP66XIJeKrj15oEw0eQjpzRpg=";
+        x64 = "sha256-5wH7muBkFOintKBM+YBJKjBt8Fn8dYhSkcAFlErMupo=";
         arm64 = throw "openhcl-kernel: dev cvm arm64 variant not available";
       };
     };


### PR DESCRIPTION
Upgrade kernel used in OpenHCL to 6.18.37.1 release tag.

Update OPENHCL_KERNEL_DEV_VERSION and OPENHCL_KERNEL_STABLE_VERSION and regenerate all variant hashes (hcl-main/hcl-dev, std/cvm, x64/arm64) in openhcl_kernel.nix.

Kernel PR: https://github.com/microsoft/OHCL-Linux-Kernel/pull/151