### PR TITLE
openvmm_entry: run ttrpc VMs on aarch64

### DIFF
--- a/openvmm/openvmm_entry/src/ttrpc/mod.rs
+++ b/openvmm/openvmm_entry/src/ttrpc/mod.rs
@@ -564,9 +564,14 @@ impl VmService {
             })?);
         }
 
+        #[cfg(guest_arch = "aarch64")]
+        let arch = vm_manifest_builder::MachineArch::Aarch64;
+        #[cfg(guest_arch = "x86_64")]
+        let arch = vm_manifest_builder::MachineArch::X86_64;
+
         let chipset_builder = VmManifestBuilder::new(
             vm_manifest_builder::BaseChipsetType::HyperVGen2LinuxDirect,
-            vm_manifest_builder::MachineArch::X86_64,
+            arch,
         )
         .with_serial(ports);
         let layout_config = chipset_builder.layout_config();

--- a/vmm_tests/vmm_tests/tests/tests/main.rs
+++ b/vmm_tests/vmm_tests/tests/tests/main.rs
@@ -17,10 +17,7 @@
 
 // Tests that run on more than one architecture.
 mod multiarch;
-// Tests for the TTRPC interface that currently only run on x86-64 but can
-// compile when targeting any architecture. As our ARM64 support improves
-// these tests should be able to someday run on both x86-64 and ARM64, and be
-// moved into a multi-arch module.
+// Tests for the TTRPC interface, which run on both x86-64 and ARM64.
 mod ttrpc;
 // Tests that currently run only on x86-64 but can compile when targeting
 // any architecture. As our ARM64 support improves these tests should be able to

--- a/vmm_tests/vmm_tests/tests/tests/ttrpc.rs
+++ b/vmm_tests/vmm_tests/tests/tests/ttrpc.rs
@@ -21,12 +21,6 @@ use unix_socket::UnixListener;
 use unix_socket::UnixStream;
 
 petri::test!(test_ttrpc_interface, |resolver| {
-    // Only supported on x86_64 for now.
-    if petri_artifacts_common::tags::MachineArch::host()
-        != petri_artifacts_common::tags::MachineArch::X86_64
-    {
-        return None;
-    }
     let openvmm = resolver.require(artifacts::OPENVMM_NATIVE);
     let kernel = resolver.require(artifacts::loadable::LINUX_DIRECT_TEST_KERNEL_NATIVE);
     let initrd = resolver.require(artifacts::loadable::LINUX_DIRECT_TEST_INITRD_NATIVE);
@@ -43,6 +37,13 @@ fn test_ttrpc_interface(
     let tempdir = tempfile::tempdir()?;
     let socket_path = tempdir.path().join("ttrpc.sock");
     let pidfile_path = tempdir.path().join("openvmm.pid");
+
+    // The serial console device differs by architecture: x86 exposes a 16550
+    // UART as `ttyS0`, while aarch64 exposes a PL011 UART as `ttyAMA0`.
+    let console = match petri_artifacts_common::tags::MachineArch::host() {
+        petri_artifacts_common::tags::MachineArch::X86_64 => "ttyS0",
+        petri_artifacts_common::tags::MachineArch::Aarch64 => "ttyAMA0",
+    };
 
     tracing::info!(socket_path = %socket_path.display(), "launching OpenVMM with ttrpc");
 
@@ -360,7 +361,7 @@ fn test_ttrpc_interface(
                                     kernel_path: kernel_path.get().to_string_lossy().to_string(),
                                     initrd_path: initrd_path.get().to_string_lossy().to_string(),
                                     kernel_cmdline: format!(
-                                        "console=ttyS0 rdinit=/bin/busybox panic=-1 -- {guest_command}"
+                                        "console={console} rdinit=/bin/busybox panic=-1 -- {guest_command}"
                                     ),
                                 },
                             )),


### PR DESCRIPTION
The ttrpc/grpc management endpoint previously hardcoded the x86-64 machine architecture when building the VM manifest, and its integration test bailed out on any non-x86-64 host. Select the guest architecture from the build target so the endpoint can construct aarch64 VMs, and enable the test on aarch64 hosts. The test now derives the guest serial console from the host architecture, since aarch64 exposes a PL011 UART (ttyAMA0) rather than the 16550 (ttyS0) used on x86-64, and threads that into the kernel command line so the guest logs reach the expected device.

Note that the endpoint always enables the Hyper-V hypervisor enlightenments and VMBus, which depend on the guest-facing synic. On aarch64 that is only available on WHP and mshv; KVM does not implement the synic on aarch64 (it bails with "synic not supported on KVM/aarch64"), so aarch64 ttrpc VMs will not run on KVM yet.