### PR TITLE
virtio: add VIRTIO_PCI_CAP_PCI_CFG access capability

### DIFF
--- a/vm/devices/virtio/virtio/src/tests.rs
+++ b/vm/devices/virtio/virtio/src/tests.rs
@@ -20,6 +20,7 @@ use crate::spec::queue::*;
 use crate::spec::*;
 use crate::transport::VirtioMmioDevice;
 use crate::transport::VirtioPciDevice;
+use chipset_device::io::IoError;
 use chipset_device::mmio::ExternallyManagedMmioIntercepts;
 use chipset_device::mmio::MmioIntercept;
 use chipset_device::pci::ByteEnabledDwordRead;
@@ -1831,7 +1832,128 @@ async fn verify_pci_config(driver: DefaultDriver) {
         .unwrap();
     assert_eq!(buf, 12);
     next_cap_offset = header[1] as u32;
+    assert_ne!(next_cap_offset, 0);
+
+    // The final capability is VIRTIO_PCI_CAP_PCI_CFG (the PCI configuration
+    // access capability). Its length is 20 bytes: the 16-byte virtio_pci_cap
+    // header plus the trailing 4-byte pci_cfg_data window.
+    let mut header = 0;
+    pci_test_device
+        .pci_device
+        .pci_cfg_read(next_cap_offset as u16, &mut header)
+        .unwrap();
+    let header = header.to_le_bytes();
+    assert_eq!(header[0], CapabilityId::VENDOR_SPECIFIC.0);
+    assert_eq!(header[3], VirtioPciCapType::PCI_CFG.0);
+    assert_eq!(header[2], 20);
+    // bar/id/offset/length are all zero until the driver programs them.
+    pci_test_device
+        .pci_device
+        .pci_cfg_read(next_cap_offset as u16 + 4, &mut buf)
+        .unwrap();
+    assert_eq!(buf, 0);
+    pci_test_device
+        .pci_device
+        .pci_cfg_read(next_cap_offset as u16 + 8, &mut buf)
+        .unwrap();
+    assert_eq!(buf, 0);
+    pci_test_device
+        .pci_device
+        .pci_cfg_read(next_cap_offset as u16 + 12, &mut buf)
+        .unwrap();
+    assert_eq!(buf, 0);
+    next_cap_offset = header[1] as u32;
     assert_eq!(next_cap_offset, 0);
+}
+
+/// Walk the capability list and return the config-space offset of the
+/// VIRTIO_PCI_CAP_PCI_CFG capability (identified by cfg_type == PCI_CFG).
+fn find_pci_cfg_cap_offset(dev: &mut VirtioPciDevice) -> u16 {
+    let mut next = 0;
+    dev.pci_cfg_read(0x34, &mut next).unwrap();
+    while next != 0 {
+        let mut header = 0;
+        dev.pci_cfg_read(next as u16, &mut header).unwrap();
+        let header = header.to_le_bytes();
+        if header[0] == CapabilityId::VENDOR_SPECIFIC.0 && header[3] == VirtioPciCapType::PCI_CFG.0
+        {
+            return next as u16;
+        }
+        next = header[1] as u32;
+    }
+    panic!("VIRTIO_PCI_CAP_PCI_CFG capability not found");
+}
+
+/// Exercise the VIRTIO_PCI_CAP_PCI_CFG `pci_cfg_data` window: program the
+/// bar/offset/length fields via config space, then read/write BAR regions
+/// through the window and confirm the accesses reach the same registers as
+/// direct MMIO.
+#[async_test]
+async fn verify_pci_cfg_access_window(driver: DefaultDriver) {
+    let mut pci_test_device =
+        VirtioPciTestDevice::new(&driver, 1, &VirtioTestMemoryAccess::new(), None);
+    let dev = &mut pci_test_device.pci_device;
+
+    let cap = find_pci_cfg_cap_offset(dev);
+    let data_off = cap + 16;
+
+    // Program the window to point at BAR0 offset 0 (device_feature_select), a
+    // 4-byte access.
+    dev.pci_cfg_write(cap + 4, 0).unwrap(); // bar = 0, id = 0
+    dev.pci_cfg_write(cap + 8, 0).unwrap(); // offset = 0
+    dev.pci_cfg_write(cap + 12, 4).unwrap(); // length = 4
+
+    // Reading the window returns the current device_feature_select (0).
+    let mut val = 0xdead_beef;
+    dev.pci_cfg_read(data_off, &mut val).unwrap();
+    assert_eq!(val, 0);
+
+    // Writing the window updates device_feature_select; a direct MMIO read of
+    // the same register must observe the change.
+    dev.pci_cfg_write(data_off, 2).unwrap();
+    let mut val = 0;
+    dev.pci_cfg_read(data_off, &mut val).unwrap();
+    assert_eq!(val, 2);
+
+    // Verify the write went to the real register by mapping BAR0 and reading
+    // device_feature_select directly.
+    let bar_address1: u64 = 0x2000000000;
+    dev.pci_cfg_write(0x14, (bar_address1 >> 32) as u32)
+        .unwrap();
+    dev.pci_cfg_write(0x10, bar_address1 as u32).unwrap();
+    dev.pci_cfg_write(
+        0x4,
+        cfg_space::Command::new()
+            .with_mmio_enabled(true)
+            .into_bits() as u32,
+    )
+    .unwrap();
+    let mut mmio = [0u8; 4];
+    dev.mmio_read(bar_address1, &mut mmio).unwrap();
+    assert_eq!(u32::from_le_bytes(mmio), 2);
+
+    // An invalid length (per spec must be 1, 2, or 4) is rejected with an
+    // access-size error; a non-multiple offset is rejected as unaligned. Both
+    // paths return an error without panicking.
+    dev.pci_cfg_write(cap + 8, 0).unwrap(); // offset = 0
+    dev.pci_cfg_write(cap + 12, 3).unwrap(); // length = 3 (invalid)
+    let mut val = 0;
+    assert!(matches!(
+        dev.pci_cfg_read(data_off, &mut val).now_or_never(),
+        Err(IoError::InvalidAccessSize)
+    ));
+    assert!(matches!(
+        dev.pci_cfg_write(data_off, 0).now_or_never(),
+        Err(IoError::InvalidAccessSize)
+    ));
+
+    // A valid length with a misaligned offset is rejected as unaligned.
+    dev.pci_cfg_write(cap + 8, 2).unwrap(); // offset = 2
+    dev.pci_cfg_write(cap + 12, 4).unwrap(); // length = 4
+    assert!(matches!(
+        dev.pci_cfg_read(data_off, &mut val).now_or_never(),
+        Err(IoError::UnalignedAccess)
+    ));
 }
 
 #[async_test]

--- a/vm/devices/virtio/virtio/src/tests.rs
+++ b/vm/devices/virtio/virtio/src/tests.rs
@@ -1840,7 +1840,10 @@ async fn verify_pci_config(driver: DefaultDriver) {
     let mut header = 0;
     pci_test_device
         .pci_device
-        .pci_cfg_read(next_cap_offset as u16, &mut header)
+        .pci_cfg_read(
+            next_cap_offset as u16,
+            ByteEnabledDwordRead::with_all_bytes_enabled(&mut header),
+        )
         .unwrap();
     let header = header.to_le_bytes();
     assert_eq!(header[0], CapabilityId::VENDOR_SPECIFIC.0);
@@ -1849,17 +1852,26 @@ async fn verify_pci_config(driver: DefaultDriver) {
     // bar/id/offset/length are all zero until the driver programs them.
     pci_test_device
         .pci_device
-        .pci_cfg_read(next_cap_offset as u16 + 4, &mut buf)
+        .pci_cfg_read(
+            next_cap_offset as u16 + 4,
+            ByteEnabledDwordRead::with_all_bytes_enabled(&mut buf),
+        )
         .unwrap();
     assert_eq!(buf, 0);
     pci_test_device
         .pci_device
-        .pci_cfg_read(next_cap_offset as u16 + 8, &mut buf)
+        .pci_cfg_read(
+            next_cap_offset as u16 + 8,
+            ByteEnabledDwordRead::with_all_bytes_enabled(&mut buf),
+        )
         .unwrap();
     assert_eq!(buf, 0);
     pci_test_device
         .pci_device
-        .pci_cfg_read(next_cap_offset as u16 + 12, &mut buf)
+        .pci_cfg_read(
+            next_cap_offset as u16 + 12,
+            ByteEnabledDwordRead::with_all_bytes_enabled(&mut buf),
+        )
         .unwrap();
     assert_eq!(buf, 0);
     next_cap_offset = header[1] as u32;
@@ -1870,10 +1882,18 @@ async fn verify_pci_config(driver: DefaultDriver) {
 /// VIRTIO_PCI_CAP_PCI_CFG capability (identified by cfg_type == PCI_CFG).
 fn find_pci_cfg_cap_offset(dev: &mut VirtioPciDevice) -> u16 {
     let mut next = 0;
-    dev.pci_cfg_read(0x34, &mut next).unwrap();
+    dev.pci_cfg_read(
+        0x34,
+        ByteEnabledDwordRead::with_all_bytes_enabled(&mut next),
+    )
+    .unwrap();
     while next != 0 {
         let mut header = 0;
-        dev.pci_cfg_read(next as u16, &mut header).unwrap();
+        dev.pci_cfg_read(
+            next as u16,
+            ByteEnabledDwordRead::with_all_bytes_enabled(&mut header),
+        )
+        .unwrap();
         let header = header.to_le_bytes();
         if header[0] == CapabilityId::VENDOR_SPECIFIC.0 && header[3] == VirtioPciCapType::PCI_CFG.0
         {
@@ -1899,33 +1919,55 @@ async fn verify_pci_cfg_access_window(driver: DefaultDriver) {
 
     // Program the window to point at BAR0 offset 0 (device_feature_select), a
     // 4-byte access.
-    dev.pci_cfg_write(cap + 4, 0).unwrap(); // bar = 0, id = 0
-    dev.pci_cfg_write(cap + 8, 0).unwrap(); // offset = 0
-    dev.pci_cfg_write(cap + 12, 4).unwrap(); // length = 4
+    dev.pci_cfg_write(cap + 4, ByteEnabledDwordWrite::with_all_bytes_enabled(0))
+        .unwrap(); // bar = 0, id = 0
+    dev.pci_cfg_write(cap + 8, ByteEnabledDwordWrite::with_all_bytes_enabled(0))
+        .unwrap(); // offset = 0
+    dev.pci_cfg_write(cap + 12, ByteEnabledDwordWrite::with_all_bytes_enabled(4))
+        .unwrap(); // length = 4
 
     // Reading the window returns the current device_feature_select (0).
     let mut val = 0xdead_beef;
-    dev.pci_cfg_read(data_off, &mut val).unwrap();
+    dev.pci_cfg_read(
+        data_off,
+        ByteEnabledDwordRead::with_all_bytes_enabled(&mut val),
+    )
+    .unwrap();
     assert_eq!(val, 0);
 
     // Writing the window updates device_feature_select; a direct MMIO read of
     // the same register must observe the change.
-    dev.pci_cfg_write(data_off, 2).unwrap();
+    dev.pci_cfg_write(data_off, ByteEnabledDwordWrite::with_all_bytes_enabled(2))
+        .unwrap();
     let mut val = 0;
-    dev.pci_cfg_read(data_off, &mut val).unwrap();
+    dev.pci_cfg_read(
+        data_off,
+        ByteEnabledDwordRead::with_all_bytes_enabled(&mut val),
+    )
+    .unwrap();
     assert_eq!(val, 2);
 
     // Verify the write went to the real register by mapping BAR0 and reading
     // device_feature_select directly.
     let bar_address1: u64 = 0x2000000000;
-    dev.pci_cfg_write(0x14, (bar_address1 >> 32) as u32)
-        .unwrap();
-    dev.pci_cfg_write(0x10, bar_address1 as u32).unwrap();
+    dev.pci_cfg_write(
+        0x14,
+        ByteEnabledDwordWrite::with_all_bytes_enabled((bar_address1 >> 32) as u32),
+    )
+    .unwrap();
+    dev.pci_cfg_write(
+        0x10,
+        ByteEnabledDwordWrite::with_all_bytes_enabled(bar_address1 as u32),
+    )
+    .unwrap();
     dev.pci_cfg_write(
         0x4,
-        cfg_space::Command::new()
-            .with_mmio_enabled(true)
-            .into_bits() as u32,
+        ByteEnabledDwordWrite::new(
+            cfg_space::Command::new()
+                .with_mmio_enabled(true)
+                .into_bits() as u32,
+            PciConfigByteEnable::LOW_WORD,
+        ),
     )
     .unwrap();
     let mut mmio = [0u8; 4];
@@ -1935,23 +1977,36 @@ async fn verify_pci_cfg_access_window(driver: DefaultDriver) {
     // An invalid length (per spec must be 1, 2, or 4) is rejected with an
     // access-size error; a non-multiple offset is rejected as unaligned. Both
     // paths return an error without panicking.
-    dev.pci_cfg_write(cap + 8, 0).unwrap(); // offset = 0
-    dev.pci_cfg_write(cap + 12, 3).unwrap(); // length = 3 (invalid)
+    dev.pci_cfg_write(cap + 8, ByteEnabledDwordWrite::with_all_bytes_enabled(0))
+        .unwrap(); // offset = 0
+    dev.pci_cfg_write(cap + 12, ByteEnabledDwordWrite::with_all_bytes_enabled(3))
+        .unwrap(); // length = 3 (invalid)
     let mut val = 0;
     assert!(matches!(
-        dev.pci_cfg_read(data_off, &mut val).now_or_never(),
+        dev.pci_cfg_read(
+            data_off,
+            ByteEnabledDwordRead::with_all_bytes_enabled(&mut val)
+        )
+        .now_or_never(),
         Err(IoError::InvalidAccessSize)
     ));
     assert!(matches!(
-        dev.pci_cfg_write(data_off, 0).now_or_never(),
+        dev.pci_cfg_write(data_off, ByteEnabledDwordWrite::with_all_bytes_enabled(0))
+            .now_or_never(),
         Err(IoError::InvalidAccessSize)
     ));
 
     // A valid length with a misaligned offset is rejected as unaligned.
-    dev.pci_cfg_write(cap + 8, 2).unwrap(); // offset = 2
-    dev.pci_cfg_write(cap + 12, 4).unwrap(); // length = 4
+    dev.pci_cfg_write(cap + 8, ByteEnabledDwordWrite::with_all_bytes_enabled(2))
+        .unwrap(); // offset = 2
+    dev.pci_cfg_write(cap + 12, ByteEnabledDwordWrite::with_all_bytes_enabled(4))
+        .unwrap(); // length = 4
     assert!(matches!(
-        dev.pci_cfg_read(data_off, &mut val).now_or_never(),
+        dev.pci_cfg_read(
+            data_off,
+            ByteEnabledDwordRead::with_all_bytes_enabled(&mut val)
+        )
+        .now_or_never(),
         Err(IoError::UnalignedAccess)
     ));
 }

--- a/vm/devices/virtio/virtio/src/tests.rs
+++ b/vm/devices/virtio/virtio/src/tests.rs
@@ -21,6 +21,7 @@ use crate::spec::*;
 use crate::transport::VirtioMmioDevice;
 use crate::transport::VirtioPciDevice;
 use chipset_device::io::IoError;
+use chipset_device::io::IoResult;
 use chipset_device::mmio::ExternallyManagedMmioIntercepts;
 use chipset_device::mmio::MmioIntercept;
 use chipset_device::pci::ByteEnabledDwordRead;
@@ -1302,8 +1303,16 @@ impl VirtioDevice for TestDevice {
         self.traits.clone()
     }
 
-    async fn read_registers_u32(&mut self, _offset: u16) -> u32 {
-        0
+    async fn read_registers_u32(&mut self, offset: u16) -> u32 {
+        // Return a recognizable, offset-encoded value: the byte at
+        // device-config offset `N` reads back as `N`. This lets tests verify
+        // the positioning of device-config accesses routed through this task.
+        u32::from_le_bytes([
+            offset as u8,
+            offset.wrapping_add(1) as u8,
+            offset.wrapping_add(2) as u8,
+            offset.wrapping_add(3) as u8,
+        ])
     }
 
     async fn write_registers_u32(&mut self, _offset: u16, _val: u32) {}
@@ -2009,6 +2018,136 @@ async fn verify_pci_cfg_access_window(driver: DefaultDriver) {
         .now_or_never(),
         Err(IoError::UnalignedAccess)
     ));
+}
+
+/// Regression test for sub-dword (`cap.length` < 4) accesses through the
+/// `VIRTIO_PCI_CAP_PCI_CFG` `pci_cfg_data` window.
+///
+/// Per the virtio spec (4.1.4.9.1) the device stores/uses the *first*
+/// `cap.length` bytes of `pci_cfg_data`, regardless of how `cap.offset` is
+/// aligned within its containing DWORD. So a 2-byte access at a BAR offset
+/// whose low bits are `2` must still land in the low two bytes of
+/// `pci_cfg_data` — not bytes 2..4.
+#[async_test]
+async fn verify_pci_cfg_access_window_subdword(driver: DefaultDriver) {
+    let mut pci_test_device =
+        VirtioPciTestDevice::new(&driver, 1, &VirtioTestMemoryAccess::new(), None);
+    let dev = &mut pci_test_device.pci_device;
+
+    let cap = find_pci_cfg_cap_offset(dev);
+    let data_off = cap + 16;
+
+    // Seed device_feature_select (a 4-byte BAR0 register at offset 0) so its
+    // upper 16 bits hold a recognizable value.
+    dev.write_u32(0, 0xbbbb_aaaa);
+
+    // Program the window for a 2-byte access at BAR0 offset 2 (the upper half
+    // of device_feature_select); `offset & 3 == 2`.
+    dev.pci_cfg_write(cap + 4, ByteEnabledDwordWrite::with_all_bytes_enabled(0))
+        .unwrap(); // bar = 0, id = 0
+    dev.pci_cfg_write(cap + 8, ByteEnabledDwordWrite::with_all_bytes_enabled(2))
+        .unwrap(); // offset = 2
+    dev.pci_cfg_write(cap + 12, ByteEnabledDwordWrite::with_all_bytes_enabled(2))
+        .unwrap(); // length = 2
+
+    // A read through the window must return the accessed bytes in the low two
+    // bytes of pci_cfg_data.
+    let mut val = 0;
+    dev.pci_cfg_read(
+        data_off,
+        ByteEnabledDwordRead::with_all_bytes_enabled(&mut val),
+    )
+    .unwrap();
+    assert_eq!(
+        val & 0xffff,
+        0xbbbb,
+        "read data must occupy the first cap.length bytes of pci_cfg_data (got {val:#010x})",
+    );
+
+    // A write through the window must take its value from the low two bytes of
+    // pci_cfg_data and store it at BAR0 offset 2.
+    dev.pci_cfg_write(
+        data_off,
+        ByteEnabledDwordWrite::with_all_bytes_enabled(0x0000_cccc),
+    )
+    .unwrap();
+    assert_eq!(
+        dev.read_u32(0) >> 16,
+        0xcccc,
+        "written data must be taken from the first cap.length bytes of pci_cfg_data",
+    );
+}
+
+/// Exercise the *deferred* device-config path of the `pci_cfg_data` window.
+///
+/// Device-specific config registers are owned by the async device task, so an
+/// access through the window at `cap.offset >= BAR0_DEVICE_CFG_OFFSET` is
+/// deferred. The PCI config bus polls the deferred read with a 4-byte dword
+/// buffer, so the completion must be a full dword with the accessed
+/// `cap.length` bytes left-aligned into the low bytes of `pci_cfg_data`.
+///
+/// The test device reports byte `N` at device-config offset `N`.
+#[async_test]
+async fn verify_pci_cfg_access_window_deferred(driver: DefaultDriver) {
+    let mut pci_test_device =
+        VirtioPciTestDevice::new(&driver, 1, &VirtioTestMemoryAccess::new(), None);
+    let dev = &mut pci_test_device.pci_device;
+
+    let cap = find_pci_cfg_cap_offset(dev);
+    let data_off = cap + 16;
+
+    // Device config starts after the common (56), notify (4), and ISR (4)
+    // regions in BAR0.
+    const DEVICE_CFG_BAR0_OFFSET: u32 = 56 + 4 + 4;
+
+    // Point the window at BAR0 (bar = 0, id = 0).
+    dev.pci_cfg_write(cap + 4, ByteEnabledDwordWrite::with_all_bytes_enabled(0))
+        .unwrap();
+
+    // Aligned 4-byte read at device-config offset 0 => bytes [0, 1, 2, 3].
+    dev.pci_cfg_write(
+        cap + 8,
+        ByteEnabledDwordWrite::with_all_bytes_enabled(DEVICE_CFG_BAR0_OFFSET),
+    )
+    .unwrap(); // offset = device cfg + 0
+    dev.pci_cfg_write(cap + 12, ByteEnabledDwordWrite::with_all_bytes_enabled(4))
+        .unwrap(); // length = 4
+
+    let mut val = 0;
+    let mut buf = [0u8; 4];
+    match dev.pci_cfg_read(
+        data_off,
+        ByteEnabledDwordRead::with_all_bytes_enabled(&mut val),
+    ) {
+        IoResult::Defer(token) => token.read_future(&mut buf).await.unwrap(),
+        other => panic!("expected a deferred read, got {other:?}"),
+    }
+    assert_eq!(buf, [0, 1, 2, 3]);
+
+    // Sub-dword 2-byte read at device-config offset 2 (`offset & 3 == 2`). The
+    // accessed bytes [2, 3] must land in the low two bytes of pci_cfg_data.
+    dev.pci_cfg_write(
+        cap + 8,
+        ByteEnabledDwordWrite::with_all_bytes_enabled(DEVICE_CFG_BAR0_OFFSET + 2),
+    )
+    .unwrap(); // offset = device cfg + 2
+    dev.pci_cfg_write(cap + 12, ByteEnabledDwordWrite::with_all_bytes_enabled(2))
+        .unwrap(); // length = 2
+
+    let mut val = 0;
+    let mut buf = [0u8; 4];
+    match dev.pci_cfg_read(
+        data_off,
+        ByteEnabledDwordRead::with_all_bytes_enabled(&mut val),
+    ) {
+        IoResult::Defer(token) => token.read_future(&mut buf).await.unwrap(),
+        other => panic!("expected a deferred read, got {other:?}"),
+    }
+    assert_eq!(
+        u32::from_le_bytes(buf) & 0xffff,
+        0x0302,
+        "deferred device-config bytes must be left-aligned in pci_cfg_data",
+    );
 }
 
 #[async_test]

--- a/vm/devices/virtio/virtio/src/tests.rs
+++ b/vm/devices/virtio/virtio/src/tests.rs
@@ -2020,6 +2020,60 @@ async fn verify_pci_cfg_access_window(driver: DefaultDriver) {
     ));
 }
 
+/// A `pci_cfg_data` access whose `cap.offset`/`cap.length` falls outside the
+/// selected BAR must be rejected as `InvalidRegister`, rather than truncating
+/// the offset to `u16` or routing past the end of the BAR.
+#[async_test]
+async fn verify_pci_cfg_access_window_bounds(driver: DefaultDriver) {
+    let mut pci_test_device =
+        VirtioPciTestDevice::new(&driver, 1, &VirtioTestMemoryAccess::new(), None);
+    let dev = &mut pci_test_device.pci_device;
+
+    let cap = find_pci_cfg_cap_offset(dev);
+    let data_off = cap + 16;
+
+    // A BAR0 offset far past the end of the transport + device-config region.
+    // This value fits in a u16, so it exercises the BAR-size check rather than
+    // the u16 bound.
+    dev.pci_cfg_write(cap + 4, ByteEnabledDwordWrite::with_all_bytes_enabled(0))
+        .unwrap(); // bar = 0
+    dev.pci_cfg_write(
+        cap + 8,
+        ByteEnabledDwordWrite::with_all_bytes_enabled(0xf000),
+    )
+    .unwrap(); // offset = 0xf000
+    dev.pci_cfg_write(cap + 12, ByteEnabledDwordWrite::with_all_bytes_enabled(4))
+        .unwrap(); // length = 4
+    let mut val = 0;
+    assert!(matches!(
+        dev.pci_cfg_read(
+            data_off,
+            ByteEnabledDwordRead::with_all_bytes_enabled(&mut val)
+        )
+        .now_or_never(),
+        Err(IoError::InvalidRegister)
+    ));
+    assert!(matches!(
+        dev.pci_cfg_write(data_off, ByteEnabledDwordWrite::with_all_bytes_enabled(0))
+            .now_or_never(),
+        Err(IoError::InvalidRegister)
+    ));
+
+    // A BAR that the window cannot reach is rejected as well.
+    dev.pci_cfg_write(cap + 4, ByteEnabledDwordWrite::with_all_bytes_enabled(1))
+        .unwrap(); // bar = 1
+    dev.pci_cfg_write(cap + 8, ByteEnabledDwordWrite::with_all_bytes_enabled(0))
+        .unwrap(); // offset = 0
+    assert!(matches!(
+        dev.pci_cfg_read(
+            data_off,
+            ByteEnabledDwordRead::with_all_bytes_enabled(&mut val)
+        )
+        .now_or_never(),
+        Err(IoError::InvalidRegister)
+    ));
+}
+
 /// Regression test for sub-dword (`cap.length` < 4) accesses through the
 /// `VIRTIO_PCI_CAP_PCI_CFG` `pci_cfg_data` window.
 ///

--- a/vm/devices/virtio/virtio/src/transport/mmio.rs
+++ b/vm/devices/virtio/virtio/src/transport/mmio.rs
@@ -4,6 +4,7 @@
 use super::StalledIo;
 use super::core::TransportOps;
 use super::core::VirtioTransportCore;
+use super::task::ConfigReadCompletion;
 use super::task::defer_config_read;
 use super::task::defer_config_write;
 use crate::DynVirtioDevice;
@@ -462,6 +463,7 @@ impl MmioIntercept for VirtioMmioDevice {
                 &self.core.device_sender,
                 offset - VirtioMmioRegister::CONFIG.0,
                 data.len() as u8,
+                ConfigReadCompletion::Exact,
             );
         }
         if self.core.state.is_busy() {

--- a/vm/devices/virtio/virtio/src/transport/pci.rs
+++ b/vm/devices/virtio/virtio/src/transport/pci.rs
@@ -47,6 +47,8 @@ use pci_core::cfg_space_emu::ConfigSpaceType0Emulator;
 use pci_core::cfg_space_emu::DeviceBars;
 use pci_core::cfg_space_emu::IntxInterrupt;
 use pci_core::msi::MsiTarget;
+use pci_core::spec::caps::COMMON_HEADER_END;
+use pci_core::spec::caps::CapabilityId;
 use pci_core::spec::hwid::ClassCode;
 use pci_core::spec::hwid::HardwareIds;
 use pci_core::spec::hwid::ProgrammingInterface;
@@ -56,6 +58,10 @@ use std::sync::Arc;
 use vmcore::device_state::ChangeDeviceState;
 use vmcore::interrupt::Interrupt;
 use vmcore::line_interrupt::LineInterrupt;
+use vmcore::save_restore::NoSavedState;
+use vmcore::save_restore::RestoreError;
+use vmcore::save_restore::SaveError;
+use vmcore::save_restore::SaveRestore;
 
 /// What kind of PCI interrupts [`VirtioPciDevice`] should use.
 pub enum PciInterruptModel<'a> {
@@ -129,6 +135,12 @@ struct PciTransport {
     msix_config_vector: u16,
     #[inspect(hex)]
     shared_memory_size: u64,
+    /// Shared window state for the `VIRTIO_PCI_CAP_PCI_CFG` capability.
+    #[inspect(skip)]
+    pci_cfg_access: Arc<Mutex<PciCfgAccessState>>,
+    /// Config-space offset of the `pci_cfg_data` window.
+    #[inspect(hex)]
+    pci_cfg_data_offset: u16,
 }
 
 impl TransportOps for PciTransport {
@@ -304,6 +316,25 @@ impl VirtioPciDevice {
                 .map_err(io::Error::other)?;
         }
 
+        // Add the VIRTIO_PCI_CAP_PCI_CFG capability last. It provides an
+        // alternative access path to the virtio BAR regions through PCI
+        // configuration space. The `pci_cfg_data` window is serviced by
+        // `pci_cfg_read`/`pci_cfg_write` below, using the shared window state.
+        let pci_cfg_access = Arc::new(Mutex::new(PciCfgAccessState::default()));
+        caps.push(Box::new(VirtioPciCfgCapability {
+            state: pci_cfg_access.clone(),
+        }));
+        // Capabilities are laid out consecutively starting at the end of the
+        // common PCI header in the order they appear in `caps`; the pci_cfg
+        // capability is last, so its offset is the header end plus the total
+        // length of all preceding capabilities.
+        let pci_cfg_cap_offset = COMMON_HEADER_END
+            + caps[..caps.len() - 1]
+                .iter()
+                .map(|c| c.len() as u16)
+                .sum::<u16>();
+        let pci_cfg_data_offset = pci_cfg_cap_offset + VIRTIO_PCI_CFG_DATA_OFFSET;
+
         let mut config_space = ConfigSpaceType0Emulator::new(hardware_ids, caps, Vec::new(), bars);
         let interrupt_kind = match interrupt_model {
             PciInterruptModel::Msix(_) => InterruptKind::Msix(msix.unwrap()),
@@ -322,6 +353,8 @@ impl VirtioPciDevice {
                 interrupt_status: Arc::new(Mutex::new(0)),
                 msix_config_vector: 0,
                 shared_memory_size,
+                pci_cfg_access,
+                pci_cfg_data_offset,
             },
         })
     }
@@ -517,6 +550,120 @@ impl VirtioPciDevice {
         });
     }
 
+    /// Service a read of the `VIRTIO_PCI_CAP_PCI_CFG` `pci_cfg_data` window.
+    ///
+    /// The accessed bytes are placed at their natural position within the
+    /// returned dword (`offset & 3`), matching how the PCI configuration
+    /// mechanism extracts sub-dword accesses. The device-config region is
+    /// owned by the async device task and is therefore deferred; that path
+    /// fills the low bytes of the dword, so it is only accurate for
+    /// dword-aligned device-config accesses (the common case).
+    fn read_pci_cfg_data(&mut self, value: &mut u32) -> IoResult {
+        let (bar, offset, length) = {
+            let state = self.pci.pci_cfg_access.lock();
+            (state.bar, state.offset, state.length)
+        };
+        // Per the virtio spec, length MUST be 1, 2, or 4 and offset MUST be a
+        // multiple of length. Reject anything else without panicking.
+        if !matches!(length, 1 | 2 | 4) {
+            return IoResult::Err(IoError::InvalidAccessSize);
+        }
+        if !offset.is_multiple_of(length) {
+            return IoResult::Err(IoError::UnalignedAccess);
+        }
+        let len = length as usize;
+        if bar == 0 && offset >= BAR0_DEVICE_CFG_OFFSET as u32 {
+            return defer_config_read(
+                &self.core.device_sender,
+                (offset - BAR0_DEVICE_CFG_OFFSET as u32) as u16,
+                len as u8,
+            );
+        }
+        let byte = (offset & 3) as usize;
+        let mut buf = [0u8; 4];
+        let result = self.read_pci_cfg_bar(bar, offset, &mut buf[byte..byte + len]);
+        if let IoResult::Ok = result {
+            *value = u32::from_le_bytes(buf);
+        }
+        result
+    }
+
+    /// Service a write of the `VIRTIO_PCI_CAP_PCI_CFG` `pci_cfg_data` window.
+    fn write_pci_cfg_data(&mut self, value: u32) -> IoResult {
+        let (bar, offset, length) = {
+            let state = self.pci.pci_cfg_access.lock();
+            (state.bar, state.offset, state.length)
+        };
+        if !matches!(length, 1 | 2 | 4) {
+            return IoResult::Err(IoError::InvalidAccessSize);
+        }
+        if !offset.is_multiple_of(length) {
+            return IoResult::Err(IoError::UnalignedAccess);
+        }
+        let len = length as usize;
+        let byte = (offset & 3) as usize;
+        let bytes = value.to_le_bytes();
+        let data = &bytes[byte..byte + len];
+        if bar == 0 && offset >= BAR0_DEVICE_CFG_OFFSET as u32 {
+            return defer_config_write(
+                &self.core.device_sender,
+                (offset - BAR0_DEVICE_CFG_OFFSET as u32) as u16,
+                data,
+            );
+        }
+        self.write_pci_cfg_bar(bar, offset, data)
+    }
+
+    /// Read `data.len()` bytes from a synchronous BAR region (BAR0 transport or
+    /// BAR2 MSI-X) on behalf of a `pci_cfg_data` access. The device-config
+    /// region must be handled separately via deferral by the caller.
+    fn read_pci_cfg_bar(&mut self, bar: u8, offset: u32, data: &mut [u8]) -> IoResult {
+        match bar {
+            0 => self.read_transport(offset as u16, data),
+            2 => read_as_u32_chunks(offset as u16, data, |offset| {
+                if let InterruptKind::Msix(msix) = &self.pci.interrupt_kind {
+                    msix.read_u32(offset as u64)
+                } else {
+                    !0
+                }
+            }),
+            _ => return IoResult::Err(IoError::InvalidRegister),
+        }
+        IoResult::Ok
+    }
+
+    /// Write `data` to a synchronous BAR region (BAR0 transport or BAR2 MSI-X)
+    /// on behalf of a `pci_cfg_data` access. The device-config region must be
+    /// handled separately via deferral by the caller.
+    fn write_pci_cfg_bar(&mut self, bar: u8, offset: u32, data: &[u8]) -> IoResult {
+        match bar {
+            0 => self.write_transport(offset as u16, data),
+            2 => {
+                write_as_u32_chunks(
+                    offset as u16,
+                    data,
+                    |offset, request_type| match request_type {
+                        ReadWriteRequestType::Write(value) => {
+                            if let InterruptKind::Msix(msix) = &mut self.pci.interrupt_kind {
+                                msix.write_u32(offset as u64, value)
+                            }
+                            None
+                        }
+                        ReadWriteRequestType::Read => {
+                            if let InterruptKind::Msix(msix) = &self.pci.interrupt_kind {
+                                Some(msix.read_u32(offset as u64))
+                            } else {
+                                Some(!0)
+                            }
+                        }
+                    },
+                );
+            }
+            _ => return IoResult::Err(IoError::InvalidRegister),
+        }
+        IoResult::Ok
+    }
+
     /// Replay MMIO accesses that were stalled while the transport was busy.
     fn replay_stalled_io(&mut self) {
         let stalled = std::mem::take(&mut self.core.stalled_io);
@@ -646,7 +793,7 @@ mod saved_state {
     impl SaveRestore for VirtioPciDevice {
         type SavedState = state::SavedState;
 
-        fn save(&mut self) -> Result<Self::SavedState, vmcore::save_restore::SaveError> {
+        fn save(&mut self) -> Result<Self::SavedState, SaveError> {
             Ok(state::SavedState {
                 common: self.core.save_common()?,
                 msix_config_vector: self.pci.msix_config_vector,
@@ -664,10 +811,7 @@ mod saved_state {
             })
         }
 
-        fn restore(
-            &mut self,
-            state: Self::SavedState,
-        ) -> Result<(), vmcore::save_restore::RestoreError> {
+        fn restore(&mut self, state: Self::SavedState) -> Result<(), RestoreError> {
             let saved_queue_count = state.queues.len();
             self.core.restore_common(
                 &mut self.pci,
@@ -782,12 +926,138 @@ impl MmioIntercept for VirtioPciDevice {
 }
 
 impl PciConfigSpace for VirtioPciDevice {
-    fn pci_cfg_read(&mut self, offset: u16, value: ByteEnabledDwordRead<'_>) -> IoResult {
+    fn pci_cfg_read(&mut self, offset: u16, mut value: ByteEnabledDwordRead<'_>) -> IoResult {
+        if offset == self.pci.pci_cfg_data_offset {
+            let mut dword = 0;
+            let result = self.read_pci_cfg_data(&mut dword);
+            if let IoResult::Ok = result {
+                value.set(dword);
+            }
+            return result;
+        }
         self.pci.config_space.read_byte_enabled(offset, value)
     }
 
     fn pci_cfg_write(&mut self, offset: u16, value: ByteEnabledDwordWrite) -> IoResult {
+        if offset == self.pci.pci_cfg_data_offset {
+            return self.write_pci_cfg_data(value.merge(0));
+        }
         self.pci.config_space.write_byte_enabled(offset, value)
+    }
+}
+
+/// Length of the `virtio_pci_cfg_cap` structure: the 16-byte `virtio_pci_cap`
+/// header plus the trailing 4-byte `pci_cfg_data` window.
+const VIRTIO_PCI_CFG_CAP_LEN: u8 = 20;
+/// Byte offset of the `pci_cfg_data` window within `virtio_pci_cfg_cap`.
+const VIRTIO_PCI_CFG_DATA_OFFSET: u16 = 16;
+
+/// Shared window state for the `VIRTIO_PCI_CAP_PCI_CFG` capability.
+///
+/// The driver programs `bar`, `offset`, and `length` by writing the
+/// capability's config-space fields, then reads or writes the `pci_cfg_data`
+/// window to perform an access into the selected BAR region. Both the
+/// capability (which owns the field writes) and [`VirtioPciDevice`] (which
+/// services the `pci_cfg_data` window) hold a clone of this state.
+#[derive(Debug, Default, Inspect)]
+struct PciCfgAccessState {
+    bar: u8,
+    id: u8,
+    #[inspect(hex)]
+    offset: u32,
+    #[inspect(hex)]
+    length: u32,
+}
+
+/// The `VIRTIO_PCI_CAP_PCI_CFG` capability (`virtio_pci_cfg_cap`).
+///
+/// Provides an alternative access path to the virtio BAR regions purely
+/// through PCI configuration space, for drivers or firmware that cannot map
+/// the device's memory BARs. See the virtio 1.x spec, "PCI configuration
+/// access capability". The `pci_cfg_data` window itself is serviced by
+/// [`VirtioPciDevice`], which has access to the BAR regions; this capability
+/// only tracks the programmed `bar`/`offset`/`length` fields.
+struct VirtioPciCfgCapability {
+    state: Arc<Mutex<PciCfgAccessState>>,
+}
+
+impl Inspect for VirtioPciCfgCapability {
+    fn inspect(&self, req: inspect::Request<'_>) {
+        let state = self.state.lock();
+        req.respond()
+            .field("label", "virtio-pci-cfg")
+            .field("bar", state.bar)
+            .field("id", state.id)
+            .hex("offset", state.offset)
+            .hex("length", state.length);
+    }
+}
+
+impl PciCapability for VirtioPciCfgCapability {
+    fn label(&self) -> &str {
+        "virtio-pci-cfg"
+    }
+
+    fn capability_id(&self) -> CapabilityId {
+        CapabilityId::VENDOR_SPECIFIC
+    }
+
+    fn len(&self) -> usize {
+        VIRTIO_PCI_CFG_CAP_LEN as usize
+    }
+
+    fn read(&self, offset: u16, mut value: ByteEnabledDwordRead<'_>) {
+        let state = self.state.lock();
+        let dword = match offset {
+            // cap_vndr | cap_next (filled in by the config space emulator) |
+            // cap_len | cfg_type
+            0 => {
+                CapabilityId::VENDOR_SPECIFIC.0 as u32
+                    | (VIRTIO_PCI_CFG_CAP_LEN as u32) << 16
+                    | (VirtioPciCapType::PCI_CFG.0 as u32) << 24
+            }
+            // bar | id | padding
+            4 => state.bar as u32 | (state.id as u32) << 8,
+            8 => state.offset,
+            12 => state.length,
+            // pci_cfg_data is serviced by VirtioPciDevice::pci_cfg_read.
+            _ => 0,
+        };
+        value.set(dword);
+    }
+
+    fn write(&mut self, offset: u16, val: ByteEnabledDwordWrite) {
+        let mut state = self.state.lock();
+        match offset {
+            // The header dword (cap_vndr/cap_next/cap_len/cfg_type) is
+            // read-only.
+            0 => {}
+            4 => {
+                let merged = val.merge(state.bar as u32 | (state.id as u32) << 8);
+                state.bar = merged as u8;
+                state.id = (merged >> 8) as u8;
+            }
+            8 => state.offset = val.merge(state.offset),
+            12 => state.length = val.merge(state.length),
+            // pci_cfg_data is serviced by VirtioPciDevice::pci_cfg_write.
+            _ => {}
+        }
+    }
+
+    fn reset(&mut self) {
+        *self.state.lock() = PciCfgAccessState::default();
+    }
+}
+
+impl SaveRestore for VirtioPciCfgCapability {
+    type SavedState = NoSavedState;
+
+    fn save(&mut self) -> Result<Self::SavedState, SaveError> {
+        Ok(NoSavedState)
+    }
+
+    fn restore(&mut self, NoSavedState: Self::SavedState) -> Result<(), RestoreError> {
+        Ok(())
     }
 }
 

--- a/vm/devices/virtio/virtio/src/transport/pci.rs
+++ b/vm/devices/virtio/virtio/src/transport/pci.rs
@@ -60,7 +60,6 @@ use vmcore::interrupt::Interrupt;
 use vmcore::line_interrupt::LineInterrupt;
 use vmcore::save_restore::RestoreError;
 use vmcore::save_restore::SaveError;
-use vmcore::save_restore::SaveRestore;
 
 /// What kind of PCI interrupts [`VirtioPciDevice`] should use.
 pub enum PciInterruptModel<'a> {
@@ -792,6 +791,19 @@ mod saved_state {
             #[mesh(4)]
             pub interrupt_status: u32,
         }
+
+        #[derive(Protobuf, SavedStateRoot)]
+        #[mesh(package = "virtio.transport.pci")]
+        pub struct CfgCapSavedState {
+            #[mesh(1)]
+            pub bar: u8,
+            #[mesh(2)]
+            pub id: u8,
+            #[mesh(3)]
+            pub offset: u32,
+            #[mesh(4)]
+            pub length: u32,
+        }
     }
 
     use super::*;
@@ -837,6 +849,35 @@ mod saved_state {
             }
             self.pci.msix_config_vector = state.msix_config_vector;
 
+            Ok(())
+        }
+    }
+
+    impl SaveRestore for VirtioPciCfgCapability {
+        type SavedState = state::CfgCapSavedState;
+
+        fn save(&mut self) -> Result<Self::SavedState, SaveError> {
+            let state = self.state.lock();
+            Ok(state::CfgCapSavedState {
+                bar: state.bar,
+                id: state.id,
+                offset: state.offset,
+                length: state.length,
+            })
+        }
+
+        fn restore(&mut self, saved_state: Self::SavedState) -> Result<(), RestoreError> {
+            let state::CfgCapSavedState {
+                bar,
+                id,
+                offset,
+                length,
+            } = saved_state;
+            let mut state = self.state.lock();
+            state.bar = bar;
+            state.id = id;
+            state.offset = offset;
+            state.length = length;
             Ok(())
         }
     }
@@ -1053,53 +1094,6 @@ impl PciCapability for VirtioPciCfgCapability {
 
     fn reset(&mut self) {
         *self.state.lock() = PciCfgAccessState::default();
-    }
-}
-
-impl SaveRestore for VirtioPciCfgCapability {
-    type SavedState = pci_cfg_cap_state::SavedState;
-
-    fn save(&mut self) -> Result<Self::SavedState, SaveError> {
-        let state = self.state.lock();
-        Ok(pci_cfg_cap_state::SavedState {
-            bar: state.bar,
-            id: state.id,
-            offset: state.offset,
-            length: state.length,
-        })
-    }
-
-    fn restore(&mut self, saved_state: Self::SavedState) -> Result<(), RestoreError> {
-        let pci_cfg_cap_state::SavedState {
-            bar,
-            id,
-            offset,
-            length,
-        } = saved_state;
-        let mut state = self.state.lock();
-        state.bar = bar;
-        state.id = id;
-        state.offset = offset;
-        state.length = length;
-        Ok(())
-    }
-}
-
-mod pci_cfg_cap_state {
-    use mesh::payload::Protobuf;
-    use vmcore::save_restore::SavedStateRoot;
-
-    #[derive(Protobuf, SavedStateRoot)]
-    #[mesh(package = "virtio.transport.pci.cfg_cap")]
-    pub struct SavedState {
-        #[mesh(1)]
-        pub bar: u8,
-        #[mesh(2)]
-        pub id: u8,
-        #[mesh(3)]
-        pub offset: u32,
-        #[mesh(4)]
-        pub length: u32,
     }
 }
 

--- a/vm/devices/virtio/virtio/src/transport/pci.rs
+++ b/vm/devices/virtio/virtio/src/transport/pci.rs
@@ -58,7 +58,6 @@ use std::sync::Arc;
 use vmcore::device_state::ChangeDeviceState;
 use vmcore::interrupt::Interrupt;
 use vmcore::line_interrupt::LineInterrupt;
-use vmcore::save_restore::NoSavedState;
 use vmcore::save_restore::RestoreError;
 use vmcore::save_restore::SaveError;
 use vmcore::save_restore::SaveRestore;
@@ -556,8 +555,8 @@ impl VirtioPciDevice {
     /// returned dword (`offset & 3`), matching how the PCI configuration
     /// mechanism extracts sub-dword accesses. The device-config region is
     /// owned by the async device task and is therefore deferred; that path
-    /// fills the low bytes of the dword, so it is only accurate for
-    /// dword-aligned device-config accesses (the common case).
+    /// reads the dword containing the access, so the completed size always
+    /// matches the 4-byte buffer the PCI config bus polls deferred reads with.
     fn read_pci_cfg_data(&mut self, value: &mut u32) -> IoResult {
         let (bar, offset, length) = {
             let state = self.pci.pci_cfg_access.lock();
@@ -571,13 +570,20 @@ impl VirtioPciDevice {
         if !offset.is_multiple_of(length) {
             return IoResult::Err(IoError::UnalignedAccess);
         }
+        // The transport, MSI-X, and device-config regions all live within the
+        // first 64 KiB of their BARs. Reject guest-programmed offsets that do
+        // not fit in `u16` rather than truncating and routing to the wrong
+        // register.
+        let Ok(offset) = u16::try_from(offset) else {
+            return IoResult::Err(IoError::InvalidRegister);
+        };
         let len = length as usize;
-        if bar == 0 && offset >= BAR0_DEVICE_CFG_OFFSET as u32 {
-            return defer_config_read(
-                &self.core.device_sender,
-                (offset - BAR0_DEVICE_CFG_OFFSET as u32) as u16,
-                len as u8,
-            );
+        if bar == 0 && offset >= BAR0_DEVICE_CFG_OFFSET {
+            // The device-config region is polled as a full dword, so always
+            // defer a dword-aligned 4-byte read. The requested bytes land at
+            // `offset & 3` within the returned dword, matching the spec.
+            let dev_offset = offset - BAR0_DEVICE_CFG_OFFSET;
+            return defer_config_read(&self.core.device_sender, dev_offset & !3, 4);
         }
         let byte = (offset & 3) as usize;
         let mut buf = [0u8; 4];
@@ -600,14 +606,19 @@ impl VirtioPciDevice {
         if !offset.is_multiple_of(length) {
             return IoResult::Err(IoError::UnalignedAccess);
         }
+        // Reject guest-programmed offsets that do not fit in `u16` rather than
+        // truncating and routing to the wrong register.
+        let Ok(offset) = u16::try_from(offset) else {
+            return IoResult::Err(IoError::InvalidRegister);
+        };
         let len = length as usize;
         let byte = (offset & 3) as usize;
         let bytes = value.to_le_bytes();
         let data = &bytes[byte..byte + len];
-        if bar == 0 && offset >= BAR0_DEVICE_CFG_OFFSET as u32 {
+        if bar == 0 && offset >= BAR0_DEVICE_CFG_OFFSET {
             return defer_config_write(
                 &self.core.device_sender,
-                (offset - BAR0_DEVICE_CFG_OFFSET as u32) as u16,
+                offset - BAR0_DEVICE_CFG_OFFSET,
                 data,
             );
         }
@@ -617,10 +628,10 @@ impl VirtioPciDevice {
     /// Read `data.len()` bytes from a synchronous BAR region (BAR0 transport or
     /// BAR2 MSI-X) on behalf of a `pci_cfg_data` access. The device-config
     /// region must be handled separately via deferral by the caller.
-    fn read_pci_cfg_bar(&mut self, bar: u8, offset: u32, data: &mut [u8]) -> IoResult {
+    fn read_pci_cfg_bar(&mut self, bar: u8, offset: u16, data: &mut [u8]) -> IoResult {
         match bar {
-            0 => self.read_transport(offset as u16, data),
-            2 => read_as_u32_chunks(offset as u16, data, |offset| {
+            0 => self.read_transport(offset, data),
+            2 => read_as_u32_chunks(offset, data, |offset| {
                 if let InterruptKind::Msix(msix) = &self.pci.interrupt_kind {
                     msix.read_u32(offset as u64)
                 } else {
@@ -635,29 +646,25 @@ impl VirtioPciDevice {
     /// Write `data` to a synchronous BAR region (BAR0 transport or BAR2 MSI-X)
     /// on behalf of a `pci_cfg_data` access. The device-config region must be
     /// handled separately via deferral by the caller.
-    fn write_pci_cfg_bar(&mut self, bar: u8, offset: u32, data: &[u8]) -> IoResult {
+    fn write_pci_cfg_bar(&mut self, bar: u8, offset: u16, data: &[u8]) -> IoResult {
         match bar {
-            0 => self.write_transport(offset as u16, data),
+            0 => self.write_transport(offset, data),
             2 => {
-                write_as_u32_chunks(
-                    offset as u16,
-                    data,
-                    |offset, request_type| match request_type {
-                        ReadWriteRequestType::Write(value) => {
-                            if let InterruptKind::Msix(msix) = &mut self.pci.interrupt_kind {
-                                msix.write_u32(offset as u64, value)
-                            }
-                            None
+                write_as_u32_chunks(offset, data, |offset, request_type| match request_type {
+                    ReadWriteRequestType::Write(value) => {
+                        if let InterruptKind::Msix(msix) = &mut self.pci.interrupt_kind {
+                            msix.write_u32(offset as u64, value)
                         }
-                        ReadWriteRequestType::Read => {
-                            if let InterruptKind::Msix(msix) = &self.pci.interrupt_kind {
-                                Some(msix.read_u32(offset as u64))
-                            } else {
-                                Some(!0)
-                            }
+                        None
+                    }
+                    ReadWriteRequestType::Read => {
+                        if let InterruptKind::Msix(msix) = &self.pci.interrupt_kind {
+                            Some(msix.read_u32(offset as u64))
+                        } else {
+                            Some(!0)
                         }
-                    },
-                );
+                    }
+                });
             }
             _ => return IoResult::Err(IoError::InvalidRegister),
         }
@@ -1050,14 +1057,49 @@ impl PciCapability for VirtioPciCfgCapability {
 }
 
 impl SaveRestore for VirtioPciCfgCapability {
-    type SavedState = NoSavedState;
+    type SavedState = pci_cfg_cap_state::SavedState;
 
     fn save(&mut self) -> Result<Self::SavedState, SaveError> {
-        Ok(NoSavedState)
+        let state = self.state.lock();
+        Ok(pci_cfg_cap_state::SavedState {
+            bar: state.bar,
+            id: state.id,
+            offset: state.offset,
+            length: state.length,
+        })
     }
 
-    fn restore(&mut self, NoSavedState: Self::SavedState) -> Result<(), RestoreError> {
+    fn restore(&mut self, saved_state: Self::SavedState) -> Result<(), RestoreError> {
+        let pci_cfg_cap_state::SavedState {
+            bar,
+            id,
+            offset,
+            length,
+        } = saved_state;
+        let mut state = self.state.lock();
+        state.bar = bar;
+        state.id = id;
+        state.offset = offset;
+        state.length = length;
         Ok(())
+    }
+}
+
+mod pci_cfg_cap_state {
+    use mesh::payload::Protobuf;
+    use vmcore::save_restore::SavedStateRoot;
+
+    #[derive(Protobuf, SavedStateRoot)]
+    #[mesh(package = "virtio.transport.pci.cfg_cap")]
+    pub struct SavedState {
+        #[mesh(1)]
+        pub bar: u8,
+        #[mesh(2)]
+        pub id: u8,
+        #[mesh(3)]
+        pub offset: u32,
+        #[mesh(4)]
+        pub length: u32,
     }
 }
 

--- a/vm/devices/virtio/virtio/src/transport/pci.rs
+++ b/vm/devices/virtio/virtio/src/transport/pci.rs
@@ -140,6 +140,10 @@ struct PciTransport {
     /// Config-space offset of the `pci_cfg_data` window.
     #[inspect(hex)]
     pci_cfg_data_offset: u16,
+    /// Length of the device-specific config region within BAR0, used to
+    /// bound `pci_cfg_data` accesses.
+    #[inspect(hex)]
+    device_register_length: u32,
 }
 
 impl TransportOps for PciTransport {
@@ -354,6 +358,7 @@ impl VirtioPciDevice {
                 shared_memory_size,
                 pci_cfg_access,
                 pci_cfg_data_offset,
+                device_register_length: traits.device_register_length,
             },
         })
     }
@@ -549,6 +554,20 @@ impl VirtioPciDevice {
         });
     }
 
+    /// Length of the BAR selected by a `pci_cfg_data` access, or `None` if
+    /// `bar` does not correspond to a BAR reachable through the window. Used to
+    /// bound guest-programmed `cap.offset`/`cap.length` accesses.
+    fn pci_cfg_bar_len(&self, bar: u8) -> Option<u32> {
+        match bar {
+            0 => Some(u32::from(BAR0_DEVICE_CFG_OFFSET) + self.pci.device_register_length),
+            2 => match &self.pci.interrupt_kind {
+                InterruptKind::Msix(msix) => Some(msix.bar_len() as u32),
+                _ => None,
+            },
+            _ => None,
+        }
+    }
+
     /// Service a read of the `VIRTIO_PCI_CAP_PCI_CFG` `pci_cfg_data` window.
     ///
     /// Per the virtio spec (4.1.4.9.1) the accessed bytes are stored in the
@@ -570,13 +589,16 @@ impl VirtioPciDevice {
         if !offset.is_multiple_of(length) {
             return IoResult::Err(IoError::UnalignedAccess);
         }
-        // The transport, MSI-X, and device-config regions all live within the
-        // first 64 KiB of their BARs. Reject guest-programmed offsets that do
-        // not fit in `u16` rather than truncating and routing to the wrong
-        // register.
-        let Ok(offset) = u16::try_from(offset) else {
+        // Reject accesses that fall outside the selected BAR. The transport,
+        // MSI-X, and device-config regions all live within the first 64 KiB of
+        // their BARs, so a validated offset always fits in a `u16`.
+        let Some(bar_len) = self.pci_cfg_bar_len(bar) else {
             return IoResult::Err(IoError::InvalidRegister);
         };
+        if offset.checked_add(length).is_none_or(|end| end > bar_len) {
+            return IoResult::Err(IoError::InvalidRegister);
+        }
+        let offset = offset as u16;
         let len = length as usize;
         if bar == 0 && offset >= BAR0_DEVICE_CFG_OFFSET {
             // The device-config region is owned by the async device task, so
@@ -614,11 +636,15 @@ impl VirtioPciDevice {
         if !offset.is_multiple_of(length) {
             return IoResult::Err(IoError::UnalignedAccess);
         }
-        // Reject guest-programmed offsets that do not fit in `u16` rather than
-        // truncating and routing to the wrong register.
-        let Ok(offset) = u16::try_from(offset) else {
+        // Reject accesses that fall outside the selected BAR (see
+        // `read_pci_cfg_data`).
+        let Some(bar_len) = self.pci_cfg_bar_len(bar) else {
             return IoResult::Err(IoError::InvalidRegister);
         };
+        if offset.checked_add(length).is_none_or(|end| end > bar_len) {
+            return IoResult::Err(IoError::InvalidRegister);
+        }
+        let offset = offset as u16;
         let len = length as usize;
         // Take the value from the first `cap.length` bytes of `pci_cfg_data`,
         // as required by the spec.

--- a/vm/devices/virtio/virtio/src/transport/pci.rs
+++ b/vm/devices/virtio/virtio/src/transport/pci.rs
@@ -808,10 +808,8 @@ mod saved_state {
             #[mesh(1)]
             pub bar: u8,
             #[mesh(2)]
-            pub id: u8,
-            #[mesh(3)]
             pub offset: u32,
-            #[mesh(4)]
+            #[mesh(3)]
             pub length: u32,
         }
     }
@@ -870,7 +868,6 @@ mod saved_state {
             let state = self.state.lock();
             Ok(state::CfgCapSavedState {
                 bar: state.bar,
-                id: state.id,
                 offset: state.offset,
                 length: state.length,
             })
@@ -879,13 +876,11 @@ mod saved_state {
         fn restore(&mut self, saved_state: Self::SavedState) -> Result<(), RestoreError> {
             let state::CfgCapSavedState {
                 bar,
-                id,
                 offset,
                 length,
             } = saved_state;
             let mut state = self.state.lock();
             state.bar = bar;
-            state.id = id;
             state.offset = offset;
             state.length = length;
             Ok(())
@@ -1021,7 +1016,6 @@ const VIRTIO_PCI_CFG_DATA_OFFSET: u16 = 16;
 #[derive(Debug, Default, Inspect)]
 struct PciCfgAccessState {
     bar: u8,
-    id: u8,
     #[inspect(hex)]
     offset: u32,
     #[inspect(hex)]
@@ -1046,7 +1040,6 @@ impl Inspect for VirtioPciCfgCapability {
         req.respond()
             .field("label", "virtio-pci-cfg")
             .field("bar", state.bar)
-            .field("id", state.id)
             .hex("offset", state.offset)
             .hex("length", state.length);
     }
@@ -1075,8 +1068,9 @@ impl PciCapability for VirtioPciCfgCapability {
                     | (VIRTIO_PCI_CFG_CAP_LEN as u32) << 16
                     | (VirtioPciCapType::PCI_CFG.0 as u32) << 24
             }
-            // bar | id | padding
-            4 => state.bar as u32 | (state.id as u32) << 8,
+            // bar | id | padding. The id field is read-only and unused for
+            // this capability, so it always reads as zero.
+            4 => state.bar as u32,
             8 => state.offset,
             12 => state.length,
             // pci_cfg_data is serviced by VirtioPciDevice::pci_cfg_read.
@@ -1091,11 +1085,9 @@ impl PciCapability for VirtioPciCfgCapability {
             // The header dword (cap_vndr/cap_next/cap_len/cfg_type) is
             // read-only.
             0 => {}
-            4 => {
-                let merged = val.merge(state.bar as u32 | (state.id as u32) << 8);
-                state.bar = merged as u8;
-                state.id = (merged >> 8) as u8;
-            }
+            // Only bar is writable here; the id byte is read-only and unused
+            // for this capability.
+            4 => state.bar = val.merge(state.bar.into()) as u8,
             8 => state.offset = val.merge(state.offset),
             12 => state.length = val.merge(state.length),
             // pci_cfg_data is serviced by VirtioPciDevice::pci_cfg_write.

--- a/vm/devices/virtio/virtio/src/transport/pci.rs
+++ b/vm/devices/virtio/virtio/src/transport/pci.rs
@@ -554,18 +554,25 @@ impl VirtioPciDevice {
         });
     }
 
-    /// Length of the BAR selected by a `pci_cfg_data` access, or `None` if
-    /// `bar` does not correspond to a BAR reachable through the window. Used to
-    /// bound guest-programmed `cap.offset`/`cap.length` accesses.
-    fn pci_cfg_bar_len(&self, bar: u8) -> Option<u32> {
-        match bar {
-            0 => Some(u32::from(BAR0_DEVICE_CFG_OFFSET) + self.pci.device_register_length),
+    /// Validate a guest-programmed `pci_cfg_data` access against the selected
+    /// BAR, returning the offset as a `u16`, or `None` if `bar`, `offset`, and
+    /// `length` do not address `length` bytes within a reachable BAR.
+    fn pci_cfg_bar_offset(&self, bar: u8, offset: u32, length: u32) -> Option<u16> {
+        let bar_len = match bar {
+            0 => u32::from(BAR0_DEVICE_CFG_OFFSET) + self.pci.device_register_length,
             2 => match &self.pci.interrupt_kind {
-                InterruptKind::Msix(msix) => Some(msix.bar_len() as u32),
-                _ => None,
+                InterruptKind::Msix(msix) => msix.bar_len() as u32,
+                _ => return None,
             },
-            _ => None,
+            _ => return None,
+        };
+        // The access must fit entirely within the BAR, and the offset must be
+        // addressable as a `u16` (all reachable regions live within the first
+        // 64 KiB of their BARs).
+        if offset.checked_add(length)? > bar_len {
+            return None;
         }
+        u16::try_from(offset).ok()
     }
 
     /// Service a read of the `VIRTIO_PCI_CAP_PCI_CFG` `pci_cfg_data` window.
@@ -589,16 +596,11 @@ impl VirtioPciDevice {
         if !offset.is_multiple_of(length) {
             return IoResult::Err(IoError::UnalignedAccess);
         }
-        // Reject accesses that fall outside the selected BAR. The transport,
-        // MSI-X, and device-config regions all live within the first 64 KiB of
-        // their BARs, so a validated offset always fits in a `u16`.
-        let Some(bar_len) = self.pci_cfg_bar_len(bar) else {
+        // Reject accesses that do not address `length` bytes within the
+        // selected BAR.
+        let Some(offset) = self.pci_cfg_bar_offset(bar, offset, length) else {
             return IoResult::Err(IoError::InvalidRegister);
         };
-        if offset.checked_add(length).is_none_or(|end| end > bar_len) {
-            return IoResult::Err(IoError::InvalidRegister);
-        }
-        let offset = offset as u16;
         let len = length as usize;
         if bar == 0 && offset >= BAR0_DEVICE_CFG_OFFSET {
             // The device-config region is owned by the async device task, so
@@ -636,15 +638,11 @@ impl VirtioPciDevice {
         if !offset.is_multiple_of(length) {
             return IoResult::Err(IoError::UnalignedAccess);
         }
-        // Reject accesses that fall outside the selected BAR (see
-        // `read_pci_cfg_data`).
-        let Some(bar_len) = self.pci_cfg_bar_len(bar) else {
+        // Reject accesses that do not address `length` bytes within the
+        // selected BAR (see `read_pci_cfg_data`).
+        let Some(offset) = self.pci_cfg_bar_offset(bar, offset, length) else {
             return IoResult::Err(IoError::InvalidRegister);
         };
-        if offset.checked_add(length).is_none_or(|end| end > bar_len) {
-            return IoResult::Err(IoError::InvalidRegister);
-        }
-        let offset = offset as u16;
         let len = length as usize;
         // Take the value from the first `cap.length` bytes of `pci_cfg_data`,
         // as required by the spec.

--- a/vm/devices/virtio/virtio/src/transport/pci.rs
+++ b/vm/devices/virtio/virtio/src/transport/pci.rs
@@ -7,6 +7,7 @@ use self::capabilities::*;
 use super::StalledIo;
 use super::core::TransportOps;
 use super::core::VirtioTransportCore;
+use super::task::ConfigReadCompletion;
 use super::task::defer_config_read;
 use super::task::defer_config_write;
 use crate::DynVirtioDevice;
@@ -550,9 +551,9 @@ impl VirtioPciDevice {
 
     /// Service a read of the `VIRTIO_PCI_CAP_PCI_CFG` `pci_cfg_data` window.
     ///
-    /// The accessed bytes are placed at their natural position within the
-    /// returned dword (`offset & 3`), matching how the PCI configuration
-    /// mechanism extracts sub-dword accesses. The device-config region is
+    /// Per the virtio spec (4.1.4.9.1) the accessed bytes are stored in the
+    /// *first* `cap.length` bytes of `pci_cfg_data`, regardless of how
+    /// `cap.offset` is aligned within its dword. The device-config region is
     /// owned by the async device task and is therefore deferred; that path
     /// reads the dword containing the access, so the completed size always
     /// matches the 4-byte buffer the PCI config bus polls deferred reads with.
@@ -578,15 +579,23 @@ impl VirtioPciDevice {
         };
         let len = length as usize;
         if bar == 0 && offset >= BAR0_DEVICE_CFG_OFFSET {
-            // The device-config region is polled as a full dword, so always
-            // defer a dword-aligned 4-byte read. The requested bytes land at
-            // `offset & 3` within the returned dword, matching the spec.
+            // The device-config region is owned by the async device task, so
+            // the access is deferred. The PCI config bus polls the deferred
+            // read with a 4-byte dword buffer, so the completion must be a full
+            // dword with the accessed `cap.length` bytes left-aligned into the
+            // low bytes of `pci_cfg_data`, as required by the spec.
             let dev_offset = offset - BAR0_DEVICE_CFG_OFFSET;
-            return defer_config_read(&self.core.device_sender, dev_offset & !3, 4);
+            return defer_config_read(
+                &self.core.device_sender,
+                dev_offset,
+                len as u8,
+                ConfigReadCompletion::LeftAlignedDword,
+            );
         }
-        let byte = (offset & 3) as usize;
+        // Store the accessed bytes in the first `cap.length` bytes of
+        // `pci_cfg_data`, as required by the spec.
         let mut buf = [0u8; 4];
-        let result = self.read_pci_cfg_bar(bar, offset, &mut buf[byte..byte + len]);
+        let result = self.read_pci_cfg_bar(bar, offset, &mut buf[..len]);
         if let IoResult::Ok = result {
             *value = u32::from_le_bytes(buf);
         }
@@ -611,9 +620,10 @@ impl VirtioPciDevice {
             return IoResult::Err(IoError::InvalidRegister);
         };
         let len = length as usize;
-        let byte = (offset & 3) as usize;
+        // Take the value from the first `cap.length` bytes of `pci_cfg_data`,
+        // as required by the spec.
         let bytes = value.to_le_bytes();
-        let data = &bytes[byte..byte + len];
+        let data = &bytes[..len];
         if bar == 0 && offset >= BAR0_DEVICE_CFG_OFFSET {
             return defer_config_write(
                 &self.core.device_sender,
@@ -894,6 +904,7 @@ impl MmioIntercept for VirtioPciDevice {
                 &self.core.device_sender,
                 offset - BAR0_DEVICE_CFG_OFFSET,
                 data.len() as u8,
+                ConfigReadCompletion::Exact,
             );
         }
         if bar == 0 && self.core.state.is_busy() {

--- a/vm/devices/virtio/virtio/src/transport/task.rs
+++ b/vm/devices/virtio/virtio/src/transport/task.rs
@@ -45,6 +45,7 @@ pub enum DeviceCommand {
     ReadConfig {
         offset: u16,
         len: u8,
+        completion: ConfigReadCompletion,
         deferred: DeferredRead,
     },
     /// Config register write at byte offset with raw data.
@@ -56,6 +57,19 @@ pub enum DeviceCommand {
     },
     /// Inspect the device state.
     Inspect(inspect::Deferred),
+}
+
+/// How a deferred config read completion should be sized and positioned.
+#[derive(Copy, Clone, Debug)]
+pub enum ConfigReadCompletion {
+    /// Complete exactly `len` bytes at their natural position — used when the
+    /// caller polls the deferred read with a `len`-sized buffer (direct MMIO).
+    Exact,
+    /// Complete a full 4-byte dword with the accessed `len` bytes left-aligned
+    /// into the low bytes — used by the `VIRTIO_PCI_CAP_PCI_CFG` `pci_cfg_data`
+    /// window, which the PCI config bus polls with a 4-byte dword buffer. Per
+    /// the virtio spec the accessed bytes occupy the first `cap.length` bytes.
+    LeftAlignedDword,
 }
 
 /// Parameters for the Enable command.
@@ -273,6 +287,7 @@ pub async fn run_device_task(
             DeviceCommand::ReadConfig {
                 offset,
                 len,
+                completion,
                 deferred,
             } => {
                 let start_word = offset & !3;
@@ -284,7 +299,15 @@ pub async fn run_device_task(
                     buf[i..i + 4].copy_from_slice(&val.to_ne_bytes());
                 }
                 let byte_off = (offset - start_word) as usize;
-                deferred.complete(&buf[byte_off..byte_off + len as usize]);
+                let data = &buf[byte_off..byte_off + len as usize];
+                match completion {
+                    ConfigReadCompletion::Exact => deferred.complete(data),
+                    ConfigReadCompletion::LeftAlignedDword => {
+                        let mut dword = [0u8; 4];
+                        dword[..len as usize].copy_from_slice(data);
+                        deferred.complete(&dword);
+                    }
+                }
             }
             DeviceCommand::WriteConfig {
                 offset,
@@ -326,11 +349,17 @@ pub async fn run_device_task(
 }
 
 /// Send a config read to the device task, returning a deferred IO token.
-pub fn defer_config_read(sender: &mesh::Sender<DeviceCommand>, offset: u16, len: u8) -> IoResult {
+pub fn defer_config_read(
+    sender: &mesh::Sender<DeviceCommand>,
+    offset: u16,
+    len: u8,
+    completion: ConfigReadCompletion,
+) -> IoResult {
     let (deferred, token) = defer_read();
     sender.send(DeviceCommand::ReadConfig {
         offset,
         len,
+        completion,
         deferred,
     });
     IoResult::Defer(token)

--- a/vm/devices/virtio/virtio_spec/src/lib.rs
+++ b/vm/devices/virtio/virtio_spec/src/lib.rs
@@ -137,7 +137,7 @@ pub mod pci {
             NOTIFY_CFG = 2,
             ISR_CFG = 3,
             DEVICE_CFG = 4,
-            // PCI_CFG = 5,
+            PCI_CFG = 5,
             SHARED_MEMORY_CFG = 8,
         }
     }


### PR DESCRIPTION
The virtio PCI transport did not expose the PCI configuration access capability, so drivers or firmware that cannot map the device's memory BARs had no way to reach the virtio registers. This adds the VIRTIO_PCI_CAP_PCI_CFG capability, which provides an alternative access path to the BAR regions entirely through PCI configuration space.

The capability tracks the driver-programmed bar/offset/length fields, and the pci_cfg_data window is serviced by VirtioPciDevice, which routes each access to the selected BAR region: the transport (BAR0), MSI-X (BAR2), or the async-owned device-config region (deferred). Accesses are validated per the spec—length must be 1, 2, or 4 and offset a multiple of length—and rejected without panicking on untrusted driver input.

A new test walks the capability list to locate the window, programs it, and confirms reads and writes reach the same registers as direct MMIO, including the error paths for invalid length and misaligned offset.