### PR TITLE
virt_whp: mask enlightened GPA-flush bits for nested guests

### DIFF
--- a/vm/hv1/hvdef/src/lib.rs
+++ b/vm/hv1/hvdef/src/lib.rs
@@ -643,6 +643,25 @@ impl HvEnlightenmentInformation {
     }
 }
 
+/// The EAX result of the `HV_CPUID_FUNCTION_MS_HV_NESTED_FEATURES` (0x4000000A)
+/// cpuid leaf, describing the nested virtualization enlightenments the
+/// hypervisor offers to a nested (L1) hypervisor.
+#[bitfield(u32)]
+#[derive(IntoBytes, Immutable, KnownLayout, FromBytes)]
+pub struct HvNestedVirtFeaturesEax {
+    pub enlightened_vmcs_version_low: u8,
+    pub enlightened_vmcs_version_high: u8,
+    _reserved16: bool,
+    pub nested_flush_virtual_hypercall: bool,
+    pub flush_guest_physical_hypercall: bool,
+    pub msr_bitmap: bool,
+    pub virtualization_exception: bool,
+    pub debug_ctl: bool,
+    pub enlightened_npt_tlb: bool,
+    #[bits(9)]
+    _reserved23: u32,
+}
+
 #[bitfield(u128)]
 pub struct HvHardwareFeatures {
     pub apic_overlay_assist_in_use: bool,

--- a/vmm_core/virt_whp/src/lib.rs
+++ b/vmm_core/virt_whp/src/lib.rs
@@ -1116,11 +1116,8 @@ impl WhpPartitionInner {
                     .with_flush_guest_physical_hypercall(true)
                     .with_enlightened_npt_tlb(true);
                 cpuid.push(
-                    virt::CpuidLeaf::new(
-                        hvdef::HV_CPUID_FUNCTION_MS_HV_NESTED_FEATURES,
-                        [0; 4],
-                    )
-                    .masked([u32::from(flush_gpa_mask), 0, 0, 0]),
+                    virt::CpuidLeaf::new(hvdef::HV_CPUID_FUNCTION_MS_HV_NESTED_FEATURES, [0; 4])
+                        .masked([u32::from(flush_gpa_mask), 0, 0, 0]),
                 );
             }
 

--- a/vmm_core/virt_whp/src/lib.rs
+++ b/vmm_core/virt_whp/src/lib.rs
@@ -1097,6 +1097,33 @@ impl WhpPartitionInner {
                 }
             }
 
+            if nested_virt {
+                // WORKAROUND: The L0 hypervisor advertises the enlightened
+                // guest-physical-address flush hypercall
+                // (HvCallFlushGuestPhysicalAddressSpace / ...List) in the nested
+                // features cpuid leaf whenever a partition is nested-capable,
+                // but the hypercall is actually rejected at dispatch for exo
+                // (WHP) partitions. Mask off the flush-GPA enlightenment bits so
+                // that the guest hypervisor falls back to non-enlightened
+                // NPT/EPT TLB invalidation instead of issuing a hypercall that
+                // will fail.
+                //
+                // Both the Intel (flush_guest_physical_hypercall) and AMD
+                // (enlightened_npt_tlb) bits are cleared unconditionally; only
+                // the platform-relevant bit is ever set in the passthrough
+                // value.
+                let flush_gpa_mask = hvdef::HvNestedVirtFeaturesEax::new()
+                    .with_flush_guest_physical_hypercall(true)
+                    .with_enlightened_npt_tlb(true);
+                cpuid.push(
+                    virt::CpuidLeaf::new(
+                        hvdef::HV_CPUID_FUNCTION_MS_HV_NESTED_FEATURES,
+                        [0; 4],
+                    )
+                    .masked([u32::from(flush_gpa_mask), 0, 0, 0]),
+                );
+            }
+
             cpuid.extend(config.cpuid);
 
             // Add topology CPUID leaves.


### PR DESCRIPTION
When nested virtualization is enabled, the L0 hypervisor advertises the enlightened guest-physical-address flush hypercall (HvCallFlushGuestPhysicalAddressSpace / ...List) in the nested-features CPUID leaf to any nested-capable partition. However, the hypercall is actually rejected at dispatch for exo partitions, which is what WHP partitions are. A guest hypervisor that trusts the advertised bit will opt into the enlightenment and then fail when it issues the hypercall.

Filter the flush-GPA enlightenment bits out of the nested-features leaf presented to the guest so that the guest hypervisor falls back to non-enlightened NPT/EPT TLB invalidation instead. Both the Intel (flush_guest_physical_hypercall) and AMD (enlightened_npt_tlb) bits are cleared unconditionally, since only the platform-relevant one is ever set in the passthrough value.

Add an HvNestedVirtFeaturesEax bitfield to hvdef so the mask is expressed in terms of named capability bits rather than raw bit positions.