### PR TITLE
build_info: fix Apple-target build failure from invalid Mach-O section

### DIFF
--- a/openhcl/build_info/src/lib.rs
+++ b/openhcl/build_info/src/lib.rs
@@ -193,9 +193,10 @@ pub static OPENHCL_VERSION: OpenHclVersion = OpenHclVersion::new();
 // UNSAFETY: link_section and export_name are unsafe.
 #[expect(unsafe_code)]
 // SAFETY: The build_info section is custom and carries no safety requirements.
-// Mach-O requires a segment-qualified section name, while shipping OpenHCL
-// binaries use ELF/COFF. Keep the static but omit its custom section on Apple.
-#[cfg_attr(not(target_vendor = "apple"), unsafe(link_section = ".build_info"))]
+// The `.build_info` section is only consumed by the OpenHCL (ELF) split-debug
+// step, so emit it on Linux only: it is invalid on Mach-O (needs a
+// segment,section name) and unused on COFF.
+#[cfg_attr(target_os = "linux", unsafe(link_section = ".build_info"))]
 // SAFETY: The name "BUILD_INFO" is only declared here in OpenHCL and shouldn't
 // collide with any other symbols. It is a special symbol intended for
 // post-mortem debugging, and no runtime functionality should depend on it.

--- a/openhcl/build_info/src/lib.rs
+++ b/openhcl/build_info/src/lib.rs
@@ -193,7 +193,9 @@ pub static OPENHCL_VERSION: OpenHclVersion = OpenHclVersion::new();
 // UNSAFETY: link_section and export_name are unsafe.
 #[expect(unsafe_code)]
 // SAFETY: The build_info section is custom and carries no safety requirements.
-#[unsafe(link_section = ".build_info")]
+// Mach-O requires a segment-qualified section name, while shipping OpenHCL
+// binaries use ELF/COFF. Keep the static but omit its custom section on Apple.
+#[cfg_attr(not(target_vendor = "apple"), unsafe(link_section = ".build_info"))]
 // SAFETY: The name "BUILD_INFO" is only declared here in OpenHCL and shouldn't
 // collide with any other symbols. It is a special symbol intended for
 // post-mortem debugging, and no runtime functionality should depend on it.


### PR DESCRIPTION
On Apple targets, build_info fails to compile: `cargo test -p build_info` (and any macOS build linking build_info) dies with
```
  rustc-LLVM ERROR: Global variable 'BUILD_INFO' has an invalid section
  specifier '.build_info': mach-o section specifier requires a segment and
  section separated by a comma.
```
The custom `.build_info` name is ELF/COFF-only; Mach-O needs a `segment,section` specifier. Gate the link_section attribute to non-Apple targets. BUILD_INFO, its export_name, and get() are unchanged; the section's only consumer is the OpenHCL ELF split-debug step, which never runs on Mach-O.