### PR TITLE
sidecar: Put a spin lock around serial writes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7497,6 +7497,7 @@ dependencies = [
  "minimal_rt",
  "minimal_rt_build",
  "sidecar_defs",
+ "spin",
  "x86defs",
  "zerocopy",
 ]

--- a/openhcl/minimal_rt/src/arch/x86_64/serial.rs
+++ b/openhcl/minimal_rt/src/arch/x86_64/serial.rs
@@ -94,7 +94,7 @@ impl<T: IoAccess> Serial<T> {
     }
 
     /// Create an instance without calling init.
-    pub fn new(io: T) -> Self {
+    pub const fn new(io: T) -> Self {
         Self { io }
     }
 

--- a/openhcl/sidecar/Cargo.toml
+++ b/openhcl/sidecar/Cargo.toml
@@ -22,6 +22,7 @@ sidecar_defs.workspace = true
 x86defs.workspace = true
 
 arrayvec.workspace = true
+spin.workspace = true
 zerocopy.workspace = true
 
 [build-dependencies]

--- a/openhcl/sidecar/src/arch/x86_64/mod.rs
+++ b/openhcl/sidecar/src/arch/x86_64/mod.rs
@@ -18,6 +18,7 @@ use hvdef::HvError;
 use hvdef::HypercallCode;
 use minimal_rt::arch::Serial;
 use minimal_rt::arch::msr::write_msr;
+use spin::Mutex;
 use x86defs::Exception;
 use zerocopy::FromBytes;
 use zerocopy::IntoBytes;
@@ -170,6 +171,8 @@ static mut VSM_CAPABILITIES: hvdef::HvRegisterVsmCapabilities =
     hvdef::HvRegisterVsmCapabilities::new();
 static AFTER_INIT: AtomicBool = AtomicBool::new(false);
 static ENABLE_LOG: AtomicBool = AtomicBool::new(false);
+/// The COM3 UART used for sidecar logging
+static SERIAL: Mutex<Serial<InstrIoAccess>> = Mutex::new(Serial::new(InstrIoAccess));
 
 macro_rules! log {
     () => {};
@@ -188,13 +191,14 @@ use minimal_rt::arch::InstrIoAccess;
 
 fn log_fmt(args: core::fmt::Arguments<'_>) {
     if ENABLE_LOG.load(Acquire) {
+        let mut serial = SERIAL.lock();
         if AFTER_INIT.load(Acquire) {
             // SAFETY: `hv_vp_index` is not being concurrently modified.
             // TODO: improve how per-VP globals work.
             let vp_index = unsafe { &*addr_space::globals() }.hv_vp_index;
-            let _ = writeln!(Serial::new(InstrIoAccess), "sidecar#{vp_index}: {}", args);
+            let _ = writeln!(serial, "sidecar#{vp_index}: {}", args);
         } else {
-            let _ = writeln!(Serial::new(InstrIoAccess), "sidecar: {}", args);
+            let _ = writeln!(serial, "sidecar: {}", args);
         }
     }
 }


### PR DESCRIPTION
I encountered a run recently that contained extremely garbled sidecar logs, which ultimately resulted in a test failure when we tried to process those logs. Fix this by putting a spinlock around sidecar serial writes.