### PR TITLE
petri: quiet disk_blob debug trace output

### DIFF
--- a/petri/src/vm/openvmm/start.rs
+++ b/petri/src/vm/openvmm/start.rs
@@ -88,7 +88,9 @@ impl PetriVmConfigOpenVmm {
 
         let log_env = match host_log_levels {
             None | Some(OpenvmmLogConfig::TestDefault) => BTreeMap::<OsString, OsString>::from([
-                ("OPENVMM_LOG".into(), "debug".into()),
+                // Quiet down `hyper_util`'s connection-pool debug spam that
+                // `disk_blob` triggers on every HTTP range request.
+                ("OPENVMM_LOG".into(), "debug,hyper_util=info".into()),
                 ("OPENVMM_SHOW_SPANS".into(), "true".into()),
             ]),
             Some(OpenvmmLogConfig::BuiltInDefault) => BTreeMap::new(),


### PR DESCRIPTION
hyper_util traces a bunch of stuff per IO at debug level. This clogs up the petri logs when running VMM tests locally. Update OPENVMM_LOG to hide these log entries.