### PR TITLE
Add release/1.8.2607 labeler entry and logview quick filters

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -10,3 +10,6 @@ release_2505:
 
 release_1.7.2511:
  - base-branch: 'release/1.7.2511'
+
+release_1.8.2607:
+ - base-branch: 'release/1.8.2607'

--- a/petri/logview/src/branch_quick_filters.tsx
+++ b/petri/logview/src/branch_quick_filters.tsx
@@ -6,6 +6,7 @@
 export const run_filters: string[] = [
     "all",
     "main",
+    "release/1.8.2607",
     "release/1.7.2511",
     "release/2505",
 ];
@@ -14,6 +15,7 @@ export const run_filters: string[] = [
 // branch name exactly.
 export const test_filters: string[] = [
     "main",
+    "release/1.8.2607",
     "release/1.7.2511",
     "release/2505",
     "all",


### PR DESCRIPTION
Prep for the release/1.8.2607 fork (main-side changes).

- Add `release_1.8.2607` entry to `.github/labeler.yml` for the release tagging action.
- Add `release/1.8.2607` to the Runs and Tests quick-filter lists in `petri/logview/src/branch_quick_filters.tsx`.

Per Guide/src/openhcl/ops/release.md (OpenVMM repo, 'in main before forking'). The `release_1.8.2607` label still needs to be created in the repo separately.