### PR TITLE
petri: default guest RAM to private memory

### DIFF
--- a/petri/burette/src/tests/boot_time.rs
+++ b/petri/burette/src/tests/boot_time.rs
@@ -79,6 +79,18 @@ impl BootProfile {
                     }
                 })
             });
+        } else {
+            // Guest RAM defaults to private memory; force shared memory for
+            // the non-private profiles so they measure the shared backing.
+            builder = builder.modify_backend(|c| {
+                c.with_custom_config(|c| {
+                    for node in &mut c.numa.nodes {
+                        if let Some(mem) = &mut node.mem {
+                            mem.private_memory = false;
+                        }
+                    }
+                })
+            });
         }
 
         if self.uses_quiet_serial() {

--- a/petri/burette/src/tests/boot_time.rs
+++ b/petri/burette/src/tests/boot_time.rs
@@ -231,7 +231,7 @@ impl crate::harness::ColdPerfTest for BootTimeTest {
             })
             .with_memory(petri::MemoryConfig {
                 startup_bytes: self.mem_mb * 1024 * 1024,
-                private_memory: self.profile.uses_private_memory(),
+                private_memory: Some(self.profile.uses_private_memory()),
                 ..Default::default()
             });
 

--- a/petri/burette/src/tests/boot_time.rs
+++ b/petri/burette/src/tests/boot_time.rs
@@ -52,11 +52,13 @@ impl BootProfile {
     /// Create a VM builder configured for this profile.
     ///
     /// Uses `PetriVmBuilder::minimal()` for minimal profiles and
-    /// `PetriVmBuilder::new()` for standard profiles, applying
-    /// profile-specific configuration (private memory, quiet serial).
+    /// `PetriVmBuilder::new()` for standard profiles, applying the
+    /// quiet-serial cmdline tweak for the `QuietSerial` profile.
     ///
-    /// The caller is responsible for setting topology, memory size,
-    /// and attaching an initrd (for minimal profiles).
+    /// The caller is responsible for setting topology, memory size and
+    /// backing (pass `MemoryConfig::private_memory` from
+    /// [`BootProfile::uses_private_memory`]), and attaching an initrd
+    /// (for minimal profiles).
     pub fn create_builder(
         &self,
         params: petri::PetriTestParams<'_>,
@@ -69,30 +71,7 @@ impl BootProfile {
             petri::PetriVmBuilder::new(params, artifacts, driver)?
         };
 
-        if self.uses_private_memory() {
-            builder = builder.modify_backend(|c| {
-                c.with_custom_config(|c| {
-                    for node in &mut c.numa.nodes {
-                        if let Some(mem) = &mut node.mem {
-                            mem.private_memory = true;
-                        }
-                    }
-                })
-            });
-        } else {
-            // Guest RAM defaults to private memory; force shared memory for
-            // the non-private profiles so they measure the shared backing.
-            builder = builder.modify_backend(|c| {
-                c.with_custom_config(|c| {
-                    for node in &mut c.numa.nodes {
-                        if let Some(mem) = &mut node.mem {
-                            mem.private_memory = false;
-                        }
-                    }
-                })
-            });
-        }
-
+        // Memory backing is selected by the caller via `with_memory`.
         if self.uses_quiet_serial() {
             builder = builder.modify_backend(|c| {
                 c.with_custom_config(|c| {
@@ -252,6 +231,7 @@ impl crate::harness::ColdPerfTest for BootTimeTest {
             })
             .with_memory(petri::MemoryConfig {
                 startup_bytes: self.mem_mb * 1024 * 1024,
+                private_memory: self.profile.uses_private_memory(),
                 ..Default::default()
             });
 

--- a/petri/burette/src/tests/memory.rs
+++ b/petri/burette/src/tests/memory.rs
@@ -80,6 +80,7 @@ impl crate::harness::ColdPerfTest for MemoryTest {
             })
             .with_memory(petri::MemoryConfig {
                 startup_bytes: self.mem_mb * 1024 * 1024,
+                private_memory: self.profile.uses_private_memory(),
                 ..Default::default()
             });
 

--- a/petri/burette/src/tests/memory.rs
+++ b/petri/burette/src/tests/memory.rs
@@ -80,7 +80,7 @@ impl crate::harness::ColdPerfTest for MemoryTest {
             })
             .with_memory(petri::MemoryConfig {
                 startup_bytes: self.mem_mb * 1024 * 1024,
-                private_memory: self.profile.uses_private_memory(),
+                private_memory: Some(self.profile.uses_private_memory()),
                 ..Default::default()
             });
 

--- a/petri/burette/src/tests/scale_boot.rs
+++ b/petri/burette/src/tests/scale_boot.rs
@@ -269,7 +269,7 @@ fn make_builder(
         })
         .with_memory(petri::MemoryConfig {
             startup_bytes: test.mem_mb * 1024 * 1024,
-            private_memory: test.profile.uses_private_memory(),
+            private_memory: Some(test.profile.uses_private_memory()),
             ..Default::default()
         }))
 }

--- a/petri/burette/src/tests/scale_boot.rs
+++ b/petri/burette/src/tests/scale_boot.rs
@@ -269,6 +269,7 @@ fn make_builder(
         })
         .with_memory(petri::MemoryConfig {
             startup_bytes: test.mem_mb * 1024 * 1024,
+            private_memory: test.profile.uses_private_memory(),
             ..Default::default()
         }))
 }

--- a/petri/src/vm/mod.rs
+++ b/petri/src/vm/mod.rs
@@ -2299,6 +2299,16 @@ pub struct MemoryConfig {
     ///
     /// Only applies to the OpenVMM backend; ignored by Hyper-V.
     pub private_memory: bool,
+    /// Mark private guest RAM as eligible for Transparent Huge Pages (THP),
+    /// improving performance for large allocations.
+    ///
+    /// Defaults to `true`. Only takes effect when the guest RAM is backed by
+    /// private anonymous memory (see [`Self::private_memory`]) and only on
+    /// Linux; it is silently ignored otherwise (shared memory, hugetlb/file
+    /// backing, OpenHCL, PCAT/Gen1, or non-Linux hosts).
+    ///
+    /// Only applies to the OpenVMM backend; ignored by Hyper-V.
+    pub transparent_hugepages: bool,
 }
 
 impl Default for MemoryConfig {
@@ -2308,6 +2318,7 @@ impl Default for MemoryConfig {
             dynamic_memory_range: None,
             numa_mem_sizes: None,
             private_memory: true,
+            transparent_hugepages: true,
         }
     }
 }

--- a/petri/src/vm/mod.rs
+++ b/petri/src/vm/mod.rs
@@ -2293,7 +2293,9 @@ pub struct MemoryConfig {
     /// RAM backing to be shareable with another process, such as vhost-user
     /// backends. Note that `with_hugepages` and `with_memory_backing_file`
     /// force shared memory regardless of this setting, since they require a
-    /// file-backed mapping.
+    /// file-backed mapping. Private memory is also forced off for OpenHCL
+    /// (which shares VTL0 RAM with VTL2 via a remote mapper) and PCAT/Gen1
+    /// (which relies on x86 legacy support), since both require shared memory.
     ///
     /// Only applies to the OpenVMM backend; ignored by Hyper-V.
     pub private_memory: bool,

--- a/petri/src/vm/mod.rs
+++ b/petri/src/vm/mod.rs
@@ -2286,19 +2286,25 @@ pub struct MemoryConfig {
     /// Per-NUMA-node memory sizes. When set, RAM is distributed across
     /// vNUMA nodes instead of assigning all RAM to node 0.
     pub numa_mem_sizes: Option<Vec<u64>>,
-    /// Back guest RAM with private anonymous memory rather than a shared
-    /// (file/memfd-backed) memory section.
+    /// Whether to back guest RAM with private anonymous memory rather than a
+    /// shared (file/memfd-backed) memory section.
     ///
-    /// Defaults to `true`. Set to `false` for tests that require the guest
-    /// RAM backing to be shareable with another process, such as vhost-user
-    /// backends. Note that `with_hugepages` and `with_memory_backing_file`
-    /// force shared memory regardless of this setting, since they require a
-    /// file-backed mapping. Private memory is also forced off for OpenHCL
-    /// (which shares VTL0 RAM with VTL2 via a remote mapper) and PCAT/Gen1
-    /// (which relies on x86 legacy support), since both require shared memory.
+    /// - `None` (the default) uses private memory whenever the configuration
+    ///   allows it, falling back to shared memory otherwise. Private anonymous
+    ///   memory is cheaper to set up and eligible for Transparent Huge Pages,
+    ///   so it is preferred for performance; this lets each VM get the best
+    ///   backing for its firmware without the test having to know the details.
+    /// - `Some(true)` explicitly requires private memory. This is an error if
+    ///   the configuration is incompatible with private memory (OpenHCL, which
+    ///   shares VTL0 RAM with VTL2 via a remote mapper, and PCAT/Gen1, which
+    ///   relies on x86 legacy support, both require shared memory), rather than
+    ///   silently downgrading to shared.
+    /// - `Some(false)` explicitly requires shared memory, for tests that need
+    ///   the guest RAM backing to be shareable with another process, such as
+    ///   vhost-user backends.
     ///
     /// Only applies to the OpenVMM backend; ignored by Hyper-V.
-    pub private_memory: bool,
+    pub private_memory: Option<bool>,
     /// Mark private guest RAM as eligible for Transparent Huge Pages (THP),
     /// improving performance for large allocations.
     ///
@@ -2317,7 +2323,7 @@ impl Default for MemoryConfig {
             startup_bytes: 4 * 1024 * 1024 * 1024, // 4 GiB
             dynamic_memory_range: None,
             numa_mem_sizes: None,
-            private_memory: true,
+            private_memory: None,
             transparent_hugepages: true,
         }
     }

--- a/petri/src/vm/mod.rs
+++ b/petri/src/vm/mod.rs
@@ -2286,6 +2286,17 @@ pub struct MemoryConfig {
     /// Per-NUMA-node memory sizes. When set, RAM is distributed across
     /// vNUMA nodes instead of assigning all RAM to node 0.
     pub numa_mem_sizes: Option<Vec<u64>>,
+    /// Back guest RAM with private anonymous memory rather than a shared
+    /// (file/memfd-backed) memory section.
+    ///
+    /// Defaults to `true`. Set to `false` for tests that require the guest
+    /// RAM backing to be shareable with another process, such as vhost-user
+    /// backends. Note that `with_hugepages` and `with_memory_backing_file`
+    /// force shared memory regardless of this setting, since they require a
+    /// file-backed mapping.
+    ///
+    /// Only applies to the OpenVMM backend; ignored by Hyper-V.
+    pub private_memory: bool,
 }
 
 impl Default for MemoryConfig {
@@ -2294,6 +2305,7 @@ impl Default for MemoryConfig {
             startup_bytes: 4 * 1024 * 1024 * 1024, // 4 GiB
             dynamic_memory_range: None,
             numa_mem_sizes: None,
+            private_memory: true,
         }
     }
 }

--- a/petri/src/vm/openvmm/construct.rs
+++ b/petri/src/vm/openvmm/construct.rs
@@ -423,6 +423,10 @@ impl PetriVmConfigOpenVmm {
             .build()
             .context("failed to build chipset configuration")?;
 
+        // Preserve the caller's explicit private-memory request so that backend
+        // methods which force shared memory can fail on an explicit conflict.
+        let requested_private_memory = memory.private_memory;
+
         let numa = {
             let MemoryConfig {
                 startup_bytes,
@@ -443,9 +447,22 @@ impl PetriVmConfigOpenVmm {
             // - PCAT (Gen1) relies on x86 legacy support (the VGA hole and
             //   PAM registers), which toggles low RAM visibility in a way
             //   that requires shared, file-backed memory.
-            // Force shared memory in these cases regardless of the requested
-            // setting.
-            let private_memory = private_memory && !firmware.is_openhcl() && !firmware.is_pcat();
+            let private_incompatible = firmware.is_openhcl() || firmware.is_pcat();
+            let private_memory = match private_memory {
+                // An explicit request for private memory that the firmware
+                // cannot honor is an error, rather than a silent downgrade.
+                Some(true) if private_incompatible => {
+                    anyhow::bail!(
+                        "private guest memory was explicitly requested but is \
+                         not supported with this firmware (OpenHCL and \
+                         PCAT/Gen1 require shared memory)"
+                    );
+                }
+                Some(explicit) => explicit,
+                // Default: prefer private memory for performance, falling back
+                // to shared when the firmware requires it.
+                None => !private_incompatible,
+            };
 
             // THP is only valid for private anonymous memory and only on
             // Linux; disable it otherwise to avoid a memory build error.
@@ -732,6 +749,7 @@ impl PetriVmConfigOpenVmm {
             openvmm_log_file: log_source.log_file("openvmm")?,
 
             memory_backing_file: None,
+            requested_private_memory,
 
             ged,
             framebuffer_view,

--- a/petri/src/vm/openvmm/construct.rs
+++ b/petri/src/vm/openvmm/construct.rs
@@ -435,6 +435,17 @@ impl PetriVmConfigOpenVmm {
                 anyhow::bail!("dynamic memory not supported in OpenVMM");
             }
 
+            // Private (anonymous) guest memory is incompatible with two
+            // OpenVMM features that petri enables based on the firmware:
+            // - OpenHCL uses a remote VA mapper to share VTL0 RAM with VTL2,
+            //   which requires a shareable memory section.
+            // - PCAT (Gen1) relies on x86 legacy support (the VGA hole and
+            //   PAM registers), which toggles low RAM visibility in a way
+            //   that requires shared, file-backed memory.
+            // Force shared memory in these cases regardless of the requested
+            // setting.
+            let private_memory = private_memory && !firmware.is_openhcl() && !firmware.is_pcat();
+
             let make_mem = |size: u64| openvmm_defs::config::MemoryConfig {
                 mem_size: size,
                 prefetch_memory: false,

--- a/petri/src/vm/openvmm/construct.rs
+++ b/petri/src/vm/openvmm/construct.rs
@@ -428,6 +428,7 @@ impl PetriVmConfigOpenVmm {
                 startup_bytes,
                 dynamic_memory_range,
                 numa_mem_sizes,
+                private_memory,
             } = memory;
 
             if dynamic_memory_range.is_some() {
@@ -437,7 +438,7 @@ impl PetriVmConfigOpenVmm {
             let make_mem = |size: u64| openvmm_defs::config::MemoryConfig {
                 mem_size: size,
                 prefetch_memory: false,
-                private_memory: false,
+                private_memory,
                 transparent_hugepages: false,
                 hugepages: false,
                 hugepage_size: None,

--- a/petri/src/vm/openvmm/construct.rs
+++ b/petri/src/vm/openvmm/construct.rs
@@ -429,6 +429,7 @@ impl PetriVmConfigOpenVmm {
                 dynamic_memory_range,
                 numa_mem_sizes,
                 private_memory,
+                transparent_hugepages,
             } = memory;
 
             if dynamic_memory_range.is_some() {
@@ -446,11 +447,16 @@ impl PetriVmConfigOpenVmm {
             // setting.
             let private_memory = private_memory && !firmware.is_openhcl() && !firmware.is_pcat();
 
+            // THP is only valid for private anonymous memory and only on
+            // Linux; disable it otherwise to avoid a memory build error.
+            let transparent_hugepages =
+                transparent_hugepages && private_memory && cfg!(target_os = "linux");
+
             let make_mem = |size: u64| openvmm_defs::config::MemoryConfig {
                 mem_size: size,
                 prefetch_memory: false,
                 private_memory,
-                transparent_hugepages: false,
+                transparent_hugepages,
                 hugepages: false,
                 hugepage_size: None,
                 host_numa_node: None,

--- a/petri/src/vm/openvmm/mod.rs
+++ b/petri/src/vm/openvmm/mod.rs
@@ -171,6 +171,13 @@ pub struct PetriVmConfigOpenVmm {
     // File-backed guest memory.
     memory_backing_file: Option<PathBuf>,
 
+    // The private-memory setting explicitly requested via
+    // `MemoryConfig::private_memory`, preserved so that backend methods which
+    // force shared memory (e.g. `with_hugepages`, `with_memory_backing_file`)
+    // can fail when the caller explicitly asked for private memory rather than
+    // silently downgrading it.
+    requested_private_memory: Option<bool>,
+
     // Resources that are only used during startup.
     ged: Option<get_resources::ged::GuestEmulationDeviceHandle>,
     framebuffer_view: Option<framebuffer::View>,

--- a/petri/src/vm/openvmm/modify.rs
+++ b/petri/src/vm/openvmm/modify.rs
@@ -335,17 +335,29 @@ impl PetriVmConfigOpenVmm {
     /// The file at the given path will be created (or opened) and sized to
     /// match the VM's configured memory. Guest memory is then backed by
     /// this file, which persists across snapshot save/restore.
+    ///
+    /// This forces shared (non-private) memory, since a file-backed mapping
+    /// is incompatible with private anonymous RAM.
     pub fn with_memory_backing_file(mut self, path: impl Into<std::path::PathBuf>) -> Self {
         self.memory_backing_file = Some(path.into());
+        for node in &mut self.config.numa.nodes {
+            if let Some(mem) = &mut node.mem {
+                mem.private_memory = false;
+            }
+        }
         self
     }
 
     /// Use explicit hugetlb-backed guest memory.
+    ///
+    /// This forces shared (non-private) memory, since hugetlb backing
+    /// requires a file-backed mapping rather than private anonymous RAM.
     pub fn with_hugepages(mut self, hugepage_size: Option<u64>) -> Self {
         for node in &mut self.config.numa.nodes {
             if let Some(mem) = &mut node.mem {
                 mem.hugepages = true;
                 mem.hugepage_size = hugepage_size;
+                mem.private_memory = false;
             }
         }
         self

--- a/petri/src/vm/openvmm/modify.rs
+++ b/petri/src/vm/openvmm/modify.rs
@@ -343,6 +343,7 @@ impl PetriVmConfigOpenVmm {
         for node in &mut self.config.numa.nodes {
             if let Some(mem) = &mut node.mem {
                 mem.private_memory = false;
+                mem.transparent_hugepages = false;
             }
         }
         self
@@ -358,6 +359,7 @@ impl PetriVmConfigOpenVmm {
                 mem.hugepages = true;
                 mem.hugepage_size = hugepage_size;
                 mem.private_memory = false;
+                mem.transparent_hugepages = false;
             }
         }
         self

--- a/petri/src/vm/openvmm/modify.rs
+++ b/petri/src/vm/openvmm/modify.rs
@@ -337,8 +337,17 @@ impl PetriVmConfigOpenVmm {
     /// this file, which persists across snapshot save/restore.
     ///
     /// This forces shared (non-private) memory, since a file-backed mapping
-    /// is incompatible with private anonymous RAM.
+    /// is incompatible with private anonymous RAM. Panics if the caller
+    /// explicitly requested private memory via
+    /// [`MemoryConfig::private_memory`](crate::MemoryConfig::private_memory),
+    /// rather than silently downgrading it.
     pub fn with_memory_backing_file(mut self, path: impl Into<std::path::PathBuf>) -> Self {
+        assert_ne!(
+            self.requested_private_memory,
+            Some(true),
+            "with_memory_backing_file forces shared memory, which conflicts with \
+             the explicitly requested private memory"
+        );
         self.memory_backing_file = Some(path.into());
         for node in &mut self.config.numa.nodes {
             if let Some(mem) = &mut node.mem {
@@ -353,7 +362,16 @@ impl PetriVmConfigOpenVmm {
     ///
     /// This forces shared (non-private) memory, since hugetlb backing
     /// requires a file-backed mapping rather than private anonymous RAM.
+    /// Panics if the caller explicitly requested private memory via
+    /// [`MemoryConfig::private_memory`](crate::MemoryConfig::private_memory),
+    /// rather than silently downgrading it.
     pub fn with_hugepages(mut self, hugepage_size: Option<u64>) -> Self {
+        assert_ne!(
+            self.requested_private_memory,
+            Some(true),
+            "with_hugepages forces shared memory, which conflicts with the \
+             explicitly requested private memory"
+        );
         for node in &mut self.config.numa.nodes {
             if let Some(mem) = &mut node.mem {
                 mem.hugepages = true;

--- a/petri/src/vm/openvmm/start.rs
+++ b/petri/src/vm/openvmm/start.rs
@@ -40,6 +40,7 @@ impl PetriVmConfigOpenVmm {
             openvmm_log_file,
 
             memory_backing_file,
+            requested_private_memory: _,
 
             ged,
             framebuffer_view,
@@ -118,6 +119,31 @@ impl PetriVmConfigOpenVmm {
                 openvmm_helpers::shared_memory::open_memory_backing_file(mem_path, total_mem_size)
             })
             .transpose()?;
+
+        // Log the resolved guest RAM backing mode for diagnostics. Read from
+        // the final config so it reflects any backend overrides (e.g.
+        // `with_hugepages` / `with_memory_backing_file` forcing shared). Log
+        // per node, since NUMA nodes can have heterogeneous backings.
+        for (node, mem) in config
+            .numa
+            .nodes
+            .iter()
+            .enumerate()
+            .filter_map(|(i, n)| n.mem.as_ref().map(|m| (i, m)))
+        {
+            tracing::info!(
+                node,
+                mem_size = mem.mem_size,
+                backing_mode = if mem.private_memory {
+                    "private"
+                } else {
+                    "shared"
+                },
+                transparent_hugepages = mem.transparent_hugepages,
+                hugepages = mem.hugepages,
+                "guest RAM backing"
+            );
+        }
 
         let (worker, halt_notif) = Worker::launch(&host, config, shared_memory)
             .await

--- a/vmm_tests/vmm_tests/tests/tests/multiarch.rs
+++ b/vmm_tests/vmm_tests/tests/tests/multiarch.rs
@@ -168,21 +168,17 @@ async fn smbios_dmi(config: PetriVmBuilder<OpenVmmPetriBackend>) -> anyhow::Resu
     Ok(())
 }
 
-/// Boot with private anonymous memory instead of shared memory sections.
+/// Boot with shared (file/memfd-backed) memory sections instead of the
+/// default private anonymous memory.
 #[openvmm_test(
     linux_direct_x64,
     // TODO: add linux_direct_aarch64 (GH #1798)
 )]
-async fn boot_private_memory(config: PetriVmBuilder<OpenVmmPetriBackend>) -> anyhow::Result<()> {
+async fn boot_shared_memory(config: PetriVmBuilder<OpenVmmPetriBackend>) -> anyhow::Result<()> {
     let (vm, agent) = config
-        .modify_backend(|b| {
-            b.with_custom_config(|c| {
-                for node in &mut c.numa.nodes {
-                    if let Some(mem) = &mut node.mem {
-                        mem.private_memory = true;
-                    }
-                }
-            })
+        .with_memory(MemoryConfig {
+            private_memory: false,
+            ..Default::default()
         })
         .run()
         .await?;
@@ -922,6 +918,12 @@ async fn vhost_user_blk_device<T>(
     .into_resource();
 
     let (vm, agent) = config
+        // vhost-user requires the guest RAM backing to be shareable with the
+        // backend process, so opt out of the default private memory.
+        .with_memory(MemoryConfig {
+            private_memory: false,
+            ..Default::default()
+        })
         .modify_backend(move |b| {
             b.with_custom_config(|c| {
                 c.virtio_devices.push((VirtioBus::Mmio, vhost_resource));

--- a/vmm_tests/vmm_tests/tests/tests/multiarch.rs
+++ b/vmm_tests/vmm_tests/tests/tests/multiarch.rs
@@ -177,7 +177,7 @@ async fn smbios_dmi(config: PetriVmBuilder<OpenVmmPetriBackend>) -> anyhow::Resu
 async fn boot_shared_memory(config: PetriVmBuilder<OpenVmmPetriBackend>) -> anyhow::Result<()> {
     let (vm, agent) = config
         .with_memory(MemoryConfig {
-            private_memory: false,
+            private_memory: Some(false),
             ..Default::default()
         })
         .run()
@@ -921,7 +921,7 @@ async fn vhost_user_blk_device<T>(
         // vhost-user requires the guest RAM backing to be shareable with the
         // backend process, so opt out of the default private memory.
         .with_memory(MemoryConfig {
-            private_memory: false,
+            private_memory: Some(false),
             ..Default::default()
         })
         .modify_backend(move |b| {

--- a/vmm_tests/vmm_tests/tests/tests/multiarch/memstat.rs
+++ b/vmm_tests/vmm_tests/tests/tests/multiarch/memstat.rs
@@ -403,8 +403,7 @@ async fn idle_test<T: PetriVmmBackend>(
         .with_memory({
             MemoryConfig {
                 startup_bytes: 16 * (1024 * 1024 * 1024),
-                dynamic_memory_range: None,
-                numa_mem_sizes: None,
+                ..Default::default()
             }
         })
         .with_openhcl_log_levels(OpenvmmLogConfig::BuiltInDefault)

--- a/vmm_tests/vmm_tests/tests/tests/multiarch/numa.rs
+++ b/vmm_tests/vmm_tests/tests/tests/multiarch/numa.rs
@@ -23,11 +23,11 @@ use vmm_test_macros::openvmm_test;
 const SIZE_1_GB: u64 = 1024 * 1024 * 1024;
 const SIZE_2_GB: u64 = 2 * SIZE_1_GB;
 
-fn make_mem(size: u64) -> MemoryConfig {
+fn make_mem(size: u64, private_memory: bool) -> MemoryConfig {
     MemoryConfig {
         mem_size: size,
         prefetch_memory: false,
-        private_memory: false,
+        private_memory,
         transparent_hugepages: false,
         hugepages: false,
         hugepage_size: None,
@@ -103,8 +103,8 @@ async fn boot_numa_two_nodes(config: PetriVmBuilder<OpenVmmPetriBackend>) -> any
     let (vm, agent) = config
         .with_memory(petri::MemoryConfig {
             startup_bytes: SIZE_2_GB * 2,
-            dynamic_memory_range: None,
             numa_mem_sizes: Some(vec![SIZE_2_GB, SIZE_2_GB]),
+            ..Default::default()
         })
         .with_processor_topology(petri::ProcessorTopology {
             vp_count: 4,
@@ -144,10 +144,13 @@ async fn boot_numa_two_nodes(config: PetriVmBuilder<OpenVmmPetriBackend>) -> any
 /// Boot a 4-node NUMA VM with asymmetric memory, a CPU-only node, a
 /// memory-only node, explicit VP assignment, and custom SLIT distances.
 ///
-/// - Node 0: 1 GB RAM, VPs [0, 1]
-/// - Node 1: 2 GB RAM, VPs [2, 3]
+/// - Node 0: 1 GB RAM, VPs [0, 1] (private memory)
+/// - Node 1: 2 GB RAM, VPs [2, 3] (shared memory)
 /// - Node 2: no memory, VPs [4, 5] (CPU-only)
-/// - Node 3: 1 GB RAM, no VPs (memory-only)
+/// - Node 3: 1 GB RAM, no VPs (memory-only, private memory)
+///
+/// The mix of private and shared per-node backing also exercises the
+/// memory manager building heterogeneous RAM backings in one VM.
 ///
 /// Custom distances: 10 self, 15/25/30 between select pairs.
 #[openvmm_test(linux_direct_x64, linux_direct_aarch64)]
@@ -164,14 +167,14 @@ async fn boot_numa_complex_topology(
             b.with_custom_config(|c| {
                 c.numa = NumaTopology {
                     nodes: vec![
-                        // Node 0: 1 GB, VPs 0-1
+                        // Node 0: 1 GB, VPs 0-1 (private memory)
                         NumaNode {
-                            mem: Some(make_mem(SIZE_1_GB)),
+                            mem: Some(make_mem(SIZE_1_GB, true)),
                             vps: VpAssignment::Explicit(vec![0, 1]),
                         },
-                        // Node 1: 2 GB, VPs 2-3
+                        // Node 1: 2 GB, VPs 2-3 (shared memory)
                         NumaNode {
-                            mem: Some(make_mem(SIZE_2_GB)),
+                            mem: Some(make_mem(SIZE_2_GB, false)),
                             vps: VpAssignment::Explicit(vec![2, 3]),
                         },
                         // Node 2: CPU-only (no memory), VPs 4-5
@@ -179,9 +182,9 @@ async fn boot_numa_complex_topology(
                             mem: None,
                             vps: VpAssignment::Explicit(vec![4, 5]),
                         },
-                        // Node 3: memory-only (1 GB), no VPs
+                        // Node 3: memory-only (1 GB), no VPs (private memory)
                         NumaNode {
-                            mem: Some(make_mem(SIZE_1_GB)),
+                            mem: Some(make_mem(SIZE_1_GB, true)),
                             vps: VpAssignment::Empty,
                         },
                     ],
@@ -314,11 +317,11 @@ async fn pcie_device_numa_affinity(
                 c.numa = NumaTopology {
                     nodes: vec![
                         NumaNode {
-                            mem: Some(make_mem(SIZE_2_GB)),
+                            mem: Some(make_mem(SIZE_2_GB, true)),
                             vps: VpAssignment::Explicit(vec![0, 1]),
                         },
                         NumaNode {
-                            mem: Some(make_mem(SIZE_2_GB)),
+                            mem: Some(make_mem(SIZE_2_GB, true)),
                             vps: VpAssignment::Explicit(vec![2, 3]),
                         },
                     ],


### PR DESCRIPTION
Guest RAM in petri tests was always backed by a shared (file/memfd-backed) memory section. Switch the default to private anonymous memory, which is both cheaper to set up and, more importantly, eligible for transparent huge pages. Building on that, also default petri's `MemoryConfig` to mark private guest RAM as THP-eligible, matching the capability the CLI and RPC paths already expose so that petri VMs actually benefit from THP. THP is only valid for private anonymous memory and only on Linux, so it is silently gated off whenever the backing falls back to shared memory or the host isn't Linux. This pairs with PR 3927 (enable THP by default): the kernel readily promotes private anonymous guest RAM to huge pages, whereas THP on shared memfd/tmpfs mappings depends on the shmem policy and often has no effect, so private memory is what actually lets petri VMs benefit from THP-by-default.

Shared memory is still needed whenever the guest RAM must be mappable outside the VMM process or as a file: vhost-user backends, hugetlb backing, and file-backed memory used for snapshot save/restore. The vhost-user test now requests shared memory explicitly, and the with_hugepages and with_memory_backing_file helpers force it on since those mappings are incompatible with private anonymous RAM, clearing the THP flag along with it. The boot-time perf profiles that document a shared backing continue to request it so they keep measuring the same thing, and now select their memory backing through the typed with_memory API rather than a second modify_backend closure.

For coverage of the non-default path, the former boot_private_memory test becomes boot_shared_memory, and the complex NUMA topology test now mixes private and shared per-node backings to exercise the memory manager building heterogeneous RAM backings within a single VM.