### PR TITLE
netvsp: Ensure all channels use the correct packet size (#3908)

### DIFF
--- a/vm/devices/net/netvsp/src/lib.rs
+++ b/vm/devices/net/netvsp/src/lib.rs
@@ -435,12 +435,22 @@ struct NetChannel<T: RingMem> {
 }
 
 // Use an enum to give the compiler more visibility into the packet size.
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, PartialEq)]
 enum PacketSize {
     /// [`protocol::PACKET_SIZE_V1`]
     V1,
     /// [`protocol::PACKET_SIZE_V61`]
     V61,
+}
+
+impl From<Version> for PacketSize {
+    fn from(v: Version) -> Self {
+        if v >= Version::V61 {
+            PacketSize::V61
+        } else {
+            PacketSize::V1
+        }
+    }
 }
 
 /// Buffers used during packet processing.
@@ -2087,7 +2097,10 @@ impl Packet<'_> {
 fn read_packet_data<T: IntoBytes + FromBytes + Immutable + KnownLayout>(
     reader: &mut impl MemoryRead,
 ) -> Result<T, PacketError> {
-    reader.read_plain().map_err(PacketError::Access)
+    reader
+        .read_plain()
+        .map_err(PacketError::Access)
+        .inspect_err(|_| tracelimit::info_ratelimited!("read_packet_data"))
 }
 
 fn parse_packet<'a, T: RingMem>(
@@ -2106,8 +2119,10 @@ fn parse_packet<'a, T: RingMem>(
                 PacketData::SwitchDataPathCompletion
             } else {
                 let mut reader = completion.reader();
-                let header: protocol::MessageHeader =
-                    reader.read_plain().map_err(PacketError::Access)?;
+                let header: protocol::MessageHeader = reader
+                    .read_plain()
+                    .map_err(PacketError::Access)
+                    .inspect_err(|_| tracelimit::info_ratelimited!("parsing completion header"))?;
                 match header.message_type {
                     protocol::MESSAGE1_TYPE_SEND_RNDIS_PACKET_COMPLETE => {
                         PacketData::RndisPacketComplete(read_packet_data(&mut reader)?)
@@ -2124,7 +2139,10 @@ fn parse_packet<'a, T: RingMem>(
     };
 
     let mut reader = packet.reader();
-    let header: protocol::MessageHeader = reader.read_plain().map_err(PacketError::Access)?;
+    let header: protocol::MessageHeader = reader
+        .read_plain()
+        .map_err(PacketError::Access)
+        .inspect_err(|_| tracelimit::info_ratelimited!("parsing data packet header"))?;
     let data = match header.message_type {
         protocol::MESSAGE_TYPE_INIT => PacketData::Init(read_packet_data(&mut reader)?),
         protocol::MESSAGE1_TYPE_SEND_NDIS_VERSION if version >= Some(Version::V1) => {
@@ -4628,6 +4646,8 @@ impl Coordinator {
             self.num_queues = num_queues;
         }
 
+        // Determining packet size before taking mutable borrows
+        let packet_size = state.buffers.version.into();
         self.active_packet_filter = self.workers[0].state().unwrap().channel.packet_filter;
         // Provide the queue and receive buffer ranges for each worker.
         for (((worker, queue), rx_buffer), rx_vlan_counter) in self
@@ -4652,6 +4672,10 @@ impl Coordinator {
                     ready_state.state.pending_rx_packets.clear();
                     ready_state.reset_tx_after_endpoint_stop();
                 }
+
+                // Ensure we're sending the negotiated packet size.
+                // Guests with less-compatible, older, or more stringent netvsc would drop packets otherwise.
+                worker.channel.packet_size = packet_size;
             }
         }
 
@@ -5030,11 +5054,9 @@ impl<T: 'static + RingMem> NetChannel<T> {
                         if let Some(version) = version {
                             tracelimit::info_ratelimited!(?version, "network negotiated");
 
-                            if version >= Version::V61 {
-                                // Update the packet size so that the appropriate padding is
-                                // appended for picky Windows guests.
-                                self.packet_size = PacketSize::V61;
-                            }
+                            // Ensure packet size is set appropriately for the protocol version.
+                            self.packet_size = version.into();
+
                             *initializing = Some(InitState {
                                 version,
                                 ndis_config: None,


### PR DESCRIPTION
Backport to the 1.7 release. This is identical to the previous change; no modifications to the cherry-pick were required. Original commit message is as follows:

Non-primary channels were still sending V1-sized packets, which some guests reject when they've negotiated later versions of the protocol. This change ensures all channels check and update packet size to match the negotiated version.

Changes were validated against a live repro of the issue in a lab environment.