### PR TITLE
arm64: enable MSHV VFIO PCI passthrough

### DIFF
--- a/openvmm/openvmm_core/src/worker/dispatch.rs
+++ b/openvmm/openvmm_core/src/worker/dispatch.rs
@@ -685,6 +685,7 @@ fn build_aarch64_topology(
     let gic_msi = if let Some(count) = v2m_spi_count {
         GicMsiController::V2m(GicV2mInfo {
             frame_base: openvmm_defs::config::DEFAULT_GIC_V2M_MSI_FRAME_BASE,
+            doorbell_base: openvmm_defs::config::DEFAULT_GIC_V2M_DOORBELL_BASE,
             spi_base: spi_layout
                 .v2m_spi_base
                 .expect("v2m base must be allocated when v2m_spi_count is Some"),

--- a/openvmm/openvmm_defs/src/config.rs
+++ b/openvmm/openvmm_defs/src/config.rs
@@ -75,12 +75,20 @@ pub const DEFAULT_GIC_REDISTRIBUTORS_BASE: u64 = if cfg!(target_os = "linux") {
     0xEFFE_E000
 };
 
-/// Base address of the GIC v2m MSI frame. Uses the Hyper-V convention address
-/// `0xEFF6_8000`, which sits below the ITS region, the PL011 UARTs, and the GIC
-/// dist/redist, and is clear of VMBus/chipset MMIO.
-pub const DEFAULT_GIC_V2M_MSI_FRAME_BASE: u64 = 0xEFF6_8000;
+/// Base address of the guest-visible GIC v2m MSI frame (exposed via the MADT
+/// and used by the software v2m SETSPI decoder for emulated devices). This is
+/// OpenVMM-emulated MMIO (one 4 KiB page), not shadowed by the hypervisor, so
+/// it stays at the conventional address.
+pub const DEFAULT_GIC_V2M_MSI_FRAME_BASE: u64 = 0xEFFE_8000;
 /// Size of the v2m MSI frame (one 4KB page is the architectural minimum).
 pub const GIC_V2M_MSI_FRAME_SIZE: u64 = 0x1000;
+
+/// Base address of the GIC v2m MSI doorbell used for passthrough on the
+/// MSHV root/arm64 backend. Registered with the hypervisor as
+/// GITS_TRANSLATER_BASE_ADDRESS.
+/// The hypervisor shadows a ~64 KiB region at this base,
+/// so it uses the Hyper-V convention address 0xEFF6_8000.
+pub const DEFAULT_GIC_V2M_DOORBELL_BASE: u64 = 0xEFF6_8000;
 
 /// Base address of the GICv3 ITS MMIO region. Must be 64 KiB aligned,
 /// below the v2m frame address, and not overlap other devices.

--- a/openvmm/openvmm_defs/src/config.rs
+++ b/openvmm/openvmm_defs/src/config.rs
@@ -75,9 +75,10 @@ pub const DEFAULT_GIC_REDISTRIBUTORS_BASE: u64 = if cfg!(target_os = "linux") {
     0xEFFE_E000
 };
 
-/// Base address of the GIC v2m MSI frame. Must not overlap GIC dist/redist,
-/// serial UARTs, or VMBus MMIO. Matches the Hyper-V convention.
-pub const DEFAULT_GIC_V2M_MSI_FRAME_BASE: u64 = 0xEFFE_8000;
+/// Base address of the GIC v2m MSI frame. Uses the Hyper-V convention address
+/// `0xEFF6_8000`, which sits below the ITS region, the PL011 UARTs, and the GIC
+/// dist/redist, and is clear of VMBus/chipset MMIO.
+pub const DEFAULT_GIC_V2M_MSI_FRAME_BASE: u64 = 0xEFF6_8000;
 /// Size of the v2m MSI frame (one 4KB page is the architectural minimum).
 pub const GIC_V2M_MSI_FRAME_SIZE: u64 = 0x1000;
 

--- a/vm/devices/pci/vfio_assigned_device/src/lib.rs
+++ b/vm/devices/pci/vfio_assigned_device/src/lib.rs
@@ -568,10 +568,10 @@ impl VfioAssignedPciDevice {
         let msix = self.msix.as_ref().expect("msix must be present");
         let count = msix.vector_count;
 
-        // VFIO map_msix has a hard limit of 256 eventfds per call.
+        // VFIO map_msix has a hard limit of 2048 eventfds per call.
         anyhow::ensure!(
-            count <= 256,
-            "MSI-X vector count ({count}) exceeds VFIO limit of 256"
+            count <= 2048,
+            "MSI-X vector count ({count}) exceeds VFIO limit of 2048"
         );
 
         // Get an interrupt for each vector and trigger lazy irqfd route

--- a/vm/devices/pci/vfio_assigned_device/src/lib.rs
+++ b/vm/devices/pci/vfio_assigned_device/src/lib.rs
@@ -568,12 +568,6 @@ impl VfioAssignedPciDevice {
         let msix = self.msix.as_ref().expect("msix must be present");
         let count = msix.vector_count;
 
-        // VFIO map_msix has a hard limit of 2048 eventfds per call.
-        anyhow::ensure!(
-            count <= 2048,
-            "MSI-X vector count ({count}) exceeds VFIO limit of 2048"
-        );
-
         // Get an interrupt for each vector and trigger lazy irqfd route
         // creation by requesting the backing event.
         let interrupts: Vec<_> = (0..count)

--- a/vm/devices/user_driver/vfio_sys/src/lib.rs
+++ b/vm/devices/user_driver/vfio_sys/src/lib.rs
@@ -622,51 +622,61 @@ impl Device {
         I: IntoIterator,
         I::Item: AsFd,
     {
-        // Raised from 256 to support devices with large MSI-X tables
-        // (e.g. 513 vectors). Matches cloud-hypervisor's per-device limit.
-        const MAX_MSIX_VECTORS: usize = 2048;
+        // Collect the eventfds up front so we know how many MSI-X vectors to
+        // bind; holding the borrowed fds keeps them open for the ioctl.
+        let fds: Vec<_> = eventfd.into_iter().collect();
 
+        // VFIO_DEVICE_SET_IRQS takes a vfio_irq_set header immediately followed
+        // by a variable-length array of eventfd file descriptors (one per
+        // vector). Build it with a HeaderVec so the header and the fd tail are
+        // laid out contiguously and the vector count is bounded only by what
+        // the device and kernel accept.
+        // vfio_irq_set itself is not Copy (it ends in an incomplete-array
+        // member), so it cannot be a HeaderVec head; VfioIrqSetHeader mirrors
+        // its fixed 20-byte prefix and the i32 tail supplies the fd array.
         #[repr(C)]
-        struct VfioIrqSetWithArray {
-            header: vfio_irq_set,
-            fd: [i32; MAX_MSIX_VECTORS],
+        #[derive(Copy, Clone)]
+        struct VfioIrqSetHeader {
+            argsz: u32,
+            flags: u32,
+            index: u32,
+            start: u32,
+            count: u32,
         }
-        let mut param = VfioIrqSetWithArray {
-            header: vfio_irq_set {
-                argsz: size_of::<VfioIrqSetWithArray>() as u32,
+        const _: () = assert!(
+            size_of::<VfioIrqSetHeader>() == size_of::<vfio_irq_set>(),
+            "VfioIrqSetHeader must match the fixed prefix of vfio_irq_set"
+        );
+
+        let mut param = HeaderVec::<VfioIrqSetHeader, i32, 0>::with_capacity(
+            VfioIrqSetHeader {
+                argsz: 0, // set below, once the fd tail length is known
                 flags: VFIO_IRQ_SET_ACTION_TRIGGER,
                 index: VFIO_PCI_MSIX_IRQ_INDEX,
                 start,
                 count: 0,
-                // data is a zero-sized array, the real data is fd.
-                data: Default::default(),
             },
-            fd: [-1; MAX_MSIX_VECTORS],
-        };
-
-        let fds: Vec<_> = eventfd.into_iter().collect();
-        anyhow::ensure!(
-            fds.len() <= MAX_MSIX_VECTORS,
-            "MSI-X vector count {} exceeds maximum {MAX_MSIX_VECTORS}",
-            fds.len()
+            fds.len(),
         );
-
-        let mut count = 0u32;
-        for (x, y) in fds.iter().zip(&mut param.fd) {
-            *y = x.as_fd().as_raw_fd();
-            count += 1;
+        for fd in &fds {
+            param.push_tail(fd.as_fd().as_raw_fd());
         }
-        param.header.count = count;
 
-        if param.header.count == 0 {
-            param.header.flags |= VFIO_IRQ_SET_DATA_NONE;
+        // argsz spans the header plus the contiguous fd tail.
+        let argsz = param.total_byte_len() as u32;
+        param.head.argsz = argsz;
+        param.head.count = fds.len() as u32;
+        if fds.is_empty() {
+            param.head.flags |= VFIO_IRQ_SET_DATA_NONE;
         } else {
-            param.header.flags |= VFIO_IRQ_SET_DATA_EVENTFD;
+            param.head.flags |= VFIO_IRQ_SET_DATA_EVENTFD;
         }
 
-        // SAFETY: The file descriptor is valid and a correctly constructed struct is being passed.
+        // SAFETY: The file descriptor is valid. HeaderVec lays out the header
+        // and fd tail contiguously exactly as vfio_irq_set expects, and argsz
+        // spans the whole buffer, so the pointer is valid for the ioctl read.
         unsafe {
-            ioctl::vfio_device_set_irqs(self.file.as_raw_fd(), &param.header)
+            ioctl::vfio_device_set_irqs(self.file.as_raw_fd(), param.as_ptr().cast())
                 .context("failed to set msi-x trigger")?;
         }
         Ok(())

--- a/vm/devices/user_driver/vfio_sys/src/lib.rs
+++ b/vm/devices/user_driver/vfio_sys/src/lib.rs
@@ -622,7 +622,9 @@ impl Device {
         I: IntoIterator,
         I::Item: AsFd,
     {
-        const MAX_MSIX_VECTORS: usize = 256;
+        // Raised from 256 to support devices with large MSI-X tables
+        // (e.g. 513 vectors). Matches cloud-hypervisor's per-device limit.
+        const MAX_MSIX_VECTORS: usize = 2048;
 
         #[repr(C)]
         struct VfioIrqSetWithArray {

--- a/vm/vmcore/vm_topology/src/processor/aarch64.rs
+++ b/vm/vmcore/vm_topology/src/processor/aarch64.rs
@@ -88,9 +88,14 @@ pub struct Aarch64PlatformConfig {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[cfg_attr(feature = "inspect", derive(inspect::Inspect))]
 pub struct GicV2mInfo {
-    /// Physical base address of the v2m MSI frame.
+    /// Physical base address of the guest-visible v2m MSI frame.
     #[cfg_attr(feature = "inspect", inspect(hex))]
     pub frame_base: u64,
+    /// Physical base address of the v2m MSI doorbell registered with the
+    /// hypervisor for PCI passthrough (GITS translater base). May differ from
+    /// `frame_base`; consumed only by the MSHV root/arm64 backend.
+    #[cfg_attr(feature = "inspect", inspect(hex))]
+    pub doorbell_base: u64,
     /// First GIC interrupt ID in the SPI range owned by this frame.
     pub spi_base: u32,
     /// Number of SPIs owned by this frame.

--- a/vmm_core/virt_mshv/src/aarch64/mod.rs
+++ b/vmm_core/virt_mshv/src/aarch64/mod.rs
@@ -106,6 +106,30 @@ impl virt::Hypervisor for LinuxMshv {
         )
         .map_err(|e| ErrorInner::SetPartitionProperty(e.into()))?;
 
+        // When a GICv2m MSI frame is configured, disable LPI support
+        // (GICD_TYPER.LPIS=0) so Linux routes PCIe MSIs through the v2m frame
+        // (SPI-based) instead of looking for an ITS. Mirrors the WHP backend.
+        let v2m_frame_base = match config.processor_topology.gic_msi() {
+            vm_topology::processor::aarch64::GicMsiController::V2m(v2m) => Some(v2m.frame_base),
+            _ => None,
+        };
+        let gic_lpi_int_id_bits = if v2m_frame_base.is_some() { 0u64 } else { 1u64 };
+        vmfd.set_partition_property(
+            HvPartitionPropertyCode::GicLpiIntIdBits.0,
+            gic_lpi_int_id_bits,
+        )
+        .map_err(|e| ErrorInner::SetPartitionProperty(e.into()))?;
+
+        // Register the GICv2m MSI frame base with the hypervisor as the MSI
+        // doorbell (GITS translater) base.
+        if let Some(frame_base) = v2m_frame_base {
+            vmfd.set_partition_property(
+                HvPartitionPropertyCode::GitsTranslaterBaseAddress.0,
+                frame_base,
+            )
+            .map_err(|e| ErrorInner::SetPartitionProperty(e.into()))?;
+        }
+
         // Set the PMU PPI if the topology provides one.
         if let Some(pmu_gsiv) = config.processor_topology.pmu_gsiv() {
             vmfd.set_partition_property(
@@ -153,6 +177,10 @@ impl ProtoPartition for MshvProtoPartition<'_> {
             caps,
             synic_ports: Default::default(),
             time_frozen: false.into(),
+            gic_msi: self.config.processor_topology.gic_msi(),
+            gsi_states: parking_lot::Mutex::new(Box::new(
+                [crate::irqfd::GsiState::Unallocated; crate::irqfd::NUM_GSIS],
+            )),
         });
 
         let partition = MshvPartition {
@@ -197,6 +225,21 @@ impl virt::Partition for MshvPartition {
 
     fn request_msi(&self, _vtl: Vtl, request: MsiRequest) {
         self.inner.signal_msi(None, request.address, request.data);
+    }
+
+    fn as_signal_msi(&self, _vtl: Vtl) -> Option<Arc<dyn SignalMsi>> {
+        let v2m = match &self.inner.gic_msi {
+            vm_topology::processor::aarch64::GicMsiController::V2m(v2m) => v2m,
+            _ => return None,
+        };
+        let irqcon = self.inner.clone() as Arc<dyn virt::irqcon::ControlGic>;
+        Some(Arc::new(virt::aarch64::gic_v2m::GicV2mSignalMsi::new(
+            v2m, irqcon,
+        )))
+    }
+
+    fn irqfd(&self) -> Option<Arc<dyn virt::irqfd::IrqFd>> {
+        Some(Arc::new(crate::irqfd::MshvIrqFd::new(self.inner.clone())))
     }
 
     fn request_yield(&self, vp_index: VpIndex) {

--- a/vmm_core/virt_mshv/src/aarch64/mod.rs
+++ b/vmm_core/virt_mshv/src/aarch64/mod.rs
@@ -109,23 +109,28 @@ impl virt::Hypervisor for LinuxMshv {
         // When a GICv2m MSI frame is configured, disable LPI support
         // (GICD_TYPER.LPIS=0) so Linux routes PCIe MSIs through the v2m frame
         // (SPI-based) instead of looking for an ITS. Mirrors the WHP backend.
-        let v2m_frame_base = match config.processor_topology.gic_msi() {
-            vm_topology::processor::aarch64::GicMsiController::V2m(v2m) => Some(v2m.frame_base),
+        let v2m_doorbell_base = match config.processor_topology.gic_msi() {
+            vm_topology::processor::aarch64::GicMsiController::V2m(v2m) => Some(v2m.doorbell_base),
             _ => None,
         };
-        let gic_lpi_int_id_bits = if v2m_frame_base.is_some() { 0u64 } else { 1u64 };
+        let gic_lpi_int_id_bits = if v2m_doorbell_base.is_some() {
+            0u64
+        } else {
+            1u64
+        };
         vmfd.set_partition_property(
             HvPartitionPropertyCode::GicLpiIntIdBits.0,
             gic_lpi_int_id_bits,
         )
         .map_err(|e| ErrorInner::SetPartitionProperty(e.into()))?;
 
-        // Register the GICv2m MSI frame base with the hypervisor as the MSI
-        // doorbell (GITS translater) base.
-        if let Some(frame_base) = v2m_frame_base {
+        // Register the v2m MSI doorbell base with the hypervisor as the
+        // GITS translater base, so an assigned device's DMA MSI-X write is
+        // trapped and injected as a guest SPI.
+        if let Some(doorbell_base) = v2m_doorbell_base {
             vmfd.set_partition_property(
                 HvPartitionPropertyCode::GitsTranslaterBaseAddress.0,
-                frame_base,
+                doorbell_base,
             )
             .map_err(|e| ErrorInner::SetPartitionProperty(e.into()))?;
         }

--- a/vmm_core/virt_mshv/src/irqfd.rs
+++ b/vmm_core/virt_mshv/src/irqfd.rs
@@ -192,19 +192,18 @@ impl IrqFd for MshvIrqFd {
             .alloc_gsi()
             .context("no free GSIs available for irqfd")?;
 
+        // Defer the MSHV_IRQFD registration until `enable()` has installed the
+        // MSI routing for this GSI. On aarch64 the kernel maps a passthrough
+        // device interrupt to the guest vector at irqfd-assign (add-producer)
+        // time and does not retarget on a later routing change, so the routing
+        // must be in place *before* the irqfd is armed. Arming lazily also
+        // works for x86_64 (enable() arms after setting the route).
         let event = Event::new();
-        // SAFETY: `event` is moved into `MshvIrqFdRoute` below, which keeps
-        // it alive until `Drop` calls `unregister_irqfd`.
-        if let Err(e) = unsafe { self.partition.register_irqfd(&event, gsi) } {
-            self.partition.free_gsi(gsi);
-            return Err(e);
-        }
-
         Ok(Box::new(MshvIrqFdRoute {
             partition: self.partition.clone(),
             gsi,
             event,
-            armed: Mutex::new(true),
+            armed: Mutex::new(false),
         }))
     }
 }

--- a/vmm_core/virt_mshv/src/lib.rs
+++ b/vmm_core/virt_mshv/src/lib.rs
@@ -17,9 +17,8 @@ use aarch64 as arch;
 #[cfg(guest_arch = "x86_64")]
 use x86_64 as arch;
 
-// irqfd is arch-independent but only wired up on x86_64 for now.
-// TODO: wire up on aarch64 once MSI signaling is implemented.
-#[cfg(guest_arch = "x86_64")]
+// irqfd is arch-independent (MSI routing + MSHV_IRQFD), wired up on both
+// x86_64 and aarch64.
 pub mod irqfd;
 
 use guestmem::DoorbellRegistration;
@@ -252,7 +251,6 @@ struct MshvPartitionInner {
     vps: Vec<MshvVpInner>,
     #[cfg(guest_arch = "x86_64")]
     irq_routes: virt::irqcon::IrqRoutes,
-    #[cfg(guest_arch = "x86_64")]
     #[inspect(skip)]
     gsi_states: Mutex<Box<[irqfd::GsiState; irqfd::NUM_GSIS]>>,
     caps: virt::PartitionCapabilities,
@@ -264,6 +262,11 @@ struct MshvPartitionInner {
     /// Set to `true` when partition time is frozen (e.g. during reset).
     /// The first VP to enter `run_vp` after a freeze will thaw time.
     time_frozen: Mutex<bool>,
+    /// aarch64 GIC MSI controller config, used to decode PCIe MSIs into SPI
+    /// assertions via a v2m frame.
+    #[cfg(guest_arch = "aarch64")]
+    #[inspect(skip)]
+    gic_msi: vm_topology::processor::aarch64::GicMsiController,
 }
 
 struct MshvVpInner {


### PR DESCRIPTION
Enable assigning physical PCI devices (via Linux VFIO) to guests on the aarch64 Microsoft Hypervisor (MSHV) backend. Previously this path was x86_64-only; the arm64 backend had no guest MSI controller and no irqfd, so assigned-device interrupts could not be delivered.

Changes:
- virt_mshv (aarch64): provide a GICv2m SignalMsi via as_signal_msi, and register the partition GIC properties needed for MSI delivery - GicLpiIntIdBits=0 (so Linux uses the v2m frame rather than an ITS) and GitsTranslaterBaseAddress = v2m frame base, so a passthrough device's DMA MSI-X write to the doorbell is trapped by the hypervisor and injected as a guest SPI.
- virt_mshv: un-gate the irqfd module (MSI routing + MSHV_IRQFD) for aarch64 and implement Partition::irqfd(). The route is armed after its MSI routing is installed, matching the arm64 assign-time mapping model.
- spi_layout: allocate the GICv2m SPI block top-down from the high SPI range to avoid conflicting with the guest vPCI (pci-hyperv) MSI allocator, which allocates bottom-up from INTID 64.
- config: place the GICv2m MSI frame at the Hyper-V convention base 0xEFF6_8000, clear of the emulated PL011 UARTs, GIC dist/redist, ITS, and VMBus MMIO (the hypervisor shadows a ~64 KiB region at this base).
- vfio: raise the per-device MSI-X vector limit from 256 to 2048 so devices with large MSI-X tables (e.g. NVMe controllers with 513 vectors) can be assigned.

Verified end-to-end by assigning an NVMe controller to an aarch64 guest: the device enumerates, MSI-X interrupts are delivered, and I/O works.