### PR TITLE
intel_vtd: advertise Pass Through and Snoop Control in ECAP

### DIFF
--- a/vm/devices/iommu/intel_vtd/src/lib.rs
+++ b/vm/devices/iommu/intel_vtd/src/lib.rs
@@ -99,6 +99,8 @@ const ECAP_VALUE: u64 = EcapReg::new()
     .with_qi(true)
     .with_ir(true)
     .with_eim(true)
+    .with_pt(true)
+    .with_sc(true)
     .with_iro(Reg::IVA.0 / 16)
     .with_mhmv(15) // max IM field in interrupt cache invalidation (4-bit max)
     .into_bits();


### PR DESCRIPTION
Set the PT (Pass Through) and SC (Snoop Control) bits in the emulated Extended Capability Register so guests see these capabilities on the VT-d IOMMU.

Pass Through advertises support for the pass-through translation type in context entries, where an IOVA maps identically to its guest address without a page-table walk. The translate path already handles this translation type, so advertising it simply lets guests select it.

Snoop Control is required by a nested hypervisor before it will enable IOMMU-backed device assignment: it derives its "force snoop" capability directly from this bit and refuses to expose device passthrough without it. Because all DMA in the emulator flows through coherent guest-memory accesses, the per-page snoop bit needs no special handling — the coherency guarantee it requests is always in effect — so advertising SC is both safe and necessary to unblock nested device assignment.