### PR TITLE
virtio: don't emit zero-length DEVICE_CFG capability

### DIFF
--- a/vm/devices/virtio/virtio/src/tests.rs
+++ b/vm/devices/virtio/virtio/src/tests.rs
@@ -1412,6 +1412,16 @@ impl VirtioPciTestDevice {
         test_mem: &Arc<VirtioTestMemoryAccess>,
         queue_work: Option<TestDeviceQueueWorkFn>,
     ) -> Self {
+        Self::new_with_register_length(driver, num_queues, test_mem, queue_work, 12)
+    }
+
+    fn new_with_register_length(
+        driver: &DefaultDriver,
+        num_queues: u16,
+        test_mem: &Arc<VirtioTestMemoryAccess>,
+        queue_work: Option<TestDeviceQueueWorkFn>,
+        device_register_length: u32,
+    ) -> Self {
         let doorbell_registration: Arc<dyn DoorbellRegistration> = test_mem.clone();
         let mem = GuestMemory::new("test", test_mem.clone());
         let msi_conn = MsiConnection::new();
@@ -1426,7 +1436,7 @@ impl VirtioPciTestDevice {
                         .with_bank(0, 2 | VIRTIO_F_RING_INDIRECT_DESC | VIRTIO_F_RING_EVENT_IDX)
                         .with_bank(1, VIRTIO_F_RING_PACKED),
                     max_queues: num_queues,
-                    device_register_length: 12,
+                    device_register_length,
                     ..Default::default()
                 },
                 queue_work,
@@ -1832,6 +1842,52 @@ async fn verify_pci_config(driver: DefaultDriver) {
     assert_eq!(buf, 12);
     next_cap_offset = header[1] as u32;
     assert_eq!(next_cap_offset, 0);
+}
+
+#[async_test]
+async fn verify_pci_config_no_device_cfg(driver: DefaultDriver) {
+    // A virtio device with no device-specific config (device_register_length == 0)
+    // must not emit a DEVICE_CFG capability, since a zero-length virtio capability
+    // is rejected by drivers (e.g. Linux: "virtio_pci: bad capability len 0").
+    let mut pci_test_device = VirtioPciTestDevice::new_with_register_length(
+        &driver,
+        1,
+        &VirtioTestMemoryAccess::new(),
+        None,
+        0,
+    );
+
+    // Walk the PCI capability list and ensure no DEVICE_CFG virtio capability
+    // is present.
+    let mut next_cap_offset = 0;
+    pci_test_device
+        .pci_device
+        .pci_cfg_read(
+            0x34,
+            ByteEnabledDwordRead::with_all_bytes_enabled(&mut next_cap_offset),
+        )
+        .unwrap();
+    assert_ne!(next_cap_offset, 0);
+
+    while next_cap_offset != 0 {
+        let mut header = 0;
+        pci_test_device
+            .pci_device
+            .pci_cfg_read(
+                next_cap_offset as u16,
+                ByteEnabledDwordRead::with_all_bytes_enabled(&mut header),
+            )
+            .unwrap();
+        let header = header.to_le_bytes();
+        if header[0] == CapabilityId::VENDOR_SPECIFIC.0 {
+            assert_ne!(
+                header[3],
+                VirtioPciCapType::DEVICE_CFG.0,
+                "DEVICE_CFG capability must not be emitted when device_register_length is 0"
+            );
+        }
+        next_cap_offset = header[1] as u32;
+    }
 }
 
 #[async_test]

--- a/vm/devices/virtio/virtio/src/transport/pci.rs
+++ b/vm/devices/virtio/virtio/src/transport/pci.rs
@@ -243,7 +243,16 @@ impl VirtioPciDevice {
                     BAR0_ISR_SIZE as u32,
                 ),
             )),
-            Box::new(ReadOnlyCapability::new(
+        ];
+
+        // Only advertise a device-specific config capability when the device
+        // actually has device-specific config registers. Per the virtio spec
+        // (v1.2 section 4.1.4.6), a VIRTIO_PCI_CAP_DEVICE_CFG capability is
+        // required only for device types that have a device-specific
+        // configuration; devices without one (e.g. the entropy device) must
+        // not advertise a zero-length capability.
+        if traits.device_register_length > 0 {
+            caps.push(Box::new(ReadOnlyCapability::new(
                 "virtio-pci-device",
                 VirtioCapability::new(
                     VirtioPciCapType::DEVICE_CFG.0,
@@ -252,8 +261,8 @@ impl VirtioPciDevice {
                     BAR0_DEVICE_CFG_OFFSET as u32,
                     traits.device_register_length,
                 ),
-            )),
-        ];
+            )));
+        }
 
         let mut bars = DeviceBars::new().bar0(
             BAR0_DEVICE_CFG_OFFSET as u64 + traits.device_register_length as u64,

--- a/vmm_tests/vmm_tests/tests/tests/x86_64.rs
+++ b/vmm_tests/vmm_tests/tests/tests/x86_64.rs
@@ -393,17 +393,21 @@ async fn virtio_blk_device(config: PetriVmBuilder<OpenVmmPetriBackend>) -> anyho
     Ok(())
 }
 
-/// Boot with a virtio-rng device via virtio-mmio and verify the guest can read entropy.
+/// Boot with a virtio-rng device on a PCIe root port and verify the guest can
+/// read entropy.
 #[openvmm_test(linux_direct_x64)]
 async fn virtio_rng_device(config: PetriVmBuilder<OpenVmmPetriBackend>) -> anyhow::Result<()> {
-    use openvmm_defs::config::VirtioBus;
+    use openvmm_defs::config::PcieDeviceConfig;
     use virtio_resources::rng::VirtioRngHandle;
 
     let (vm, agent) = config
         .modify_backend(|b| {
-            b.with_custom_config(|c| {
-                c.virtio_devices
-                    .push((VirtioBus::Mmio, VirtioRngHandle.into_resource()));
+            b.with_pcie_root_topology(1, 1, 1).with_custom_config(|c| {
+                c.pcie_devices.push(PcieDeviceConfig {
+                    port_name: "s0rc0rp0".to_string(),
+                    resource: VirtioPciDeviceHandle(VirtioRngHandle.into_resource())
+                        .into_resource(),
+                });
             })
         })
         .run()


### PR DESCRIPTION
A virtio-pci device with no device-specific configuration was still advertising a VIRTIO_PCI_CAP_DEVICE_CFG capability with a length of zero. The virtio spec (v1.2 section 4.1.4.6) requires this capability only for device types that actually have a device-specific configuration, and a zero-length capability causes conformant guest drivers to reject the device entirely, so devices such as virtio-rng failed to probe over PCI.

Only advertise the device-config capability when the device exposes device-specific registers. The existing virtio-rng VMM test is switched from the virtio-mmio transport to a PCIe root port so it exercises the PCI capability path that previously regressed, and a unit test asserts that a device with no device-specific config emits no DEVICE_CFG capability.

Fixes #3925.