### PR TITLE
sidecar: Detect 'empty' nodes and skip them

### DIFF
--- a/openhcl/openhcl_boot/src/sidecar.rs
+++ b/openhcl/openhcl_boot/src/sidecar.rs
@@ -89,7 +89,7 @@ fn sidecar_node_is_empty(
         return false;
     }
     // Empty iff no non-base VP is left for sidecar to start.
-    !(1..size).any(|i| overrides.sidecar_starts_cpu[base_vp + i])
+    size != 1 && !(1..size).any(|i| overrides.sidecar_starts_cpu[base_vp + i])
 }
 
 pub fn start_sidecar<'a>(

--- a/openhcl/openhcl_boot/src/sidecar.rs
+++ b/openhcl/openhcl_boot/src/sidecar.rs
@@ -74,13 +74,11 @@ impl core::fmt::Display for SidecarKernelCommandLine<'_> {
 }
 
 /// Returns true if, with per-CPU sidecar overrides active, the sidecar node
-/// whose VPs are `base_vp..base_vp + size` has application processors but none
-/// are left for sidecar to start (every AP is kernel-started).
+/// whose VPs are `base_vp..base_vp + size` has no application processors left
+/// for sidecar to start (every AP is kernel-started).
 ///
 /// The first VP of a node is its base VP and is always kernel-started, so
-/// sidecar only ever starts the remaining VPs. A single-VP node therefore has
-/// no APs at all and is never considered empty; this predicate only reports
-/// `true` for nodes with at least two VPs.
+/// sidecar only ever starts the remaining VPs.
 fn sidecar_node_is_empty(
     overrides: &sidecar_defs::PerCpuState,
     base_vp: usize,
@@ -88,10 +86,6 @@ fn sidecar_node_is_empty(
 ) -> bool {
     // Without per-CPU overrides sidecar starts every non-base VP.
     if !overrides.per_cpu_state_specified {
-        return false;
-    }
-    // A single-VP node has no APs at all and is never empty.
-    if size == 1 {
         return false;
     }
     // Empty iff no non-base VP is left for sidecar to start.

--- a/openhcl/openhcl_boot/src/sidecar.rs
+++ b/openhcl/openhcl_boot/src/sidecar.rs
@@ -74,11 +74,13 @@ impl core::fmt::Display for SidecarKernelCommandLine<'_> {
 }
 
 /// Returns true if, with per-CPU sidecar overrides active, the sidecar node
-/// whose VPs are `base_vp..base_vp + size` has no application processor left for
-/// sidecar to start (every AP is kernel-started).
+/// whose VPs are `base_vp..base_vp + size` has application processors but none
+/// are left for sidecar to start (every AP is kernel-started).
 ///
 /// The first VP of a node is its base VP and is always kernel-started, so
-/// sidecar only ever starts the remaining VPs.
+/// sidecar only ever starts the remaining VPs. A single-VP node therefore has
+/// no APs at all and is never considered empty; this predicate only reports
+/// `true` for nodes with at least two VPs.
 fn sidecar_node_is_empty(
     overrides: &sidecar_defs::PerCpuState,
     base_vp: usize,

--- a/openhcl/openhcl_boot/src/sidecar.rs
+++ b/openhcl/openhcl_boot/src/sidecar.rs
@@ -86,7 +86,7 @@ fn sidecar_node_is_empty(
 ) -> bool {
     // Without per-CPU overrides sidecar starts every non-base VP.
     if !overrides.per_cpu_state_specified {
-        return false;
+        return size == 1;
     }
     // Empty iff no non-base VP is left for sidecar to start.
     !(1..size).any(|i| overrides.sidecar_starts_cpu[base_vp + i])

--- a/openhcl/openhcl_boot/src/sidecar.rs
+++ b/openhcl/openhcl_boot/src/sidecar.rs
@@ -73,6 +73,35 @@ impl core::fmt::Display for SidecarKernelCommandLine<'_> {
     }
 }
 
+/// Returns true if, with per-CPU sidecar overrides active, the sidecar node
+/// whose VPs are `base_vp..base_vp + size` has no application processor left for
+/// sidecar to start (every AP is kernel-started).
+///
+/// The first VP of a node is its base VP and is always kernel-started, so
+/// sidecar only ever starts the remaining VPs.
+fn sidecar_node_is_empty(
+    overrides: &sidecar_defs::PerCpuState,
+    base_vp: usize,
+    size: usize,
+) -> bool {
+    // Without per-CPU overrides sidecar starts every non-base VP.
+    if !overrides.per_cpu_state_specified {
+        return false;
+    }
+    // A single-VP node has no APs at all and is never empty.
+    if size == 1 {
+        return false;
+    }
+    // Empty iff no non-base VP is left for sidecar to start.
+    !(1..size).any(|i| {
+        overrides
+            .sidecar_starts_cpu
+            .get(base_vp + i)
+            .copied()
+            .unwrap_or(false)
+    })
+}
+
 pub fn start_sidecar<'a>(
     p: &ShimParams,
     partition_info: &PartitionInfo,
@@ -143,8 +172,6 @@ pub fn start_sidecar<'a>(
         log::info!("sidecar: all NUMA nodes have one CPU");
         return None;
     }
-    let node_count = cpus_by_node().count();
-
     let mut total_ram;
     {
         let SidecarParams {
@@ -163,8 +190,29 @@ pub fn start_sidecar<'a>(
 
         let mut base_vp = 0;
         total_ram = 0;
+        *node_count = 0;
         *initial_state = partition_info.sidecar_cpu_overrides.clone();
-        for (cpus, node) in cpus_by_node().zip(nodes) {
+        for cpus in cpus_by_node() {
+            // Skip creating a sidecar node when none of its application
+            // processors are left for sidecar to start (all are kernel-started).
+            if sidecar_node_is_empty(
+                &partition_info.sidecar_cpu_overrides,
+                base_vp as usize,
+                cpus.len(),
+            ) {
+                if initial_state.per_cpu_state_specified {
+                    // Kernel-start the base VP too; its APs are already
+                    // excluded, so every VP in the node ends up in `boot_cpus=`.
+                    initial_state.sidecar_starts_cpu[base_vp as usize] = false;
+                }
+                log::info!(
+                    "sidecar: node at base VP {base_vp} ({} VPs) has no sidecar-started APs; kernel-starting all of them",
+                    cpus.len(),
+                );
+                base_vp += cpus.len() as u32;
+                continue;
+            }
+
             let required_ram = sidecar_defs::required_memory(cpus.len() as u32) as u64;
             // Take some VTL2 RAM for sidecar use. Try to use the same NUMA node
             // as the first CPU.
@@ -200,7 +248,7 @@ pub fn start_sidecar<'a>(
                 }
             };
 
-            *node = SidecarNodeParams {
+            nodes[*node_count as usize] = SidecarNodeParams {
                 memory_base: mem.range.start(),
                 memory_size: mem.range.len(),
                 base_vp,
@@ -221,6 +269,14 @@ pub fn start_sidecar<'a>(
             *node_count += 1;
             total_ram += required_ram;
         }
+    }
+
+    // If per-CPU overrides left every node empty, there is nothing for
+    // sidecar to do; behave as if it were disabled entirely.
+    let node_count = sidecar_params.node_count as usize;
+    if node_count == 0 {
+        log::info!("sidecar: no nodes have sidecar-started APs; disabling sidecar");
+        return None;
     }
 
     // SAFETY: the parameter blob is trusted.

--- a/openhcl/openhcl_boot/src/sidecar.rs
+++ b/openhcl/openhcl_boot/src/sidecar.rs
@@ -89,7 +89,7 @@ fn sidecar_node_is_empty(
         return false;
     }
     // Empty iff no non-base VP is left for sidecar to start.
-    size != 1 && !(1..size).any(|i| overrides.sidecar_starts_cpu[base_vp + i])
+    !(1..size).any(|i| overrides.sidecar_starts_cpu[base_vp + i])
 }
 
 pub fn start_sidecar<'a>(

--- a/openhcl/openhcl_boot/src/sidecar.rs
+++ b/openhcl/openhcl_boot/src/sidecar.rs
@@ -95,13 +95,7 @@ fn sidecar_node_is_empty(
         return false;
     }
     // Empty iff no non-base VP is left for sidecar to start.
-    !(1..size).any(|i| {
-        overrides
-            .sidecar_starts_cpu
-            .get(base_vp + i)
-            .copied()
-            .unwrap_or(false)
-    })
+    !(1..size).any(|i| overrides.sidecar_starts_cpu[base_vp + i])
 }
 
 pub fn start_sidecar<'a>(

--- a/openhcl/sidecar/src/arch/x86_64/init.rs
+++ b/openhcl/sidecar/src/arch/x86_64/init.rs
@@ -345,6 +345,21 @@ fn init(
                     };
                 }
             }
+
+            // Sidecar must never be run for a node whose application processors
+            // are all kernel-started (REMOVED). Advertising one to the Linux
+            // sidecar driver via the device tree while its VPs are also
+            // kernel-started via `boot_cpus=` makes the driver and the
+            // kernel-start path contend over the same VP and hang AP bring-up.
+            // If one ever reaches sidecar, fail loudly here.
+            if !cpu_status[1..vp_count as usize]
+                .iter()
+                .any(|status| status.load(Relaxed) == CpuStatus::RUN.0)
+            {
+                panic!(
+                    "sidecar node {node_index} (base_vp={base_vp}, vp_count={vp_count}) has no sidecar-started APs"
+                );
+            }
         }
 
         node_init.push(NodeInit {

--- a/openhcl/sidecar/src/arch/x86_64/init.rs
+++ b/openhcl/sidecar/src/arch/x86_64/init.rs
@@ -352,9 +352,13 @@ fn init(
             // kernel-started via `boot_cpus=` makes the driver and the
             // kernel-start path contend over the same VP and hang AP bring-up.
             // If one ever reaches sidecar, fail loudly here.
-            if !cpu_status[1..vp_count as usize]
-                .iter()
-                .any(|status| status.load(Relaxed) == CpuStatus::RUN.0)
+            //
+            // Only nodes that actually have APs (vp_count > 1) can be "empty" in
+            // this sense; a single-VP node legitimately has no APs to start.
+            if vp_count > 1
+                && !cpu_status[1..vp_count as usize]
+                    .iter()
+                    .any(|status| status.load(Relaxed) == CpuStatus::RUN.0)
             {
                 panic!(
                     "sidecar node {node_index} (base_vp={base_vp}, vp_count={vp_count}) has no sidecar-started APs"

--- a/openhcl/sidecar/src/arch/x86_64/init.rs
+++ b/openhcl/sidecar/src/arch/x86_64/init.rs
@@ -352,13 +352,9 @@ fn init(
             // kernel-started via `boot_cpus=` makes the driver and the
             // kernel-start path contend over the same VP and hang AP bring-up.
             // If one ever reaches sidecar, fail loudly here.
-            //
-            // Only nodes that actually have APs (vp_count > 1) can be "empty" in
-            // this sense; a single-VP node legitimately has no APs to start.
-            if vp_count > 1
-                && !cpu_status[1..vp_count as usize]
-                    .iter()
-                    .any(|status| status.load(Relaxed) == CpuStatus::RUN.0)
+            if !cpu_status[1..vp_count as usize]
+                .iter()
+                .any(|status| status.load(Relaxed) == CpuStatus::RUN.0)
             {
                 panic!(
                     "sidecar node {node_index} (base_vp={base_vp}, vp_count={vp_count}) has no sidecar-started APs"


### PR DESCRIPTION
On OpenHCL servicing restore with NVMe keepalive, per-CPU overrides can leave a NUMA node with all its APs kernel-started. Sidecar still advertised such "empty" nodes to the Linux sidecar driver, which then contended with the kernel's boot_cpus= start over the same VP and hung AP bring-up — the intermittent servicing_keepalive_* hangs.

* openhcl_boot: skip creating empty sidecar nodes (their VPs are kernel-started instead); disable sidecar entirely if all nodes are empty.
* sidecar: panic loudly if handed a node with no sidecar-started APs, rather than hanging.