### PR TITLE
consomme: reply to forwarded UDP clients from the published port

### DIFF
--- a/vm/devices/net/net_consomme/consomme/src/udp.rs
+++ b/vm/devices/net/net_consomme/consomme/src/udp.rs
@@ -104,6 +104,7 @@ struct UdpListener {
     /// The guest port to forward received packets to.
     guest_port: u16,
     stats: Stats,
+    gso_size: Option<u16>,
 }
 
 #[derive(InspectMut)]
@@ -462,6 +463,41 @@ impl<T: Client> Access<'_, T> {
             if let Some(listener) = self.inner.udp.listeners.get(&key) {
                 dst_sock_addr.set_port(listener.host_addr.port());
             }
+
+            // Guest reply from a published port to a local client: send from the listener's
+            // host socket so the reply's source matches the published port. A per-connection
+            // socket would use an ephemeral port, which a connected client rejects.
+            let src_key = PortForwardKey::from_socket_addr(guest_addr, guest_addr.port());
+            if let Some(listener) = self.inner.udp.listeners.get_mut(&src_key) {
+                if let Some(socket) = listener.socket.as_ref() {
+                    let socket = socket.get();
+                    if listener.gso_size != checksum.gso {
+                        platform::set_udp_gso_size(socket, checksum.gso.unwrap_or(0))
+                            .map_err(DropReason::Io)?;
+                        listener.gso_size = checksum.gso;
+                    }
+                    let result = platform::send_to(
+                        socket,
+                        udp_packet.payload(),
+                        &dst_sock_addr,
+                        checksum.gso,
+                    );
+                    return match result {
+                        Ok(_) => {
+                            listener.stats.tx_packets.increment();
+                            Ok(())
+                        }
+                        Err(err) if err.kind() == ErrorKind::WouldBlock => {
+                            listener.stats.tx_dropped.increment();
+                            Err(DropReason::SendBufferFull)
+                        }
+                        Err(err) => {
+                            listener.stats.tx_errors.increment();
+                            Err(DropReason::Io(err))
+                        }
+                    };
+                }
+            }
         }
 
         let conn = self.get_or_insert(guest_addr, Some(frame.src_addr))?;
@@ -587,6 +623,7 @@ impl<T: Client> Access<'_, T> {
                 host_addr,
                 guest_port,
                 stats: Default::default(),
+                gso_size: None,
             },
         );
         Ok(())
@@ -975,6 +1012,82 @@ mod tests {
             udp.dst_port(),
             guest_port,
             "forwarded packet should target the guest port"
+        );
+    }
+
+    #[pal_async::async_test]
+    async fn test_udp_reply_source_port(driver: DefaultDriver) {
+        // A guest reply from a published port must egress from the listener's host socket so its
+        // source matches the published port.
+        let driver = Arc::new(driver);
+        let mut consomme = create_consomme_with_timeout(Duration::from_secs(30));
+        let mut client = TestClient::new(driver.clone());
+
+        let guest_mac = consomme.params_mut().client_mac;
+        let gateway_mac = consomme.params_mut().gateway_mac;
+        let guest_ip: Ipv4Address = consomme.params_mut().client_ip;
+
+        // Bind a listener socket on an ephemeral host port for `guest_port`.
+        let listener_socket =
+            Socket::new(socket2::Domain::IPV4, socket2::Type::DGRAM, None).unwrap();
+        listener_socket
+            .bind(&SocketAddrV4::new(Ipv4Addr::LOCALHOST, 0).into())
+            .unwrap();
+        let host_addr: SocketAddr = listener_socket.local_addr().unwrap().as_socket().unwrap();
+        let guest_port = 7777;
+
+        // A host client socket that will receive the guest's reply.
+        let host_client = UdpSocket::bind("127.0.0.1:0").unwrap();
+        host_client
+            .set_read_timeout(Some(Duration::from_secs(5)))
+            .unwrap();
+        let client_port = host_client.local_addr().unwrap().port();
+
+        let mut access = consomme.access(&mut client);
+        access
+            .bind_udp_port(listener_socket, guest_port)
+            .expect("bind should succeed");
+
+        // Build a guest-originated UDP datagram whose source is the published guest port and whose
+        // destination is the host client on loopback (a local address).
+        let target_ip: Ipv4Address = Ipv4Addr::LOCALHOST;
+        let payload = b"reply";
+        let mut buffer =
+            vec![0u8; ETHERNET_HEADER_LEN + IPV4_HEADER_LEN + UDP_HEADER_LEN + payload.len()];
+        buffer[ETHERNET_HEADER_LEN + IPV4_HEADER_LEN + UDP_HEADER_LEN..].copy_from_slice(payload);
+        let mut eth_frame = EthernetFrame::new_unchecked(&mut buffer[..]);
+        let packet_len = build_udp_packet(
+            &mut eth_frame,
+            IpAddress::Ipv4(guest_ip),
+            IpAddress::Ipv4(target_ip),
+            guest_port,
+            client_port,
+            payload.len(),
+            guest_mac,
+            gateway_mac,
+        );
+
+        let _ = access.send(&buffer[..packet_len], &ChecksumState::NONE);
+        let mut cx = Context::from_waker(std::task::Waker::noop());
+        access.poll(&mut cx);
+
+        // The reply must reuse the listener; no per-connection socket should be created.
+        assert_eq!(
+            access.udp_connection_count(),
+            0,
+            "reply should not create a new UDP connection"
+        );
+
+        // The host client must receive the reply from the published host port.
+        let mut recv_buf = [0u8; 64];
+        let (n, src) = host_client
+            .recv_from(&mut recv_buf)
+            .expect("client should receive the reply");
+        assert_eq!(&recv_buf[..n], payload);
+        assert_eq!(
+            src.port(),
+            host_addr.port(),
+            "reply source port must match the published host port"
         );
     }
 

--- a/vm/devices/net/net_consomme/consomme/src/udp.rs
+++ b/vm/devices/net/net_consomme/consomme/src/udp.rs
@@ -104,6 +104,7 @@ struct UdpListener {
     /// The guest port to forward received packets to.
     guest_port: u16,
     stats: Stats,
+    gso_size: Option<u16>,
 }
 
 #[derive(InspectMut)]
@@ -444,6 +445,41 @@ impl<T: Client> Access<'_, T> {
             if let Some(listener) = self.inner.udp.listeners.get(&key) {
                 dst_sock_addr.set_port(listener.host_addr.port());
             }
+
+            // Guest reply from a published port to a local client: send from the listener's
+            // host socket so the reply's source matches the published port. A per-connection
+            // socket would use an ephemeral port, which a connected client rejects.
+            let src_key = PortForwardKey::from_socket_addr(guest_addr, guest_addr.port());
+            if let Some(listener) = self.inner.udp.listeners.get_mut(&src_key) {
+                if let Some(socket) = listener.socket.as_ref() {
+                    let socket = socket.get();
+                    if listener.gso_size != checksum.gso {
+                        platform::set_udp_gso_size(socket, checksum.gso.unwrap_or(0))
+                            .map_err(DropReason::Io)?;
+                        listener.gso_size = checksum.gso;
+                    }
+                    let result = platform::send_to(
+                        socket,
+                        udp_packet.payload(),
+                        &dst_sock_addr,
+                        checksum.gso,
+                    );
+                    return match result {
+                        Ok(_) => {
+                            listener.stats.tx_packets.increment();
+                            Ok(())
+                        }
+                        Err(err) if err.kind() == ErrorKind::WouldBlock => {
+                            listener.stats.tx_dropped.increment();
+                            Err(DropReason::SendBufferFull)
+                        }
+                        Err(err) => {
+                            listener.stats.tx_errors.increment();
+                            Err(DropReason::Io(err))
+                        }
+                    };
+                }
+            }
         }
 
         let conn = self.get_or_insert(guest_addr, Some(frame.src_addr))?;
@@ -567,6 +603,7 @@ impl<T: Client> Access<'_, T> {
                 host_addr,
                 guest_port,
                 stats: Default::default(),
+                gso_size: None,
             },
         );
         Ok(())
@@ -923,6 +960,82 @@ mod tests {
             udp.dst_port(),
             guest_port,
             "forwarded packet should target the guest port"
+        );
+    }
+
+    #[pal_async::async_test]
+    async fn test_udp_reply_source_port(driver: DefaultDriver) {
+        // A guest reply from a published port must egress from the listener's host socket so its
+        // source matches the published port.
+        let driver = Arc::new(driver);
+        let mut consomme = create_consomme_with_timeout(Duration::from_secs(30));
+        let mut client = TestClient::new(driver.clone());
+
+        let guest_mac = consomme.params_mut().client_mac;
+        let gateway_mac = consomme.params_mut().gateway_mac;
+        let guest_ip: Ipv4Address = consomme.params_mut().client_ip;
+
+        // Bind a listener socket on an ephemeral host port for `guest_port`.
+        let listener_socket =
+            Socket::new(socket2::Domain::IPV4, socket2::Type::DGRAM, None).unwrap();
+        listener_socket
+            .bind(&SocketAddrV4::new(Ipv4Addr::LOCALHOST, 0).into())
+            .unwrap();
+        let host_addr: SocketAddr = listener_socket.local_addr().unwrap().as_socket().unwrap();
+        let guest_port = 7777;
+
+        // A host client socket that will receive the guest's reply.
+        let host_client = UdpSocket::bind("127.0.0.1:0").unwrap();
+        host_client
+            .set_read_timeout(Some(Duration::from_secs(5)))
+            .unwrap();
+        let client_port = host_client.local_addr().unwrap().port();
+
+        let mut access = consomme.access(&mut client);
+        access
+            .bind_udp_port(listener_socket, guest_port)
+            .expect("bind should succeed");
+
+        // Build a guest-originated UDP datagram whose source is the published guest port and whose
+        // destination is the host client on loopback (a local address).
+        let target_ip: Ipv4Address = Ipv4Addr::LOCALHOST;
+        let payload = b"reply";
+        let mut buffer =
+            vec![0u8; ETHERNET_HEADER_LEN + IPV4_HEADER_LEN + UDP_HEADER_LEN + payload.len()];
+        buffer[ETHERNET_HEADER_LEN + IPV4_HEADER_LEN + UDP_HEADER_LEN..].copy_from_slice(payload);
+        let mut eth_frame = EthernetFrame::new_unchecked(&mut buffer[..]);
+        let packet_len = build_udp_packet(
+            &mut eth_frame,
+            IpAddress::Ipv4(guest_ip),
+            IpAddress::Ipv4(target_ip),
+            guest_port,
+            client_port,
+            payload.len(),
+            guest_mac,
+            gateway_mac,
+        );
+
+        let _ = access.send(&buffer[..packet_len], &ChecksumState::NONE);
+        let mut cx = Context::from_waker(std::task::Waker::noop());
+        access.poll(&mut cx);
+
+        // The reply must reuse the listener; no per-connection socket should be created.
+        assert_eq!(
+            access.udp_connection_count(),
+            0,
+            "reply should not create a new UDP connection"
+        );
+
+        // The host client must receive the reply from the published host port.
+        let mut recv_buf = [0u8; 64];
+        let (n, src) = host_client
+            .recv_from(&mut recv_buf)
+            .expect("client should receive the reply");
+        assert_eq!(&recv_buf[..n], payload);
+        assert_eq!(
+            src.port(),
+            host_addr.port(),
+            "reply source port must match the published host port"
         );
     }
 

--- a/vm/devices/net/net_consomme/consomme/src/udp.rs
+++ b/vm/devices/net/net_consomme/consomme/src/udp.rs
@@ -60,6 +60,8 @@ use std::time::Instant;
 
 use crate::DNS_PORT;
 
+const UDP_LISTENER_PEER_LIMIT: usize = 1024;
+
 #[cfg(unix)]
 use crate::unix as platform;
 #[cfg(windows)]
@@ -96,29 +98,35 @@ impl InspectMut for Udp {
 
 #[derive(InspectMut)]
 struct UdpListener {
-    #[inspect(skip)]
-    socket: Option<PolledSocket<UdpSocket>>,
+    #[inspect(flatten)]
+    socket_state: UdpSocketState,
     // The host address listening for UDP packets.
     #[inspect(display)]
     host_addr: SocketAddr,
     /// The guest port to forward received packets to.
     guest_port: u16,
-    stats: Stats,
-    gso_size: Option<u16>,
+    #[inspect(with = "|x| x.len()")]
+    peers: HashMap<SocketAddr, Instant>,
 }
 
 #[derive(InspectMut)]
 struct UdpConnection {
-    #[inspect(skip)]
-    socket: Option<PolledSocket<UdpSocket>>,
+    #[inspect(flatten)]
+    socket_state: UdpSocketState,
     host_port: u16,
     #[inspect(display)]
     guest_mac: EthernetAddress,
-    stats: Stats,
     #[inspect(mut)]
     recycle: bool,
     #[inspect(debug)]
     last_activity: Instant,
+}
+
+#[derive(Inspect)]
+struct UdpSocketState {
+    #[inspect(skip)]
+    socket: Option<PolledSocket<UdpSocket>>,
+    stats: Stats,
     gso_size: Option<u16>,
 }
 
@@ -128,6 +136,44 @@ struct Stats {
     tx_dropped: Counter,
     tx_errors: Counter,
     rx_packets: Counter,
+}
+
+impl UdpSocketState {
+    fn new(socket: PolledSocket<UdpSocket>) -> Self {
+        Self {
+            socket: Some(socket),
+            stats: Default::default(),
+            gso_size: None,
+        }
+    }
+
+    fn send_to(
+        &mut self,
+        payload: &[u8],
+        dst_addr: &SocketAddr,
+        gso_size: Option<u16>,
+    ) -> Result<(), DropReason> {
+        let socket = self.socket.as_ref().unwrap().get();
+        if self.gso_size != gso_size {
+            platform::set_udp_gso_size(socket, gso_size.unwrap_or(0)).map_err(DropReason::Io)?;
+            self.gso_size = gso_size;
+        }
+
+        match platform::send_to(socket, payload, dst_addr, gso_size) {
+            Ok(_) => {
+                self.stats.tx_packets.increment();
+                Ok(())
+            }
+            Err(err) if err.kind() == ErrorKind::WouldBlock => {
+                self.stats.tx_dropped.increment();
+                Err(DropReason::SendBufferFull)
+            }
+            Err(err) => {
+                self.stats.tx_errors.increment();
+                Err(DropReason::Io(err))
+            }
+        }
+    }
 }
 
 impl UdpConnection {
@@ -158,7 +204,7 @@ impl UdpConnection {
                 SocketAddr::V6(_) => IPV6_HEADER_LEN + UDP_HEADER_LEN,
             };
 
-            match self.socket.as_mut().unwrap().poll_io(
+            match self.socket_state.socket.as_mut().unwrap().poll_io(
                 cx,
                 InterestSlot::Read,
                 PollEvents::IN,
@@ -196,7 +242,7 @@ impl UdpConnection {
                         SocketAddr::V6(_) => ChecksumState::NONE,
                     };
                     client.recv(&eth.as_ref()[..packet_len], &checksum_state);
-                    self.stats.rx_packets.increment();
+                    self.socket_state.stats.rx_packets.increment();
                     self.last_activity = Instant::now();
                 }
                 Poll::Ready(Err(err)) => {
@@ -214,6 +260,40 @@ impl UdpConnection {
 }
 
 impl UdpListener {
+    fn record_peer(peers: &mut HashMap<SocketAddr, Instant>, peer_addr: SocketAddr) {
+        let now = Instant::now();
+        if let Some(last_activity) = peers.get_mut(&peer_addr) {
+            *last_activity = now;
+            return;
+        }
+
+        if peers.len() >= UDP_LISTENER_PEER_LIMIT {
+            if let Some(oldest) = peers
+                .iter()
+                .min_by_key(|(_, last_activity)| *last_activity)
+                .map(|(peer_addr, _)| *peer_addr)
+            {
+                peers.remove(&oldest);
+            }
+        }
+        peers.insert(peer_addr, now);
+    }
+
+    fn send_to_peer(
+        &mut self,
+        peer_addr: &SocketAddr,
+        dst_addr: &SocketAddr,
+        payload: &[u8],
+        gso_size: Option<u16>,
+    ) -> Option<Result<(), DropReason>> {
+        let last_activity = self.peers.get_mut(peer_addr)?;
+        let result = self.socket_state.send_to(payload, dst_addr, gso_size);
+        if result.is_ok() {
+            *last_activity = Instant::now();
+        }
+        Some(result)
+    }
+
     fn poll_listener(
         &mut self,
         cx: &mut Context<'_>,
@@ -221,7 +301,7 @@ impl UdpListener {
         client: &mut impl Client,
         connections: &HashMap<SocketAddr, UdpConnection>,
     ) {
-        let Some(socket) = self.socket.as_mut() else {
+        let Some(socket) = self.socket_state.socket.as_mut() else {
             return;
         };
         let mut eth = EthernetFrame::new_unchecked(&mut state.buffer);
@@ -258,6 +338,7 @@ impl UdpListener {
                     ) else {
                         continue;
                     };
+                    Self::record_peer(&mut self.peers, other_addr);
                     tracing::trace!(
                         ?other_addr,
                         guest_port = self.guest_port,
@@ -278,7 +359,7 @@ impl UdpListener {
                         SocketAddr::V6(_) => ChecksumState::NONE,
                     };
                     client.recv(&eth.as_ref()[..packet_len], &checksum_state);
-                    self.stats.rx_packets.increment();
+                    self.socket_state.stats.rx_packets.increment();
                 }
                 Poll::Ready(Err(err)) => {
                     tracelimit::error_ratelimited!(
@@ -314,6 +395,9 @@ impl<T: Client> Access<'_, T> {
         });
 
         for listener in self.inner.udp.listeners.values_mut() {
+            listener
+                .peers
+                .retain(|_, last_activity| now.duration_since(*last_activity) <= timeout);
             listener.poll_listener(
                 cx,
                 &mut self.inner.state,
@@ -331,10 +415,10 @@ impl<T: Client> Access<'_, T> {
 
     pub(crate) fn refresh_udp_driver(&mut self) {
         self.inner.udp.connections.retain(|dst_addr, conn| {
-            let socket = conn.socket.take().unwrap().into_inner();
+            let socket = conn.socket_state.socket.take().unwrap().into_inner();
             match PolledSocket::new(self.client.driver(), socket) {
                 Ok(socket) => {
-                    conn.socket = Some(socket);
+                    conn.socket_state.socket = Some(socket);
                     true
                 }
                 Err(err) => {
@@ -348,10 +432,10 @@ impl<T: Client> Access<'_, T> {
             }
         });
         self.inner.udp.listeners.retain(|key, listener| {
-            let socket = listener.socket.take().unwrap().into_inner();
+            let socket = listener.socket_state.socket.take().unwrap().into_inner();
             match PolledSocket::new(self.client.driver(), socket) {
                 Ok(socket) => {
-                    listener.socket = Some(socket);
+                    listener.socket_state.socket = Some(socket);
                     true
                 }
                 Err(err) => {
@@ -456,6 +540,7 @@ impl<T: Client> Access<'_, T> {
 
         // Resolve virtual mapped addresses back to the real host address.
         let mut dst_sock_addr = self.inner.state.resolve_destination(&dst_sock_addr);
+        let peer_addr = dst_sock_addr;
         if self.inner.state.params.is_local_address(&dst_sock_addr) {
             // This packet is destined for a local address. If the port matches a listener,
             // translate it so that the connection loops back to the expected destination.
@@ -463,66 +548,29 @@ impl<T: Client> Access<'_, T> {
             if let Some(listener) = self.inner.udp.listeners.get(&key) {
                 dst_sock_addr.set_port(listener.host_addr.port());
             }
+        }
 
-            // Guest reply from a published port to a local client: send from the listener's
-            // host socket so the reply's source matches the published port. A per-connection
-            // socket would use an ephemeral port, which a connected client rejects.
-            let src_key = PortForwardKey::from_socket_addr(guest_addr, guest_addr.port());
-            if let Some(listener) = self.inner.udp.listeners.get_mut(&src_key) {
-                if let Some(socket) = listener.socket.as_ref() {
-                    let socket = socket.get();
-                    if listener.gso_size != checksum.gso {
-                        platform::set_udp_gso_size(socket, checksum.gso.unwrap_or(0))
-                            .map_err(DropReason::Io)?;
-                        listener.gso_size = checksum.gso;
-                    }
-                    let result = platform::send_to(
-                        socket,
-                        udp_packet.payload(),
-                        &dst_sock_addr,
-                        checksum.gso,
-                    );
-                    return match result {
-                        Ok(_) => {
-                            listener.stats.tx_packets.increment();
-                            Ok(())
-                        }
-                        Err(err) if err.kind() == ErrorKind::WouldBlock => {
-                            listener.stats.tx_dropped.increment();
-                            Err(DropReason::SendBufferFull)
-                        }
-                        Err(err) => {
-                            listener.stats.tx_errors.increment();
-                            Err(DropReason::Io(err))
-                        }
-                    };
-                }
+        // Preserve the published source port when replying to a listener peer.
+        let src_key = PortForwardKey::from_socket_addr(guest_addr, guest_addr.port());
+        if let Some(listener) = self.inner.udp.listeners.get_mut(&src_key) {
+            if let Some(result) = listener.send_to_peer(
+                &peer_addr,
+                &dst_sock_addr,
+                udp_packet.payload(),
+                checksum.gso,
+            ) {
+                return result;
             }
         }
 
         let conn = self.get_or_insert(guest_addr, Some(frame.src_addr))?;
-        let socket = conn.socket.as_ref().unwrap().get();
-        if conn.gso_size != checksum.gso {
-            platform::set_udp_gso_size(socket, checksum.gso.unwrap_or(0))
-                .map_err(DropReason::Io)?;
-            conn.gso_size = checksum.gso;
+        let result = conn
+            .socket_state
+            .send_to(udp_packet.payload(), &dst_sock_addr, checksum.gso);
+        if result.is_ok() {
+            conn.last_activity = Instant::now();
         }
-        let result = platform::send_to(socket, udp_packet.payload(), &dst_sock_addr, checksum.gso);
-        match result {
-            Ok(_) => {
-                conn.stats.tx_packets.increment();
-                conn.last_activity = Instant::now();
-                Ok(())
-            }
-            Err(err) if err.kind() == ErrorKind::WouldBlock => {
-                conn.stats.tx_dropped.increment();
-                Err(DropReason::SendBufferFull)
-            }
-            Err(err) => {
-                conn.stats.tx_errors.increment();
-                Err(DropReason::Io(err))
-            }
-        }
+        result
     }
 
     fn get_or_insert(
@@ -548,13 +596,11 @@ impl<T: Client> Access<'_, T> {
                     PolledSocket::new(self.client.driver(), socket).map_err(DropReason::Io)?;
                 let host_port = socket.get().local_addr().map_err(DropReason::Io)?.port();
                 let conn = UdpConnection {
-                    socket: Some(socket),
+                    socket_state: UdpSocketState::new(socket),
                     host_port,
                     guest_mac: guest_mac.unwrap_or(self.inner.state.params.client_mac),
-                    stats: Default::default(),
                     recycle: false,
                     last_activity: Instant::now(),
-                    gso_size: None,
                 };
                 Ok(e.insert(conn))
             }
@@ -619,11 +665,10 @@ impl<T: Client> Access<'_, T> {
         self.inner.udp.listeners.insert(
             key,
             UdpListener {
-                socket: Some(socket),
+                socket_state: UdpSocketState::new(socket),
                 host_addr,
                 guest_port,
-                stats: Default::default(),
-                gso_size: None,
+                peers: HashMap::new(),
             },
         );
         Ok(())
@@ -1017,8 +1062,6 @@ mod tests {
 
     #[pal_async::async_test]
     async fn test_udp_reply_source_port(driver: DefaultDriver) {
-        // A guest reply from a published port must egress from the listener's host socket so its
-        // source matches the published port.
         let driver = Arc::new(driver);
         let mut consomme = create_consomme_with_timeout(Duration::from_secs(30));
         let mut client = TestClient::new(driver.clone());
@@ -1041,16 +1084,36 @@ mod tests {
         host_client
             .set_read_timeout(Some(Duration::from_secs(5)))
             .unwrap();
-        let client_port = host_client.local_addr().unwrap().port();
 
+        let packets = client.received_packets.clone();
         let mut access = consomme.access(&mut client);
         access
             .bind_udp_port(listener_socket, guest_port)
             .expect("bind should succeed");
 
-        // Build a guest-originated UDP datagram whose source is the published guest port and whose
-        // destination is the host client on loopback (a local address).
-        let target_ip: Ipv4Address = Ipv4Addr::LOCALHOST;
+        host_client.send_to(b"request", host_addr).unwrap();
+        let deadline = Instant::now() + Duration::from_secs(5);
+        loop {
+            std::future::poll_fn(|cx| {
+                access.poll(cx);
+                Poll::Ready(())
+            })
+            .await;
+            if !packets.lock().is_empty() {
+                break;
+            }
+            assert!(Instant::now() < deadline, "timed out waiting for request");
+            pal_async::timer::PolledTimer::new(&*driver)
+                .sleep(Duration::from_millis(10))
+                .await;
+        }
+
+        let request = packets.lock()[0].clone();
+        let request = EthernetFrame::new_unchecked(request.as_slice());
+        let request = Ipv4Packet::new_unchecked(request.payload());
+        let target_ip = request.src_addr();
+        let request = UdpPacket::new_unchecked(request.payload());
+        let client_port = request.src_port();
         let payload = b"reply";
         let mut buffer =
             vec![0u8; ETHERNET_HEADER_LEN + IPV4_HEADER_LEN + UDP_HEADER_LEN + payload.len()];
@@ -1089,6 +1152,152 @@ mod tests {
             host_addr.port(),
             "reply source port must match the published host port"
         );
+
+        // Unrelated outbound traffic must use a routable connection socket.
+        let remote_ip = Ipv4Address::new(192, 0, 2, 1);
+        let mut eth_frame = EthernetFrame::new_unchecked(&mut buffer[..]);
+        let packet_len = build_udp_packet(
+            &mut eth_frame,
+            IpAddress::Ipv4(guest_ip),
+            IpAddress::Ipv4(remote_ip),
+            guest_port,
+            client_port,
+            payload.len(),
+            guest_mac,
+            gateway_mac,
+        );
+        let _ = access.send(&buffer[..packet_len], &ChecksumState::NONE);
+        assert_eq!(
+            access.udp_connection_count(),
+            1,
+            "unrelated traffic should create a UDP connection"
+        );
+    }
+
+    #[pal_async::async_test]
+    async fn test_udp_remote_reply_source_port(driver: DefaultDriver) {
+        let probe = UdpSocket::bind((Ipv4Addr::UNSPECIFIED, 0)).unwrap();
+        probe.connect((Ipv4Addr::new(192, 0, 2, 1), 9)).unwrap();
+        let IpAddr::V4(host_ip) = probe.local_addr().unwrap().ip() else {
+            unreachable!();
+        };
+        assert!(!host_ip.is_loopback());
+
+        let driver = Arc::new(driver);
+        let mut consomme = create_consomme_with_timeout(Duration::from_secs(30));
+        let mut client = TestClient::new(driver.clone());
+        let guest_mac = consomme.params_mut().client_mac;
+        let gateway_mac = consomme.params_mut().gateway_mac;
+        let guest_ip: Ipv4Address = consomme.params_mut().client_ip;
+        let guest_port = 7778;
+
+        let listener_socket =
+            Socket::new(socket2::Domain::IPV4, socket2::Type::DGRAM, None).unwrap();
+        listener_socket
+            .bind(&SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, 0).into())
+            .unwrap();
+        let host_port = listener_socket
+            .local_addr()
+            .unwrap()
+            .as_socket()
+            .unwrap()
+            .port();
+
+        let remote_client = UdpSocket::bind((host_ip, 0)).unwrap();
+        remote_client
+            .set_read_timeout(Some(Duration::from_secs(5)))
+            .unwrap();
+
+        let packets = client.received_packets.clone();
+        let mut access = consomme.access(&mut client);
+        access
+            .bind_udp_port(listener_socket, guest_port)
+            .expect("bind should succeed");
+
+        remote_client
+            .send_to(b"request", SocketAddrV4::new(host_ip, host_port))
+            .unwrap();
+        let deadline = Instant::now() + Duration::from_secs(5);
+        loop {
+            std::future::poll_fn(|cx| {
+                access.poll(cx);
+                Poll::Ready(())
+            })
+            .await;
+            if !packets.lock().is_empty() {
+                break;
+            }
+            assert!(Instant::now() < deadline, "timed out waiting for request");
+            pal_async::timer::PolledTimer::new(&*driver)
+                .sleep(Duration::from_millis(10))
+                .await;
+        }
+
+        let request = packets.lock()[0].clone();
+        let request = EthernetFrame::new_unchecked(request.as_slice());
+        let request = Ipv4Packet::new_unchecked(request.payload());
+        let target_ip = request.src_addr();
+        let request = UdpPacket::new_unchecked(request.payload());
+        let payload = b"reply";
+        let mut buffer =
+            vec![0u8; ETHERNET_HEADER_LEN + IPV4_HEADER_LEN + UDP_HEADER_LEN + payload.len()];
+        buffer[ETHERNET_HEADER_LEN + IPV4_HEADER_LEN + UDP_HEADER_LEN..].copy_from_slice(payload);
+        let mut eth_frame = EthernetFrame::new_unchecked(&mut buffer[..]);
+        let packet_len = build_udp_packet(
+            &mut eth_frame,
+            IpAddress::Ipv4(guest_ip),
+            IpAddress::Ipv4(target_ip),
+            guest_port,
+            request.src_port(),
+            payload.len(),
+            guest_mac,
+            gateway_mac,
+        );
+
+        access
+            .send(&buffer[..packet_len], &ChecksumState::NONE)
+            .unwrap();
+        assert_eq!(access.udp_connection_count(), 0);
+
+        let mut recv_buf = [0u8; 64];
+        let (n, src) = remote_client.recv_from(&mut recv_buf).unwrap();
+        assert_eq!(&recv_buf[..n], payload);
+        assert_eq!(src, SocketAddrV4::new(host_ip, host_port).into());
+    }
+
+    #[pal_async::async_test]
+    async fn test_udp_listener_peer_limit(driver: DefaultDriver) {
+        let mut consomme = create_consomme_with_timeout(Duration::from_secs(30));
+        let mut client = TestClient::new(Arc::new(driver));
+        let guest_port = 7779;
+        let listener_socket =
+            Socket::new(socket2::Domain::IPV4, socket2::Type::DGRAM, None).unwrap();
+        listener_socket
+            .bind(&SocketAddrV4::new(Ipv4Addr::LOCALHOST, 0).into())
+            .unwrap();
+
+        let mut access = consomme.access(&mut client);
+        access
+            .bind_udp_port(listener_socket, guest_port)
+            .expect("bind should succeed");
+        let listener = access
+            .inner
+            .udp
+            .listeners
+            .get_mut(&PortForwardKey::new(IpVersion::Ipv4, guest_port))
+            .unwrap();
+
+        for port in 1..=UDP_LISTENER_PEER_LIMIT + 1 {
+            UdpListener::record_peer(
+                &mut listener.peers,
+                SocketAddrV4::new(Ipv4Addr::LOCALHOST, port as u16).into(),
+            );
+        }
+
+        assert_eq!(listener.peers.len(), UDP_LISTENER_PEER_LIMIT);
+        assert!(listener.peers.contains_key(
+            &SocketAddrV4::new(Ipv4Addr::LOCALHOST, (UDP_LISTENER_PEER_LIMIT + 1) as u16).into()
+        ));
     }
 
     #[pal_async::async_test]

--- a/vm/devices/net/net_consomme/consomme/src/udp.rs
+++ b/vm/devices/net/net_consomme/consomme/src/udp.rs
@@ -936,6 +936,23 @@ mod tests {
         Consomme::new(params)
     }
 
+    async fn recv_udp(driver: &DefaultDriver, socket: &UdpSocket) -> (Vec<u8>, SocketAddr) {
+        socket.set_nonblocking(true).unwrap();
+        let deadline = Instant::now() + Duration::from_secs(5);
+        let mut buffer = [0; 64];
+        loop {
+            match socket.recv_from(&mut buffer) {
+                Ok((n, addr)) => return (buffer[..n].to_vec(), addr),
+                Err(err) if err.kind() == ErrorKind::WouldBlock => {}
+                Err(err) => panic!("failed to receive UDP packet: {err}"),
+            }
+            assert!(Instant::now() < deadline, "timed out waiting for packet");
+            pal_async::timer::PolledTimer::new(driver)
+                .sleep(Duration::from_millis(10))
+                .await;
+        }
+    }
+
     #[pal_async::async_test]
     async fn test_udp_connection_timeout(driver: DefaultDriver) {
         let driver = Arc::new(driver);
@@ -1081,9 +1098,6 @@ mod tests {
 
         // A host client socket that will receive the guest's reply.
         let host_client = UdpSocket::bind("127.0.0.1:0").unwrap();
-        host_client
-            .set_read_timeout(Some(Duration::from_secs(5)))
-            .unwrap();
 
         let packets = client.received_packets.clone();
         let mut access = consomme.access(&mut client);
@@ -1142,11 +1156,8 @@ mod tests {
         );
 
         // The host client must receive the reply from the published host port.
-        let mut recv_buf = [0u8; 64];
-        let (n, src) = host_client
-            .recv_from(&mut recv_buf)
-            .expect("client should receive the reply");
-        assert_eq!(&recv_buf[..n], payload);
+        let (received, src) = recv_udp(&driver, &host_client).await;
+        assert_eq!(received, payload);
         assert_eq!(
             src.port(),
             host_addr.port(),
@@ -1176,13 +1187,6 @@ mod tests {
 
     #[pal_async::async_test]
     async fn test_udp_remote_reply_source_port(driver: DefaultDriver) {
-        let probe = UdpSocket::bind((Ipv4Addr::UNSPECIFIED, 0)).unwrap();
-        probe.connect((Ipv4Addr::new(192, 0, 2, 1), 9)).unwrap();
-        let IpAddr::V4(host_ip) = probe.local_addr().unwrap().ip() else {
-            unreachable!();
-        };
-        assert!(!host_ip.is_loopback());
-
         let driver = Arc::new(driver);
         let mut consomme = create_consomme_with_timeout(Duration::from_secs(30));
         let mut client = TestClient::new(driver.clone());
@@ -1203,41 +1207,24 @@ mod tests {
             .unwrap()
             .port();
 
-        let remote_client = UdpSocket::bind((host_ip, 0)).unwrap();
-        remote_client
-            .set_read_timeout(Some(Duration::from_secs(5)))
-            .unwrap();
-
-        let packets = client.received_packets.clone();
+        let remote_client = UdpSocket::bind((Ipv4Addr::UNSPECIFIED, 0)).unwrap();
+        let remote_addr = SocketAddrV4::new(
+            Ipv4Addr::UNSPECIFIED,
+            remote_client.local_addr().unwrap().port(),
+        )
+        .into();
         let mut access = consomme.access(&mut client);
         access
             .bind_udp_port(listener_socket, guest_port)
             .expect("bind should succeed");
-
-        remote_client
-            .send_to(b"request", SocketAddrV4::new(host_ip, host_port))
+        let listener = access
+            .inner
+            .udp
+            .listeners
+            .get_mut(&PortForwardKey::new(IpVersion::Ipv4, guest_port))
             .unwrap();
-        let deadline = Instant::now() + Duration::from_secs(5);
-        loop {
-            std::future::poll_fn(|cx| {
-                access.poll(cx);
-                Poll::Ready(())
-            })
-            .await;
-            if !packets.lock().is_empty() {
-                break;
-            }
-            assert!(Instant::now() < deadline, "timed out waiting for request");
-            pal_async::timer::PolledTimer::new(&*driver)
-                .sleep(Duration::from_millis(10))
-                .await;
-        }
+        UdpListener::record_peer(&mut listener.peers, remote_addr);
 
-        let request = packets.lock()[0].clone();
-        let request = EthernetFrame::new_unchecked(request.as_slice());
-        let request = Ipv4Packet::new_unchecked(request.payload());
-        let target_ip = request.src_addr();
-        let request = UdpPacket::new_unchecked(request.payload());
         let payload = b"reply";
         let mut buffer =
             vec![0u8; ETHERNET_HEADER_LEN + IPV4_HEADER_LEN + UDP_HEADER_LEN + payload.len()];
@@ -1246,9 +1233,9 @@ mod tests {
         let packet_len = build_udp_packet(
             &mut eth_frame,
             IpAddress::Ipv4(guest_ip),
-            IpAddress::Ipv4(target_ip),
+            IpAddress::Ipv4(Ipv4Addr::UNSPECIFIED),
             guest_port,
-            request.src_port(),
+            remote_addr.port(),
             payload.len(),
             guest_mac,
             gateway_mac,
@@ -1259,10 +1246,9 @@ mod tests {
             .unwrap();
         assert_eq!(access.udp_connection_count(), 0);
 
-        let mut recv_buf = [0u8; 64];
-        let (n, src) = remote_client.recv_from(&mut recv_buf).unwrap();
-        assert_eq!(&recv_buf[..n], payload);
-        assert_eq!(src, SocketAddrV4::new(host_ip, host_port).into());
+        let (received, src) = recv_udp(&driver, &remote_client).await;
+        assert_eq!(received, payload);
+        assert_eq!(src.port(), host_port);
     }
 
     #[pal_async::async_test]


### PR DESCRIPTION
## Summary

Fixes microsoft/WSL#40999. UDP replies from a wslc container on a published port came back to the host client from a random ephemeral source port instead of the published port, so connected UDP clients (ENet, QUIC, DTLS, most game netcode) rejected them and timed out. TCP publishing was unaffected.

## Root cause

wslc UDP port publishing routes through consomme (the wslrelay path is TCP only). When the container replies to a forwarded client, `handle_udp` resolves the destination back to the host client (a local address) but then falls through to `get_or_insert`, which binds a fresh per-connection ephemeral socket and sends the reply from it. The client, using a connected UDP socket, only accepts datagrams from the exact address it sent to (the published port), so the reply is dropped.

Inbound forwarding was fine because the listener socket is bound to the published port; only the return path picked the wrong socket.

## Fix

In `handle_udp`, when a datagram's source port is published to the host and its destination is a local address, send it from the listener's host socket. The reply's source then matches the published port, matching Docker's behavior. GSO size is tracked on the listener the same way it is on per-connection sockets. Non-local (genuine guest-initiated outbound) flows are unaffected and continue to use per-connection sockets.

## Testing

- New unit test `test_udp_reply_source_port`: binds a listener, injects a guest datagram whose source is the published port and destination is a host client on loopback, and verifies the client receives the reply from the published host port and that no per-connection socket is created.
- `cargo test -p consomme`: 100/100 pass.
- `cargo clippy -p consomme --all-targets` and `cargo fmt -p consomme -- --check` clean.
