### PR TITLE
flowey: build Windows guest payloads with mingw on Linux

### DIFF
--- a/flowey/flowey_hvlite/src/pipelines/vmm_tests_run.rs
+++ b/flowey/flowey_hvlite/src/pipelines/vmm_tests_run.rs
@@ -14,6 +14,7 @@ use flowey::node::prelude::ReadVar;
 use flowey::pipeline::prelude::*;
 use flowey_lib_hvlite::_jobs::local_build_and_run_nextest_vmm_tests::BuildSelections;
 use flowey_lib_hvlite::_jobs::local_build_and_run_nextest_vmm_tests::VmmTestSelections;
+use flowey_lib_hvlite::common::CommonPlatform;
 use flowey_lib_hvlite::common::CommonTriple;
 use flowey_lib_hvlite::install_vmm_tests_deps::VmmTestsDepSelections;
 use flowey_lib_hvlite::install_vmm_tests_deps::VmmTestsDepSelectionsWindows;
@@ -194,6 +195,19 @@ impl IntoPipeline for VmmTestsRunCli {
         let target_os = target.as_triple().operating_system;
         let target_architecture = target.common_arch()?;
         let target_str = target.as_triple().to_string();
+
+        // Windows *guest* payloads (e.g. pipette) must be PE binaries even when
+        // the VMM host target is Linux. On a non-WSL Linux build host the MSVC
+        // toolchain / Windows SDK is unavailable, so cross-compile those guest
+        // binaries with the GNU (mingw-w64) toolchain instead.
+        let windows_guest_platform =
+            if matches!(FlowPlatform::host(backend_hint), FlowPlatform::Linux(_))
+                && !flowey_cli::running_in_wsl()
+            {
+                CommonPlatform::WindowsGnu
+            } else {
+                CommonPlatform::WindowsMsvc
+            };
 
         let repo_root = crate::repo_root();
 
@@ -395,6 +409,7 @@ impl IntoPipeline for VmmTestsRunCli {
             .dep_on(|ctx| {
                 flowey_lib_hvlite::_jobs::local_build_and_run_nextest_vmm_tests::Params {
                     target,
+                    windows_guest_platform,
                     test_content_dir,
                     selections: selections_from_resolved(filter, resolved, target_os),
                     release,

--- a/flowey/flowey_lib_common/src/run_cargo_build.rs
+++ b/flowey/flowey_lib_common/src/run_cargo_build.rs
@@ -94,7 +94,12 @@ impl CargoCrateType {
 pub enum CargoBuildOutput {
     WindowsBin {
         exe: PathBuf,
-        pdb: PathBuf,
+        /// Path to the separate debug file (`.pdb`), if one was produced.
+        ///
+        /// The MSVC toolchain emits a `.pdb`; the GNU (mingw-w64) toolchain
+        /// embeds DWARF debug info in the `.exe` and produces no separate
+        /// file, so this is `None` for GNU builds.
+        pdb: Option<PathBuf>,
     },
     ElfBin {
         bin: PathBuf,
@@ -394,7 +399,13 @@ fn rename_output(
         CargoCrateType::Bin => {
             if find_source(&format!("{out_name}.exe")).is_some() {
                 let exe = do_rename("exe", false)?;
-                let pdb = do_rename("pdb", true)?;
+                // No `.pdb` is produced for GNU (mingw-w64) builds.
+                let pdb_name = format!("{}.pdb", out_name.replace('-', "_"));
+                let pdb = if find_source(&pdb_name).is_some() {
+                    Some(do_rename("pdb", true)?)
+                } else {
+                    None
+                };
                 CargoBuildOutput::WindowsBin { exe, pdb }
             } else if find_source(&format!("{out_name}.efi")).is_some() {
                 let efi = do_rename("efi", false)?;

--- a/flowey/flowey_lib_hvlite/src/_jobs/local_build_and_run_nextest_vmm_tests.rs
+++ b/flowey/flowey_lib_hvlite/src/_jobs/local_build_and_run_nextest_vmm_tests.rs
@@ -62,6 +62,12 @@ flowey_request! {
     pub struct Params {
         pub target: CommonTriple,
 
+        /// Toolchain platform to use when cross-compiling Windows *guest*
+        /// payloads (e.g. pipette). On a non-WSL Linux build host this is
+        /// [`CommonPlatform::WindowsGnu`], since the MSVC toolchain is
+        /// unavailable there; otherwise it is [`CommonPlatform::WindowsMsvc`].
+        pub windows_guest_platform: CommonPlatform,
+
         pub test_content_dir: PathBuf,
 
         pub selections: VmmTestSelections,
@@ -136,6 +142,7 @@ impl SimpleFlowNode for Node {
     fn process_request(request: Self::Request, ctx: &mut NodeCtx<'_>) -> anyhow::Result<()> {
         let Params {
             target,
+            windows_guest_platform,
             test_content_dir,
             selections,
             release,
@@ -321,11 +328,9 @@ impl SimpleFlowNode for Node {
             if copy_extras {
                 copy_to_dir.push((
                     extras_dir.to_owned(),
-                    output.map(ctx, |x| {
-                        Some(match x {
-                            crate::build_openvmm::OpenvmmOutput::WindowsBin { exe: _, pdb } => pdb,
-                            crate::build_openvmm::OpenvmmOutput::LinuxBin { bin: _, dbg } => dbg,
-                        })
+                    output.map(ctx, |x| match x {
+                        crate::build_openvmm::OpenvmmOutput::WindowsBin { exe: _, pdb } => pdb,
+                        crate::build_openvmm::OpenvmmOutput::LinuxBin { bin: _, dbg } => Some(dbg),
                     }),
                 ));
             }
@@ -346,7 +351,7 @@ impl SimpleFlowNode for Node {
             let output = ctx.reqv(|v| crate::build_pipette::Request {
                 target: CommonTriple::Common {
                     arch,
-                    platform: CommonPlatform::WindowsMsvc,
+                    platform: windows_guest_platform,
                 },
                 profile: CommonProfile::from_release(release),
                 pipette: v,
@@ -354,11 +359,9 @@ impl SimpleFlowNode for Node {
             if copy_extras {
                 copy_to_dir.push((
                     extras_dir.to_owned(),
-                    output.map(ctx, |x| {
-                        Some(match x {
-                            crate::build_pipette::PipetteOutput::WindowsBin { exe: _, pdb } => pdb,
-                            _ => unreachable!(),
-                        })
+                    output.map(ctx, |x| match x {
+                        crate::build_pipette::PipetteOutput::WindowsBin { exe: _, pdb } => pdb,
+                        _ => unreachable!(),
                     }),
                 ));
             }
@@ -417,7 +420,7 @@ impl SimpleFlowNode for Node {
             let output = ctx.reqv(|v| crate::build_tpm_guest_tests::Request {
                 target: CommonTriple::Common {
                     arch,
-                    platform: CommonPlatform::WindowsMsvc,
+                    platform: windows_guest_platform,
                 },
                 profile: CommonProfile::from_release(release),
                 tpm_guest_tests: v,
@@ -426,11 +429,9 @@ impl SimpleFlowNode for Node {
             if copy_extras {
                 copy_to_dir.push((
                     extras_dir.to_owned(),
-                    output.map(ctx, |x| {
-                        Some(match x {
-                            TpmGuestTestsOutput::WindowsBin { pdb, .. } => pdb.clone(),
-                            TpmGuestTestsOutput::LinuxBin { .. } => unreachable!(),
-                        })
+                    output.map(ctx, |x| match x {
+                        TpmGuestTestsOutput::WindowsBin { pdb, .. } => pdb.clone(),
+                        TpmGuestTestsOutput::LinuxBin { .. } => unreachable!(),
                     }),
                 ));
             }
@@ -472,10 +473,7 @@ impl SimpleFlowNode for Node {
             });
 
             if copy_extras {
-                copy_to_dir.push((
-                    extras_dir.to_owned(),
-                    output.map(ctx, |x| Some(x.pdb.clone())),
-                ));
+                copy_to_dir.push((extras_dir.to_owned(), output.map(ctx, |x| x.pdb.clone())));
             }
             output
         });
@@ -492,11 +490,9 @@ impl SimpleFlowNode for Node {
             if copy_extras {
                 copy_to_dir.push((
                     extras_dir.to_owned(),
-                    output.map(ctx, |x| {
-                        Some(match x {
-                            crate::build_tmk_vmm::TmkVmmOutput::WindowsBin { exe: _, pdb } => pdb,
-                            _ => unreachable!(),
-                        })
+                    output.map(ctx, |x| match x {
+                        crate::build_tmk_vmm::TmkVmmOutput::WindowsBin { exe: _, pdb } => pdb,
+                        _ => unreachable!(),
                     }),
                 ));
             }
@@ -564,16 +560,11 @@ impl SimpleFlowNode for Node {
             if copy_extras {
                 copy_to_dir.push((
                     extras_dir.to_owned(),
-                    output.map(ctx, |x| {
-                        Some(match x {
-                            crate::build_prep_steps::PrepStepsOutput::WindowsBin {
-                                exe: _,
-                                pdb,
-                            } => pdb,
-                            crate::build_prep_steps::PrepStepsOutput::LinuxBin { bin: _, dbg } => {
-                                dbg
-                            }
-                        })
+                    output.map(ctx, |x| match x {
+                        crate::build_prep_steps::PrepStepsOutput::WindowsBin { exe: _, pdb } => pdb,
+                        crate::build_prep_steps::PrepStepsOutput::LinuxBin { bin: _, dbg } => {
+                            Some(dbg)
+                        }
                     }),
                 ));
             }
@@ -618,13 +609,11 @@ impl SimpleFlowNode for Node {
             if copy_extras {
                 copy_to_dir.push((
                     extras_dir.to_owned(),
-                    output.map(ctx, |x| {
-                        Some(match x {
-                            crate::build_vmgstool::VmgstoolOutput::WindowsBin { exe: _, pdb } => {
-                                pdb
-                            }
-                            crate::build_vmgstool::VmgstoolOutput::LinuxBin { bin: _, dbg } => dbg,
-                        })
+                    output.map(ctx, |x| match x {
+                        crate::build_vmgstool::VmgstoolOutput::WindowsBin { exe: _, pdb } => pdb,
+                        crate::build_vmgstool::VmgstoolOutput::LinuxBin { bin: _, dbg } => {
+                            Some(dbg)
+                        }
                     }),
                 ));
             }

--- a/flowey/flowey_lib_hvlite/src/_jobs/publish_vmgstool_gh_release.rs
+++ b/flowey/flowey_lib_hvlite/src/_jobs/publish_vmgstool_gh_release.rs
@@ -52,9 +52,11 @@ impl SimpleFlowNode for Node {
                             fs_err::hard_link(&exe, &exe_name)?;
                             files.push((exe_name.absolute()?, None));
 
-                            let pdb_name = PathBuf::from(format!("vmgstool-{target}.pdb"));
-                            fs_err::hard_link(&pdb, &pdb_name)?;
-                            files.push((pdb_name.absolute()?, None));
+                            if let Some(pdb) = pdb {
+                                let pdb_name = PathBuf::from(format!("vmgstool-{target}.pdb"));
+                                fs_err::hard_link(&pdb, &pdb_name)?;
+                                files.push((pdb_name.absolute()?, None));
+                            }
                         }
                     }
                 }

--- a/flowey/flowey_lib_hvlite/src/build_hypestv.rs
+++ b/flowey/flowey_lib_hvlite/src/build_hypestv.rs
@@ -12,7 +12,8 @@ pub struct HypestvOutput {
     #[serde(rename = "hypestv.exe")]
     pub exe: PathBuf,
     #[serde(rename = "hypestv.pdb")]
-    pub pdb: PathBuf,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pdb: Option<PathBuf>,
 }
 
 impl Artifact for HypestvOutput {}

--- a/flowey/flowey_lib_hvlite/src/build_igvmfilegen.rs
+++ b/flowey/flowey_lib_hvlite/src/build_igvmfilegen.rs
@@ -21,7 +21,8 @@ pub enum IgvmfilegenOutput {
         #[serde(rename = "igvmfilegen.exe")]
         exe: PathBuf,
         #[serde(rename = "igvmfilegen.pdb")]
-        pdb: PathBuf,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        pdb: Option<PathBuf>,
     },
 }
 

--- a/flowey/flowey_lib_hvlite/src/build_ohcldiag_dev.rs
+++ b/flowey/flowey_lib_hvlite/src/build_ohcldiag_dev.rs
@@ -20,7 +20,8 @@ pub enum OhcldiagDevOutput {
         #[serde(rename = "ohcldiag-dev.exe")]
         exe: PathBuf,
         #[serde(rename = "ohcldiag-dev.pdb")]
-        pdb: PathBuf,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        pdb: Option<PathBuf>,
     },
 }
 

--- a/flowey/flowey_lib_hvlite/src/build_openvmm.rs
+++ b/flowey/flowey_lib_hvlite/src/build_openvmm.rs
@@ -30,7 +30,8 @@ pub enum OpenvmmOutput {
         #[serde(rename = "openvmm.exe")]
         exe: PathBuf,
         #[serde(rename = "openvmm.pdb")]
-        pdb: PathBuf,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        pdb: Option<PathBuf>,
     },
     LinuxBin {
         #[serde(rename = "openvmm")]

--- a/flowey/flowey_lib_hvlite/src/build_pipette.rs
+++ b/flowey/flowey_lib_hvlite/src/build_pipette.rs
@@ -20,7 +20,8 @@ pub enum PipetteOutput {
         #[serde(rename = "pipette.exe")]
         exe: PathBuf,
         #[serde(rename = "pipette.pdb")]
-        pdb: PathBuf,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        pdb: Option<PathBuf>,
     },
 }
 

--- a/flowey/flowey_lib_hvlite/src/build_prep_steps.rs
+++ b/flowey/flowey_lib_hvlite/src/build_prep_steps.rs
@@ -20,7 +20,8 @@ pub enum PrepStepsOutput {
         #[serde(rename = "prep_steps.exe")]
         exe: PathBuf,
         #[serde(rename = "prep_steps.pdb")]
-        pdb: PathBuf,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        pdb: Option<PathBuf>,
     },
 }
 

--- a/flowey/flowey_lib_hvlite/src/build_test_igvm_agent_rpc_server.rs
+++ b/flowey/flowey_lib_hvlite/src/build_test_igvm_agent_rpc_server.rs
@@ -14,7 +14,8 @@ pub struct TestIgvmAgentRpcServerOutput {
     #[serde(rename = "test_igvm_agent_rpc_server.exe")]
     pub exe: PathBuf,
     #[serde(rename = "test_igvm_agent_rpc_server.pdb")]
-    pub pdb: PathBuf,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pdb: Option<PathBuf>,
 }
 
 impl Artifact for TestIgvmAgentRpcServerOutput {}

--- a/flowey/flowey_lib_hvlite/src/build_tmk_vmm.rs
+++ b/flowey/flowey_lib_hvlite/src/build_tmk_vmm.rs
@@ -15,7 +15,8 @@ pub enum TmkVmmOutput {
         #[serde(rename = "tmk_vmm.exe")]
         exe: PathBuf,
         #[serde(rename = "tmk_vmm.pdb")]
-        pdb: PathBuf,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        pdb: Option<PathBuf>,
     },
     LinuxBin {
         #[serde(rename = "tmk_vmm")]

--- a/flowey/flowey_lib_hvlite/src/build_tpm_guest_tests.rs
+++ b/flowey/flowey_lib_hvlite/src/build_tpm_guest_tests.rs
@@ -16,7 +16,8 @@ pub enum TpmGuestTestsOutput {
         #[serde(rename = "tpm_guest_tests.exe")]
         exe: PathBuf,
         #[serde(rename = "tpm_guest_tests.pdb")]
-        pdb: PathBuf,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        pdb: Option<PathBuf>,
     },
     LinuxBin {
         #[serde(rename = "tpm_guest_tests")]

--- a/flowey/flowey_lib_hvlite/src/build_vmgstool.rs
+++ b/flowey/flowey_lib_hvlite/src/build_vmgstool.rs
@@ -22,7 +22,8 @@ pub enum VmgstoolOutput {
         #[serde(rename = "vmgstool.exe")]
         exe: PathBuf,
         #[serde(rename = "vmgstool.pdb")]
-        pdb: PathBuf,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        pdb: Option<PathBuf>,
     },
 }
 

--- a/flowey/flowey_lib_hvlite/src/build_xtask.rs
+++ b/flowey/flowey_lib_hvlite/src/build_xtask.rs
@@ -11,7 +11,7 @@ use flowey_lib_common::run_cargo_build::CargoCrateType;
 #[derive(Serialize, Deserialize)]
 pub enum XtaskOutput {
     LinuxBin { bin: PathBuf, dbg: PathBuf },
-    WindowsBin { exe: PathBuf, pdb: PathBuf },
+    WindowsBin { exe: PathBuf, pdb: Option<PathBuf> },
 }
 
 flowey_request! {

--- a/flowey/flowey_lib_hvlite/src/common.rs
+++ b/flowey/flowey_lib_hvlite/src/common.rs
@@ -102,6 +102,10 @@ impl TryFrom<FlowArch> for CommonArch {
 #[derive(Serialize, Deserialize, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Debug)]
 pub enum CommonPlatform {
     WindowsMsvc,
+    /// Windows via the GNU (mingw-w64) toolchain. Used to cross-compile
+    /// Windows *guest* payloads (e.g. pipette) from a non-WSL Linux host,
+    /// where the MSVC toolchain / Windows SDK is unavailable.
+    WindowsGnu,
     LinuxGnu,
     LinuxMusl,
     MacOs,
@@ -134,6 +138,10 @@ impl CommonTriple {
         arch: CommonArch::X86_64,
         platform: CommonPlatform::WindowsMsvc,
     };
+    pub const X86_64_WINDOWS_GNU: Self = Self::Common {
+        arch: CommonArch::X86_64,
+        platform: CommonPlatform::WindowsGnu,
+    };
     pub const X86_64_LINUX_GNU: Self = Self::Common {
         arch: CommonArch::X86_64,
         platform: CommonPlatform::LinuxGnu,
@@ -145,6 +153,10 @@ impl CommonTriple {
     pub const AARCH64_WINDOWS_MSVC: Self = Self::Common {
         arch: CommonArch::Aarch64,
         platform: CommonPlatform::WindowsMsvc,
+    };
+    pub const AARCH64_WINDOWS_GNU: Self = Self::Common {
+        arch: CommonArch::Aarch64,
+        platform: CommonPlatform::WindowsGnu,
     };
     pub const AARCH64_LINUX_GNU: Self = Self::Common {
         arch: CommonArch::Aarch64,
@@ -191,6 +203,13 @@ impl CommonTriple {
                     vendor: target_lexicon::Vendor::Pc,
                     operating_system: target_lexicon::OperatingSystem::Windows,
                     environment: target_lexicon::Environment::Msvc,
+                    binary_format: target_lexicon::BinaryFormat::Coff,
+                },
+                CommonPlatform::WindowsGnu => target_lexicon::Triple {
+                    architecture: arch.as_arch(),
+                    vendor: target_lexicon::Vendor::Pc,
+                    operating_system: target_lexicon::OperatingSystem::Windows,
+                    environment: target_lexicon::Environment::Gnu,
                     binary_format: target_lexicon::BinaryFormat::Coff,
                 },
                 CommonPlatform::LinuxGnu => target_lexicon::Triple {

--- a/flowey/flowey_lib_hvlite/src/init_cross_build.rs
+++ b/flowey/flowey_lib_hvlite/src/init_cross_build.rs
@@ -154,13 +154,44 @@ impl FlowNode for Node {
                             );
                         }
                     }
-                    // Cross compiling for Windows relies on the appropriate
-                    // Visual Studio Build Tools components being installed.
-                    // The necessary libraries can be accessed from WSL,
-                    // allowing for compilation of Windows applications from Linux.
-                    // For now, just silently continue regardless.
+                    // Cross compiling for Windows with the MSVC toolchain
+                    // relies on the appropriate Visual Studio Build Tools
+                    // components being installed. The necessary libraries can
+                    // be accessed from WSL, allowing for compilation of Windows
+                    // applications from Linux. For now, just silently continue
+                    // regardless.
                     // TODO: Detect (and potentially install) these dependencies
-                    (FlowPlatform::Linux(_), target_lexicon::OperatingSystem::Windows) => {}
+                    //
+                    // Cross compiling for Windows with the GNU (mingw-w64)
+                    // toolchain works on a native (non-WSL) Linux host without
+                    // the Windows SDK, and is used to build Windows *guest*
+                    // payloads (e.g. pipette). Install the mingw-w64 cross gcc,
+                    // which rustc auto-detects as the linker
+                    // (`x86_64-w64-mingw32-gcc`).
+                    (
+                        FlowPlatform::Linux(linux_distribution),
+                        target_lexicon::OperatingSystem::Windows,
+                    ) => {
+                        if matches!(target.environment, target_lexicon::Environment::Gnu)
+                            && matches!(target.architecture, Architecture::X86_64)
+                        {
+                            let pkg = match linux_distribution {
+                                FlowPlatformLinuxDistro::Ubuntu => {
+                                    Some("gcc-mingw-w64-x86-64-win32")
+                                }
+                                FlowPlatformLinuxDistro::Fedora => Some("mingw64-gcc"),
+                                _ => None,
+                            };
+                            if let Some(pkg) = pkg {
+                                pre_build_deps.push(ctx.reqv(|v| {
+                                    flowey_lib_common::install_dist_pkg::Request::Install {
+                                        package_names: vec![pkg.into()],
+                                        done: v,
+                                    }
+                                }));
+                            }
+                        }
+                    }
                     (FlowPlatform::Windows, target_lexicon::OperatingSystem::Windows) => {}
                     (_, target_lexicon::OperatingSystem::None_) => {}
                     (_, target_lexicon::OperatingSystem::Uefi) => {}

--- a/flowey/flowey_lib_hvlite/src/run_cargo_build.rs
+++ b/flowey/flowey_lib_hvlite/src/run_cargo_build.rs
@@ -22,7 +22,11 @@ use std::collections::BTreeMap;
 pub enum CargoBuildOutput {
     WindowsBin {
         exe: PathBuf,
-        pdb: PathBuf,
+        /// Path to the separate debug file (`.pdb`), if one was produced.
+        ///
+        /// `None` for GNU (mingw-w64) builds, which embed debug info in the
+        /// `.exe` rather than emitting a separate `.pdb`.
+        pdb: Option<PathBuf>,
     },
     ElfBin {
         bin: PathBuf,


### PR DESCRIPTION
Running VMM tests with Windows guests from a native (non-WSL) Linux host was impossible. The guest-side payloads that have to be Windows PE binaries — pipette and the TPM guest tests — were only ever built with the MSVC toolchain, which cannot cross-compile on a plain Linux host because it needs the Windows SDK reachable only from WSL or native Windows. As a result `cargo xflowey vmm-tests-run` could not produce the artifacts needed to exercise a Windows guest, even though the VMM host itself runs as a Linux binary.

These guest payloads are ordinary leaf binaries, so they cross-compile cleanly from Linux with the GNU (mingw-w64) toolchain, which needs no Windows SDK. This teaches the runner to pick the gnu toolchain for Windows guest payloads when the build host is non-WSL Linux, while leaving the MSVC path untouched everywhere it already works (native Windows, WSL, and any host-side Windows artifacts, which still require the SDK and are only built when the test target itself is Windows).

The gnu toolchain embeds DWARF debug info directly in the executable and emits no separate .pdb, so the debug sidecar is now modeled as an optional file uniformly across the Windows binary build outputs. This keeps every build-output mapping a verbatim pass-through and lets the few consumers that copy symbols simply skip the copy when no sidecar exists, rather than forcing the absence to be handled at each call site.

To make this work out of the box on a fresh Linux checkout, the cross build setup installs the win32-threads mingw cross gcc. rustc only uses that gcc as the linker driver (it ships its own self-contained mingw libs), so the win32 variant is pinned deliberately to avoid dragging in the posix variant and to keep the default toolchain alternative stable.