### PR TITLE
SNP: Rework cache management during page acceptance

### DIFF
--- a/openhcl/openhcl_boot/src/arch/x86_64/memory.rs
+++ b/openhcl/openhcl_boot/src/arch/x86_64/memory.rs
@@ -342,6 +342,15 @@ fn accept_pending_vtl2_memory(
                     _ => unreachable!(),
                 }
 
+                // On SNP, evict any stale private (C=1) cache lines for these
+                // pages before writing the preserved contents back through the
+                // identity mapping.
+                if isolation_type == IsolationType::Snp {
+                    for page_offset in (0..range.len()).step_by(hvdef::HV_PAGE_SIZE as usize) {
+                        super::snp::cache_lines_flush_page(range.start() + page_offset);
+                    }
+                }
+
                 // Copy the buffer back. Use the identity map now that the memory has been accepted.
                 {
                     // SAFETY: Known memory region that was just accepted.

--- a/openhcl/openhcl_boot/src/arch/x86_64/memory.rs
+++ b/openhcl/openhcl_boot/src/arch/x86_64/memory.rs
@@ -305,17 +305,6 @@ fn accept_pending_vtl2_memory(
 
                     let mapping = local_map.map_pages(map_range, false);
                     ram_buffer.copy_from_slice(mapping.data);
-
-                    // On SNP, evict the shared (C=0) cache lines for these
-                    // pages while the C=0 mapping is still live.
-                    if isolation_type == IsolationType::Snp {
-                        let mapping_va = mapping.data.as_ptr() as u64;
-                        for page_offset in
-                            (0..mapping.data.len() as u64).step_by(hvdef::HV_PAGE_SIZE as usize)
-                        {
-                            super::snp::cache_lines_flush_page(mapping_va + page_offset);
-                        }
-                    }
                 }
 
                 // Change visibility on the pages for this iteration.
@@ -340,15 +329,6 @@ fn accept_pending_vtl2_memory(
                             .expect("accepting vtl 2 memory must not fail");
                     }
                     _ => unreachable!(),
-                }
-
-                // On SNP, evict any stale private (C=1) cache lines for these
-                // pages before writing the preserved contents back through the
-                // identity mapping.
-                if isolation_type == IsolationType::Snp {
-                    for page_offset in (0..range.len()).step_by(hvdef::HV_PAGE_SIZE as usize) {
-                        super::snp::cache_lines_flush_page(range.start() + page_offset);
-                    }
                 }
 
                 // Copy the buffer back. Use the identity map now that the memory has been accepted.

--- a/openhcl/openhcl_boot/src/arch/x86_64/snp.rs
+++ b/openhcl/openhcl_boot/src/arch/x86_64/snp.rs
@@ -42,7 +42,12 @@ pub(super) fn cache_lines_flush_page(addr: u64) {
     let start = addr & !(X64_PAGE_SIZE - 1);
     let end = start + X64_PAGE_SIZE;
 
-    // Make sure there are no pending writes on the cache lines.
+    // Drain any pending stores before the flush. Per the AMD64 APM (vol. 3,
+    // CLFLUSH), CLFLUSH may take effect on a cache line while stores from
+    // earlier store instructions are still pending in the store buffer; such
+    // stores would otherwise re-cache and modify the line after the CLFLUSH has
+    // completed, defeating the eviction. A leading MFENCE forces those stores
+    // to be included in the line that is flushed.
     fence(Ordering::SeqCst);
 
     for addr in (start..end).step_by(FLUSH_SIZE as usize) {
@@ -51,6 +56,16 @@ pub(super) fn cache_lines_flush_page(addr: u64) {
             asm!("clflush [{0}]", in(reg) addr, options(nostack));
         }
     }
+
+    // CLFLUSH is only strongly ordered by MFENCE. Per the AMD64 APM (vol. 3,
+    // CLFLUSH), speculative loads and later memory operations may be reordered
+    // around CLFLUSH, and LFENCE, SFENCE, and serializing instructions are not
+    // ordered with respect to it. In particular, the following PVALIDATE /
+    // VMGEXIT must not be assumed to order these evictions. A trailing MFENCE
+    // is therefore required so the evictions complete before the caller
+    // performs the page-state change or accesses the page under the new C-bit
+    // setting.
+    fence(Ordering::SeqCst);
 }
 
 #[cfg(feature = "cvm_boot_log")]
@@ -670,6 +685,13 @@ impl Ghcb {
 
         flush_tlb();
 
+        // No post-acceptance flush of the private (C=1) cache lines is needed
+        // here, unlike the shared -> private transition in
+        // `accept_pending_vtl2_memory`. That path preserves the page contents
+        // and later reads them back for integrity checks, so stale private
+        // lines left over from speculation must be evicted before the
+        // authoritative write-back. Here the previous contents are
+        // intentionally zeroed over, so any stale private lines are irrelevant.
         ghcb_access::zero_page();
 
         // SAFETY: Always safe to write the GHCB MSR, no concurrency issues.

--- a/openhcl/openhcl_boot/src/arch/x86_64/snp.rs
+++ b/openhcl/openhcl_boot/src/arch/x86_64/snp.rs
@@ -5,8 +5,8 @@
 
 use super::address_space::LocalMap;
 use core::arch::asm;
+use core::sync::atomic::AtomicU8;
 use core::sync::atomic::Ordering;
-use core::sync::atomic::fence;
 use memory_range::MemoryRange;
 use minimal_rt::arch::msr::read_msr;
 use minimal_rt::arch::msr::write_msr;
@@ -22,50 +22,38 @@ use {
     super::address_space::X64_PTE_READ_WRITE,
     crate::arch::x86_64::address_space::X64_PTE_CONFIDENTIAL,
     crate::single_threaded::SingleThreaded, bitfield_struct::bitfield, core::cell::Cell,
-    core::cell::UnsafeCell, core::sync::atomic::compiler_fence, hvdef::HvRegisterValue,
-    hvdef::HvX64RegisterName, hvdef::hypercall::HvInputVtl, hvdef::hypercall::HypercallOutput,
-    x86defs::snp::GhcbProtocolVersion, x86defs::snp::GhcbUsage, x86defs::snp::SevExitCode,
-    x86defs::snp::SevIoAccessInfo, zerocopy::IntoBytes,
+    core::cell::UnsafeCell, core::sync::atomic::compiler_fence, core::sync::atomic::fence,
+    hvdef::HvRegisterValue, hvdef::HvX64RegisterName, hvdef::hypercall::HvInputVtl,
+    hvdef::hypercall::HypercallOutput, x86defs::snp::GhcbProtocolVersion, x86defs::snp::GhcbUsage,
+    x86defs::snp::SevExitCode, x86defs::snp::SevIoAccessInfo, zerocopy::IntoBytes,
 };
 
-/// Flush all cache lines covering a single page-sized region starting at the
-/// given virtual address.
+/// Touch a freshly (re)assigned page so the cache engine clears any stale
+/// state left over from the previous page assignment.
 ///
-/// On AMD SEV-SNP, the C-bit is part of the cache-line tag for a physical
-/// address. When transitioning a page between shared (C=0) and private (C=1)
-/// state, any cache lines tagged with the old C-bit setting must be evicted
-/// before the new mapping is accessed; otherwise stale cache lines can lead
-/// to data corruption observed via the new mapping. Callers must invoke this
-/// using a VA whose PTE has the C-bit setting that is being torn down.
-pub(super) fn cache_lines_flush_page(addr: u64) {
-    const FLUSH_SIZE: u64 = 64; // NOTE: hardcoded cache line size.
+/// Per AMD guidance, following a page assignment change (for example, a
+/// `pvalidate`) software must read the first and last byte of each 4 KiB page
+/// to force the cache engine to clear its state; failing to do so can result
+/// in memory corruption. Relaxed atomic loads are used so the compiler cannot
+/// optimize the accesses away and so they remain well defined even if the host
+/// concurrently modifies shared memory. The loaded values are intentionally
+/// discarded.
+///
+/// # Safety
+///
+/// The caller must guarantee that the 4 KiB page containing `addr` is mapped
+/// and safely accessible for reads for the duration of the call.
+pub(super) unsafe fn cache_lines_fixup_page(addr: u64) {
     let start = addr & !(X64_PAGE_SIZE - 1);
-    let end = start + X64_PAGE_SIZE;
-
-    // Drain any pending stores before the flush. Per the AMD64 APM (vol. 3,
-    // CLFLUSH), CLFLUSH may take effect on a cache line while stores from
-    // earlier store instructions are still pending in the store buffer; such
-    // stores would otherwise re-cache and modify the line after the CLFLUSH has
-    // completed, defeating the eviction. A leading MFENCE forces those stores
-    // to be included in the line that is flushed.
-    fence(Ordering::SeqCst);
-
-    for addr in (start..end).step_by(FLUSH_SIZE as usize) {
-        // SAFETY: No concurrency issues.
-        unsafe {
-            asm!("clflush [{0}]", in(reg) addr, options(nostack));
-        }
+    let last = start + X64_PAGE_SIZE - 1;
+    for byte_addr in [start, last] {
+        // SAFETY: The caller guarantees the page containing `addr` is mapped
+        // and readable, so `byte_addr` (its first or last byte) is a valid,
+        // readable address. The access only ever loads and the result is
+        // discarded.
+        let byte = unsafe { &*(byte_addr as *const AtomicU8) };
+        let _ = byte.load(Ordering::Relaxed);
     }
-
-    // CLFLUSH is only strongly ordered by MFENCE. Per the AMD64 APM (vol. 3,
-    // CLFLUSH), speculative loads and later memory operations may be reordered
-    // around CLFLUSH, and LFENCE, SFENCE, and serializing instructions are not
-    // ordered with respect to it. In particular, the following PVALIDATE /
-    // VMGEXIT must not be assumed to order these evictions. A trailing MFENCE
-    // is therefore required so the evictions complete before the caller
-    // performs the page-state change or accesses the page under the new C-bit
-    // setting.
-    fence(Ordering::SeqCst);
 }
 
 #[cfg(feature = "cvm_boot_log")]
@@ -562,8 +550,6 @@ impl Ghcb {
         page_table[PT_INDEX] = pte_for_pfn(page_number, true);
 
         flush_tlb();
-        // Evict the page from the cache before changing the encrypted state.
-        cache_lines_flush_page(GHCB_GVA.into_bits());
 
         // Unaccept the page, invalidates page state.
         pvalidate(page_number, GHCB_GVA.into_bits(), false, false).expect("memory unaccept");
@@ -578,8 +564,12 @@ impl Ghcb {
         // Map the page as non-confidential by updating the PTE.
         page_table[PT_INDEX] = pte_for_pfn(page_number, false);
         flush_tlb();
-        // Evict the page from the cache before changing the encrypted state.
-        cache_lines_flush_page(GHCB_GVA.into_bits());
+        // Fixup the page from the cache before changing the encrypted state.
+        // SAFETY: The GHCB page is mapped at `GHCB_GVA` (its PTE was set above
+        // and the TLB flushed), so it is mapped and readable here.
+        unsafe {
+            cache_lines_fixup_page(GHCB_GVA.into_bits());
+        }
 
         // Flipping the C-bit makes the contents of the GHCB page scrambled,
         // zero it out.
@@ -659,9 +649,6 @@ impl Ghcb {
 
         // Map the GHCB page in the guest as confidential and accept it again
         // to return to the original state.
-
-        // Evict the page from the cache before changing the encrypted state.
-        cache_lines_flush_page(GHCB_GVA.into_bits());
 
         // Update the page table entry to make it confidential.
         // Running in identical mapping.
@@ -883,6 +870,10 @@ fn pvalidate(
 
 /// Accepts or unaccepts a specific gpa range. On SNP systems, this corresponds to issuing a
 /// pvalidate over the GPA range with the desired value of the validate bit.
+///
+/// When accepting (`validate` is true), the cache lines of each freshly
+/// validated page are fixed up before the page is accessed under its new
+/// (private) assignment. No fixup is performed when unvalidating.
 pub fn set_page_acceptance(
     local_map: &mut LocalMap<'_>,
     range: MemoryRange,
@@ -922,6 +913,24 @@ pub fn set_page_acceptance(
             AcceptGpaStatus::Retry => {
                 // Cannot retry on a regular sized page.
                 return Err(AcceptGpaError::Unknown);
+            }
+        }
+    }
+
+    // On acceptance, fix up the cache for every 4K page that was just
+    // validated, before it is accessed under its new (private) assignment.
+    if validate {
+        let mapping = local_map.map_pages(
+            MemoryRange::from_4k_gpn_range(range.start_4k_gpn()..range.end_4k_gpn()),
+            true,
+        );
+        let va = mapping.data.as_ptr() as u64;
+        for page in 0..range.page_count_4k() {
+            // SAFETY: `va` is the base of a local mapping covering
+            // `range.page_count_4k()` pages, so `va + page * X64_PAGE_SIZE` is
+            // a mapped, readable page for every `page` in the range.
+            unsafe {
+                cache_lines_fixup_page(va + page * X64_PAGE_SIZE);
             }
         }
     }

--- a/openhcl/openhcl_boot/src/arch/x86_64/snp.rs
+++ b/openhcl/openhcl_boot/src/arch/x86_64/snp.rs
@@ -885,16 +885,29 @@ pub fn set_page_acceptance(
 
     while page_count != 0 {
         // Attempt to validate a large page.
-        // Even when pvalidating a large page, the processor only does a 1 byte read. As a result
-        // mapping a single page is sufficient.
-        let mapping = local_map.map_pages(
-            MemoryRange::from_4k_gpn_range(page_base..page_base + 1),
-            true,
-        );
         if page_base.is_multiple_of(pages_per_large_page) && page_count >= pages_per_large_page {
-            let res = pvalidate(page_base, mapping.data.as_ptr() as u64, true, validate)?;
+            let mapping = local_map.map_pages(
+                MemoryRange::from_4k_gpn_range(page_base..page_base + pages_per_large_page),
+                true,
+            );
+            let va = mapping.data.as_ptr() as u64;
+            let res = pvalidate(page_base, va, true, validate)?;
             match res {
                 AcceptGpaStatus::Success => {
+                    if validate {
+                        // Fix up the cache state of every 4K page that was just
+                        // validated, before it is accessed under its new
+                        // (private) assignment.
+                        for page in 0..pages_per_large_page {
+                            // SAFETY: `va` is the base of a mapping covering
+                            // `pages_per_large_page` readable pages, so
+                            // `va + page * X64_PAGE_SIZE` is a mapped, readable
+                            // page.
+                            unsafe {
+                                cache_lines_fixup_page(va + page * X64_PAGE_SIZE);
+                            }
+                        }
+                    }
                     page_count -= pages_per_large_page;
                     page_base += pages_per_large_page;
                     continue;
@@ -904,33 +917,29 @@ pub fn set_page_acceptance(
         }
 
         // Attempt to validate a regular sized page.
-        let res = pvalidate(page_base, mapping.data.as_ptr() as u64, false, validate)?;
+        let mapping = local_map.map_pages(
+            MemoryRange::from_4k_gpn_range(page_base..page_base + 1),
+            true,
+        );
+        let va = mapping.data.as_ptr() as u64;
+        let res = pvalidate(page_base, va, false, validate)?;
         match res {
             AcceptGpaStatus::Success => {
+                if validate {
+                    // Fix up the cache state of the page just validated, before
+                    // it is accessed under its new (private) assignment.
+                    // SAFETY: `va` is the base of a mapping covering this
+                    // readable page.
+                    unsafe {
+                        cache_lines_fixup_page(va);
+                    }
+                }
                 page_count -= 1;
                 page_base += 1;
             }
             AcceptGpaStatus::Retry => {
                 // Cannot retry on a regular sized page.
                 return Err(AcceptGpaError::Unknown);
-            }
-        }
-    }
-
-    // On acceptance, fix up the cache for every 4K page that was just
-    // validated, before it is accessed under its new (private) assignment.
-    if validate {
-        let mapping = local_map.map_pages(
-            MemoryRange::from_4k_gpn_range(range.start_4k_gpn()..range.end_4k_gpn()),
-            true,
-        );
-        let va = mapping.data.as_ptr() as u64;
-        for page in 0..range.page_count_4k() {
-            // SAFETY: `va` is the base of a local mapping covering
-            // `range.page_count_4k()` pages, so `va + page * X64_PAGE_SIZE` is
-            // a mapped, readable page for every `page` in the range.
-            unsafe {
-                cache_lines_fixup_page(va + page * X64_PAGE_SIZE);
             }
         }
     }


### PR DESCRIPTION
Reworks how we manage cache coherency when accepting pages to match the behavior of the legacy HCL. Supercedes #3806.