### PR TITLE
vpci_{client|relay}: support partial-DWORD config space accesses

### DIFF
--- a/vm/devices/pci/vpci_client/Cargo.toml
+++ b/vm/devices/pci/vpci_client/Cargo.toml
@@ -7,6 +7,7 @@ rust-version.workspace = true
 edition.workspace = true
 
 [dependencies]
+chipset_device.workspace = true
 openhcl_tdisp.workspace = true
 pci_core.workspace = true
 tdisp.workspace = true
@@ -32,7 +33,6 @@ tracing.workspace = true
 zerocopy.workspace = true
 
 [dev-dependencies]
-chipset_device.workspace = true
 closeable_mutex.workspace = true
 test_with_tracing.workspace = true
 vpci.workspace = true

--- a/vm/devices/pci/vpci_client/src/lib.rs
+++ b/vm/devices/pci/vpci_client/src/lib.rs
@@ -446,7 +446,7 @@ impl VpciDevice {
     /// Offset must be u32 aligned.
     pub fn read_cfg(&self, offset: u16, mut value: ByteEnabledDwordRead<'_>) {
         // For static values, return values from the device's description.
-        let value = match HeaderType00(offset) {
+        match HeaderType00(offset) {
             HeaderType00::STATUS_COMMAND => {
                 let shadows = self.shadows.lock();
                 self.config_space
@@ -496,7 +496,6 @@ impl VpciDevice {
                 .read(self.dev.id, offset, value.reborrow()),
         };
         tracing::trace!(?offset, ?value, "config space read");
-        value
     }
 
     /// Writes device configuration space.

--- a/vm/devices/pci/vpci_client/src/lib.rs
+++ b/vm/devices/pci/vpci_client/src/lib.rs
@@ -12,6 +12,8 @@
 mod tests;
 
 use anyhow::Context;
+use chipset_device::pci::ByteEnabledDwordRead;
+use chipset_device::pci::ByteEnabledDwordWrite;
 use futures::FutureExt;
 use futures::Stream;
 use futures::StreamExt;
@@ -183,10 +185,10 @@ async fn send_eject_complete<M: RingMem>(
 pub trait MemoryAccess: Send {
     /// Returns the base GPA of the allocated MMIO space.
     fn gpa(&mut self) -> u64;
-    /// Reads a 32-bit value from the given address.
-    fn read(&mut self, addr: u64) -> u32;
-    /// Writes a 32-bit value to the given address.
-    fn write(&mut self, addr: u64, value: u32);
+    /// Reads a 1-, 2-, or 4-byte value from the given address.
+    fn read(&mut self, addr: u64, data: &mut [u8]);
+    /// Writes a 1-, 2-, or 4-byte value to the given address.
+    fn write(&mut self, addr: u64, data: &[u8]);
 }
 
 /// The amount of MMIO space required by the VPCI bus.
@@ -274,35 +276,45 @@ impl ConfigSpaceAccessor {
         if id.slot != self.current_slot {
             self.mem.write(
                 self.base_gpa + protocol::MMIO_PAGE_SLOT_NUMBER,
-                id.slot.into(),
+                &u32::from(id.slot).to_ne_bytes(),
             );
             self.current_slot = id.slot;
         }
         true
     }
 
-    fn read(&mut self, id: DeviceId, offset: u16) -> u32 {
+    /// Reads a value from the configuration space of the given device.
+    /// Offset must be u32 aligned.
+    fn read(&mut self, id: DeviceId, offset: u16, mut value: ByteEnabledDwordRead<'_>) {
         if !self.set_slot(id) {
             tracelimit::warn_ratelimited!(?id, offset, "device is gone, ignoring cfg read");
-            return !0;
+            value.set(!0);
+            return;
         }
-        let value = self
-            .mem
-            .read(self.base_gpa + protocol::MMIO_PAGE_CONFIG_SPACE + offset as u64);
-        tracing::trace!(?id, offset, value, "host config space read");
-        value
+        let (byte_offset, _) = value.byte_enable().to_byte_offset_len();
+        let addr = self.base_gpa
+            + protocol::MMIO_PAGE_CONFIG_SPACE
+            + (offset as u64)
+            + (byte_offset as u64);
+        self.mem
+            .read(addr, value.reborrow().into_valid_byte_slice());
+        tracing::trace!(?id, offset, ?value, "host config space read");
     }
 
-    fn write(&mut self, id: DeviceId, offset: u16, value: u32) {
+    /// Writes a value to the configuration space of the given device.
+    /// Offset must be u32 aligned.
+    fn write(&mut self, id: DeviceId, offset: u16, value: ByteEnabledDwordWrite) {
         if !self.set_slot(id) {
             tracelimit::warn_ratelimited!(?id, offset, "device is gone, ignoring cfg write");
             return;
         }
-        tracing::trace!(?id, offset, value, "host config space write");
-        self.mem.write(
-            self.base_gpa + protocol::MMIO_PAGE_CONFIG_SPACE + offset as u64,
-            value,
-        );
+        tracing::trace!(?id, offset, ?value, "host config space write");
+        let (byte_offset, _) = value.byte_enable().to_byte_offset_len();
+        let addr = self.base_gpa
+            + protocol::MMIO_PAGE_CONFIG_SPACE
+            + (offset as u64)
+            + (byte_offset as u64);
+        self.mem.write(addr, value.as_valid_byte_slice());
     }
 }
 
@@ -431,29 +443,40 @@ impl VpciDevice {
     /// Reads device configuration space.
     ///
     /// Some values will be handled without communicating with the host.
-    pub fn read_cfg(&self, offset: u16) -> u32 {
+    /// Offset must be u32 aligned.
+    pub fn read_cfg(&self, offset: u16, mut value: ByteEnabledDwordRead<'_>) {
         // For static values, return values from the device's description.
         let value = match HeaderType00(offset) {
             HeaderType00::STATUS_COMMAND => {
                 let shadows = self.shadows.lock();
-                let status_command = self.config_space.lock().read(self.dev.id, offset);
+                self.config_space
+                    .lock()
+                    .read(self.dev.id, offset, value.reborrow());
                 // Preserve the MMIO enabled bit in the command register, since
                 // Hyper-V does not always emulate it correctly for reads.
                 let mask = u32::from(u16::from(Command::new().with_mmio_enabled(true)));
-                (status_command & !mask) | (u32::from(u16::from(shadows.command)) & mask)
+                if value.valid_mask() & mask != 0 {
+                    value.set(
+                        (value.extract() & !mask) | (u32::from(u16::from(shadows.command)) & mask),
+                    );
+                }
             }
             HeaderType00::DEVICE_VENDOR => {
-                (self.hw_ids.vendor_id as u32) | ((self.hw_ids.device_id as u32) << 16)
+                value.set_low_high(self.hw_ids.vendor_id, self.hw_ids.device_id);
             }
             HeaderType00::CLASS_REVISION => {
-                (self.hw_ids.revision_id as u32)
-                    | ((self.hw_ids.prog_if.0 as u32) << 8)
-                    | ((self.hw_ids.sub_class.0 as u32) << 16)
-                    | ((self.hw_ids.base_class.0 as u32) << 24)
+                value.set_bytes(
+                    self.hw_ids.revision_id,
+                    self.hw_ids.prog_if.0,
+                    self.hw_ids.sub_class.0,
+                    self.hw_ids.base_class.0,
+                );
             }
             HeaderType00::SUBSYSTEM_ID => {
-                (self.hw_ids.type0_sub_vendor_id as u32)
-                    | ((self.hw_ids.type0_sub_system_id as u32) << 16)
+                value.set_low_high(
+                    self.hw_ids.type0_sub_vendor_id,
+                    self.hw_ids.type0_sub_system_id,
+                );
             }
             HeaderType00::BAR0
             | HeaderType00::BAR1
@@ -465,28 +488,33 @@ impl VpciDevice {
                 // BAR reads. Return the shadowed value.
                 let shadows = self.shadows.lock();
                 let i = (offset - HeaderType00::BAR0.0) as usize / 4;
-                shadows.bars[i] | self.bar_rao[i]
+                value.set(shadows.bars[i] | self.bar_rao[i]);
             }
-            _ => self.config_space.lock().read(self.dev.id, offset),
+            _ => self
+                .config_space
+                .lock()
+                .read(self.dev.id, offset, value.reborrow()),
         };
-        tracing::trace!(?offset, value, "config space read");
+        tracing::trace!(?offset, ?value, "config space read");
         value
     }
 
     /// Writes device configuration space.
-    pub fn write_cfg(&self, offset: u16, value: u32) {
-        tracing::trace!(?offset, value, "config space write");
+    /// Offset must be u32 aligned.
+    pub fn write_cfg(&self, offset: u16, value: ByteEnabledDwordWrite) {
+        tracing::trace!(?offset, ?value, "config space write");
         let mut shadows = self.shadows.lock();
         let shadows = &mut *shadows;
         let mut accessor = self.config_space.lock();
         match HeaderType00(offset) {
             HeaderType00::STATUS_COMMAND => {
-                let new_command = Command::from(value as u16);
+                let new_command = Command::from(value.merge_low(shadows.command.into_bits()));
                 if new_command.mmio_enabled() && !shadows.command.mmio_enabled() {
                     // Flush the BAR shadow to the device.
                     for (i, &bar) in shadows.bars.iter().enumerate() {
                         let bar_offset = HeaderType00::BAR0.0 + (i as u16 * 4);
-                        accessor.write(self.dev.id, bar_offset, bar);
+                        let write_dword = ByteEnabledDwordWrite::with_all_bytes_enabled(bar);
+                        accessor.write(self.dev.id, bar_offset, write_dword);
                     }
                 }
                 shadows.command = new_command;
@@ -501,7 +529,8 @@ impl VpciDevice {
                 // is enabled to avoid wasting time writing probe values to the
                 // host.
                 let i = (offset - HeaderType00::BAR0.0) as usize / 4;
-                shadows.bars[i] = value & self.bar_masks[i] | self.bar_rao[i];
+                let new_bar_value = value.merge(shadows.bars[i]);
+                shadows.bars[i] = new_bar_value & self.bar_masks[i] | self.bar_rao[i];
                 return;
             }
             _ => {}

--- a/vm/devices/pci/vpci_client/src/tests.rs
+++ b/vm/devices/pci/vpci_client/src/tests.rs
@@ -67,21 +67,19 @@ impl super::MemoryAccess for BusWrapper {
         0x123456780000
     }
 
-    fn read(&mut self, addr: u64) -> u32 {
-        let mut data = [0; 4];
+    fn read(&mut self, addr: u64, value: &mut [u8]) {
         self.0
             .supports_mmio()
             .unwrap()
-            .mmio_read(addr, &mut data)
+            .mmio_read(addr, value)
             .unwrap();
-        u32::from_ne_bytes(data)
     }
 
-    fn write(&mut self, addr: u64, value: u32) {
+    fn write(&mut self, addr: u64, value: &[u8]) {
         self.0
             .supports_mmio()
             .unwrap()
-            .mmio_write(addr, &value.to_ne_bytes())
+            .mmio_write(addr, value)
             .unwrap();
     }
 }
@@ -136,7 +134,12 @@ async fn test_negotiate_version(driver: DefaultDriver) {
         .await
         .unwrap();
 
-    assert_eq!(device.read_cfg(256), 0);
+    let mut value = 0;
+    device.read_cfg(
+        256,
+        ByteEnabledDwordRead::with_all_bytes_enabled(&mut value),
+    );
+    assert_eq!(value, 0);
 
     device.unregister_interrupt(address, data).await;
 }

--- a/vm/devices/pci/vpci_relay/src/lib.rs
+++ b/vm/devices/pci/vpci_relay/src/lib.rs
@@ -418,18 +418,13 @@ impl ChipsetDevice for RelayedVpciDevice {
 }
 
 impl PciConfigSpace for RelayedVpciDevice {
-    fn pci_cfg_read(&mut self, offset: u16, mut value: ByteEnabledDwordRead<'_>) -> IoResult {
-        value.set(self.0.read_cfg(offset));
+    fn pci_cfg_read(&mut self, offset: u16, value: ByteEnabledDwordRead<'_>) -> IoResult {
+        self.0.read_cfg(offset, value);
         IoResult::Ok
     }
 
     fn pci_cfg_write(&mut self, offset: u16, value: ByteEnabledDwordWrite) -> IoResult {
-        let new_value = if value.is_full() {
-            value.extract()
-        } else {
-            value.merge(self.0.read_cfg(offset))
-        };
-        self.0.write_cfg(offset, new_value);
+        self.0.write_cfg(offset, value);
         IoResult::Ok
     }
 }

--- a/vm/devices/pci/vpci_relay/src/linux_mmio.rs
+++ b/vm/devices/pci/vpci_relay/src/linux_mmio.rs
@@ -43,30 +43,63 @@ impl MemoryAccess for DirectMmioInstance {
         self.0
     }
 
-    fn read(&mut self, addr: u64) -> u32 {
+    fn read(&mut self, addr: u64, data: &mut [u8]) {
         let offset = addr
             .checked_sub(self.gpa())
             .and_then(|o| o.try_into().ok())
             .unwrap_or(!0);
-        match self.1.read_volatile(offset) {
-            Ok(v) => v,
+        let res = match data.len() {
+            1 => self.1.read_volatile::<[u8; 1]>(offset).map(|v| v.to_vec()),
+            2 => self.1.read_volatile::<[u8; 2]>(offset).map(|v| v.to_vec()),
+            4 => self.1.read_volatile::<[u8; 4]>(offset).map(|v| v.to_vec()),
+            _ => {
+                tracelimit::error_ratelimited!(
+                    addr,
+                    len = data.len(),
+                    "vpci mmio read failure: unsupported length"
+                );
+                data.fill(!0);
+                return;
+            }
+        };
+        match res {
+            Ok(value) => data.copy_from_slice(&value),
             Err(err) => {
                 tracelimit::error_ratelimited!(
                     addr,
                     error = &err as &dyn std::error::Error,
                     "vpci mmio read failure"
                 );
-                !0
+                data.fill(!0);
             }
         }
     }
 
-    fn write(&mut self, addr: u64, value: u32) {
+    fn write(&mut self, addr: u64, value: &[u8]) {
         let offset = addr
             .checked_sub(self.gpa())
             .and_then(|o| o.try_into().ok())
             .unwrap_or(!0);
-        if let Err(err) = self.1.write_volatile(offset, &value) {
+        let res = match value.len() {
+            1 => self
+                .1
+                .write_volatile(offset, &<[u8; 1]>::try_from(value).unwrap()),
+            2 => self
+                .1
+                .write_volatile(offset, &<[u8; 2]>::try_from(value).unwrap()),
+            4 => self
+                .1
+                .write_volatile(offset, &<[u8; 4]>::try_from(value).unwrap()),
+            _ => {
+                tracelimit::error_ratelimited!(
+                    addr,
+                    len = value.len(),
+                    "vpci mmio write failure: unsupported length"
+                );
+                return;
+            }
+        };
+        if let Err(err) = res {
             tracelimit::error_ratelimited!(
                 addr,
                 value,
@@ -105,27 +138,22 @@ impl MemoryAccess for HypercallMmioInstance {
         self.0
     }
 
-    fn read(&mut self, addr: u64) -> u32 {
-        let mut data = [0; 4];
-        match self.1.mmio_read(addr, &mut data) {
-            Ok(()) => u32::from_ne_bytes(data),
-            Err(err) => {
-                tracelimit::error_ratelimited!(
-                    addr,
-                    error = &err as &dyn std::error::Error,
-                    "vpci mmio read failure"
-                );
-                !0
-            }
+    fn read(&mut self, addr: u64, data: &mut [u8]) {
+        if let Err(err) = self.1.mmio_read(addr, data) {
+            tracelimit::error_ratelimited!(
+                addr,
+                error = &err as &dyn std::error::Error,
+                "vpci mmio read failure"
+            );
+            data.fill(!0);
         }
     }
 
-    fn write(&mut self, addr: u64, value: u32) {
-        let data = value.to_ne_bytes();
-        if let Err(err) = self.1.mmio_write(addr, &data) {
+    fn write(&mut self, addr: u64, data: &[u8]) {
+        if let Err(err) = self.1.mmio_write(addr, data) {
             tracelimit::error_ratelimited!(
                 addr,
-                value,
+                data,
                 error = &err as &dyn std::error::Error,
                 "vpci mmio write failure"
             );

--- a/vm/devices/pci/vpci_relay/src/linux_mmio.rs
+++ b/vm/devices/pci/vpci_relay/src/linux_mmio.rs
@@ -49,9 +49,18 @@ impl MemoryAccess for DirectMmioInstance {
             .and_then(|o| o.try_into().ok())
             .unwrap_or(!0);
         let res = match data.len() {
-            1 => self.1.read_volatile::<[u8; 1]>(offset).map(|v| v.to_vec()),
-            2 => self.1.read_volatile::<[u8; 2]>(offset).map(|v| v.to_vec()),
-            4 => self.1.read_volatile::<[u8; 4]>(offset).map(|v| v.to_vec()),
+            1 => self
+                .1
+                .read_volatile::<[u8; 1]>(offset)
+                .map(|v| data.copy_from_slice(&v)),
+            2 => self
+                .1
+                .read_volatile::<[u8; 2]>(offset)
+                .map(|v| data.copy_from_slice(&v)),
+            4 => self
+                .1
+                .read_volatile::<[u8; 4]>(offset)
+                .map(|v| data.copy_from_slice(&v)),
             _ => {
                 tracelimit::error_ratelimited!(
                     addr,
@@ -62,16 +71,13 @@ impl MemoryAccess for DirectMmioInstance {
                 return;
             }
         };
-        match res {
-            Ok(value) => data.copy_from_slice(&value),
-            Err(err) => {
-                tracelimit::error_ratelimited!(
-                    addr,
-                    error = &err as &dyn std::error::Error,
-                    "vpci mmio read failure"
-                );
-                data.fill(!0);
-            }
+        if let Err(err) = res {
+            tracelimit::error_ratelimited!(
+                addr,
+                error = &err as &dyn std::error::Error,
+                "vpci mmio read failure"
+            );
+            data.fill(!0);
         }
     }
 

--- a/vm/devices/pci/vpci_relay/src/linux_mmio.rs
+++ b/vm/devices/pci/vpci_relay/src/linux_mmio.rs
@@ -61,15 +61,7 @@ impl MemoryAccess for DirectMmioInstance {
                 .1
                 .read_volatile::<[u8; 4]>(offset)
                 .map(|v| data.copy_from_slice(&v)),
-            _ => {
-                tracelimit::error_ratelimited!(
-                    addr,
-                    len = data.len(),
-                    "vpci mmio read failure: unsupported length"
-                );
-                data.fill(!0);
-                return;
-            }
+            _ => panic!("size must be 1-, 2-, or 4-bytes"),
         };
         if let Err(err) = res {
             tracelimit::error_ratelimited!(
@@ -96,14 +88,7 @@ impl MemoryAccess for DirectMmioInstance {
             4 => self
                 .1
                 .write_volatile(offset, &<[u8; 4]>::try_from(value).unwrap()),
-            _ => {
-                tracelimit::error_ratelimited!(
-                    addr,
-                    len = value.len(),
-                    "vpci mmio write failure: unsupported length"
-                );
-                return;
-            }
+            _ => panic!("size must be 1-, 2-, or 4-bytes"),
         };
         if let Err(err) = res {
             tracelimit::error_ratelimited!(


### PR DESCRIPTION
This change updates relayed VPCI devices to forward partial-DWORD config space accesses. Config space access functions now deal in `ByteEnabledDwordRead` / `ByteEnabledDwordWrite`, and memory access APIs now deal in byte slices.