### PR TITLE
petri: don't print to stderr when an artifact is missing

### DIFF
--- a/vmm_tests/petri_artifact_resolver_openvmm_known_paths/src/lib.rs
+++ b/vmm_tests/petri_artifact_resolver_openvmm_known_paths/src/lib.rs
@@ -954,9 +954,6 @@ pub fn get_path(
         get_repo_root()?.join(search_path)
     };
 
-    // Return a descriptive error (including the path we looked for) rather than
-    // writing to stderr, so callers that expect a possible miss — e.g.
-    // `resolve_source` falling back to a remote URL — can recover silently.
     let full_path = file_path.join(file_name);
     if !full_path.fs_err_try_exists()? {
         missing_cmd

--- a/vmm_tests/petri_artifact_resolver_openvmm_known_paths/src/lib.rs
+++ b/vmm_tests/petri_artifact_resolver_openvmm_known_paths/src/lib.rs
@@ -6,6 +6,7 @@
 #![forbid(unsafe_code)]
 
 use anyhow::Context;
+use fs_err::PathExt;
 use petri_artifacts_common::tags::MachineArch;
 use petri_artifacts_core::ArtifactSource;
 use petri_artifacts_core::AsArtifactHandle;
@@ -942,7 +943,7 @@ pub fn get_path(
 
     if let Ok(env_dir) = std::env::var(VMM_TESTS_DIR_ENV_VAR) {
         let full_path = Path::new(&env_dir).join(file_name);
-        if full_path.try_exists()? {
+        if full_path.fs_err_try_exists()? {
             return Ok(full_path);
         }
     }
@@ -957,7 +958,7 @@ pub fn get_path(
     // writing to stderr, so callers that expect a possible miss — e.g.
     // `resolve_source` falling back to a remote URL — can recover silently.
     let full_path = file_path.join(file_name);
-    if !full_path.exists() {
+    if !full_path.fs_err_try_exists()? {
         missing_cmd
             .to_error()
             .with_context(|| format!("failed to find {}", full_path.display()))?;

--- a/vmm_tests/petri_artifact_resolver_openvmm_known_paths/src/lib.rs
+++ b/vmm_tests/petri_artifact_resolver_openvmm_known_paths/src/lib.rs
@@ -5,6 +5,7 @@
 
 #![forbid(unsafe_code)]
 
+use anyhow::Context;
 use petri_artifacts_common::tags::MachineArch;
 use petri_artifacts_core::ArtifactSource;
 use petri_artifacts_core::AsArtifactHandle;
@@ -952,10 +953,14 @@ pub fn get_path(
         get_repo_root()?.join(search_path)
     };
 
+    // Return a descriptive error (including the path we looked for) rather than
+    // writing to stderr, so callers that expect a possible miss — e.g.
+    // `resolve_source` falling back to a remote URL — can recover silently.
     let full_path = file_path.join(file_name);
     if !full_path.exists() {
-        eprintln!("Failed to find {:?}.", full_path);
-        missing_cmd.to_error()?;
+        missing_cmd
+            .to_error()
+            .with_context(|| format!("failed to find {}", full_path.display()))?;
     }
 
     Ok(full_path)


### PR DESCRIPTION
The known-paths artifact resolver's `get_path` helper printed a "Failed to find ..." line to stderr whenever a file was absent, in addition to returning a descriptive error. This side effect leaked confusing "file not found" noise even when the caller fully intended to recover from the miss — most notably `resolve_source`, which treats a missing local file as the normal case and falls back to streaming the disk from remote blob storage for lazy VHD fetching.

Remove the stderr write and instead attach the searched path to the returned error via context, so the path information the message used to provide is preserved but only surfaces if the error actually propagates. Callers that expect a possible miss now recover silently.