### PR TITLE
petri: Log windows event properties

### DIFF
--- a/petri/src/vm/hyperv/powershell.rs
+++ b/petri/src/vm/hyperv/powershell.rs
@@ -1424,29 +1424,40 @@ pub struct WinEvent {
     pub properties: Vec<String>,
 }
 
-/// Deserialize the `Properties` projection of a Windows event.
-///
-/// PowerShell's `ConvertTo-Json` renders a property array of length one as a
-/// bare scalar and an absent/empty array as `null`, so accept a string, an
-/// array of strings, or null.
+/// Deserialize the `Properties` projection of a Windows event into a flat list
+/// of stringified values.
 fn deserialize_event_properties<'de, D>(deserializer: D) -> Result<Vec<String>, D::Error>
 where
     D: serde::Deserializer<'de>,
 {
     use serde::Deserialize as _;
+    use serde_json::Value;
 
-    #[derive(Deserialize)]
-    #[serde(untagged)]
-    enum OneOrMany {
-        One(String),
-        Many(Vec<String>),
+    fn flatten(value: Value, out: &mut Vec<String>) {
+        match value {
+            Value::Null => out.push("<null>".to_string()),
+            Value::String(s) => out.push(s),
+            Value::Bool(b) => out.push(b.to_string()),
+            Value::Number(n) => out.push(n.to_string()),
+            Value::Array(items) => {
+                for item in items {
+                    flatten(item, out);
+                }
+            }
+            // PowerShell wraps the array as
+            // `{ "value": [...], "Count": N }` (and an empty array as `{}`).
+            // Pull the values out and ignore the bookkeeping `Count` field.
+            Value::Object(mut map) => {
+                if let Some(inner) = map.remove("value") {
+                    flatten(inner, out);
+                }
+            }
+        }
     }
 
-    Ok(match Option::<OneOrMany>::deserialize(deserializer)? {
-        None => Vec::new(),
-        Some(OneOrMany::One(value)) => vec![value],
-        Some(OneOrMany::Many(values)) => values,
-    })
+    let mut properties = Vec::new();
+    flatten(Value::deserialize(deserializer)?, &mut properties);
+    Ok(properties)
 }
 
 /// Get event logs

--- a/petri/src/vm/hyperv/powershell.rs
+++ b/petri/src/vm/hyperv/powershell.rs
@@ -1418,6 +1418,35 @@ pub struct WinEvent {
     pub id: u32,
     /// Message content
     pub message: String,
+    /// Raw event data property values, stringified in template order. Empty
+    /// when the event carries no data.
+    #[serde(default, deserialize_with = "deserialize_event_properties")]
+    pub properties: Vec<String>,
+}
+
+/// Deserialize the `Properties` projection of a Windows event.
+///
+/// PowerShell's `ConvertTo-Json` renders a property array of length one as a
+/// bare scalar and an absent/empty array as `null`, so accept a string, an
+/// array of strings, or null.
+fn deserialize_event_properties<'de, D>(deserializer: D) -> Result<Vec<String>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    use serde::Deserialize as _;
+
+    #[derive(Deserialize)]
+    #[serde(untagged)]
+    enum OneOrMany {
+        One(String),
+        Many(Vec<String>),
+    }
+
+    Ok(match Option::<OneOrMany>::deserialize(deserializer)? {
+        None => Vec::new(),
+        Some(OneOrMany::One(value)) => vec![value],
+        Some(OneOrMany::Many(values)) => values,
+    })
 }
 
 /// Get event logs
@@ -1467,6 +1496,15 @@ pub async fn run_get_winevent(
         ps::Value::new("Level"),
         ps::Value::new("Id"),
         ps::Value::new("Message"),
+        ps::Value::new(ps::HashTable::new([
+            ("label", ps::Value::new("Properties")),
+            (
+                "expression",
+                ps::Value::new(ps::Script::new(
+                    "@($_.Properties | ForEach-Object { [string]$_.Value })",
+                )),
+            ),
+        ])),
     ]);
 
     let output = run_host_cmd(

--- a/petri/src/vm/hyperv/vm.rs
+++ b/petri/src/vm/hyperv/vm.rs
@@ -158,8 +158,13 @@ impl HyperVVM {
                 _ => Level::INFO,
             },
             format_args!(
-                "[{}] {}: ({}, {}) {}",
-                event.time_created, event.provider_name, event.level, event.id, event.message,
+                "[{}] {}: ({}, {}) {} ({})",
+                event.time_created,
+                event.provider_name,
+                event.level,
+                event.id,
+                event.message,
+                event.properties.join(",")
             ),
         );
 


### PR DESCRIPTION
When logging hyper-v ETW events log any event properties in addition to the previously logged data. The hope is that this additional data may provide clarity on the SNP flakiness we've been seeing.