### PR TITLE
openvmm: support booting UEFI without hypervisor enlightenments

### DIFF
--- a/flowey/flowey_lib_hvlite/src/_jobs/cfg_versions.rs
+++ b/flowey/flowey_lib_hvlite/src/_jobs/cfg_versions.rs
@@ -24,7 +24,7 @@ pub const GH_CLI: &str = "2.52.0";
 pub const MDBOOK: &str = "0.4.40";
 pub const MDBOOK_ADMONISH: &str = "1.18.0";
 pub const MDBOOK_MERMAID: &str = "0.14.0";
-pub const MU_MSVM: &str = "26.0.13";
+pub const MU_MSVM: &str = "26.0.19";
 pub const NEXTEST: &str = "0.9.133";
 pub const NODEJS: &str = "24.x";
 // N.B. Kernel version numbers for dev and stable branches are not directly

--- a/openvmm/openvmm_core/src/worker/dispatch.rs
+++ b/openvmm/openvmm_core/src/worker/dispatch.rs
@@ -3219,6 +3219,7 @@ impl LoadedVmInner {
                 bios_guid,
                 enable_vmbus,
                 force_dma_bounce,
+                enable_hv,
             } => {
                 let acpi_tables = [
                     // MADT
@@ -3255,6 +3256,7 @@ impl LoadedVmInner {
                     bios_guid,
                     vmbus: enable_vmbus,
                     force_dma_bounce,
+                    hv: enable_hv,
                 };
                 let regs =
                     super::vm_loaders::uefi::load_uefi(&super::vm_loaders::uefi::LoadUefiParams {

--- a/openvmm/openvmm_core/src/worker/vm_loaders/uefi.rs
+++ b/openvmm/openvmm_core/src/worker/vm_loaders/uefi.rs
@@ -50,6 +50,11 @@ pub struct UefiLoadSettings {
     pub vmbus: bool,
     /// Force UEFI to bounce-buffer all DMA traffic.
     pub force_dma_bounce: bool,
+    /// Whether the hypervisor (HV#1) enlightenments are exposed to the guest.
+    /// When `false`, the firmware is told (via the SEC platform type in `x2` on
+    /// aarch64) not to attempt to use hypervisor-specific facilities. This is
+    /// required to boot UEFI without hypervisor support (e.g. aarch64 KVM).
+    pub hv: bool,
 }
 
 /// All inputs needed by [`load_uefi`].
@@ -222,6 +227,7 @@ pub fn load_uefi(params: &LoadUefiParams<'_>) -> Result<Vec<Register>, Error> {
         &mut loader,
         image,
         loader::uefi::ConfigType::ConfigBlob(cfg),
+        settings.hv,
     )
     .map_err(Error::Loader)?;
 

--- a/openvmm/openvmm_defs/src/config.rs
+++ b/openvmm/openvmm_defs/src/config.rs
@@ -146,6 +146,7 @@ pub enum LoadMode {
         bios_guid: Guid,
         enable_vmbus: bool,
         force_dma_bounce: bool,
+        enable_hv: bool,
     },
     Pcat {
         firmware: RomFileLocation,

--- a/openvmm/openvmm_entry/src/cli_args.rs
+++ b/openvmm/openvmm_entry/src/cli_args.rs
@@ -249,6 +249,12 @@ Examples:
     #[clap(long)]
     pub hv: bool,
 
+    /// Boot UEFI without exposing hypervisor (HV#1) enlightenments. Required to
+    /// boot UEFI without hypervisor support (e.g. aarch64 KVM). Requires
+    /// `--no-vmbus` since VMBus depends on the hypervisor.
+    #[clap(long, requires("no_vmbus"), conflicts_with_all = ["hv", "vtl2", "get", "pcat"])]
+    pub no_hv: bool,
+
     /// Use a full device tree instead of ACPI tables for ARM64 Linux direct
     /// boot. By default, ARM64 uses ACPI mode (stub DT + EFI + ACPI tables).
     /// This flag selects the legacy DT-only path. Rejected on x86.

--- a/openvmm/openvmm_entry/src/lib.rs
+++ b/openvmm/openvmm_entry/src/lib.rs
@@ -1280,7 +1280,13 @@ async fn vm_config_from_command_line(
     } else if opt.uefi {
         use openvmm_defs::config::UefiConsoleMode;
 
-        with_hv = true;
+        if opt.no_hv && cfg!(guest_arch = "x86_64") {
+            anyhow::bail!(
+                "--no-hv is not supported on x86_64; the firmware always runs under Hyper-V"
+            );
+        }
+
+        with_hv = !opt.no_hv;
 
         let firmware = fs_err::File::open(
             (opt.uefi_firmware.0)
@@ -1310,6 +1316,7 @@ async fn vm_config_from_command_line(
             bios_guid,
             enable_vmbus: !opt.no_vmbus,
             force_dma_bounce: opt.uefi_force_dma_bounce,
+            enable_hv: !opt.no_hv,
         };
     } else {
         // Linux Direct

--- a/petri/src/vm/mod.rs
+++ b/petri/src/vm/mod.rs
@@ -184,6 +184,8 @@ pub struct PetriVmBuilder<T: PetriVmmBackend> {
     use_virtio_vsock: bool,
     // Disable VMBus entirely (no vmbus server, no vmbus storage controllers).
     no_vmbus: bool,
+    // Disable the hypervisor (HV#1) enlightenments. Implies `no_vmbus`.
+    no_hv: bool,
 }
 
 impl<T: PetriVmmBackend> Debug for PetriVmBuilder<T> {
@@ -206,6 +208,7 @@ impl<T: PetriVmmBackend> Debug for PetriVmBuilder<T> {
             .field("prebuilt_initrd", &self.prebuilt_initrd)
             .field("use_virtio_vsock", &self.use_virtio_vsock)
             .field("no_vmbus", &self.no_vmbus)
+            .field("no_hv", &self.no_hv)
             .finish()
     }
 }
@@ -291,6 +294,8 @@ pub struct PetriVmProperties {
     pub use_virtio_vsock: bool,
     /// VMBus is entirely disabled
     pub no_vmbus: bool,
+    /// The hypervisor (HV#1) enlightenments are entirely disabled
+    pub no_hv: bool,
 }
 
 /// VM configuration that can be changed after the VM is created
@@ -463,6 +468,7 @@ impl<T: PetriVmmBackend> PetriVmBuilder<T> {
             prebuilt_initrd: None,
             use_virtio_vsock: false,
             no_vmbus: false,
+            no_hv: false,
         }
         .add_petri_scsi_controllers()
         .add_guest_crash_disk(params.post_test_hooks))
@@ -539,6 +545,7 @@ impl<T: PetriVmmBackend> PetriVmBuilder<T> {
             prebuilt_initrd: None,
             use_virtio_vsock: false,
             no_vmbus: false,
+            no_hv: false,
         })
     }
 
@@ -663,6 +670,16 @@ impl<T: PetriVmmBackend> PetriVmBuilder<T> {
         }
         self.config.vmbus_storage_controllers.clear();
         self
+    }
+
+    /// Disable the hypervisor (HV#1) enlightenments.
+    ///
+    /// This also disables VMBus (see [`Self::with_no_vmbus`]), since VMBus
+    /// depends on the hypervisor. On aarch64 UEFI this causes the loader to pass
+    /// the `Generic` SEC platform type to the firmware. Not supported on x86_64.
+    pub fn with_no_hv(mut self) -> Self {
+        self.no_hv = true;
+        self.with_no_vmbus()
     }
 
     fn add_petri_scsi_controllers(self) -> Self {
@@ -964,6 +981,7 @@ impl<T: PetriVmmBackend> PetriVmBuilder<T> {
             has_agent_disk: self.has_agent_disk(),
             use_virtio_vsock: self.use_virtio_vsock,
             no_vmbus: self.no_vmbus,
+            no_hv: self.no_hv,
         }
     }
 

--- a/petri/src/vm/openvmm/construct.rs
+++ b/petri/src/vm/openvmm/construct.rs
@@ -147,6 +147,7 @@ impl PetriVmConfigOpenVmm {
             enable_serial: properties.enable_serial,
             use_virtio_vsock: properties.use_virtio_vsock,
             no_vmbus: properties.no_vmbus,
+            no_hv: properties.no_hv,
         };
 
         let mut chipset = VmManifestBuilder::new(
@@ -591,7 +592,7 @@ impl PetriVmConfigOpenVmm {
 
             // Basic virtualization device support
             hypervisor: HypervisorConfig {
-                with_hv: true,
+                with_hv: !properties.no_hv,
                 with_vtl2,
                 with_isolation: match firmware.isolation() {
                     Some(IsolationType::Vbs) => Some(openvmm_defs::config::IsolationType::Vbs),
@@ -736,6 +737,7 @@ struct PetriVmConfigSetupCore<'a> {
     enable_serial: bool,
     use_virtio_vsock: bool,
     no_vmbus: bool,
+    no_hv: bool,
 }
 
 struct SerialData {
@@ -917,6 +919,7 @@ impl PetriVmConfigSetupCore<'_> {
                     bios_guid: Guid::new_random(),
                     enable_vmbus: !self.no_vmbus,
                     force_dma_bounce: *force_dma_bounce,
+                    enable_hv: !self.no_hv,
                 }
             }
             (

--- a/vm/loader/igvmfilegen/src/main.rs
+++ b/vm/loader/igvmfilegen/src/main.rs
@@ -482,7 +482,7 @@ impl IgvmfilegenRegister for X86Register {
         image: &[u8],
         config: loader::uefi::ConfigType,
     ) -> Result<loader::uefi::LoadInfo, loader::uefi::Error> {
-        loader::uefi::x86_64::load(importer, image, config)
+        loader::uefi::x86_64::load(importer, image, config, true)
     }
 
     fn load_linux_kernel_and_initrd<F>(
@@ -539,7 +539,7 @@ impl IgvmfilegenRegister for Aarch64Register {
         image: &[u8],
         config: loader::uefi::ConfigType,
     ) -> Result<loader::uefi::LoadInfo, loader::uefi::Error> {
-        loader::uefi::aarch64::load(importer, image, config)
+        loader::uefi::aarch64::load(importer, image, config, true)
     }
 
     fn load_linux_kernel_and_initrd<F>(

--- a/vm/loader/loader_defs/src/lib.rs
+++ b/vm/loader/loader_defs/src/lib.rs
@@ -9,3 +9,4 @@
 pub mod linux;
 pub mod paravisor;
 pub mod shim;
+pub mod uefi;

--- a/vm/loader/loader_defs/src/uefi.rs
+++ b/vm/loader/loader_defs/src/uefi.rs
@@ -1,0 +1,23 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Definitions for loading the MSVM UEFI firmware.
+
+use open_enum::open_enum;
+
+open_enum! {
+    /// SEC platform type passed by the loader to the firmware in `x2` at SEC
+    /// entry on aarch64. Mirrors `MSVM_SEC_PLATFORM_TYPE` in the mu_msvm
+    /// firmware (`MsvmPkg/Include/Ppi/SecPlatformType.h`).
+    ///
+    /// [`SecPlatformType::HYPERV`] (0) is the reset default, so it does not need
+    /// to be set explicitly; [`SecPlatformType::GENERIC`] (1) is passed when the
+    /// hypervisor (HV#1) enlightenments are not exposed to the guest (e.g.
+    /// booting under aarch64 KVM).
+    pub enum SecPlatformType: u64 {
+        /// Hyper-V with Microsoft extensions.
+        HYPERV = 0,
+        /// Generic virtualization without Microsoft hypervisor extensions.
+        GENERIC = 1,
+    }
+}

--- a/vm/loader/src/uefi/mod.rs
+++ b/vm/loader/src/uefi/mod.rs
@@ -330,6 +330,8 @@ pub enum Error {
     InvalidSharedGpaBoundary,
     #[error("Invalid config type")]
     InvalidConfigType(String),
+    #[error("x86_64 UEFI firmware requires the hypervisor to be enabled")]
+    HvRequired,
     #[error("Importer error")]
     Importer(#[source] anyhow::Error),
     #[error("PageTableBuilder: {0}")]
@@ -389,11 +391,22 @@ pub mod x86_64 {
     pub const CONFIG_BLOB_GPA_BASE: u64 = MISC_PAGES_GPA_BASE + MISC_PAGES_SIZE; // 0x709000
 
     /// Load a UEFI image with the provided config type.
+    ///
+    /// `hv_enabled` indicates whether the hypervisor (HV#1) enlightenments are
+    /// exposed to the guest. On x86_64 the firmware always runs under Hyper-V,
+    /// so `false` is rejected with [`Error::HvRequired`]. This parameter exists
+    /// to keep a uniform signature with the aarch64 loader, where it selects the
+    /// SEC platform type.
     pub fn load(
         importer: &mut dyn ImageLoad<X86Register>,
         image: &[u8],
         config: ConfigType,
+        hv_enabled: bool,
     ) -> Result<LoadInfo, Error> {
+        if !hv_enabled {
+            return Err(Error::HvRequired);
+        }
+
         if image.len() != IMAGE_SIZE as usize {
             return Err(Error::InvalidImageSize);
         }
@@ -873,10 +886,20 @@ pub mod aarch64 {
     pub const CONFIG_BLOB_GPA_BASE: u64 = 0x824000;
 
     /// Load a UEFI image with the provided config type.
+    ///
+    /// `hv_enabled` indicates whether the hypervisor (HV#1) enlightenments are
+    /// exposed to the guest. It selects the SEC platform type passed to the
+    /// firmware in `x2` at SEC entry:
+    /// [`HYPERV`](loader_defs::uefi::SecPlatformType::HYPERV) when `true`, or
+    /// [`GENERIC`](loader_defs::uefi::SecPlatformType::GENERIC) when `false` so
+    /// the firmware does not attempt to use hypervisor-specific facilities.
+    /// `GENERIC` is required to boot UEFI without hypervisor support (e.g.
+    /// aarch64 KVM).
     pub fn load(
         importer: &mut dyn ImageLoad<Aarch64Register>,
         image: &[u8],
         config: ConfigType,
+        hv_enabled: bool,
     ) -> Result<LoadInfo, Error> {
         if image.len() != IMAGE_SIZE as usize {
             return Err(Error::InvalidImageSize);
@@ -957,6 +980,15 @@ pub mod aarch64 {
         import_reg(Aarch64Register::X0(0x1000))?;
         import_reg(Aarch64Register::Pc(0x1000))?;
         import_reg(Aarch64Register::X1(stack_end))?;
+
+        // Pass the SEC platform type to the firmware in x2, so it knows whether
+        // to use hypervisor-specific facilities.
+        let platform_type = if hv_enabled {
+            loader_defs::uefi::SecPlatformType::HYPERV
+        } else {
+            loader_defs::uefi::SecPlatformType::GENERIC
+        };
+        import_reg(Aarch64Register::X2(platform_type.0))?;
 
         import_reg(Aarch64Register::Ttbr0El1(page_table_offset))?;
 

--- a/vmm_tests/vmm_tests/tests/tests/multiarch.rs
+++ b/vmm_tests/vmm_tests/tests/tests/multiarch.rs
@@ -170,6 +170,43 @@ async fn smbios_dmi(config: PetriVmBuilder<OpenVmmPetriBackend>) -> anyhow::Resu
     Ok(())
 }
 
+/// Boot aarch64 Linux direct with the hypervisor (HV#1) enlightenments
+/// disabled.
+///
+/// Exercises the no-hv configuration: no hypervisor enlightenments and, as a
+/// consequence, no VMBus. Virtio-vsock provides the pipette transport.
+#[openvmm_test(linux_direct_aarch64)]
+async fn boot_no_hv(config: PetriVmBuilder<OpenVmmPetriBackend>) -> anyhow::Result<()> {
+    let (vm, agent) = config
+        .with_no_hv()
+        .modify_backend(|b| b.with_pcie_root_topology(1, 1, 1))
+        .run()
+        .await?;
+    agent.power_off().await?;
+    vm.wait_for_clean_teardown().await?;
+    Ok(())
+}
+
+/// Boot aarch64 Linux via UEFI with the hypervisor (HV#1) enlightenments
+/// disabled.
+///
+/// Exercises the aarch64 UEFI no-hv path, where the loader passes the `Generic`
+/// SEC platform type to the firmware in `x2`. With VMBus disabled, the guest
+/// boots from PCIe NVMe and uses virtio-vsock for the pipette transport.
+#[openvmm_test(uefi_aarch64(vhd(alpine_3_23_aarch64)))]
+async fn boot_no_hv_uefi(config: PetriVmBuilder<OpenVmmPetriBackend>) -> anyhow::Result<()> {
+    let (vm, agent) = config
+        .with_no_hv()
+        .with_boot_device_type(petri::BootDeviceType::PcieNvme)
+        .with_default_boot_always_attempt(true)
+        .modify_backend(|b| b.with_pcie_root_topology(1, 1, 3))
+        .run()
+        .await?;
+    agent.power_off().await?;
+    vm.wait_for_clean_teardown().await?;
+    Ok(())
+}
+
 /// Boot with private anonymous memory instead of shared memory sections.
 #[openvmm_test(
     linux_direct_x64,


### PR DESCRIPTION
OpenVMM's UEFI boot path unconditionally exposed the Hyper-V (HV#1) enlightenments to the guest, which prevented booting the MSVM firmware in environments that lack Microsoft hypervisor support, such as aarch64 KVM.

Add a `--no-hv` option (and a corresponding `with_no_hv` petri builder) that threads a "hypervisor enabled" flag through the UEFI loaders. On aarch64 the loader now selects the SEC platform type passed to the firmware in `x2` at SEC entry: `HYPERV` when enlightenments are present, or `GENERIC` when they are not so the firmware avoids hypervisor-specific facilities. On x86_64 the firmware always runs under Hyper-V, so the flag is rejected there.

Because VMBus depends on the hypervisor, `--no-hv` requires `--no-vmbus`. New multiarch VMM tests cover the no-hv path for both aarch64 Linux direct boot and aarch64 UEFI boot, the latter booting from PCIe NVMe with virtio-vsock as the pipette transport. The bundled mu_msvm firmware version is bumped to 26.0.19 to pick up firmware that honors the SEC platform type.