### PR TITLE
CI: Don't block on SNP tests

### DIFF
--- a/.github/workflows/openvmm-ci.yaml
+++ b/.github/workflows/openvmm-ci.yaml
@@ -6498,7 +6498,6 @@ jobs:
     - job20
     - job21
     - job22
-    - job23
     - job24
     - job25
     - job26

--- a/.github/workflows/openvmm-pr-release.yaml
+++ b/.github/workflows/openvmm-pr-release.yaml
@@ -4694,7 +4694,6 @@ jobs:
       contents: read
       id-token: write
     needs:
-    - job0
     - job11
     - job2
     - job3

--- a/.github/workflows/openvmm-pr.yaml
+++ b/.github/workflows/openvmm-pr.yaml
@@ -5098,7 +5098,6 @@ jobs:
       contents: read
       id-token: write
     needs:
-    - job0
     - job12
     - job2
     - job3
@@ -7002,7 +7001,6 @@ jobs:
     - job22
     - job23
     - job24
-    - job25
     - job26
     - job27
     - job28

--- a/flowey/flowey_hvlite/src/pipelines/checkin_gates.rs
+++ b/flowey/flowey_hvlite/src/pipelines/checkin_gates.rs
@@ -1751,8 +1751,9 @@ impl IntoPipeline for CheckinGatesCli {
                 );
             }
 
+            let vmm_tests_run_job = vmm_tests_run_job.finish();
             if !label.contains("snp") {
-                all_jobs.push(vmm_tests_run_job.finish());
+                all_jobs.push(vmm_tests_run_job);
             }
         }
 

--- a/flowey/flowey_hvlite/src/pipelines/checkin_gates.rs
+++ b/flowey/flowey_hvlite/src/pipelines/checkin_gates.rs
@@ -1751,7 +1751,9 @@ impl IntoPipeline for CheckinGatesCli {
                 );
             }
 
-            all_jobs.push(vmm_tests_run_job.finish());
+            if !label.contains("snp") {
+                all_jobs.push(vmm_tests_run_job.finish());
+            }
         }
 
         // test the flowey local backend by running cargo xflowey build-igvm on x64


### PR DESCRIPTION
Make it so that the only job that matters to Github, the all-good-job, no longer depends on SNP tests passing.

This has the side effect of making the SNP test job not depend on the quick-check job, but this is fine as it still depends on all the build steps, which themselves depend on quick-check.

The SNP tests will still be run, and the bot that comments about test failures will still comment about their failures, but merging will be unblocked.