### PR TITLE
virt_whp: Unhalt the VP when injecting a deliverability notification

### DIFF
--- a/vmm_core/virt_whp/src/apic.rs
+++ b/vmm_core/virt_whp/src/apic.rs
@@ -680,6 +680,7 @@ impl WhpProcessor<'_> {
             || cr8 >= priority as u64
             || pending_event.event_pending()
         {
+            // Not ready. Register a notification.
             let notifications = self.state.vtls[vtl].deliverability_notifications;
             if !notifications.interrupt_notification()
                 || (notifications.interrupt_priority() != 0
@@ -693,6 +694,7 @@ impl WhpProcessor<'_> {
                 );
             }
 
+            self.state.halted = false;
             return;
         }
 


### PR DESCRIPTION
It is possible to end up in a state where an interrupt notification is pending, but the guest never sees it and we hang forever. Fix this by unhalting the VP. This matches the behavior or `inject_nmi` and `inject_extint`. Hopefully will reduce test flakiness.