### PR TITLE
vm: fix typos in readme

### DIFF
--- a/vm/README.md
+++ b/vm/README.md
@@ -1,7 +1,7 @@
-This directory is for library and infrastructure crates that are provide
+This directory is for library and infrastructure crates that provide
 VM-related functionality, _without_ being tied to any particular "VMM frontend"
 (e.g: OpenVMM, OpenHCL, etc...)
 
-Crates in this directly must not take any direct dependencies on any code
+Crates in this directory must not take any direct dependencies on any code
 outside of `vm/`, _except_ for crates pulled from crates.io, or crates under
 `../support/`.


### PR DESCRIPTION
Fixes some minor typos in `vm/README.md`