### PR TITLE
nvme: accept mandatory Set/Get Features for PCIe I/O controller

### DIFF
--- a/vm/devices/storage/nvme/src/tests/controller_tests.rs
+++ b/vm/devices/storage/nvme/src/tests/controller_tests.rs
@@ -1360,3 +1360,78 @@ async fn test_mandatory_features_roundtrip(driver: DefaultDriver) {
 
     let _ = admin_slot;
 }
+
+/// CNS 06h (I/O Command Set specific Identify Controller): the NVM command set
+/// (CSI 0h) defines no such data structure, so the controller must return a
+/// zero-filled 4096-byte structure (NVMe Base 2.3 §5.2.13.2.6). A request for
+/// an unsupported command set is rejected with Invalid Field in Command.
+#[async_test]
+async fn test_identify_io_command_set_specific_controller(driver: DefaultDriver) {
+    let acq = PrpRange::new(vec![0], 0, PAGE_SIZE64).unwrap();
+    let asq = PrpRange::new(vec![0x1000], 0, PAGE_SIZE64).unwrap();
+    let gm = test_memory();
+    let int_controller = TestPciInterruptController::new();
+
+    let mut nvmec = instantiate_and_build_admin_queue(
+        &acq,
+        64,
+        &asq,
+        64,
+        true,
+        Some(&int_controller),
+        driver.clone(),
+        &gm,
+    )
+    .await;
+
+    let data_gpa = 0x8000u64;
+    // Pre-fill the target with a non-zero pattern to prove the controller
+    // actually writes a zero-filled structure back.
+    gm.write_plain::<[u8; 4096]>(data_gpa, &[0xff; 4096])
+        .unwrap();
+
+    let mut cmd = spec::Command::new_zeroed();
+    cmd.cdw0.set_opcode(spec::AdminOpcode::IDENTIFY.0);
+    cmd.cdw10 = spec::Cdw10Identify::new()
+        .with_cns(spec::Cns::SPECIFIC_CONTROLLER_IO_COMMAND_SET.0)
+        .into();
+    cmd.cdw11 = 0; // CSI 0h (NVM command set)
+    cmd.dptr[0] = data_gpa;
+
+    let cqe = submit_admin_command(
+        &mut nvmec,
+        &gm,
+        &asq,
+        &acq,
+        &int_controller,
+        driver.clone(),
+        0,
+        &cmd,
+    )
+    .await;
+    assert_eq!(cqe.status.status(), spec::Status::SUCCESS.0);
+    let data = gm.read_plain::<[u8; 4096]>(data_gpa).unwrap();
+    assert!(
+        data.iter().all(|&b| b == 0),
+        "CNS 06h must return a zero-filled structure"
+    );
+
+    // A request for a command set the controller does not support (CSI 1h) must
+    // be aborted with Invalid Field in Command.
+    cmd.cdw11 = 1 << 24;
+    let cqe = submit_admin_command(
+        &mut nvmec,
+        &gm,
+        &asq,
+        &acq,
+        &int_controller,
+        driver.clone(),
+        1,
+        &cmd,
+    )
+    .await;
+    assert_eq!(
+        cqe.status.status(),
+        spec::Status::INVALID_FIELD_IN_COMMAND.0
+    );
+}

--- a/vm/devices/storage/nvme/src/tests/controller_tests.rs
+++ b/vm/devices/storage/nvme/src/tests/controller_tests.rs
@@ -1356,9 +1356,12 @@ async fn test_mandatory_features_roundtrip(driver: DefaultDriver) {
         .with_fid(spec::Feature::ARBITRATION.0)
         .with_sel(1)
         .into();
-    submit!(sel_cmd, spec::Status::INVALID_FIELD_IN_COMMAND.0);
-
-    let _ = admin_slot;
+    // This is the last command submitted, so the `admin_slot` increment inside
+    // `submit!` is never read afterwards.
+    #[expect(unused_assignments, reason = "final submit! bumps admin_slot")]
+    {
+        submit!(sel_cmd, spec::Status::INVALID_FIELD_IN_COMMAND.0);
+    }
 }
 
 /// CNS 06h (I/O Command Set specific Identify Controller): the NVM command set

--- a/vm/devices/storage/nvme/src/tests/controller_tests.rs
+++ b/vm/devices/storage/nvme/src/tests/controller_tests.rs
@@ -1438,3 +1438,64 @@ async fn test_identify_io_command_set_specific_controller(driver: DefaultDriver)
         spec::Status::INVALID_FIELD_IN_COMMAND.0
     );
 }
+
+/// The Supported Log Pages log page (LID 00h) is mandatory for an NVMe 2.0 I/O
+/// controller. It must report an LSUPP bit for each supported log page (NVMe
+/// Base 2.3 §5.2.12.1.1, Figures 207/208).
+#[async_test]
+async fn test_get_supported_log_pages(driver: DefaultDriver) {
+    let acq = PrpRange::new(vec![0], 0, PAGE_SIZE64).unwrap();
+    let asq = PrpRange::new(vec![0x1000], 0, PAGE_SIZE64).unwrap();
+    let gm = test_memory();
+    let int_controller = TestPciInterruptController::new();
+
+    let mut nvmec = instantiate_and_build_admin_queue(
+        &acq,
+        64,
+        &asq,
+        64,
+        true,
+        Some(&int_controller),
+        driver.clone(),
+        &gm,
+    )
+    .await;
+
+    let data_gpa = 0x8000u64;
+    // Pre-fill so we can confirm unsupported LIDs are reported as zero.
+    gm.write_plain::<[u8; 1024]>(data_gpa, &[0xff; 1024])
+        .unwrap();
+
+    let mut cmd = spec::Command::new_zeroed();
+    cmd.cdw0.set_opcode(spec::AdminOpcode::GET_LOG_PAGE.0);
+    // 1024 bytes = 256 dwords; NUMDL is a 0-based dword count.
+    cmd.cdw10 = spec::Cdw10GetLogPage::new()
+        .with_lid(spec::LogPageIdentifier::SUPPORTED_LOG_PAGES.0)
+        .with_numdl_z(255)
+        .into();
+    cmd.dptr[0] = data_gpa;
+
+    let cqe = submit_admin_command(
+        &mut nvmec,
+        &gm,
+        &asq,
+        &acq,
+        &int_controller,
+        driver.clone(),
+        0,
+        &cmd,
+    )
+    .await;
+    assert_eq!(cqe.status.status(), spec::Status::SUCCESS.0);
+
+    let page = gm.read_plain::<[u32; 256]>(data_gpa).unwrap();
+    let supported = [0usize, 1, 2, 3, 4];
+    for (lid, entry) in page.iter().enumerate() {
+        let lsupp = spec::LidSupportedAndEffects::from(*entry).lsupp();
+        assert_eq!(
+            lsupp,
+            supported.contains(&lid),
+            "LID {lid:#x} LSUPP bit mismatch"
+        );
+    }
+}

--- a/vm/devices/storage/nvme/src/tests/controller_tests.rs
+++ b/vm/devices/storage/nvme/src/tests/controller_tests.rs
@@ -1141,3 +1141,222 @@ async fn test_identify_reports_fixed_nn(driver: DefaultDriver) {
         "NN must remain MAX_NSID after adding a namespace"
     );
 }
+
+// =============================================================================
+// Mandatory Set/Get Features compliance (NVMe Base 2.3 §3.1.3.6, Figure 32).
+//
+// An I/O controller must *accept* every mandatory feature and round-trip its
+// CDW11 rather than aborting with Invalid Field in Command. These tests submit
+// real admin Set/Get Features commands through the controller and verify the
+// stored value is echoed back.
+
+fn set_feature_command(fid: spec::Feature, cdw11: u32) -> spec::Command {
+    let mut command = spec::Command::new_zeroed();
+    command.cdw0.set_opcode(spec::AdminOpcode::SET_FEATURES.0);
+    command.cdw10 = spec::Cdw10SetFeatures::new().with_fid(fid.0).into();
+    command.cdw11 = cdw11;
+    command
+}
+
+fn get_feature_command(fid: spec::Feature, cdw11: u32) -> spec::Command {
+    let mut command = spec::Command::new_zeroed();
+    command.cdw0.set_opcode(spec::AdminOpcode::GET_FEATURES.0);
+    command.cdw10 = spec::Cdw10GetFeatures::new().with_fid(fid.0).into();
+    command.cdw11 = cdw11;
+    command
+}
+
+/// Submits a single admin command in slot `admin_slot` and returns its
+/// completion.
+async fn submit_admin_command(
+    nvmec: &mut NvmeController,
+    gm: &GuestMemory,
+    asq: &PrpRange,
+    acq: &PrpRange,
+    int_controller: &TestPciInterruptController,
+    driver: DefaultDriver,
+    admin_slot: u32,
+    command: &spec::Command,
+) -> spec::Completion {
+    write_command_to_queue(gm, asq, admin_slot as usize, command);
+    nvmec
+        .write_bar0(0x1000, (admin_slot + 1).as_bytes())
+        .unwrap();
+    wait_for_msi(driver, int_controller, 1000, 0xfeed0000, 0x1111).await;
+    read_completion_from_queue(gm, acq, admin_slot as usize)
+}
+
+#[async_test]
+async fn test_mandatory_features_roundtrip(driver: DefaultDriver) {
+    let acq = PrpRange::new(vec![0], 0, PAGE_SIZE64).unwrap();
+    let asq = PrpRange::new(vec![0x1000], 0, PAGE_SIZE64).unwrap();
+    let gm = test_memory();
+    let int_controller = TestPciInterruptController::new();
+
+    let mut nvmec = instantiate_and_build_admin_queue(
+        &acq,
+        64,
+        &asq,
+        64,
+        true,
+        Some(&int_controller),
+        driver.clone(),
+        &gm,
+    )
+    .await;
+
+    let mut admin_slot = 0u32;
+
+    // Helper: submit a command, assert its status, and return the completion.
+    macro_rules! submit {
+        ($command:expr, $expected_status:expr) => {{
+            let cqe = submit_admin_command(
+                &mut nvmec,
+                &gm,
+                &asq,
+                &acq,
+                &int_controller,
+                driver.clone(),
+                admin_slot,
+                &$command,
+            )
+            .await;
+            assert_eq!(
+                cqe.status.status(),
+                spec::Status($expected_status).0,
+                "unexpected status for admin_slot {admin_slot}"
+            );
+            admin_slot += 1;
+            cqe
+        }};
+    }
+
+    // Features whose entire CDW11 round-trips verbatim.
+    for (fid, cdw11) in [
+        (spec::Feature::ARBITRATION, 0x0102_0304u32),
+        (
+            spec::Feature::ERROR_RECOVERY,
+            u32::from(
+                spec::Cdw11FeatureErrorRecovery::new()
+                    .with_tler(100)
+                    .with_dulbe(true),
+            ),
+        ),
+        (
+            spec::Feature::INTERRUPT_COALESCING,
+            u32::from(
+                spec::Cdw11FeatureInterruptCoalescing::new()
+                    .with_thr(8)
+                    .with_time(16),
+            ),
+        ),
+    ] {
+        submit!(set_feature_command(fid, cdw11), spec::Status::SUCCESS.0);
+        let cqe = submit!(get_feature_command(fid, 0), spec::Status::SUCCESS.0);
+        assert_eq!(cqe.dw0, cdw11, "feature {fid:?} did not round-trip");
+    }
+
+    // Power Management: PS 0 is accepted, PS != 0 is rejected.
+    let pm = u32::from(
+        spec::Cdw11FeaturePowerManagement::new()
+            .with_ps(0)
+            .with_wh(2),
+    );
+    submit!(
+        set_feature_command(spec::Feature::POWER_MANAGEMENT, pm),
+        spec::Status::SUCCESS.0
+    );
+    let cqe = submit!(
+        get_feature_command(spec::Feature::POWER_MANAGEMENT, 0),
+        spec::Status::SUCCESS.0
+    );
+    assert_eq!(cqe.dw0, pm);
+    submit!(
+        set_feature_command(
+            spec::Feature::POWER_MANAGEMENT,
+            spec::Cdw11FeaturePowerManagement::new().with_ps(1).into(),
+        ),
+        spec::Status::INVALID_FIELD_IN_COMMAND.0
+    );
+
+    // Temperature Threshold: accepted but stateless — the emulator models no
+    // temperature sensors, so Set is ignored and Get reports the reset defaults.
+    submit!(
+        set_feature_command(
+            spec::Feature::TEMPERATURE_THRESHOLD,
+            spec::Cdw11FeatureTemperatureThreshold::new()
+                .with_tmpth(350)
+                .with_tmpsel(0)
+                .with_thsel(0)
+                .into(),
+        ),
+        spec::Status::SUCCESS.0
+    );
+    // Over-temperature threshold defaults to the maximum (effectively disabled).
+    let over = spec::Cdw11FeatureTemperatureThreshold::new().with_thsel(0);
+    let cqe = submit!(
+        get_feature_command(spec::Feature::TEMPERATURE_THRESHOLD, over.into()),
+        spec::Status::SUCCESS.0
+    );
+    assert_eq!(
+        spec::Cdw11FeatureTemperatureThreshold::from(cqe.dw0).tmpth(),
+        0xffff
+    );
+    // Under-temperature threshold defaults to zero.
+    let under = spec::Cdw11FeatureTemperatureThreshold::new().with_thsel(1);
+    let cqe = submit!(
+        get_feature_command(spec::Feature::TEMPERATURE_THRESHOLD, under.into()),
+        spec::Status::SUCCESS.0
+    );
+    assert_eq!(
+        spec::Cdw11FeatureTemperatureThreshold::from(cqe.dw0).tmpth(),
+        0x0000
+    );
+
+    // Interrupt Vector Configuration: valid vector accepted, unknown rejected.
+    let ivc = spec::Cdw11FeatureInterruptVectorConfig::new()
+        .with_iv(0)
+        .with_cd(true);
+    submit!(
+        set_feature_command(spec::Feature::INTERRUPT_VECTOR_CONFIG, ivc.into()),
+        spec::Status::SUCCESS.0
+    );
+    let cqe = submit!(
+        get_feature_command(
+            spec::Feature::INTERRUPT_VECTOR_CONFIG,
+            spec::Cdw11FeatureInterruptVectorConfig::new()
+                .with_iv(0)
+                .into(),
+        ),
+        spec::Status::SUCCESS.0
+    );
+    assert_eq!(cqe.dw0, u32::from(ivc));
+    submit!(
+        set_feature_command(
+            spec::Feature::INTERRUPT_VECTOR_CONFIG,
+            spec::Cdw11FeatureInterruptVectorConfig::new()
+                .with_iv(0xffff)
+                .into(),
+        ),
+        spec::Status::INVALID_FIELD_IN_COMMAND.0
+    );
+
+    // Save (Set) and non-current Select (Get) are unsupported because
+    // Identify Controller ONCS.SSFS is 0: they must be rejected rather than
+    // silently applied.
+    let mut save_cmd = set_feature_command(spec::Feature::ARBITRATION, 0);
+    save_cmd.cdw10 = spec::Cdw10SetFeatures::new()
+        .with_fid(spec::Feature::ARBITRATION.0)
+        .with_save(true)
+        .into();
+    submit!(save_cmd, spec::Status::FEATURE_IDENTIFIER_NOT_SAVEABLE.0);
+
+    let mut sel_cmd = get_feature_command(spec::Feature::ARBITRATION, 0);
+    sel_cmd.cdw10 = spec::Cdw10GetFeatures::new()
+        .with_fid(spec::Feature::ARBITRATION.0)
+        .with_sel(1)
+        .into();
+    submit!(sel_cmd, spec::Status::INVALID_FIELD_IN_COMMAND.0);
+
+    let _ = admin_slot;
+}

--- a/vm/devices/storage/nvme/src/workers/admin.rs
+++ b/vm/devices/storage/nvme/src/workers/admin.rs
@@ -125,7 +125,6 @@ pub struct AdminState {
     send_changed_namespace: futures::channel::mpsc::Sender<u32>,
     #[inspect(skip)]
     poll_namespace_change: BTreeMap<u32, Task<()>>,
-    #[inspect(flatten)]
     features: FeatureState,
 }
 

--- a/vm/devices/storage/nvme/src/workers/admin.rs
+++ b/vm/devices/storage/nvme/src/workers/admin.rs
@@ -125,6 +125,50 @@ pub struct AdminState {
     send_changed_namespace: futures::channel::mpsc::Sender<u32>,
     #[inspect(skip)]
     poll_namespace_change: BTreeMap<u32, Task<()>>,
+    #[inspect(flatten)]
+    features: FeatureState,
+}
+
+/// Stored configuration for the mandatory Set/Get Features that the controller
+/// accepts and echoes back but does not otherwise act upon. Storing and echoing
+/// these values satisfies the NVMe Base 2.3 §3.1.3.6 (Figure 32) requirement
+/// that an I/O controller accept every mandatory feature.
+#[derive(Inspect)]
+struct FeatureState {
+    #[inspect(hex)]
+    arbitration: u32,
+    #[inspect(hex)]
+    power_management: u32,
+    #[inspect(hex)]
+    error_recovery: u32,
+    #[inspect(hex)]
+    interrupt_coalescing: u32,
+    /// Coalescing Disable bit per interrupt vector, indexed by interrupt vector.
+    #[inspect(iter_by_index)]
+    interrupt_vector_coalescing_disable: Vec<bool>,
+}
+
+impl FeatureState {
+    fn new(num_interrupt_vectors: usize) -> Self {
+        Self {
+            arbitration: 0,
+            power_management: 0,
+            error_recovery: 0,
+            interrupt_coalescing: 0,
+            interrupt_vector_coalescing_disable: vec![false; num_interrupt_vectors],
+        }
+    }
+}
+
+/// The Temperature Threshold value reported for the requested threshold type.
+///
+/// The emulator models no temperature sensors, so thresholds never trip and no
+/// state needs to be stored: Set Features is accepted and ignored, and Get
+/// Features always reports the reset defaults — an over-temperature threshold
+/// of the maximum (effectively disabled) and an under-temperature threshold of
+/// zero.
+fn default_temperature_threshold(thsel: u8) -> u16 {
+    if thsel == 0 { 0xffff } else { 0x0000 }
 }
 
 #[derive(Inspect)]
@@ -189,6 +233,7 @@ impl AdminState {
             recv_changed_namespace,
             send_changed_namespace,
             poll_namespace_change,
+            features: FeatureState::new(handler.config.interrupts.len()),
         };
         state.set_max_queues(handler, handler.config.max_sqs, handler.config.max_cqs);
         state
@@ -678,7 +723,13 @@ impl AdminHandler {
     ) -> Result<CommandResult, NvmeError> {
         let cdw10: spec::Cdw10SetFeatures = command.cdw10.into();
         let mut dw = [0; 2];
-        // Note that we don't support non-zero cdw10.save, since ONCS.save == 0.
+        // This controller does not support saving feature values across power
+        // cycles or resets (Identify Controller ONCS.SSFS is 0), so a request
+        // to save a feature value must be rejected rather than silently applied
+        // for the current power cycle only.
+        if cdw10.save() {
+            return Err(spec::Status::FEATURE_IDENTIFIER_NOT_SAVEABLE.into());
+        }
         match spec::Feature(cdw10.fid()) {
             spec::Feature::NUMBER_OF_QUEUES => {
                 if state.io_sqs.iter().any(|sq| sq.is_some())
@@ -718,6 +769,41 @@ impl AdminHandler {
                 // relevant bits before firing each notification class.
                 state.async_event_config = command.cdw11;
             }
+            spec::Feature::ARBITRATION => {
+                state.features.arbitration = command.cdw11;
+            }
+            spec::Feature::POWER_MANAGEMENT => {
+                let cdw11 = spec::Cdw11FeaturePowerManagement::from(command.cdw11);
+                // Only power state 0 is supported (NPSS is 0 in the Identify
+                // Controller data structure, i.e. one power state).
+                if cdw11.ps() != 0 {
+                    return Err(spec::Status::INVALID_FIELD_IN_COMMAND.into());
+                }
+                state.features.power_management = command.cdw11;
+            }
+            spec::Feature::TEMPERATURE_THRESHOLD => {
+                let cdw11 = spec::Cdw11FeatureTemperatureThreshold::from(command.cdw11);
+                // Only over- and under-temperature thresholds are defined.
+                if cdw11.thsel() > 1 {
+                    return Err(spec::Status::INVALID_FIELD_IN_COMMAND.into());
+                }
+                // Accepted and ignored: the emulator models no temperature.
+            }
+            spec::Feature::ERROR_RECOVERY => {
+                state.features.error_recovery = command.cdw11;
+            }
+            spec::Feature::INTERRUPT_COALESCING => {
+                state.features.interrupt_coalescing = command.cdw11;
+            }
+            spec::Feature::INTERRUPT_VECTOR_CONFIG => {
+                let cdw11 = spec::Cdw11FeatureInterruptVectorConfig::from(command.cdw11);
+                let cd = state
+                    .features
+                    .interrupt_vector_coalescing_disable
+                    .get_mut(cdw11.iv() as usize)
+                    .ok_or(spec::Status::INVALID_FIELD_IN_COMMAND)?;
+                *cd = cdw11.cd();
+            }
             feature => {
                 tracelimit::warn_ratelimited!(?feature, "unsupported feature");
                 return Err(spec::Status::INVALID_FIELD_IN_COMMAND.into());
@@ -734,7 +820,12 @@ impl AdminHandler {
         let cdw10: spec::Cdw10GetFeatures = command.cdw10.into();
         let mut dw = [0; 2];
 
-        // Note that we don't support non-zero cdw10.sel, since ONCS.save == 0.
+        // Only the current value (Select 000b) is supported; the controller
+        // does not support default/saved/supported-capabilities selects
+        // (Identify Controller ONCS.SSFS is 0).
+        if cdw10.sel() != 0 {
+            return Err(spec::Status::INVALID_FIELD_IN_COMMAND.into());
+        }
         match spec::Feature(cdw10.fid()) {
             spec::Feature::NUMBER_OF_QUEUES => {
                 let num_cqs = state.io_cqs.len();
@@ -766,6 +857,41 @@ impl AdminHandler {
                     .ok_or(spec::Status::INVALID_NAMESPACE_OR_FORMAT)?;
 
                 return namespace.get_feature(command).await;
+            }
+            spec::Feature::ARBITRATION => {
+                dw[0] = state.features.arbitration;
+            }
+            spec::Feature::POWER_MANAGEMENT => {
+                dw[0] = state.features.power_management;
+            }
+            spec::Feature::TEMPERATURE_THRESHOLD => {
+                let cdw11 = spec::Cdw11FeatureTemperatureThreshold::from(command.cdw11);
+                if cdw11.thsel() > 1 {
+                    return Err(spec::Status::INVALID_FIELD_IN_COMMAND.into());
+                }
+                dw[0] = spec::Cdw11FeatureTemperatureThreshold::new()
+                    .with_tmpth(default_temperature_threshold(cdw11.thsel()))
+                    .with_tmpsel(cdw11.tmpsel())
+                    .with_thsel(cdw11.thsel())
+                    .into();
+            }
+            spec::Feature::ERROR_RECOVERY => {
+                dw[0] = state.features.error_recovery;
+            }
+            spec::Feature::INTERRUPT_COALESCING => {
+                dw[0] = state.features.interrupt_coalescing;
+            }
+            spec::Feature::INTERRUPT_VECTOR_CONFIG => {
+                let cdw11 = spec::Cdw11FeatureInterruptVectorConfig::from(command.cdw11);
+                let cd = *state
+                    .features
+                    .interrupt_vector_coalescing_disable
+                    .get(cdw11.iv() as usize)
+                    .ok_or(spec::Status::INVALID_FIELD_IN_COMMAND)?;
+                dw[0] = spec::Cdw11FeatureInterruptVectorConfig::new()
+                    .with_iv(cdw11.iv())
+                    .with_cd(cd)
+                    .into();
             }
             feature => {
                 tracelimit::warn_ratelimited!(?feature, "unsupported feature");

--- a/vm/devices/storage/nvme/src/workers/admin.rs
+++ b/vm/devices/storage/nvme/src/workers/admin.rs
@@ -670,6 +670,19 @@ impl AdminHandler {
                     tracing::debug!(nsid = command.nsid, "inactive namespace id");
                 }
             }
+            spec::Cns::SPECIFIC_CONTROLLER_IO_COMMAND_SET => {
+                // CSI is in Command Dword 11, bits 31:24. Only the NVM command
+                // set (CSI 0h) is supported, and it defines no I/O Command Set
+                // specific Identify Controller data structure, so return a
+                // zero-filled structure per NVMe Base 2.3 section 5.2.13.2.6.
+                // Any other command set is unsupported.
+                let csi = (command.cdw11 >> 24) as u8;
+                if csi != 0 {
+                    return Err(spec::Status::INVALID_FIELD_IN_COMMAND.into());
+                }
+                // The buffer is already zero-filled; fall through to write it
+                // back to the host.
+            }
             cns => {
                 tracelimit::warn_ratelimited!(?cns, "unsupported cns");
                 return Err(spec::Status::INVALID_FIELD_IN_COMMAND.into());

--- a/vm/devices/storage/nvme/src/workers/admin.rs
+++ b/vm/devices/storage/nvme/src/workers/admin.rs
@@ -1140,6 +1140,24 @@ impl AdminHandler {
         let prp = PrpRange::parse(&self.config.mem, len, command.dptr)?;
 
         match spec::LogPageIdentifier(cdw10.lid()) {
+            spec::LogPageIdentifier::SUPPORTED_LOG_PAGES => {
+                // Figure 207: one 4-byte LID Supported and Effects entry per
+                // LID (0h..=FFh), 1024 bytes total. Mark each log page this
+                // controller supports with LSUPP set.
+                let mut page = [0u32; 256];
+                let supported = spec::LidSupportedAndEffects::new().with_lsupp(true);
+                for lid in [
+                    spec::LogPageIdentifier::SUPPORTED_LOG_PAGES,
+                    spec::LogPageIdentifier::ERROR_INFORMATION,
+                    spec::LogPageIdentifier::HEALTH_INFORMATION,
+                    spec::LogPageIdentifier::FIRMWARE_SLOT_INFORMATION,
+                    spec::LogPageIdentifier::CHANGED_NAMESPACE_LIST,
+                ] {
+                    page[lid.0 as usize] = supported.into();
+                }
+                let bytes = page.as_bytes();
+                prp.write(&self.config.mem, &bytes[..len.min(bytes.len())])?;
+            }
             spec::LogPageIdentifier::ERROR_INFORMATION => {
                 // Write empty log entries.
                 prp.zero(

--- a/vm/devices/storage/nvme_spec/src/lib.rs
+++ b/vm/devices/storage/nvme_spec/src/lib.rs
@@ -768,11 +768,11 @@ pub struct Cdw11FeatureArbitration {
     pub ab: u8,
     #[bits(5)]
     _rsvd: u8,
-    /// Low Priority Weight (0's based)
+    /// Low Priority Weight (0-based)
     pub lpw: u8,
-    /// Medium Priority Weight (0's based)
+    /// Medium Priority Weight (0-based)
     pub mpw: u8,
-    /// High Priority Weight (0's based)
+    /// High Priority Weight (0-based)
     pub hpw: u8,
 }
 
@@ -822,7 +822,7 @@ pub struct Cdw11FeatureErrorRecovery {
 /// Interrupt Coalescing feature (08h). See NVMe Base 2.3 Figure 474.
 #[bitfield(u32)]
 pub struct Cdw11FeatureInterruptCoalescing {
-    /// Aggregation Threshold (0's based)
+    /// Aggregation Threshold (0-based)
     pub thr: u8,
     /// Aggregation Time, in 100 µs units (`0h` = no delay)
     pub time: u8,

--- a/vm/devices/storage/nvme_spec/src/lib.rs
+++ b/vm/devices/storage/nvme_spec/src/lib.rs
@@ -899,6 +899,20 @@ open_enum! {
     }
 }
 
+/// LID Supported and Effects Data Structure, one per LID in the Supported Log
+/// Pages log page (LID 00h). See NVMe Base 2.3 Figure 208.
+#[bitfield(u32)]
+pub struct LidSupportedAndEffects {
+    /// LID Supported
+    pub lsupp: bool,
+    /// Index Offset Supported
+    pub ios: bool,
+    #[bits(14)]
+    _rsvd: u16,
+    /// LID Specific Parameter
+    pub lidsp: u16,
+}
+
 #[bitfield(u32)]
 pub struct AsynchronousEventRequestDw0 {
     #[bits(3)]

--- a/vm/devices/storage/nvme_spec/src/lib.rs
+++ b/vm/devices/storage/nvme_spec/src/lib.rs
@@ -760,6 +760,87 @@ pub struct Cdw11FeatureAsyncEventConfig {
     _higher_bits: u32,
 }
 
+/// Arbitration feature (01h). See NVMe Base 2.3 Figure 404.
+#[bitfield(u32)]
+pub struct Cdw11FeatureArbitration {
+    /// Arbitration Burst (power-of-two burst; `111b` means no limit)
+    #[bits(3)]
+    pub ab: u8,
+    #[bits(5)]
+    _rsvd: u8,
+    /// Low Priority Weight (0's based)
+    pub lpw: u8,
+    /// Medium Priority Weight (0's based)
+    pub mpw: u8,
+    /// High Priority Weight (0's based)
+    pub hpw: u8,
+}
+
+/// Power Management feature (02h). See NVMe Base 2.3 Figure 405.
+#[bitfield(u32)]
+pub struct Cdw11FeaturePowerManagement {
+    /// Power State
+    #[bits(5)]
+    pub ps: u8,
+    /// Workload Hint
+    #[bits(3)]
+    pub wh: u8,
+    #[bits(24)]
+    _rsvd: u32,
+}
+
+/// Temperature Threshold feature (04h). See NVMe Base 2.3 Figure 407.
+#[bitfield(u32)]
+pub struct Cdw11FeatureTemperatureThreshold {
+    /// Temperature Threshold, in Kelvin
+    pub tmpth: u16,
+    /// Threshold Temperature Select (`0h` = composite, `1h`-`8h` = sensors,
+    /// `Fh` = all sensors on a Set)
+    #[bits(4)]
+    pub tmpsel: u8,
+    /// Threshold Type Select (`00b` = over-temperature, `01b` = under-temperature)
+    #[bits(2)]
+    pub thsel: u8,
+    /// Temperature Threshold Hysteresis
+    #[bits(3)]
+    pub tmpthh: u8,
+    #[bits(7)]
+    _rsvd: u8,
+}
+
+/// Error Recovery feature (05h). See NVM Command Set 1.2 Figure 96.
+#[bitfield(u32)]
+pub struct Cdw11FeatureErrorRecovery {
+    /// Time Limited Error Recovery, in 100 ms units
+    pub tler: u16,
+    /// Deallocated or Unwritten Logical Block Error Enable
+    pub dulbe: bool,
+    #[bits(15)]
+    _rsvd: u16,
+}
+
+/// Interrupt Coalescing feature (08h). See NVMe Base 2.3 Figure 474.
+#[bitfield(u32)]
+pub struct Cdw11FeatureInterruptCoalescing {
+    /// Aggregation Threshold (0's based)
+    pub thr: u8,
+    /// Aggregation Time, in 100 µs units (`0h` = no delay)
+    pub time: u8,
+    #[bits(16)]
+    _rsvd: u16,
+}
+
+/// Interrupt Vector Configuration feature (09h). See NVMe Base 2.3 Figure 475.
+#[bitfield(u32)]
+pub struct Cdw11FeatureInterruptVectorConfig {
+    /// Interrupt Vector
+    pub iv: u16,
+    /// Coalescing Disable
+    pub cd: bool,
+    #[bits(15)]
+    _rsvd: u16,
+}
+
 #[bitfield(u32)]
 pub struct Cdw10CreateIoQueue {
     pub qid: u16,

--- a/vm/devices/storage/nvme_test/src/workers/admin.rs
+++ b/vm/devices/storage/nvme_test/src/workers/admin.rs
@@ -1303,6 +1303,24 @@ impl AdminHandler {
         let prp = PrpRange::parse(&self.config.mem, len, command.dptr)?;
 
         match spec::LogPageIdentifier(cdw10.lid()) {
+            spec::LogPageIdentifier::SUPPORTED_LOG_PAGES => {
+                // Figure 207: one 4-byte LID Supported and Effects entry per
+                // LID (0h..=FFh), 1024 bytes total. Mark each log page this
+                // controller supports with LSUPP set.
+                let mut page = [0u32; 256];
+                let supported = spec::LidSupportedAndEffects::new().with_lsupp(true);
+                for lid in [
+                    spec::LogPageIdentifier::SUPPORTED_LOG_PAGES,
+                    spec::LogPageIdentifier::ERROR_INFORMATION,
+                    spec::LogPageIdentifier::HEALTH_INFORMATION,
+                    spec::LogPageIdentifier::FIRMWARE_SLOT_INFORMATION,
+                    spec::LogPageIdentifier::CHANGED_NAMESPACE_LIST,
+                ] {
+                    page[lid.0 as usize] = supported.into();
+                }
+                let bytes = page.as_bytes();
+                prp.write(&self.config.mem, &bytes[..len.min(bytes.len())])?;
+            }
             spec::LogPageIdentifier::ERROR_INFORMATION => {
                 // Write empty log entries.
                 prp.zero(

--- a/vm/devices/storage/nvme_test/src/workers/admin.rs
+++ b/vm/devices/storage/nvme_test/src/workers/admin.rs
@@ -862,6 +862,19 @@ impl AdminHandler {
                     tracing::debug!(nsid = command.nsid, "inactive namespace id");
                 }
             }
+            spec::Cns::SPECIFIC_CONTROLLER_IO_COMMAND_SET => {
+                // CSI is in Command Dword 11, bits 31:24. Only the NVM command
+                // set (CSI 0h) is supported, and it defines no I/O Command Set
+                // specific Identify Controller data structure, so return a
+                // zero-filled structure per NVMe Base 2.3 section 5.2.13.2.6.
+                // Any other command set is unsupported.
+                let csi = (command.cdw11 >> 24) as u8;
+                if csi != 0 {
+                    return Err(spec::Status::INVALID_FIELD_IN_COMMAND.into());
+                }
+                // The buffer is already zero-filled; fall through to write it
+                // back to the host.
+            }
             cns => {
                 tracelimit::warn_ratelimited!(?cns, "unsupported cns");
                 return Err(spec::Status::INVALID_FIELD_IN_COMMAND.into());

--- a/vm/devices/storage/nvme_test/src/workers/admin.rs
+++ b/vm/devices/storage/nvme_test/src/workers/admin.rs
@@ -122,6 +122,50 @@ pub struct AdminState {
     poll_namespace_change: BTreeMap<u32, Task<()>>,
     #[inspect(skip)]
     confirm_namespace_change_fault: Option<Rpc<(), ()>>,
+    #[inspect(flatten)]
+    features: FeatureState,
+}
+
+/// Stored configuration for the mandatory Set/Get Features that the controller
+/// accepts and echoes back but does not otherwise act upon. Storing and echoing
+/// these values satisfies the NVMe Base 2.3 §3.1.3.6 (Figure 32) requirement
+/// that an I/O controller accept every mandatory feature.
+#[derive(Inspect)]
+struct FeatureState {
+    #[inspect(hex)]
+    arbitration: u32,
+    #[inspect(hex)]
+    power_management: u32,
+    #[inspect(hex)]
+    error_recovery: u32,
+    #[inspect(hex)]
+    interrupt_coalescing: u32,
+    /// Coalescing Disable bit per interrupt vector, indexed by interrupt vector.
+    #[inspect(iter_by_index)]
+    interrupt_vector_coalescing_disable: Vec<bool>,
+}
+
+impl FeatureState {
+    fn new(num_interrupt_vectors: usize) -> Self {
+        Self {
+            arbitration: 0,
+            power_management: 0,
+            error_recovery: 0,
+            interrupt_coalescing: 0,
+            interrupt_vector_coalescing_disable: vec![false; num_interrupt_vectors],
+        }
+    }
+}
+
+/// The Temperature Threshold value reported for the requested threshold type.
+///
+/// The emulator models no temperature sensors, so thresholds never trip and no
+/// state needs to be stored: Set Features is accepted and ignored, and Get
+/// Features always reports the reset defaults — an over-temperature threshold
+/// of the maximum (effectively disabled) and an under-temperature threshold of
+/// zero.
+fn default_temperature_threshold(thsel: u8) -> u16 {
+    if thsel == 0 { 0xffff } else { 0x0000 }
 }
 
 #[derive(Inspect)]
@@ -196,6 +240,7 @@ impl AdminState {
             send_changed_namespace,
             poll_namespace_change,
             confirm_namespace_change_fault: None,
+            features: FeatureState::new(handler.config.interrupts.len()),
         };
         state.set_max_queues(handler, handler.config.max_sqs, handler.config.max_cqs);
         state
@@ -870,7 +915,13 @@ impl AdminHandler {
     ) -> Result<CommandResult, NvmeError> {
         let cdw10: spec::Cdw10SetFeatures = command.cdw10.into();
         let mut dw = [0; 2];
-        // Note that we don't support non-zero cdw10.save, since ONCS.save == 0.
+        // This controller does not support saving feature values across power
+        // cycles or resets (Identify Controller ONCS.SSFS is 0), so a request
+        // to save a feature value must be rejected rather than silently applied
+        // for the current power cycle only.
+        if cdw10.save() {
+            return Err(spec::Status::FEATURE_IDENTIFIER_NOT_SAVEABLE.into());
+        }
         match spec::Feature(cdw10.fid()) {
             spec::Feature::NUMBER_OF_QUEUES => {
                 if state.io_sqs.iter().any(|sq| sq.task.has_state())
@@ -899,6 +950,41 @@ impl AdminHandler {
                     );
                 }
             }
+            spec::Feature::ARBITRATION => {
+                state.features.arbitration = command.cdw11;
+            }
+            spec::Feature::POWER_MANAGEMENT => {
+                let cdw11 = spec::Cdw11FeaturePowerManagement::from(command.cdw11);
+                // Only power state 0 is supported (NPSS is 0 in the Identify
+                // Controller data structure, i.e. one power state).
+                if cdw11.ps() != 0 {
+                    return Err(spec::Status::INVALID_FIELD_IN_COMMAND.into());
+                }
+                state.features.power_management = command.cdw11;
+            }
+            spec::Feature::TEMPERATURE_THRESHOLD => {
+                let cdw11 = spec::Cdw11FeatureTemperatureThreshold::from(command.cdw11);
+                // Only over- and under-temperature thresholds are defined.
+                if cdw11.thsel() > 1 {
+                    return Err(spec::Status::INVALID_FIELD_IN_COMMAND.into());
+                }
+                // Accepted and ignored: the emulator models no temperature.
+            }
+            spec::Feature::ERROR_RECOVERY => {
+                state.features.error_recovery = command.cdw11;
+            }
+            spec::Feature::INTERRUPT_COALESCING => {
+                state.features.interrupt_coalescing = command.cdw11;
+            }
+            spec::Feature::INTERRUPT_VECTOR_CONFIG => {
+                let cdw11 = spec::Cdw11FeatureInterruptVectorConfig::from(command.cdw11);
+                let cd = state
+                    .features
+                    .interrupt_vector_coalescing_disable
+                    .get_mut(cdw11.iv() as usize)
+                    .ok_or(spec::Status::INVALID_FIELD_IN_COMMAND)?;
+                *cd = cdw11.cd();
+            }
             feature => {
                 tracelimit::warn_ratelimited!(?feature, "unsupported feature");
                 return Err(spec::Status::INVALID_FIELD_IN_COMMAND.into());
@@ -915,7 +1001,12 @@ impl AdminHandler {
         let cdw10: spec::Cdw10GetFeatures = command.cdw10.into();
         let mut dw = [0; 2];
 
-        // Note that we don't support non-zero cdw10.sel, since ONCS.save == 0.
+        // Only the current value (Select 000b) is supported; the controller
+        // does not support default/saved/supported-capabilities selects
+        // (Identify Controller ONCS.SSFS is 0).
+        if cdw10.sel() != 0 {
+            return Err(spec::Status::INVALID_FIELD_IN_COMMAND.into());
+        }
         match spec::Feature(cdw10.fid()) {
             spec::Feature::NUMBER_OF_QUEUES => {
                 let num_cqs = state.io_cqs.len();
@@ -938,6 +1029,41 @@ impl AdminHandler {
                     .ok_or(spec::Status::INVALID_NAMESPACE_OR_FORMAT)?;
 
                 return namespace.get_feature(command).await;
+            }
+            spec::Feature::ARBITRATION => {
+                dw[0] = state.features.arbitration;
+            }
+            spec::Feature::POWER_MANAGEMENT => {
+                dw[0] = state.features.power_management;
+            }
+            spec::Feature::TEMPERATURE_THRESHOLD => {
+                let cdw11 = spec::Cdw11FeatureTemperatureThreshold::from(command.cdw11);
+                if cdw11.thsel() > 1 {
+                    return Err(spec::Status::INVALID_FIELD_IN_COMMAND.into());
+                }
+                dw[0] = spec::Cdw11FeatureTemperatureThreshold::new()
+                    .with_tmpth(default_temperature_threshold(cdw11.thsel()))
+                    .with_tmpsel(cdw11.tmpsel())
+                    .with_thsel(cdw11.thsel())
+                    .into();
+            }
+            spec::Feature::ERROR_RECOVERY => {
+                dw[0] = state.features.error_recovery;
+            }
+            spec::Feature::INTERRUPT_COALESCING => {
+                dw[0] = state.features.interrupt_coalescing;
+            }
+            spec::Feature::INTERRUPT_VECTOR_CONFIG => {
+                let cdw11 = spec::Cdw11FeatureInterruptVectorConfig::from(command.cdw11);
+                let cd = *state
+                    .features
+                    .interrupt_vector_coalescing_disable
+                    .get(cdw11.iv() as usize)
+                    .ok_or(spec::Status::INVALID_FIELD_IN_COMMAND)?;
+                dw[0] = spec::Cdw11FeatureInterruptVectorConfig::new()
+                    .with_iv(cdw11.iv())
+                    .with_cd(cd)
+                    .into();
             }
             feature => {
                 tracelimit::warn_ratelimited!(?feature, "unsupported feature");


### PR DESCRIPTION
## Summary

The emulated NVMe controller (the `nvme` crate, used by `--nvme`) advertises itself as an NVMe 2.0 **I/O controller** but rejected several mandatory admin operations with `Invalid Field in Command` / `Invalid Log Page`, producing log noise during Windows guest boot (the inbox `stornvme` driver probes them at init) and leaving real compliance gaps:

1. Several Set/Get Features that **NVMe Base 2.3 §3.1.3.6 (Figure 32)** marks **mandatory** for an I/O controller.
2. The I/O Command Set specific Identify Controller data structure (**CNS 06h**).
3. The **Supported Log Pages** log page (**LID 00h**).

## Mandatory Set/Get Features

Per Figure 32: *"If any feature is supported, then the Set Features command and the Get Features command shall be supported."* A store-and-echo is sufficient for an emulator — the physical behavior may be a no-op — but the controller must **accept** mandatory features rather than abort them.

| Feature | ID | Figure 32 (I/O) | Behavior |
|---|---|---|---|
| Arbitration | 01h | M | store & echo |
| Power Management | 02h | M | store & echo; **rejects PS != 0** (NPSS = 0) |
| Temperature Threshold | 04h | M | **stateless** — accept-and-ignore on Set, return reset defaults on Get |
| Error Recovery | 05h | M | store & echo |
| Interrupt Coalescing | 08h | M (PCIe) | store & echo |
| Interrupt Vector Configuration | 09h | M (PCIe) | stores Coalescing-Disable bit per vector; rejects out-of-range IV |

Temperature Threshold is intentionally stateless: the emulator models no temperature sensors, so thresholds never trip and nothing needs to be stored — Get always reports the reset defaults (over-temp `0xFFFF`, under-temp `0x0000`).

### Save / Select correctness
Since Identify Controller **ONCS.SSFS = 0**, the controller does not support saving feature values or non-current selects. These are now **actively rejected** instead of silently ignored:
- Set Features with the **Save** bit set -> `Feature Identifier Not Saveable` (0Dh).
- Get Features with a non-current **Select** -> `Invalid Field in Command`.

## Identify CNS 06h

Per NVMe Base 2.3 §5.2.13.2.6, if the I/O Command Set selected by the CSI field has no Identify Controller data structure, the controller **shall return a zero-filled structure**. The NVM command set (CSI 0h) — the only set this controller supports — defines no such structure, so CNS 06h with CSI 0h now returns a zero-filled 4096-byte structure; any other (unsupported) command set is aborted with `Invalid Field in Command`.

## Supported Log Pages (LID 00h)

The Supported Log Pages log page is **mandatory** for an NVMe 2.0 I/O controller. Per NVMe Base 2.3 §5.2.12.1.1 (Figures 207/208), Get Log Page for LID 00h now returns the 1024-byte structure of 256 four-byte *LID Supported and Effects* entries, with the **LSUPP** bit set for each log page the controller supports (00h Supported Log Pages, 01h Error Information, 02h SMART/Health, 03h Firmware Slot Information, 04h Changed Namespace List).

## Other
- Added the six `Cdw11Feature*` bitfields and a `LidSupportedAndEffects` bitfield to `nvme_spec` (layouts verified against the ratified NVMe Base 2.3 / NVM Command Set 1.2 specs).
- Added unit tests: `test_mandatory_features_roundtrip`, `test_identify_io_command_set_specific_controller`, and `test_get_supported_log_pages`.
- Mirrored all behavior in the `nvme_test` fault-injection controller.

## Deliberately unchanged (already compliant)
Optional/vendor probes remain rejected, which is compliant per Figure 32 / vendor-range rules: Autonomous Power State Transition (0Ch, O), and vendor-specific feature/log-page IDs (C0h-FFh, e.g. `feature=d0`, `lid=c0`, `lid=c1`).

## Testing
- `cargo clippy --all-targets -p nvme -p nvme_test -p nvme_spec` — clean
- `cargo doc --no-deps` — clean
- `cargo test -p nvme -p nvme_test -p nvme_spec` — all pass (incl. new tests and existing Async Event Config tests)
- `cargo xtask fmt --fix` — clean
