### PR TITLE
vmm_tests_run: only require --dir when tests need a Windows disk

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -94,9 +94,13 @@ For VMM test validation during development, use `cargo xflowey vmm-tests-run`:
 ```bash
 cargo xflowey vmm-tests-run --filter "test(my_test_name)"
 ```
-Do not pass `--dir` — it is only required when cross-compiling for Windows
-from WSL2 (where the output directory must be on the Windows filesystem, e.g.,
-`--dir /mnt/d/vmm_tests`). For native host tests it is unnecessary.
+Do not pass `--dir` in most cases. When cross-compiling for Windows from WSL2,
+`--dir` on the Windows filesystem (e.g., `--dir /mnt/d/vmm_tests`) is required
+only when the selected tests use disk images that need a Windows filesystem
+(Hyper-V tests, or VHDX / dynamic VHD1 images); `vmm-tests-run` detects this and
+errors with a clear message when it's needed. For native host tests, and for
+Windows-from-WSL2 tests that stream disks or use fixed VHD1 / VMGS / ISO images,
+it is unnecessary.
 
 This automatically discovers artifacts, builds dependencies, and runs tests.
 See `Guide/src/dev_guide/tests/vmm.md` for details.

--- a/.github/skills/vmm-tests/SKILL.md
+++ b/.github/skills/vmm-tests/SKILL.md
@@ -25,9 +25,13 @@ cargo xflowey vmm-tests-run --filter "test(/^boot_/)"
 cargo xflowey vmm-tests-run --filter "all()"
 ```
 
-Do not pass `--dir` — it defaults to `target/vmm_tests` and is only required
-when cross-compiling for Windows from WSL2, where the output directory must be
-on the Windows filesystem (e.g., `--dir /mnt/d/vmm_tests`).
+Usually you don't need `--dir` — it defaults to `target/vmm_tests`. When
+cross-compiling for Windows from WSL2, `--dir` on the Windows filesystem (e.g.,
+`--dir /mnt/d/vmm_tests`) is required **only** when the selected tests use disk
+images that need a Windows filesystem: **Hyper-V tests**, or tests using **VHDX
+/ dynamic VHD1** images. For everything else (streamed disks, or plain fixed
+VHD1 / VMGS / ISO files), the default WSL-side directory works. `vmm-tests-run`
+detects this and errors with a clear message if `--dir` is required.
 
 ## Filter Syntax
 
@@ -47,7 +51,7 @@ cross-compilation:
 
 ```bash
 # Cross-compile and run Windows tests from WSL2
-cargo xflowey vmm-tests-run --target windows-x64 --dir /mnt/d/vmm_tests
+cargo xflowey vmm-tests-run --target windows-x64
 ```
 
 | Target | Description |
@@ -56,9 +60,11 @@ cargo xflowey vmm-tests-run --target windows-x64 --dir /mnt/d/vmm_tests
 | `windows-aarch64` | Windows ARM64 (Hyper-V / WHP) |
 | `linux-x64` | Linux x86_64 |
 
-**Windows from WSL2**: The output directory **must** be on the Windows
-filesystem (e.g., `/mnt/d/...`). `--dir` is required in this case.
-Cross-compilation setup is required first — see
+**Windows from WSL2**: The default output directory works for most tests. Add
+`--dir` on the Windows filesystem (e.g., `--dir /mnt/d/vmm_tests`) only when the
+selected tests use disk images requiring a Windows filesystem (Hyper-V tests,
+or VHDX / dynamic VHD1 images); `vmm-tests-run` errors with a clear message when
+it's needed. Cross-compilation setup is required first — see
 `Guide/src/dev_guide/getting_started/cross_compile.md`.
 
 ## Artifact Handling (Lazy Fetch)
@@ -97,8 +103,10 @@ Run `cargo xflowey vmm-tests-run --help` for the full option list.
 
 - **Don't use `cargo nextest run -p vmm_tests` directly** — artifacts won't
   be present and tests will fail with missing-artifact errors.
-- **Windows output dir from WSL** — must be on `/mnt/c/` or `/mnt/d/`, not
-  in the WSL filesystem.
+- **Windows output dir from WSL** — when the selected tests need a Windows
+  filesystem (Hyper-V tests, or VHDX / dynamic VHD1 images), `--dir` must be on
+  `/mnt/c/` or `/mnt/d/`, not in the WSL filesystem. Other tests use the
+  default.
 - **Hyper-V tests** — require Hyper-V Administrators group membership and
   disable lazy fetch automatically.
 - **CI failures** — use the `openvmm-ci-investigation` skill to diagnose

--- a/Guide/src/dev_guide/tests/vmm.md
+++ b/Guide/src/dev_guide/tests/vmm.md
@@ -109,12 +109,27 @@ build for a different platform. The supported targets are:
 and run Windows VMM tests directly from your WSL2 shell. This requires the
 cross-compilation environment to be set up first.
 
-Then target Windows as usual. The output directory **must** be on the Windows
-filesystem (e.g., `/mnt/d/...`):
+Then target Windows as usual:
+
+```bash
+cargo xflowey vmm-tests-run --target windows-x64
+```
+
+Most tests work with the default output directory (on the WSL filesystem),
+because their disk images are either streamed on demand or opened as plain
+files (fixed VHD1, VMGS, ISO), which work fine over the `\\wsl$` path. You only
+need to override `--dir` to a Windows filesystem path (a DrvFs mount like
+`/mnt/d/...`) when the selected tests use disk images that require a Windows
+filesystem — namely **Hyper-V tests** (their VHDs are attached to a real
+Hyper-V VM) or tests using **VHDX / dynamic VHD1** images (opened via the
+Windows virtual-disk mount API):
 
 ```bash
 cargo xflowey vmm-tests-run --target windows-x64 --dir /mnt/d/vmm_tests
 ```
+
+`vmm-tests-run` detects this automatically and will tell you if `--dir` is
+required for your selection.
 
 For full cross-compilation setup instructions, see
 [Cross Compiling for Windows](../getting_started/cross_compile.md).

--- a/flowey/flowey_hvlite/src/pipelines/vmm_tests_run.rs
+++ b/flowey/flowey_hvlite/src/pipelines/vmm_tests_run.rs
@@ -41,8 +41,10 @@ pub struct VmmTestsRunCli {
     /// Directory for the output artifacts.
     ///
     /// If not specified, defaults to `target/vmm_tests`.
-    /// WSL-to-Windows runs still require explicitly overriding this to a
-    /// Windows-accessible output directory.
+    /// WSL-to-Windows runs must override this to a Windows-accessible output
+    /// directory (a DrvFs mount like `/mnt/c/...`) only when the selected tests
+    /// use disk images that require a Windows filesystem (Hyper-V disks, or
+    /// VHDX / dynamic VHD1 images); otherwise the default works.
     #[clap(long)]
     dir: Option<PathBuf>,
 
@@ -211,11 +213,6 @@ impl IntoPipeline for VmmTestsRunCli {
 
         let repo_root = crate::repo_root();
 
-        // Validate output directory for WSL
-        validate_output_dir(dir.as_deref(), target_os)?;
-        let test_content_dir = dir.unwrap_or_else(|| repo_root.join("target").join("vmm_tests"));
-        std::fs::create_dir_all(&test_content_dir).context("failed to create output directory")?;
-
         // Resolve the incubator profile path. `--incubator` with no value uses
         // the default profile for the target; `--incubator <PATH>` overrides.
         let incubator_profile = match incubator {
@@ -350,6 +347,31 @@ impl IntoPipeline for VmmTestsRunCli {
         }
 
         log::info!("Resolved selections: {:?}", resolved);
+
+        // Validate the output directory now that we know which disk images the
+        // selected tests need. When targeting Windows from WSL, the only hard
+        // filesystem constraint is that certain disk images must live on a
+        // Windows filesystem rather than a `\\wsl$` 9p path:
+        //
+        // - Hyper-V tests attach their VHDs to a real Hyper-V VM, whose worker
+        //   process can't open disks over 9p, so any Hyper-V disk needs a
+        //   Windows path regardless of format.
+        // - OpenVMM opens fixed VHD1, VMGS, and raw/ISO images as plain files
+        //   (fine over 9p), but routes VHDX (and dynamic/differencing VHD1)
+        //   disks through the Windows virtual-disk mount API, which requires a
+        //   real local volume. The only such artifact today is the `.vhdx`.
+        //
+        // All other cases (streamed disks, or fixed-VHD1 files even with
+        // `--no-lazy-fetch`) work fine from the default WSL-side directory.
+        let needs_windows_disk = !build_only
+            && (resolved.needs_hyperv
+                || resolved
+                    .downloads
+                    .iter()
+                    .any(|a| a.filename().ends_with(".vhdx")));
+        validate_output_dir(dir.as_deref(), target_os, needs_windows_disk)?;
+        let test_content_dir = dir.unwrap_or_else(|| repo_root.join("target").join("vmm_tests"));
+        std::fs::create_dir_all(&test_content_dir).context("failed to create output directory")?;
 
         let openvmm_repo = flowey_lib_common::git_checkout::RepoSource::ExistingClone(
             ReadVar::from_static(repo_root),
@@ -650,29 +672,39 @@ fn default_incubator_profile(repo_root: &Path, target: &CommonTriple) -> Option<
 
 /// Validate the output directory path based on the current platform.
 ///
-/// When running under WSL and targeting Windows, the output directory must be a
-/// Windows-accessible path (DrvFs mount like `/mnt/c/...`) because Windows
-/// requires VHDs to reside on a Windows filesystem. On native Windows or Linux
-/// this check is a no-op.
+/// When running under WSL and targeting Windows, some disk images must live on
+/// a Windows-accessible path (a DrvFs mount like `/mnt/c/...`) rather than a
+/// `\\wsl$` 9p path: Hyper-V disks (attached to a real Hyper-V VM) and VHDX /
+/// dynamic VHD1 images (opened via the Windows virtual-disk mount API). This
+/// constraint only applies when the selected tests actually use such a disk
+/// (`needs_windows_disk`); fixed-VHD1, VMGS, ISO, and streamed disks work fine
+/// from the WSL side. On native Windows or Linux this check is a no-op.
 fn validate_output_dir(
     dir: Option<&Path>,
     target_os: target_lexicon::OperatingSystem,
+    needs_windows_disk: bool,
 ) -> anyhow::Result<()> {
-    if flowey_cli::running_in_wsl() && matches!(target_os, target_lexicon::OperatingSystem::Windows)
+    if needs_windows_disk
+        && flowey_cli::running_in_wsl()
+        && matches!(target_os, target_lexicon::OperatingSystem::Windows)
     {
         if let Some(dir) = dir {
             if !flowey_cli::is_wsl_windows_path(dir) {
                 anyhow::bail!(
                     "When targeting Windows from WSL, --dir must be a path on Windows \
-                        (i.e., on a DrvFs mount like /mnt/c/vmm_tests). \
+                        (i.e., on a DrvFs mount like /mnt/c/vmm_tests) because the selected \
+                        tests use disk images that require a Windows filesystem (Hyper-V \
+                        disks, or VHDX / dynamic VHD1 images). \
                         Got: {}",
                     dir.display()
                 );
             }
         } else {
             anyhow::bail!(
-                "An output directory on the Windows filesystem \
-                    must be specified when targeting Windows from WSL."
+                "The selected tests use disk images that require a Windows filesystem \
+                    (Hyper-V disks, or VHDX / dynamic VHD1 images) when targeting Windows \
+                    from WSL. Specify an output directory on a DrvFs mount with --dir \
+                    (e.g., --dir /mnt/c/vmm_tests)."
             )
         }
     }


### PR DESCRIPTION
Previously any WSL-to-Windows VMM test run demanded an output directory on a Windows filesystem, even though most tests work fine from the default WSL-side directory. The Windows-filesystem constraint only applies to disk images that can't be opened over a \\wsl$ 9p path: Hyper-V disks (attached to a real Hyper-V VM) and VHDX / dynamic VHD1 images (opened through the Windows virtual-disk mount API). Streamed disks, fixed VHD1, VMGS, and ISO images all work from the WSL side.

Defer the output-directory validation until after test selections are resolved, so we know which disk images are actually needed, and only enforce the Windows-path requirement when the selection includes a Hyper-V test or a .vhdx artifact. The error messages now explain why --dir is required. Documentation, the vmm-tests skill, and the copilot-instructions guidance are updated to match the new behavior.