### PR TITLE
ohcl: forward KERN_INFO kmsg messages to the host

### DIFF
--- a/openhcl/underhill_core/src/get_tracing/kmsg_stream.rs
+++ b/openhcl/underhill_core/src/get_tracing/kmsg_stream.rs
@@ -90,7 +90,7 @@ impl Stream for KmsgStream {
                         kmsg_defs::UNDERHILL_INIT_KMSG_FACILITY => {
                             // Don't log debug init messages.
                             // TODO: Support configuring this dynamically.
-                            if entry.level > kmsg_defs::LOGLEVEL_NOTICE {
+                            if entry.level > kmsg_defs::LOGLEVEL_INFO {
                                 continue;
                             }
                             // Use a separate target for the init process messages.
@@ -121,7 +121,7 @@ impl Stream for KmsgStream {
                             // user-mode facilities are logged as is,
                             // but don't log too many.
                             // TODO: Support configuring this dynamically.
-                            if entry.level > kmsg_defs::LOGLEVEL_NOTICE {
+                            if entry.level > kmsg_defs::LOGLEVEL_INFO {
                                 continue;
                             }
                             ("kmsg", entry.level, entry.message)


### PR DESCRIPTION
The kmsg-to-host relay was capped at LOGLEVEL_NOTICE (level 5), which silently dropped almost every kernel boot message (KERN_INFO, level 6). Production telemetry consumers (e.g. Kusto) were therefore seeing only a handful of kmsg records per VM lifetime.

Raise the cutoff to LOGLEVEL_INFO so the full kernel dmesg, including the boot log, flows through the GET tracing channel. KERN_DEBUG is still dropped, and since the OpenHCL kernel is built without CONFIG_DYNAMIC_DEBUG, no DEBUG records exist to forward in practice.

The same change is applied to UNDERHILL_INIT_KMSG_FACILITY for parity.


Signed-off-by: Hardik Garg <hargar@microsoft.com>