### PR TITLE
vfio_assigned_device: map guest RAM into the IOMMU by file

### DIFF
--- a/vm/devices/pci/vfio_assigned_device/src/manager.rs
+++ b/vm/devices/pci/vfio_assigned_device/src/manager.rs
@@ -484,19 +484,42 @@ impl membacking::DmaTarget for IommufdDmaTarget {
         let iova = range.start();
         let user_va = vaddr as u64;
         let length = range.len();
-        // SAFETY: The caller (DmaMapper in membacking) guarantees that the
-        // host VA is backed and stable via eager mapping + VaMapper lifetime.
-        let result = unsafe {
-            self.ctx
-                .ioas_map(self.ioas_id, iova, user_va, length, request.writable)
-                .with_context(|| {
-                    format!(
-                        "iommufd IOAS DMA map failed: iova={iova:#x} user_va={user_va:#x} \
-                         length={length:#x} ioas_id={}",
-                        self.ioas_id
-                    )
-                })
+        // Prefer map-by-file for guest RAM: it is memfd-backed, so the kernel
+        // can pin the folios directly (no host VA pinning). Device BAR memory
+        // is backed by the VFIO cdev fd, which is neither a memfd nor (yet) a
+        // dmabuf, so map-by-file would misinterpret it — keep those on the VA
+        // path. Private/anonymous RAM has no backing fd and also uses the VA
+        // path.
+        let backing = match request.mapping_type {
+            membacking::MappingType::Ram => request
+                .mappable
+                .map(|mappable| (mappable.as_fd().as_raw_fd(), request.file_offset)),
+            membacking::MappingType::Device => None,
         };
+        let result = match backing {
+            Some((fd, file_offset)) => self.ctx.ioas_map_file(
+                self.ioas_id,
+                iova,
+                fd,
+                file_offset,
+                length,
+                request.writable,
+            ),
+            // SAFETY: The caller (DmaMapper in membacking) guarantees that the
+            // host VA is backed and stable via eager mapping + VaMapper
+            // lifetime, satisfying the safety contract of `ioas_map`.
+            None => unsafe {
+                self.ctx
+                    .ioas_map(self.ioas_id, iova, user_va, length, request.writable)
+            },
+        }
+        .with_context(|| {
+            format!(
+                "iommufd IOAS DMA map failed: iova={iova:#x} user_va={user_va:#x} \
+                 length={length:#x} ioas_id={}",
+                self.ioas_id
+            )
+        });
         if let Err(e) = &result {
             if request.mapping_type == membacking::MappingType::Device {
                 // Device BAR memory may not be mappable into the IOMMU (e.g.,

--- a/vm/devices/pci/vfio_assigned_device/src/manager.rs
+++ b/vm/devices/pci/vfio_assigned_device/src/manager.rs
@@ -513,13 +513,7 @@ impl membacking::DmaTarget for IommufdDmaTarget {
                     .ioas_map(self.ioas_id, iova, user_va, length, request.writable)
             },
         }
-        .with_context(|| {
-            format!(
-                "iommufd IOAS DMA map failed: iova={iova:#x} user_va={user_va:#x} \
-                 length={length:#x} ioas_id={}",
-                self.ioas_id
-            )
-        });
+        .with_context(|| format!("failed to map {range} into iommufd IOAS"));
         if let Err(e) = &result {
             if request.mapping_type == membacking::MappingType::Device {
                 // Device BAR memory may not be mappable into the IOMMU (e.g.,

--- a/vm/devices/user_driver/vfio_sys/src/iommufd.rs
+++ b/vm/devices/user_driver/vfio_sys/src/iommufd.rs
@@ -4,8 +4,8 @@
 //! Bindings for the Linux iommufd subsystem (`/dev/iommu`).
 //!
 //! Provides safe wrappers around `IOMMU_IOAS_ALLOC`, `IOMMU_IOAS_MAP`,
-//! `IOMMU_IOAS_UNMAP`, and `IOMMU_DESTROY` ioctls, which together support
-//! identity DMA mapping via an IOAS.
+//! `IOMMU_IOAS_MAP_FILE`, `IOMMU_IOAS_UNMAP`, and `IOMMU_DESTROY` ioctls,
+//! which together support identity DMA mapping via an IOAS.
 
 use anyhow::Context as _;
 use std::fs;
@@ -22,6 +22,7 @@ const IOMMUFD_CMD_DESTROY: u8 = IOMMUFD_CMD_BASE;
 const IOMMUFD_CMD_IOAS_ALLOC: u8 = IOMMUFD_CMD_BASE + 1;
 const IOMMUFD_CMD_IOAS_MAP: u8 = IOMMUFD_CMD_BASE + 5;
 const IOMMUFD_CMD_IOAS_UNMAP: u8 = IOMMUFD_CMD_BASE + 6;
+const IOMMUFD_CMD_IOAS_MAP_FILE: u8 = IOMMUFD_CMD_BASE + 15;
 
 /// Flags for `IOMMU_IOAS_MAP`.
 pub const IOMMU_IOAS_MAP_FIXED_IOVA: u32 = 1 << 0;
@@ -58,6 +59,14 @@ mod ioctl {
         super::IommuIoasMap
     );
     nix::ioctl_readwrite_bad!(
+        iommu_ioas_map_file,
+        request_code_none!(
+            super::IOMMUFD_TYPE as u32,
+            super::IOMMUFD_CMD_IOAS_MAP_FILE as u32
+        ),
+        super::IommuIoasMapFile
+    );
+    nix::ioctl_readwrite_bad!(
         iommu_ioas_unmap,
         request_code_none!(
             super::IOMMUFD_TYPE as u32,
@@ -89,6 +98,17 @@ pub struct IommuIoasMap {
     pub ioas_id: u32,
     pub __reserved: u32,
     pub user_va: u64,
+    pub length: u64,
+    pub iova: u64,
+}
+
+#[repr(C)]
+pub struct IommuIoasMapFile {
+    pub size: u32,
+    pub flags: u32,
+    pub ioas_id: u32,
+    pub fd: i32,
+    pub start: u64,
     pub length: u64,
     pub iova: u64,
 }
@@ -177,6 +197,48 @@ impl IommufdCtx {
         unsafe {
             ioctl::iommu_ioas_map(self.file.as_raw_fd(), &mut cmd)
                 .context("IOMMU_IOAS_MAP failed")?;
+        }
+        Ok(())
+    }
+
+    /// Map a file/memfd range into an IOAS at a fixed IOVA via
+    /// `IOMMU_IOAS_MAP_FILE`.
+    ///
+    /// Unlike [`Self::ioas_map`], the kernel pins the backing folios directly
+    /// from `fd`, so no host VA is required. `start` is the byte offset within
+    /// the file (must be page-aligned). Requires a kernel with
+    /// `IOMMU_IOAS_MAP_FILE` (Linux 6.13+).
+    pub fn ioas_map_file(
+        &self,
+        ioas_id: u32,
+        iova: u64,
+        fd: RawFd,
+        start: u64,
+        length: u64,
+        writable: bool,
+    ) -> anyhow::Result<()> {
+        let mut flags = IOMMU_IOAS_MAP_FIXED_IOVA | IOMMU_IOAS_MAP_READABLE;
+        if writable {
+            flags |= IOMMU_IOAS_MAP_WRITEABLE;
+        }
+        let mut cmd = IommuIoasMapFile {
+            size: size_of::<IommuIoasMapFile>() as u32,
+            flags,
+            ioas_id,
+            fd,
+            start,
+            length,
+            iova,
+        };
+        // SAFETY: the iommufd fd is valid and the struct is correctly sized and
+        // constructed. `fd` is only read during the ioctl.
+        unsafe {
+            ioctl::iommu_ioas_map_file(self.file.as_raw_fd(), &mut cmd).with_context(|| {
+                format!(
+                    "IOMMU_IOAS_MAP_FILE failed: iova={iova:#x} fd={fd} \
+                     start={start:#x} length={length:#x} ioas_id={ioas_id}"
+                )
+            })?;
         }
         Ok(())
     }

--- a/vm/devices/user_driver/vfio_sys/src/iommufd.rs
+++ b/vm/devices/user_driver/vfio_sys/src/iommufd.rs
@@ -206,8 +206,9 @@ impl IommufdCtx {
     ///
     /// Unlike [`Self::ioas_map`], the kernel pins the backing folios directly
     /// from `fd`, so no host VA is required. `start` is the byte offset within
-    /// the file (must be page-aligned). Requires a kernel with
-    /// `IOMMU_IOAS_MAP_FILE` (Linux 6.13+).
+    /// the file; like [`Self::ioas_map`], both `start` and `length` must be
+    /// page-aligned. Requires a kernel with `IOMMU_IOAS_MAP_FILE` (Linux
+    /// 6.13+).
     pub fn ioas_map_file(
         &self,
         ioas_id: u32,
@@ -233,12 +234,8 @@ impl IommufdCtx {
         // SAFETY: the iommufd fd is valid and the struct is correctly sized and
         // constructed. `fd` is only read during the ioctl.
         unsafe {
-            ioctl::iommu_ioas_map_file(self.file.as_raw_fd(), &mut cmd).with_context(|| {
-                format!(
-                    "IOMMU_IOAS_MAP_FILE failed: iova={iova:#x} fd={fd} \
-                     start={start:#x} length={length:#x} ioas_id={ioas_id}"
-                )
-            })?;
+            ioctl::iommu_ioas_map_file(self.file.as_raw_fd(), &mut cmd)
+                .context("IOMMU_IOAS_MAP_FILE failed")?;
         }
         Ok(())
     }

--- a/vm/devices/user_driver/vfio_sys/src/iommufd.rs
+++ b/vm/devices/user_driver/vfio_sys/src/iommufd.rs
@@ -11,114 +11,99 @@ use anyhow::Context as _;
 use std::fs;
 use std::os::unix::prelude::*;
 
-/// iommufd ioctl type character (';' = 0x3B).
-const IOMMUFD_TYPE: u8 = b';';
-
-/// Base command number for iommufd ioctls.
-const IOMMUFD_CMD_BASE: u8 = 0x80;
-
-// Command numbers (IOMMUFD_CMD_BASE + offset).
-const IOMMUFD_CMD_DESTROY: u8 = IOMMUFD_CMD_BASE;
-const IOMMUFD_CMD_IOAS_ALLOC: u8 = IOMMUFD_CMD_BASE + 1;
-const IOMMUFD_CMD_IOAS_MAP: u8 = IOMMUFD_CMD_BASE + 5;
-const IOMMUFD_CMD_IOAS_UNMAP: u8 = IOMMUFD_CMD_BASE + 6;
-const IOMMUFD_CMD_IOAS_MAP_FILE: u8 = IOMMUFD_CMD_BASE + 15;
-
-/// Flags for `IOMMU_IOAS_MAP`.
-pub const IOMMU_IOAS_MAP_FIXED_IOVA: u32 = 1 << 0;
-pub const IOMMU_IOAS_MAP_WRITEABLE: u32 = 1 << 1;
-pub const IOMMU_IOAS_MAP_READABLE: u32 = 1 << 2;
-
 mod ioctl {
     use nix::request_code_none;
+
+    /// iommufd ioctl type character (';' = 0x3B).
+    const IOMMUFD_TYPE: u8 = b';';
+
+    /// Base command number for iommufd ioctls.
+    const IOMMUFD_CMD_BASE: u8 = 0x80;
+
+    // Command numbers (IOMMUFD_CMD_BASE + offset).
+    const IOMMUFD_CMD_DESTROY: u8 = IOMMUFD_CMD_BASE;
+    const IOMMUFD_CMD_IOAS_ALLOC: u8 = IOMMUFD_CMD_BASE + 1;
+    const IOMMUFD_CMD_IOAS_MAP: u8 = IOMMUFD_CMD_BASE + 5;
+    const IOMMUFD_CMD_IOAS_UNMAP: u8 = IOMMUFD_CMD_BASE + 6;
+    const IOMMUFD_CMD_IOAS_MAP_FILE: u8 = IOMMUFD_CMD_BASE + 15;
+
+    /// Flags for `IOMMU_IOAS_MAP`.
+    pub(super) const IOMMU_IOAS_MAP_FIXED_IOVA: u32 = 1 << 0;
+    pub(super) const IOMMU_IOAS_MAP_WRITEABLE: u32 = 1 << 1;
+    pub(super) const IOMMU_IOAS_MAP_READABLE: u32 = 1 << 2;
 
     // IOMMUFD ioctls use _IO (no direction, just type + nr).
     // The kernel defines them as _IO(IOMMUFD_TYPE, cmd_nr).
     nix::ioctl_readwrite_bad!(
         iommu_destroy,
-        request_code_none!(
-            super::IOMMUFD_TYPE as u32,
-            super::IOMMUFD_CMD_DESTROY as u32
-        ),
-        super::IommuDestroy
+        request_code_none!(IOMMUFD_TYPE as u32, IOMMUFD_CMD_DESTROY as u32),
+        IommuDestroy
     );
     nix::ioctl_readwrite_bad!(
         iommu_ioas_alloc,
-        request_code_none!(
-            super::IOMMUFD_TYPE as u32,
-            super::IOMMUFD_CMD_IOAS_ALLOC as u32
-        ),
-        super::IommuIoasAlloc
+        request_code_none!(IOMMUFD_TYPE as u32, IOMMUFD_CMD_IOAS_ALLOC as u32),
+        IommuIoasAlloc
     );
     nix::ioctl_readwrite_bad!(
         iommu_ioas_map,
-        request_code_none!(
-            super::IOMMUFD_TYPE as u32,
-            super::IOMMUFD_CMD_IOAS_MAP as u32
-        ),
-        super::IommuIoasMap
+        request_code_none!(IOMMUFD_TYPE as u32, IOMMUFD_CMD_IOAS_MAP as u32),
+        IommuIoasMap
     );
     nix::ioctl_readwrite_bad!(
         iommu_ioas_map_file,
-        request_code_none!(
-            super::IOMMUFD_TYPE as u32,
-            super::IOMMUFD_CMD_IOAS_MAP_FILE as u32
-        ),
-        super::IommuIoasMapFile
+        request_code_none!(IOMMUFD_TYPE as u32, IOMMUFD_CMD_IOAS_MAP_FILE as u32),
+        IommuIoasMapFile
     );
     nix::ioctl_readwrite_bad!(
         iommu_ioas_unmap,
-        request_code_none!(
-            super::IOMMUFD_TYPE as u32,
-            super::IOMMUFD_CMD_IOAS_UNMAP as u32
-        ),
-        super::IommuIoasUnmap
+        request_code_none!(IOMMUFD_TYPE as u32, IOMMUFD_CMD_IOAS_UNMAP as u32),
+        IommuIoasUnmap
     );
-}
 
-// Kernel ABI structs — must match `include/uapi/linux/iommufd.h` exactly.
+    // Kernel ABI structs — must match `include/uapi/linux/iommufd.h` exactly.
 
-#[repr(C)]
-pub struct IommuDestroy {
-    pub size: u32,
-    pub id: u32,
-}
+    #[repr(C)]
+    pub(super) struct IommuDestroy {
+        pub(super) size: u32,
+        pub(super) id: u32,
+    }
 
-#[repr(C)]
-pub struct IommuIoasAlloc {
-    pub size: u32,
-    pub flags: u32,
-    pub out_ioas_id: u32,
-}
+    #[repr(C)]
+    pub(super) struct IommuIoasAlloc {
+        pub(super) size: u32,
+        pub(super) flags: u32,
+        pub(super) out_ioas_id: u32,
+    }
 
-#[repr(C)]
-pub struct IommuIoasMap {
-    pub size: u32,
-    pub flags: u32,
-    pub ioas_id: u32,
-    pub __reserved: u32,
-    pub user_va: u64,
-    pub length: u64,
-    pub iova: u64,
-}
+    #[repr(C)]
+    pub(super) struct IommuIoasMap {
+        pub(super) size: u32,
+        pub(super) flags: u32,
+        pub(super) ioas_id: u32,
+        pub(super) __reserved: u32,
+        pub(super) user_va: u64,
+        pub(super) length: u64,
+        pub(super) iova: u64,
+    }
 
-#[repr(C)]
-pub struct IommuIoasMapFile {
-    pub size: u32,
-    pub flags: u32,
-    pub ioas_id: u32,
-    pub fd: i32,
-    pub start: u64,
-    pub length: u64,
-    pub iova: u64,
-}
+    #[repr(C)]
+    pub(super) struct IommuIoasMapFile {
+        pub(super) size: u32,
+        pub(super) flags: u32,
+        pub(super) ioas_id: u32,
+        pub(super) fd: i32,
+        pub(super) start: u64,
+        pub(super) length: u64,
+        pub(super) iova: u64,
+    }
 
-#[repr(C)]
-pub struct IommuIoasUnmap {
-    pub size: u32,
-    pub ioas_id: u32,
-    pub iova: u64,
-    pub length: u64,
+    #[repr(C)]
+    pub(super) struct IommuIoasUnmap {
+        pub(super) size: u32,
+        pub(super) ioas_id: u32,
+        pub(super) iova: u64,
+        pub(super) length: u64,
+    }
 }
 
 /// An open iommufd file descriptor (`/dev/iommu`).
@@ -149,8 +134,8 @@ impl IommufdCtx {
     ///
     /// Returns the kernel-assigned IOAS object ID.
     pub fn ioas_alloc(&self) -> anyhow::Result<u32> {
-        let mut cmd = IommuIoasAlloc {
-            size: size_of::<IommuIoasAlloc>() as u32,
+        let mut cmd = ioctl::IommuIoasAlloc {
+            size: size_of::<ioctl::IommuIoasAlloc>() as u32,
             flags: 0,
             out_ioas_id: 0,
         };
@@ -179,12 +164,12 @@ impl IommufdCtx {
         length: u64,
         writable: bool,
     ) -> anyhow::Result<()> {
-        let mut flags = IOMMU_IOAS_MAP_FIXED_IOVA | IOMMU_IOAS_MAP_READABLE;
+        let mut flags = ioctl::IOMMU_IOAS_MAP_FIXED_IOVA | ioctl::IOMMU_IOAS_MAP_READABLE;
         if writable {
-            flags |= IOMMU_IOAS_MAP_WRITEABLE;
+            flags |= ioctl::IOMMU_IOAS_MAP_WRITEABLE;
         }
-        let mut cmd = IommuIoasMap {
-            size: size_of::<IommuIoasMap>() as u32,
+        let mut cmd = ioctl::IommuIoasMap {
+            size: size_of::<ioctl::IommuIoasMap>() as u32,
             flags,
             ioas_id,
             __reserved: 0,
@@ -218,12 +203,12 @@ impl IommufdCtx {
         length: u64,
         writable: bool,
     ) -> anyhow::Result<()> {
-        let mut flags = IOMMU_IOAS_MAP_FIXED_IOVA | IOMMU_IOAS_MAP_READABLE;
+        let mut flags = ioctl::IOMMU_IOAS_MAP_FIXED_IOVA | ioctl::IOMMU_IOAS_MAP_READABLE;
         if writable {
-            flags |= IOMMU_IOAS_MAP_WRITEABLE;
+            flags |= ioctl::IOMMU_IOAS_MAP_WRITEABLE;
         }
-        let mut cmd = IommuIoasMapFile {
-            size: size_of::<IommuIoasMapFile>() as u32,
+        let mut cmd = ioctl::IommuIoasMapFile {
+            size: size_of::<ioctl::IommuIoasMapFile>() as u32,
             flags,
             ioas_id,
             fd,
@@ -244,8 +229,8 @@ impl IommufdCtx {
     ///
     /// Returns the number of bytes actually unmapped.
     pub fn ioas_unmap(&self, ioas_id: u32, iova: u64, length: u64) -> anyhow::Result<u64> {
-        let mut cmd = IommuIoasUnmap {
-            size: size_of::<IommuIoasUnmap>() as u32,
+        let mut cmd = ioctl::IommuIoasUnmap {
+            size: size_of::<ioctl::IommuIoasUnmap>() as u32,
             ioas_id,
             iova,
             length,
@@ -260,8 +245,8 @@ impl IommufdCtx {
 
     /// Destroy an iommufd object by its ID.
     pub fn destroy(&self, id: u32) -> anyhow::Result<()> {
-        let mut cmd = IommuDestroy {
-            size: size_of::<IommuDestroy>() as u32,
+        let mut cmd = ioctl::IommuDestroy {
+            size: size_of::<ioctl::IommuDestroy>() as u32,
             id,
         };
         // SAFETY: fd is valid, struct correctly constructed.


### PR DESCRIPTION
When an assigned device's DMA mappings are programmed into an iommufd IOAS, guest RAM was always mapped by host virtual address (IOMMU_IOAS_MAP), which requires the kernel to pin the backing pages by VA. Guest RAM is memfd-backed, so the kernel can instead pin the folios directly from the fd via IOMMU_IOAS_MAP_FILE, avoiding VA pinning and, as a bonus, unblocking future userland live-update (IOMMU_IOAS_CHANGE_PROCESS only works for file-backed mappings).

The iommufd DMA target now maps memfd-backed guest RAM by fd + offset and keeps the map-by-VA path for mappings that have no backing fd: private or anonymous RAM, and device BAR memory (whose fd is the VFIO cdev, not a memfd — peer-to-peer BAR mapping is handled separately). IOMMU_IOAS_MAP_FILE has been available since Linux 6.13; support is assumed rather than probed, so a map failure surfaces instead of silently falling back.