### PR TITLE
pci: replace `secondary_bus_number` with `access_type` in *_with_routing variants

### DIFF
--- a/openvmm/openvmm_core/src/worker/dispatch.rs
+++ b/openvmm/openvmm_core/src/worker/dispatch.rs
@@ -26,6 +26,7 @@ use cfg_if::cfg_if;
 use chipset_device::io::IoResult;
 use chipset_device::pci::ByteEnabledDwordRead;
 use chipset_device::pci::ByteEnabledDwordWrite;
+use chipset_device::pci::PciConfigAddress;
 use chipset_device_resources::IRQ_LINE_SET;
 use chipset_resources::LEGACY_CHIPSET_PCI_BUS_NAME;
 use chipset_resources::cmos_rtc_time_source::SystemTimeClockHandle;
@@ -4181,12 +4182,9 @@ impl pci_bus::GenericPciBusDevice for WeakMutexPciBusDevice {
         )
     }
 
-    fn pci_cfg_read_with_routing(
+    fn pci_cfg_type0_read(
         &mut self,
-        secondary_bus: u8,
-        target_bus: u8,
-        function: u8,
-        offset: u16,
+        address: PciConfigAddress,
         value: ByteEnabledDwordRead<'_>,
     ) -> Option<IoResult> {
         Some(
@@ -4194,16 +4192,13 @@ impl pci_bus::GenericPciBusDevice for WeakMutexPciBusDevice {
                 .upgrade()?
                 .lock()
                 .supports_pci()?
-                .pci_cfg_read_with_routing(secondary_bus, target_bus, function, offset, value),
+                .pci_cfg_type0_read(address, value),
         )
     }
 
-    fn pci_cfg_write_with_routing(
+    fn pci_cfg_type0_write(
         &mut self,
-        secondary_bus: u8,
-        target_bus: u8,
-        function: u8,
-        offset: u16,
+        address: PciConfigAddress,
         value: ByteEnabledDwordWrite,
     ) -> Option<IoResult> {
         Some(
@@ -4211,7 +4206,35 @@ impl pci_bus::GenericPciBusDevice for WeakMutexPciBusDevice {
                 .upgrade()?
                 .lock()
                 .supports_pci()?
-                .pci_cfg_write_with_routing(secondary_bus, target_bus, function, offset, value),
+                .pci_cfg_type0_write(address, value),
+        )
+    }
+
+    fn pci_cfg_type1_read(
+        &mut self,
+        address: PciConfigAddress,
+        value: ByteEnabledDwordRead<'_>,
+    ) -> Option<IoResult> {
+        Some(
+            self.0
+                .upgrade()?
+                .lock()
+                .supports_pci()?
+                .pci_cfg_type1_read(address, value),
+        )
+    }
+
+    fn pci_cfg_type1_write(
+        &mut self,
+        address: PciConfigAddress,
+        value: ByteEnabledDwordWrite,
+    ) -> Option<IoResult> {
+        Some(
+            self.0
+                .upgrade()?
+                .lock()
+                .supports_pci()?
+                .pci_cfg_type1_write(address, value),
         )
     }
 }

--- a/openvmm/openvmm_core/src/worker/dispatch.rs
+++ b/openvmm/openvmm_core/src/worker/dispatch.rs
@@ -26,6 +26,7 @@ use cfg_if::cfg_if;
 use chipset_device::io::IoResult;
 use chipset_device::pci::ByteEnabledDwordRead;
 use chipset_device::pci::ByteEnabledDwordWrite;
+use chipset_device::pci::PciConfigAccessType;
 use chipset_device::pci::PciConfigAddress;
 use chipset_device_resources::IRQ_LINE_SET;
 use chipset_resources::LEGACY_CHIPSET_PCI_BUS_NAME;
@@ -4182,8 +4183,9 @@ impl pci_bus::GenericPciBusDevice for WeakMutexPciBusDevice {
         )
     }
 
-    fn pci_cfg_type0_read(
+    fn pci_cfg_read_with_routing(
         &mut self,
+        access_type: PciConfigAccessType,
         address: PciConfigAddress,
         value: ByteEnabledDwordRead<'_>,
     ) -> Option<IoResult> {
@@ -4192,12 +4194,13 @@ impl pci_bus::GenericPciBusDevice for WeakMutexPciBusDevice {
                 .upgrade()?
                 .lock()
                 .supports_pci()?
-                .pci_cfg_type0_read(address, value),
+                .pci_cfg_read_with_routing(access_type, address, value),
         )
     }
 
-    fn pci_cfg_type0_write(
+    fn pci_cfg_write_with_routing(
         &mut self,
+        access_type: PciConfigAccessType,
         address: PciConfigAddress,
         value: ByteEnabledDwordWrite,
     ) -> Option<IoResult> {
@@ -4206,35 +4209,7 @@ impl pci_bus::GenericPciBusDevice for WeakMutexPciBusDevice {
                 .upgrade()?
                 .lock()
                 .supports_pci()?
-                .pci_cfg_type0_write(address, value),
-        )
-    }
-
-    fn pci_cfg_type1_read(
-        &mut self,
-        address: PciConfigAddress,
-        value: ByteEnabledDwordRead<'_>,
-    ) -> Option<IoResult> {
-        Some(
-            self.0
-                .upgrade()?
-                .lock()
-                .supports_pci()?
-                .pci_cfg_type1_read(address, value),
-        )
-    }
-
-    fn pci_cfg_type1_write(
-        &mut self,
-        address: PciConfigAddress,
-        value: ByteEnabledDwordWrite,
-    ) -> Option<IoResult> {
-        Some(
-            self.0
-                .upgrade()?
-                .lock()
-                .supports_pci()?
-                .pci_cfg_type1_write(address, value),
+                .pci_cfg_write_with_routing(access_type, address, value),
         )
     }
 }

--- a/vm/chipset_device/src/pci.rs
+++ b/vm/chipset_device/src/pci.rs
@@ -336,6 +336,17 @@ impl PciConfigAddress {
     }
 }
 
+/// Represents the type of PCI configuration space access.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Inspect)]
+pub enum PciConfigAccessType {
+    /// Type 0 PCI configuration space access. Type 0 accesses have
+    /// been fully routed to the target bus number.
+    Type0,
+    /// Type 1 PCI configuration space access. Type 1 accesses have
+    /// not been fully routed to the target bus number.
+    Type1,
+}
+
 /// Implemented by devices which have a PCI config space.
 pub trait PciConfigSpace: ChipsetDevice {
     /// Dispatch a PCI config space read to the device with the given address.
@@ -343,7 +354,8 @@ pub trait PciConfigSpace: ChipsetDevice {
     /// This function serves as a shorthand that single-function endpoint devices
     /// can implement directly. More advanced routing components (switches, bridges)
     /// and multi-function devices should instead implement
-    /// [`pci_cfg_type0_read`](Self::pci_cfg_type0_read) for full routing context.
+    /// [`pci_cfg_read_with_routing`](Self::pci_cfg_read_with_routing) for full
+    /// routing context.
     ///
     /// `byte_offset` is guaranteed to be aligned to a 4-byte boundary.
     fn pci_cfg_read(&mut self, byte_offset: u16, value: ByteEnabledDwordRead<'_>) -> IoResult;
@@ -353,110 +365,66 @@ pub trait PciConfigSpace: ChipsetDevice {
     /// This function serves as a shorthand that single-function endpoint devices
     /// can implement directly. More advanced routing components (switches, bridges)
     /// and multi-function devices should instead implement
-    /// [`pci_cfg_type0_write`](Self::pci_cfg_type0_write) for full routing context.
+    /// [`pci_cfg_write_with_routing`](Self::pci_cfg_write_with_routing) for full
+    /// routing context.
     ///
     /// `byte_offset` is guaranteed to be aligned to a 4-byte boundary.
     fn pci_cfg_write(&mut self, byte_offset: u16, value: ByteEnabledDwordWrite) -> IoResult;
 
-    /// Handle a Type 0 PCI configuration space read with full routing context.
+    /// Dispatch a PCI configuration space read with full routing context.
     ///
-    /// This method receives configuration space accesses with the target bus,
-    /// packed device/function number, and DWORD offset. For a device directly
-    /// behind a PCIe port, the device number is always zero and `devfn`
-    /// identifies the function within that endpoint.
+    /// This method receives configuration space read with the access type,
+    /// target bus, target device/function number, and DWORD offset.
     ///
-    /// The default implementation dispatches function 0 to
+    /// The default implementation dispatches type 0 access to function 0 to
     /// [`pci_cfg_read`](Self::pci_cfg_read) and returns all-1s for other
     /// functions (the standard "no device present" response). Routing
     /// components (switches, bridges) and multi-function devices should
     /// override this method.
     ///
     /// # Parameters
+    /// - `access_type`: The type of PCI configuration space access (Type 0 or Type 1)
     /// - `address`: The target address (BDF + offset) being accessed
     /// - `value`: Byte-enabled DWORD value to receive the read
-    fn pci_cfg_type0_read(
+    fn pci_cfg_read_with_routing(
         &mut self,
+        access_type: PciConfigAccessType,
         address: PciConfigAddress,
         mut value: ByteEnabledDwordRead<'_>,
     ) -> IoResult {
-        if address.devfn == 0 {
-            self.pci_cfg_read(address.byte_offset(), value)
-        } else {
-            value.set(!0);
-            IoResult::Ok
+        match (access_type, address.devfn) {
+            (PciConfigAccessType::Type0, 0) => self.pci_cfg_read(address.byte_offset(), value),
+            _ => {
+                value.set(!0);
+                IoResult::Ok
+            }
         }
     }
 
-    /// Handle a Type 0 PCI configuration space write with full routing context.
+    /// Dispatch a PCI configuration space write with full routing context.
     ///
-    /// This method receives configuration space accesses with the target bus,
-    /// packed device/function number, and DWORD offset. For a device directly
-    /// behind a PCIe port, the device number is always zero and `devfn`
-    /// identifies the function within that endpoint.
+    /// This method receives configuration space write with the access type,
+    /// target bus, target device/function number, and DWORD offset.
     ///
-    /// The default implementation dispatches function 0 to
+    /// The default implementation dispatches type 0 access to function 0 to
     /// [`pci_cfg_write`](Self::pci_cfg_write) and silently drops writes to
     /// other functions. Routing components (switches, bridges) and
     /// multi-function devices should override this method.
     ///
     /// # Parameters
+    /// - `access_type`: The type of PCI configuration space access (Type 0 or Type 1)
     /// - `address`: The target address (BDF + offset) being accessed
     /// - `value`: Byte-enabled DWORD value to write
-    fn pci_cfg_type0_write(
+    fn pci_cfg_write_with_routing(
         &mut self,
+        access_type: PciConfigAccessType,
         address: PciConfigAddress,
         value: ByteEnabledDwordWrite,
     ) -> IoResult {
-        if address.devfn == 0 {
-            self.pci_cfg_write(address.byte_offset(), value)
-        } else {
-            IoResult::Ok
+        match (access_type, address.devfn) {
+            (PciConfigAccessType::Type0, 0) => self.pci_cfg_write(address.byte_offset(), value),
+            _ => IoResult::Ok,
         }
-    }
-
-    /// Handle a Type 1 PCI configuration space read with full routing context.
-    ///
-    /// This method receives configuration space accesses with the target bus,
-    /// packed device/function number, and DWORD offset. For a device directly
-    /// behind a PCIe port, the device number is always zero and `devfn`
-    /// identifies the function within that endpoint.
-    ///
-    /// The default implementation returns all-1s. Routing components (switches,
-    /// bridges) and multi-function devices that span bus numbers should override
-    /// this method.
-    ///
-    /// # Parameters
-    /// - `address`: The target address (BDF + offset) being accessed
-    /// - `value`: Byte-enabled DWORD value to receive the read
-    fn pci_cfg_type1_read(
-        &mut self,
-        _address: PciConfigAddress,
-        mut value: ByteEnabledDwordRead<'_>,
-    ) -> IoResult {
-        value.set(!0);
-        IoResult::Ok
-    }
-
-    /// Handle a Type 1 PCI configuration space write with full routing context.
-    ///
-    /// This method receives configuration space accesses with the target bus,
-    /// packed device/function number, and DWORD offset. For a device directly
-    /// behind a PCIe port, the device number is always zero and `devfn`
-    /// identifies the function within that endpoint.
-    ///
-    /// The default implementation drops writes. Routing components (switches,
-    /// bridges) and multi-function devices that span bus numbers should override
-    /// this method.
-    ///
-    /// # Parameters
-    /// - `address`: The target address (BDF + offset) being accessed
-    /// - `value`: Byte-enabled DWORD value to write
-    fn pci_cfg_type1_write(
-        &mut self,
-        _address: PciConfigAddress,
-        _value: ByteEnabledDwordWrite,
-    ) -> IoResult {
-        IoResult::Ok
     }
 
     /// Check if the device has a suggested (bus, device, function) it expects

--- a/vm/chipset_device/src/pci.rs
+++ b/vm/chipset_device/src/pci.rs
@@ -345,7 +345,7 @@ pub trait PciConfigSpace: ChipsetDevice {
     /// and multi-function devices should instead implement
     /// [`pci_cfg_type0_read`](Self::pci_cfg_type0_read) for full routing context.
     ///
-    /// `byte_offset` is guaranteed be aligned to a 4-byte boundary.
+    /// `byte_offset` is guaranteed to be aligned to a 4-byte boundary.
     fn pci_cfg_read(&mut self, byte_offset: u16, value: ByteEnabledDwordRead<'_>) -> IoResult;
 
     /// Dispatch a PCI config space write to the device with the given address.
@@ -355,7 +355,7 @@ pub trait PciConfigSpace: ChipsetDevice {
     /// and multi-function devices should instead implement
     /// [`pci_cfg_type0_write`](Self::pci_cfg_type0_write) for full routing context.
     ///
-    /// `byte_offset` is guaranteed be aligned to a 4-byte boundary.
+    /// `byte_offset` is guaranteed to be aligned to a 4-byte boundary.
     fn pci_cfg_write(&mut self, byte_offset: u16, value: ByteEnabledDwordWrite) -> IoResult;
 
     /// Handle a Type 0 PCI configuration space read with full routing context.

--- a/vm/chipset_device/src/pci.rs
+++ b/vm/chipset_device/src/pci.rs
@@ -302,32 +302,32 @@ pub struct PciConfigAddress {
     /// Target bus number.
     pub bus: u8,
     /// Target packed device/function number (`device << 3 | function`).
-    pub device_function: u8,
+    pub devfn: u8,
     /// Aligned DWORD register number in configuration space.
     dword_number: u16,
 }
 
 impl PciConfigAddress {
     /// Create a new PCI configuration-space request.
-    pub const fn new(bus: u8, device_function: u8, dword_number: u16) -> Option<Self> {
+    pub const fn new(bus: u8, devfn: u8, dword_number: u16) -> Option<Self> {
         if dword_number >= 1024 {
             return None;
         }
         Some(Self {
             bus,
-            device_function,
+            devfn,
             dword_number,
         })
     }
 
     /// Target device number.
     pub const fn device(self) -> u8 {
-        self.device_function >> 3
+        self.devfn >> 3
     }
 
     /// Target function number.
     pub const fn function(self) -> u8 {
-        self.device_function & 0x7
+        self.devfn & 0x7
     }
 
     /// Aligned byte offset of the addressed DWORD in configuration space.
@@ -339,25 +339,31 @@ impl PciConfigAddress {
 /// Implemented by devices which have a PCI config space.
 pub trait PciConfigSpace: ChipsetDevice {
     /// Dispatch a PCI config space read to the device with the given address.
-    fn pci_cfg_read(&mut self, offset: u16, value: ByteEnabledDwordRead<'_>) -> IoResult;
-    /// Dispatch a PCI config space write to the device with the given address.
-    fn pci_cfg_write(&mut self, offset: u16, value: ByteEnabledDwordWrite) -> IoResult;
+    ///
+    /// This function serves as a shorthand that single-function endpoint devices
+    /// can implement directly. More advanced routing components (switches, bridges)
+    /// and multi-function devices should instead implement
+    /// [`pci_cfg_type0_read`](Self::pci_cfg_type0_read) for full routing context.
+    ///
+    /// `byte_offset` is guaranteed be aligned to a 4-byte boundary.
+    fn pci_cfg_read(&mut self, byte_offset: u16, value: ByteEnabledDwordRead<'_>) -> IoResult;
 
-    /// Handle a PCI configuration space read with full routing context.
+    /// Dispatch a PCI config space write to the device with the given address.
     ///
-    /// This method receives configuration space accesses with the target bus
-    /// and function number. The interpretation of `function` depends on the
-    /// bus topology: on a legacy PCI bus it carries packed device/function
-    /// bits (0..=255), while downstream of a PCIe port the device number is
-    /// always zero so all 8 bits represent functions within a single
-    /// endpoint.
+    /// This function serves as a shorthand that single-function endpoint devices
+    /// can implement directly. More advanced routing components (switches, bridges)
+    /// and multi-function devices should instead implement
+    /// [`pci_cfg_type0_write`](Self::pci_cfg_type0_write) for full routing context.
     ///
-    /// A device can distinguish Type 0 (local) from Type 1 (forwarded)
-    /// configuration cycles by comparing `target_bus` and `secondary_bus`:
-    /// when they are equal the access targets this device directly (Type 0),
-    /// otherwise it should be routed downstream (Type 1). An SR-IOV
-    /// capable device can use `secondary_bus` together with `target_bus` and
-    /// `function` to compute the VF number.
+    /// `byte_offset` is guaranteed be aligned to a 4-byte boundary.
+    fn pci_cfg_write(&mut self, byte_offset: u16, value: ByteEnabledDwordWrite) -> IoResult;
+
+    /// Handle a Type 0 PCI configuration space read with full routing context.
+    ///
+    /// This method receives configuration space accesses with the target bus,
+    /// packed device/function number, and DWORD offset. For a device directly
+    /// behind a PCIe port, the device number is always zero and `devfn`
+    /// identifies the function within that endpoint.
     ///
     /// The default implementation dispatches function 0 to
     /// [`pci_cfg_read`](Self::pci_cfg_read) and returns all-1s for other
@@ -366,44 +372,27 @@ pub trait PciConfigSpace: ChipsetDevice {
     /// override this method.
     ///
     /// # Parameters
-    /// - `secondary_bus`: The secondary bus number of the downstream port
-    ///   that forwarded this access
-    /// - `target_bus`: The bus number targeted by the configuration access
-    /// - `function`: Device/function identifier — packed device/function on
-    ///   a legacy bus, or flat function number on PCIe
-    /// - `offset`: Configuration space offset
-    /// - `value`: Pointer to receive the read value
-    fn pci_cfg_read_with_routing(
+    /// - `address`: The target address (BDF + offset) being accessed
+    /// - `value`: Byte-enabled DWORD value to receive the read
+    fn pci_cfg_type0_read(
         &mut self,
-        secondary_bus: u8,
-        target_bus: u8,
-        function: u8,
-        offset: u16,
+        address: PciConfigAddress,
         mut value: ByteEnabledDwordRead<'_>,
     ) -> IoResult {
-        if secondary_bus == target_bus && function == 0 {
-            self.pci_cfg_read(offset, value)
+        if address.devfn == 0 {
+            self.pci_cfg_read(address.byte_offset(), value)
         } else {
             value.set(!0);
             IoResult::Ok
         }
     }
 
-    /// Handle a PCI configuration space write with full routing context.
+    /// Handle a Type 0 PCI configuration space write with full routing context.
     ///
-    /// This method receives configuration space accesses with the target bus
-    /// and function number. The interpretation of `function` depends on the
-    /// bus topology: on a legacy PCI bus it carries packed device/function
-    /// bits (0..=255), while downstream of a PCIe port the device number is
-    /// always zero so all 8 bits represent functions within a single
-    /// endpoint.
-    ///
-    /// A device can distinguish Type 0 (local) from Type 1 (forwarded)
-    /// configuration cycles by comparing `target_bus` and `secondary_bus`:
-    /// when they are equal the access targets this device directly (Type 0),
-    /// otherwise it should be routed downstream (Type 1). An SR-IOV
-    /// capable device can use `secondary_bus` together with `target_bus` and
-    /// `function` to compute the VF number.
+    /// This method receives configuration space accesses with the target bus,
+    /// packed device/function number, and DWORD offset. For a device directly
+    /// behind a PCIe port, the device number is always zero and `devfn`
+    /// identifies the function within that endpoint.
     ///
     /// The default implementation dispatches function 0 to
     /// [`pci_cfg_write`](Self::pci_cfg_write) and silently drops writes to
@@ -411,26 +400,63 @@ pub trait PciConfigSpace: ChipsetDevice {
     /// multi-function devices should override this method.
     ///
     /// # Parameters
-    /// - `secondary_bus`: The secondary bus number of the downstream port
-    ///   that forwarded this access
-    /// - `target_bus`: The bus number targeted by the configuration access
-    /// - `function`: Device/function identifier — packed device/function on
-    ///   a legacy bus, or flat function number on PCIe
-    /// - `offset`: Configuration space offset
-    /// - `value`: Value to write
-    fn pci_cfg_write_with_routing(
+    /// - `address`: The target address (BDF + offset) being accessed
+    /// - `value`: Byte-enabled DWORD value to write
+    fn pci_cfg_type0_write(
         &mut self,
-        secondary_bus: u8,
-        target_bus: u8,
-        function: u8,
-        offset: u16,
+        address: PciConfigAddress,
         value: ByteEnabledDwordWrite,
     ) -> IoResult {
-        if secondary_bus == target_bus && function == 0 {
-            self.pci_cfg_write(offset, value)
+        if address.devfn == 0 {
+            self.pci_cfg_write(address.byte_offset(), value)
         } else {
             IoResult::Ok
         }
+    }
+
+    /// Handle a Type 1 PCI configuration space read with full routing context.
+    ///
+    /// This method receives configuration space accesses with the target bus,
+    /// packed device/function number, and DWORD offset. For a device directly
+    /// behind a PCIe port, the device number is always zero and `devfn`
+    /// identifies the function within that endpoint.
+    ///
+    /// The default implementation returns all-1s. Routing components (switches,
+    /// bridges) and multi-function devices that span bus numbers should override
+    /// this method.
+    ///
+    /// # Parameters
+    /// - `address`: The target address (BDF + offset) being accessed
+    /// - `value`: Byte-enabled DWORD value to receive the read
+    fn pci_cfg_type1_read(
+        &mut self,
+        _address: PciConfigAddress,
+        mut value: ByteEnabledDwordRead<'_>,
+    ) -> IoResult {
+        value.set(!0);
+        IoResult::Ok
+    }
+
+    /// Handle a Type 1 PCI configuration space write with full routing context.
+    ///
+    /// This method receives configuration space accesses with the target bus,
+    /// packed device/function number, and DWORD offset. For a device directly
+    /// behind a PCIe port, the device number is always zero and `devfn`
+    /// identifies the function within that endpoint.
+    ///
+    /// The default implementation drops writes. Routing components (switches,
+    /// bridges) and multi-function devices that span bus numbers should override
+    /// this method.
+    ///
+    /// # Parameters
+    /// - `address`: The target address (BDF + offset) being accessed
+    /// - `value`: Byte-enabled DWORD value to write
+    fn pci_cfg_type1_write(
+        &mut self,
+        _address: PciConfigAddress,
+        _value: ByteEnabledDwordWrite,
+    ) -> IoResult {
+        IoResult::Ok
     }
 
     /// Check if the device has a suggested (bus, device, function) it expects
@@ -560,7 +586,7 @@ mod tests {
         let address = PciConfigAddress::new(0x12, 0x1d, 0x40).unwrap();
 
         assert_eq!(address.bus, 0x12);
-        assert_eq!(address.device_function, 0x1d);
+        assert_eq!(address.devfn, 0x1d);
         assert_eq!(address.device(), 3);
         assert_eq!(address.function(), 5);
         assert_eq!(address.byte_offset(), 0x100);

--- a/vm/devices/pci/pci_bus/src/lib.rs
+++ b/vm/devices/pci/pci_bus/src/lib.rs
@@ -76,7 +76,7 @@ pub trait GenericPciBusDevice: 'static + Send {
     /// and multi-function devices should instead implement
     /// [`pci_cfg_type0_read`](Self::pci_cfg_type0_read) for full routing context.
     ///
-    /// `byte_offset` is guaranteed be aligned to a 4-byte boundary.
+    /// `byte_offset` is guaranteed to be aligned to a 4-byte boundary.
     fn pci_cfg_read(
         &mut self,
         byte_offset: u16,
@@ -90,7 +90,7 @@ pub trait GenericPciBusDevice: 'static + Send {
     /// and multi-function devices should instead implement
     /// [`pci_cfg_type0_write`](Self::pci_cfg_type0_write) for full routing context.
     ///
-    /// `byte_offset` is guaranteed be aligned to a 4-byte boundary.
+    /// `byte_offset` is guaranteed to be aligned to a 4-byte boundary.
     fn pci_cfg_write(&mut self, byte_offset: u16, value: ByteEnabledDwordWrite)
     -> Option<IoResult>;
 

--- a/vm/devices/pci/pci_bus/src/lib.rs
+++ b/vm/devices/pci/pci_bus/src/lib.rs
@@ -22,6 +22,7 @@ use chipset_device::io::IoError;
 use chipset_device::io::IoResult;
 use chipset_device::pci::ByteEnabledDwordRead;
 use chipset_device::pci::ByteEnabledDwordWrite;
+use chipset_device::pci::PciConfigAccessType;
 use chipset_device::pci::PciConfigAddress;
 use chipset_device::pci::PciConfigByteEnable;
 use chipset_device::pio::ControlPortIoIntercept;
@@ -74,7 +75,8 @@ pub trait GenericPciBusDevice: 'static + Send {
     /// This function serves as a shorthand that single-function endpoint devices
     /// can implement directly. More advanced routing components (switches, bridges)
     /// and multi-function devices should instead implement
-    /// [`pci_cfg_type0_read`](Self::pci_cfg_type0_read) for full routing context.
+    /// [`pci_cfg_read_with_routing`](Self::pci_cfg_read_with_routing) for full
+    /// routing context.
     ///
     /// `byte_offset` is guaranteed to be aligned to a 4-byte boundary.
     fn pci_cfg_read(
@@ -88,111 +90,67 @@ pub trait GenericPciBusDevice: 'static + Send {
     /// This function serves as a shorthand that single-function endpoint devices
     /// can implement directly. More advanced routing components (switches, bridges)
     /// and multi-function devices should instead implement
-    /// [`pci_cfg_type0_write`](Self::pci_cfg_type0_write) for full routing context.
+    /// [`pci_cfg_write_with_routing`](Self::pci_cfg_write_with_routing) for full
+    /// routing context.
     ///
     /// `byte_offset` is guaranteed to be aligned to a 4-byte boundary.
     fn pci_cfg_write(&mut self, byte_offset: u16, value: ByteEnabledDwordWrite)
     -> Option<IoResult>;
 
-    /// Handle a Type 0 PCI configuration space read with full routing context.
+    /// Dispatch a PCI configuration space read with full routing context.
     ///
-    /// This method receives configuration space accesses with the target bus,
-    /// packed device/function number, and DWORD offset. For a device directly
-    /// behind a PCIe port, the device number is always zero and `devfn`
-    /// identifies the function within that endpoint.
+    /// This method receives configuration space read with the access type,
+    /// target bus, target device/function number, and DWORD offset.
     ///
-    /// The default implementation dispatches function 0 to
+    /// The default implementation dispatches type 0 access to function 0 to
     /// [`pci_cfg_read`](Self::pci_cfg_read) and returns all-1s for other
     /// functions (the standard "no device present" response). Routing
     /// components (switches, bridges) and multi-function devices should
     /// override this method.
     ///
     /// # Parameters
+    /// - `access_type`: The type of PCI configuration space access (Type 0 or Type 1)
     /// - `address`: The target address (BDF + offset) being accessed
     /// - `value`: Byte-enabled DWORD value to receive the read
-    fn pci_cfg_type0_read(
+    fn pci_cfg_read_with_routing(
         &mut self,
+        access_type: PciConfigAccessType,
         address: PciConfigAddress,
         mut value: ByteEnabledDwordRead<'_>,
     ) -> Option<IoResult> {
-        if address.devfn == 0 {
-            self.pci_cfg_read(address.byte_offset(), value)
-        } else {
-            value.set(!0);
-            Some(IoResult::Ok)
+        match (access_type, address.devfn) {
+            (PciConfigAccessType::Type0, 0) => self.pci_cfg_read(address.byte_offset(), value),
+            _ => {
+                value.set(!0);
+                Some(IoResult::Ok)
+            }
         }
     }
 
-    /// Handle a Type 0 PCI configuration space write with full routing context.
+    /// Dispatch a PCI configuration space write with full routing context.
     ///
-    /// This method receives configuration space accesses with the target bus,
-    /// packed device/function number, and DWORD offset. For a device directly
-    /// behind a PCIe port, the device number is always zero and `devfn`
-    /// identifies the function within that endpoint.
+    /// This method receives configuration space write with the access type,
+    /// target bus, target device/function number, and DWORD offset.
     ///
-    /// The default implementation dispatches function 0 to
+    /// The default implementation dispatches type 0 access to function 0 to
     /// [`pci_cfg_write`](Self::pci_cfg_write) and silently drops writes to
     /// other functions. Routing components (switches, bridges) and
     /// multi-function devices should override this method.
     ///
     /// # Parameters
+    /// - `access_type`: The type of PCI configuration space access (Type 0 or Type 1)
     /// - `address`: The target address (BDF + offset) being accessed
     /// - `value`: Byte-enabled DWORD value to write
-    fn pci_cfg_type0_write(
+    fn pci_cfg_write_with_routing(
         &mut self,
+        access_type: PciConfigAccessType,
         address: PciConfigAddress,
         value: ByteEnabledDwordWrite,
     ) -> Option<IoResult> {
-        if address.devfn == 0 {
-            self.pci_cfg_write(address.byte_offset(), value)
-        } else {
-            Some(IoResult::Ok)
+        match (access_type, address.devfn) {
+            (PciConfigAccessType::Type0, 0) => self.pci_cfg_write(address.byte_offset(), value),
+            _ => Some(IoResult::Ok),
         }
-    }
-
-    /// Handle a Type 1 PCI configuration space read with full routing context.
-    ///
-    /// This method receives configuration space accesses with the target bus,
-    /// packed device/function number, and DWORD offset. For a device directly
-    /// behind a PCIe port, the device number is always zero and `devfn`
-    /// identifies the function within that endpoint.
-    ///
-    /// The default implementation returns all-1s. Routing components (switches,
-    /// bridges) and multi-function devices that span bus numbers should override
-    /// this method.
-    ///
-    /// # Parameters
-    /// - `address`: The target address (BDF + offset) being accessed
-    /// - `value`: Byte-enabled DWORD value to receive the read
-    fn pci_cfg_type1_read(
-        &mut self,
-        _address: PciConfigAddress,
-        mut value: ByteEnabledDwordRead<'_>,
-    ) -> Option<IoResult> {
-        value.set(!0);
-        Some(IoResult::Ok)
-    }
-
-    /// Handle a Type 1 PCI configuration space write with full routing context.
-    ///
-    /// This method receives configuration space accesses with the target bus,
-    /// packed device/function number, and DWORD offset. For a device directly
-    /// behind a PCIe port, the device number is always zero and `devfn`
-    /// identifies the function within that endpoint.
-    ///
-    /// The default implementation drops writes. Routing components (switches,
-    /// bridges) and multi-function devices that span bus numbers should override
-    /// this method.
-    ///
-    /// # Parameters
-    /// - `address`: The target address (BDF + offset) being accessed
-    /// - `value`: Byte-enabled DWORD value to write
-    fn pci_cfg_type1_write(
-        &mut self,
-        _address: PciConfigAddress,
-        _value: ByteEnabledDwordWrite,
-    ) -> Option<IoResult> {
-        Some(IoResult::Ok)
     }
 }
 

--- a/vm/devices/pci/pci_bus/src/lib.rs
+++ b/vm/devices/pci/pci_bus/src/lib.rs
@@ -70,26 +70,36 @@ pub mod standard_x86_io_ports {
 /// by providing implementations for the forwarding methods.
 pub trait GenericPciBusDevice: 'static + Send {
     /// Dispatch a PCI config space read to the device with the given address.
-    fn pci_cfg_read(&mut self, offset: u16, value: ByteEnabledDwordRead<'_>) -> Option<IoResult>;
+    ///
+    /// This function serves as a shorthand that single-function endpoint devices
+    /// can implement directly. More advanced routing components (switches, bridges)
+    /// and multi-function devices should instead implement
+    /// [`pci_cfg_type0_read`](Self::pci_cfg_type0_read) for full routing context.
+    ///
+    /// `byte_offset` is guaranteed be aligned to a 4-byte boundary.
+    fn pci_cfg_read(
+        &mut self,
+        byte_offset: u16,
+        value: ByteEnabledDwordRead<'_>,
+    ) -> Option<IoResult>;
 
     /// Dispatch a PCI config space write to the device with the given address.
-    fn pci_cfg_write(&mut self, offset: u16, value: ByteEnabledDwordWrite) -> Option<IoResult>;
+    ///
+    /// This function serves as a shorthand that single-function endpoint devices
+    /// can implement directly. More advanced routing components (switches, bridges)
+    /// and multi-function devices should instead implement
+    /// [`pci_cfg_type0_write`](Self::pci_cfg_type0_write) for full routing context.
+    ///
+    /// `byte_offset` is guaranteed be aligned to a 4-byte boundary.
+    fn pci_cfg_write(&mut self, byte_offset: u16, value: ByteEnabledDwordWrite)
+    -> Option<IoResult>;
 
-    /// Handle a PCI configuration space read with full routing context.
+    /// Handle a Type 0 PCI configuration space read with full routing context.
     ///
-    /// This method receives configuration space accesses with the target bus
-    /// and function number. The interpretation of `function` depends on the
-    /// bus topology: on a legacy PCI bus it carries packed device/function
-    /// bits (0..=255), while downstream of a PCIe port the device number is
-    /// always zero so all 8 bits represent functions within a single
-    /// endpoint.
-    ///
-    /// A device can distinguish Type 0 (local) from Type 1 (forwarded)
-    /// configuration cycles by comparing `target_bus` and `secondary_bus`:
-    /// when they are equal the access targets this device directly (Type 0),
-    /// otherwise it should be routed downstream (Type 1). An SR-IOV
-    /// capable device can use `secondary_bus` together with `target_bus` and
-    /// `function` to compute the VF number.
+    /// This method receives configuration space accesses with the target bus,
+    /// packed device/function number, and DWORD offset. For a device directly
+    /// behind a PCIe port, the device number is always zero and `devfn`
+    /// identifies the function within that endpoint.
     ///
     /// The default implementation dispatches function 0 to
     /// [`pci_cfg_read`](Self::pci_cfg_read) and returns all-1s for other
@@ -97,58 +107,92 @@ pub trait GenericPciBusDevice: 'static + Send {
     /// components (switches, bridges) and multi-function devices should
     /// override this method.
     ///
-    /// Returns `None` if the backing device is no longer responding.
-    fn pci_cfg_read_with_routing(
+    /// # Parameters
+    /// - `address`: The target address (BDF + offset) being accessed
+    /// - `value`: Byte-enabled DWORD value to receive the read
+    fn pci_cfg_type0_read(
         &mut self,
-        secondary_bus: u8,
-        target_bus: u8,
-        function: u8,
-        offset: u16,
+        address: PciConfigAddress,
         mut value: ByteEnabledDwordRead<'_>,
     ) -> Option<IoResult> {
-        if secondary_bus == target_bus && function == 0 {
-            self.pci_cfg_read(offset, value)
+        if address.devfn == 0 {
+            self.pci_cfg_read(address.byte_offset(), value)
         } else {
             value.set(!0);
             Some(IoResult::Ok)
         }
     }
 
-    /// Handle a PCI configuration space write with full routing context.
+    /// Handle a Type 0 PCI configuration space write with full routing context.
     ///
-    /// This method receives configuration space accesses with the target bus
-    /// and function number. The interpretation of `function` depends on the
-    /// bus topology: on a legacy PCI bus it carries packed device/function
-    /// bits (0..=255), while downstream of a PCIe port the device number is
-    /// always zero so all 8 bits represent functions within a single
-    /// endpoint.
-    ///
-    /// A device can distinguish Type 0 (local) from Type 1 (forwarded)
-    /// configuration cycles by comparing `target_bus` and `secondary_bus`:
-    /// when they are equal the access targets this device directly (Type 0),
-    /// otherwise it should be routed downstream (Type 1). An SR-IOV
-    /// capable device can use `secondary_bus` together with `target_bus` and
-    /// `function` to compute the VF number.
+    /// This method receives configuration space accesses with the target bus,
+    /// packed device/function number, and DWORD offset. For a device directly
+    /// behind a PCIe port, the device number is always zero and `devfn`
+    /// identifies the function within that endpoint.
     ///
     /// The default implementation dispatches function 0 to
     /// [`pci_cfg_write`](Self::pci_cfg_write) and silently drops writes to
     /// other functions. Routing components (switches, bridges) and
     /// multi-function devices should override this method.
     ///
-    /// Returns `None` if the backing device is no longer responding.
-    fn pci_cfg_write_with_routing(
+    /// # Parameters
+    /// - `address`: The target address (BDF + offset) being accessed
+    /// - `value`: Byte-enabled DWORD value to write
+    fn pci_cfg_type0_write(
         &mut self,
-        secondary_bus: u8,
-        target_bus: u8,
-        function: u8,
-        offset: u16,
+        address: PciConfigAddress,
         value: ByteEnabledDwordWrite,
     ) -> Option<IoResult> {
-        if secondary_bus == target_bus && function == 0 {
-            self.pci_cfg_write(offset, value)
+        if address.devfn == 0 {
+            self.pci_cfg_write(address.byte_offset(), value)
         } else {
             Some(IoResult::Ok)
         }
+    }
+
+    /// Handle a Type 1 PCI configuration space read with full routing context.
+    ///
+    /// This method receives configuration space accesses with the target bus,
+    /// packed device/function number, and DWORD offset. For a device directly
+    /// behind a PCIe port, the device number is always zero and `devfn`
+    /// identifies the function within that endpoint.
+    ///
+    /// The default implementation returns all-1s. Routing components (switches,
+    /// bridges) and multi-function devices that span bus numbers should override
+    /// this method.
+    ///
+    /// # Parameters
+    /// - `address`: The target address (BDF + offset) being accessed
+    /// - `value`: Byte-enabled DWORD value to receive the read
+    fn pci_cfg_type1_read(
+        &mut self,
+        _address: PciConfigAddress,
+        mut value: ByteEnabledDwordRead<'_>,
+    ) -> Option<IoResult> {
+        value.set(!0);
+        Some(IoResult::Ok)
+    }
+
+    /// Handle a Type 1 PCI configuration space write with full routing context.
+    ///
+    /// This method receives configuration space accesses with the target bus,
+    /// packed device/function number, and DWORD offset. For a device directly
+    /// behind a PCIe port, the device number is always zero and `devfn`
+    /// identifies the function within that endpoint.
+    ///
+    /// The default implementation drops writes. Routing components (switches,
+    /// bridges) and multi-function devices that span bus numbers should override
+    /// this method.
+    ///
+    /// # Parameters
+    /// - `address`: The target address (BDF + offset) being accessed
+    /// - `value`: Byte-enabled DWORD value to write
+    fn pci_cfg_type1_write(
+        &mut self,
+        _address: PciConfigAddress,
+        _value: ByteEnabledDwordWrite,
+    ) -> Option<IoResult> {
+        Some(IoResult::Ok)
     }
 }
 

--- a/vm/devices/pci/pci_core/src/cfg_space_emu.rs
+++ b/vm/devices/pci/pci_core/src/cfg_space_emu.rs
@@ -536,22 +536,22 @@ impl<const N: usize> ConfigSpaceCommonHeaderEmulator<N> {
         }
     }
 
-    /// Retrieved the captured bus number.
+    /// Returns the currently captured bus number.
     pub fn captured_bus_number(&self) -> u8 {
         self.state.captured_bus_number
     }
 
-    /// Retrieved the captured devfn (device << 3 | function) number.
+    /// Returns the currently captured devfn (device << 3 | function) number.
     pub fn captured_devfn(&self) -> u8 {
         self.state.captured_devfn
     }
 
-    /// Overwrite the captured bus number.
+    /// Overwrites the captured bus number.
     pub fn set_captured_bus_number(&mut self, bus_number: u8) {
         self.state.captured_bus_number = bus_number;
     }
 
-    /// Overwrite the captured devfn (device << 3 | fn) number.
+    /// Overwrites the captured devfn (device << 3 | fn) number.
     pub fn set_captured_devfn(&mut self, devfn: u8) {
         self.state.captured_devfn = devfn;
     }
@@ -1108,12 +1108,12 @@ impl ConfigSpaceType0Emulator {
         self.common.set_interrupt_pin(pin, line)
     }
 
-    /// Retrieved the captured bus number.
+    /// Returns the currently captured bus number.
     pub fn captured_bus_number(&self) -> u8 {
         self.common.captured_bus_number()
     }
 
-    /// Retrieved the captured devfn (device << 3 | function) number.
+    /// Returns the currently captured devfn (device << 3 | function) number.
     pub fn captured_devfn(&self) -> u8 {
         self.common.captured_devfn()
     }
@@ -1395,12 +1395,12 @@ impl ConfigSpaceType1Emulator {
         }
     }
 
-    /// Retrieved the captured bus number.
+    /// Returns the currently captured bus number.
     pub fn captured_bus_number(&self) -> u8 {
         self.common.captured_bus_number()
     }
 
-    /// Retrieved the captured devfn (device << 3 | function) number.
+    /// Returns the currently captured devfn (device << 3 | function) number.
     pub fn captured_devfn(&self) -> u8 {
         self.common.captured_devfn()
     }

--- a/vm/devices/pci/pci_core/src/cfg_space_emu.rs
+++ b/vm/devices/pci/pci_core/src/cfg_space_emu.rs
@@ -182,6 +182,10 @@ struct ConfigSpaceCommonHeaderEmulatorState<const N: usize> {
     /// for firmware to communicate IRQ assignments to the OS, but it can really
     /// be used for just about anything.
     interrupt_line: u8,
+    /// The bus number captured by this emulator.
+    captured_bus_number: u8,
+    /// The combined devfn (device << 3 | function) captured by this emulator.
+    captured_devfn: u8,
 }
 
 impl<const N: usize> ConfigSpaceCommonHeaderEmulatorState<N> {
@@ -193,6 +197,8 @@ impl<const N: usize> ConfigSpaceCommonHeaderEmulatorState<N> {
                 [ZERO; N]
             },
             interrupt_line: 0,
+            captured_bus_number: 0,
+            captured_devfn: 0,
         }
     }
 }
@@ -530,6 +536,26 @@ impl<const N: usize> ConfigSpaceCommonHeaderEmulator<N> {
         }
     }
 
+    /// Retrieved the captured bus number.
+    pub fn captured_bus_number(&self) -> u8 {
+        self.state.captured_bus_number
+    }
+
+    /// Retrieved the captured devfn (device << 3 | function) number.
+    pub fn captured_devfn(&self) -> u8 {
+        self.state.captured_devfn
+    }
+
+    /// Overwrite the captured bus number.
+    pub fn set_captured_bus_number(&mut self, bus_number: u8) {
+        self.state.captured_bus_number = bus_number;
+    }
+
+    /// Overwrite the captured devfn (device << 3 | fn) number.
+    pub fn set_captured_devfn(&mut self, devfn: u8) {
+        self.state.captured_devfn = devfn;
+    }
+
     // ===== Configuration Space Read/Write Functions =====
 
     /// Read from the config space.
@@ -617,6 +643,23 @@ impl<const N: usize> ConfigSpaceCommonHeaderEmulator<N> {
             "ConfigSpaceCommonHeaderEmulator: write offset={:#x}",
             offset,
         );
+
+        // Capture the bus number as described in section 2.2.6.2.1 of the PCIe spec (Rev 7.0).
+        // The spec recommends that functions only capture these values on successful handling of
+        // the access, but we can't really tell that here from this shared emulation helper so we
+        // instead capture unconditionally.
+        if address.bus != self.state.captured_bus_number
+            || address.devfn != self.state.captured_devfn
+        {
+            tracing::debug!(
+                "ConfigSpaceCommonHeaderEmulator: capturing bdf {:x}:{:x}.{:x}",
+                address.bus,
+                address.device(),
+                address.function(),
+            );
+        }
+        self.state.captured_bus_number = address.bus;
+        self.state.captured_devfn = address.devfn;
 
         match CommonHeader(offset) {
             CommonHeader::STATUS_COMMAND => {
@@ -1065,6 +1108,16 @@ impl ConfigSpaceType0Emulator {
         self.common.set_interrupt_pin(pin, line)
     }
 
+    /// Retrieved the captured bus number.
+    pub fn captured_bus_number(&self) -> u8 {
+        self.common.captured_bus_number()
+    }
+
+    /// Retrieved the captured devfn (device << 3 | function) number.
+    pub fn captured_devfn(&self) -> u8 {
+        self.common.captured_devfn()
+    }
+
     /// Resets the configuration space state.
     pub fn reset(&mut self) {
         self.common.reset();
@@ -1121,19 +1174,6 @@ impl ConfigSpaceType0Emulator {
         IoResult::Ok
     }
 
-    /// Read a full DWORD from the config space. `offset` must be 32-bit aligned.
-    pub fn read_u32(&self, offset: u16, value: &mut u32) -> IoResult {
-        if !offset.is_multiple_of(4) {
-            return IoResult::Err(IoError::UnalignedAccess);
-        }
-
-        let Some(addr) = PciConfigAddress::new(0, 0, offset / 4) else {
-            return IoResult::Err(IoError::InvalidRegister);
-        };
-
-        self.read(addr, ByteEnabledDwordRead::with_all_bytes_enabled(value))
-    }
-
     /// Read a byte-enabled DWORD from the config space. `offset` must be 32-bit aligned.
     pub fn read_byte_enabled(&self, offset: u16, value: ByteEnabledDwordRead<'_>) -> IoResult {
         if !offset.is_multiple_of(4) {
@@ -1186,19 +1226,6 @@ impl ConfigSpaceType0Emulator {
         }
 
         IoResult::Ok
-    }
-
-    /// Write a full DWORD to the config space. `offset` must be 32-bit aligned.
-    pub fn write_u32(&mut self, offset: u16, val: u32) -> IoResult {
-        if !offset.is_multiple_of(4) {
-            return IoResult::Err(IoError::UnalignedAccess);
-        }
-
-        let Some(addr) = PciConfigAddress::new(0, 0, offset / 4) else {
-            return IoResult::Err(IoError::InvalidRegister);
-        };
-
-        self.write(addr, ByteEnabledDwordWrite::with_all_bytes_enabled(val))
     }
 
     /// Write a byte-enabled DWORD from the config space. `offset` must be 32-bit aligned.
@@ -1368,6 +1395,16 @@ impl ConfigSpaceType1Emulator {
         }
     }
 
+    /// Retrieved the captured bus number.
+    pub fn captured_bus_number(&self) -> u8 {
+        self.common.captured_bus_number()
+    }
+
+    /// Retrieved the captured devfn (device << 3 | function) number.
+    pub fn captured_devfn(&self) -> u8 {
+        self.common.captured_devfn()
+    }
+
     /// Resets the configuration space state.
     pub fn reset(&mut self) {
         self.common.reset();
@@ -1506,19 +1543,6 @@ impl ConfigSpaceType1Emulator {
         IoResult::Ok
     }
 
-    /// Read a full DWORD from the config space. `offset` must be 32-bit aligned.
-    pub fn read_u32(&self, offset: u16, value: &mut u32) -> IoResult {
-        if !offset.is_multiple_of(4) {
-            return IoResult::Err(IoError::UnalignedAccess);
-        }
-
-        let Some(addr) = PciConfigAddress::new(0, 0, offset / 4) else {
-            return IoResult::Err(IoError::InvalidRegister);
-        };
-
-        self.read(addr, ByteEnabledDwordRead::with_all_bytes_enabled(value))
-    }
-
     /// Read a byte-enabled DWORD from the config space. `offset` must be 32-bit aligned.
     pub fn read_byte_enabled(&self, offset: u16, value: ByteEnabledDwordRead<'_>) -> IoResult {
         if !offset.is_multiple_of(4) {
@@ -1596,19 +1620,6 @@ impl ConfigSpaceType1Emulator {
         }
 
         IoResult::Ok
-    }
-
-    /// Write a full DWORD to the config space. `offset` must be 32-bit aligned.
-    pub fn write_u32(&mut self, offset: u16, val: u32) -> IoResult {
-        if !offset.is_multiple_of(4) {
-            return IoResult::Err(IoError::UnalignedAccess);
-        }
-
-        let Some(addr) = PciConfigAddress::new(0, 0, offset / 4) else {
-            return IoResult::Err(IoError::InvalidRegister);
-        };
-
-        self.write(addr, ByteEnabledDwordWrite::with_all_bytes_enabled(val))
     }
 
     /// Write a byte-enabled DWORD to the config space. `offset` must be 32-bit aligned.
@@ -1701,6 +1712,10 @@ mod save_restore {
             pub capabilities: Vec<(String, SavedStateBlob)>,
             #[mesh(16)]
             pub extended_capabilities: Vec<(String, SavedStateBlob)>,
+            #[mesh(17)]
+            pub captured_bus_number: u8,
+            #[mesh(18)]
+            pub captured_devfn: u8,
 
             // Type 1 specific fields (bridge devices)
             // These fields default to 0 for backward compatibility with old save state
@@ -1764,6 +1779,8 @@ mod save_restore {
                         Ok((id, cap.save()?))
                     })
                     .collect::<Result<_, _>>()?,
+                captured_bus_number: self.common.captured_bus_number(),
+                captured_devfn: self.common.captured_devfn(),
                 // Type 1 specific fields - not used for Type 0
                 subordinate_bus_number: 0,
                 secondary_bus_number: 0,
@@ -1788,6 +1805,8 @@ mod save_restore {
                 latency_timer,
                 capabilities,
                 extended_capabilities,
+                captured_bus_number,
+                captured_devfn,
                 // Type 1 specific fields - ignored for Type 0
                 subordinate_bus_number: _,
                 secondary_bus_number: _,
@@ -1856,6 +1875,9 @@ mod save_restore {
                 }
             }
 
+            self.common.set_captured_bus_number(captured_bus_number);
+            self.common.set_captured_devfn(captured_devfn);
+
             Ok(())
         }
     }
@@ -1906,6 +1928,8 @@ mod save_restore {
                         Ok((id, cap.save()?))
                     })
                     .collect::<Result<_, _>>()?,
+                captured_bus_number: self.common.captured_bus_number(),
+                captured_devfn: self.common.captured_devfn(),
                 // Type 1 specific fields
                 subordinate_bus_number,
                 secondary_bus_number,
@@ -1930,6 +1954,8 @@ mod save_restore {
                 latency_timer: _, // Not used for Type 1
                 capabilities,
                 extended_capabilities,
+                captured_bus_number,
+                captured_devfn,
                 subordinate_bus_number,
                 secondary_bus_number,
                 primary_bus_number,
@@ -2014,6 +2040,9 @@ mod save_restore {
                 }
             }
 
+            self.common.set_captured_bus_number(captured_bus_number);
+            self.common.set_captured_devfn(captured_devfn);
+
             Ok(())
         }
     }
@@ -2029,12 +2058,14 @@ mod tests {
     use crate::spec::hwid::ClassCode;
     use crate::spec::hwid::ProgrammingInterface;
     use crate::spec::hwid::Subclass;
+    use crate::test_helpers::TestCfgAccess;
     use chipset_device::pci::ByteEnabledDwordRead;
     use chipset_device::pci::ByteEnabledDwordWrite;
     use chipset_device::pci::PciConfigByteEnable;
     use std::sync::Arc;
     use std::sync::atomic::AtomicBool;
     use std::sync::atomic::Ordering;
+    use vmcore::save_restore::SaveRestore;
 
     fn create_type0_emulator(caps: Vec<Box<dyn PciCapability>>) -> ConfigSpaceType0Emulator {
         ConfigSpaceType0Emulator::new(
@@ -2071,21 +2102,15 @@ mod tests {
         )
     }
 
-    fn read_cfg(emulator: &ConfigSpaceType1Emulator, offset: u16) -> u32 {
-        let mut val = 0;
-        emulator.read_u32(offset, &mut val).unwrap();
-        val
-    }
-
     #[test]
     fn test_type1_probe() {
         let emu = create_type1_emulator(vec![]);
-        assert_eq!(read_cfg(&emu, 0), 0x2222_1111);
-        assert_eq!(read_cfg(&emu, 4) & 0x10_0000, 0); // Capabilities pointer
+        assert_eq!(emu.read_u32(0), 0x2222_1111);
+        assert_eq!(emu.read_u32(4) & 0x10_0000, 0); // Capabilities pointer
 
         let emu = create_type1_emulator(vec![Box::new(ReadOnlyCapability::new("foo", 0))]);
-        assert_eq!(read_cfg(&emu, 0), 0x2222_1111);
-        assert_eq!(read_cfg(&emu, 4) & 0x10_0000, 0x10_0000); // Capabilities pointer
+        assert_eq!(emu.read_u32(0), 0x2222_1111);
+        assert_eq!(emu.read_u32(4) & 0x10_0000, 0x10_0000); // Capabilities pointer
     }
 
     #[test]
@@ -2094,36 +2119,36 @@ mod tests {
 
         // The bus number (and latency timer) registers are
         // all default 0.
-        assert_eq!(read_cfg(&emu, 0x18), 0);
+        assert_eq!(emu.read_u32(0x18), 0);
         assert_eq!(emu.assigned_bus_range(), 0..=0);
 
         // The bus numbers can be programmed one by one,
         // and the range may not be valid during the middle
         // of allocation.
-        emu.write_u32(0x18, 0x0000_1000).unwrap();
-        assert_eq!(read_cfg(&emu, 0x18), 0x0000_1000);
+        emu.write_u32(0x18, 0x0000_1000);
+        assert_eq!(emu.read_u32(0x18), 0x0000_1000);
         assert_eq!(emu.assigned_bus_range(), 0..=0);
-        emu.write_u32(0x18, 0x0012_1000).unwrap();
-        assert_eq!(read_cfg(&emu, 0x18), 0x0012_1000);
+        emu.write_u32(0x18, 0x0012_1000);
+        assert_eq!(emu.read_u32(0x18), 0x0012_1000);
         assert_eq!(emu.assigned_bus_range(), 0x10..=0x12);
 
         // The primary bus number register is read/write for compatability
         // but unused.
-        emu.write_u32(0x18, 0x0012_1033).unwrap();
-        assert_eq!(read_cfg(&emu, 0x18), 0x0012_1033);
+        emu.write_u32(0x18, 0x0012_1033);
+        assert_eq!(emu.read_u32(0x18), 0x0012_1033);
         assert_eq!(emu.assigned_bus_range(), 0x10..=0x12);
 
         // Software can also just write the entire 4byte value at once
-        emu.write_u32(0x18, 0x0047_4411).unwrap();
-        assert_eq!(read_cfg(&emu, 0x18), 0x0047_4411);
+        emu.write_u32(0x18, 0x0047_4411);
+        assert_eq!(emu.read_u32(0x18), 0x0047_4411);
         assert_eq!(emu.assigned_bus_range(), 0x44..=0x47);
 
         // The subordinate bus number can equal the secondary bus number...
-        emu.write_u32(0x18, 0x0088_8800).unwrap();
+        emu.write_u32(0x18, 0x0088_8800);
         assert_eq!(emu.assigned_bus_range(), 0x88..=0x88);
 
         // ... but it cannot be less, that's a confused guest OS.
-        emu.write_u32(0x18, 0x0087_8800).unwrap();
+        emu.write_u32(0x18, 0x0087_8800);
         assert_eq!(emu.assigned_bus_range(), 0..=0);
     }
 
@@ -2139,7 +2164,7 @@ mod tests {
             ),
         )
         .unwrap();
-        assert_eq!(read_cfg(&emu, 0x18), 0x0000_0011);
+        assert_eq!(emu.read_u32(0x18), 0x0000_0011);
         assert_eq!(emu.assigned_bus_range(), 0..=0);
 
         emu.write(
@@ -2150,7 +2175,7 @@ mod tests {
             ),
         )
         .unwrap();
-        assert_eq!(read_cfg(&emu, 0x18), 0x0000_2211);
+        assert_eq!(emu.read_u32(0x18), 0x0000_2211);
         assert_eq!(emu.assigned_bus_range(), 0..=0);
 
         emu.write(
@@ -2161,7 +2186,7 @@ mod tests {
             ),
         )
         .unwrap();
-        assert_eq!(read_cfg(&emu, 0x18), 0x0033_2211);
+        assert_eq!(emu.read_u32(0x18), 0x0033_2211);
         assert_eq!(emu.assigned_bus_range(), 0x22..=0x33);
 
         emu.write(
@@ -2172,7 +2197,7 @@ mod tests {
             ),
         )
         .unwrap();
-        assert_eq!(read_cfg(&emu, 0x18), 0x0033_2211);
+        assert_eq!(emu.read_u32(0x18), 0x0033_2211);
         assert_eq!(emu.assigned_bus_range(), 0x22..=0x33);
     }
 
@@ -2186,33 +2211,33 @@ mod tests {
 
         // The guest can write whatever it wants while MMIO
         // is disabled.
-        emu.write_u32(0x20, 0xDEAD_BEEF).unwrap();
+        emu.write_u32(0x20, 0xDEAD_BEEF);
         assert!(emu.assigned_memory_range().is_none());
 
         // The guest can program a valid resource assignment...
-        emu.write_u32(0x20, 0xFFF0_FF00).unwrap();
+        emu.write_u32(0x20, 0xFFF0_FF00);
         assert!(emu.assigned_memory_range().is_none());
         // ... enable memory decoding...
-        emu.write_u32(0x4, MMIO_ENABLED).unwrap();
+        emu.write_u32(0x4, MMIO_ENABLED);
         assert_eq!(emu.assigned_memory_range(), Some(0xFF00_0000..=0xFFFF_FFFF));
         // ... then disable memory decoding it.
-        emu.write_u32(0x4, MMIO_DISABLED).unwrap();
+        emu.write_u32(0x4, MMIO_DISABLED);
         assert!(emu.assigned_memory_range().is_none());
 
         // Setting memory base equal to memory limit is a valid 1MB range.
-        emu.write_u32(0x20, 0xBBB0_BBB0).unwrap();
-        emu.write_u32(0x4, MMIO_ENABLED).unwrap();
+        emu.write_u32(0x20, 0xBBB0_BBB0);
+        emu.write_u32(0x4, MMIO_ENABLED);
         assert_eq!(emu.assigned_memory_range(), Some(0xBBB0_0000..=0xBBBF_FFFF));
-        emu.write_u32(0x4, MMIO_DISABLED).unwrap();
+        emu.write_u32(0x4, MMIO_DISABLED);
         assert!(emu.assigned_memory_range().is_none());
 
         // The guest can try to program an invalid assignment (base > limit), we
         // just won't decode it.
-        emu.write_u32(0x20, 0xAA00_BB00).unwrap();
+        emu.write_u32(0x20, 0xAA00_BB00);
         assert!(emu.assigned_memory_range().is_none());
-        emu.write_u32(0x4, MMIO_ENABLED).unwrap();
+        emu.write_u32(0x4, MMIO_ENABLED);
         assert!(emu.assigned_memory_range().is_none());
-        emu.write_u32(0x4, MMIO_DISABLED).unwrap();
+        emu.write_u32(0x4, MMIO_DISABLED);
         assert!(emu.assigned_memory_range().is_none());
     }
 
@@ -2222,10 +2247,10 @@ mod tests {
 
         let mut emu = create_type1_emulator(vec![]);
 
-        emu.write_u32(0x20, 0x567f_123f).unwrap();
-        assert_eq!(read_cfg(&emu, 0x20), 0x5670_1230);
+        emu.write_u32(0x20, 0x567f_123f);
+        assert_eq!(emu.read_u32(0x20), 0x5670_1230);
 
-        emu.write_u32(0x4, MMIO_ENABLED).unwrap();
+        emu.write_u32(0x4, MMIO_ENABLED);
         assert_eq!(emu.assigned_memory_range(), Some(0x1230_0000..=0x567f_ffff));
     }
 
@@ -2238,18 +2263,18 @@ mod tests {
         assert!(emu.assigned_prefetch_range().is_none());
 
         // The guest can program a valid prefetch range...
-        emu.write_u32(0x24, 0xFFF0_FF00).unwrap(); // limit + base
-        emu.write_u32(0x28, 0x00AA_BBCC).unwrap(); // base upper
-        emu.write_u32(0x2C, 0x00DD_EEFF).unwrap(); // limit upper
+        emu.write_u32(0x24, 0xFFF0_FF00); // limit + base
+        emu.write_u32(0x28, 0x00AA_BBCC); // base upper
+        emu.write_u32(0x2C, 0x00DD_EEFF); // limit upper
         assert!(emu.assigned_prefetch_range().is_none());
         // ... enable memory decoding...
-        emu.write_u32(0x4, MMIO_ENABLED).unwrap();
+        emu.write_u32(0x4, MMIO_ENABLED);
         assert_eq!(
             emu.assigned_prefetch_range(),
             Some(0x00AA_BBCC_FF00_0000..=0x00DD_EEFF_FFFF_FFFF)
         );
         // ... then disable memory decoding it.
-        emu.write_u32(0x4, MMIO_DISABLED).unwrap();
+        emu.write_u32(0x4, MMIO_DISABLED);
         assert!(emu.assigned_prefetch_range().is_none());
 
         // The validity of the assignment is determined using the combined 64-bit
@@ -2257,29 +2282,29 @@ mod tests {
 
         // Lower bits of the limit are greater than the lower bits of the
         // base, but the upper bits make that valid.
-        emu.write_u32(0x24, 0xFF00_FFF0).unwrap(); // limit + base
-        emu.write_u32(0x28, 0x00AA_BBCC).unwrap(); // base upper
-        emu.write_u32(0x2C, 0x00DD_EEFF).unwrap(); // limit upper
+        emu.write_u32(0x24, 0xFF00_FFF0); // limit + base
+        emu.write_u32(0x28, 0x00AA_BBCC); // base upper
+        emu.write_u32(0x2C, 0x00DD_EEFF); // limit upper
         assert!(emu.assigned_prefetch_range().is_none());
-        emu.write_u32(0x4, MMIO_ENABLED).unwrap();
+        emu.write_u32(0x4, MMIO_ENABLED);
         assert_eq!(
             emu.assigned_prefetch_range(),
             Some(0x00AA_BBCC_FFF0_0000..=0x00DD_EEFF_FF0F_FFFF)
         );
-        emu.write_u32(0x4, MMIO_DISABLED).unwrap();
+        emu.write_u32(0x4, MMIO_DISABLED);
         assert!(emu.assigned_prefetch_range().is_none());
 
         // The base can equal the limit, which is a valid 1MB range.
-        emu.write_u32(0x24, 0xDD00_DD00).unwrap(); // limit + base
-        emu.write_u32(0x28, 0x00AA_BBCC).unwrap(); // base upper
-        emu.write_u32(0x2C, 0x00AA_BBCC).unwrap(); // limit upper
+        emu.write_u32(0x24, 0xDD00_DD00); // limit + base
+        emu.write_u32(0x28, 0x00AA_BBCC); // base upper
+        emu.write_u32(0x2C, 0x00AA_BBCC); // limit upper
         assert!(emu.assigned_prefetch_range().is_none());
-        emu.write_u32(0x4, MMIO_ENABLED).unwrap();
+        emu.write_u32(0x4, MMIO_ENABLED);
         assert_eq!(
             emu.assigned_prefetch_range(),
             Some(0x00AA_BBCC_DD00_0000..=0x00AA_BBCC_DD0F_FFFF)
         );
-        emu.write_u32(0x4, MMIO_DISABLED).unwrap();
+        emu.write_u32(0x4, MMIO_DISABLED);
         assert!(emu.assigned_prefetch_range().is_none());
     }
 
@@ -2289,10 +2314,10 @@ mod tests {
 
         let mut emu = create_type1_emulator(vec![]);
 
-        emu.write_u32(0x24, 0x567e_123e).unwrap();
-        assert_eq!(read_cfg(&emu, 0x24), 0x5671_1231);
+        emu.write_u32(0x24, 0x567e_123e);
+        assert_eq!(emu.read_u32(0x24), 0x5671_1231);
 
-        emu.write_u32(0x4, MMIO_ENABLED).unwrap();
+        emu.write_u32(0x4, MMIO_ENABLED);
         assert_eq!(
             emu.assigned_prefetch_range(),
             Some(0x1230_0000..=0x567f_ffff)
@@ -2301,12 +2326,10 @@ mod tests {
 
     #[test]
     fn test_type1_restore_masks_bridge_memory_range_reserved_bits() {
-        use vmcore::save_restore::SaveRestore;
-
         const MMIO_ENABLED: u32 = 0x0000_0002;
 
         let mut source = create_type1_emulator(vec![]);
-        source.write_u32(0x4, MMIO_ENABLED).unwrap();
+        source.write_u32(0x4, MMIO_ENABLED);
         source.state.memory_base = 0x123f;
         source.state.memory_limit = 0x567f;
         source.state.prefetch_base = 0x234e;
@@ -2317,8 +2340,8 @@ mod tests {
         let mut emu = create_type1_emulator(vec![]);
         emu.restore(saved_state).expect("restore should succeed");
 
-        assert_eq!(read_cfg(&emu, 0x20), 0x5670_1230);
-        assert_eq!(read_cfg(&emu, 0x24), 0x6781_2341);
+        assert_eq!(emu.read_u32(0x20), 0x5670_1230);
+        assert_eq!(emu.read_u32(0x24), 0x6781_2341);
         assert_eq!(emu.assigned_memory_range(), Some(0x1230_0000..=0x567f_ffff));
         assert_eq!(
             emu.assigned_prefetch_range(),
@@ -2773,21 +2796,17 @@ mod tests {
 
     #[test]
     fn test_type0_emulator_save_restore() {
-        use vmcore::save_restore::SaveRestore;
-
         // Test Type 0 emulator save/restore
         let mut emu = create_type0_emulator(vec![]);
 
         // Modify some state by writing to command register
-        emu.write_u32(0x04, 0x0007).unwrap(); // Enable some command bits
+        emu.write_u32(0x04, 0x0007); // Enable some command bits
 
         // Read back and verify
-        let mut test_val = 0u32;
-        emu.read_u32(0x04, &mut test_val).unwrap();
-        assert_eq!(test_val & 0x0007, 0x0007);
+        assert_eq!(emu.read_u32(0x04) & 0x0007, 0x0007);
 
         // Write to latency timer / interrupt register
-        emu.write_u32(0x3C, 0x0040_0000).unwrap(); // Set latency_timer
+        emu.write_u32(0x3C, 0x0040_0000); // Set latency_timer
 
         // Save the state
         let saved_state = emu.save().expect("save should succeed");
@@ -2796,47 +2815,36 @@ mod tests {
         emu.reset();
 
         // Verify state is reset
-        emu.read_u32(0x04, &mut test_val).unwrap();
-        assert_eq!(test_val & 0x0007, 0x0000); // Should be reset
+        assert_eq!(emu.read_u32(0x04) & 0x0007, 0x0000); // Should be reset
 
         // Restore the state
         emu.restore(saved_state).expect("restore should succeed");
 
         // Verify state is restored
-        emu.read_u32(0x04, &mut test_val).unwrap();
-        assert_eq!(test_val & 0x0007, 0x0007); // Should be restored
+        assert_eq!(emu.read_u32(0x04) & 0x0007, 0x0007); // Should be restored
     }
 
     #[test]
     fn test_type1_emulator_save_restore() {
-        use vmcore::save_restore::SaveRestore;
-
         // Test Type 1 emulator save/restore
         let mut emu = create_type1_emulator(vec![]);
 
         // Modify some state
-        emu.write_u32(0x04, 0x0003).unwrap(); // Enable command bits
-        emu.write_u32(0x18, 0x0012_1000).unwrap(); // Set bus numbers
-        emu.write_u32(0x20, 0xFFF0_FF00).unwrap(); // Set memory range
-        emu.write_u32(0x24, 0xFFF0_FF00).unwrap(); // Set prefetch range
-        emu.write_u32(0x28, 0x00AA_BBCC).unwrap(); // Set prefetch base upper
-        emu.write_u32(0x2C, 0x00DD_EEFF).unwrap(); // Set prefetch limit upper
-        emu.write_u32(0x3C, 0x0001_0000).unwrap(); // Set bridge control
+        emu.write_u32(0x04, 0x0003); // Enable command bits
+        emu.write_u32(0x18, 0x0012_1000); // Set bus numbers
+        emu.write_u32(0x20, 0xFFF0_FF00); // Set memory range
+        emu.write_u32(0x24, 0xFFF0_FF00); // Set prefetch range
+        emu.write_u32(0x28, 0x00AA_BBCC); // Set prefetch base upper
+        emu.write_u32(0x2C, 0x00DD_EEFF); // Set prefetch limit upper
+        emu.write_u32(0x3C, 0x0001_0000); // Set bridge control
 
         // Verify values
-        let mut test_val = 0u32;
-        emu.read_u32(0x04, &mut test_val).unwrap();
-        assert_eq!(test_val & 0x0003, 0x0003);
-        emu.read_u32(0x18, &mut test_val).unwrap();
-        assert_eq!(test_val, 0x0012_1000);
-        emu.read_u32(0x20, &mut test_val).unwrap();
-        assert_eq!(test_val, 0xFFF0_FF00);
-        emu.read_u32(0x28, &mut test_val).unwrap();
-        assert_eq!(test_val, 0x00AA_BBCC);
-        emu.read_u32(0x2C, &mut test_val).unwrap();
-        assert_eq!(test_val, 0x00DD_EEFF);
-        emu.read_u32(0x3C, &mut test_val).unwrap();
-        assert_eq!(test_val >> 16, 0x0001); // bridge_control
+        assert_eq!(emu.read_u32(0x04) & 0x0003, 0x0003);
+        assert_eq!(emu.read_u32(0x18), 0x0012_1000);
+        assert_eq!(emu.read_u32(0x20), 0xFFF0_FF00);
+        assert_eq!(emu.read_u32(0x28), 0x00AA_BBCC);
+        assert_eq!(emu.read_u32(0x2C), 0x00DD_EEFF);
+        assert_eq!(emu.read_u32(0x3C) >> 16, 0x0001); // bridge_control
 
         // Save the state
         let saved_state = emu.save().expect("save should succeed");
@@ -2845,33 +2853,25 @@ mod tests {
         emu.reset();
 
         // Verify state is reset
-        emu.read_u32(0x04, &mut test_val).unwrap();
+        let test_val = emu.read_u32(0x04);
         assert_eq!(test_val & 0x0003, 0x0000);
-        emu.read_u32(0x18, &mut test_val).unwrap();
+        let test_val = emu.read_u32(0x18);
         assert_eq!(test_val, 0x0000_0000);
 
         // Restore the state
         emu.restore(saved_state).expect("restore should succeed");
 
         // Verify state is restored
-        emu.read_u32(0x04, &mut test_val).unwrap();
-        assert_eq!(test_val & 0x0003, 0x0003);
-        emu.read_u32(0x18, &mut test_val).unwrap();
-        assert_eq!(test_val, 0x0012_1000);
-        emu.read_u32(0x20, &mut test_val).unwrap();
-        assert_eq!(test_val, 0xFFF0_FF00);
-        emu.read_u32(0x28, &mut test_val).unwrap();
-        assert_eq!(test_val, 0x00AA_BBCC);
-        emu.read_u32(0x2C, &mut test_val).unwrap();
-        assert_eq!(test_val, 0x00DD_EEFF);
-        emu.read_u32(0x3C, &mut test_val).unwrap();
-        assert_eq!(test_val >> 16, 0x0001); // bridge_control
+        assert_eq!(emu.read_u32(0x04) & 0x0003, 0x0003);
+        assert_eq!(emu.read_u32(0x18), 0x0012_1000);
+        assert_eq!(emu.read_u32(0x20), 0xFFF0_FF00);
+        assert_eq!(emu.read_u32(0x28), 0x00AA_BBCC);
+        assert_eq!(emu.read_u32(0x2C), 0x00DD_EEFF);
+        assert_eq!(emu.read_u32(0x3C) >> 16, 0x0001); // bridge_control
     }
 
     #[test]
     fn test_type1_emulator_save_restore_with_extended_capabilities() {
-        use vmcore::save_restore::SaveRestore;
-
         let mut emu = ConfigSpaceType1Emulator::new(
             HardwareIds {
                 vendor_id: 0x1111,
@@ -2891,21 +2891,17 @@ mod tests {
         );
 
         // Enable all supported ACS control bits.
-        emu.write_u32(0x104, 0xffff_0000).unwrap();
+        emu.write_u32(0x104, 0xffff_0000);
 
-        let mut value = 0u32;
-        emu.read_u32(0x104, &mut value).unwrap();
-        assert_eq!((value >> 16) as u16, 0x005f);
+        assert_eq!((emu.read_u32(0x104) >> 16) as u16, 0x005f);
 
         let saved_state = emu.save().expect("save should succeed");
 
         emu.reset();
-        emu.read_u32(0x104, &mut value).unwrap();
-        assert_eq!((value >> 16) as u16, 0);
+        assert_eq!((emu.read_u32(0x104) >> 16) as u16, 0);
 
         emu.restore(saved_state).expect("restore should succeed");
-        emu.read_u32(0x104, &mut value).unwrap();
-        assert_eq!((value >> 16) as u16, 0x005f);
+        assert_eq!((emu.read_u32(0x104) >> 16) as u16, 0x005f);
     }
 
     #[test]
@@ -2920,9 +2916,7 @@ mod tests {
         let mut emulator = create_type1_emulator(vec![Box::new(pcie_cap)]);
 
         // Initially, presence detect state should be 0
-        let mut slot_status_val = 0u32;
-        let result = emulator.read_u32(COMMON_HEADER_END + 0x18, &mut slot_status_val); // COMMON_HEADER_END (cap start) + 0x18 (slot control/status)
-        assert!(matches!(result, IoResult::Ok));
+        let slot_status_val = emulator.read_u32(COMMON_HEADER_END + 0x18); // COMMON_HEADER_END (cap start) + 0x18 (slot control/status)
         let initial_presence_detect = (slot_status_val >> 22) & 0x1; // presence_detect_state is bit 6 of slot status
         assert_eq!(
             initial_presence_detect, 0,
@@ -2931,8 +2925,7 @@ mod tests {
 
         // Set device as present
         emulator.set_presence_detect_state(true);
-        let result = emulator.read_u32(0x58, &mut slot_status_val);
-        assert!(matches!(result, IoResult::Ok));
+        let slot_status_val = emulator.read_u32(0x58);
         let present_presence_detect = (slot_status_val >> 22) & 0x1;
         assert_eq!(
             present_presence_detect, 1,
@@ -2941,8 +2934,7 @@ mod tests {
 
         // Set device as not present
         emulator.set_presence_detect_state(false);
-        let result = emulator.read_u32(0x58, &mut slot_status_val);
-        assert!(matches!(result, IoResult::Ok));
+        let slot_status_val = emulator.read_u32(0x58);
         let absent_presence_detect = (slot_status_val >> 22) & 0x1;
         assert_eq!(
             absent_presence_detect, 0,
@@ -2984,21 +2976,18 @@ mod tests {
         );
 
         // Initially, no interrupt pin should be configured
-        let mut val = 0u32;
-        emu.read_u32(0x3C, &mut val).unwrap(); // LATENCY_INTERRUPT register
-        assert_eq!(val & 0xFF00, 0); // Interrupt pin should be 0
+        assert_eq!(emu.read_u32(0x3C) & 0xFF00, 0); // Interrupt pin should be 0
 
         // Configure interrupt pin A
         let line_interrupt = LineInterrupt::detached();
         emu.set_interrupt_pin(PciInterruptPin::IntA, line_interrupt);
 
         // Read the register again
-        emu.read_u32(0x3C, &mut val).unwrap();
-        assert_eq!((val >> 8) & 0xFF, 1); // Interrupt pin should be 1 (INTA)
+        assert_eq!((emu.read_u32(0x3C) >> 8) & 0xFF, 1); // Interrupt pin should be 1 (INTA)
 
         // Set interrupt line to 0x42 and verify both pin and line are correct
-        emu.write_u32(0x3C, 0x00110042).unwrap(); // Latency=0x11, pin=ignored, line=0x42
-        emu.read_u32(0x3C, &mut val).unwrap();
+        emu.write_u32(0x3C, 0x00110042); // Latency=0x11, pin=ignored, line=0x42
+        let val = emu.read_u32(0x3C);
         assert_eq!(val & 0xFF, 0x42); // Interrupt line should be 0x42
         assert_eq!((val >> 8) & 0xFF, 1); // Interrupt pin should still be 1 (writes ignored)
         assert_eq!((val >> 16) & 0xFF, 0x11); // Latency timer should be 0x11
@@ -3023,8 +3012,7 @@ mod tests {
         let line_interrupt_d = LineInterrupt::detached();
         emu_d.set_interrupt_pin(PciInterruptPin::IntD, line_interrupt_d);
 
-        emu_d.read_u32(0x3C, &mut val).unwrap();
-        assert_eq!((val >> 8) & 0xFF, 4); // Interrupt pin should be 4 (INTD)
+        assert_eq!((emu_d.read_u32(0x3C) >> 8) & 0xFF, 4); // Interrupt pin should be 4 (INTD)
     }
 
     #[test]
@@ -3277,5 +3265,105 @@ mod tests {
         // no-op for the intercept and must not panic.
         drop(common_emu);
         assert!(!mapped.load(Ordering::SeqCst));
+    }
+
+    #[test]
+    fn test_type1_bdf_capturing() {
+        // Test that the bridge captures the BDF of the device behind it
+        let mut type1_emulator = create_type1_emulator(vec![]);
+
+        // Initially, the captured BDF should be 0.
+        assert_eq!(type1_emulator.captured_bus_number(), 0);
+        assert_eq!(type1_emulator.captured_devfn(), 0);
+
+        // Reads do not capture the BDF.
+        let mut read_value = 0;
+        let _ = type1_emulator.read(
+            PciConfigAddress::new(1, 1, 0).unwrap(),
+            ByteEnabledDwordRead::with_all_bytes_enabled(&mut read_value),
+        );
+        assert_eq!(type1_emulator.captured_bus_number(), 0);
+        assert_eq!(type1_emulator.captured_devfn(), 0);
+
+        // Writes capture the BDF.
+        let _ = type1_emulator.write(
+            PciConfigAddress::new(1, 1, 0).unwrap(),
+            ByteEnabledDwordWrite::with_all_bytes_enabled(0xdead_beef),
+        );
+        assert_eq!(type1_emulator.captured_bus_number(), 1);
+        assert_eq!(type1_emulator.captured_devfn(), 1);
+
+        // And writing a new BDF overwrites the old.
+        let _ = type1_emulator.write(
+            PciConfigAddress::new(4, 1, 0).unwrap(),
+            ByteEnabledDwordWrite::with_all_bytes_enabled(0xdead_beef),
+        );
+        assert_eq!(type1_emulator.captured_bus_number(), 4);
+        assert_eq!(type1_emulator.captured_devfn(), 1);
+
+        // Save state with BDF captured.
+        let saved_state = type1_emulator.save().expect("save should succeed");
+
+        // Captured BDF should be cleared on reset.
+        type1_emulator.reset();
+        assert_eq!(type1_emulator.captured_bus_number(), 0);
+        assert_eq!(type1_emulator.captured_devfn(), 0);
+
+        // Restore the state, captured BDF should be restored.
+        type1_emulator
+            .restore(saved_state)
+            .expect("restore should succeed");
+        assert_eq!(type1_emulator.captured_bus_number(), 4);
+        assert_eq!(type1_emulator.captured_devfn(), 1);
+    }
+
+    #[test]
+    fn test_type0_bdf_capturing() {
+        // Test that the bridge captures the BDF of the device behind it
+        let mut type0_emulator = create_type0_emulator(vec![]);
+
+        // Initially, the captured BDF should be 0.
+        assert_eq!(type0_emulator.captured_bus_number(), 0);
+        assert_eq!(type0_emulator.captured_devfn(), 0);
+
+        // Reads do not capture the BDF.
+        let mut read_value = 0;
+        let _ = type0_emulator.read(
+            PciConfigAddress::new(1, 1, 0).unwrap(),
+            ByteEnabledDwordRead::with_all_bytes_enabled(&mut read_value),
+        );
+        assert_eq!(type0_emulator.captured_bus_number(), 0);
+        assert_eq!(type0_emulator.captured_devfn(), 0);
+
+        // Writes capture the BDF.
+        let _ = type0_emulator.write(
+            PciConfigAddress::new(1, 1, 0).unwrap(),
+            ByteEnabledDwordWrite::with_all_bytes_enabled(0xdead_beef),
+        );
+        assert_eq!(type0_emulator.captured_bus_number(), 1);
+        assert_eq!(type0_emulator.captured_devfn(), 1);
+
+        // And writing a new BDF overwrites the old.
+        let _ = type0_emulator.write(
+            PciConfigAddress::new(4, 1, 0).unwrap(),
+            ByteEnabledDwordWrite::with_all_bytes_enabled(0xdead_beef),
+        );
+        assert_eq!(type0_emulator.captured_bus_number(), 4);
+        assert_eq!(type0_emulator.captured_devfn(), 1);
+
+        // Save state with BDF captured.
+        let saved_state = type0_emulator.save().expect("save should succeed");
+
+        // Captured BDF should be cleared on reset.
+        type0_emulator.reset();
+        assert_eq!(type0_emulator.captured_bus_number(), 0);
+        assert_eq!(type0_emulator.captured_devfn(), 0);
+
+        // Restore the state, captured BDF should be restored.
+        type0_emulator
+            .restore(saved_state)
+            .expect("restore should succeed");
+        assert_eq!(type0_emulator.captured_bus_number(), 4);
+        assert_eq!(type0_emulator.captured_devfn(), 1);
     }
 }

--- a/vm/devices/pci/pci_core/src/cfg_space_emu.rs
+++ b/vm/devices/pci/pci_core/src/cfg_space_emu.rs
@@ -3269,7 +3269,8 @@ mod tests {
 
     #[test]
     fn test_type1_bdf_capturing() {
-        // Test that the bridge captures the BDF of the device behind it
+        // Test that the type1 config space emulator captures
+        // the BDF of accesses it receives.
         let mut type1_emulator = create_type1_emulator(vec![]);
 
         // Initially, the captured BDF should be 0.
@@ -3319,7 +3320,8 @@ mod tests {
 
     #[test]
     fn test_type0_bdf_capturing() {
-        // Test that the bridge captures the BDF of the device behind it
+        // Test that the type0 config space emulator captures
+        // the BDF of accesses it receives.
         let mut type0_emulator = create_type0_emulator(vec![]);
 
         // Initially, the captured BDF should be 0.

--- a/vm/devices/pci/pci_core/src/test_helpers/mod.rs
+++ b/vm/devices/pci/pci_core/src/test_helpers/mod.rs
@@ -66,6 +66,7 @@ pub trait TestCfgAccess {
 
 impl TestCfgAccess for ConfigSpaceType0Emulator {
     fn read_u32(&self, offset: u16) -> u32 {
+        assert!(offset.is_multiple_of(4));
         let mut val = 0;
         self.read(
             PciConfigAddress::new(0, 0, offset / 4).unwrap(),
@@ -76,6 +77,7 @@ impl TestCfgAccess for ConfigSpaceType0Emulator {
     }
 
     fn write_u32(&mut self, offset: u16, value: u32) {
+        assert!(offset.is_multiple_of(4));
         self.write(
             PciConfigAddress::new(0, 0, offset / 4).unwrap(),
             ByteEnabledDwordWrite::with_all_bytes_enabled(value),
@@ -86,6 +88,7 @@ impl TestCfgAccess for ConfigSpaceType0Emulator {
 
 impl TestCfgAccess for ConfigSpaceType1Emulator {
     fn read_u32(&self, offset: u16) -> u32 {
+        assert!(offset.is_multiple_of(4));
         let mut val = 0;
         self.read(
             PciConfigAddress::new(0, 0, offset / 4).unwrap(),
@@ -96,6 +99,7 @@ impl TestCfgAccess for ConfigSpaceType1Emulator {
     }
 
     fn write_u32(&mut self, offset: u16, value: u32) {
+        assert!(offset.is_multiple_of(4));
         self.write(
             PciConfigAddress::new(0, 0, offset / 4).unwrap(),
             ByteEnabledDwordWrite::with_all_bytes_enabled(value),

--- a/vm/devices/pci/pci_core/src/test_helpers/mod.rs
+++ b/vm/devices/pci/pci_core/src/test_helpers/mod.rs
@@ -3,7 +3,14 @@
 
 //! Mock types for unit-testing various PCI behaviors.
 
+use crate::capabilities::PciCapability;
+use crate::capabilities::extended::PciExtendedCapability;
+use crate::cfg_space_emu::ConfigSpaceType0Emulator;
+use crate::cfg_space_emu::ConfigSpaceType1Emulator;
 use crate::msi::SignalMsi;
+use chipset_device::pci::ByteEnabledDwordRead;
+use chipset_device::pci::ByteEnabledDwordWrite;
+use chipset_device::pci::PciConfigAddress;
 use parking_lot::Mutex;
 use std::collections::VecDeque;
 use std::sync::Arc;
@@ -48,45 +55,81 @@ impl SignalMsi for TestPciInterruptControllerInner {
     }
 }
 
+/// Test-only DWORD access helpers for config-space-like objects.
+pub trait TestCfgAccess {
+    /// Read a DWORD at the given object-relative offset.
+    fn read_u32(&self, offset: u16) -> u32;
+
+    /// Write a DWORD at the given object-relative offset.
+    fn write_u32(&mut self, offset: u16, value: u32);
+}
+
+impl TestCfgAccess for ConfigSpaceType0Emulator {
+    fn read_u32(&self, offset: u16) -> u32 {
+        let mut val = 0;
+        self.read(
+            PciConfigAddress::new(0, 0, offset / 4).unwrap(),
+            ByteEnabledDwordRead::with_all_bytes_enabled(&mut val),
+        )
+        .unwrap();
+        val
+    }
+
+    fn write_u32(&mut self, offset: u16, value: u32) {
+        self.write(
+            PciConfigAddress::new(0, 0, offset / 4).unwrap(),
+            ByteEnabledDwordWrite::with_all_bytes_enabled(value),
+        )
+        .unwrap();
+    }
+}
+
+impl TestCfgAccess for ConfigSpaceType1Emulator {
+    fn read_u32(&self, offset: u16) -> u32 {
+        let mut val = 0;
+        self.read(
+            PciConfigAddress::new(0, 0, offset / 4).unwrap(),
+            ByteEnabledDwordRead::with_all_bytes_enabled(&mut val),
+        )
+        .unwrap();
+        val
+    }
+
+    fn write_u32(&mut self, offset: u16, value: u32) {
+        self.write(
+            PciConfigAddress::new(0, 0, offset / 4).unwrap(),
+            ByteEnabledDwordWrite::with_all_bytes_enabled(value),
+        )
+        .unwrap();
+    }
+}
+
 /// Read a u32 from a `PciCapability`.
-pub fn read_cap_u32(cap: &impl crate::capabilities::PciCapability, offset: u16) -> u32 {
+pub fn read_cap_u32(cap: &impl PciCapability, offset: u16) -> u32 {
     let mut value = 0;
     cap.read(
         offset,
-        chipset_device::pci::ByteEnabledDwordRead::with_all_bytes_enabled(&mut value),
+        ByteEnabledDwordRead::with_all_bytes_enabled(&mut value),
     );
     value
 }
 
 /// Write a u32 to a `PciCapability`.
-pub fn write_cap_u32(cap: &mut impl crate::capabilities::PciCapability, offset: u16, val: u32) {
-    cap.write(
-        offset,
-        chipset_device::pci::ByteEnabledDwordWrite::with_all_bytes_enabled(val),
-    )
+pub fn write_cap_u32(cap: &mut impl PciCapability, offset: u16, val: u32) {
+    cap.write(offset, ByteEnabledDwordWrite::with_all_bytes_enabled(val))
 }
 
 /// Read a u32 from a `PciExtendedCapability`.
-pub fn read_extended_cap_u32(
-    cap: &impl crate::capabilities::extended::PciExtendedCapability,
-    offset: u16,
-) -> u32 {
+pub fn read_extended_cap_u32(cap: &impl PciExtendedCapability, offset: u16) -> u32 {
     let mut value = 0;
     cap.read(
         offset,
-        chipset_device::pci::ByteEnabledDwordRead::with_all_bytes_enabled(&mut value),
+        ByteEnabledDwordRead::with_all_bytes_enabled(&mut value),
     );
     value
 }
 
 /// Write a u32 to a `PciExtendedCapability`.
-pub fn write_extended_cap_u32(
-    cap: &mut impl crate::capabilities::extended::PciExtendedCapability,
-    offset: u16,
-    val: u32,
-) {
-    cap.write(
-        offset,
-        chipset_device::pci::ByteEnabledDwordWrite::with_all_bytes_enabled(val),
-    )
+pub fn write_extended_cap_u32(cap: &mut impl PciExtendedCapability, offset: u16, val: u32) {
+    cap.write(offset, ByteEnabledDwordWrite::with_all_bytes_enabled(val))
 }

--- a/vm/devices/pci/pcie/fuzz/fuzz_pcie.rs
+++ b/vm/devices/pci/pcie/fuzz/fuzz_pcie.rs
@@ -82,7 +82,7 @@ impl GenericPciBusDevice for SwitchAdapter {
         address: PciConfigAddress,
         value: ByteEnabledDwordRead<'_>,
     ) -> Option<IoResult> {
-        Some(PciConfigSpace::pci_cfg_type0_read(
+        Some(PciConfigSpace::pci_cfg_read_with_routing(
             &mut self.0,
             access_type,
             address,
@@ -96,7 +96,7 @@ impl GenericPciBusDevice for SwitchAdapter {
         address: PciConfigAddress,
         value: ByteEnabledDwordWrite,
     ) -> Option<IoResult> {
-        Some(PciConfigSpace::pci_cfg_type0_write(
+        Some(PciConfigSpace::pci_cfg_write_with_routing(
             &mut self.0,
             access_type,
             address,

--- a/vm/devices/pci/pcie/fuzz/fuzz_pcie.rs
+++ b/vm/devices/pci/pcie/fuzz/fuzz_pcie.rs
@@ -12,6 +12,7 @@ use chipset_device::io::deferred::DeferredToken;
 use chipset_device::mmio::MmioIntercept;
 use chipset_device::pci::ByteEnabledDwordRead;
 use chipset_device::pci::ByteEnabledDwordWrite;
+use chipset_device::pci::PciConfigAccessType;
 use chipset_device::pci::PciConfigAddress;
 use chipset_device::pci::PciConfigSpace;
 use memory_range::MemoryRange;
@@ -75,25 +76,29 @@ impl GenericPciBusDevice for SwitchAdapter {
         Some(self.0.pci_cfg_write(offset, value))
     }
 
-    fn pci_cfg_type0_read(
+    fn pci_cfg_read_with_routing(
         &mut self,
+        access_type: PciConfigAccessType,
         address: PciConfigAddress,
         value: ByteEnabledDwordRead<'_>,
     ) -> Option<IoResult> {
         Some(PciConfigSpace::pci_cfg_type0_read(
             &mut self.0,
+            access_type,
             address,
             value,
         ))
     }
 
-    fn pci_cfg_type0_write(
+    fn pci_cfg_write_with_routing(
         &mut self,
+        access_type: PciConfigAccessType,
         address: PciConfigAddress,
         value: ByteEnabledDwordWrite,
     ) -> Option<IoResult> {
         Some(PciConfigSpace::pci_cfg_type0_write(
             &mut self.0,
+            access_type,
             address,
             value,
         ))

--- a/vm/devices/pci/pcie/fuzz/fuzz_pcie.rs
+++ b/vm/devices/pci/pcie/fuzz/fuzz_pcie.rs
@@ -12,6 +12,7 @@ use chipset_device::io::deferred::DeferredToken;
 use chipset_device::mmio::MmioIntercept;
 use chipset_device::pci::ByteEnabledDwordRead;
 use chipset_device::pci::ByteEnabledDwordWrite;
+use chipset_device::pci::PciConfigAddress;
 use chipset_device::pci::PciConfigSpace;
 use memory_range::MemoryRange;
 use pci_bus::GenericPciBusDevice;
@@ -74,32 +75,28 @@ impl GenericPciBusDevice for SwitchAdapter {
         Some(self.0.pci_cfg_write(offset, value))
     }
 
-    fn pci_cfg_read_with_routing(
+    fn pci_cfg_type0_read(
         &mut self,
-        secondary_bus: u8,
-        target_bus: u8,
-        function: u8,
-        offset: u16,
+        address: PciConfigAddress,
         value: ByteEnabledDwordRead<'_>,
     ) -> Option<IoResult> {
-        Some(
-            self.0
-                .pci_cfg_read_with_routing(secondary_bus, target_bus, function, offset, value),
-        )
+        Some(PciConfigSpace::pci_cfg_type0_read(
+            &mut self.0,
+            address,
+            value,
+        ))
     }
 
-    fn pci_cfg_write_with_routing(
+    fn pci_cfg_type0_write(
         &mut self,
-        secondary_bus: u8,
-        target_bus: u8,
-        function: u8,
-        offset: u16,
+        address: PciConfigAddress,
         value: ByteEnabledDwordWrite,
     ) -> Option<IoResult> {
-        Some(
-            self.0
-                .pci_cfg_write_with_routing(secondary_bus, target_bus, function, offset, value),
-        )
+        Some(PciConfigSpace::pci_cfg_type0_write(
+            &mut self.0,
+            address,
+            value,
+        ))
     }
 }
 

--- a/vm/devices/pci/pcie/src/port.rs
+++ b/vm/devices/pci/pcie/src/port.rs
@@ -711,11 +711,13 @@ impl PcieDownstreamPort {
             PciConfigAccessType::Type1
         };
 
-        device.pci_cfg_read_with_routing(new_access_type, addr,value.reborrow()).unwrap_or_else(|| {
-            tracelimit::warn_ratelimited!("failed to read from connected device");
-            value.set(!0);
-            IoResult::Ok
-        })
+        device
+            .pci_cfg_read_with_routing(new_access_type, addr, value.reborrow())
+            .unwrap_or_else(|| {
+                tracelimit::warn_ratelimited!("failed to read from connected device");
+                value.set(!0);
+                IoResult::Ok
+            })
     }
 
     /// Forward a configuration space write to the connected device.
@@ -757,10 +759,12 @@ impl PcieDownstreamPort {
             PciConfigAccessType::Type1
         };
 
-        device.pci_cfg_write_with_routing(new_access_type, addr, value).unwrap_or_else(|| {
-            tracelimit::warn_ratelimited!("failed to write to connected device");
-            IoResult::Ok
-        })
+        device
+            .pci_cfg_write_with_routing(new_access_type, addr, value)
+            .unwrap_or_else(|| {
+                tracelimit::warn_ratelimited!("failed to write to connected device");
+                IoResult::Ok
+            })
     }
 
     /// Connect a device to this specific port by exact name match.

--- a/vm/devices/pci/pcie/src/port.rs
+++ b/vm/devices/pci/pcie/src/port.rs
@@ -702,20 +702,19 @@ impl PcieDownstreamPort {
             return IoResult::Ok;
         };
 
-        let secondary_bus = *bus_range.start();
-        device
-            .pci_cfg_read_with_routing(
-                secondary_bus,
-                addr.bus,
-                addr.device_function,
-                addr.byte_offset(),
-                value.reborrow(),
-            )
-            .unwrap_or_else(|| {
-                tracelimit::warn_ratelimited!("failed to read from connected device");
-                value.set(!0);
-                IoResult::Ok
-            })
+        // If the target bus number is the secondary bus number of this port, turn the type 1 access into
+        // a type 0 access to the connected device. Otherwise, forward the type 1 access as-is.
+        let result = if addr.bus == *bus_range.start() {
+            device.pci_cfg_type0_read(addr, value.reborrow())
+        } else {
+            device.pci_cfg_type1_read(addr, value.reborrow())
+        };
+
+        result.unwrap_or_else(|| {
+            tracelimit::warn_ratelimited!("failed to read from connected device");
+            value.set(!0);
+            IoResult::Ok
+        })
     }
 
     /// Forward a configuration space write to the connected device.
@@ -749,19 +748,18 @@ impl PcieDownstreamPort {
             return IoResult::Ok;
         };
 
-        let secondary_bus = *bus_range.start();
-        device
-            .pci_cfg_write_with_routing(
-                secondary_bus,
-                addr.bus,
-                addr.device_function,
-                addr.byte_offset(),
-                value,
-            )
-            .unwrap_or_else(|| {
-                tracelimit::warn_ratelimited!("failed to write to connected device");
-                IoResult::Ok
-            })
+        // If the target bus number is the secondary bus number of this port, turn the type 1 access into
+        // a type 0 access to the connected device. Otherwise, forward the type 1 access as-is.
+        let result = if addr.bus == *bus_range.start() {
+            device.pci_cfg_type0_write(addr, value)
+        } else {
+            device.pci_cfg_type1_write(addr, value)
+        };
+
+        result.unwrap_or_else(|| {
+            tracelimit::warn_ratelimited!("failed to write to connected device");
+            IoResult::Ok
+        })
     }
 
     /// Connect a device to this specific port by exact name match.
@@ -864,6 +862,7 @@ mod tests {
     use parking_lot::Mutex;
     use pci_bus::GenericPciBusDevice;
     use pci_core::spec::hwid::HardwareIds;
+    use pci_core::test_helpers::TestCfgAccess;
     use std::sync::Arc;
 
     fn make_cxl_bar_port() -> PcieDownstreamPort {
@@ -932,9 +931,11 @@ mod tests {
     #[derive(Default, Debug, Clone, PartialEq, Eq)]
     struct RoutingStats {
         direct_reads: usize,
-        forward_reads: Vec<(u8, u8, u16)>,
         direct_writes: usize,
-        forward_writes: Vec<(u8, u8, u16, ByteEnabledDwordWrite)>,
+        type0_reads: Vec<PciConfigAddress>,
+        type0_writes: Vec<PciConfigAddress>,
+        type1_reads: Vec<PciConfigAddress>,
+        type1_writes: Vec<PciConfigAddress>,
     }
 
     struct MultiFunctionMockDevice {
@@ -960,34 +961,41 @@ mod tests {
             Some(IoResult::Ok)
         }
 
-        fn pci_cfg_read_with_routing(
+        fn pci_cfg_type0_read(
             &mut self,
-            _secondary_bus: u8,
-            target_bus: u8,
-            function: u8,
-            offset: u16,
+            address: PciConfigAddress,
             mut value: ByteEnabledDwordRead<'_>,
         ) -> Option<IoResult> {
-            self.stats
-                .lock()
-                .forward_reads
-                .push((target_bus, function, offset));
+            self.stats.lock().type0_reads.push(address);
             value.set(0x1234_5678);
             Some(IoResult::Ok)
         }
 
-        fn pci_cfg_write_with_routing(
+        fn pci_cfg_type0_write(
             &mut self,
-            _secondary_bus: u8,
-            target_bus: u8,
-            function: u8,
-            offset: u16,
-            value: ByteEnabledDwordWrite,
+            address: PciConfigAddress,
+            _value: ByteEnabledDwordWrite,
         ) -> Option<IoResult> {
-            self.stats
-                .lock()
-                .forward_writes
-                .push((target_bus, function, offset, value));
+            self.stats.lock().type0_writes.push(address);
+            Some(IoResult::Ok)
+        }
+
+        fn pci_cfg_type1_read(
+            &mut self,
+            address: PciConfigAddress,
+            mut value: ByteEnabledDwordRead<'_>,
+        ) -> Option<IoResult> {
+            self.stats.lock().type1_reads.push(address);
+            value.set(0x1234_5678);
+            Some(IoResult::Ok)
+        }
+
+        fn pci_cfg_type1_write(
+            &mut self,
+            address: PciConfigAddress,
+            _value: ByteEnabledDwordWrite,
+        ) -> Option<IoResult> {
+            self.stats.lock().type1_writes.push(address);
             Some(IoResult::Ok)
         }
     }
@@ -1022,9 +1030,7 @@ mod tests {
         );
 
         // Initially, presence detect state should be 0
-        let mut slot_status_val = 0u32;
-        let result = port.cfg_space.read_u32(0x58, &mut slot_status_val); // 0x40 (cap start) + 0x18 (slot control/status)
-        assert!(matches!(result, IoResult::Ok));
+        let slot_status_val = port.cfg_space.read_u32(0x58); // 0x40 (cap start) + 0x18 (slot control/status)
         let initial_presence_detect = (slot_status_val >> 22) & 0x1; // presence_detect_state is bit 6 of slot status
         assert_eq!(
             initial_presence_detect, 0,
@@ -1037,8 +1043,7 @@ mod tests {
         assert!(result.is_ok(), "Adding device should succeed");
 
         // Check that presence detect state is now 1
-        let result = port.cfg_space.read_u32(0x58, &mut slot_status_val);
-        assert!(matches!(result, IoResult::Ok));
+        let slot_status_val = port.cfg_space.read_u32(0x58); // 0x40 (cap start) + 0x18 (slot control/status)
         let present_presence_detect = (slot_status_val >> 22) & 0x1;
         assert_eq!(
             present_presence_detect, 1,
@@ -1112,9 +1117,7 @@ mod tests {
             None,
         );
 
-        port.cfg_space
-            .write_u32(0x18, (1u32 << 16) | (1u32 << 8))
-            .unwrap();
+        port.cfg_space.write_u32(0x18, (1u32 << 16) | (1u32 << 8));
 
         let stats = Arc::new(Mutex::new(RoutingStats::default()));
         port.link = Some((
@@ -1125,9 +1128,9 @@ mod tests {
         ));
 
         let mut value = 0;
-        // All accesses on the secondary bus go through
-        // pci_cfg_read_with_routing — the linked device is responsible
-        // for dispatching function 0 to its own config space.
+        // All accesses on the secondary bus go through the linked device's
+        // Type 0 routing hook, which is responsible for dispatching function 0
+        // to its own config space.
         assert!(matches!(
             port.forward_cfg_read_with_routing(
                 PciConfigAddress::new(1, 0, 0x10 / 4).unwrap(),
@@ -1145,7 +1148,13 @@ mod tests {
 
         let stats = stats.lock().clone();
         assert_eq!(stats.direct_reads, 0);
-        assert_eq!(stats.forward_reads, vec![(1, 0, 0x10), (1, 3, 0x14)]);
+        assert_eq!(
+            stats.type0_reads,
+            vec![
+                PciConfigAddress::new(1, 0, 0x10 / 4).unwrap(),
+                PciConfigAddress::new(1, 3, 0x14 / 4).unwrap()
+            ]
+        );
     }
 
     #[test]
@@ -1176,9 +1185,7 @@ mod tests {
             None,
         );
 
-        port.cfg_space
-            .write_u32(0x18, (1u32 << 16) | (1u32 << 8))
-            .unwrap();
+        port.cfg_space.write_u32(0x18, (1u32 << 16) | (1u32 << 8));
 
         let stats = Arc::new(Mutex::new(RoutingStats::default()));
         port.link = Some((
@@ -1188,9 +1195,9 @@ mod tests {
             }),
         ));
 
-        // All accesses on the secondary bus go through
-        // pci_cfg_write_with_routing — the linked device is responsible
-        // for dispatching function 0 to its own config space.
+        // All accesses on the secondary bus go through the linked device's
+        // Type 0 routing hook, which is responsible for dispatching function 0
+        // to its own config space.
         assert!(matches!(
             port.forward_cfg_write_with_routing(
                 PciConfigAddress::new(1, 0, 0x10 / 4).unwrap(),
@@ -1209,20 +1216,10 @@ mod tests {
         let stats = stats.lock().clone();
         assert_eq!(stats.direct_writes, 0);
         assert_eq!(
-            stats.forward_writes,
+            stats.type0_writes,
             vec![
-                (
-                    1,
-                    0,
-                    0x10,
-                    ByteEnabledDwordWrite::with_all_bytes_enabled(0xAAAA_0000)
-                ),
-                (
-                    1,
-                    2,
-                    0x14,
-                    ByteEnabledDwordWrite::with_all_bytes_enabled(0xBBBB_0000)
-                )
+                PciConfigAddress::new(1, 0, 0x10 / 4).unwrap(),
+                PciConfigAddress::new(1, 2, 0x14 / 4).unwrap()
             ]
         );
     }
@@ -1257,13 +1254,13 @@ mod tests {
         );
 
         // Program bridge bus numbers (Type1 register at offset 0x18).
-        port.cfg_space.write_u32(0x18, 0x0012_1000).unwrap();
+        port.cfg_space.write_u32(0x18, 0x0012_1000);
         assert_eq!(port.cfg_space.assigned_bus_range(), 0x10..=0x12);
 
         let saved = port.cfg_space.save().expect("save should succeed");
 
         // Change state away from saved values.
-        port.cfg_space.write_u32(0x18, 0x0000_0000).unwrap();
+        port.cfg_space.write_u32(0x18, 0x0000_0000);
         assert_eq!(port.cfg_space.assigned_bus_range(), 0..=0);
 
         port.cfg_space
@@ -1323,8 +1320,7 @@ mod tests {
             None,
             None,
         );
-        let mut value = 0u32;
-        with_acs.cfg_space.read_u32(0x100, &mut value).unwrap();
+        let value = with_acs.cfg_space.read_u32(0x100);
         assert_eq!(value & 0xffff, ExtendedCapabilityId::ACS.0 as u32);
 
         let without_acs = PcieDownstreamPort::new(
@@ -1338,7 +1334,7 @@ mod tests {
             None,
             None,
         );
-        without_acs.cfg_space.read_u32(0x100, &mut value).unwrap();
+        let value = without_acs.cfg_space.read_u32(0x100);
         assert_eq!(value, 0);
     }
 
@@ -1384,8 +1380,7 @@ mod tests {
             }),
         );
 
-        let mut value = 0u32;
-        port.cfg_space.read_u32(0x100, &mut value).unwrap();
+        let value = port.cfg_space.read_u32(0x100);
         assert_eq!(
             value, 0,
             "CXL DVSECs should be absent when CXL component-register BAR backing is invalid"

--- a/vm/devices/pci/pcie/src/port.rs
+++ b/vm/devices/pci/pcie/src/port.rs
@@ -9,6 +9,7 @@ use chipset_device::io::IoResult;
 use chipset_device::mmio::RegisterMmioIntercept;
 use chipset_device::pci::ByteEnabledDwordRead;
 use chipset_device::pci::ByteEnabledDwordWrite;
+use chipset_device::pci::PciConfigAccessType;
 use chipset_device::pci::PciConfigAddress;
 use cxl_spec::CxlComponentRegisters;
 use cxl_spec::CxlFlexBusPortDvsecExtendedCapability;
@@ -704,13 +705,13 @@ impl PcieDownstreamPort {
 
         // If the target bus number is the secondary bus number of this port, turn the type 1 access into
         // a type 0 access to the connected device. Otherwise, forward the type 1 access as-is.
-        let result = if addr.bus == *bus_range.start() {
-            device.pci_cfg_type0_read(addr, value.reborrow())
+        let new_access_type = if addr.bus == *bus_range.start() {
+            PciConfigAccessType::Type0
         } else {
-            device.pci_cfg_type1_read(addr, value.reborrow())
+            PciConfigAccessType::Type1
         };
 
-        result.unwrap_or_else(|| {
+        device.pci_cfg_read_with_routing(new_access_type, addr,value.reborrow()).unwrap_or_else(|| {
             tracelimit::warn_ratelimited!("failed to read from connected device");
             value.set(!0);
             IoResult::Ok
@@ -750,13 +751,13 @@ impl PcieDownstreamPort {
 
         // If the target bus number is the secondary bus number of this port, turn the type 1 access into
         // a type 0 access to the connected device. Otherwise, forward the type 1 access as-is.
-        let result = if addr.bus == *bus_range.start() {
-            device.pci_cfg_type0_write(addr, value)
+        let new_access_type = if addr.bus == *bus_range.start() {
+            PciConfigAccessType::Type0
         } else {
-            device.pci_cfg_type1_write(addr, value)
+            PciConfigAccessType::Type1
         };
 
-        result.unwrap_or_else(|| {
+        device.pci_cfg_write_with_routing(new_access_type, addr, value).unwrap_or_else(|| {
             tracelimit::warn_ratelimited!("failed to write to connected device");
             IoResult::Ok
         })
@@ -961,41 +962,32 @@ mod tests {
             Some(IoResult::Ok)
         }
 
-        fn pci_cfg_type0_read(
+        fn pci_cfg_read_with_routing(
             &mut self,
+            access_type: PciConfigAccessType,
             address: PciConfigAddress,
             mut value: ByteEnabledDwordRead<'_>,
         ) -> Option<IoResult> {
-            self.stats.lock().type0_reads.push(address);
+            let mut stats = self.stats.lock();
+            match access_type {
+                PciConfigAccessType::Type0 => stats.type0_reads.push(address),
+                PciConfigAccessType::Type1 => stats.type1_reads.push(address),
+            }
             value.set(0x1234_5678);
             Some(IoResult::Ok)
         }
 
-        fn pci_cfg_type0_write(
+        fn pci_cfg_write_with_routing(
             &mut self,
+            access_type: PciConfigAccessType,
             address: PciConfigAddress,
             _value: ByteEnabledDwordWrite,
         ) -> Option<IoResult> {
-            self.stats.lock().type0_writes.push(address);
-            Some(IoResult::Ok)
-        }
-
-        fn pci_cfg_type1_read(
-            &mut self,
-            address: PciConfigAddress,
-            mut value: ByteEnabledDwordRead<'_>,
-        ) -> Option<IoResult> {
-            self.stats.lock().type1_reads.push(address);
-            value.set(0x1234_5678);
-            Some(IoResult::Ok)
-        }
-
-        fn pci_cfg_type1_write(
-            &mut self,
-            address: PciConfigAddress,
-            _value: ByteEnabledDwordWrite,
-        ) -> Option<IoResult> {
-            self.stats.lock().type1_writes.push(address);
+            let mut stats = self.stats.lock();
+            match access_type {
+                PciConfigAccessType::Type0 => stats.type0_writes.push(address),
+                PciConfigAccessType::Type1 => stats.type1_writes.push(address),
+            }
             Some(IoResult::Ok)
         }
     }

--- a/vm/devices/pci/pcie/src/root.rs
+++ b/vm/devices/pci/pcie/src/root.rs
@@ -23,6 +23,7 @@ use chipset_device::mmio::RegisterMmioIntercept;
 use chipset_device::pci::ByteEnabledDwordRead;
 use chipset_device::pci::ByteEnabledDwordWrite;
 use chipset_device::pci::PciConfigAddress;
+use chipset_device::pci::PciConfigAccessType;
 use chipset_device::pci::PciConfigByteEnable;
 use chipset_device::poll_device::PollDevice;
 use cxl_spec::CxlComponentRegisters;
@@ -458,10 +459,10 @@ impl GenericPcieRootComplex {
     /// Most RCiEPs should be registered at function 0. Config space
     /// accesses to other functions of the same device will be forwarded
     /// to the function 0 device via
-    /// [`pci_cfg_type0_read`](GenericPciBusDevice::pci_cfg_type0_read),
+    /// [`pci_cfg_read_with_routing`](GenericPciBusDevice::pci_cfg_read_with_routing),
     /// whose default implementation returns all-1s (no device present).
-    /// A multi-function RCiEP should override `pci_cfg_type0_read`
-    /// and `pci_cfg_type0_write` to handle non-zero functions.
+    /// A multi-function RCiEP should override `pci_cfg_read_with_routing`
+    /// and `pci_cfg_write_with_routing` to handle non-zero functions.
     pub fn add_rciep(
         &mut self,
         devfn: u8,
@@ -693,7 +694,7 @@ impl<'a> PciBusCfgAccessCallbackView<'a> {
             // Look up the exact devfn first; if not found, fall back to
             // function 0 of the same device so that multi-function
             // endpoints can handle the access via
-            // `pci_cfg_type0_read`/`pci_cfg_type0_write`.
+            // `pci_cfg_read_with_routing`/`pci_cfg_write_with_routing`.
             let devfn_fn0 = addr.devfn & !7;
             let mut idx = None;
             let mut exact = false;
@@ -751,7 +752,7 @@ impl<'a> PciBusCfgAccessCallbacks for PciBusCfgAccessCallbackView<'a> {
 
         match target {
             CfgAccessTarget::Rciep(dev) => dev
-                .pci_cfg_type0_read(addr, value.reborrow())
+                .pci_cfg_read_with_routing(PciConfigAccessType::Type0, addr, value.reborrow())
                 .unwrap_or_else(|| {
                     value.set(!0);
                     IoResult::Ok
@@ -769,7 +770,7 @@ impl<'a> PciBusCfgAccessCallbacks for PciBusCfgAccessCallbackView<'a> {
 
         match target {
             CfgAccessTarget::Rciep(dev) => {
-                dev.pci_cfg_type0_write(addr, value).unwrap_or(IoResult::Ok)
+                dev.pci_cfg_write_with_routing(PciConfigAccessType::Type0, addr, value).unwrap_or(IoResult::Ok)
             }
             CfgAccessTarget::RootPort(port) => port.port.cfg_space.write(addr, value),
             CfgAccessTarget::DownstreamDevice(port) => port.forward_cfg_write(addr, value),
@@ -1137,36 +1138,22 @@ mod tests {
             Some(self.0.lock().pci_cfg_write(offset, value))
         }
 
-        fn pci_cfg_type0_read(
+        fn pci_cfg_read_with_routing(
             &mut self,
+            access_type: PciConfigAccessType,
             address: PciConfigAddress,
             value: ByteEnabledDwordRead<'_>,
         ) -> Option<IoResult> {
-            Some(self.0.lock().pci_cfg_type0_read(address, value))
+            Some(self.0.lock().pci_cfg_read_with_routing(access_type, address, value))
         }
 
-        fn pci_cfg_type0_write(
+        fn pci_cfg_write_with_routing(
             &mut self,
+            access_type: PciConfigAccessType,
             address: PciConfigAddress,
             value: ByteEnabledDwordWrite,
         ) -> Option<IoResult> {
-            Some(self.0.lock().pci_cfg_type0_write(address, value))
-        }
-
-        fn pci_cfg_type1_read(
-            &mut self,
-            address: PciConfigAddress,
-            value: ByteEnabledDwordRead<'_>,
-        ) -> Option<IoResult> {
-            Some(self.0.lock().pci_cfg_type1_read(address, value))
-        }
-
-        fn pci_cfg_type1_write(
-            &mut self,
-            address: PciConfigAddress,
-            value: ByteEnabledDwordWrite,
-        ) -> Option<IoResult> {
-            Some(self.0.lock().pci_cfg_type1_write(address, value))
+            Some(self.0.lock().pci_cfg_write_with_routing(access_type, address, value))
         }
     }
 
@@ -1571,7 +1558,8 @@ mod tests {
 
         switch
             .lock()
-            .pci_cfg_type0_write(
+            .pci_cfg_write_with_routing(
+                PciConfigAccessType::Type0,
                 PciConfigAddress::new(SWITCH_BUS, 0, 0x18 / 4).unwrap(),
                 ByteEnabledDwordWrite::with_all_bytes_enabled(
                     (10u32 << 16) | ((SWITCH_INTERNAL_BUS as u32) << 8) | SWITCH_BUS as u32,
@@ -1580,7 +1568,8 @@ mod tests {
             .unwrap();
         switch
             .lock()
-            .pci_cfg_type1_write(
+            .pci_cfg_write_with_routing(
+                PciConfigAccessType::Type1,
                 PciConfigAddress::new(SWITCH_INTERNAL_BUS, 0, 0x18 / 4).unwrap(),
                 ByteEnabledDwordWrite::with_all_bytes_enabled(
                     ((ENDPOINT_BUS as u32) << 16)
@@ -2109,7 +2098,7 @@ mod tests {
     #[test]
     fn test_rciep_function0_fallback() {
         // Test that a config read to function 1 of an RCiEP device falls
-        // back to the function-0 device via pci_cfg_type0_read,
+        // back to the function-0 device via pci_cfg_read_with_routing,
         // which by default returns all-1s for non-zero functions.
         let mut register_mmio = TestPcieMmioRegistration {};
         let start_bus: u8 = 0;
@@ -2136,7 +2125,7 @@ mod tests {
         assert_eq!(val, 0xCAFE_F00D);
 
         // Function 1 (devfn 1) falls back to the function-0 device's
-        // pci_cfg_type0_read, which returns all-1s by default.
+        // pci_cfg_read_with_routing, which returns all-1s by default.
         let mut val_fn1: u32 = 0;
         // devfn 1 → offset 1 * 4096
         rc.mmio_read(4096, val_fn1.as_mut_bytes()).unwrap();

--- a/vm/devices/pci/pcie/src/root.rs
+++ b/vm/devices/pci/pcie/src/root.rs
@@ -22,8 +22,8 @@ use chipset_device::mmio::MmioIntercept;
 use chipset_device::mmio::RegisterMmioIntercept;
 use chipset_device::pci::ByteEnabledDwordRead;
 use chipset_device::pci::ByteEnabledDwordWrite;
-use chipset_device::pci::PciConfigAddress;
 use chipset_device::pci::PciConfigAccessType;
+use chipset_device::pci::PciConfigAddress;
 use chipset_device::pci::PciConfigByteEnable;
 use chipset_device::poll_device::PollDevice;
 use cxl_spec::CxlComponentRegisters;
@@ -769,9 +769,9 @@ impl<'a> PciBusCfgAccessCallbacks for PciBusCfgAccessCallbackView<'a> {
         };
 
         match target {
-            CfgAccessTarget::Rciep(dev) => {
-                dev.pci_cfg_write_with_routing(PciConfigAccessType::Type0, addr, value).unwrap_or(IoResult::Ok)
-            }
+            CfgAccessTarget::Rciep(dev) => dev
+                .pci_cfg_write_with_routing(PciConfigAccessType::Type0, addr, value)
+                .unwrap_or(IoResult::Ok),
             CfgAccessTarget::RootPort(port) => port.port.cfg_space.write(addr, value),
             CfgAccessTarget::DownstreamDevice(port) => port.forward_cfg_write(addr, value),
         }
@@ -1144,7 +1144,11 @@ mod tests {
             address: PciConfigAddress,
             value: ByteEnabledDwordRead<'_>,
         ) -> Option<IoResult> {
-            Some(self.0.lock().pci_cfg_read_with_routing(access_type, address, value))
+            Some(
+                self.0
+                    .lock()
+                    .pci_cfg_read_with_routing(access_type, address, value),
+            )
         }
 
         fn pci_cfg_write_with_routing(
@@ -1153,7 +1157,11 @@ mod tests {
             address: PciConfigAddress,
             value: ByteEnabledDwordWrite,
         ) -> Option<IoResult> {
-            Some(self.0.lock().pci_cfg_write_with_routing(access_type, address, value))
+            Some(
+                self.0
+                    .lock()
+                    .pci_cfg_write_with_routing(access_type, address, value),
+            )
         }
     }
 

--- a/vm/devices/pci/pcie/src/root.rs
+++ b/vm/devices/pci/pcie/src/root.rs
@@ -458,10 +458,10 @@ impl GenericPcieRootComplex {
     /// Most RCiEPs should be registered at function 0. Config space
     /// accesses to other functions of the same device will be forwarded
     /// to the function 0 device via
-    /// [`pci_cfg_read_with_routing`](GenericPciBusDevice::pci_cfg_read_with_routing),
+    /// [`pci_cfg_type0_read`](GenericPciBusDevice::pci_cfg_type0_read),
     /// whose default implementation returns all-1s (no device present).
-    /// A multi-function RCiEP should override `pci_cfg_read_with_routing`
-    /// and `pci_cfg_write_with_routing` to handle non-zero functions.
+    /// A multi-function RCiEP should override `pci_cfg_type0_read`
+    /// and `pci_cfg_type0_write` to handle non-zero functions.
     pub fn add_rciep(
         &mut self,
         devfn: u8,
@@ -693,12 +693,12 @@ impl<'a> PciBusCfgAccessCallbackView<'a> {
             // Look up the exact devfn first; if not found, fall back to
             // function 0 of the same device so that multi-function
             // endpoints can handle the access via
-            // `pci_cfg_read_with_routing`.
-            let devfn_fn0 = addr.device_function & !7;
+            // `pci_cfg_type0_read`/`pci_cfg_type0_write`.
+            let devfn_fn0 = addr.devfn & !7;
             let mut idx = None;
             let mut exact = false;
             for (i, (d, _)) in self.devices.iter().enumerate() {
-                if *d == addr.device_function {
+                if *d == addr.devfn {
                     idx = Some(i);
                     exact = true;
                     break;
@@ -706,7 +706,7 @@ impl<'a> PciBusCfgAccessCallbackView<'a> {
                 if *d == devfn_fn0 {
                     idx = Some(i);
                 }
-                if *d > addr.device_function {
+                if *d > addr.devfn {
                     break;
                 }
             }
@@ -751,21 +751,12 @@ impl<'a> PciBusCfgAccessCallbacks for PciBusCfgAccessCallbackView<'a> {
 
         match target {
             CfgAccessTarget::Rciep(dev) => dev
-                .pci_cfg_read_with_routing(
-                    addr.bus,
-                    addr.bus,
-                    addr.device_function,
-                    addr.byte_offset(),
-                    value.reborrow(),
-                )
+                .pci_cfg_type0_read(addr, value.reborrow())
                 .unwrap_or_else(|| {
                     value.set(!0);
                     IoResult::Ok
                 }),
-            CfgAccessTarget::RootPort(port) => port
-                .port
-                .cfg_space
-                .read_byte_enabled(addr.byte_offset(), value),
+            CfgAccessTarget::RootPort(port) => port.port.cfg_space.read(addr, value),
             CfgAccessTarget::DownstreamDevice(port) => port.forward_cfg_read(addr, value),
         }
     }
@@ -777,19 +768,10 @@ impl<'a> PciBusCfgAccessCallbacks for PciBusCfgAccessCallbackView<'a> {
         };
 
         match target {
-            CfgAccessTarget::Rciep(dev) => dev
-                .pci_cfg_write_with_routing(
-                    addr.bus,
-                    addr.bus,
-                    addr.device_function,
-                    addr.byte_offset(),
-                    value,
-                )
-                .unwrap_or(IoResult::Ok),
-            CfgAccessTarget::RootPort(port) => port
-                .port
-                .cfg_space
-                .write_byte_enabled(addr.byte_offset(), value),
+            CfgAccessTarget::Rciep(dev) => {
+                dev.pci_cfg_type0_write(addr, value).unwrap_or(IoResult::Ok)
+            }
+            CfgAccessTarget::RootPort(port) => port.port.cfg_space.write(addr, value),
             CfgAccessTarget::DownstreamDevice(port) => port.forward_cfg_write(addr, value),
         }
     }
@@ -1080,6 +1062,7 @@ mod tests {
     use cxl_spec::component_registers::test_helper::TestCxlComponentRegisterBlock;
     use pal_async::async_test;
     use parking_lot::Mutex;
+    use pci_core::test_helpers::TestCfgAccess;
     use zerocopy::IntoBytes;
 
     struct DeferredEndpoint {
@@ -1154,38 +1137,36 @@ mod tests {
             Some(self.0.lock().pci_cfg_write(offset, value))
         }
 
-        fn pci_cfg_read_with_routing(
+        fn pci_cfg_type0_read(
             &mut self,
-            secondary_bus: u8,
-            target_bus: u8,
-            function: u8,
-            offset: u16,
+            address: PciConfigAddress,
             value: ByteEnabledDwordRead<'_>,
         ) -> Option<IoResult> {
-            Some(self.0.lock().pci_cfg_read_with_routing(
-                secondary_bus,
-                target_bus,
-                function,
-                offset,
-                value,
-            ))
+            Some(self.0.lock().pci_cfg_type0_read(address, value))
         }
 
-        fn pci_cfg_write_with_routing(
+        fn pci_cfg_type0_write(
             &mut self,
-            secondary_bus: u8,
-            target_bus: u8,
-            function: u8,
-            offset: u16,
+            address: PciConfigAddress,
             value: ByteEnabledDwordWrite,
         ) -> Option<IoResult> {
-            Some(self.0.lock().pci_cfg_write_with_routing(
-                secondary_bus,
-                target_bus,
-                function,
-                offset,
-                value,
-            ))
+            Some(self.0.lock().pci_cfg_type0_write(address, value))
+        }
+
+        fn pci_cfg_type1_read(
+            &mut self,
+            address: PciConfigAddress,
+            value: ByteEnabledDwordRead<'_>,
+        ) -> Option<IoResult> {
+            Some(self.0.lock().pci_cfg_type1_read(address, value))
+        }
+
+        fn pci_cfg_type1_write(
+            &mut self,
+            address: PciConfigAddress,
+            value: ByteEnabledDwordWrite,
+        ) -> Option<IoResult> {
+            Some(self.0.lock().pci_cfg_type1_write(address, value))
         }
     }
 
@@ -1590,11 +1571,8 @@ mod tests {
 
         switch
             .lock()
-            .pci_cfg_write_with_routing(
-                SWITCH_BUS,
-                SWITCH_BUS,
-                0,
-                0x18,
+            .pci_cfg_type0_write(
+                PciConfigAddress::new(SWITCH_BUS, 0, 0x18 / 4).unwrap(),
                 ByteEnabledDwordWrite::with_all_bytes_enabled(
                     (10u32 << 16) | ((SWITCH_INTERNAL_BUS as u32) << 8) | SWITCH_BUS as u32,
                 ),
@@ -1602,11 +1580,8 @@ mod tests {
             .unwrap();
         switch
             .lock()
-            .pci_cfg_write_with_routing(
-                SWITCH_BUS,
-                SWITCH_INTERNAL_BUS,
-                0,
-                0x18,
+            .pci_cfg_type1_write(
+                PciConfigAddress::new(SWITCH_INTERNAL_BUS, 0, 0x18 / 4).unwrap(),
                 ByteEnabledDwordWrite::with_all_bytes_enabled(
                     ((ENDPOINT_BUS as u32) << 16)
                         | ((ENDPOINT_BUS as u32) << 8)
@@ -1805,12 +1780,7 @@ mod tests {
         };
         // We can't easily verify hotplug is disabled without accessing internal state,
         // but we can verify the port was created successfully
-        let mut vendor_device_id: u32 = 0;
-        root_port_no_hotplug
-            .port
-            .cfg_space
-            .read_u32(0x0, &mut vendor_device_id)
-            .unwrap();
+        let vendor_device_id = root_port_no_hotplug.port.cfg_space.read_u32(0x0);
         let expected = (ROOT_PORT_DEVICE_ID as u32) << 16 | (VENDOR_ID as u32);
         assert_eq!(vendor_device_id, expected);
 
@@ -1827,12 +1797,7 @@ mod tests {
                 PciePortSettings::default(),
             )
         };
-        let mut vendor_device_id_hotplug: u32 = 0;
-        root_port_with_hotplug
-            .port
-            .cfg_space
-            .read_u32(0x0, &mut vendor_device_id_hotplug)
-            .unwrap();
+        let vendor_device_id_hotplug = root_port_with_hotplug.port.cfg_space.read_u32(0x0);
         assert_eq!(vendor_device_id_hotplug, expected);
         // The slot number and hotplug capability would be tested via PCIe capability registers
         // but that requires more complex setup
@@ -2144,7 +2109,7 @@ mod tests {
     #[test]
     fn test_rciep_function0_fallback() {
         // Test that a config read to function 1 of an RCiEP device falls
-        // back to the function-0 device via pci_cfg_read_with_routing,
+        // back to the function-0 device via pci_cfg_type0_read,
         // which by default returns all-1s for non-zero functions.
         let mut register_mmio = TestPcieMmioRegistration {};
         let start_bus: u8 = 0;
@@ -2171,7 +2136,7 @@ mod tests {
         assert_eq!(val, 0xCAFE_F00D);
 
         // Function 1 (devfn 1) falls back to the function-0 device's
-        // pci_cfg_read_with_routing, which returns all-1s by default.
+        // pci_cfg_type0_read, which returns all-1s by default.
         let mut val_fn1: u32 = 0;
         // devfn 1 → offset 1 * 4096
         rc.mmio_read(4096, val_fn1.as_mut_bytes()).unwrap();

--- a/vm/devices/pci/pcie/src/switch.rs
+++ b/vm/devices/pci/pcie/src/switch.rs
@@ -21,6 +21,7 @@ use chipset_device::ChipsetDevice;
 use chipset_device::io::IoResult;
 use chipset_device::pci::ByteEnabledDwordRead;
 use chipset_device::pci::ByteEnabledDwordWrite;
+use chipset_device::pci::PciConfigAccessType;
 use chipset_device::pci::PciConfigAddress;
 use chipset_device::pci::PciConfigSpace;
 use chipset_device::poll_device::PollDevice;
@@ -379,38 +380,22 @@ impl PciConfigSpace for GenericPcieSwitch {
             .write_byte_enabled(byte_offset, value)
     }
 
-    /// Reads the switch's own upstream-port config space (Type 0 view).
-    fn pci_cfg_type0_read(
+    fn pci_cfg_read_with_routing(
         &mut self,
+        access_type: PciConfigAccessType,
         address: PciConfigAddress,
         mut value: ByteEnabledDwordRead<'_>,
     ) -> IoResult {
-        if address.devfn == 0 {
-            self.upstream_port.cfg_space.read(address, value)
-        } else {
-            value.set(!0);
-            IoResult::Ok
+        // Type 0 accesses are handled by the upstream port emulator, only devfn 0 is valid.
+        if access_type == PciConfigAccessType::Type0 {
+            if address.devfn == 0 {
+                return self.upstream_port.cfg_space.read(address, value);
+            } else {
+                value.set(!0);
+                return IoResult::Ok;
+            }
         }
-    }
 
-    /// Writes the switch's own upstream-port config space (Type 0 view).
-    fn pci_cfg_type0_write(
-        &mut self,
-        address: PciConfigAddress,
-        value: ByteEnabledDwordWrite,
-    ) -> IoResult {
-        if address.devfn == 0 {
-            self.upstream_port.cfg_space.write(address, value)
-        } else {
-            IoResult::Ok
-        }
-    }
-
-    fn pci_cfg_type1_read(
-        &mut self,
-        address: PciConfigAddress,
-        mut value: ByteEnabledDwordRead<'_>,
-    ) -> IoResult {
         // If the bus range is 0..=0, this indicates invalid/uninitialized bus configuration
         let upstream_bus_range = self.upstream_port.cfg_space.assigned_bus_range();
         if upstream_bus_range == (0..=0) {
@@ -441,11 +426,21 @@ impl PciConfigSpace for GenericPcieSwitch {
         self.bus_cfg_handler.read(address, value, &mut callback)
     }
 
-    fn pci_cfg_type1_write(
+    fn pci_cfg_write_with_routing(
         &mut self,
+        access_type: PciConfigAccessType,
         address: PciConfigAddress,
         value: ByteEnabledDwordWrite,
     ) -> IoResult {
+        // Type 0 accesses are handled by the upstream port emulator, only devfn 0 is valid.
+        if access_type == PciConfigAccessType::Type0 {
+            if address.devfn == 0 {
+                return self.upstream_port.cfg_space.write(address, value);
+            } else {
+                return IoResult::Ok;
+            }
+        }
+
         // If the bus range is 0..=0, this indicates invalid/uninitialized bus configuration.
         let upstream_bus_range = self.upstream_port.cfg_space.assigned_bus_range();
         if upstream_bus_range == (0..=0) {
@@ -1004,7 +999,8 @@ mod tests {
 
         // Test direct access to downstream port 0 using function = 0
         let mut value = 0u32;
-        let result = switch.pci_cfg_type1_read(
+        let result = switch.pci_cfg_read_with_routing(
+            PciConfigAccessType::Type1,
             PciConfigAddress::new(switch_internal_bus, 0, 0).unwrap(),
             ByteEnabledDwordRead::with_all_bytes_enabled(&mut value),
         );
@@ -1016,7 +1012,8 @@ mod tests {
 
         // Test direct access to downstream port 2 using function = 2
         let mut value2 = 0u32;
-        let result2 = switch.pci_cfg_type1_read(
+        let result2 = switch.pci_cfg_read_with_routing(
+            PciConfigAccessType::Type1,
             PciConfigAddress::new(switch_internal_bus, 2, 0).unwrap(),
             ByteEnabledDwordRead::with_all_bytes_enabled(&mut value2),
         );
@@ -1025,7 +1022,8 @@ mod tests {
 
         // Test access to non-existent downstream port using function = 5
         let mut value3 = 0u32;
-        let result3 = switch.pci_cfg_type1_read(
+        let result3 = switch.pci_cfg_read_with_routing(
+            PciConfigAccessType::Type1,
             PciConfigAddress::new(switch_internal_bus, 5, 0).unwrap(),
             ByteEnabledDwordRead::with_all_bytes_enabled(&mut value3),
         );
@@ -1049,21 +1047,24 @@ mod tests {
 
         // Test that any access returns 1s when bus range is invalid
         let mut value = 0u32;
-        let result = switch.pci_cfg_type1_read(
+        let result = switch.pci_cfg_read_with_routing(
+            PciConfigAccessType::Type1,
             PciConfigAddress::new(1, 0, 0).unwrap(),
             ByteEnabledDwordRead::with_all_bytes_enabled(&mut value),
         );
         assert!(matches!(result, IoResult::Ok));
         assert_eq!(value, !0);
 
-        let result2 = switch.pci_cfg_type1_read(
+        let result2 = switch.pci_cfg_read_with_routing(
+            PciConfigAccessType::Type1,
             PciConfigAddress::new(1, 0, 0).unwrap(),
             ByteEnabledDwordRead::with_all_bytes_enabled(&mut value),
         );
         assert!(matches!(result2, IoResult::Ok));
         assert_eq!(value, !0);
 
-        let result3 = switch.pci_cfg_type1_read(
+        let result3 = switch.pci_cfg_read_with_routing(
+            PciConfigAccessType::Type1,
             PciConfigAddress::new(2, 0, 0).unwrap(),
             ByteEnabledDwordRead::with_all_bytes_enabled(&mut value),
         );
@@ -1097,7 +1098,8 @@ mod tests {
         let mut value = 0u32;
 
         // Access to bus 2 should return 1s since no downstream port has a valid bus range
-        let result = switch.pci_cfg_type1_read(
+        let result = switch.pci_cfg_read_with_routing(
+            PciConfigAccessType::Type1,
             PciConfigAddress::new(2, 0, 0).unwrap(),
             ByteEnabledDwordRead::with_all_bytes_enabled(&mut value),
         );
@@ -1105,7 +1107,8 @@ mod tests {
         assert_eq!(value, !0);
 
         // Access to bus 5 should also return 1s
-        let result2 = switch.pci_cfg_type1_read(
+        let result2 = switch.pci_cfg_read_with_routing(
+            PciConfigAccessType::Type1,
             PciConfigAddress::new(5, 0, 0).unwrap(),
             ByteEnabledDwordRead::with_all_bytes_enabled(&mut value),
         );
@@ -1113,7 +1116,8 @@ mod tests {
         assert_eq!(value, !0);
 
         // Access to the secondary bus (switch internal) should still work for downstream port config
-        let result3 = switch.pci_cfg_type1_read(
+        let result3 = switch.pci_cfg_read_with_routing(
+            PciConfigAccessType::Type1,
             PciConfigAddress::new(secondary_bus, 0, 0).unwrap(),
             ByteEnabledDwordRead::with_all_bytes_enabled(&mut value),
         );
@@ -1472,49 +1476,29 @@ mod tests {
             Some(PciConfigSpace::pci_cfg_write(&mut self.0, offset, value))
         }
 
-        fn pci_cfg_type0_read(
+        fn pci_cfg_read_with_routing(
             &mut self,
+            access_type: PciConfigAccessType,
             address: PciConfigAddress,
             value: ByteEnabledDwordRead<'_>,
         ) -> Option<IoResult> {
-            Some(PciConfigSpace::pci_cfg_type0_read(
+            Some(PciConfigSpace::pci_cfg_read_with_routing(
                 &mut self.0,
+                access_type,
                 address,
                 value,
             ))
         }
 
-        fn pci_cfg_type0_write(
+        fn pci_cfg_write_with_routing(
             &mut self,
+            access_type: PciConfigAccessType,
             address: PciConfigAddress,
             value: ByteEnabledDwordWrite,
         ) -> Option<IoResult> {
-            Some(PciConfigSpace::pci_cfg_type0_write(
+            Some(PciConfigSpace::pci_cfg_write_with_routing(
                 &mut self.0,
-                address,
-                value,
-            ))
-        }
-
-        fn pci_cfg_type1_read(
-            &mut self,
-            address: PciConfigAddress,
-            value: ByteEnabledDwordRead<'_>,
-        ) -> Option<IoResult> {
-            Some(PciConfigSpace::pci_cfg_type1_read(
-                &mut self.0,
-                address,
-                value,
-            ))
-        }
-
-        fn pci_cfg_type1_write(
-            &mut self,
-            address: PciConfigAddress,
-            value: ByteEnabledDwordWrite,
-        ) -> Option<IoResult> {
-            Some(PciConfigSpace::pci_cfg_type1_write(
-                &mut self.0,
+                access_type,
                 address,
                 value,
             ))

--- a/vm/devices/pci/pcie/src/switch.rs
+++ b/vm/devices/pci/pcie/src/switch.rs
@@ -18,7 +18,6 @@ use crate::port::PcieDownstreamPort;
 use crate::port::PciePortSettings;
 use anyhow::Context;
 use chipset_device::ChipsetDevice;
-use chipset_device::io::IoError;
 use chipset_device::io::IoResult;
 use chipset_device::pci::ByteEnabledDwordRead;
 use chipset_device::pci::ByteEnabledDwordWrite;
@@ -297,7 +296,7 @@ impl GenericPcieSwitch {
         let (_, _, downstream_port) = self
             .downstream_ports
             .iter_mut()
-            .find(|(devfn, _, _)| *devfn == addr.device_function)?;
+            .find(|(devfn, _, _)| *devfn == addr.devfn)?;
         Some(downstream_port.port.cfg_space.read(addr, value))
     }
 
@@ -310,7 +309,7 @@ impl GenericPcieSwitch {
         let (_, _, downstream_port) = self
             .downstream_ports
             .iter_mut()
-            .find(|(devfn, _, _)| *devfn == addr.device_function)?;
+            .find(|(devfn, _, _)| *devfn == addr.devfn)?;
         Some(downstream_port.port.cfg_space.write(addr, value))
     }
 
@@ -367,70 +366,69 @@ impl ChipsetDevice for GenericPcieSwitch {
 
 impl PciConfigSpace for GenericPcieSwitch {
     /// Reads the switch's own upstream-port config space (Type 0 view).
-    fn pci_cfg_read(&mut self, offset: u16, value: ByteEnabledDwordRead<'_>) -> IoResult {
-        // Forward to the upstream port's configuration space (the switch presents as the upstream port)
+    fn pci_cfg_read(&mut self, byte_offset: u16, value: ByteEnabledDwordRead<'_>) -> IoResult {
         self.upstream_port
             .cfg_space
-            .read_byte_enabled(offset, value)
+            .read_byte_enabled(byte_offset, value)
     }
 
     /// Writes the switch's own upstream-port config space (Type 0 view).
-    fn pci_cfg_write(&mut self, offset: u16, value: ByteEnabledDwordWrite) -> IoResult {
-        // Forward to the upstream port's configuration space (the switch presents as the upstream port)
+    fn pci_cfg_write(&mut self, byte_offset: u16, value: ByteEnabledDwordWrite) -> IoResult {
         self.upstream_port
             .cfg_space
-            .write_byte_enabled(offset, value)
+            .write_byte_enabled(byte_offset, value)
     }
 
-    fn pci_cfg_read_with_routing(
+    /// Reads the switch's own upstream-port config space (Type 0 view).
+    fn pci_cfg_type0_read(
         &mut self,
-        secondary_bus: u8,
-        target_bus: u8,
-        function: u8,
-        offset: u16,
+        address: PciConfigAddress,
         mut value: ByteEnabledDwordRead<'_>,
     ) -> IoResult {
-        if !offset.is_multiple_of(4) {
-            return IoResult::Err(IoError::UnalignedAccess);
+        if address.devfn == 0 {
+            self.upstream_port.cfg_space.read(address, value)
+        } else {
+            value.set(!0);
+            IoResult::Ok
         }
+    }
 
-        let Some(addr) = PciConfigAddress::new(target_bus, function, offset / 4) else {
-            return IoResult::Err(IoError::InvalidRegister);
-        };
-
-        // If target_bus == secondary_bus, this is a Type 0 access to the switch's own config space.
-        // We only implement function 0.
-        if target_bus == secondary_bus {
-            if function == 0 {
-                return self
-                    .upstream_port
-                    .cfg_space
-                    .read_byte_enabled(offset, value);
-            } else {
-                value.set(!0);
-                return IoResult::Ok;
-            }
+    /// Writes the switch's own upstream-port config space (Type 0 view).
+    fn pci_cfg_type0_write(
+        &mut self,
+        address: PciConfigAddress,
+        value: ByteEnabledDwordWrite,
+    ) -> IoResult {
+        if address.devfn == 0 {
+            self.upstream_port.cfg_space.write(address, value)
+        } else {
+            IoResult::Ok
         }
+    }
 
-        let upstream_bus_range = self.upstream_port.cfg_space.assigned_bus_range();
-
+    fn pci_cfg_type1_read(
+        &mut self,
+        address: PciConfigAddress,
+        mut value: ByteEnabledDwordRead<'_>,
+    ) -> IoResult {
         // If the bus range is 0..=0, this indicates invalid/uninitialized bus configuration
+        let upstream_bus_range = self.upstream_port.cfg_space.assigned_bus_range();
         if upstream_bus_range == (0..=0) {
             value.set(!0);
             return IoResult::Ok;
         }
 
         // If the target bus is not within the upstream bus range, we cannot route it. Return all-1s.
-        if !upstream_bus_range.contains(&target_bus) {
+        if !upstream_bus_range.contains(&address.bus) {
             value.set(!0);
             return IoResult::Ok;
         }
 
         // If the target bus is the start of the upstream bus range, this access targets one of the
         // downstream ports on the internal bus of the switch.
-        if target_bus == *upstream_bus_range.start() {
+        if address.bus == *upstream_bus_range.start() {
             return self
-                .handle_downstream_port_read(addr, value.reborrow())
+                .handle_downstream_port_read(address, value.reborrow())
                 .unwrap_or_else(|| {
                     value.set(!0);
                     IoResult::Ok
@@ -440,62 +438,37 @@ impl PciConfigSpace for GenericPcieSwitch {
         // The access must be routed somewhere downstream of a downstream port, invoke the
         // config space handler for dealing with deferrals and such.
         let mut callback = PciBusCfgAccessCallbackView::new(&mut self.downstream_ports);
-        self.bus_cfg_handler.read(addr, value, &mut callback)
+        self.bus_cfg_handler.read(address, value, &mut callback)
     }
 
-    fn pci_cfg_write_with_routing(
+    fn pci_cfg_type1_write(
         &mut self,
-        secondary_bus: u8,
-        target_bus: u8,
-        function: u8,
-        offset: u16,
+        address: PciConfigAddress,
         value: ByteEnabledDwordWrite,
     ) -> IoResult {
-        if !offset.is_multiple_of(4) {
-            return IoResult::Err(IoError::UnalignedAccess);
-        }
-
-        let Some(addr) = PciConfigAddress::new(target_bus, function, offset / 4) else {
-            return IoResult::Err(IoError::InvalidRegister);
-        };
-
-        // If target_bus == secondary_bus, this is a Type 0 access to the switch's own config space.
-        // We only implement function 0.
-        if target_bus == secondary_bus {
-            if function == 0 {
-                return self
-                    .upstream_port
-                    .cfg_space
-                    .write_byte_enabled(offset, value);
-            } else {
-                return IoResult::Ok;
-            }
-        }
-
-        let upstream_bus_range = self.upstream_port.cfg_space.assigned_bus_range();
-
         // If the bus range is 0..=0, this indicates invalid/uninitialized bus configuration.
+        let upstream_bus_range = self.upstream_port.cfg_space.assigned_bus_range();
         if upstream_bus_range == (0..=0) {
             return IoResult::Ok;
         }
 
         // If the target bus is not within the upstream bus range, we cannot route it.
-        if !upstream_bus_range.contains(&target_bus) {
+        if !upstream_bus_range.contains(&address.bus) {
             return IoResult::Ok;
         }
 
         // If the target bus is the start of the upstream bus range, this access targets one of the
         // downstream ports on the internal bus of the switch.
-        if target_bus == *upstream_bus_range.start() {
+        if address.bus == *upstream_bus_range.start() {
             return self
-                .handle_downstream_port_write(addr, value)
+                .handle_downstream_port_write(address, value)
                 .unwrap_or(IoResult::Ok);
         }
 
         // The access must be routed somewhere downstream of a downstream port, invoke the
         // config space handler for dealing with deferrals and such.
         let mut callback = PciBusCfgAccessCallbackView::new(&mut self.downstream_ports);
-        self.bus_cfg_handler.write(addr, value, &mut callback)
+        self.bus_cfg_handler.write(address, value, &mut callback)
     }
 
     fn suggested_bdf(&mut self) -> Option<(u8, u8, u8)> {
@@ -696,6 +669,7 @@ mod save_restore {
 mod tests {
     use super::*;
     use pci_core::msi::MsiConnection;
+    use pci_core::test_helpers::TestCfgAccess;
 
     /// Builds a switch definition with `downstream_port_count` uniform
     /// downstream ports named `{name}-downstream-{i}`, mirroring the naming
@@ -731,8 +705,7 @@ mod tests {
         let port = UpstreamSwitchPort::new();
 
         // Verify that we can read the vendor/device ID from config space
-        let mut vendor_device_id: u32 = 0;
-        port.cfg_space.read_u32(0x0, &mut vendor_device_id).unwrap();
+        let vendor_device_id = port.cfg_space.read_u32(0x0);
         let expected = (UPSTREAM_SWITCH_PORT_DEVICE_ID as u32) << 16 | (VENDOR_ID as u32);
         assert_eq!(vendor_device_id, expected);
     }
@@ -749,11 +722,7 @@ mod tests {
         assert!(port.port.link.is_none());
 
         // Verify that we can read the vendor/device ID from config space
-        let mut vendor_device_id: u32 = 0;
-        port.port
-            .cfg_space
-            .read_u32(0x0, &mut vendor_device_id)
-            .unwrap();
+        let vendor_device_id = port.port.cfg_space.read_u32(0x0);
         let expected = (DOWNSTREAM_SWITCH_PORT_DEVICE_ID as u32) << 16 | (VENDOR_ID as u32);
         assert_eq!(vendor_device_id, expected);
     }
@@ -768,11 +737,7 @@ mod tests {
             &MsiTarget::disconnected(),
             PciePortSettings::default(),
         );
-        let mut header_type_value: u32 = 0;
-        port_default
-            .cfg_space()
-            .read_u32(0x0C, &mut header_type_value)
-            .unwrap();
+        let header_type_value = port_default.cfg_space().read_u32(0x0C);
         let header_type_field = (header_type_value >> 16) & 0xFF;
         assert_eq!(
             header_type_field & 0x80,
@@ -788,11 +753,7 @@ mod tests {
             &MsiTarget::disconnected(),
             PciePortSettings::default(),
         );
-        let mut header_type_value_false: u32 = 0;
-        port_false
-            .cfg_space()
-            .read_u32(0x0C, &mut header_type_value_false)
-            .unwrap();
+        let header_type_value_false = port_false.cfg_space().read_u32(0x0C);
         let header_type_field_false = (header_type_value_false >> 16) & 0xFF;
         assert_eq!(
             header_type_field_false & 0x80,
@@ -808,11 +769,7 @@ mod tests {
             &MsiTarget::disconnected(),
             PciePortSettings::default(),
         );
-        let mut header_type_value_true: u32 = 0;
-        port_true
-            .cfg_space()
-            .read_u32(0x0C, &mut header_type_value_true)
-            .unwrap();
+        let header_type_value_true = port_true.cfg_space().read_u32(0x0C);
         let header_type_field_true = (header_type_value_true >> 16) & 0xFF;
         assert_eq!(
             header_type_field_true & 0x80,
@@ -833,11 +790,7 @@ mod tests {
         );
         // We can't easily verify hotplug is disabled without accessing internal state,
         // but we can verify the port was created successfully
-        let mut vendor_device_id: u32 = 0;
-        port_no_hotplug
-            .cfg_space()
-            .read_u32(0x0, &mut vendor_device_id)
-            .unwrap();
+        let vendor_device_id = port_no_hotplug.cfg_space().read_u32(0x0);
         let expected = (DOWNSTREAM_SWITCH_PORT_DEVICE_ID as u32) << 16 | (VENDOR_ID as u32);
         assert_eq!(vendor_device_id, expected);
 
@@ -849,11 +802,7 @@ mod tests {
             &MsiTarget::disconnected(),
             PciePortSettings::default(),
         );
-        let mut vendor_device_id_hotplug: u32 = 0;
-        port_with_hotplug
-            .cfg_space()
-            .read_u32(0x0, &mut vendor_device_id_hotplug)
-            .unwrap();
+        let vendor_device_id_hotplug = port_with_hotplug.cfg_space().read_u32(0x0);
         assert_eq!(vendor_device_id_hotplug, expected);
         // The slot number and hotplug capability would be tested via PCIe capability registers
         // but that requires more complex setup
@@ -956,12 +905,7 @@ mod tests {
         assert!(add_result.is_ok());
 
         // Test basic configuration space access through the PCI interface
-        let mut value = 0u32;
-        let result = switch
-            .upstream_port
-            .cfg_space_mut()
-            .read_u32(0x0, &mut value);
-        assert!(matches!(result, IoResult::Ok));
+        let value = switch.upstream_port.cfg_space_mut().read_u32(0x0);
 
         // Verify vendor/device ID is from the upstream port
         let expected = (UPSTREAM_SWITCH_PORT_DEVICE_ID as u32) << 16 | (VENDOR_ID as u32);
@@ -1048,10 +992,7 @@ mod tests {
         let subordinate_bus = 10u8;
         // Set secondary bus number (offset 0x18) - bits 8-15 of the 32-bit value at 0x18
         let bus_config = (subordinate_bus as u32) << 16 | ((secondary_bus as u32) << 8);
-        let result = switch.pci_cfg_write_with_routing(
-            0,
-            0,
-            0,
+        let result = switch.pci_cfg_write(
             0x18,
             ByteEnabledDwordWrite::with_all_bytes_enabled(bus_config),
         );
@@ -1063,11 +1004,8 @@ mod tests {
 
         // Test direct access to downstream port 0 using function = 0
         let mut value = 0u32;
-        let result = switch.pci_cfg_read_with_routing(
-            0,
-            switch_internal_bus,
-            0,
-            0x0,
+        let result = switch.pci_cfg_type1_read(
+            PciConfigAddress::new(switch_internal_bus, 0, 0).unwrap(),
             ByteEnabledDwordRead::with_all_bytes_enabled(&mut value),
         );
         assert!(matches!(result, IoResult::Ok));
@@ -1078,11 +1016,8 @@ mod tests {
 
         // Test direct access to downstream port 2 using function = 2
         let mut value2 = 0u32;
-        let result2 = switch.pci_cfg_read_with_routing(
-            0,
-            switch_internal_bus,
-            2,
-            0x0,
+        let result2 = switch.pci_cfg_type1_read(
+            PciConfigAddress::new(switch_internal_bus, 2, 0).unwrap(),
             ByteEnabledDwordRead::with_all_bytes_enabled(&mut value2),
         );
         assert!(matches!(result2, IoResult::Ok));
@@ -1090,11 +1025,8 @@ mod tests {
 
         // Test access to non-existent downstream port using function = 5
         let mut value3 = 0u32;
-        let result3 = switch.pci_cfg_read_with_routing(
-            0,
-            switch_internal_bus,
-            5,
-            0x0,
+        let result3 = switch.pci_cfg_type1_read(
+            PciConfigAddress::new(switch_internal_bus, 5, 0).unwrap(),
             ByteEnabledDwordRead::with_all_bytes_enabled(&mut value3),
         );
         assert!(matches!(result3, IoResult::Ok));
@@ -1117,31 +1049,22 @@ mod tests {
 
         // Test that any access returns 1s when bus range is invalid
         let mut value = 0u32;
-        let result = switch.pci_cfg_read_with_routing(
-            0,
-            1,
-            0,
-            0x0,
+        let result = switch.pci_cfg_type1_read(
+            PciConfigAddress::new(1, 0, 0).unwrap(),
             ByteEnabledDwordRead::with_all_bytes_enabled(&mut value),
         );
         assert!(matches!(result, IoResult::Ok));
         assert_eq!(value, !0);
 
-        let result2 = switch.pci_cfg_read_with_routing(
-            0,
-            1,
-            0,
-            0x0,
+        let result2 = switch.pci_cfg_type1_read(
+            PciConfigAddress::new(1, 0, 0).unwrap(),
             ByteEnabledDwordRead::with_all_bytes_enabled(&mut value),
         );
         assert!(matches!(result2, IoResult::Ok));
         assert_eq!(value, !0);
 
-        let result3 = switch.pci_cfg_read_with_routing(
-            0,
-            2,
-            0,
-            0x0,
+        let result3 = switch.pci_cfg_type1_read(
+            PciConfigAddress::new(2, 0, 0).unwrap(),
             ByteEnabledDwordRead::with_all_bytes_enabled(&mut value),
         );
         assert!(matches!(result3, IoResult::Ok));
@@ -1167,41 +1090,31 @@ mod tests {
         switch
             .upstream_port
             .cfg_space_mut()
-            .write_u32(0x18, bus_config)
-            .unwrap();
+            .write_u32(0x18, bus_config);
 
         // Downstream ports still have invalid bus ranges (0..=0 by default)
         // so any access to buses beyond the secondary bus should return 1s.
         let mut value = 0u32;
 
         // Access to bus 2 should return 1s since no downstream port has a valid bus range
-        let result = switch.pci_cfg_read_with_routing(
-            0,
-            2,
-            0,
-            0x0,
+        let result = switch.pci_cfg_type1_read(
+            PciConfigAddress::new(2, 0, 0).unwrap(),
             ByteEnabledDwordRead::with_all_bytes_enabled(&mut value),
         );
         assert!(matches!(result, IoResult::Ok));
         assert_eq!(value, !0);
 
         // Access to bus 5 should also return 1s
-        let result2 = switch.pci_cfg_read_with_routing(
-            0,
-            5,
-            0,
-            0x0,
+        let result2 = switch.pci_cfg_type1_read(
+            PciConfigAddress::new(5, 0, 0).unwrap(),
             ByteEnabledDwordRead::with_all_bytes_enabled(&mut value),
         );
         assert!(matches!(result2, IoResult::Ok));
         assert_eq!(value, !0);
 
         // Access to the secondary bus (switch internal) should still work for downstream port config
-        let result3 = switch.pci_cfg_read_with_routing(
-            secondary_bus,
-            secondary_bus,
-            0,
-            0x0,
+        let result3 = switch.pci_cfg_type1_read(
+            PciConfigAddress::new(secondary_bus, 0, 0).unwrap(),
             ByteEnabledDwordRead::with_all_bytes_enabled(&mut value),
         );
         assert!(matches!(result3, IoResult::Ok));
@@ -1225,11 +1138,7 @@ mod tests {
             if let Some((_, _, downstream_port)) =
                 multi_port_switch.downstream_ports.get(port_num as usize)
             {
-                let mut header_type_value: u32 = 0;
-                downstream_port
-                    .cfg_space()
-                    .read_u32(0x0C, &mut header_type_value)
-                    .unwrap();
+                let header_type_value = downstream_port.cfg_space().read_u32(0x0C);
 
                 // Extract the header type field (bits 16-23, with multi-function bit at bit 23)
                 let header_type_field = (header_type_value >> 16) & 0xFF;
@@ -1267,11 +1176,7 @@ mod tests {
             if let Some((_, _, downstream_port)) =
                 single_port_switch.downstream_ports.get(port_num as usize)
             {
-                let mut header_type_value: u32 = 0;
-                downstream_port
-                    .cfg_space()
-                    .read_u32(0x0C, &mut header_type_value)
-                    .unwrap();
+                let header_type_value = downstream_port.cfg_space().read_u32(0x0C);
 
                 // Extract the header type field (bits 16-23)
                 let header_type_field = (header_type_value >> 16) & 0xFF;
@@ -1404,8 +1309,7 @@ mod tests {
         switch
             .upstream_port
             .cfg_space_mut()
-            .write_u32(0x18, bus_config)
-            .unwrap();
+            .write_u32(0x18, bus_config);
 
         // Verify the bus range is set
         let bus_range = switch.upstream_port.cfg_space().assigned_bus_range();
@@ -1460,11 +1364,7 @@ mod tests {
             let bus_config = ((subordinate_bus as u32) << 16)
                 | ((secondary_bus as u32) << 8)
                 | (primary_bus as u32);
-            downstream_port
-                .port
-                .cfg_space
-                .write_u32(0x18, bus_config)
-                .unwrap();
+            downstream_port.port.cfg_space.write_u32(0x18, bus_config);
         }
 
         // Verify the downstream port bus range is set
@@ -1521,16 +1421,11 @@ mod tests {
         switch
             .upstream_port
             .cfg_space_mut()
-            .write_u32(0x18, 0x0014_1200)
-            .unwrap();
+            .write_u32(0x18, 0x0014_1200);
 
         // Downstream port 1 bus range.
         if let Some((_, _, downstream_port)) = switch.downstream_ports.get_mut(1) {
-            downstream_port
-                .port
-                .cfg_space
-                .write_u32(0x18, 0x0020_1f12)
-                .unwrap();
+            downstream_port.port.cfg_space.write_u32(0x18, 0x0020_1f12);
         }
 
         let saved_state = switch.save().expect("save should succeed");
@@ -1577,36 +1472,50 @@ mod tests {
             Some(PciConfigSpace::pci_cfg_write(&mut self.0, offset, value))
         }
 
-        fn pci_cfg_read_with_routing(
+        fn pci_cfg_type0_read(
             &mut self,
-            secondary_bus: u8,
-            target_bus: u8,
-            function: u8,
-            offset: u16,
+            address: PciConfigAddress,
             value: ByteEnabledDwordRead<'_>,
         ) -> Option<IoResult> {
-            Some(self.0.pci_cfg_read_with_routing(
-                secondary_bus,
-                target_bus,
-                function,
-                offset,
+            Some(PciConfigSpace::pci_cfg_type0_read(
+                &mut self.0,
+                address,
                 value,
             ))
         }
 
-        fn pci_cfg_write_with_routing(
+        fn pci_cfg_type0_write(
             &mut self,
-            secondary_bus: u8,
-            target_bus: u8,
-            function: u8,
-            offset: u16,
+            address: PciConfigAddress,
             value: ByteEnabledDwordWrite,
         ) -> Option<IoResult> {
-            Some(self.0.pci_cfg_write_with_routing(
-                secondary_bus,
-                target_bus,
-                function,
-                offset,
+            Some(PciConfigSpace::pci_cfg_type0_write(
+                &mut self.0,
+                address,
+                value,
+            ))
+        }
+
+        fn pci_cfg_type1_read(
+            &mut self,
+            address: PciConfigAddress,
+            value: ByteEnabledDwordRead<'_>,
+        ) -> Option<IoResult> {
+            Some(PciConfigSpace::pci_cfg_type1_read(
+                &mut self.0,
+                address,
+                value,
+            ))
+        }
+
+        fn pci_cfg_type1_write(
+            &mut self,
+            address: PciConfigAddress,
+            value: ByteEnabledDwordWrite,
+        ) -> Option<IoResult> {
+            Some(PciConfigSpace::pci_cfg_type1_write(
+                &mut self.0,
+                address,
                 value,
             ))
         }
@@ -1642,9 +1551,7 @@ mod tests {
         );
 
         // Configure the root port's bus range: secondary=1, subordinate=10
-        port.cfg_space
-            .write_u32(0x18, (10u32 << 16) | (1u32 << 8))
-            .unwrap();
+        port.cfg_space.write_u32(0x18, (10u32 << 16) | (1u32 << 8));
 
         // Create and attach a switch behind the port
         let switch = build(switch_def(
@@ -1705,12 +1612,7 @@ mod tests {
         ));
 
         // Upstream switch ports do not expose ACS in this model.
-        let mut upstream_header = 0u32;
-        switch
-            .upstream_port()
-            .cfg_space()
-            .read_u32(0x100, &mut upstream_header)
-            .unwrap();
+        let upstream_header = switch.upstream_port().cfg_space().read_u32(0x100);
         assert_eq!(upstream_header, 0);
 
         let mut switch = switch;
@@ -1720,21 +1622,13 @@ mod tests {
             .next()
             .expect("expected downstream port");
 
-        let mut downstream_header = 0u32;
-        downstream_port
-            .cfg_space_mut()
-            .read_u32(0x100, &mut downstream_header)
-            .unwrap();
+        let downstream_header = downstream_port.cfg_space_mut().read_u32(0x100);
         assert_eq!(
             downstream_header & 0xffff,
             ExtendedCapabilityId::ACS.0 as u32
         );
 
-        let mut caps_control = 0u32;
-        downstream_port
-            .cfg_space_mut()
-            .read_u32(0x104, &mut caps_control)
-            .unwrap();
+        let caps_control = downstream_port.cfg_space_mut().read_u32(0x104);
         assert_eq!(caps_control as u16, 0x0001);
     }
 

--- a/vm/devices/pci/vpci/src/bus.rs
+++ b/vm/devices/pci/vpci/src/bus.rs
@@ -349,7 +349,7 @@ impl<'a> PciBusCfgAccessCallbacks for PciBusCfgAccessCallbackView<'a> {
             .lock()
             .supports_pci()
             .unwrap()
-            .pci_cfg_read(addr.byte_offset(), value)
+            .pci_cfg_type0_read(addr, value)
     }
 
     fn write(&mut self, addr: PciConfigAddress, value: ByteEnabledDwordWrite) -> IoResult {
@@ -357,7 +357,7 @@ impl<'a> PciBusCfgAccessCallbacks for PciBusCfgAccessCallbackView<'a> {
             .lock()
             .supports_pci()
             .unwrap()
-            .pci_cfg_write(addr.byte_offset(), value)
+            .pci_cfg_type0_write(addr, value)
     }
 }
 

--- a/vm/devices/pci/vpci/src/bus.rs
+++ b/vm/devices/pci/vpci/src/bus.rs
@@ -349,7 +349,7 @@ impl<'a> PciBusCfgAccessCallbacks for PciBusCfgAccessCallbackView<'a> {
             .lock()
             .supports_pci()
             .unwrap()
-            .pci_cfg_type0_read(addr, value)
+            .pci_cfg_read(addr.byte_offset(), value)
     }
 
     fn write(&mut self, addr: PciConfigAddress, value: ByteEnabledDwordWrite) -> IoResult {
@@ -357,7 +357,7 @@ impl<'a> PciBusCfgAccessCallbacks for PciBusCfgAccessCallbackView<'a> {
             .lock()
             .supports_pci()
             .unwrap()
-            .pci_cfg_type0_write(addr, value)
+            .pci_cfg_write(addr.byte_offset(), value)
     }
 }
 

--- a/vmm_core/vmotherboard/src/base_chipset.rs
+++ b/vmm_core/vmotherboard/src/base_chipset.rs
@@ -654,6 +654,7 @@ mod weak_mutex_pci {
     use chipset_device::io::IoResult;
     use chipset_device::pci::ByteEnabledDwordRead;
     use chipset_device::pci::ByteEnabledDwordWrite;
+    use chipset_device::pci::PciConfigAccessType;
     use chipset_device::pci::PciConfigAddress;
     use closeable_mutex::CloseableMutex;
     use pci_bus::GenericPciBusDevice;
@@ -691,8 +692,9 @@ mod weak_mutex_pci {
             )
         }
 
-        fn pci_cfg_type0_read(
+        fn pci_cfg_read_with_routing(
             &mut self,
+            access_type: PciConfigAccessType,
             address: PciConfigAddress,
             value: ByteEnabledDwordRead<'_>,
         ) -> Option<IoResult> {
@@ -702,12 +704,13 @@ mod weak_mutex_pci {
                     .lock()
                     .supports_pci()
                     .expect("builder code ensures supports_pci.is_some()")
-                    .pci_cfg_type0_read(address, value),
+                    .pci_cfg_read_with_routing(access_type, address, value),
             )
         }
 
-        fn pci_cfg_type0_write(
+        fn pci_cfg_write_with_routing(
             &mut self,
+            access_type: PciConfigAccessType,
             address: PciConfigAddress,
             value: ByteEnabledDwordWrite,
         ) -> Option<IoResult> {
@@ -717,37 +720,7 @@ mod weak_mutex_pci {
                     .lock()
                     .supports_pci()
                     .expect("builder code ensures supports_pci.is_some()")
-                    .pci_cfg_type0_write(address, value),
-            )
-        }
-
-        fn pci_cfg_type1_read(
-            &mut self,
-            address: PciConfigAddress,
-            value: ByteEnabledDwordRead<'_>,
-        ) -> Option<IoResult> {
-            Some(
-                self.0
-                    .upgrade()?
-                    .lock()
-                    .supports_pci()
-                    .expect("builder code ensures supports_pci.is_some()")
-                    .pci_cfg_type1_read(address, value),
-            )
-        }
-
-        fn pci_cfg_type1_write(
-            &mut self,
-            address: PciConfigAddress,
-            value: ByteEnabledDwordWrite,
-        ) -> Option<IoResult> {
-            Some(
-                self.0
-                    .upgrade()?
-                    .lock()
-                    .supports_pci()
-                    .expect("builder code ensures supports_pci.is_some()")
-                    .pci_cfg_type1_write(address, value),
+                    .pci_cfg_write_with_routing(access_type, address, value),
             )
         }
     }

--- a/vmm_core/vmotherboard/src/base_chipset.rs
+++ b/vmm_core/vmotherboard/src/base_chipset.rs
@@ -654,6 +654,7 @@ mod weak_mutex_pci {
     use chipset_device::io::IoResult;
     use chipset_device::pci::ByteEnabledDwordRead;
     use chipset_device::pci::ByteEnabledDwordWrite;
+    use chipset_device::pci::PciConfigAddress;
     use closeable_mutex::CloseableMutex;
     use pci_bus::GenericPciBusDevice;
     use std::sync::Arc;
@@ -690,12 +691,9 @@ mod weak_mutex_pci {
             )
         }
 
-        fn pci_cfg_read_with_routing(
+        fn pci_cfg_type0_read(
             &mut self,
-            secondary_bus: u8,
-            target_bus: u8,
-            function: u8,
-            offset: u16,
+            address: PciConfigAddress,
             value: ByteEnabledDwordRead<'_>,
         ) -> Option<IoResult> {
             Some(
@@ -704,16 +702,13 @@ mod weak_mutex_pci {
                     .lock()
                     .supports_pci()
                     .expect("builder code ensures supports_pci.is_some()")
-                    .pci_cfg_read_with_routing(secondary_bus, target_bus, function, offset, value),
+                    .pci_cfg_type0_read(address, value),
             )
         }
 
-        fn pci_cfg_write_with_routing(
+        fn pci_cfg_type0_write(
             &mut self,
-            secondary_bus: u8,
-            target_bus: u8,
-            function: u8,
-            offset: u16,
+            address: PciConfigAddress,
             value: ByteEnabledDwordWrite,
         ) -> Option<IoResult> {
             Some(
@@ -722,7 +717,37 @@ mod weak_mutex_pci {
                     .lock()
                     .supports_pci()
                     .expect("builder code ensures supports_pci.is_some()")
-                    .pci_cfg_write_with_routing(secondary_bus, target_bus, function, offset, value),
+                    .pci_cfg_type0_write(address, value),
+            )
+        }
+
+        fn pci_cfg_type1_read(
+            &mut self,
+            address: PciConfigAddress,
+            value: ByteEnabledDwordRead<'_>,
+        ) -> Option<IoResult> {
+            Some(
+                self.0
+                    .upgrade()?
+                    .lock()
+                    .supports_pci()
+                    .expect("builder code ensures supports_pci.is_some()")
+                    .pci_cfg_type1_read(address, value),
+            )
+        }
+
+        fn pci_cfg_type1_write(
+            &mut self,
+            address: PciConfigAddress,
+            value: ByteEnabledDwordWrite,
+        ) -> Option<IoResult> {
+            Some(
+                self.0
+                    .upgrade()?
+                    .lock()
+                    .supports_pci()
+                    .expect("builder code ensures supports_pci.is_some()")
+                    .pci_cfg_type1_write(address, value),
             )
         }
     }


### PR DESCRIPTION
This change aligns `PciConfigSpace` more closely to PCI TLP definitions by passing an explicit access type (type0 and type1) as opposed to having the bus implementation stamp the secondary bus number of the parent port in the request. PCI device implementations that want to know their bus number can capture it during type0 accesses as described in the spec.

This change additionally adds BDF capturing to `pci_core::cfg_space_emu::ConfigSpaceType{0|1}Emulator` by default, so long as the device uses the `read`/`write` variants that include the address.