### PR TITLE
membacking: support Windows large-page guest RAM backing

### DIFF
--- a/Guide/src/SUMMARY.md
+++ b/Guide/src/SUMMARY.md
@@ -131,6 +131,7 @@
 - [Architecture](./reference/architecture.md)
   - [OpenVMM Architecture](./reference/architecture/openvmm.md)
     - [Memory Layout](./reference/architecture/openvmm/memory-layout.md)
+    - [Memory Backing](./reference/architecture/openvmm/memory-backing.md)
     - [NUMA Topology](./reference/architecture/openvmm/numa.md)
     - [mesh](./reference/architecture/openvmm/mesh.md)
       - [Using mesh](./reference/architecture/openvmm/mesh/usage.md)

--- a/Guide/src/reference/architecture/openvmm/memory-backing.md
+++ b/Guide/src/reference/architecture/openvmm/memory-backing.md
@@ -31,20 +31,20 @@ need to hand that object to something else:
 
 - **Snapshots** — the backing file is what gets saved and restored (see
   [Snapshots](../../../user_guide/openvmm/snapshots.md)).
-- **DMA to real hardware / IOMMU** — VFIO passthrough and emulated IOMMUs
-  need a backing fd to program device page tables.
 - **VTL2 / OpenHCL** and other consumers that mmap guest RAM out of process.
 
 **Private** memory is ordinary anonymous memory (`MAP_ANONYMOUS` on Linux,
 `VirtualAlloc` on Windows) with no backing object to share. It is lighter
-weight but cannot be used with the features above. Private memory is also
+weight but cannot be handed to another process. It can still be mapped into
+in-process DMA targets by host virtual address, so assigned-device and IOMMU
+DMA do not inherently require shared memory. Private memory is also
 incompatible with x86 PCAT/legacy RAM splitting and with reusing an existing
 backing.
 
 ```admonish tip
-Use `shared=on` when you need a feature that requires it — snapshots, device
-passthrough, or a paravisor — and `shared=off` (private) otherwise, for the
-lighter-weight anonymous backing.
+Use `shared=on` when you need a feature that requires a shareable backing
+object — such as snapshots or a paravisor — and `shared=off` (private)
+otherwise, for the lighter-weight anonymous backing.
 ```
 
 ## Prefetch
@@ -140,8 +140,9 @@ memory or explicit huge pages.
 | Goal | Backing |
 |---|---|
 | Default, general use | `shared=on` (file-backed shared memory) |
-| Smallest footprint, no snapshots/passthrough | `shared=off` (private) |
-| Snapshots, VFIO passthrough, IOMMU, VTL2 | `shared=on` |
+| Smallest footprint, no snapshots/out-of-process sharing | `shared=off` (private) |
+| Snapshots, VTL2, out-of-process memory consumers | `shared=on` |
+| In-process assigned-device/IOMMU DMA | Either backing mode |
 | Save/restore to a specific file | `file=<PATH>` |
 | Opportunistic 2 MB pages, Linux | `shared=off,thp=on` |
 | Guaranteed large pages, best TLB behavior | `hugepages=on` |
@@ -151,7 +152,7 @@ memory or explicit huge pages.
 
 | Option | Requires | Platform | Notes |
 |---|---|---|---|
-| `shared=off` (private) | — | all | No snapshots/passthrough; not with PCAT legacy RAM |
+| `shared=off` (private) | — | all | No snapshots/out-of-process sharing; not with PCAT legacy RAM |
 | `prefetch=on` | — | WHP only | Commits + populates SLAT up front; no-op on KVM/mshv |
 | `thp=on` | `shared=off` | Linux | Best-effort 2 MB pages |
 | `hugepages=on` | `shared=on` | Linux, Windows | Guaranteed; size/range must be huge-page aligned |

--- a/Guide/src/reference/architecture/openvmm/memory-backing.md
+++ b/Guide/src/reference/architecture/openvmm/memory-backing.md
@@ -60,14 +60,13 @@ not take a fault/exit the first time it touches each page. With prefetch off
 (the default), startup is fast and only the memory the guest actually touches
 is committed, but each first touch costs a fault.
 
-Two things limit where prefetch has any effect:
+Prefetch applies to both **shared** (file-backed) and **private** (anonymous)
+guest RAM.
 
-- It only applies to **shared** (file-backed) RAM. For private (anonymous)
-  memory the flag is ignored.
-- Only the **WHP** (Windows) backend implements it. On **KVM** and **mshv**,
-  `prefetch=on` is a no-op — those backends do not pre-populate their
-  second-stage page tables or pre-fault the host mapping, so guest RAM is
-  always faulted in on demand.
+One thing limits where it has any effect: only the **WHP** (Windows) backend
+implements it. On **KVM** and **mshv**, `prefetch=on` is a no-op — those
+backends do not pre-populate their second-stage page tables or pre-fault the
+host mapping, so guest RAM is always faulted in on demand.
 
 ## Huge pages
 
@@ -153,7 +152,7 @@ memory or explicit huge pages.
 | Option | Requires | Platform | Notes |
 |---|---|---|---|
 | `shared=off` (private) | — | all | No snapshots/passthrough; not with PCAT legacy RAM |
-| `prefetch=on` | shared memory | WHP only | Commits + populates SLAT up front; no-op on KVM/mshv |
+| `prefetch=on` | — | WHP only | Commits + populates SLAT up front; no-op on KVM/mshv |
 | `thp=on` | `shared=off` | Linux | Best-effort 2 MB pages |
 | `hugepages=on` | `shared=on` | Linux, Windows | Guaranteed; size/range must be huge-page aligned |
 | `hugepage_size=<SIZE>` | `hugepages=on` | Linux (any), Windows (2 MB only) | Default 2 MB |

--- a/Guide/src/reference/architecture/openvmm/memory-backing.md
+++ b/Guide/src/reference/architecture/openvmm/memory-backing.md
@@ -1,0 +1,160 @@
+# Memory Backing
+
+Guest RAM is just a range of guest physical addresses (see
+[Memory Layout](./memory-layout.md)); OpenVMM still has to decide what *host*
+memory sits behind those addresses and how it is mapped. That decision — the
+**memory backing** — affects startup time, runtime performance, which features
+are available (snapshots, DMA passthrough, VTL2), and how much physical memory
+the VM commits up front.
+
+This page explains the backing modes and the tradeoffs between them. The
+specific command-line syntax lives in the
+[CLI reference](../../openvmm/management/cli.md); the `--memory` and `--numa`
+options select a backing per VM (or per NUMA node) using the keys described
+below. The builder API is
+[`RamBackingRequest`](https://openvmm.dev/rustdoc/linux/membacking/struct.RamBackingRequest.html)
+in the `membacking` crate.
+
+## Shared vs. private memory
+
+The most fundamental choice is whether guest RAM is **shared** or **private**.
+The distinction is whether the host memory can be shared with other processes:
+shared memory lives in an OS memory object (with a file descriptor or handle)
+that can be mapped into more than one process, while private memory belongs to
+the OpenVMM process alone and cannot be handed out. It is selected with
+`shared=on|off` and defaults to `on`.
+
+**Shared** memory is backed by such an object — a `memfd` on Linux, or a
+pagefile-backed section on Windows. Because there is a real, shareable backing
+object behind every guest page, shared memory is required for the features that
+need to hand that object to something else:
+
+- **Snapshots** — the backing file is what gets saved and restored (see
+  [Snapshots](../../../user_guide/openvmm/snapshots.md)).
+- **DMA to real hardware / IOMMU** — VFIO passthrough and emulated IOMMUs
+  need a backing fd to program device page tables.
+- **VTL2 / OpenHCL** and other consumers that mmap guest RAM out of process.
+
+**Private** memory is ordinary anonymous memory (`MAP_ANONYMOUS` on Linux,
+`VirtualAlloc` on Windows) with no backing object to share. It is lighter
+weight but cannot be used with the features above. Private memory is also
+incompatible with x86 PCAT/legacy RAM splitting and with reusing an existing
+backing.
+
+```admonish tip
+Use `shared=on` when you need a feature that requires it — snapshots, device
+passthrough, or a paravisor — and `shared=off` (private) otherwise, for the
+lighter-weight anonymous backing.
+```
+
+## Prefetch
+
+`prefetch=on|off` asks OpenVMM to commit guest RAM and program it into the
+hypervisor's second-stage page tables (the SLAT) up front, instead of faulting
+each page in lazily on first guest access.
+
+This is a tradeoff. Prefetching forces the whole guest RAM range to be
+allocated in advance and inserted into the SLAT before the guest runs, which
+raises initial memory use and lengthens startup. In exchange, the guest does
+not take a fault/exit the first time it touches each page. With prefetch off
+(the default), startup is fast and only the memory the guest actually touches
+is committed, but each first touch costs a fault.
+
+Two things limit where prefetch has any effect:
+
+- It only applies to **shared** (file-backed) RAM. For private (anonymous)
+  memory the flag is ignored.
+- Only the **WHP** (Windows) backend implements it. On **KVM** and **mshv**,
+  `prefetch=on` is a no-op — those backends do not pre-populate their
+  second-stage page tables or pre-fault the host mapping, so guest RAM is
+  always faulted in on demand.
+
+## Huge pages
+
+There are two independent mechanisms for backing guest RAM with pages larger
+than 4 KiB. They pull in **opposite** directions on the shared/private choice,
+so it is worth keeping them straight.
+
+### Transparent Huge Pages (`thp=on`)
+
+Transparent Huge Pages are a **Linux, private-memory** feature. Setting
+`thp=on` marks the anonymous guest RAM as THP-eligible (via `madvise` with
+`MADV_HUGEPAGE`), inviting the kernel to *opportunistically* back it with 2 MB
+pages. It is best-effort: the kernel promotes pages when it can and silently
+falls back to 4 KB when it cannot, so nothing is pinned or guaranteed.
+
+- Requires `shared=off` (private memory).
+- Linux only.
+
+### Explicit huge pages (`hugepages=on`)
+
+`hugepages=on` requests **explicit, guaranteed** large-page backing from a
+reserved pool. Unlike THP this is not best-effort — the allocation either gets
+large pages or fails.
+
+- Requires **shared** memory (`shared=on`); incompatible with private memory,
+  file-backed memory, and x86 PCAT/legacy RAM splitting.
+- Guest RAM size and each RAM range must be a multiple of the huge-page size.
+- `hugepage_size=<SIZE>` overrides the default of 2 MB.
+
+**On Linux**, this uses `hugetlb`-backed memory. The pages come from the
+kernel's pre-reserved hugetlb pool, so that pool must be large enough for the
+whole guest; otherwise allocation fails with a message telling you to grow the
+pool or shrink the VM.
+
+**On Windows**, this uses a large-page (`SEC_LARGE_PAGES`) section. Several
+Windows-specific rules apply:
+
+- The process must hold the **"Lock pages in memory"**
+  (`SeLockMemoryPrivilege`) privilege.
+- The whole guest RAM is committed and pinned up front. Allocation *fails*
+  (rather than falling back to 4 KB) if enough contiguous physical memory is
+  not available — so request it at startup.
+- `hugepages=on` implies `prefetch=on`: Windows only installs 2 MB SLAT
+  entries when the SLAT is populated in large batches, so the RAM is
+  pre-populated up front to make the large-page backing actually yield 2 MB
+  SLAT mappings.
+- Only the 2 MB large-page size is supported (matching
+  `GetLargePageMinimum()`); other sizes are rejected.
+
+````admonish note title="Granting \"Lock pages in memory\" on Windows"
+Grant `SeLockMemoryPrivilege` to the current user from an **elevated**
+PowerShell prompt:
+
+```powershell
+.\scripts\grant-privilege.ps1
+```
+
+Sign out and back in for it to take effect, then verify with `whoami /priv`.
+````
+
+## File-backed RAM (`file=<PATH>`)
+
+`file=<PATH>` backs guest RAM with an existing file rather than an anonymous
+`memfd`. This is the mechanism behind [Snapshots](../../../user_guide/openvmm/snapshots.md):
+the backing file persists guest memory to disk so it can be saved and
+restored. It is a form of shared memory and cannot be combined with private
+memory or explicit huge pages.
+
+## Choosing a backing
+
+| Goal | Backing |
+|---|---|
+| Default, general use | `shared=on` (file-backed shared memory) |
+| Smallest footprint, no snapshots/passthrough | `shared=off` (private) |
+| Snapshots, VFIO passthrough, IOMMU, VTL2 | `shared=on` |
+| Save/restore to a specific file | `file=<PATH>` |
+| Opportunistic 2 MB pages, Linux | `shared=off,thp=on` |
+| Guaranteed large pages, best TLB behavior | `hugepages=on` |
+| Avoid first-touch faults (WHP only) | add `prefetch=on` |
+
+## Compatibility summary
+
+| Option | Requires | Platform | Notes |
+|---|---|---|---|
+| `shared=off` (private) | — | all | No snapshots/passthrough; not with PCAT legacy RAM |
+| `prefetch=on` | shared memory | WHP only | Commits + populates SLAT up front; no-op on KVM/mshv |
+| `thp=on` | `shared=off` | Linux | Best-effort 2 MB pages |
+| `hugepages=on` | `shared=on` | Linux, Windows | Guaranteed; size/range must be huge-page aligned |
+| `hugepage_size=<SIZE>` | `hugepages=on` | Linux (any), Windows (2 MB only) | Default 2 MB |
+| `file=<PATH>` | `shared=on` | all | Persistent backing file for snapshots |

--- a/Guide/src/reference/openvmm/management/cli.md
+++ b/Guide/src/reference/openvmm/management/cli.md
@@ -16,20 +16,25 @@ as well as the generated CLI help (via `cargo run -- --help`).
   --memory size=4G,shared=on,prefetch=off
   ```
 
+  The keys below select the guest RAM **memory backing**. For an explanation
+  of shared vs. private memory, prefetch, huge pages, and file-backed RAM —
+  and how to choose between them — see
+  [Memory Backing](../../architecture/openvmm/memory-backing.md).
+
   Supported keys:
   * `size=<SIZE>` - guest RAM size. Sizes accept `K`, `M`, `G`, and
     `T` suffixes, optionally followed by `B`.
   * `shared=on|off` - use shared file-backed guest RAM. The default is
     `on`; `off` uses private anonymous memory.
-  * `prefetch=on|off` - pre-populate shared guest RAM mappings.
+  * `prefetch=on|off` - pre-populate guest RAM mappings up front.
   * `thp=on|off` - mark private guest RAM as Transparent Huge Page
-    eligible. Requires `shared=off`.
-  * `hugepages=on|off` - allocate guest RAM from Linux hugetlb pages.
-    This is Linux-only, requires shared memory, and cannot be combined
-    with file-backed memory or PCAT/legacy x86 RAM splitting.
-  * `hugepage_size=<SIZE>` - request a specific hugetlb page size, such
-    as `2MB` or `1GB`. Requires `hugepages=on`; if omitted,
-    OpenVMM uses 2 MB pages.
+    eligible (Linux only). Requires `shared=off`.
+  * `hugepages=on|off` - allocate guest RAM from explicit large/huge pages
+    (Linux hugetlb pages or a Windows `SEC_LARGE_PAGES` section). Requires
+    shared memory.
+  * `hugepage_size=<SIZE>` - request a specific large-page size, such
+    as `2MB` or `1GB`. Requires `hugepages=on`; defaults to 2 MB. On
+    Windows only 2 MB is supported.
   * `file=<PATH>` - use an existing file as the guest RAM backing file.
     This is used by snapshots.
 

--- a/Guide/src/reference/openvmm/management/cli.md
+++ b/Guide/src/reference/openvmm/management/cli.md
@@ -27,6 +27,7 @@ as well as the generated CLI help (via `cargo run -- --help`).
   * `shared=on|off` - use shared file-backed guest RAM. The default is
     `on`; `off` uses private anonymous memory.
   * `prefetch=on|off` - pre-populate guest RAM mappings up front.
+    Only has an effect under WHP; a no-op on KVM/mshv.
   * `thp=on|off` - mark private guest RAM as Transparent Huge Page
     eligible (Linux only). Requires `shared=off`.
   * `hugepages=on|off` - allocate guest RAM from explicit large/huge pages

--- a/openvmm/membacking/src/mapping_manager/va_mapper.rs
+++ b/openvmm/membacking/src/mapping_manager/va_mapper.rs
@@ -437,6 +437,7 @@ impl VaMapper {
                     process.as_handle().try_clone_to_owned().unwrap().into(),
                     None,
                     len as usize,
+                    minimum_alignment.unwrap_or(1),
                 ),
             },
         }

--- a/openvmm/membacking/src/memory_manager/mod.rs
+++ b/openvmm/membacking/src/memory_manager/mod.rs
@@ -501,6 +501,13 @@ impl GuestMemoryBuilder {
                     let hugepage_size =
                         validate_hugepage_size(req.hugepage_size.unwrap_or(DEFAULT_HUGEPAGE_SIZE))?;
                     validate_hugepage_ram_alignment(size, &req.ranges, hugepage_size as u64)?;
+                    // TODO: on Windows, when this large-page (SEC_LARGE_PAGES)
+                    // section is later mapped into the guest VA, we should
+                    // really map it with MEM_LARGE_PAGES so the view itself
+                    // uses large pages. Released versions of Windows don't
+                    // support MEM_LARGE_PAGES together with the placeholder
+                    // reservations that sparse_mmap relies on, so we leave it
+                    // out for now.
                     sparse_mmap::alloc_shared_memory_hugetlb(
                         backing_size,
                         &name,

--- a/openvmm/membacking/src/memory_manager/mod.rs
+++ b/openvmm/membacking/src/memory_manager/mod.rs
@@ -155,8 +155,8 @@ pub enum MemoryBuildError {
     /// Hugepage size is too large.
     #[error("hugepage size {0} is too large")]
     HugepageSizeTooLarge(MemorySize),
-    /// Hugepages are only supported on Linux.
-    #[error("hugepages are only supported on Linux")]
+    /// Hugepages are only supported on Linux and Windows.
+    #[error("hugepages are only supported on Linux and Windows")]
     HugepagesUnsupportedPlatform,
     /// Host NUMA node binding is only supported on Linux and Windows.
     #[error("host NUMA node binding is only supported on Linux and Windows")]
@@ -426,7 +426,7 @@ impl GuestMemoryBuilder {
                 return Err(MemoryBuildError::HostNumaNodeUnsupportedPlatform);
             }
             if req.hugepages {
-                if !cfg!(target_os = "linux") {
+                if !cfg!(any(target_os = "linux", target_os = "windows")) {
                     return Err(MemoryBuildError::HugepagesUnsupportedPlatform);
                 }
                 if req.private_memory {
@@ -522,7 +522,13 @@ impl GuestMemoryBuilder {
             backings.push(RamBacking {
                 mappable: Some(mappable),
                 ranges: req.ranges,
-                prefetch: req.prefetch,
+                // On Windows, hugepage (SEC_LARGE_PAGES) backing only yields 2 MB
+                // SLAT entries when the SLAT is populated in >= 512-page batches;
+                // lazy per-page demand faults produce 4 KB entries. Prefetching
+                // populates each region up front in large contiguous batches, so
+                // force it on for hugepage-backed RAM. (Linux hugetlb faults the
+                // whole large page on first touch, so this is not needed there.)
+                prefetch: req.prefetch || (cfg!(windows) && req.hugepages),
                 transparent_hugepages: false,
                 host_numa_node: req.host_numa_node,
             });

--- a/openvmm/membacking/src/memory_manager/mod.rs
+++ b/openvmm/membacking/src/memory_manager/mod.rs
@@ -433,6 +433,9 @@ impl GuestMemoryBuilder {
                 if req.private_memory {
                     return Err(MemoryBuildError::HugepagesWithPrivateMemory);
                 }
+                if req.existing_mappable.is_some() {
+                    return Err(MemoryBuildError::HugepagesWithExistingBacking);
+                }
                 if self.x86_legacy_support {
                     return Err(MemoryBuildError::HugepagesWithLegacy);
                 }
@@ -885,6 +888,7 @@ impl RamVisibilityControl {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use pal_async::async_test;
     use std::error::Error as _;
 
     /// Build a GuestMemoryManager with the given backing range groups,
@@ -906,6 +910,24 @@ mod tests {
         let mgr = builder.build(max_addr).await.unwrap();
         let gm = mgr.client().guest_memory().await.unwrap();
         (mgr, gm)
+    }
+
+    #[async_test]
+    async fn test_hugepages_with_existing_backing_rejected() {
+        const SIZE: u64 = 2 * 1024 * 1024;
+        let mappable = sparse_mmap::alloc_shared_memory(SIZE as usize, "test").unwrap();
+        let backing = RamBackingRequest::new(vec![MemoryRange::new(0..SIZE)])
+            .hugepages(None)
+            .existing_mappable(mappable.into());
+        let err = GuestMemoryBuilder::new()
+            .add_backing(backing)
+            .build(SIZE)
+            .await
+            .unwrap_err();
+        assert!(matches!(
+            err,
+            MemoryBuildError::HugepagesWithExistingBacking
+        ));
     }
 
     #[test]

--- a/openvmm/membacking/src/memory_manager/mod.rs
+++ b/openvmm/membacking/src/memory_manager/mod.rs
@@ -268,7 +268,8 @@ impl RamBackingRequest {
     }
 
     /// Bind this backing's memory to a specific host NUMA node
-    /// (Linux: `mbind(MPOL_BIND)`, Windows: `MemExtendedParameterNumaNode`).
+    /// (Linux: `mbind(MPOL_BIND)`, Windows: `CreateFileMappingNuma` for
+    /// large-page sections and `MemExtendedParameterNumaNode` otherwise).
     ///
     /// Only supported on Linux and Windows; returns
     /// [`MemoryBuildError::HostNumaNodeUnsupportedPlatform`] at build time on
@@ -504,6 +505,7 @@ impl GuestMemoryBuilder {
                         backing_size,
                         &name,
                         Some(hugepage_size),
+                        req.host_numa_node,
                     )
                     .map_err(|error| MemoryBuildError::HugepageAllocationFailed {
                         size: MemorySize(size),

--- a/openvmm/membacking/src/memory_manager/mod.rs
+++ b/openvmm/membacking/src/memory_manager/mod.rs
@@ -628,7 +628,7 @@ impl GuestMemoryBuilder {
                         .map(MapParams {
                             writable: true,
                             executable: true,
-                            prefetch: backing.prefetch && backing.mappable.is_some(),
+                            prefetch: backing.prefetch,
                         })
                         .await
                         .map_err(|error| MemoryBuildError::RamRegionEnable {

--- a/openvmm/openvmm_entry/src/cli_args.rs
+++ b/openvmm/openvmm_entry/src/cli_args.rs
@@ -135,7 +135,7 @@ Size suffixes accept K, M, G, and T, optionally followed by B.
 Options:
     size=<SIZE>              guest RAM size, default 1GB
     shared=on|off            use shared file-backed RAM, default on
-    prefetch=on|off          pre-populate shared RAM mappings
+    prefetch=on|off          pre-populate guest RAM mappings
     thp=on|off               mark private RAM as THP-eligible; requires shared=off
     hugepages=on|off         allocate RAM from hugetlb/large pages (Linux, Windows)
     hugepage_size=<SIZE>     hugepage size, default 2MB; requires hugepages=on
@@ -165,7 +165,7 @@ Syntax: key=value[,key=value...]
 Options:
     size=<SIZE>              RAM for this node (required)
     shared=on|off            use shared file-backed RAM, default on
-    prefetch=on|off          pre-populate shared RAM mappings
+    prefetch=on|off          pre-populate guest RAM mappings
     thp=on|off               mark private RAM as THP-eligible; requires shared=off
     hugepages=on|off         allocate RAM from hugetlb pages
     hugepage_size=<SIZE>     hugetlb page size; requires hugepages=on

--- a/openvmm/openvmm_entry/src/cli_args.rs
+++ b/openvmm/openvmm_entry/src/cli_args.rs
@@ -137,8 +137,8 @@ Options:
     shared=on|off            use shared file-backed RAM, default on
     prefetch=on|off          pre-populate shared RAM mappings
     thp=on|off               mark private RAM as THP-eligible; requires shared=off
-    hugepages=on|off         allocate RAM from Linux hugetlb pages
-    hugepage_size=<SIZE>     hugetlb page size, default 2MB; requires hugepages=on
+    hugepages=on|off         allocate RAM from hugetlb/large pages (Linux, Windows)
+    hugepage_size=<SIZE>     hugepage size, default 2MB; requires hugepages=on
     file=<PATH>              use an existing file as guest RAM backing
 
 Examples:
@@ -1262,8 +1262,8 @@ impl Options {
             anyhow::bail!("transparent huge pages requires private memory mode");
         }
         if self.memory.hugepages {
-            if !cfg!(target_os = "linux") {
-                anyhow::bail!("hugepages are only supported on Linux");
+            if !cfg!(any(target_os = "linux", target_os = "windows")) {
+                anyhow::bail!("hugepages are only supported on Linux and Windows");
             }
             if self.private_memory() {
                 anyhow::bail!("hugepages conflict with private memory");

--- a/openvmm/openvmm_entry/src/cli_args.rs
+++ b/openvmm/openvmm_entry/src/cli_args.rs
@@ -167,8 +167,8 @@ Options:
     shared=on|off            use shared file-backed RAM, default on
     prefetch=on|off          pre-populate guest RAM mappings
     thp=on|off               mark private RAM as THP-eligible; requires shared=off
-    hugepages=on|off         allocate RAM from hugetlb pages
-    hugepage_size=<SIZE>     hugetlb page size; requires hugepages=on
+    hugepages=on|off         allocate RAM from hugetlb/large pages (Linux, Windows)
+    hugepage_size=<SIZE>     hugepage size, default 2MB; requires hugepages=on
     host_numa_node=<N>       bind allocation to host NUMA node N
     vps=<LIST>               explicit VP indices (e.g. "[0,1,2,3]")
 

--- a/openvmm/openvmm_entry/src/cli_args.rs
+++ b/openvmm/openvmm_entry/src/cli_args.rs
@@ -1245,6 +1245,12 @@ impl Options {
     }
 
     /// Validates combinations that span the new `--memory` parser and legacy aliases.
+    ///
+    /// Only checks that cannot be expressed elsewhere live here. Conflicts
+    /// within a single `--memory` string are enforced by the parser, and
+    /// semantic constraints (platform support, private-vs-shared, huge pages
+    /// vs. legacy RAM, etc.) are enforced by the membacking builder at VM
+    /// build time; those are not duplicated here.
     pub fn validate_memory_options(&self) -> anyhow::Result<()> {
         if self.memory.file.is_some() && self.deprecated_memory_backing_file.is_some() {
             anyhow::bail!("--memory file=... conflicts with --memory-backing-file");
@@ -1254,26 +1260,6 @@ impl Options {
         }
         if self.memory.shared == Some(true) && self.deprecated_private_memory {
             anyhow::bail!("--memory shared=on conflicts with --private-memory");
-        }
-        if self.memory_backing_file().is_some() && self.private_memory() {
-            anyhow::bail!("file-backed memory conflicts with private memory");
-        }
-        if self.transparent_hugepages() && !self.private_memory() {
-            anyhow::bail!("transparent huge pages requires private memory mode");
-        }
-        if self.memory.hugepages {
-            if !cfg!(any(target_os = "linux", target_os = "windows")) {
-                anyhow::bail!("hugepages are only supported on Linux and Windows");
-            }
-            if self.private_memory() {
-                anyhow::bail!("hugepages conflict with private memory");
-            }
-            if self.memory_backing_file().is_some() || self.restore_snapshot.is_some() {
-                anyhow::bail!("hugepages conflict with file-backed memory");
-            }
-            if self.pcat {
-                anyhow::bail!("hugepages conflict with x86 legacy RAM splitting");
-            }
         }
         Ok(())
     }
@@ -5072,24 +5058,6 @@ mod tests {
     fn test_memory_options_reject_conflicting_legacy_aliases() {
         let opt = Options::try_parse_from(["openvmm", "--memory", "shared=on", "--private-memory"])
             .unwrap();
-        assert!(opt.validate_memory_options().is_err());
-    }
-
-    #[test]
-    fn test_memory_options_reject_hugepage_legacy_conflicts() {
-        let opt =
-            Options::try_parse_from(["openvmm", "--memory", "hugepages=on", "--private-memory"])
-                .unwrap();
-        assert!(opt.validate_memory_options().is_err());
-
-        let opt = Options::try_parse_from([
-            "openvmm",
-            "--memory",
-            "hugepages=on",
-            "--memory-backing-file",
-            "/tmp/memory.bin",
-        ])
-        .unwrap();
         assert!(opt.validate_memory_options().is_err());
     }
 

--- a/petri/src/vm/mod.rs
+++ b/petri/src/vm/mod.rs
@@ -1121,7 +1121,7 @@ impl<T: PetriVmmBackend> PetriVmBuilder<T> {
                 tracing::warn!("Test timeout reached after {TIMEOUT_DURATION_MINUTES} minutes, collecting diagnostics.");
                 let mut timeout_tasks = Vec::new();
                 if let Some(inspector) = vmm_inspector {
-                    timeout_tasks.push(inspect_task.clone()("vmm", &driver, Box::pin(async move { inspector.inspect_all().await })) );
+                    timeout_tasks.push(inspect_task.clone()("vmm", &driver, Box::pin(async move { inspector.inspect("").await })) );
                 }
                 if let Some(openhcl_diag_handler) = openhcl_diag_handler {
                     timeout_tasks.push(inspect_task("openhcl", &driver, Box::pin(async move { openhcl_diag_handler.inspect("", None, None).await })));
@@ -1790,6 +1790,26 @@ impl<T: PetriVmmBackend> PetriVm<T> {
         self.inspect_openhcl("", None, None).await.map(|_| ())
     }
 
+    /// Invoke Inspect on the running VMM process itself (e.g. OpenVMM),
+    /// returning the inspect tree rooted at `path` (pass `""` for the whole
+    /// tree).
+    ///
+    /// Only backends that expose an inspect interface (currently OpenVMM)
+    /// support this; other backends return an error.
+    ///
+    /// IMPORTANT: As mentioned in the Guide, inspect output is *not* guaranteed
+    /// to be stable. Use this to verify that components are working as you
+    /// expect, not to assert on output that some other tool depends on.
+    pub async fn inspect_vmm(&self, path: &str) -> anyhow::Result<inspect::Node> {
+        use anyhow::Context;
+
+        let inspector = self
+            .runtime
+            .inspector()
+            .context("this VMM backend does not support inspect")?;
+        inspector.inspect(path).await
+    }
+
     /// Wait for VTL 2 to report that it is ready to respond to commands.
     /// Will fail if the VM is not running OpenHCL.
     ///
@@ -1877,7 +1897,7 @@ impl<T: PetriVmmBackend> PetriVm<T> {
                     if let Some(inspector) = self.runtime.inspector() {
                         save_inspect(
                             "vmm",
-                            Box::pin(async move { inspector.inspect_all().await }),
+                            Box::pin(async move { inspector.inspect("").await }),
                             &self.resources.log_source,
                         )
                         .await;
@@ -2153,15 +2173,16 @@ pub trait PetriVmRuntime: Send + Sync + 'static {
 /// Interface for getting information about the state of the VM
 #[async_trait]
 pub trait PetriVmInspector: Send + Sync + 'static {
-    /// Get information about the state of the VM
-    async fn inspect_all(&self) -> anyhow::Result<inspect::Node>;
+    /// Get information about the state of the VM at the given inspect `path`.
+    /// Pass `""` to inspect the entire tree.
+    async fn inspect(&self, path: &str) -> anyhow::Result<inspect::Node>;
 }
 
 /// Use this for the associated type if not supported
 pub struct NoPetriVmInspector;
 #[async_trait]
 impl PetriVmInspector for NoPetriVmInspector {
-    async fn inspect_all(&self) -> anyhow::Result<inspect::Node> {
+    async fn inspect(&self, _path: &str) -> anyhow::Result<inspect::Node> {
         unreachable!()
     }
 }

--- a/petri/src/vm/openvmm/runtime.rs
+++ b/petri/src/vm/openvmm/runtime.rs
@@ -740,8 +740,8 @@ pub struct OpenVmmInspector {
 
 #[async_trait]
 impl PetriVmInspector for OpenVmmInspector {
-    async fn inspect_all(&self) -> anyhow::Result<inspect::Node> {
-        Ok(self.worker.inspect_all().await)
+    async fn inspect(&self, path: &str) -> anyhow::Result<inspect::Node> {
+        Ok(self.worker.inspect(path).await)
     }
 }
 

--- a/petri/src/worker.rs
+++ b/petri/src/worker.rs
@@ -119,8 +119,8 @@ impl Worker {
         Ok(())
     }
 
-    pub(crate) async fn inspect_all(&self) -> inspect::Node {
-        let mut inspection = inspect::inspect("", &self.handle);
+    pub(crate) async fn inspect(&self, path: &str) -> inspect::Node {
+        let mut inspection = inspect::inspect(path, &self.handle);
         inspection.resolve().await;
         inspection.results()
     }

--- a/scripts/grant-privilege.ps1
+++ b/scripts/grant-privilege.ps1
@@ -58,7 +58,7 @@ using System;
 using System.Runtime.InteropServices;
 public static class Lsa {
   [StructLayout(LayoutKind.Sequential)] struct LSA_UNICODE_STRING { public ushort Length, MaximumLength; public IntPtr Buffer; }
-  [StructLayout(LayoutKind.Sequential)] struct LSA_OBJECT_ATTRIBUTES { public int Length; public IntPtr a,b,c; public int d; public IntPtr e; }
+  [StructLayout(LayoutKind.Sequential)] struct LSA_OBJECT_ATTRIBUTES { public int Length; public IntPtr RootDirectory, ObjectName; public int Attributes; public IntPtr SecurityDescriptor, SecurityQualityOfService; }
   [DllImport("advapi32.dll", SetLastError=true)] static extern uint LsaOpenPolicy(IntPtr s, ref LSA_OBJECT_ATTRIBUTES o, int a, out IntPtr h);
   [DllImport("advapi32.dll", SetLastError=true)] static extern uint LsaAddAccountRights(IntPtr h, byte[] sid, LSA_UNICODE_STRING[] r, int c);
   [DllImport("advapi32.dll", SetLastError=true)] static extern uint LsaRemoveAccountRights(IntPtr h, byte[] sid, [MarshalAs(UnmanagedType.U1)] bool all, LSA_UNICODE_STRING[] r, int c);

--- a/scripts/grant-privilege.ps1
+++ b/scripts/grant-privilege.ps1
@@ -61,7 +61,7 @@ public static class Lsa {
   [StructLayout(LayoutKind.Sequential)] struct LSA_OBJECT_ATTRIBUTES { public int Length; public IntPtr a,b,c; public int d; public IntPtr e; }
   [DllImport("advapi32.dll", SetLastError=true)] static extern uint LsaOpenPolicy(IntPtr s, ref LSA_OBJECT_ATTRIBUTES o, int a, out IntPtr h);
   [DllImport("advapi32.dll", SetLastError=true)] static extern uint LsaAddAccountRights(IntPtr h, byte[] sid, LSA_UNICODE_STRING[] r, int c);
-  [DllImport("advapi32.dll", SetLastError=true)] static extern uint LsaRemoveAccountRights(IntPtr h, byte[] sid, bool all, LSA_UNICODE_STRING[] r, int c);
+  [DllImport("advapi32.dll", SetLastError=true)] static extern uint LsaRemoveAccountRights(IntPtr h, byte[] sid, [MarshalAs(UnmanagedType.U1)] bool all, LSA_UNICODE_STRING[] r, int c);
   [DllImport("advapi32.dll")] static extern uint LsaClose(IntPtr h);
   [DllImport("advapi32.dll")] static extern int LsaNtStatusToWinError(uint s);
   static IntPtr OpenPolicy() {

--- a/scripts/grant-privilege.ps1
+++ b/scripts/grant-privilege.ps1
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 <#
 .SYNOPSIS
     Grants or revokes a Windows user-right (privilege) for an account by SID

--- a/scripts/grant-privilege.ps1
+++ b/scripts/grant-privilege.ps1
@@ -1,0 +1,113 @@
+<#
+.SYNOPSIS
+    Grants or revokes a Windows user-right (privilege) for an account by SID
+    via the LSA API.
+
+.DESCRIPTION
+    Makes it easy to grant a privilege such as SeLockMemoryPrivilege ("Lock
+    pages in memory") to an account. It calls LsaAddAccountRights (or
+    LsaRemoveAccountRights with -Remove) directly, which takes a raw SID and
+    works for any account.
+
+    Run from an ELEVATED PowerShell prompt. Privilege changes take effect at
+    the next logon, so sign out and back in, then verify with `whoami /priv`.
+
+.PARAMETER Privilege
+    The privilege constant to grant or revoke (default: SeLockMemoryPrivilege).
+
+.PARAMETER Sid
+    The account SID to change it for. Defaults to the current user's SID.
+
+.PARAMETER Remove
+    Revoke the privilege instead of granting it.
+
+.EXAMPLE
+    .\grant-privilege.ps1
+    Grants SeLockMemoryPrivilege to the current user.
+
+.EXAMPLE
+    .\grant-privilege.ps1 -Privilege SeServiceLogonRight -Sid S-1-12-1-...
+    Grants a specific privilege to a specific SID.
+
+.EXAMPLE
+    .\grant-privilege.ps1 -Remove
+    Revokes SeLockMemoryPrivilege from the current user.
+#>
+[CmdletBinding()]
+param(
+    [string]$Privilege = 'SeLockMemoryPrivilege',
+    [string]$Sid = ([System.Security.Principal.WindowsIdentity]::GetCurrent().User.Value),
+    [switch]$Remove
+)
+
+$ErrorActionPreference = 'Stop'
+
+# Require elevation — the LSA account-rights APIs need admin rights.
+$isAdmin = ([System.Security.Principal.WindowsPrincipal] `
+    [System.Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole(
+        [System.Security.Principal.WindowsBuiltInRole]::Administrator)
+if (-not $isAdmin) {
+    throw "This script must be run from an elevated (Administrator) PowerShell prompt."
+}
+
+$sig = @'
+using System;
+using System.Runtime.InteropServices;
+public static class Lsa {
+  [StructLayout(LayoutKind.Sequential)] struct LSA_UNICODE_STRING { public ushort Length, MaximumLength; public IntPtr Buffer; }
+  [StructLayout(LayoutKind.Sequential)] struct LSA_OBJECT_ATTRIBUTES { public int Length; public IntPtr a,b,c; public int d; public IntPtr e; }
+  [DllImport("advapi32.dll", SetLastError=true)] static extern uint LsaOpenPolicy(IntPtr s, ref LSA_OBJECT_ATTRIBUTES o, int a, out IntPtr h);
+  [DllImport("advapi32.dll", SetLastError=true)] static extern uint LsaAddAccountRights(IntPtr h, byte[] sid, LSA_UNICODE_STRING[] r, int c);
+  [DllImport("advapi32.dll", SetLastError=true)] static extern uint LsaRemoveAccountRights(IntPtr h, byte[] sid, bool all, LSA_UNICODE_STRING[] r, int c);
+  [DllImport("advapi32.dll")] static extern uint LsaClose(IntPtr h);
+  [DllImport("advapi32.dll")] static extern int LsaNtStatusToWinError(uint s);
+  static IntPtr OpenPolicy() {
+    var oa = new LSA_OBJECT_ATTRIBUTES(); oa.Length = Marshal.SizeOf(oa);
+    IntPtr h;
+    // POLICY_CREATE_ACCOUNT (0x10) | POLICY_LOOKUP_NAMES (0x800)
+    uint st = LsaOpenPolicy(IntPtr.Zero, ref oa, 0x00000010 | 0x00000800, out h);
+    if (st != 0) throw new Exception("LsaOpenPolicy failed: Win32 error " + LsaNtStatusToWinError(st));
+    return h;
+  }
+  static LSA_UNICODE_STRING[] MakeRight(string right) {
+    var us = new LSA_UNICODE_STRING[1];
+    us[0].Buffer = Marshal.StringToHGlobalUni(right);
+    us[0].Length = (ushort)(right.Length * 2);
+    us[0].MaximumLength = (ushort)((right.Length + 1) * 2);
+    return us;
+  }
+  static byte[] SidBytes(string sidStr) {
+    var sid = new System.Security.Principal.SecurityIdentifier(sidStr);
+    var sidBytes = new byte[sid.BinaryLength]; sid.GetBinaryForm(sidBytes, 0);
+    return sidBytes;
+  }
+  public static void Grant(string sidStr, string right) {
+    var sidBytes = SidBytes(sidStr);
+    IntPtr h = OpenPolicy();
+    var us = MakeRight(right);
+    uint st = LsaAddAccountRights(h, sidBytes, us, 1);
+    LsaClose(h);
+    Marshal.FreeHGlobal(us[0].Buffer);
+    if (st != 0) throw new Exception("LsaAddAccountRights failed: Win32 error " + LsaNtStatusToWinError(st));
+  }
+  public static void Revoke(string sidStr, string right) {
+    var sidBytes = SidBytes(sidStr);
+    IntPtr h = OpenPolicy();
+    var us = MakeRight(right);
+    uint st = LsaRemoveAccountRights(h, sidBytes, false, us, 1);
+    LsaClose(h);
+    Marshal.FreeHGlobal(us[0].Buffer);
+    if (st != 0) throw new Exception("LsaRemoveAccountRights failed: Win32 error " + LsaNtStatusToWinError(st));
+  }
+}
+'@
+
+Add-Type -TypeDefinition $sig
+if ($Remove) {
+    [Lsa]::Revoke($Sid, $Privilege)
+    Write-Host "Revoked $Privilege from $Sid"
+} else {
+    [Lsa]::Grant($Sid, $Privilege)
+    Write-Host "Granted $Privilege to $Sid"
+}
+Write-Host "Sign out and back in for it to take effect, then verify with: whoami /priv"

--- a/support/sparse_mmap/Cargo.toml
+++ b/support/sparse_mmap/Cargo.toml
@@ -22,7 +22,9 @@ getrandom.workspace = true
 [target.'cfg(windows)'.dependencies]
 parking_lot.workspace = true
 windows-sys = { workspace = true, features = [
+    "Wdk_System_SystemServices",
     "Win32_Foundation",
+    "Win32_Security",
     "Win32_System_Diagnostics_Debug",
     "Win32_System_Kernel",
     "Win32_System_Memory",

--- a/support/sparse_mmap/Cargo.toml
+++ b/support/sparse_mmap/Cargo.toml
@@ -28,6 +28,7 @@ windows-sys = { workspace = true, features = [
     "Win32_System_Diagnostics_Debug",
     "Win32_System_Kernel",
     "Win32_System_Memory",
+    "Win32_System_SystemServices",
     "Win32_System_Threading",
 ]}
 

--- a/support/sparse_mmap/src/lib.rs
+++ b/support/sparse_mmap/src/lib.rs
@@ -40,6 +40,24 @@ pub enum SparseMappingError {
     Memory(trycopy::MemoryError),
 }
 
+/// Computes the reservation alignment for a mapping of `len` bytes.
+///
+/// Larger mappings are aligned to large-page boundaries (2 MB, then 1 GB) so
+/// that they can back large pages without the caller having to ask. The result
+/// is always at least `minimum_alignment` and at least the system page size.
+fn reservation_alignment(len: usize, minimum_alignment: usize) -> usize {
+    const SIZE_2M: usize = 0x200000;
+    const SIZE_1G: usize = 0x40000000;
+    let default_alignment = if len < SIZE_2M {
+        SparseMapping::page_size()
+    } else if len < SIZE_1G {
+        SIZE_2M
+    } else {
+        SIZE_1G
+    };
+    default_alignment.max(minimum_alignment)
+}
+
 impl SparseMapping {
     /// Gets the supported page size for sparse mappings.
     pub fn page_size() -> usize {
@@ -212,23 +230,29 @@ mod tests {
                 .unwrap();
         assert_eq!(mapping.as_ptr() as usize % alignment, 0);
 
+        // Alignments larger than the allocation granularity are honored on
+        // both platforms.
         let alignment = 0x200000;
+        let mapping =
+            SparseMapping::new_with_minimum_alignment(SparseMapping::page_size(), alignment)
+                .unwrap();
+        assert_eq!(mapping.as_ptr() as usize % alignment, 0);
+    }
 
-        #[cfg(unix)]
-        {
-            let mapping =
-                SparseMapping::new_with_minimum_alignment(SparseMapping::page_size(), alignment)
-                    .unwrap();
-            assert_eq!(mapping.as_ptr() as usize % alignment, 0);
-        }
+    #[test]
+    fn test_sparse_mapping_default_alignment() {
+        // A small mapping only needs page alignment.
+        let mapping = SparseMapping::new(SparseMapping::page_size()).unwrap();
+        assert_eq!(mapping.as_ptr() as usize % SparseMapping::page_size(), 0);
 
-        #[cfg(windows)]
-        {
-            let error =
-                SparseMapping::new_with_minimum_alignment(SparseMapping::page_size(), alignment)
-                    .unwrap_err();
-            assert_eq!(error.kind(), std::io::ErrorKind::Unsupported);
-        }
+        // Mappings of at least 2 MB are aligned to a 2 MB boundary so that they
+        // can back large pages.
+        let mapping = SparseMapping::new(0x200000).unwrap();
+        assert_eq!(mapping.as_ptr() as usize % 0x200000, 0);
+
+        // Mappings of at least 1 GB are aligned to a 1 GB boundary.
+        let mapping = SparseMapping::new(0x40000000).unwrap();
+        assert_eq!(mapping.as_ptr() as usize % 0x40000000, 0);
     }
 
     #[test]

--- a/support/sparse_mmap/src/lib.rs
+++ b/support/sparse_mmap/src/lib.rs
@@ -45,7 +45,15 @@ pub enum SparseMappingError {
 /// Larger mappings are aligned to large-page boundaries (2 MB, then 1 GB) so
 /// that they can back large pages without the caller having to ask. The result
 /// is always at least `minimum_alignment` and at least the system page size.
-fn reservation_alignment(len: usize, minimum_alignment: usize) -> usize {
+///
+/// Returns an error if `minimum_alignment` is not a power of two.
+fn reservation_alignment(len: usize, minimum_alignment: usize) -> std::io::Result<usize> {
+    if !minimum_alignment.is_power_of_two() {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "alignment must be a power of two",
+        ));
+    }
     const SIZE_2M: usize = 0x200000;
     const SIZE_1G: usize = 0x40000000;
     let default_alignment = if len < SIZE_2M {
@@ -55,7 +63,7 @@ fn reservation_alignment(len: usize, minimum_alignment: usize) -> usize {
     } else {
         SIZE_1G
     };
-    default_alignment.max(minimum_alignment)
+    Ok(default_alignment.max(minimum_alignment))
 }
 
 impl SparseMapping {

--- a/support/sparse_mmap/src/unix.rs
+++ b/support/sparse_mmap/src/unix.rs
@@ -109,15 +109,9 @@ impl SparseMapping {
                 "length must be greater than 0",
             ));
         }
-        if !minimum_alignment.is_power_of_two() {
-            return Err(Error::new(
-                io::ErrorKind::InvalidInput,
-                "alignment must be a power of two",
-            ));
-        }
 
         let page_size = page_size();
-        let alignment = crate::reservation_alignment(len, minimum_alignment);
+        let alignment = crate::reservation_alignment(len, minimum_alignment)?;
 
         let len = len
             .checked_add(alignment - 1)

--- a/support/sparse_mmap/src/unix.rs
+++ b/support/sparse_mmap/src/unix.rs
@@ -525,6 +525,7 @@ pub fn alloc_shared_memory_hugetlb(
     size: usize,
     name: &str,
     hugepage_size: Option<usize>,
+    _numa_node: Option<u32>,
 ) -> io::Result<OwnedFd> {
     const MFD_HUGE_SHIFT: libc::c_uint = 26;
 
@@ -560,6 +561,7 @@ pub fn alloc_shared_memory_hugetlb(
     _size: usize,
     _name: &str,
     _hugepage_size: Option<usize>,
+    _numa_node: Option<u32>,
 ) -> io::Result<OwnedFd> {
     Err(Error::new(
         io::ErrorKind::Unsupported,

--- a/support/sparse_mmap/src/unix.rs
+++ b/support/sparse_mmap/src/unix.rs
@@ -116,17 +116,8 @@ impl SparseMapping {
             ));
         }
 
-        let size_4k = 4096;
-        let size_2m = 0x200000;
-        let size_1g = 0x40000000;
-        let default_alignment = if len < size_2m {
-            size_4k
-        } else if len < size_1g {
-            size_2m
-        } else {
-            size_1g
-        };
-        let alignment = default_alignment.max(minimum_alignment);
+        let page_size = page_size();
+        let alignment = crate::reservation_alignment(len, minimum_alignment);
 
         let len = len
             .checked_add(alignment - 1)
@@ -140,7 +131,7 @@ impl SparseMapping {
 
         let alloc_len = len
             .checked_add(alignment)
-            .map(|temp| temp - size_4k)
+            .map(|temp| temp - page_size)
             .ok_or_else(|| {
                 Error::new(
                     io::ErrorKind::InvalidInput,

--- a/support/sparse_mmap/src/windows.rs
+++ b/support/sparse_mmap/src/windows.rs
@@ -341,28 +341,30 @@ impl SparseMapping {
     /// for large-page backing) are requested explicitly via a
     /// `MEM_ADDRESS_REQUIREMENTS` extended parameter.
     pub fn new_with_minimum_alignment(len: usize, minimum_alignment: usize) -> Result<Self, Error> {
-        if !minimum_alignment.is_power_of_two() {
-            return Err(Error::new(
-                io::ErrorKind::InvalidInput,
-                "alignment must be a power of two",
-            ));
-        }
         trycopy::initialize_try_copy();
 
         // Pick a default alignment based on the mapping size so that larger
         // mappings land on large-page boundaries, matching the Linux backend.
-        let alignment = crate::reservation_alignment(len, minimum_alignment);
+        let alignment = crate::reservation_alignment(len, minimum_alignment)?;
         Self::new_inner(None, None, len, alignment)
     }
 
     /// Reserves a sparse mapping range with the given address and size in a
     /// remote process.
+    ///
+    /// As with [`Self::new_with_minimum_alignment`], the range is aligned to
+    /// the larger of `minimum_alignment` and the largest system page size
+    /// that's smaller or equal to `len`, so that large mappings can back large
+    /// pages. When an explicit `address` is provided the caller controls
+    /// placement, so no additional alignment requirement is imposed.
     pub fn new_remote(
         process: Process,
         address: Option<*mut c_void>,
         len: usize,
+        minimum_alignment: usize,
     ) -> Result<Self, Error> {
-        Self::new_inner(Some(process), address, len, 1)
+        let alignment = crate::reservation_alignment(len, minimum_alignment)?;
+        Self::new_inner(Some(process), address, len, alignment)
     }
 
     fn new_inner(
@@ -375,8 +377,11 @@ impl SparseMapping {
         // explicit address requirement; smaller alignments are satisfied
         // implicitly by the reservation base. This also keeps
         // MEM_ADDRESS_REQUIREMENTS.Alignment valid, since it must be zero or a
-        // power of two that is at least the allocation granularity.
-        let requirement = (alignment > ALLOCATION_GRANULARITY).then_some(alignment);
+        // power of two that is at least the allocation granularity. An address
+        // requirement is mutually exclusive with an explicit base address, so
+        // skip it when the caller chose the address.
+        let requirement =
+            (address.is_none() && alignment > ALLOCATION_GRANULARITY).then_some(alignment);
         unsafe {
             let mut requirements = Memory::MEM_ADDRESS_REQUIREMENTS {
                 LowestStartingAddress: null_mut(),
@@ -1097,7 +1102,7 @@ mod tests {
     fn test_remote() {
         let process = pal::windows::process::empty_process().unwrap();
         let shmem = alloc_shared_memory(0x100000, "test").unwrap();
-        let sparse = SparseMapping::new_remote(process.process, None, 0x100000).unwrap();
+        let sparse = SparseMapping::new_remote(process.process, None, 0x100000, 1).unwrap();
         sparse.map_file(0, 0x10000, &shmem, 0, true).unwrap();
 
         let process_addr = pal::windows::process::empty_process().unwrap();
@@ -1105,6 +1110,7 @@ mod tests {
             process_addr.process,
             Some(0x100000 as *mut std::ffi::c_void),
             0x100000,
+            1,
         )
         .unwrap();
         sparse_addr.map_file(0, 0x10000, &shmem, 0, true).unwrap();

--- a/support/sparse_mmap/src/windows.rs
+++ b/support/sparse_mmap/src/windows.rs
@@ -5,6 +5,7 @@
 
 #![cfg(windows)]
 
+use Memory::CreateFileMappingNumaW;
 use Memory::CreateFileMappingW;
 use Memory::GetLargePageMinimum;
 use Memory::MEM_COMMIT;
@@ -39,6 +40,7 @@ use std::ptr::null;
 use std::ptr::null_mut;
 use windows_sys::Win32::Foundation::INVALID_HANDLE_VALUE;
 use windows_sys::Win32::System::Memory;
+use windows_sys::Win32::System::SystemServices::NUMA_NO_PREFERRED_NODE;
 use windows_sys::Win32::System::Threading::GetCurrentProcess;
 
 const PAGE_SIZE: usize = 4096;
@@ -890,6 +892,7 @@ pub fn alloc_shared_memory_hugetlb(
     size: usize,
     _name: &str,
     hugepage_size: Option<usize>,
+    numa_node: Option<u32>,
 ) -> io::Result<OwnedHandle> {
     // SAFETY: no preconditions.
     let large_page_minimum = unsafe { GetLargePageMinimum() };
@@ -928,13 +931,14 @@ pub fn alloc_shared_memory_hugetlb(
     with_lock_memory_privilege(|| {
         // SAFETY: calling according to API
         let h = unsafe {
-            CreateFileMappingW(
+            CreateFileMappingNumaW(
                 INVALID_HANDLE_VALUE,
                 null_mut(),
                 PAGE_READWRITE | SEC_COMMIT | SEC_LARGE_PAGES,
                 (size >> 32) as u32,
                 size as u32,
                 null(),
+                numa_node.unwrap_or(NUMA_NO_PREFERRED_NODE),
             )
         } as RawHandle;
         if h.is_null() {

--- a/support/sparse_mmap/src/windows.rs
+++ b/support/sparse_mmap/src/windows.rs
@@ -6,6 +6,7 @@
 #![cfg(windows)]
 
 use Memory::CreateFileMappingW;
+use Memory::GetLargePageMinimum;
 use Memory::MEM_COMMIT;
 use Memory::MEM_DECOMMIT;
 use Memory::MEM_RELEASE;
@@ -20,6 +21,8 @@ use Memory::PAGE_NOACCESS;
 use Memory::PAGE_READONLY;
 use Memory::PAGE_READWRITE;
 use Memory::PAGE_WRITECOPY;
+use Memory::SEC_COMMIT;
+use Memory::SEC_LARGE_PAGES;
 use Memory::SECTION_MAP_READ;
 use Memory::SECTION_MAP_WRITE;
 use Memory::UnmapViewOfFile2;
@@ -319,15 +322,22 @@ impl MappingList {
 
 impl SparseMapping {
     /// Reserves a sparse mapping range with the given size.
+    ///
+    /// The range will be aligned to the largest system page size that's smaller
+    /// or equal to `len`.
     pub fn new(len: usize) -> Result<Self, Error> {
-        trycopy::initialize_try_copy();
-        Self::new_inner(None, None, len)
+        Self::new_with_minimum_alignment(len, 1)
     }
 
     /// Reserves a sparse mapping range with at least the requested alignment.
     ///
-    /// Windows virtual address reservations are aligned to the system
-    /// allocation granularity.
+    /// The range will be aligned to the larger of `minimum_alignment` and the
+    /// largest system page size that's smaller or equal to `len`.
+    ///
+    /// Alignments up to the Windows allocation granularity (64 KB) are
+    /// satisfied implicitly by the reservation. Larger alignments (e.g. 2 MB
+    /// for large-page backing) are requested explicitly via a
+    /// `MEM_ADDRESS_REQUIREMENTS` extended parameter.
     pub fn new_with_minimum_alignment(len: usize, minimum_alignment: usize) -> Result<Self, Error> {
         if !minimum_alignment.is_power_of_two() {
             return Err(Error::new(
@@ -335,13 +345,12 @@ impl SparseMapping {
                 "alignment must be a power of two",
             ));
         }
-        if minimum_alignment > ALLOCATION_GRANULARITY {
-            return Err(Error::new(
-                io::ErrorKind::Unsupported,
-                "sparse mapping alignment greater than the Windows allocation granularity is not supported",
-            ));
-        }
-        Self::new(len)
+        trycopy::initialize_try_copy();
+
+        // Pick a default alignment based on the mapping size so that larger
+        // mappings land on large-page boundaries, matching the Linux backend.
+        let alignment = crate::reservation_alignment(len, minimum_alignment);
+        Self::new_inner(None, None, len, alignment)
     }
 
     /// Reserves a sparse mapping range with the given address and size in a
@@ -351,15 +360,39 @@ impl SparseMapping {
         address: Option<*mut c_void>,
         len: usize,
     ) -> Result<Self, Error> {
-        Self::new_inner(Some(process), address, len)
+        Self::new_inner(Some(process), address, len, 1)
     }
 
     fn new_inner(
         process: Option<Process>,
         address: Option<*mut c_void>,
         len: usize,
+        alignment: usize,
     ) -> Result<Self, Error> {
+        // Only alignments larger than the allocation granularity need an
+        // explicit address requirement; smaller alignments are satisfied
+        // implicitly by the reservation base. This also keeps
+        // MEM_ADDRESS_REQUIREMENTS.Alignment valid, since it must be zero or a
+        // power of two that is at least the allocation granularity.
+        let requirement = (alignment > ALLOCATION_GRANULARITY).then_some(alignment);
         unsafe {
+            let mut requirements = Memory::MEM_ADDRESS_REQUIREMENTS {
+                LowestStartingAddress: null_mut(),
+                HighestEndingAddress: null_mut(),
+                Alignment: requirement.unwrap_or(0),
+            };
+            let mut param = Memory::MEM_EXTENDED_PARAMETER::default();
+            param.Anonymous1._bitfield =
+                Memory::MemExtendedParameterAddressRequirements as u64 & 0xff;
+            param.Anonymous2.Pointer = std::ptr::from_mut(&mut requirements).cast();
+            let mut params = [param];
+            let extended_parameters: &mut [Memory::MEM_EXTENDED_PARAMETER] =
+                if requirement.is_some() {
+                    params.as_mut_slice()
+                } else {
+                    &mut []
+                };
+
             // Allocate a placeholder reservation to reserve a virtual address
             // range. This will be split up and recombined as mappings come and
             // go.
@@ -369,7 +402,7 @@ impl SparseMapping {
                 len,
                 MEM_RESERVE | MEM_RESERVE_PLACEHOLDER,
                 PAGE_NOACCESS,
-                &mut [],
+                extended_parameters,
             )?;
             Ok(Self {
                 address,
@@ -843,15 +876,174 @@ pub fn alloc_shared_memory(size: usize, _name: &str) -> io::Result<OwnedHandle> 
 }
 
 /// Allocates a hugetlb mappable shared memory object of `size` bytes.
+///
+/// On Windows this creates a large-page section (`SEC_LARGE_PAGES`). Only the
+/// large-page minimum size reported by `GetLargePageMinimum` (2 MB on x64) is
+/// supported; any other `hugepage_size` is rejected. The physical memory is
+/// allocated and pinned immediately, so allocation fails (rather than falling
+/// back to small pages) if sufficient contiguous physical memory is
+/// unavailable. Requires `SeLockMemoryPrivilege` (the "Lock pages in memory"
+/// user right), which is enabled on a thread-scoped impersonation token only
+/// for the duration of the section-creation call, so the process token is left
+/// unchanged.
 pub fn alloc_shared_memory_hugetlb(
-    _size: usize,
+    size: usize,
     _name: &str,
-    _hugepage_size: Option<usize>,
+    hugepage_size: Option<usize>,
 ) -> io::Result<OwnedHandle> {
-    Err(Error::new(
-        io::ErrorKind::Unsupported,
-        "hugetlb shared memory is only supported on Linux",
-    ))
+    // SAFETY: no preconditions.
+    let large_page_minimum = unsafe { GetLargePageMinimum() };
+    if large_page_minimum == 0 {
+        return Err(Error::new(
+            io::ErrorKind::Unsupported,
+            "large pages are not supported by this processor",
+        ));
+    }
+
+    if let Some(hugepage_size) = hugepage_size {
+        if hugepage_size != large_page_minimum {
+            return Err(Error::new(
+                io::ErrorKind::InvalidInput,
+                format!(
+                    "unsupported hugepage size {hugepage_size:#x}; Windows large-page sections only support the large-page minimum ({large_page_minimum:#x})"
+                ),
+            ));
+        }
+    }
+
+    if !size.is_multiple_of(large_page_minimum) {
+        return Err(Error::new(
+            io::ErrorKind::InvalidInput,
+            format!(
+                "large-page allocation size {size:#x} is not a multiple of the large-page minimum ({large_page_minimum:#x})"
+            ),
+        ));
+    }
+
+    // The physical pages backing a SEC_LARGE_PAGES section are allocated and
+    // pinned at creation time, so SeLockMemoryPrivilege must be enabled for the
+    // CreateFileMapping call. Scope it to this thread (via an impersonation
+    // token) so the privilege is not left enabled process-wide, which would
+    // race with concurrent large-page allocations on other threads.
+    with_lock_memory_privilege(|| {
+        // SAFETY: calling according to API
+        let h = unsafe {
+            CreateFileMappingW(
+                INVALID_HANDLE_VALUE,
+                null_mut(),
+                PAGE_READWRITE | SEC_COMMIT | SEC_LARGE_PAGES,
+                (size >> 32) as u32,
+                size as u32,
+                null(),
+            )
+        } as RawHandle;
+        if h.is_null() {
+            return Err(Error::last_os_error());
+        }
+        // SAFETY: `h` is a freshly created, owned section handle.
+        Ok(unsafe { OwnedHandle::from_raw_handle(h) })
+    })
+}
+
+/// Runs `f` with `SeLockMemoryPrivilege` ("Lock pages in memory") enabled on a
+/// thread-scoped impersonation token, then reverts the thread to its normal
+/// security context.
+///
+/// The privilege is enabled on a private per-thread copy of the process token
+/// rather than on the process token itself, so it is never left enabled
+/// process-wide -- which would broaden the enabled window unnecessarily and
+/// race with concurrent large-page allocations on other threads.
+///
+/// Fails loudly if the privilege is not held, rather than silently allowing the
+/// large-page allocation in `f` to fail with a less actionable error.
+fn with_lock_memory_privilege<R>(f: impl FnOnce() -> io::Result<R>) -> io::Result<R> {
+    use windows_sys::Wdk::System::SystemServices::SE_LOCK_MEMORY_PRIVILEGE;
+    use windows_sys::Win32::Foundation::ERROR_NOT_ALL_ASSIGNED;
+    use windows_sys::Win32::Foundation::GetLastError;
+    use windows_sys::Win32::Foundation::LUID;
+    use windows_sys::Win32::Security::AdjustTokenPrivileges;
+    use windows_sys::Win32::Security::ImpersonateSelf;
+    use windows_sys::Win32::Security::LUID_AND_ATTRIBUTES;
+    use windows_sys::Win32::Security::RevertToSelf;
+    use windows_sys::Win32::Security::SE_PRIVILEGE_ENABLED;
+    use windows_sys::Win32::Security::SecurityImpersonation;
+    use windows_sys::Win32::Security::TOKEN_ADJUST_PRIVILEGES;
+    use windows_sys::Win32::Security::TOKEN_PRIVILEGES;
+    use windows_sys::Win32::Security::TOKEN_QUERY;
+    use windows_sys::Win32::System::Threading::GetCurrentThread;
+    use windows_sys::Win32::System::Threading::OpenThreadToken;
+
+    /// Reverts the calling thread to its process security context on drop, so
+    /// the impersonation token is removed even if `f` panics or an early return
+    /// occurs after impersonation is established.
+    struct RevertToSelfGuard;
+    impl Drop for RevertToSelfGuard {
+        fn drop(&mut self) {
+            // SAFETY: no preconditions.
+            if unsafe { RevertToSelf() } == 0 {
+                panic!(
+                    "failed to revert thread impersonation: {}",
+                    Error::last_os_error()
+                );
+            }
+        }
+    }
+
+    // Give the current thread an impersonation token copied from the process
+    // token, so that the privilege change below is scoped to this thread.
+    // SAFETY: calling per API contract.
+    if unsafe { ImpersonateSelf(SecurityImpersonation) } == 0 {
+        return Err(Error::last_os_error());
+    }
+    let _revert = RevertToSelfGuard;
+
+    // Open this thread's impersonation token for privilege adjustment.
+    // SAFETY: calling per API contract; the returned token handle is owned and
+    // closed on drop.
+    let token = unsafe {
+        let mut token = null_mut();
+        if OpenThreadToken(
+            GetCurrentThread(),
+            TOKEN_ADJUST_PRIVILEGES | TOKEN_QUERY,
+            // Open using this thread's (impersonation) context.
+            0,
+            &mut token,
+        ) == 0
+        {
+            return Err(Error::last_os_error());
+        }
+        OwnedHandle::from_raw_handle(token as RawHandle)
+    };
+
+    let tkp = TOKEN_PRIVILEGES {
+        PrivilegeCount: 1,
+        Privileges: [LUID_AND_ATTRIBUTES {
+            Luid: LUID {
+                LowPart: SE_LOCK_MEMORY_PRIVILEGE as u32,
+                HighPart: 0,
+            },
+            Attributes: SE_PRIVILEGE_ENABLED,
+        }],
+    };
+
+    // SAFETY: calling per API contract with an initialized privileges struct.
+    let r =
+        unsafe { AdjustTokenPrivileges(token.as_raw_handle(), 0, &tkp, 0, null_mut(), null_mut()) };
+    if r == 0 {
+        return Err(Error::last_os_error());
+    }
+
+    // AdjustTokenPrivileges returns success even when the token does not hold
+    // the requested privilege; the failure is reported via GetLastError.
+    // SAFETY: no preconditions; no intervening calls clobber the last error.
+    if unsafe { GetLastError() } == ERROR_NOT_ALL_ASSIGNED {
+        return Err(Error::new(
+            io::ErrorKind::PermissionDenied,
+            "SeLockMemoryPrivilege is not held",
+        ));
+    }
+
+    f()
 }
 
 #[cfg(test)]

--- a/support/sparse_mmap/src/windows.rs
+++ b/support/sparse_mmap/src/windows.rs
@@ -904,7 +904,7 @@ pub fn alloc_shared_memory_hugetlb(
     if large_page_minimum == 0 {
         return Err(Error::new(
             io::ErrorKind::Unsupported,
-            "large pages are not supported by this processor",
+            "large pages are not supported by this system",
         ));
     }
 

--- a/support/sparse_mmap/src/windows.rs
+++ b/support/sparse_mmap/src/windows.rs
@@ -43,7 +43,26 @@ use windows_sys::Win32::System::Memory;
 use windows_sys::Win32::System::SystemServices::NUMA_NO_PREFERRED_NODE;
 use windows_sys::Win32::System::Threading::GetCurrentProcess;
 
+/// The system page size: the unit at which memory is committed and protection
+/// is applied.
+///
+/// `GetSystemInfo` reports the actual value, but every architecture Windows
+/// runs on (x86, x64, and ARM64) uses 4 KB pages, so we hardcode it rather than
+/// querying it at runtime.
 const PAGE_SIZE: usize = 4096;
+
+/// The Windows *allocation granularity*.
+///
+/// Windows has two distinct memory sizes. The page size (4 KB) is the unit at
+/// which memory is committed and protection is applied. The *allocation
+/// granularity* is the coarser unit — 64 KB — that the base address of every
+/// virtual-address *reservation* must be aligned to: `VirtualAlloc`,
+/// `VirtualAlloc2`, `MapViewOfFile3`, etc. round the base of a new reservation
+/// down to a multiple of this value. (This is separate from, and larger than,
+/// the page size; it exists mainly for historical Alpha/portability reasons.)
+///
+/// `GetSystemInfo` reports the actual value, but it is never larger than 64 KB,
+/// so we hardcode that rather than querying it at runtime.
 const ALLOCATION_GRANULARITY: usize = 0x10000;
 
 pub(crate) fn page_size() -> usize {
@@ -1057,8 +1076,12 @@ fn with_lock_memory_privilege<R>(f: impl FnOnce() -> io::Result<R>) -> io::Resul
 
 #[cfg(test)]
 mod tests {
+    use super::GetLargePageMinimum;
+    use super::PAGE_SIZE;
     use super::SparseMapping;
     use super::alloc_shared_memory;
+    use super::alloc_shared_memory_hugetlb;
+    use std::io;
     use trycopy::try_copy;
     use windows_sys::Win32::System::Memory::PAGE_READWRITE;
 
@@ -1114,5 +1137,72 @@ mod tests {
         )
         .unwrap();
         sparse_addr.map_file(0, 0x10000, &shmem, 0, true).unwrap();
+    }
+
+    /// Rejects hugepage sizes and allocation sizes that are not the large-page
+    /// minimum before any privileged allocation is attempted, so this needs no
+    /// special privilege and runs in CI.
+    #[test]
+    fn test_large_page_rejects_bad_size() {
+        // SAFETY: no preconditions.
+        let large_page_minimum = unsafe { GetLargePageMinimum() };
+        if large_page_minimum == 0 {
+            // Large pages are unsupported on this system; nothing to validate.
+            return;
+        }
+
+        // A hugepage size other than the large-page minimum is rejected up
+        // front (before SeLockMemoryPrivilege is ever needed).
+        let err = alloc_shared_memory_hugetlb(
+            large_page_minimum,
+            "test",
+            Some(large_page_minimum * 2),
+            None,
+        )
+        .unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
+
+        // A size that is not a multiple of the large-page minimum is likewise
+        // rejected up front.
+        let err = alloc_shared_memory_hugetlb(large_page_minimum + PAGE_SIZE, "test", None, None)
+            .unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
+    }
+
+    /// Exercises the actual large-page (`SEC_LARGE_PAGES`) allocation and
+    /// mapping path. This requires the "Lock pages in memory" user right
+    /// (`SeLockMemoryPrivilege`), which is not held by default, so it is
+    /// ignored. To run it manually, grant the privilege (see
+    /// `scripts/grant-privilege.ps1`), sign out and back in, then run:
+    ///
+    /// ```text
+    /// cargo test -p sparse_mmap -- --ignored large_page_alloc
+    /// ```
+    #[test]
+    #[ignore = "requires SeLockMemoryPrivilege; run manually"]
+    fn test_large_page_alloc_and_map() {
+        trycopy::initialize_try_copy();
+
+        // SAFETY: no preconditions.
+        let large_page_minimum = unsafe { GetLargePageMinimum() };
+        assert_ne!(large_page_minimum, 0, "large pages not supported");
+
+        let size = large_page_minimum;
+        let shmem = alloc_shared_memory_hugetlb(size, "test", Some(large_page_minimum), None)
+            .expect("large-page allocation failed (is SeLockMemoryPrivilege held?)");
+
+        let sparse = SparseMapping::new(size).unwrap();
+        sparse
+            .map_view_of_file(0, size, &shmem, 0, PAGE_READWRITE, None)
+            .unwrap();
+
+        // Round-trip values through the large-page-backed mapping.
+        let data: &mut [u32] =
+            unsafe { std::slice::from_raw_parts_mut(sparse.as_ptr().cast(), sparse.len() / 4) };
+        for (i, d) in data.iter_mut().enumerate() {
+            *d = i as u32;
+        }
+        assert_eq!(data[0], 0);
+        assert_eq!(data[size / 4 - 1], (size / 4 - 1) as u32);
     }
 }

--- a/vm/whp/src/abi.rs
+++ b/vm/whp/src/abi.rs
@@ -1056,3 +1056,17 @@ pub struct WHV_ARM64_IC_PARAMETERS {
     pub Reserved: u32,
     pub GicV3Parameters: WHV_ARM64_IC_GIC_V3_PARAMETERS,
 }
+
+#[repr(transparent)]
+#[derive(Debug, Copy, Clone)]
+pub struct WHV_PARTITION_COUNTER_SET(u32);
+
+pub const WHvPartitionCounterSetMemory: WHV_PARTITION_COUNTER_SET = WHV_PARTITION_COUNTER_SET(0);
+
+#[repr(C)]
+#[derive(Debug, Copy, Clone, Default)]
+pub struct WHV_PARTITION_MEMORY_COUNTERS {
+    pub Mapped4KPageCount: u64,
+    pub Mapped2MPageCount: u64,
+    pub Mapped1GPageCount: u64,
+}

--- a/vm/whp/src/api.rs
+++ b/vm/whp/src/api.rs
@@ -46,6 +46,14 @@ unsafe extern "system" {
         len: u32,
     ) -> HRESULT;
 
+    pub fn WHvGetPartitionCounters(
+        _: WHV_PARTITION_HANDLE,
+        counter_set: WHV_PARTITION_COUNTER_SET,
+        buffer: *mut u8,
+        len: u32,
+        out_len: *mut u32,
+    ) -> HRESULT;
+
     pub fn WHvRequestInterrupt(
         _: WHV_PARTITION_HANDLE,
         control: *const WHV_INTERRUPT_CONTROL,

--- a/vm/whp/src/lib.rs
+++ b/vm/whp/src/lib.rs
@@ -542,6 +542,10 @@ impl Partition {
                 len,
                 &mut outn,
             ))?;
+            // Unlike `get_property`, it is fine for `outn` to be smaller than
+            // `len`: `counters` is zero-initialized, so if an older host fills
+            // in fewer counters than our struct defines, the trailing (unknown)
+            // counters simply read back as zero rather than garbage.
         }
         Ok(counters)
     }

--- a/vm/whp/src/lib.rs
+++ b/vm/whp/src/lib.rs
@@ -521,6 +521,31 @@ impl Partition {
         }
     }
 
+    /// Reads the partition's SLAT (nested page table) mapping counters,
+    /// reporting how many guest pages the hypervisor has mapped at 4 KB, 2 MB,
+    /// and 1 GB granularity.
+    ///
+    /// Returns [`WHvError`] with `WHV_E_UNKNOWN_PROPERTY` if the host platform
+    /// does not support the memory counter set; callers should treat this as
+    /// "counters unavailable" rather than a fatal error.
+    pub fn memory_counters(&self) -> Result<abi::WHV_PARTITION_MEMORY_COUNTERS> {
+        let mut counters = abi::WHV_PARTITION_MEMORY_COUNTERS::default();
+        // SAFETY: passing a correctly sized buffer for the counter set per the
+        // WHvGetPartitionCounters contract.
+        unsafe {
+            let len = size_of_val(&counters) as u32;
+            let mut outn = 0;
+            check_hresult(api::WHvGetPartitionCounters(
+                self.handle,
+                abi::WHvPartitionCounterSetMemory,
+                std::ptr::from_mut(&mut counters).cast::<u8>(),
+                len,
+                &mut outn,
+            ))?;
+        }
+        Ok(counters)
+    }
+
     pub fn vp(&self, index: u32) -> Processor<'_> {
         Processor {
             partition: self,

--- a/vmm_core/virt_whp/src/lib.rs
+++ b/vmm_core/virt_whp/src/lib.rs
@@ -153,22 +153,17 @@ struct VtlPartition {
 
 impl VtlPartition {
     /// Adds the WHP partition's SLAT (nested page table) mapping counters to
-    /// the inspection under `memory/slat_pages`, reporting how many guest pages
-    /// the hypervisor has mapped at 4 KB, 2 MB, and 1 GB granularity.
-    ///
-    /// Degrades gracefully to `slat_pages = "unavailable"` if the host platform
-    /// does not support the memory counter set.
+    /// the inspection under `memory`, reporting how many guest pages the
+    /// hypervisor has mapped at 4 KB, 2 MB, and 1 GB granularity.
     fn inspect_extra(&self, resp: &mut inspect::Response<'_>) {
         resp.field(
             "memory",
             inspect::adhoc(|req| {
-                if let Some(counters) = self.whp.memory_counters() {
+                if let Ok(counters) = self.whp.memory_counters() {
                     req.respond()
                         .field("mapped_4k", counters.Mapped4KPageCount)
                         .field("mapped_2m", counters.Mapped2MPageCount)
                         .field("mapped_1g", counters.Mapped1GPageCount);
-                } else {
-                    req.ignore();
                 }
             }),
         );

--- a/vmm_core/virt_whp/src/lib.rs
+++ b/vmm_core/virt_whp/src/lib.rs
@@ -128,6 +128,7 @@ struct WhpPartitionInner {
 }
 
 #[derive(Inspect)]
+#[inspect(extra = "Self::inspect_extra")]
 struct VtlPartition {
     #[inspect(skip)]
     whp: whp::Partition,
@@ -151,6 +152,28 @@ struct VtlPartition {
 }
 
 impl VtlPartition {
+    /// Adds the WHP partition's SLAT (nested page table) mapping counters to
+    /// the inspection under `memory/slat_pages`, reporting how many guest pages
+    /// the hypervisor has mapped at 4 KB, 2 MB, and 1 GB granularity.
+    ///
+    /// Degrades gracefully to `slat_pages = "unavailable"` if the host platform
+    /// does not support the memory counter set.
+    fn inspect_extra(&self, resp: &mut inspect::Response<'_>) {
+        resp.field(
+            "memory",
+            inspect::adhoc(|req| {
+                if let Some(counters) = self.whp.memory_counters() {
+                    req.respond()
+                        .field("mapped_4k", counters.Mapped4KPageCount)
+                        .field("mapped_2m", counters.Mapped2MPageCount)
+                        .field("mapped_1g", counters.Mapped1GPageCount);
+                } else {
+                    req.ignore();
+                }
+            }),
+        );
+    }
+
     /// Query the default CPUID result for the given leaf/subleaf from VP0.
     #[cfg(guest_arch = "x86_64")]
     fn cpuid(&self, eax: u32, ecx: u32) -> [u32; 4] {

--- a/vmm_tests/vmm_tests/tests/tests/multiarch.rs
+++ b/vmm_tests/vmm_tests/tests/tests/multiarch.rs
@@ -27,6 +27,9 @@ use vmm_test_macros::vmm_test_with;
 mod dio_nic;
 /// Tests for Hyper-V integration components.
 mod ic;
+/// Tests for Windows large-page (2 MB SLAT) guest RAM backing.
+#[cfg(windows)]
+mod large_pages;
 // Memory Validation tests.
 mod memstat;
 /// NUMA topology tests.
@@ -215,83 +218,6 @@ async fn hugetlb_memory_boot(config: PetriVmBuilder<OpenVmmPetriBackend>) -> any
     vm.wait_for_clean_teardown().await?;
 
     Ok(())
-}
-
-/// Verify that backing OpenVMM guest RAM with 2 MB large pages on Windows (WHP)
-/// actually produces 2 MB SLAT (nested page table) entries.
-///
-/// This boots a guest with `hugepages` enabled (a `SEC_LARGE_PAGES` section on
-/// Windows), which forces `prefetch` on so the guest RAM mappings are
-/// pre-populated in the SLAT at startup, then reads the WHP partition memory
-/// counters through the OpenVMM inspect tree and asserts that all guest memory
-/// has been backed by 2 MB pages.
-///
-/// Requires the "Lock pages in memory" privilege (`SeLockMemoryPrivilege`) so
-/// that the large-page section allocation succeeds; the test fails (rather than
-/// skips) if large-page backing is unavailable, per design.
-#[cfg(windows)]
-#[openvmm_test(linux_direct_x64, linux_direct_aarch64)]
-async fn large_pages_slat(config: PetriVmBuilder<OpenVmmPetriBackend>) -> anyhow::Result<()> {
-    const HUGEPAGE_SIZE: u64 = 2 * 1024 * 1024;
-    const GIGAPAGE_SIZE: u64 = 1024 * 1024 * 1024;
-    // 1 GiB of guest RAM, an exact multiple of the 2 MB hugepage size.
-    const STARTUP_BYTES: u64 = 512 * HUGEPAGE_SIZE;
-
-    let (vm, agent) = config
-        .with_memory(MemoryConfig {
-            startup_bytes: STARTUP_BYTES,
-            ..Default::default()
-        })
-        .modify_backend(|b| b.with_hugepages(None))
-        .run()
-        .await?;
-
-    let node = vm.inspect_vmm(SLAT_INSPECT_PATH).await?;
-    let (mapped_2m, mapped_1g) =
-        read_slat_counters(&node).context("could not read WHP SLAT counters from inspect tree")?;
-    tracing::info!(mapped_2m, mapped_1g, "WHP SLAT page counts");
-
-    // Count large SLAT entries in units of 2 MB pages (each 1 GB entry covers
-    // 512). It won't exactly equal guest RAM / 2 MB: the guest places a few 4 KB
-    // hypervisor overlay pages (hypercall, SynIC, monitor, etc.) inside RAM,
-    // each demoting its containing 2 MB region to 4 KB entries. Allow a small
-    // tolerance; a real regression would drop the count by hundreds.
-    const MAX_OVERLAY_DEMOTIONS: u64 = 16;
-    let expected_2m = STARTUP_BYTES / HUGEPAGE_SIZE;
-    let mapped_2m_equiv = mapped_2m + mapped_1g * (GIGAPAGE_SIZE / HUGEPAGE_SIZE);
-    tracing::info!(mapped_2m_equiv, expected_2m, "large-page SLAT coverage");
-    assert!(
-        mapped_2m_equiv >= expected_2m - MAX_OVERLAY_DEMOTIONS,
-        "large-page backing: got {mapped_2m_equiv} 2 MB pages, expected ~{expected_2m}"
-    );
-
-    agent.power_off().await?;
-    vm.wait_for_clean_teardown().await?;
-    Ok(())
-}
-
-/// The inspect path to the WHP partition SLAT (nested page table) mapping
-/// counters for VTL0. `linux_direct` is not an OpenHCL config, so only the
-/// VTL0 partition exists.
-#[cfg(windows)]
-const SLAT_INSPECT_PATH: &str = "partition/vtl0/memory";
-
-/// Read the `(mapped_2m, mapped_1g)` counters from the `memory` inspect node
-/// (as returned by inspecting [`SLAT_INSPECT_PATH`]).
-///
-/// Fails if the expected fields are missing, including when WHP could not
-/// retrieve the memory counter set and therefore omitted them from inspect.
-#[cfg(windows)]
-fn read_slat_counters(node: &inspect::Node) -> anyhow::Result<(u64, u64)> {
-    let json: serde_json::Value = serde_json::from_str(&node.json().to_string())
-        .context("failed to parse inspect output as JSON")?;
-    let mapped_2m = json["mapped_2m"]
-        .as_u64()
-        .context("memory.mapped_2m missing or not an integer")?;
-    let mapped_1g = json["mapped_1g"]
-        .as_u64()
-        .context("memory.mapped_1g missing or not an integer")?;
-    Ok((mapped_2m, mapped_1g))
 }
 
 /// Basic boot test for images that require small amounts of ram, like alpine.

--- a/vmm_tests/vmm_tests/tests/tests/multiarch.rs
+++ b/vmm_tests/vmm_tests/tests/tests/multiarch.rs
@@ -274,8 +274,8 @@ const SLAT_INSPECT_PATH: &str = "partition/vtl0/memory";
 /// Read the `(mapped_2m, mapped_1g)` counters from the `memory` inspect node
 /// (as returned by inspecting [`SLAT_INSPECT_PATH`]).
 ///
-/// Fails if the node reports `"unavailable"` (the host does not support the WHP
-/// memory counter set) or is missing the expected fields.
+/// Fails if the expected fields are missing, including when WHP could not
+/// retrieve the memory counter set and therefore omitted them from inspect.
 #[cfg(windows)]
 fn read_slat_counters(node: &inspect::Node) -> anyhow::Result<(u64, u64)> {
     let json: serde_json::Value = serde_json::from_str(&node.json().to_string())

--- a/vmm_tests/vmm_tests/tests/tests/multiarch.rs
+++ b/vmm_tests/vmm_tests/tests/tests/multiarch.rs
@@ -232,10 +232,13 @@ async fn hugetlb_memory_boot(config: PetriVmBuilder<OpenVmmPetriBackend>) -> any
 #[openvmm_test(linux_direct_x64, linux_direct_aarch64)]
 async fn large_pages_slat(config: PetriVmBuilder<OpenVmmPetriBackend>) -> anyhow::Result<()> {
     const HUGEPAGE_SIZE: u64 = 2 * 1024 * 1024;
+    const GIGAPAGE_SIZE: u64 = 1024 * 1024 * 1024;
+    // 1 GiB of guest RAM, an exact multiple of the 2 MB hugepage size.
+    const STARTUP_BYTES: u64 = 512 * HUGEPAGE_SIZE;
 
     let (vm, agent) = config
         .with_memory(MemoryConfig {
-            startup_bytes: 1024 * 1024 * 1024, // 1 GiB, a multiple of 2 MB
+            startup_bytes: STARTUP_BYTES,
             ..Default::default()
         })
         .modify_backend(|b| b.with_hugepages(None))
@@ -247,9 +250,13 @@ async fn large_pages_slat(config: PetriVmBuilder<OpenVmmPetriBackend>) -> anyhow
         read_slat_counters(&node).context("could not read WHP SLAT counters from inspect tree")?;
     tracing::info!(mapped_2m, mapped_1g, "WHP SLAT page counts");
 
+    // Count all large SLAT entries in units of 2 MB pages (each 1 GB entry
+    // covers 512 of them). With large-page backing every guest page should be
+    // mapped as a large page, so this must equal the total guest RAM / 2 MB.
+    let mapped_2m_equiv = mapped_2m + mapped_1g * (GIGAPAGE_SIZE / HUGEPAGE_SIZE);
     assert_eq!(
-        mapped_2m + mapped_1g * 512,
-        512,
+        mapped_2m_equiv,
+        STARTUP_BYTES / HUGEPAGE_SIZE,
         "expected large SLAT entries with large-page backing"
     );
 
@@ -262,9 +269,9 @@ async fn large_pages_slat(config: PetriVmBuilder<OpenVmmPetriBackend>) -> anyhow
 /// counters for VTL0. `linux_direct` is not an OpenHCL config, so only the
 /// VTL0 partition exists.
 #[cfg(windows)]
-const SLAT_INSPECT_PATH: &str = "partition/vtl0/memory/slat_pages";
+const SLAT_INSPECT_PATH: &str = "partition/vtl0/memory";
 
-/// Read the `(mapped_2m, mapped_1g)` counters from a `slat_pages` inspect node
+/// Read the `(mapped_2m, mapped_1g)` counters from the `memory` inspect node
 /// (as returned by inspecting [`SLAT_INSPECT_PATH`]).
 ///
 /// Fails if the node reports `"unavailable"` (the host does not support the WHP
@@ -278,10 +285,10 @@ fn read_slat_counters(node: &inspect::Node) -> anyhow::Result<(u64, u64)> {
     }
     let mapped_2m = json["mapped_2m"]
         .as_u64()
-        .context("slat_pages.mapped_2m missing or not an integer")?;
+        .context("memory.mapped_2m missing or not an integer")?;
     let mapped_1g = json["mapped_1g"]
         .as_u64()
-        .context("slat_pages.mapped_1g missing or not an integer")?;
+        .context("memory.mapped_1g missing or not an integer")?;
     Ok((mapped_2m, mapped_1g))
 }
 

--- a/vmm_tests/vmm_tests/tests/tests/multiarch.rs
+++ b/vmm_tests/vmm_tests/tests/tests/multiarch.rs
@@ -251,14 +251,18 @@ async fn large_pages_slat(config: PetriVmBuilder<OpenVmmPetriBackend>) -> anyhow
         read_slat_counters(&node).context("could not read WHP SLAT counters from inspect tree")?;
     tracing::info!(mapped_2m, mapped_1g, "WHP SLAT page counts");
 
-    // Count all large SLAT entries in units of 2 MB pages (each 1 GB entry
-    // covers 512 of them). With large-page backing every guest page should be
-    // mapped as a large page, so this must equal the total guest RAM / 2 MB.
+    // Count large SLAT entries in units of 2 MB pages (each 1 GB entry covers
+    // 512). It won't exactly equal guest RAM / 2 MB: the guest places a few 4 KB
+    // hypervisor overlay pages (hypercall, SynIC, monitor, etc.) inside RAM,
+    // each demoting its containing 2 MB region to 4 KB entries. Allow a small
+    // tolerance; a real regression would drop the count by hundreds.
+    const MAX_OVERLAY_DEMOTIONS: u64 = 16;
+    let expected_2m = STARTUP_BYTES / HUGEPAGE_SIZE;
     let mapped_2m_equiv = mapped_2m + mapped_1g * (GIGAPAGE_SIZE / HUGEPAGE_SIZE);
-    assert_eq!(
-        mapped_2m_equiv,
-        STARTUP_BYTES / HUGEPAGE_SIZE,
-        "expected large SLAT entries with large-page backing"
+    tracing::info!(mapped_2m_equiv, expected_2m, "large-page SLAT coverage");
+    assert!(
+        mapped_2m_equiv >= expected_2m - MAX_OVERLAY_DEMOTIONS,
+        "large-page backing: got {mapped_2m_equiv} 2 MB pages, expected ~{expected_2m}"
     );
 
     agent.power_off().await?;

--- a/vmm_tests/vmm_tests/tests/tests/multiarch.rs
+++ b/vmm_tests/vmm_tests/tests/tests/multiarch.rs
@@ -217,6 +217,74 @@ async fn hugetlb_memory_boot(config: PetriVmBuilder<OpenVmmPetriBackend>) -> any
     Ok(())
 }
 
+/// Verify that backing OpenVMM guest RAM with 2 MB large pages on Windows (WHP)
+/// actually produces 2 MB SLAT (nested page table) entries.
+///
+/// This boots a guest with `hugepages` enabled (a `SEC_LARGE_PAGES` section on
+/// Windows), touches guest RAM so the hypervisor faults in the SLAT, then reads
+/// the WHP partition memory counters through the OpenVMM inspect tree and
+/// asserts that all guest memory has been backed by 2 MB pages.
+///
+/// Requires the "Lock pages in memory" privilege (`SeLockMemoryPrivilege`) so
+/// that the large-page section allocation succeeds; the test fails (rather than
+/// skips) if large-page backing is unavailable, per design.
+#[cfg(windows)]
+#[openvmm_test(linux_direct_x64, linux_direct_aarch64)]
+async fn large_pages_slat(config: PetriVmBuilder<OpenVmmPetriBackend>) -> anyhow::Result<()> {
+    const HUGEPAGE_SIZE: u64 = 2 * 1024 * 1024;
+
+    let (vm, agent) = config
+        .with_memory(MemoryConfig {
+            startup_bytes: 1024 * 1024 * 1024, // 1 GiB, a multiple of 2 MB
+            ..Default::default()
+        })
+        .modify_backend(|b| b.with_hugepages(None))
+        .run()
+        .await?;
+
+    let node = vm.inspect_vmm(SLAT_INSPECT_PATH).await?;
+    let (mapped_2m, mapped_1g) =
+        read_slat_counters(&node).context("could not read WHP SLAT counters from inspect tree")?;
+    tracing::info!(mapped_2m, mapped_1g, "WHP SLAT page counts");
+
+    assert_eq!(
+        mapped_2m + mapped_1g * 512,
+        512,
+        "expected large SLAT entries with large-page backing"
+    );
+
+    agent.power_off().await?;
+    vm.wait_for_clean_teardown().await?;
+    Ok(())
+}
+
+/// The inspect path to the WHP partition SLAT (nested page table) mapping
+/// counters for VTL0. `linux_direct` is not an OpenHCL config, so only the
+/// VTL0 partition exists.
+#[cfg(windows)]
+const SLAT_INSPECT_PATH: &str = "partition/vtl0/memory/slat_pages";
+
+/// Read the `(mapped_2m, mapped_1g)` counters from a `slat_pages` inspect node
+/// (as returned by inspecting [`SLAT_INSPECT_PATH`]).
+///
+/// Fails if the node reports `"unavailable"` (the host does not support the WHP
+/// memory counter set) or is missing the expected fields.
+#[cfg(windows)]
+fn read_slat_counters(node: &inspect::Node) -> anyhow::Result<(u64, u64)> {
+    let json: serde_json::Value = serde_json::from_str(&node.json().to_string())
+        .context("failed to parse inspect output as JSON")?;
+    if let Some(s) = json.as_str() {
+        anyhow::bail!("WHP memory counters unavailable: {s}");
+    }
+    let mapped_2m = json["mapped_2m"]
+        .as_u64()
+        .context("slat_pages.mapped_2m missing or not an integer")?;
+    let mapped_1g = json["mapped_1g"]
+        .as_u64()
+        .context("slat_pages.mapped_1g missing or not an integer")?;
+    Ok((mapped_2m, mapped_1g))
+}
+
 /// Basic boot test for images that require small amounts of ram, like alpine.
 #[vmm_test(
     openvmm_uefi_x64(vhd(alpine_3_23_x64)),

--- a/vmm_tests/vmm_tests/tests/tests/multiarch.rs
+++ b/vmm_tests/vmm_tests/tests/tests/multiarch.rs
@@ -221,9 +221,10 @@ async fn hugetlb_memory_boot(config: PetriVmBuilder<OpenVmmPetriBackend>) -> any
 /// actually produces 2 MB SLAT (nested page table) entries.
 ///
 /// This boots a guest with `hugepages` enabled (a `SEC_LARGE_PAGES` section on
-/// Windows), touches guest RAM so the hypervisor faults in the SLAT, then reads
-/// the WHP partition memory counters through the OpenVMM inspect tree and
-/// asserts that all guest memory has been backed by 2 MB pages.
+/// Windows), which forces `prefetch` on so the guest RAM mappings are
+/// pre-populated in the SLAT at startup, then reads the WHP partition memory
+/// counters through the OpenVMM inspect tree and asserts that all guest memory
+/// has been backed by 2 MB pages.
 ///
 /// Requires the "Lock pages in memory" privilege (`SeLockMemoryPrivilege`) so
 /// that the large-page section allocation succeeds; the test fails (rather than
@@ -280,9 +281,6 @@ const SLAT_INSPECT_PATH: &str = "partition/vtl0/memory";
 fn read_slat_counters(node: &inspect::Node) -> anyhow::Result<(u64, u64)> {
     let json: serde_json::Value = serde_json::from_str(&node.json().to_string())
         .context("failed to parse inspect output as JSON")?;
-    if let Some(s) = json.as_str() {
-        anyhow::bail!("WHP memory counters unavailable: {s}");
-    }
     let mapped_2m = json["mapped_2m"]
         .as_u64()
         .context("memory.mapped_2m missing or not an integer")?;

--- a/vmm_tests/vmm_tests/tests/tests/multiarch/large_pages.rs
+++ b/vmm_tests/vmm_tests/tests/tests/multiarch/large_pages.rs
@@ -1,0 +1,84 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Tests for Windows large-page (2 MB SLAT) guest RAM backing.
+
+use anyhow::Context;
+use petri::MemoryConfig;
+use petri::PetriVmBuilder;
+use petri::openvmm::OpenVmmPetriBackend;
+use vmm_test_macros::openvmm_test;
+
+/// Verify that backing OpenVMM guest RAM with 2 MB large pages on Windows (WHP)
+/// actually produces 2 MB SLAT (nested page table) entries.
+///
+/// This boots a guest with `hugepages` enabled (a `SEC_LARGE_PAGES` section on
+/// Windows), which forces `prefetch` on so the guest RAM mappings are
+/// pre-populated in the SLAT at startup, then reads the WHP partition memory
+/// counters through the OpenVMM inspect tree and asserts that all guest memory
+/// has been backed by 2 MB pages.
+///
+/// Requires the "Lock pages in memory" privilege (`SeLockMemoryPrivilege`) so
+/// that the large-page section allocation succeeds; the test fails (rather than
+/// skips) if large-page backing is unavailable, per design.
+#[openvmm_test(linux_direct_x64, linux_direct_aarch64)]
+async fn large_pages_slat(config: PetriVmBuilder<OpenVmmPetriBackend>) -> anyhow::Result<()> {
+    const HUGEPAGE_SIZE: u64 = 2 * 1024 * 1024;
+    const GIGAPAGE_SIZE: u64 = 1024 * 1024 * 1024;
+    // 1 GiB of guest RAM, an exact multiple of the 2 MB hugepage size.
+    const STARTUP_BYTES: u64 = 512 * HUGEPAGE_SIZE;
+
+    let (vm, agent) = config
+        .with_memory(MemoryConfig {
+            startup_bytes: STARTUP_BYTES,
+            ..Default::default()
+        })
+        .modify_backend(|b| b.with_hugepages(None))
+        .run()
+        .await?;
+
+    let node = vm.inspect_vmm(SLAT_INSPECT_PATH).await?;
+    let (mapped_2m, mapped_1g) =
+        read_slat_counters(&node).context("could not read WHP SLAT counters from inspect tree")?;
+    tracing::info!(mapped_2m, mapped_1g, "WHP SLAT page counts");
+
+    // Count large SLAT entries in units of 2 MB pages (each 1 GB entry covers
+    // 512). It won't exactly equal guest RAM / 2 MB: the guest places a few 4 KB
+    // hypervisor overlay pages (hypercall, SynIC, monitor, etc.) inside RAM,
+    // each demoting its containing 2 MB region to 4 KB entries. Allow a small
+    // tolerance; a real regression would drop the count by hundreds.
+    const MAX_OVERLAY_DEMOTIONS: u64 = 16;
+    let expected_2m = STARTUP_BYTES / HUGEPAGE_SIZE;
+    let mapped_2m_equiv = mapped_2m + mapped_1g * (GIGAPAGE_SIZE / HUGEPAGE_SIZE);
+    tracing::info!(mapped_2m_equiv, expected_2m, "large-page SLAT coverage");
+    assert!(
+        mapped_2m_equiv >= expected_2m - MAX_OVERLAY_DEMOTIONS,
+        "large-page backing: got {mapped_2m_equiv} 2 MB pages, expected ~{expected_2m}"
+    );
+
+    agent.power_off().await?;
+    vm.wait_for_clean_teardown().await?;
+    Ok(())
+}
+
+/// The inspect path to the WHP partition SLAT (nested page table) mapping
+/// counters for VTL0. `linux_direct` is not an OpenHCL config, so only the
+/// VTL0 partition exists.
+const SLAT_INSPECT_PATH: &str = "partition/vtl0/memory";
+
+/// Read the `(mapped_2m, mapped_1g)` counters from the `memory` inspect node
+/// (as returned by inspecting [`SLAT_INSPECT_PATH`]).
+///
+/// Fails if the expected fields are missing, including when WHP could not
+/// retrieve the memory counter set and therefore omitted them from inspect.
+fn read_slat_counters(node: &inspect::Node) -> anyhow::Result<(u64, u64)> {
+    let json: serde_json::Value = serde_json::from_str(&node.json().to_string())
+        .context("failed to parse inspect output as JSON")?;
+    let mapped_2m = json["mapped_2m"]
+        .as_u64()
+        .context("memory.mapped_2m missing or not an integer")?;
+    let mapped_1g = json["mapped_1g"]
+        .as_u64()
+        .context("memory.mapped_1g missing or not an integer")?;
+    Ok((mapped_2m, mapped_1g))
+}

--- a/vmm_tests/vmm_tests/tests/tests/multiarch/large_pages.rs
+++ b/vmm_tests/vmm_tests/tests/tests/multiarch/large_pages.rs
@@ -21,8 +21,11 @@ use vmm_test_macros::openvmm_test;
 /// Requires the "Lock pages in memory" privilege (`SeLockMemoryPrivilege`) so
 /// that the large-page section allocation succeeds; the test fails (rather than
 /// skips) if large-page backing is unavailable, per design.
-#[openvmm_test(linux_direct_x64, linux_direct_aarch64)]
-async fn large_pages_slat(config: PetriVmBuilder<OpenVmmPetriBackend>) -> anyhow::Result<()> {
+///
+/// TODO: clear unstable prefix once the CI runners have the
+/// SeLockMemoryPrivilege enabled for the test user.
+#[openvmm_test(unstable_linux_direct_x64, unstable_linux_direct_aarch64)]
+async fn whp_large_pages_slat(config: PetriVmBuilder<OpenVmmPetriBackend>) -> anyhow::Result<()> {
     const HUGEPAGE_SIZE: u64 = 2 * 1024 * 1024;
     const GIGAPAGE_SIZE: u64 = 1024 * 1024 * 1024;
     // 1 GiB of guest RAM, an exact multiple of the 2 MB hugepage size.


### PR DESCRIPTION
OpenVMM could only satisfy `hugepages=on` on Linux (via hugetlb); on Windows the request failed outright. This adds an equivalent large-page backing on Windows so guests can get guaranteed 2 MB pages there too, along with the plumbing needed to verify that the backing actually produces 2 MB SLAT entries.

On Windows, hugepage-backed guest RAM is allocated from a large-page (SEC_LARGE_PAGES) section. Because those sections pin physical memory at creation time, the allocation requires SeLockMemoryPrivilege; the privilege is enabled on a thread-scoped impersonation token only for the duration of the section-creation call, so it is never left enabled process-wide. Only the large-page minimum size reported by GetLargePageMinimum (2 MB on x64) is supported, and the size must be a multiple of it. A grant-privilege.ps1 helper is included to grant the "Lock pages in memory" user right, and the Guide documents the requirement.

The Windows hypervisor only installs 2 MB SLAT entries when the SLAT is populated in large batches, so hugepage-backed RAM forces prefetch on to pre-populate each region up front; lazy per-page demand faults would otherwise degrade the mapping back to 4 KB entries. The sparse_mmap reservation-alignment logic that lands large mappings on large-page boundaries is shared between the Unix and Windows backends, and the Windows backend now honors alignments larger than the allocation granularity via a MEM_ADDRESS_REQUIREMENTS extended parameter.

To make the behavior testable, WHP gains a memory_counters accessor over WHvGetPartitionCounters, virt_whp exposes the SLAT 4 KB/2 MB/1 GB mapping counts under its inspect tree, and petri's VM inspector is generalized from inspect_all to an inspect(path) call (with a new inspect_vmm helper). A new large_pages_slat VMM test boots a guest with hugepages on Windows, touches guest RAM, and asserts that all of it is backed by 2 MB SLAT entries. A new memory-backing architecture page in the Guide explains the shared/private, prefetch, THP, and hugepage tradeoffs.