### PR TITLE
CI/igvmfilegen: Support overriding CVM diagnostics on release builds, do so in CI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3757,6 +3757,7 @@ dependencies = [
  "thiserror 2.0.16",
  "tracing",
  "tracing-subscriber",
+ "underhill_confidentiality",
  "vbs_defs",
  "x86defs",
  "zerocopy",

--- a/flowey/flowey_hvlite/src/pipelines/build_igvm.rs
+++ b/flowey/flowey_hvlite/src/pipelines/build_igvm.rs
@@ -137,7 +137,11 @@ pub struct BuildIgvmCliCustomizations {
     /// Enable confidential diagnostics by adding `OPENHCL_CONFIDENTIAL_DEBUG=1`
     /// to the measured OpenHCL command line. This disables the diagnostic
     /// filtering that CVM release builds otherwise apply, so
-    /// diagnostics remain available. Only meaningful for CVM recipes.
+    /// diagnostics remain available
+    ///
+    /// WARNING: This is security-sensitive. OpenHCL uses this flag to decide
+    /// whether it can trust host-provided boot options for isolated guests.
+    /// Only enable this flag if you understand the security implications.
     #[clap(long)]
     pub confidential_debug: bool,
 

--- a/flowey/flowey_hvlite/src/pipelines/build_igvm.rs
+++ b/flowey/flowey_hvlite/src/pipelines/build_igvm.rs
@@ -134,6 +134,13 @@ pub struct BuildIgvmCliCustomizations {
     #[clap(long)]
     pub disable_secure_avic: bool,
 
+    /// Enable confidential diagnostics by adding `OPENHCL_CONFIDENTIAL_DEBUG=1`
+    /// to the measured OpenHCL command line. This disables the diagnostic
+    /// filtering that CVM release builds otherwise apply, so
+    /// diagnostics remain available. Only meaningful for CVM recipes.
+    #[clap(long)]
+    pub confidential_debug: bool,
+
     /// Path to custom openvmm_hcl binary, none means openhcl will be built.
     #[clap(long)]
     pub custom_openvmm_hcl: Option<PathBuf>,
@@ -304,6 +311,7 @@ impl IntoPipeline for BuildIgvmCli {
                     with_debuginfo,
                     with_mi_secure,
                     disable_secure_avic,
+                    confidential_debug,
                     custom_openvmm_hcl,
                     custom_openhcl_boot,
                     custom_uefi,
@@ -439,6 +447,7 @@ impl IntoPipeline for BuildIgvmCli {
                 with_debuginfo,
                 with_mi_secure,
                 disable_secure_avic,
+                confidential_debug,
                 override_kernel_pkg: override_kernel_pkg.map(|p| match p {
                     KernelPackageKindCli::Main => OpenhclKernelPackage::Main,
                     KernelPackageKindCli::Cvm => OpenhclKernelPackage::Cvm,

--- a/flowey/flowey_hvlite/src/pipelines/build_reproducible.rs
+++ b/flowey/flowey_hvlite/src/pipelines/build_reproducible.rs
@@ -126,6 +126,7 @@ impl IntoPipeline for BuildReproducibleCli {
                         custom_target: Some(CommonTriple::Custom(openhcl_musl_target(recipe_arch))),
                         extra_features: BTreeSet::new(),
                         release_cfg: release,
+                        confidential_debug: false,
                     },
                     ctx.publish_typed_artifact(pub_openhcl_igvm),
                     ctx.publish_typed_artifact(pub_openhcl_igvm_extras),

--- a/flowey/flowey_hvlite/src/pipelines/checkin_gates.rs
+++ b/flowey/flowey_hvlite/src/pipelines/checkin_gates.rs
@@ -1129,6 +1129,9 @@ impl IntoPipeline for CheckinGatesCli {
                                         // VTL2 memory) since mi-secure adds overhead that may not fit in
                                         // the tighter release memory budget.
                                         release_cfg: release && !mi_secure,
+                                        // Enable confidential diagnostics on the CVM IGVM
+                                        // consumed by the VMM tests.
+                                        confidential_debug: true,
                                     },
                                     ctx.publish_typed_artifact(pub_openhcl_igvm),
                                     ctx.publish_typed_artifact(pub_openhcl_igvm_extras),

--- a/flowey/flowey_lib_hvlite/src/_jobs/build_and_publish_openhcl_igvm_from_recipe.rs
+++ b/flowey/flowey_lib_hvlite/src/_jobs/build_and_publish_openhcl_igvm_from_recipe.rs
@@ -30,6 +30,10 @@ pub struct OpenhclIgvmBuildParams {
     pub extra_features: BTreeSet<OpenvmmHclFeature>,
     /// Whether to use release configuration (release manifests, no gdb, etc.).
     pub release_cfg: bool,
+    /// Add the confidential debug flag to the measured OpenHCL command line,
+    /// enabling confidential diagnostics on CVM builds. Used by the
+    /// VMM tests so that release CVM IGVMs still emit diagnostics.
+    pub confidential_debug: bool,
 }
 
 flowey_request! {
@@ -81,6 +85,7 @@ impl SimpleFlowNode for Node {
                 custom_target,
                 extra_features,
                 release_cfg,
+                confidential_debug,
             },
             openhcl_igvm,
             openhcl_igvm_extras,
@@ -93,6 +98,7 @@ impl SimpleFlowNode for Node {
                 recipe: OpenhclIgvmRecipeType::WellKnown(recipe.clone()),
                 extra_features: extra_features.clone(),
                 disable_secure_avic: false,
+                confidential_debug,
                 openhcl_igvm,
                 openhcl_igvm_extras,
             });

--- a/flowey/flowey_lib_hvlite/src/_jobs/local_build_and_run_nextest_vmm_tests.rs
+++ b/flowey/flowey_lib_hvlite/src/_jobs/local_build_and_run_nextest_vmm_tests.rs
@@ -270,6 +270,7 @@ impl SimpleFlowNode for Node {
                     custom_target: None,
                     extra_features: BTreeSet::new(),
                     disable_secure_avic,
+                    confidential_debug: true,
                     openhcl_igvm,
                     openhcl_igvm_extras,
                 });

--- a/flowey/flowey_lib_hvlite/src/_jobs/local_build_igvm.rs
+++ b/flowey/flowey_lib_hvlite/src/_jobs/local_build_igvm.rs
@@ -34,6 +34,7 @@ pub struct Customizations {
     pub custom_sidecar: Option<PathBuf>,
     pub custom_vtl0_kernel: Option<PathBuf>,
     pub custom_extra_rootfs: Vec<PathBuf>,
+    pub confidential_debug: bool,
     pub disable_secure_avic: bool,
     pub override_arch: Option<CommonArch>,
     pub override_kernel_pkg: Option<OpenhclKernelPackage>,
@@ -96,6 +97,7 @@ impl SimpleFlowNode for Node {
             override_kernel_pkg,
             override_openvmm_hcl_feature,
             override_max_trace_level,
+            confidential_debug,
             disable_secure_avic,
             with_debuginfo,
             with_mi_secure,
@@ -251,6 +253,7 @@ impl SimpleFlowNode for Node {
             custom_target: None,
             extra_features: BTreeSet::new(),
             disable_secure_avic,
+            confidential_debug,
             openhcl_igvm: write_openhcl_igvm,
             openhcl_igvm_extras: write_openhcl_igvm_extras,
         });

--- a/flowey/flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs
+++ b/flowey/flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs
@@ -527,6 +527,9 @@ flowey_request! {
         /// Additional features to enable on top of the recipe's defaults.
         pub extra_features: BTreeSet<OpenvmmHclFeature>,
         pub disable_secure_avic: bool,
+        /// Add the confidential debug flag to the measured OpenHCL command
+        /// line, enabling confidential diagnostics on CVM builds.
+        pub confidential_debug: bool,
 
         pub openhcl_igvm: WriteVar<OpenhclIgvmOutput>,
         pub openhcl_igvm_extras: WriteVar<OpenhclIgvmExtrasOutput>,
@@ -562,6 +565,7 @@ impl SimpleFlowNode for Node {
             custom_target,
             extra_features,
             disable_secure_avic,
+            confidential_debug,
             openhcl_igvm,
             openhcl_igvm_extras,
         } = request;
@@ -909,6 +913,7 @@ impl SimpleFlowNode for Node {
             manifest,
             resources,
             disable_secure_avic,
+            confidential_debug,
             igvm: v,
         });
 

--- a/flowey/flowey_lib_hvlite/src/run_igvmfilegen.rs
+++ b/flowey/flowey_lib_hvlite/src/run_igvmfilegen.rs
@@ -27,6 +27,10 @@ flowey_request! {
         pub resources: ReadVar<BTreeMap<ResourceType, PathBuf>>,
         /// Whether to patch the manifest to set secure_avic to disabled
         pub disable_secure_avic: bool,
+        /// Whether to add the confidential debug flag to the measured OpenHCL
+        /// command line, enabling confidential diagnostics on CVM builds even
+        /// in release builds.
+        pub confidential_debug: bool,
         /// Output path of generated igvm file
         pub igvm: WriteVar<IgvmOutput>,
     }
@@ -45,6 +49,7 @@ impl SimpleFlowNode for Node {
             manifest,
             resources,
             disable_secure_avic,
+            confidential_debug,
             igvm,
         } = request;
 
@@ -79,6 +84,10 @@ impl SimpleFlowNode for Node {
 
                 if disable_secure_avic {
                     cmd = cmd.arg("--disable-secure-avic");
+                }
+
+                if confidential_debug {
+                    cmd = cmd.arg("--confidential-debug");
                 }
 
                 cmd.run()?;

--- a/vm/loader/igvmfilegen/Cargo.toml
+++ b/vm/loader/igvmfilegen/Cargo.toml
@@ -14,6 +14,7 @@ loader_defs.workspace = true
 hvdef.workspace = true
 
 memory_range.workspace = true
+underhill_confidentiality.workspace = true
 vbs_defs.workspace = true
 x86defs.workspace = true
 

--- a/vm/loader/igvmfilegen/src/main.rs
+++ b/vm/loader/igvmfilegen/src/main.rs
@@ -47,6 +47,7 @@ use std::io::Write;
 use std::path::PathBuf;
 use tracing_subscriber::EnvFilter;
 use tracing_subscriber::filter::LevelFilter;
+use underhill_confidentiality::OPENHCL_CONFIDENTIAL_DEBUG_ENV_VAR_NAME;
 use zerocopy::FromBytes;
 use zerocopy::IntoBytes;
 
@@ -78,6 +79,11 @@ enum Options {
         /// Override secure AVIC to disabled for debug SNP guest configs
         #[clap(long)]
         disable_secure_avic: bool,
+        /// Add the confidential debug flag to the measured OpenHCL command
+        /// line, enabling confidential diagnostics on CVM guest configs even
+        /// in release builds.
+        #[clap(long)]
+        confidential_debug: bool,
     },
 }
 
@@ -116,6 +122,7 @@ fn main() -> anyhow::Result<()> {
             output,
             debug_validation,
             disable_secure_avic,
+            confidential_debug,
         } => {
             // Read the config from the JSON manifest path.
             let mut config: Config = serde_json::from_str(
@@ -129,6 +136,20 @@ fn main() -> anyhow::Result<()> {
                         &mut guest_config.isolation_type
                     {
                         *secure_avic = SecureAvicType::Disabled;
+                    }
+                }
+            }
+
+            if confidential_debug {
+                for guest_config in &mut config.guest_configs {
+                    if let Image::Openhcl { command_line, .. } = &mut guest_config.image {
+                        if !command_line.contains(OPENHCL_CONFIDENTIAL_DEBUG_ENV_VAR_NAME) {
+                            if !command_line.is_empty() {
+                                command_line.push(' ');
+                            }
+                            command_line.push_str(OPENHCL_CONFIDENTIAL_DEBUG_ENV_VAR_NAME);
+                            command_line.push_str("=1");
+                        }
                     }
                 }
             }

--- a/vm/loader/igvmfilegen/src/main.rs
+++ b/vm/loader/igvmfilegen/src/main.rs
@@ -143,13 +143,11 @@ fn main() -> anyhow::Result<()> {
             if confidential_debug {
                 for guest_config in &mut config.guest_configs {
                     if let Image::Openhcl { command_line, .. } = &mut guest_config.image {
-                        if !command_line.contains(OPENHCL_CONFIDENTIAL_DEBUG_ENV_VAR_NAME) {
-                            if !command_line.is_empty() {
-                                command_line.push(' ');
-                            }
-                            command_line.push_str(OPENHCL_CONFIDENTIAL_DEBUG_ENV_VAR_NAME);
-                            command_line.push_str("=1");
+                        if !command_line.is_empty() {
+                            command_line.push(' ');
                         }
+                        command_line.push_str(OPENHCL_CONFIDENTIAL_DEBUG_ENV_VAR_NAME);
+                        command_line.push_str("=1");
                     }
                 }
             }

--- a/vm/loader/igvmfilegen/src/main.rs
+++ b/vm/loader/igvmfilegen/src/main.rs
@@ -82,6 +82,10 @@ enum Options {
         /// Add the confidential debug flag to the measured OpenHCL command
         /// line, enabling confidential diagnostics on CVM guest configs even
         /// in release builds.
+        ///
+        /// WARNING: This is security-sensitive. OpenHCL uses this flag to decide
+        /// whether it can trust host-provided boot options for isolated guests.
+        /// Only enable this flag if you understand the security implications.
         #[clap(long)]
         confidential_debug: bool,
     },


### PR DESCRIPTION
This PR adds a new patch option to igvmfilegen to insert the confidential debugging flag into an igvm command line during its build. This allows us to enable confidential diagnostics on release CVM builds. This must be done during IGVM generation time, as a release build will not trust any signal coming from the host later. Then set this new flag during CI runs.

This should not affect anything we ship, as the onebranch pipelines will not be setting this new flag.