### PR TITLE
memory_layout: place PCIe ECAM above 4 GiB

### DIFF
--- a/Guide/src/reference/architecture/openvmm/memory-layout.md
+++ b/Guide/src/reference/architecture/openvmm/memory-layout.md
@@ -116,18 +116,19 @@ issues requests in this order:
 
 3. **Chipset high MMIO** (`Mmio64`) — the corresponding high range. 2 MB
    alignment.
-4. **PCIe ECAM** (`Mmio32`), one block per PCI segment. Root complexes
+4. **PCIe ECAM** (`Mmio64`), one block per PCI segment. Root complexes
    that share a segment are grouped so the segment gets a single
    contiguous ECAM block (keeping the MCFG bus-0 base consistent for every
    RC in the segment), which is then subdivided into per-RC sub-ranges.
    The block size is derived from the segment's combined bus window as
    `(max_bus - min_bus + 1) * 1 MB` (32 devices × 8 functions × 4 KiB per
-   config space). Every ECAM range must start at or above a fixed
-   `256 MiB` minimum: the ACPI MCFG table reports the bus-0 base as
-   `ecam_start - start_bus * 1 MiB`, and since `start_bus` is a `u8` up to
-   255 MiB of headroom may be required. A resolved ECAM below this minimum
-   fails VM construction rather than producing an unrepresentable MCFG
-   entry.
+   config space). ECAM is placed above 4 GiB so the low MMIO window stays
+   free for devices that require 32-bit addressing. Every ECAM range must
+   start at or above a fixed `256 MiB` minimum: the ACPI MCFG table reports
+   the bus-0 base as `ecam_start - start_bus * 1 MiB`, and since `start_bus`
+   is a `u8` up to 255 MiB of headroom may be required. A resolved ECAM
+   below this minimum fails VM construction rather than producing an
+   unrepresentable MCFG entry.
 5. **PCIe per-root-complex ranges**, one set per root complex:
     - **Low MMIO** (`Mmio32`), 2 MB aligned. A caller can pin this to a
       fixed range instead of supplying a size, for assigned-device, IOMMU,

--- a/openvmm/openvmm_core/src/worker/memory_layout.rs
+++ b/openvmm/openvmm_core/src/worker/memory_layout.rs
@@ -232,11 +232,8 @@ pub(super) fn resolve_memory_layout(
         }
     }
 
-    // ECAM: always dynamically allocated below 4GB (since Linux on x86_64
-    // refuses to use ECAM above 4GB unless the BIOS is of a special shape).
-    //
-    // TODO: fix the Linux loader and move this above 4GB before the layout
-    // is stabilized.
+    // ECAM: dynamically allocated above 4GB, keeping the low MMIO window free
+    // for devices that require 32-bit addressing.
     for se in &mut segment_ecams {
         let bus_count = u64::from(se.max_bus - se.min_bus) + 1;
         builder.request(
@@ -244,7 +241,7 @@ pub(super) fn resolve_memory_layout(
             &mut se.range,
             bus_count * PCIE_ECAM_BYTES_PER_BUS,
             PCIE_ECAM_BYTES_PER_BUS,
-            Placement::Mmio32,
+            Placement::Mmio64,
         );
     }
 
@@ -748,8 +745,8 @@ mod tests {
         let ranges = &actual.pcie_root_complex_ranges[0];
 
         assert!(
-            ranges.ecam_range.end() <= 4 * GB,
-            "ECAM should be below 4 GB"
+            ranges.ecam_range.start() >= 4 * GB,
+            "ECAM should be above 4 GB"
         );
         assert_eq!(ranges.low_mmio.len(), 64 * MB);
         assert_eq!(ranges.high_mmio.len(), GB);
@@ -1031,33 +1028,6 @@ mod tests {
             err.to_string().contains("must end at or below 4 GiB"),
             "unexpected error: {err}"
         );
-    }
-
-    #[test]
-    fn ecam_below_256mb_is_rejected() {
-        // Force ECAM placement below 256 MiB by reserving most of the free
-        // Mmio32 window for low_mmio. The fixed chipset_low_mmio at the top
-        // of 32-bit space leaves 3968 MiB on x86_64 and 3584 MiB on aarch64
-        // for dynamic Mmio32 requests; size low_mmio to push ECAM near
-        // 127 MiB on both. The resolver must bail because MCFG cannot
-        // represent a bus-0 base below the ECAM start.
-        let low_mmio_size = if cfg!(guest_arch = "x86_64") {
-            3840 * MB
-        } else {
-            3456 * MB
-        };
-        let root_complexes = [pcie_root_complex(
-            PcieMmioRangeConfig::Dynamic {
-                size: low_mmio_size,
-            },
-            PcieMmioRangeConfig::Dynamic { size: GB },
-        )];
-        let mut config = input(&[2 * GB], None);
-        config.pcie_root_complexes = &root_complexes;
-
-        let err = resolve_memory_layout(config).unwrap_err();
-
-        assert!(err.to_string().contains("ECAM"), "unexpected error: {err}");
     }
 
     #[test]


### PR DESCRIPTION
ECAM was pinned below 4 GiB because Linux on x86_64 would only accept an ECAM window above 4 GiB when firmware advertised it in a particular shape. Now that SMBIOS tables are delivered on x86 Linux direct boot, that constraint is lifted, so ECAM can move into the high MMIO window on every architecture.

Placing ECAM above 4 GiB frees the scarce 32-bit MMIO window for devices that genuinely require it. The resolver now requests ECAM as an Mmio64 allocation, which applies uniformly to x86_64 and aarch64 since the ECAM path has no architecture-specific handling. The 256 MiB minimum-address guard is retained for the MCFG bus-0 base invariant, though it is trivially satisfied once ECAM sits above 4 GiB; its now-unreachable test is dropped and the placement test updated to expect the high window.