### PR TITLE
iommu: translate IOAPIC interrupt routes lazily

### DIFF
--- a/openvmm/openvmm_core/src/worker/dispatch/ioapic_iommu_wiring.rs
+++ b/openvmm/openvmm_core/src/worker/dispatch/ioapic_iommu_wiring.rs
@@ -13,9 +13,14 @@ use iommu_common::InterruptRemapper;
 use iommu_common::RetranslateInterrupts;
 use parking_lot::Mutex;
 use std::sync::Arc;
+use std::sync::atomic::AtomicU32;
+use std::sync::atomic::Ordering;
 use virt::irqcon::IRQ_LINES;
 use virt::irqcon::IoApicRouting;
 use virt::irqcon::MsiRequest;
+
+/// Bitmask with a bit set for every valid IRQ line.
+const ALL_IRQS: u32 = (1 << IRQ_LINES) - 1;
 
 /// Device/function (devfn) used as the IOAPIC requestor ID (RID) for
 /// interrupt remapping, as required by the Linux AMD-Vi driver.
@@ -47,8 +52,8 @@ pub(super) struct IoapicIommuSelection {
 /// [`connect_remapper`](Self::connect_remapper) wires in the IOMMU later, once
 /// it exists. The two roles share the same [`Inner`], but callers only see the
 /// control handle and the `dyn IoApicRouting` target. Cached routes are
-/// re-translated when the remapper connects and on each
-/// [`retranslate`](RetranslateInterrupts::retranslate).
+/// (re)translated lazily, at their next delivery, after the remapper connects
+/// and on each [`retranslate`](RetranslateInterrupts::retranslate).
 pub struct IoApicRoutingConnection {
     inner: Arc<IoApicRoutingInner>,
 }
@@ -56,6 +61,21 @@ pub struct IoApicRoutingConnection {
 struct IoApicRoutingInner {
     /// The hypervisor's `IoApicRouting` implementation; final routes go here.
     hv_routing: Arc<dyn IoApicRouting>,
+    /// Bitmask (one bit per IRQ) of routes whose cached translation is stale
+    /// and must be re-translated before their next delivery.
+    ///
+    /// Kept outside [`state`](Self::state) so the hot [`assert_irq`] path can
+    /// test it with a single relaxed load and forward the interrupt without
+    /// taking the lock; only a route that was (re)programmed or invalidated
+    /// takes the lock to translate. Every write happens under `state`, so
+    /// writers never race each other and use plain relaxed load/stores (see
+    /// [`mark_dirty`]/[`clear_dirty`]) rather than atomic read-modify-writes;
+    /// the lock-free reader in `assert_irq` is the only unsynchronized accessor.
+    ///
+    /// [`assert_irq`]: IoApicRoutingInner::assert_irq
+    /// [`mark_dirty`]: IoApicRoutingInner::mark_dirty
+    /// [`clear_dirty`]: IoApicRoutingInner::clear_dirty
+    dirty: AtomicU32,
     state: Mutex<IoApicRoutingState>,
 }
 
@@ -71,7 +91,7 @@ struct Route {
     /// Raw (pre-remapping) MSI request from the IOAPIC.
     raw: Option<MsiRequest>,
     /// Last translated route programmed into `hv_routing`. Used to skip
-    /// redundant `set_irq_route` calls on retranslation.
+    /// redundant `set_irq_route` calls.
     programmed: Option<MsiRequest>,
 }
 
@@ -89,6 +109,7 @@ impl IoApicRoutingConnection {
         Self {
             inner: Arc::new(IoApicRoutingInner {
                 hv_routing,
+                dirty: AtomicU32::new(0),
                 state: Mutex::new(IoApicRoutingState {
                     remap: None,
                     routes: [Route::default(); IRQ_LINES],
@@ -118,13 +139,20 @@ impl IoApicRoutingConnection {
             "IOAPIC remapper connected more than once"
         );
         state.remap = Some(RemapState { rid, remapper });
-        self.inner.set_all_routes(&mut state);
+        // Routes are (re)translated lazily; mark them all dirty so each is
+        // translated on its next delivery rather than translating eagerly here.
+        self.inner.mark_dirty(ALL_IRQS);
     }
 }
 
 impl IoApicRoutingInner {
     /// Translate the cached raw route for `irq` through the remapper (if any)
     /// and program it into `hv_routing`, skipping the call if unchanged.
+    ///
+    /// This is the delivery-time translation: the remapper's IRTE lookup
+    /// (which may record a fault) runs here, so callers must only invoke it
+    /// when the interrupt is actually being delivered. Must be called with
+    /// `state` held; clears the route's dirty bit.
     fn set_route(&self, state: &mut IoApicRoutingState, irq: u8) {
         let route = &mut state.routes[irq as usize];
         let translated = match &state.remap {
@@ -140,26 +168,51 @@ impl IoApicRoutingInner {
             route.programmed = translated;
             self.hv_routing.set_irq_route(irq, translated);
         }
+        self.clear_dirty(1 << irq);
     }
 
-    /// Re-translate and re-program all cached routes.
-    fn set_all_routes(&self, state: &mut IoApicRoutingState) {
-        for irq in 0..IRQ_LINES {
-            self.set_route(state, irq as u8);
-        }
+    /// Mark the IRQ lines in `mask` dirty. Callers must hold `state`: since
+    /// every writer is serialized by that lock there is no racing writer, so a
+    /// plain load/store suffices rather than an atomic read-modify-write. The
+    /// only lock-free accessor is the reader in `assert_irq`.
+    fn mark_dirty(&self, mask: u32) {
+        self.dirty
+            .store(self.dirty.load(Ordering::Relaxed) | mask, Ordering::Relaxed);
+    }
+
+    /// Clear the dirty bits for the IRQ lines in `mask`. Callers must hold
+    /// `state`.
+    fn clear_dirty(&self, mask: u32) {
+        self.dirty.store(
+            self.dirty.load(Ordering::Relaxed) & !mask,
+            Ordering::Relaxed,
+        );
     }
 }
 
 impl IoApicRouting for IoApicRoutingInner {
     fn set_irq_route(&self, irq: u8, request: Option<MsiRequest>) {
-        // Hold the lock across translate to serialize with retranslate().
+        // Hold the lock across the update to serialize with retranslate().
         let mut state = self.state.lock();
         state.routes[irq as usize].raw = request;
-        self.set_route(&mut state, irq);
+        if state.remap.is_some() {
+            // Remapping mode: defer translation until the interrupt is actually
+            // delivered to avoid spurious faults for routes that never fire.
+            self.mark_dirty(1 << irq);
+        } else {
+            // Passthrough mode: no IOMMU, so program the route directly.
+            self.set_route(&mut state, irq);
+        }
     }
 
     fn assert_irq(&self, irq: u8) {
-        // Route is already programmed in the hypervisor; just forward.
+        if self.dirty.load(Ordering::Relaxed) & (1 << irq) != 0 {
+            let mut state = self.state.lock();
+            // Re-check under the lock: another thread may have translated it.
+            if self.dirty.load(Ordering::Relaxed) & (1 << irq) != 0 {
+                self.set_route(&mut state, irq);
+            }
+        }
         self.hv_routing.assert_irq(irq);
     }
 }
@@ -174,14 +227,20 @@ impl RetranslateInterrupts for IoApicRoutingInner {
     }
 
     fn retranslate(&self) {
-        let mut state = self.state.lock();
-        self.set_all_routes(&mut state);
+        // Mark every route for re-translation at its next delivery rather than
+        // translating now: translating (and potentially faulting) a route that
+        // never fires would record a spurious fault. Take the state lock so
+        // this cannot interleave with a `set_route` clearing a dirty bit for a
+        // stale (pre-invalidation) translation. See [`IoApicRoutingInner::dirty`].
+        let _state = self.state.lock();
+        self.mark_dirty(ALL_IRQS);
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::atomic::AtomicBool;
     use std::sync::atomic::AtomicU32;
     use std::sync::atomic::Ordering;
 
@@ -211,6 +270,8 @@ mod tests {
 
     struct TestRemapper {
         data_delta: AtomicU32,
+        /// When set, `remap_msi` returns `None` (an interrupt-remapping fault).
+        fault: AtomicBool,
         routes: iommu_common::RetranslateInterruptsList,
         seen_device_ids: Mutex<Vec<u16>>,
     }
@@ -219,6 +280,7 @@ mod tests {
         fn new(data_delta: u32) -> Self {
             Self {
                 data_delta: AtomicU32::new(data_delta),
+                fault: AtomicBool::new(false),
                 routes: iommu_common::RetranslateInterruptsList::new(),
                 seen_device_ids: Mutex::new(Vec::new()),
             }
@@ -228,6 +290,9 @@ mod tests {
     impl InterruptRemapper for TestRemapper {
         fn remap_msi(&self, device_id: u16, address: u64, data: u32) -> Option<(u64, u32)> {
             self.seen_device_ids.lock().push(device_id);
+            if self.fault.load(Ordering::SeqCst) {
+                return None;
+            }
             Some((
                 address + 0x1000,
                 data + self.data_delta.load(Ordering::SeqCst),
@@ -253,11 +318,17 @@ mod tests {
             data: 0x20,
         };
 
+        // Passthrough mode: the route is programmed directly.
         target.set_irq_route(4, Some(raw));
         assert_eq!(hv_routing.last_route(4), Some(raw));
 
+        // Connecting the remapper defers translation to the next delivery.
         let remapper = Arc::new(TestRemapper::new(1));
         connection.connect_remapper(0x00A0, remapper.clone());
+        assert_eq!(hv_routing.last_route(4), Some(raw));
+
+        // Delivery triggers translation.
+        target.assert_irq(4);
         assert_eq!(
             hv_routing.last_route(4),
             Some(MsiRequest {
@@ -266,8 +337,19 @@ mod tests {
             })
         );
 
+        // Invalidation defers re-translation to the next delivery.
         remapper.data_delta.store(2, Ordering::SeqCst);
         remapper.routes.invalidate(None);
+        assert_eq!(
+            hv_routing.last_route(4),
+            Some(MsiRequest {
+                address: raw.address + 0x1000,
+                data: raw.data + 1,
+            })
+        );
+
+        // Delivery re-translates against the updated table.
+        target.assert_irq(4);
         assert_eq!(
             hv_routing.last_route(4),
             Some(MsiRequest {
@@ -282,5 +364,149 @@ mod tests {
                 .iter()
                 .all(|device_id| *device_id == 0x00A0)
         );
+    }
+
+    #[test]
+    fn translation_is_deferred_until_delivery() {
+        let hv_routing = Arc::new(RecordingIoApicRouting::default());
+        let connection = IoApicRoutingConnection::new(hv_routing.clone());
+        let target = connection.target();
+        let remapper = Arc::new(TestRemapper::new(1));
+        connection.connect_remapper(0x00A0, remapper.clone());
+
+        // Programming a route must not translate it: no interrupt has fired.
+        target.set_irq_route(
+            4,
+            Some(MsiRequest {
+                address: 0xFEE0_0000,
+                data: 0x20,
+            }),
+        );
+        assert!(remapper.seen_device_ids.lock().is_empty());
+
+        // Neither must an invalidation.
+        remapper.routes.invalidate(None);
+        assert!(remapper.seen_device_ids.lock().is_empty());
+
+        // Only actual delivery triggers the IRTE lookup.
+        target.assert_irq(4);
+        assert_eq!(remapper.seen_device_ids.lock().len(), 1);
+    }
+
+    #[test]
+    fn faulting_route_is_looked_up_and_masked_only_on_delivery() {
+        let hv_routing = Arc::new(RecordingIoApicRouting::default());
+        let connection = IoApicRoutingConnection::new(hv_routing.clone());
+        let target = connection.target();
+        let remapper = Arc::new(TestRemapper::new(1));
+        remapper.fault.store(true, Ordering::SeqCst);
+        connection.connect_remapper(0x00A0, remapper.clone());
+
+        // Program an unmasked route whose lookup will fault. Because it is
+        // never delivered, the remapper must not be consulted — this is what
+        // keeps a never-firing entry from recording a spurious remapping fault.
+        target.set_irq_route(
+            4,
+            Some(MsiRequest {
+                address: 0xFEE0_0000,
+                data: 0x20,
+            }),
+        );
+        assert!(remapper.seen_device_ids.lock().is_empty());
+
+        // On delivery the lookup runs and, faulting, masks the hv route.
+        target.assert_irq(4);
+        assert_eq!(remapper.seen_device_ids.lock().len(), 1);
+        assert_eq!(hv_routing.last_route(4), None);
+    }
+
+    #[test]
+    fn masked_route_is_not_looked_up() {
+        let hv_routing = Arc::new(RecordingIoApicRouting::default());
+        let connection = IoApicRoutingConnection::new(hv_routing.clone());
+        let target = connection.target();
+        let remapper = Arc::new(TestRemapper::new(1));
+        connection.connect_remapper(0x00A0, remapper.clone());
+
+        // A masked (None) route must never invoke the remapper, even on
+        // delivery.
+        target.set_irq_route(4, None);
+        target.assert_irq(4);
+        assert!(remapper.seen_device_ids.lock().is_empty());
+    }
+
+    #[test]
+    fn clean_route_is_not_retranslated_without_invalidation() {
+        let hv_routing = Arc::new(RecordingIoApicRouting::default());
+        let connection = IoApicRoutingConnection::new(hv_routing.clone());
+        let target = connection.target();
+        let remapper = Arc::new(TestRemapper::new(1));
+        connection.connect_remapper(0x00A0, remapper.clone());
+        target.set_irq_route(
+            4,
+            Some(MsiRequest {
+                address: 0xFEE0_0000,
+                data: 0x20,
+            }),
+        );
+
+        // First delivery translates once.
+        target.assert_irq(4);
+        assert_eq!(remapper.seen_device_ids.lock().len(), 1);
+
+        // Further deliveries without an invalidation reuse the cached route.
+        target.assert_irq(4);
+        target.assert_irq(4);
+        assert_eq!(remapper.seen_device_ids.lock().len(), 1);
+
+        // An invalidation forces exactly one re-translation on the next
+        // delivery, not on every delivery after it.
+        remapper.routes.invalidate(None);
+        target.assert_irq(4);
+        target.assert_irq(4);
+        assert_eq!(remapper.seen_device_ids.lock().len(), 2);
+    }
+
+    #[test]
+    fn dirty_state_is_tracked_per_irq() {
+        let hv_routing = Arc::new(RecordingIoApicRouting::default());
+        let connection = IoApicRoutingConnection::new(hv_routing.clone());
+        let target = connection.target();
+        let remapper = Arc::new(TestRemapper::new(1));
+        connection.connect_remapper(0x00A0, remapper.clone());
+
+        let raw4 = MsiRequest {
+            address: 0xFEE0_0000,
+            data: 0x20,
+        };
+        let raw7 = MsiRequest {
+            address: 0xFEE0_0000,
+            data: 0x21,
+        };
+        target.set_irq_route(4, Some(raw4));
+        target.set_irq_route(7, Some(raw7));
+
+        // Delivering IRQ 4 translates only IRQ 4; IRQ 7 stays deferred.
+        target.assert_irq(4);
+        assert_eq!(
+            hv_routing.last_route(4),
+            Some(MsiRequest {
+                address: raw4.address + 0x1000,
+                data: raw4.data + 1,
+            })
+        );
+        assert_eq!(hv_routing.last_route(7), None);
+        assert_eq!(remapper.seen_device_ids.lock().len(), 1);
+
+        // Delivering IRQ 7 translates it independently.
+        target.assert_irq(7);
+        assert_eq!(
+            hv_routing.last_route(7),
+            Some(MsiRequest {
+                address: raw7.address + 0x1000,
+                data: raw7.data + 1,
+            })
+        );
+        assert_eq!(remapper.seen_device_ids.lock().len(), 2);
     }
 }

--- a/vm/devices/chipset/src/ioapic/mod.rs
+++ b/vm/devices/chipset/src/ioapic/mod.rs
@@ -526,3 +526,59 @@ impl MmioIntercept for IoApicDevice {
         )]
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A redirection entry in the VT-d/AMD remappable interrupt format must be
+    /// emitted as a remappable-format MSI, carrying the interrupt-remap index
+    /// as the message handle. The remappable RTE deliberately overlays the
+    /// index onto the legacy destination fields, so the ordinary address
+    /// computation already produces the correct message with no special-casing.
+    #[test]
+    fn remappable_rte_emits_remappable_msi() {
+        // Remappable RTE: format bit (48) set, index[14:0] in bits 63:49 and
+        // index[15] in bit 11, vector in bits 7:0. Use an index with bit 15
+        // set to also exercise the bit-11 path.
+        let index: u16 = 0x9234;
+        let vector = 0x30u8;
+        let bits = u64::from(vector)
+            | (1 << 48)
+            | ((u64::from(index) & 0x7fff) << 49)
+            | (((u64::from(index) >> 15) & 1) << 11);
+        let rte = RedirectionEntry::from(bits);
+
+        let (address, data) = rte.as_msi().expect("unmasked entry yields an MSI");
+
+        // Remappable format (address bit 4), no subhandle (SHV, bit 3), and the
+        // index recoverable as the handle = {addr[2], addr[19:5]}.
+        assert_eq!((address >> 4) & 1, 1, "remappable format bit set");
+        assert_eq!((address >> 3) & 1, 0, "SHV clear (no subhandle)");
+        let handle = (((address >> 2) & 1) << 15) | ((address >> 5) & 0x7fff);
+        assert_eq!(handle as u16, index, "handle carries the IRTE index");
+        assert_eq!(data as u8, vector, "vector preserved for EOI matching");
+    }
+
+    /// A compatibility-format entry (format bit clear) is emitted as a
+    /// compatibility-format MSI (address bit 4 clear).
+    #[test]
+    fn compat_rte_emits_compat_msi() {
+        let rte = RedirectionEntry::new()
+            .with_vector(0x30)
+            .with_destination(0x04);
+        let (address, _data) = rte.as_msi().expect("unmasked entry yields an MSI");
+        assert_eq!(
+            (address >> 4) & 1,
+            0,
+            "compatibility format (not remappable)"
+        );
+    }
+
+    /// A masked entry produces no MSI regardless of format.
+    #[test]
+    fn masked_rte_emits_nothing() {
+        let rte = RedirectionEntry::new().with_masked(true).with_vector(0x30);
+        assert_eq!(rte.as_msi(), None);
+    }
+}

--- a/vm/devices/iommu/amd_iommu/src/lib.rs
+++ b/vm/devices/iommu/amd_iommu/src/lib.rs
@@ -1016,11 +1016,19 @@ impl iommu_common::InterruptRemapper for IommuSharedState {
         match self.remap_msi(device_id, address, data) {
             Ok(result) => Some(result),
             Err(fault) => {
-                self.queue_event(fault.to_event_entry());
+                // This runs at interrupt delivery time (the IOAPIC wiring
+                // translates its routes lazily, on assertion), so a fault here
+                // corresponds to an interrupt actually firing through a bad
+                // entry. Log it, matching hardware which performs the IRTE
+                // lookup at delivery time.
                 tracelimit::warn_ratelimited!(
                     device_id,
-                    "interrupt remapping fault on cached route, masking"
+                    address,
+                    data,
+                    error = &fault as &dyn std::error::Error,
+                    "interrupt remapping fault on registered-route delivery, dropping interrupt"
                 );
+                self.queue_event(fault.to_event_entry());
                 None
             }
         }

--- a/vm/devices/iommu/intel_vtd/src/lib.rs
+++ b/vm/devices/iommu/intel_vtd/src/lib.rs
@@ -1036,12 +1036,15 @@ impl SignalMsi for VtdSignalMsi {
             }
             Err(fault) => {
                 drop(state);
-                // MSI is a posted write transaction, so is_write=true.
-                fault.record(&self.shared, true);
                 tracelimit::warn_ratelimited!(
                     source_id,
+                    address,
+                    data,
+                    error = &fault as &dyn std::error::Error,
                     "vtd: MSI remapping fault, interrupt dropped"
                 );
+                // MSI is a posted write transaction, so is_write=true.
+                fault.record(&self.shared, true);
             }
         }
     }
@@ -1054,11 +1057,19 @@ impl iommu_common::InterruptRemapper for VtdSharedState {
             Ok(result) => Some(result),
             Err(fault) => {
                 drop(state);
-                fault.record(self, true);
+                // This runs at interrupt delivery time (the IOAPIC wiring
+                // translates its routes lazily, on assertion), so a fault here
+                // corresponds to an interrupt actually firing through a bad
+                // entry. Record it, matching hardware which performs the IRTE
+                // lookup and records faults at delivery time.
                 tracelimit::warn_ratelimited!(
                     device_id,
-                    "vtd: interrupt remapping fault on cached route, masking"
+                    address,
+                    data,
+                    error = &fault as &dyn std::error::Error,
+                    "vtd: interrupt remapping fault on registered-route delivery, dropping interrupt"
                 );
+                fault.record(self, true);
                 None
             }
         }


### PR DESCRIPTION
The IOAPIC-to-IOMMU interrupt-remapping wiring translated each route eagerly — at RTE programming time and again on every interrupt-entry-cache invalidation — and pushed the pre-translated route into the hypervisor. This caused a guest bugcheck (DRIVER_VERIFIER_DMA_VIOLATION, 0xE6) when running the Hyper-V role in a nested Windows guest with VT-d interrupt remapping enabled: after switching to x2APIC/EIME, Windows leaves a stale, never-firing compatibility-format IOAPIC entry programmed. Eager retranslation ran that entry through the remapper, hit a compatibility-format-blocked fault, and recorded it in the IOMMU fault registers, tripping the guest's interrupt-remapping DMA verifier — even though the interrupt never actually fires.

Translate routes lazily instead, at delivery time. A per-IRQ dirty bitmask marks routes that need (re)translation; the IRTE lookup (and any resulting fault) now happens in assert_irq, only when an interrupt truly fires. This matches hardware, which performs the lookup at delivery, and structurally avoids spurious faults for entries the guest programs but never triggers. Genuine faults on interrupts that do fire are still recorded, so the fault recording removed from the eager path is restored in the remap_msi delivery path for both Intel VT-d and AMD IOMMU. The dirty bitmask lives outside the state lock so the hot assert_irq path stays lock-free for already-translated routes; because every write holds the lock, the bitmask uses plain relaxed load/stores.

Also improves the remapping-fault trace to include the faulting MSI address/data and the fault reason, which is what pinpointed the root cause.