### PR TITLE
fs/lxutil: allow ftruncate on files opened with O_APPEND

### DIFF
--- a/vm/devices/support/fs/lxutil/src/lib.rs
+++ b/vm/devices/support/fs/lxutil/src/lib.rs
@@ -1274,6 +1274,20 @@ mod tests {
     }
 
     #[test]
+    fn readonly_truncate() {
+        // ftruncate on a descriptor that was not opened for writing must fail, matching Linux.
+        // This guards against the Windows truncate path reopening the file with write access and
+        // succeeding on a read-only descriptor.
+        let env = TestEnv::new();
+        env.create_file("testfile", "hello");
+
+        let file = env.volume.open("testfile", lx::O_RDONLY, None).unwrap();
+        assert_eq!(file.truncate(1, 0).unwrap_err().value(), lx::EINVAL);
+        // The file must be unchanged.
+        assert_eq!(file.fstat().unwrap().file_size, 5);
+    }
+
+    #[test]
     fn read_dir() {
         let env = TestEnv::new();
         let mut map = HashMap::new();

--- a/vm/devices/support/fs/lxutil/src/lib.rs
+++ b/vm/devices/support/fs/lxutil/src/lib.rs
@@ -1248,6 +1248,32 @@ mod tests {
     }
 
     #[test]
+    fn append_truncate() {
+        // A file opened with O_APPEND must still support ftruncate, matching Linux behavior. On
+        // Windows, O_APPEND strips FILE_WRITE_DATA to enforce append-only writes, which previously
+        // caused the truncate to fail with EACCES.
+        let env = TestEnv::new();
+        let file = env
+            .volume
+            .open(
+                "testfile",
+                lx::O_WRONLY | lx::O_APPEND | lx::O_CREAT | lx::O_EXCL,
+                Some(LxCreateOptions::new(0o666, 0, 0)),
+            )
+            .unwrap();
+
+        assert_eq!(file.pwrite(b"hello", 0, 0).unwrap(), 5);
+        assert_eq!(file.fstat().unwrap().file_size, 5);
+
+        // ftruncate on an O_APPEND descriptor should succeed.
+        file.truncate(1, 0).unwrap();
+        assert_eq!(file.fstat().unwrap().file_size, 1);
+
+        file.truncate(0, 0).unwrap();
+        assert_eq!(file.fstat().unwrap().file_size, 0);
+    }
+
+    #[test]
     fn read_dir() {
         let env = TestEnv::new();
         let mut map = HashMap::new();

--- a/vm/devices/support/fs/lxutil/src/windows/mod.rs
+++ b/vm/devices/support/fs/lxutil/src/windows/mod.rs
@@ -1112,11 +1112,10 @@ impl LxFile {
     }
 
     pub fn set_attr(&self, mut attr: SetAttributes) -> lx::Result<()> {
-        // A size change (truncate) requires the descriptor to have been opened for writing, to
-        // match Linux where ftruncate on an O_RDONLY descriptor fails with EINVAL. This must be
-        // enforced explicitly: the truncate below may run on a handle reopened with FILE_WRITE_DATA
-        // (needed to truncate an O_APPEND descriptor, which lacks that access), which would
-        // otherwise let a read-only descriptor be truncated whenever a reopen occurs.
+        // ftruncate requires the descriptor to be writable, matching Linux where truncating an
+        // O_RDONLY descriptor fails with EINVAL. This is enforced here because the truncate below
+        // may run on a handle reopened with FILE_WRITE_DATA, which would otherwise allow truncating
+        // a read-only descriptor.
         if attr.size.is_some()
             && (self.access & (W32Fs::FILE_WRITE_DATA | W32Fs::FILE_APPEND_DATA)).0 == 0
         {
@@ -1127,10 +1126,9 @@ impl LxFile {
 
         let desired_access = util::permissions_for_set_attr(&attr, self.state.options.metadata);
 
-        // Only reopen if there's an operation that requires it, and we don't already have the
-        // required permissions. A size change (truncate) is included because a file opened with
-        // O_APPEND lacks FILE_WRITE_DATA (stripped to enforce append-only writes), so it must be
-        // reopened to obtain the access `permissions_for_set_attr` requires for the truncate.
+        // Only reopen if there's an operation that requires it and we don't already have the
+        // required permissions. A size change is included so a file opened O_APPEND (which lacks
+        // FILE_WRITE_DATA) is reopened with the write access needed to truncate.
         let mut _file = None;
         let handle = if self.access & desired_access != desired_access
             && (attr.mode.is_some()

--- a/vm/devices/support/fs/lxutil/src/windows/mod.rs
+++ b/vm/devices/support/fs/lxutil/src/windows/mod.rs
@@ -1117,8 +1117,9 @@ impl LxFile {
         let desired_access = util::permissions_for_set_attr(&attr, self.state.options.metadata);
 
         // Only reopen if there's an operation that requires it, and we don't already have the
-        // required permissions. Note that a size change needs a reopen for files opened with
-        // O_APPEND, which strips FILE_WRITE_DATA to enforce append-only writes.
+        // required permissions. A size change (truncate) is included because a file opened with
+        // O_APPEND lacks FILE_WRITE_DATA (stripped to enforce append-only writes), so it must be
+        // reopened to obtain the access `permissions_for_set_attr` requires for the truncate.
         let mut _file = None;
         let handle = if self.access & desired_access != desired_access
             && (attr.mode.is_some()

--- a/vm/devices/support/fs/lxutil/src/windows/mod.rs
+++ b/vm/devices/support/fs/lxutil/src/windows/mod.rs
@@ -1116,11 +1116,22 @@ impl LxFile {
 
         let desired_access = util::permissions_for_set_attr(&attr, self.state.options.metadata);
 
+        // Truncating a file opened with O_APPEND is allowed on Linux, but O_APPEND strips
+        // FILE_WRITE_DATA from the access mask on Windows to enforce append-only writes. The
+        // presence of FILE_APPEND_DATA (without FILE_WRITE_DATA) means the file was opened for
+        // writing and so ftruncate should be permitted; a file that isn't writable at all (e.g.
+        // opened read-only) has neither bit, and must not be reopened so that its truncate fails.
+        let truncate_needs_reopen = attr.size.is_some()
+            && (self.access & W32Fs::FILE_WRITE_DATA).0 == 0
+            && (self.access & W32Fs::FILE_APPEND_DATA).0 != 0;
+
         // Only reopen if there's an operation that requires it, and we don't already have the
-        // required permissions.
+        // required permissions. `desired_access` already includes FILE_WRITE_DATA when a size is
+        // being set, so the reopened handle can be used for the truncate as well.
         let mut _file = None;
         let handle = if self.access & desired_access != desired_access
-            && (attr.mode.is_some()
+            && (truncate_needs_reopen
+                || attr.mode.is_some()
                 || attr.uid.is_some()
                 || attr.gid.is_some()
                 || !attr.atime.is_omit()
@@ -1134,9 +1145,15 @@ impl LxFile {
             &self.handle
         };
 
-        // Do truncate with the original handle, even if we reopened, so the write requirement
-        // is enforced.
-        util::set_attr_core(handle, &self.handle, &self.state, &attr)?;
+        // Do the truncate with the reopened handle when the file was opened append-only, otherwise
+        // with the original handle so the write requirement is enforced.
+        let truncate_handle = if truncate_needs_reopen {
+            handle
+        } else {
+            &self.handle
+        };
+
+        util::set_attr_core(handle, truncate_handle, &self.state, &attr)?;
 
         if self.state.options.metadata {
             if let Some(mode) = attr.mode {

--- a/vm/devices/support/fs/lxutil/src/windows/mod.rs
+++ b/vm/devices/support/fs/lxutil/src/windows/mod.rs
@@ -1116,24 +1116,17 @@ impl LxFile {
 
         let desired_access = util::permissions_for_set_attr(&attr, self.state.options.metadata);
 
-        // Truncating a file opened with O_APPEND is allowed on Linux, but O_APPEND strips
-        // FILE_WRITE_DATA from the access mask on Windows to enforce append-only writes. The
-        // presence of FILE_APPEND_DATA (without FILE_WRITE_DATA) means the file was opened for
-        // writing and so ftruncate should be permitted; a file that isn't writable at all (e.g.
-        // opened read-only) has neither bit, and must not be reopened so that its truncate fails.
-        let truncate_needs_reopen = attr.size.is_some()
-            && (self.access & W32Fs::FILE_WRITE_DATA).0 == 0
-            && (self.access & W32Fs::FILE_APPEND_DATA).0 != 0;
-
         // Only reopen if there's an operation that requires it, and we don't already have the
-        // required permissions. `desired_access` already includes FILE_WRITE_DATA when a size is
-        // being set, so the reopened handle can be used for the truncate as well.
+        // required permissions. `permissions_for_set_attr` includes FILE_WRITE_DATA when a size is
+        // being set, which is needed to truncate a file opened with O_APPEND: such a file has
+        // FILE_WRITE_DATA stripped to enforce append-only writes, even though Linux permits
+        // ftruncate on the descriptor.
         let mut _file = None;
         let handle = if self.access & desired_access != desired_access
-            && (truncate_needs_reopen
-                || attr.mode.is_some()
+            && (attr.mode.is_some()
                 || attr.uid.is_some()
                 || attr.gid.is_some()
+                || attr.size.is_some()
                 || !attr.atime.is_omit()
                 || !attr.mtime.is_omit()
                 || !attr.ctime.is_omit())
@@ -1145,15 +1138,7 @@ impl LxFile {
             &self.handle
         };
 
-        // Do the truncate with the reopened handle when the file was opened append-only, otherwise
-        // with the original handle so the write requirement is enforced.
-        let truncate_handle = if truncate_needs_reopen {
-            handle
-        } else {
-            &self.handle
-        };
-
-        util::set_attr_core(handle, truncate_handle, &self.state, &attr)?;
+        util::set_attr_core(handle, &self.state, &attr)?;
 
         if self.state.options.metadata {
             if let Some(mode) = attr.mode {

--- a/vm/devices/support/fs/lxutil/src/windows/mod.rs
+++ b/vm/devices/support/fs/lxutil/src/windows/mod.rs
@@ -1117,10 +1117,8 @@ impl LxFile {
         let desired_access = util::permissions_for_set_attr(&attr, self.state.options.metadata);
 
         // Only reopen if there's an operation that requires it, and we don't already have the
-        // required permissions. `permissions_for_set_attr` includes FILE_WRITE_DATA when a size is
-        // being set, which is needed to truncate a file opened with O_APPEND: such a file has
-        // FILE_WRITE_DATA stripped to enforce append-only writes, even though Linux permits
-        // ftruncate on the descriptor.
+        // required permissions. Note that a size change needs a reopen for files opened with
+        // O_APPEND, which strips FILE_WRITE_DATA to enforce append-only writes.
         let mut _file = None;
         let handle = if self.access & desired_access != desired_access
             && (attr.mode.is_some()

--- a/vm/devices/support/fs/lxutil/src/windows/mod.rs
+++ b/vm/devices/support/fs/lxutil/src/windows/mod.rs
@@ -1111,14 +1111,17 @@ impl LxFile {
         )
     }
 
+    /// Returns whether the file was opened with write access (including append-only).
+    fn is_writable(&self) -> bool {
+        (self.access & (W32Fs::FILE_WRITE_DATA | W32Fs::FILE_APPEND_DATA)).0 != 0
+    }
+
     pub fn set_attr(&self, mut attr: SetAttributes) -> lx::Result<()> {
         // ftruncate requires the descriptor to be writable, matching Linux where truncating an
         // O_RDONLY descriptor fails with EINVAL. This is enforced here because the truncate below
         // may run on a handle reopened with FILE_WRITE_DATA, which would otherwise allow truncating
         // a read-only descriptor.
-        if attr.size.is_some()
-            && (self.access & (W32Fs::FILE_WRITE_DATA | W32Fs::FILE_APPEND_DATA)).0 == 0
-        {
+        if attr.size.is_some() && !self.is_writable() {
             return Err(lx::Error::EINVAL);
         }
 
@@ -1269,7 +1272,7 @@ impl LxFile {
         // Linux allows using fsync on files that have been opened read-only, while
         // Windows does not, so reopen the file if necessary.
         let mut _reopened = None;
-        let handle = if (self.access & (W32Fs::FILE_WRITE_DATA | W32Fs::FILE_APPEND_DATA)).0 != 0 {
+        let handle = if self.is_writable() {
             &self.handle
         } else {
             let file = match util::reopen_file(&self.handle, W32Fs::FILE_WRITE_DATA) {

--- a/vm/devices/support/fs/lxutil/src/windows/mod.rs
+++ b/vm/devices/support/fs/lxutil/src/windows/mod.rs
@@ -1112,6 +1112,17 @@ impl LxFile {
     }
 
     pub fn set_attr(&self, mut attr: SetAttributes) -> lx::Result<()> {
+        // A size change (truncate) requires the descriptor to have been opened for writing, to
+        // match Linux where ftruncate on an O_RDONLY descriptor fails with EINVAL. This must be
+        // enforced explicitly: the truncate below may run on a handle reopened with FILE_WRITE_DATA
+        // (needed to truncate an O_APPEND descriptor, which lacks that access), which would
+        // otherwise let a read-only descriptor be truncated whenever a reopen occurs.
+        if attr.size.is_some()
+            && (self.access & (W32Fs::FILE_WRITE_DATA | W32Fs::FILE_APPEND_DATA)).0 == 0
+        {
+            return Err(lx::Error::EINVAL);
+        }
+
         util::set_attr_check_kill_priv(&self.handle, &self.state, &mut attr)?;
 
         let desired_access = util::permissions_for_set_attr(&attr, self.state.options.metadata);

--- a/vm/devices/support/fs/lxutil/src/windows/util.rs
+++ b/vm/devices/support/fs/lxutil/src/windows/util.rs
@@ -973,19 +973,18 @@ pub fn set_attr(
     mut attr: SetAttributes,
 ) -> lx::Result<()> {
     set_attr_check_kill_priv(handle, state, &mut attr)?;
-    set_attr_core(handle, handle, state, &attr)
+    set_attr_core(handle, state, &attr)
 }
 
 /// Set the attributes of a file (assumes the kill privilege check was already done)
 /// N.B. All functions attempting to change attributes should call set_attr_check_kill_priv() first.
 pub fn set_attr_core(
     handle: &OwnedHandle,
-    truncate_handle: &OwnedHandle,
     state: &super::VolumeState,
     attr: &SetAttributes,
 ) -> lx::Result<()> {
     if let Some(size) = attr.size {
-        fs::truncate(truncate_handle, size as u64)?;
+        fs::truncate(handle, size as u64)?;
     }
 
     if state.options.metadata && (attr.mode.is_some() || attr.uid.is_some() || attr.gid.is_some()) {


### PR DESCRIPTION
On Windows, opening a file with `O_APPEND` strips `FILE_WRITE_DATA` from the NT access mask to enforce append-only writes. This caused `ftruncate` on an `O_APPEND` descriptor to fail with EACCES via virtiofs, even though Linux permits it (repro: microsoft/WSL#40987).

The truncate is now performed on a handle reopened with `FILE_WRITE_DATA` when the file was opened writable (append-only), while still rejecting truncate on files not opened writable at all. Adds a cross-platform `append_truncate` unit test.