### PR TITLE
flowey: only run the Hyper-V check when Hyper-V is required

### DIFF
--- a/flowey/flowey_lib_hvlite/src/install_vmm_tests_deps.rs
+++ b/flowey/flowey_lib_hvlite/src/install_vmm_tests_deps.rs
@@ -202,7 +202,7 @@ fn install_windows_deps(
                 }
             }
         }
-    } else if installing && !auto_install && !features_to_enable.is_empty() {
+    } else if installing && !auto_install && hyperv {
         if powershell_builder::PowerShellBuilder::new()
             .cmdlet("Get-VM")
             .finish()


### PR DESCRIPTION
In `install_windows_deps`, the non-admin branch verifies Hyper-V via `Get-VM` and bails with a Hyper-V-specific error. It was gated on `!features_to_enable.is_empty()`, which is also true when only WHP features (`HypervisorPlatform`) are requested. As a result, a non-admin run that needs only WHP would incorrectly run the Hyper-V check and fail even though Hyper-V isn't needed. Gate the branch on `hyperv` instead so WHP-only runs fall through to the normal feature-install path.