### PR TITLE
virt: promote nested virtualization to a generic partition request

### DIFF
--- a/Guide/src/reference/openvmm/management/cli.md
+++ b/Guide/src/reference/openvmm/management/cli.md
@@ -58,29 +58,23 @@ as well as the generated CLI help (via `cargo run -- --help`).
   * `user_mode_apic` — use the user-mode APIC emulator instead of WHP's
     in-hypervisor APIC
   * `no_enlightenments` — disable in-hypervisor Hyper-V enlightenment support
-  * `nested_virt` — expose VMX/SVM to the guest so it can run its own
-    hypervisor (Hyper-V, KVM, etc.). Cannot be combined with
-    `user_mode_apic` or `--hv` (vmbus is not yet supported with nested
-    virt). The host must expose virtualization extensions to the VM
-    running OpenVMM.
-
-  KVM accepts the following parameters (x86_64 guests only):
-  * `nested_virt` — expose VMX/SVM to the guest so it can run its own
-    hypervisor. Off by default: when enabled, a Windows guest detects
-    nested virtualization support and turns on Virtual Secure Mode (VSM),
-    which hurts performance and breaks boot while VMBus devices are in use.
-    The host must support KVM nested virtualization; the backend validates
-    this and fails early if it does not.
 
   Examples:
   ```bash
   --hypervisor whp
   --hypervisor whp:user_mode_apic
   --hypervisor whp:user_mode_apic,no_enlightenments
-  --hypervisor whp:nested_virt
   --hypervisor kvm
-  --hypervisor kvm:nested_virt
   ```
+* `--nested-virt`: Expose hardware virtualization (VMX/SVM) to the guest so it
+  can run its own hypervisor (Hyper-V, KVM, etc.). Only supported on `x86_64`,
+  and only by backends that support nested virtualization (currently WHP and
+  KVM); requesting it with a backend that does not support it fails early. The
+  host must expose virtualization extensions to the VM running OpenVMM. When
+  enabled, a guest may detect nested virtualization and turn on features such
+  as Virtual Secure Mode (VSM), which can hurt performance and interfere with
+  VMBus devices; nested virt cannot currently be combined with `--hv`/VMBus or
+  `--hypervisor whp:user_mode_apic`.
 * `--uefi`: Boot using `mu_msvm` UEFI
 * `--uefi-firmware <FILE>`: Path to the UEFI firmware file (`MSVM.fd`). When `--uefi` is specified, this option is required only if you do not set the environment variable `OPENVMM_UEFI_FIRMWARE` (or the architecture-specific variants `X86_64_OPENVMM_UEFI_FIRMWARE`, or `AARCH64_OPENVMM_UEFI_FIRMWARE`). If omitted, the default is read from `OPENVMM_UEFI_FIRMWARE` first, then falls back to the architecture-specific variables.
 * `--pcat`: Boot using the Microsoft Hyper-V PCAT BIOS

--- a/openvmm/hypervisor_resources/src/lib.rs
+++ b/openvmm/hypervisor_resources/src/lib.rs
@@ -35,12 +35,6 @@ pub struct KvmHandle {
     /// An open `/dev/kvm` file descriptor, open with read and write
     /// permissions.
     pub kvm: std::fs::File,
-    /// Configure the partition for nested virtualization, so that the
-    /// guest can run its own hypervisor (Hyper-V, KVM, etc.).
-    ///
-    /// When false (the default), VMX/SVM CPUID bits and the MS hypervisor
-    /// nested-features leaf are stripped from the guest's view.
-    pub nested_virt: bool,
 }
 
 impl ResourceId<HypervisorKind> for KvmHandle {
@@ -71,13 +65,6 @@ pub struct WhpHandle {
     /// Only supported on x86_64. Setting this to `false` on aarch64 will cause
     /// partition creation to fail.
     pub offload_enlightenments: bool,
-    /// Configure the partition for nested virtualization, so that the
-    /// guest can run its own hypervisor (Hyper-V, KVM, etc.).
-    ///
-    /// Only supported on x86_64. Requires `user_mode_apic = false` and a
-    /// host WHP implementation that exposes nested-virt support; partition
-    /// creation will fail otherwise.
-    pub nested_virt: bool,
 }
 
 impl Default for WhpHandle {
@@ -85,7 +72,6 @@ impl Default for WhpHandle {
         Self {
             user_mode_apic: false,
             offload_enlightenments: true,
-            nested_virt: false,
         }
     }
 }

--- a/openvmm/openvmm_core/src/worker/dispatch.rs
+++ b/openvmm/openvmm_core/src/worker/dispatch.rs
@@ -1053,6 +1053,13 @@ impl InitializedVm {
             }
         }
 
+        // A backend must explicitly recognize an optional feature; requesting
+        // one it does not recognize fails here rather than being silently
+        // ignored during partition creation.
+        if cfg.hypervisor.nested_virt && !hypervisor.recognizes_nested_virt() {
+            anyhow::bail!("the selected hypervisor does not support nested virtualization");
+        }
+
         let proto = hypervisor
             .new_partition(virt::ProtoPartitionConfig {
                 processor_topology: &processor_topology,
@@ -1063,6 +1070,7 @@ impl InitializedVm {
                     .with_isolation
                     .map(|typ| typ.into())
                     .unwrap_or(virt::IsolationType::None),
+                nested_virt: cfg.hypervisor.nested_virt,
             })
             .context("failed to create the prototype partition")?;
 

--- a/openvmm/openvmm_defs/src/config.rs
+++ b/openvmm/openvmm_defs/src/config.rs
@@ -486,6 +486,11 @@ pub struct HypervisorConfig {
     pub with_hv: bool,
     pub with_vtl2: Option<Vtl2Config>,
     pub with_isolation: Option<IsolationType>,
+    /// Expose hardware virtualization (VMX/SVM) to the guest so that it can run
+    /// its own hypervisor. A backend that does not recognize this request
+    /// rejects it rather than silently ignoring it (see
+    /// `virt::Hypervisor::recognizes_nested_virt`).
+    pub nested_virt: bool,
 }
 
 #[derive(Debug, MeshPayload)]

--- a/openvmm/openvmm_entry/src/cli_args.rs
+++ b/openvmm/openvmm_entry/src/cli_args.rs
@@ -854,25 +854,22 @@ flags:
     /// WHP parameters (x86_64 guests only):
     ///   user_mode_apic       - use user-mode APIC emulator
     ///   no_enlightenments    - disable in-hypervisor enlightenments
-    ///   nested_virt          - expose VMX/SVM to the guest so it can run
-    ///                          its own hypervisor (requires
-    ///                          user_mode_apic=false and host WHP
-    ///                          support)
-    ///
-    /// KVM parameters (x86_64 guests only):
-    ///   nested_virt          - expose VMX/SVM to the guest so it can run
-    ///                          its own hypervisor (requires host KVM
-    ///                          nested-virt support)
     ///
     /// Examples:
     ///   --hypervisor whp
     ///   --hypervisor whp:user_mode_apic
     ///   --hypervisor whp:user_mode_apic,no_enlightenments
-    ///   --hypervisor whp:nested_virt
     ///   --hypervisor kvm
-    ///   --hypervisor kvm:nested_virt
     #[clap(long)]
     pub hypervisor: Option<String>,
+
+    /// expose hardware virtualization (VMX/SVM) to the guest so it can run its
+    /// own hypervisor.
+    ///
+    /// Only supported on x86_64, and only by backends that support nested
+    /// virtualization (currently WHP and KVM). Requires host support.
+    #[clap(long)]
+    pub nested_virt: bool,
 
     /// (dev utility) boot linux using a custom (raw) DSDT table.
     ///

--- a/openvmm/openvmm_entry/src/lib.rs
+++ b/openvmm/openvmm_entry/src/lib.rs
@@ -1961,6 +1961,7 @@ async fn vm_config_from_command_line(
                 },
             }),
             with_isolation,
+            nested_virt: opt.nested_virt,
         },
         #[cfg(windows)]
         kernel_vmnics,

--- a/openvmm/openvmm_hypervisors/src/kvm.rs
+++ b/openvmm/openvmm_hypervisors/src/kvm.rs
@@ -25,35 +25,15 @@ impl hypervisor_resources::HypervisorProbe for KvmProbe {
             Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(None),
             Err(err) => return Err(err.into()),
         };
-        Ok(Some(
-            KvmHandle {
-                kvm: kvm.into(),
-                nested_virt: false,
-            }
-            .into_resource(),
-        ))
+        Ok(Some(KvmHandle { kvm: kvm.into() }.into_resource()))
     }
 
     fn new_resource(&self, params: &[(&str, &str)]) -> anyhow::Result<Resource<HypervisorKind>> {
-        let mut nested_virt = false;
-        for &(key, val) in params {
-            match key {
-                "nested_virt" => {
-                    if cfg!(guest_arch = "x86_64") {
-                        nested_virt = parse_bool_param(key, val)?;
-                    } else {
-                        anyhow::bail!("kvm parameter {key} is only supported for x86_64 guests");
-                    }
-                }
-                _ => anyhow::bail!("unknown kvm parameter: {key}"),
-            }
+        for &(key, _val) in params {
+            anyhow::bail!("unknown kvm parameter: {key}");
         }
         let kvm = open_kvm().context("KVM is not available")?;
-        Ok(KvmHandle {
-            kvm: kvm.into(),
-            nested_virt,
-        }
-        .into_resource())
+        Ok(KvmHandle { kvm: kvm.into() }.into_resource())
     }
 }
 
@@ -63,5 +43,3 @@ fn open_kvm() -> std::io::Result<fs_err::File> {
         .write(true)
         .open("/dev/kvm")
 }
-
-use crate::parse_bool_param;

--- a/openvmm/openvmm_hypervisors/src/kvm.rs
+++ b/openvmm/openvmm_hypervisors/src/kvm.rs
@@ -29,7 +29,7 @@ impl hypervisor_resources::HypervisorProbe for KvmProbe {
     }
 
     fn new_resource(&self, params: &[(&str, &str)]) -> anyhow::Result<Resource<HypervisorKind>> {
-        for &(key, _val) in params {
+        if let Some(&(key, _val)) = params.first() {
             anyhow::bail!("unknown kvm parameter: {key}");
         }
         let kvm = open_kvm().context("KVM is not available")?;

--- a/openvmm/openvmm_hypervisors/src/whp.rs
+++ b/openvmm/openvmm_hypervisors/src/whp.rs
@@ -40,13 +40,6 @@ impl hypervisor_resources::HypervisorProbe for WhpProbe {
                         anyhow::bail!("whp parameter {key} is only supported for x86_64 guests");
                     }
                 }
-                "nested_virt" => {
-                    if cfg!(guest_arch = "x86_64") {
-                        handle.nested_virt = parse_bool_param(key, val)?;
-                    } else {
-                        anyhow::bail!("whp parameter {key} is only supported for x86_64 guests");
-                    }
-                }
                 _ => anyhow::bail!("unknown whp parameter: {key}"),
             }
         }

--- a/openvmm/openvmm_resources/src/hypervisor_resolvers/kvm.rs
+++ b/openvmm/openvmm_resources/src/hypervisor_resolvers/kvm.rs
@@ -18,12 +18,7 @@ impl vm_resource::ResolveResource<HypervisorKind, KvmHandle> for KvmResolver {
 
     fn resolve(&self, resource: KvmHandle, _input: ()) -> Result<Self::Output, Self::Error> {
         let kvm = resource.kvm;
-        #[cfg_attr(not(guest_arch = "x86_64"), expect(unused_mut))]
-        let mut backend = virt_kvm::Kvm::from_kvm(kvm)?;
-        #[cfg(guest_arch = "x86_64")]
-        {
-            backend.nested_virt = resource.nested_virt;
-        }
+        let backend = virt_kvm::Kvm::from_kvm(kvm)?;
         Ok(ResolvedHypervisorBackend::new(backend))
     }
 }

--- a/openvmm/openvmm_resources/src/hypervisor_resolvers/whp.rs
+++ b/openvmm/openvmm_resources/src/hypervisor_resolvers/whp.rs
@@ -20,7 +20,6 @@ impl vm_resource::ResolveResource<HypervisorKind, WhpHandle> for WhpResolver {
         Ok(ResolvedHypervisorBackend::new(virt_whp::Whp {
             user_mode_apic: resource.user_mode_apic,
             offload_enlightenments: resource.offload_enlightenments,
-            nested_virt: resource.nested_virt,
         }))
     }
 }

--- a/petri/src/vm/openvmm/construct.rs
+++ b/petri/src/vm/openvmm/construct.rs
@@ -589,6 +589,7 @@ impl PetriVmConfigOpenVmm {
                     None => None,
                     _ => anyhow::bail!("unsupported isolation type"),
                 },
+                nested_virt: false,
             },
             vmbus: if properties.no_vmbus {
                 None

--- a/tmk/tmk_vmm/src/host_vmm.rs
+++ b/tmk/tmk_vmm/src/host_vmm.rs
@@ -44,6 +44,7 @@ impl RunContext<'_> {
                 hv_config: None,
                 vmtime: self.vmtime_source,
                 isolation: virt::IsolationType::None,
+                nested_virt: false,
             })
             .context("failed to create proto partition")?;
 

--- a/tmk/tmk_vmm/src/main.rs
+++ b/tmk/tmk_vmm/src/main.rs
@@ -146,7 +146,6 @@ async fn do_main(driver: DefaultDriver) -> Result<()> {
                             virt_whp::Whp {
                                 user_mode_apic: state.state.opts.disable_offloads,
                                 offload_enlightenments: !state.state.opts.disable_offloads,
-                                nested_virt: false,
                             },
                             test,
                         )

--- a/vmm_core/virt/src/generic.rs
+++ b/vmm_core/virt/src/generic.rs
@@ -64,6 +64,19 @@ pub struct PlatformInfo {
     pub supports_its: bool,
 }
 
+/// A hypervisor backend capable of creating partitions.
+///
+/// # Recognized features
+///
+/// The `recognizes_*` methods report whether the backend acts on an optional
+/// partition request rather than silently ignoring it: it either honors the
+/// request or fails partition creation with a specific error. They let the code
+/// assembling a [`ProtoPartitionConfig`] reject a request up front when the
+/// backend has no concept of it, instead of the request being quietly dropped.
+/// Recognition is *not* a promise that the request succeeds — the backend may
+/// still reject it in combination with another feature, or fail later during
+/// partition creation. Each method defaults to `false`, so a new optional
+/// feature is unrecognized everywhere until a backend overrides its method.
 pub trait Hypervisor: 'static {
     /// The prototype partition type.
     type ProtoPartition<'a>: ProtoPartition<Partition = Self::Partition>;
@@ -78,6 +91,13 @@ pub trait Hypervisor: 'static {
     /// information needed for topology construction and firmware table
     /// generation.
     fn platform_info(&self) -> PlatformInfo;
+
+    /// Whether the backend recognizes a request to expose hardware
+    /// virtualization (VMX/SVM) to the guest so it can run its own hypervisor.
+    /// See the [`Hypervisor`] trait docs on recognized features.
+    fn recognizes_nested_virt(&self) -> bool {
+        false
+    }
 
     /// Returns a new prototype partition from the given configuration.
     fn new_partition<'a>(
@@ -161,6 +181,13 @@ pub struct ProtoPartitionConfig<'a> {
     pub vmtime: &'a VmTimeSource,
     /// Isolation type for this partition.
     pub isolation: IsolationType,
+    /// Expose hardware virtualization (VMX/SVM) to the guest so that it can run
+    /// its own hypervisor.
+    ///
+    /// The code assembling this config must only set this when the chosen
+    /// backend recognizes it via [`Hypervisor::recognizes_nested_virt`]; a
+    /// backend that receives an unrecognized request may silently ignore it.
+    pub nested_virt: bool,
 }
 
 /// Partition creation configuration.

--- a/vmm_core/virt_kvm/src/arch/x86_64/mod.rs
+++ b/vmm_core/virt_kvm/src/arch/x86_64/mod.rs
@@ -99,8 +99,6 @@ const MYSTERY_MSRS: &[u32] = &[0x88, 0x89, 0x8a, 0x116, 0x118, 0x119, 0x11a, 0x1
 #[derive(Debug)]
 pub struct Kvm {
     kvm: kvm::Kvm,
-    /// Enable nested virtualization (VMX/SVM) for the guest.
-    pub nested_virt: bool,
 }
 
 impl Kvm {
@@ -108,17 +106,13 @@ impl Kvm {
     pub fn new() -> Result<Self, KvmError> {
         Ok(Self {
             kvm: kvm::Kvm::new()?,
-            nested_virt: false,
         })
     }
 
     /// Creates a KVM hypervisor instance from a pre-opened `/dev/kvm` fd.
     pub fn from_kvm(file: std::fs::File) -> Result<Self, KvmError> {
         let kvm = kvm::Kvm::from(file);
-        Ok(Self {
-            kvm,
-            nested_virt: false,
-        })
+        Ok(Self { kvm })
     }
 }
 
@@ -141,6 +135,10 @@ impl virt::Hypervisor for Kvm {
         virt::PlatformInfo {}
     }
 
+    fn recognizes_nested_virt(&self) -> bool {
+        true
+    }
+
     fn new_partition<'a>(
         &mut self,
         config: ProtoPartitionConfig<'a>,
@@ -149,7 +147,7 @@ impl virt::Hypervisor for Kvm {
             return Err(KvmError::IsolationNotSupported);
         }
 
-        let nested_virt = self.nested_virt;
+        let nested_virt = config.nested_virt;
         let supported_cpuid = self.kvm.supported_cpuid()?;
 
         // KVM's in-kernel LAPIC only exposes the CMCI LVT register (APIC
@@ -274,7 +272,7 @@ impl virt::Hypervisor for Kvm {
             // nested virtualization features leaf (0x4000000A), but only
             // expose it when nested virtualization is enabled.
             let kvm_hv_cpuid = self.kvm.supported_hv_cpuid()?;
-            let nested_leaf = if self.nested_virt {
+            let nested_leaf = if nested_virt {
                 kvm_hv_cpuid
                     .iter()
                     .find(|e| e.function == HV_CPUID_FUNCTION_MS_HV_NESTED_FEATURES)
@@ -365,7 +363,7 @@ impl virt::Hypervisor for Kvm {
             vm,
             config,
             cpuid: cpuid_entries,
-            nested_virt: self.nested_virt,
+            nested_virt,
             supported_mce_cap,
         })
     }

--- a/vmm_core/virt_whp/src/lib.rs
+++ b/vmm_core/virt_whp/src/lib.rs
@@ -86,8 +86,6 @@ pub struct Whp {
     pub user_mode_apic: bool,
     /// Use the hypervisor's in-built enlightenment support if available.
     pub offload_enlightenments: bool,
-    /// Enable nested virtualization (VMX/SVM) for the guest.
-    pub nested_virt: bool,
 }
 
 #[derive(Inspect)]
@@ -836,13 +834,17 @@ impl virt::Hypervisor for Whp {
         }
     }
 
+    fn recognizes_nested_virt(&self) -> bool {
+        cfg!(guest_arch = "x86_64")
+    }
+
     fn new_partition<'a>(
         &mut self,
         config: ProtoPartitionConfig<'a>,
     ) -> Result<WhpProtoPartition<'a>, Error> {
         let user_mode_apic = self.user_mode_apic;
         let offload_enlightenments = self.offload_enlightenments;
-        let nested_virt = self.nested_virt;
+        let nested_virt = config.nested_virt;
 
         // Nested virt is x86-only.
         #[cfg(guest_arch = "x86_64")]


### PR DESCRIPTION
Nested virtualization was configured per hypervisor via the
`--hypervisor whp:nested_virt` / `kvm:nested_virt` config strings, stored on
the `WhpHandle`/`KvmHandle` resource handles and copied onto each backend
struct. This made a genuinely cross-backend concept look backend-specific,
and it meant a backend could silently drop the request: nothing structurally
connected "the user asked for nested virt" to "this backend will actually act
on it."

Promote the request to a plain `nested_virt` field on the shared
`ProtoPartitionConfig`, sourced from a generic `--nested-virt` CLI flag threaded
through `HypervisorConfig`. Add a `Hypervisor::recognizes_nested_virt()` query
that reports whether the backend *recognizes* the request — that is, whether it
will act on it, either honoring it or failing partition creation with a specific
error, rather than silently ignoring it. It defaults to `false`, and WHP and KVM
override it on x86_64. The code that assembles the partition config consults the
query and fails with a deterministic error when nested virt is requested against
a backend that does not recognize it, rather than letting the request evaporate.

Recognition is deliberately weaker than "supported": a backend that recognizes
nested virt may still reject a particular configuration (for example when
combined with the user-mode APIC or VTL2) or discover during partition creation
that the host cannot provide it. The goal is to eliminate silent no-ops, not to
fully validate host support up front.

Each optional feature is its own defaulted `recognizes_*` method, so adding a
future feature is a single method that defaults to unrecognized everywhere; only
the backends that recognize it need to change. The per-hypervisor `nested_virt`
parameter and the handle fields are removed in favor of the generic flag.
