### PR TITLE
pci: update PciConfigSpace to pass partial-DWORDs through all devices

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -624,7 +624,6 @@ dependencies = [
  "parking_lot",
  "range_map_vec",
  "tracing",
- "zerocopy",
 ]
 
 [[package]]

--- a/openvmm/openvmm_core/src/worker/dispatch.rs
+++ b/openvmm/openvmm_core/src/worker/dispatch.rs
@@ -4153,7 +4153,7 @@ impl pci_bus::GenericPciBusDevice for WeakMutexPciBusDevice {
     fn pci_cfg_read(
         &mut self,
         offset: u16,
-        value: &mut u32,
+        value: chipset_device::pci::ByteEnabledDwordRead<'_>,
     ) -> Option<chipset_device::io::IoResult> {
         Some(
             self.0
@@ -4164,7 +4164,7 @@ impl pci_bus::GenericPciBusDevice for WeakMutexPciBusDevice {
         )
     }
 
-    fn pci_cfg_write(&mut self, offset: u16, value: u32) -> Option<chipset_device::io::IoResult> {
+    fn pci_cfg_write(&mut self, offset: u16, value: chipset_device::pci::ByteEnabledDwordWrite) -> Option<chipset_device::io::IoResult> {
         Some(
             self.0
                 .upgrade()?
@@ -4180,7 +4180,7 @@ impl pci_bus::GenericPciBusDevice for WeakMutexPciBusDevice {
         target_bus: u8,
         function: u8,
         offset: u16,
-        value: &mut u32,
+        value: chipset_device::pci::ByteEnabledDwordRead<'_>,
     ) -> Option<chipset_device::io::IoResult> {
         Some(
             self.0
@@ -4197,7 +4197,7 @@ impl pci_bus::GenericPciBusDevice for WeakMutexPciBusDevice {
         target_bus: u8,
         function: u8,
         offset: u16,
-        value: u32,
+        value: chipset_device::pci::ByteEnabledDwordWrite,
     ) -> Option<chipset_device::io::IoResult> {
         Some(
             self.0

--- a/openvmm/openvmm_core/src/worker/dispatch.rs
+++ b/openvmm/openvmm_core/src/worker/dispatch.rs
@@ -23,6 +23,9 @@ use crate::worker::rom::RomBuilder;
 use acpi::dsdt;
 use anyhow::Context;
 use cfg_if::cfg_if;
+use chipset_device::io::IoResult;
+use chipset_device::pci::ByteEnabledDwordRead;
+use chipset_device::pci::ByteEnabledDwordWrite;
 use chipset_device_resources::IRQ_LINE_SET;
 use chipset_resources::LEGACY_CHIPSET_PCI_BUS_NAME;
 use chipset_resources::cmos_rtc_time_source::SystemTimeClockHandle;
@@ -4150,11 +4153,7 @@ struct WeakMutexPciBusDevice(
 );
 
 impl pci_bus::GenericPciBusDevice for WeakMutexPciBusDevice {
-    fn pci_cfg_read(
-        &mut self,
-        offset: u16,
-        value: chipset_device::pci::ByteEnabledDwordRead<'_>,
-    ) -> Option<chipset_device::io::IoResult> {
+    fn pci_cfg_read(&mut self, offset: u16, value: ByteEnabledDwordRead<'_>) -> Option<IoResult> {
         Some(
             self.0
                 .upgrade()?
@@ -4164,7 +4163,7 @@ impl pci_bus::GenericPciBusDevice for WeakMutexPciBusDevice {
         )
     }
 
-    fn pci_cfg_write(&mut self, offset: u16, value: chipset_device::pci::ByteEnabledDwordWrite) -> Option<chipset_device::io::IoResult> {
+    fn pci_cfg_write(&mut self, offset: u16, value: ByteEnabledDwordWrite) -> Option<IoResult> {
         Some(
             self.0
                 .upgrade()?
@@ -4180,8 +4179,8 @@ impl pci_bus::GenericPciBusDevice for WeakMutexPciBusDevice {
         target_bus: u8,
         function: u8,
         offset: u16,
-        value: chipset_device::pci::ByteEnabledDwordRead<'_>,
-    ) -> Option<chipset_device::io::IoResult> {
+        value: ByteEnabledDwordRead<'_>,
+    ) -> Option<IoResult> {
         Some(
             self.0
                 .upgrade()?
@@ -4197,8 +4196,8 @@ impl pci_bus::GenericPciBusDevice for WeakMutexPciBusDevice {
         target_bus: u8,
         function: u8,
         offset: u16,
-        value: chipset_device::pci::ByteEnabledDwordWrite,
-    ) -> Option<chipset_device::io::IoResult> {
+        value: ByteEnabledDwordWrite,
+    ) -> Option<IoResult> {
         Some(
             self.0
                 .upgrade()?

--- a/vm/chipset_device/src/pci.rs
+++ b/vm/chipset_device/src/pci.rs
@@ -9,9 +9,10 @@ use crate::io::IoResult;
 use inspect::Inspect;
 use inspect::InspectMut;
 use zerocopy::IntoBytes;
+use mesh::MeshPayload;
 
 /// Byte enables for the four lanes of a PCI configuration DWORD.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Inspect)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Inspect, MeshPayload)]
 pub struct PciConfigByteEnable(u8);
 
 impl PciConfigByteEnable {
@@ -135,9 +136,21 @@ impl ByteEnabledDwordWrite {
         Self::new(temp, byte_enable)
     }
 
+    /// Retrieve a mutable slice of the enabled byte lanes of the DWORD.
+    pub fn as_valid_byte_slice(&self) -> &[u8] {
+        let (byte_offset, len) = self.byte_enable.to_byte_offset_len();
+        let byte_offset = byte_offset as usize;
+        &self.value.as_bytes()[byte_offset..byte_offset + len]
+    }
+
     /// Returns true if all byte lanes are enabled.
     pub const fn is_full(self) -> bool {
         self.byte_enable.is_full()
+    }
+
+    /// Retrieve the underlying byte enable.
+    pub const fn byte_enable(&self) -> PciConfigByteEnable {
+        self.byte_enable
     }
 
     /// Get the mask of valid bytes.
@@ -208,10 +221,15 @@ impl<'a> ByteEnabledDwordRead<'a> {
 
     /// Fill the intercept buffer with the enabled byte lanes of the DWORD.
     pub fn fill_intercept_buffer(self, buffer: &mut [u8]) {
+        let src = self.into_valid_byte_slice();
+        buffer.copy_from_slice(src);
+    }
+
+    /// Retrieve a mutable slice of the enabled byte lanes of the DWORD.
+    pub fn into_valid_byte_slice(self) -> &'a mut [u8] {
         let (byte_offset, len) = self.byte_enable.to_byte_offset_len();
         let byte_offset = byte_offset as usize;
-        let src = self.value.as_bytes()[byte_offset..byte_offset + len].as_ref();
-        buffer.copy_from_slice(src);
+        &mut self.value.as_mut_bytes()[byte_offset..byte_offset + len]
     }
 
     /// Update the value of the DWORD, honoring byte enables.
@@ -316,9 +334,9 @@ impl PciConfigAddress {
 /// Implemented by devices which have a PCI config space.
 pub trait PciConfigSpace: ChipsetDevice {
     /// Dispatch a PCI config space read to the device with the given address.
-    fn pci_cfg_read(&mut self, offset: u16, value: &mut u32) -> IoResult;
+    fn pci_cfg_read(&mut self, offset: u16, value: ByteEnabledDwordRead<'_>) -> IoResult;
     /// Dispatch a PCI config space write to the device with the given address.
-    fn pci_cfg_write(&mut self, offset: u16, value: u32) -> IoResult;
+    fn pci_cfg_write(&mut self, offset: u16, value: ByteEnabledDwordWrite) -> IoResult;
 
     /// Handle a PCI configuration space read with full routing context.
     ///
@@ -356,12 +374,12 @@ pub trait PciConfigSpace: ChipsetDevice {
         target_bus: u8,
         function: u8,
         offset: u16,
-        value: &mut u32,
+        mut value: ByteEnabledDwordRead<'_>,
     ) -> IoResult {
         if secondary_bus == target_bus && function == 0 {
             self.pci_cfg_read(offset, value)
         } else {
-            *value = !0;
+            value.set(!0);
             IoResult::Ok
         }
     }
@@ -401,7 +419,7 @@ pub trait PciConfigSpace: ChipsetDevice {
         target_bus: u8,
         function: u8,
         offset: u16,
-        value: u32,
+        value: ByteEnabledDwordWrite,
     ) -> IoResult {
         if secondary_bus == target_bus && function == 0 {
             self.pci_cfg_write(offset, value)

--- a/vm/chipset_device/src/pci.rs
+++ b/vm/chipset_device/src/pci.rs
@@ -8,8 +8,8 @@ use crate::io::IoError;
 use crate::io::IoResult;
 use inspect::Inspect;
 use inspect::InspectMut;
-use zerocopy::IntoBytes;
 use mesh::MeshPayload;
+use zerocopy::IntoBytes;
 
 /// Byte enables for the four lanes of a PCI configuration DWORD.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Inspect, MeshPayload)]

--- a/vm/chipset_device/src/pci.rs
+++ b/vm/chipset_device/src/pci.rs
@@ -232,6 +232,11 @@ impl<'a> ByteEnabledDwordRead<'a> {
         &mut self.value.as_mut_bytes()[byte_offset..byte_offset + len]
     }
 
+    /// Get the mask of valid bytes.
+    pub const fn valid_mask(&self) -> u32 {
+        self.byte_enable.mask()
+    }
+
     /// Update the value of the DWORD, honoring byte enables.
     pub fn set(&mut self, value: u32) {
         *self.value = self.byte_enable.merge(*self.value, value);

--- a/vm/chipset_device_fuzz/Cargo.toml
+++ b/vm/chipset_device_fuzz/Cargo.toml
@@ -16,7 +16,6 @@ range_map_vec.workspace = true
 
 arbitrary = { workspace = true, features = ["derive"] }
 parking_lot.workspace = true
-zerocopy.workspace = true
 tracing.workspace = true
 
 [lints]

--- a/vm/chipset_device_fuzz/src/lib.rs
+++ b/vm/chipset_device_fuzz/src/lib.rs
@@ -20,6 +20,8 @@ use chipset_device::io::IoResult;
 use chipset_device::io::deferred::DeferredToken;
 use chipset_device::mmio::ControlMmioIntercept;
 use chipset_device::mmio::RegisterMmioIntercept;
+use chipset_device::pci::ByteEnabledDwordRead;
+use chipset_device::pci::ByteEnabledDwordWrite;
 use chipset_device::pio::ControlPortIoIntercept;
 use chipset_device::pio::RegisterPortIoIntercept;
 use closeable_mutex::CloseableMutex;
@@ -32,7 +34,6 @@ use std::sync::Weak;
 use std::task::Context;
 use std::task::Poll;
 use std::task::Waker;
-use zerocopy::FromBytes;
 
 type InterceptRanges<U> =
     Arc<RwLock<RangeMap<U, (Box<str>, Weak<CloseableMutex<dyn ChipsetDevice>>)>>>;
@@ -171,10 +172,14 @@ impl FuzzChipset {
     fn pci_read(&self, bdf: (u8, u8, u8), offset: u16, data: &mut [u8]) -> Option<()> {
         let dev = self.pci_devices.get(&bdf)?.upgrade().unwrap();
         let mut locked_dev = dev.lock();
+        let mut value = 0;
         let result = locked_dev
             .supports_pci()
             .expect("objects on the pci bus support pci")
-            .pci_cfg_read(offset, u32::mut_from_bytes(data).unwrap());
+            .pci_cfg_read(
+                offset,
+                ByteEnabledDwordRead::with_all_bytes_enabled(&mut value),
+            );
         // Convert to a non-deferred result
         let result = match result {
             IoResult::Ok => Ok(()),
@@ -182,7 +187,7 @@ impl FuzzChipset {
             IoResult::Defer(t) => self.defer_read_now_or_never(&mut *locked_dev, t, data),
         };
         match result {
-            Ok(()) => {}
+            Ok(()) => data.copy_from_slice(&value.to_ne_bytes()[..data.len()]),
             Err(_) => {
                 data.fill(0);
             }
@@ -197,7 +202,7 @@ impl FuzzChipset {
         let result = locked_dev
             .supports_pci()
             .expect("objects on the pci bus support pci")
-            .pci_cfg_write(offset, value);
+            .pci_cfg_write(offset, ByteEnabledDwordWrite::with_all_bytes_enabled(value));
         match result {
             IoResult::Ok => {}
             IoResult::Err(_) => {}
@@ -348,7 +353,7 @@ impl FuzzChipset {
                 let attached_bdfs = self.pci_devices.keys().collect::<Vec<_>>();
                 let bdf = **u.choose(&attached_bdfs)?;
 
-                let offset = u.int_in_range(0..=4096)?; // pci-e max cfg space size
+                let offset = u.int_in_range(0..=1023)? * 4; // pci-e max cfg space size
 
                 if matches!(action_kind, ChipsetActionKind::PciRead) {
                     ChipsetAction::PciRead { bdf, offset }

--- a/vm/devices/chipset_legacy/src/i440bx_host_pci_bridge/mod.rs
+++ b/vm/devices/chipset_legacy/src/i440bx_host_pci_bridge/mod.rs
@@ -11,6 +11,8 @@ pub use chipset_resources::i440bx_host_pci_bridge::GpaState;
 use chipset_device::ChipsetDevice;
 use chipset_device::io::IoError;
 use chipset_device::io::IoResult;
+use chipset_device::pci::ByteEnabledDwordRead;
+use chipset_device::pci::ByteEnabledDwordWrite;
 use chipset_device::pci::PciConfigSpace;
 use inspect::Inspect;
 use inspect::InspectMut;
@@ -157,13 +159,13 @@ impl ChipsetDevice for HostPciBridge {
 }
 
 impl PciConfigSpace for HostPciBridge {
-    fn pci_cfg_read(&mut self, offset: u16, value: &mut u32) -> IoResult {
-        *value = match ConfigSpace(offset) {
+    fn pci_cfg_read(&mut self, offset: u16, mut value: ByteEnabledDwordRead<'_>) -> IoResult {
+        value.set(match ConfigSpace(offset) {
             // for bug-for-bug compat with the hyper-v implementation: return
             // hardcoded status register instead of letting the config space
             // emulator take care of it
             _ if offset == pci_core::spec::cfg_space::HeaderType00::STATUS_COMMAND.0 => 0x02000006,
-            _ if offset < 0x40 => return self.cfg_space.read_u32(offset, value),
+            _ if offset < 0x40 => return self.cfg_space.read_byte_enabled(offset, value),
             ConfigSpace::PAM1 => self.state.pam_reg1,
             ConfigSpace::PAM2 => self.state.pam_reg2,
             ConfigSpace::DRB_1 => self.state.host_pci_dram1,
@@ -198,29 +200,31 @@ impl PciConfigSpace for HostPciBridge {
                 tracing::debug!(?offset, "unimplemented config space read");
                 return IoResult::Err(IoError::InvalidRegister);
             }
-        };
+        });
 
         IoResult::Ok
     }
 
-    fn pci_cfg_write(&mut self, offset: u16, value: u32) -> IoResult {
+    fn pci_cfg_write(&mut self, offset: u16, value: ByteEnabledDwordWrite) -> IoResult {
         match ConfigSpace(offset) {
-            _ if offset < 0x40 => return self.cfg_space.write_u32(offset, value),
-            ConfigSpace::DRB_1 => self.state.host_pci_dram1 = value,
-            ConfigSpace::DRB_2 => self.state.host_pci_dram2 = value,
+            _ if offset < 0x40 => return self.cfg_space.write_byte_enabled(offset, value),
+            ConfigSpace::DRB_1 => value.merge_into(&mut self.state.host_pci_dram1),
+            ConfigSpace::DRB_2 => value.merge_into(&mut self.state.host_pci_dram2),
             ConfigSpace::PAM1 => {
+                let value = value.merge(self.state.pam_reg1);
                 self.adjust_bios_override_ranges(value, self.state.pam_reg2, false);
             }
             ConfigSpace::PAM2 => {
+                let value = value.merge(self.state.pam_reg2);
                 self.adjust_bios_override_ranges(self.state.pam_reg1, value, false);
             }
-            ConfigSpace::BSPAD_1 => self.state.bios_scratch1 = value,
-            ConfigSpace::BSPAD_2 => self.state.bios_scratch2 = value,
+            ConfigSpace::BSPAD_1 => value.merge_into(&mut self.state.bios_scratch1),
+            ConfigSpace::BSPAD_2 => value.merge_into(&mut self.state.bios_scratch2),
             ConfigSpace::SMRAM => {
                 // Configuration registers 70-71 are reserved. Only 72-73 (the top 16
                 // bits of this four-byte range) are defined. We'll therefore shift
                 // off the bottom portion.
-                let mut new_smm_word = (value >> 16) as u16;
+                let mut new_smm_word = value.merge_low(self.state.smm_config_word);
 
                 // If the register is "locked" (i.e. bit 4 has been set), then
                 // all of the other bits become read-only.

--- a/vm/devices/chipset_legacy/src/i440bx_host_pci_bridge/mod.rs
+++ b/vm/devices/chipset_legacy/src/i440bx_host_pci_bridge/mod.rs
@@ -224,7 +224,7 @@ impl PciConfigSpace for HostPciBridge {
                 // Configuration registers 70-71 are reserved. Only 72-73 (the top 16
                 // bits of this four-byte range) are defined. We'll therefore shift
                 // off the bottom portion.
-                let mut new_smm_word = value.merge_low(self.state.smm_config_word);
+                let mut new_smm_word = value.merge_high(self.state.smm_config_word);
 
                 // If the register is "locked" (i.e. bit 4 has been set), then
                 // all of the other bits become read-only.

--- a/vm/devices/chipset_legacy/src/piix4_pci_isa_bridge/mod.rs
+++ b/vm/devices/chipset_legacy/src/piix4_pci_isa_bridge/mod.rs
@@ -8,6 +8,8 @@ pub mod resolver;
 use chipset_device::ChipsetDevice;
 use chipset_device::io::IoError;
 use chipset_device::io::IoResult;
+use chipset_device::pci::ByteEnabledDwordRead;
+use chipset_device::pci::ByteEnabledDwordWrite;
 use chipset_device::pci::PciConfigSpace;
 use chipset_device::pio::PortIoIntercept;
 use inspect::Inspect;
@@ -222,13 +224,13 @@ impl PortIoIntercept for PciIsaBridge {
 }
 
 impl PciConfigSpace for PciIsaBridge {
-    fn pci_cfg_read(&mut self, offset: u16, value: &mut u32) -> IoResult {
-        *value = match ConfigSpace(offset) {
+    fn pci_cfg_read(&mut self, offset: u16, mut value: ByteEnabledDwordRead<'_>) -> IoResult {
+        value.set(match ConfigSpace(offset) {
             // for bug-for-bug compat with the hyper-v implementation: return
             // hardcoded status register instead of letting the config space
             // emulator take care of it
             _ if offset == pci_core::spec::cfg_space::HeaderType00::STATUS_COMMAND.0 => 0x02000007,
-            _ if offset < 0x40 => return self.cfg_space.read_u32(offset, value),
+            _ if offset < 0x40 => return self.cfg_space.read_byte_enabled(offset, value),
             // these magic values mainly consist of default values pulled from
             // the PIIX4 documentation
             ConfigSpace::TOP => 0x00000200,
@@ -252,15 +254,16 @@ impl PciConfigSpace for PciIsaBridge {
                 tracing::debug!(?offset, "unimplemented config space read");
                 return IoResult::Err(IoError::InvalidRegister);
             }
-        };
+        });
 
         IoResult::Ok
     }
 
-    fn pci_cfg_write(&mut self, offset: u16, value: u32) -> IoResult {
+    fn pci_cfg_write(&mut self, offset: u16, value: ByteEnabledDwordWrite) -> IoResult {
         match ConfigSpace(offset) {
-            _ if offset < 0x40 => return self.cfg_space.write_u32(offset, value),
+            _ if offset < 0x40 => return self.cfg_space.write_byte_enabled(offset, value),
             ConfigSpace::PIRQ => {
+                let value = value.merge(self.state.pci_irq_routing);
                 if self.state.pci_irq_routing != value {
                     tracelimit::info_ratelimited!(new_pci_irq_routing = ?value, "custom PCI IRQ routing is not implemented!");
                 }
@@ -268,6 +271,7 @@ impl PciConfigSpace for PciIsaBridge {
                 self.state.pci_irq_routing = value;
             }
             ConfigSpace::SER_IRQ => {
+                let value = value.extract();
                 if !(value == 0x0000000D0 || value == 0x000000010) {
                     tracelimit::warn_ratelimited!(
                         ?value,
@@ -279,17 +283,21 @@ impl PciConfigSpace for PciIsaBridge {
                 // Make sure ISA/DMA 512-640K Region Forwarding Enable is never cleared.
                 // This controls whether addresses 512K to 640K are forwarded to RAM
                 // (which we always want to do).
+                let value = value.extract();
                 if (value & 0x00000200) == 0 {
                     tracing::debug!("ISA/DMA 512-640K Region Forwarding Enable was cleared!");
                 }
             }
-            ConfigSpace::SMI => self.state.smi_control = value & 0x00FF001F,
-            ConfigSpace::SEE => self.state.system_event = value,
-            ConfigSpace::FTM => self.state.smi_request = value,
-            ConfigSpace::CTL_TMR => self.state.clock_scale = value,
+            ConfigSpace::SMI => {
+                self.state.smi_control = value.merge(self.state.smi_control) & 0x00FF001F;
+            }
+            ConfigSpace::SEE => value.merge_into(&mut self.state.system_event),
+            ConfigSpace::FTM => value.merge_into(&mut self.state.smi_request),
+            ConfigSpace::CTL_TMR => value.merge_into(&mut self.state.clock_scale),
             ConfigSpace::RTC_CONFIG => {
                 // For now, the code assumes the default value. We don't support
                 // disabling extended CMOS (upper 128 bytes).
+                let value = value.extract();
                 if (value & 0x04000000) == 0 {
                     tracing::debug!("Trying to disable extended CMOS - not supported")
                 }
@@ -301,6 +309,7 @@ impl PciConfigSpace for PciIsaBridge {
             ConfigSpace::APIC_BASE => {
                 // If any of bits 0..5 have changed, then we need to change the base of
                 // the IoApic.
+                let value = value.merge(self.state.apic_base);
                 if (value & 0x3F) != (self.state.apic_base & 0x3F) {
                     // DEVNOTE: this shouldn't actually be all that difficult to
                     // implement, but until there is definitive proof that there

--- a/vm/devices/chipset_legacy/src/piix4_pm/mod.rs
+++ b/vm/devices/chipset_legacy/src/piix4_pm/mod.rs
@@ -390,7 +390,9 @@ impl PciConfigSpace for Piix4Pm {
             }
             ConfigSpace::COUNT_A => value.merge_into(&mut self.state.counter_info_a),
             ConfigSpace::COUNT_B => value.merge_into(&mut self.state.counter_info_b),
-            ConfigSpace::GENERAL_PURPOSE => value.merge_into(&mut self.state.general_purpose_config_info),
+            ConfigSpace::GENERAL_PURPOSE => {
+                value.merge_into(&mut self.state.general_purpose_config_info)
+            }
             ConfigSpace::ACTIVITY_A => value.merge_into(&mut self.state.device_activity_flags[0]),
             ConfigSpace::ACTIVITY_B => value.merge_into(&mut self.state.device_activity_flags[1]),
             ConfigSpace::RESOURCE_A => value.merge_into(&mut self.state.device_resource_flags[0]),

--- a/vm/devices/chipset_legacy/src/piix4_pm/mod.rs
+++ b/vm/devices/chipset_legacy/src/piix4_pm/mod.rs
@@ -11,6 +11,8 @@ use chipset_device::ChipsetDevice;
 use chipset_device::interrupt::LineInterruptTarget;
 use chipset_device::io::IoError;
 use chipset_device::io::IoResult;
+use chipset_device::pci::ByteEnabledDwordRead;
+use chipset_device::pci::ByteEnabledDwordWrite;
 use chipset_device::pci::PciConfigSpace;
 use chipset_device::pio::ControlPortIoIntercept;
 use chipset_device::pio::PortIoIntercept;
@@ -317,8 +319,8 @@ impl LineInterruptTarget for Piix4Pm {
 
 /// Sidestep the config space emulator, and match legacy stub behavior directly
 impl PciConfigSpace for Piix4Pm {
-    fn pci_cfg_read(&mut self, offset: u16, value: &mut u32) -> IoResult {
-        *value = match ConfigSpace(offset) {
+    fn pci_cfg_read(&mut self, offset: u16, mut value: ByteEnabledDwordRead<'_>) -> IoResult {
+        value.set(match ConfigSpace(offset) {
             // for bug-for-bug compat with the hyper-v implementation: return
             // hardcoded status register instead of letting the config space
             // emulator take care of it
@@ -333,11 +335,11 @@ impl PciConfigSpace for Piix4Pm {
             _ if offset == pci_core::spec::cfg_space::HeaderType00::LATENCY_INTERRUPT.0 => {
                 // report that the device is hard-wired to PCI interrupt lane A
                 // (even though we don't actually use the IRQ for anything)
-                let res = self.cfg_space.read_u32(offset, value);
-                *value = *value & 0xff | (1 << 8);
+                let res = self.cfg_space.read_byte_enabled(offset, value.reborrow());
+                value.set(value.extract() & 0xff | (1 << 8));
                 return res;
             }
-            _ if offset < 0x40 => return self.cfg_space.read_u32(offset, value),
+            _ if offset < 0x40 => return self.cfg_space.read_byte_enabled(offset, value),
             // The bottom bit is always 1 to indicate an I/O address.
             ConfigSpace::IO_BASE => self.state.base_io_addr as u32 | 1,
             ConfigSpace::COUNT_A => self.state.counter_info_a,
@@ -361,45 +363,50 @@ impl PciConfigSpace for Piix4Pm {
                 tracing::debug!(?offset, "unimplemented config space read");
                 return IoResult::Err(IoError::InvalidRegister);
             }
-        };
+        });
 
         IoResult::Ok
     }
 
-    fn pci_cfg_write(&mut self, offset: u16, value: u32) -> IoResult {
+    fn pci_cfg_write(&mut self, offset: u16, value: ByteEnabledDwordWrite) -> IoResult {
         match ConfigSpace(offset) {
             // intercept smbus_io_enabled bit
             // We don't have SMBus support, but the bit still needs to get latched.
             _ if offset == pci_core::spec::cfg_space::HeaderType00::STATUS_COMMAND.0 => {
-                self.state.smbus_io_enabled = value & 1 != 0;
-                return self.cfg_space.write_u32(offset, value);
+                if value.valid_mask() & 1 != 0 {
+                    self.state.smbus_io_enabled = value.extract() & 1 != 0;
+                }
+                return self.cfg_space.write_byte_enabled(offset, value);
             }
-            _ if offset < 0x40 => return self.cfg_space.write_u32(offset, value),
+            _ if offset < 0x40 => return self.cfg_space.write_byte_enabled(offset, value),
             ConfigSpace::IO_BASE => {
                 // mask off the read-only bits
                 //
                 // NOTE: this implies that the base address of the pm device
                 // will always be a multiple of 0x100
-                self.state.base_io_addr = (value & 0xFFC0) as u16;
+                let value = value.merge_low(self.state.base_io_addr);
+                self.state.base_io_addr = value & 0xFFC0;
                 self.update_io_mappings()
             }
-            ConfigSpace::COUNT_A => self.state.counter_info_a = value,
-            ConfigSpace::COUNT_B => self.state.counter_info_b = value,
-            ConfigSpace::GENERAL_PURPOSE => self.state.general_purpose_config_info = value,
-            ConfigSpace::ACTIVITY_A => self.state.device_activity_flags[0] = value,
-            ConfigSpace::ACTIVITY_B => self.state.device_activity_flags[1] = value,
-            ConfigSpace::RESOURCE_A => self.state.device_resource_flags[0] = value,
-            ConfigSpace::RESOURCE_B => self.state.device_resource_flags[1] = value,
-            ConfigSpace::RESOURCE_C => self.state.device_resource_flags[2] = value,
-            ConfigSpace::RESOURCE_D => self.state.device_resource_flags[3] = value,
-            ConfigSpace::RESOURCE_E => self.state.device_resource_flags[4] = value,
-            ConfigSpace::RESOURCE_F => self.state.device_resource_flags[5] = value,
-            ConfigSpace::RESOURCE_G => self.state.device_resource_flags[6] = value,
-            ConfigSpace::RESOURCE_H => self.state.device_resource_flags[7] = value,
-            ConfigSpace::RESOURCE_I => self.state.device_resource_flags[8] = value,
-            ConfigSpace::RESOURCE_J => self.state.device_resource_flags[9] = value,
+            ConfigSpace::COUNT_A => value.merge_into(&mut self.state.counter_info_a),
+            ConfigSpace::COUNT_B => value.merge_into(&mut self.state.counter_info_b),
+            ConfigSpace::GENERAL_PURPOSE => value.merge_into(&mut self.state.general_purpose_config_info),
+            ConfigSpace::ACTIVITY_A => value.merge_into(&mut self.state.device_activity_flags[0]),
+            ConfigSpace::ACTIVITY_B => value.merge_into(&mut self.state.device_activity_flags[1]),
+            ConfigSpace::RESOURCE_A => value.merge_into(&mut self.state.device_resource_flags[0]),
+            ConfigSpace::RESOURCE_B => value.merge_into(&mut self.state.device_resource_flags[1]),
+            ConfigSpace::RESOURCE_C => value.merge_into(&mut self.state.device_resource_flags[2]),
+            ConfigSpace::RESOURCE_D => value.merge_into(&mut self.state.device_resource_flags[3]),
+            ConfigSpace::RESOURCE_E => value.merge_into(&mut self.state.device_resource_flags[4]),
+            ConfigSpace::RESOURCE_F => value.merge_into(&mut self.state.device_resource_flags[5]),
+            ConfigSpace::RESOURCE_G => value.merge_into(&mut self.state.device_resource_flags[6]),
+            ConfigSpace::RESOURCE_H => value.merge_into(&mut self.state.device_resource_flags[7]),
+            ConfigSpace::RESOURCE_I => value.merge_into(&mut self.state.device_resource_flags[8]),
+            ConfigSpace::RESOURCE_J => value.merge_into(&mut self.state.device_resource_flags[9]),
             ConfigSpace::IO_ENABLE => {
-                self.state.base_io_enable = value & 1 != 0;
+                if value.valid_mask() & 1 != 0 {
+                    self.state.base_io_enable = value.extract() & 1 != 0;
+                }
                 self.update_io_mappings()
             }
             ConfigSpace::SM_BASE | ConfigSpace::SM_HOST => {} // Hyper-V ignores these, so do we.

--- a/vm/devices/chipset_legacy/src/piix4_uhci.rs
+++ b/vm/devices/chipset_legacy/src/piix4_uhci.rs
@@ -5,6 +5,8 @@
 
 use chipset_device::ChipsetDevice;
 use chipset_device::io::IoResult;
+use chipset_device::pci::ByteEnabledDwordRead;
+use chipset_device::pci::ByteEnabledDwordWrite;
 use chipset_device::pci::PciConfigSpace;
 use chipset_resources::piix4_uhci::PIIX4_PCI_USB_UHCI_STUB_BDF;
 use inspect::InspectMut;
@@ -47,9 +49,9 @@ impl ChipsetDevice for Piix4UsbUhciStub {
 
 /// Sidestep the config space emulator, and match legacy stub behavior directly
 impl PciConfigSpace for Piix4UsbUhciStub {
-    fn pci_cfg_read(&mut self, offset: u16, value: &mut u32) -> IoResult {
+    fn pci_cfg_read(&mut self, offset: u16, mut value: ByteEnabledDwordRead<'_>) -> IoResult {
         use pci_core::spec::cfg_space::HeaderType00;
-        *value = match HeaderType00(offset) {
+        value.set(match HeaderType00(offset) {
             HeaderType00::BIST_HEADER => 0,
             HeaderType00::BAR4 => 0,
             HeaderType00::STATUS_COMMAND => 0x02800000,
@@ -68,12 +70,12 @@ impl PciConfigSpace for Piix4UsbUhciStub {
                 // stub-out all other registers as well, since this is just a stub device
                 0
             }
-        };
+        });
 
         IoResult::Ok
     }
 
-    fn pci_cfg_write(&mut self, offset: u16, value: u32) -> IoResult {
+    fn pci_cfg_write(&mut self, offset: u16, value: ByteEnabledDwordWrite) -> IoResult {
         use pci_core::spec::cfg_space::HeaderType00;
         match HeaderType00(offset) {
             HeaderType00::BIST_HEADER => {}

--- a/vm/devices/cxl/src/test/cxl_test_device.rs
+++ b/vm/devices/cxl/src/test/cxl_test_device.rs
@@ -9,6 +9,8 @@ use chipset_device::io::IoResult;
 use chipset_device::mmio::ControlMmioIntercept;
 use chipset_device::mmio::MmioIntercept;
 use chipset_device::mmio::RegisterMmioIntercept;
+use chipset_device::pci::ByteEnabledDwordRead;
+use chipset_device::pci::ByteEnabledDwordWrite;
 use chipset_device::pci::PciConfigSpace;
 use inspect::InspectMut;
 use mesh::MeshPayload;
@@ -457,12 +459,12 @@ impl MmioIntercept for CxlTestDevice {
 }
 
 impl PciConfigSpace for CxlTestDevice {
-    fn pci_cfg_read(&mut self, offset: u16, value: &mut u32) -> IoResult {
-        self.cfg_space.read_u32(offset, value)
+    fn pci_cfg_read(&mut self, offset: u16, value: ByteEnabledDwordRead<'_>) -> IoResult {
+        self.cfg_space.read_byte_enabled(offset, value)
     }
 
-    fn pci_cfg_write(&mut self, offset: u16, value: u32) -> IoResult {
-        self.cfg_space.write_u32(offset, value)
+    fn pci_cfg_write(&mut self, offset: u16, value: ByteEnabledDwordWrite) -> IoResult {
+        self.cfg_space.write_byte_enabled(offset, value)
     }
 }
 

--- a/vm/devices/iommu/amd_iommu/src/lib.rs
+++ b/vm/devices/iommu/amd_iommu/src/lib.rs
@@ -18,6 +18,8 @@ use chipset_device::ChipsetDevice;
 use chipset_device::io::IoError;
 use chipset_device::io::IoResult;
 use chipset_device::mmio::MmioIntercept;
+use chipset_device::pci::ByteEnabledDwordRead;
+use chipset_device::pci::ByteEnabledDwordWrite;
 use chipset_device::pci::PciConfigSpace;
 use guestmem::GuestMemory;
 use inspect::Inspect;
@@ -1655,12 +1657,12 @@ impl ChipsetDevice for AmdIommuDevice {
 // =============================================================================
 
 impl PciConfigSpace for AmdIommuDevice {
-    fn pci_cfg_read(&mut self, offset: u16, value: &mut u32) -> IoResult {
-        self.cfg_space.read_u32(offset, value)
+    fn pci_cfg_read(&mut self, offset: u16, value: ByteEnabledDwordRead<'_>) -> IoResult {
+        self.cfg_space.read_byte_enabled(offset, value)
     }
 
-    fn pci_cfg_write(&mut self, offset: u16, value: u32) -> IoResult {
-        self.cfg_space.write_u32(offset, value)
+    fn pci_cfg_write(&mut self, offset: u16, value: ByteEnabledDwordWrite) -> IoResult {
+        self.cfg_space.write_byte_enabled(offset, value)
     }
 
     fn suggested_bdf(&mut self) -> Option<(u8, u8, u8)> {

--- a/vm/devices/iommu/amd_iommu/src/lib.rs
+++ b/vm/devices/iommu/amd_iommu/src/lib.rs
@@ -1784,7 +1784,10 @@ mod tests {
     /// Helper to read a 32-bit PCI config register.
     fn pci_read(dev: &mut AmdIommuDevice, offset: u16) -> u32 {
         let mut value = 0u32;
-        let _ = dev.pci_cfg_read(offset, &mut value);
+        let _ = dev.pci_cfg_read(
+            offset,
+            ByteEnabledDwordRead::with_all_bytes_enabled(&mut value),
+        );
         value
     }
 
@@ -2481,14 +2484,26 @@ mod tests {
 
         // Configure MSI: address = 0xFEE00000, data = 0x41.
         // Write address low (offset + 4).
-        let _ = dev.pci_cfg_write(msi_cap_offset + 4, 0xFEE0_0000);
+        let _ = dev.pci_cfg_write(
+            msi_cap_offset + 4,
+            ByteEnabledDwordWrite::with_all_bytes_enabled(0xFEE0_0000),
+        );
         // Write address high (offset + 8) — 64-bit capable.
-        let _ = dev.pci_cfg_write(msi_cap_offset + 8, 0);
+        let _ = dev.pci_cfg_write(
+            msi_cap_offset + 8,
+            ByteEnabledDwordWrite::with_all_bytes_enabled(0),
+        );
         // Write data (offset + 12 for 64-bit).
-        let _ = dev.pci_cfg_write(msi_cap_offset + 12, 0x41);
+        let _ = dev.pci_cfg_write(
+            msi_cap_offset + 12,
+            ByteEnabledDwordWrite::with_all_bytes_enabled(0x41),
+        );
         // Enable MSI (write control register at offset + 0, set enable bit).
         let control = pci_read(&mut dev, msi_cap_offset);
-        let _ = dev.pci_cfg_write(msi_cap_offset, control | (1 << 16));
+        let _ = dev.pci_cfg_write(
+            msi_cap_offset,
+            ByteEnabledDwordWrite::with_all_bytes_enabled(control | (1 << 16)),
+        );
 
         setup_iommu_enabled(&mut dev);
 
@@ -6220,11 +6235,23 @@ mod tests {
         // Enable MSI on PCI config space.
         let iommu_cap_header = pci_read(&mut dev, 0x40);
         let msi_cap_offset = ((iommu_cap_header >> 8) & 0xFF) as u16;
-        let _ = dev.pci_cfg_write(msi_cap_offset + 4, 0xFEE0_0000);
-        let _ = dev.pci_cfg_write(msi_cap_offset + 8, 0);
-        let _ = dev.pci_cfg_write(msi_cap_offset + 12, 0x41);
+        let _ = dev.pci_cfg_write(
+            msi_cap_offset + 4,
+            ByteEnabledDwordWrite::with_all_bytes_enabled(0xFEE0_0000),
+        );
+        let _ = dev.pci_cfg_write(
+            msi_cap_offset + 8,
+            ByteEnabledDwordWrite::with_all_bytes_enabled(0),
+        );
+        let _ = dev.pci_cfg_write(
+            msi_cap_offset + 12,
+            ByteEnabledDwordWrite::with_all_bytes_enabled(0x41),
+        );
         let control = pci_read(&mut dev, msi_cap_offset);
-        let _ = dev.pci_cfg_write(msi_cap_offset, control | (1 << 16));
+        let _ = dev.pci_cfg_write(
+            msi_cap_offset,
+            ByteEnabledDwordWrite::with_all_bytes_enabled(control | (1 << 16)),
+        );
 
         setup_iommu_enabled(&mut dev);
 

--- a/vm/devices/missing_dev/src/lib.rs
+++ b/vm/devices/missing_dev/src/lib.rs
@@ -14,6 +14,8 @@ use chipset_device::io::IoResult;
 use chipset_device::mmio::ControlMmioIntercept;
 use chipset_device::mmio::MmioIntercept;
 use chipset_device::mmio::RegisterMmioIntercept;
+use chipset_device::pci::ByteEnabledDwordRead;
+use chipset_device::pci::ByteEnabledDwordWrite;
 use chipset_device::pci::PciConfigSpace;
 use chipset_device::pio::ControlPortIoIntercept;
 use chipset_device::pio::PortIoIntercept;
@@ -172,7 +174,7 @@ impl PortIoIntercept for MissingDev {
 }
 
 impl PciConfigSpace for MissingDev {
-    fn pci_cfg_read(&mut self, offset: u16, value: &mut u32) -> IoResult {
+    fn pci_cfg_read(&mut self, offset: u16, value: ByteEnabledDwordRead<'_>) -> IoResult {
         let pci = self.pci.as_ref().unwrap();
 
         pci_core::cfg_space_emu::ConfigSpaceType0Emulator::new(
@@ -190,10 +192,10 @@ impl PciConfigSpace for MissingDev {
             vec![],
             pci_core::cfg_space_emu::DeviceBars::new(),
         )
-        .read_u32(offset, value)
+        .read_byte_enabled(offset, value)
     }
 
-    fn pci_cfg_write(&mut self, _offset: u16, _value: u32) -> IoResult {
+    fn pci_cfg_write(&mut self, _offset: u16, _value: ByteEnabledDwordWrite) -> IoResult {
         IoResult::Ok
     }
 

--- a/vm/devices/net/gdma/src/lib.rs
+++ b/vm/devices/net/gdma/src/lib.rs
@@ -14,6 +14,8 @@ use chipset_device::ChipsetDevice;
 use chipset_device::io::IoResult;
 use chipset_device::mmio::MmioIntercept;
 use chipset_device::mmio::RegisterMmioIntercept;
+use chipset_device::pci::ByteEnabledDwordRead;
+use chipset_device::pci::ByteEnabledDwordWrite;
 use chipset_device::pci::PciConfigSpace;
 use device_emulators::ReadWriteRequestType;
 use device_emulators::read_as_u32_chunks;
@@ -437,11 +439,11 @@ impl MmioIntercept for GdmaDevice {
 }
 
 impl PciConfigSpace for GdmaDevice {
-    fn pci_cfg_read(&mut self, offset: u16, value: &mut u32) -> IoResult {
-        self.config.read_u32(offset, value)
+    fn pci_cfg_read(&mut self, offset: u16, value: ByteEnabledDwordRead<'_>) -> IoResult {
+        self.config.read_byte_enabled(offset, value)
     }
 
-    fn pci_cfg_write(&mut self, offset: u16, value: u32) -> IoResult {
-        self.config.write_u32(offset, value)
+    fn pci_cfg_write(&mut self, offset: u16, value: ByteEnabledDwordWrite) -> IoResult {
+        self.config.write_byte_enabled(offset, value)
     }
 }

--- a/vm/devices/pci/pci_bus/src/lib.rs
+++ b/vm/devices/pci/pci_bus/src/lib.rs
@@ -70,10 +70,10 @@ pub mod standard_x86_io_ports {
 /// by providing implementations for the forwarding methods.
 pub trait GenericPciBusDevice: 'static + Send {
     /// Dispatch a PCI config space read to the device with the given address.
-    fn pci_cfg_read(&mut self, offset: u16, value: &mut u32) -> Option<IoResult>;
+    fn pci_cfg_read(&mut self, offset: u16, value: ByteEnabledDwordRead<'_>) -> Option<IoResult>;
 
     /// Dispatch a PCI config space write to the device with the given address.
-    fn pci_cfg_write(&mut self, offset: u16, value: u32) -> Option<IoResult>;
+    fn pci_cfg_write(&mut self, offset: u16, value: ByteEnabledDwordWrite) -> Option<IoResult>;
 
     /// Handle a PCI configuration space read with full routing context.
     ///
@@ -104,12 +104,12 @@ pub trait GenericPciBusDevice: 'static + Send {
         target_bus: u8,
         function: u8,
         offset: u16,
-        value: &mut u32,
+        mut value: ByteEnabledDwordRead<'_>,
     ) -> Option<IoResult> {
         if secondary_bus == target_bus && function == 0 {
             self.pci_cfg_read(offset, value)
         } else {
-            *value = !0;
+            value.set(!0);
             Some(IoResult::Ok)
         }
     }
@@ -142,7 +142,7 @@ pub trait GenericPciBusDevice: 'static + Send {
         target_bus: u8,
         function: u8,
         offset: u16,
-        value: u32,
+        value: ByteEnabledDwordWrite,
     ) -> Option<IoResult> {
         if secondary_bus == target_bus && function == 0 {
             self.pci_cfg_write(offset, value)
@@ -425,8 +425,7 @@ impl PortIoIntercept for GenericPciBus {
 
 impl PollDevice for GenericPciBus {
     fn poll_device(&mut self, cx: &mut Context<'_>) {
-        let mut callback = PciBusCfgAccessCallbackView::new(&mut self.pci_devices);
-        self.bus_cfg_handler.poll(cx, &mut callback);
+        self.bus_cfg_handler.poll(cx);
     }
 }
 
@@ -443,18 +442,18 @@ impl<'a> PciBusCfgAccessCallbackView<'a> {
 }
 
 impl<'a> PciBusCfgAccessCallbacks for PciBusCfgAccessCallbackView<'a> {
-    fn read(&mut self, addr: PciConfigAddress, value: &mut u32) -> IoResult {
+    fn read(&mut self, addr: PciConfigAddress, mut value: ByteEnabledDwordRead<'_>) -> IoResult {
         let address = PciAddr::from(addr);
         match self.pci_devices.get_mut(&address) {
             Some((name, device)) => {
                 let offset = addr.byte_offset();
-                let res = device.pci_cfg_read(offset, value);
+                let res = device.pci_cfg_read(offset, value.reborrow());
                 if let Some(result) = res {
                     tracing::trace!(
                         device = &**name,
                         %address,
                         offset,
-                        value,
+                        ?value,
                         "cfg space read"
                     );
                     result
@@ -468,30 +467,30 @@ impl<'a> PciBusCfgAccessCallbacks for PciBusCfgAccessCallbackView<'a> {
                         offset,
                         "cfg space read failed, device went away"
                     );
-                    *value = !0;
+                    value.set(!0);
                     IoResult::Ok
                 }
             }
             None => {
                 tracing::trace!(%address, "no device found - returning F's");
-                *value = !0;
+                value.set(!0);
                 IoResult::Ok
             }
         }
     }
 
-    fn write(&mut self, addr: PciConfigAddress, data: u32) -> IoResult {
+    fn write(&mut self, addr: PciConfigAddress, value: ByteEnabledDwordWrite) -> IoResult {
         let address = PciAddr::from(addr);
         match self.pci_devices.get_mut(&address) {
             Some((name, device)) => {
                 let offset = addr.byte_offset();
-                let res = device.pci_cfg_write(offset, data);
+                let res = device.pci_cfg_write(offset, value);
                 if let Some(result) = res {
                     tracing::trace!(
                         device = &**name,
                         %address,
                         offset,
-                        data,
+                        ?value,
                         "cfg space write"
                     );
                     result

--- a/vm/devices/pci/pci_core/src/bus_cfg.rs
+++ b/vm/devices/pci/pci_core/src/bus_cfg.rs
@@ -251,7 +251,11 @@ mod tests {
     }
 
     impl PciBusCfgAccessCallbacks for DeferredCallbacks {
-        fn read(&mut self, addr: PciConfigAddress, mut value: ByteEnabledDwordRead<'_>) -> IoResult {
+        fn read(
+            &mut self,
+            addr: PciConfigAddress,
+            mut value: ByteEnabledDwordRead<'_>,
+        ) -> IoResult {
             self.reads.push(addr);
             match self.read_action {
                 ReadAction::Ok(read_value) => {

--- a/vm/devices/pci/pci_core/src/bus_cfg.rs
+++ b/vm/devices/pci/pci_core/src/bus_cfg.rs
@@ -21,10 +21,10 @@ use zerocopy::IntoBytes;
 /// Callback trait for the [`PciBusCfgAccessHandler`] for bus-specific operations.
 pub trait PciBusCfgAccessCallbacks {
     /// Dispatches a read to the downstream config-space target.
-    fn read(&mut self, addr: PciConfigAddress, value: &mut u32) -> IoResult;
+    fn read(&mut self, addr: PciConfigAddress, value: ByteEnabledDwordRead<'_>) -> IoResult;
 
     /// Dispatches a write to the downstream config-space target.
-    fn write(&mut self, addr: PciConfigAddress, value: u32) -> IoResult;
+    fn write(&mut self, addr: PciConfigAddress, value: ByteEnabledDwordWrite) -> IoResult;
 }
 
 /// A pending config space access that was deferred by a downstream device.
@@ -39,16 +39,6 @@ enum DeferredCfgAccess {
         bus_read: DeferredRead,
         addr: PciConfigAddress,
         byte_enable: PciConfigByteEnable,
-    },
-    /// A read that was deferred by a downstream device that was initiated
-    /// as part of a read-modify-write operation.
-    ReadForWrite {
-        #[inspect(skip)]
-        deferred_device_read: DeferredToken,
-        #[inspect(skip)]
-        bus_write: DeferredWrite,
-        addr: PciConfigAddress,
-        value: ByteEnabledDwordWrite,
     },
     /// A write that was deferred by a downstream device.
     Write {
@@ -90,12 +80,8 @@ impl PciBusCfgAccessHandler {
         mut inline_completion_value: ByteEnabledDwordRead<'_>,
         callbacks: &mut impl PciBusCfgAccessCallbacks,
     ) -> IoResult {
-        let mut value = 0;
-        match callbacks.read(addr, &mut value) {
-            IoResult::Ok => {
-                inline_completion_value.set(value);
-                IoResult::Ok
-            }
+        match callbacks.read(addr, inline_completion_value.reborrow()) {
+            IoResult::Ok => IoResult::Ok,
             IoResult::Err(err) => IoResult::Err(err),
             IoResult::Defer(deferred_device_read) => {
                 let (bus_read, bus_token) = defer_read();
@@ -117,31 +103,7 @@ impl PciBusCfgAccessHandler {
         value: ByteEnabledDwordWrite,
         callbacks: &mut impl PciBusCfgAccessCallbacks,
     ) -> IoResult {
-        let write_value = if value.is_full() {
-            // The write spans a full DWORD, so we can extract the value directly.
-            value.extract()
-        } else {
-            // Need to read-for-write, which the device may itself defer.
-            let mut old_value = 0;
-            match callbacks.read(addr, &mut old_value) {
-                IoResult::Ok => value.merge(old_value),
-                IoResult::Err(err) => {
-                    return IoResult::Err(err);
-                }
-                IoResult::Defer(deferred_device_read) => {
-                    let (bus_write, bus_token) = defer_write();
-                    self.push_action(DeferredCfgAccess::ReadForWrite {
-                        deferred_device_read,
-                        bus_write,
-                        addr,
-                        value,
-                    });
-                    return IoResult::Defer(bus_token);
-                }
-            }
-        };
-
-        let result = callbacks.write(addr, write_value);
+        let result = callbacks.write(addr, value);
         if let IoResult::Defer(deferred_device_write) = result {
             let (bus_write, bus_token) = defer_write();
             self.push_action(DeferredCfgAccess::Write {
@@ -156,7 +118,7 @@ impl PciBusCfgAccessHandler {
     }
 
     /// Polls pending accesses and keeps any that are still incomplete.
-    pub fn poll(&mut self, cx: &mut Context<'_>, callbacks: &mut impl PciBusCfgAccessCallbacks) {
+    pub fn poll(&mut self, cx: &mut Context<'_>) {
         self.waker = Some(cx.waker().clone());
         self.actions = std::mem::take(&mut self.actions)
             .into_iter()
@@ -191,56 +153,6 @@ impl PciBusCfgAccessHandler {
                             bus_read,
                             addr,
                             byte_enable,
-                        })
-                    }
-                }
-                DeferredCfgAccess::ReadForWrite {
-                    mut deferred_device_read,
-                    bus_write,
-                    addr,
-                    value,
-                } => {
-                    // If the inner read succeeded, proceed with the write. If the inner
-                    // read failed, fail the outer write.
-                    let mut old_value = 0;
-                    if let Poll::Ready(res) =
-                        deferred_device_read.poll_read(cx, old_value.as_mut_bytes())
-                    {
-                        match res {
-                            Ok(()) => {
-                                let merged_value = value.merge(old_value);
-                                match callbacks.write(addr, merged_value) {
-                                    IoResult::Ok => {
-                                        bus_write.complete();
-                                        None
-                                    }
-                                    IoResult::Err(err) => {
-                                        bus_write.complete_error(err);
-                                        None
-                                    }
-                                    IoResult::Defer(deferred_device_write) => {
-                                        cx.waker().wake_by_ref();
-                                        Some(DeferredCfgAccess::Write {
-                                            deferred_device_write,
-                                            bus_write,
-                                            addr,
-                                        })
-                                    }
-                                }
-                            }
-                            Err(err) => {
-                                bus_write.complete_error(err);
-                                None
-                            }
-                        }
-                    } else {
-                        // If the inner read is not ready, keep the write pending and
-                        // leave the deferred action in the list for the next poll.
-                        Some(DeferredCfgAccess::ReadForWrite {
-                            deferred_device_read,
-                            bus_write,
-                            addr,
-                            value,
                         })
                     }
                 }
@@ -339,11 +251,11 @@ mod tests {
     }
 
     impl PciBusCfgAccessCallbacks for DeferredCallbacks {
-        fn read(&mut self, addr: PciConfigAddress, value: &mut u32) -> IoResult {
+        fn read(&mut self, addr: PciConfigAddress, mut value: ByteEnabledDwordRead<'_>) -> IoResult {
             self.reads.push(addr);
             match self.read_action {
                 ReadAction::Ok(read_value) => {
-                    *value = read_value;
+                    value.set(read_value);
                     IoResult::Ok
                 }
                 ReadAction::Err(error) => IoResult::Err(error),
@@ -355,8 +267,8 @@ mod tests {
             }
         }
 
-        fn write(&mut self, addr: PciConfigAddress, value: u32) -> IoResult {
-            self.writes.push((addr, value));
+        fn write(&mut self, addr: PciConfigAddress, value: ByteEnabledDwordWrite) -> IoResult {
+            self.writes.push((addr, value.extract()));
             match self.write_action {
                 WriteAction::Ok => IoResult::Ok,
                 WriteAction::Err(error) => IoResult::Err(error),
@@ -369,9 +281,9 @@ mod tests {
         }
     }
 
-    fn poll_once(handler: &mut PciBusCfgAccessHandler, callbacks: &mut DeferredCallbacks) {
+    fn poll_once(handler: &mut PciBusCfgAccessHandler) {
         let mut cx = Context::from_waker(std::task::Waker::noop());
-        handler.poll(&mut cx, callbacks);
+        handler.poll(&mut cx);
     }
 
     fn poll_read_token(token: &mut DeferredToken, bytes: &mut [u8]) -> Poll<Result<(), IoError>> {
@@ -417,6 +329,30 @@ mod tests {
     }
 
     #[test]
+    fn deferred_read_applies_byte_enable() {
+        let mut handler = PciBusCfgAccessHandler::new();
+        let mut callbacks = DeferredCallbacks::new(ReadAction::Defer, WriteAction::Ok);
+        let addr = PciConfigAddress::new(0, 0, 1).unwrap();
+        let mut buffer = 0xffff_ffff;
+        let value = ByteEnabledDwordRead::new(&mut buffer, PciConfigByteEnable::HIGH_WORD);
+
+        let IoResult::Defer(mut bus_token) = handler.read(addr, value, &mut callbacks) else {
+            panic!("read should defer");
+        };
+
+        callbacks.complete_read(0x1122_3344);
+        poll_once(&mut handler);
+
+        let mut read_data = [0; 2];
+        assert!(matches!(
+            poll_read_token(&mut bus_token, &mut read_data),
+            Poll::Ready(Ok(()))
+        ));
+
+        assert_eq!(read_data, [0x22, 0x11]);
+    }
+
+    #[test]
     fn deferred_read_error_completes_outer_read_with_error() {
         let mut handler = PciBusCfgAccessHandler::new();
         let mut callbacks = DeferredCallbacks::new(ReadAction::Defer, WriteAction::Ok);
@@ -429,7 +365,7 @@ mod tests {
         };
 
         callbacks.complete_read_error(IoError::NoResponse);
-        poll_once(&mut handler, &mut callbacks);
+        poll_once(&mut handler);
 
         let mut read_data = [0; 4];
         assert!(matches!(
@@ -439,7 +375,7 @@ mod tests {
     }
 
     #[test]
-    fn immediate_partial_write_reads_merges_and_writes() {
+    fn partial_writes_do_not_read_for_write() {
         let mut handler = PciBusCfgAccessHandler::new();
         let mut callbacks = DeferredCallbacks::new(ReadAction::Ok(0x1122_3344), WriteAction::Ok);
         let addr = PciConfigAddress::new(0, 0, 1).unwrap();
@@ -449,12 +385,12 @@ mod tests {
             handler.write(addr, write_value, &mut callbacks),
             IoResult::Ok
         ));
-        assert_eq!(callbacks.reads, vec![addr]);
-        assert_eq!(callbacks.writes, vec![(addr, 0x1122_aa44)]);
+        assert_eq!(callbacks.reads, vec![]);
+        assert_eq!(callbacks.writes, vec![(addr, 0x0000_aa00)]);
     }
 
     #[test]
-    fn write_error_is_returned_after_successful_read_for_write() {
+    fn immediate_write_error_is_returned() {
         let mut handler = PciBusCfgAccessHandler::new();
         let mut callbacks = DeferredCallbacks::new(
             ReadAction::Ok(0x1122_3344),
@@ -467,7 +403,28 @@ mod tests {
             handler.write(addr, write_value, &mut callbacks),
             IoResult::Err(IoError::InvalidRegister)
         ));
-        assert_eq!(callbacks.writes, vec![(addr, 0x1122_aa44)]);
+        assert_eq!(callbacks.writes, vec![(addr, 0x0000_aa00)]);
+    }
+
+    #[test]
+    fn deferred_writes_complete_outer_write() {
+        let mut handler = PciBusCfgAccessHandler::new();
+        let mut callbacks = DeferredCallbacks::new(ReadAction::Ok(0), WriteAction::Defer);
+        let addr = PciConfigAddress::new(0, 0, 1).unwrap();
+        let write_value = ByteEnabledDwordWrite::with_all_bytes_enabled(0xaabb_ccdd);
+
+        let IoResult::Defer(mut bus_token) = handler.write(addr, write_value, &mut callbacks)
+        else {
+            panic!("write should defer");
+        };
+
+        callbacks.complete_write();
+        poll_once(&mut handler);
+
+        assert!(matches!(
+            poll_write_token(&mut bus_token),
+            Poll::Ready(Ok(()))
+        ));
     }
 
     #[test]
@@ -483,39 +440,11 @@ mod tests {
         };
 
         callbacks.complete_write_error(IoError::NoResponse);
-        poll_once(&mut handler, &mut callbacks);
+        poll_once(&mut handler);
 
         assert!(matches!(
             poll_write_token(&mut bus_token),
             Poll::Ready(Err(IoError::NoResponse))
         ));
-    }
-
-    #[test]
-    fn deferred_read_for_write_completes_after_deferred_write() {
-        let mut handler = PciBusCfgAccessHandler::new();
-        let mut callbacks = DeferredCallbacks::new(ReadAction::Defer, WriteAction::Defer);
-        let addr = PciConfigAddress::new(0, 0, 1).unwrap();
-        let write_value = ByteEnabledDwordWrite::new(0xaa00, PciConfigByteEnable::BYTE1);
-
-        let IoResult::Defer(mut bus_token) = handler.write(addr, write_value, &mut callbacks)
-        else {
-            panic!("partial write should defer while reading the old value");
-        };
-
-        callbacks.complete_read(0x1122_3344);
-        poll_once(&mut handler, &mut callbacks);
-
-        let mut expected = 0x1122_3344u32.to_ne_bytes();
-        expected[1] = 0xaa;
-        assert_eq!(callbacks.writes, vec![(addr, u32::from_ne_bytes(expected))]);
-
-        callbacks.complete_write();
-        poll_once(&mut handler, &mut callbacks);
-
-        assert!(
-            matches!(poll_write_token(&mut bus_token), Poll::Ready(Ok(()))),
-            "read-for-write bus token should complete after the deferred write completes"
-        );
     }
 }

--- a/vm/devices/pci/pci_core/src/cfg_space_emu.rs
+++ b/vm/devices/pci/pci_core/src/cfg_space_emu.rs
@@ -1509,7 +1509,6 @@ impl ConfigSpaceType1Emulator {
         self.read(addr, value)
     }
 
-
     /// Write to the config space.
     pub fn write(&mut self, address: PciConfigAddress, val: ByteEnabledDwordWrite) -> IoResult {
         use cfg_space::HeaderType01;
@@ -1601,7 +1600,6 @@ impl ConfigSpaceType1Emulator {
 
         self.write(addr, value)
     }
-
 
     /// Checks if this device is a PCIe device by looking for the PCI Express capability.
     pub fn is_pcie_device(&self) -> bool {

--- a/vm/devices/pci/pci_core/src/cfg_space_emu.rs
+++ b/vm/devices/pci/pci_core/src/cfg_space_emu.rs
@@ -1111,6 +1111,19 @@ impl ConfigSpaceType0Emulator {
         self.read(addr, ByteEnabledDwordRead::with_all_bytes_enabled(value))
     }
 
+    /// Read a byte-enabled DWORD from the config space. `offset` must be 32-bit aligned.
+    pub fn read_byte_enabled(&self, offset: u16, value: ByteEnabledDwordRead<'_>) -> IoResult {
+        if !offset.is_multiple_of(4) {
+            return IoResult::Err(IoError::UnalignedAccess);
+        }
+
+        let Some(addr) = PciConfigAddress::new(0, 0, offset / 4) else {
+            return IoResult::Err(IoError::InvalidRegister);
+        };
+
+        self.read(addr, value)
+    }
+
     /// Write to the config space.
     pub fn write(&mut self, address: PciConfigAddress, val: ByteEnabledDwordWrite) -> IoResult {
         use cfg_space::HeaderType00;
@@ -1163,6 +1176,19 @@ impl ConfigSpaceType0Emulator {
         };
 
         self.write(addr, ByteEnabledDwordWrite::with_all_bytes_enabled(val))
+    }
+
+    /// Write a byte-enabled DWORD from the config space. `offset` must be 32-bit aligned.
+    pub fn write_byte_enabled(&mut self, offset: u16, value: ByteEnabledDwordWrite) -> IoResult {
+        if !offset.is_multiple_of(4) {
+            return IoResult::Err(IoError::UnalignedAccess);
+        }
+
+        let Some(addr) = PciConfigAddress::new(0, 0, offset / 4) else {
+            return IoResult::Err(IoError::InvalidRegister);
+        };
+
+        self.write(addr, value)
     }
 
     /// Finds a BAR + offset by address.
@@ -1470,6 +1496,20 @@ impl ConfigSpaceType1Emulator {
         self.read(addr, ByteEnabledDwordRead::with_all_bytes_enabled(value))
     }
 
+    /// Read a byte-enabled DWORD from the config space. `offset` must be 32-bit aligned.
+    pub fn read_byte_enabled(&self, offset: u16, value: ByteEnabledDwordRead<'_>) -> IoResult {
+        if !offset.is_multiple_of(4) {
+            return IoResult::Err(IoError::UnalignedAccess);
+        }
+
+        let Some(addr) = PciConfigAddress::new(0, 0, offset / 4) else {
+            return IoResult::Err(IoError::InvalidRegister);
+        };
+
+        self.read(addr, value)
+    }
+
+
     /// Write to the config space.
     pub fn write(&mut self, address: PciConfigAddress, val: ByteEnabledDwordWrite) -> IoResult {
         use cfg_space::HeaderType01;
@@ -1548,6 +1588,20 @@ impl ConfigSpaceType1Emulator {
 
         self.write(addr, ByteEnabledDwordWrite::with_all_bytes_enabled(val))
     }
+
+    /// Write a byte-enabled DWORD to the config space. `offset` must be 32-bit aligned.
+    pub fn write_byte_enabled(&mut self, offset: u16, value: ByteEnabledDwordWrite) -> IoResult {
+        if !offset.is_multiple_of(4) {
+            return IoResult::Err(IoError::UnalignedAccess);
+        }
+
+        let Some(addr) = PciConfigAddress::new(0, 0, offset / 4) else {
+            return IoResult::Err(IoError::InvalidRegister);
+        };
+
+        self.write(addr, value)
+    }
+
 
     /// Checks if this device is a PCIe device by looking for the PCI Express capability.
     pub fn is_pcie_device(&self) -> bool {

--- a/vm/devices/pci/pci_core/src/chipset_device_ext.rs
+++ b/vm/devices/pci/pci_core/src/chipset_device_ext.rs
@@ -8,9 +8,9 @@ use crate::spec::hwid::HardwareIds;
 use crate::spec::hwid::ProgrammingInterface;
 use crate::spec::hwid::Subclass;
 use chipset_device::ChipsetDevice;
-use chipset_device::pci::PciConfigSpace;
 use chipset_device::pci::ByteEnabledDwordRead;
 use chipset_device::pci::ByteEnabledDwordWrite;
+use chipset_device::pci::PciConfigSpace;
 
 /// An extension trait to simplify probing PCI [`ChipsetDevice`] devices.
 pub trait PciChipsetDeviceExt: ChipsetDevice + PciConfigSpace {
@@ -36,7 +36,8 @@ where
                 .now_or_never()
                 .map(|_| buf_u32)
                 .unwrap_or(0);
-            self.pci_cfg_write(addr, ByteEnabledDwordWrite::with_all_bytes_enabled(!0)).unwrap();
+            self.pci_cfg_write(addr, ByteEnabledDwordWrite::with_all_bytes_enabled(!0))
+                .unwrap();
             let mut buf_u32 = 0;
             let buf = ByteEnabledDwordRead::with_all_bytes_enabled(&mut buf_u32);
             masks[i] = self
@@ -44,7 +45,8 @@ where
                 .now_or_never()
                 .map(|_| buf_u32)
                 .unwrap_or(0);
-            self.pci_cfg_write(addr, ByteEnabledDwordWrite::with_all_bytes_enabled(old)).unwrap();
+            self.pci_cfg_write(addr, ByteEnabledDwordWrite::with_all_bytes_enabled(old))
+                .unwrap();
         }
         masks
     }

--- a/vm/devices/pci/pci_core/src/chipset_device_ext.rs
+++ b/vm/devices/pci/pci_core/src/chipset_device_ext.rs
@@ -9,6 +9,8 @@ use crate::spec::hwid::ProgrammingInterface;
 use crate::spec::hwid::Subclass;
 use chipset_device::ChipsetDevice;
 use chipset_device::pci::PciConfigSpace;
+use chipset_device::pci::ByteEnabledDwordRead;
+use chipset_device::pci::ByteEnabledDwordWrite;
 
 /// An extension trait to simplify probing PCI [`ChipsetDevice`] devices.
 pub trait PciChipsetDeviceExt: ChipsetDevice + PciConfigSpace {
@@ -27,19 +29,22 @@ where
     fn probe_bar_masks(&mut self) -> [u32; 6] {
         let mut masks = [0; 6];
         for (i, addr) in (0x10..=0x24).step_by(4).enumerate() {
-            let mut buf = 0;
+            let mut buf_u32 = 0;
+            let buf = ByteEnabledDwordRead::with_all_bytes_enabled(&mut buf_u32);
             let old = self
-                .pci_cfg_read(addr, &mut buf)
+                .pci_cfg_read(addr, buf)
                 .now_or_never()
-                .map(|_| buf)
+                .map(|_| buf_u32)
                 .unwrap_or(0);
-            self.pci_cfg_write(addr, !0).unwrap();
+            self.pci_cfg_write(addr, ByteEnabledDwordWrite::with_all_bytes_enabled(!0)).unwrap();
+            let mut buf_u32 = 0;
+            let buf = ByteEnabledDwordRead::with_all_bytes_enabled(&mut buf_u32);
             masks[i] = self
-                .pci_cfg_read(addr, &mut buf)
+                .pci_cfg_read(addr, buf)
                 .now_or_never()
-                .map(|_| buf)
+                .map(|_| buf_u32)
                 .unwrap_or(0);
-            self.pci_cfg_write(addr, old).unwrap();
+            self.pci_cfg_write(addr, ByteEnabledDwordWrite::with_all_bytes_enabled(old)).unwrap();
         }
         masks
     }
@@ -49,17 +54,17 @@ where
         let mut p8 = 0;
         let mut p2c = 0;
         p0 = self
-            .pci_cfg_read(0, &mut p0)
+            .pci_cfg_read(0, ByteEnabledDwordRead::with_all_bytes_enabled(&mut p0))
             .now_or_never()
             .map(|_| p0)
             .unwrap_or(0);
         p8 = self
-            .pci_cfg_read(8, &mut p8)
+            .pci_cfg_read(8, ByteEnabledDwordRead::with_all_bytes_enabled(&mut p8))
             .now_or_never()
             .map(|_| p8)
             .unwrap_or(0);
         p2c = self
-            .pci_cfg_read(0x2c, &mut p2c)
+            .pci_cfg_read(0x2c, ByteEnabledDwordRead::with_all_bytes_enabled(&mut p2c))
             .now_or_never()
             .map(|_| p2c)
             .unwrap_or(0);

--- a/vm/devices/pci/pcie/fuzz/fuzz_pcie.rs
+++ b/vm/devices/pci/pcie/fuzz/fuzz_pcie.rs
@@ -10,6 +10,8 @@ use chipset_device::io::IoError;
 use chipset_device::io::IoResult;
 use chipset_device::io::deferred::DeferredToken;
 use chipset_device::mmio::MmioIntercept;
+use chipset_device::pci::ByteEnabledDwordRead;
+use chipset_device::pci::ByteEnabledDwordWrite;
 use chipset_device::pci::PciConfigSpace;
 use memory_range::MemoryRange;
 use pci_bus::GenericPciBusDevice;
@@ -39,15 +41,19 @@ struct FuzzEndpoint {
 }
 
 impl GenericPciBusDevice for FuzzEndpoint {
-    fn pci_cfg_read(&mut self, _offset: u16, value: &mut u32) -> Option<IoResult> {
+    fn pci_cfg_read(
+        &mut self,
+        _offset: u16,
+        mut value: ByteEnabledDwordRead<'_>,
+    ) -> Option<IoResult> {
         if self.offline {
             return None;
         }
-        *value = self.read_value;
+        value.set(self.read_value);
         Some(IoResult::Ok)
     }
 
-    fn pci_cfg_write(&mut self, _offset: u16, _value: u32) -> Option<IoResult> {
+    fn pci_cfg_write(&mut self, _offset: u16, _value: ByteEnabledDwordWrite) -> Option<IoResult> {
         if self.offline {
             return None;
         }
@@ -60,11 +66,11 @@ impl GenericPciBusDevice for FuzzEndpoint {
 struct SwitchAdapter(GenericPcieSwitch);
 
 impl GenericPciBusDevice for SwitchAdapter {
-    fn pci_cfg_read(&mut self, offset: u16, value: &mut u32) -> Option<IoResult> {
+    fn pci_cfg_read(&mut self, offset: u16, value: ByteEnabledDwordRead<'_>) -> Option<IoResult> {
         Some(self.0.pci_cfg_read(offset, value))
     }
 
-    fn pci_cfg_write(&mut self, offset: u16, value: u32) -> Option<IoResult> {
+    fn pci_cfg_write(&mut self, offset: u16, value: ByteEnabledDwordWrite) -> Option<IoResult> {
         Some(self.0.pci_cfg_write(offset, value))
     }
 
@@ -74,7 +80,7 @@ impl GenericPciBusDevice for SwitchAdapter {
         target_bus: u8,
         function: u8,
         offset: u16,
-        value: &mut u32,
+        value: ByteEnabledDwordRead<'_>,
     ) -> Option<IoResult> {
         Some(
             self.0
@@ -88,7 +94,7 @@ impl GenericPciBusDevice for SwitchAdapter {
         target_bus: u8,
         function: u8,
         offset: u16,
-        value: u32,
+        value: ByteEnabledDwordWrite,
     ) -> Option<IoResult> {
         Some(
             self.0

--- a/vm/devices/pci/pcie/src/port.rs
+++ b/vm/devices/pci/pcie/src/port.rs
@@ -912,11 +912,19 @@ mod tests {
     struct MockDevice;
 
     impl GenericPciBusDevice for MockDevice {
-        fn pci_cfg_read(&mut self, _offset: u16, _value: ByteEnabledDwordRead<'_>) -> Option<IoResult> {
+        fn pci_cfg_read(
+            &mut self,
+            _offset: u16,
+            _value: ByteEnabledDwordRead<'_>,
+        ) -> Option<IoResult> {
             None
         }
 
-        fn pci_cfg_write(&mut self, _offset: u16, _value: ByteEnabledDwordWrite) -> Option<IoResult> {
+        fn pci_cfg_write(
+            &mut self,
+            _offset: u16,
+            _value: ByteEnabledDwordWrite,
+        ) -> Option<IoResult> {
             None
         }
     }
@@ -934,12 +942,20 @@ mod tests {
     }
 
     impl GenericPciBusDevice for MultiFunctionMockDevice {
-        fn pci_cfg_read(&mut self, _offset: u16, _value: ByteEnabledDwordRead<'_>) -> Option<IoResult> {
+        fn pci_cfg_read(
+            &mut self,
+            _offset: u16,
+            _value: ByteEnabledDwordRead<'_>,
+        ) -> Option<IoResult> {
             self.stats.lock().direct_reads += 1;
             Some(IoResult::Ok)
         }
 
-        fn pci_cfg_write(&mut self, _offset: u16, _value: ByteEnabledDwordWrite) -> Option<IoResult> {
+        fn pci_cfg_write(
+            &mut self,
+            _offset: u16,
+            _value: ByteEnabledDwordWrite,
+        ) -> Option<IoResult> {
             self.stats.lock().direct_writes += 1;
             Some(IoResult::Ok)
         }
@@ -1195,8 +1211,18 @@ mod tests {
         assert_eq!(
             stats.forward_writes,
             vec![
-                (1, 0, 0x10, ByteEnabledDwordWrite::with_all_bytes_enabled(0xAAAA_0000)),
-                (1, 2, 0x14, ByteEnabledDwordWrite::with_all_bytes_enabled(0xBBBB_0000))
+                (
+                    1,
+                    0,
+                    0x10,
+                    ByteEnabledDwordWrite::with_all_bytes_enabled(0xAAAA_0000)
+                ),
+                (
+                    1,
+                    2,
+                    0x14,
+                    ByteEnabledDwordWrite::with_all_bytes_enabled(0xBBBB_0000)
+                )
             ]
         );
     }

--- a/vm/devices/pci/pcie/src/port.rs
+++ b/vm/devices/pci/pcie/src/port.rs
@@ -7,6 +7,8 @@ use anyhow::bail;
 use chipset_device::io::IoError;
 use chipset_device::io::IoResult;
 use chipset_device::mmio::RegisterMmioIntercept;
+use chipset_device::pci::ByteEnabledDwordRead;
+use chipset_device::pci::ByteEnabledDwordWrite;
 use chipset_device::pci::PciConfigAddress;
 use cxl_spec::CxlComponentRegisters;
 use cxl_spec::CxlFlexBusPortDvsecExtendedCapability;
@@ -671,7 +673,7 @@ impl PcieDownstreamPort {
     pub fn forward_cfg_read_with_routing(
         &mut self,
         addr: PciConfigAddress,
-        value: &mut u32,
+        mut value: ByteEnabledDwordRead<'_>,
     ) -> IoResult {
         let bus_range = self.cfg_space.assigned_bus_range();
 
@@ -679,7 +681,7 @@ impl PcieDownstreamPort {
         // and the access should not have been routed to this port.
         if bus_range == (0..=0) {
             tracelimit::warn_ratelimited!("invalid access: port bus number range not configured");
-            *value = !0;
+            value.set(!0);
             return IoResult::Ok;
         }
 
@@ -689,14 +691,14 @@ impl PcieDownstreamPort {
             tracelimit::warn_ratelimited!(
                 "bus number to access not within port's bus number range"
             );
-            *value = !0;
+            value.set(!0);
             return IoResult::Ok;
         }
 
         // If there is no device connected to the port, then we should return all-1s.
         let Some((_, device)) = &mut self.link else {
             tracing::trace!("no device connected to port");
-            *value = !0;
+            value.set(!0);
             return IoResult::Ok;
         };
 
@@ -707,11 +709,11 @@ impl PcieDownstreamPort {
                 addr.bus,
                 addr.device_function,
                 addr.byte_offset(),
-                value,
+                value.reborrow(),
             )
             .unwrap_or_else(|| {
                 tracelimit::warn_ratelimited!("failed to read from connected device");
-                *value = !0;
+                value.set(!0);
                 IoResult::Ok
             })
     }
@@ -721,7 +723,7 @@ impl PcieDownstreamPort {
     pub fn forward_cfg_write_with_routing(
         &mut self,
         addr: PciConfigAddress,
-        value: u32,
+        value: ByteEnabledDwordWrite,
     ) -> IoResult {
         let bus_range = self.cfg_space.assigned_bus_range();
 
@@ -910,11 +912,11 @@ mod tests {
     struct MockDevice;
 
     impl GenericPciBusDevice for MockDevice {
-        fn pci_cfg_read(&mut self, _offset: u16, _value: &mut u32) -> Option<IoResult> {
+        fn pci_cfg_read(&mut self, _offset: u16, _value: ByteEnabledDwordRead<'_>) -> Option<IoResult> {
             None
         }
 
-        fn pci_cfg_write(&mut self, _offset: u16, _value: u32) -> Option<IoResult> {
+        fn pci_cfg_write(&mut self, _offset: u16, _value: ByteEnabledDwordWrite) -> Option<IoResult> {
             None
         }
     }
@@ -924,7 +926,7 @@ mod tests {
         direct_reads: usize,
         forward_reads: Vec<(u8, u8, u16)>,
         direct_writes: usize,
-        forward_writes: Vec<(u8, u8, u16, u32)>,
+        forward_writes: Vec<(u8, u8, u16, ByteEnabledDwordWrite)>,
     }
 
     struct MultiFunctionMockDevice {
@@ -932,12 +934,12 @@ mod tests {
     }
 
     impl GenericPciBusDevice for MultiFunctionMockDevice {
-        fn pci_cfg_read(&mut self, _offset: u16, _value: &mut u32) -> Option<IoResult> {
+        fn pci_cfg_read(&mut self, _offset: u16, _value: ByteEnabledDwordRead<'_>) -> Option<IoResult> {
             self.stats.lock().direct_reads += 1;
             Some(IoResult::Ok)
         }
 
-        fn pci_cfg_write(&mut self, _offset: u16, _value: u32) -> Option<IoResult> {
+        fn pci_cfg_write(&mut self, _offset: u16, _value: ByteEnabledDwordWrite) -> Option<IoResult> {
             self.stats.lock().direct_writes += 1;
             Some(IoResult::Ok)
         }
@@ -948,13 +950,13 @@ mod tests {
             target_bus: u8,
             function: u8,
             offset: u16,
-            value: &mut u32,
+            mut value: ByteEnabledDwordRead<'_>,
         ) -> Option<IoResult> {
             self.stats
                 .lock()
                 .forward_reads
                 .push((target_bus, function, offset));
-            *value = 0x1234_5678;
+            value.set(0x1234_5678);
             Some(IoResult::Ok)
         }
 
@@ -964,7 +966,7 @@ mod tests {
             target_bus: u8,
             function: u8,
             offset: u16,
-            value: u32,
+            value: ByteEnabledDwordWrite,
         ) -> Option<IoResult> {
             self.stats
                 .lock()
@@ -1113,14 +1115,14 @@ mod tests {
         assert!(matches!(
             port.forward_cfg_read_with_routing(
                 PciConfigAddress::new(1, 0, 0x10 / 4).unwrap(),
-                &mut value
+                ByteEnabledDwordRead::with_all_bytes_enabled(&mut value)
             ),
             IoResult::Ok
         ));
         assert!(matches!(
             port.forward_cfg_read_with_routing(
                 PciConfigAddress::new(1, 3, 0x14 / 4).unwrap(),
-                &mut value
+                ByteEnabledDwordRead::with_all_bytes_enabled(&mut value)
             ),
             IoResult::Ok
         ));
@@ -1176,14 +1178,14 @@ mod tests {
         assert!(matches!(
             port.forward_cfg_write_with_routing(
                 PciConfigAddress::new(1, 0, 0x10 / 4).unwrap(),
-                0xAAAA_0000
+                ByteEnabledDwordWrite::with_all_bytes_enabled(0xAAAA_0000)
             ),
             IoResult::Ok
         ));
         assert!(matches!(
             port.forward_cfg_write_with_routing(
                 PciConfigAddress::new(1, 2, 0x14 / 4).unwrap(),
-                0xBBBB_0000
+                ByteEnabledDwordWrite::with_all_bytes_enabled(0xBBBB_0000)
             ),
             IoResult::Ok
         ));
@@ -1192,7 +1194,10 @@ mod tests {
         assert_eq!(stats.direct_writes, 0);
         assert_eq!(
             stats.forward_writes,
-            vec![(1, 0, 0x10, 0xAAAA_0000), (1, 2, 0x14, 0xBBBB_0000)]
+            vec![
+                (1, 0, 0x10, ByteEnabledDwordWrite::with_all_bytes_enabled(0xAAAA_0000)),
+                (1, 2, 0x14, ByteEnabledDwordWrite::with_all_bytes_enabled(0xBBBB_0000))
+            ]
         );
     }
 

--- a/vm/devices/pci/pcie/src/root.rs
+++ b/vm/devices/pci/pcie/src/root.rs
@@ -593,9 +593,7 @@ impl ChipsetDevice for GenericPcieRootComplex {
 
 impl PollDevice for GenericPcieRootComplex {
     fn poll_device(&mut self, cx: &mut std::task::Context<'_>) {
-        let mut callback =
-            PciBusCfgAccessCallbackView::new(&self.start_bus, &self.end_bus, &mut self.devices);
-        self.bus_cfg_handler.poll(cx, &mut callback);
+        self.bus_cfg_handler.poll(cx);
     }
 }
 
@@ -744,10 +742,10 @@ impl<'a> PciBusCfgAccessCallbackView<'a> {
 }
 
 impl<'a> PciBusCfgAccessCallbacks for PciBusCfgAccessCallbackView<'a> {
-    fn read(&mut self, addr: PciConfigAddress, value: &mut u32) -> IoResult {
+    fn read(&mut self, addr: PciConfigAddress, mut value: ByteEnabledDwordRead<'_>) -> IoResult {
         let Some(target) = self.route_cfg_access(addr) else {
             tracing::trace!(?addr, "unroutable config space access");
-            *value = !0;
+            value.set(!0);
             return IoResult::Ok;
         };
 
@@ -758,20 +756,20 @@ impl<'a> PciBusCfgAccessCallbacks for PciBusCfgAccessCallbackView<'a> {
                     addr.bus,
                     addr.device_function,
                     addr.byte_offset(),
-                    value,
+                    value.reborrow(),
                 )
                 .unwrap_or_else(|| {
-                    *value = !0;
+                    value.set(!0);
                     IoResult::Ok
                 }),
             CfgAccessTarget::RootPort(port) => {
-                port.port.cfg_space.read_u32(addr.byte_offset(), value)
+                port.port.cfg_space.read_byte_enabled(addr.byte_offset(), value)
             }
             CfgAccessTarget::DownstreamDevice(port) => port.forward_cfg_read(addr, value),
         }
     }
 
-    fn write(&mut self, addr: PciConfigAddress, value: u32) -> IoResult {
+    fn write(&mut self, addr: PciConfigAddress, value: ByteEnabledDwordWrite) -> IoResult {
         let Some(target) = self.route_cfg_access(addr) else {
             tracing::trace!(?addr, "unroutable config space access");
             return IoResult::Ok;
@@ -788,7 +786,7 @@ impl<'a> PciBusCfgAccessCallbacks for PciBusCfgAccessCallbackView<'a> {
                 )
                 .unwrap_or(IoResult::Ok),
             CfgAccessTarget::RootPort(port) => {
-                port.port.cfg_space.write_u32(addr.byte_offset(), value)
+                port.port.cfg_space.write_byte_enabled(addr.byte_offset(), value)
             }
             CfgAccessTarget::DownstreamDevice(port) => port.forward_cfg_write(addr, value),
         }
@@ -882,11 +880,11 @@ impl RootPort {
         }
     }
 
-    fn forward_cfg_read(&mut self, addr: PciConfigAddress, value: &mut u32) -> IoResult {
+    fn forward_cfg_read(&mut self, addr: PciConfigAddress, value: ByteEnabledDwordRead<'_>) -> IoResult {
         self.port.forward_cfg_read_with_routing(addr, value)
     }
 
-    fn forward_cfg_write(&mut self, addr: PciConfigAddress, value: u32) -> IoResult {
+    fn forward_cfg_write(&mut self, addr: PciConfigAddress, value: ByteEnabledDwordWrite) -> IoResult {
         self.port.forward_cfg_write_with_routing(addr, value)
     }
 }
@@ -1065,6 +1063,8 @@ mod tests {
     use chipset_device::io::deferred::DeferredWrite;
     use chipset_device::io::deferred::defer_read;
     use chipset_device::io::deferred::defer_write;
+    use chipset_device::pci::ByteEnabledDwordRead;
+    use chipset_device::pci::ByteEnabledDwordWrite;
     use chipset_device::pci::PciConfigSpace;
     use cxl_spec::CxlComponentRegisterType;
     use cxl_spec::component_registers::test_helper::TestCxlComponentRegisterBlock;
@@ -1082,7 +1082,7 @@ mod tests {
         defer_writes: bool,
         pending_read: Option<DeferredRead>,
         pending_write: Option<DeferredWrite>,
-        writes: Vec<(u16, u32)>,
+        writes: Vec<(u16, ByteEnabledDwordWrite)>,
     }
 
     impl DeferredEndpointState {
@@ -1099,7 +1099,7 @@ mod tests {
     }
 
     impl GenericPciBusDevice for DeferredEndpoint {
-        fn pci_cfg_read(&mut self, offset: u16, value: &mut u32) -> Option<IoResult> {
+        fn pci_cfg_read(&mut self, offset: u16, mut value: ByteEnabledDwordRead<'_>) -> Option<IoResult> {
             let mut state = self.state.lock();
             if state.defer_reads {
                 let (deferred, token) = defer_read();
@@ -1107,12 +1107,12 @@ mod tests {
                 Some(IoResult::Defer(token))
             } else {
                 assert_eq!(offset, 0);
-                *value = state.read_value;
+                value.set(state.read_value);
                 Some(IoResult::Ok)
             }
         }
 
-        fn pci_cfg_write(&mut self, offset: u16, value: u32) -> Option<IoResult> {
+        fn pci_cfg_write(&mut self, offset: u16, value: ByteEnabledDwordWrite) -> Option<IoResult> {
             let mut state = self.state.lock();
             state.writes.push((offset, value));
             if state.defer_writes {
@@ -1128,11 +1128,11 @@ mod tests {
     struct SwitchAdapter(Arc<Mutex<GenericPcieSwitch>>);
 
     impl GenericPciBusDevice for SwitchAdapter {
-        fn pci_cfg_read(&mut self, offset: u16, value: &mut u32) -> Option<IoResult> {
+        fn pci_cfg_read(&mut self, offset: u16, value: ByteEnabledDwordRead<'_>) -> Option<IoResult> {
             Some(self.0.lock().pci_cfg_read(offset, value))
         }
 
-        fn pci_cfg_write(&mut self, offset: u16, value: u32) -> Option<IoResult> {
+        fn pci_cfg_write(&mut self, offset: u16, value: ByteEnabledDwordWrite) -> Option<IoResult> {
             Some(self.0.lock().pci_cfg_write(offset, value))
         }
 
@@ -1142,7 +1142,7 @@ mod tests {
             target_bus: u8,
             function: u8,
             offset: u16,
-            value: &mut u32,
+            value: ByteEnabledDwordRead<'_>,
         ) -> Option<IoResult> {
             Some(self.0.lock().pci_cfg_read_with_routing(
                 secondary_bus,
@@ -1159,7 +1159,7 @@ mod tests {
             target_bus: u8,
             function: u8,
             offset: u16,
-            value: u32,
+            value: ByteEnabledDwordWrite,
         ) -> Option<IoResult> {
             Some(self.0.lock().pci_cfg_write_with_routing(
                 secondary_bus,
@@ -1358,9 +1358,9 @@ mod tests {
         let mut rc = instantiate_root_complex(0, 0, 1);
 
         let endpoint1 = TestPcieEndpoint::new(
-            |offset, value| match offset {
+            |offset, mut value| match offset {
                 0x0 => {
-                    *value = 0xAAAA_AAAA;
+                    value.set(0xAAAA_AAAA);
                     Some(IoResult::Ok)
                 }
                 _ => Some(IoResult::Err(IoError::InvalidRegister)),
@@ -1416,9 +1416,9 @@ mod tests {
         assert_eq!(value_32, 0xFFFF_FFFF);
 
         let endpoint = TestPcieEndpoint::new(
-            |offset, value| match offset {
+            |offset, mut value| match offset {
                 0x0 => {
-                    *value = 0xDEAD_BEEF;
+                    value.set(0xDEAD_BEEF);
                     Some(IoResult::Ok)
                 }
                 _ => Some(IoResult::Err(IoError::InvalidRegister)),
@@ -1506,23 +1506,7 @@ mod tests {
         ));
 
         let partial_write = rc.mmio_write(ENDPOINT_ECAM + 1, &[0xaa]);
-        let IoResult::Defer(partial_write_token) = partial_write else {
-            panic!("sub-dword downstream config write should defer on read-for-write");
-        };
-        state
-            .lock()
-            .pending_read
-            .take()
-            .unwrap()
-            .complete(&0x1122_3344u32.as_bytes()[..4]);
-        poll_root(&mut rc);
-        partial_write_token.write_future().await.unwrap();
-        let mut expected = 0x1122_3344u32.to_ne_bytes();
-        expected[1] = 0xaa;
-        assert_eq!(
-            state.lock().writes.pop(),
-            Some((0, u32::from_ne_bytes(expected)))
-        );
+        assert!(matches!(partial_write, IoResult::Ok));
 
         state.lock().defer_reads = false;
         state.lock().defer_writes = true;
@@ -1533,7 +1517,7 @@ mod tests {
         state.lock().pending_write.take().unwrap().complete();
         poll_root(&mut rc);
         full_write_token.write_future().await.unwrap();
-        assert_eq!(state.lock().writes.pop(), Some((0, 0xaabb_ccdd)));
+        assert_eq!(state.lock().writes.pop(), Some((0, ByteEnabledDwordWrite::with_all_bytes_enabled(0xaabb_ccdd))));
 
         let full_write = rc.mmio_write(ENDPOINT_ECAM, 0x1122_3344u32.as_bytes());
         let IoResult::Defer(full_write_token) = full_write else {
@@ -1587,7 +1571,7 @@ mod tests {
                 SWITCH_BUS,
                 0,
                 0x18,
-                (10u32 << 16) | ((SWITCH_INTERNAL_BUS as u32) << 8) | SWITCH_BUS as u32,
+                ByteEnabledDwordWrite::with_all_bytes_enabled((10u32 << 16) | ((SWITCH_INTERNAL_BUS as u32) << 8) | SWITCH_BUS as u32),
             )
             .unwrap();
         switch
@@ -1597,9 +1581,9 @@ mod tests {
                 SWITCH_INTERNAL_BUS,
                 0,
                 0x18,
-                ((ENDPOINT_BUS as u32) << 16)
+                ByteEnabledDwordWrite::with_all_bytes_enabled(((ENDPOINT_BUS as u32) << 16)
                     | ((ENDPOINT_BUS as u32) << 8)
-                    | SWITCH_INTERNAL_BUS as u32,
+                    | SWITCH_INTERNAL_BUS as u32),
             )
             .unwrap();
 
@@ -1850,10 +1834,10 @@ mod tests {
         let mut value = 0u32;
         let result = root_port
             .port
-            .forward_cfg_read_with_routing(addr, &mut value);
+            .forward_cfg_read_with_routing(addr, ByteEnabledDwordRead::with_all_bytes_enabled(&mut value));
         assert!(matches!(result, IoResult::Ok));
 
-        let result = root_port.port.forward_cfg_write_with_routing(addr, value);
+        let result = root_port.port.forward_cfg_write_with_routing(addr, ByteEnabledDwordWrite::with_all_bytes_enabled(value));
         assert!(matches!(result, IoResult::Ok));
     }
 
@@ -2092,9 +2076,9 @@ mod tests {
 
         // Attach an RCiEP at device 0 function 0 (devfn 0).
         let rciep = TestPcieEndpoint::new(
-            |offset, value| {
+            |offset, mut value| {
                 if offset == 0 {
-                    *value = 0xDEAD_BEEF;
+                    value.set(0xDEAD_BEEF);
                 }
                 Some(IoResult::Ok)
             },
@@ -2139,9 +2123,9 @@ mod tests {
             .unwrap();
 
         let rciep = TestPcieEndpoint::new(
-            |offset, value| {
+            |offset, mut value| {
                 if offset == 0 {
-                    *value = 0xCAFE_F00D;
+                    value.set(0xCAFE_F00D);
                 }
                 Some(IoResult::Ok)
             },

--- a/vm/devices/pci/pcie/src/root.rs
+++ b/vm/devices/pci/pcie/src/root.rs
@@ -762,9 +762,10 @@ impl<'a> PciBusCfgAccessCallbacks for PciBusCfgAccessCallbackView<'a> {
                     value.set(!0);
                     IoResult::Ok
                 }),
-            CfgAccessTarget::RootPort(port) => {
-                port.port.cfg_space.read_byte_enabled(addr.byte_offset(), value)
-            }
+            CfgAccessTarget::RootPort(port) => port
+                .port
+                .cfg_space
+                .read_byte_enabled(addr.byte_offset(), value),
             CfgAccessTarget::DownstreamDevice(port) => port.forward_cfg_read(addr, value),
         }
     }
@@ -785,9 +786,10 @@ impl<'a> PciBusCfgAccessCallbacks for PciBusCfgAccessCallbackView<'a> {
                     value,
                 )
                 .unwrap_or(IoResult::Ok),
-            CfgAccessTarget::RootPort(port) => {
-                port.port.cfg_space.write_byte_enabled(addr.byte_offset(), value)
-            }
+            CfgAccessTarget::RootPort(port) => port
+                .port
+                .cfg_space
+                .write_byte_enabled(addr.byte_offset(), value),
             CfgAccessTarget::DownstreamDevice(port) => port.forward_cfg_write(addr, value),
         }
     }
@@ -880,11 +882,19 @@ impl RootPort {
         }
     }
 
-    fn forward_cfg_read(&mut self, addr: PciConfigAddress, value: ByteEnabledDwordRead<'_>) -> IoResult {
+    fn forward_cfg_read(
+        &mut self,
+        addr: PciConfigAddress,
+        value: ByteEnabledDwordRead<'_>,
+    ) -> IoResult {
         self.port.forward_cfg_read_with_routing(addr, value)
     }
 
-    fn forward_cfg_write(&mut self, addr: PciConfigAddress, value: ByteEnabledDwordWrite) -> IoResult {
+    fn forward_cfg_write(
+        &mut self,
+        addr: PciConfigAddress,
+        value: ByteEnabledDwordWrite,
+    ) -> IoResult {
         self.port.forward_cfg_write_with_routing(addr, value)
     }
 }
@@ -1099,7 +1109,11 @@ mod tests {
     }
 
     impl GenericPciBusDevice for DeferredEndpoint {
-        fn pci_cfg_read(&mut self, offset: u16, mut value: ByteEnabledDwordRead<'_>) -> Option<IoResult> {
+        fn pci_cfg_read(
+            &mut self,
+            offset: u16,
+            mut value: ByteEnabledDwordRead<'_>,
+        ) -> Option<IoResult> {
             let mut state = self.state.lock();
             if state.defer_reads {
                 let (deferred, token) = defer_read();
@@ -1128,7 +1142,11 @@ mod tests {
     struct SwitchAdapter(Arc<Mutex<GenericPcieSwitch>>);
 
     impl GenericPciBusDevice for SwitchAdapter {
-        fn pci_cfg_read(&mut self, offset: u16, value: ByteEnabledDwordRead<'_>) -> Option<IoResult> {
+        fn pci_cfg_read(
+            &mut self,
+            offset: u16,
+            value: ByteEnabledDwordRead<'_>,
+        ) -> Option<IoResult> {
             Some(self.0.lock().pci_cfg_read(offset, value))
         }
 
@@ -1517,7 +1535,13 @@ mod tests {
         state.lock().pending_write.take().unwrap().complete();
         poll_root(&mut rc);
         full_write_token.write_future().await.unwrap();
-        assert_eq!(state.lock().writes.pop(), Some((0, ByteEnabledDwordWrite::with_all_bytes_enabled(0xaabb_ccdd))));
+        assert_eq!(
+            state.lock().writes.pop(),
+            Some((
+                0,
+                ByteEnabledDwordWrite::with_all_bytes_enabled(0xaabb_ccdd)
+            ))
+        );
 
         let full_write = rc.mmio_write(ENDPOINT_ECAM, 0x1122_3344u32.as_bytes());
         let IoResult::Defer(full_write_token) = full_write else {
@@ -1571,7 +1595,9 @@ mod tests {
                 SWITCH_BUS,
                 0,
                 0x18,
-                ByteEnabledDwordWrite::with_all_bytes_enabled((10u32 << 16) | ((SWITCH_INTERNAL_BUS as u32) << 8) | SWITCH_BUS as u32),
+                ByteEnabledDwordWrite::with_all_bytes_enabled(
+                    (10u32 << 16) | ((SWITCH_INTERNAL_BUS as u32) << 8) | SWITCH_BUS as u32,
+                ),
             )
             .unwrap();
         switch
@@ -1581,9 +1607,11 @@ mod tests {
                 SWITCH_INTERNAL_BUS,
                 0,
                 0x18,
-                ByteEnabledDwordWrite::with_all_bytes_enabled(((ENDPOINT_BUS as u32) << 16)
-                    | ((ENDPOINT_BUS as u32) << 8)
-                    | SWITCH_INTERNAL_BUS as u32),
+                ByteEnabledDwordWrite::with_all_bytes_enabled(
+                    ((ENDPOINT_BUS as u32) << 16)
+                        | ((ENDPOINT_BUS as u32) << 8)
+                        | SWITCH_INTERNAL_BUS as u32,
+                ),
             )
             .unwrap();
 
@@ -1832,12 +1860,16 @@ mod tests {
         // Test that forwarding returns Ok but doesn't crash when bus range is invalid
         let addr = PciConfigAddress::new(1, 0, 0x0).unwrap();
         let mut value = 0u32;
-        let result = root_port
-            .port
-            .forward_cfg_read_with_routing(addr, ByteEnabledDwordRead::with_all_bytes_enabled(&mut value));
+        let result = root_port.port.forward_cfg_read_with_routing(
+            addr,
+            ByteEnabledDwordRead::with_all_bytes_enabled(&mut value),
+        );
         assert!(matches!(result, IoResult::Ok));
 
-        let result = root_port.port.forward_cfg_write_with_routing(addr, ByteEnabledDwordWrite::with_all_bytes_enabled(value));
+        let result = root_port.port.forward_cfg_write_with_routing(
+            addr,
+            ByteEnabledDwordWrite::with_all_bytes_enabled(value),
+        );
         assert!(matches!(result, IoResult::Ok));
     }
 

--- a/vm/devices/pci/pcie/src/switch.rs
+++ b/vm/devices/pci/pcie/src/switch.rs
@@ -292,7 +292,7 @@ impl GenericPcieSwitch {
     fn handle_downstream_port_read(
         &mut self,
         addr: PciConfigAddress,
-        value: &mut u32,
+        value: ByteEnabledDwordRead<'_>,
     ) -> Option<IoResult> {
         let (_, _, downstream_port) = self
             .downstream_ports
@@ -302,7 +302,7 @@ impl GenericPcieSwitch {
             downstream_port
                 .port
                 .cfg_space
-                .read_u32(addr.byte_offset(), value),
+                .read(addr, value),
         )
     }
 
@@ -310,7 +310,7 @@ impl GenericPcieSwitch {
     fn handle_downstream_port_write(
         &mut self,
         addr: PciConfigAddress,
-        value: u32,
+        value: ByteEnabledDwordWrite,
     ) -> Option<IoResult> {
         let (_, _, downstream_port) = self
             .downstream_ports
@@ -320,7 +320,7 @@ impl GenericPcieSwitch {
             downstream_port
                 .port
                 .cfg_space
-                .write_u32(addr.byte_offset(), value),
+                .write(addr, value),
         )
     }
 
@@ -377,15 +377,15 @@ impl ChipsetDevice for GenericPcieSwitch {
 
 impl PciConfigSpace for GenericPcieSwitch {
     /// Reads the switch's own upstream-port config space (Type 0 view).
-    fn pci_cfg_read(&mut self, offset: u16, value: &mut u32) -> IoResult {
+    fn pci_cfg_read(&mut self, offset: u16, value: ByteEnabledDwordRead<'_>) -> IoResult {
         // Forward to the upstream port's configuration space (the switch presents as the upstream port)
-        self.upstream_port.cfg_space.read_u32(offset, value)
+        self.upstream_port.cfg_space.read_byte_enabled(offset, value)
     }
 
     /// Writes the switch's own upstream-port config space (Type 0 view).
-    fn pci_cfg_write(&mut self, offset: u16, value: u32) -> IoResult {
+    fn pci_cfg_write(&mut self, offset: u16, value: ByteEnabledDwordWrite) -> IoResult {
         // Forward to the upstream port's configuration space (the switch presents as the upstream port)
-        self.upstream_port.cfg_space.write_u32(offset, value)
+        self.upstream_port.cfg_space.write_byte_enabled(offset, value)
     }
 
     fn pci_cfg_read_with_routing(
@@ -394,7 +394,7 @@ impl PciConfigSpace for GenericPcieSwitch {
         target_bus: u8,
         function: u8,
         offset: u16,
-        value: &mut u32,
+        mut value: ByteEnabledDwordRead<'_>,
     ) -> IoResult {
         if !offset.is_multiple_of(4) {
             return IoResult::Err(IoError::UnalignedAccess);
@@ -408,9 +408,9 @@ impl PciConfigSpace for GenericPcieSwitch {
         // We only implement function 0.
         if target_bus == secondary_bus {
             if function == 0 {
-                return self.upstream_port.cfg_space.read_u32(offset, value);
+                return self.upstream_port.cfg_space.read_byte_enabled(offset, value);
             } else {
-                *value = !0;
+                value.set(!0);
                 return IoResult::Ok;
             }
         }
@@ -419,13 +419,13 @@ impl PciConfigSpace for GenericPcieSwitch {
 
         // If the bus range is 0..=0, this indicates invalid/uninitialized bus configuration
         if upstream_bus_range == (0..=0) {
-            *value = !0;
+            value.set(!0);
             return IoResult::Ok;
         }
 
         // If the target bus is not within the upstream bus range, we cannot route it. Return all-1s.
         if !upstream_bus_range.contains(&target_bus) {
-            *value = !0;
+            value.set(!0);
             return IoResult::Ok;
         }
 
@@ -433,16 +433,15 @@ impl PciConfigSpace for GenericPcieSwitch {
         // downstream ports on the internal bus of the switch.
         if target_bus == *upstream_bus_range.start() {
             return self
-                .handle_downstream_port_read(addr, value)
+                .handle_downstream_port_read(addr, value.reborrow())
                 .unwrap_or_else(|| {
-                    *value = !0;
+                    value.set(!0);
                     IoResult::Ok
                 });
         }
 
         // The access must be routed somewhere downstream of a downstream port, invoke the
         // config space handler for dealing with deferrals and such.
-        let value = ByteEnabledDwordRead::with_all_bytes_enabled(value);
         let mut callback = PciBusCfgAccessCallbackView::new(&mut self.downstream_ports);
         self.bus_cfg_handler.read(addr, value, &mut callback)
     }
@@ -453,7 +452,7 @@ impl PciConfigSpace for GenericPcieSwitch {
         target_bus: u8,
         function: u8,
         offset: u16,
-        value: u32,
+        value: ByteEnabledDwordWrite,
     ) -> IoResult {
         if !offset.is_multiple_of(4) {
             return IoResult::Err(IoError::UnalignedAccess);
@@ -467,7 +466,7 @@ impl PciConfigSpace for GenericPcieSwitch {
         // We only implement function 0.
         if target_bus == secondary_bus {
             if function == 0 {
-                return self.upstream_port.cfg_space.write_u32(offset, value);
+                return self.upstream_port.cfg_space.write_byte_enabled(offset, value);
             } else {
                 return IoResult::Ok;
             }
@@ -495,7 +494,6 @@ impl PciConfigSpace for GenericPcieSwitch {
 
         // The access must be routed somewhere downstream of a downstream port, invoke the
         // config space handler for dealing with deferrals and such.
-        let value = ByteEnabledDwordWrite::with_all_bytes_enabled(value);
         let mut callback = PciBusCfgAccessCallbackView::new(&mut self.downstream_ports);
         self.bus_cfg_handler.write(addr, value, &mut callback)
     }
@@ -508,8 +506,7 @@ impl PciConfigSpace for GenericPcieSwitch {
 
 impl PollDevice for GenericPcieSwitch {
     fn poll_device(&mut self, cx: &mut std::task::Context<'_>) {
-        let mut callback = PciBusCfgAccessCallbackView::new(&mut self.downstream_ports);
-        self.bus_cfg_handler.poll(cx, &mut callback);
+        self.bus_cfg_handler.poll(cx);
     }
 }
 
@@ -524,7 +521,7 @@ impl<'a> PciBusCfgAccessCallbackView<'a> {
 }
 
 impl<'a> PciBusCfgAccessCallbacks for PciBusCfgAccessCallbackView<'a> {
-    fn read(&mut self, addr: PciConfigAddress, value: &mut u32) -> IoResult {
+    fn read(&mut self, addr: PciConfigAddress, mut value: ByteEnabledDwordRead<'_>) -> IoResult {
         for (_, _, downstream_port) in self.downstream_ports.iter_mut() {
             let downstream_bus_range = downstream_port.cfg_space().assigned_bus_range();
 
@@ -541,12 +538,12 @@ impl<'a> PciBusCfgAccessCallbacks for PciBusCfgAccessCallbackView<'a> {
         }
 
         // No downstream port could handle this bus number
-        *value = !0;
+        value.set(!0);
         IoResult::Ok
     }
 
     /// Route configuration space write to downstream ports for further forwarding.
-    fn write(&mut self, addr: PciConfigAddress, value: u32) -> IoResult {
+    fn write(&mut self, addr: PciConfigAddress, value: ByteEnabledDwordWrite) -> IoResult {
         for (_, _, downstream_port) in self.downstream_ports.iter_mut() {
             let downstream_bus_range = downstream_port.cfg_space().assigned_bus_range();
 
@@ -904,9 +901,9 @@ mod tests {
         ));
 
         let downstream_device = TestPcieEndpoint::new(
-            |offset, value| match offset {
+            |offset, mut value| match offset {
                 0x0 => {
-                    *value = 0xABCD_EF01;
+                    value.set(0xABCD_EF01);
                     Some(IoResult::Ok)
                 }
                 _ => Some(IoResult::Err(IoError::InvalidRegister)),
@@ -992,7 +989,7 @@ mod tests {
 
         // Test PciConfigSpace interface
         let mut value = 0u32;
-        let result = PciConfigSpace::pci_cfg_read(&mut switch, 0x0, &mut value);
+        let result = PciConfigSpace::pci_cfg_read(&mut switch, 0x0, ByteEnabledDwordRead::with_all_bytes_enabled(&mut value));
         assert!(matches!(result, IoResult::Ok));
 
         // Verify we get the expected vendor/device ID
@@ -1000,7 +997,7 @@ mod tests {
         assert_eq!(value, expected);
 
         // Test write operation
-        let result = PciConfigSpace::pci_cfg_write(&mut switch, 0x4, 0x12345678);
+        let result = PciConfigSpace::pci_cfg_write(&mut switch, 0x4, ByteEnabledDwordWrite::with_all_bytes_enabled(0x12345678));
         assert!(matches!(result, IoResult::Ok));
     }
 
@@ -1043,7 +1040,7 @@ mod tests {
         let subordinate_bus = 10u8;
         // Set secondary bus number (offset 0x18) - bits 8-15 of the 32-bit value at 0x18
         let bus_config = (subordinate_bus as u32) << 16 | ((secondary_bus as u32) << 8);
-        let result = switch.pci_cfg_write_with_routing(0, 0, 0, 0x18, bus_config);
+        let result = switch.pci_cfg_write_with_routing(0, 0, 0, 0x18, ByteEnabledDwordWrite::with_all_bytes_enabled(bus_config));
         assert!(matches!(result, IoResult::Ok));
 
         let bus_range = switch.upstream_port.cfg_space().assigned_bus_range();
@@ -1052,7 +1049,7 @@ mod tests {
 
         // Test direct access to downstream port 0 using function = 0
         let mut value = 0u32;
-        let result = switch.pci_cfg_read_with_routing(0, switch_internal_bus, 0, 0x0, &mut value);
+        let result = switch.pci_cfg_read_with_routing(0, switch_internal_bus, 0, 0x0, ByteEnabledDwordRead::with_all_bytes_enabled(&mut value));
         assert!(matches!(result, IoResult::Ok));
 
         // Verify we got the downstream switch port's vendor/device ID
@@ -1061,13 +1058,13 @@ mod tests {
 
         // Test direct access to downstream port 2 using function = 2
         let mut value2 = 0u32;
-        let result2 = switch.pci_cfg_read_with_routing(0, switch_internal_bus, 2, 0x0, &mut value2);
+        let result2 = switch.pci_cfg_read_with_routing(0, switch_internal_bus, 2, 0x0, ByteEnabledDwordRead::with_all_bytes_enabled(&mut value2));
         assert!(matches!(result2, IoResult::Ok));
         assert_eq!(value2, expected);
 
         // Test access to non-existent downstream port using function = 5
         let mut value3 = 0u32;
-        let result3 = switch.pci_cfg_read_with_routing(0, switch_internal_bus, 5, 0x0, &mut value3);
+        let result3 = switch.pci_cfg_read_with_routing(0, switch_internal_bus, 5, 0x0, ByteEnabledDwordRead::with_all_bytes_enabled(&mut value3));
         assert!(matches!(result3, IoResult::Ok));
         assert_eq!(value3, !0);
     }
@@ -1088,15 +1085,15 @@ mod tests {
 
         // Test that any access returns 1s when bus range is invalid
         let mut value = 0u32;
-        let result = switch.pci_cfg_read_with_routing(0, 1, 0, 0x0, &mut value);
+        let result = switch.pci_cfg_read_with_routing(0, 1, 0, 0x0, ByteEnabledDwordRead::with_all_bytes_enabled(&mut value));
         assert!(matches!(result, IoResult::Ok));
         assert_eq!(value, !0);
 
-        let result2 = switch.pci_cfg_read_with_routing(0, 1, 0, 0x0, &mut value);
+        let result2 = switch.pci_cfg_read_with_routing(0, 1, 0, 0x0, ByteEnabledDwordRead::with_all_bytes_enabled(&mut value));
         assert!(matches!(result2, IoResult::Ok));
         assert_eq!(value, !0);
 
-        let result3 = switch.pci_cfg_read_with_routing(0, 2, 0, 0x0, &mut value);
+        let result3 = switch.pci_cfg_read_with_routing(0, 2, 0, 0x0, ByteEnabledDwordRead::with_all_bytes_enabled(&mut value));
         assert!(matches!(result3, IoResult::Ok));
         assert_eq!(value, !0);
     }
@@ -1128,18 +1125,18 @@ mod tests {
         let mut value = 0u32;
 
         // Access to bus 2 should return 1s since no downstream port has a valid bus range
-        let result = switch.pci_cfg_read_with_routing(0, 2, 0, 0x0, &mut value);
+        let result = switch.pci_cfg_read_with_routing(0, 2, 0, 0x0, ByteEnabledDwordRead::with_all_bytes_enabled(&mut value));
         assert!(matches!(result, IoResult::Ok));
         assert_eq!(value, !0);
 
         // Access to bus 5 should also return 1s
-        let result2 = switch.pci_cfg_read_with_routing(0, 5, 0, 0x0, &mut value);
+        let result2 = switch.pci_cfg_read_with_routing(0, 5, 0, 0x0, ByteEnabledDwordRead::with_all_bytes_enabled(&mut value));
         assert!(matches!(result2, IoResult::Ok));
         assert_eq!(value, !0);
 
         // Access to the secondary bus (switch internal) should still work for downstream port config
         let result3 =
-            switch.pci_cfg_read_with_routing(secondary_bus, secondary_bus, 0, 0x0, &mut value);
+            switch.pci_cfg_read_with_routing(secondary_bus, secondary_bus, 0, 0x0, ByteEnabledDwordRead::with_all_bytes_enabled(&mut value));
         assert!(matches!(result3, IoResult::Ok));
         assert!(value != !0);
     }
@@ -1501,11 +1498,11 @@ mod tests {
     struct SwitchAdapter(GenericPcieSwitch);
 
     impl GenericPciBusDevice for SwitchAdapter {
-        fn pci_cfg_read(&mut self, offset: u16, value: &mut u32) -> Option<IoResult> {
+        fn pci_cfg_read(&mut self, offset: u16, value: ByteEnabledDwordRead<'_>) -> Option<IoResult> {
             Some(PciConfigSpace::pci_cfg_read(&mut self.0, offset, value))
         }
 
-        fn pci_cfg_write(&mut self, offset: u16, value: u32) -> Option<IoResult> {
+        fn pci_cfg_write(&mut self, offset: u16, value: ByteEnabledDwordWrite) -> Option<IoResult> {
             Some(PciConfigSpace::pci_cfg_write(&mut self.0, offset, value))
         }
 
@@ -1515,7 +1512,7 @@ mod tests {
             target_bus: u8,
             function: u8,
             offset: u16,
-            value: &mut u32,
+            value: ByteEnabledDwordRead<'_>,
         ) -> Option<IoResult> {
             Some(self.0.pci_cfg_read_with_routing(
                 secondary_bus,
@@ -1532,7 +1529,7 @@ mod tests {
             target_bus: u8,
             function: u8,
             offset: u16,
-            value: u32,
+            value: ByteEnabledDwordWrite,
         ) -> Option<IoResult> {
             Some(self.0.pci_cfg_write_with_routing(
                 secondary_bus,
@@ -1594,7 +1591,7 @@ mod tests {
         // vendor/device ID.
         let mut value = 0u32;
         let addr = PciConfigAddress::new(1, 0, 0x0).unwrap();
-        let result = port.forward_cfg_read_with_routing(addr, &mut value);
+        let result = port.forward_cfg_read_with_routing(addr, ByteEnabledDwordRead::with_all_bytes_enabled(&mut value));
         assert!(matches!(result, IoResult::Ok));
 
         let expected = (UPSTREAM_SWITCH_PORT_DEVICE_ID as u32) << 16 | (VENDOR_ID as u32);
@@ -1607,7 +1604,7 @@ mod tests {
         // upstream port is single-function).
         let mut value2 = 0u32;
         let addr2 = PciConfigAddress::new(1, 1, 0x0).unwrap();
-        let result2 = port.forward_cfg_read_with_routing(addr2, &mut value2);
+        let result2 = port.forward_cfg_read_with_routing(addr2, ByteEnabledDwordRead::with_all_bytes_enabled(&mut value2));
         assert!(matches!(result2, IoResult::Ok));
         assert_eq!(
             value2, !0,

--- a/vm/devices/pci/pcie/src/switch.rs
+++ b/vm/devices/pci/pcie/src/switch.rs
@@ -298,12 +298,7 @@ impl GenericPcieSwitch {
             .downstream_ports
             .iter_mut()
             .find(|(devfn, _, _)| *devfn == addr.device_function)?;
-        Some(
-            downstream_port
-                .port
-                .cfg_space
-                .read(addr, value),
-        )
+        Some(downstream_port.port.cfg_space.read(addr, value))
     }
 
     /// Handle direct configuration space write to downstream switch ports.
@@ -316,12 +311,7 @@ impl GenericPcieSwitch {
             .downstream_ports
             .iter_mut()
             .find(|(devfn, _, _)| *devfn == addr.device_function)?;
-        Some(
-            downstream_port
-                .port
-                .cfg_space
-                .write(addr, value),
-        )
+        Some(downstream_port.port.cfg_space.write(addr, value))
     }
 
     /// Attach the provided `GenericPciBusDevice` to the port identified.
@@ -379,13 +369,17 @@ impl PciConfigSpace for GenericPcieSwitch {
     /// Reads the switch's own upstream-port config space (Type 0 view).
     fn pci_cfg_read(&mut self, offset: u16, value: ByteEnabledDwordRead<'_>) -> IoResult {
         // Forward to the upstream port's configuration space (the switch presents as the upstream port)
-        self.upstream_port.cfg_space.read_byte_enabled(offset, value)
+        self.upstream_port
+            .cfg_space
+            .read_byte_enabled(offset, value)
     }
 
     /// Writes the switch's own upstream-port config space (Type 0 view).
     fn pci_cfg_write(&mut self, offset: u16, value: ByteEnabledDwordWrite) -> IoResult {
         // Forward to the upstream port's configuration space (the switch presents as the upstream port)
-        self.upstream_port.cfg_space.write_byte_enabled(offset, value)
+        self.upstream_port
+            .cfg_space
+            .write_byte_enabled(offset, value)
     }
 
     fn pci_cfg_read_with_routing(
@@ -408,7 +402,10 @@ impl PciConfigSpace for GenericPcieSwitch {
         // We only implement function 0.
         if target_bus == secondary_bus {
             if function == 0 {
-                return self.upstream_port.cfg_space.read_byte_enabled(offset, value);
+                return self
+                    .upstream_port
+                    .cfg_space
+                    .read_byte_enabled(offset, value);
             } else {
                 value.set(!0);
                 return IoResult::Ok;
@@ -466,7 +463,10 @@ impl PciConfigSpace for GenericPcieSwitch {
         // We only implement function 0.
         if target_bus == secondary_bus {
             if function == 0 {
-                return self.upstream_port.cfg_space.write_byte_enabled(offset, value);
+                return self
+                    .upstream_port
+                    .cfg_space
+                    .write_byte_enabled(offset, value);
             } else {
                 return IoResult::Ok;
             }
@@ -989,7 +989,11 @@ mod tests {
 
         // Test PciConfigSpace interface
         let mut value = 0u32;
-        let result = PciConfigSpace::pci_cfg_read(&mut switch, 0x0, ByteEnabledDwordRead::with_all_bytes_enabled(&mut value));
+        let result = PciConfigSpace::pci_cfg_read(
+            &mut switch,
+            0x0,
+            ByteEnabledDwordRead::with_all_bytes_enabled(&mut value),
+        );
         assert!(matches!(result, IoResult::Ok));
 
         // Verify we get the expected vendor/device ID
@@ -997,7 +1001,11 @@ mod tests {
         assert_eq!(value, expected);
 
         // Test write operation
-        let result = PciConfigSpace::pci_cfg_write(&mut switch, 0x4, ByteEnabledDwordWrite::with_all_bytes_enabled(0x12345678));
+        let result = PciConfigSpace::pci_cfg_write(
+            &mut switch,
+            0x4,
+            ByteEnabledDwordWrite::with_all_bytes_enabled(0x12345678),
+        );
         assert!(matches!(result, IoResult::Ok));
     }
 
@@ -1040,7 +1048,13 @@ mod tests {
         let subordinate_bus = 10u8;
         // Set secondary bus number (offset 0x18) - bits 8-15 of the 32-bit value at 0x18
         let bus_config = (subordinate_bus as u32) << 16 | ((secondary_bus as u32) << 8);
-        let result = switch.pci_cfg_write_with_routing(0, 0, 0, 0x18, ByteEnabledDwordWrite::with_all_bytes_enabled(bus_config));
+        let result = switch.pci_cfg_write_with_routing(
+            0,
+            0,
+            0,
+            0x18,
+            ByteEnabledDwordWrite::with_all_bytes_enabled(bus_config),
+        );
         assert!(matches!(result, IoResult::Ok));
 
         let bus_range = switch.upstream_port.cfg_space().assigned_bus_range();
@@ -1049,7 +1063,13 @@ mod tests {
 
         // Test direct access to downstream port 0 using function = 0
         let mut value = 0u32;
-        let result = switch.pci_cfg_read_with_routing(0, switch_internal_bus, 0, 0x0, ByteEnabledDwordRead::with_all_bytes_enabled(&mut value));
+        let result = switch.pci_cfg_read_with_routing(
+            0,
+            switch_internal_bus,
+            0,
+            0x0,
+            ByteEnabledDwordRead::with_all_bytes_enabled(&mut value),
+        );
         assert!(matches!(result, IoResult::Ok));
 
         // Verify we got the downstream switch port's vendor/device ID
@@ -1058,13 +1078,25 @@ mod tests {
 
         // Test direct access to downstream port 2 using function = 2
         let mut value2 = 0u32;
-        let result2 = switch.pci_cfg_read_with_routing(0, switch_internal_bus, 2, 0x0, ByteEnabledDwordRead::with_all_bytes_enabled(&mut value2));
+        let result2 = switch.pci_cfg_read_with_routing(
+            0,
+            switch_internal_bus,
+            2,
+            0x0,
+            ByteEnabledDwordRead::with_all_bytes_enabled(&mut value2),
+        );
         assert!(matches!(result2, IoResult::Ok));
         assert_eq!(value2, expected);
 
         // Test access to non-existent downstream port using function = 5
         let mut value3 = 0u32;
-        let result3 = switch.pci_cfg_read_with_routing(0, switch_internal_bus, 5, 0x0, ByteEnabledDwordRead::with_all_bytes_enabled(&mut value3));
+        let result3 = switch.pci_cfg_read_with_routing(
+            0,
+            switch_internal_bus,
+            5,
+            0x0,
+            ByteEnabledDwordRead::with_all_bytes_enabled(&mut value3),
+        );
         assert!(matches!(result3, IoResult::Ok));
         assert_eq!(value3, !0);
     }
@@ -1085,15 +1117,33 @@ mod tests {
 
         // Test that any access returns 1s when bus range is invalid
         let mut value = 0u32;
-        let result = switch.pci_cfg_read_with_routing(0, 1, 0, 0x0, ByteEnabledDwordRead::with_all_bytes_enabled(&mut value));
+        let result = switch.pci_cfg_read_with_routing(
+            0,
+            1,
+            0,
+            0x0,
+            ByteEnabledDwordRead::with_all_bytes_enabled(&mut value),
+        );
         assert!(matches!(result, IoResult::Ok));
         assert_eq!(value, !0);
 
-        let result2 = switch.pci_cfg_read_with_routing(0, 1, 0, 0x0, ByteEnabledDwordRead::with_all_bytes_enabled(&mut value));
+        let result2 = switch.pci_cfg_read_with_routing(
+            0,
+            1,
+            0,
+            0x0,
+            ByteEnabledDwordRead::with_all_bytes_enabled(&mut value),
+        );
         assert!(matches!(result2, IoResult::Ok));
         assert_eq!(value, !0);
 
-        let result3 = switch.pci_cfg_read_with_routing(0, 2, 0, 0x0, ByteEnabledDwordRead::with_all_bytes_enabled(&mut value));
+        let result3 = switch.pci_cfg_read_with_routing(
+            0,
+            2,
+            0,
+            0x0,
+            ByteEnabledDwordRead::with_all_bytes_enabled(&mut value),
+        );
         assert!(matches!(result3, IoResult::Ok));
         assert_eq!(value, !0);
     }
@@ -1125,18 +1175,35 @@ mod tests {
         let mut value = 0u32;
 
         // Access to bus 2 should return 1s since no downstream port has a valid bus range
-        let result = switch.pci_cfg_read_with_routing(0, 2, 0, 0x0, ByteEnabledDwordRead::with_all_bytes_enabled(&mut value));
+        let result = switch.pci_cfg_read_with_routing(
+            0,
+            2,
+            0,
+            0x0,
+            ByteEnabledDwordRead::with_all_bytes_enabled(&mut value),
+        );
         assert!(matches!(result, IoResult::Ok));
         assert_eq!(value, !0);
 
         // Access to bus 5 should also return 1s
-        let result2 = switch.pci_cfg_read_with_routing(0, 5, 0, 0x0, ByteEnabledDwordRead::with_all_bytes_enabled(&mut value));
+        let result2 = switch.pci_cfg_read_with_routing(
+            0,
+            5,
+            0,
+            0x0,
+            ByteEnabledDwordRead::with_all_bytes_enabled(&mut value),
+        );
         assert!(matches!(result2, IoResult::Ok));
         assert_eq!(value, !0);
 
         // Access to the secondary bus (switch internal) should still work for downstream port config
-        let result3 =
-            switch.pci_cfg_read_with_routing(secondary_bus, secondary_bus, 0, 0x0, ByteEnabledDwordRead::with_all_bytes_enabled(&mut value));
+        let result3 = switch.pci_cfg_read_with_routing(
+            secondary_bus,
+            secondary_bus,
+            0,
+            0x0,
+            ByteEnabledDwordRead::with_all_bytes_enabled(&mut value),
+        );
         assert!(matches!(result3, IoResult::Ok));
         assert!(value != !0);
     }
@@ -1498,7 +1565,11 @@ mod tests {
     struct SwitchAdapter(GenericPcieSwitch);
 
     impl GenericPciBusDevice for SwitchAdapter {
-        fn pci_cfg_read(&mut self, offset: u16, value: ByteEnabledDwordRead<'_>) -> Option<IoResult> {
+        fn pci_cfg_read(
+            &mut self,
+            offset: u16,
+            value: ByteEnabledDwordRead<'_>,
+        ) -> Option<IoResult> {
             Some(PciConfigSpace::pci_cfg_read(&mut self.0, offset, value))
         }
 
@@ -1591,7 +1662,10 @@ mod tests {
         // vendor/device ID.
         let mut value = 0u32;
         let addr = PciConfigAddress::new(1, 0, 0x0).unwrap();
-        let result = port.forward_cfg_read_with_routing(addr, ByteEnabledDwordRead::with_all_bytes_enabled(&mut value));
+        let result = port.forward_cfg_read_with_routing(
+            addr,
+            ByteEnabledDwordRead::with_all_bytes_enabled(&mut value),
+        );
         assert!(matches!(result, IoResult::Ok));
 
         let expected = (UPSTREAM_SWITCH_PORT_DEVICE_ID as u32) << 16 | (VENDOR_ID as u32);
@@ -1604,7 +1678,10 @@ mod tests {
         // upstream port is single-function).
         let mut value2 = 0u32;
         let addr2 = PciConfigAddress::new(1, 1, 0x0).unwrap();
-        let result2 = port.forward_cfg_read_with_routing(addr2, ByteEnabledDwordRead::with_all_bytes_enabled(&mut value2));
+        let result2 = port.forward_cfg_read_with_routing(
+            addr2,
+            ByteEnabledDwordRead::with_all_bytes_enabled(&mut value2),
+        );
         assert!(matches!(result2, IoResult::Ok));
         assert_eq!(
             value2, !0,

--- a/vm/devices/pci/pcie/src/test_helpers.rs
+++ b/vm/devices/pci/pcie/src/test_helpers.rs
@@ -4,6 +4,8 @@
 use chipset_device::io::IoResult;
 use chipset_device::mmio::ControlMmioIntercept;
 use chipset_device::mmio::RegisterMmioIntercept;
+use chipset_device::pci::ByteEnabledDwordRead;
+use chipset_device::pci::ByteEnabledDwordWrite;
 use pci_bus::GenericPciBusDevice;
 use std::fmt::Debug;
 
@@ -63,8 +65,8 @@ impl ControlMmioIntercept for TestPcieControlMmioIntercept {
 
 pub struct TestPcieEndpoint<R, W>
 where
-    R: Fn(u16, &mut u32) -> Option<IoResult> + 'static + Send,
-    W: FnMut(u16, u32) -> Option<IoResult> + 'static + Send,
+    R: Fn(u16, ByteEnabledDwordRead<'_>) -> Option<IoResult> + 'static + Send,
+    W: FnMut(u16, ByteEnabledDwordWrite) -> Option<IoResult> + 'static + Send,
 {
     cfg_read_closure: R,
     cfg_write_closure: W,
@@ -72,8 +74,8 @@ where
 
 impl<R, W> TestPcieEndpoint<R, W>
 where
-    R: Fn(u16, &mut u32) -> Option<IoResult> + 'static + Send,
-    W: FnMut(u16, u32) -> Option<IoResult> + 'static + Send,
+    R: Fn(u16, ByteEnabledDwordRead<'_>) -> Option<IoResult> + 'static + Send,
+    W: FnMut(u16, ByteEnabledDwordWrite) -> Option<IoResult> + 'static + Send,
 {
     pub fn new(cfg_read_closure: R, cfg_write_closure: W) -> Self {
         Self {
@@ -85,22 +87,22 @@ where
 
 impl<R, W> GenericPciBusDevice for TestPcieEndpoint<R, W>
 where
-    R: Fn(u16, &mut u32) -> Option<IoResult> + 'static + Send,
-    W: FnMut(u16, u32) -> Option<IoResult> + 'static + Send,
+    R: Fn(u16, ByteEnabledDwordRead<'_>) -> Option<IoResult> + 'static + Send,
+    W: FnMut(u16, ByteEnabledDwordWrite) -> Option<IoResult> + 'static + Send,
 {
-    fn pci_cfg_read(&mut self, offset: u16, value: &mut u32) -> Option<IoResult> {
+    fn pci_cfg_read(&mut self, offset: u16, value: ByteEnabledDwordRead<'_>) -> Option<IoResult> {
         (self.cfg_read_closure)(offset, value)
     }
 
-    fn pci_cfg_write(&mut self, offset: u16, value: u32) -> Option<IoResult> {
+    fn pci_cfg_write(&mut self, offset: u16, value: ByteEnabledDwordWrite) -> Option<IoResult> {
         (self.cfg_write_closure)(offset, value)
     }
 }
 
 impl<R, W> Debug for TestPcieEndpoint<R, W>
 where
-    R: Fn(u16, &mut u32) -> Option<IoResult> + 'static + Send,
-    W: FnMut(u16, u32) -> Option<IoResult> + 'static + Send,
+    R: Fn(u16, ByteEnabledDwordRead<'_>) -> Option<IoResult> + 'static + Send,
+    W: FnMut(u16, ByteEnabledDwordWrite) -> Option<IoResult> + 'static + Send,
 {
     fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         writeln!(fmt, "TestPcieEndpoint")

--- a/vm/devices/pci/vfio_assigned_device/src/lib.rs
+++ b/vm/devices/pci/vfio_assigned_device/src/lib.rs
@@ -225,36 +225,46 @@ struct VfioPciDevice {
 }
 
 impl ConfigSpaceRead for VfioPciDevice {
-    fn read_config_u32(&self, offset: u16) -> anyhow::Result<u32> {
-        if (offset as u64) + 4 > self.config_size {
-            anyhow::bail!("config read offset {offset:#x} out of range");
+    fn read_config(&self, offset: u16, value: ByteEnabledDwordRead<'_>) -> anyhow::Result<()> {
+        let (byte_offset, len) = value.byte_enable().to_byte_offset_len();
+        let cfg_offset = (offset as u64) + (byte_offset as u64);
+        if cfg_offset + (len as u64) > self.config_size {
+            anyhow::bail!(
+                "config read offset {offset:#x} (byte offset {byte_offset:#x}, length {len:#x}) out of range"
+            );
         }
-        let mut buf = [0u8; 4];
         let n = self
             .device
             .as_ref()
-            .read_at(&mut buf, self.config_offset + offset as u64)
+            .read_at(
+                value.into_valid_byte_slice(),
+                self.config_offset + cfg_offset,
+            )
             .with_context(|| format!("failed to read config at offset {offset:#x}"))?;
         anyhow::ensure!(
-            n == 4,
-            "short config read at offset {offset:#x}: got {n} bytes"
+            n == len,
+            "short config read at offset {offset:#x}: got {n} bytes expected {len}"
         );
-        Ok(u32::from_ne_bytes(buf))
+        Ok(())
     }
 }
 
 impl VfioPciDevice {
-    fn write_config_u32(&self, offset: u16, value: u32) -> anyhow::Result<()> {
-        if (offset as u64) + 4 > self.config_size {
-            anyhow::bail!("config write offset {offset:#x} out of range");
+    fn write_config(&self, offset: u16, value: ByteEnabledDwordWrite) -> anyhow::Result<()> {
+        let (byte_offset, len) = value.byte_enable().to_byte_offset_len();
+        let cfg_offset = (offset as u64) + (byte_offset as u64);
+        if cfg_offset + (len as u64) > self.config_size {
+            anyhow::bail!(
+                "config write offset {offset:#x} (byte offset {byte_offset:#x}, length {len:#x}) out of range"
+            );
         }
         let n = self
             .device
             .as_ref()
-            .write_at(&value.to_ne_bytes(), self.config_offset + offset as u64)?;
+            .write_at(value.as_valid_byte_slice(), self.config_offset + cfg_offset)?;
         anyhow::ensure!(
-            n == 4,
-            "short config write at offset {offset:#x}: wrote {n} bytes"
+            n == len,
+            "short config write at offset {offset:#x}: wrote {n} bytes expected {len}"
         );
         Ok(())
     }
@@ -366,9 +376,14 @@ impl VfioAssignedPciDevice {
                 continue;
             }
 
-            let flags = vfio_device.read_config_u32(HeaderType00::BAR0.0 + (i as u16) * 4)? & 0xf;
-            bar_flags[i] = flags;
-            let encoded = cfg_space::BarEncodingBits::from(flags);
+            let mut flags = 0;
+            vfio_device.read_config(
+                HeaderType00::BAR0.0 + (i as u16) * 4,
+                ByteEnabledDwordRead::with_all_bytes_enabled(&mut flags),
+            )?;
+            flags &= 0xf;
+            bar_flags[i] &= flags;
+            let encoded = cfg_space::BarEncodingBits::from(bar_flags[i]);
             if encoded.use_pio() {
                 anyhow::bail!("PIO BARs are not supported");
             }
@@ -502,27 +517,18 @@ impl VfioAssignedPciDevice {
         })
     }
 
-    fn read_phys_config(&self, offset: u16) -> u32 {
-        match self.vfio_device.read_config_u32(offset) {
-            Ok(value) => value,
-            Err(e) => {
-                tracelimit::warn_ratelimited!(
-                    offset,
-                    error = e.as_ref() as &dyn std::error::Error,
-                    "VFIO config space read failed"
-                );
-                !0
-            }
+    fn read_phys_config(&self, offset: u16, value: ByteEnabledDwordRead<'_>) {
+        if let Err(e) = self.vfio_device.read_config(offset, value) {
+            tracelimit::warn_ratelimited!(
+                offset,
+                error = e.as_ref() as &dyn std::error::Error,
+                "VFIO config space read failed"
+            );
         }
     }
 
     fn write_phys_config(&self, offset: u16, value: ByteEnabledDwordWrite) {
-        let value = if value.is_full() {
-            value.extract()
-        } else {
-            value.merge(self.read_phys_config(offset))
-        };
-        if let Err(e) = self.vfio_device.write_config_u32(offset, value) {
+        if let Err(e) = self.vfio_device.write_config(offset, value) {
             tracelimit::warn_ratelimited!(
                 offset,
                 error = e.as_ref() as &dyn std::error::Error,
@@ -820,8 +826,8 @@ fn read_physical_bar_addresses(pci_id: &str) -> anyhow::Result<[u64; 6]> {
 /// Abstraction over PCI config space reads, allowing the capability
 /// discovery logic to be tested without a real VFIO device.
 trait ConfigSpaceRead {
-    /// Read a DWORD from PCI config space at the given DWORD-aligned offset.
-    fn read_config_u32(&self, offset: u16) -> anyhow::Result<u32>;
+    /// Read a partial DWORD from PCI config space at the given DWORD-aligned offset.
+    fn read_config(&self, offset: u16, value: ByteEnabledDwordRead<'_>) -> anyhow::Result<()>;
 }
 
 /// Results from walking both the standard and extended PCI capability chains.
@@ -867,10 +873,16 @@ fn discover_capabilities(
 
     // --- Standard capability chain (offsets < 0x100) ---
 
-    let cap_ptr_dword = match config.read_config_u32(HeaderType00::RESERVED_CAP_PTR.0) {
-        Ok(v) => v,
-        Err(_) => return result,
-    };
+    let mut cap_ptr_dword = 0;
+    if config
+        .read_config(
+            HeaderType00::RESERVED_CAP_PTR.0,
+            ByteEnabledDwordRead::with_all_bytes_enabled(&mut cap_ptr_dword),
+        )
+        .is_err()
+    {
+        return result;
+    }
     let mut cap_ptr = (cap_ptr_dword & 0xFC) as u16; // mask off reserved bits [1:0]
     let mut iterations = 0usize;
 
@@ -883,10 +895,16 @@ fn discover_capabilities(
         }
         iterations += 1;
 
-        let header = match config.read_config_u32(cap_ptr) {
-            Ok(v) => v,
-            Err(_) => break,
-        };
+        let mut header = 0;
+        if config
+            .read_config(
+                cap_ptr,
+                ByteEnabledDwordRead::with_all_bytes_enabled(&mut header),
+            )
+            .is_err()
+        {
+            break;
+        }
         let cap_id = (header & 0xFF) as u8;
         let next_ptr = ((header >> 8) & 0xFC) as u16;
 
@@ -896,18 +914,30 @@ fn discover_capabilities(
             let table_count = (msg_ctrl & 0x7FF) + 1;
 
             // Table Offset/BIR (second DWORD of the capability).
-            let table_dword = match config.read_config_u32(cap_ptr + 4) {
-                Ok(v) => v,
-                Err(_) => break,
-            };
+            let mut table_dword = 0;
+            if config
+                .read_config(
+                    cap_ptr + 4,
+                    ByteEnabledDwordRead::with_all_bytes_enabled(&mut table_dword),
+                )
+                .is_err()
+            {
+                break;
+            }
             let table_bir = (table_dword & 0x7) as u8;
             let table_offset = table_dword & !0x7;
 
             // PBA Offset/BIR (third DWORD of the capability).
-            let pba_dword = match config.read_config_u32(cap_ptr + 8) {
-                Ok(v) => v,
-                Err(_) => break,
-            };
+            let mut pba_dword = 0;
+            if config
+                .read_config(
+                    cap_ptr + 8,
+                    ByteEnabledDwordRead::with_all_bytes_enabled(&mut pba_dword),
+                )
+                .is_err()
+            {
+                break;
+            }
             let pba_bir = (pba_dword & 0x7) as u8;
             let pba_offset = pba_dword & !0x7;
 
@@ -955,7 +985,14 @@ fn discover_capabilities(
     // --- Extended capability chain (offsets 0x100+) ---
 
     // Check if extended caps are reachable by probing the first offset.
-    if config.read_config_u32(caps::EXT_CAP_START).is_ok() {
+    let mut ext_cap_header = 0;
+    if config
+        .read_config(
+            caps::EXT_CAP_START,
+            ByteEnabledDwordRead::with_all_bytes_enabled(&mut ext_cap_header),
+        )
+        .is_ok()
+    {
         let mut offset = caps::EXT_CAP_START;
         let mut iterations = 0usize;
 
@@ -969,9 +1006,16 @@ fn discover_capabilities(
             }
             iterations += 1;
 
-            let Ok(header) = config.read_config_u32(offset) else {
+            let mut header = 0;
+            if config
+                .read_config(
+                    offset,
+                    ByteEnabledDwordRead::with_all_bytes_enabled(&mut header),
+                )
+                .is_err()
+            {
                 break;
-            };
+            }
 
             if header == 0 {
                 break;
@@ -1150,7 +1194,7 @@ impl ChipsetDevice for VfioAssignedPciDevice {
 
 impl PciConfigSpace for VfioAssignedPciDevice {
     fn pci_cfg_read(&mut self, offset: u16, mut value: ByteEnabledDwordRead<'_>) -> IoResult {
-        value.set(match HeaderType00(offset) {
+        match HeaderType00(offset) {
             // BAR registers: return locally cached values.
             HeaderType00::BAR0
             | HeaderType00::BAR1
@@ -1159,7 +1203,7 @@ impl PciConfigSpace for VfioAssignedPciDevice {
             | HeaderType00::BAR4
             | HeaderType00::BAR5 => {
                 let i = (offset - HeaderType00::BAR0.0) as usize / 4;
-                self.bars[i]
+                value.set(self.bars[i]);
             }
             // MSI-X capability first DWORD: merge hardware ID/NextPtr (low
             // 16 bits) with emulator's Message Control (high 16 bits). The
@@ -1168,20 +1212,21 @@ impl PciConfigSpace for VfioAssignedPciDevice {
             // capability chain remains intact.
             offset if self.msix.as_ref().is_some_and(|m| offset.0 == m.cap_offset) => {
                 let msix = self.msix.as_ref().unwrap();
-                // Read the full DWORD from hardware.
-                let mut emu = self.read_phys_config(offset.0);
-                // Overwrite the high word with the emulator.
-                msix.capability.read(
-                    0,
-                    ByteEnabledDwordRead::new(&mut emu, PciConfigByteEnable::HIGH_WORD),
-                );
-                emu
+                // The low word (if targeted) comes from hardware.
+                if let Some(v) = value.restrict(PciConfigByteEnable::LOW_WORD) {
+                    self.read_phys_config(offset.0, v);
+                }
+                // The high word (if targeted) comes from the emulator.
+                if let Some(v) = value.restrict(PciConfigByteEnable::HIGH_WORD) {
+                    msix.capability.read(0, v);
+                }
             }
             // Everything else: read from physical device, applying any
             // config space patches.
             _ => {
-                let hw = self.read_phys_config(offset);
+                self.read_phys_config(offset, value.reborrow());
                 if let Some(patch) = self.config_patches.get(&offset) {
+                    let hw = value.extract();
                     let patched = (hw & !patch.mask) | (patch.value & patch.mask);
                     tracing::trace!(
                         offset = format_args!("{offset:#x}"),
@@ -1189,12 +1234,10 @@ impl PciConfigSpace for VfioAssignedPciDevice {
                         patched = format_args!("{patched:#010x}"),
                         "applied config space patch"
                     );
-                    patched
-                } else {
-                    hw
+                    value.set(patched);
                 }
             }
-        });
+        }
 
         IoResult::Ok
     }
@@ -1203,7 +1246,10 @@ impl PciConfigSpace for VfioAssignedPciDevice {
         match HeaderType00(offset) {
             // Command register: track MMIO enable/disable.
             HeaderType00::STATUS_COMMAND => {
-                let mse_mask: u32 = cfg_space::Command::new().with_mmio_enabled(true).into_bits().into();
+                let mse_mask: u32 = cfg_space::Command::new()
+                    .with_mmio_enabled(true)
+                    .into_bits()
+                    .into();
                 if value.valid_mask() & mse_mask != 0 {
                     let command = cfg_space::Command::from_bits(value.extract_low());
                     let new_mmio_enabled = command.mmio_enabled();
@@ -1255,8 +1301,7 @@ impl PciConfigSpace for VfioAssignedPciDevice {
                         // If the write fails, leave BARs unmapped to
                         // avoid SIGBUS from VFIO mmaps that are still
                         // faulting.
-                        let value = value.merge(self.read_phys_config(offset));
-                        if let Err(e) = self.vfio_device.write_config_u32(offset, value) {
+                        if let Err(e) = self.vfio_device.write_config(offset, value) {
                             tracelimit::warn_ratelimited!(
                                 offset,
                                 error = e.as_ref() as &dyn std::error::Error,
@@ -1307,8 +1352,7 @@ impl PciConfigSpace for VfioAssignedPciDevice {
                     match self.msix_enable() {
                         Ok(()) => {
                             let msix = self.msix.as_mut().unwrap();
-                            msix.capability
-                                .write(0, value);
+                            msix.capability.write(0, value);
                             msix.enabled = true;
                         }
                         Err(e) => {
@@ -1322,14 +1366,12 @@ impl PciConfigSpace for VfioAssignedPciDevice {
                 } else if was_enabled && !new_enabled {
                     // Write capability first to disable vectors,
                     // then tear down VFIO mapping.
-                    msix.capability
-                        .write(0, value);
+                    msix.capability.write(0, value);
                     self.msix_disable();
                     self.msix.as_mut().unwrap().enabled = false;
                 } else {
                     // No enable/disable transition — just forward.
-                    msix.capability
-                        .write(0, value);
+                    msix.capability.write(0, value);
                 }
                 // Skip write_phys_config for MSI-X control register.
                 return IoResult::Ok;
@@ -1494,14 +1536,21 @@ mod tests {
     }
 
     impl ConfigSpaceRead for MockConfigSpace {
-        fn read_config_u32(&self, offset: u16) -> anyhow::Result<u32> {
+        fn read_config(
+            &self,
+            offset: u16,
+            mut value: ByteEnabledDwordRead<'_>,
+        ) -> anyhow::Result<()> {
             let off = offset as usize;
-            if off + 4 > self.data.len() {
-                anyhow::bail!("config read offset {offset:#x} out of range");
+            let (byte_offset, len) = value.byte_enable().to_byte_offset_len();
+            let cfg_offset = off + byte_offset as usize;
+            if cfg_offset + len > self.data.len() {
+                anyhow::bail!("config read offset {offset:#x} len {len:#x} out of range");
             }
-            Ok(u32::from_ne_bytes(
-                self.data[off..off + 4].try_into().unwrap(),
-            ))
+            value.set(u32::from_ne_bytes(
+                self.data[cfg_offset..cfg_offset + len].try_into().unwrap(),
+            ));
+            Ok(())
         }
     }
 

--- a/vm/devices/pci/vfio_assigned_device/src/lib.rs
+++ b/vm/devices/pci/vfio_assigned_device/src/lib.rs
@@ -517,13 +517,14 @@ impl VfioAssignedPciDevice {
         })
     }
 
-    fn read_phys_config(&self, offset: u16, value: ByteEnabledDwordRead<'_>) {
-        if let Err(e) = self.vfio_device.read_config(offset, value) {
+    fn read_phys_config(&self, offset: u16, mut value: ByteEnabledDwordRead<'_>) {
+        if let Err(e) = self.vfio_device.read_config(offset, value.reborrow()) {
             tracelimit::warn_ratelimited!(
                 offset,
                 error = e.as_ref() as &dyn std::error::Error,
                 "VFIO config space read failed"
             );
+            value.set(!0);
         }
     }
 
@@ -1548,7 +1549,7 @@ mod tests {
                 anyhow::bail!("config read offset {offset:#x} len {len:#x} out of range");
             }
             value.set(u32::from_ne_bytes(
-                self.data[cfg_offset..cfg_offset + len].try_into().unwrap(),
+                self.data[cfg_offset..cfg_offset + 4].try_into().unwrap(),
             ));
             Ok(())
         }

--- a/vm/devices/pci/vfio_assigned_device/src/lib.rs
+++ b/vm/devices/pci/vfio_assigned_device/src/lib.rs
@@ -382,7 +382,7 @@ impl VfioAssignedPciDevice {
                 ByteEnabledDwordRead::with_all_bytes_enabled(&mut flags),
             )?;
             flags &= 0xf;
-            bar_flags[i] &= flags;
+            bar_flags[i] = flags;
             let encoded = cfg_space::BarEncodingBits::from(bar_flags[i]);
             if encoded.use_pio() {
                 anyhow::bail!("PIO BARs are not supported");

--- a/vm/devices/pci/vfio_assigned_device/src/lib.rs
+++ b/vm/devices/pci/vfio_assigned_device/src/lib.rs
@@ -516,7 +516,12 @@ impl VfioAssignedPciDevice {
         }
     }
 
-    fn write_phys_config(&self, offset: u16, value: u32) {
+    fn write_phys_config(&self, offset: u16, value: ByteEnabledDwordWrite) {
+        let value = if value.is_full() {
+            value.extract()
+        } else {
+            value.merge(self.read_phys_config(offset))
+        };
         if let Err(e) = self.vfio_device.write_config_u32(offset, value) {
             tracelimit::warn_ratelimited!(
                 offset,
@@ -1144,8 +1149,8 @@ impl ChipsetDevice for VfioAssignedPciDevice {
 }
 
 impl PciConfigSpace for VfioAssignedPciDevice {
-    fn pci_cfg_read(&mut self, offset: u16, value: &mut u32) -> IoResult {
-        *value = match HeaderType00(offset) {
+    fn pci_cfg_read(&mut self, offset: u16, mut value: ByteEnabledDwordRead<'_>) -> IoResult {
+        value.set(match HeaderType00(offset) {
             // BAR registers: return locally cached values.
             HeaderType00::BAR0
             | HeaderType00::BAR1
@@ -1189,26 +1194,29 @@ impl PciConfigSpace for VfioAssignedPciDevice {
                     hw
                 }
             }
-        };
+        });
 
         IoResult::Ok
     }
 
-    fn pci_cfg_write(&mut self, offset: u16, value: u32) -> IoResult {
+    fn pci_cfg_write(&mut self, offset: u16, value: ByteEnabledDwordWrite) -> IoResult {
         match HeaderType00(offset) {
             // Command register: track MMIO enable/disable.
             HeaderType00::STATUS_COMMAND => {
-                let command = cfg_space::Command::from_bits(value as u16);
-                let new_mmio_enabled = command.mmio_enabled();
+                let mse_mask: u32 = cfg_space::Command::new().with_mmio_enabled(true).into_bits().into();
+                if value.valid_mask() & mse_mask != 0 {
+                    let command = cfg_space::Command::from_bits(value.extract_low());
+                    let new_mmio_enabled = command.mmio_enabled();
 
-                if new_mmio_enabled != self.mmio_enabled {
-                    self.mmio_enabled = new_mmio_enabled;
-                    self.update_bar_mappings();
-                    tracing::debug!(
-                        pci_id = self.pci_id.as_str(),
-                        enabled = new_mmio_enabled,
-                        "MMIO state changed by guest"
-                    );
+                    if new_mmio_enabled != self.mmio_enabled {
+                        self.mmio_enabled = new_mmio_enabled;
+                        self.update_bar_mappings();
+                        tracing::debug!(
+                            pci_id = self.pci_id.as_str(),
+                            enabled = new_mmio_enabled,
+                            "MMIO state changed by guest"
+                        );
+                    }
                 }
 
                 self.write_phys_config(offset, value);
@@ -1223,6 +1231,7 @@ impl PciConfigSpace for VfioAssignedPciDevice {
             | HeaderType00::BAR4
             | HeaderType00::BAR5 => {
                 let i = (offset - HeaderType00::BAR0.0) as usize / 4;
+                let value = value.merge(self.bars[i]);
                 self.bars[i] = (value & self.bar_masks[i]) | self.bar_flags[i];
 
                 if self.mmio_enabled {
@@ -1237,36 +1246,39 @@ impl PciConfigSpace for VfioAssignedPciDevice {
                 //
                 // When returning to D0, write PMCSR first so the faults are
                 // resolvable before remapping MMIO into guest space.
-                let power_state = value & 0x3; // bits [1:0] = PowerState
-                let new_in_d0 = power_state == 0;
-                let old_in_d0 = self.in_d0;
-                if new_in_d0 {
-                    // Entering D0: forward first, then remap BARs.
-                    // If the write fails, leave BARs unmapped to
-                    // avoid SIGBUS from VFIO mmaps that are still
-                    // faulting.
-                    if let Err(e) = self.vfio_device.write_config_u32(offset, value) {
-                        tracelimit::warn_ratelimited!(
-                            offset,
-                            error = e.as_ref() as &dyn std::error::Error,
-                            "VFIO config space write failed"
-                        );
-                        return IoResult::Ok;
+                if value.valid_mask() & 0x3 != 0 {
+                    let power_state = value.extract() & 0x3; // bits [1:0] = PowerState
+                    let new_in_d0 = power_state == 0;
+                    let old_in_d0 = self.in_d0;
+                    if new_in_d0 {
+                        // Entering D0: forward first, then remap BARs.
+                        // If the write fails, leave BARs unmapped to
+                        // avoid SIGBUS from VFIO mmaps that are still
+                        // faulting.
+                        let value = value.merge(self.read_phys_config(offset));
+                        if let Err(e) = self.vfio_device.write_config_u32(offset, value) {
+                            tracelimit::warn_ratelimited!(
+                                offset,
+                                error = e.as_ref() as &dyn std::error::Error,
+                                "VFIO config space write failed"
+                            );
+                            return IoResult::Ok;
+                        }
                     }
-                }
-                self.in_d0 = new_in_d0;
-                self.update_bar_mappings();
-                if !new_in_d0 {
-                    // Leaving D0: unmap BARs first, then forward.
-                    self.write_phys_config(offset, value);
-                }
-                if new_in_d0 && !old_in_d0 {
-                    tracing::debug!(
-                        pci_id = self.pci_id.as_str(),
-                        power_state,
-                        in_d0 = new_in_d0,
-                        "PM power state changed by guest"
-                    );
+                    self.in_d0 = new_in_d0;
+                    self.update_bar_mappings();
+                    if !new_in_d0 {
+                        // Leaving D0: unmap BARs first, then forward.
+                        self.write_phys_config(offset, value);
+                    }
+                    if new_in_d0 && !old_in_d0 {
+                        tracing::debug!(
+                            pci_id = self.pci_id.as_str(),
+                            power_state,
+                            in_d0 = new_in_d0,
+                            "PM power state changed by guest"
+                        );
+                    }
                 }
                 return IoResult::Ok;
             }
@@ -1278,9 +1290,14 @@ impl PciConfigSpace for VfioAssignedPciDevice {
                 // VFIO_DEVICE_SET_IRQS. Writing it again through config space
                 // causes VFIO to tear down and re-setup MSI-X, losing the
                 // eventfd associations.
+                const MSIX_ENABLE_MASK: u32 = 0x8000_0000;
                 let msix = self.msix.as_mut().unwrap();
-                let new_enabled = value & 0x8000_0000 != 0;
                 let was_enabled = msix.enabled;
+                let new_enabled = if value.valid_mask() & MSIX_ENABLE_MASK != 0 {
+                    value.extract() & MSIX_ENABLE_MASK != 0
+                } else {
+                    was_enabled
+                };
 
                 if new_enabled && !was_enabled {
                     // Install irqfd routes BEFORE writing the
@@ -1291,7 +1308,7 @@ impl PciConfigSpace for VfioAssignedPciDevice {
                         Ok(()) => {
                             let msix = self.msix.as_mut().unwrap();
                             msix.capability
-                                .write(0, ByteEnabledDwordWrite::with_all_bytes_enabled(value));
+                                .write(0, value);
                             msix.enabled = true;
                         }
                         Err(e) => {
@@ -1306,13 +1323,13 @@ impl PciConfigSpace for VfioAssignedPciDevice {
                     // Write capability first to disable vectors,
                     // then tear down VFIO mapping.
                     msix.capability
-                        .write(0, ByteEnabledDwordWrite::with_all_bytes_enabled(value));
+                        .write(0, value);
                     self.msix_disable();
                     self.msix.as_mut().unwrap().enabled = false;
                 } else {
                     // No enable/disable transition — just forward.
                     msix.capability
-                        .write(0, ByteEnabledDwordWrite::with_all_bytes_enabled(value));
+                        .write(0, value);
                 }
                 // Skip write_phys_config for MSI-X control register.
                 return IoResult::Ok;

--- a/vm/devices/pci/vpci/src/bus.rs
+++ b/vm/devices/pci/vpci/src/bus.rs
@@ -212,8 +212,7 @@ impl ChipsetDevice for VpciBusDevice {
 
 impl PollDevice for VpciBusDevice {
     fn poll_device(&mut self, cx: &mut Context<'_>) {
-        let mut callback = PciBusCfgAccessCallbackView::new(&mut self.device);
-        self.bus_cfg_handler.poll(cx, &mut callback);
+        self.bus_cfg_handler.poll(cx);
     }
 }
 
@@ -345,7 +344,7 @@ impl<'a> PciBusCfgAccessCallbackView<'a> {
 }
 
 impl<'a> PciBusCfgAccessCallbacks for PciBusCfgAccessCallbackView<'a> {
-    fn read(&mut self, addr: PciConfigAddress, value: &mut u32) -> IoResult {
+    fn read(&mut self, addr: PciConfigAddress, value: ByteEnabledDwordRead<'_>) -> IoResult {
         self.device
             .lock()
             .supports_pci()
@@ -353,7 +352,7 @@ impl<'a> PciBusCfgAccessCallbacks for PciBusCfgAccessCallbackView<'a> {
             .pci_cfg_read(addr.byte_offset(), value)
     }
 
-    fn write(&mut self, addr: PciConfigAddress, value: u32) -> IoResult {
+    fn write(&mut self, addr: PciConfigAddress, value: ByteEnabledDwordWrite) -> IoResult {
         self.device
             .lock()
             .supports_pci()
@@ -520,7 +519,7 @@ mod tests {
     }
 
     impl PciConfigSpace for DeferWriteDevice {
-        fn pci_cfg_read(&mut self, _offset: u16, value: &mut u32) -> IoResult {
+        fn pci_cfg_read(&mut self, _offset: u16, mut value: ByteEnabledDwordRead<'_>) -> IoResult {
             if self.defer_reads {
                 assert!(
                     self.pending_read.is_none(),
@@ -530,13 +529,13 @@ mod tests {
                 self.pending_read = Some(deferred);
                 IoResult::Defer(token)
             } else {
-                *value = self.read_value;
+                value.set(self.read_value);
                 IoResult::Ok
             }
         }
 
-        fn pci_cfg_write(&mut self, offset: u16, value: u32) -> IoResult {
-            self.writes.push((offset, value));
+        fn pci_cfg_write(&mut self, offset: u16, value: ByteEnabledDwordWrite) -> IoResult {
+            self.writes.push((offset, value.extract()));
             if self.defer_writes {
                 assert!(
                     self.pending_write.is_none(),
@@ -656,7 +655,7 @@ mod tests {
     }
 
     #[async_test]
-    async fn verify_deferred_pci_cfg_read_and_read_for_write_via_bus(_driver: DefaultDriver) {
+    async fn verify_deferred_pci_cfg_read_via_bus(_driver: DefaultDriver) {
         const BASE_ADDR: u64 = 0x1000_0000;
         const READ_OFFSET: u64 = 4;
         const WRITE_OFFSET: u64 = 5;
@@ -705,41 +704,7 @@ mod tests {
         device.lock().start_deferring_reads(0x1122_3344);
         let write_addr = BASE_ADDR + protocol::MMIO_PAGE_CONFIG_SPACE + WRITE_OFFSET;
         let write_result = bus.lock().mmio_write(write_addr, &[0xaa]);
-        assert!(matches!(write_result, IoResult::Defer(_)));
-
-        std::future::poll_fn(|cx| {
-            bus.lock().poll_device(cx);
-            device.lock().poll_device(cx);
-            bus.lock().poll_device(cx);
-            Poll::Ready(())
-        })
-        .await;
-
-        if let IoResult::Defer(token) = write_result {
-            token
-                .write_future()
-                .await
-                .expect("deferred PCI config read-for-write should complete successfully");
-        }
-
-        let mut expected = 0x1122_3344u32.to_ne_bytes();
-        expected[1] = 0xaa;
-        assert_eq!(
-            device.lock().writes.pop(),
-            Some((4, u32::from_ne_bytes(expected)))
-        );
-
-        let mut read_data = [0; 2];
-        let read_addr = BASE_ADDR + protocol::MMIO_PAGE_CONFIG_SPACE + 7;
-        let read_result = bus.lock().mmio_read(read_addr, &mut read_data);
-        assert!(
-            matches!(read_result, IoResult::Err(_)),
-            "read crossing a DWORD boundary should be rejected"
-        );
-        assert!(
-            device.lock().pending_read.is_none(),
-            "rejected read should not issue a device read"
-        );
+        assert!(matches!(write_result, IoResult::Ok));
     }
 
     #[async_test]

--- a/vm/devices/pci/vpci/src/device.rs
+++ b/vm/devices/pci/vpci/src/device.rs
@@ -7,6 +7,8 @@ use async_trait::async_trait;
 use chipset_device::ChipsetDevice;
 use chipset_device::io::IoResult;
 use chipset_device::mmio::ControlMmioIntercept;
+use chipset_device::pci::ByteEnabledDwordRead;
+use chipset_device::pci::ByteEnabledDwordWrite;
 use closeable_mutex::CloseableMutex;
 use guestmem::AccessError;
 use guestmem::MemoryRead;
@@ -1014,10 +1016,11 @@ impl VpciChannel {
             let mut device = self.device.lock();
             let mut buf = 0;
             [0, 1, 2, 3, 4, 5].map(|i| {
+                let value = ByteEnabledDwordRead::with_all_bytes_enabled(&mut buf);
                 device
                     .supports_pci()
                     .unwrap()
-                    .pci_cfg_read(cfg_space::HeaderType00::BAR0.0 + 4 * i, &mut buf)
+                    .pci_cfg_read(cfg_space::HeaderType00::BAR0.0 + 4 * i, value)
                     .now_or_never()
                     .map(|_| buf)
                     .unwrap_or(0)
@@ -1074,6 +1077,7 @@ impl VpciChannel {
 
         {
             for (i, bar) in bars.into_iter().enumerate() {
+                let bar = ByteEnabledDwordWrite::with_all_bytes_enabled(bar);
                 let result = self
                     .device
                     .lock()
@@ -1106,10 +1110,11 @@ impl VpciChannel {
             let mut device = self.device.lock();
             let pci = device.supports_pci().unwrap();
             let mut command = {
-                let mut value = 0;
-                pci.pci_cfg_read(cfg_space::HeaderType00::STATUS_COMMAND.0, &mut value)
+                let mut value_u32 = 0;
+                let value = ByteEnabledDwordRead::with_all_bytes_enabled(&mut value_u32);
+                pci.pci_cfg_read(cfg_space::HeaderType00::STATUS_COMMAND.0, value)
                     .now_or_never()
-                    .map(|_| value)
+                    .map(|_| value_u32)
                     .unwrap_or(0)
             };
             let mmio = cfg_space::Command::new()
@@ -1120,6 +1125,7 @@ impl VpciChannel {
             } else {
                 command &= !mmio;
             }
+            let command = ByteEnabledDwordWrite::with_all_bytes_enabled(command);
             pci.pci_cfg_write(cfg_space::HeaderType00::STATUS_COMMAND.0, command)
         };
         match result {
@@ -1450,6 +1456,8 @@ mod tests {
     use chipset_device::mmio::ExternallyManagedMmioIntercepts;
     use chipset_device::mmio::MmioIntercept;
     use chipset_device::mmio::RegisterMmioIntercept;
+    use chipset_device::pci::ByteEnabledDwordRead;
+    use chipset_device::pci::ByteEnabledDwordWrite;
     use chipset_device::pci::PciConfigSpace;
     use closeable_mutex::CloseableMutex;
     use device_emulators::ReadWriteRequestType;
@@ -1879,12 +1887,12 @@ mod tests {
     }
 
     impl PciConfigSpace for NullDevice {
-        fn pci_cfg_read(&mut self, offset: u16, value: &mut u32) -> IoResult {
-            self.config_space.read_u32(offset, value)
+        fn pci_cfg_read(&mut self, offset: u16, value: ByteEnabledDwordRead<'_>) -> IoResult {
+            self.config_space.read_byte_enabled(offset, value)
         }
 
-        fn pci_cfg_write(&mut self, offset: u16, value: u32) -> IoResult {
-            self.config_space.write_u32(offset, value)
+        fn pci_cfg_write(&mut self, offset: u16, value: ByteEnabledDwordWrite) -> IoResult {
+            self.config_space.write_byte_enabled(offset, value)
         }
     }
 
@@ -2001,53 +2009,55 @@ mod tests {
         let base_address = 0x80000000;
         guest_driver.start_device(base_address).await;
         for i in 0..6 {
-            let result = pci.lock().pci_cfg_write(0x10 + 4 * i, 0xffffffff);
+            let result = pci.lock().pci_cfg_write(0x10 + 4 * i, ByteEnabledDwordWrite::with_all_bytes_enabled(0xffffffff));
             complete_write(result).await;
         }
 
         let mut value = 0;
-        pci.lock().pci_cfg_read(0x10, &mut value).unwrap();
+        pci.lock().pci_cfg_read(0x10, ByteEnabledDwordRead::with_all_bytes_enabled(&mut value)).unwrap();
         assert_eq!(value & 0xfffffff0, 0xfffff000);
         assert_eq!(value & 0x4, 0x4); // 64-bit BAR
         assert_eq!(value & 0x8, 0x8); // prefetchable
-        pci.lock().pci_cfg_read(0x14, &mut value).unwrap();
+        pci.lock().pci_cfg_read(0x14, ByteEnabledDwordRead::with_all_bytes_enabled(&mut value)).unwrap();
         assert_eq!(value, 0xffffffff);
-        pci.lock().pci_cfg_read(0x18, &mut value).unwrap();
+        pci.lock().pci_cfg_read(0x18, ByteEnabledDwordRead::with_all_bytes_enabled(&mut value)).unwrap();
         assert_eq!(value, 0);
-        pci.lock().pci_cfg_read(0x1c, &mut value).unwrap();
+        pci.lock().pci_cfg_read(0x1c, ByteEnabledDwordRead::with_all_bytes_enabled(&mut value)).unwrap();
         assert_eq!(value, 0);
-        pci.lock().pci_cfg_read(0x20, &mut value).unwrap();
+        pci.lock().pci_cfg_read(0x20, ByteEnabledDwordRead::with_all_bytes_enabled(&mut value)).unwrap();
         assert_eq!(value, 0);
-        pci.lock().pci_cfg_read(0x24, &mut value).unwrap();
+        pci.lock().pci_cfg_read(0x24, ByteEnabledDwordRead::with_all_bytes_enabled(&mut value)).unwrap();
         assert_eq!(value, 0);
 
-        complete_write(pci.lock().pci_cfg_write(0x14, 0x20)).await;
-        complete_write(pci.lock().pci_cfg_write(0x10, 0x0)).await;
-        pci.lock().pci_cfg_read(0x10, &mut value).unwrap();
+        complete_write(pci.lock().pci_cfg_write(0x14, ByteEnabledDwordWrite::with_all_bytes_enabled(0x20))).await;
+        complete_write(pci.lock().pci_cfg_write(0x10, ByteEnabledDwordWrite::with_all_bytes_enabled(0x0))).await;
+        pci.lock().pci_cfg_read(0x10, ByteEnabledDwordRead::with_all_bytes_enabled(&mut value)).unwrap();
         assert_eq!(value & 0xfffffff0, 0);
         assert_eq!(value & 0x4, 0x4); // 64-bit BAR
         assert_eq!(value & 0x8, 0x8); // prefetchable
-        pci.lock().pci_cfg_read(0x14, &mut value).unwrap();
+        pci.lock().pci_cfg_read(0x14, ByteEnabledDwordRead::with_all_bytes_enabled(&mut value)).unwrap();
         assert_eq!(value, 0x20);
 
         complete_write(
             pci.lock().pci_cfg_write(
                 0x4,
-                pci_core::spec::cfg_space::Command::new()
-                    .with_mmio_enabled(true)
-                    .into_bits() as u32,
+                ByteEnabledDwordWrite::with_all_bytes_enabled(
+                    pci_core::spec::cfg_space::Command::new()
+                        .with_mmio_enabled(true)
+                        .into_bits() as u32,
+                ),
             ),
         )
         .await;
 
         // Writes to BAR address are not allowed once MMIO is enabled.
-        complete_write(pci.lock().pci_cfg_write(0x14, 0xffffffff)).await;
-        complete_write(pci.lock().pci_cfg_write(0x10, 0xffffffff)).await;
-        pci.lock().pci_cfg_read(0x10, &mut value).unwrap();
+        complete_write(pci.lock().pci_cfg_write(0x14, ByteEnabledDwordWrite::with_all_bytes_enabled(0xffffffff))).await;
+        complete_write(pci.lock().pci_cfg_write(0x10, ByteEnabledDwordWrite::with_all_bytes_enabled(0xffffffff))).await;
+        pci.lock().pci_cfg_read(0x10, ByteEnabledDwordRead::with_all_bytes_enabled(&mut value)).unwrap();
         assert_eq!(value & 0xfffffff0, 0);
         assert_eq!(value & 0x4, 0x4); // 64-bit BAR
         assert_eq!(value & 0x8, 0x8); // prefetchable
-        pci.lock().pci_cfg_read(0x14, &mut value).unwrap();
+        pci.lock().pci_cfg_read(0x14, ByteEnabledDwordRead::with_all_bytes_enabled(&mut value)).unwrap();
         assert_eq!(value, 0x20);
     }
 
@@ -2163,11 +2173,11 @@ mod tests {
     }
 
     impl PciConfigSpace for TestDevice {
-        fn pci_cfg_read(&mut self, offset: u16, value: &mut u32) -> IoResult {
-            self.config_space.read_u32(offset, value)
+        fn pci_cfg_read(&mut self, offset: u16, value: ByteEnabledDwordRead<'_>) -> IoResult {
+            self.config_space.read_byte_enabled(offset, value)
         }
-        fn pci_cfg_write(&mut self, offset: u16, value: u32) -> IoResult {
-            self.config_space.write_u32(offset, value)
+        fn pci_cfg_write(&mut self, offset: u16, value: ByteEnabledDwordWrite) -> IoResult {
+            self.config_space.write_byte_enabled(offset, value)
         }
     }
 
@@ -2201,33 +2211,34 @@ mod tests {
         let bar_address1 = 0x2000000000;
         complete_write(
             pci.lock()
-                .pci_cfg_write(0x14, u32::try_from(bar_address1 >> 32).unwrap()),
+                .pci_cfg_write(0x14, ByteEnabledDwordWrite::with_all_bytes_enabled(u32::try_from(bar_address1 >> 32).unwrap())),
         )
         .await;
         complete_write(
             pci.lock()
-                .pci_cfg_write(0x10, u32::try_from(bar_address1 & 0xffffffff).unwrap()),
+                .pci_cfg_write(0x10, ByteEnabledDwordWrite::with_all_bytes_enabled(u32::try_from(bar_address1 & 0xffffffff).unwrap())),
         )
         .await;
 
         let bar_address2: u64 = 0x4000;
         complete_write(
             pci.lock()
-                .pci_cfg_write(0x1c, u32::try_from(bar_address2 >> 32).unwrap()),
+                .pci_cfg_write(0x1c, ByteEnabledDwordWrite::with_all_bytes_enabled(u32::try_from(bar_address2 >> 32).unwrap())),
         )
         .await;
         complete_write(
             pci.lock()
-                .pci_cfg_write(0x18, u32::try_from(bar_address2 & 0xffffffff).unwrap()),
+                .pci_cfg_write(0x18, ByteEnabledDwordWrite::with_all_bytes_enabled(u32::try_from(bar_address2 & 0xffffffff).unwrap())),
         )
         .await;
 
         complete_write(
             pci.lock().pci_cfg_write(
                 0x4,
+                ByteEnabledDwordWrite::with_all_bytes_enabled(
                 pci_core::spec::cfg_space::Command::new()
                     .with_mmio_enabled(true)
-                    .into_bits() as u32,
+                    .into_bits() as u32),
             ),
         )
         .await;

--- a/vm/devices/pci/vpci/src/device.rs
+++ b/vm/devices/pci/vpci/src/device.rs
@@ -2009,33 +2009,84 @@ mod tests {
         let base_address = 0x80000000;
         guest_driver.start_device(base_address).await;
         for i in 0..6 {
-            let result = pci.lock().pci_cfg_write(0x10 + 4 * i, ByteEnabledDwordWrite::with_all_bytes_enabled(0xffffffff));
+            let result = pci.lock().pci_cfg_write(
+                0x10 + 4 * i,
+                ByteEnabledDwordWrite::with_all_bytes_enabled(0xffffffff),
+            );
             complete_write(result).await;
         }
 
         let mut value = 0;
-        pci.lock().pci_cfg_read(0x10, ByteEnabledDwordRead::with_all_bytes_enabled(&mut value)).unwrap();
+        pci.lock()
+            .pci_cfg_read(
+                0x10,
+                ByteEnabledDwordRead::with_all_bytes_enabled(&mut value),
+            )
+            .unwrap();
         assert_eq!(value & 0xfffffff0, 0xfffff000);
         assert_eq!(value & 0x4, 0x4); // 64-bit BAR
         assert_eq!(value & 0x8, 0x8); // prefetchable
-        pci.lock().pci_cfg_read(0x14, ByteEnabledDwordRead::with_all_bytes_enabled(&mut value)).unwrap();
+        pci.lock()
+            .pci_cfg_read(
+                0x14,
+                ByteEnabledDwordRead::with_all_bytes_enabled(&mut value),
+            )
+            .unwrap();
         assert_eq!(value, 0xffffffff);
-        pci.lock().pci_cfg_read(0x18, ByteEnabledDwordRead::with_all_bytes_enabled(&mut value)).unwrap();
+        pci.lock()
+            .pci_cfg_read(
+                0x18,
+                ByteEnabledDwordRead::with_all_bytes_enabled(&mut value),
+            )
+            .unwrap();
         assert_eq!(value, 0);
-        pci.lock().pci_cfg_read(0x1c, ByteEnabledDwordRead::with_all_bytes_enabled(&mut value)).unwrap();
+        pci.lock()
+            .pci_cfg_read(
+                0x1c,
+                ByteEnabledDwordRead::with_all_bytes_enabled(&mut value),
+            )
+            .unwrap();
         assert_eq!(value, 0);
-        pci.lock().pci_cfg_read(0x20, ByteEnabledDwordRead::with_all_bytes_enabled(&mut value)).unwrap();
+        pci.lock()
+            .pci_cfg_read(
+                0x20,
+                ByteEnabledDwordRead::with_all_bytes_enabled(&mut value),
+            )
+            .unwrap();
         assert_eq!(value, 0);
-        pci.lock().pci_cfg_read(0x24, ByteEnabledDwordRead::with_all_bytes_enabled(&mut value)).unwrap();
+        pci.lock()
+            .pci_cfg_read(
+                0x24,
+                ByteEnabledDwordRead::with_all_bytes_enabled(&mut value),
+            )
+            .unwrap();
         assert_eq!(value, 0);
 
-        complete_write(pci.lock().pci_cfg_write(0x14, ByteEnabledDwordWrite::with_all_bytes_enabled(0x20))).await;
-        complete_write(pci.lock().pci_cfg_write(0x10, ByteEnabledDwordWrite::with_all_bytes_enabled(0x0))).await;
-        pci.lock().pci_cfg_read(0x10, ByteEnabledDwordRead::with_all_bytes_enabled(&mut value)).unwrap();
+        complete_write(
+            pci.lock()
+                .pci_cfg_write(0x14, ByteEnabledDwordWrite::with_all_bytes_enabled(0x20)),
+        )
+        .await;
+        complete_write(
+            pci.lock()
+                .pci_cfg_write(0x10, ByteEnabledDwordWrite::with_all_bytes_enabled(0x0)),
+        )
+        .await;
+        pci.lock()
+            .pci_cfg_read(
+                0x10,
+                ByteEnabledDwordRead::with_all_bytes_enabled(&mut value),
+            )
+            .unwrap();
         assert_eq!(value & 0xfffffff0, 0);
         assert_eq!(value & 0x4, 0x4); // 64-bit BAR
         assert_eq!(value & 0x8, 0x8); // prefetchable
-        pci.lock().pci_cfg_read(0x14, ByteEnabledDwordRead::with_all_bytes_enabled(&mut value)).unwrap();
+        pci.lock()
+            .pci_cfg_read(
+                0x14,
+                ByteEnabledDwordRead::with_all_bytes_enabled(&mut value),
+            )
+            .unwrap();
         assert_eq!(value, 0x20);
 
         complete_write(
@@ -2051,13 +2102,31 @@ mod tests {
         .await;
 
         // Writes to BAR address are not allowed once MMIO is enabled.
-        complete_write(pci.lock().pci_cfg_write(0x14, ByteEnabledDwordWrite::with_all_bytes_enabled(0xffffffff))).await;
-        complete_write(pci.lock().pci_cfg_write(0x10, ByteEnabledDwordWrite::with_all_bytes_enabled(0xffffffff))).await;
-        pci.lock().pci_cfg_read(0x10, ByteEnabledDwordRead::with_all_bytes_enabled(&mut value)).unwrap();
+        complete_write(pci.lock().pci_cfg_write(
+            0x14,
+            ByteEnabledDwordWrite::with_all_bytes_enabled(0xffffffff),
+        ))
+        .await;
+        complete_write(pci.lock().pci_cfg_write(
+            0x10,
+            ByteEnabledDwordWrite::with_all_bytes_enabled(0xffffffff),
+        ))
+        .await;
+        pci.lock()
+            .pci_cfg_read(
+                0x10,
+                ByteEnabledDwordRead::with_all_bytes_enabled(&mut value),
+            )
+            .unwrap();
         assert_eq!(value & 0xfffffff0, 0);
         assert_eq!(value & 0x4, 0x4); // 64-bit BAR
         assert_eq!(value & 0x8, 0x8); // prefetchable
-        pci.lock().pci_cfg_read(0x14, ByteEnabledDwordRead::with_all_bytes_enabled(&mut value)).unwrap();
+        pci.lock()
+            .pci_cfg_read(
+                0x14,
+                ByteEnabledDwordRead::with_all_bytes_enabled(&mut value),
+            )
+            .unwrap();
         assert_eq!(value, 0x20);
     }
 
@@ -2209,36 +2278,45 @@ mod tests {
         };
 
         let bar_address1 = 0x2000000000;
-        complete_write(
-            pci.lock()
-                .pci_cfg_write(0x14, ByteEnabledDwordWrite::with_all_bytes_enabled(u32::try_from(bar_address1 >> 32).unwrap())),
-        )
+        complete_write(pci.lock().pci_cfg_write(
+            0x14,
+            ByteEnabledDwordWrite::with_all_bytes_enabled(
+                u32::try_from(bar_address1 >> 32).unwrap(),
+            ),
+        ))
         .await;
-        complete_write(
-            pci.lock()
-                .pci_cfg_write(0x10, ByteEnabledDwordWrite::with_all_bytes_enabled(u32::try_from(bar_address1 & 0xffffffff).unwrap())),
-        )
+        complete_write(pci.lock().pci_cfg_write(
+            0x10,
+            ByteEnabledDwordWrite::with_all_bytes_enabled(
+                u32::try_from(bar_address1 & 0xffffffff).unwrap(),
+            ),
+        ))
         .await;
 
         let bar_address2: u64 = 0x4000;
-        complete_write(
-            pci.lock()
-                .pci_cfg_write(0x1c, ByteEnabledDwordWrite::with_all_bytes_enabled(u32::try_from(bar_address2 >> 32).unwrap())),
-        )
+        complete_write(pci.lock().pci_cfg_write(
+            0x1c,
+            ByteEnabledDwordWrite::with_all_bytes_enabled(
+                u32::try_from(bar_address2 >> 32).unwrap(),
+            ),
+        ))
         .await;
-        complete_write(
-            pci.lock()
-                .pci_cfg_write(0x18, ByteEnabledDwordWrite::with_all_bytes_enabled(u32::try_from(bar_address2 & 0xffffffff).unwrap())),
-        )
+        complete_write(pci.lock().pci_cfg_write(
+            0x18,
+            ByteEnabledDwordWrite::with_all_bytes_enabled(
+                u32::try_from(bar_address2 & 0xffffffff).unwrap(),
+            ),
+        ))
         .await;
 
         complete_write(
             pci.lock().pci_cfg_write(
                 0x4,
                 ByteEnabledDwordWrite::with_all_bytes_enabled(
-                pci_core::spec::cfg_space::Command::new()
-                    .with_mmio_enabled(true)
-                    .into_bits() as u32),
+                    pci_core::spec::cfg_space::Command::new()
+                        .with_mmio_enabled(true)
+                        .into_bits() as u32,
+                ),
             ),
         )
         .await;

--- a/vm/devices/pci/vpci/src/device.rs
+++ b/vm/devices/pci/vpci/src/device.rs
@@ -9,6 +9,7 @@ use chipset_device::io::IoResult;
 use chipset_device::mmio::ControlMmioIntercept;
 use chipset_device::pci::ByteEnabledDwordRead;
 use chipset_device::pci::ByteEnabledDwordWrite;
+use chipset_device::pci::PciConfigByteEnable;
 use closeable_mutex::CloseableMutex;
 use guestmem::AccessError;
 use guestmem::MemoryRead;
@@ -1111,7 +1112,8 @@ impl VpciChannel {
             let pci = device.supports_pci().unwrap();
             let mut command = {
                 let mut value_u32 = 0;
-                let value = ByteEnabledDwordRead::with_all_bytes_enabled(&mut value_u32);
+                let value =
+                    ByteEnabledDwordRead::new(&mut value_u32, PciConfigByteEnable::LOW_WORD);
                 pci.pci_cfg_read(cfg_space::HeaderType00::STATUS_COMMAND.0, value)
                     .now_or_never()
                     .map(|_| value_u32)
@@ -1125,7 +1127,7 @@ impl VpciChannel {
             } else {
                 command &= !mmio;
             }
-            let command = ByteEnabledDwordWrite::with_all_bytes_enabled(command);
+            let command = ByteEnabledDwordWrite::new(command, PciConfigByteEnable::LOW_WORD);
             pci.pci_cfg_write(cfg_space::HeaderType00::STATUS_COMMAND.0, command)
         };
         match result {

--- a/vm/devices/pci/vpci_client/src/lib.rs
+++ b/vm/devices/pci/vpci_client/src/lib.rs
@@ -431,7 +431,7 @@ impl VpciDevice {
     /// Reads device configuration space.
     ///
     /// Some values will be handled without communicating with the host.
-    pub fn read_cfg(&self, offset: u16, mut value: ByteEnabledDwordRead<'_>) {
+    pub fn read_cfg(&self, offset: u16) -> u32 {
         // For static values, return values from the device's description.
         let value = match HeaderType00(offset) {
             HeaderType00::STATUS_COMMAND => {

--- a/vm/devices/pci/vpci_client/src/lib.rs
+++ b/vm/devices/pci/vpci_client/src/lib.rs
@@ -431,7 +431,7 @@ impl VpciDevice {
     /// Reads device configuration space.
     ///
     /// Some values will be handled without communicating with the host.
-    pub fn read_cfg(&self, offset: u16) -> u32 {
+    pub fn read_cfg(&self, offset: u16, mut value: ByteEnabledDwordRead<'_>) {
         // For static values, return values from the device's description.
         let value = match HeaderType00(offset) {
             HeaderType00::STATUS_COMMAND => {

--- a/vm/devices/pci/vpci_client/src/tests.rs
+++ b/vm/devices/pci/vpci_client/src/tests.rs
@@ -48,12 +48,12 @@ impl ChipsetDevice for NoopDevice {
 }
 
 impl PciConfigSpace for NoopDevice {
-    fn pci_cfg_read(&mut self, _offset: u16, value: &mut u32) -> IoResult {
-        *value = 0;
+    fn pci_cfg_read(&mut self, _offset: u16, mut value: ByteEnabledDwordRead<'_>) -> IoResult {
+        value.set(0);
         IoResult::Ok
     }
 
-    fn pci_cfg_write(&mut self, _offset: u16, _value: u32) -> IoResult {
+    fn pci_cfg_write(&mut self, _offset: u16, _value: ByteEnabledDwordWrite) -> IoResult {
         IoResult::Ok
     }
 }

--- a/vm/devices/pci/vpci_client/src/tests.rs
+++ b/vm/devices/pci/vpci_client/src/tests.rs
@@ -8,6 +8,8 @@
 use chipset_device::ChipsetDevice;
 use chipset_device::io::IoResult;
 use chipset_device::mmio::ExternallyManagedMmioIntercepts;
+use chipset_device::pci::ByteEnabledDwordRead;
+use chipset_device::pci::ByteEnabledDwordWrite;
 use chipset_device::pci::PciConfigSpace;
 use closeable_mutex::CloseableMutex;
 use guestmem::GuestMemory;

--- a/vm/devices/pci/vpci_relay/src/lib.rs
+++ b/vm/devices/pci/vpci_relay/src/lib.rs
@@ -21,6 +21,8 @@ pub use pci_core::spec::hwid::Subclass;
 use anyhow::Context as _;
 use chipset_device::ChipsetDevice;
 use chipset_device::io::IoResult;
+use chipset_device::pci::ByteEnabledDwordRead;
+use chipset_device::pci::ByteEnabledDwordWrite;
 use chipset_device::pci::PciConfigSpace;
 use futures::StreamExt as _;
 use inspect::Inspect;
@@ -416,13 +418,18 @@ impl ChipsetDevice for RelayedVpciDevice {
 }
 
 impl PciConfigSpace for RelayedVpciDevice {
-    fn pci_cfg_read(&mut self, offset: u16, value: &mut u32) -> IoResult {
-        *value = self.0.read_cfg(offset);
+    fn pci_cfg_read(&mut self, offset: u16, mut value: ByteEnabledDwordRead<'_>) -> IoResult {
+        value.set(self.0.read_cfg(offset));
         IoResult::Ok
     }
 
-    fn pci_cfg_write(&mut self, offset: u16, value: u32) -> IoResult {
-        self.0.write_cfg(offset, value);
+    fn pci_cfg_write(&mut self, offset: u16, value: ByteEnabledDwordWrite) -> IoResult {
+        let new_value = if value.is_full() {
+            value.extract()
+        } else {
+            value.merge(self.0.read_cfg(offset))
+        };
+        self.0.write_cfg(offset, new_value);
         IoResult::Ok
     }
 }

--- a/vm/devices/storage/ide/fuzz/fuzz_ide.rs
+++ b/vm/devices/storage/ide/fuzz/fuzz_ide.rs
@@ -7,6 +7,7 @@
 use arbitrary::Arbitrary;
 use arbitrary::Unstructured;
 use chipset_arc_mutex_device::services::PortIoInterceptServices;
+use chipset_device::pci::ByteEnabledDwordWrite;
 use chipset_device::pci::PciConfigSpace;
 use guestmem::GuestMemory;
 use ide::DriveMedia;
@@ -107,10 +108,16 @@ fn do_fuzz(u: &mut Unstructured<'_>) -> arbitrary::Result<()> {
 
     // set a bus master base to avoid wasted cycles
     (ide_device.lock())
-        .pci_cfg_write(HeaderType00::BAR4.0, 0x1000)
+        .pci_cfg_write(
+            HeaderType00::BAR4.0,
+            ByteEnabledDwordWrite::with_all_bytes_enabled(0x1000),
+        )
         .unwrap();
     (ide_device.lock())
-        .pci_cfg_write(HeaderType00::STATUS_COMMAND.0, 0x5)
+        .pci_cfg_write(
+            HeaderType00::STATUS_COMMAND.0,
+            ByteEnabledDwordWrite::with_all_bytes_enabled(0x5),
+        )
         .unwrap();
 
     // remaining fuzzer input is used to drive device actions

--- a/vm/devices/storage/ide/src/lib.rs
+++ b/vm/devices/storage/ide/src/lib.rs
@@ -44,6 +44,8 @@ use chipset_device::io::IoError;
 use chipset_device::io::IoResult;
 use chipset_device::io::deferred::DeferredWrite;
 use chipset_device::io::deferred::defer_write;
+use chipset_device::pci::ByteEnabledDwordRead;
+use chipset_device::pci::ByteEnabledDwordWrite;
 use chipset_device::pci::PciConfigSpace;
 use chipset_device::pio::ControlPortIoIntercept;
 use chipset_device::pio::PortIoIntercept;
@@ -967,8 +969,8 @@ impl PortIoIntercept for IdeDevice {
 }
 
 impl PciConfigSpace for IdeDevice {
-    fn pci_cfg_read(&mut self, offset: u16, value: &mut u32) -> IoResult {
-        *value = if offset < HEADER_TYPE_00_SIZE {
+    fn pci_cfg_read(&mut self, offset: u16, mut value: ByteEnabledDwordRead<'_>) -> IoResult {
+        value.set(if offset < HEADER_TYPE_00_SIZE {
             match HeaderType00(offset) {
                 HeaderType00::DEVICE_VENDOR => protocol::BX_PCI_ISA_BRIDGE_IDE_IDREG_VALUE,
                 HeaderType00::STATUS_COMMAND => self.bus_master_state.cmd_status_reg,
@@ -997,16 +999,16 @@ impl PciConfigSpace for IdeDevice {
                     return IoResult::Err(IoError::InvalidRegister);
                 }
             }
-        };
+        });
 
-        tracing::trace!(?offset, value, "ide pci config space read");
+        tracing::trace!(?offset, ?value, "ide pci config space read");
         IoResult::Ok
     }
 
-    fn pci_cfg_write(&mut self, offset: u16, value: u32) -> IoResult {
+    fn pci_cfg_write(&mut self, offset: u16, value: ByteEnabledDwordWrite) -> IoResult {
         if offset < HEADER_TYPE_00_SIZE {
             let offset = HeaderType00(offset);
-            tracing::trace!(?offset, value, "ide pci config space write");
+            tracing::trace!(?offset, ?value, "ide pci config space write");
 
             const BUS_MASTER_IO_ENABLE_MASK: u32 = Command::new()
                 .with_pio_enabled(true)
@@ -1016,6 +1018,7 @@ impl PciConfigSpace for IdeDevice {
             match offset {
                 HeaderType00::STATUS_COMMAND => {
                     // Several bits are used to reset status bits when written as 1s.
+                    let value = value.merge(self.bus_master_state.cmd_status_reg);
                     self.bus_master_state.cmd_status_reg &= !(0x38000000 & value);
                     // Only allow writes to two bits (0 and 2). All other bits are read-only.
                     self.bus_master_state.cmd_status_reg &= !BUS_MASTER_IO_ENABLE_MASK;
@@ -1042,6 +1045,7 @@ impl PciConfigSpace for IdeDevice {
                 }
                 HeaderType00::BAR4 => {
                     // Only allow writes to bits 4 to 15
+                    let value = value.merge(self.bus_master_state.port_addr_reg);
                     self.bus_master_state.port_addr_reg =
                         (value & 0x0000FFF0) | DEFAULT_BUS_MASTER_PORT_ADDR_REG;
                 }
@@ -1049,14 +1053,14 @@ impl PciConfigSpace for IdeDevice {
             }
         } else {
             let offset = IdeConfigSpace(offset);
-            tracing::trace!(?offset, value, "ide pci config space write");
+            tracing::trace!(?offset, ?value, "ide pci config space write");
 
             match offset {
-                IdeConfigSpace::PRIMARY_TIMING_REG_ADDR => self.bus_master_state.timing_reg = value,
+                IdeConfigSpace::PRIMARY_TIMING_REG_ADDR => value.merge_into(&mut self.bus_master_state.timing_reg),
                 IdeConfigSpace::SECONDARY_TIMING_REG_ADDR => {
-                    self.bus_master_state.secondary_timing_reg = value
+                    value.merge_into(&mut self.bus_master_state.secondary_timing_reg)
                 }
-                IdeConfigSpace::UDMA_CTL_REG_ADDR => self.bus_master_state.dma_ctl_reg = value,
+                IdeConfigSpace::UDMA_CTL_REG_ADDR => value.merge_into(&mut self.bus_master_state.dma_ctl_reg),
                 _ => tracing::trace!(?offset, "undefined ide pci config space write"),
             }
         }

--- a/vm/devices/storage/ide/src/lib.rs
+++ b/vm/devices/storage/ide/src/lib.rs
@@ -1056,11 +1056,15 @@ impl PciConfigSpace for IdeDevice {
             tracing::trace!(?offset, ?value, "ide pci config space write");
 
             match offset {
-                IdeConfigSpace::PRIMARY_TIMING_REG_ADDR => value.merge_into(&mut self.bus_master_state.timing_reg),
+                IdeConfigSpace::PRIMARY_TIMING_REG_ADDR => {
+                    value.merge_into(&mut self.bus_master_state.timing_reg)
+                }
                 IdeConfigSpace::SECONDARY_TIMING_REG_ADDR => {
                     value.merge_into(&mut self.bus_master_state.secondary_timing_reg)
                 }
-                IdeConfigSpace::UDMA_CTL_REG_ADDR => value.merge_into(&mut self.bus_master_state.dma_ctl_reg),
+                IdeConfigSpace::UDMA_CTL_REG_ADDR => {
+                    value.merge_into(&mut self.bus_master_state.dma_ctl_reg)
+                }
                 _ => tracing::trace!(?offset, "undefined ide pci config space write"),
             }
         }

--- a/vm/devices/storage/nvme/src/pci.rs
+++ b/vm/devices/storage/nvme/src/pci.rs
@@ -22,6 +22,8 @@ use chipset_device::io::IoError::InvalidRegister;
 use chipset_device::io::IoResult;
 use chipset_device::mmio::MmioIntercept;
 use chipset_device::mmio::RegisterMmioIntercept;
+use chipset_device::pci::ByteEnabledDwordRead;
+use chipset_device::pci::ByteEnabledDwordWrite;
 use chipset_device::pci::PciConfigSpace;
 use device_emulators::ReadWriteRequestType;
 use device_emulators::read_as_u32_chunks;
@@ -489,12 +491,12 @@ impl MmioIntercept for NvmeController {
 }
 
 impl PciConfigSpace for NvmeController {
-    fn pci_cfg_read(&mut self, offset: u16, value: &mut u32) -> IoResult {
-        self.cfg_space.read_u32(offset, value)
+    fn pci_cfg_read(&mut self, offset: u16, value: ByteEnabledDwordRead<'_>) -> IoResult {
+        self.cfg_space.read_byte_enabled(offset, value)
     }
 
-    fn pci_cfg_write(&mut self, offset: u16, value: u32) -> IoResult {
-        self.cfg_space.write_u32(offset, value)
+    fn pci_cfg_write(&mut self, offset: u16, value: ByteEnabledDwordWrite) -> IoResult {
+        self.cfg_space.write_byte_enabled(offset, value)
     }
 }
 

--- a/vm/devices/storage/nvme/src/tests/controller_tests.rs
+++ b/vm/devices/storage/nvme/src/tests/controller_tests.rs
@@ -13,6 +13,8 @@ use crate::tests::test_helpers::read_completion_from_queue;
 use crate::tests::test_helpers::test_memory;
 use crate::tests::test_helpers::write_command_to_queue;
 use chipset_device::mmio::MmioIntercept;
+use chipset_device::pci::ByteEnabledDwordRead;
+use chipset_device::pci::ByteEnabledDwordWrite;
 use chipset_device::pci::PciConfigSpace;
 use disklayer_ram::ram_disk;
 use guestmem::GuestMemory;
@@ -114,24 +116,42 @@ pub async fn instantiate_and_build_admin_queue(
 ) -> NvmeController {
     let mut nvmec = instantiate_controller(driver.clone(), gm, int_controller);
     // Set the BARs.
-    nvmec.pci_cfg_write(0x10, 0).unwrap();
-    nvmec.pci_cfg_write(0x20, BAR0_LEN as u32).unwrap();
+    nvmec
+        .pci_cfg_write(0x10, ByteEnabledDwordWrite::with_all_bytes_enabled(0))
+        .unwrap();
+    nvmec
+        .pci_cfg_write(
+            0x20,
+            ByteEnabledDwordWrite::with_all_bytes_enabled(BAR0_LEN as u32),
+        )
+        .unwrap();
 
     // Find the MSI-X cap struct.
     let mut cfg_dword = 0;
-    nvmec.pci_cfg_read(0x34, &mut cfg_dword).unwrap();
+    nvmec
+        .pci_cfg_read(
+            0x34,
+            ByteEnabledDwordRead::with_all_bytes_enabled(&mut cfg_dword),
+        )
+        .unwrap();
     cfg_dword &= 0xff;
     loop {
         // Read a cap struct header and pull out the fields.
         let mut cap_header = 0;
         nvmec
-            .pci_cfg_read(cfg_dword as u16, &mut cap_header)
+            .pci_cfg_read(
+                cfg_dword as u16,
+                ByteEnabledDwordRead::with_all_bytes_enabled(&mut cap_header),
+            )
             .unwrap();
         if cap_header & 0xff == 0x11 {
             // Read the table BIR and offset.
             let mut table_loc = 0;
             nvmec
-                .pci_cfg_read(cfg_dword as u16 + 4, &mut table_loc)
+                .pci_cfg_read(
+                    cfg_dword as u16 + 4,
+                    ByteEnabledDwordRead::with_all_bytes_enabled(&mut table_loc),
+                )
                 .unwrap();
             // Code in other places assumes that the MSI-X table is at the beginning
             // of BAR 4.  If this becomes a fluid concept, capture the values
@@ -140,7 +160,12 @@ pub async fn instantiate_and_build_admin_queue(
             assert_eq!(table_loc >> 3, 0);
 
             // Found MSI-X, enable it.
-            nvmec.pci_cfg_write(cfg_dword as u16, 0x80000000).unwrap();
+            nvmec
+                .pci_cfg_write(
+                    cfg_dword as u16,
+                    ByteEnabledDwordWrite::with_all_bytes_enabled(0x80000000),
+                )
+                .unwrap();
             break;
         }
         // Isolate the ptr to the next cap struct.
@@ -153,7 +178,9 @@ pub async fn instantiate_and_build_admin_queue(
 
     // Turn on MMIO access by writing to the Command register in config space.  Enable
     // MMIO and DMA.
-    nvmec.pci_cfg_write(4, 6).unwrap();
+    nvmec
+        .pci_cfg_write(4, ByteEnabledDwordWrite::with_all_bytes_enabled(6))
+        .unwrap();
 
     // Set the ACQ base.
     let base = acq_buffer.range().gpns()[0] * PAGE_SIZE64;

--- a/vm/devices/storage/nvme_test/src/pci.rs
+++ b/vm/devices/storage/nvme_test/src/pci.rs
@@ -22,6 +22,8 @@ use chipset_device::io::IoError::InvalidRegister;
 use chipset_device::io::IoResult;
 use chipset_device::mmio::MmioIntercept;
 use chipset_device::mmio::RegisterMmioIntercept;
+use chipset_device::pci::ByteEnabledDwordRead;
+use chipset_device::pci::ByteEnabledDwordWrite;
 use chipset_device::pci::PciConfigSpace;
 use device_emulators::ReadWriteRequestType;
 use device_emulators::read_as_u32_chunks;
@@ -552,12 +554,12 @@ impl MmioIntercept for NvmeFaultController {
 }
 
 impl PciConfigSpace for NvmeFaultController {
-    fn pci_cfg_read(&mut self, offset: u16, value: &mut u32) -> IoResult {
-        self.cfg_space.read_u32(offset, value)
+    fn pci_cfg_read(&mut self, offset: u16, value: ByteEnabledDwordRead<'_>) -> IoResult {
+        self.cfg_space.read_byte_enabled(offset, value)
     }
 
-    fn pci_cfg_write(&mut self, offset: u16, value: u32) -> IoResult {
-        self.cfg_space.write_u32(offset, value)
+    fn pci_cfg_write(&mut self, offset: u16, value: ByteEnabledDwordWrite) -> IoResult {
+        self.cfg_space.write_byte_enabled(offset, value)
     }
 }
 

--- a/vm/devices/storage/nvme_test/src/tests/controller_tests.rs
+++ b/vm/devices/storage/nvme_test/src/tests/controller_tests.rs
@@ -13,6 +13,8 @@ use crate::tests::test_helpers::read_completion_from_queue;
 use crate::tests::test_helpers::test_memory;
 use crate::tests::test_helpers::write_command_to_queue;
 use chipset_device::mmio::MmioIntercept;
+use chipset_device::pci::ByteEnabledDwordRead;
+use chipset_device::pci::ByteEnabledDwordWrite;
 use chipset_device::pci::PciConfigSpace;
 use guestmem::GuestMemory;
 use guid::Guid;
@@ -121,24 +123,42 @@ pub async fn instantiate_and_build_admin_queue(
 ) -> NvmeFaultController {
     let mut nvmec = instantiate_controller(driver.clone(), gm, int_controller, fault_configuration);
     // Set the BARs.
-    nvmec.pci_cfg_write(0x10, 0).unwrap();
-    nvmec.pci_cfg_write(0x20, BAR0_LEN as u32).unwrap();
+    nvmec
+        .pci_cfg_write(0x10, ByteEnabledDwordWrite::with_all_bytes_enabled(0))
+        .unwrap();
+    nvmec
+        .pci_cfg_write(
+            0x20,
+            ByteEnabledDwordWrite::with_all_bytes_enabled(BAR0_LEN as u32),
+        )
+        .unwrap();
 
     // Find the MSI-X cap struct.
     let mut cfg_dword = 0;
-    nvmec.pci_cfg_read(0x34, &mut cfg_dword).unwrap();
+    nvmec
+        .pci_cfg_read(
+            0x34,
+            ByteEnabledDwordRead::with_all_bytes_enabled(&mut cfg_dword),
+        )
+        .unwrap();
     cfg_dword &= 0xff;
     loop {
         // Read a cap struct header and pull out the fields.
         let mut cap_header = 0;
         nvmec
-            .pci_cfg_read(cfg_dword as u16, &mut cap_header)
+            .pci_cfg_read(
+                cfg_dword as u16,
+                ByteEnabledDwordRead::with_all_bytes_enabled(&mut cap_header),
+            )
             .unwrap();
         if cap_header & 0xff == 0x11 {
             // Read the table BIR and offset.
             let mut table_loc = 0;
             nvmec
-                .pci_cfg_read(cfg_dword as u16 + 4, &mut table_loc)
+                .pci_cfg_read(
+                    cfg_dword as u16 + 4,
+                    ByteEnabledDwordRead::with_all_bytes_enabled(&mut table_loc),
+                )
                 .unwrap();
             // Code in other places assumes that the MSI-X table is at the beginning
             // of BAR 4.  If this becomes a fluid concept, capture the values
@@ -147,7 +167,12 @@ pub async fn instantiate_and_build_admin_queue(
             assert_eq!(table_loc >> 3, 0);
 
             // Found MSI-X, enable it.
-            nvmec.pci_cfg_write(cfg_dword as u16, 0x80000000).unwrap();
+            nvmec
+                .pci_cfg_write(
+                    cfg_dword as u16,
+                    ByteEnabledDwordWrite::with_all_bytes_enabled(0x80000000),
+                )
+                .unwrap();
             break;
         }
         // Isolate the ptr to the next cap struct.
@@ -160,7 +185,9 @@ pub async fn instantiate_and_build_admin_queue(
 
     // Turn on MMIO access by writing to the Command register in config space.  Enable
     // MMIO and DMA.
-    nvmec.pci_cfg_write(4, 6).unwrap();
+    nvmec
+        .pci_cfg_write(4, ByteEnabledDwordWrite::with_all_bytes_enabled(6))
+        .unwrap();
 
     // Set the ACQ base.
     let base = acq_buffer.range().gpns()[0] * PAGE_SIZE64;

--- a/vm/devices/user_driver_emulated_mock/src/lib.rs
+++ b/vm/devices/user_driver_emulated_mock/src/lib.rs
@@ -11,6 +11,8 @@ use crate::guest_memory_access_wrapper::GuestMemoryAccessWrapper;
 
 use anyhow::Context;
 use chipset_device::mmio::MmioIntercept;
+use chipset_device::pci::ByteEnabledDwordRead;
+use chipset_device::pci::ByteEnabledDwordWrite;
 use chipset_device::pci::PciConfigSpace;
 use guestmem::GuestMemory;
 use inspect::Inspect;
@@ -89,21 +91,29 @@ impl<T: PciConfigSpace + MmioIntercept, U: DmaClient> EmulatedDevice<T, U> {
         let bar0_len = !(bars[0] & !0xf) as usize + 1;
 
         // Enable BAR0 at 0, BAR4 at X.
-        device.pci_cfg_write(0x20, 0).unwrap();
-        device.pci_cfg_write(0x24, 0x1).unwrap();
+        device
+            .pci_cfg_write(0x20, ByteEnabledDwordWrite::with_all_bytes_enabled(0))
+            .unwrap();
+        device
+            .pci_cfg_write(0x24, ByteEnabledDwordWrite::with_all_bytes_enabled(0x1))
+            .unwrap();
         device
             .pci_cfg_write(
                 0x4,
-                pci_core::spec::cfg_space::Command::new()
-                    .with_mmio_enabled(true)
-                    .into_bits() as u32,
+                ByteEnabledDwordWrite::with_all_bytes_enabled(
+                    pci_core::spec::cfg_space::Command::new()
+                        .with_mmio_enabled(true)
+                        .into_bits() as u32,
+                ),
             )
             .unwrap();
 
         // Determine the number of MSI-X vectors.
         let msix_table_size = {
             let mut n = 0;
-            device.pci_cfg_read(0x40, &mut n).unwrap();
+            device
+                .pci_cfg_read(0x40, ByteEnabledDwordRead::with_all_bytes_enabled(&mut n))
+                .unwrap();
             ((n >> 16) & 0x7ff) + 1
         } as usize;
 
@@ -120,7 +130,12 @@ impl<T: PciConfigSpace + MmioIntercept, U: DmaClient> EmulatedDevice<T, U> {
                 .mmio_write((0x1 << 32) + i * 16 + 12, &0u32.to_ne_bytes())
                 .unwrap();
         }
-        device.pci_cfg_write(0x40, 0x80000000).unwrap();
+        device
+            .pci_cfg_write(
+                0x40,
+                ByteEnabledDwordWrite::with_all_bytes_enabled(0x80000000),
+            )
+            .unwrap();
 
         Self {
             device: Arc::new(Mutex::new(device)),

--- a/vm/devices/vga/src/emu.rs
+++ b/vm/devices/vga/src/emu.rs
@@ -18,6 +18,8 @@ use crate::spec::VgaPort;
 use crate::spec::VgaSequencerReg;
 use chipset_device::io::IoError;
 use chipset_device::io::IoResult;
+use chipset_device::pci::ByteEnabledDwordRead;
+use chipset_device::pci::ByteEnabledDwordWrite;
 use framebuffer::FramebufferLocalControl;
 use guestmem::GuestMemory;
 use guestmem::MapRom;
@@ -612,11 +614,11 @@ impl Emulator {
     pub fn notify_pci_config_access_write(
         &mut self,
         in_reg_address: u16,
-        io_data: u32,
+        io_data: ByteEnabledDwordWrite,
     ) -> IoResult {
         tracing::trace!(
             reg = ?HeaderType00(in_reg_address),
-            io_data,
+            ?io_data,
             "pci config write"
         );
 
@@ -624,6 +626,7 @@ impl Emulator {
             HeaderType00::STATUS_COMMAND => {
                 // Write the command register portion of the status/command register
                 // The WHQL video tests require that these bits be read-only: 0x06FFF800
+                let io_data = io_data.merge(self.state.persistent_state.video_pci_status);
                 self.state.persistent_state.video_pci_status = io_data & 0x07FF;
             }
 
@@ -636,6 +639,7 @@ impl Emulator {
                 // to guarantee that the plug-n-play software
                 // allocates an address range that is correctly sized and
                 // aligned.
+                let io_data = io_data.merge(self.state.persistent_state.s3.linear_addr_window);
                 self.s3_set_linear_address_base(io_data as u64 & 0xFC000000); // S3 device
             }
 
@@ -646,11 +650,13 @@ impl Emulator {
             | HeaderType00::BAR5 => return IoResult::Err(IoError::InvalidRegister),
 
             HeaderType00::LATENCY_INTERRUPT => {
+                let io_data = io_data.merge(self.state.persistent_state.interrupt_line_info);
                 self.state.persistent_state.interrupt_line_info = io_data;
             }
 
             HeaderType00::EXPANSION_ROM_BASE => {
                 if let Some(rom) = &self.rom {
+                    let io_data = io_data.merge(self.state.persistent_state.expansion_rom_base);
                     let reg = io_data & 0xFFFF0001;
                     if reg != self.state.persistent_state.expansion_rom_base {
                         self.state.persistent_state.expansion_rom_base = reg;
@@ -671,7 +677,7 @@ impl Emulator {
             }
 
             reg => {
-                tracing::warn!(?reg, data = io_data, "unhandled vga config space write");
+                tracing::warn!(?reg, data = ?io_data, "unhandled vga config space write");
                 return IoResult::Err(IoError::InvalidRegister);
             }
         }
@@ -682,13 +688,13 @@ impl Emulator {
     pub fn notify_pci_config_access_read(
         &self,
         in_reg_address: u16,
-        io_data: &mut u32,
+        mut io_data: ByteEnabledDwordRead<'_>,
     ) -> IoResult {
         tracing::trace!(
             reg = ?HeaderType00(in_reg_address),
             "pci config read"
         );
-        *io_data = match HeaderType00(in_reg_address) {
+        io_data.set(match HeaderType00(in_reg_address) {
             HeaderType00::DEVICE_VENDOR => {
                 // Use constant Vendor ID and configured Device ID
                 spec::PCI_VENDOR_ID as u32 | ((spec::PCI_DEVICE_ID as u32) << 16)
@@ -735,11 +741,11 @@ impl Emulator {
                 tracing::warn!(?reg, "unhandled vga config space read");
                 return IoResult::Err(IoError::InvalidRegister);
             }
-        };
+        });
 
         tracing::trace!(
             reg = ?HeaderType00(in_reg_address),
-            io_data,
+            ?io_data,
             "pci config read finished"
         );
         IoResult::Ok

--- a/vm/devices/vga/src/lib.rs
+++ b/vm/devices/vga/src/lib.rs
@@ -26,6 +26,8 @@ mod text_mode;
 use chipset_device::ChipsetDevice;
 use chipset_device::io::IoResult;
 use chipset_device::mmio::MmioIntercept;
+use chipset_device::pci::ByteEnabledDwordRead;
+use chipset_device::pci::ByteEnabledDwordWrite;
 use chipset_device::pci::PciConfigSpace;
 use chipset_device::pio::PortIoIntercept;
 use framebuffer::FramebufferLocalControl;
@@ -103,11 +105,11 @@ impl ChipsetDevice for VgaDevice {
 }
 
 impl PciConfigSpace for VgaDevice {
-    fn pci_cfg_read(&mut self, offset: u16, value: &mut u32) -> IoResult {
+    fn pci_cfg_read(&mut self, offset: u16, value: ByteEnabledDwordRead<'_>) -> IoResult {
         self.emu.notify_pci_config_access_read(offset, value)
     }
 
-    fn pci_cfg_write(&mut self, offset: u16, value: u32) -> IoResult {
+    fn pci_cfg_write(&mut self, offset: u16, value: ByteEnabledDwordWrite) -> IoResult {
         self.emu.notify_pci_config_access_write(offset, value)
     }
 

--- a/vm/devices/vga_proxy/src/lib.rs
+++ b/vm/devices/vga_proxy/src/lib.rs
@@ -136,7 +136,7 @@ impl PciConfigSpace for VgaProxyDevice {
                     value.merge(proxy.vga_proxy_pci_read(offset).await)
                 };
                 proxy.vga_proxy_pci_write(offset, new_value).await
-             }
+            }
         };
 
         self.pending_actions

--- a/vm/devices/vga_proxy/src/lib.rs
+++ b/vm/devices/vga_proxy/src/lib.rs
@@ -106,7 +106,7 @@ impl ChipsetDevice for VgaProxyDevice {
 }
 
 impl PciConfigSpace for VgaProxyDevice {
-    fn pci_cfg_read(&mut self, offset: u16, _value: &mut u32) -> IoResult {
+    fn pci_cfg_read(&mut self, offset: u16, _value: ByteEnabledDwordRead<'_>) -> IoResult {
         tracing::trace!(?offset, "VGA proxy read");
         let (read, token) = defer_read();
 
@@ -123,13 +123,20 @@ impl PciConfigSpace for VgaProxyDevice {
         IoResult::Defer(token)
     }
 
-    fn pci_cfg_write(&mut self, offset: u16, value: u32) -> IoResult {
+    fn pci_cfg_write(&mut self, offset: u16, value: ByteEnabledDwordWrite) -> IoResult {
         tracing::trace!(?offset, ?value, "VGA proxy write");
         let (write, token) = defer_write();
 
         let fut = {
             let proxy = self.pci_cfg_proxy.clone();
-            async move { proxy.vga_proxy_pci_write(offset, value).await }
+            async move {
+                let new_value = if value.is_full() {
+                    value.extract()
+                } else {
+                    value.merge(proxy.vga_proxy_pci_read(offset).await)
+                };
+                proxy.vga_proxy_pci_write(offset, new_value).await
+             }
         };
 
         self.pending_actions

--- a/vm/devices/vga_proxy/src/lib.rs
+++ b/vm/devices/vga_proxy/src/lib.rs
@@ -13,6 +13,8 @@ use chipset_device::io::deferred::DeferredRead;
 use chipset_device::io::deferred::DeferredWrite;
 use chipset_device::io::deferred::defer_read;
 use chipset_device::io::deferred::defer_write;
+use chipset_device::pci::ByteEnabledDwordRead;
+use chipset_device::pci::ByteEnabledDwordWrite;
 use chipset_device::pci::PciConfigSpace;
 use chipset_device::pio::PortIoIntercept;
 use chipset_device::poll_device::PollDevice;

--- a/vm/devices/virtio/virtio/src/tests.rs
+++ b/vm/devices/virtio/virtio/src/tests.rs
@@ -22,6 +22,9 @@ use crate::transport::VirtioMmioDevice;
 use crate::transport::VirtioPciDevice;
 use chipset_device::mmio::ExternallyManagedMmioIntercepts;
 use chipset_device::mmio::MmioIntercept;
+use chipset_device::pci::ByteEnabledDwordRead;
+use chipset_device::pci::ByteEnabledDwordWrite;
+use chipset_device::pci::PciConfigByteEnable;
 use chipset_device::pci::PciConfigSpace;
 use chipset_device::poll_device::PollDevice;
 use futures::StreamExt;
@@ -527,26 +530,41 @@ impl VirtioTestGuest {
     ) {
         let bar_address1: u64 = 0x10000000000;
         dev.pci_device
-            .pci_cfg_write(0x14, (bar_address1 >> 32) as u32)
+            .pci_cfg_write(
+                0x14,
+                ByteEnabledDwordWrite::with_all_bytes_enabled((bar_address1 >> 32) as u32),
+            )
             .unwrap();
         dev.pci_device
-            .pci_cfg_write(0x10, bar_address1 as u32)
+            .pci_cfg_write(
+                0x10,
+                ByteEnabledDwordWrite::with_all_bytes_enabled(bar_address1 as u32),
+            )
             .unwrap();
 
         let bar_address2: u64 = 0x20000000000;
         dev.pci_device
-            .pci_cfg_write(0x1c, (bar_address2 >> 32) as u32)
+            .pci_cfg_write(
+                0x1c,
+                ByteEnabledDwordWrite::with_all_bytes_enabled((bar_address2 >> 32) as u32),
+            )
             .unwrap();
         dev.pci_device
-            .pci_cfg_write(0x18, bar_address2 as u32)
+            .pci_cfg_write(
+                0x18,
+                ByteEnabledDwordWrite::with_all_bytes_enabled(bar_address2 as u32),
+            )
             .unwrap();
 
         dev.pci_device
             .pci_cfg_write(
                 0x4,
-                cfg_space::Command::new()
-                    .with_mmio_enabled(true)
-                    .into_bits() as u32,
+                ByteEnabledDwordWrite::new(
+                    cfg_space::Command::new()
+                        .with_mmio_enabled(true)
+                        .into_bits() as u32,
+                    PciConfigByteEnable::LOW_WORD,
+                ),
             )
             .unwrap();
 
@@ -618,7 +636,12 @@ impl VirtioTestGuest {
                 .unwrap();
         }
         // enable all device MSI interrupts
-        dev.pci_device.pci_cfg_write(0x40, 0x80000000).unwrap();
+        dev.pci_device
+            .pci_cfg_write(
+                0x40,
+                ByteEnabledDwordWrite::with_all_bytes_enabled(0x80000000),
+            )
+            .unwrap();
         // run device — use the write_u32 test helper to bypass MmioIntercept
         // stall/deferred logic.
         let current = dev.pci_device.read_u32(20);
@@ -1617,7 +1640,10 @@ async fn verify_pci_config(driver: DefaultDriver) {
     let mut capabilities = 0;
     pci_test_device
         .pci_device
-        .pci_cfg_read(4, &mut capabilities)
+        .pci_cfg_read(
+            4,
+            ByteEnabledDwordRead::with_all_bytes_enabled(&mut capabilities),
+        )
         .unwrap();
     assert_eq!(
         capabilities,
@@ -1629,14 +1655,20 @@ async fn verify_pci_config(driver: DefaultDriver) {
     let mut next_cap_offset = 0;
     pci_test_device
         .pci_device
-        .pci_cfg_read(0x34, &mut next_cap_offset)
+        .pci_cfg_read(
+            0x34,
+            ByteEnabledDwordRead::with_all_bytes_enabled(&mut next_cap_offset),
+        )
         .unwrap();
     assert_ne!(next_cap_offset, 0);
 
     let mut header = 0;
     pci_test_device
         .pci_device
-        .pci_cfg_read(next_cap_offset as u16, &mut header)
+        .pci_cfg_read(
+            next_cap_offset as u16,
+            ByteEnabledDwordRead::with_all_bytes_enabled(&mut header),
+        )
         .unwrap();
     let header = header.to_le_bytes();
     assert_eq!(header[0], CapabilityId::MSIX.0);
@@ -1646,7 +1678,10 @@ async fn verify_pci_config(driver: DefaultDriver) {
     let mut header = 0;
     pci_test_device
         .pci_device
-        .pci_cfg_read(next_cap_offset as u16, &mut header)
+        .pci_cfg_read(
+            next_cap_offset as u16,
+            ByteEnabledDwordRead::with_all_bytes_enabled(&mut header),
+        )
         .unwrap();
     let header = header.to_le_bytes();
     assert_eq!(header[0], CapabilityId::VENDOR_SPECIFIC.0);
@@ -1656,17 +1691,26 @@ async fn verify_pci_config(driver: DefaultDriver) {
 
     pci_test_device
         .pci_device
-        .pci_cfg_read(next_cap_offset as u16 + 4, &mut buf)
+        .pci_cfg_read(
+            next_cap_offset as u16 + 4,
+            ByteEnabledDwordRead::with_all_bytes_enabled(&mut buf),
+        )
         .unwrap();
     assert_eq!(buf, 0);
     pci_test_device
         .pci_device
-        .pci_cfg_read(next_cap_offset as u16 + 8, &mut buf)
+        .pci_cfg_read(
+            next_cap_offset as u16 + 8,
+            ByteEnabledDwordRead::with_all_bytes_enabled(&mut buf),
+        )
         .unwrap();
     assert_eq!(buf, 0);
     pci_test_device
         .pci_device
-        .pci_cfg_read(next_cap_offset as u16 + 12, &mut buf)
+        .pci_cfg_read(
+            next_cap_offset as u16 + 12,
+            ByteEnabledDwordRead::with_all_bytes_enabled(&mut buf),
+        )
         .unwrap();
     assert_eq!(buf, 0x38);
     next_cap_offset = header[1] as u32;
@@ -1675,7 +1719,10 @@ async fn verify_pci_config(driver: DefaultDriver) {
     let mut header = 0;
     pci_test_device
         .pci_device
-        .pci_cfg_read(next_cap_offset as u16, &mut header)
+        .pci_cfg_read(
+            next_cap_offset as u16,
+            ByteEnabledDwordRead::with_all_bytes_enabled(&mut header),
+        )
         .unwrap();
     let header = header.to_le_bytes();
     assert_eq!(header[0], CapabilityId::VENDOR_SPECIFIC.0);
@@ -1683,17 +1730,26 @@ async fn verify_pci_config(driver: DefaultDriver) {
     assert_eq!(header[2], 20);
     pci_test_device
         .pci_device
-        .pci_cfg_read(next_cap_offset as u16 + 4, &mut buf)
+        .pci_cfg_read(
+            next_cap_offset as u16 + 4,
+            ByteEnabledDwordRead::with_all_bytes_enabled(&mut buf),
+        )
         .unwrap();
     assert_eq!(buf, 0);
     pci_test_device
         .pci_device
-        .pci_cfg_read(next_cap_offset as u16 + 8, &mut buf)
+        .pci_cfg_read(
+            next_cap_offset as u16 + 8,
+            ByteEnabledDwordRead::with_all_bytes_enabled(&mut buf),
+        )
         .unwrap();
     assert_eq!(buf, 0x38);
     pci_test_device
         .pci_device
-        .pci_cfg_read(next_cap_offset as u16 + 12, &mut buf)
+        .pci_cfg_read(
+            next_cap_offset as u16 + 12,
+            ByteEnabledDwordRead::with_all_bytes_enabled(&mut buf),
+        )
         .unwrap();
     assert_eq!(buf, 4);
     next_cap_offset = header[1] as u32;
@@ -1702,7 +1758,10 @@ async fn verify_pci_config(driver: DefaultDriver) {
     let mut header = 0;
     pci_test_device
         .pci_device
-        .pci_cfg_read(next_cap_offset as u16, &mut header)
+        .pci_cfg_read(
+            next_cap_offset as u16,
+            ByteEnabledDwordRead::with_all_bytes_enabled(&mut header),
+        )
         .unwrap();
     let header = header.to_le_bytes();
     assert_eq!(header[0], CapabilityId::VENDOR_SPECIFIC.0);
@@ -1710,17 +1769,26 @@ async fn verify_pci_config(driver: DefaultDriver) {
     assert_eq!(header[2], 16);
     pci_test_device
         .pci_device
-        .pci_cfg_read(next_cap_offset as u16 + 4, &mut buf)
+        .pci_cfg_read(
+            next_cap_offset as u16 + 4,
+            ByteEnabledDwordRead::with_all_bytes_enabled(&mut buf),
+        )
         .unwrap();
     assert_eq!(buf, 0);
     pci_test_device
         .pci_device
-        .pci_cfg_read(next_cap_offset as u16 + 8, &mut buf)
+        .pci_cfg_read(
+            next_cap_offset as u16 + 8,
+            ByteEnabledDwordRead::with_all_bytes_enabled(&mut buf),
+        )
         .unwrap();
     assert_eq!(buf, 0x3c);
     pci_test_device
         .pci_device
-        .pci_cfg_read(next_cap_offset as u16 + 12, &mut buf)
+        .pci_cfg_read(
+            next_cap_offset as u16 + 12,
+            ByteEnabledDwordRead::with_all_bytes_enabled(&mut buf),
+        )
         .unwrap();
     assert_eq!(buf, 4);
     next_cap_offset = header[1] as u32;
@@ -1729,7 +1797,10 @@ async fn verify_pci_config(driver: DefaultDriver) {
     let mut header = 0;
     pci_test_device
         .pci_device
-        .pci_cfg_read(next_cap_offset as u16, &mut header)
+        .pci_cfg_read(
+            next_cap_offset as u16,
+            ByteEnabledDwordRead::with_all_bytes_enabled(&mut header),
+        )
         .unwrap();
     let header = header.to_le_bytes();
     assert_eq!(header[0], CapabilityId::VENDOR_SPECIFIC.0);
@@ -1737,17 +1808,26 @@ async fn verify_pci_config(driver: DefaultDriver) {
     assert_eq!(header[2], 16);
     pci_test_device
         .pci_device
-        .pci_cfg_read(next_cap_offset as u16 + 4, &mut buf)
+        .pci_cfg_read(
+            next_cap_offset as u16 + 4,
+            ByteEnabledDwordRead::with_all_bytes_enabled(&mut buf),
+        )
         .unwrap();
     assert_eq!(buf, 0);
     pci_test_device
         .pci_device
-        .pci_cfg_read(next_cap_offset as u16 + 8, &mut buf)
+        .pci_cfg_read(
+            next_cap_offset as u16 + 8,
+            ByteEnabledDwordRead::with_all_bytes_enabled(&mut buf),
+        )
         .unwrap();
     assert_eq!(buf, 0x40);
     pci_test_device
         .pci_device
-        .pci_cfg_read(next_cap_offset as u16 + 12, &mut buf)
+        .pci_cfg_read(
+            next_cap_offset as u16 + 12,
+            ByteEnabledDwordRead::with_all_bytes_enabled(&mut buf),
+        )
         .unwrap();
     assert_eq!(buf, 12);
     next_cap_offset = header[1] as u32;
@@ -1761,30 +1841,45 @@ async fn verify_pci_registers(driver: DefaultDriver) {
     let bar_address1: u64 = 0x2000000000;
     pci_test_device
         .pci_device
-        .pci_cfg_write(0x14, (bar_address1 >> 32) as u32)
+        .pci_cfg_write(
+            0x14,
+            ByteEnabledDwordWrite::with_all_bytes_enabled((bar_address1 >> 32) as u32),
+        )
         .unwrap();
     pci_test_device
         .pci_device
-        .pci_cfg_write(0x10, bar_address1 as u32)
+        .pci_cfg_write(
+            0x10,
+            ByteEnabledDwordWrite::with_all_bytes_enabled(bar_address1 as u32),
+        )
         .unwrap();
 
     let bar_address2: u64 = 0x4000;
     pci_test_device
         .pci_device
-        .pci_cfg_write(0x1c, (bar_address2 >> 32) as u32)
+        .pci_cfg_write(
+            0x1c,
+            ByteEnabledDwordWrite::with_all_bytes_enabled((bar_address2 >> 32) as u32),
+        )
         .unwrap();
     pci_test_device
         .pci_device
-        .pci_cfg_write(0x18, bar_address2 as u32)
+        .pci_cfg_write(
+            0x18,
+            ByteEnabledDwordWrite::with_all_bytes_enabled(bar_address2 as u32),
+        )
         .unwrap();
 
     pci_test_device
         .pci_device
         .pci_cfg_write(
             0x4,
-            cfg_space::Command::new()
-                .with_mmio_enabled(true)
-                .into_bits() as u32,
+            ByteEnabledDwordWrite::new(
+                cfg_space::Command::new()
+                    .with_mmio_enabled(true)
+                    .into_bits() as u32,
+                PciConfigByteEnable::LOW_WORD,
+            ),
         )
         .unwrap();
 
@@ -2898,20 +2993,37 @@ async fn verify_enable_failure_pci_does_not_set_driver_ok(_driver: DefaultDriver
     .unwrap();
 
     let bar_address1: u64 = 0x10000000000;
-    dev.pci_cfg_write(0x14, (bar_address1 >> 32) as u32)
-        .unwrap();
-    dev.pci_cfg_write(0x10, bar_address1 as u32).unwrap();
+    dev.pci_cfg_write(
+        0x14,
+        ByteEnabledDwordWrite::with_all_bytes_enabled((bar_address1 >> 32) as u32),
+    )
+    .unwrap();
+    dev.pci_cfg_write(
+        0x10,
+        ByteEnabledDwordWrite::with_all_bytes_enabled(bar_address1 as u32),
+    )
+    .unwrap();
 
     let bar_address2: u64 = 0x20000000000;
-    dev.pci_cfg_write(0x1c, (bar_address2 >> 32) as u32)
-        .unwrap();
-    dev.pci_cfg_write(0x18, bar_address2 as u32).unwrap();
+    dev.pci_cfg_write(
+        0x1c,
+        ByteEnabledDwordWrite::with_all_bytes_enabled((bar_address2 >> 32) as u32),
+    )
+    .unwrap();
+    dev.pci_cfg_write(
+        0x18,
+        ByteEnabledDwordWrite::with_all_bytes_enabled(bar_address2 as u32),
+    )
+    .unwrap();
 
     dev.pci_cfg_write(
         0x4,
-        cfg_space::Command::new()
-            .with_mmio_enabled(true)
-            .into_bits() as u32,
+        ByteEnabledDwordWrite::new(
+            cfg_space::Command::new()
+                .with_mmio_enabled(true)
+                .into_bits() as u32,
+            PciConfigByteEnable::LOW_WORD,
+        ),
     )
     .unwrap();
 
@@ -2957,7 +3069,11 @@ async fn verify_enable_failure_pci_does_not_set_driver_ok(_driver: DefaultDriver
     dev.mmio_write(bar_address1 + 28, &1u16.to_le_bytes())
         .unwrap();
     // Enable all MSI interrupts
-    dev.pci_cfg_write(0x40, 0x80000000).unwrap();
+    dev.pci_cfg_write(
+        0x40,
+        ByteEnabledDwordWrite::with_all_bytes_enabled(0x80000000),
+    )
+    .unwrap();
 
     // Attempt DRIVER_OK — enable() will fail (use write_u32 to bypass deferred IO)
     let current = dev.read_u32(20);
@@ -3727,19 +3843,37 @@ impl PciTestTransport {
         .unwrap();
 
         let bar_address: u64 = 0x10000000000;
-        dev.pci_cfg_write(0x14, (bar_address >> 32) as u32).unwrap();
-        dev.pci_cfg_write(0x10, bar_address as u32).unwrap();
+        dev.pci_cfg_write(
+            0x14,
+            ByteEnabledDwordWrite::with_all_bytes_enabled((bar_address >> 32) as u32),
+        )
+        .unwrap();
+        dev.pci_cfg_write(
+            0x10,
+            ByteEnabledDwordWrite::with_all_bytes_enabled(bar_address as u32),
+        )
+        .unwrap();
 
         let bar_address2: u64 = 0x20000000000;
-        dev.pci_cfg_write(0x1c, (bar_address2 >> 32) as u32)
-            .unwrap();
-        dev.pci_cfg_write(0x18, bar_address2 as u32).unwrap();
+        dev.pci_cfg_write(
+            0x1c,
+            ByteEnabledDwordWrite::with_all_bytes_enabled((bar_address2 >> 32) as u32),
+        )
+        .unwrap();
+        dev.pci_cfg_write(
+            0x18,
+            ByteEnabledDwordWrite::with_all_bytes_enabled(bar_address2 as u32),
+        )
+        .unwrap();
 
         dev.pci_cfg_write(
             0x4,
-            cfg_space::Command::new()
-                .with_mmio_enabled(true)
-                .into_bits() as u32,
+            ByteEnabledDwordWrite::new(
+                cfg_space::Command::new()
+                    .with_mmio_enabled(true)
+                    .into_bits() as u32,
+                PciConfigByteEnable::LOW_WORD,
+            ),
         )
         .unwrap();
 
@@ -3786,7 +3920,11 @@ impl PciTestTransport {
             dev.mmio_write(bar_address + 28, &1u16.to_le_bytes())
                 .unwrap();
         }
-        dev.pci_cfg_write(0x40, 0x80000000).unwrap();
+        dev.pci_cfg_write(
+            0x40,
+            ByteEnabledDwordWrite::with_all_bytes_enabled(0x80000000),
+        )
+        .unwrap();
 
         Self { dev }
     }
@@ -3981,13 +4119,24 @@ async fn pci_intx_line_deasserted_on_reset(driver: DefaultDriver) {
     .unwrap();
 
     let bar_address: u64 = 0x10000000000;
-    dev.pci_cfg_write(0x14, (bar_address >> 32) as u32).unwrap();
-    dev.pci_cfg_write(0x10, bar_address as u32).unwrap();
+    dev.pci_cfg_write(
+        0x14,
+        ByteEnabledDwordWrite::with_all_bytes_enabled((bar_address >> 32) as u32),
+    )
+    .unwrap();
+    dev.pci_cfg_write(
+        0x10,
+        ByteEnabledDwordWrite::with_all_bytes_enabled(bar_address as u32),
+    )
+    .unwrap();
     dev.pci_cfg_write(
         0x4,
-        cfg_space::Command::new()
-            .with_mmio_enabled(true)
-            .into_bits() as u32,
+        ByteEnabledDwordWrite::new(
+            cfg_space::Command::new()
+                .with_mmio_enabled(true)
+                .into_bits() as u32,
+            PciConfigByteEnable::LOW_WORD,
+        ),
     )
     .unwrap();
 
@@ -4344,17 +4493,26 @@ async fn pci_restore_reinstalls_doorbells(driver: DefaultDriver) {
     // Configure BARs on the target device so doorbells can be registered.
     let bar_address1: u64 = 0x10000000000;
     dev2.pci_device
-        .pci_cfg_write(0x14, (bar_address1 >> 32) as u32)
+        .pci_cfg_write(
+            0x14,
+            ByteEnabledDwordWrite::with_all_bytes_enabled((bar_address1 >> 32) as u32),
+        )
         .unwrap();
     dev2.pci_device
-        .pci_cfg_write(0x10, bar_address1 as u32)
+        .pci_cfg_write(
+            0x10,
+            ByteEnabledDwordWrite::with_all_bytes_enabled(bar_address1 as u32),
+        )
         .unwrap();
     dev2.pci_device
         .pci_cfg_write(
             0x4,
-            cfg_space::Command::new()
-                .with_mmio_enabled(true)
-                .into_bits() as u32,
+            ByteEnabledDwordWrite::new(
+                cfg_space::Command::new()
+                    .with_mmio_enabled(true)
+                    .into_bits() as u32,
+                PciConfigByteEnable::LOW_WORD,
+            ),
         )
         .unwrap();
     // Reset counter to isolate restore behavior.

--- a/vm/devices/virtio/virtio/src/transport/pci.rs
+++ b/vm/devices/virtio/virtio/src/transport/pci.rs
@@ -23,6 +23,8 @@ use chipset_device::io::deferred::defer_read;
 use chipset_device::io::deferred::defer_write;
 use chipset_device::mmio::MmioIntercept;
 use chipset_device::mmio::RegisterMmioIntercept;
+use chipset_device::pci::ByteEnabledDwordRead;
+use chipset_device::pci::ByteEnabledDwordWrite;
 use chipset_device::pci::PciConfigSpace;
 use chipset_device::poll_device::PollDevice;
 use device_emulators::ReadWriteRequestType;
@@ -736,12 +738,12 @@ impl MmioIntercept for VirtioPciDevice {
 }
 
 impl PciConfigSpace for VirtioPciDevice {
-    fn pci_cfg_read(&mut self, offset: u16, value: &mut u32) -> IoResult {
-        self.pci.config_space.read_u32(offset, value)
+    fn pci_cfg_read(&mut self, offset: u16, value: ByteEnabledDwordRead<'_>) -> IoResult {
+        self.pci.config_space.read_byte_enabled(offset, value)
     }
 
-    fn pci_cfg_write(&mut self, offset: u16, value: u32) -> IoResult {
-        self.pci.config_space.write_u32(offset, value)
+    fn pci_cfg_write(&mut self, offset: u16, value: ByteEnabledDwordWrite) -> IoResult {
+        self.pci.config_space.write_byte_enabled(offset, value)
     }
 }
 

--- a/vmm_core/virt_whp/src/device.rs
+++ b/vmm_core/virt_whp/src/device.rs
@@ -8,6 +8,8 @@ use chipset_device::mmio::ControlMmioIntercept;
 use chipset_device::mmio::MmioIntercept;
 use chipset_device::mmio::RegisterMmioIntercept;
 use chipset_device::pci::PciConfigSpace;
+use chipset_device::pci::ByteEnabledDwordRead;
+use chipset_device::pci::ByteEnabledDwordWrite;
 use hv1_hypercall::HvInterruptParameters;
 use hvdef::Vtl;
 use inspect::Inspect;
@@ -360,38 +362,37 @@ impl AssignedPciDevice {
         })
     }
 
-    fn read_phys_config(&self, offset: u16) -> u32 {
-        let mut data = [0; 4];
-        match self.device.device().read_register(
+    fn read_phys_config(&self, offset: u16, mut value: ByteEnabledDwordRead<'_>) {
+        let (byte_offset, _) = value.byte_enable().to_byte_offset_len();
+        let offset = offset as u64;
+        self.device.device().read_register(
             whp::abi::WHvVpciConfigSpace,
-            offset.into(),
-            &mut data,
-        ) {
-            Ok(_) => u32::from_ne_bytes(data),
-            Err(e) => {
-                tracing::warn!(
-                    offset,
-                    error = &e as &dyn std::error::Error,
-                    "config space read",
-                );
-                !0
-            }
-        }
+            offset + (byte_offset as u64),
+            value.reborrow().into_valid_byte_slice(),
+        ).unwrap_or_else(|e| {
+            tracing::warn!(
+                offset,
+                error = &e as &dyn std::error::Error,
+                "config space read",
+            );
+            value.set(!0);
+        });
     }
 
-    fn write_phys_config(&self, offset: u16, value: u32) {
-        match self.device.device().write_register(
+    fn write_phys_config(&self, offset: u16, value: ByteEnabledDwordWrite) {
+        let (byte_offset, _) = value.byte_enable().to_byte_offset_len();
+        let offset = offset as u64;
+        self.device.device().write_register(
             whp::abi::WHvVpciConfigSpace,
-            offset.into(),
-            &value.to_ne_bytes(),
-        ) {
-            Ok(_) => (),
-            Err(e) => tracing::warn!(
+            offset + (byte_offset as u64),
+            value.as_valid_byte_slice(),
+        ).unwrap_or_else(|e| {
+            tracing::warn!(
                 offset,
                 error = &e as &dyn std::error::Error,
                 "config space write",
-            ),
-        }
+            );
+        });
     }
 
     fn set_power_state(&mut self, power_state: u32) {
@@ -474,30 +475,31 @@ impl SaveRestore for AssignedPciDevice {
 }
 
 impl PciConfigSpace for AssignedPciDevice {
-    fn pci_cfg_read(&mut self, offset: u16, value: &mut u32) -> IoResult {
+    fn pci_cfg_read(&mut self, offset: u16, mut value: ByteEnabledDwordRead<'_>) -> IoResult {
         match offset {
             0x10 | 0x14 | 0x18 | 0x1c | 0x20 | 0x24 => {
                 let i = (offset - 0x10) as usize / 4;
-                *value = self.bars[i]
+                value.set(self.bars[i]);
             }
             _ => {
-                let phys = self.read_phys_config(offset);
-                *value = if Some(offset as u32) == self.power_reg {
-                    self.power_state | (phys & !3)
+                let mut phys_u32 = 0;
+                self.read_phys_config(offset, ByteEnabledDwordRead::with_all_bytes_enabled(&mut phys_u32));
+                value.set(if Some(offset as u32) == self.power_reg {
+                    self.power_state | (phys_u32 & !3)
                 } else {
-                    phys
-                }
+                    phys_u32
+                });
             }
         }
 
         IoResult::Ok
     }
 
-    fn pci_cfg_write(&mut self, offset: u16, value: u32) -> IoResult {
+    fn pci_cfg_write(&mut self, offset: u16, value: ByteEnabledDwordWrite) -> IoResult {
         match offset {
             4 => {
                 // Power on/off the device if there is no power cap.
-                let command = cfg_space::Command::from_bits(value as u16);
+                let command = cfg_space::Command::from_bits(value.merge_low(self.command));
                 if command.mmio_enabled() {
                     if self.power_reg.is_none() && self.power_state != 0 {
                         tracing::info!("implicitly transitioning to D0");
@@ -519,11 +521,11 @@ impl PciConfigSpace for AssignedPciDevice {
 
             0x10 | 0x14 | 0x18 | 0x1c | 0x20 | 0x24 => {
                 let i = (offset - 0x10) as usize / 4;
-                self.bars[i] = value & self.probed_bars[i] | self.bar_flags[i];
+                self.bars[i] = value.merge(self.bars[i]) & self.probed_bars[i] | self.bar_flags[i];
             }
             _ => {
                 if Some(offset as u32) == self.power_reg {
-                    let power_state = value & 3;
+                    let power_state = value.merge(self.power_state) & 3;
                     if power_state == 0 && cfg_space::Command::from(self.command).mmio_enabled() {
                         self.set_power_state(power_state);
                         self.enable_mmio();

--- a/vmm_core/virt_whp/src/device.rs
+++ b/vmm_core/virt_whp/src/device.rs
@@ -488,16 +488,11 @@ impl PciConfigSpace for AssignedPciDevice {
                 value.set(self.bars[i]);
             }
             _ => {
-                let mut phys_u32 = 0;
-                self.read_phys_config(
-                    offset,
-                    ByteEnabledDwordRead::with_all_bytes_enabled(&mut phys_u32),
-                );
-                value.set(if Some(offset as u32) == self.power_reg {
-                    self.power_state | (phys_u32 & !3)
-                } else {
-                    phys_u32
-                });
+                const PMCSR_POWER_STATE_MASK: u32 = 0b11;
+                self.read_phys_config(offset, value.reborrow());
+                if value.valid_mask() & PMCSR_POWER_STATE_MASK != 0 {
+                    value.set(self.power_state | (value.extract() & !PMCSR_POWER_STATE_MASK));
+                }
             }
         }
 

--- a/vmm_core/virt_whp/src/device.rs
+++ b/vmm_core/virt_whp/src/device.rs
@@ -7,9 +7,9 @@ use chipset_device::io::IoResult;
 use chipset_device::mmio::ControlMmioIntercept;
 use chipset_device::mmio::MmioIntercept;
 use chipset_device::mmio::RegisterMmioIntercept;
-use chipset_device::pci::PciConfigSpace;
 use chipset_device::pci::ByteEnabledDwordRead;
 use chipset_device::pci::ByteEnabledDwordWrite;
+use chipset_device::pci::PciConfigSpace;
 use hv1_hypercall::HvInterruptParameters;
 use hvdef::Vtl;
 use inspect::Inspect;
@@ -365,34 +365,40 @@ impl AssignedPciDevice {
     fn read_phys_config(&self, offset: u16, mut value: ByteEnabledDwordRead<'_>) {
         let (byte_offset, _) = value.byte_enable().to_byte_offset_len();
         let offset = offset as u64;
-        self.device.device().read_register(
-            whp::abi::WHvVpciConfigSpace,
-            offset + (byte_offset as u64),
-            value.reborrow().into_valid_byte_slice(),
-        ).unwrap_or_else(|e| {
-            tracing::warn!(
-                offset,
-                error = &e as &dyn std::error::Error,
-                "config space read",
-            );
-            value.set(!0);
-        });
+        self.device
+            .device()
+            .read_register(
+                whp::abi::WHvVpciConfigSpace,
+                offset + (byte_offset as u64),
+                value.reborrow().into_valid_byte_slice(),
+            )
+            .unwrap_or_else(|e| {
+                tracing::warn!(
+                    offset,
+                    error = &e as &dyn std::error::Error,
+                    "config space read",
+                );
+                value.set(!0);
+            });
     }
 
     fn write_phys_config(&self, offset: u16, value: ByteEnabledDwordWrite) {
         let (byte_offset, _) = value.byte_enable().to_byte_offset_len();
         let offset = offset as u64;
-        self.device.device().write_register(
-            whp::abi::WHvVpciConfigSpace,
-            offset + (byte_offset as u64),
-            value.as_valid_byte_slice(),
-        ).unwrap_or_else(|e| {
-            tracing::warn!(
-                offset,
-                error = &e as &dyn std::error::Error,
-                "config space write",
-            );
-        });
+        self.device
+            .device()
+            .write_register(
+                whp::abi::WHvVpciConfigSpace,
+                offset + (byte_offset as u64),
+                value.as_valid_byte_slice(),
+            )
+            .unwrap_or_else(|e| {
+                tracing::warn!(
+                    offset,
+                    error = &e as &dyn std::error::Error,
+                    "config space write",
+                );
+            });
     }
 
     fn set_power_state(&mut self, power_state: u32) {
@@ -483,7 +489,10 @@ impl PciConfigSpace for AssignedPciDevice {
             }
             _ => {
                 let mut phys_u32 = 0;
-                self.read_phys_config(offset, ByteEnabledDwordRead::with_all_bytes_enabled(&mut phys_u32));
+                self.read_phys_config(
+                    offset,
+                    ByteEnabledDwordRead::with_all_bytes_enabled(&mut phys_u32),
+                );
                 value.set(if Some(offset as u32) == self.power_reg {
                     self.power_state | (phys_u32 & !3)
                 } else {

--- a/vmm_core/vmotherboard/src/base_chipset.rs
+++ b/vmm_core/vmotherboard/src/base_chipset.rs
@@ -664,7 +664,11 @@ mod weak_mutex_pci {
     pub struct WeakMutexPciDeviceWrapper(Weak<CloseableMutex<dyn ChipsetDevice>>);
 
     impl GenericPciBusDevice for WeakMutexPciDeviceWrapper {
-        fn pci_cfg_read(&mut self, offset: u16, value: ByteEnabledDwordRead<'_>) -> Option<IoResult> {
+        fn pci_cfg_read(
+            &mut self,
+            offset: u16,
+            value: ByteEnabledDwordRead<'_>,
+        ) -> Option<IoResult> {
             Some(
                 self.0
                     .upgrade()?

--- a/vmm_core/vmotherboard/src/base_chipset.rs
+++ b/vmm_core/vmotherboard/src/base_chipset.rs
@@ -652,6 +652,8 @@ mod weak_mutex_pci {
     use crate::chipset::backing::arc_mutex::pci::RegisterWeakMutexPcie;
     use chipset_device::ChipsetDevice;
     use chipset_device::io::IoResult;
+    use chipset_device::pci::ByteEnabledDwordRead;
+    use chipset_device::pci::ByteEnabledDwordWrite;
     use closeable_mutex::CloseableMutex;
     use pci_bus::GenericPciBusDevice;
     use std::sync::Arc;
@@ -662,7 +664,7 @@ mod weak_mutex_pci {
     pub struct WeakMutexPciDeviceWrapper(Weak<CloseableMutex<dyn ChipsetDevice>>);
 
     impl GenericPciBusDevice for WeakMutexPciDeviceWrapper {
-        fn pci_cfg_read(&mut self, offset: u16, value: &mut u32) -> Option<IoResult> {
+        fn pci_cfg_read(&mut self, offset: u16, value: ByteEnabledDwordRead<'_>) -> Option<IoResult> {
             Some(
                 self.0
                     .upgrade()?
@@ -673,7 +675,7 @@ mod weak_mutex_pci {
             )
         }
 
-        fn pci_cfg_write(&mut self, offset: u16, value: u32) -> Option<IoResult> {
+        fn pci_cfg_write(&mut self, offset: u16, value: ByteEnabledDwordWrite) -> Option<IoResult> {
             Some(
                 self.0
                     .upgrade()?
@@ -690,7 +692,7 @@ mod weak_mutex_pci {
             target_bus: u8,
             function: u8,
             offset: u16,
-            value: &mut u32,
+            value: ByteEnabledDwordRead<'_>,
         ) -> Option<IoResult> {
             Some(
                 self.0
@@ -708,7 +710,7 @@ mod weak_mutex_pci {
             target_bus: u8,
             function: u8,
             offset: u16,
-            value: u32,
+            value: ByteEnabledDwordWrite,
         ) -> Option<IoResult> {
             Some(
                 self.0

--- a/workers/chipset_device_worker/src/protocol.rs
+++ b/workers/chipset_device_worker/src/protocol.rs
@@ -4,6 +4,7 @@
 //! The internal protocol for communications between the proxy and the device wrapper.
 
 use chipset_device::io::IoError;
+use chipset_device::pci::PciConfigByteEnable;
 use mesh::MeshPayload;
 use mesh::error::RemoteError;
 use mesh::rpc::Rpc;
@@ -55,9 +56,9 @@ pub(crate) enum DeviceRequest {
     /// Perform a PIO write operation.
     PioWrite(WriteRequest<u16, Vec<u8>>),
     /// Perform a PCI config space read.
-    PciConfigRead(ReadRequest<u16>),
+    PciConfigRead(ReadRequest<u16>, PciConfigByteEnable),
     /// Perform a PCI config space write.
-    PciConfigWrite(WriteRequest<u16, u32>),
+    PciConfigWrite(WriteRequest<u16, u32>, PciConfigByteEnable),
     /// Start the device
     Start,
     /// Stop the device

--- a/workers/chipset_device_worker/src/proxy.rs
+++ b/workers/chipset_device_worker/src/proxy.rs
@@ -17,6 +17,8 @@ use chipset_device::io::deferred::defer_read;
 use chipset_device::io::deferred::defer_write;
 use chipset_device::mmio::MmioIntercept;
 use chipset_device::pci::PciConfigSpace;
+use chipset_device::pci::ByteEnabledDwordRead;
+use chipset_device::pci::ByteEnabledDwordWrite;
 use chipset_device::pio::PortIoIntercept;
 use chipset_device::poll_device::PollDevice;
 use chipset_device_resources::ResolveChipsetDeviceHandleParams;
@@ -200,7 +202,7 @@ impl PortIoIntercept for ChipsetDeviceProxy {
 }
 
 impl PciConfigSpace for ChipsetDeviceProxy {
-    fn pci_cfg_read(&mut self, offset: u16, _value: &mut u32) -> IoResult {
+    fn pci_cfg_read(&mut self, offset: u16, value: ByteEnabledDwordRead<'_>) -> IoResult {
         let (read, token) = defer_read();
         let id = self.in_flight_reads.insert(read);
         self.req_send
@@ -208,19 +210,23 @@ impl PciConfigSpace for ChipsetDeviceProxy {
                 id,
                 address: offset,
                 size: 4,
-            }));
+            },
+            value.byte_enable(),
+        ));
         IoResult::Defer(token)
     }
 
-    fn pci_cfg_write(&mut self, offset: u16, value: u32) -> IoResult {
+    fn pci_cfg_write(&mut self, offset: u16, value: ByteEnabledDwordWrite) -> IoResult {
         let (write, token) = defer_write();
         let id = self.in_flight_writes.insert(write);
         self.req_send
             .send(DeviceRequest::PciConfigWrite(WriteRequest {
                 id,
                 address: offset,
-                data: value,
-            }));
+                data: value.extract(),
+            },
+            value.byte_enable(),
+        ));
         IoResult::Defer(token)
     }
 

--- a/workers/chipset_device_worker/src/proxy.rs
+++ b/workers/chipset_device_worker/src/proxy.rs
@@ -16,9 +16,9 @@ use chipset_device::io::deferred::DeferredWrite;
 use chipset_device::io::deferred::defer_read;
 use chipset_device::io::deferred::defer_write;
 use chipset_device::mmio::MmioIntercept;
-use chipset_device::pci::PciConfigSpace;
 use chipset_device::pci::ByteEnabledDwordRead;
 use chipset_device::pci::ByteEnabledDwordWrite;
+use chipset_device::pci::PciConfigSpace;
 use chipset_device::pio::PortIoIntercept;
 use chipset_device::poll_device::PollDevice;
 use chipset_device_resources::ResolveChipsetDeviceHandleParams;
@@ -205,8 +205,8 @@ impl PciConfigSpace for ChipsetDeviceProxy {
     fn pci_cfg_read(&mut self, offset: u16, value: ByteEnabledDwordRead<'_>) -> IoResult {
         let (read, token) = defer_read();
         let id = self.in_flight_reads.insert(read);
-        self.req_send
-            .send(DeviceRequest::PciConfigRead(ReadRequest {
+        self.req_send.send(DeviceRequest::PciConfigRead(
+            ReadRequest {
                 id,
                 address: offset,
                 size: 4,
@@ -219,8 +219,8 @@ impl PciConfigSpace for ChipsetDeviceProxy {
     fn pci_cfg_write(&mut self, offset: u16, value: ByteEnabledDwordWrite) -> IoResult {
         let (write, token) = defer_write();
         let id = self.in_flight_writes.insert(write);
-        self.req_send
-            .send(DeviceRequest::PciConfigWrite(WriteRequest {
+        self.req_send.send(DeviceRequest::PciConfigWrite(
+            WriteRequest {
                 id,
                 address: offset,
                 data: value.extract(),

--- a/workers/chipset_device_worker/src/worker.rs
+++ b/workers/chipset_device_worker/src/worker.rs
@@ -18,6 +18,8 @@ use anyhow::Context;
 use chipset_device::ChipsetDevice;
 use chipset_device::io::IoResult;
 use chipset_device::io::deferred::DeferredToken;
+use chipset_device::pci::ByteEnabledDwordRead;
+use chipset_device::pci::ByteEnabledDwordWrite;
 use chipset_device_resources::ErasedChipsetDevice;
 use chipset_device_resources::ResolveChipsetDeviceHandleParams;
 use mesh::MeshPayload;
@@ -290,22 +292,24 @@ impl<T: RemoteDynamicResolvers> Worker for RemoteChipsetDeviceWorker<T> {
                                 self.device.supports_pio().unwrap().io_write(address, &data);
                             self.handle_write_result(id, result);
                         }
-                        DeviceRequest::PciConfigRead(ReadRequest { id, address, size }) => {
+                        DeviceRequest::PciConfigRead(ReadRequest { id, address, size }, byte_enable) => {
                             assert_eq!(size, 4);
-                            let mut data = 0;
+                            let mut data_u32 = 0;
+                            let mut value = ByteEnabledDwordRead::new(&mut data_u32, byte_enable);
                             let result = self
                                 .device
                                 .supports_pci()
                                 .unwrap()
-                                .pci_cfg_read(address, &mut data);
-                            self.handle_read_result(id, result, data.to_ne_bytes().to_vec());
+                                .pci_cfg_read(address, value.reborrow());
+                            self.handle_read_result(id, result, data_u32.to_ne_bytes().to_vec());
                         }
-                        DeviceRequest::PciConfigWrite(WriteRequest { id, address, data }) => {
+                        DeviceRequest::PciConfigWrite(WriteRequest { id, address, data }, byte_enable) => {
+                            let value = ByteEnabledDwordWrite::new(data, byte_enable);
                             let result = self
                                 .device
                                 .supports_pci()
                                 .unwrap()
-                                .pci_cfg_write(address, data);
+                                .pci_cfg_write(address, value);
                             self.handle_write_result(id, result);
                         }
                         DeviceRequest::Save(rpc) => {

--- a/workers/chipset_device_worker/src/worker.rs
+++ b/workers/chipset_device_worker/src/worker.rs
@@ -292,7 +292,10 @@ impl<T: RemoteDynamicResolvers> Worker for RemoteChipsetDeviceWorker<T> {
                                 self.device.supports_pio().unwrap().io_write(address, &data);
                             self.handle_write_result(id, result);
                         }
-                        DeviceRequest::PciConfigRead(ReadRequest { id, address, size }, byte_enable) => {
+                        DeviceRequest::PciConfigRead(
+                            ReadRequest { id, address, size },
+                            byte_enable,
+                        ) => {
                             assert_eq!(size, 4);
                             let mut data_u32 = 0;
                             let mut value = ByteEnabledDwordRead::new(&mut data_u32, byte_enable);
@@ -303,7 +306,10 @@ impl<T: RemoteDynamicResolvers> Worker for RemoteChipsetDeviceWorker<T> {
                                 .pci_cfg_read(address, value.reborrow());
                             self.handle_read_result(id, result, data_u32.to_ne_bytes().to_vec());
                         }
-                        DeviceRequest::PciConfigWrite(WriteRequest { id, address, data }, byte_enable) => {
+                        DeviceRequest::PciConfigWrite(
+                            WriteRequest { id, address, data },
+                            byte_enable,
+                        ) => {
                             let value = ByteEnabledDwordWrite::new(data, byte_enable);
                             let result = self
                                 .device


### PR DESCRIPTION
This change builds on #3751 and #3830 to push partial-DWORD config space accesses to all devices in the `PciConfigSpace` trait. 

Updated devices fall into a couple categories:
- Bus type devices (vpci, legacy pci, pcie) now no longer do read-modify-write on partial accesses, they just pass the corresponding byte-enabled value downstream through the trait
- Endpoint devices that delegate all config space accesses to shared `pci_core::cfg_space_emu` helpers continue to do so, passing the byte-enabled values now
- Endpoint devices with custom config space emulation are updated on a case by case basis.