### PR TITLE
local_clock: Fix flakiness in unit tests

### DIFF
--- a/support/local_clock/src/clock_impls.rs
+++ b/support/local_clock/src/clock_impls.rs
@@ -126,6 +126,8 @@ mod tests {
 
         let delta = new_time - time;
 
+        // cannot use assert_eq, because there is a *bit* of extra time elapsed
+        // aside from the thread sleep.
         eprintln!("delta: {delta:?}");
         assert!(delta >= LocalClockDelta::from_millis(999)); // allow for rounding to lose a milli
         assert!(delta < std::time::Duration::from_secs(2).into()); // sanity check
@@ -159,6 +161,8 @@ mod tests {
 
         let delta = new_time - time;
 
+        // cannot use assert_eq, because there is a *bit* of extra time elapsed
+        // aside from the thread sleep.
         eprintln!("delta: {delta:?}");
         assert!(delta >= LocalClockDelta::from_millis(999)); // allow for rounding to lose a milli
         assert!(delta < std::time::Duration::from_secs(2).into()); // sanity check

--- a/support/local_clock/src/clock_impls.rs
+++ b/support/local_clock/src/clock_impls.rs
@@ -126,9 +126,8 @@ mod tests {
 
         let delta = new_time - time;
 
-        // cannot use assert_eq, because there is a *bit* of extra time elapsed
-        // aside from the thread sleep.
-        assert!(delta >= std::time::Duration::from_secs(1).into());
+        eprintln!("delta: {delta:?}");
+        assert!(delta >= LocalClockDelta::from_millis(999)); // allow for rounding to lose a milli
         assert!(delta < std::time::Duration::from_secs(2).into()); // sanity check
     }
 
@@ -160,9 +159,8 @@ mod tests {
 
         let delta = new_time - time;
 
-        // cannot use assert_eq, because there is a *bit* of extra time elapsed
-        // aside from the thread sleep.
-        assert!(delta >= std::time::Duration::from_secs(1).into());
+        eprintln!("delta: {delta:?}");
+        assert!(delta >= LocalClockDelta::from_millis(999)); // allow for rounding to lose a milli
         assert!(delta < std::time::Duration::from_secs(2).into()); // sanity check
     }
 }


### PR DESCRIPTION
Make a minor adjustment to the time delta assertions in the local_clock test suite to allow for a slight rounding error by accepting a minimum delta of 999 milliseconds instead of a full second. Also add a debug print statement for easier troubleshooting.

Failure hit in https://github.com/microsoft/openvmm/actions/runs/28676536703/job/85051045477