### PR TITLE
virt_kvm: normalize accessed bit on segment save

### DIFF
--- a/vmm_core/virt_kvm/src/arch/x86_64/vp_state.rs
+++ b/vmm_core/virt_kvm/src/arch/x86_64/vp_state.rs
@@ -117,15 +117,24 @@ fn seg_reg(reg: SegmentRegister) -> kvm::kvm_segment {
 }
 
 fn seg_reg_from_kvm(reg: kvm::kvm_segment) -> SegmentRegister {
+    // KVM forces the "accessed" bit (bit 0 of the segment type) on every
+    // non-LDTR segment when unrestricted guest mode is active. For unusable
+    // segments (`present == 0`) this bit is architecturally meaningless, but it
+    // makes a save/restore round trip non-idempotent: a null segment saved as
+    // `0xc000` is read back as `0xc001`. Mask the accessed bit back off for
+    // non-present segments so that the value read here is canonical and stable
+    // across a round trip.
+    let present = reg.present == 1;
+    let segment_type = if present { reg.type_ } else { reg.type_ & !1 };
     SegmentRegister {
         base: reg.base,
         limit: reg.limit,
         selector: reg.selector,
         attributes: SegmentAttributes::new()
-            .with_segment_type(reg.type_)
+            .with_segment_type(segment_type)
             .with_non_system_segment(reg.s == 1)
             .with_descriptor_privilege_level(reg.dpl)
-            .with_present(reg.present == 1)
+            .with_present(present)
             .with_available(reg.avl == 1)
             .with_long(reg.l == 1)
             .with_default(reg.db == 1)


### PR DESCRIPTION
When unrestricted guest mode is active, KVM unconditionally forces the "accessed" bit (bit 0 of the segment type) on every non-LDTR segment as it writes guest state, regardless of the value userspace supplied. For unusable segments this bit is architecturally meaningless, but the forcing means a segment saved as e.g. 0xc000 reads back as 0xc001 after a restore, so a save/restore round trip is not idempotent. That instability trips up anything that compares VP state across a round trip.

Mask the accessed bit back off when reading a non-present segment so the value observed at the save boundary is canonical and stable. Usable segments and LDTR are left untouched, and this brings KVM's reported attributes in line with the other backends, which never set the bit for unusable segments.