### PR TITLE
virt_kvm: advertise CMCI in guest MCG_CAP for x2APIC

### DIFF
--- a/vm/kvm/src/lib.rs
+++ b/vm/kvm/src/lib.rs
@@ -114,6 +114,10 @@ mod ioctl {
     ioctl_read!(kvm_arm_preferred_target, KVMIO, 0xaf, kvm_vcpu_init);
     ioctl_write_ptr!(kvm_ioeventfd, KVMIO, 0x79, kvm_ioeventfd);
     ioctl_write_ptr!(kvm_set_guest_debug, KVMIO, 0x9b, kvm_guest_debug);
+    #[cfg(target_arch = "x86_64")]
+    ioctl_write_ptr!(kvm_x86_setup_mce, KVMIO, 0x9c, u64);
+    #[cfg(target_arch = "x86_64")]
+    ioctl_read!(kvm_x86_get_mce_cap_supported, KVMIO, 0x9d, u64);
     ioctl_write_ptr!(
         kvm_set_memory_attributes,
         KVMIO,
@@ -324,6 +328,10 @@ pub enum Error {
     GetMsrs(#[source] nix::Error),
     #[error("SetMsrs")]
     SetMsrs(#[source] nix::Error),
+    #[error("SetupMce")]
+    SetupMce(#[source] nix::Error),
+    #[error("GetMceCapSupported")]
+    GetMceCapSupported(#[source] nix::Error),
     #[error("GetMpState")]
     GetMpState(#[source] nix::Error),
     #[error("SetMpState")]
@@ -413,6 +421,20 @@ impl Kvm {
         }
 
         Ok(supported_cpuid.entries[..supported_cpuid.cpuid.nent as usize].to_vec())
+    }
+
+    /// Returns the set of `IA32_MCG_CAP` capability bits that KVM supports
+    /// setting via [`Processor::setup_mce`] on this host (e.g. `MCG_CMCI_P`,
+    /// `MCG_LMCE_P` on Intel).
+    #[cfg(target_arch = "x86_64")]
+    pub fn supported_mce_cap(&self) -> Result<u64> {
+        let mut cap: u64 = 0;
+        // SAFETY: passing a valid pointer to a u64 for the ioctl to fill in.
+        unsafe {
+            ioctl::kvm_x86_get_mce_cap_supported(self.as_fd().as_raw_fd(), &mut cap)
+                .map_err(Error::GetMceCapSupported)?;
+        }
+        Ok(cap)
     }
 
     /// Returns the Hyper-V CPUID values that KVM supports for guest
@@ -1407,6 +1429,22 @@ impl<'a> Processor<'a> {
         unsafe {
             ioctl::kvm_set_msrs(self.get().vcpu.as_raw_fd(), &input.header)
                 .map_err(Error::SetMsrs)?;
+        }
+        Ok(())
+    }
+
+    /// Configures the vCPU's machine-check capability register
+    /// (`IA32_MCG_CAP`) via `KVM_X86_SETUP_MCE`.
+    ///
+    /// `mcg_cap` should only contain capability bits reported as supported by
+    /// [`Kvm::supported_mce_cap`] (plus the bank count in the low byte);
+    /// otherwise KVM returns `EINVAL`.
+    #[cfg(target_arch = "x86_64")]
+    pub fn setup_mce(&self, mcg_cap: u64) -> Result<()> {
+        // SAFETY: passing a valid pointer to a u64 for the ioctl to read.
+        unsafe {
+            ioctl::kvm_x86_setup_mce(self.get().vcpu.as_raw_fd(), &mcg_cap)
+                .map_err(Error::SetupMce)?;
         }
         Ok(())
     }

--- a/vm/x86/x86defs/src/lib.rs
+++ b/vm/x86/x86defs/src/lib.rs
@@ -214,6 +214,44 @@ pub const X86X_MSR_SYSENTER_ESP: u32 = 0x175;
 pub const X86X_MSR_SYSENTER_EIP: u32 = 0x176;
 pub const X86X_MSR_MCG_CAP: u32 = 0x179;
 pub const X86X_MSR_MCG_STATUS: u32 = 0x17a;
+
+/// [`X86X_MSR_MCG_CAP`] (MSR 0x179): global machine-check capability register.
+///
+/// Layout per the Intel SDM Volume 3B, Section 18.3.1.1 / Figure 18-2
+/// (doc 325384-092).
+#[bitfield(u64)]
+#[derive(PartialEq, Eq)]
+pub struct McgCap {
+    /// Number of hardware unit error-reporting banks.
+    pub count: u8,
+    /// `MCG_CTL_P`: `IA32_MCG_CTL` MSR is present.
+    pub ctl_p: bool,
+    /// `MCG_EXT_P`: extended machine-check state MSRs (at 0x180) are present.
+    pub ext_p: bool,
+    /// `MCG_CMCI_P`: corrected MC error counting/signaling extension present.
+    pub cmci_p: bool,
+    /// `MCG_TES_P`: threshold-based error status present.
+    pub tes_p: bool,
+    /// `MCG_SEAM_NR_P`: `IA32_MCG_STATUS.SEAM_NR` (bit 12) is supported.
+    pub seam_nr_p: bool,
+    #[bits(3)]
+    _reserved: u8,
+    /// `MCG_EXT_CNT`: number of extended machine-check state registers
+    /// (meaningful only when `ext_p` is set).
+    pub ext_cnt: u8,
+    /// `MCG_SER_P`: software error recovery is supported.
+    pub ser_p: bool,
+    /// `MCG_EMC_P`: enhanced machine-check capability (firmware-first
+    /// signaling) is supported.
+    pub emc_p: bool,
+    /// `MCG_ELOG_P`: extended error logging is supported.
+    pub elog_p: bool,
+    /// `MCG_LMCE_P`: local machine-check exception is supported.
+    pub lmce_p: bool,
+    #[bits(36)]
+    _reserved2: u64,
+}
+
 pub const X86X_IA32_MSR_MISC_ENABLE: u32 = 0x1a0;
 pub const X86X_MSR_MTRR_PHYSBASE0: u32 = 0x200;
 pub const X86X_MSR_MTRR_FIX64K_00000: u32 = 0x0250;

--- a/vmm_core/virt_kvm/src/arch/x86_64/mod.rs
+++ b/vmm_core/virt_kvm/src/arch/x86_64/mod.rs
@@ -152,6 +152,12 @@ impl virt::Hypervisor for Kvm {
         let nested_virt = self.nested_virt;
         let supported_cpuid = self.kvm.supported_cpuid()?;
 
+        // KVM's in-kernel LAPIC only exposes the CMCI LVT register (APIC
+        // offset 0x2F0) when the guest's IA32_MCG_CAP advertises MCG_CMCI_P.
+        // Query which MCE capability bits this host allows us to set so that
+        // bind() can advertise CMCI to the guest where supported (Intel).
+        let supported_mce_cap = self.kvm.supported_mce_cap()?;
+
         // Determine the CPU vendor from CPUID leaf 0.
         let vendor = supported_cpuid
             .iter()
@@ -360,6 +366,7 @@ impl virt::Hypervisor for Kvm {
             config,
             cpuid: cpuid_entries,
             nested_virt: self.nested_virt,
+            supported_mce_cap,
         })
     }
 }
@@ -370,6 +377,9 @@ pub struct KvmProtoPartition<'a> {
     config: ProtoPartitionConfig<'a>,
     cpuid: CpuidLeafSet,
     nested_virt: bool,
+    /// MCE capability bits (`IA32_MCG_CAP`) the host allows setting, from
+    /// `KVM_X86_GET_MCE_CAP_SUPPORTED`.
+    supported_mce_cap: u64,
 }
 
 impl ProtoPartition for KvmProtoPartition<'_> {
@@ -484,6 +494,7 @@ impl ProtoPartition for KvmProtoPartition<'_> {
             caps,
             cpuid,
             reserved_vps_per_socket: self.config.processor_topology.reserved_vps_per_socket(),
+            mce_cmci_supported: x86defs::McgCap::from(self.supported_mce_cap).cmci_p(),
             synic_ports: Default::default(),
         });
 
@@ -739,6 +750,21 @@ impl virt::BindProcessor for KvmProcessorBinder {
                         .with_vmx_enabled_outside_smx(ecx.vmx()),
                 ),
             )])?;
+        }
+
+        // Advertise CMCI support (MCG_CMCI_P) in the guest's IA32_MCG_CAP when
+        // the host permits it. KVM's in-kernel LAPIC only exposes the CMCI LVT
+        // register (APIC offset 0x2F0) when MCG_CMCI_P is set, yet KVM defaults
+        // MCG_CAP with it clear; without it, a guest that programs the CMCI LVT
+        // via an x2APIC MSR takes a #GP. Preserve the default bank count and
+        // other capability bits.
+        if self.partition.mce_cmci_supported {
+            let mut mcg_cap = [0u64];
+            kvm.get_msrs(&[x86defs::X86X_MSR_MCG_CAP], &mut mcg_cap)?;
+            let cap = x86defs::McgCap::from(mcg_cap[0]);
+            if !cap.cmci_p() {
+                kvm.setup_mce(cap.with_cmci_p(true).into())?;
+            }
         }
 
         // Set per-VP CPUID entries, fixing up APIC ID fields.

--- a/vmm_core/virt_kvm/src/lib.rs
+++ b/vmm_core/virt_kvm/src/lib.rs
@@ -112,6 +112,11 @@ struct KvmPartitionInner {
     #[cfg(guest_arch = "x86_64")]
     reserved_vps_per_socket: u32,
 
+    /// Whether the host allows advertising `MCG_CMCI_P` in the guest's
+    /// `IA32_MCG_CAP` (required for KVM to expose the CMCI LVT register).
+    #[cfg(guest_arch = "x86_64")]
+    mce_cmci_supported: bool,
+
     /// The GIC device fd, kept alive for the VM lifetime.
     #[cfg(guest_arch = "aarch64")]
     #[inspect(skip)]


### PR DESCRIPTION
KVM's in-kernel local APIC only exposes the CMCI LVT register (APIC offset 0x2F0) when the guest's IA32_MCG_CAP advertises MCG_CMCI_P, and KVM leaves that bit clear by default. A guest that programs the CMCI LVT via an x2APIC MSR write then takes a #GP, because KVM rejects a write to a register it considers absent. In xAPIC mode the equivalent write goes through MMIO and is silently dropped, so the failure only surfaces once the guest runs in x2APIC mode.

Hyper-V on Windows Server 2025 relies on this: it unconditionally programs the CMCI LVT during APIC bring-up on Intel, and switches its LAPIC to x2APIC when it detects VT-d interrupt remapping. Running such a guest nested on OpenVMM/KVM therefore hit the #GP and rebooted in a loop; earlier Windows releases did not exercise the same path.

Set MCG_CMCI_P in the guest's MCG_CAP during VP bring-up when the host permits it. The settable MCE capability bits are queried up front via KVM_X86_GET_MCE_CAP_SUPPORTED (MCG_CMCI_P is only settable on Intel hosts) and applied per-VP via KVM_X86_SETUP_MCE, preserving the default bank count and other capability bits. Where CMCI is not settable the guest's MCG_CAP is left unchanged; such guests do not program the Intel CMCI LVT and are unaffected.

The two KVM MCE ioctls and an SDM-accurate McgCap bitfield (Intel SDM Vol 3B, Section 18.3.1.1) are added to support this.