### PR TITLE
vfio_assigned_device: add device-BAR peer-to-peer DMA

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9149,7 +9149,6 @@ dependencies = [
  "membacking",
  "memory_range",
  "mesh",
- "nix 0.30.1",
  "pal_async",
  "parking_lot",
  "pci_core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9151,6 +9151,7 @@ dependencies = [
  "mesh",
  "nix 0.30.1",
  "pal_async",
+ "parking_lot",
  "pci_core",
  "pci_resources",
  "test_with_tracing",

--- a/flowey/flowey_lib_hvlite/src/_jobs/consume_and_test_nextest_vmm_tests_archive.rs
+++ b/flowey/flowey_lib_hvlite/src/_jobs/consume_and_test_nextest_vmm_tests_archive.rs
@@ -301,7 +301,7 @@ impl SimpleFlowNode for Node {
                 crate::resolve_openvmm_test_linux_kernel::Request::Get(
                     crate::resolve_openvmm_test_linux_kernel::OpenvmmTestKernelFile::Kernel,
                     arch,
-                    crate::resolve_openvmm_test_linux_kernel::DEFAULT_LINUX_TEST_KERNEL_VERSION,
+                    crate::resolve_openvmm_test_linux_kernel::INCUBATOR_LINUX_TEST_KERNEL_VERSION,
                     v,
                 )
             });

--- a/flowey/flowey_lib_hvlite/src/_jobs/local_build_and_run_nextest_vmm_tests.rs
+++ b/flowey/flowey_lib_hvlite/src/_jobs/local_build_and_run_nextest_vmm_tests.rs
@@ -866,7 +866,7 @@ impl SimpleFlowNode for Node {
                 crate::resolve_openvmm_test_linux_kernel::Request::Get(
                     crate::resolve_openvmm_test_linux_kernel::OpenvmmTestKernelFile::Kernel,
                     arch,
-                    crate::resolve_openvmm_test_linux_kernel::DEFAULT_LINUX_TEST_KERNEL_VERSION,
+                    crate::resolve_openvmm_test_linux_kernel::INCUBATOR_LINUX_TEST_KERNEL_VERSION,
                     v,
                 )
             });

--- a/flowey/flowey_lib_hvlite/src/resolve_openvmm_test_linux_kernel.rs
+++ b/flowey/flowey_lib_hvlite/src/resolve_openvmm_test_linux_kernel.rs
@@ -25,6 +25,14 @@ use std::collections::BTreeSet;
 pub enum LinuxTestKernelVersion {
     Linux6_1,
     Linux6_18,
+    /// The `kvm-cca-dev` kernel (Linux 7.1.0-rc1 at time of writing).
+    ///
+    /// Published **aarch64-only**. Beyond the ARM CCA host bits it is built
+    /// for, it also enables the P2PDMA / vfio-dmabuf / iommufd config
+    /// (`CONFIG_PCI_P2PDMA`, `CONFIG_VFIO_PCI_DMABUF`, `CONFIG_IOMMUFD`,
+    /// `CONFIG_ARM_SMMU_V3`) that the incubator's VFIO device-assignment tests
+    /// need to exercise device-BAR P2P DMA, which predate the 6.18 test kernel.
+    KvmCcaDev,
 }
 
 impl LinuxTestKernelVersion {
@@ -34,6 +42,17 @@ impl LinuxTestKernelVersion {
         match self {
             Self::Linux6_1 => "6.1",
             Self::Linux6_18 => "6.18",
+            Self::KvmCcaDev => "kvm-cca-dev",
+        }
+    }
+
+    /// Whether this kernel version is published for the given architecture.
+    ///
+    /// Most versions ship for both architectures; `kvm-cca-dev` is aarch64-only.
+    pub fn is_available_for(self, arch: CommonArch) -> bool {
+        match self {
+            Self::Linux6_1 | Self::Linux6_18 => true,
+            Self::KvmCcaDev => matches!(arch, CommonArch::Aarch64),
         }
     }
 }
@@ -72,6 +91,15 @@ impl OpenvmmTestKernelFile {
 /// which kernel they're using should pass this.
 pub const DEFAULT_LINUX_TEST_KERNEL_VERSION: LinuxTestKernelVersion =
     LinuxTestKernelVersion::Linux6_18;
+
+/// The Linux test kernel used as the **L1 host image** for the aarch64 QEMU-TCG
+/// incubator. Unlike [`DEFAULT_LINUX_TEST_KERNEL_VERSION`], this must ship the
+/// P2PDMA / vfio-dmabuf / iommufd config
+/// ([`LinuxTestKernelVersion::KvmCcaDev`], Linux 7.1.0-rc1) so incubator VFIO
+/// device-assignment tests can exercise device-BAR peer-to-peer DMA. Aarch64
+/// only (the incubator is aarch64-only).
+pub const INCUBATOR_LINUX_TEST_KERNEL_VERSION: LinuxTestKernelVersion =
+    LinuxTestKernelVersion::KvmCcaDev;
 
 flowey_config! {
     /// Config for the resolve_openvmm_test_linux_kernel node.
@@ -124,6 +152,12 @@ impl FlowNodeWithConfig for Node {
         for req in requests {
             match req {
                 Request::Get(file, arch, kver, var) => {
+                    if !kver.is_available_for(arch) {
+                        anyhow::bail!(
+                            "test kernel {:?} is not published for {arch:?}",
+                            kver.artifact_tag()
+                        );
+                    }
                     if !file.is_available_for(arch) {
                         anyhow::bail!(
                             "{file:?} is not available in the openvmm-test-linux archive for {arch:?}"

--- a/petri/incubator/profiles/aarch64-tcg-pcie.toml
+++ b/petri/incubator/profiles/aarch64-tcg-pcie.toml
@@ -23,4 +23,20 @@ type = "virtio-blk"
 name = "test-disk"
 size = "64M"
 vfio = true
-provides = "test_disk_vfio"
+
+# P2P DMA pair: `edu` is the DMA initiator, `ivshmem-plain` BAR2 is the
+# peer-BAR target. Assigning both into the L2 guest and having `edu` DMA into
+# `ivshmem`'s BAR2 exercises the vfio-dmabuf device-BAR P2P import path. The
+# edu `dma_mask` is widened from its 28-bit default so it can address the high
+# aarch64 guest physical addresses the target BAR lands at.
+[[devices]]
+type = "edu"
+name = "edu-initiator"
+dma-mask = "0xffffffffffff"
+vfio = true
+
+[[devices]]
+type = "ivshmem-plain"
+name = "ivshmem-target"
+size = "4M"
+vfio = true

--- a/petri/incubator/src/profile.rs
+++ b/petri/incubator/src/profile.rs
@@ -61,6 +61,43 @@ impl Arch {
 pub enum DeviceConfig {
     /// A virtio-blk disk device.
     VirtioBlk(VirtioBlkDeviceConfig),
+    /// A QEMU `edu` device — a simple PCI device with a register-programmed
+    /// DMA engine. Used as a P2P DMA *initiator* in device-assignment tests.
+    Edu(EduDeviceConfig),
+    /// A QEMU `ivshmem-plain` device — a PCI device whose BAR2 is a
+    /// prefetchable, RAM-backed memory window. Used as a P2P DMA *target*
+    /// (peer BAR) in device-assignment tests.
+    IvshmemPlain(IvshmemPlainDeviceConfig),
+}
+
+impl DeviceConfig {
+    /// The device's name, used in env var names (e.g. `test-disk` →
+    /// `INCUBATOR_VFIO_BDF_TEST_DISK`).
+    pub fn name(&self) -> &str {
+        match self {
+            DeviceConfig::VirtioBlk(cfg) => &cfg.name,
+            DeviceConfig::Edu(cfg) => &cfg.name,
+            DeviceConfig::IvshmemPlain(cfg) => &cfg.name,
+        }
+    }
+
+    /// Whether the device should be bound to vfio-pci after boot so it can be
+    /// assigned into the L2 guest.
+    pub fn vfio(&self) -> bool {
+        match self {
+            DeviceConfig::VirtioBlk(cfg) => cfg.vfio,
+            DeviceConfig::Edu(cfg) => cfg.vfio,
+            DeviceConfig::IvshmemPlain(cfg) => cfg.vfio,
+        }
+    }
+
+    /// The capability this device advertises once provisioned, derived from
+    /// its name with `-` replaced by `_` so it is a valid `requires(...)`
+    /// identifier (e.g. `edu-initiator` → `edu_initiator`). Tests gate on this
+    /// via `requires(...)`.
+    pub fn capability(&self) -> String {
+        self.name().replace('-', "_")
+    }
 }
 
 /// Configuration for a virtio-blk device added to the incubator.
@@ -75,12 +112,39 @@ pub struct VirtioBlkDeviceConfig {
     /// for passthrough into the L2 guest.
     #[serde(default)]
     pub vfio: bool,
-    /// Capability advertised once this device has been successfully
-    /// provisioned. Tests declare a matching `requires(...)` so they only run
-    /// where the device is available. The capability is added to
-    /// `PETRI_CAPABILITIES` alongside the device's BDF env var.
+}
+
+/// Configuration for a QEMU `edu` device added to the incubator.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub struct EduDeviceConfig {
+    /// Name for this device (used in env var names, e.g., "edu-initiator" →
+    /// `INCUBATOR_VFIO_BDF_EDU_INITIATOR`).
+    pub name: String,
+    /// Optional `dma_mask` for the edu DMA engine (e.g. "0xffffffffffff").
+    /// The edu default is 28 bits, which clamps DMA addresses to the low
+    /// 256 MiB — too small for aarch64 guest physical addresses, so P2P tests
+    /// must widen it. Accepts decimal or `0x`-prefixed hex.
     #[serde(default)]
-    pub provides: Option<String>,
+    pub dma_mask: Option<String>,
+    /// If true, bind the device to vfio-pci after boot, making it available
+    /// for passthrough into the L2 guest.
+    #[serde(default)]
+    pub vfio: bool,
+}
+
+/// Configuration for a QEMU `ivshmem-plain` device added to the incubator.
+#[derive(Debug, Deserialize)]
+pub struct IvshmemPlainDeviceConfig {
+    /// Name for this device (used in env var names, e.g., "ivshmem-target" →
+    /// `INCUBATOR_VFIO_BDF_IVSHMEM_TARGET`).
+    pub name: String,
+    /// Size of the RAM-backed shared-memory BAR2 (e.g., "4M").
+    pub size: String,
+    /// If true, bind the device to vfio-pci after boot, making it available
+    /// for passthrough into the L2 guest.
+    #[serde(default)]
+    pub vfio: bool,
 }
 
 /// QEMU TCG configuration parsed from the profile.

--- a/petri/incubator/src/qemu.rs
+++ b/petri/incubator/src/qemu.rs
@@ -68,8 +68,14 @@ pub fn build_qemu_command(
     for (i, device) in devices.iter().enumerate() {
         let rp_id = format!("hosting_rp{i}");
         let addr = EXTRA_DEVICE_ADDR_BASE + i;
-        cmd.arg("-device")
-            .arg(format!("pcie-root-port,id={rp_id},addr={addr:#x}"));
+        // Each root port needs a unique `slot` within its chassis. QEMU
+        // defaults every pcie-root-port to `chassis=0,slot=0`, so a second
+        // port collides with "Can't add chassis slot, error -16" (EBUSY).
+        // Number the slots from 1.
+        let slot = i + 1;
+        cmd.arg("-device").arg(format!(
+            "pcie-root-port,id={rp_id},addr={addr:#x},slot={slot}"
+        ));
 
         match device {
             DeviceConfig::VirtioBlk(cfg) => {
@@ -80,6 +86,28 @@ pub fn build_qemu_command(
                     .arg(format!("null-co,node-name={node_name},size={size_bytes}"));
                 cmd.arg("-device")
                     .arg(format!("virtio-blk-pci,drive={node_name},bus={rp_id},iommu_platform=on,disable-legacy=on,romfile="));
+            }
+            DeviceConfig::Edu(cfg) => {
+                // A conventional PCI endpoint with a register-programmed DMA
+                // engine. Widen `dma_mask` when provided so the engine can
+                // address high aarch64 guest physical addresses (its 28-bit
+                // default would clamp them).
+                let mut dev = format!("edu,bus={rp_id}");
+                if let Some(mask) = &cfg.dma_mask {
+                    dev.push_str(&format!(",dma_mask={mask}"));
+                }
+                cmd.arg("-device").arg(dev);
+            }
+            DeviceConfig::IvshmemPlain(cfg) => {
+                // BAR2 is a prefetchable, RAM-backed memory window served by a
+                // host memory backend — a valid P2P DMA target BAR.
+                let mem_id = format!("ivshmem_mem{i}");
+                let size_bytes = parse_size(&cfg.size)
+                    .with_context(|| format!("invalid size for device '{}'", cfg.name))?;
+                cmd.arg("-object")
+                    .arg(format!("memory-backend-ram,id={mem_id},size={size_bytes}"));
+                cmd.arg("-device")
+                    .arg(format!("ivshmem-plain,memdev={mem_id},bus={rp_id}"));
             }
         }
     }
@@ -335,14 +363,13 @@ pub async fn setup_vfio_devices(
     let mut env = BTreeMap::new();
     let mut capabilities = Vec::new();
 
-    // Collect (device_index, config) for devices that need VFIO binding.
+    // Collect (device_index, device) for devices that need VFIO binding.
+    // VFIO binding is device-type-agnostic: any extra device behind its own
+    // root port can be unbound from its driver and rebound to vfio-pci.
     let vfio_devices: Vec<_> = devices
         .iter()
         .enumerate()
-        .filter_map(|(i, d)| match d {
-            DeviceConfig::VirtioBlk(cfg) if cfg.vfio => Some((i, cfg)),
-            DeviceConfig::VirtioBlk(_) => None,
-        })
+        .filter(|(_, d)| d.vfio())
         .collect();
 
     if vfio_devices.is_empty() {
@@ -351,7 +378,8 @@ pub async fn setup_vfio_devices(
 
     tracing::info!("setting up {} VFIO device(s)", vfio_devices.len());
 
-    for (device_index, cfg) in &vfio_devices {
+    for (device_index, device) in &vfio_devices {
+        let name = device.name();
         let addr = EXTRA_DEVICE_ADDR_BASE + device_index;
 
         // The root port for this device is deterministically at
@@ -365,17 +393,13 @@ pub async fn setup_vfio_devices(
             .await
             .with_context(|| {
                 format!(
-                    "failed to read secondary bus number for device '{}' (root port {rp_bdf})",
-                    cfg.name
+                    "failed to read secondary bus number for device '{name}' (root port {rp_bdf})"
                 )
             })?;
         // sysfs reports the secondary bus number in decimal.
         let secondary_bus_str = String::from_utf8_lossy(&secondary_bus_raw);
         let secondary_bus: u8 = secondary_bus_str.trim().parse().with_context(|| {
-            format!(
-                "unexpected secondary bus number {secondary_bus_str:?} for device '{}'",
-                cfg.name
-            )
+            format!("unexpected secondary bus number {secondary_bus_str:?} for device '{name}'")
         })?;
         let bdf = format!("0000:{secondary_bus:02x}:00.0");
 
@@ -385,12 +409,11 @@ pub async fn setup_vfio_devices(
             .await
             .with_context(|| {
                 format!(
-                    "no device found behind root port {rp_bdf} (expected {bdf}) for device '{}'",
-                    cfg.name
+                    "no device found behind root port {rp_bdf} (expected {bdf}) for device '{name}'"
                 )
             })?;
 
-        tracing::info!(name = %cfg.name, %bdf, %addr, "binding device to vfio-pci");
+        tracing::info!(%name, %bdf, %addr, "binding device to vfio-pci");
 
         // Unbind from current driver
         let _ = client
@@ -418,17 +441,15 @@ pub async fn setup_vfio_devices(
         // Export env var: name "test-disk" → INCUBATOR_VFIO_BDF_TEST_DISK
         let env_name = format!(
             "INCUBATOR_VFIO_BDF_{}",
-            cfg.name.to_uppercase().replace('-', "_")
+            name.to_uppercase().replace('-', "_")
         );
         tracing::info!(%env_name, %bdf, "VFIO device ready");
         env.insert(env_name, bdf);
 
-        // Advertise the capability this device provides, now that it has been
-        // successfully provisioned. Tests gate on this via
-        // `requires(...)`.
-        if let Some(capability) = &cfg.provides {
-            capabilities.push(capability.clone());
-        }
+        // Advertise the capability this device provides (derived from its
+        // name), now that it has been successfully provisioned. Tests gate on
+        // this via `requires(...)`.
+        capabilities.push(device.capability());
     }
 
     // Advertise all provisioned capabilities to the guest command via

--- a/petri/petri_artifacts_common/src/lib.rs
+++ b/petri/petri_artifacts_common/src/lib.rs
@@ -12,8 +12,9 @@ pub mod capabilities {
     pub const VPCI: &str = "vpci";
 
     /// All capability names known to petri, including those defined by
-    /// incubators.
-    pub const KNOWN_CAPABILITIES: &[&str] = &[VPCI, "test_disk_vfio"];
+    /// incubators. Incubator device capabilities are the device's profile
+    /// `name` with `-` replaced by `_` (e.g. `edu-initiator` → `edu_initiator`).
+    pub const KNOWN_CAPABILITIES: &[&str] = &[VPCI, "test_disk", "edu_initiator", "ivshmem_target"];
 
     /// Returns `name` if it is a known capability name.
     pub fn known(name: &str) -> Option<&'static str> {

--- a/vm/devices/pci/vfio_assigned_device/Cargo.toml
+++ b/vm/devices/pci/vfio_assigned_device/Cargo.toml
@@ -24,7 +24,6 @@ vmcore.workspace = true
 
 anyhow.workspace = true
 async-trait.workspace = true
-nix.workspace = true
 parking_lot.workspace = true
 tracelimit.workspace = true
 tracing.workspace = true

--- a/vm/devices/pci/vfio_assigned_device/Cargo.toml
+++ b/vm/devices/pci/vfio_assigned_device/Cargo.toml
@@ -25,6 +25,7 @@ vmcore.workspace = true
 anyhow.workspace = true
 async-trait.workspace = true
 nix.workspace = true
+parking_lot.workspace = true
 tracelimit.workspace = true
 tracing.workspace = true
 

--- a/vm/devices/pci/vfio_assigned_device/src/lib.rs
+++ b/vm/devices/pci/vfio_assigned_device/src/lib.rs
@@ -39,13 +39,13 @@ use pci_core::spec::cfg_space;
 use pci_core::spec::cfg_space::HeaderType00;
 use std::collections::BTreeMap;
 use std::ops::Range;
+use std::os::fd::AsFd;
 use std::os::unix::fs::FileExt;
 use vmcore::device_state::ChangeDeviceState;
 use vmcore::save_restore::RestoreError;
 use vmcore::save_restore::SaveError;
 use vmcore::save_restore::SaveRestore;
 use vmcore::save_restore::SavedStateNotSupported;
-use vmcore::vm_task::VmTaskDriverSource;
 
 /// VFIO BAR region information (offset and size within the device fd).
 #[derive(Debug, Clone, Copy, Inspect)]
@@ -279,28 +279,14 @@ impl VfioAssignedPciDevice {
     pub async fn new(
         binding: manager::VfioDeviceBinding,
         pci_id: String,
-        driver_source: &VmTaskDriverSource,
         register_mmio: &mut (dyn chipset_device::mmio::RegisterMmioIntercept + Send),
         msi_target: &MsiTarget,
         memory_mapper: &dyn MemoryMapper,
         bar_pt: [bool; 6],
     ) -> anyhow::Result<Self> {
-        let driver = driver_source.simple();
-        let retry = vfio_sys::VfioRetry::new(&driver, &pci_id);
-        let is_enodev = |e: &anyhow::Error| {
-            e.chain().any(|cause| {
-                cause
-                    .downcast_ref::<nix::errno::Errno>()
-                    .is_some_and(|e| *e == nix::errno::Errno::ENODEV)
-            })
-        };
-        let vfio_device = retry
-            .retry(
-                || binding.group().open_device(&pci_id),
-                &is_enodev,
-                "open_device",
-            )
-            .await
+        let vfio_device = binding
+            .group()
+            .open_device(&pci_id)
             .with_context(|| format!("failed to open VFIO device {pci_id}"))?;
 
         Self::from_device(
@@ -339,7 +325,7 @@ impl VfioAssignedPciDevice {
 
     async fn from_device(
         vfio_device: vfio_sys::Device,
-        binding: manager::VfioBinding,
+        mut binding: manager::VfioBinding,
         pci_id: String,
         register_mmio: &mut (dyn chipset_device::mmio::RegisterMmioIntercept + Send),
         msi_target: &MsiTarget,
@@ -447,6 +433,33 @@ impl VfioAssignedPciDevice {
         // guest enables MMIO, allowing direct hardware access without VM
         // exits. Non-mmappable regions (e.g. MSI-X table/PBA) remain
         // trap-and-emulate.
+        //
+        // For the iommufd/cdev path, also export each mmappable BAR area as a
+        // dmabuf and register it under the area's intrinsic identity (cdev
+        // inode + BAR-region file offset). This lets other assigned devices
+        // perform peer-to-peer DMA to this BAR via `IOMMU_IOAS_MAP_FILE` — the
+        // kernel maps the BAR's physical MMIO through the PCI P2PDMA provider,
+        // avoiding the need to pin MMIO pages by host VA (which usually fails).
+        // The legacy group/type1 path has no registry, so dmabuf P2P is
+        // skipped there and BAR P2P falls back to best-effort VA mapping.
+        let dmabuf_registry = binding.dmabuf_registry().cloned();
+        let dmabuf_inode = if dmabuf_registry.is_some() && vfio_device.device.supports_dma_buf()? {
+            Some(
+                vfio_sys::fd_identity(vfio_device.device.as_fd())
+                    .context("failed to stat VFIO cdev for dmabuf registration")?,
+            )
+        } else {
+            None
+        };
+        // Record the cdev inode up front, before registering any BAR dmabufs
+        // in the loop below. If device setup fails partway through (e.g. a
+        // region mapping error returns early), the binding's `Drop` then
+        // deregisters and closes whatever dmabufs were already registered.
+        // Deferring this until after the loop would leak those fds into the
+        // shared per-IOAS registry on an early return.
+        if let Some(inode) = dmabuf_inode {
+            binding.set_dmabuf_inode(inode);
+        }
         let mut bar_direct_maps = Vec::new();
         for (i, areas) in bar_mmap_areas.iter().enumerate() {
             let Some(region) = &bar_regions[i] else {
@@ -479,6 +492,45 @@ impl VfioAssignedPciDevice {
                     bar_range: area,
                     mapping: None,
                 });
+
+                // Export a dmabuf for this BAR area and register it under the
+                // same key the DMA target computes at map time: the cdev inode
+                // plus the BAR-region file offset (`vfio_offset + area.start`).
+                // The dmabuf itself is created from the BAR-relative range.
+                if let (Some(registry), Some((st_dev, st_ino))) = (&dmabuf_registry, dmabuf_inode) {
+                    match vfio_device
+                        .device
+                        .export_dma_buf(i as u32, area.start(), area.len())
+                    {
+                        Ok(dmabuf) => {
+                            registry.register(
+                                st_dev,
+                                st_ino,
+                                region.vfio_offset + area.start(),
+                                dmabuf,
+                            );
+                        }
+                        // Exporting a BAR dmabuf is best-effort and never
+                        // fatal. The common failure is EINVAL when the BAR has
+                        // no P2PDMA provider on this platform/topology (the
+                        // kernel's `vfio_pci_core_get_dmabuf_phys` calls
+                        // `pcim_p2pdma_provider()` and reports EINVAL when it
+                        // returns NULL). That just means this area can't be a
+                        // peer-to-peer DMA *target* here, so fall back to
+                        // best-effort VA mapping; device assignment still works
+                        // for everything except P2P into this BAR.
+                        Err(e) => {
+                            tracing::warn!(
+                                error = e.as_ref() as &dyn std::error::Error,
+                                pci_id = pci_id.as_str(),
+                                bar = i,
+                                area = %area,
+                                "failed to export BAR dmabuf; P2P DMA to this \
+                                 area will fall back to best-effort VA mapping"
+                            );
+                        }
+                    }
+                }
             }
         }
 
@@ -1251,22 +1303,48 @@ impl PciConfigSpace for VfioAssignedPciDevice {
                     .with_mmio_enabled(true)
                     .into_bits()
                     .into();
-                if value.valid_mask() & mse_mask != 0 {
+
+                let mmio_change = if value.valid_mask() & mse_mask != 0 {
                     let command = cfg_space::Command::from_bits(value.extract_low());
                     let new_mmio_enabled = command.mmio_enabled();
+                    (new_mmio_enabled != self.mmio_enabled).then_some(new_mmio_enabled)
+                } else {
+                    None
+                };
 
-                    if new_mmio_enabled != self.mmio_enabled {
-                        self.mmio_enabled = new_mmio_enabled;
+                match mmio_change {
+                    // Enabling MMIO: propagate the Command write to the
+                    // physical device *before* mapping BARs into the IOMMU.
+                    // Enabling memory space on the real device un-revokes any
+                    // exported BAR dmabufs; the IOAS map-by-file P2P import
+                    // (IOMMU_IOAS_MAP_FILE) returns ENODEV while a dmabuf is
+                    // revoked, so the hardware enable must land first.
+                    Some(true) => {
+                        self.mmio_enabled = true;
+                        self.write_phys_config(offset, value);
                         self.update_bar_mappings();
-                        tracing::debug!(
-                            pci_id = self.pci_id.as_str(),
-                            enabled = new_mmio_enabled,
-                            "MMIO state changed by guest"
-                        );
+                    }
+                    // Disabling MMIO: tear down the IOMMU mappings while device
+                    // memory is still enabled, then propagate the disable to
+                    // the physical device.
+                    Some(false) => {
+                        self.mmio_enabled = false;
+                        self.update_bar_mappings();
+                        self.write_phys_config(offset, value);
+                    }
+                    // No MMIO-enable change: just forward the write.
+                    None => {
+                        self.write_phys_config(offset, value);
                     }
                 }
 
-                self.write_phys_config(offset, value);
+                if let Some(enabled) = mmio_change {
+                    tracing::debug!(
+                        pci_id = self.pci_id.as_str(),
+                        enabled,
+                        "MMIO state changed by guest"
+                    );
+                }
             }
             // BAR registers: mask and cache locally. If MMIO is active,
             // re-evaluate mappings so the device responds at the new address

--- a/vm/devices/pci/vfio_assigned_device/src/manager.rs
+++ b/vm/devices/pci/vfio_assigned_device/src/manager.rs
@@ -511,16 +511,31 @@ impl DmaBufRegistry {
         );
     }
 
-    /// Look up the dmabuf fd registered for a mapping's intrinsic identity.
-    fn lookup(&self, st_dev: u64, st_ino: u64, file_offset: u64) -> Option<RawFd> {
-        self.entries
-            .lock()
-            .get(&DmaBufKey {
-                st_dev,
-                st_ino,
-                file_offset,
-            })
-            .map(|fd| fd.as_raw_fd())
+    /// Look up the dmabuf fd registered for a mapping's intrinsic identity and,
+    /// while still holding the registry lock, invoke `f` with the raw fd.
+    ///
+    /// Holding the lock across `f` is what makes handing out a bare [`RawFd`]
+    /// sound: [`Self::deregister_device`] (which drops the owning [`OwnedFd`],
+    /// closing it) also takes this lock, so it cannot run — and the fd cannot
+    /// be closed — for the duration of `f`. Callers therefore pass the ioctl
+    /// that consumes the fd (e.g. `ioas_map_file`) as `f`.
+    ///
+    /// Returns `None` (without calling `f`) if no dmabuf is registered for the
+    /// key, in which case the caller falls back to the host-VA mapping path.
+    fn with_lookup<R>(
+        &self,
+        st_dev: u64,
+        st_ino: u64,
+        file_offset: u64,
+        f: impl FnOnce(RawFd) -> R,
+    ) -> Option<R> {
+        let entries = self.entries.lock();
+        let fd = entries.get(&DmaBufKey {
+            st_dev,
+            st_ino,
+            file_offset,
+        })?;
+        Some(f(fd.as_raw_fd()))
     }
 
     /// Remove (and close) all dmabufs registered for a device's cdev inode.
@@ -559,32 +574,46 @@ impl membacking::DmaTarget for IommufdDmaTarget {
         // intrinsic identity (cdev inode + file offset). Everything else
         // (private/anonymous RAM, or a BAR without an exported dmabuf) uses the
         // host VA path.
-        let backing = match request.mapping_type {
-            membacking::MappingType::Ram => request
-                .mappable
-                .map(|mappable| (mappable.as_fd().as_raw_fd(), request.file_offset)),
+        //
+        // `by_file` is `None` when there is no fd to map by file, meaning the
+        // host-VA fallback below is used.
+        let by_file = match request.mapping_type {
+            membacking::MappingType::Ram => request.mappable.map(|mappable| {
+                self.ctx.ioas_map_file(
+                    self.ioas_id,
+                    iova,
+                    mappable.as_fd().as_raw_fd(),
+                    request.file_offset,
+                    length,
+                    request.writable,
+                )
+            }),
             membacking::MappingType::Device => match request.mappable {
                 Some(mappable) => {
                     let (st_dev, st_ino) = vfio_sys::fd_identity(mappable.as_fd())
                         .context("failed to stat VFIO cdev for dmabuf lookup")?;
-                    // The dmabuf covers exactly this BAR area starting at its
-                    // own byte 0, so map from offset 0.
+                    // Perform the `ioas_map_file` while the registry lock is
+                    // held (inside `with_lookup`), so the dmabuf fd cannot be
+                    // deregistered/closed between lookup and use. The dmabuf
+                    // covers exactly this BAR area starting at its own byte 0,
+                    // so map from offset 0.
                     self.dmabuf_registry
-                        .lookup(st_dev, st_ino, request.file_offset)
-                        .map(|fd| (fd, 0))
+                        .with_lookup(st_dev, st_ino, request.file_offset, |fd| {
+                            self.ctx.ioas_map_file(
+                                self.ioas_id,
+                                iova,
+                                fd,
+                                0,
+                                length,
+                                request.writable,
+                            )
+                        })
                 }
                 None => None,
             },
         };
-        let result = match backing {
-            Some((fd, file_offset)) => self.ctx.ioas_map_file(
-                self.ioas_id,
-                iova,
-                fd,
-                file_offset,
-                length,
-                request.writable,
-            ),
+        let result = match by_file {
+            Some(r) => r,
             // SAFETY: The caller (DmaMapper in membacking) guarantees that the
             // host VA is backed and stable via eager mapping + VaMapper
             // lifetime, satisfying the safety contract of `ioas_map`.

--- a/vm/devices/pci/vfio_assigned_device/src/manager.rs
+++ b/vm/devices/pci/vfio_assigned_device/src/manager.rs
@@ -16,6 +16,7 @@ use membacking::DmaMapperClient;
 use mesh::rpc::FailableRpc;
 use mesh::rpc::RpcSend as _;
 use pal_async::task::Spawn as _;
+use parking_lot::Mutex;
 use std::collections::HashMap;
 use std::fs::File;
 use std::os::unix::prelude::*;
@@ -467,6 +468,69 @@ impl VfioContainerManager {
 
 // --- iommufd / cdev support ---
 
+/// Intrinsic identity of a device BAR area used to key exported dmabufs.
+///
+/// `st_dev`/`st_ino` come from the VFIO cdev inode (disambiguating devices
+/// that share one IOAS); `file_offset` is the BAR-region file offset that the
+/// region manager stamps on the corresponding `Device` mapping. This is the
+/// same value on both the exporter (BAR setup) and importer (`map_dma`) sides,
+/// and — unlike a guest physical address — is stable across BAR moves and MMIO
+/// enable/disable.
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
+struct DmaBufKey {
+    st_dev: u64,
+    st_ino: u64,
+    file_offset: u64,
+}
+
+/// Per-IOAS registry mapping a device BAR area's intrinsic identity to an
+/// exported VFIO dmabuf fd.
+///
+/// This lets `IommufdDmaTarget::map_dma` program peer-to-peer DMA to a device
+/// BAR via `IOMMU_IOAS_MAP_FILE` (which pins the BAR's physical MMIO via the
+/// PCI P2PDMA provider) instead of failing to pin MMIO pages by host VA. The
+/// exporter (BAR setup in `lib.rs`) and the importer (`map_dma`) live in the
+/// same crate and share one registry per IOAS via `Arc`; the legacy VFIO
+/// type1 path has no registry, so dmabuf P2P is iommufd-only.
+#[derive(Default)]
+pub(crate) struct DmaBufRegistry {
+    entries: Mutex<HashMap<DmaBufKey, OwnedFd>>,
+}
+
+impl DmaBufRegistry {
+    /// Register an exported dmabuf for a BAR area, keyed by the exporting
+    /// cdev's inode and the area's BAR-region file offset.
+    pub(crate) fn register(&self, st_dev: u64, st_ino: u64, file_offset: u64, dmabuf: OwnedFd) {
+        self.entries.lock().insert(
+            DmaBufKey {
+                st_dev,
+                st_ino,
+                file_offset,
+            },
+            dmabuf,
+        );
+    }
+
+    /// Look up the dmabuf fd registered for a mapping's intrinsic identity.
+    fn lookup(&self, st_dev: u64, st_ino: u64, file_offset: u64) -> Option<RawFd> {
+        self.entries
+            .lock()
+            .get(&DmaBufKey {
+                st_dev,
+                st_ino,
+                file_offset,
+            })
+            .map(|fd| fd.as_raw_fd())
+    }
+
+    /// Remove (and close) all dmabufs registered for a device's cdev inode.
+    fn deregister_device(&self, st_dev: u64, st_ino: u64) {
+        self.entries
+            .lock()
+            .retain(|k, _| k.st_dev != st_dev || k.st_ino != st_ino);
+    }
+}
+
 /// Implements [`membacking::DmaTarget`] for iommufd IOAS-based DMA mapping.
 ///
 /// Like `VfioType1DmaTarget`, this uses host virtual addresses for mapping,
@@ -475,6 +539,9 @@ impl VfioContainerManager {
 struct IommufdDmaTarget {
     ctx: Arc<vfio_sys::iommufd::IommufdCtx>,
     ioas_id: u32,
+    /// Registry of exported device-BAR dmabufs, shared with the devices on
+    /// this IOAS, used to program peer-to-peer DMA to BAR MMIO by file.
+    dmabuf_registry: Arc<DmaBufRegistry>,
 }
 
 impl membacking::DmaTarget for IommufdDmaTarget {
@@ -484,17 +551,30 @@ impl membacking::DmaTarget for IommufdDmaTarget {
         let iova = range.start();
         let user_va = vaddr as u64;
         let length = range.len();
-        // Prefer map-by-file for guest RAM: it is memfd-backed, so the kernel
-        // can pin the folios directly (no host VA pinning). Device BAR memory
-        // is backed by the VFIO cdev fd, which is neither a memfd nor (yet) a
-        // dmabuf, so map-by-file would misinterpret it — keep those on the VA
-        // path. Private/anonymous RAM has no backing fd and also uses the VA
-        // path.
+        // Prefer map-by-file where possible. Guest RAM is memfd-backed, so the
+        // kernel can pin the folios directly from the fd (no host VA pinning).
+        // A device BAR is backed by the VFIO cdev fd — which is neither a
+        // memfd nor a dmabuf — so it can only be mapped by file if the device
+        // exported a dmabuf for this BAR area, looked up by the area's
+        // intrinsic identity (cdev inode + file offset). Everything else
+        // (private/anonymous RAM, or a BAR without an exported dmabuf) uses the
+        // host VA path.
         let backing = match request.mapping_type {
             membacking::MappingType::Ram => request
                 .mappable
                 .map(|mappable| (mappable.as_fd().as_raw_fd(), request.file_offset)),
-            membacking::MappingType::Device => None,
+            membacking::MappingType::Device => match request.mappable {
+                Some(mappable) => {
+                    let (st_dev, st_ino) = vfio_sys::fd_identity(mappable.as_fd())
+                        .context("failed to stat VFIO cdev for dmabuf lookup")?;
+                    // The dmabuf covers exactly this BAR area starting at its
+                    // own byte 0, so map from offset 0.
+                    self.dmabuf_registry
+                        .lookup(st_dev, st_ino, request.file_offset)
+                        .map(|fd| (fd, 0))
+                }
+                None => None,
+            },
         };
         let result = match backing {
             Some((fd, file_offset)) => self.ctx.ioas_map_file(
@@ -573,6 +653,10 @@ struct IoasManager {
     /// Keeps the DMA mapper registered with the region manager.
     #[inspect(skip)]
     _dma_handle: membacking::DmaMapperHandle,
+    /// Registry of exported device-BAR dmabufs for this IOAS, shared with the
+    /// DMA target and each device for peer-to-peer DMA by file.
+    #[inspect(skip)]
+    dmabuf_registry: Arc<DmaBufRegistry>,
     /// Active devices on this IOAS.
     #[inspect(with = "|x| inspect::iter_by_key(x.iter().map(|d| (&d.pci_id, ())))")]
     devices: Vec<CdevDeviceEntry>,
@@ -605,9 +689,12 @@ impl IoasManager {
             .ioas_alloc()
             .context("failed to allocate iommufd IOAS")?;
 
+        let dmabuf_registry = Arc::new(DmaBufRegistry::default());
+
         let dma_target: Arc<dyn membacking::DmaTarget> = Arc::new(IommufdDmaTarget {
             ctx: ctx.clone(),
             ioas_id,
+            dmabuf_registry: dmabuf_registry.clone(),
         });
         // This target programs the IOMMU by host VA, so it does not require a
         // backing fd (needs_fd = false) and is compatible with private RAM.
@@ -623,6 +710,7 @@ impl IoasManager {
             ctx,
             ioas_id,
             _dma_handle: dma_handle,
+            dmabuf_registry,
             devices: Vec::new(),
             next_device_id: 0,
             recv,
@@ -690,6 +778,7 @@ impl IoasManager {
             ioas_id: self.ioas_id,
             device_id,
             manager_send: self.recv.sender(),
+            dmabuf_registry: self.dmabuf_registry.clone(),
         })
     }
 
@@ -733,6 +822,9 @@ pub(crate) struct CdevPrepareResponse {
     pub device_id: u64,
     /// Sender to the per-iommu manager for drop notification.
     pub manager_send: mesh::Sender<IoasManagerRpc>,
+    /// Registry of exported device-BAR dmabufs for this IOAS, shared so the
+    /// device can register its BAR dmabufs for peer-to-peer DMA.
+    pub dmabuf_registry: Arc<DmaBufRegistry>,
 }
 
 /// Dispatches cdev device requests to per-iommu [`IoasManager`] tasks.
@@ -897,6 +989,9 @@ pub(crate) struct VfioCdevBinding {
     /// Sender to the per-iommu manager for drop notification.
     #[inspect(skip)]
     manager_send: mesh::Sender<IoasManagerRpc>,
+    /// Registry of exported device-BAR dmabufs for this device's IOAS.
+    #[inspect(skip)]
+    dmabuf_registry: Arc<DmaBufRegistry>,
 }
 
 impl VfioCdevBinding {
@@ -909,6 +1004,7 @@ impl VfioCdevBinding {
             ioas_id: resp.ioas_id,
             device_id: resp.device_id,
             manager_send: resp.manager_send,
+            dmabuf_registry: resp.dmabuf_registry,
         }
     }
 
@@ -924,6 +1020,7 @@ impl VfioCdevBinding {
             ioas_id,
             device_id,
             manager_send,
+            dmabuf_registry,
         } = self;
         (
             device,
@@ -933,6 +1030,8 @@ impl VfioCdevBinding {
                 ioas_id,
                 device_id,
                 manager_send,
+                dmabuf_registry,
+                dmabuf_inode: None,
             },
         )
     }
@@ -951,10 +1050,20 @@ pub(crate) struct VfioCdevBindingState {
     device_id: u64,
     #[inspect(skip)]
     manager_send: mesh::Sender<IoasManagerRpc>,
+    /// Registry of exported device-BAR dmabufs for this device's IOAS.
+    #[inspect(skip)]
+    dmabuf_registry: Arc<DmaBufRegistry>,
+    /// The `(st_dev, st_ino)` of this device's VFIO cdev, set once BAR
+    /// dmabufs are registered, so they can be deregistered on drop.
+    #[inspect(skip)]
+    dmabuf_inode: Option<(u64, u64)>,
 }
 
 impl Drop for VfioCdevBindingState {
     fn drop(&mut self) {
+        if let Some((st_dev, st_ino)) = self.dmabuf_inode {
+            self.dmabuf_registry.deregister_device(st_dev, st_ino);
+        }
         self.manager_send
             .send(IoasManagerRpc::RemoveDevice(self.device_id));
     }
@@ -969,4 +1078,24 @@ impl Drop for VfioCdevBindingState {
 pub(crate) enum VfioBinding {
     Group(VfioDeviceBinding),
     Cdev(VfioCdevBindingState),
+}
+
+impl VfioBinding {
+    /// Returns the per-IOAS dmabuf registry for a cdev/iommufd binding, or
+    /// `None` for the legacy group/type1 path (which has no registry — dmabuf
+    /// P2P is iommufd-only).
+    pub(crate) fn dmabuf_registry(&self) -> Option<&Arc<DmaBufRegistry>> {
+        match self {
+            VfioBinding::Cdev(state) => Some(&state.dmabuf_registry),
+            VfioBinding::Group(_) => None,
+        }
+    }
+
+    /// Records the VFIO cdev inode under which BAR dmabufs were registered, so
+    /// they are deregistered when the binding drops. No-op for the group path.
+    pub(crate) fn set_dmabuf_inode(&mut self, inode: (u64, u64)) {
+        if let VfioBinding::Cdev(state) = self {
+            state.dmabuf_inode = Some(inode);
+        }
+    }
 }

--- a/vm/devices/pci/vfio_assigned_device/src/resolver.rs
+++ b/vm/devices/pci/vfio_assigned_device/src/resolver.rs
@@ -93,7 +93,6 @@ impl AsyncResolveResource<PciDeviceHandleKind, VfioDeviceHandle> for VfioDeviceR
         let device = VfioAssignedPciDevice::new(
             binding,
             pci_id,
-            input.driver_source,
             input.register_mmio,
             input.dma_target.msi_target(),
             memory_mapper,

--- a/vm/devices/user_driver/vfio_sys/src/lib.rs
+++ b/vm/devices/user_driver/vfio_sys/src/lib.rs
@@ -129,6 +129,61 @@ mod ioctl {
         request_code_none!(VFIO_TYPE, VFIO_BASE + 14),
         vfio_iommu_type1_dma_unmap
     );
+    // VFIO_DEVICE_FEATURE - _IO(VFIO_TYPE, VFIO_BASE + 17). The GET direction
+    // for the dmabuf feature returns a new dmabuf fd as the ioctl return
+    // value.
+    nix::ioctl_write_ptr_bad!(
+        vfio_device_feature_dma_buf,
+        request_code_none!(VFIO_TYPE, VFIO_BASE + 17),
+        super::VfioDeviceFeatureDmaBuf
+    );
+}
+
+/// `VFIO_DEVICE_FEATURE` direction/probe flags (`include/uapi/linux/vfio.h`).
+const VFIO_DEVICE_FEATURE_GET: u32 = 1 << 16;
+const VFIO_DEVICE_FEATURE_PROBE: u32 = 1 << 18;
+/// Feature index for exporting a device-region dmabuf for peer-to-peer DMA.
+const VFIO_DEVICE_FEATURE_DMA_BUF: u32 = 11;
+
+/// Combined `struct vfio_device_feature` header and
+/// `struct vfio_device_feature_dma_buf` payload with a single
+/// `struct vfio_region_dma_range`.
+///
+/// The kernel dmabuf-to-iommufd interconnect currently supports only
+/// `nr_ranges == 1`, so a fixed single-range struct suffices (one dmabuf per
+/// contiguous BAR area). Layout must match `include/uapi/linux/vfio.h`
+/// exactly.
+#[repr(C)]
+struct VfioDeviceFeatureDmaBuf {
+    // `struct vfio_device_feature`
+    argsz: u32,
+    flags: u32,
+    // `struct vfio_device_feature_dma_buf`
+    region_index: u32,
+    open_flags: u32,
+    dma_buf_flags: u32,
+    nr_ranges: u32,
+    // `struct vfio_region_dma_range dma_ranges[1]`
+    range_offset: u64,
+    range_length: u64,
+}
+
+/// Returns the `(st_dev, st_ino)` identity of a file descriptor.
+///
+/// Used to key device BAR areas by their intrinsic identity (the VFIO cdev
+/// inode plus a BAR-region file offset) rather than by a guest-controlled
+/// address.
+pub fn fd_identity(fd: BorrowedFd<'_>) -> std::io::Result<(u64, u64)> {
+    // SAFETY: `fstat` fully initializes the buffer on success; the fd is
+    // valid for the duration of the call.
+    let mut stat = unsafe { std::mem::zeroed::<libc::stat>() };
+    // SAFETY: `fd` is a valid file descriptor and `stat` points to a valid,
+    // correctly sized `libc::stat`.
+    let ret = unsafe { libc::fstat(fd.as_raw_fd(), &mut stat) };
+    if ret != 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+    Ok((stat.st_dev as u64, stat.st_ino as u64))
 }
 
 pub struct Container {
@@ -570,7 +625,20 @@ impl Device {
         }
 
         if flags.mmap() {
-            Ok(vec![MemoryRange::new(0..info.size)])
+            // The kernel can report a mmappable region whose size is not a
+            // multiple of the page size — e.g. a sub-page MMIO BAR that recent
+            // vfio-pci exposes for direct mapping. `MemoryRange` requires
+            // page-aligned bounds, and a sub-page region cannot be safely
+            // direct-mapped into guest GPA at page granularity anyway, so align
+            // the size down to the host page size and skip the region entirely
+            // if nothing remains (it stays trap-and-emulate).
+            let page_mask = host_page_size() - 1;
+            let aligned_size = info.size & !page_mask;
+            if aligned_size == 0 {
+                Ok(Vec::new())
+            } else {
+                Ok(vec![MemoryRange::new(0..aligned_size)])
+            }
         } else {
             Ok(Vec::new())
         }
@@ -615,6 +683,69 @@ impl Device {
             return Err(std::io::Error::last_os_error()).context("failed to map region");
         }
         Ok(MappedRegion { addr, len })
+    }
+
+    /// Returns whether the device supports exporting a region as a dmabuf for
+    /// peer-to-peer DMA (`VFIO_DEVICE_FEATURE_DMA_BUF`).
+    ///
+    /// `Ok(false)` means the feature is unavailable and the caller should fall
+    /// back to host-VA mapping. An unexpected probe failure is returned as an
+    /// error.
+    pub fn supports_dma_buf(&self) -> anyhow::Result<bool> {
+        let feature = VfioDeviceFeatureDmaBuf {
+            argsz: size_of::<VfioDeviceFeatureDmaBuf>() as u32,
+            flags: VFIO_DEVICE_FEATURE_PROBE
+                | VFIO_DEVICE_FEATURE_GET
+                | VFIO_DEVICE_FEATURE_DMA_BUF,
+            region_index: 0,
+            open_flags: 0,
+            dma_buf_flags: 0,
+            nr_ranges: 0,
+            range_offset: 0,
+            range_length: 0,
+        };
+        // SAFETY: the fd is valid and the struct is correctly sized. With the
+        // PROBE flag the kernel only reports support and does not export.
+        match unsafe { ioctl::vfio_device_feature_dma_buf(self.file.as_raw_fd(), &feature) } {
+            Ok(_) => Ok(true),
+            // The feature is not available on this kernel or device.
+            Err(nix::errno::Errno::ENOTTY | nix::errno::Errno::EOPNOTSUPP) => Ok(false),
+            Err(e) => Err(e).context("VFIO_DEVICE_FEATURE_DMA_BUF probe failed"),
+        }
+    }
+
+    /// Exports a single page-aligned range of a device region (BAR) as a
+    /// dmabuf for peer-to-peer DMA via iommufd (`VFIO_DEVICE_FEATURE_DMA_BUF`).
+    ///
+    /// `region_index` is the VFIO region (BAR) index. `offset` and `length`
+    /// are BAR-relative and must be page-aligned. The kernel interconnect
+    /// currently supports only a single range per dmabuf, so this exports
+    /// exactly one range. Returns an owned dmabuf fd.
+    pub fn export_dma_buf(
+        &self,
+        region_index: u32,
+        offset: u64,
+        length: u64,
+    ) -> anyhow::Result<OwnedFd> {
+        let feature = VfioDeviceFeatureDmaBuf {
+            argsz: size_of::<VfioDeviceFeatureDmaBuf>() as u32,
+            flags: VFIO_DEVICE_FEATURE_GET | VFIO_DEVICE_FEATURE_DMA_BUF,
+            region_index,
+            open_flags: (libc::O_RDWR | libc::O_CLOEXEC) as u32,
+            dma_buf_flags: 0,
+            nr_ranges: 1,
+            range_offset: offset,
+            range_length: length,
+        };
+        // SAFETY: the fd is valid and the struct is correctly sized and
+        // constructed. On GET the kernel returns a freshly-opened dmabuf fd as
+        // the ioctl return value.
+        let fd = unsafe {
+            ioctl::vfio_device_feature_dma_buf(self.file.as_raw_fd(), &feature)
+                .context("VFIO_DEVICE_FEATURE_DMA_BUF export failed")?
+        };
+        // SAFETY: the kernel returned a new, owned dmabuf fd.
+        Ok(unsafe { OwnedFd::from_raw_fd(fd) })
     }
 
     pub fn map_msix<I>(&self, start: u32, eventfd: I) -> anyhow::Result<()>

--- a/vmm_tests/vmm_test_macros/src/lib.rs
+++ b/vmm_tests/vmm_test_macros/src/lib.rs
@@ -921,7 +921,7 @@ pub fn vmm_test(
 /// last; both are enforced.
 ///
 /// example: #[vmm_test_with(noagent, configs(linux_direct_x64, ...))]
-/// example: #[vmm_test_with(openvmm, requires(test_disk_vfio), configs(linux_direct_aarch64))]
+/// example: #[vmm_test_with(openvmm, requires(test_disk), configs(linux_direct_aarch64))]
 /// example: #[vmm_test_with(openvmm, amd, configs(linux_direct_x64))]
 #[proc_macro_attribute]
 pub fn vmm_test_with(

--- a/vmm_tests/vmm_tests/tests/tests/aarch64_exclusive.rs
+++ b/vmm_tests/vmm_tests/tests/tests/aarch64_exclusive.rs
@@ -376,15 +376,15 @@ async fn assigned_device_peer_to_peer_dma_aarch64_tcg(
         parse_hex_u64(start)
     };
 
-    // Enable PCI memory-space decode + bus mastering (COMMAND |= MEM|BUSMASTER)
-    // by writing the low COMMAND byte through sysfs config space. 0x0006 =
+    // Enable PCI memory-space decode + bus mastering by writing COMMAND =
+    // MEM|BUSMASTER through sysfs config space. The device is freshly bound, so
+    // a fixed write (rather than read/modify/write) is sufficient. 0x0006 =
     // MEM (bit1) | BUSMASTER (bit2), at the 16-bit COMMAND register (offset 4).
     let enable_mem_bus_master = async |bdf: &str| -> anyhow::Result<()> {
         let cfg = format!("/sys/bus/pci/devices/{bdf}/config");
         cmd!(sh, "dd of={cfg} bs=1 seek=4 count=2 conv=notrunc")
             .stdin([0x06u8, 0x00u8])
             .ignore_stdout()
-            .ignore_stderr()
             .run()
             .await
             .with_context(|| format!("failed to enable MEM|BUSMASTER on {bdf}"))

--- a/vmm_tests/vmm_tests/tests/tests/aarch64_exclusive.rs
+++ b/vmm_tests/vmm_tests/tests/tests/aarch64_exclusive.rs
@@ -4,10 +4,13 @@
 //! Integration tests for aarch64 guests.
 
 use anyhow::Context;
+use pal_async::DefaultDriver;
+use pal_async::timer::PolledTimer;
 use petri::PetriVmBuilder;
 use petri::PetriVmmBackend;
 use petri::openvmm::OpenVmmPetriBackend;
 use petri::pipette::cmd;
+use std::time::Duration;
 use vm_resource::IntoResource;
 use vmm_test_macros::vmm_test;
 use vmm_test_macros::vmm_test_with;
@@ -86,21 +89,21 @@ async fn boot_dt(config: PetriVmBuilder<OpenVmmPetriBackend>) -> Result<(), anyh
 ///
 /// This test is intended to run inside a QEMU TCG incubator with KVM.
 /// The incubator profile sets up a virtio-blk device bound to vfio-pci,
-/// and exports its BDF via the `INCUBATOR_VFIO_BDF_TEST_DISK` env var.
-/// The test assigns that device into the L2 guest and verifies it appears
-/// as a block device, then reads from it to exercise DMA and interrupts.
+/// and publishes its BDF under the profile name `test-disk` (see
+/// [`incubator_vfio_bdf`]). The test assigns that device into the L2 guest
+/// and verifies it appears as a block device, then reads from it to exercise
+/// DMA and interrupts.
 ///
 /// The `_aarch64_tcg` name suffix opts this test into the TCG incubator
 /// pass: CI selects it via the `test(aarch64_tcg)` nextest filter.
-#[vmm_test_with(openvmm, requires(test_disk_vfio), configs(linux_direct_aarch64))]
+#[vmm_test_with(openvmm, requires(test_disk), configs(linux_direct_aarch64))]
 async fn boot_no_vmbus_pcie_aarch64_tcg(
     config: PetriVmBuilder<OpenVmmPetriBackend>,
 ) -> anyhow::Result<()> {
-    // Read the VFIO BDF from the environment. This is set by the incubator
-    // when it binds a device to vfio-pci before running the test.
-    // The "test_disk_vfio" capability requirement ensures this is set before
-    // the test runs.
-    let vfio_bdf = std::env::var("INCUBATOR_VFIO_BDF_TEST_DISK").unwrap();
+    // Look up the assigned device's BDF by its incubator profile name. The
+    // matching `requires(test_disk)` capability ensures it is provisioned
+    // before the test runs.
+    let vfio_bdf = incubator_vfio_bdf("test-disk")?;
 
     tracing::info!(vfio_bdf = %vfio_bdf, "assigning VFIO device to guest");
 
@@ -181,6 +184,282 @@ async fn boot_no_vmbus_pcie_aarch64_tcg(
     anyhow::ensure!(
         dd_output.contains("16+0 records"),
         "expected 16 records read, got: {dd_output}"
+    );
+
+    agent.power_off().await?;
+    vm.wait_for_clean_teardown().await?;
+    Ok(())
+}
+
+/// Open the VFIO cdev for an assigned device given its PCI BDF.
+///
+/// Returns the opened character device file. The device must already be bound
+/// to `vfio-pci` (the incubator does this before running the test).
+fn open_vfio_cdev(vfio_bdf: &str) -> anyhow::Result<std::fs::File> {
+    let sysfs_path = std::path::Path::new("/sys/bus/pci/devices").join(vfio_bdf);
+    let vfio_dev_dir = sysfs_path.join("vfio-dev");
+    let cdev_name = std::fs::read_dir(&vfio_dev_dir)
+        .with_context(|| {
+            format!(
+                "failed to read {}: is {} bound to vfio-pci?",
+                vfio_dev_dir.display(),
+                vfio_bdf
+            )
+        })?
+        .next()
+        .context("no vfio-dev entry found")?
+        .context("failed to read vfio-dev entry")?;
+    std::fs::OpenOptions::new()
+        .read(true)
+        .write(true)
+        .open(std::path::Path::new("/dev/vfio/devices").join(cdev_name.file_name()))
+        .context("failed to open VFIO cdev")
+}
+
+/// Look up the PCI BDF of an incubator-provisioned VFIO device by its profile
+/// `name` (e.g. `"edu-initiator"`).
+///
+/// The incubator publishes each provisioned device's BDF in the environment as
+/// `INCUBATOR_VFIO_BDF_<NAME>` (the name upper-cased with `-` replaced by `_`);
+/// this derivation must match `setup_vfio_devices` in
+/// `petri/incubator/src/qemu.rs`. Gate the test on the matching
+/// `requires(...)` capability (the same name with `-` replaced by `_`) so the
+/// device is guaranteed to be provisioned.
+fn incubator_vfio_bdf(name: &str) -> anyhow::Result<String> {
+    let env_name = format!(
+        "INCUBATOR_VFIO_BDF_{}",
+        name.to_uppercase().replace('-', "_")
+    );
+    std::env::var(&env_name).with_context(|| {
+        format!("{env_name} not set; is device '{name}' provisioned by the incubator?")
+    })
+}
+
+/// Validate device-BAR peer-to-peer DMA through the vfio-dmabuf import path.
+///
+/// This test assigns two emulated PCI devices from the incubator into the L2
+/// OpenVMM guest, both under the *same* iommufd IOAS (`iommu0`):
+///
+/// - `edu` (QEMU's educational device) is the DMA **initiator**: it has a
+///   register-programmed DMA engine that copies between its internal 4 KiB
+///   buffer and an arbitrary bus address.
+/// - `ivshmem-plain` is the DMA **target**: its BAR2 is a prefetchable,
+///   RAM-backed memory BAR that serves as a peer-BAR DMA sink.
+///
+/// The guest (using only busybox `devmem`, no drivers) writes a pattern into
+/// `ivshmem` BAR2, has `edu` DMA it into `edu`'s buffer (a peer-BAR *read*),
+/// then DMA that buffer back out to a different `ivshmem` BAR2 offset (a
+/// peer-BAR *write*), and finally reads that offset back to confirm the value
+/// round-tripped through `edu`'s device-initiated DMA.
+///
+/// Because `ivshmem`'s BAR2 is device MMIO (not RAM), the only way `edu`'s DMA
+/// can reach it is if OpenVMM imported `ivshmem`'s BAR dmabuf into the shared
+/// IOAS (the Phase 2 vfio-dmabuf P2P path). Without that import the DMA faults
+/// in the SMMU and the sink offset stays at its initialized sentinel, so a
+/// matching read-back proves the dmabuf import engaged.
+///
+/// The `_aarch64_tcg` name suffix opts this test into the TCG incubator pass.
+#[vmm_test_with(
+    openvmm,
+    requires(edu_initiator, ivshmem_target),
+    configs(linux_direct_aarch64)
+)]
+async fn assigned_device_peer_to_peer_dma_aarch64_tcg(
+    config: PetriVmBuilder<OpenVmmPetriBackend>,
+    _: (),
+    driver: DefaultDriver,
+) -> anyhow::Result<()> {
+    // BDFs of the two assigned devices, looked up by their incubator profile
+    // names. The capability requirements above ensure both are provisioned
+    // before the test runs.
+    let edu_bdf = incubator_vfio_bdf("edu-initiator")?;
+    let ivshmem_bdf = incubator_vfio_bdf("ivshmem-target")?;
+
+    tracing::info!(%edu_bdf, %ivshmem_bdf, "assigning P2P device pair to guest");
+
+    let edu_cdev = open_vfio_cdev(&edu_bdf)?;
+    let ivshmem_cdev = open_vfio_cdev(&ivshmem_bdf)?;
+
+    // Both devices must share one iommufd instance so they land in the same
+    // IOAS (and thus the same dmabuf registry). Open /dev/iommu once and clone
+    // the fd for the second device; OpenVMM dedups on the `iommu_id` string.
+    let iommufd = std::fs::OpenOptions::new()
+        .read(true)
+        .write(true)
+        .open("/dev/iommu")
+        .context("failed to open /dev/iommu")?;
+    let iommufd2 = iommufd
+        .try_clone()
+        .context("failed to clone /dev/iommu fd")?;
+
+    let (edu_bdf_for_cfg, ivshmem_bdf_for_cfg) = (edu_bdf.clone(), ivshmem_bdf.clone());
+    let (vm, agent) = config
+        .with_no_vmbus()
+        .with_memory(petri::MemoryConfig {
+            startup_bytes: 1024 * 1024 * 1024,
+            ..Default::default()
+        })
+        .modify_backend(move |b| {
+            b.with_pcie_root_topology(1, 1, 3).with_custom_config(|c| {
+                c.hypervisor.with_hv = false;
+                c.pcie_devices.push(openvmm_defs::config::PcieDeviceConfig {
+                    port_name: "s0rc0rp1".into(),
+                    resource: vfio_assigned_device_resources::VfioCdevDeviceHandle {
+                        pci_id: edu_bdf_for_cfg.clone(),
+                        cdev: edu_cdev,
+                        iommufd,
+                        iommu_id: "iommu0".into(),
+                        bar_pt: [false; 6],
+                    }
+                    .into_resource(),
+                });
+                c.pcie_devices.push(openvmm_defs::config::PcieDeviceConfig {
+                    port_name: "s0rc0rp2".into(),
+                    resource: vfio_assigned_device_resources::VfioCdevDeviceHandle {
+                        pci_id: ivshmem_bdf_for_cfg.clone(),
+                        cdev: ivshmem_cdev,
+                        iommufd: iommufd2,
+                        iommu_id: "iommu0".into(),
+                        bar_pt: [false; 6],
+                    }
+                    .into_resource(),
+                });
+            })
+        })
+        .run()
+        .await?;
+
+    // Drive the P2P sequence from the test over pipette, one guest operation
+    // at a time (no embedded shell script). edu BAR0 register map: 0x80 = DMA
+    // source, 0x88 = DMA destination, 0x90 = transfer count (bytes), 0x98 = DMA
+    // command (bit0 RUN, bit1 direction: 0 = bus -> edu buffer, 1 = edu buffer
+    // -> bus). edu's internal buffer is addressed at 0x40000. BAR GPAs live in
+    // the 64-bit high-MMIO window, so the DMA registers are written with 64-bit
+    // accesses.
+    const PATTERN: u64 = 0xDEAD_BEEF;
+    const EDU_BUF: u64 = 0x40000;
+    let sh = agent.unix_shell();
+
+    // Parse a `0x`-prefixed (or bare) hex string into a `u64`.
+    fn parse_hex_u64(s: &str) -> anyhow::Result<u64> {
+        let t = s.trim();
+        let hex = t.strip_prefix("0x").unwrap_or(t);
+        u64::from_str_radix(hex, 16).with_context(|| format!("failed to parse hex {s:?}"))
+    }
+
+    // Write a value to guest physical memory via busybox `devmem`.
+    let devmem_write = async |addr: u64, width: u32, val: u64| -> anyhow::Result<()> {
+        let addr = format!("{addr:#x}");
+        let width = width.to_string();
+        let val = format!("{val:#x}");
+        cmd!(sh, "devmem {addr} {width} {val}").run().await
+    };
+
+    // Read a value from guest physical memory via busybox `devmem`.
+    let devmem_read = async |addr: u64, width: u32| -> anyhow::Result<u64> {
+        let addr = format!("{addr:#x}");
+        let width = width.to_string();
+        let out = cmd!(sh, "devmem {addr} {width}").read().await?;
+        parse_hex_u64(&out)
+    };
+
+    // Read the base GPA of a PCI BAR from sysfs (`resource` line index = BAR#).
+    let pci_bar_base = async |bdf: &str, bar: usize| -> anyhow::Result<u64> {
+        let resource = sh
+            .read_file(format!("/sys/bus/pci/devices/{bdf}/resource"))
+            .await?;
+        let start = resource
+            .lines()
+            .nth(bar)
+            .and_then(|l| l.split_whitespace().next())
+            .with_context(|| format!("BAR {bar} missing in resource for {bdf}"))?;
+        parse_hex_u64(start)
+    };
+
+    // Enable PCI memory-space decode + bus mastering (COMMAND |= MEM|BUSMASTER)
+    // by writing the low COMMAND byte through sysfs config space. 0x0006 =
+    // MEM (bit1) | BUSMASTER (bit2), at the 16-bit COMMAND register (offset 4).
+    let enable_mem_bus_master = async |bdf: &str| -> anyhow::Result<()> {
+        let cfg = format!("/sys/bus/pci/devices/{bdf}/config");
+        cmd!(sh, "dd of={cfg} bs=1 seek=4 count=2 conv=notrunc")
+            .stdin([0x06u8, 0x00u8])
+            .ignore_stdout()
+            .ignore_stderr()
+            .run()
+            .await
+            .with_context(|| format!("failed to enable MEM|BUSMASTER on {bdf}"))
+    };
+
+    // Poll edu's DMA command register until the RUN bit (bit 0) clears, waiting
+    // between polls (edu runs the transfer on a ~100ms timer).
+    let wait_dma = async |reg_cmd: u64| -> anyhow::Result<()> {
+        let mut timer = PolledTimer::new(&driver);
+        for _ in 0..30 {
+            if devmem_read(reg_cmd, 64).await? & 1 == 0 {
+                return Ok(());
+            }
+            timer.sleep(Duration::from_millis(100)).await;
+        }
+        anyhow::bail!("edu DMA RUN bit never cleared (peer-BAR DMA did not complete)")
+    };
+
+    // Enable memory-space decode + bus mastering on both devices so edu can
+    // initiate DMA and ivshmem's BAR decodes.
+    enable_mem_bus_master(&edu_bdf).await?;
+    enable_mem_bus_master(&ivshmem_bdf).await?;
+
+    // BAR base GPAs: edu BAR0 (registers) and ivshmem BAR2 (shared memory).
+    let edu_bar0 = pci_bar_base(&edu_bdf, 0).await?;
+    let ivs_bar2 = pci_bar_base(&ivshmem_bdf, 2).await?;
+    tracing::info!("resolved BAR GPAs: edu_bar0={edu_bar0:#x} ivs_bar2={ivs_bar2:#x}");
+
+    let reg_src = edu_bar0 + 0x80;
+    let reg_dst = edu_bar0 + 0x88;
+    let reg_cnt = edu_bar0 + 0x90;
+    let reg_cmd = edu_bar0 + 0x98;
+    let ivs_src = ivs_bar2;
+    let ivs_sink = ivs_bar2 + 0x1000;
+
+    // Sanity: edu BAR0 MMIO is live (identification register), so a later
+    // failure is easy to triage.
+    let edu_id = devmem_read(edu_bar0, 32).await?;
+    anyhow::ensure!(
+        edu_id == 0x0100_00ed,
+        "edu identification register read {edu_id:#010x}, expected 0x010000ed"
+    );
+
+    // Seed the ivshmem source, clear the sink (CPU MMIO into ivshmem BAR2), and
+    // confirm the seed landed.
+    devmem_write(ivs_sink, 32, 0).await?;
+    devmem_write(ivs_src, 32, PATTERN).await?;
+    let seed = devmem_read(ivs_src, 32).await?;
+    anyhow::ensure!(
+        seed == PATTERN,
+        "ivshmem BAR2 seed read {seed:#010x}, expected {PATTERN:#010x}"
+    );
+
+    // DMA #1 (FROM bus): P2P-read the ivshmem source into edu's buffer.
+    devmem_write(reg_src, 64, ivs_src).await?;
+    devmem_write(reg_dst, 64, EDU_BUF).await?;
+    devmem_write(reg_cnt, 64, 4).await?;
+    devmem_write(reg_cmd, 64, 1).await?; // RUN | FROM_PCI
+    wait_dma(reg_cmd).await?;
+
+    // DMA #2 (TO bus): P2P-write edu's buffer to the ivshmem sink offset.
+    devmem_write(reg_src, 64, EDU_BUF).await?;
+    devmem_write(reg_dst, 64, ivs_sink).await?;
+    devmem_write(reg_cnt, 64, 4).await?;
+    devmem_write(reg_cmd, 64, 3).await?; // RUN | TO_PCI
+    wait_dma(reg_cmd).await?;
+
+    // The pattern only reaches the sink if the Phase 2 dmabuf import routed
+    // edu's peer-BAR DMA into ivshmem's BAR2 through the shared IOAS. Without
+    // it the DMA faults in the IOAS and the sink stays zero.
+    let result = devmem_read(ivs_sink, 32).await?;
+    anyhow::ensure!(
+        result == PATTERN,
+        "peer-BAR P2P DMA did not round-trip the pattern: sink read {result:#010x}, \
+         expected {PATTERN:#010x}"
     );
 
     agent.power_off().await?;


### PR DESCRIPTION
An assigned PCI device that wants to DMA into another assigned device's BAR (peer-to-peer) cannot do so through the existing host-VA mapping path: MMIO pages generally cannot be pinned by virtual address, so the mapping silently fails and the DMA faults in the IOMMU. The kernel's vfio-dmabuf feature solves this by exporting a device BAR region as a dmabuf whose physical MMIO can be programmed into an IOAS via IOMMU_IOAS_MAP_FILE, routing the mapping through the PCI P2PDMA provider instead of pinning host VA.

Wire this into the iommufd/cdev assignment path. Each mmappable BAR area is exported as a dmabuf at device setup and registered in a per-IOAS registry keyed by the area's intrinsic identity (the VFIO cdev inode plus its BAR-region file offset), which is stable across BAR moves and MMIO enable/disable. When a device programs peer DMA to that BAR, the DMA target looks the area up in the registry and maps it by file rather than by host VA. Devices sharing one iommufd land in the same IOAS and thus the same registry, so peer BARs become reachable; the legacy type1 path has no registry and falls back to best-effort VA mapping.

Ordering of the guest's Command-register MMIO enable is made explicit so the physical enable lands before the IOAS import (a revoked dmabuf makes the map-by-file import return ENODEV), and sub-page mmappable regions are aligned down so they stay trap-and-emulate instead of tripping the page-aligned MemoryRange invariant.

To exercise the path end to end, the aarch64 QEMU-TCG incubator gains a generic multi-device VFIO story: profiles can declare arbitrary devices (each advertising a capability derived from its name), and a new profile pairs QEMU's edu device (a register-programmed DMA initiator) with an ivshmem-plain device (a RAM-backed peer BAR target). A new driverless P2P test drives edu's DMA engine over pipette to round-trip a value through the ivshmem BAR, which only succeeds if the dmabuf import engaged. The incubator's L1 host kernel is switched to a build that ships the required P2PDMA / vfio-dmabuf / iommufd config.