### PR TITLE
crypto: Split public and private key methods for ECDSA

### DIFF
--- a/support/crypto/src/ecdsa/mod.rs
+++ b/support/crypto/src/ecdsa/mod.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-//! ECDSA cryptographic operations (key generation, signing, public key export).
+//! ECDSA cryptographic operations.
 
 #![cfg(any(openssl, symcrypt, all(native, windows)))]
 
@@ -44,7 +44,8 @@ impl EcdsaCurve {
     }
 }
 
-/// An ECDSA key pair (private + public key).
+/// An ECDSA private key (key pair).
+#[repr(transparent)] // Needed for the transmute in deref.
 pub struct EcdsaKeyPair(sys::EcdsaKeyPairInner);
 
 impl EcdsaKeyPair {
@@ -60,11 +61,17 @@ impl EcdsaKeyPair {
         let hash = hash_algorithm.hash(data);
         self.0.sign_prehash(&hash)
     }
+}
 
+/// An ECDSA public key.
+#[repr(transparent)] // Needed for the transmute in deref.
+pub struct EcdsaPublicKey(sys::EcdsaPublicKeyInner);
+
+impl EcdsaPublicKey {
     /// Hash `data` with `hash_algorithm` and verify `signature` against this
-    /// key pair's public key. The signature must be `r || s` in big-endian,
+    /// public key. The signature must be `r || s` in big-endian,
     /// each component `curve.key_size()` bytes (i.e. the format produced by
-    /// [`sign`](Self::sign)). Returns `Ok(true)` if the signature is valid,
+    /// [`EcdsaKeyPair::sign`]). Returns `Ok(true)` if the signature is valid,
     /// `Ok(false)` if it is invalid, or an error for other failures.
     pub fn verify(
         &self,
@@ -80,6 +87,17 @@ impl EcdsaKeyPair {
     /// `curve.key_size()` bytes.
     pub fn public_key_bytes(&self) -> Result<Vec<u8>, EcdsaError> {
         self.0.public_key_bytes()
+    }
+}
+
+impl std::ops::Deref for EcdsaKeyPair {
+    type Target = EcdsaPublicKey;
+
+    fn deref(&self) -> &Self::Target {
+        // SAFETY: EcdsaPublicKey is just a wrapper around EcdsaPublicKeyInner.
+        unsafe {
+            std::mem::transmute::<&sys::EcdsaPublicKeyInner, &EcdsaPublicKey>(self.0.as_pub())
+        }
     }
 }
 
@@ -166,19 +184,22 @@ mod tests {
     #[test]
     fn roundtrip_sign_verify() {
         let key = EcdsaKeyPair::generate(EcdsaCurve::P384).unwrap();
+        let public_key: &EcdsaPublicKey = &key;
         let message = b"roundtrip test message";
 
         let signature = key.sign(HashAlgorithm::Sha384, message).unwrap();
 
         // A valid signature over the original message verifies.
         assert!(
-            key.verify(HashAlgorithm::Sha384, message, &signature)
+            public_key
+                .verify(HashAlgorithm::Sha384, message, &signature)
                 .unwrap()
         );
 
         // A signature checked against a different message does not verify.
         assert!(
-            !key.verify(HashAlgorithm::Sha384, b"tampered message", &signature)
+            !public_key
+                .verify(HashAlgorithm::Sha384, b"tampered message", &signature)
                 .unwrap()
         );
 
@@ -186,7 +207,8 @@ mod tests {
         let mut bad_signature = signature.clone();
         *bad_signature.last_mut().unwrap() ^= 0x01;
         assert!(
-            !key.verify(HashAlgorithm::Sha384, message, &bad_signature)
+            !public_key
+                .verify(HashAlgorithm::Sha384, message, &bad_signature)
                 .unwrap()
         );
     }

--- a/support/crypto/src/ecdsa/ossl.rs
+++ b/support/crypto/src/ecdsa/ossl.rs
@@ -10,6 +10,7 @@ fn err(e: openssl::error::ErrorStack, op: &'static str) -> EcdsaError {
     EcdsaError(crate::BackendError(e, op))
 }
 
+#[repr(C)] // Needed for the transmute in as_pub.
 pub struct EcdsaKeyPairInner {
     pkey: openssl::pkey::PKey<openssl::pkey::Private>,
     curve: EcdsaCurve,
@@ -53,6 +54,19 @@ impl EcdsaKeyPairInner {
         Ok(result)
     }
 
+    pub(crate) fn as_pub(&self) -> &EcdsaPublicKeyInner {
+        // SAFETY: PKey<Private> can be safely treated as PKey<Public> for read-only operations.
+        unsafe { std::mem::transmute::<&EcdsaKeyPairInner, &EcdsaPublicKeyInner>(self) }
+    }
+}
+
+#[repr(C)] // Needed for the transmute in as_pub.
+pub struct EcdsaPublicKeyInner {
+    pkey: openssl::pkey::PKey<openssl::pkey::Public>,
+    curve: EcdsaCurve,
+}
+
+impl EcdsaPublicKeyInner {
     pub fn verify_prehash(&self, hash: &[u8], signature: &[u8]) -> Result<bool, EcdsaError> {
         let key_size = self.curve.key_size();
         // A signature must be exactly `r || s`, each `key_size` bytes. Any

--- a/support/crypto/src/ecdsa/symcrypt.rs
+++ b/support/crypto/src/ecdsa/symcrypt.rs
@@ -10,6 +10,7 @@ fn err(e: symcrypt::errors::SymCryptError, op: &'static str) -> EcdsaError {
     EcdsaError(crate::BackendError::SymCrypt(e, op))
 }
 
+#[repr(transparent)] // Needed for the transmute in as_pub.
 pub struct EcdsaKeyPairInner {
     key: symcrypt::ecc::EcKey,
 }
@@ -29,6 +30,18 @@ impl EcdsaKeyPairInner {
         self.key.ecdsa_sign(hash).map_err(|e| err(e, "ECDSA sign"))
     }
 
+    pub(crate) fn as_pub(&self) -> &EcdsaPublicKeyInner {
+        // SAFETY: EcdsaPublicKeyInner is just a wrapper around the same EcKey.
+        unsafe { std::mem::transmute::<&EcdsaKeyPairInner, &EcdsaPublicKeyInner>(self) }
+    }
+}
+
+#[repr(transparent)] // Needed for the transmute in as_pub.
+pub struct EcdsaPublicKeyInner {
+    key: symcrypt::ecc::EcKey,
+}
+
+impl EcdsaPublicKeyInner {
     pub fn verify_prehash(&self, hash: &[u8], signature: &[u8]) -> Result<bool, EcdsaError> {
         match self.key.ecdsa_verify(signature, hash) {
             Ok(()) => Ok(true),

--- a/support/crypto/src/ecdsa/win.rs
+++ b/support/crypto/src/ecdsa/win.rs
@@ -37,6 +37,7 @@ fn alg_handle(curve: EcdsaCurve) -> Result<&'static AlgHandle, EcdsaError> {
     }
 }
 
+#[repr(C)] // Needed for the transmute in as_pub.
 pub struct EcdsaKeyPairInner {
     handle: BCRYPT_KEY_HANDLE,
     curve: EcdsaCurve,
@@ -95,6 +96,20 @@ impl EcdsaKeyPairInner {
         Ok(signature)
     }
 
+    pub(crate) fn as_pub(&self) -> &EcdsaPublicKeyInner {
+        // SAFETY: both types have the same layout, and a private key handle is
+        // valid for any public-key operation.
+        unsafe { std::mem::transmute::<&EcdsaKeyPairInner, &EcdsaPublicKeyInner>(self) }
+    }
+}
+
+#[repr(C)] // Needed for the transmute in as_pub.
+pub struct EcdsaPublicKeyInner {
+    handle: BCRYPT_KEY_HANDLE,
+    curve: EcdsaCurve,
+}
+
+impl EcdsaPublicKeyInner {
     pub fn verify_prehash(&self, hash: &[u8], signature: &[u8]) -> Result<bool, EcdsaError> {
         // A signature must be exactly `r || s`, each `curve.key_size()` bytes.
         if signature.len() != self.curve.key_size() * 2 {


### PR DESCRIPTION
This mirrors the same split in RSA. We will likely expand ECDSA support as needed.