### PR TITLE
netvsp: Ensure all channels use the correct packet size

### DIFF
--- a/vm/devices/net/netvsp/src/lib.rs
+++ b/vm/devices/net/netvsp/src/lib.rs
@@ -4833,6 +4833,8 @@ impl Coordinator {
             self.num_queues = num_queues;
         }
 
+        // Determining packet size before taking mutable borrows
+        let packet_size = state.buffers.version.into();
         self.active_packet_filter = self.workers[0].state().unwrap().channel.packet_filter;
         // Provide the queue and receive buffer ranges for each worker.
         for (((worker, mut queue), rx_buffer), initial) in self
@@ -4861,6 +4863,10 @@ impl Coordinator {
                     ready_state.state.pending_rx_packets.clear();
                     ready_state.reset_tx_after_endpoint_stop();
                 }
+
+                // Ensure we're sending the negotiated packet size.
+                // Guests with less-compatible, older, or more stringent netvsc would drop packets otherwise.
+                worker.channel.packet_size = packet_size;
             }
         }
 
@@ -4971,17 +4977,6 @@ impl<T: RingMem + 'static> Worker<T> {
                         // This task will be restarted when the queues are ready.
                         stop.until_stopped(pending()).await?
                     };
-
-                    let packet_size = state.buffers.version.into();
-                    if self.channel.packet_size != packet_size {
-                        // Ensure we're not sending the incorrect packet length to guests.
-                        // Guests with less-compatible, older, or more stringent netvsc would drop packets otherwise.
-                        tracelimit::info_ratelimited!(
-                            channel_idx = self.channel_idx,
-                            "updating packet size"
-                        );
-                        self.channel.packet_size = packet_size;
-                    }
 
                     let result = self.channel.main_loop(stop, state, queue_state).await;
                     let msg = match result {

--- a/vm/devices/net/netvsp/src/lib.rs
+++ b/vm/devices/net/netvsp/src/lib.rs
@@ -2156,7 +2156,7 @@ fn read_packet_data<T: IntoBytes + FromBytes + Immutable + KnownLayout>(
     reader
         .read_plain()
         .map_err(PacketError::Access)
-        .inspect_err(|_| tracelimit::error_ratelimited!("read_packet_data"))
+        .inspect_err(|_| tracelimit::info_ratelimited!("read_packet_data"))
 }
 
 fn parse_packet<'a, T: RingMem>(
@@ -2178,7 +2178,7 @@ fn parse_packet<'a, T: RingMem>(
                 let header: protocol::MessageHeader = reader
                     .read_plain()
                     .map_err(PacketError::Access)
-                    .inspect_err(|_| tracelimit::error_ratelimited!("parsing completion header"))?;
+                    .inspect_err(|_| tracelimit::info_ratelimited!("parsing completion header"))?;
                 match header.message_type {
                     protocol::MESSAGE1_TYPE_SEND_RNDIS_PACKET_COMPLETE => {
                         PacketData::RndisPacketComplete(read_packet_data(&mut reader)?)
@@ -2198,7 +2198,7 @@ fn parse_packet<'a, T: RingMem>(
     let header: protocol::MessageHeader = reader
         .read_plain()
         .map_err(PacketError::Access)
-        .inspect_err(|_| tracelimit::error_ratelimited!("parsing data packet header"))?;
+        .inspect_err(|_| tracelimit::info_ratelimited!("parsing data packet header"))?;
     let data = match header.message_type {
         protocol::MESSAGE_TYPE_INIT => PacketData::Init(read_packet_data(&mut reader)?),
         protocol::MESSAGE1_TYPE_SEND_NDIS_VERSION if version >= Some(Version::V1) => {

--- a/vm/devices/net/netvsp/src/lib.rs
+++ b/vm/devices/net/netvsp/src/lib.rs
@@ -5249,7 +5249,11 @@ impl<T: 'static + RingMem> NetChannel<T> {
 
                         if let Some(version) = version {
                             tracelimit::info_ratelimited!(?version, "network negotiated");
-
+                            if version >= Version::V61 {
+                                // Update the packet size so that the appropriate padding is
+                                // appended for picky Windows guests.
+                                self.packet_size = PacketSize::V61;
+                            }
                             *initializing = Some(InitState {
                                 version,
                                 ndis_config: None,

--- a/vm/devices/net/netvsp/src/lib.rs
+++ b/vm/devices/net/netvsp/src/lib.rs
@@ -746,11 +746,7 @@ impl Inspect for PrimaryChannelState {
                     PendingLinkAction::Default => "None".to_string(),
                 },
             )
-            .sensitivity_field(
-                "version",
-                SensitivityLevel::Safe,
-                self.version
-            );
+            .sensitivity_field("version", SensitivityLevel::Safe, self.version);
     }
 }
 
@@ -925,7 +921,7 @@ impl PrimaryChannelState {
         tx_spread_sent: bool,
         guest_link_down: bool,
         pending_link_action: Option<bool>,
-        version: Version
+        version: Version,
     ) -> Result<Self, NetRestoreError> {
         // Restore control messages.
         let control_messages_len = control_messages.iter().map(|msg| msg.data.len()).sum();
@@ -2154,7 +2150,10 @@ impl Packet<'_> {
 fn read_packet_data<T: IntoBytes + FromBytes + Immutable + KnownLayout>(
     reader: &mut impl MemoryRead,
 ) -> Result<T, PacketError> {
-    reader.read_plain().map_err(PacketError::Access).inspect_err(|_| tracing::error!("read_packet_data"))
+    reader
+        .read_plain()
+        .map_err(PacketError::Access)
+        .inspect_err(|_| tracelimit::error_ratelimited!("read_packet_data"))
 }
 
 fn parse_packet<'a, T: RingMem>(
@@ -2173,8 +2172,10 @@ fn parse_packet<'a, T: RingMem>(
                 PacketData::SwitchDataPathCompletion
             } else {
                 let mut reader = completion.reader();
-                let header: protocol::MessageHeader =
-                    reader.read_plain().map_err(PacketError::Access).inspect_err(|_| tracing::error!("parsing completion header"))?;
+                let header: protocol::MessageHeader = reader
+                    .read_plain()
+                    .map_err(PacketError::Access)
+                    .inspect_err(|_| tracelimit::error_ratelimited!("parsing completion header"))?;
                 match header.message_type {
                     protocol::MESSAGE1_TYPE_SEND_RNDIS_PACKET_COMPLETE => {
                         PacketData::RndisPacketComplete(read_packet_data(&mut reader)?)
@@ -2191,7 +2192,10 @@ fn parse_packet<'a, T: RingMem>(
     };
 
     let mut reader = packet.reader();
-    let header: protocol::MessageHeader = reader.read_plain().map_err(PacketError::Access).inspect_err(|_| tracing::error!("parsing data packet header"))?;
+    let header: protocol::MessageHeader = reader
+        .read_plain()
+        .map_err(PacketError::Access)
+        .inspect_err(|_| tracelimit::error_ratelimited!("parsing data packet header"))?;
     let data = match header.message_type {
         protocol::MESSAGE_TYPE_INIT => PacketData::Init(read_packet_data(&mut reader)?),
         protocol::MESSAGE1_TYPE_SEND_NDIS_VERSION if version >= Some(Version::V1) => {
@@ -4962,7 +4966,10 @@ impl<T: RingMem + 'static> Worker<T> {
                     if state.buffers.version >= Version::V61 {
                         // Ensure we're not sending the incorrect packet length to guests.
                         // Some guests will care significantly more than others.
-                        tracelimit::info_ratelimited!(channel_idx = self.channel_idx, "updating packet size");
+                        tracelimit::info_ratelimited!(
+                            channel_idx = self.channel_idx,
+                            "updating packet size"
+                        );
                         self.channel.packet_size = PacketSize::V61;
                     }
 

--- a/vm/devices/net/netvsp/src/lib.rs
+++ b/vm/devices/net/netvsp/src/lib.rs
@@ -5266,11 +5266,10 @@ impl<T: 'static + RingMem> NetChannel<T> {
 
                         if let Some(version) = version {
                             tracelimit::info_ratelimited!(?version, "network negotiated");
-                            if version >= Version::V61 {
-                                // Update the packet size so that the appropriate padding is
-                                // appended for picky Windows guests.
-                                self.packet_size = PacketSize::V61;
-                            }
+
+                            // Ensure packet size is set appropriately for the protocol version.
+                            self.packet_size = version.into();
+
                             *initializing = Some(InitState {
                                 version,
                                 ndis_config: None,

--- a/vm/devices/net/netvsp/src/lib.rs
+++ b/vm/devices/net/netvsp/src/lib.rs
@@ -703,7 +703,6 @@ struct PrimaryChannelState {
     /// The serial number sent in the most recent VF association message, so
     /// that the matching disassociation message uses the same serial number.
     advertised_vf_serial_number: Option<u32>,
-    version: Version,
 }
 
 impl Inspect for PrimaryChannelState {
@@ -754,8 +753,7 @@ impl Inspect for PrimaryChannelState {
                     PendingLinkAction::Delay(up) => format!("Delay({:x?})", up),
                     PendingLinkAction::Default => "None".to_string(),
                 },
-            )
-            .sensitivity_field("version", SensitivityLevel::Safe, self.version);
+            );
     }
 }
 
@@ -894,7 +892,7 @@ pub enum RndisState {
 }
 
 impl PrimaryChannelState {
-    fn new(offload_config: OffloadConfig, version: Version) -> Self {
+    fn new(offload_config: OffloadConfig) -> Self {
         Self {
             guest_vf_state: PrimaryChannelGuestVfState::Initializing,
             is_data_path_switched: None,
@@ -912,7 +910,6 @@ impl PrimaryChannelState {
             guest_link_up: true,
             pending_link_action: PendingLinkAction::Default,
             advertised_vf_serial_number: None,
-            version,
         }
     }
 
@@ -930,7 +927,6 @@ impl PrimaryChannelState {
         tx_spread_sent: bool,
         guest_link_down: bool,
         pending_link_action: Option<bool>,
-        version: Version,
     ) -> Result<Self, NetRestoreError> {
         // Restore control messages.
         let control_messages_len = control_messages.iter().map(|msg| msg.data.len()).sum();
@@ -1025,7 +1021,6 @@ impl PrimaryChannelState {
             guest_link_up: !guest_link_down,
             pending_link_action,
             advertised_vf_serial_number,
-            version,
         })
     }
 }
@@ -1780,7 +1775,6 @@ impl Nic {
                                 tx_spread_sent,
                                 guest_link_down,
                                 pending_link_action,
-                                version,
                             )?;
                             active.primary = Some(primary);
                         }
@@ -5080,7 +5074,6 @@ impl<T: 'static + RingMem> NetChannel<T> {
                     let state = ActiveState::new(
                         Some(PrimaryChannelState::new(
                             self.adapter.offload_support.clone(),
-                            initializing.version,
                         )),
                         recv_buffer.count,
                     );

--- a/vm/devices/net/netvsp/src/lib.rs
+++ b/vm/devices/net/netvsp/src/lib.rs
@@ -4975,7 +4975,7 @@ impl<T: RingMem + 'static> Worker<T> {
                     let packet_size = state.buffers.version.into();
                     if self.channel.packet_size != packet_size {
                         // Ensure we're not sending the incorrect packet length to guests.
-                        // Some guests will care significantly more than others.
+                        // Guests with less-compatible, older, or more stringent netvsc would drop packets otherwise.
                         tracelimit::info_ratelimited!(
                             channel_idx = self.channel_idx,
                             "updating packet size"

--- a/vm/devices/net/netvsp/src/lib.rs
+++ b/vm/devices/net/netvsp/src/lib.rs
@@ -468,12 +468,21 @@ struct NetChannel<T: RingMem> {
 }
 
 // Use an enum to give the compiler more visibility into the packet size.
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, PartialEq)]
 enum PacketSize {
     /// [`protocol::PACKET_SIZE_V1`]
     V1,
     /// [`protocol::PACKET_SIZE_V61`]
     V61,
+}
+
+impl From<Version> for PacketSize {
+    fn from(v: Version) -> Self {
+        match v {
+            Version::V61 => PacketSize::V61,
+            _ => PacketSize::V1,
+        }
+    }
 }
 
 /// Buffers used during packet processing.
@@ -4963,14 +4972,15 @@ impl<T: RingMem + 'static> Worker<T> {
                         stop.until_stopped(pending()).await?
                     };
 
-                    if state.buffers.version >= Version::V61 {
+                    let packet_size = state.buffers.version.into();
+                    if self.channel.packet_size != packet_size {
                         // Ensure we're not sending the incorrect packet length to guests.
                         // Some guests will care significantly more than others.
                         tracelimit::info_ratelimited!(
                             channel_idx = self.channel_idx,
                             "updating packet size"
                         );
-                        self.channel.packet_size = PacketSize::V61;
+                        self.channel.packet_size = packet_size;
                     }
 
                     let result = self.channel.main_loop(stop, state, queue_state).await;

--- a/vm/devices/net/netvsp/src/lib.rs
+++ b/vm/devices/net/netvsp/src/lib.rs
@@ -694,6 +694,7 @@ struct PrimaryChannelState {
     /// The serial number sent in the most recent VF association message, so
     /// that the matching disassociation message uses the same serial number.
     advertised_vf_serial_number: Option<u32>,
+    version: Version,
 }
 
 impl Inspect for PrimaryChannelState {
@@ -744,6 +745,11 @@ impl Inspect for PrimaryChannelState {
                     PendingLinkAction::Delay(up) => format!("Delay({:x?})", up),
                     PendingLinkAction::Default => "None".to_string(),
                 },
+            )
+            .sensitivity_field(
+                "version",
+                SensitivityLevel::Safe,
+                self.version
             );
     }
 }
@@ -883,7 +889,7 @@ pub enum RndisState {
 }
 
 impl PrimaryChannelState {
-    fn new(offload_config: OffloadConfig) -> Self {
+    fn new(offload_config: OffloadConfig, version: Version) -> Self {
         Self {
             guest_vf_state: PrimaryChannelGuestVfState::Initializing,
             is_data_path_switched: None,
@@ -901,6 +907,7 @@ impl PrimaryChannelState {
             guest_link_up: true,
             pending_link_action: PendingLinkAction::Default,
             advertised_vf_serial_number: None,
+            version,
         }
     }
 
@@ -918,6 +925,7 @@ impl PrimaryChannelState {
         tx_spread_sent: bool,
         guest_link_down: bool,
         pending_link_action: Option<bool>,
+        version: Version
     ) -> Result<Self, NetRestoreError> {
         // Restore control messages.
         let control_messages_len = control_messages.iter().map(|msg| msg.data.len()).sum();
@@ -1012,6 +1020,7 @@ impl PrimaryChannelState {
             guest_link_up: !guest_link_down,
             pending_link_action,
             advertised_vf_serial_number,
+            version,
         })
     }
 }
@@ -1766,6 +1775,7 @@ impl Nic {
                                 tx_spread_sent,
                                 guest_link_down,
                                 pending_link_action,
+                                version,
                             )?;
                             active.primary = Some(primary);
                         }
@@ -2144,7 +2154,7 @@ impl Packet<'_> {
 fn read_packet_data<T: IntoBytes + FromBytes + Immutable + KnownLayout>(
     reader: &mut impl MemoryRead,
 ) -> Result<T, PacketError> {
-    reader.read_plain().map_err(PacketError::Access)
+    reader.read_plain().map_err(PacketError::Access).inspect_err(|_| tracing::error!("read_packet_data"))
 }
 
 fn parse_packet<'a, T: RingMem>(
@@ -2164,7 +2174,7 @@ fn parse_packet<'a, T: RingMem>(
             } else {
                 let mut reader = completion.reader();
                 let header: protocol::MessageHeader =
-                    reader.read_plain().map_err(PacketError::Access)?;
+                    reader.read_plain().map_err(PacketError::Access).inspect_err(|_| tracing::error!("parsing completion header"))?;
                 match header.message_type {
                     protocol::MESSAGE1_TYPE_SEND_RNDIS_PACKET_COMPLETE => {
                         PacketData::RndisPacketComplete(read_packet_data(&mut reader)?)
@@ -2181,7 +2191,7 @@ fn parse_packet<'a, T: RingMem>(
     };
 
     let mut reader = packet.reader();
-    let header: protocol::MessageHeader = reader.read_plain().map_err(PacketError::Access)?;
+    let header: protocol::MessageHeader = reader.read_plain().map_err(PacketError::Access).inspect_err(|_| tracing::error!("parsing data packet header"))?;
     let data = match header.message_type {
         protocol::MESSAGE_TYPE_INIT => PacketData::Init(read_packet_data(&mut reader)?),
         protocol::MESSAGE1_TYPE_SEND_NDIS_VERSION if version >= Some(Version::V1) => {
@@ -4949,6 +4959,13 @@ impl<T: RingMem + 'static> Worker<T> {
                         stop.until_stopped(pending()).await?
                     };
 
+                    if state.buffers.version >= Version::V61 {
+                        // Ensure we're not sending the incorrect packet length to guests.
+                        // Some guests will care significantly more than others.
+                        tracelimit::info_ratelimited!(channel_idx = self.channel_idx, "updating packet size");
+                        self.channel.packet_size = PacketSize::V61;
+                    }
+
                     let result = self.channel.main_loop(stop, state, queue_state).await;
                     let msg = match result {
                         Ok(restart) => {
@@ -5051,6 +5068,7 @@ impl<T: 'static + RingMem> NetChannel<T> {
                     let state = ActiveState::new(
                         Some(PrimaryChannelState::new(
                             self.adapter.offload_support.clone(),
+                            initializing.version,
                         )),
                         recv_buffer.count,
                     );
@@ -5232,11 +5250,6 @@ impl<T: 'static + RingMem> NetChannel<T> {
                         if let Some(version) = version {
                             tracelimit::info_ratelimited!(?version, "network negotiated");
 
-                            if version >= Version::V61 {
-                                // Update the packet size so that the appropriate padding is
-                                // appended for picky Windows guests.
-                                self.packet_size = PacketSize::V61;
-                            }
                             *initializing = Some(InitState {
                                 version,
                                 ndis_config: None,

--- a/vm/devices/net/netvsp/src/lib.rs
+++ b/vm/devices/net/netvsp/src/lib.rs
@@ -478,9 +478,10 @@ enum PacketSize {
 
 impl From<Version> for PacketSize {
     fn from(v: Version) -> Self {
-        match v {
-            Version::V61 => PacketSize::V61,
-            _ => PacketSize::V1,
+        if v >= Version::V61 {
+            PacketSize::V61
+        } else {
+            PacketSize::V1
         }
     }
 }


### PR DESCRIPTION
Non-primary channels were still sending V1-sized packets, which some guests reject when they've negotiated later versions of the protocol. This change ensures all channels check and update packet size to match the negotiated version.

Changes were validated against a live repro of the issue in a lab environment.