### PR TITLE
Revert "vmm_tests: Stabilize pcie_save_restore (#3896)"

### DIFF
--- a/vmm_tests/vmm_tests/tests/tests/multiarch/pcie.rs
+++ b/vmm_tests/vmm_tests/tests/tests/multiarch/pcie.rs
@@ -413,7 +413,7 @@ async fn pcie_hotplug(
 /// 2. Enumerates PCI devices visible to the guest
 /// 3. Pulses save/restore (pause → save → restore → resume)
 /// 4. Re-enumerates PCI devices and verifies they match
-#[openvmm_test(linux_direct_x64)]
+#[openvmm_test(unstable_linux_direct_x64)]
 async fn pcie_save_restore(config: PetriVmBuilder<OpenVmmPetriBackend>) -> anyhow::Result<()> {
     let os_flavor = config.os_flavor();
     let (mut vm, agent) = config


### PR DESCRIPTION
Turns out it's not quite stable yet, it's hitting the same failures as blkio, just more rarely.