### PR TITLE
Update release table for OpenHCL 1.8

### DIFF
--- a/Guide/src/dev_guide/contrib/release.md
+++ b/Guide/src/dev_guide/contrib/release.md
@@ -69,12 +69,13 @@ When creating a backport PR to a release branch:
   
 ## Existing Release Branches
 
-| Release          | Phase              | Notes                                                                |
-| ---------------- | ------------------ | -------------------------------------------------------------------- |
-| release/2411     | Out of service     |                                                                      |
-| release/2505     | Servicing          | Supports runtime servicing from release/2411.                        |
-| release/1.7.2511 | Ask Mode           | Supports runtime servicing from release/2411 and release/2505.       |
-| _tbd, in main_   | Active Development | Supports runtime servicing from release/2411 and release/2505.       |
+| Release          | Phase              | Notes                                                                                |
+| ---------------- | ------------------ | ------------------------------------------------------------------------------------ |
+| release/2411     | Out of service     |                                                                                      |
+| release/2505     | Out of service     | Supports runtime servicing from release/2411.                                        |
+| release/1.7.2511 | Servicing          | Supports runtime servicing from release/2411 and release/2505.                       |
+| release/1.8.2607 | Stabilization      | Supports runtime servicing from release/2411, release/2505, and release/1.7.2511.    |
+| _tbd, in main_   | Active Development | Supports runtime servicing from release/2411, release/2505, and release/1.7.2511.    |
 
 ## Taking a Dependency on a Release
 


### PR DESCRIPTION
Update the OpenVMM release guide's existing release branch table now that `release/1.8.2607` has been forked.

- Add `release/1.8.2607` as Stabilization.
- Update the main/future row to include runtime servicing from `release/1.7.2511`.