### PR TITLE
release/1.8.2607 fork config

### DIFF
--- a/.github/scripts/refresh_mirror/refresh-mirror.py
+++ b/.github/scripts/refresh_mirror/refresh-mirror.py
@@ -19,7 +19,7 @@ def main(pipeline_id: str, token: str, organization: str, project: str, debug: b
 
         build = {
                     'definition': {'id': pipeline_id},
-                    'templateParameters': {'branchToMirror': 'release/1.8.2607', 'branchToUpdateSubmodule': 'staging/1.8.2607', 'updateSubmodule': 'true'},
+                    'templateParameters': {'branchToMirror': 'release/1.8.2607', 'branchToUpdateSubmodule': 'release/1.8.2607', 'updateSubmodule': 'true'},
                 }
         build = client.queue_build(build, project=project)
         print(f'Scheduled build: {build.id}. Url: {organization}/{project}/_build/results?buildId={build.id}&view=results', file=sys.stderr)

--- a/.github/scripts/refresh_mirror/refresh-mirror.py
+++ b/.github/scripts/refresh_mirror/refresh-mirror.py
@@ -19,7 +19,7 @@ def main(pipeline_id: str, token: str, organization: str, project: str, debug: b
 
         build = {
                     'definition': {'id': pipeline_id},
-                    'templateParameters': {'branchToMirror': 'release/1.8.2607', 'branchToUpdateSubmodule': 'release/1.8.2607', 'updateSubmodule': 'true'},
+                    'templateParameters': {'branchToMirror': 'release/1.8.2607', 'branchToUpdateSubmodule': 'staging/1.8.2607', 'updateSubmodule': 'true'},
                 }
         build = client.queue_build(build, project=project)
         print(f'Scheduled build: {build.id}. Url: {organization}/{project}/_build/results?buildId={build.id}&view=results', file=sys.stderr)

--- a/.github/scripts/refresh_mirror/refresh-mirror.py
+++ b/.github/scripts/refresh_mirror/refresh-mirror.py
@@ -19,7 +19,7 @@ def main(pipeline_id: str, token: str, organization: str, project: str, debug: b
 
         build = {
                     'definition': {'id': pipeline_id},
-                    'templateParameters': {'branchToMirror': 'main', 'branchToUpdateSubmodule': 'main', 'updateSubmodule': 'true'},
+                    'templateParameters': {'branchToMirror': 'release/1.8.2607', 'branchToUpdateSubmodule': 'release/1.8.2607', 'updateSubmodule': 'true'},
                 }
         build = client.queue_build(build, project=project)
         print(f'Scheduled build: {build.id}. Url: {organization}/{project}/_build/results?buildId={build.id}&view=results', file=sys.stderr)

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,5 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+[toolchain]
+channel = "1.95.0"


### PR DESCRIPTION
Release-branch fork config for `release/1.8.2607`.

- `.github/scripts/refresh_mirror/refresh-mirror.py`: set `branchToMirror` to `release/1.8.2607` and `branchToUpdateSubmodule` to `staging/1.8.2607`.
- Add `rust-toolchain.toml` pinned to channel `1.95.0` (matches HvLite prod MSRUSTUP 1.95.0).