### PR TITLE
virt_whp: swallow AMD perf MSR writes on AMD hosts

### DIFF
--- a/vmm_core/virt_whp/src/vp.rs
+++ b/vmm_core/virt_whp/src/vp.rs
@@ -1275,7 +1275,8 @@ mod x86 {
                     msr @ (X86X_MSR_APIC_BASE | X2APIC_MSR_BASE..=X2APIC_MSR_END) => {
                         self.apic_msr_write(dev, msr, v)
                     }
-                    x86defs::X86X_AMD_MSR_HW_CFG
+                    x86defs::X86X_AMD_MSR_PERF_EVT_SEL0..=x86defs::X86X_AMD_MSR_PERF_CTR3
+                    | x86defs::X86X_AMD_MSR_HW_CFG
                     | x86defs::X86X_AMD_MSR_IGNNE
                     | x86defs::X86X_AMD_MSR_NB_CFG
                         if self.vp.partition.caps.vendor.is_amd_compatible() =>


### PR DESCRIPTION
The WHP backend does not emulate an AMD performance-monitoring unit, so a guest writing to the perf event-select or counter MSRs would take a #GP. The read path already returns 0 for this range on AMD-compatible hosts, but the write path only stubbed out the config MSRs, leaving perf-counter writes to fault. Extend the write handler to also silently accept writes to PERF_EVT_SEL0..3 and PERF_CTR0..3 on AMD, keeping guests that touch these MSRs from crashing.