### PR TITLE
mana_driver: return None from save() when VF reconfiguration is pending

### DIFF
--- a/openhcl/underhill_core/src/emuplat/netvsp.rs
+++ b/openhcl/underhill_core/src/emuplat/netvsp.rs
@@ -79,6 +79,7 @@ enum VfManagerSaveResult {
     Saved(ManaSavedState),
     DeviceMissing,
     SaveFailed,
+    NoSavedState,
 }
 
 async fn create_mana_device(
@@ -978,7 +979,7 @@ impl HclNetworkVFManagerWorker {
                     .await;
 
                 match saved_state {
-                    Ok(saved_state) => {
+                    Ok(Some(saved_state)) => {
                         // Closing the VFIO device handle can take a long time.
                         // Leak the handle by stashing it away.
                         std::mem::forget(device);
@@ -986,6 +987,11 @@ impl HclNetworkVFManagerWorker {
                             mana_device: saved_state,
                             pci_id: self.vtl2_pci_id.clone(),
                         })
+                    }
+                    Ok(None) => {
+                        tracing::info!(vtl2_vfid, "skipping saved state");
+                        drop(device);
+                        VfManagerSaveResult::NoSavedState
                     }
                     Err(err) => {
                         tracing::error!(
@@ -1893,6 +1899,10 @@ impl HclNetworkVFManager {
             }
             Ok(VfManagerSaveResult::SaveFailed) => {
                 tracing::error!("MANA device present but save failed");
+                None
+            }
+            Ok(VfManagerSaveResult::NoSavedState) => {
+                tracing::info!("No MANA device state to save, restore will reinitialize");
                 None
             }
             Err(err) => {

--- a/vm/devices/net/mana_driver/src/gdma_driver.rs
+++ b/vm/devices/net/mana_driver/src/gdma_driver.rs
@@ -529,20 +529,21 @@ impl<T: DeviceBacking> GdmaDriver<T> {
         Ok(this)
     }
 
-    pub async fn save(&mut self) -> anyhow::Result<GdmaDriverSavedState> {
+    pub async fn save(&mut self) -> anyhow::Result<Option<GdmaDriverSavedState>> {
         if self.hwc_failure {
             anyhow::bail!("cannot save/restore after HWC failure");
         }
 
         if self.reset_request_pending.is_some() {
-            anyhow::bail!("cannot save/restore with HWC reset request pending");
+            tracing::info!("HWC reset request pending. Not returning any saved state.");
+            return Ok(None);
         }
 
         self.state_saved = true;
 
         let doorbell = self.bar0.save(Some(self.db_id as u64));
 
-        Ok(GdmaDriverSavedState {
+        Ok(Some(GdmaDriverSavedState {
             mem: SavedMemoryState {
                 base_pfn: self.dma_buffer.pfns()[0],
                 len: self.dma_buffer.len(),
@@ -558,7 +559,7 @@ impl<T: DeviceBacking> GdmaDriver<T> {
             num_msix: self.num_msix,
             min_queue_avail: self.min_queue_avail,
             link_toggle: self.link_toggle.clone(),
-        })
+        }))
     }
 
     pub fn init(device: &mut T) -> anyhow::Result<(<T as DeviceBacking>::Registers, RegMap)> {

--- a/vm/devices/net/mana_driver/src/mana.rs
+++ b/vm/devices/net/mana_driver/src/mana.rs
@@ -177,7 +177,7 @@ impl<T: DeviceBacking> ManaDevice<T> {
     }
 
     /// Saves the device's state for servicing
-    pub async fn save(self) -> (anyhow::Result<ManaDeviceSavedState>, T) {
+    pub async fn save(self) -> (anyhow::Result<Option<ManaDeviceSavedState>>, T) {
         self.inspect_task.cancel().await;
         if let Some(hwc_task) = self.hwc_task {
             hwc_task.cancel().await;
@@ -187,16 +187,22 @@ impl<T: DeviceBacking> ManaDevice<T> {
             .expect("MANA device save failed, multiple references remain.");
         let mut driver = inner.gdma.into_inner();
 
-        if let Ok(saved_state) = driver.save().await {
-            let mana_saved_state = ManaDeviceSavedState { gdma: saved_state };
-
-            (Ok(mana_saved_state), driver.into_device())
-        } else {
-            tracing::error!("Failed to save MANA device state");
-            (
-                Err(anyhow::anyhow!("Failed to save MANA device state")),
-                driver.into_device(),
-            )
+        match driver.save().await {
+            Ok(Some(saved_state)) => {
+                let mana_saved_state = ManaDeviceSavedState { gdma: saved_state };
+                (Ok(Some(mana_saved_state)), driver.into_device())
+            }
+            Ok(None) => {
+                tracing::info!("MANA device save skipped");
+                (Ok(None), driver.into_device())
+            }
+            Err(err) => {
+                tracing::error!(
+                    err = err.as_ref() as &dyn std::error::Error,
+                    "Failed to save MANA device state"
+                );
+                (Err(err), driver.into_device())
+            }
         }
     }
 

--- a/vm/devices/net/mana_driver/src/mana.rs
+++ b/vm/devices/net/mana_driver/src/mana.rs
@@ -176,7 +176,8 @@ impl<T: DeviceBacking> ManaDevice<T> {
         Ok(device)
     }
 
-    /// Saves the device's state for servicing
+    /// Saves the device's state for servicing,
+    /// unless the device does not return state to save.
     pub async fn save(self) -> (anyhow::Result<Option<ManaDeviceSavedState>>, T) {
         self.inspect_task.cancel().await;
         if let Some(hwc_task) = self.hwc_task {

--- a/vm/devices/net/mana_driver/src/tests.rs
+++ b/vm/devices/net/mana_driver/src/tests.rs
@@ -193,7 +193,10 @@ async fn test_gdma_save_restore(driver: DefaultDriver) {
 
         gdma.test_eq().await.unwrap();
         gdma.verify_vf_driver_version().await.unwrap();
-        gdma.save().await.unwrap()
+        gdma.save()
+            .await
+            .unwrap()
+            .expect("save should return Some without a reset request pending")
     };
 
     let mut new_gdma = GdmaDriver::restore(saved_state, cloned_device, gdma_buffer)
@@ -435,5 +438,49 @@ async fn test_gdma_reset_request_with_revoke(driver: DefaultDriver) {
         gdma.get_reset_request_pending(),
         Some(true),
         "reset_request_pending should remain revoke_vtl0_vf=true after deregister_device"
+    );
+}
+
+#[async_test]
+async fn test_gdma_save_vf_reset_pending(driver: DefaultDriver) {
+    let mem = DeviceTestMemory::new(128, false, "test_gdma");
+    let msi_conn = MsiConnection::new(AssignedBusRange::new(), 0);
+    let device = gdma::GdmaDevice::new(
+        &VmTaskDriverSource::new(SingleDriverBackend::new(driver.clone())),
+        mem.guest_memory(),
+        msi_conn.target(),
+        vec![VportConfig {
+            mac_address: [1, 2, 3, 4, 5, 6].into(),
+            endpoint: Box::new(NullEndpoint::new()),
+        }],
+        &mut ExternallyManagedMmioIntercepts,
+    );
+    let dma_client = mem.dma_client();
+    let device = EmulatedDevice::new(device, msi_conn, dma_client);
+    let dma_client = device.dma_client();
+    let buffer = dma_client.allocate_dma_buffer(6 * PAGE_SIZE).unwrap();
+
+    let mut gdma = GdmaDriver::new(&driver, device, 1, Some(buffer))
+        .await
+        .unwrap();
+
+    // Trigger the VF reset request EQE 135
+    gdma.generate_reset_request_eqe(false).await.unwrap();
+
+    // Some - Reset is pending. false - VTL0 VF revoke not requested.
+    assert_eq!(
+        gdma.get_reset_request_pending(),
+        Some(false),
+        "reset_request_pending should be set"
+    );
+
+    let result = gdma.save().await;
+    assert!(
+        result.is_ok(),
+        "save() should not return an error when VF reset is pending"
+    );
+    assert!(
+        result.unwrap().is_none(),
+        "save() should return None (no saved state) when VF reset is pending"
     );
 }

--- a/vm/devices/net/mana_driver/src/tests.rs
+++ b/vm/devices/net/mana_driver/src/tests.rs
@@ -444,11 +444,11 @@ async fn test_gdma_reset_request_with_revoke(driver: DefaultDriver) {
 #[async_test]
 async fn test_gdma_save_vf_reset_pending(driver: DefaultDriver) {
     let mem = DeviceTestMemory::new(128, false, "test_gdma");
-    let msi_conn = MsiConnection::new(AssignedBusRange::new(), 0);
+    let msi_conn = MsiConnection::new();
     let device = gdma::GdmaDevice::new(
         &VmTaskDriverSource::new(SingleDriverBackend::new(driver.clone())),
         mem.guest_memory(),
-        msi_conn.target(),
+        &msi_conn.target(),
         vec![VportConfig {
             mac_address: [1, 2, 3, 4, 5, 6].into(),
             endpoint: Box::new(NullEndpoint::new()),


### PR DESCRIPTION
When the GDMA driver receives EQE 135 (VF reconfiguration request), it sets reset_request_pending. Calling save() in this state will return an Err(...), which causes the netvsp save path to treat it as a genuine driver failure and schedule an FLR.

* GdmaDriver::save() returns Ok(None) when VF reconfiguration is pending. 
* ManaDevice::save() returns Ok(None) when Ok(None) is returned by GdmaDriver::save().
* The emuplat netvsp save path recognizes Ok(None) via a new `VfManagerSaveResult::NoSavedState` variant and returns no saved state without triggering FLR.
  * On restore, the device will simply reinitialize from scratch.
* New unit test `test_gdma_save_vf_reset_pending` verifies that save() returns Ok(None) after EQE 135 is fired. The existing `test_gdma_save_restore` test is updated to unwrap the Option.