### PR TITLE
opentmk: drop nightly requirement for interrupt handling

### DIFF
--- a/opentmk/build.rs
+++ b/opentmk/build.rs
@@ -1,9 +1,0 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
-
-#![expect(missing_docs)]
-
-fn main() {
-    // Allow a cfg of nightly to avoid using a feature, see main.rs.
-    println!("cargo:rustc-check-cfg=cfg(nightly)");
-}

--- a/opentmk/src/arch/x86_64/interrupt.rs
+++ b/opentmk/src/arch/x86_64/interrupt.rs
@@ -1,64 +1,62 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-//! x86_64-specific interrupt handling implementation.
+//! x86_64-specific interrupt handling.
 
 use alloc::boxed::Box;
 
 use spin::Lazy;
 use spin::Mutex;
 use x86_64::structures::idt::InterruptDescriptorTable;
-use x86_64::structures::idt::InterruptStackFrame;
 
 use super::interrupt_handler_register::register_interrupt_handler;
-use super::interrupt_handler_register::set_common_handler;
 
 static IDT: Lazy<InterruptDescriptorTable> = Lazy::new(|| {
     let mut idt = InterruptDescriptorTable::new();
     register_interrupt_handler(&mut idt);
-    idt.double_fault.set_handler_fn(handler_double_fault);
     idt
 });
 
 static mut HANDLERS: [Option<Box<dyn Fn() + 'static>>; 256] = [const { None }; 256];
-static MUTEX: Mutex<()> = Mutex::new(());
+static WRITE_LOCK: Mutex<()> = Mutex::new(());
 
-fn common_handler(_stack_frame: InterruptStackFrame, interrupt: u8) {
-    // SAFETY: Handlers are initialized to None and only set via set_handler which is
-    // protected by a mutex.
-    unsafe {
-        if let Some(handler) = &HANDLERS[interrupt as usize] {
-            handler()
+/// Dispatches to the registered handler for `vector`, if any.
+///
+/// Called from the assembly ISR trampoline with interrupts disabled.
+pub(super) fn dispatch(vector: u8) {
+    // SAFETY: entries are only published by `set_handler` (serialized by
+    // `WRITE_LOCK`, before the corresponding interrupt is armed), and the IDT
+    // gates disable interrupts on entry so this read cannot race a writer.
+    let handlers = unsafe { &*core::ptr::addr_of!(HANDLERS) };
+    if let Some(handler) = handlers[vector as usize].as_ref() {
+        handler();
+        return;
+    }
+    // No handler registered: log so an unexpected fault is not silently
+    // `iretq`'d back into the faulting instruction with no diagnostics.
+    log::error!("unhandled interrupt/exception vector {vector}");
+    // Vectors 8 (#DF) and 18 (#MC) cannot be resumed; returning here would
+    // `iretq` and almost certainly re-fault into a triple fault (silent reset).
+    // Halt instead so the message above survives on the serial log.
+    if matches!(vector, 8 | 18) {
+        loop {
+            x86_64::instructions::hlt();
         }
     }
 }
 
-/// Sets the handler for a specific interrupt number.
+/// Sets the handler for a specific interrupt vector.
 pub fn set_handler(interrupt: u8, handler: Box<dyn Fn() + 'static>) {
-    let _lock = MUTEX.lock();
-    // SAFETY: handlers is protected by a mutex.
-    unsafe {
-        HANDLERS[interrupt as usize] = Some(handler);
-    }
+    let _lock = WRITE_LOCK.lock();
+    // SAFETY: writers are serialized by `WRITE_LOCK`, and `set_handler` runs
+    // during test setup before the corresponding interrupt is armed, so no ISR
+    // reads a partially written entry.
+    let handlers = unsafe { &mut *core::ptr::addr_of_mut!(HANDLERS) };
+    handlers[interrupt as usize] = Some(handler);
 }
 
-extern "x86-interrupt" fn handler_double_fault(
-    stack_frame: InterruptStackFrame,
-    _error_code: u64,
-) -> ! {
-    log::error!(
-        "EXCEPTION:\n\tERROR_CODE: {}\n\tDOUBLE FAULT\n{:#?}",
-        _error_code,
-        stack_frame
-    );
-    loop {
-        core::hint::spin_loop();
-    }
-}
-
-/// Initialize the IDT
+/// Initializes and loads the IDT and enables interrupts.
 pub fn init() {
     IDT.load();
-    set_common_handler(common_handler);
     x86_64::instructions::interrupts::enable();
 }

--- a/opentmk/src/arch/x86_64/interrupt.rs
+++ b/opentmk/src/arch/x86_64/interrupt.rs
@@ -44,8 +44,10 @@ pub(super) fn dispatch(vector: u8) {
 
 /// Sets the handler for a specific interrupt vector.
 pub fn set_handler(interrupt: u8, handler: Box<dyn Fn() + Send + Sync + 'static>) {
-    let mut handlers = HANDLERS.write();
-    handlers[interrupt as usize] = Some(handler);
+    x86_64::instructions::interrupts::without_interrupts(|| {
+        let mut handlers = HANDLERS.write();
+        handlers[interrupt as usize] = Some(handler);
+    });
 }
 
 /// Initializes and loads the IDT and enables interrupts.

--- a/opentmk/src/arch/x86_64/interrupt.rs
+++ b/opentmk/src/arch/x86_64/interrupt.rs
@@ -6,7 +6,7 @@
 use alloc::boxed::Box;
 
 use spin::Lazy;
-use spin::Mutex;
+use spin::RwLock;
 use x86_64::structures::idt::InterruptDescriptorTable;
 
 use super::interrupt_handler_register::register_interrupt_handler;
@@ -17,24 +17,21 @@ static IDT: Lazy<InterruptDescriptorTable> = Lazy::new(|| {
     idt
 });
 
-static mut HANDLERS: [Option<Box<dyn Fn() + 'static>>; 256] = [const { None }; 256];
-static WRITE_LOCK: Mutex<()> = Mutex::new(());
+static HANDLERS: RwLock<[Option<Box<dyn Fn() + Send + Sync + 'static>>; 256]> =
+    RwLock::new([const { None }; 256]);
 
 /// Dispatches to the registered handler for `vector`, if any.
 ///
-/// Called from the assembly ISR trampoline with interrupts disabled.
+/// Called by ISR handler
 pub(super) fn dispatch(vector: u8) {
-    // SAFETY: entries are only published by `set_handler` (serialized by
-    // `WRITE_LOCK`, before the corresponding interrupt is armed), and the IDT
-    // gates disable interrupts on entry so this read cannot race a writer.
-    let handlers = unsafe { &*core::ptr::addr_of!(HANDLERS) };
+    let handlers = HANDLERS.read();
     if let Some(handler) = handlers[vector as usize].as_ref() {
         handler();
         return;
     }
-    // No handler registered: log so an unexpected fault is not silently
-    // `iretq`'d back into the faulting instruction with no diagnostics.
+
     log::error!("unhandled interrupt/exception vector {vector}");
+
     // Vectors 8 (#DF) and 18 (#MC) cannot be resumed; returning here would
     // `iretq` and almost certainly re-fault into a triple fault (silent reset).
     // Halt instead so the message above survives on the serial log.
@@ -46,12 +43,8 @@ pub(super) fn dispatch(vector: u8) {
 }
 
 /// Sets the handler for a specific interrupt vector.
-pub fn set_handler(interrupt: u8, handler: Box<dyn Fn() + 'static>) {
-    let _lock = WRITE_LOCK.lock();
-    // SAFETY: writers are serialized by `WRITE_LOCK`, and `set_handler` runs
-    // during test setup before the corresponding interrupt is armed, so no ISR
-    // reads a partially written entry.
-    let handlers = unsafe { &mut *core::ptr::addr_of_mut!(HANDLERS) };
+pub fn set_handler(interrupt: u8, handler: Box<dyn Fn() + Send + Sync + 'static>) {
+    let mut handlers = HANDLERS.write();
     handlers[interrupt as usize] = Some(handler);
 }
 

--- a/opentmk/src/arch/x86_64/interrupt_handler_register.rs
+++ b/opentmk/src/arch/x86_64/interrupt_handler_register.rs
@@ -21,6 +21,9 @@ use x86_64::structures::idt::InterruptDescriptorTable;
 /// bytes) followed by a `jmp rel32` to `isr_common` (5 bytes).
 const ISR_STUB_LEN: usize = 10;
 
+#[cfg(target_feature = "avx")]
+compile_error!("AVX is not supported by this module");
+
 core::arch::global_asm! {
     ".globl isr_common",
     "isr_common:",
@@ -72,6 +75,9 @@ core::arch::global_asm! {
 
 unsafe extern "C" {
     /// Base of the 256 assembly interrupt entry stubs defined in `global_asm!`.
+    //  SAFETY: ISR0 is used as reference symbol, we don't actually read/write to it,
+    //  the handler operations are already marked as unsafe when handlers defined
+    //  in global_asm are called.
     safe static ISR0: [u8; 256 * ISR_STUB_LEN];
 }
 
@@ -107,9 +113,10 @@ fn has_error_code(vector: u8) -> bool {
 ///
 /// # Safety
 /// Must only be called from `isr_common` with a valid pointer to the saved
-/// [`Frame`] on the interrupt stack.
+/// [`Frame`] on the interrupt stack. Invalid Frame pointers can cause
+/// undefined behavior.
 unsafe extern "sysv64" fn isr_handler(frame: *mut Frame) -> bool {
-    // SAFETY: `isr_common` passes a valid pointer to the saved frame.
+    // SAFETY: Caller guarantees a valid pointer to the saved frame.
     let vector = unsafe { (*frame).vector as u8 };
     super::interrupt::dispatch(vector);
     has_error_code(vector)

--- a/opentmk/src/arch/x86_64/interrupt_handler_register.rs
+++ b/opentmk/src/arch/x86_64/interrupt_handler_register.rs
@@ -1,596 +1,161 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-#![expect(dead_code)]
-use spin::Mutex;
+//! x86_64 interrupt entry stubs and IDT registration.
+//!
+//! Uses assembly interrupt entry stubs (one per vector) that funnel into a
+//! single `extern "sysv64"` handler, so the nightly `abi_x86_interrupt` feature
+//! is not required. Stub addresses are installed into the IDT via the stable
+//! [`x86_64::structures::idt::Entry::set_handler_addr`].
+//!
+//! `isr_common` preserves the full architectural register state across the
+//! handler: the integer GPRs plus x87/SSE state (x87, MXCSR, XMM0-15) via
+//! `fxsave64`/`fxrstor64`. The `x86_64-unknown-uefi` target is built for the
+//! SSE2 baseline (no AVX), so `fxsave64` captures the complete vector state; if
+//! AVX is ever enabled here, switch to `xsave`.
+
+use x86_64::VirtAddr;
 use x86_64::structures::idt::InterruptDescriptorTable;
-use x86_64::structures::idt::InterruptStackFrame;
-use x86_64::structures::idt::PageFaultErrorCode;
-static mut COMMON_HANDLER: fn(InterruptStackFrame, u8) = common_handler;
-static COMMON_HANDLER_MUTEX: Mutex<()> = Mutex::new(());
 
-#[unsafe(no_mangle)]
-fn abstraction_handle(stack_frame: InterruptStackFrame, interrupt: u8) {
-    // SAFETY: COMMON_HANDLER is only set via set_common_handler which is protected by a mutex.
-    unsafe { (COMMON_HANDLER)(stack_frame, interrupt) };
-    log::debug!("Interrupt: {}", interrupt);
+/// Length of each entry in [`ISR0`]: a `push imm32` of the vector number (5
+/// bytes) followed by a `jmp rel32` to `isr_common` (5 bytes).
+const ISR_STUB_LEN: usize = 10;
+
+core::arch::global_asm! {
+    ".globl isr_common",
+    "isr_common:",
+    "push rbp",
+    "push r11",
+    "push r10",
+    "push r9",
+    "push r8",
+    "push rdi",
+    "push rsi",
+    "push rdx",
+    "push rcx",
+    "push rax",
+    "mov rbp, rsp",
+    "mov rdi, rbp",                 // arg0 = pointer to saved Frame
+    "sub rsp, 512",                 // reserve a 512-byte FXSAVE area below the frame
+    "and rsp, 0xfffffffffffffff0",  // 16-byte align it (fxsave requires it; also aligns the call)
+    "fxsave64 [rsp]",               // preserve the interrupted x87/MXCSR/XMM state
+    "call {isr_handler}",
+    "fxrstor64 [rsp]",              // restore x87/MXCSR/XMM (leaves al and flags intact)
+    "test al, al",                  // al = whether the vector pushed an error code
+    "mov rsp, rbp",                 // discard the FXSAVE area, back to the saved frame
+    "pop rax",
+    "pop rcx",
+    "pop rdx",
+    "pop rsi",
+    "pop rdi",
+    "pop r8",
+    "pop r9",
+    "pop r10",
+    "pop r11",
+    "pop rbp",
+    "jz 2f",
+    "add rsp, 8",                   // has error code: pop the vector too
+    "2:",
+    "add rsp, 8",                   // pop the error code or the vector
+    "iretq",
+
+    // 256 interrupt entry points, each `push <vector>; jmp isr_common`.
+    ".globl {isr0}",
+    "{isr0}:",
+    ".rept 256",
+    ".byte 0x68", ".long \\+",                  // push imm32 (the vector number)
+    ".byte 0xe9", ".long isr_common - . - 4",   // jmp rel32 to isr_common
+    ".endr",
+    isr_handler = sym isr_handler,
+    isr0 = sym ISR0,
 }
 
-macro_rules! create_fn {
-    ($name:ident, $i: expr) => {
-        extern "x86-interrupt" fn $name(stack_frame: InterruptStackFrame) {
-            abstraction_handle(stack_frame, $i);
-        }
-    };
+unsafe extern "C" {
+    /// Base of the 256 assembly interrupt entry stubs defined in `global_asm!`.
+    safe static ISR0: [u8; 256 * ISR_STUB_LEN];
 }
 
-macro_rules! create_fn_create_with_errorcode {
-    ($name:ident, $i: expr) => {
-        extern "x86-interrupt" fn $name(stack_frame: InterruptStackFrame, _error_code: u64) {
-            abstraction_handle(stack_frame, $i);
-        }
-    };
+/// Volatile register state saved by `isr_common` before calling [`isr_handler`].
+#[repr(C)]
+struct Frame {
+    rax: u64,
+    rcx: u64,
+    rdx: u64,
+    rsi: u64,
+    rdi: u64,
+    r8: u64,
+    r9: u64,
+    r10: u64,
+    r11: u64,
+    rbp: u64,
+    vector: u64,
 }
 
-macro_rules! create_fn_divergent_create_with_errorcode {
-    ($name:ident, $i: expr) => {
-        extern "x86-interrupt" fn $name(stack_frame: InterruptStackFrame, _error_code: u64) -> ! {
-            abstraction_handle(stack_frame, $i);
-            loop {}
-        }
-    };
+/// Whether the CPU pushes an error code for `vector`.
+fn has_error_code(vector: u8) -> bool {
+    matches!(vector, 8 | 10..=14 | 17 | 21 | 29 | 30)
 }
 
-macro_rules! create_fn_divergent_create {
-    ($name:ident, $i: expr) => {
-        extern "x86-interrupt" fn $name(stack_frame: InterruptStackFrame) -> ! {
-            abstraction_handle(stack_frame, $i);
-            loop {}
-        }
-    };
+/// Common interrupt handler, called by `isr_common`.
+///
+/// Returns whether the vector pushed an error code so the assembly epilogue can
+/// pop it before `iretq`.
+///
+/// Uses the SysV ABI (argument in `rdi`, no shadow space) to match the
+/// hand-written `isr_common` trampoline; the target's `extern "C"` would be the
+/// Win64 ABI on `x86_64-unknown-uefi`.
+///
+/// # Safety
+/// Must only be called from `isr_common` with a valid pointer to the saved
+/// [`Frame`] on the interrupt stack.
+unsafe extern "sysv64" fn isr_handler(frame: *mut Frame) -> bool {
+    // SAFETY: `isr_common` passes a valid pointer to the saved frame.
+    let vector = unsafe { (*frame).vector as u8 };
+    super::interrupt::dispatch(vector);
+    has_error_code(vector)
 }
 
-static mut BACKUP_RSP: u64 = 0;
-
-macro_rules! create_page_fault_fn {
-    ($name:ident, $i: expr) => {
-        extern "x86-interrupt" fn $name(
-            stack_frame: InterruptStackFrame,
-            _error_code: PageFaultErrorCode,
-        ) {
-            abstraction_handle(stack_frame, $i);
-        }
-    };
+/// Address of the entry stub for `vector`.
+fn isr_addr(vector: usize) -> VirtAddr {
+    VirtAddr::new(core::ptr::addr_of!(ISR0) as u64 + (vector * ISR_STUB_LEN) as u64)
 }
 
-macro_rules! register_interrupt_handler {
-    ($idt: expr, $i: expr, $name: ident) => {
-        $idt[$i].set_handler_fn($name);
-    };
-}
-
-fn common_handler(_stack_frame: InterruptStackFrame, interrupt: u8) {
-    log::info!("Default interrupt handler fired: {}", interrupt);
-}
-
-pub fn set_common_handler(handler: fn(InterruptStackFrame, u8)) {
-    let _guard = COMMON_HANDLER_MUTEX.lock();
-    // SAFETY: COMMON_HANDLER is only set via this function which is protected by a mutex.
+/// Points every IDT entry at its assembly entry stub.
+pub fn register_interrupt_handler(idt: &mut InterruptDescriptorTable) {
+    // SAFETY: each address is a valid interrupt entry point (defined in the
+    // `global_asm!` block above) whose stub handles any entry type correctly.
     unsafe {
-        COMMON_HANDLER = handler;
+        idt.divide_error.set_handler_addr(isr_addr(0));
+        idt.debug.set_handler_addr(isr_addr(1));
+        idt.non_maskable_interrupt.set_handler_addr(isr_addr(2));
+        idt.breakpoint.set_handler_addr(isr_addr(3));
+        idt.overflow.set_handler_addr(isr_addr(4));
+        idt.bound_range_exceeded.set_handler_addr(isr_addr(5));
+        idt.invalid_opcode.set_handler_addr(isr_addr(6));
+        idt.device_not_available.set_handler_addr(isr_addr(7));
+        idt.double_fault.set_handler_addr(isr_addr(8));
+        idt[9u8].set_handler_addr(isr_addr(9));
+        idt.invalid_tss.set_handler_addr(isr_addr(10));
+        idt.segment_not_present.set_handler_addr(isr_addr(11));
+        idt.stack_segment_fault.set_handler_addr(isr_addr(12));
+        idt.general_protection_fault.set_handler_addr(isr_addr(13));
+        idt.page_fault.set_handler_addr(isr_addr(14));
+        idt.x87_floating_point.set_handler_addr(isr_addr(16));
+        idt.alignment_check.set_handler_addr(isr_addr(17));
+        idt.machine_check.set_handler_addr(isr_addr(18));
+        idt.simd_floating_point.set_handler_addr(isr_addr(19));
+        idt.virtualization.set_handler_addr(isr_addr(20));
+        idt.cp_protection_exception.set_handler_addr(isr_addr(21));
+        idt.hv_injection_exception.set_handler_addr(isr_addr(28));
+        idt.vmm_communication_exception
+            .set_handler_addr(isr_addr(29));
+        idt.security_exception.set_handler_addr(isr_addr(30));
+        // Vectors 15, 22-27, and 31 are Intel-reserved: the x86_64 crate's IDT
+        // API cannot set them and hardware never delivers them. A spurious
+        // delivery would fault through the #GP (vector 13) stub rather than
+        // silently, so leave them unset.
+        for vector in 32..=255usize {
+            idt[vector as u8].set_handler_addr(isr_addr(vector));
+        }
     }
 }
-
-extern "x86-interrupt" fn no_op(_stack_frame: InterruptStackFrame) {}
-
-pub fn register_interrupt_handler(idt: &mut InterruptDescriptorTable) {
-    idt.divide_error.set_handler_fn(handler_0);
-    idt.debug.set_handler_fn(handler_1);
-    idt.non_maskable_interrupt.set_handler_fn(handler_2);
-    idt.breakpoint.set_handler_fn(handler_3);
-    idt.overflow.set_handler_fn(handler_4);
-    idt.bound_range_exceeded.set_handler_fn(handler_5);
-    idt.invalid_opcode.set_handler_fn(handler_6);
-    idt.device_not_available.set_handler_fn(handler_7);
-    idt.double_fault.set_handler_fn(handler_8);
-    register_interrupt_handler!(idt, 9, handler_9);
-    idt.invalid_tss.set_handler_fn(handler_10);
-    idt.segment_not_present.set_handler_fn(handler_11);
-    idt.stack_segment_fault.set_handler_fn(handler_12);
-    idt.general_protection_fault.set_handler_fn(handler_13);
-    idt.page_fault.set_handler_fn(handler_14);
-    // Vector 15 is reserved
-    idt.x87_floating_point.set_handler_fn(handler_16);
-    idt.alignment_check.set_handler_fn(handler_17);
-    idt.machine_check.set_handler_fn(handler_18);
-    idt.simd_floating_point.set_handler_fn(handler_19);
-    idt.virtualization.set_handler_fn(handler_20);
-    idt.cp_protection_exception.set_handler_fn(handler_21);
-    // Vector 22-27 is reserved
-    idt.hv_injection_exception.set_handler_fn(handler_28);
-    idt.vmm_communication_exception.set_handler_fn(handler_29);
-    idt.security_exception.set_handler_fn(handler_30);
-    // Vector 31 is reserved
-
-    register_interrupt_handler!(idt, 32, handler_32);
-    register_interrupt_handler!(idt, 33, handler_33);
-    register_interrupt_handler!(idt, 34, handler_34);
-    register_interrupt_handler!(idt, 35, handler_35);
-    register_interrupt_handler!(idt, 36, handler_36);
-    register_interrupt_handler!(idt, 37, handler_37);
-    register_interrupt_handler!(idt, 38, handler_38);
-    register_interrupt_handler!(idt, 39, handler_39);
-    register_interrupt_handler!(idt, 40, handler_40);
-    register_interrupt_handler!(idt, 41, handler_41);
-    register_interrupt_handler!(idt, 42, handler_42);
-    register_interrupt_handler!(idt, 43, handler_43);
-    register_interrupt_handler!(idt, 44, handler_44);
-    register_interrupt_handler!(idt, 45, handler_45);
-    register_interrupt_handler!(idt, 46, handler_46);
-    register_interrupt_handler!(idt, 47, handler_47);
-    register_interrupt_handler!(idt, 48, handler_48);
-    register_interrupt_handler!(idt, 49, handler_49);
-    register_interrupt_handler!(idt, 50, handler_50);
-    register_interrupt_handler!(idt, 51, handler_51);
-    register_interrupt_handler!(idt, 52, handler_52);
-    register_interrupt_handler!(idt, 53, handler_53);
-    register_interrupt_handler!(idt, 54, handler_54);
-    register_interrupt_handler!(idt, 55, handler_55);
-    register_interrupt_handler!(idt, 56, handler_56);
-    register_interrupt_handler!(idt, 57, handler_57);
-    register_interrupt_handler!(idt, 58, handler_58);
-    register_interrupt_handler!(idt, 59, handler_59);
-    register_interrupt_handler!(idt, 60, handler_60);
-    register_interrupt_handler!(idt, 61, handler_61);
-    register_interrupt_handler!(idt, 62, handler_62);
-    register_interrupt_handler!(idt, 63, handler_63);
-    register_interrupt_handler!(idt, 64, handler_64);
-    register_interrupt_handler!(idt, 65, handler_65);
-    register_interrupt_handler!(idt, 66, handler_66);
-    register_interrupt_handler!(idt, 67, handler_67);
-    register_interrupt_handler!(idt, 68, handler_68);
-    register_interrupt_handler!(idt, 69, handler_69);
-    register_interrupt_handler!(idt, 70, handler_70);
-    register_interrupt_handler!(idt, 71, handler_71);
-    register_interrupt_handler!(idt, 72, handler_72);
-    register_interrupt_handler!(idt, 73, handler_73);
-    register_interrupt_handler!(idt, 74, handler_74);
-    register_interrupt_handler!(idt, 75, handler_75);
-    register_interrupt_handler!(idt, 76, handler_76);
-    register_interrupt_handler!(idt, 77, handler_77);
-    register_interrupt_handler!(idt, 78, handler_78);
-    register_interrupt_handler!(idt, 79, handler_79);
-    register_interrupt_handler!(idt, 80, handler_80);
-    register_interrupt_handler!(idt, 81, handler_81);
-    register_interrupt_handler!(idt, 82, handler_82);
-    register_interrupt_handler!(idt, 83, handler_83);
-    register_interrupt_handler!(idt, 84, handler_84);
-    register_interrupt_handler!(idt, 85, handler_85);
-    register_interrupt_handler!(idt, 86, handler_86);
-    register_interrupt_handler!(idt, 87, handler_87);
-    register_interrupt_handler!(idt, 88, handler_88);
-    register_interrupt_handler!(idt, 89, handler_89);
-    register_interrupt_handler!(idt, 90, handler_90);
-    register_interrupt_handler!(idt, 91, handler_91);
-    register_interrupt_handler!(idt, 92, handler_92);
-    register_interrupt_handler!(idt, 93, handler_93);
-    register_interrupt_handler!(idt, 94, handler_94);
-    register_interrupt_handler!(idt, 95, handler_95);
-    register_interrupt_handler!(idt, 96, handler_96);
-    register_interrupt_handler!(idt, 97, handler_97);
-    register_interrupt_handler!(idt, 98, handler_98);
-    register_interrupt_handler!(idt, 99, handler_99);
-    register_interrupt_handler!(idt, 100, handler_100);
-    register_interrupt_handler!(idt, 101, handler_101);
-    register_interrupt_handler!(idt, 102, handler_102);
-    register_interrupt_handler!(idt, 103, handler_103);
-    register_interrupt_handler!(idt, 104, handler_104);
-    register_interrupt_handler!(idt, 105, handler_105);
-    register_interrupt_handler!(idt, 106, handler_106);
-    register_interrupt_handler!(idt, 107, handler_107);
-    register_interrupt_handler!(idt, 108, handler_108);
-    register_interrupt_handler!(idt, 109, handler_109);
-    register_interrupt_handler!(idt, 110, handler_110);
-    register_interrupt_handler!(idt, 111, handler_111);
-    register_interrupt_handler!(idt, 112, handler_112);
-    register_interrupt_handler!(idt, 113, handler_113);
-    register_interrupt_handler!(idt, 114, handler_114);
-    register_interrupt_handler!(idt, 115, handler_115);
-    register_interrupt_handler!(idt, 116, handler_116);
-    register_interrupt_handler!(idt, 117, handler_117);
-    register_interrupt_handler!(idt, 118, handler_118);
-    register_interrupt_handler!(idt, 119, handler_119);
-    register_interrupt_handler!(idt, 120, handler_120);
-    register_interrupt_handler!(idt, 121, handler_121);
-    register_interrupt_handler!(idt, 122, handler_122);
-    register_interrupt_handler!(idt, 123, handler_123);
-    register_interrupt_handler!(idt, 124, handler_124);
-    register_interrupt_handler!(idt, 125, handler_125);
-    register_interrupt_handler!(idt, 126, handler_126);
-    register_interrupt_handler!(idt, 127, handler_127);
-    register_interrupt_handler!(idt, 128, handler_128);
-    register_interrupt_handler!(idt, 129, handler_129);
-    register_interrupt_handler!(idt, 130, handler_130);
-    register_interrupt_handler!(idt, 131, handler_131);
-    register_interrupt_handler!(idt, 132, handler_132);
-    register_interrupt_handler!(idt, 133, handler_133);
-    register_interrupt_handler!(idt, 134, handler_134);
-    register_interrupt_handler!(idt, 135, handler_135);
-    register_interrupt_handler!(idt, 136, handler_136);
-    register_interrupt_handler!(idt, 137, handler_137);
-    register_interrupt_handler!(idt, 138, handler_138);
-    register_interrupt_handler!(idt, 139, handler_139);
-    register_interrupt_handler!(idt, 140, handler_140);
-    register_interrupt_handler!(idt, 141, handler_141);
-    register_interrupt_handler!(idt, 142, handler_142);
-    register_interrupt_handler!(idt, 143, handler_143);
-    register_interrupt_handler!(idt, 144, handler_144);
-    register_interrupt_handler!(idt, 145, handler_145);
-    register_interrupt_handler!(idt, 146, handler_146);
-    register_interrupt_handler!(idt, 147, handler_147);
-    register_interrupt_handler!(idt, 148, handler_148);
-    register_interrupt_handler!(idt, 149, handler_149);
-    register_interrupt_handler!(idt, 150, handler_150);
-    register_interrupt_handler!(idt, 151, handler_151);
-    register_interrupt_handler!(idt, 152, handler_152);
-    register_interrupt_handler!(idt, 153, handler_153);
-    register_interrupt_handler!(idt, 154, handler_154);
-    register_interrupt_handler!(idt, 155, handler_155);
-    register_interrupt_handler!(idt, 156, handler_156);
-    register_interrupt_handler!(idt, 157, handler_157);
-    register_interrupt_handler!(idt, 158, handler_158);
-    register_interrupt_handler!(idt, 159, handler_159);
-    register_interrupt_handler!(idt, 160, handler_160);
-    register_interrupt_handler!(idt, 161, handler_161);
-    register_interrupt_handler!(idt, 162, handler_162);
-    register_interrupt_handler!(idt, 163, handler_163);
-    register_interrupt_handler!(idt, 164, handler_164);
-    register_interrupt_handler!(idt, 165, handler_165);
-    register_interrupt_handler!(idt, 166, handler_166);
-    register_interrupt_handler!(idt, 167, handler_167);
-    register_interrupt_handler!(idt, 168, handler_168);
-    register_interrupt_handler!(idt, 169, handler_169);
-    register_interrupt_handler!(idt, 170, handler_170);
-    register_interrupt_handler!(idt, 171, handler_171);
-    register_interrupt_handler!(idt, 172, handler_172);
-    register_interrupt_handler!(idt, 173, handler_173);
-    register_interrupt_handler!(idt, 174, handler_174);
-    register_interrupt_handler!(idt, 175, handler_175);
-    register_interrupt_handler!(idt, 176, handler_176);
-    register_interrupt_handler!(idt, 177, handler_177);
-    register_interrupt_handler!(idt, 178, handler_178);
-    register_interrupt_handler!(idt, 179, handler_179);
-    register_interrupt_handler!(idt, 180, handler_180);
-    register_interrupt_handler!(idt, 181, handler_181);
-    register_interrupt_handler!(idt, 182, handler_182);
-    register_interrupt_handler!(idt, 183, handler_183);
-    register_interrupt_handler!(idt, 184, handler_184);
-    register_interrupt_handler!(idt, 185, handler_185);
-    register_interrupt_handler!(idt, 186, handler_186);
-    register_interrupt_handler!(idt, 187, handler_187);
-    register_interrupt_handler!(idt, 188, handler_188);
-    register_interrupt_handler!(idt, 189, handler_189);
-    register_interrupt_handler!(idt, 190, handler_190);
-    register_interrupt_handler!(idt, 191, handler_191);
-    register_interrupt_handler!(idt, 192, handler_192);
-    register_interrupt_handler!(idt, 193, handler_193);
-    register_interrupt_handler!(idt, 194, handler_194);
-    register_interrupt_handler!(idt, 195, handler_195);
-    register_interrupt_handler!(idt, 196, handler_196);
-    register_interrupt_handler!(idt, 197, handler_197);
-    register_interrupt_handler!(idt, 198, handler_198);
-    register_interrupt_handler!(idt, 199, handler_199);
-    register_interrupt_handler!(idt, 200, handler_200);
-    register_interrupt_handler!(idt, 201, handler_201);
-    register_interrupt_handler!(idt, 202, handler_202);
-    register_interrupt_handler!(idt, 203, handler_203);
-    register_interrupt_handler!(idt, 204, handler_204);
-    register_interrupt_handler!(idt, 205, handler_205);
-    register_interrupt_handler!(idt, 206, handler_206);
-    register_interrupt_handler!(idt, 207, handler_207);
-    register_interrupt_handler!(idt, 208, handler_208);
-    register_interrupt_handler!(idt, 209, handler_209);
-    register_interrupt_handler!(idt, 210, handler_210);
-    register_interrupt_handler!(idt, 211, handler_211);
-    register_interrupt_handler!(idt, 212, handler_212);
-    register_interrupt_handler!(idt, 213, handler_213);
-    register_interrupt_handler!(idt, 214, handler_214);
-    register_interrupt_handler!(idt, 215, handler_215);
-    register_interrupt_handler!(idt, 216, handler_216);
-    register_interrupt_handler!(idt, 217, handler_217);
-    register_interrupt_handler!(idt, 218, handler_218);
-    register_interrupt_handler!(idt, 219, handler_219);
-    register_interrupt_handler!(idt, 220, handler_220);
-    register_interrupt_handler!(idt, 221, handler_221);
-    register_interrupt_handler!(idt, 222, handler_222);
-    register_interrupt_handler!(idt, 223, handler_223);
-    register_interrupt_handler!(idt, 224, handler_224);
-    register_interrupt_handler!(idt, 225, handler_225);
-    register_interrupt_handler!(idt, 226, handler_226);
-    register_interrupt_handler!(idt, 227, handler_227);
-    register_interrupt_handler!(idt, 228, handler_228);
-    register_interrupt_handler!(idt, 229, handler_229);
-    register_interrupt_handler!(idt, 230, handler_230);
-    register_interrupt_handler!(idt, 231, handler_231);
-    register_interrupt_handler!(idt, 232, handler_232);
-    register_interrupt_handler!(idt, 233, handler_233);
-    register_interrupt_handler!(idt, 234, handler_234);
-    register_interrupt_handler!(idt, 235, handler_235);
-    register_interrupt_handler!(idt, 236, handler_236);
-    register_interrupt_handler!(idt, 237, handler_237);
-    register_interrupt_handler!(idt, 238, handler_238);
-    register_interrupt_handler!(idt, 239, handler_239);
-    register_interrupt_handler!(idt, 240, handler_240);
-    register_interrupt_handler!(idt, 241, handler_241);
-    register_interrupt_handler!(idt, 242, handler_242);
-    register_interrupt_handler!(idt, 243, handler_243);
-    register_interrupt_handler!(idt, 244, handler_244);
-    register_interrupt_handler!(idt, 245, handler_245);
-    register_interrupt_handler!(idt, 246, handler_246);
-    register_interrupt_handler!(idt, 247, handler_247);
-    register_interrupt_handler!(idt, 248, handler_248);
-    register_interrupt_handler!(idt, 249, handler_249);
-    register_interrupt_handler!(idt, 250, handler_250);
-    register_interrupt_handler!(idt, 251, handler_251);
-    register_interrupt_handler!(idt, 252, handler_252);
-    register_interrupt_handler!(idt, 253, handler_253);
-    register_interrupt_handler!(idt, 254, handler_254);
-    register_interrupt_handler!(idt, 255, handler_255);
-}
-
-create_fn!(handler_0, 0);
-create_fn!(handler_1, 1);
-create_fn!(handler_2, 2);
-create_fn!(handler_3, 3);
-create_fn!(handler_4, 4);
-create_fn!(handler_5, 5);
-create_fn!(handler_6, 6);
-create_fn!(handler_7, 7);
-create_fn_divergent_create_with_errorcode!(handler_8, 8);
-create_fn!(handler_9, 9);
-create_fn_create_with_errorcode!(handler_10, 10);
-create_fn_create_with_errorcode!(handler_11, 11);
-create_fn_create_with_errorcode!(handler_12, 12);
-create_fn_create_with_errorcode!(handler_13, 13);
-create_page_fault_fn!(handler_14, 14);
-create_fn!(handler_15, 15);
-create_fn!(handler_16, 16);
-create_fn_create_with_errorcode!(handler_17, 17);
-create_fn_divergent_create!(handler_18, 18);
-create_fn!(handler_19, 19);
-create_fn!(handler_20, 20);
-create_fn_create_with_errorcode!(handler_21, 21);
-create_fn!(handler_22, 22);
-create_fn!(handler_23, 23);
-create_fn!(handler_24, 24);
-create_fn!(handler_25, 25);
-create_fn!(handler_26, 26);
-create_fn!(handler_27, 27);
-create_fn!(handler_28, 28);
-create_fn_create_with_errorcode!(handler_29, 29);
-create_fn_create_with_errorcode!(handler_30, 30);
-create_fn!(handler_31, 31);
-create_fn!(handler_32, 32);
-create_fn!(handler_33, 33);
-create_fn!(handler_34, 34);
-create_fn!(handler_35, 35);
-create_fn!(handler_36, 36);
-create_fn!(handler_37, 37);
-create_fn!(handler_38, 38);
-create_fn!(handler_39, 39);
-create_fn!(handler_40, 40);
-create_fn!(handler_41, 41);
-create_fn!(handler_42, 42);
-create_fn!(handler_43, 43);
-create_fn!(handler_44, 44);
-create_fn!(handler_45, 45);
-create_fn!(handler_46, 46);
-create_fn!(handler_47, 47);
-create_fn!(handler_48, 48);
-create_fn!(handler_49, 49);
-create_fn!(handler_50, 50);
-create_fn!(handler_51, 51);
-create_fn!(handler_52, 52);
-create_fn!(handler_53, 53);
-create_fn!(handler_54, 54);
-create_fn!(handler_55, 55);
-create_fn!(handler_56, 56);
-create_fn!(handler_57, 57);
-create_fn!(handler_58, 58);
-create_fn!(handler_59, 59);
-create_fn!(handler_60, 60);
-create_fn!(handler_61, 61);
-create_fn!(handler_62, 62);
-create_fn!(handler_63, 63);
-create_fn!(handler_64, 64);
-create_fn!(handler_65, 65);
-create_fn!(handler_66, 66);
-create_fn!(handler_67, 67);
-create_fn!(handler_68, 68);
-create_fn!(handler_69, 69);
-create_fn!(handler_70, 70);
-create_fn!(handler_71, 71);
-create_fn!(handler_72, 72);
-create_fn!(handler_73, 73);
-create_fn!(handler_74, 74);
-create_fn!(handler_75, 75);
-create_fn!(handler_76, 76);
-create_fn!(handler_77, 77);
-create_fn!(handler_78, 78);
-create_fn!(handler_79, 79);
-create_fn!(handler_80, 80);
-create_fn!(handler_81, 81);
-create_fn!(handler_82, 82);
-create_fn!(handler_83, 83);
-create_fn!(handler_84, 84);
-create_fn!(handler_85, 85);
-create_fn!(handler_86, 86);
-create_fn!(handler_87, 87);
-create_fn!(handler_88, 88);
-create_fn!(handler_89, 89);
-create_fn!(handler_90, 90);
-create_fn!(handler_91, 91);
-create_fn!(handler_92, 92);
-create_fn!(handler_93, 93);
-create_fn!(handler_94, 94);
-create_fn!(handler_95, 95);
-create_fn!(handler_96, 96);
-create_fn!(handler_97, 97);
-create_fn!(handler_98, 98);
-create_fn!(handler_99, 99);
-create_fn!(handler_100, 100);
-create_fn!(handler_101, 101);
-create_fn!(handler_102, 102);
-create_fn!(handler_103, 103);
-create_fn!(handler_104, 104);
-create_fn!(handler_105, 105);
-create_fn!(handler_106, 106);
-create_fn!(handler_107, 107);
-create_fn!(handler_108, 108);
-create_fn!(handler_109, 109);
-create_fn!(handler_110, 110);
-create_fn!(handler_111, 111);
-create_fn!(handler_112, 112);
-create_fn!(handler_113, 113);
-create_fn!(handler_114, 114);
-create_fn!(handler_115, 115);
-create_fn!(handler_116, 116);
-create_fn!(handler_117, 117);
-create_fn!(handler_118, 118);
-create_fn!(handler_119, 119);
-create_fn!(handler_120, 120);
-create_fn!(handler_121, 121);
-create_fn!(handler_122, 122);
-create_fn!(handler_123, 123);
-create_fn!(handler_124, 124);
-create_fn!(handler_125, 125);
-create_fn!(handler_126, 126);
-create_fn!(handler_127, 127);
-create_fn!(handler_128, 128);
-create_fn!(handler_129, 129);
-create_fn!(handler_130, 130);
-create_fn!(handler_131, 131);
-create_fn!(handler_132, 132);
-create_fn!(handler_133, 133);
-create_fn!(handler_134, 134);
-create_fn!(handler_135, 135);
-create_fn!(handler_136, 136);
-create_fn!(handler_137, 137);
-create_fn!(handler_138, 138);
-create_fn!(handler_139, 139);
-create_fn!(handler_140, 140);
-create_fn!(handler_141, 141);
-create_fn!(handler_142, 142);
-create_fn!(handler_143, 143);
-create_fn!(handler_144, 144);
-create_fn!(handler_145, 145);
-create_fn!(handler_146, 146);
-create_fn!(handler_147, 147);
-create_fn!(handler_148, 148);
-create_fn!(handler_149, 149);
-create_fn!(handler_150, 150);
-create_fn!(handler_151, 151);
-create_fn!(handler_152, 152);
-create_fn!(handler_153, 153);
-create_fn!(handler_154, 154);
-create_fn!(handler_155, 155);
-create_fn!(handler_156, 156);
-create_fn!(handler_157, 157);
-create_fn!(handler_158, 158);
-create_fn!(handler_159, 159);
-create_fn!(handler_160, 160);
-create_fn!(handler_161, 161);
-create_fn!(handler_162, 162);
-create_fn!(handler_163, 163);
-create_fn!(handler_164, 164);
-create_fn!(handler_165, 165);
-create_fn!(handler_166, 166);
-create_fn!(handler_167, 167);
-create_fn!(handler_168, 168);
-create_fn!(handler_169, 169);
-create_fn!(handler_170, 170);
-create_fn!(handler_171, 171);
-create_fn!(handler_172, 172);
-create_fn!(handler_173, 173);
-create_fn!(handler_174, 174);
-create_fn!(handler_175, 175);
-create_fn!(handler_176, 176);
-create_fn!(handler_177, 177);
-create_fn!(handler_178, 178);
-create_fn!(handler_179, 179);
-create_fn!(handler_180, 180);
-create_fn!(handler_181, 181);
-create_fn!(handler_182, 182);
-create_fn!(handler_183, 183);
-create_fn!(handler_184, 184);
-create_fn!(handler_185, 185);
-create_fn!(handler_186, 186);
-create_fn!(handler_187, 187);
-create_fn!(handler_188, 188);
-create_fn!(handler_189, 189);
-create_fn!(handler_190, 190);
-create_fn!(handler_191, 191);
-create_fn!(handler_192, 192);
-create_fn!(handler_193, 193);
-create_fn!(handler_194, 194);
-create_fn!(handler_195, 195);
-create_fn!(handler_196, 196);
-create_fn!(handler_197, 197);
-create_fn!(handler_198, 198);
-create_fn!(handler_199, 199);
-create_fn!(handler_200, 200);
-create_fn!(handler_201, 201);
-create_fn!(handler_202, 202);
-create_fn!(handler_203, 203);
-create_fn!(handler_204, 204);
-create_fn!(handler_205, 205);
-create_fn!(handler_206, 206);
-create_fn!(handler_207, 207);
-create_fn!(handler_208, 208);
-create_fn!(handler_209, 209);
-create_fn!(handler_210, 210);
-create_fn!(handler_211, 211);
-create_fn!(handler_212, 212);
-create_fn!(handler_213, 213);
-create_fn!(handler_214, 214);
-create_fn!(handler_215, 215);
-create_fn!(handler_216, 216);
-create_fn!(handler_217, 217);
-create_fn!(handler_218, 218);
-create_fn!(handler_219, 219);
-create_fn!(handler_220, 220);
-create_fn!(handler_221, 221);
-create_fn!(handler_222, 222);
-create_fn!(handler_223, 223);
-create_fn!(handler_224, 224);
-create_fn!(handler_225, 225);
-create_fn!(handler_226, 226);
-create_fn!(handler_227, 227);
-create_fn!(handler_228, 228);
-create_fn!(handler_229, 229);
-create_fn!(handler_230, 230);
-create_fn!(handler_231, 231);
-create_fn!(handler_232, 232);
-create_fn!(handler_233, 233);
-create_fn!(handler_234, 234);
-create_fn!(handler_235, 235);
-create_fn!(handler_236, 236);
-create_fn!(handler_237, 237);
-create_fn!(handler_238, 238);
-create_fn!(handler_239, 239);
-create_fn!(handler_240, 240);
-create_fn!(handler_241, 241);
-create_fn!(handler_242, 242);
-create_fn!(handler_243, 243);
-create_fn!(handler_244, 244);
-create_fn!(handler_245, 245);
-create_fn!(handler_246, 246);
-create_fn!(handler_247, 247);
-create_fn!(handler_248, 248);
-create_fn!(handler_249, 249);
-create_fn!(handler_250, 250);
-create_fn!(handler_251, 251);
-create_fn!(handler_252, 252);
-create_fn!(handler_253, 253);
-create_fn!(handler_254, 254);
-create_fn!(handler_255, 255);

--- a/opentmk/src/arch/x86_64/mod.rs
+++ b/opentmk/src/arch/x86_64/mod.rs
@@ -2,9 +2,7 @@
 // Licensed under the MIT License.
 
 pub mod hypercall;
-#[cfg(nightly)]
 pub mod interrupt;
-#[cfg(nightly)]
 mod interrupt_handler_register;
 mod io;
 pub mod rtc;

--- a/opentmk/src/context.rs
+++ b/opentmk/src/context.rs
@@ -15,7 +15,6 @@ use hvdef::Vtl;
 
 use crate::tmkdefs::TmkResult;
 
-#[cfg(nightly)]
 /// Trait for platforms that support secure-world intercepts.
 pub trait SecureInterceptPlatformTrait {
     /// Installs a secure-world intercept for the given interrupt.
@@ -31,7 +30,6 @@ pub trait SecureInterceptPlatformTrait {
     fn signal_intercept_handled(&mut self) -> TmkResult<()>;
 }
 
-#[cfg(nightly)]
 /// Trait for platforms that support Interrupts.
 pub trait InterruptPlatformTrait {
     /// Associates an interrupt vector with a handler inside the

--- a/opentmk/src/main.rs
+++ b/opentmk/src/main.rs
@@ -3,7 +3,6 @@
 
 // UNSAFETY: This crate contains unsafe code to perform low-level operations such as managing memory, handling interrupts, and invoking hypercalls.
 #![expect(unsafe_code)]
-#![cfg_attr(nightly, feature(abi_x86_interrupt))]
 #![doc = include_str!("../README.md")]
 #![cfg_attr(all(not(test), target_os = "uefi"), no_main)]
 #![cfg_attr(all(not(test), target_os = "uefi"), no_std)]

--- a/opentmk/src/platform/hyperv/arch/x86_64/ctx.rs
+++ b/opentmk/src/platform/hyperv/arch/x86_64/ctx.rs
@@ -20,10 +20,8 @@ use memory_range::MemoryRange;
 use minimal_rt::arch::msr::read_msr;
 use minimal_rt::arch::msr::write_msr;
 
-#[cfg(nightly)]
 use crate::context::InterruptPlatformTrait;
 use crate::context::MsrPlatformTrait;
-#[cfg(nightly)]
 use crate::context::SecureInterceptPlatformTrait;
 use crate::context::VirtualProcessorPlatformTrait;
 use crate::context::VpExecToken;
@@ -36,7 +34,6 @@ use crate::platform::hyperv::ctx::vtl_transform;
 use crate::tmkdefs::TmkError;
 use crate::tmkdefs::TmkResult;
 
-#[cfg(nightly)]
 impl SecureInterceptPlatformTrait for HvTestCtx {
     /// Configure the Secure Interrupt Message Page (SIMP) and the first
     /// SynIC interrupt (SINT0) so that the hypervisor can vector
@@ -89,7 +86,6 @@ impl SecureInterceptPlatformTrait for HvTestCtx {
     }
 }
 
-#[cfg(nightly)]
 impl InterruptPlatformTrait for HvTestCtx {
     /// Install an interrupt handler for the supplied vector on x86-64.
     fn set_interrupt_idx(&mut self, interrupt_idx: u8, handler: fn(HvTestCtx)) -> TmkResult<()> {

--- a/opentmk/src/tests/hyperv/hv_memory_protect_read.rs
+++ b/opentmk/src/tests/hyperv/hv_memory_protect_read.rs
@@ -75,6 +75,7 @@ where
             Layout::from_size_align(1024 * 1024, 4096).expect("msg: failed to create layout");
         // SAFETY: Layout has a non zero size
         let ptr = unsafe { alloc(layout) };
+        tmk_assert!(!ptr.is_null(), "heap allocation should succeed");
         log::info!("allocated some memory in the heap from vtl1");
 
         #[expect(static_mut_refs)]

--- a/opentmk/src/tests/hyperv/hv_memory_protect_read.rs
+++ b/opentmk/src/tests/hyperv/hv_memory_protect_read.rs
@@ -18,7 +18,7 @@ use crate::context::VtlPlatformTrait;
 use crate::create_function_with_restore;
 use crate::tmk_assert;
 
-static mut HEAP_ALLOC_PTR: RefCell<*mut u8> = RefCell::new(0 as *mut u8);
+static mut HEAP_ALLOC_PTR: RefCell<*mut u8> = RefCell::new(core::ptr::null_mut());
 
 static mut RETURN_VALUE: u8 = 0;
 
@@ -28,6 +28,8 @@ static mut RETURN_VALUE: u8 = 0;
 #[expect(static_mut_refs)]
 // writing to a static generates a warning. we safely handle RETURN_VALUE so ignoring it here.
 fn violate_heap() {
+    // SAFETY: intentionally reads through the test-controlled heap pointer to
+    // trigger a VTL memory-protection intercept.
     unsafe {
         let alloc_ptr = *HEAP_ALLOC_PTR.borrow();
         // after a VTL switch we can't trust the value returned by eax
@@ -76,6 +78,7 @@ where
 
         #[expect(static_mut_refs)]
         // writing to a static generates a warning. we safely handle HEAP_ALLOC_PTR so ignoring it here.
+        // SAFETY: initializes the test-controlled heap pointer during setup.
         unsafe {
             let mut z = HEAP_ALLOC_PTR.borrow_mut();
             *z = ptr;

--- a/opentmk/src/tests/hyperv/hv_memory_protect_read.rs
+++ b/opentmk/src/tests/hyperv/hv_memory_protect_read.rs
@@ -27,9 +27,10 @@ static mut RETURN_VALUE: u8 = 0;
 #[inline(never)]
 #[expect(static_mut_refs)]
 // writing to a static generates a warning. we safely handle RETURN_VALUE so ignoring it here.
+/// Violates the heap memory protection by reading a value from the heap allocated in VTL1 while running in VTL0.
 fn violate_heap() {
-    // SAFETY: intentionally reads through the test-controlled heap pointer to
-    // trigger a VTL memory-protection intercept.
+    // SAFETY: the test driver guarantees that the heap pointer is valid and points to a
+    // valid memory region before calling this function.
     unsafe {
         let alloc_ptr = *HEAP_ALLOC_PTR.borrow();
         // after a VTL switch we can't trust the value returned by eax
@@ -72,13 +73,14 @@ where
 
         let layout =
             Layout::from_size_align(1024 * 1024, 4096).expect("msg: failed to create layout");
-        // SAFETY: we are allocating memory to heap, we don't free it in this test.
+        // SAFETY: Layout has a non zero size
         let ptr = unsafe { alloc(layout) };
         log::info!("allocated some memory in the heap from vtl1");
 
         #[expect(static_mut_refs)]
         // writing to a static generates a warning. we safely handle HEAP_ALLOC_PTR so ignoring it here.
-        // SAFETY: initializes the test-controlled heap pointer during setup.
+        // SAFETY: the test at this point is single threaded
+        // and we are writing to a static variable that is only written to once.
         unsafe {
             let mut z = HEAP_ALLOC_PTR.borrow_mut();
             *z = ptr;

--- a/opentmk/src/tests/hyperv/hv_memory_protect_write.rs
+++ b/opentmk/src/tests/hyperv/hv_memory_protect_write.rs
@@ -75,6 +75,7 @@ where
             Layout::from_size_align(1024 * 1024, 4096).expect("msg: failed to create layout");
         // SAFETY: Layout has a non zero size
         let ptr = unsafe { alloc(layout) };
+        tmk_assert!(!ptr.is_null(), "heap allocation should succeed");
         log::info!("allocated some memory in the heap from vtl1");
 
         #[expect(static_mut_refs)]

--- a/opentmk/src/tests/hyperv/hv_memory_protect_write.rs
+++ b/opentmk/src/tests/hyperv/hv_memory_protect_write.rs
@@ -19,7 +19,7 @@ use crate::context::VtlPlatformTrait;
 use crate::create_function_with_restore;
 use crate::tmk_assert;
 
-static mut HEAP_ALLOC_PTR: RefCell<*mut u8> = RefCell::new(0 as *mut u8);
+static mut HEAP_ALLOC_PTR: RefCell<*mut u8> = RefCell::new(core::ptr::null_mut());
 static FAULT_CALLED: Mutex<bool> = Mutex::new(false);
 
 // Without inline the compiler may optimize away the call and the VTL switch may
@@ -28,6 +28,8 @@ static FAULT_CALLED: Mutex<bool> = Mutex::new(false);
 // SAFETY: we safely handle HEAP_ALLOC_PTR so ignoring it here.
 #[expect(static_mut_refs)]
 fn violate_heap() {
+    // SAFETY: intentionally writes through the test-controlled heap pointer to
+    // trigger a VTL memory-protection intercept.
     unsafe {
         let alloc_ptr = *HEAP_ALLOC_PTR.borrow();
         *(alloc_ptr.add(10)) = 0x56;
@@ -76,6 +78,7 @@ where
         log::info!("allocated some memory in the heap from vtl1");
 
         #[expect(static_mut_refs)]
+        // SAFETY: initializes the test-controlled heap pointer during setup.
         unsafe {
             let mut z = HEAP_ALLOC_PTR.borrow_mut();
             *z = ptr;

--- a/opentmk/src/tests/hyperv/hv_memory_protect_write.rs
+++ b/opentmk/src/tests/hyperv/hv_memory_protect_write.rs
@@ -25,11 +25,11 @@ static FAULT_CALLED: Mutex<bool> = Mutex::new(false);
 // Without inline the compiler may optimize away the call and the VTL switch may
 // distort the architectural registers
 #[inline(never)]
-// SAFETY: we safely handle HEAP_ALLOC_PTR so ignoring it here.
 #[expect(static_mut_refs)]
+/// Violates the heap memory protection by writing a value to the heap allocated in VTL1 while running in VTL0.
 fn violate_heap() {
-    // SAFETY: intentionally writes through the test-controlled heap pointer to
-    // trigger a VTL memory-protection intercept.
+    // SAFETY: the test driver guarantees that the heap pointer is valid and points to a
+    // valid memory region before calling this function.
     unsafe {
         let alloc_ptr = *HEAP_ALLOC_PTR.borrow();
         *(alloc_ptr.add(10)) = 0x56;
@@ -73,12 +73,13 @@ where
 
         let layout =
             Layout::from_size_align(1024 * 1024, 4096).expect("msg: failed to create layout");
-        // SAFETY: we are allocating memory to heap, we don't free it in this test.
+        // SAFETY: Layout has a non zero size
         let ptr = unsafe { alloc(layout) };
         log::info!("allocated some memory in the heap from vtl1");
 
         #[expect(static_mut_refs)]
-        // SAFETY: initializes the test-controlled heap pointer during setup.
+        // SAFETY: the test at this point is single threaded
+        // and we are writing to a static variable that is only written to once.
         unsafe {
             let mut z = HEAP_ALLOC_PTR.borrow_mut();
             *z = ptr;

--- a/opentmk/src/tests/hyperv/mod.rs
+++ b/opentmk/src/tests/hyperv/mod.rs
@@ -2,18 +2,15 @@
 // Licensed under the MIT License.
 
 pub mod hv_error_vp_start;
-#[cfg(nightly)]
+#[cfg(target_arch = "x86_64")] // xtask-fmt allow-target-arch sys-crate
 pub mod hv_memory_protect_read;
-#[cfg(nightly)]
+#[cfg(target_arch = "x86_64")] // xtask-fmt allow-target-arch sys-crate
 pub mod hv_memory_protect_write;
 pub mod hv_processor;
-#[cfg(nightly)]
 #[cfg(target_arch = "x86_64")] // xtask-fmt allow-target-arch sys-crate
 pub mod hv_register_intercept;
-#[cfg(nightly)]
 #[cfg(target_arch = "x86_64")] // xtask-fmt allow-target-arch sys-crate
 pub mod hv_tpm_read_cvm;
-#[cfg(nightly)]
 #[cfg(target_arch = "x86_64")] // xtask-fmt allow-target-arch sys-crate
 pub mod hv_tpm_write_cvm;
 pub mod test_helpers;


### PR DESCRIPTION
## Summary

Drop the nightly Rust requirement for OpenTMK's interrupt handling.

OpenTMK's IDT handlers previously used `extern "x86-interrupt"`, which
requires the unstable `abi_x86_interrupt` feature, so the interrupt tests
(`hv_memory_protect_read`/`write`, `hv_register_intercept`,
`hv_tpm_read`/`write_cvm`) were gated behind `#[cfg(nightly)]` and could
not build on stable.

This replaces that with assembly interrupt entry stubs (one per vector)
that funnel into a single `extern "sysv64"` handler, installed into the
IDT via the stable `Entry::set_handler_addr` — the same approach used by
`tmk_core`. The stubs preserve the full architectural register state
(integer GPRs plus x87/SSE via `fxsave64`/`fxrstor64`; the
`x86_64-unknown-uefi` target is built for the SSE2 baseline, so this
captures the complete vector state).

## Changes

- Remove the `abi_x86_interrupt` feature and all `#[cfg(nightly)]` gates.
- Remove the now-unused `build.rs` `cfg(nightly)` declaration.
- Rewrite `interrupt.rs` / `interrupt_handler_register.rs` to use the
  assembly-stub dispatch mechanism.
- Gate the interrupt tests to `x86_64` (interrupt handling is
  x86_64-specific).

## Testing

`cargo build -p opentmk --target x86_64-unknown-uefi` now succeeds on
**stable** Rust.

> Note: this is one of a few PRs splitting a larger OpenTMK change into
> reviewable pieces. This one is self-contained (guest crate only).
