### PR TITLE
virt_mshv: Narrow cancellation TOCTOU window

### DIFF
--- a/vmm_core/virt_mshv/src/lib.rs
+++ b/vmm_core/virt_mshv/src/lib.rs
@@ -558,9 +558,6 @@ impl virt::Processor for MshvProcessor<'_> {
         let mut last_waker: Option<Waker> = None;
 
         loop {
-            vpinner.needs_yield.maybe_yield().await;
-            stop.check()?;
-
             // Ensure the waker is set so device threads can wake us.
             poll_fn(|cx| {
                 if !last_waker.as_ref().is_some_and(|w| cx.waker().will_wake(w)) {
@@ -581,6 +578,11 @@ impl virt::Processor for MshvProcessor<'_> {
                     self.flush_messages(pending_sints);
                 }
             }
+
+            // Check after all pre-run work to narrow the signal-to-run race.
+            // Closing it requires sticky cancellation support from MSHV.
+            vpinner.needs_yield.maybe_yield().await;
+            stop.check()?;
 
             match self.runner.run() {
                 Ok(exit) => {


### PR DESCRIPTION
Reduce an MSHV lost-wakeup window exposed by CI run 29092442921.

Move the yield and stop checks after SynIC message flushing and immediately before MSHV_RUN_VP, preventing pre-run work from consuming the wake signal.

This addresses the observed hang but does not eliminate the entire check-to-ioctl race. Full resolution requires a sticky cancellation primitive in the MSHV driver.