### PR TITLE
vmcore: fix per-VP task pool thread/fd leak on guest reset

### DIFF
--- a/support/pal/pal_async/src/io_pool.rs
+++ b/support/pal/pal_async/src/io_pool.rs
@@ -13,9 +13,10 @@ use std::future::Future;
 use std::future::poll_fn;
 use std::pin::pin;
 use std::sync::Arc;
+use std::sync::Weak;
 use std::task::Poll;
 
-/// An single-threaded task pool backed by IO backend `T`.
+/// A single-threaded task pool backed by IO backend `T`.
 #[derive(Debug)]
 pub struct IoPool<T> {
     driver: IoDriver<T>,
@@ -35,6 +36,53 @@ impl<T> Clone for IoDriver<T> {
             inner: self.inner.clone(),
             scheduler: self.scheduler.clone(),
         }
+    }
+}
+
+impl<T> IoDriver<T> {
+    /// Returns a weak reference to this driver.
+    ///
+    /// A [`WeakIoDriver`] does not keep the backing [`IoPool`] alive: [`IoPool::run`]
+    /// returns once the last strong `IoDriver` is dropped. Use this to publish a
+    /// reference to a pool's own driver (e.g. into thread-local storage on the
+    /// pool's thread) without preventing the pool from ever shutting down. A
+    /// strong self-reference held for the lifetime of `run` would instead keep the
+    /// pool's task queue open forever (the pool never sees its last driver drop),
+    /// leaking the thread and its IO backend.
+    pub fn downgrade(&self) -> WeakIoDriver<T> {
+        WeakIoDriver {
+            inner: Arc::downgrade(&self.inner),
+            scheduler: Arc::downgrade(&self.scheduler),
+        }
+    }
+}
+
+/// A weak reference to an [`IoDriver`], obtained via [`IoDriver::downgrade`].
+#[derive(Debug)]
+pub struct WeakIoDriver<T> {
+    inner: Weak<T>,
+    scheduler: Weak<Scheduler>,
+}
+
+impl<T> Clone for WeakIoDriver<T> {
+    fn clone(&self) -> Self {
+        Self {
+            inner: self.inner.clone(),
+            scheduler: self.scheduler.clone(),
+        }
+    }
+}
+
+impl<T> WeakIoDriver<T> {
+    /// Attempts to upgrade to a strong [`IoDriver`].
+    ///
+    /// Returns `None` if the backing [`IoPool`] has already shut down (all strong
+    /// drivers dropped).
+    pub fn upgrade(&self) -> Option<IoDriver<T>> {
+        Some(IoDriver {
+            inner: self.inner.upgrade()?,
+            scheduler: self.scheduler.upgrade()?,
+        })
     }
 }
 

--- a/support/pal/pal_async/src/lib.rs
+++ b/support/pal/pal_async/src/lib.rs
@@ -60,6 +60,8 @@ pub mod unix {
 
 /// The default single-threaded IO driver for the platform.
 pub type DefaultDriver = sys::DefaultDriver;
+/// A weak reference to the platform's [`DefaultDriver`].
+pub type WeakDefaultDriver = sys::WeakDefaultDriver;
 /// The default single-threaded task pool for the platform.
 pub type DefaultPool = sys::DefaultPool;
 

--- a/support/pal/pal_async/src/unix/epoll.rs
+++ b/support/pal/pal_async/src/unix/epoll.rs
@@ -48,6 +48,9 @@ pub type EpollPool = IoPool<EpollBackend>;
 /// A driver to spawn tasks and IO objects on [`EpollPool`].
 pub type EpollDriver = IoDriver<EpollBackend>;
 
+/// A weak reference to an [`EpollDriver`].
+pub type WeakEpollDriver = crate::io_pool::WeakIoDriver<EpollBackend>;
+
 #[derive(Debug)]
 pub struct EpollBackend {
     epfd: EpollFd,

--- a/support/pal/pal_async/src/unix/kqueue.rs
+++ b/support/pal/pal_async/src/unix/kqueue.rs
@@ -45,6 +45,9 @@ pub type KqueuePool = IoPool<KqueueBackend>;
 /// A driver to spawn tasks and IO objects on [`KqueuePool`].
 pub type KqueueDriver = IoDriver<KqueueBackend>;
 
+/// A weak reference to a [`KqueueDriver`].
+pub type WeakKqueueDriver = crate::io_pool::WeakIoDriver<KqueueBackend>;
+
 #[derive(Debug)]
 pub struct KqueueBackend {
     kqfd: KqueueFd,

--- a/support/pal/pal_async/src/unix/mod.rs
+++ b/support/pal/pal_async/src/unix/mod.rs
@@ -21,11 +21,13 @@ cfg_if! {
 
         pub use epoll::EpollDriver as DefaultDriver;
         pub use epoll::EpollPool as DefaultPool;
+        pub use epoll::WeakEpollDriver as WeakDefaultDriver;
     } else if #[cfg(target_os = "macos")] {
         pub mod kqueue;
 
         pub use kqueue::KqueueDriver as DefaultDriver;
         pub use kqueue::KqueuePool as DefaultPool;
+        pub use kqueue::WeakKqueueDriver as WeakDefaultDriver;
     }
 }
 

--- a/support/pal/pal_async/src/windows/iocp.rs
+++ b/support/pal/pal_async/src/windows/iocp.rs
@@ -56,6 +56,9 @@ pub type IocpPool = IoPool<IocpBackend>;
 /// A driver to spawn tasks and IO objects on [`IocpPool`].
 pub type IocpDriver = IoDriver<IocpBackend>;
 
+/// A weak reference to an [`IocpDriver`].
+pub type WeakIocpDriver = crate::io_pool::WeakIoDriver<IocpBackend>;
+
 #[derive(Debug)]
 pub struct IocpBackend {
     port: IoCompletionPort,

--- a/support/pal/pal_async/src/windows/mod.rs
+++ b/support/pal/pal_async/src/windows/mod.rs
@@ -17,6 +17,7 @@ pub mod tp;
 
 pub use iocp::IocpDriver as DefaultDriver;
 pub use iocp::IocpPool as DefaultPool;
+pub use iocp::WeakIocpDriver as WeakDefaultDriver;
 
 pub(crate) fn monotonic_nanos_now() -> u64 {
     let mut time = 0;

--- a/vm/vmcore/src/vm_task.rs
+++ b/vm/vmcore/src/vm_task.rs
@@ -387,13 +387,18 @@ pub mod thread {
     use loan_cell::LoanCell;
     use pal_async::DefaultDriver;
     use pal_async::DefaultPool;
+    use pal_async::WeakDefaultDriver;
     use pal_async::driver::Driver;
     use pal_async::task::Spawn;
     use pal_async::task::TaskMetadata;
     use std::sync::Arc;
 
     thread_local! {
-        static CURRENT_DRIVER: LoanCell<DefaultDriver> = const { LoanCell::new() };
+        // Holds a WEAK reference on purpose: this is lent for the entire lifetime
+        // of a dedicated pool thread's `run()`, and a strong reference would keep
+        // the pool's task queue (and its IO backend fds) alive forever, so the
+        // thread could never exit once its device drops the driver. See `build`.
+        static CURRENT_DRIVER: LoanCell<WeakDefaultDriver> = const { LoanCell::new() };
     }
 
     /// A backend for [`VmTaskDriverSource`](super::VmTaskDriverSource) based on
@@ -429,7 +434,16 @@ pub mod thread {
             if target_vp.is_some() {
                 let pool = DefaultPool::new();
                 let driver = pool.driver();
-                let tls_driver = driver.clone();
+                // Publish a *weak* reference to this pool's driver into the thread
+                // local so that resources built with `VmTaskDriverSource::current()`
+                // (e.g. block-device disks) dispatch their IO onto this thread while
+                // they run here. It must be weak: `pool.run()` returns only once the
+                // last strong driver is dropped, and this reference is lent for the
+                // whole of `run()`. A strong clone would be a self-reference that
+                // keeps the queue open forever, so the thread (and its epoll/eventfd)
+                // would never be reclaimed after the device closes its channel --
+                // leaking a thread and fds on every guest reset.
+                let tls_driver = driver.downgrade();
                 std::thread::Builder::new()
                     .name(name)
                     .spawn(move || {
@@ -488,7 +502,20 @@ pub mod thread {
 
     impl CurrentThreadDriver {
         fn with_driver<R>(&self, f: impl FnOnce(&DefaultDriver) -> R) -> R {
-            CURRENT_DRIVER.with(|cell| cell.borrow(|driver| f(driver.unwrap_or(&self.default))))
+            CURRENT_DRIVER.with(|cell| {
+                cell.borrow(|weak| {
+                    // The thread local only holds a weak reference (see `build`),
+                    // so upgrade it transiently for the duration of `f`. A borrow
+                    // only ever runs from a task on the pool's own thread, so the
+                    // pool -- kept alive by the device that scheduled that task --
+                    // is live here and the upgrade succeeds. Fall back to the
+                    // default when not on a dedicated pool thread.
+                    match weak.and_then(|w| w.upgrade()) {
+                        Some(driver) => f(&driver),
+                        None => f(&self.default),
+                    }
+                })
+            })
         }
     }
 
@@ -565,12 +592,15 @@ pub mod thread {
         ) -> std::pin::Pin<Box<dyn Future<Output = std::io::Result<i32>> + Send + '_>> {
             use pal_async::io_uring::{IoUringDriver, IoUringSubmit};
             Box::pin(async move {
-                // We have to clone the driver, since the current driver may
-                // change across the lifetime of the async block. This is not
-                // very expensive, though--in practice this is an Arc refcount
-                // increment, and the driver is per-thread so there is no cache
-                // contention.
-                let driver = CURRENT_DRIVER.with(|cell| cell.borrow(|driver| driver.cloned()));
+                // Upgrade the thread local's weak driver to an owned strong one,
+                // since the current driver may change across the lifetime of the
+                // async block. This is not very expensive, though--in practice
+                // this is an Arc refcount increment, and the driver is per-thread
+                // so there is no cache contention. Holding the strong reference
+                // across the in-flight IO is correct: the pool must stay alive
+                // until the IO completes.
+                let driver =
+                    CURRENT_DRIVER.with(|cell| cell.borrow(|weak| weak.and_then(|w| w.upgrade())));
                 let driver = driver.as_ref().unwrap_or(&self.default);
                 // SAFETY: passthru from caller
                 unsafe {
@@ -610,5 +640,47 @@ pub mod thread {
         }
 
         fn retarget_vp(&self, _target_vp: u32) {}
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::CURRENT_DRIVER;
+        use pal_async::DefaultPool;
+        use std::time::Duration;
+        use std::time::Instant;
+
+        /// Regression test for the guest-reset thread/fd leak: a dedicated per-VP
+        /// pool thread must exit once every strong driver is dropped. The thread
+        /// publishes its own driver into `CURRENT_DRIVER` while running; a strong
+        /// reference there would keep `pool.run()` from ever returning, leaking the
+        /// thread and its IO backend fds on every guest reset. Lending a weak
+        /// reference lets the thread exit here.
+        #[test]
+        fn dedicated_pool_thread_exits_when_driver_dropped() {
+            let pool = DefaultPool::new();
+            let driver = pool.driver();
+            let weak = driver.downgrade();
+            let handle = std::thread::Builder::new()
+                .name("test-vp-pool".into())
+                .spawn(move || {
+                    CURRENT_DRIVER.with(|cell| cell.lend(&weak, || pool.run()));
+                })
+                .unwrap();
+
+            // Drop the only strong driver; the pool's task queue should close and
+            // the thread should exit promptly.
+            drop(driver);
+
+            let start = Instant::now();
+            while !handle.is_finished() {
+                assert!(
+                    start.elapsed() < Duration::from_secs(5),
+                    "dedicated pool thread did not exit after its driver was dropped; \
+                     a strong self-reference is leaking the thread"
+                );
+                std::thread::sleep(Duration::from_millis(5));
+            }
+            handle.join().unwrap();
+        }
     }
 }


### PR DESCRIPTION
## Problem

A device that builds a target-VP task driver via `ThreadDriverBackend` (netvsp, storvsp, and any resource using `VmTaskDriverSource::current()` on a per-VP thread) spawns a dedicated `IoPool` thread. Since #3310 that thread lends a clone of its own pool's driver into the `CURRENT_DRIVER` thread-local for the entire lifetime of `pool.run()`.

`IoPool::run` returns only once the last strong `IoDriver` is dropped. The lent clone is a strong self-reference held across the whole run, so after the device closes its channel and drops its own `ThreadDriver`, the pool's task queue never closes: the thread parks forever in `recv().await`, never releasing its epoll fd and wakeup eventfd.

A guest reset (reboot) repeatedly rebuilds these per-channel drivers, so every reboot stacks a fresh set of parked threads and fds. On a Linux guest with VMBus netvsp/storvsp devices, the worker leaked ~132 threads and ~247 fds per reboot until it hit its fd limit.

Regressed in #3310 (thread-local IO dispatch).

## Fix

Publish a *weak* reference into `CURRENT_DRIVER`. It is only borrowed by code running on the pool's own thread while a task executes, so a strong driver provably still exists and the transient upgrade succeeds; at rest the thread holds no strong reference, so the pool shuts down and the thread exits once the device drops its driver. Adds `WeakIoDriver` / `IoDriver::downgrade` to pal_async and a regression test.
