### PR TITLE
burette: add high-connection-count mode to network test

### DIFF
--- a/Guide/src/dev_guide/tests/perf.md
+++ b/Guide/src/dev_guide/tests/perf.md
@@ -63,7 +63,16 @@ burette run --test network -o network.json
 
 # Test with virtio-net instead of VMBus
 burette run --test network --nic virtio-net -o network.json
+
+# Drive many concurrent TCP connections (high-connection-count regime)
+burette run --test network --net-parallel 128 -o network.json
 ```
+
+The `--net-parallel` flag sets the number of parallel iperf3 streams for
+the TCP tests. It defaults to `1` (single stream); larger values open many
+concurrent connections, which is required to exercise optimizations that
+only matter at high connection counts. Keep the same `--net-parallel` value
+across baseline and candidate runs so `burette compare` lines up.
 
 Reported metrics:
 

--- a/petri/burette/src/main.rs
+++ b/petri/burette/src/main.rs
@@ -132,6 +132,12 @@ struct RunArgs {
     #[arg(long, default_value = "consomme")]
     backend: NetBackend,
 
+    /// Number of parallel iperf3 streams for the TCP network tests.
+    /// Values greater than 1 drive many concurrent connections, which is
+    /// required to exercise the high-connection-count regime.
+    #[arg(long, default_value = "1")]
+    net_parallel: u32,
+
     /// Record `perf record -p <pid> -g` traces scoped to each test,
     /// saving per-test .data files in this directory. Linux only.
     #[arg(long)]
@@ -325,6 +331,7 @@ fn cmd_run(args: RunArgs) -> anyhow::Result<()> {
                     diag: args.diag,
                     nic: args.nic,
                     backend: args.backend,
+                    parallel: args.net_parallel,
                     perf_dir: args.perf_dir.clone(),
                 };
 

--- a/petri/burette/src/main.rs
+++ b/petri/burette/src/main.rs
@@ -135,7 +135,7 @@ struct RunArgs {
     /// Number of parallel iperf3 streams for the TCP network tests.
     /// Values greater than 1 drive many concurrent connections, which is
     /// required to exercise the high-connection-count regime.
-    #[arg(long, default_value = "1")]
+    #[arg(long, default_value = "1", value_parser = clap::value_parser!(u32).range(1..))]
     net_parallel: u32,
 
     /// Record `perf record -p <pid> -g` traces scoped to each test,

--- a/petri/burette/src/tests/network.rs
+++ b/petri/burette/src/tests/network.rs
@@ -56,6 +56,10 @@ pub struct NetworkTest {
     pub nic: NicBackend,
     /// Which network backend to use.
     pub backend: NetBackend,
+    /// Number of parallel iperf3 streams for the TCP tests. `1` preserves
+    /// the single-stream behavior; larger values open many concurrent
+    /// connections to exercise the high-connection-count regime.
+    pub parallel: u32,
     /// If set, record per-phase perf traces in this directory.
     pub perf_dir: Option<std::path::PathBuf>,
 }
@@ -410,7 +414,15 @@ impl NetworkTest {
             .await;
 
         // Run guest iperf3 client.
-        run_guest_iperf3_client(&state.agent, host_ip, port, &mode, metric_name).await?;
+        run_guest_iperf3_client(
+            &state.agent,
+            host_ip,
+            port,
+            &mode,
+            self.parallel,
+            metric_name,
+        )
+        .await?;
 
         // Collect JSON from the helper.
         let json = json_future.await.context("iperf3 helper RPC failed")?;
@@ -434,23 +446,38 @@ async fn run_guest_iperf3_client(
     host_ip: &str,
     port: u16,
     mode: &IperfMode,
+    parallel: u32,
     metric_name: &str,
 ) -> anyhow::Result<()> {
     let mut sh = agent.unix_shell();
     sh.chroot("/perf");
     let port_str = port.to_string();
+
+    let parallel_args: Vec<String> = match mode {
+        IperfMode::TcpTx | IperfMode::TcpRx if parallel > 1 => {
+            vec!["-P".to_string(), parallel.to_string()]
+        }
+        _ => Vec::new(),
+    };
+
     match mode {
         IperfMode::TcpTx => {
-            cmd!(sh, "iperf3 -c {host_ip} -p {port_str} -t 10 -J")
-                .ignore_status()
-                .run()
-                .await
+            cmd!(
+                sh,
+                "iperf3 -c {host_ip} -p {port_str} -t 10 -J {parallel_args...}"
+            )
+            .ignore_status()
+            .run()
+            .await
         }
         IperfMode::TcpRx => {
-            cmd!(sh, "iperf3 -c {host_ip} -p {port_str} -t 10 -R -J")
-                .ignore_status()
-                .run()
-                .await
+            cmd!(
+                sh,
+                "iperf3 -c {host_ip} -p {port_str} -t 10 -R -J {parallel_args...}"
+            )
+            .ignore_status()
+            .run()
+            .await
         }
         IperfMode::UdpTx => {
             cmd!(sh, "iperf3 -c {host_ip} -p {port_str} -t 10 -u -b 0 -J")


### PR DESCRIPTION
## Summary

Adds a `--net-parallel <N>` flag to the burette `network` test. It sets the number of parallel iperf3 streams (`-P`) for the TCP TX/RX subtests. It defaults to `1`, preserving the existing single-stream behavior; larger values open many concurrent connections so the harness can exercise and measure optimizations that only appear in the high-connection-count regime. UDP stays single-stream.

Metric names are unchanged, so a `burette compare` between a baseline and a candidate run lines up as long as the same `--net-parallel` value is used for both.

## Details

- `petri/burette/src/main.rs`: new `--net-parallel` CLI arg, threaded into `NetworkTest`.
- `petri/burette/src/tests/network.rs`: `parallel` field; `-P N` added to the TCP client invocations when `N > 1`.
- `Guide/src/dev_guide/tests/perf.md`: documents the flag.

## Testing

- `cargo check -p burette`
- `cargo clippy --all-targets -p burette`
- `cargo doc --no-deps -p burette`
- `cargo xtask fmt --fix`

(burette has no unit tests.)