### PR TITLE
virt_whp: translate GVAs via the hypervisor under nested virt

### DIFF
--- a/vm/whp/src/abi.rs
+++ b/vm/whp/src/abi.rs
@@ -603,6 +603,12 @@ pub const WHvTranslateGvaFlagPrivilegeExempt: WHV_TRANSLATE_GVA_FLAGS =
     WHV_TRANSLATE_GVA_FLAGS(0x00000008);
 pub const WHvTranslateGvaFlagSetPageTableBits: WHV_TRANSLATE_GVA_FLAGS =
     WHV_TRANSLATE_GVA_FLAGS(0x00000010);
+#[cfg(target_arch = "x86_64")]
+pub const WHvTranslateGvaFlagEnforceSmap: WHV_TRANSLATE_GVA_FLAGS =
+    WHV_TRANSLATE_GVA_FLAGS(0x00000100);
+#[cfg(target_arch = "x86_64")]
+pub const WHvTranslateGvaFlagOverrideSmap: WHV_TRANSLATE_GVA_FLAGS =
+    WHV_TRANSLATE_GVA_FLAGS(0x00000200);
 
 #[repr(C)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]

--- a/vmm_core/virt_whp/src/emu.rs
+++ b/vmm_core/virt_whp/src/emu.rs
@@ -220,6 +220,50 @@ impl<T: CpuIo> virt_support_x86emu::emulate::EmulatorSupport for WhpEmulationSta
         gva: u64,
         mode: TranslateMode,
     ) -> Result<EmuTranslateResult, EmuTranslateError> {
+        // When nested virtualization is enabled, the software page table walker
+        // cannot account for the hypervisor's nested paging state, so defer the
+        // translation to the hypervisor via `WHvTranslateGva`.
+        if self.vp.vp.partition.caps.nested_virt {
+            let mut flags = whp::abi::WHvTranslateGvaFlagSetPageTableBits;
+            flags |= match mode {
+                TranslateMode::Read => whp::abi::WHvTranslateGvaFlagValidateRead,
+                TranslateMode::Write => {
+                    whp::abi::WHvTranslateGvaFlagValidateRead
+                        | whp::abi::WHvTranslateGvaFlagValidateWrite
+                }
+                TranslateMode::Execute => whp::abi::WHvTranslateGvaFlagValidateExecute,
+            };
+            let vtl = self.vp.state.active_vtl;
+            return match self.vp.translate_gva_via_hypervisor(vtl, gva, flags) {
+                Ok(gpa) => Ok(EmuTranslateResult {
+                    gpa,
+                    overlay_page: None,
+                }),
+                // `event_info` is `None` because `WHvTranslateGva` cannot
+                // surface the hypervisor's pending event. In particular, a
+                // nested page-table violation (a page table page missing from
+                // the L1's SLAT while translating an L2 GVA) reports
+                // `INTERCEPT` here with no way to reconstruct the nested memory
+                // intercept that should be reflected to L1. With no event, the
+                // emulator declines to inject a fault and the emulation aborts
+                // (the VP halts). This is acceptable for now because the
+                // condition is rare.
+                //
+                // The proper fix requires WHP to expose the pending event, so
+                // that we can reflect the nested intercept to L1 and resume.
+                // Until then, if this abort is actually hit, an interim
+                // alternative that needs no WHP change is to resume the VP
+                // without injecting anything and let it re-fault, giving L1 a
+                // chance to repopulate its SLAT. That risks looping forever if
+                // the fault is not transient (e.g. an L1 that keeps the page
+                // unmapped), so it would need a bound on retries.
+                Err(code) => Err(EmuTranslateError {
+                    code,
+                    event_info: None,
+                }),
+            };
+        }
+
         emulate_translate_gva(self, gva, mode)
     }
 
@@ -471,5 +515,30 @@ impl WhpProcessor<'_> {
             ss: from_seg_reg(&ss),
             encryption_mode: virt_support_x86emu::translate::EncryptionMode::None,
         }
+    }
+
+    /// Translates a GVA to a GPA using the hypervisor's `WHvTranslateGva` API.
+    ///
+    /// This must be used instead of the software page table walker
+    /// ([`translate_gva_to_gpa`](virt_support_x86emu::translate::translate_gva_to_gpa))
+    /// when nested virtualization is enabled, so that the hypervisor's nested
+    /// paging state is taken into account.
+    ///
+    /// On success, returns the full byte GPA with the page offset from `gva`
+    /// preserved.
+    pub(crate) fn translate_gva_via_hypervisor(
+        &self,
+        vtl: Vtl,
+        gva: u64,
+        flags: whp::abi::WHV_TRANSLATE_GVA_FLAGS,
+    ) -> Result<u64, hvdef::hypercall::TranslateGvaResultCode> {
+        // `WHvTranslateGva` already returns the full byte GPA with the page
+        // offset from `gva` preserved, and its result codes match the
+        // hypervisor's `TranslateGvaResultCode`.
+        self.vp
+            .whp(vtl)
+            .translate_gva(gva, flags)
+            .expect("translate gva should not fail")
+            .map_err(|code| hvdef::hypercall::TranslateGvaResultCode(code.0))
     }
 }

--- a/vmm_core/virt_whp/src/emu.rs
+++ b/vmm_core/virt_whp/src/emu.rs
@@ -234,7 +234,7 @@ impl<T: CpuIo> virt_support_x86emu::emulate::EmulatorSupport for WhpEmulationSta
                 TranslateMode::Execute => whp::abi::WHvTranslateGvaFlagValidateExecute,
             };
             let vtl = self.vp.state.active_vtl;
-            return match self.vp.translate_gva_via_hypervisor(vtl, gva, flags) {
+            match self.vp.translate_gva_via_hypervisor(vtl, gva, flags) {
                 Ok(gpa) => Ok(EmuTranslateResult {
                     gpa,
                     overlay_page: None,
@@ -261,10 +261,10 @@ impl<T: CpuIo> virt_support_x86emu::emulate::EmulatorSupport for WhpEmulationSta
                     code,
                     event_info: None,
                 }),
-            };
+            }
+        } else {
+            emulate_translate_gva(self, gva, mode)
         }
-
-        emulate_translate_gva(self, gva, mode)
     }
 
     fn inject_pending_event(&mut self, event_info: hvdef::HvX64PendingEvent) {

--- a/vmm_core/virt_whp/src/hypercalls.rs
+++ b/vmm_core/virt_whp/src/hypercalls.rs
@@ -734,7 +734,6 @@ mod x86 {
     use std::sync::atomic::Ordering;
     use tracing_helpers::ErrorValueExt;
     use virt::VpIndex;
-
     use virt_support_x86emu::translate::TranslateFlags;
     use virt_support_x86emu::translate::TranslatePrivilegeCheck;
     use virt_support_x86emu::translate::TranslateResult;

--- a/vmm_core/virt_whp/src/hypercalls.rs
+++ b/vmm_core/virt_whp/src/hypercalls.rs
@@ -1304,30 +1304,72 @@ mod x86 {
                 todo!("WHP can only translate gvas against VTL0");
             }
 
-            let flags = convert_translate_control_flags(control_flags)?;
+            let result = if self.vp.vp.partition.caps.nested_virt {
+                // When nested virtualization is enabled, the software page table
+                // walker cannot account for the hypervisor's nested paging
+                // state, so defer the translation to the hypervisor via
+                // `WHvTranslateGva`.
+                let mut flags = whp::abi::WHvTranslateGvaFlagNone;
+                if control_flags.validate_read() {
+                    flags |= whp::abi::WHvTranslateGvaFlagValidateRead;
+                }
+                if control_flags.validate_write() {
+                    flags |= whp::abi::WHvTranslateGvaFlagValidateWrite;
+                }
+                if control_flags.validate_execute() {
+                    flags |= whp::abi::WHvTranslateGvaFlagValidateExecute;
+                }
+                if control_flags.privilege_exempt() {
+                    flags |= whp::abi::WHvTranslateGvaFlagPrivilegeExempt;
+                }
+                if control_flags.set_page_table_bits() {
+                    flags |= whp::abi::WHvTranslateGvaFlagSetPageTableBits;
+                }
 
-            let result = translate_gva_to_gpa(
-                &self.vp.vp.partition.gm,
-                gva_page * HV_PAGE_SIZE,
-                &self.vp.translation_registers(Vtl::Vtl0),
-                flags,
-            );
-
-            let result = match result {
-                Ok(TranslateResult { gpa, cache_info: _ }) => {
-                    hvdef::hypercall::TranslateVirtualAddressExOutputX64 {
+                match self.vp.translate_gva_via_hypervisor(
+                    Vtl::Vtl0,
+                    gva_page * HV_PAGE_SIZE,
+                    flags,
+                ) {
+                    Ok(gpa) => hvdef::hypercall::TranslateVirtualAddressExOutputX64 {
                         gpa_page: gpa / HV_PAGE_SIZE,
                         ..FromZeros::new_zeroed()
-                    }
-                }
-                Err(err) => hvdef::hypercall::TranslateVirtualAddressExOutputX64 {
-                    translation_result: hvdef::hypercall::TranslateGvaResultExX64 {
-                        result: hvdef::hypercall::TranslateGvaResult::new()
-                            .with_result_code(TranslateGvaResultCode::from(err).0),
+                    },
+                    Err(code) => hvdef::hypercall::TranslateVirtualAddressExOutputX64 {
+                        translation_result: hvdef::hypercall::TranslateGvaResultExX64 {
+                            result: hvdef::hypercall::TranslateGvaResult::new()
+                                .with_result_code(code.0),
+                            ..FromZeros::new_zeroed()
+                        },
                         ..FromZeros::new_zeroed()
                     },
-                    ..FromZeros::new_zeroed()
-                },
+                }
+            } else {
+                let flags = convert_translate_control_flags(control_flags)?;
+
+                let result = translate_gva_to_gpa(
+                    &self.vp.vp.partition.gm,
+                    gva_page * HV_PAGE_SIZE,
+                    &self.vp.translation_registers(Vtl::Vtl0),
+                    flags,
+                );
+
+                match result {
+                    Ok(TranslateResult { gpa, cache_info: _ }) => {
+                        hvdef::hypercall::TranslateVirtualAddressExOutputX64 {
+                            gpa_page: gpa / HV_PAGE_SIZE,
+                            ..FromZeros::new_zeroed()
+                        }
+                    }
+                    Err(err) => hvdef::hypercall::TranslateVirtualAddressExOutputX64 {
+                        translation_result: hvdef::hypercall::TranslateGvaResultExX64 {
+                            result: hvdef::hypercall::TranslateGvaResult::new()
+                                .with_result_code(TranslateGvaResultCode::from(err).0),
+                            ..FromZeros::new_zeroed()
+                        },
+                        ..FromZeros::new_zeroed()
+                    },
+                }
             };
 
             Ok(result)

--- a/vmm_core/virt_whp/src/hypercalls.rs
+++ b/vmm_core/virt_whp/src/hypercalls.rs
@@ -1314,7 +1314,9 @@ mod x86 {
                 // Validate and normalize the control flags the same way as the
                 // non-nested path so that unsupported/reserved bits still return
                 // `HvError::InvalidParameter` rather than being silently ignored,
-                // then build the WHP flags from the validated result.
+                // then build the WHP flags from the validated result. Controls
+                // that `WHvTranslateGva` cannot represent (an explicit
+                // user/supervisor access mode) are rejected rather than dropped.
                 let translate_flags = convert_translate_control_flags(control_flags)?;
 
                 let mut flags = whp::abi::WHvTranslateGvaFlagNone;
@@ -1327,11 +1329,35 @@ mod x86 {
                 if translate_flags.validate_execute {
                     flags |= whp::abi::WHvTranslateGvaFlagValidateExecute;
                 }
-                if matches!(
-                    translate_flags.privilege_check,
-                    TranslatePrivilegeCheck::None
-                ) {
-                    flags |= whp::abi::WHvTranslateGvaFlagPrivilegeExempt;
+                match translate_flags.privilege_check {
+                    // No privilege checks: exempt the walk from access-mode
+                    // enforcement.
+                    TranslatePrivilegeCheck::None => {
+                        flags |= whp::abi::WHvTranslateGvaFlagPrivilegeExempt;
+                    }
+                    // Check against the VP's current privilege level. This is
+                    // `WHvTranslateGva`'s default behavior when no privilege
+                    // flag is set, so there is nothing to map.
+                    TranslatePrivilegeCheck::CurrentPrivilegeLevel => {}
+                    // WHP has no way to request an explicit user- or
+                    // supervisor-mode access independent of the current CPL, so
+                    // these controls cannot be honored under nested virt.
+                    //
+                    // TODO: `WHvTranslateGva` exposes no equivalent of the
+                    // `USER_ACCESS`/`SUPERVISOR_ACCESS` hypercall flags. No
+                    // in-tree caller sets them today, so reject them rather than
+                    // silently translating with different privilege semantics.
+                    TranslatePrivilegeCheck::User
+                    | TranslatePrivilegeCheck::Supervisor
+                    | TranslatePrivilegeCheck::Both => {
+                        return Err(HvError::InvalidParameter);
+                    }
+                }
+                if translate_flags.override_smap {
+                    flags |= whp::abi::WHvTranslateGvaFlagOverrideSmap;
+                }
+                if translate_flags.enforce_smap {
+                    flags |= whp::abi::WHvTranslateGvaFlagEnforceSmap;
                 }
                 if translate_flags.set_page_table_bits {
                     flags |= whp::abi::WHvTranslateGvaFlagSetPageTableBits;

--- a/vmm_core/virt_whp/src/hypercalls.rs
+++ b/vmm_core/virt_whp/src/hypercalls.rs
@@ -736,6 +736,7 @@ mod x86 {
     use virt::VpIndex;
 
     use virt_support_x86emu::translate::TranslateFlags;
+    use virt_support_x86emu::translate::TranslatePrivilegeCheck;
     use virt_support_x86emu::translate::TranslateResult;
     use virt_support_x86emu::translate::translate_gva_to_gpa;
     use vmcore::vpci_msi::VpciInterruptParameters;
@@ -1309,20 +1310,30 @@ mod x86 {
                 // walker cannot account for the hypervisor's nested paging
                 // state, so defer the translation to the hypervisor via
                 // `WHvTranslateGva`.
+                //
+                // Validate and normalize the control flags the same way as the
+                // non-nested path so that unsupported/reserved bits still return
+                // `HvError::InvalidParameter` rather than being silently ignored,
+                // then build the WHP flags from the validated result.
+                let translate_flags = convert_translate_control_flags(control_flags)?;
+
                 let mut flags = whp::abi::WHvTranslateGvaFlagNone;
-                if control_flags.validate_read() {
+                if translate_flags.validate_read {
                     flags |= whp::abi::WHvTranslateGvaFlagValidateRead;
                 }
-                if control_flags.validate_write() {
+                if translate_flags.validate_write {
                     flags |= whp::abi::WHvTranslateGvaFlagValidateWrite;
                 }
-                if control_flags.validate_execute() {
+                if translate_flags.validate_execute {
                     flags |= whp::abi::WHvTranslateGvaFlagValidateExecute;
                 }
-                if control_flags.privilege_exempt() {
+                if matches!(
+                    translate_flags.privilege_check,
+                    TranslatePrivilegeCheck::None
+                ) {
                     flags |= whp::abi::WHvTranslateGvaFlagPrivilegeExempt;
                 }
-                if control_flags.set_page_table_bits() {
+                if translate_flags.set_page_table_bits {
                     flags |= whp::abi::WHvTranslateGvaFlagSetPageTableBits;
                 }
 


### PR DESCRIPTION
The emulator and the TranslateVirtualAddressEx hypercall handler both translated guest virtual addresses with the software page table walker, which reads the guest's page tables directly out of the L1 GPA space. When nested virtualization is active and the VP is running an L2 guest, that is incorrect: an L2 GVA requires a two-dimensional walk that also traverses the L1-programmed nested paging (SLAT) structures, and the software walker has no knowledge of that second dimension. It would read L2 page tables as though their PFNs were L1 GPAs and produce garbage.

Route translation through WHvTranslateGva when nested virt is enabled so the hypervisor performs the walk in the VP's current context and accounts for nested state. The non-nested path keeps the software walker, which is correct and cheaper there.

WHvTranslateGva cannot surface the hypervisor's pending event, so a nested page-table violation (an L2 page table page missing from the L1's SLAT) cannot be reflected to L1 as a nested memory intercept; the translation fails and the emulation aborts (the VP halts). This is acceptable for now because the condition is rare and requires L2 to access an L0-emulated resource with its page tables not resident in the L1 SLAT. The tradeoff and the future strategies (reflect the intercept once WHP exposes the event, or resume-and-retry with a bound) are documented in the code.