### PR TITLE
consomme: readiness-driven TCP connection polling

### DIFF
--- a/vm/devices/net/net_consomme/consomme/src/tcp.rs
+++ b/vm/devices/net/net_consomme/consomme/src/tcp.rs
@@ -115,8 +115,13 @@ impl ReadyList {
             let mut inner = self.inner.lock();
             if inner.queued.insert(ft) {
                 inner.queue.push_back(ft);
+                inner.outer.clone()
+            } else {
+                // Already queued, so a poll cycle is already pending to service
+                // this connection. Skip the redundant outer wake to avoid extra
+                // contention under readiness storms.
+                None
             }
-            inner.outer.clone()
         };
         if let Some(outer) = outer {
             outer.wake();

--- a/vm/devices/net/net_consomme/consomme/src/tcp.rs
+++ b/vm/devices/net/net_consomme/consomme/src/tcp.rs
@@ -123,8 +123,13 @@ impl ReadyList {
             let mut inner = self.inner.lock();
             if inner.queued.insert(ft) {
                 inner.queue.push_back(ft);
+                inner.outer.clone()
+            } else {
+                // Already queued, so a poll cycle is already pending to service
+                // this connection. Skip the redundant outer wake to avoid extra
+                // contention under readiness storms.
+                None
             }
-            inner.outer.clone()
         };
         if let Some(outer) = outer {
             outer.wake();

--- a/vm/devices/net/net_consomme/consomme/src/tcp.rs
+++ b/vm/devices/net/net_consomme/consomme/src/tcp.rs
@@ -29,6 +29,7 @@ use pal_async::socket::PollReady;
 use pal_async::socket::PolledSocket;
 use pal_async::timer::Instant as TimerInstant;
 use pal_async::timer::PolledTimer as TcpTimer;
+use parking_lot::Mutex;
 use smoltcp::phy::ChecksumCapabilities;
 use smoltcp::wire::ETHERNET_HEADER_LEN;
 use smoltcp::wire::EthernetFrame;
@@ -50,6 +51,8 @@ use socket2::SockAddr;
 use socket2::Socket;
 use socket2::Type;
 use std::collections::HashMap;
+use std::collections::HashSet;
+use std::collections::VecDeque;
 use std::collections::hash_map;
 use std::io;
 use std::io::ErrorKind;
@@ -61,8 +64,11 @@ use std::net::SocketAddr;
 use std::net::SocketAddrV4;
 use std::net::SocketAddrV6;
 use std::pin::Pin;
+use std::sync::Arc;
 use std::task::Context;
 use std::task::Poll;
+use std::task::Wake;
+use std::task::Waker;
 use std::time::Duration;
 use thiserror::Error;
 
@@ -74,8 +80,97 @@ pub(crate) struct Tcp {
     listeners: HashMap<PortForwardKey, TcpListener>,
     #[inspect(skip)]
     timer: Option<TcpTimer>,
+    #[inspect(skip)]
+    timer_deadline: Option<TimerInstant>,
     connection_params: ConnectionParams,
     aggregate_stats: TcpAggregateStats,
+    #[inspect(skip)]
+    ready: Arc<ReadyList>,
+}
+
+/// Tracks which TCP connections need polling, so that `poll_tcp` can service
+/// only the connections that have pending work instead of walking every
+/// connection on every wake. Connections are enqueued when the guest touches
+/// them and when their per-connection [`Waker`] fires from socket or DNS
+/// readiness.
+#[derive(Default)]
+struct ReadyList {
+    inner: Mutex<ReadyInner>,
+}
+
+#[derive(Default)]
+struct ReadyInner {
+    queue: VecDeque<FourTuple>,
+    queued: HashSet<FourTuple>,
+    outer: Option<Waker>,
+}
+
+impl ReadyList {
+    /// Enqueues a connection for polling without waking the outer task. Used
+    /// from within a poll cycle, where `poll_tcp` drains the queue regardless.
+    fn enqueue(&self, ft: FourTuple) {
+        let mut inner = self.inner.lock();
+        if inner.queued.insert(ft) {
+            inner.queue.push_back(ft);
+        }
+    }
+
+    /// Enqueues a connection and wakes the outer task so a new poll cycle
+    /// runs. Used from connection wakers fired by socket or DNS readiness,
+    /// which may happen on another thread.
+    fn wake(&self, ft: FourTuple) {
+        let outer = {
+            let mut inner = self.inner.lock();
+            if inner.queued.insert(ft) {
+                inner.queue.push_back(ft);
+            }
+            inner.outer.clone()
+        };
+        if let Some(outer) = outer {
+            outer.wake();
+        }
+    }
+
+    /// Records the outer task waker so connection wakers can re-drive polling.
+    fn set_outer(&self, waker: &Waker) {
+        let mut inner = self.inner.lock();
+        if !inner.outer.as_ref().is_some_and(|w| w.will_wake(waker)) {
+            inner.outer = Some(waker.clone());
+        }
+    }
+
+    /// Takes the set of connections that need polling this cycle.
+    fn drain(&self) -> VecDeque<FourTuple> {
+        let mut inner = self.inner.lock();
+        inner.queued.clear();
+        std::mem::take(&mut inner.queue)
+    }
+
+    /// Builds a [`Waker`] that re-enqueues `ft` when the connection's socket or
+    /// DNS backend signals readiness.
+    fn waker_for(self: &Arc<Self>, ft: FourTuple) -> Waker {
+        Waker::from(Arc::new(ConnWaker {
+            ready: self.clone(),
+            ft,
+        }))
+    }
+}
+
+/// Per-connection waker: waking it marks the connection ready for the next
+/// `poll_tcp` cycle.
+struct ConnWaker {
+    ready: Arc<ReadyList>,
+    ft: FourTuple,
+}
+
+impl Wake for ConnWaker {
+    fn wake(self: Arc<Self>) {
+        self.ready.wake(self.ft);
+    }
+
+    fn wake_by_ref(self: &Arc<Self>) {
+        self.ready.wake(self.ft);
+    }
 }
 
 /// Aggregate statistics across all TCP connections for inspect/diagnostics.
@@ -164,11 +259,13 @@ impl Tcp {
             connections: HashMap::new(),
             listeners: HashMap::new(),
             timer: None,
+            timer_deadline: None,
             connection_params: ConnectionParams {
                 rx_buffer: NormalizedBufferBounds::from_bounds(rx_buffer),
                 tx_buffer: NormalizedBufferBounds::from_bounds(tx_buffer),
             },
             aggregate_stats: TcpAggregateStats::default(),
+            ready: Arc::new(ReadyList::default()),
         }
     }
 }
@@ -259,6 +356,10 @@ struct TcpConnection {
     backend: TcpBackend,
     #[inspect(flatten)]
     inner: TcpConnectionInner,
+    /// Per-connection waker used to re-enqueue this connection when its socket
+    /// or DNS backend becomes ready. Created lazily on first poll.
+    #[inspect(skip)]
+    waker: Option<Waker>,
 }
 
 #[derive(Inspect)]
@@ -777,6 +878,9 @@ impl TcpState {
 
 impl<T: Client> Access<'_, T> {
     pub(crate) fn poll_tcp(&mut self, cx: &mut Context<'_>) {
+        let ready = self.inner.tcp.ready.clone();
+        ready.set_outer(cx.waker());
+
         // Check for any new incoming connections
         self.inner
             .tcp
@@ -845,6 +949,7 @@ impl<T: Client> Access<'_, T> {
                                 );
                                 e.insert(conn);
                                 self.inner.tcp.aggregate_stats.connections_accepted.increment();
+                                ready.enqueue(ft);
                             }
                             hash_map::Entry::Occupied(_) => {
                                 tracing::warn!(
@@ -859,20 +964,113 @@ impl<T: Client> Access<'_, T> {
                 }
                 Err(_) => false,
             });
-        // Check for any new incoming data.
-        let mut now = None;
-        let mut next_deadline: Option<TimerInstant> = None;
-        self.inner.tcp.connections.retain(|ft, conn| {
+        let timer_expired = self.inner.tcp.timer_deadline.is_some_and(|deadline| {
+            self.inner
+                .tcp
+                .timer
+                .get_or_insert_with(|| TcpTimer::new(self.client.driver()))
+                .poll_until(cx, deadline)
+                .is_ready()
+        });
+        let mut next_deadline = if timer_expired {
+            None
+        } else {
+            self.inner.tcp.timer_deadline
+        };
+
+        // Timer wakeups are infrequent relative to socket readiness. Scan all
+        // connections only when the shared timer fires to process expired
+        // timers and find the next deadline.
+        if timer_expired {
+            let now = TimerInstant::now();
+            let super::Consomme {
+                tcp, state, dns, ..
+            } = &mut *self.inner;
+            let Tcp {
+                connections,
+                aggregate_stats,
+                ..
+            } = tcp;
+            connections.retain(|ft, conn| {
+                let mut sender = Sender {
+                    ft,
+                    state,
+                    client: self.client,
+                };
+                if conn.inner.process_expired_timers(now, &mut sender) {
+                    tracing::debug!(
+                        src = %ft.src,
+                        dst = %ft.dst,
+                        state = ?conn.inner.state,
+                        "TCP connection timer expired, reclaiming connection",
+                    );
+                    if matches!(
+                        conn.backend,
+                        TcpBackend::Dns(ref handler) if handler.is_in_flight()
+                    ) {
+                        dns.complete_tcp_query();
+                    }
+                    match conn.inner.state {
+                        TcpState::TimeWait => {
+                            aggregate_stats.record_close(ConnectionCloseReason::Normal)
+                        }
+                        _ => {
+                            let guest_has_seen_connection = !matches!(
+                                conn.inner.state,
+                                TcpState::Connecting | TcpState::SynSent | TcpState::SynReceived
+                            ) || conn.inner.tx_syn != TxSynState::None;
+                            if guest_has_seen_connection && sender.client.rx_mtu() != 0 {
+                                let ack_number = (conn.inner.tx_syn != TxSynState::Syn)
+                                    .then_some(conn.inner.rx_seq);
+                                if sender.try_rst(conn.inner.tx_send, ack_number) {
+                                    conn.inner.stats.rsts_tx.increment();
+                                }
+                            }
+                            aggregate_stats.record_timeout_close();
+                        }
+                    }
+                    return false;
+                }
+
+                if let Some(deadline) = conn.inner.next_timer_deadline() {
+                    next_deadline = Some(
+                        next_deadline.map_or(deadline, |next_deadline| next_deadline.min(deadline)),
+                    );
+                }
+                true
+            });
+        }
+
+        // Service only the connections that have pending work: those marked
+        // ready by guest activity this cycle, or by their own socket/DNS waker
+        // firing. Each connection is polled with its own waker so a later
+        // readiness event re-enqueues just that connection instead of forcing a
+        // walk of every connection.
+        for ft in ready.drain() {
+            let super::Consomme {
+                tcp, state, dns, ..
+            } = &mut *self.inner;
+            let Some(conn) = tcp.connections.get_mut(&ft) else {
+                continue;
+            };
+            let conn_waker = conn
+                .waker
+                .get_or_insert_with(|| ready.waker_for(ft))
+                .clone();
+            let mut conn_cx = Context::from_waker(&conn_waker);
             let mut sender = Sender {
-                ft,
-                state: &mut self.inner.state,
+                ft: &ft,
+                state,
                 client: self.client,
             };
-            let timed_out = conn.inner.next_timer_deadline().is_some_and(|deadline| {
-                let now = *now.get_or_insert_with(TimerInstant::now);
-                deadline <= now && conn.inner.process_expired_timers(now, &mut sender)
-            });
-            if timed_out {
+            let now = TimerInstant::now();
+            let timed_out = conn
+                .inner
+                .next_timer_deadline()
+                .is_some_and(|deadline| {
+                    deadline <= now && conn.inner.process_expired_timers(now, &mut sender)
+                });
+            let keep = if timed_out {
                 tracing::debug!(
                     src = %ft.src,
                     dst = %ft.dst,
@@ -883,71 +1081,71 @@ impl<T: Client> Access<'_, T> {
                     conn.backend,
                     TcpBackend::Dns(ref handler) if handler.is_in_flight()
                 ) {
-                    self.inner.dns.complete_tcp_query();
+                    dns.complete_tcp_query();
                 }
                 match conn.inner.state {
-                    TcpState::TimeWait => self
-                        .inner
-                        .tcp
-                        .aggregate_stats
-                        .record_close(ConnectionCloseReason::Normal),
+                    TcpState::TimeWait => {
+                        tcp.aggregate_stats
+                            .record_close(ConnectionCloseReason::Normal);
+                    }
                     _ => {
                         let guest_has_seen_connection = !matches!(
                             conn.inner.state,
                             TcpState::Connecting | TcpState::SynSent | TcpState::SynReceived
                         ) || conn.inner.tx_syn != TxSynState::None;
                         if guest_has_seen_connection && sender.client.rx_mtu() != 0 {
-                            let ack_number =
-                                (conn.inner.tx_syn != TxSynState::Syn).then_some(conn.inner.rx_seq);
+                            let ack_number = (conn.inner.tx_syn != TxSynState::Syn)
+                                .then_some(conn.inner.rx_seq);
                             if sender.try_rst(conn.inner.tx_send, ack_number) {
                                 conn.inner.stats.rsts_tx.increment();
                             }
                         }
-                        self.inner.tcp.aggregate_stats.record_timeout_close();
+                        tcp.aggregate_stats.record_timeout_close();
                     }
                 }
-                return false;
-            }
-
-            let keep = match &mut conn.backend {
-                TcpBackend::Dns(dns_handler) => {
-                    if self.inner.dns.can_answer_queries() {
-                        conn.inner.poll_dns_backend(
-                            cx,
-                            &mut sender,
-                            dns_handler,
-                            &mut self.inner.dns,
-                        )
-                    } else {
-                        tracelimit::warn_ratelimited!(
-                            src = %ft.src,
-                            dst = %ft.dst,
-                            "DNS TCP connection without an answer source, dropping"
-                        );
-                        false
+                false
+            } else {
+                match &mut conn.backend {
+                    TcpBackend::Dns(dns_handler) => {
+                        if dns.can_answer_queries() {
+                            conn.inner.poll_dns_backend(
+                                &mut conn_cx,
+                                &mut sender,
+                                dns_handler,
+                                dns,
+                            )
+                        } else {
+                            tracelimit::warn_ratelimited!(
+                                src = %ft.src,
+                                dst = %ft.dst,
+                                "DNS TCP connection without an answer source, dropping"
+                            );
+                            false
+                        }
                     }
+                    TcpBackend::Socket { socket, static_dns } => conn.inner.poll_socket_backend(
+                        &mut conn_cx,
+                        &mut sender,
+                        socket,
+                        static_dns,
+                        dns,
+                    ),
                 }
-                TcpBackend::Socket { socket, static_dns } => conn.inner.poll_socket_backend(
-                    cx,
-                    &mut sender,
-                    socket,
-                    static_dns,
-                    &self.inner.dns,
-                ),
             };
             if !keep {
-                self.inner
-                    .tcp
-                    .aggregate_stats
-                    .record_close(conn.inner.last_close_reason);
+                if !timed_out {
+                    tcp.aggregate_stats
+                        .record_close(conn.inner.last_close_reason);
+                }
+                tcp.connections.remove(&ft);
             } else if let Some(deadline) = conn.inner.next_timer_deadline() {
                 next_deadline = Some(
                     next_deadline.map_or(deadline, |next_deadline| next_deadline.min(deadline)),
                 );
             }
-            keep
-        });
+        }
 
+        self.inner.tcp.timer_deadline = next_deadline;
         if let Some(deadline) = next_deadline {
             let timer = self
                 .inner
@@ -990,6 +1188,14 @@ impl<T: Client> Access<'_, T> {
                 }
             }
         });
+
+        // The sockets were rebuilt on a new driver, so any previously
+        // registered readiness wakeups are gone. Mark every connection ready so
+        // the next poll re-registers each one with the new driver.
+        let ready = self.inner.tcp.ready.clone();
+        for ft in self.inner.tcp.connections.keys() {
+            ready.enqueue(*ft);
+        }
     }
 
     pub(crate) fn handle_tcp(
@@ -1050,6 +1256,7 @@ impl<T: Client> Access<'_, T> {
             state: &mut self.inner.state,
         };
 
+        let mut mark_ready = false;
         match self.inner.tcp.connections.entry(ft) {
             hash_map::Entry::Occupied(mut e) => {
                 let keep = e.get_mut().inner.handle_packet(&mut sender, &tcp)?;
@@ -1066,6 +1273,7 @@ impl<T: Client> Access<'_, T> {
                     // every guest packet would trigger a zero-payload ACK back,
                     // doubling packet rate and creating an ACK storm.
                     e.get_mut().inner.send_next(&mut sender, AckPolicy::Defer);
+                    mark_ready = true;
                 } else {
                     self.inner
                         .tcp
@@ -1137,10 +1345,14 @@ impl<T: Client> Access<'_, T> {
                         .aggregate_stats
                         .connections_initiated
                         .increment();
+                    mark_ready = true;
                 } else {
                     // Ignore the packet.
                 }
             }
+        }
+        if mark_ready {
+            self.inner.tcp.ready.enqueue(ft);
         }
         Ok(())
     }
@@ -1452,6 +1664,7 @@ impl TcpConnection {
                 static_dns: inspect_static_dns.then(StaticDnsTcpInspection::default),
             },
             inner,
+            waker: None,
         })
     }
 
@@ -1477,6 +1690,7 @@ impl TcpConnection {
                 static_dns: None,
             },
             inner,
+            waker: None,
         })
     }
 
@@ -1506,6 +1720,7 @@ impl TcpConnection {
         Ok(Self {
             backend: TcpBackend::Dns(DnsTcpHandler::new(flow)),
             inner,
+            waker: None,
         })
     }
 }

--- a/vm/devices/net/net_consomme/consomme/src/tcp.rs
+++ b/vm/devices/net/net_consomme/consomme/src/tcp.rs
@@ -969,14 +969,11 @@ impl<T: Client> Access<'_, T> {
                 }
                 Err(_) => false,
             });
-        let timer_expired = self.inner.tcp.timer_deadline.is_some_and(|deadline| {
-            self.inner
-                .tcp
-                .timer
-                .get_or_insert_with(|| TcpTimer::new(self.client.driver()))
-                .poll_until(cx, deadline)
-                .is_ready()
-        });
+        let timer_expired = self
+            .inner
+            .tcp
+            .timer_deadline
+            .is_some_and(|deadline| deadline <= TimerInstant::now());
         let mut next_deadline = if timer_expired {
             None
         } else {
@@ -1069,8 +1066,8 @@ impl<T: Client> Access<'_, T> {
                 state,
                 client: self.client,
             };
-            let now = TimerInstant::now();
             let timed_out = conn.inner.next_timer_deadline().is_some_and(|deadline| {
+                let now = TimerInstant::now();
                 deadline <= now && conn.inner.process_expired_timers(now, &mut sender)
             });
             let keep = if timed_out {

--- a/vm/devices/net/net_consomme/consomme/src/tcp.rs
+++ b/vm/devices/net/net_consomme/consomme/src/tcp.rs
@@ -1023,7 +1023,8 @@ impl<T: Client> Access<'_, T> {
                             let guest_has_seen_connection = !matches!(
                                 conn.inner.state,
                                 TcpState::Connecting | TcpState::SynSent | TcpState::SynReceived
-                            ) || conn.inner.tx_syn != TxSynState::None;
+                            ) || conn.inner.tx_syn
+                                != TxSynState::None;
                             if guest_has_seen_connection && sender.client.rx_mtu() != 0 {
                                 let ack_number = (conn.inner.tx_syn != TxSynState::Syn)
                                     .then_some(conn.inner.rx_seq);
@@ -1069,12 +1070,9 @@ impl<T: Client> Access<'_, T> {
                 client: self.client,
             };
             let now = TimerInstant::now();
-            let timed_out = conn
-                .inner
-                .next_timer_deadline()
-                .is_some_and(|deadline| {
-                    deadline <= now && conn.inner.process_expired_timers(now, &mut sender)
-                });
+            let timed_out = conn.inner.next_timer_deadline().is_some_and(|deadline| {
+                deadline <= now && conn.inner.process_expired_timers(now, &mut sender)
+            });
             let keep = if timed_out {
                 tracing::debug!(
                     src = %ft.src,
@@ -1099,8 +1097,8 @@ impl<T: Client> Access<'_, T> {
                             TcpState::Connecting | TcpState::SynSent | TcpState::SynReceived
                         ) || conn.inner.tx_syn != TxSynState::None;
                         if guest_has_seen_connection && sender.client.rx_mtu() != 0 {
-                            let ack_number = (conn.inner.tx_syn != TxSynState::Syn)
-                                .then_some(conn.inner.rx_seq);
+                            let ack_number =
+                                (conn.inner.tx_syn != TxSynState::Syn).then_some(conn.inner.rx_seq);
                             if sender.try_rst(conn.inner.tx_send, ack_number) {
                                 conn.inner.stats.rsts_tx.increment();
                             }
@@ -1113,12 +1111,8 @@ impl<T: Client> Access<'_, T> {
                 match &mut conn.backend {
                     TcpBackend::Dns(dns_handler) => {
                         if dns.can_answer_queries() {
-                            conn.inner.poll_dns_backend(
-                                &mut conn_cx,
-                                &mut sender,
-                                dns_handler,
-                                dns,
-                            )
+                            conn.inner
+                                .poll_dns_backend(&mut conn_cx, &mut sender, dns_handler, dns)
                         } else {
                             tracelimit::warn_ratelimited!(
                                 src = %ft.src,

--- a/vm/devices/net/net_consomme/consomme/src/tcp.rs
+++ b/vm/devices/net/net_consomme/consomme/src/tcp.rs
@@ -26,6 +26,7 @@ use pal_async::driver::Driver;
 use pal_async::interest::PollEvents;
 use pal_async::socket::PollReady;
 use pal_async::socket::PolledSocket;
+use parking_lot::Mutex;
 use smoltcp::phy::ChecksumCapabilities;
 use smoltcp::wire::ETHERNET_HEADER_LEN;
 use smoltcp::wire::EthernetFrame;
@@ -47,6 +48,8 @@ use socket2::SockAddr;
 use socket2::Socket;
 use socket2::Type;
 use std::collections::HashMap;
+use std::collections::HashSet;
+use std::collections::VecDeque;
 use std::collections::hash_map;
 use std::io;
 use std::io::ErrorKind;
@@ -58,8 +61,11 @@ use std::net::SocketAddr;
 use std::net::SocketAddrV4;
 use std::net::SocketAddrV6;
 use std::pin::Pin;
+use std::sync::Arc;
 use std::task::Context;
 use std::task::Poll;
+use std::task::Wake;
+use std::task::Waker;
 use thiserror::Error;
 
 #[derive(InspectMut)]
@@ -70,6 +76,93 @@ pub(crate) struct Tcp {
     listeners: HashMap<PortForwardKey, TcpListener>,
     connection_params: ConnectionParams,
     aggregate_stats: TcpAggregateStats,
+    #[inspect(skip)]
+    ready: Arc<ReadyList>,
+}
+
+/// Tracks which TCP connections need polling, so that `poll_tcp` can service
+/// only the connections that have pending work instead of walking every
+/// connection on every wake. Connections are enqueued when the guest touches
+/// them and when their per-connection [`Waker`] fires from socket or DNS
+/// readiness.
+#[derive(Default)]
+struct ReadyList {
+    inner: Mutex<ReadyInner>,
+}
+
+#[derive(Default)]
+struct ReadyInner {
+    queue: VecDeque<FourTuple>,
+    queued: HashSet<FourTuple>,
+    outer: Option<Waker>,
+}
+
+impl ReadyList {
+    /// Enqueues a connection for polling without waking the outer task. Used
+    /// from within a poll cycle, where `poll_tcp` drains the queue regardless.
+    fn enqueue(&self, ft: FourTuple) {
+        let mut inner = self.inner.lock();
+        if inner.queued.insert(ft) {
+            inner.queue.push_back(ft);
+        }
+    }
+
+    /// Enqueues a connection and wakes the outer task so a new poll cycle
+    /// runs. Used from connection wakers fired by socket or DNS readiness,
+    /// which may happen on another thread.
+    fn wake(&self, ft: FourTuple) {
+        let outer = {
+            let mut inner = self.inner.lock();
+            if inner.queued.insert(ft) {
+                inner.queue.push_back(ft);
+            }
+            inner.outer.clone()
+        };
+        if let Some(outer) = outer {
+            outer.wake();
+        }
+    }
+
+    /// Records the outer task waker so connection wakers can re-drive polling.
+    fn set_outer(&self, waker: &Waker) {
+        let mut inner = self.inner.lock();
+        if !inner.outer.as_ref().is_some_and(|w| w.will_wake(waker)) {
+            inner.outer = Some(waker.clone());
+        }
+    }
+
+    /// Takes the set of connections that need polling this cycle.
+    fn drain(&self) -> VecDeque<FourTuple> {
+        let mut inner = self.inner.lock();
+        inner.queued.clear();
+        std::mem::take(&mut inner.queue)
+    }
+
+    /// Builds a [`Waker`] that re-enqueues `ft` when the connection's socket or
+    /// DNS backend signals readiness.
+    fn waker_for(self: &Arc<Self>, ft: FourTuple) -> Waker {
+        Waker::from(Arc::new(ConnWaker {
+            ready: self.clone(),
+            ft,
+        }))
+    }
+}
+
+/// Per-connection waker: waking it marks the connection ready for the next
+/// `poll_tcp` cycle.
+struct ConnWaker {
+    ready: Arc<ReadyList>,
+    ft: FourTuple,
+}
+
+impl Wake for ConnWaker {
+    fn wake(self: Arc<Self>) {
+        self.ready.wake(self.ft);
+    }
+
+    fn wake_by_ref(self: &Arc<Self>) {
+        self.ready.wake(self.ft);
+    }
 }
 
 /// Aggregate statistics across all TCP connections for inspect/diagnostics.
@@ -143,6 +236,7 @@ impl Tcp {
                 tx_buffer: NormalizedBufferBounds::from_bounds(tx_buffer),
             },
             aggregate_stats: TcpAggregateStats::default(),
+            ready: Arc::new(ReadyList::default()),
         }
     }
 }
@@ -172,6 +266,10 @@ struct TcpConnection {
     backend: TcpBackend,
     #[inspect(flatten)]
     inner: TcpConnectionInner,
+    /// Per-connection waker used to re-enqueue this connection when its socket
+    /// or DNS backend becomes ready. Created lazily on first poll.
+    #[inspect(skip)]
+    waker: Option<Waker>,
 }
 
 #[derive(Inspect)]
@@ -357,6 +455,9 @@ impl TcpState {
 
 impl<T: Client> Access<'_, T> {
     pub(crate) fn poll_tcp(&mut self, cx: &mut Context<'_>) {
+        let ready = self.inner.tcp.ready.clone();
+        ready.set_outer(cx.waker());
+
         // Check for any new incoming connections
         self.inner
             .tcp
@@ -421,6 +522,7 @@ impl<T: Client> Access<'_, T> {
                                 tracing::trace!(?ft, "TCP connection established");
                                 e.insert(conn);
                                 self.inner.tcp.aggregate_stats.connections_accepted.increment();
+                                ready.enqueue(ft);
                             }
                             hash_map::Entry::Occupied(_) => {
                                 tracing::warn!(
@@ -435,35 +537,51 @@ impl<T: Client> Access<'_, T> {
                 }
                 Err(_) => false,
             });
-        // Check for any new incoming data
-        self.inner.tcp.connections.retain(|ft, conn| {
+
+        // Service only the connections that have pending work: those marked
+        // ready by guest activity this cycle, or by their own socket/DNS waker
+        // firing. Each connection is polled with its own waker so a later
+        // readiness event re-enqueues just that connection instead of forcing a
+        // walk of every connection.
+        for ft in ready.drain() {
+            let super::Consomme {
+                tcp, state, dns, ..
+            } = &mut *self.inner;
+            let Some(conn) = tcp.connections.get_mut(&ft) else {
+                continue;
+            };
+            let conn_waker = conn
+                .waker
+                .get_or_insert_with(|| ready.waker_for(ft))
+                .clone();
+            let mut conn_cx = Context::from_waker(&conn_waker);
             let mut sender = Sender {
-                ft,
-                state: &mut self.inner.state,
+                ft: &ft,
+                state,
                 client: self.client,
             };
             let keep = match &mut conn.backend {
-                TcpBackend::Dns(dns_handler) => match &mut self.inner.dns {
-                    Some(dns) => conn
-                        .inner
-                        .poll_dns_backend(cx, &mut sender, dns_handler, dns),
+                TcpBackend::Dns(dns_handler) => match dns {
+                    Some(dns) => {
+                        conn.inner
+                            .poll_dns_backend(&mut conn_cx, &mut sender, dns_handler, dns)
+                    }
                     None => {
                         tracing::warn!("DNS TCP connection without DNS resolver, dropping");
                         false
                     }
                 },
                 TcpBackend::Socket(opt_socket) => {
-                    conn.inner.poll_socket_backend(cx, &mut sender, opt_socket)
+                    conn.inner
+                        .poll_socket_backend(&mut conn_cx, &mut sender, opt_socket)
                 }
             };
             if !keep {
-                self.inner
-                    .tcp
-                    .aggregate_stats
-                    .record_close(conn.inner.last_close_reason);
+                let reason = conn.inner.last_close_reason;
+                tcp.aggregate_stats.record_close(reason);
+                tcp.connections.remove(&ft);
             }
-            keep
-        })
+        }
     }
 
     pub(crate) fn refresh_tcp_driver(&mut self) {
@@ -492,6 +610,14 @@ impl<T: Client> Access<'_, T> {
                 }
             }
         });
+
+        // The sockets were rebuilt on a new driver, so any previously
+        // registered readiness wakeups are gone. Mark every connection ready so
+        // the next poll re-registers each one with the new driver.
+        let ready = self.inner.tcp.ready.clone();
+        for ft in self.inner.tcp.connections.keys() {
+            ready.enqueue(*ft);
+        }
     }
 
     pub(crate) fn handle_tcp(
@@ -529,6 +655,7 @@ impl<T: Client> Access<'_, T> {
             state: &mut self.inner.state,
         };
 
+        let mut mark_ready = false;
         match self.inner.tcp.connections.entry(ft) {
             hash_map::Entry::Occupied(mut e) => {
                 let keep = e.get_mut().inner.handle_packet(&mut sender, &tcp)?;
@@ -545,6 +672,7 @@ impl<T: Client> Access<'_, T> {
                     // every guest packet would trigger a zero-payload ACK back,
                     // doubling packet rate and creating an ACK storm.
                     e.get_mut().inner.send_next(&mut sender, AckPolicy::Defer);
+                    mark_ready = true;
                 } else {
                     self.inner
                         .tcp
@@ -617,10 +745,14 @@ impl<T: Client> Access<'_, T> {
                         .aggregate_stats
                         .connections_initiated
                         .increment();
+                    mark_ready = true;
                 } else {
                     // Ignore the packet.
                 }
             }
+        }
+        if mark_ready {
+            self.inner.tcp.ready.enqueue(ft);
         }
         Ok(())
     }
@@ -909,6 +1041,7 @@ impl TcpConnection {
         Ok(Self {
             backend: TcpBackend::Socket(Some(socket)),
             inner,
+            waker: None,
         })
     }
 
@@ -931,6 +1064,7 @@ impl TcpConnection {
                 PolledSocket::new(sender.client.driver(), socket).map_err(DropReason::Io)?,
             )),
             inner,
+            waker: None,
         })
     }
 
@@ -960,6 +1094,7 @@ impl TcpConnection {
         Ok(Self {
             backend: TcpBackend::Dns(DnsTcpHandler::new(flow)),
             inner,
+            waker: None,
         })
     }
 }

--- a/vm/devices/net/net_consomme/consomme/src/tcp.rs
+++ b/vm/devices/net/net_consomme/consomme/src/tcp.rs
@@ -102,6 +102,7 @@ struct ReadyList {
 struct ReadyInner {
     queue: VecDeque<FourTuple>,
     queued: HashSet<FourTuple>,
+    blocked_on_rx: HashSet<FourTuple>,
     outer: Option<Waker>,
 }
 
@@ -112,6 +113,28 @@ impl ReadyList {
         let mut inner = self.inner.lock();
         if inner.queued.insert(ft) {
             inner.queue.push_back(ft);
+        }
+    }
+
+    /// Records a connection that could not make progress because the client
+    /// had no receive capacity.
+    fn block_on_rx(&self, ft: FourTuple) {
+        self.inner.lock().blocked_on_rx.insert(ft);
+    }
+
+    fn forget(&self, ft: FourTuple) {
+        let mut inner = self.inner.lock();
+        inner.queued.remove(&ft);
+        inner.blocked_on_rx.remove(&ft);
+    }
+
+    /// Re-enqueues connections that were blocked on client receive capacity.
+    fn retry_rx_blocked(&self) {
+        let mut inner = self.inner.lock();
+        for ft in std::mem::take(&mut inner.blocked_on_rx) {
+            if inner.queued.insert(ft) {
+                inner.queue.push_back(ft);
+            }
         }
     }
 
@@ -885,6 +908,9 @@ impl<T: Client> Access<'_, T> {
     pub(crate) fn poll_tcp(&mut self, cx: &mut Context<'_>) {
         let ready = self.inner.tcp.ready.clone();
         ready.set_outer(cx.waker());
+        if self.client.rx_mtu() != 0 {
+            ready.retry_rx_blocked();
+        }
 
         // Check for any new incoming connections
         self.inner
@@ -1032,6 +1058,7 @@ impl<T: Client> Access<'_, T> {
                             aggregate_stats.record_timeout_close();
                         }
                     }
+                    ready.forget(*ft);
                     return false;
                 }
 
@@ -1134,10 +1161,16 @@ impl<T: Client> Access<'_, T> {
                         .record_close(conn.inner.last_close_reason);
                 }
                 tcp.connections.remove(&ft);
-            } else if let Some(deadline) = conn.inner.next_timer_deadline() {
-                next_deadline = Some(
-                    next_deadline.map_or(deadline, |next_deadline| next_deadline.min(deadline)),
-                );
+                ready.forget(ft);
+            } else {
+                if sender.client.rx_mtu() == 0 {
+                    ready.block_on_rx(ft);
+                }
+                if let Some(deadline) = conn.inner.next_timer_deadline() {
+                    next_deadline = Some(
+                        next_deadline.map_or(deadline, |next_deadline| next_deadline.min(deadline)),
+                    );
+                }
             }
         }
 
@@ -1156,6 +1189,7 @@ impl<T: Client> Access<'_, T> {
 
     pub(crate) fn refresh_tcp_driver(&mut self) {
         self.inner.tcp.timer = Some(TcpTimer::new(self.client.driver()));
+        let ready = self.inner.tcp.ready.clone();
         self.inner.tcp.connections.retain(|ft, conn| {
             let TcpBackend::Socket {
                 socket: opt_socket, ..
@@ -1180,6 +1214,7 @@ impl<T: Client> Access<'_, T> {
                         dst = %ft.dst,
                         "failed to update driver for tcp connection"
                     );
+                    ready.forget(*ft);
                     false
                 }
             }
@@ -1188,7 +1223,6 @@ impl<T: Client> Access<'_, T> {
         // The sockets were rebuilt on a new driver, so any previously
         // registered readiness wakeups are gone. Mark every connection ready so
         // the next poll re-registers each one with the new driver.
-        let ready = self.inner.tcp.ready.clone();
         for ft in self.inner.tcp.connections.keys() {
             ready.enqueue(*ft);
         }
@@ -1227,6 +1261,7 @@ impl<T: Client> Access<'_, T> {
         );
         let inspect_static_dns =
             ft.dst.port() == crate::DNS_PORT && self.inner.dns.should_intercept_static_queries();
+        let ready = self.inner.tcp.ready.clone();
 
         let replace_time_wait = tcp.control == TcpControl::Syn
             && tcp.ack_number.is_none()
@@ -1234,6 +1269,7 @@ impl<T: Client> Access<'_, T> {
                 conn.inner.state == TcpState::TimeWait && tcp.seq_number > conn.inner.rx_seq
             });
         if replace_time_wait && let Some(conn) = self.inner.tcp.connections.remove(&ft) {
+            ready.forget(ft);
             if matches!(
                 conn.backend,
                 TcpBackend::Dns(ref handler) if handler.is_in_flight()
@@ -1280,6 +1316,7 @@ impl<T: Client> Access<'_, T> {
                         TcpBackend::Dns(ref h) if h.is_in_flight()
                     );
                     e.remove();
+                    ready.forget(ft);
                     if dns_in_flight {
                         self.inner.dns.complete_tcp_query();
                     }
@@ -1348,7 +1385,7 @@ impl<T: Client> Access<'_, T> {
             }
         }
         if mark_ready {
-            self.inner.tcp.ready.enqueue(ft);
+            ready.enqueue(ft);
         }
         Ok(())
     }

--- a/vm/devices/net/net_consomme/consomme/src/tcp/tests.rs
+++ b/vm/devices/net/net_consomme/consomme/src/tcp/tests.rs
@@ -756,6 +756,10 @@ impl TcpTestHarness {
         }
     }
 
+    fn mark_connection_ready(&self) {
+        self.consomme.tcp.ready.enqueue(self.four_tuple());
+    }
+
     /// Borrow the established connection's inner state for assertions.
     fn connection_inner(&self) -> &TcpConnectionInner {
         let ft = self.four_tuple();
@@ -1237,6 +1241,8 @@ async fn test_tcp_port_forward_defers_initial_syn_without_rx_buffer(driver: Defa
     ));
     connection.inner.lifetime_timer =
         LifetimeTimer::Handshake(TimerInstant::now() - Duration::from_millis(1));
+    let ft = *consomme.tcp.connections.keys().next().unwrap();
+    consomme.tcp.ready.enqueue(ft);
     received.lock().clear();
     client.add_rx_buffers(1);
     std::future::poll_fn(|cx| {
@@ -2705,6 +2711,7 @@ async fn test_tcp_time_wait_cleanup(driver: DefaultDriver) {
         // Force the deadline into the past to simulate timeout expiry.
         conn.inner.lifetime_timer = LifetimeTimer::Close(Instant::now() - Duration::from_secs(1));
     }
+    h.mark_connection_ready();
 
     // Polling should reap the expired TimeWait connection.
     std::future::poll_fn(|cx| {
@@ -2760,6 +2767,7 @@ async fn test_tcp_guest_action_timeout_cleanup(driver: DefaultDriver) {
             conn.inner.lifetime_timer =
                 LifetimeTimer::Close(Instant::now() - Duration::from_secs(1));
         }
+        h.mark_connection_ready();
 
         std::future::poll_fn(|cx| {
             h.consomme.access(&mut h.client).poll(cx);
@@ -2965,6 +2973,7 @@ async fn test_tcp_closing_cleanup(driver: DefaultDriver) {
         );
         conn.inner.lifetime_timer = LifetimeTimer::Close(Instant::now() - Duration::from_secs(1));
     }
+    h.mark_connection_ready();
 
     std::future::poll_fn(|cx| {
         h.consomme.access(&mut h.client).poll(cx);
@@ -3039,6 +3048,7 @@ async fn test_tcp_last_ack_cleanup(driver: DefaultDriver) {
         );
         conn.inner.lifetime_timer = LifetimeTimer::Close(Instant::now() - Duration::from_secs(1));
     }
+    h.mark_connection_ready();
 
     std::future::poll_fn(|cx| {
         h.consomme.access(&mut h.client).poll(cx);
@@ -3099,6 +3109,7 @@ async fn test_tcp_retransmits_unacknowledged_data(driver: DefaultDriver) {
             recover: None,
         };
     }
+    h.mark_connection_ready();
     std::future::poll_fn(|cx| {
         h.consomme.access(&mut h.client).poll(cx);
         Poll::Ready(())
@@ -3150,6 +3161,7 @@ async fn test_tcp_retransmits_fin_until_acknowledged(driver: DefaultDriver) {
             recover: None,
         };
     }
+    h.mark_connection_ready();
     std::future::poll_fn(|cx| {
         h.consomme.access(&mut h.client).poll(cx);
         Poll::Ready(())
@@ -3204,6 +3216,7 @@ async fn test_tcp_close_before_syn_ack_retransmits_syn_then_fin(driver: DefaultD
         };
         assert_eq!(conn.inner.state, TcpState::SynReceived);
     }
+    h.mark_connection_ready();
 
     std::future::poll_fn(|cx| {
         h.consomme.access(&mut h.client).poll(cx);
@@ -3253,6 +3266,7 @@ async fn test_tcp_zero_window_persist_probe(driver: DefaultDriver) {
             recover: None,
         };
     }
+    h.mark_connection_ready();
 
     h.clear_guest_packets();
     std::future::poll_fn(|cx| {
@@ -3287,6 +3301,7 @@ async fn test_tcp_zero_window_persist_probe(driver: DefaultDriver) {
             recover: None,
         };
     }
+    h.mark_connection_ready();
     h.client.rx_buffers = Some(0);
     h.clear_guest_packets();
     std::future::poll_fn(|cx| {
@@ -3313,6 +3328,7 @@ async fn test_tcp_zero_window_persist_probe(driver: DefaultDriver) {
             recover: None,
         };
     }
+    h.mark_connection_ready();
     h.clear_guest_packets();
     std::future::poll_fn(|cx| {
         h.consomme.access(&mut h.client).poll(cx);
@@ -3410,6 +3426,7 @@ async fn test_tcp_zero_window_persist_preserves_recovery(driver: DefaultDriver) 
             recover: None,
         };
     }
+    h.mark_connection_ready();
     std::future::poll_fn(|cx| {
         h.consomme.access(&mut h.client).poll(cx);
         Poll::Ready(())
@@ -3436,6 +3453,7 @@ async fn test_tcp_zero_window_persist_preserves_recovery(driver: DefaultDriver) 
             recover: Some(recover),
         };
     }
+    h.mark_connection_ready();
     h.clear_guest_packets();
     std::future::poll_fn(|cx| {
         h.consomme.access(&mut h.client).poll(cx);
@@ -3477,6 +3495,7 @@ async fn test_tcp_zero_window_persist_preserves_recovery(driver: DefaultDriver) 
             recover: Some(recover),
         };
     }
+    h.mark_connection_ready();
     std::future::poll_fn(|cx| {
         h.consomme.access(&mut h.client).poll(cx);
         Poll::Ready(())
@@ -3673,6 +3692,7 @@ async fn test_tcp_rto_recovery_advances_on_each_ack(driver: DefaultDriver) {
             recover: None,
         };
     }
+    h.mark_connection_ready();
     h.clear_guest_packets();
     std::future::poll_fn(|cx| {
         h.consomme.access(&mut h.client).poll(cx);


### PR DESCRIPTION
## Summary

`poll_tcp` previously walked **every** TCP connection on every wake, calling `poll_socket_backend` on each with the shared task waker. At high connection counts this O(N) scan dominates the single consomme thread: a readiness event on one socket forces a walk of all connections. This is the biggest single-thread bottleneck for workloads with many concurrent connections.

This PR replaces the full scan with a **readiness-driven ready list**:

- Each connection gets its own `Waker`. When its socket or DNS backend signals readiness, that waker enqueues **only that connection** into a shared ready list and wakes the outer task.
- `poll_tcp` drains the ready set and services only the enqueued connections, instead of walking the whole `HashMap`.
- Connections are also enqueued when guest activity touches them (`handle_tcp`), when accepted from a listener, and when the IO driver is refreshed, so no wakeup source is lost.

## Correctness

Guest-facing behavior is unchanged:
- Deferred ACKs still flush in the same poll cycle, because a guest packet enqueues the connection (in `handle_tcp`, which runs before the trailing `poll_tcp` in the same `poll_ready`).
- DNS async resolution completion re-drives via the per-connection waker (`poll_dns_backend` polls the resolver with that waker).
- The TCP stack has no internal timers (it NATs to real host sockets and relies on guest retransmission), so there is no periodic-poll requirement that readiness-driven polling could starve.

All 98 `consomme` unit tests pass. The async TCP tests drive the stack through real `poll_fn` futures over loopback sockets, so a missed wakeup would hang them; bulk-transfer, out-of-order reassembly, and window-close/reopen tests all still pass.

## Measurement

> [!NOTE]
> This is a perf change whose win only appears with many concurrent connections. It should be benchmarked with the burette `network` test's high-connection-count mode (`--net-parallel`, see #3862) and **re-validated on Windows/IOCP** before merge, since production consomme (wsldevicehost) uses the IOCP backend while Linux uses epoll.

## Testing

- `cargo clippy --all-targets -p consomme`
- `cargo doc --no-deps -p consomme`
- `cargo nextest run --profile agent -p consomme` (98 passed)
- `cargo xtask fmt --fix`