### PR TITLE
loader: deliver SMBIOS tables to aarch64 Linux direct boot

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4213,6 +4213,7 @@ dependencies = [
  "object 0.37.3",
  "open_enum",
  "page_table",
+ "static_assertions",
  "thiserror 2.0.16",
  "tracing",
  "vm_topology",

--- a/openvmm/openvmm_core/src/worker/vm_loaders/linux.rs
+++ b/openvmm/openvmm_core/src/worker/vm_loaders/linux.rs
@@ -54,6 +54,33 @@ pub struct KernelConfig<'a> {
     pub mem_layout: &'a MemoryLayout,
 }
 
+/// The default SMBIOS identity for firmware-less Linux direct boot.
+///
+/// There is no configuration surface yet, so every direct-boot VM gets this
+/// fixed OpenVMM identity. The UUID is left nil.
+fn default_smbios_tables() -> loader::smbios::SmbiosTables<'static> {
+    use loader::smbios;
+
+    smbios::SmbiosTables {
+        bios: smbios::SmbiosBiosInfo {
+            vendor: "OpenVMM",
+            version: "OpenVMM Direct",
+            release_date: "06/19/2026",
+            major: 0,
+            minor: 0,
+        },
+        system: smbios::SmbiosSystemInfo {
+            manufacturer: "OpenVMM",
+            product_name: "OpenVMM Virtual Machine",
+            version: "",
+            serial_number: "",
+            sku_number: "",
+            family: "",
+            uuid: [0; 16],
+        },
+    }
+}
+
 pub struct AcpiTables {
     /// The RDSP. Assumed to be given a whole page.
     pub rdsp: Vec<u8>,
@@ -634,6 +661,7 @@ fn write_efi_and_acpi_tables(
     use uefi_specs::uefi::boot::EfiMemoryType;
     use uefi_specs::uefi::boot::EfiRtPropertiesTable;
     use uefi_specs::uefi::boot::EfiSystemTable;
+    use uefi_specs::uefi::boot::SMBIOS3_TABLE_GUID;
 
     // Helper to align a value up to the given power-of-two alignment.
     fn align_up(val: u64, align: u64) -> u64 {
@@ -657,7 +685,7 @@ fn write_efi_and_acpi_tables(
 
     // Configuration table entries (24 bytes each: 16-byte GUID + 8-byte pointer)
     const CONFIG_ENTRY_SIZE: u64 = 24;
-    let num_config_entries: u64 = 2;
+    let num_config_entries: u64 = 3;
     let config_table_addr = cursor;
     cursor += num_config_entries * CONFIG_ENTRY_SIZE;
 
@@ -675,6 +703,19 @@ fn write_efi_and_acpi_tables(
     let rt_props = EfiRtPropertiesTable::NONE_SUPPORTED;
     cursor += size_of::<EfiRtPropertiesTable>() as u64;
 
+    // SMBIOS — unlike x86 (which brute-force scans the F-segment for the
+    // `_SM3_` anchor), the aarch64 kernel discovers DMI only via the SMBIOS3
+    // EFI configuration-table entry. Reserve the entry point and structure
+    // table from the metadata page (16-byte aligned) and build them with the
+    // shared arch-neutral table builder.
+    cursor = align_up(cursor, 16);
+    let smbios_ep_addr = cursor;
+    cursor += loader::smbios::ENTRY_POINT_SIZE as u64;
+    cursor = align_up(cursor, 16);
+    let smbios_table_addr = cursor;
+    let smbios = loader::smbios::build(&default_smbios_tables(), smbios_table_addr);
+    cursor += smbios.structure_table.len() as u64;
+
     // Compute how many pages the metadata region spans.
     let metadata_end = align_up(cursor, 0x1000);
     let metadata_pages = (metadata_end - efi_base) / 0x1000;
@@ -687,11 +728,18 @@ fn write_efi_and_acpi_tables(
     gm.write_at(rt_props_addr, rt_props.as_bytes())
         .map_err(Error::Efi)?;
 
-    let mut config_entries = [0u8; 48];
+    gm.write_at(smbios_ep_addr, &smbios.entry_point)
+        .map_err(Error::Efi)?;
+    gm.write_at(smbios_table_addr, &smbios.structure_table)
+        .map_err(Error::Efi)?;
+
+    let mut config_entries = [0u8; 72];
     config_entries[0..16].copy_from_slice(ACPI_20_TABLE_GUID.as_bytes());
     config_entries[16..24].copy_from_slice(&rsdp_addr.to_le_bytes());
     config_entries[24..40].copy_from_slice(EFI_RT_PROPERTIES_TABLE_GUID.as_bytes());
     config_entries[40..48].copy_from_slice(&rt_props_addr.to_le_bytes());
+    config_entries[48..64].copy_from_slice(SMBIOS3_TABLE_GUID.as_bytes());
+    config_entries[64..72].copy_from_slice(&smbios_ep_addr.to_le_bytes());
     gm.write_at(config_table_addr, &config_entries)
         .map_err(Error::Efi)?;
 

--- a/vm/devices/firmware/uefi_specs/src/uefi/boot.rs
+++ b/vm/devices/firmware/uefi_specs/src/uefi/boot.rs
@@ -241,6 +241,10 @@ pub const ACPI_20_TABLE_GUID: Guid = guid::guid!("8868e871-e4f1-11d3-bc22-0080c7
 /// EFI RT Properties Table GUID (UEFI spec 4.6).
 pub const EFI_RT_PROPERTIES_TABLE_GUID: Guid = guid::guid!("eb66918a-7eef-402a-842e-931d21c38ae9");
 
+/// SMBIOS 3.x (64-bit) entry point table GUID for EFI configuration table
+/// entries (SMBIOS spec / UEFI spec).
+pub const SMBIOS3_TABLE_GUID: Guid = guid::guid!("f2fd1544-9794-4a2c-992e-e5bbcf20e394");
+
 /// From UEFI spec 4.6 — EFI_RT_PROPERTIES_TABLE
 ///
 /// Installed in the EFI Configuration Table to tell the OS which runtime

--- a/vm/loader/Cargo.toml
+++ b/vm/loader/Cargo.toml
@@ -23,6 +23,7 @@ bitfield-struct.workspace = true
 crc32fast.workspace = true
 object = { workspace = true, features = ["elf", "std", "read_core"] }
 open_enum.workspace = true
+static_assertions.workspace = true
 thiserror.workspace = true
 tracing.workspace = true
 zerocopy.workspace = true

--- a/vm/loader/src/lib.rs
+++ b/vm/loader/src/lib.rs
@@ -13,4 +13,5 @@ pub mod importer;
 pub mod linux;
 pub mod paravisor;
 pub mod pcat;
+pub mod smbios;
 pub mod uefi;

--- a/vm/loader/src/smbios.rs
+++ b/vm/loader/src/smbios.rs
@@ -5,15 +5,11 @@
 //!
 //! In firmware-less Linux direct boot there is no UEFI/PCAT firmware to
 //! synthesize SMBIOS tables, so the loader must build them itself. This module
-//! builds a SMBIOS 3.0 entry point (`_SM3_`) and a minimal structure table
+//! builds a SMBIOS 3.1 entry point (`_SM3_`) and a minimal structure table
 //! (Type 0 BIOS, Type 1 System, Type 127 End-of-table). The caller decides
 //! where the structure table lives in guest memory and how the entry point is
 //! delivered to the guest (x86 F-segment scan vs. aarch64 EFI configuration
 //! table).
-//!
-//! The structures use plain `#[repr(C)]` with `zerocopy` little-endian integer
-//! wrappers (which are alignment-1), so they are naturally packed and free of
-//! padding while requiring no `unsafe`.
 
 mod spec;
 
@@ -60,8 +56,8 @@ pub struct SmbiosSystemInfo<'a> {
     pub uuid: [u8; 16],
 }
 
-/// Aggregate of the SMBIOS structures to build. `Default` yields the Hyper-V /
-/// mu_msvm default identity with a nil UUID.
+/// Aggregate of the SMBIOS structures to build. The caller supplies all of the
+/// identity strings and the system UUID.
 #[derive(Debug, Copy, Clone)]
 pub struct SmbiosTables<'a> {
     /// Type 0 BIOS Information.
@@ -70,7 +66,7 @@ pub struct SmbiosTables<'a> {
     pub system: SmbiosSystemInfo<'a>,
 }
 
-/// Size in bytes of the SMBIOS 3.0 entry point (`_SM3_`). Callers that place
+/// Size in bytes of the SMBIOS 3.1 entry point (`_SM3_`). Callers that place
 /// the entry point and structure table separately (e.g. the aarch64 EFI
 /// configuration-table path) use this to reserve space for the entry point
 /// before knowing the structure table's address.
@@ -107,7 +103,7 @@ impl StringSet {
             return 0;
         }
         self.strings.push(s.to_string());
-        self.strings.len() as u8
+        self.strings.len().try_into().unwrap()
     }
 
     /// Appends the NUL-terminated string set to `out`, ending with the extra
@@ -220,7 +216,7 @@ pub fn build(tables: &SmbiosTables<'_>, table_gpa: u64) -> BuiltSmbios {
         docrev: 0,
         revision: 0x01,
         reserved: 0,
-        max_size: (structure_table.len() as u32).into(),
+        max_size: u32::try_from(structure_table.len()).unwrap().into(),
         table_addr: table_gpa.into(),
     };
     let sum = entry_point

--- a/vm/loader/src/smbios.rs
+++ b/vm/loader/src/smbios.rs
@@ -1,0 +1,378 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Arch-neutral SMBIOS 3.x (DMI) table builder.
+//!
+//! In firmware-less Linux direct boot there is no UEFI/PCAT firmware to
+//! synthesize SMBIOS tables, so the loader must build them itself. This module
+//! builds a SMBIOS 3.0 entry point (`_SM3_`) and a minimal structure table
+//! (Type 0 BIOS, Type 1 System, Type 127 End-of-table). The caller decides
+//! where the structure table lives in guest memory and how the entry point is
+//! delivered to the guest (x86 F-segment scan vs. aarch64 EFI configuration
+//! table).
+//!
+//! The structures use plain `#[repr(C)]` with `zerocopy` little-endian integer
+//! wrappers (which are alignment-1), so they are naturally packed and free of
+//! padding while requiring no `unsafe`.
+
+mod spec;
+
+use spec::Smbios30EntryPoint;
+use spec::SmbiosType0;
+use spec::SmbiosType1;
+use spec::SmbiosType127;
+use zerocopy::IntoBytes;
+use zerocopy::LE;
+use zerocopy::U16;
+
+/// BIOS Information (SMBIOS Type 0).
+#[derive(Debug, Copy, Clone)]
+pub struct SmbiosBiosInfo<'a> {
+    /// BIOS vendor string.
+    pub vendor: &'a str,
+    /// BIOS version string.
+    pub version: &'a str,
+    /// BIOS release date string.
+    pub release_date: &'a str,
+    /// System BIOS Major Release.
+    pub major: u8,
+    /// System BIOS Minor Release.
+    pub minor: u8,
+}
+
+/// System Information (SMBIOS Type 1).
+#[derive(Debug, Copy, Clone)]
+pub struct SmbiosSystemInfo<'a> {
+    /// System manufacturer string.
+    pub manufacturer: &'a str,
+    /// System product name string.
+    pub product_name: &'a str,
+    /// System version string.
+    pub version: &'a str,
+    /// System serial number string.
+    pub serial_number: &'a str,
+    /// System SKU number string.
+    pub sku_number: &'a str,
+    /// System family string.
+    pub family: &'a str,
+    /// System UUID, as raw EFI GUID bytes (mixed-endian, as stored by the UEFI
+    /// path).
+    pub uuid: [u8; 16],
+}
+
+/// Aggregate of the SMBIOS structures to build. `Default` yields the Hyper-V /
+/// mu_msvm default identity with a nil UUID.
+#[derive(Debug, Copy, Clone)]
+pub struct SmbiosTables<'a> {
+    /// Type 0 BIOS Information.
+    pub bios: SmbiosBiosInfo<'a>,
+    /// Type 1 System Information.
+    pub system: SmbiosSystemInfo<'a>,
+}
+
+/// Size in bytes of the SMBIOS 3.0 entry point (`_SM3_`). Callers that place
+/// the entry point and structure table separately (e.g. the aarch64 EFI
+/// configuration-table path) use this to reserve space for the entry point
+/// before knowing the structure table's address.
+pub const ENTRY_POINT_SIZE: usize = size_of::<Smbios30EntryPoint>();
+
+/// The built SMBIOS blobs, ready to be placed in guest memory.
+#[derive(Debug, Clone)]
+pub struct BuiltSmbios {
+    /// The 24-byte `_SM3_` entry point.
+    pub entry_point: Vec<u8>,
+    /// The structure table (Type 0, Type 1, Type 127, plus string sets).
+    pub structure_table: Vec<u8>,
+}
+
+/// Accumulates the strings referenced by a single SMBIOS structure and emits
+/// the trailing string set.
+#[derive(Default)]
+struct StringSet {
+    strings: Vec<String>,
+}
+
+impl StringSet {
+    /// Adds a string and returns its 1-based index, or 0 ("no string") for an
+    /// empty string.
+    ///
+    /// SMBIOS strings are NUL-terminated, so a string set cannot contain an
+    /// interior NUL. The string is truncated at the first NUL (if any) so that
+    /// caller-supplied data cannot corrupt the NUL-separated string set framing
+    /// (bytes after an interior NUL would otherwise be parsed as a separate
+    /// string, shifting every subsequent string index).
+    fn add(&mut self, s: &str) -> u8 {
+        let s = s.split('\0').next().unwrap_or("");
+        if s.is_empty() {
+            return 0;
+        }
+        self.strings.push(s.to_string());
+        self.strings.len() as u8
+    }
+
+    /// Appends the NUL-terminated string set to `out`, ending with the extra
+    /// NUL that terminates the structure. A structure with no strings emits two
+    /// NUL bytes.
+    fn write_to(&self, out: &mut Vec<u8>) {
+        if self.strings.is_empty() {
+            out.extend_from_slice(&[0, 0]);
+            return;
+        }
+        for s in &self.strings {
+            out.extend_from_slice(s.as_bytes());
+            out.push(0);
+        }
+        out.push(0);
+    }
+}
+
+/// Builds the SMBIOS entry point and structure table.
+///
+/// `table_gpa` is the guest physical address at which the returned
+/// `structure_table` will be placed; it is written into the entry point's
+/// `table_addr` field.
+pub fn build(tables: &SmbiosTables<'_>, table_gpa: u64) -> BuiltSmbios {
+    let mut structure_table = Vec::new();
+
+    // Each structure needs a handle that is unique within the table; hand them
+    // out sequentially. The values are arbitrary.
+    let mut next_handle = 0u16;
+    let mut handle = || {
+        let h = next_handle;
+        next_handle += 1;
+        U16::<LE>::new(h)
+    };
+
+    // Type 0 — BIOS Information.
+    {
+        let mut strings = StringSet::default();
+        let vendor = strings.add(tables.bios.vendor);
+        let bios_version = strings.add(tables.bios.version);
+        let bios_release_date = strings.add(tables.bios.release_date);
+        let t0 = SmbiosType0 {
+            typ: 0,
+            length: size_of::<SmbiosType0>() as u8,
+            handle: handle(),
+            vendor,
+            bios_version,
+            bios_segment: 0.into(),
+            bios_release_date,
+            bios_size: 0,
+            characteristics: spec::BIOS_CHARACTERISTICS_PCI_SUPPORTED.into(),
+            characteristics_ext: [
+                spec::BIOS_CHARACTERISTICS_EXT1_ACPI,
+                spec::BIOS_CHARACTERISTICS_EXT2_VM,
+            ],
+            bios_major: tables.bios.major,
+            bios_minor: tables.bios.minor,
+            ec_major: 0xff,
+            ec_minor: 0xff,
+            ext_rom_size: 0.into(),
+        };
+        structure_table.extend_from_slice(t0.as_bytes());
+        strings.write_to(&mut structure_table);
+    }
+
+    // Type 1 — System Information.
+    {
+        let mut strings = StringSet::default();
+        let manufacturer = strings.add(tables.system.manufacturer);
+        let product_name = strings.add(tables.system.product_name);
+        let version = strings.add(tables.system.version);
+        let serial_number = strings.add(tables.system.serial_number);
+        let sku_number = strings.add(tables.system.sku_number);
+        let family = strings.add(tables.system.family);
+        let t1 = SmbiosType1 {
+            typ: 1,
+            length: size_of::<SmbiosType1>() as u8,
+            handle: handle(),
+            manufacturer,
+            product_name,
+            version,
+            serial_number,
+            uuid: tables.system.uuid,
+            wake_up_type: spec::WAKE_UP_TYPE_POWER_SWITCH,
+            sku_number,
+            family,
+        };
+        structure_table.extend_from_slice(t1.as_bytes());
+        strings.write_to(&mut structure_table);
+    }
+
+    // Type 127 — End of Table.
+    {
+        let t127 = SmbiosType127 {
+            typ: 127,
+            length: size_of::<SmbiosType127>() as u8,
+            handle: handle(),
+        };
+        structure_table.extend_from_slice(t127.as_bytes());
+        // End-of-table has no strings: emit the double-NUL terminator.
+        structure_table.extend_from_slice(&[0, 0]);
+    }
+
+    let mut entry_point = Smbios30EntryPoint {
+        anchor: *b"_SM3_",
+        checksum: 0,
+        length: size_of::<Smbios30EntryPoint>() as u8,
+        major: 3,
+        minor: 1,
+        docrev: 0,
+        revision: 0x01,
+        reserved: 0,
+        max_size: (structure_table.len() as u32).into(),
+        table_addr: table_gpa.into(),
+    };
+    let sum = entry_point
+        .as_bytes()
+        .iter()
+        .fold(0u8, |acc, b| acc.wrapping_add(*b));
+    entry_point.checksum = 0u8.wrapping_sub(sum);
+
+    BuiltSmbios {
+        entry_point: entry_point.as_bytes().to_vec(),
+        structure_table,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_smbios_tables() -> SmbiosTables<'static> {
+        SmbiosTables {
+            system: SmbiosSystemInfo {
+                manufacturer: "Test Manufacturer",
+                product_name: "Test Product",
+                version: "Test Version",
+                serial_number: "",
+                sku_number: "Test SKU",
+                family: "Test Family",
+                uuid: [0; 16],
+            },
+            bios: SmbiosBiosInfo {
+                vendor: "Test BIOS Vendor",
+                version: "Test BIOS Version",
+                release_date: "Test BIOS Release Date",
+                major: 1,
+                minor: 2,
+            },
+        }
+    }
+
+    #[test]
+    fn entry_point_checksum_is_zero() {
+        let built = build(&test_smbios_tables(), 0xf0020);
+        let sum = built
+            .entry_point
+            .iter()
+            .fold(0u8, |acc, b| acc.wrapping_add(*b));
+        assert_eq!(sum, 0);
+    }
+
+    #[test]
+    fn entry_point_fields() {
+        let table_gpa = 0xf0020;
+        let built = build(&test_smbios_tables(), table_gpa);
+        assert_eq!(built.entry_point.len(), 0x18);
+        assert_eq!(&built.entry_point[0..5], b"_SM3_");
+        assert_eq!(built.entry_point[6], 0x18); // length
+        assert_eq!(built.entry_point[7], 3); // major
+        assert_eq!(built.entry_point[8], 1); // minor
+
+        // max_size (offset 0x0c) == structure table length.
+        let max_size = u32::from_le_bytes(built.entry_point[0x0c..0x10].try_into().unwrap());
+        assert_eq!(max_size as usize, built.structure_table.len());
+
+        // table_addr (offset 0x10) == the GPA we passed in.
+        let addr = u64::from_le_bytes(built.entry_point[0x10..0x18].try_into().unwrap());
+        assert_eq!(addr, table_gpa);
+    }
+
+    #[test]
+    fn structure_table_layout() {
+        let built = build(&test_smbios_tables(), 0xf0020);
+        let table = &built.structure_table;
+
+        // Type 0 header.
+        assert_eq!(table[0], 0); // type
+        assert_eq!(table[1], 0x1a); // length
+
+        // Type 0 string indices are assigned in order.
+        assert_eq!(table[4], 1); // vendor -> string #1
+        assert_eq!(table[5], 2); // bios_version -> string #2
+
+        // The structure table must end with the Type 127 end-of-table marker
+        // (type, length, handle) followed by the double-NUL terminator. The
+        // handle is the third one allocated (0, 1, 2), i.e. 2 little-endian.
+        let n = table.len();
+        assert_eq!(&table[n - 6..], &[127, 4, 0x02, 0x00, 0, 0]);
+    }
+
+    #[test]
+    fn strings_resolve() {
+        let built = build(&test_smbios_tables(), 0);
+        // The first string in the table (after the 0x1a-byte Type 0 formatted
+        // area) is the BIOS vendor.
+        let strings_start = 0x1a;
+        let nul = built.structure_table[strings_start..]
+            .iter()
+            .position(|&b| b == 0)
+            .unwrap();
+        let vendor = &built.structure_table[strings_start..strings_start + nul];
+        assert_eq!(vendor, "Test BIOS Vendor".as_bytes());
+    }
+
+    #[test]
+    fn empty_string_uses_index_zero() {
+        let tables = test_smbios_tables();
+        let built = build(&tables, 0);
+        let t1_off = struct_offset(&built.structure_table, 1).expect("Type 1 present");
+        // serial_number is the 4th string field, at offset 7 within the Type 1
+        // formatted area (type, length, handle:2, manufacturer, product_name,
+        // version, serial_number).
+        assert_eq!(built.structure_table[t1_off + 7], 0);
+    }
+
+    #[test]
+    fn interior_nul_is_truncated() {
+        let mut tables = test_smbios_tables();
+        // An interior NUL must not corrupt the NUL-separated string set: the
+        // string is truncated at the NUL and following bytes are dropped, so
+        // string indices are not shifted.
+        tables.system.manufacturer = "Mfg\0evil";
+        let built = build(&tables, 0);
+        let t1_off = struct_offset(&built.structure_table, 1).expect("Type 1 present");
+        // manufacturer is still string #1, product_name still #2 (unshifted).
+        assert_eq!(built.structure_table[t1_off + 4], 1);
+        assert_eq!(built.structure_table[t1_off + 5], 2);
+        // The string set holds the truncated manufacturer and none of the bytes
+        // after the interior NUL.
+        let len = built.structure_table[t1_off + 1] as usize;
+        let strings = &built.structure_table[t1_off + len..];
+        let first_nul = strings.iter().position(|&b| b == 0).unwrap();
+        assert_eq!(&strings[..first_nul], b"Mfg");
+        assert!(!strings.windows(4).any(|w| w == b"evil"));
+    }
+
+    /// Walks the structure table and returns the byte offset of the first
+    /// structure with the given type, or `None`.
+    fn struct_offset(table: &[u8], want: u8) -> Option<usize> {
+        let mut off = 0;
+        while off + 2 <= table.len() {
+            let typ = table[off];
+            let formatted_len = table[off + 1] as usize;
+            if typ == want {
+                return Some(off);
+            }
+            // Skip the formatted area, then scan past the string set, which is
+            // terminated by a double-NUL.
+            let mut i = off + formatted_len;
+            while i + 1 < table.len() && !(table[i] == 0 && table[i + 1] == 0) {
+                i += 1;
+            }
+            off = i + 2;
+        }
+        None
+    }
+}

--- a/vm/loader/src/smbios/spec.rs
+++ b/vm/loader/src/smbios/spec.rs
@@ -1,0 +1,108 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! SMBIOS specification structure and constant definitions.
+//!
+//! These types mirror the on-the-wire SMBIOS structures from the DMTF SMBIOS
+//! specification (and EDK2's `SmBios.h`). They contain no logic — only the
+//! field layouts and spec-defined constant values. The table-building logic
+//! lives in the parent module.
+//!
+//! The structures use plain `#[repr(C)]` with `zerocopy` little-endian integer
+//! wrappers (which are alignment-1), so they are naturally packed and free of
+//! padding while requiring no `unsafe`.
+
+use static_assertions::const_assert_eq;
+use zerocopy::Immutable;
+use zerocopy::IntoBytes;
+use zerocopy::KnownLayout;
+use zerocopy::LE;
+use zerocopy::U16;
+use zerocopy::U32;
+use zerocopy::U64;
+
+/// SMBIOS 3.0 64-bit entry point (`_SM3_`), 24 bytes.
+#[repr(C)]
+#[derive(Debug, Copy, Clone, IntoBytes, Immutable, KnownLayout)]
+pub struct Smbios30EntryPoint {
+    /// Anchor string, `b"_SM3_"`.
+    pub anchor: [u8; 5],
+    /// Checksum: the 8-bit sum of all bytes in this structure is zero.
+    pub checksum: u8,
+    /// Length of this entry point, `0x18`.
+    pub length: u8,
+    /// SMBIOS major version.
+    pub major: u8,
+    /// SMBIOS minor version.
+    pub minor: u8,
+    /// SMBIOS docrev.
+    pub docrev: u8,
+    /// Entry point revision.
+    pub revision: u8,
+    /// Reserved, zero.
+    pub reserved: u8,
+    /// Maximum size of the structure table, in bytes.
+    pub max_size: U32<LE>,
+    /// Guest physical address of the first structure (Type 0).
+    pub table_addr: U64<LE>,
+}
+const_assert_eq!(size_of::<Smbios30EntryPoint>(), 0x18);
+
+/// SMBIOS Type 0 — BIOS Information, formatted area length `0x1a`.
+#[repr(C)]
+#[derive(Debug, Copy, Clone, IntoBytes, Immutable, KnownLayout)]
+pub struct SmbiosType0 {
+    pub typ: u8,
+    pub length: u8,
+    pub handle: U16<LE>,
+    pub vendor: u8,
+    pub bios_version: u8,
+    pub bios_segment: U16<LE>,
+    pub bios_release_date: u8,
+    pub bios_size: u8,
+    pub characteristics: U64<LE>,
+    pub characteristics_ext: [u8; 2],
+    pub bios_major: u8,
+    pub bios_minor: u8,
+    pub ec_major: u8,
+    pub ec_minor: u8,
+    pub ext_rom_size: U16<LE>,
+}
+const_assert_eq!(size_of::<SmbiosType0>(), 0x1a);
+
+/// SMBIOS Type 1 — System Information, formatted area length `0x1b`.
+#[repr(C)]
+#[derive(Debug, Copy, Clone, IntoBytes, Immutable, KnownLayout)]
+pub struct SmbiosType1 {
+    pub typ: u8,
+    pub length: u8,
+    pub handle: U16<LE>,
+    pub manufacturer: u8,
+    pub product_name: u8,
+    pub version: u8,
+    pub serial_number: u8,
+    pub uuid: [u8; 16],
+    pub wake_up_type: u8,
+    pub sku_number: u8,
+    pub family: u8,
+}
+const_assert_eq!(size_of::<SmbiosType1>(), 0x1b);
+
+/// SMBIOS Type 127 — End of Table, 4 bytes.
+#[repr(C)]
+#[derive(Debug, Copy, Clone, IntoBytes, Immutable, KnownLayout)]
+pub struct SmbiosType127 {
+    pub typ: u8,
+    pub length: u8,
+    pub handle: U16<LE>,
+}
+const_assert_eq!(size_of::<SmbiosType127>(), 0x4);
+
+/// Type 0 BIOS characteristics: PCI supported (bit 7).
+pub const BIOS_CHARACTERISTICS_PCI_SUPPORTED: u64 = 1 << 7;
+/// Type 0 BIOS characteristics extension byte 1: ACPI supported (bit 0).
+pub const BIOS_CHARACTERISTICS_EXT1_ACPI: u8 = 1 << 0;
+/// Type 0 BIOS characteristics extension byte 2: virtual machine (bit 4).
+pub const BIOS_CHARACTERISTICS_EXT2_VM: u8 = 1 << 4;
+/// Type 1 wake-up type: power switch.
+pub const WAKE_UP_TYPE_POWER_SWITCH: u8 = 0x06;

--- a/vmm_tests/vmm_tests/tests/tests/multiarch.rs
+++ b/vmm_tests/vmm_tests/tests/tests/multiarch.rs
@@ -131,6 +131,38 @@ async fn boot_no_vmbus(config: PetriVmBuilder<OpenVmmPetriBackend>) -> anyhow::R
     Ok(())
 }
 
+/// Verify that the aarch64 Linux direct loader synthesizes SMBIOS (DMI) tables
+/// so the guest can read `/sys/class/dmi/id/*`. The aarch64 ACPI-mode kernel
+/// discovers DMI only via the SMBIOS3 EFI configuration-table entry, so this
+/// exercises that delivery path. There is no configuration surface yet, so the
+/// guest reads the fixed default OpenVMM identity.
+#[vmm_test(openvmm_linux_direct_aarch64)]
+async fn smbios_dmi(config: PetriVmBuilder<OpenVmmPetriBackend>) -> anyhow::Result<()> {
+    let (vm, agent) = config.run().await?;
+
+    let sh = agent.unix_shell();
+
+    let sys_vendor = sh
+        .read_file("/sys/class/dmi/id/sys_vendor")
+        .await
+        .context("reading sys_vendor")?;
+    assert_eq!(sys_vendor.trim(), "OpenVMM");
+
+    let product_name = sh
+        .read_file("/sys/class/dmi/id/product_name")
+        .await
+        .context("reading product_name")?;
+    assert_eq!(product_name.trim(), "OpenVMM Virtual Machine");
+
+    // NOTE: the default identity uses a nil UUID, which the Linux kernel treats
+    // as "not present" (see `dmi_save_uuid`), so `/sys/class/dmi/id/product_uuid`
+    // is not created and is intentionally not checked here.
+
+    agent.power_off().await?;
+    vm.wait_for_clean_teardown().await?;
+    Ok(())
+}
+
 /// Boot with private anonymous memory instead of shared memory sections.
 #[openvmm_test(
     linux_direct_x64,


### PR DESCRIPTION
Firmware-less Linux direct boot has no UEFI/PCAT firmware to synthesize SMBIOS (DMI) tables, so guests booted this way see no DMI at all. This is a problem for NVIDIA GB200: its drivers expect an SMBIOS table on aarch64 to detect that they are running virtualized, which in turn is the signal they use to consume the generic initiator SRAT entries that describe the NUMA topology of GPU RAM. Without SMBIOS the driver cannot find that NUMA information.

Add an arch-neutral SMBIOS 3.x table builder to the loader crate that emits a SMBIOS 3.0 entry point plus a minimal structure table (Type 0 BIOS, Type 1 System, Type 127 end-of-table), and deliver it on aarch64 ACPI-mode direct boot. Unlike x86 (where the kernel brute-force scans the F-segment for the `_SM3_` anchor), the aarch64 kernel discovers DMI only through a SMBIOS3 EFI configuration-table entry, so the aarch64 EFI/ACPI writer reserves the entry point and structure table from its metadata page and adds a third configuration-table entry pointing at them.

There is no configuration surface yet: every direct-boot VM gets a fixed default OpenVMM identity with a nil UUID. The x86, UEFI, PCAT, and GET paths are deliberately left untouched; richer configuration and the other boot paths will be layered on later. A petri test boots an aarch64 Linux direct VM and reads back the synthesized DMI identity from /sys/class/dmi/id to confirm delivery.