### PR TITLE
nvme: lower flush and dsm log level to trace

### DIFF
--- a/vm/devices/storage/nvme/src/namespace.rs
+++ b/vm/devices/storage/nvme/src/namespace.rs
@@ -174,7 +174,7 @@ impl Namespace {
                     .map_err(map_disk_error)?;
             }
             nvm::NvmOpcode::FLUSH => {
-                tracing::debug!(nsid = self.nsid, "flush");
+                tracing::trace!(nsid = self.nsid, "flush");
                 if !self.disk.is_read_only() {
                     self.disk.sync_cache().await.map_err(map_disk_error)?;
                 }
@@ -189,7 +189,7 @@ impl Namespace {
                 let prp =
                     PrpRange::parse(&self.mem, size_of_val(dsm_ranges.as_ref()), command.dptr)?;
                 prp.read(&self.mem, dsm_ranges.as_mut_bytes())?;
-                tracing::debug!(nsid = self.nsid, ?cdw11, ?dsm_ranges, "dsm");
+                tracing::trace!(nsid = self.nsid, ?cdw11, ?dsm_ranges, "dsm");
                 if cdw11.ad() {
                     for range in dsm_ranges.as_ref() {
                         self.disk


### PR DESCRIPTION
The NVMe namespace command handler logged every FLUSH and DSM command at debug level. These commands are issued frequently during normal guest I/O, so the debug output floods petri test logs with per-command noise. Drop them to trace so they no longer clutter routine test runs while remaining available when explicitly needed.