### PR TITLE
petri: Apply the PCAT flaky boot quirk to the hyperv backend too

### DIFF
--- a/petri/src/vm/hyperv/mod.rs
+++ b/petri/src/vm/hyperv/mod.rs
@@ -90,7 +90,13 @@ impl PetriVmmBackend for HyperVPetriBackend {
     }
 
     fn quirks(firmware: &Firmware) -> (GuestQuirksInner, VmmQuirks) {
-        (firmware.quirks().hyperv, VmmQuirks::default())
+        (
+            firmware.quirks().hyperv,
+            VmmQuirks {
+                // Workaround for #3897
+                flaky_boot: firmware.is_pcat().then_some(Duration::from_secs(15)),
+            },
+        )
     }
 
     fn default_servicing_flags() -> OpenHclServicingFlags {

--- a/petri/src/vm/openvmm/mod.rs
+++ b/petri/src/vm/openvmm/mod.rs
@@ -101,7 +101,7 @@ impl PetriVmmBackend for OpenVmmPetriBackend {
         (
             firmware.quirks().openvmm,
             VmmQuirks {
-                // Workaround for #1684
+                // Workaround for #3897
                 flaky_boot: firmware.is_pcat().then_some(Duration::from_secs(15)),
             },
         )


### PR DESCRIPTION
We have seen a hit of this same timeout occur on a hyper-v test a few times now, so add the quirk. An AI generated diagnosis of the underlying race has been filed in #3897.