### PR TITLE
Bump cmov to 0.5.4 (GHSA-3rjw-m598-pq24)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -823,9 +823,9 @@ dependencies = [
 
 [[package]]
 name = "cmov"
-version = "0.5.3"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f88a43d011fc4a6876cb7344703e297c71dda42494fee094d5f7c76bf13f746"
+checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
 
 [[package]]
 name = "cms"


### PR DESCRIPTION
Updates the `cmov` crate from 0.5.3 to 0.5.4 to fix Dependabot alert #45 (GHSA-3rjw-m598-pq24), where Cmov/CmovEq on aarch64 could produce incorrect results when high bits of registers are set.