### PR TITLE
guestmem: add supports_locking to gate zero-copy IO

### DIFF
--- a/vm/devices/storage/disk_blockdevice/src/lib.rs
+++ b/vm/devices/storage/disk_blockdevice/src/lib.rs
@@ -523,12 +523,16 @@ impl DiskIo for BlockDevice {
 
         let mut bounce_buffer = None;
         let locked;
-        let should_bounce = self.always_bounce || !buffers.is_aligned(self.sector_size() as usize);
+        // Memory behind an emulated IOMMU cannot be locked for zero-copy IO, so
+        // fall back to bounce buffering in that case.
+        let should_bounce = self.always_bounce
+            || !buffers.is_aligned(self.sector_size() as usize)
+            || !buffers.guest_memory().supports_locking();
         let io_vecs = if !should_bounce {
             locked = buffers.lock(true)?;
             locked.io_vecs()
         } else {
-            tracing::trace!("double buffering IO");
+            tracing::trace!("bounce buffering IO");
 
             bounce_buffer
                 .insert(self.acquire_bounce_buffer(buffers.len()).await)
@@ -581,12 +585,16 @@ impl DiskIo for BlockDevice {
 
         let mut bounce_buffer;
         let locked;
-        let should_bounce = self.always_bounce || !buffers.is_aligned(self.sector_size() as usize);
+        // Memory behind an emulated IOMMU cannot be locked for zero-copy IO, so
+        // fall back to bounce buffering in that case.
+        let should_bounce = self.always_bounce
+            || !buffers.is_aligned(self.sector_size() as usize)
+            || !buffers.guest_memory().supports_locking();
         let io_vecs = if !should_bounce {
             locked = buffers.lock(false)?;
             locked.io_vecs()
         } else {
-            tracing::trace!("double buffering IO");
+            tracing::trace!("bounce buffering IO");
             bounce_buffer = self.acquire_bounce_buffer(buffers.len()).await;
             buffers.reader().read(bounce_buffer.as_mut_bytes())?;
             bounce_buffer.io_vecs()

--- a/vm/devices/virtio/virtio_vsock/src/lib.rs
+++ b/vm/devices/virtio/virtio_vsock/src/lib.rs
@@ -600,6 +600,12 @@ fn lock_payload_data<'a, T: LockedRange<'a>>(
     writable: bool,
     locked_range: T,
 ) -> anyhow::Result<Option<LockedRangeImpl<'a, T>>> {
+    if !mem.supports_locking() {
+        // Memory behind an emulated IOMMU has no stable host mapping to lock,
+        // so fall back to a bounce buffer via read_at/write_at.
+        return Ok(None);
+    }
+
     let regions = data_regions(payload, writable, VSOCK_HEADER_SIZE as u64, data_len);
     let gpn_list = try_build_gpn_list(regions);
     let locked = if let Some((gpns, offset, len)) = &gpn_list {

--- a/vm/vmcore/guestmem/src/lib.rs
+++ b/vm/vmcore/guestmem/src/lib.rs
@@ -1192,7 +1192,7 @@ struct GuestMemoryInner<T: ?Sized = dyn DynGuestMemoryAccess> {
     regions: Vec<MemoryRegion>,
     debug_name: Arc<str>,
     allocated: bool,
-    /// Cached result of [`DynGuestMemoryAccess::supports_locking`], since it is
+    /// Cached result of [`GuestMemoryAccess::supports_locking`], since it is
     /// queried on hot zero-copy paths and never changes for a given backing.
     supports_locking: bool,
     imp: T,

--- a/vm/vmcore/guestmem/src/lib.rs
+++ b/vm/vmcore/guestmem/src/lib.rs
@@ -648,6 +648,10 @@ pub unsafe trait GuestMemoryAccess: 'static + Send + Sync {
     /// behind an emulated IOMMU) have no mapping and thus report `false`.
     /// Callers that use locking as a zero-copy fast path should check this and
     /// fall back to a copying path when it returns `false`.
+    ///
+    /// This is authoritative: when it returns `false`, the corresponding
+    /// [`GuestMemory`] locking APIs fail without invoking
+    /// [`lock_gpns`](Self::lock_gpns).
     fn supports_locking(&self) -> bool {
         self.mapping().is_some()
     }
@@ -1642,7 +1646,9 @@ impl GuestMemory {
     ///
     /// Memory behind an emulated IOMMU has no stable host mapping and cannot
     /// be locked; zero-copy callers should check this and fall back to a
-    /// copying path when it returns `false`.
+    /// copying path when it returns `false`. This is authoritative: when it
+    /// returns `false`, [`lock_gpns`](Self::lock_gpns) and
+    /// [`lock_range`](Self::lock_range) fail with a `NotLockable` error.
     pub fn supports_locking(&self) -> bool {
         self.inner.supports_locking
     }
@@ -2044,6 +2050,10 @@ impl GuestMemory {
         gpns: &[u64],
     ) -> Result<LockedPages, GuestMemoryError> {
         self.with_op(None, GuestMemoryOperation::Lock, || {
+            if !self.inner.supports_locking {
+                let gpa = gpns.first().map_or(0, |&gpn| gpn.wrapping_mul(PAGE_SIZE64));
+                return Err(GuestMemoryBackingError::other(gpa, NotLockable));
+            }
             let mut pages = Vec::with_capacity(gpns.len());
             for &gpn in gpns {
                 let gpa = gpn_to_gpa(gpn).map_err(GuestMemoryBackingError::gpn)?;
@@ -2221,6 +2231,10 @@ impl GuestMemory {
     ) -> Result<LockedRangeImpl<'a, T>, GuestMemoryError> {
         self.with_op(None, GuestMemoryOperation::Lock, || {
             let gpns = paged_range.gpns();
+            if !self.inner.supports_locking {
+                let gpa = gpns.first().map_or(0, |&gpn| gpn.wrapping_mul(PAGE_SIZE64));
+                return Err(GuestMemoryBackingError::other(gpa, NotLockable));
+            }
             for &gpn in gpns {
                 let gpa = gpn_to_gpa(gpn).map_err(GuestMemoryBackingError::gpn)?;
                 self.probe_page_for_lock(true, gpa)?;
@@ -2929,10 +2943,13 @@ mod tests {
         let gm = GuestMemory::allocate(0x10000);
         assert!(gm.supports_locking());
 
-        // A backing with no stable host mapping (e.g. on-demand translation
-        // behind an emulated IOMMU) does not support locking.
+        // A backing that reports no locking support (e.g. on-demand
+        // translation behind an emulated IOMMU) does not support locking, and
+        // `supports_locking` is authoritative: locking fails without touching
+        // the backing's `lock_gpns`.
         let gm = GuestMemory::new("nolock", ToggleLockMapping::new(SIZE_1MB, false));
         assert!(!gm.supports_locking());
+        assert!(gm.lock_gpns(false, &[0]).is_err());
 
         // Multi-region: locking is supported only when every present backing
         // supports it.

--- a/vm/vmcore/guestmem/src/lib.rs
+++ b/vm/vmcore/guestmem/src/lib.rs
@@ -638,6 +638,19 @@ pub unsafe trait GuestMemoryAccess: 'static + Send + Sync {
     fn sharing(&self) -> Option<GuestMemorySharing> {
         None
     }
+
+    /// Returns whether this backing supports locking pages via
+    /// [`lock_gpns`](Self::lock_gpns).
+    ///
+    /// Locking requires a stable host mapping (see
+    /// [`mapping`](Self::mapping)), so the default returns whether a mapping
+    /// is present. Backings that translate each access on demand (e.g., memory
+    /// behind an emulated IOMMU) have no mapping and thus report `false`.
+    /// Callers that use locking as a zero-copy fast path should check this and
+    /// fall back to a copying path when it returns `false`.
+    fn supports_locking(&self) -> bool {
+        self.mapping().is_some()
+    }
 }
 
 trait DynGuestMemoryAccess: 'static + Send + Sync + Any {
@@ -1179,6 +1192,9 @@ struct GuestMemoryInner<T: ?Sized = dyn DynGuestMemoryAccess> {
     regions: Vec<MemoryRegion>,
     debug_name: Arc<str>,
     allocated: bool,
+    /// Cached result of [`DynGuestMemoryAccess::supports_locking`], since it is
+    /// queried on hot zero-copy paths and never changes for a given backing.
+    supports_locking: bool,
     imp: T,
 }
 
@@ -1366,6 +1382,7 @@ impl GuestMemory {
 
     fn new_inner(debug_name: Arc<str>, imp: impl GuestMemoryAccess, allocated: bool) -> Self {
         let regions = vec![MemoryRegion::new(&imp)];
+        let supports_locking = imp.supports_locking();
         Self {
             inner: Arc::new(GuestMemoryInner {
                 imp,
@@ -1377,6 +1394,7 @@ impl GuestMemory {
                 },
                 regions,
                 allocated,
+                supports_locking,
             }),
         }
     }
@@ -1447,6 +1465,11 @@ impl GuestMemory {
         };
 
         imps.resize_with(region_count, || None);
+        // Locking is only supported if every backing region supports it.
+        let supports_locking = imps
+            .iter()
+            .flatten()
+            .all(GuestMemoryAccess::supports_locking);
         let imp = MultiRegionGuestMemoryAccess { imps, region_def };
 
         let inner = GuestMemoryInner {
@@ -1455,6 +1478,7 @@ impl GuestMemory {
             regions,
             imp,
             allocated: false,
+            supports_locking,
         };
 
         Ok(Self {
@@ -1605,6 +1629,16 @@ impl GuestMemory {
     /// file-based sharing. See [`GuestMemorySharing`].
     pub fn sharing(&self) -> Option<GuestMemorySharing> {
         self.inner.imp.sharing()
+    }
+
+    /// Returns whether this memory supports locking pages via
+    /// [`lock_gpns`](Self::lock_gpns) and [`lock_range`](Self::lock_range).
+    ///
+    /// Memory behind an emulated IOMMU has no stable host mapping and cannot
+    /// be locked; zero-copy callers should check this and fall back to a
+    /// copying path when it returns `false`.
+    pub fn supports_locking(&self) -> bool {
+        self.inner.supports_locking
     }
 
     /// Gets a pointer to the VA range for `gpa..gpa+len`.

--- a/vm/vmcore/guestmem/src/lib.rs
+++ b/vm/vmcore/guestmem/src/lib.rs
@@ -1331,6 +1331,12 @@ unsafe impl GuestMemoryAccess for Empty {
     fn max_address(&self) -> u64 {
         0
     }
+
+    fn supports_locking(&self) -> bool {
+        // This implementation trivially supports locking since there are no
+        // pages to lock.
+        true
+    }
 }
 
 #[derive(Debug, Error)]
@@ -2884,5 +2890,72 @@ mod tests {
         drop(gm2);
         assert_eq!(gm.inner_buf_mut().unwrap(), &pattern);
         gm.into_inner_buf().unwrap();
+    }
+
+    /// A backing whose locking support can be toggled, used to exercise
+    /// [`GuestMemory::supports_locking`] aggregation. Backed by a real mapping
+    /// so it can participate in single- and multi-region construction.
+    struct ToggleLockMapping {
+        mapping: SparseMapping,
+        lockable: bool,
+    }
+
+    impl ToggleLockMapping {
+        fn new(size: usize, lockable: bool) -> Self {
+            let mapping = SparseMapping::new(size).unwrap();
+            mapping.alloc(0, size).unwrap();
+            Self { mapping, lockable }
+        }
+    }
+
+    // SAFETY: the mapping is valid for the full range reported by `max_address`.
+    unsafe impl crate::GuestMemoryAccess for ToggleLockMapping {
+        fn mapping(&self) -> Option<NonNull<u8>> {
+            NonNull::new(self.mapping.as_ptr().cast())
+        }
+
+        fn max_address(&self) -> u64 {
+            self.mapping.len() as u64
+        }
+
+        fn supports_locking(&self) -> bool {
+            self.lockable
+        }
+    }
+
+    #[test]
+    fn test_supports_locking() {
+        // A mapping-backed backing supports locking by default.
+        let gm = GuestMemory::allocate(0x10000);
+        assert!(gm.supports_locking());
+
+        // A backing with no stable host mapping (e.g. on-demand translation
+        // behind an emulated IOMMU) does not support locking.
+        let gm = GuestMemory::new("nolock", ToggleLockMapping::new(SIZE_1MB, false));
+        assert!(!gm.supports_locking());
+
+        // Multi-region: locking is supported only when every present backing
+        // supports it.
+        let gm = GuestMemory::new_multi_region(
+            "multi-lockable",
+            SIZE_1MB as u64,
+            vec![
+                Some(ToggleLockMapping::new(SIZE_1MB / 2, true)),
+                Some(ToggleLockMapping::new(SIZE_1MB / 2, true)),
+            ],
+        )
+        .unwrap();
+        assert!(gm.supports_locking());
+
+        let gm = GuestMemory::new_multi_region(
+            "multi-mixed",
+            SIZE_1MB as u64,
+            vec![
+                Some(ToggleLockMapping::new(SIZE_1MB / 2, true)),
+                Some(ToggleLockMapping::new(SIZE_1MB / 2, false)),
+            ],
+        )
+        .unwrap();
+        assert!(!gm.supports_locking());
     }
 }


### PR DESCRIPTION
Memory behind an emulated IOMMU translates each guest access on demand and has no stable host mapping, so its pages cannot be locked for zero-copy IO. Devices that lock guest buffers as a fast path would fail or produce incorrect results against such backings.

Add a supports_locking query to GuestMemory (and the underlying GuestMemoryAccess trait) that reports whether locking is possible. The result is computed once at construction and cached, since it never changes for a given backing and is checked on hot IO paths; multi-region memory reports support only when every region supports it.

Update the block device and virtio-vsock zero-copy paths to consult this query and fall back to bounce buffering / read_at/write_at when locking is unavailable.