### PR TITLE
petri: add ignore/unstable test attributes with required reasons

### DIFF
--- a/Guide/src/dev_guide/tests/vmm.md
+++ b/Guide/src/dev_guide/tests/vmm.md
@@ -41,14 +41,16 @@ engineers' local machines and in CI. Put these special words in your test to opt
 
 ### "unstable" tests
 
-If a test is not yet reliable enough to gate PRs, add `unstable` to the macro.
+If a test is not yet reliable enough to gate PRs, mark it `unstable`. Every
+`unstable` marker requires a `reason` string documenting why the test is
+unstable (ideally referencing a tracking issue).
 
-For individual variants:
+To mark a single variant unstable, wrap it in `unstable(reason = "...", <config>)`:
 
 ```rust,ignore
 #[vmm_test(
     // unstable variant:
-    unstable_hyperv_openhcl_uefi_aarch64(vhd(windows_11_enterprise_aarch64)),
+    unstable(reason = "flaky on aarch64 in CI (microsoft/openvmm#1234)", hyperv_openhcl_uefi_aarch64(vhd(windows_11_enterprise_aarch64))),
     // other reliable variants:
     hyperv_openhcl_uefi_aarch64(vhd(ubuntu_2404_server_aarch64))
     // ...
@@ -58,10 +60,11 @@ async fn my_test<T: PetriVmmBackend>(config: PetriVmBuilder<T>) -> anyhow::Resul
 }
 ```
 
-For all variants of the test:
+To mark all variants of the test unstable, apply `unstable(reason = "...")` as a
+test-wide attribute alongside `configs(...)`:
 
 ```rust,ignore
-#[vmm_test_with(unstable, configs(
+#[vmm_test_with(unstable(reason = "flaky in CI (microsoft/openvmm#1234)"), configs(
     hyperv_openhcl_uefi_aarch64(vhd(windows_11_enterprise_aarch64)),
     hyperv_openhcl_uefi_aarch64(vhd(ubuntu_2404_server_aarch64))
     // ...
@@ -71,15 +74,52 @@ async fn my_test<T: PetriVmmBackend>(config: PetriVmBuilder<T>) -> anyhow::Resul
 }
 ```
 
-Unstable tests run in the same CI job as stable tests. When an unstable test fails
-the CI run will pass with a warning. Outside of CI, an unstable test failure is
-reported as a failure like any other test.
+Unstable tests run in the same CI job as stable tests. In CI the
+`PETRI_IGNORE_UNSTABLE_FAILURES` environment variable is set, so when an unstable
+test fails the CI run passes with a warning. Outside of CI that variable is not
+set by default, so an unstable test failure is reported as a failure like any
+other test.
 
-To promote an unstable test to stable, remove `unstable` from the macro. This is
-a single-place change — no CI or configuration updates are required.
+To promote an unstable test to stable, remove the `unstable(...)` wrapper. This
+is a single-place change — no CI or configuration updates are required.
 
 To suppress failures from `unstable` tests when running locally (matching the CI
 behavior), set the following environment variable: `PETRI_IGNORE_UNSTABLE_FAILURES=1`
+
+### "ignore" tests
+
+If a test (or a specific variant) should not run by default at all — for example
+it depends on functionality that isn't ready yet — mark it `ignore`, analogous to
+libtest's `#[ignore]`. Like `unstable`, every `ignore` marker requires a `reason`
+string (ideally referencing a tracking issue). Ignored tests are skipped unless
+explicitly requested.
+
+To ignore a single variant, wrap it in `ignore(reason = "...", <config>)`:
+
+```rust,ignore
+#[vmm_test(
+    ignore(reason = "OpenVMM VBS boot on Ubuntu is unreliable (microsoft/openvmm#2139)", openvmm_openhcl_uefi_x64[vbs](vhd(ubuntu_2504_server_x64))),
+    hyperv_openhcl_uefi_aarch64(vhd(ubuntu_2404_server_aarch64))
+    // ...
+)]
+async fn my_test<T: PetriVmmBackend>(config: PetriVmBuilder<T>) -> anyhow::Result<()> {
+    // ...
+}
+```
+
+To ignore all variants of the test, apply `ignore(reason = "...")` as a test-wide
+attribute alongside `configs(...)`:
+
+```rust,ignore
+#[vmm_test_with(ignore(reason = "needs functionality not yet implemented (microsoft/openvmm#1234)"), configs(
+    hyperv_openhcl_uefi_aarch64(vhd(windows_11_enterprise_aarch64)),
+    hyperv_openhcl_uefi_aarch64(vhd(ubuntu_2404_server_aarch64))
+    // ...
+))]
+async fn my_test<T: PetriVmmBackend>(config: PetriVmBuilder<T>) -> anyhow::Result<()> {
+    // ...
+}
+```
 
 ## Running VMM Tests (Flowey)
 

--- a/petri/src/test.rs
+++ b/petri/src/test.rs
@@ -40,33 +40,22 @@ use test_macro_support::TESTS;
 macro_rules! test {
     ($f:ident, $req:expr) => {
         $crate::multitest!(vec![
-            $crate::SimpleTest::new(
-                stringify!($f),
-                $req,
-                $f,
-                None,
-                false,
-                ::petri::RemoteAccess::LocalOnly
-            )
-            .into()
+            $crate::SimpleTest::new(stringify!($f), $req, $f).into()
         ]);
     };
 }
 
 /// Defines a single unstable test from a value that implements [`RunTest`].
+///
+/// `$reason` documents why the test is unstable and is logged when an unstable
+/// failure is ignored.
 #[macro_export]
 macro_rules! unstable_test {
-    ($f:ident, $req:expr) => {
+    ($f:ident, $req:expr, $reason:expr) => {
         $crate::multitest!(vec![
-            $crate::SimpleTest::new(
-                stringify!($f),
-                $req,
-                $f,
-                None,
-                true,
-                ::petri::RemoteAccess::LocalOnly
-            )
-            .into()
+            $crate::SimpleTest::new(stringify!($f), $req, $f)
+                .unstable($reason)
+                .into()
         ]);
     };
 }
@@ -179,7 +168,7 @@ impl Test {
             };
             Err(err)
         });
-        logger.log_test_result(&name, &r, self.test.0.unstable());
+        logger.log_test_result(&name, &r, self.test.0.unstable().is_some());
 
         for hook in post_test_hooks {
             tracing::info!(name = hook.name(), "Running post-test hook");
@@ -201,18 +190,24 @@ impl Test {
         self,
         resolve: fn(&str, TestArtifactRequirements) -> anyhow::Result<TestArtifacts>,
     ) -> libtest_mimic::Trial {
-        libtest_mimic::Trial::test(self.name(), move || match self.run(resolve) {
-            Ok(()) => Ok(()),
-            Err(err)
-                if self.test.0.unstable()
-                    && std::env::var("PETRI_IGNORE_UNSTABLE_FAILURES")
+        libtest_mimic::Trial::test(self.name(), move || {
+            let unstable = self.test.0.unstable();
+            match self.run(resolve) {
+                Ok(()) => Ok(()),
+                Err(err) => {
+                    let Some(reason) = unstable else {
+                        return Err(format!("{err:#}").into());
+                    };
+                    if std::env::var("PETRI_IGNORE_UNSTABLE_FAILURES")
                         .ok()
-                        .is_some_and(|v| !v.is_empty() && v != "0") =>
-            {
-                tracing::warn!("ignoring unstable test failure: {err:#}");
-                Ok(())
+                        .is_some_and(|v| !v.is_empty() && v != "0")
+                    {
+                        tracing::warn!(reason, "ignoring unstable test failure: {err:#}");
+                        return Ok(());
+                    }
+                    Err(format!("unstable test failed (reason: {reason}): {err:#}").into())
+                }
             }
-            Err(err) => Err(format!("{err:#}").into()),
         })
     }
 }
@@ -240,8 +235,11 @@ pub trait RunTest: Send {
     fn run(&self, params: PetriTestParams<'_>, artifacts: Self::Artifacts) -> anyhow::Result<()>;
     /// Returns the host requirements of the current test, if any.
     fn host_requirements(&self) -> Option<&TestCaseRequirements>;
-    /// Whether this test is unstable
-    fn unstable(&self) -> bool;
+    /// If this test is unstable, the reason why; `None` if stable.
+    fn unstable(&self) -> Option<&str>;
+    /// Whether this test is ignored (skipped by default, like a libtest
+    /// `#[ignore]` test).
+    fn ignored(&self) -> bool;
 }
 
 trait DynRunTest: Send {
@@ -249,7 +247,8 @@ trait DynRunTest: Send {
     fn artifact_requirements(&self) -> Option<TestArtifactRequirements>;
     fn run(&self, params: PetriTestParams<'_>, artifacts: &TestArtifacts) -> anyhow::Result<()>;
     fn host_requirements(&self) -> Option<&TestCaseRequirements>;
-    fn unstable(&self) -> bool;
+    fn unstable(&self) -> Option<&str>;
+    fn ignored(&self) -> bool;
 }
 
 impl<T: RunTest> DynRunTest for T {
@@ -274,8 +273,12 @@ impl<T: RunTest> DynRunTest for T {
         self.host_requirements()
     }
 
-    fn unstable(&self) -> bool {
+    fn unstable(&self) -> Option<&str> {
         self.unstable()
+    }
+
+    fn ignored(&self) -> bool {
+        self.ignored()
     }
 }
 
@@ -322,7 +325,8 @@ pub struct SimpleTest<A, F> {
     run: F,
     /// Optional test requirements
     pub host_requirements: Option<TestCaseRequirements>,
-    unstable: bool,
+    unstable: Option<&'static str>,
+    ignored: bool,
     remote_policy: RemoteAccess,
 }
 
@@ -332,24 +336,52 @@ where
     F: 'static + Send + Fn(PetriTestParams<'_>, AR) -> Result<(), E>,
     E: Into<anyhow::Error>,
 {
-    /// Returns a new test with the given `leaf_name`, `resolve`, `run` functions,
-    /// and optional requirements.
-    pub fn new(
-        leaf_name: &'static str,
-        resolve: A,
-        run: F,
-        host_requirements: Option<TestCaseRequirements>,
-        unstable: bool,
-        remote_policy: RemoteAccess,
-    ) -> Self {
+    /// Returns a new test with the given `leaf_name`, `resolve`, and `run`
+    /// functions.
+    ///
+    /// The test defaults to stable, not ignored, with no host requirements and
+    /// a [`RemoteAccess::LocalOnly`] policy. Use the builder methods
+    /// ([`requirements`](Self::requirements), [`unstable`](Self::unstable),
+    /// [`ignore`](Self::ignore), [`remote_access`](Self::remote_access)) to
+    /// override these.
+    pub fn new(leaf_name: &'static str, resolve: A, run: F) -> Self {
         SimpleTest {
             leaf_name,
             resolve,
             run,
-            host_requirements,
-            unstable,
-            remote_policy,
+            host_requirements: None,
+            unstable: None,
+            ignored: false,
+            remote_policy: RemoteAccess::LocalOnly,
         }
+    }
+
+    /// Sets the host requirements that must be satisfied for this test to run.
+    pub fn requirements(mut self, requirements: TestCaseRequirements) -> Self {
+        self.host_requirements = Some(requirements);
+        self
+    }
+
+    /// Marks this test as unstable, meaning its failures do not fail the run.
+    ///
+    /// `reason` documents why the test is unstable and is logged when an
+    /// unstable failure is ignored.
+    pub fn unstable(mut self, reason: &'static str) -> Self {
+        self.unstable = Some(reason);
+        self
+    }
+
+    /// Marks this test as ignored: it is skipped by default and only runs when
+    /// explicitly requested (like a libtest `#[ignore]` test).
+    pub fn ignore(mut self) -> Self {
+        self.ignored = true;
+        self
+    }
+
+    /// Sets the remote-access policy used when resolving artifacts.
+    pub fn remote_access(mut self, policy: RemoteAccess) -> Self {
+        self.remote_policy = policy;
+        self
     }
 }
 
@@ -378,8 +410,12 @@ where
         self.host_requirements.as_ref()
     }
 
-    fn unstable(&self) -> bool {
+    fn unstable(&self) -> Option<&str> {
         self.unstable
+    }
+
+    fn ignored(&self) -> bool {
+        self.ignored
     }
 }
 
@@ -483,7 +519,8 @@ pub fn test_main(
     let trials = Test::all()
         .map(|test| {
             let can_run = can_run_test_with_context(test.test.0.host_requirements(), &host_context);
-            test.trial(resolve).with_ignored_flag(!can_run)
+            let ignored = test.test.0.ignored();
+            test.trial(resolve).with_ignored_flag(!can_run || ignored)
         })
         .collect();
 

--- a/petri/src/test.rs
+++ b/petri/src/test.rs
@@ -362,7 +362,9 @@ where
         self
     }
 
-    /// Marks this test as unstable, meaning its failures do not fail the run.
+    /// Marks this test as unstable. When `PETRI_IGNORE_UNSTABLE_FAILURES` is
+    /// set (as it is in CI), a failure of this test is logged and ignored
+    /// rather than failing the run; otherwise it fails like any other test.
     ///
     /// `reason` documents why the test is unstable and is logged when an
     /// unstable failure is ignored.

--- a/tmk/tmk_tests/src/lib.rs
+++ b/tmk/tmk_tests/src/lib.rs
@@ -282,6 +282,7 @@ mod hyperv {
 
     petri::unstable_test!(
         hyperv_openhcl_tmks,
-        resolve_openhcl_tmks::<HyperVPetriBackend>
+        resolve_openhcl_tmks::<HyperVPetriBackend>,
+        "Hyper-V OpenHCL TMK execution is not yet reliable"
     );
 }

--- a/vmm_tests/vmm_test_macros/src/lib.rs
+++ b/vmm_tests/vmm_test_macros/src/lib.rs
@@ -326,6 +326,8 @@ impl Parse for ArgsWithOverrides {
                     let inner;
                     syn::parenthesized!(inner in input);
                     let reason = parse_reason(&inner)?;
+                    // Tolerate a trailing comma (e.g. from rustfmt).
+                    let _: Option<Token![,]> = inner.parse()?;
                     if !inner.is_empty() {
                         return Err(inner.error(
                             "whole-list `ignore`/`unstable` takes only `reason = \"...\"`; \
@@ -558,6 +560,8 @@ impl Parse for Config {
                 )
             })?;
             let mut config = inner.parse::<Config>()?;
+            // Tolerate a trailing comma (e.g. from rustfmt).
+            let _: Option<Token![,]> = inner.parse()?;
             if !inner.is_empty() {
                 return Err(inner.error("expected a single config after the reason"));
             }

--- a/vmm_tests/vmm_test_macros/src/lib.rs
+++ b/vmm_tests/vmm_test_macros/src/lib.rs
@@ -28,7 +28,10 @@ struct Config {
     arch: MachineArch,
     span: Span,
     extra_deps: Vec<Path>,
-    unstable: bool,
+    /// If unstable, the reason why.
+    unstable: Option<String>,
+    /// If ignored, the reason why (compile-time documentation only).
+    ignored: Option<String>,
 }
 
 struct ResolvedConfig {
@@ -36,7 +39,8 @@ struct ResolvedConfig {
     firmware: Firmware,
     arch: MachineArch,
     extra_deps: Vec<Path>,
-    unstable: bool,
+    unstable: Option<String>,
+    ignored: Option<String>,
     requires_host_vendor: Option<HostVendor>,
     requires_capabilities: Vec<&'static str>,
 }
@@ -102,7 +106,8 @@ struct Args {
 struct ArgsWithOverrides {
     args: Args,
     vmm: Option<Vmm>,
-    unstable: bool,
+    unstable: Option<String>,
+    ignored: Option<String>,
     with_vtl0_pipette: bool,
     requires_host_vendor: Option<HostVendor>,
     requires_capabilities: Vec<&'static str>,
@@ -317,6 +322,18 @@ impl Parse for ArgsWithOverrides {
                         Vmm::HyperV
                     });
                 }
+                "unstable" | "ignore" => {
+                    let inner;
+                    syn::parenthesized!(inner in input);
+                    let reason = parse_reason(&inner)?;
+                    if !inner.is_empty() {
+                        return Err(inner.error(
+                            "whole-list `ignore`/`unstable` takes only `reason = \"...\"`; \
+                             wrap an individual config to scope it",
+                        ));
+                    }
+                    overrides.set_flag_reason(&ident, reason)?;
+                }
                 _ => overrides.apply_ident(&ident)?,
             }
 
@@ -336,7 +353,8 @@ impl Parse for ArgsWithOverrides {
 
 struct ParsedOverrides {
     vmm: Option<Vmm>,
-    unstable: Option<bool>,
+    unstable: Option<String>,
+    ignored: Option<String>,
     with_vtl0_pipette: Option<bool>,
     requires_host_vendor: Option<HostVendor>,
     requires_capabilities: Vec<&'static str>,
@@ -347,6 +365,7 @@ impl ParsedOverrides {
         Self {
             vmm: None,
             unstable: None,
+            ignored: None,
             with_vtl0_pipette: None,
             requires_host_vendor: None,
             requires_capabilities: Vec::new(),
@@ -357,12 +376,6 @@ impl ParsedOverrides {
         let ident_string = ident.to_string();
         let conflict_err = || Err(Error::new(ident.span(), "conflicting override"));
         match ident_string.as_str() {
-            "unstable" => {
-                if self.unstable.is_some() {
-                    return conflict_err();
-                }
-                self.unstable = Some(true);
-            }
             "noagent" => {
                 if self.with_vtl0_pipette.is_some() {
                     return conflict_err();
@@ -386,6 +399,19 @@ impl ParsedOverrides {
         Ok(())
     }
 
+    fn set_flag_reason(&mut self, ident: &Ident, reason: String) -> syn::Result<()> {
+        let slot = match ident.to_string().as_str() {
+            "unstable" => &mut self.unstable,
+            "ignore" => &mut self.ignored,
+            _ => unreachable!(),
+        };
+        if slot.is_some() {
+            return Err(Error::new(ident.span(), "conflicting override"));
+        }
+        *slot = Some(reason);
+        Ok(())
+    }
+
     fn add_capability(&mut self, span: Span, capability: &'static str) -> syn::Result<()> {
         if self.requires_capabilities.contains(&capability) {
             return Err(Error::new(span, "duplicate required capability"));
@@ -399,7 +425,8 @@ impl ParsedOverrides {
             args,
             vmm: self.vmm,
             with_vtl0_pipette: self.with_vtl0_pipette.unwrap_or(true),
-            unstable: self.unstable.unwrap_or(false),
+            unstable: self.unstable,
+            ignored: self.ignored,
             requires_host_vendor: self.requires_host_vendor,
             requires_capabilities: self.requires_capabilities,
         }
@@ -438,6 +465,7 @@ impl ArgsWithOverrides {
             args: Args { configs },
             vmm,
             unstable,
+            ignored,
             with_vtl0_pipette,
             requires_host_vendor,
             requires_capabilities,
@@ -460,7 +488,11 @@ impl ArgsWithOverrides {
                 firmware: config.firmware,
                 arch: config.arch,
                 extra_deps: config.extra_deps,
-                unstable: config.unstable || unstable,
+                // A per-config wrapper reason wins over the whole-list override.
+                // A config may carry both `unstable` and `ignored`; `ignore`
+                // dominates at runtime (the test is skipped).
+                unstable: config.unstable.or_else(|| unstable.clone()),
+                ignored: config.ignored.or_else(|| ignored.clone()),
                 requires_host_vendor,
                 requires_capabilities: requires_capabilities.clone(),
             });
@@ -512,18 +544,43 @@ impl Parse for Config {
         let word = input.parse::<Ident>()?;
         let word_string = word.to_string();
 
-        let (unstable, remainder) = if let Some(remainder) = word_string.strip_prefix("unstable_") {
-            (true, remainder)
-        } else {
-            (false, word_string.as_str())
-        };
+        // Per-config `ignore(reason = "...", <config>)` /
+        // `unstable(reason = "...", <config>)` wrappers.
+        if word_string == "ignore" || word_string == "unstable" {
+            let inner;
+            syn::parenthesized!(inner in input);
+            let reason = parse_reason(&inner)?;
+            inner.parse::<Token![,]>().map_err(|_| {
+                Error::new(
+                    word.span(),
+                    "per-config `ignore`/`unstable` requires a config, e.g. \
+                     `ignore(reason = \"...\", linux_direct_x64)`",
+                )
+            })?;
+            let mut config = inner.parse::<Config>()?;
+            if !inner.is_empty() {
+                return Err(inner.error("expected a single config after the reason"));
+            }
+            if config.unstable.is_some() || config.ignored.is_some() {
+                return Err(Error::new(
+                    word.span(),
+                    "cannot nest `ignore`/`unstable` wrappers",
+                ));
+            }
+            if word_string == "ignore" {
+                config.ignored = Some(reason);
+            } else {
+                config.unstable = Some(reason);
+            }
+            return Ok(config);
+        }
 
-        let (vmm, remainder) = if let Some(remainder) = remainder.strip_prefix("hyperv_") {
+        let (vmm, remainder) = if let Some(remainder) = word_string.strip_prefix("hyperv_") {
             (Some(Vmm::HyperV), remainder)
-        } else if let Some(remainder) = remainder.strip_prefix("openvmm_") {
+        } else if let Some(remainder) = word_string.strip_prefix("openvmm_") {
             (Some(Vmm::OpenVmm), remainder)
         } else {
-            (None, remainder)
+            (None, word_string.as_str())
         };
 
         let (arch, firmware) = match remainder {
@@ -572,7 +629,8 @@ impl Parse for Config {
             arch,
             span: input.span(),
             extra_deps,
-            unstable,
+            unstable: None,
+            ignored: None,
         })
     }
 }
@@ -815,10 +873,24 @@ fn parse_extra_deps(input: ParseStream<'_>) -> syn::Result<Vec<Path>> {
     Ok(deps.into_iter().collect())
 }
 
+/// Parses a mandatory `reason = "..."` argument, returning the reason string.
+fn parse_reason(input: ParseStream<'_>) -> syn::Result<String> {
+    let ident = input.parse::<Ident>()?;
+    if ident != "reason" {
+        return Err(Error::new(ident.span(), "expected `reason = \"...\"`"));
+    }
+    input.parse::<Token![=]>()?;
+    let reason = input.parse::<syn::LitStr>()?;
+    Ok(reason.value())
+}
+
 /// Transform the function into VMM tests, one for each specified firmware configuration.
 ///
-/// All options can be prefixed with "unstable_" to denote that this should
-/// not block PRs if it fails.
+/// An individual config can be marked unstable (runs, but failures don't block
+/// PRs) or ignored (skipped by default, like a libtest `#[ignore]` test) by
+/// wrapping it in `unstable(reason = "...", <config>)` or
+/// `ignore(reason = "...", <config>)`. The `reason` is mandatory. Use
+/// `vmm_test_with` to apply either to the whole list of configs.
 ///
 /// Valid configuration options are:
 /// - `{vmm}_linux_direct_{arch}`: Our provided Linux direct image
@@ -883,7 +955,8 @@ pub fn vmm_test(
     let args = ArgsWithOverrides {
         args: parse_macro_input!(attr as Args),
         vmm: None,
-        unstable: false,
+        unstable: None,
+        ignored: None,
         with_vtl0_pipette: true,
         requires_host_vendor: None,
         requires_capabilities: Vec::new(),
@@ -903,13 +976,18 @@ pub fn vmm_test(
 /// ```
 ///
 /// The available attributes are:
-/// - unstable: all variants of this test are unstable
+/// - unstable(reason = "..."): all variants are unstable (failures don't block PRs)
+/// - ignore(reason = "..."): all variants are ignored (skipped by default)
 /// - noagent: don't use pipette in vtl0 for this test
 /// - amd: this test only runs on AMD-vendor hosts (skipped otherwise)
 /// - intel: this test only runs on Intel-vendor hosts (skipped otherwise)
 /// - hyperv: use hyperv as the vmm
 /// - openvmm: use openvmm as the vmm
 /// - requires(...): required capabilities (see below)
+///
+/// `unstable` and `ignore` can also be applied to a single config by wrapping
+/// it: `unstable(reason = "...", <config>)` / `ignore(reason = "...", <config>)`.
+/// A per-config wrapper cannot itself be nested inside another.
 ///
 /// `requires(...)` lists capabilities the test needs. Petri auto-detects some
 /// capabilities, such as `vpci`, and execution environments can advertise
@@ -945,7 +1023,8 @@ pub fn openvmm_test(
     let args = ArgsWithOverrides {
         args: parse_macro_input!(attr as Args),
         vmm: Some(Vmm::OpenVmm),
-        unstable: false,
+        unstable: None,
+        ignored: None,
         with_vtl0_pipette: true,
         requires_host_vendor: None,
         requires_capabilities: Vec::new(),
@@ -966,7 +1045,8 @@ pub fn openvmm_test_no_agent(
     let args = ArgsWithOverrides {
         args: parse_macro_input!(attr as Args),
         vmm: Some(Vmm::OpenVmm),
-        unstable: false,
+        unstable: None,
+        ignored: None,
         with_vtl0_pipette: false,
         requires_host_vendor: None,
         requires_capabilities: Vec::new(),
@@ -1036,7 +1116,15 @@ fn make_vmm_test(args: ArgsWithOverrides, item: ItemFn) -> syn::Result<TokenStre
         };
 
         let petri_vm_config = quote!(#petri_vm_config::new(params, artifacts, &driver)?);
-        let unstable = config.unstable.to_token_stream();
+        let unstable = match &config.unstable {
+            Some(reason) => quote!(.unstable(#reason)),
+            None => quote!(),
+        };
+        let ignore = if config.ignored.is_some() {
+            quote!(.ignore())
+        } else {
+            quote!()
+        };
 
         let test = quote! {
             #cfg_conditions
@@ -1055,10 +1143,12 @@ fn make_vmm_test(args: ArgsWithOverrides, item: ItemFn) -> syn::Result<TokenStre
                         #original_name(#original_args).await
                     })
                 },
-                Some(#requirements),
-                #unstable,
-                #remote_access,
-            ).into(),
+            )
+            .requirements(#requirements)
+            .remote_access(#remote_access)
+            #unstable
+            #ignore
+            .into(),
         };
 
         tests.extend(test);

--- a/vmm_tests/vmm_tests/tests/cca.rs
+++ b/vmm_tests/vmm_tests/tests/cca.rs
@@ -706,15 +706,7 @@ fn write_visible_output(line: &[u8], logged_len: &mut usize, output_send: &mpsc:
 }
 
 petri::multitest!(vec![
-    petri::SimpleTest::new(
-        "cca_runtime",
-        resolve_cca_runtime,
-        cca_runtime,
-        None,
-        false,
-        petri::RemoteAccess::LocalOnly,
-    )
-    .into()
+    petri::SimpleTest::new("cca_runtime", resolve_cca_runtime, cca_runtime).into()
 ]);
 
 fn main() {

--- a/vmm_tests/vmm_tests/tests/tests/multiarch.rs
+++ b/vmm_tests/vmm_tests/tests/tests/multiarch.rs
@@ -277,7 +277,7 @@ async fn boot_no_agent<T: PetriVmmBackend>(config: PetriVmBuilder<T>) -> anyhow:
     hyperv_openhcl_uefi_aarch64(vhd(ubuntu_2404_server_aarch64)),
     hyperv_openhcl_uefi_x64(vhd(windows_datacenter_core_2022_x64)),
     hyperv_openhcl_uefi_x64(vhd(ubuntu_2504_server_x64)),
-    unstable(reason = "OpenVMM VBS boot is intermittently unreliable in CI", openvmm_openhcl_uefi_x64[vbs](vhd(windows_datacenter_core_2025_x64_prepped))),
+    ignore(reason = "OpenVMM VBS boot is intermittently unreliable in CI", openvmm_openhcl_uefi_x64[vbs](vhd(windows_datacenter_core_2025_x64_prepped))),
     ignore(reason = "OpenVMM VBS boot on Ubuntu is unreliable (microsoft/openvmm#2608)", openvmm_openhcl_uefi_x64[vbs](vhd(ubuntu_2504_server_x64))),
     hyperv_openhcl_uefi_x64[vbs](vhd(windows_datacenter_core_2025_x64_prepped)),
     hyperv_openhcl_uefi_x64[vbs](vhd(ubuntu_2504_server_x64)),

--- a/vmm_tests/vmm_tests/tests/tests/multiarch.rs
+++ b/vmm_tests/vmm_tests/tests/tests/multiarch.rs
@@ -88,7 +88,7 @@ async fn frontpage<T: PetriVmmBackend>(config: PetriVmBuilder<T>) -> anyhow::Res
     hyperv_openhcl_uefi_x64(vhd(ubuntu_2404_server_x64)),
     hyperv_openhcl_uefi_x64(vhd(ubuntu_2504_server_x64)),
     openvmm_openhcl_uefi_x64[vbs](vhd(windows_datacenter_core_2025_x64_prepped)),
-    // openvmm_openhcl_uefi_x64[vbs](vhd(ubuntu_2504_server_x64)),
+    ignore(reason = "OpenVMM VBS boot on Ubuntu is unreliable (microsoft/openvmm#2139)", openvmm_openhcl_uefi_x64[vbs](vhd(ubuntu_2504_server_x64))),
     hyperv_openhcl_uefi_x64[vbs](vhd(windows_datacenter_core_2025_x64_prepped)),
     hyperv_openhcl_uefi_x64[vbs](vhd(ubuntu_2504_server_x64)),
     hyperv_openhcl_uefi_x64[snp](vhd(windows_datacenter_core_2025_x64_prepped)),
@@ -277,8 +277,8 @@ async fn boot_no_agent<T: PetriVmmBackend>(config: PetriVmBuilder<T>) -> anyhow:
     hyperv_openhcl_uefi_aarch64(vhd(ubuntu_2404_server_aarch64)),
     hyperv_openhcl_uefi_x64(vhd(windows_datacenter_core_2022_x64)),
     hyperv_openhcl_uefi_x64(vhd(ubuntu_2504_server_x64)),
-    unstable_openvmm_openhcl_uefi_x64[vbs](vhd(windows_datacenter_core_2025_x64_prepped)),
-    // openvmm_openhcl_uefi_x64[vbs](vhd(ubuntu_2504_server_x64)),
+    unstable(reason = "OpenVMM VBS boot is intermittently unreliable in CI", openvmm_openhcl_uefi_x64[vbs](vhd(windows_datacenter_core_2025_x64_prepped))),
+    ignore(reason = "OpenVMM VBS boot on Ubuntu is unreliable (microsoft/openvmm#2139)", openvmm_openhcl_uefi_x64[vbs](vhd(ubuntu_2504_server_x64))),
     hyperv_openhcl_uefi_x64[vbs](vhd(windows_datacenter_core_2025_x64_prepped)),
     hyperv_openhcl_uefi_x64[vbs](vhd(ubuntu_2504_server_x64)),
     hyperv_openhcl_uefi_x64[snp](vhd(windows_datacenter_core_2025_x64_prepped)),
@@ -299,7 +299,7 @@ async fn boot_heavy<T: PetriVmmBackend>(config: PetriVmBuilder<T>) -> anyhow::Re
 /// Basic boot test with a single VP.
 #[vmm_test(
     openvmm_openhcl_uefi_x64[vbs](vhd(windows_datacenter_core_2025_x64_prepped)),
-    // openvmm_openhcl_uefi_x64[vbs](vhd(ubuntu_2504_server_x64)),
+    ignore(reason = "OpenVMM VBS boot on Ubuntu is unreliable (microsoft/openvmm#2139)", openvmm_openhcl_uefi_x64[vbs](vhd(ubuntu_2504_server_x64))),
     hyperv_openhcl_uefi_x64[vbs](vhd(windows_datacenter_core_2025_x64_prepped)),
     hyperv_openhcl_uefi_x64[vbs](vhd(ubuntu_2504_server_x64)),
     hyperv_openhcl_uefi_x64[snp](vhd(windows_datacenter_core_2025_x64_prepped)),
@@ -323,12 +323,19 @@ async fn boot_single_proc<T: PetriVmmBackend>(config: PetriVmBuilder<T>) -> anyh
 #[vmm_test_with(
     requires(vpci),
     configs(
-        // TODO: virt_whp is missing VPCI LPI interrupt support, used by Windows (but not Linux)
-        // openvmm_uefi_aarch64(vhd(windows_11_enterprise_aarch64)),
+        ignore(
+            reason = "virt_whp lacks VPCI LPI interrupt support (Windows)",
+            openvmm_uefi_aarch64(vhd(windows_11_enterprise_aarch64))
+        ),
         openvmm_uefi_x64(vhd(windows_datacenter_core_2022_x64)),
-        // TODO: Linux image is missing VPCI driver in its initrd
-        // openvmm_uefi_aarch64(vhd(ubuntu_2404_server_aarch64)),
-        // openvmm_uefi_x64(vhd(ubuntu_2504_server_x64))
+        ignore(
+            reason = "Linux initrd lacks a VPCI driver",
+            openvmm_uefi_aarch64(vhd(ubuntu_2404_server_aarch64))
+        ),
+        ignore(
+            reason = "Linux initrd lacks a VPCI driver",
+            openvmm_uefi_x64(vhd(ubuntu_2504_server_x64))
+        )
     )
 )]
 async fn boot_nvme<T: PetriVmmBackend>(config: PetriVmBuilder<T>) -> anyhow::Result<()> {
@@ -345,12 +352,19 @@ async fn boot_nvme<T: PetriVmmBackend>(config: PetriVmBuilder<T>) -> anyhow::Res
 #[vmm_test_with(
     requires(vpci),
     configs(
-        // TODO: aarch64 support (WHP missing ARM64 VTL2 support)
-        // openvmm_openhcl_uefi_aarch64(vhd(windows_11_enterprise_aarch64)),
-        // openvmm_openhcl_uefi_aarch64(vhd(ubuntu_2404_server_aarch64)),
+        ignore(
+            reason = "WHP lacks ARM64 VTL2 support",
+            openvmm_openhcl_uefi_aarch64(vhd(windows_11_enterprise_aarch64))
+        ),
+        ignore(
+            reason = "WHP lacks ARM64 VTL2 support",
+            openvmm_openhcl_uefi_aarch64(vhd(ubuntu_2404_server_aarch64))
+        ),
         openvmm_openhcl_uefi_x64(vhd(windows_datacenter_core_2022_x64)),
-        // TODO: Linux image is missing VPCI driver in its initrd
-        // openvmm_openhcl_uefi_x64(vhd(ubuntu_2504_server_x64))
+        ignore(
+            reason = "Linux initrd lacks a VPCI driver",
+            openvmm_openhcl_uefi_x64(vhd(ubuntu_2504_server_x64))
+        )
     )
 )]
 async fn boot_nvme_vpci_relay<T: PetriVmmBackend>(config: PetriVmBuilder<T>) -> anyhow::Result<()> {
@@ -366,18 +380,17 @@ async fn boot_nvme_vpci_relay<T: PetriVmmBackend>(config: PetriVmBuilder<T>) -> 
 }
 
 /// Validate we can reboot a VM and reconnect to pipette.
-// TODO: Reenable openvmm guests that use the framebuffer once #74 is fixed.
 #[vmm_test(
     openvmm_linux_direct_x64,
     openvmm_openhcl_linux_direct_x64,
-    // openvmm_pcat_x64(vhd(windows_datacenter_core_2022_x64)),
-    // openvmm_pcat_x64(vhd(ubuntu_2504_server_x64)),
-    // openvmm_uefi_aarch64(vhd(windows_11_enterprise_aarch64)),
-    // openvmm_uefi_aarch64(vhd(ubuntu_2404_server_aarch64)),
-    // openvmm_uefi_x64(vhd(windows_datacenter_core_2022_x64)),
-    // openvmm_uefi_x64(vhd(ubuntu_2504_server_x64)),
-    // openvmm_openhcl_uefi_x64(vhd(windows_datacenter_core_2022_x64)),
-    // openvmm_openhcl_uefi_x64(vhd(ubuntu_2504_server_x64)),
+    ignore(reason = "framebuffer reboot bug (microsoft/openvmm#74)", openvmm_pcat_x64(vhd(windows_datacenter_core_2022_x64))),
+    ignore(reason = "framebuffer reboot bug (microsoft/openvmm#74)", openvmm_pcat_x64(vhd(ubuntu_2504_server_x64))),
+    ignore(reason = "framebuffer reboot bug (microsoft/openvmm#74)", openvmm_uefi_aarch64(vhd(windows_11_enterprise_aarch64))),
+    ignore(reason = "framebuffer reboot bug (microsoft/openvmm#74)", openvmm_uefi_aarch64(vhd(ubuntu_2404_server_aarch64))),
+    ignore(reason = "framebuffer reboot bug (microsoft/openvmm#74)", openvmm_uefi_x64(vhd(windows_datacenter_core_2022_x64))),
+    ignore(reason = "framebuffer reboot bug (microsoft/openvmm#74)", openvmm_uefi_x64(vhd(ubuntu_2504_server_x64))),
+    ignore(reason = "framebuffer reboot bug (microsoft/openvmm#74)", openvmm_openhcl_uefi_x64(vhd(windows_datacenter_core_2022_x64))),
+    ignore(reason = "framebuffer reboot bug (microsoft/openvmm#74)", openvmm_openhcl_uefi_x64(vhd(ubuntu_2504_server_x64))),
     hyperv_openhcl_pcat_x64(vhd(windows_datacenter_core_2022_x64)),
     hyperv_openhcl_pcat_x64(vhd(ubuntu_2504_server_x64)),
     hyperv_openhcl_uefi_aarch64(vhd(windows_11_enterprise_aarch64)),
@@ -385,7 +398,7 @@ async fn boot_nvme_vpci_relay<T: PetriVmmBackend>(config: PetriVmBuilder<T>) -> 
     hyperv_openhcl_uefi_x64(vhd(windows_datacenter_core_2022_x64)),
     hyperv_openhcl_uefi_x64(vhd(ubuntu_2504_server_x64)),
     openvmm_openhcl_uefi_x64[vbs](vhd(windows_datacenter_core_2025_x64_prepped)),
-    // openvmm_openhcl_uefi_x64[vbs](vhd(ubuntu_2504_server_x64)),
+    ignore(reason = "OpenVMM VBS boot on Ubuntu is unreliable (microsoft/openvmm#2139)", openvmm_openhcl_uefi_x64[vbs](vhd(ubuntu_2504_server_x64))),
     hyperv_openhcl_uefi_x64[vbs](vhd(ubuntu_2504_server_x64)),
     hyperv_openhcl_uefi_x64[tdx](vhd(ubuntu_2504_server_x64)),
     hyperv_openhcl_uefi_x64[snp](vhd(ubuntu_2504_server_x64))
@@ -515,10 +528,22 @@ async fn secure_boot<T: PetriVmmBackend>(config: PetriVmBuilder<T>) -> anyhow::R
         openvmm_uefi_x64(vhd(ubuntu_2504_server_x64)),
         openvmm_openhcl_uefi_x64(vhd(windows_datacenter_core_2022_x64)),
         openvmm_openhcl_uefi_x64(vhd(ubuntu_2504_server_x64)),
-        // hyperv_uefi_aarch64(vhd(windows_11_enterprise_aarch64)),
-        // hyperv_uefi_aarch64(vhd(ubuntu_2404_server_aarch64)),
-        // hyperv_uefi_x64(vhd(windows_datacenter_core_2022_x64)),
-        // hyperv_uefi_x64(vhd(ubuntu_2504_server_x64)),
+        ignore(
+            reason = "Hyper-V cannot load a per-VM UEFI firmware (system-wide only)",
+            hyperv_uefi_aarch64(vhd(windows_11_enterprise_aarch64))
+        ),
+        ignore(
+            reason = "Hyper-V cannot load a per-VM UEFI firmware (system-wide only)",
+            hyperv_uefi_aarch64(vhd(ubuntu_2404_server_aarch64))
+        ),
+        ignore(
+            reason = "Hyper-V cannot load a per-VM UEFI firmware (system-wide only)",
+            hyperv_uefi_x64(vhd(windows_datacenter_core_2022_x64))
+        ),
+        ignore(
+            reason = "Hyper-V cannot load a per-VM UEFI firmware (system-wide only)",
+            hyperv_uefi_x64(vhd(ubuntu_2504_server_x64))
+        ),
         hyperv_openhcl_uefi_aarch64(vhd(windows_11_enterprise_aarch64)),
         hyperv_openhcl_uefi_aarch64(vhd(ubuntu_2404_server_aarch64)),
         hyperv_openhcl_uefi_x64(vhd(windows_datacenter_core_2022_x64)),

--- a/vmm_tests/vmm_tests/tests/tests/multiarch.rs
+++ b/vmm_tests/vmm_tests/tests/tests/multiarch.rs
@@ -88,7 +88,7 @@ async fn frontpage<T: PetriVmmBackend>(config: PetriVmBuilder<T>) -> anyhow::Res
     hyperv_openhcl_uefi_x64(vhd(ubuntu_2404_server_x64)),
     hyperv_openhcl_uefi_x64(vhd(ubuntu_2504_server_x64)),
     openvmm_openhcl_uefi_x64[vbs](vhd(windows_datacenter_core_2025_x64_prepped)),
-    ignore(reason = "OpenVMM VBS boot on Ubuntu is unreliable (microsoft/openvmm#2139)", openvmm_openhcl_uefi_x64[vbs](vhd(ubuntu_2504_server_x64))),
+    ignore(reason = "OpenVMM VBS boot on Ubuntu is unreliable (microsoft/openvmm#2608)", openvmm_openhcl_uefi_x64[vbs](vhd(ubuntu_2504_server_x64))),
     hyperv_openhcl_uefi_x64[vbs](vhd(windows_datacenter_core_2025_x64_prepped)),
     hyperv_openhcl_uefi_x64[vbs](vhd(ubuntu_2504_server_x64)),
     hyperv_openhcl_uefi_x64[snp](vhd(windows_datacenter_core_2025_x64_prepped)),
@@ -278,7 +278,7 @@ async fn boot_no_agent<T: PetriVmmBackend>(config: PetriVmBuilder<T>) -> anyhow:
     hyperv_openhcl_uefi_x64(vhd(windows_datacenter_core_2022_x64)),
     hyperv_openhcl_uefi_x64(vhd(ubuntu_2504_server_x64)),
     unstable(reason = "OpenVMM VBS boot is intermittently unreliable in CI", openvmm_openhcl_uefi_x64[vbs](vhd(windows_datacenter_core_2025_x64_prepped))),
-    ignore(reason = "OpenVMM VBS boot on Ubuntu is unreliable (microsoft/openvmm#2139)", openvmm_openhcl_uefi_x64[vbs](vhd(ubuntu_2504_server_x64))),
+    ignore(reason = "OpenVMM VBS boot on Ubuntu is unreliable (microsoft/openvmm#2608)", openvmm_openhcl_uefi_x64[vbs](vhd(ubuntu_2504_server_x64))),
     hyperv_openhcl_uefi_x64[vbs](vhd(windows_datacenter_core_2025_x64_prepped)),
     hyperv_openhcl_uefi_x64[vbs](vhd(ubuntu_2504_server_x64)),
     hyperv_openhcl_uefi_x64[snp](vhd(windows_datacenter_core_2025_x64_prepped)),
@@ -299,7 +299,7 @@ async fn boot_heavy<T: PetriVmmBackend>(config: PetriVmBuilder<T>) -> anyhow::Re
 /// Basic boot test with a single VP.
 #[vmm_test(
     openvmm_openhcl_uefi_x64[vbs](vhd(windows_datacenter_core_2025_x64_prepped)),
-    ignore(reason = "OpenVMM VBS boot on Ubuntu is unreliable (microsoft/openvmm#2139)", openvmm_openhcl_uefi_x64[vbs](vhd(ubuntu_2504_server_x64))),
+    ignore(reason = "OpenVMM VBS boot on Ubuntu is unreliable (microsoft/openvmm#2608)", openvmm_openhcl_uefi_x64[vbs](vhd(ubuntu_2504_server_x64))),
     hyperv_openhcl_uefi_x64[vbs](vhd(windows_datacenter_core_2025_x64_prepped)),
     hyperv_openhcl_uefi_x64[vbs](vhd(ubuntu_2504_server_x64)),
     hyperv_openhcl_uefi_x64[snp](vhd(windows_datacenter_core_2025_x64_prepped)),
@@ -398,7 +398,7 @@ async fn boot_nvme_vpci_relay<T: PetriVmmBackend>(config: PetriVmBuilder<T>) -> 
     hyperv_openhcl_uefi_x64(vhd(windows_datacenter_core_2022_x64)),
     hyperv_openhcl_uefi_x64(vhd(ubuntu_2504_server_x64)),
     openvmm_openhcl_uefi_x64[vbs](vhd(windows_datacenter_core_2025_x64_prepped)),
-    ignore(reason = "OpenVMM VBS boot on Ubuntu is unreliable (microsoft/openvmm#2139)", openvmm_openhcl_uefi_x64[vbs](vhd(ubuntu_2504_server_x64))),
+    ignore(reason = "OpenVMM VBS boot on Ubuntu is unreliable (microsoft/openvmm#2608)", openvmm_openhcl_uefi_x64[vbs](vhd(ubuntu_2504_server_x64))),
     hyperv_openhcl_uefi_x64[vbs](vhd(ubuntu_2504_server_x64)),
     hyperv_openhcl_uefi_x64[tdx](vhd(ubuntu_2504_server_x64)),
     hyperv_openhcl_uefi_x64[snp](vhd(ubuntu_2504_server_x64))

--- a/vmm_tests/vmm_tests/tests/tests/multiarch/large_pages.rs
+++ b/vmm_tests/vmm_tests/tests/tests/multiarch/large_pages.rs
@@ -21,16 +21,7 @@ use vmm_test_macros::openvmm_test;
 /// Requires the "Lock pages in memory" privilege (`SeLockMemoryPrivilege`) so
 /// that the large-page section allocation succeeds; the test fails (rather than
 /// skips) if large-page backing is unavailable, per design.
-///
-/// TODO: remove the `ignore(...)` wrapper on `linux_direct_x64` once the CI
-/// runners have the SeLockMemoryPrivilege enabled for the test user.
-#[openvmm_test(
-    ignore(
-        reason = "missing SeLockMemoryPrivilege in x86_64 runners",
-        linux_direct_x64
-    ),
-    linux_direct_aarch64
-)]
+#[openvmm_test(linux_direct_x64, linux_direct_aarch64)]
 async fn whp_large_pages_slat(config: PetriVmBuilder<OpenVmmPetriBackend>) -> anyhow::Result<()> {
     const HUGEPAGE_SIZE: u64 = 2 * 1024 * 1024;
     const GIGAPAGE_SIZE: u64 = 1024 * 1024 * 1024;

--- a/vmm_tests/vmm_tests/tests/tests/multiarch/large_pages.rs
+++ b/vmm_tests/vmm_tests/tests/tests/multiarch/large_pages.rs
@@ -22,8 +22,8 @@ use vmm_test_macros::openvmm_test;
 /// that the large-page section allocation succeeds; the test fails (rather than
 /// skips) if large-page backing is unavailable, per design.
 ///
-/// TODO: clear unstable prefix once the CI runners have the
-/// SeLockMemoryPrivilege enabled for the test user.
+/// TODO: remove the `ignore(...)` wrapper on `linux_direct_x64` once the CI
+/// runners have the SeLockMemoryPrivilege enabled for the test user.
 #[openvmm_test(
     ignore(
         reason = "missing SeLockMemoryPrivilege in x86_64 runners",

--- a/vmm_tests/vmm_tests/tests/tests/multiarch/large_pages.rs
+++ b/vmm_tests/vmm_tests/tests/tests/multiarch/large_pages.rs
@@ -24,7 +24,13 @@ use vmm_test_macros::openvmm_test;
 ///
 /// TODO: clear unstable prefix once the CI runners have the
 /// SeLockMemoryPrivilege enabled for the test user.
-#[openvmm_test(unstable_linux_direct_x64, unstable_linux_direct_aarch64)]
+#[openvmm_test(
+    ignore(
+        reason = "missing SeLockMemoryPrivilege in x86_64 runners",
+        linux_direct_x64
+    ),
+    linux_direct_aarch64
+)]
 async fn whp_large_pages_slat(config: PetriVmBuilder<OpenVmmPetriBackend>) -> anyhow::Result<()> {
     const HUGEPAGE_SIZE: u64 = 2 * 1024 * 1024;
     const GIGAPAGE_SIZE: u64 = 1024 * 1024 * 1024;

--- a/vmm_tests/vmm_tests/tests/tests/multiarch/pcie.rs
+++ b/vmm_tests/vmm_tests/tests/tests/multiarch/pcie.rs
@@ -413,7 +413,10 @@ async fn pcie_hotplug(
 /// 2. Enumerates PCI devices visible to the guest
 /// 3. Pulses save/restore (pause → save → restore → resume)
 /// 4. Re-enumerates PCI devices and verifies they match
-#[openvmm_test(unstable_linux_direct_x64)]
+#[openvmm_test(unstable(
+    reason = "PCIe save/restore test is flaky on linux-direct in CI; root cause unknown",
+    linux_direct_x64
+))]
 async fn pcie_save_restore(config: PetriVmBuilder<OpenVmmPetriBackend>) -> anyhow::Result<()> {
     let os_flavor = config.os_flavor();
     let (mut vm, agent) = config

--- a/vmm_tests/vmm_tests/tests/tests/multiarch/tpm.rs
+++ b/vmm_tests/vmm_tests/tests/tests/multiarch/tpm.rs
@@ -333,7 +333,7 @@ impl<'a> TpmGuestTests<'a> {
     hyperv_openhcl_uefi_x64(vhd(windows_datacenter_core_2022_x64)),
     hyperv_openhcl_uefi_x64(vhd(ubuntu_2504_server_x64)),
     openvmm_openhcl_uefi_x64[vbs](vhd(windows_datacenter_core_2025_x64_prepped)),
-    ignore(reason = "OpenVMM VBS boot on Ubuntu is unreliable (microsoft/openvmm#2139)", openvmm_openhcl_uefi_x64[vbs](vhd(ubuntu_2504_server_x64))),
+    ignore(reason = "OpenVMM VBS boot on Ubuntu is unreliable (microsoft/openvmm#2608)", openvmm_openhcl_uefi_x64[vbs](vhd(ubuntu_2504_server_x64))),
     hyperv_openhcl_uefi_x64[vbs](vhd(windows_datacenter_core_2025_x64_prepped)),
     hyperv_openhcl_uefi_x64[vbs](vhd(ubuntu_2504_server_x64)),
     hyperv_openhcl_uefi_x64[snp](vhd(windows_datacenter_core_2025_x64_prepped)),
@@ -631,7 +631,7 @@ async fn ak_cert_retry<T, S, U: PetriVmmBackend>(
 /// VBS boot test with attestation enabled
 #[openvmm_test(
     openhcl_uefi_x64[vbs](vhd(windows_datacenter_core_2025_x64_prepped)),
-    ignore(reason = "OpenVMM VBS Ubuntu attestation boot is not yet reliable", openhcl_uefi_x64[vbs](vhd(ubuntu_2504_server_x64)))
+    ignore(reason = "OpenVMM VBS Ubuntu attestation boot is not yet reliable (microsoft/openvmm#2608)", openhcl_uefi_x64[vbs](vhd(ubuntu_2504_server_x64)))
 )]
 async fn vbs_boot_with_attestation(
     config: PetriVmBuilder<OpenVmmPetriBackend>,

--- a/vmm_tests/vmm_tests/tests/tests/multiarch/tpm.rs
+++ b/vmm_tests/vmm_tests/tests/tests/multiarch/tpm.rs
@@ -320,11 +320,10 @@ impl<'a> TpmGuestTests<'a> {
 
 /// Basic boot tests with TPM enabled.
 #[vmm_test(
-    // TODO: enable openvmm TPM tests once we can build OpenSSL on Windows in CI
-    // openvmm_uefi_aarch64(vhd(windows_11_enterprise_aarch64)),
-    // openvmm_uefi_aarch64(vhd(ubuntu_2404_server_aarch64)),
-    // openvmm_uefi_x64(vhd(windows_datacenter_core_2022_x64)),
-    // openvmm_uefi_x64(vhd(ubuntu_2504_server_x64)),
+    ignore(reason = "OpenVMM TPM needs OpenSSL, not yet buildable on Windows CI", openvmm_uefi_aarch64(vhd(windows_11_enterprise_aarch64))),
+    ignore(reason = "OpenVMM TPM needs OpenSSL, not yet buildable on Windows CI", openvmm_uefi_aarch64(vhd(ubuntu_2404_server_aarch64))),
+    ignore(reason = "OpenVMM TPM needs OpenSSL, not yet buildable on Windows CI", openvmm_uefi_x64(vhd(windows_datacenter_core_2022_x64))),
+    ignore(reason = "OpenVMM TPM needs OpenSSL, not yet buildable on Windows CI", openvmm_uefi_x64(vhd(ubuntu_2504_server_x64))),
     openvmm_openhcl_uefi_x64(vhd(alpine_3_23_x64)),
     openvmm_openhcl_uefi_x64(vhd(windows_datacenter_core_2022_x64)),
     openvmm_openhcl_uefi_x64(vhd(ubuntu_2504_server_x64)),
@@ -334,7 +333,7 @@ impl<'a> TpmGuestTests<'a> {
     hyperv_openhcl_uefi_x64(vhd(windows_datacenter_core_2022_x64)),
     hyperv_openhcl_uefi_x64(vhd(ubuntu_2504_server_x64)),
     openvmm_openhcl_uefi_x64[vbs](vhd(windows_datacenter_core_2025_x64_prepped)),
-    // openvmm_openhcl_uefi_x64[vbs](vhd(ubuntu_2504_server_x64)),
+    ignore(reason = "OpenVMM VBS boot on Ubuntu is unreliable (microsoft/openvmm#2139)", openvmm_openhcl_uefi_x64[vbs](vhd(ubuntu_2504_server_x64))),
     hyperv_openhcl_uefi_x64[vbs](vhd(windows_datacenter_core_2025_x64_prepped)),
     hyperv_openhcl_uefi_x64[vbs](vhd(ubuntu_2504_server_x64)),
     hyperv_openhcl_uefi_x64[snp](vhd(windows_datacenter_core_2025_x64_prepped)),
@@ -632,7 +631,7 @@ async fn ak_cert_retry<T, S, U: PetriVmmBackend>(
 /// VBS boot test with attestation enabled
 #[openvmm_test(
     openhcl_uefi_x64[vbs](vhd(windows_datacenter_core_2025_x64_prepped)),
-    // openhcl_uefi_x64[vbs](vhd(ubuntu_2504_server_x64))
+    ignore(reason = "OpenVMM VBS Ubuntu attestation boot is not yet reliable", openhcl_uefi_x64[vbs](vhd(ubuntu_2504_server_x64)))
 )]
 async fn vbs_boot_with_attestation(
     config: PetriVmBuilder<OpenVmmPetriBackend>,
@@ -961,7 +960,7 @@ async fn ak_pub_refresh<T, S, U: PetriVmmBackend>(
 /// test function (`skip_hw_unseal`), they all map to
 /// `KeyReleaseFailureSkipHwUnsealing`.
 #[cfg(windows)]
-#[vmm_test_with(unstable, configs(
+#[vmm_test_with(unstable(reason = "SNP hardware-unseal key-release test is unreliable in CI; awaiting a fix"), configs(
     hyperv_openhcl_uefi_x64[snp](vhd(ubuntu_2504_server_x64))[TEST_IGVM_AGENT_RPC_SERVER_WINDOWS_X64],
     hyperv_openhcl_uefi_x64[snp](vhd(windows_datacenter_core_2025_x64_prepped))[TEST_IGVM_AGENT_RPC_SERVER_WINDOWS_X64],
 ))]
@@ -1044,7 +1043,7 @@ async fn skip_hw_unseal<T, U: PetriVmmBackend>(
 /// test function (`use_hw_unseal`), they all map to
 /// `KeyReleaseFailure`.
 #[cfg(windows)]
-#[vmm_test_with(unstable, configs(
+#[vmm_test_with(unstable(reason = "SNP hardware-unseal key-release test is unreliable in CI; awaiting a fix"), configs(
     hyperv_openhcl_uefi_x64[snp](vhd(ubuntu_2504_server_x64))[TPM_GUEST_TESTS_LINUX_X64, TEST_IGVM_AGENT_RPC_SERVER_WINDOWS_X64],
     hyperv_openhcl_uefi_x64[snp](vhd(windows_datacenter_core_2025_x64_prepped))[TPM_GUEST_TESTS_WINDOWS_X64, TEST_IGVM_AGENT_RPC_SERVER_WINDOWS_X64],
 ))]

--- a/vmm_tests/vmm_tests/tests/tests/multiarch/vmbus_relay.rs
+++ b/vmm_tests/vmm_tests/tests/tests/multiarch/vmbus_relay.rs
@@ -77,7 +77,10 @@ async fn vmbus_relay_heavy<T: PetriVmmBackend>(config: PetriVmBuilder<T>) -> any
 /// TODO: investigate flakiness for openvmm_openhcl_uefi_x64(vhd(ubuntu_2504_server_x64)). Tracked by: #2100
 #[openvmm_test(
     openvmm_openhcl_linux_direct_x64,
-    // openvmm_openhcl_uefi_x64(vhd(ubuntu_2504_server_x64))
+    ignore(
+        reason = "flaky (microsoft/openvmm#2100)",
+        openvmm_openhcl_uefi_x64(vhd(ubuntu_2504_server_x64))
+    )
 )]
 async fn validate_mnf_usage_in_guest(
     config: PetriVmBuilder<OpenVmmPetriBackend>,

--- a/vmm_tests/vmm_tests/tests/tests/x86_64.rs
+++ b/vmm_tests/vmm_tests/tests/tests/x86_64.rs
@@ -281,7 +281,10 @@ async fn vpci_relay_tdisp_device(
 }
 
 /// Boot with a virtio-blk disk via virtio-mmio and verify the device appears in the guest.
-#[openvmm_test(unstable_linux_direct_x64)]
+#[openvmm_test(unstable(
+    reason = "virtio-blk over virtio-mmio boot test fails frequently in CI; root cause unknown",
+    linux_direct_x64
+))]
 async fn virtio_blk_device(config: PetriVmBuilder<OpenVmmPetriBackend>) -> anyhow::Result<()> {
     use disk_backend_resources::LayeredDiskHandle;
     use disk_backend_resources::layer::RamDiskLayerHandle;

--- a/vmm_tests/vmm_tests/tests/tests/x86_64/storage.rs
+++ b/vmm_tests/vmm_tests/tests/tests/x86_64/storage.rs
@@ -176,7 +176,10 @@ async fn test_storage_linux(
 /// vmbus relay. This should expose two disks to VTL0 via vmbus.
 #[openvmm_test(
     openhcl_linux_direct_x64,
-    //openhcl_uefi_x64(vhd(ubuntu_2504_server_x64)) TODO: re-enable once pipette issues in #2039 are resolved
+    ignore(
+        reason = "pipette issues on this config (microsoft/openvmm#2039)",
+        openhcl_uefi_x64(vhd(ubuntu_2504_server_x64))
+    )
 )]
 async fn storvsp(config: PetriVmBuilder<OpenVmmPetriBackend>) -> Result<(), anyhow::Error> {
     const NVME_INSTANCE: Guid = guid::guid!("dce4ebad-182f-46c0-8d30-8446c1c62ab3");


### PR DESCRIPTION
The only way to mark a vmm test variant as flaky was the `unstable_` name prefix, which was terse, gave no room to record why, and could only be applied per-variant. There was also no way to keep a variant that cannot currently run: such configs were commented out in the test attributes, which made them invisible and untracked.

Introduce first-class `ignore` and `unstable` attributes for the vmm test macros. `unstable` runs the variant but does not fail the run on error; `ignore` skips the variant by default like a libtest `#[ignore]` test, so it stays visible and can be run on demand. Both come in two forms: a whole-list override inside `vmm_test_with(...)` that applies to every config, and a per-config wrapper `ignore(reason = "...", <config>)` that applies to a single variant. A reason string is mandatory in both forms so the justification lives next to the test. The old `unstable_` prefix is removed.

On the petri side, thread an `ignored` flag and an optional unstable reason through the test model: ignored trials are reported to libtest as ignored, and a swallowed unstable failure now logs its reason. The SimpleTest constructor had accumulated a long, opaque positional parameter list, so it becomes a small builder.

Finally, migrate the existing unstable tests to the new form with accurate reasons, and convert the previously commented-out config variants into ignored variants, each carrying the documented reason (and, where one exists, the tracking issue) for why it is disabled.