### PR TITLE
openvmm_entry: add fd-passing protocol and unified --rpc server

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5713,6 +5713,7 @@ dependencies = [
  "openvmm_ttrpc_vmservice",
  "pal",
  "pal_async",
+ "parking_lot",
  "pcie_remote_resources",
  "prost",
  "rustyline",

--- a/Guide/src/reference/openvmm/management/grpc.md
+++ b/Guide/src/reference/openvmm/management/grpc.md
@@ -1,8 +1,23 @@
 # gRPC / ttrpc
 
-To enable gRPC or ttrpc management interfaces, pass `--grpc <SOCKETPATH>` or
-`--trpc <SOCKETPATH>`. This will spawn an OpenVMM process acting as a gRPC or
-ttrpc server.
+To enable a gRPC or ttrpc management interface, pass `--rpc`. This spawns an
+OpenVMM process acting as an RPC server on the given Unix socket:
+
+```bash
+--rpc path=/path/to/openvmm.sock[,transport=<TRANSPORT>]
+```
+
+`transport` selects which wire protocol the server accepts:
+
+* `auto` (default) — auto-detect ttrpc vs. gRPC per connection
+* `ttrpc` — accept ttrpc clients only
+* `grpc` — accept gRPC clients only
+
+For example, to accept ttrpc clients only:
+
+```bash
+--rpc path=/path/to/openvmm.sock,transport=ttrpc
+```
 
 Here is a list of supported RPCs:
 

--- a/openvmm/openvmm_entry/Cargo.toml
+++ b/openvmm/openvmm_entry/Cargo.toml
@@ -89,6 +89,7 @@ fs-err.workspace = true
 futures.workspace = true
 futures-concurrency.workspace = true
 getrandom.workspace = true
+parking_lot.workspace = true
 prost.workspace = true
 rustyline = { workspace = true, features = ["derive"] }
 shell-words.workspace = true

--- a/openvmm/openvmm_entry/src/cli_args.rs
+++ b/openvmm/openvmm_entry/src/cli_args.rs
@@ -752,13 +752,44 @@ options:
     #[clap(long, value_name = "PATH")]
     pub pidfile: Option<PathBuf>,
 
-    /// run as a ttrpc server on the specified Unix socket
+    /// \[deprecated\] run as a ttrpc server on the specified Unix socket
+    ///
+    /// Use `--rpc path=<PATH>,transport=ttrpc` instead.
     #[clap(long, value_name = "SOCKETPATH")]
     pub ttrpc: Option<PathBuf>,
 
-    /// run as a grpc server on the specified Unix socket
+    /// \[deprecated\] run as a grpc server on the specified Unix socket
+    ///
+    /// Use `--rpc path=<PATH>,transport=grpc` instead.
     #[clap(long, value_name = "SOCKETPATH", conflicts_with("ttrpc"))]
     pub grpc: Option<PathBuf>,
+
+    /// run as an RPC server on the specified Unix socket
+    #[clap(long_help = r#"
+Run as an RPC server on the specified Unix socket.
+
+syntax: path=<PATH>[,transport=<TRANSPORT>]
+
+options:
+    `path=<PATH>`                  Unix socket path to listen on (required)
+    `transport=<TRANSPORT>`        wire transport to accept (default: auto)
+
+valid transports:
+    `auto`                         auto-detect ttrpc vs. gRPC per connection
+    `ttrpc`                        accept ttrpc clients only
+    `grpc`                         accept gRPC clients only
+
+Examples:
+    --rpc path=/tmp/openvmm.sock
+    --rpc path=/tmp/openvmm.sock,transport=ttrpc
+"#)]
+    #[clap(
+        long,
+        value_name = "path=PATH[,transport=TRANSPORT]",
+        conflicts_with("ttrpc"),
+        conflicts_with("grpc")
+    )]
+    pub rpc: Option<RpcCli>,
 
     /// do not launch child processes
     #[clap(long)]
@@ -1940,6 +1971,66 @@ impl FromStr for DiskCliKind {
             },
         };
         Ok(disk)
+    }
+}
+
+/// Wire transport selection for `--rpc`.
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
+pub enum RpcTransportCli {
+    /// Auto-detect ttrpc vs. gRPC per connection, based on the first byte of
+    /// the stream.
+    #[default]
+    Auto,
+    /// Accept ttrpc clients only.
+    Ttrpc,
+    /// Accept gRPC clients only.
+    Grpc,
+}
+
+/// RPC server configuration parsed from `--rpc`.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct RpcCli {
+    /// Unix socket path to listen on.
+    pub path: PathBuf,
+    /// Wire transport to accept.
+    pub transport: RpcTransportCli,
+}
+
+impl FromStr for RpcCli {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> anyhow::Result<Self> {
+        let mut path = None;
+        let mut transport = None;
+        for part in s.split(',') {
+            let (key, value) = part
+                .split_once('=')
+                .with_context(|| format!("invalid rpc option '{part}', expected key=value"))?;
+            match key {
+                "path" => {
+                    anyhow::ensure!(path.is_none(), "duplicate option 'path'");
+                    anyhow::ensure!(!value.is_empty(), "'path' requires a value");
+                    path = Some(PathBuf::from(value));
+                }
+                "transport" => {
+                    anyhow::ensure!(transport.is_none(), "duplicate option 'transport'");
+                    transport = Some(match value {
+                        "auto" => RpcTransportCli::Auto,
+                        "ttrpc" => RpcTransportCli::Ttrpc,
+                        "grpc" => RpcTransportCli::Grpc,
+                        _ => anyhow::bail!(
+                            "invalid transport '{value}', expected auto, ttrpc, or grpc"
+                        ),
+                    });
+                }
+                _ => anyhow::bail!("unknown rpc option '{key}'"),
+            }
+        }
+
+        Ok(RpcCli {
+            path: path.context("'path' is required")?,
+            transport: transport.unwrap_or_default(),
+        })
     }
 }
 
@@ -3746,6 +3837,33 @@ mod tests {
 
     use std::path::Path;
     use test_with_tracing::test;
+
+    #[test]
+    fn test_parse_rpc() {
+        // explicit path, default transport
+        let rpc = RpcCli::from_str("path=/tmp/openvmm.sock").unwrap();
+        assert_eq!(rpc.path, Path::new("/tmp/openvmm.sock"));
+        assert_eq!(rpc.transport, RpcTransportCli::Auto);
+
+        // explicit transport
+        for (s, transport) in [
+            ("auto", RpcTransportCli::Auto),
+            ("ttrpc", RpcTransportCli::Ttrpc),
+            ("grpc", RpcTransportCli::Grpc),
+        ] {
+            let rpc = RpcCli::from_str(&format!("path=/tmp/s.sock,transport={s}")).unwrap();
+            assert_eq!(rpc.path, Path::new("/tmp/s.sock"));
+            assert_eq!(rpc.transport, transport);
+        }
+
+        // errors
+        assert!(RpcCli::from_str("").is_err());
+        assert!(RpcCli::from_str("transport=ttrpc").is_err());
+        assert!(RpcCli::from_str("path=").is_err());
+        assert!(RpcCli::from_str("path=/tmp/s.sock,transport=bogus").is_err());
+        assert!(RpcCli::from_str("path=/tmp/s.sock,bogus=1").is_err());
+        assert!(RpcCli::from_str("path=/a,path=/b").is_err());
+    }
 
     #[test]
     fn test_parse_file_opts() {

--- a/openvmm/openvmm_entry/src/lib.rs
+++ b/openvmm/openvmm_entry/src/lib.rs
@@ -2488,35 +2488,49 @@ fn do_main(pidfile_guard: &mut Option<pidfile::Pidfile>) -> anyhow::Result<i32> 
     }
 
     #[cfg(any(feature = "grpc", feature = "ttrpc"))]
-    if let Some(path) = opt.ttrpc.as_ref().or(opt.grpc.as_ref()) {
-        return block_on(async {
-            let _ = std::fs::remove_file(path);
-            let listener =
-                unix_socket::UnixListener::bind(path).context("failed to bind to socket")?;
+    {
+        let rpc = opt
+            .rpc
+            .as_ref()
+            .map(|rpc| {
+                let transport = match rpc.transport {
+                    cli_args::RpcTransportCli::Auto => ttrpc::RpcTransport::Auto,
+                    cli_args::RpcTransportCli::Ttrpc => ttrpc::RpcTransport::Ttrpc,
+                    cli_args::RpcTransportCli::Grpc => ttrpc::RpcTransport::Grpc,
+                };
+                (rpc.path.as_path(), transport)
+            })
+            .or_else(|| {
+                opt.ttrpc
+                    .as_deref()
+                    .map(|p| (p, ttrpc::RpcTransport::Ttrpc))
+            })
+            .or_else(|| opt.grpc.as_deref().map(|p| (p, ttrpc::RpcTransport::Grpc)));
 
-            let transport = if opt.ttrpc.is_some() {
-                ttrpc::RpcTransport::Ttrpc
-            } else {
-                ttrpc::RpcTransport::Grpc
-            };
+        if let Some((path, transport)) = rpc {
+            return block_on(async {
+                let _ = std::fs::remove_file(path);
+                let listener =
+                    unix_socket::UnixListener::bind(path).context("failed to bind to socket")?;
 
-            // This is a local launch
-            let mut handle =
-                mesh_worker::launch_local_worker::<ttrpc::TtrpcWorker>(ttrpc::Parameters {
-                    listener,
-                    transport,
-                })
-                .await?;
+                // This is a local launch
+                let mut handle =
+                    mesh_worker::launch_local_worker::<ttrpc::TtrpcWorker>(ttrpc::Parameters {
+                        listener,
+                        transport,
+                    })
+                    .await?;
 
-            tracing::info!(%transport, path = %path.display(), "listening");
+                tracing::info!(%transport, path = %path.display(), "listening");
 
-            // Signal the the parent process that the server is ready.
-            pal::close_stdout().context("failed to close stdout")?;
+                // Signal the the parent process that the server is ready.
+                pal::close_stdout().context("failed to close stdout")?;
 
-            handle.join().await?;
+                handle.join().await?;
 
-            Ok(0)
-        });
+                Ok(0)
+            });
+        }
     }
 
     DefaultPool::run_with(async |driver| run_control(&driver, opt).await)

--- a/openvmm/openvmm_entry/src/lib.rs
+++ b/openvmm/openvmm_entry/src/lib.rs
@@ -2523,7 +2523,7 @@ fn do_main(pidfile_guard: &mut Option<pidfile::Pidfile>) -> anyhow::Result<i32> 
 
                 tracing::info!(%transport, path = %path.display(), "listening");
 
-                // Signal the the parent process that the server is ready.
+                // Signal the parent process that the server is ready.
                 pal::close_stdout().context("failed to close stdout")?;
 
                 handle.join().await?;

--- a/openvmm/openvmm_entry/src/ttrpc/fd_passing.rs
+++ b/openvmm/openvmm_entry/src/ttrpc/fd_passing.rs
@@ -1,0 +1,494 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! The OpenVMM fd-passing protocol.
+//!
+//! This is a small, bespoke protocol that lets a client hand pre-opened file
+//! descriptors to the management server, each under a client-chosen name. A
+//! name can then be referenced from the ordinary ttrpc/gRPC API (for example a
+//! `TapBackend` may give an `fd_name` instead of a device `name`).
+//!
+//! It runs over the same `AF_UNIX` stream socket as ttrpc and gRPC, selected by
+//! a distinct magic first byte, and carries descriptors via `SCM_RIGHTS`. See
+//! `openvmm_ttrpc_vmservice/src/fd_passing.md` for the wire specification.
+//!
+//! The entire protocol is UNIX-only (it relies on `SCM_RIGHTS`), so this whole
+//! module is compiled only on `cfg(unix)`.
+
+#![cfg(unix)]
+
+use anyhow::Context as _;
+use pal_async::interest::InterestSlot;
+use pal_async::interest::PollEvents;
+use pal_async::socket::AsSockRef;
+use pal_async::socket::PolledSocket;
+use parking_lot::Mutex;
+use std::collections::HashMap;
+use std::collections::VecDeque;
+use std::future::poll_fn;
+use std::io;
+use std::os::fd::AsFd;
+use std::os::unix::io::OwnedFd;
+use std::sync::Arc;
+use unix_socket::UnixStream;
+
+pub(super) use protocol::MAGIC_FIRST_BYTE;
+
+/// The wire format of the fd-passing protocol: the on-the-socket constants that
+/// define the framing, independent of the implementation that reads and writes
+/// them. See `openvmm_ttrpc_vmservice/src/fd_passing.md` for the full
+/// specification.
+mod protocol {
+    /// The first byte of the fd-passing handshake magic. Distinct from the ttrpc
+    /// (`0x00`) and gRPC (`b'P'`) first bytes, so the server can route a connection
+    /// by peeking a single byte.
+    pub(crate) const MAGIC_FIRST_BYTE: u8 = 0xFD;
+
+    /// The 4-byte handshake magic: `0xFD 'F' 'D' 0x01`. Encodes both protocol and
+    /// revision.
+    pub(super) const HANDSHAKE_MAGIC: [u8; 4] = [0xFD, b'F', b'D', 0x01];
+
+    pub(super) const OPCODE_REGISTER: u8 = 1;
+    pub(super) const OPCODE_DEREGISTER: u8 = 2;
+
+    /// The number of descriptors a single connection's receiver can hold. Every
+    /// message in this protocol carries at most one descriptor (a `Register`
+    /// carries exactly one; nothing else carries any). A message with zero is
+    /// rejected with a failure response; a message attaching more than one is a
+    /// protocol violation that trips truncation and closes the connection.
+    pub(super) const MAX_MESSAGE_FDS: usize = 1;
+}
+
+/// A registry of file descriptors passed in via the fd-passing protocol, keyed
+/// by client-chosen name.
+///
+/// The registry is shared (cheaply cloneable). Names live in a single global
+/// namespace so that a descriptor registered on the fd-passing connection can
+/// be resolved from a separate ttrpc/gRPC connection. Cleanup, however, is
+/// per-connection: the fd-passing handler drops every name it registered when
+/// its connection closes.
+#[derive(Clone, Default)]
+pub struct FdRegistry {
+    inner: Arc<Mutex<HashMap<String, OwnedFd>>>,
+}
+
+impl FdRegistry {
+    /// Registers `fd` under `name`, failing (and dropping `fd`) if the name is
+    /// already registered by any connection.
+    fn register(&self, name: String, fd: OwnedFd) -> anyhow::Result<()> {
+        let mut map = self.inner.lock();
+        if map.contains_key(&name) {
+            anyhow::bail!("name '{name}' is already registered");
+        }
+        map.insert(name, fd);
+        Ok(())
+    }
+
+    /// Removes `name` from the registry, dropping (closing) its descriptor.
+    fn deregister(&self, name: &str) {
+        self.inner.lock().remove(name);
+    }
+
+    /// Resolves `name` to a freshly duplicated descriptor. The registry entry
+    /// remains valid.
+    pub fn resolve(&self, name: &str) -> anyhow::Result<OwnedFd> {
+        let map = self.inner.lock();
+        let fd = map
+            .get(name)
+            .with_context(|| format!("no file descriptor registered under name '{name}'"))?;
+        fd.try_clone()
+            .context("failed to duplicate registered file descriptor")
+    }
+}
+
+/// Services a single fd-passing connection: validates the handshake, then loops
+/// handling `Register`/`Deregister` requests until the peer closes the
+/// connection. Any names registered by this connection are dropped on exit.
+pub(super) async fn serve(
+    conn: PolledSocket<UnixStream>,
+    registry: &FdRegistry,
+) -> anyhow::Result<()> {
+    let mut conn = Connection::new(conn);
+
+    // Exchange handshakes: read and validate the client's, then send ours.
+    let handshake = conn
+        .read_exact(8)
+        .await
+        .context("failed to read fd-passing handshake")?;
+    if handshake[..4] != protocol::HANDSHAKE_MAGIC {
+        anyhow::bail!("invalid fd-passing handshake magic");
+    }
+    // `features` (handshake[4..8]) is reserved and ignored in this revision.
+    // The handshake carries no descriptors; drop any a misbehaving client
+    // attached.
+    conn.fd = None;
+
+    let mut server_handshake = [0u8; 8];
+    server_handshake[..4].copy_from_slice(&protocol::HANDSHAKE_MAGIC);
+    conn.write_all(&server_handshake)
+        .await
+        .context("failed to send fd-passing handshake")?;
+
+    // Track the names registered by this connection so they can be dropped when
+    // it closes.
+    let mut owned_names: Vec<String> = Vec::new();
+    let result = serve_requests(&mut conn, registry, &mut owned_names).await;
+    for name in owned_names {
+        registry.deregister(&name);
+    }
+    result
+}
+
+async fn serve_requests(
+    conn: &mut Connection,
+    registry: &FdRegistry,
+    owned_names: &mut Vec<String>,
+) -> anyhow::Result<()> {
+    loop {
+        // Read the request header (opcode + name length). A clean EOF here (at
+        // a frame boundary) is a normal shutdown.
+        let Some(header) = conn
+            .try_read_exact(2)
+            .await
+            .context("failed to read request header")?
+        else {
+            return Ok(());
+        };
+        let opcode = header[0];
+        let name_len = header[1] as usize;
+        let name_bytes = conn
+            .read_exact(name_len)
+            .await
+            .context("failed to read request name")?;
+
+        // Take the descriptor (if any) that arrived with this message, clearing
+        // it so it never lingers into the next message. Only a register consumes
+        // one; any other message carrying a descriptor is malformed and is
+        // rejected below (or closes the connection).
+        let fd = conn.fd.take();
+
+        match opcode {
+            protocol::OPCODE_REGISTER => match parse_name(&name_bytes) {
+                Some(name) => match fd {
+                    Some(fd) => match registry.register(name.clone(), fd) {
+                        Ok(()) => {
+                            owned_names.push(name);
+                            conn.write_response(None).await?;
+                        }
+                        Err(err) => conn.write_response(Some(&err.to_string())).await?,
+                    },
+                    None => {
+                        conn.write_response(Some(
+                            "register requires exactly one attached descriptor",
+                        ))
+                        .await?
+                    }
+                },
+                None => {
+                    // Invalid name; drop any attached descriptor.
+                    drop(fd);
+                    conn.write_response(Some("invalid name")).await?;
+                }
+            },
+            protocol::OPCODE_DEREGISTER => match parse_name(&name_bytes) {
+                _ if fd.is_some() => {
+                    conn.write_response(Some("deregister does not accept an attached descriptor"))
+                        .await?
+                }
+                Some(name) => {
+                    if let Some(pos) = owned_names.iter().position(|n| *n == name) {
+                        owned_names.swap_remove(pos);
+                        registry.deregister(&name);
+                        conn.write_response(None).await?;
+                    } else {
+                        conn.write_response(Some("name not registered by this connection"))
+                            .await?;
+                    }
+                }
+                None => conn.write_response(Some("invalid name")).await?,
+            },
+            // An unknown opcode is unrecoverable: the stream has no length
+            // prefix to resynchronize on, so close the connection. Any received
+            // descriptors are dropped with `conn`.
+            other => anyhow::bail!("unknown fd-passing opcode {other}"),
+        }
+    }
+}
+
+/// Validates a request name: it must be non-empty and valid UTF-8.
+fn parse_name(bytes: &[u8]) -> Option<String> {
+    match std::str::from_utf8(bytes) {
+        Ok(name) if !name.is_empty() => Some(name.to_owned()),
+        _ => None,
+    }
+}
+
+/// Buffers a stream socket, reassembling length-known frames and holding the
+/// single descriptor received via `SCM_RIGHTS` with the current message.
+struct Connection {
+    conn: PolledSocket<UnixStream>,
+    read_buf: VecDeque<u8>,
+    receiver: unix_socket::ScmReceiver,
+    /// The descriptor received with the message currently being read, if any.
+    /// Every message carries at most one (`MAX_MESSAGE_FDS == 1`), and the
+    /// kernel never merges descriptors across a sender's message boundary, so
+    /// at most one is ever held: each message consumes or discards it before
+    /// the next message's header is read.
+    fd: Option<OwnedFd>,
+}
+
+impl Connection {
+    fn new(conn: PolledSocket<UnixStream>) -> Self {
+        Self {
+            conn,
+            read_buf: VecDeque::new(),
+            receiver: unix_socket::ScmReceiver::new(protocol::MAX_MESSAGE_FDS),
+            fd: None,
+        }
+    }
+
+    /// Performs a single `recvmsg`, appending received bytes to the read buffer
+    /// and taking the at-most-one descriptor into `fd`. Returns the number of
+    /// bytes read (0 on EOF).
+    async fn fill(&mut self) -> io::Result<usize> {
+        let mut buf = [0u8; 512];
+        let n = poll_fn(|cx| {
+            self.conn
+                .poll_io(cx, InterestSlot::Read, PollEvents::IN, |this| {
+                    let sock = this.get().as_sock_ref();
+                    self.receiver.recv(sock.as_fd(), &mut buf)
+                })
+        })
+        .await?;
+        self.read_buf.extend(&buf[..n]);
+        // Drain immediately: the next `recv` closes any fds still held. At most
+        // one arrives per `recv`, and the previous message's descriptor has
+        // already been consumed, so `fd` is empty here.
+        if let Some(fd) = self.receiver.drain().next() {
+            let prev = self.fd.replace(fd);
+            assert!(prev.is_none(), "a descriptor was left unconsumed");
+        }
+        Ok(n)
+    }
+
+    /// Reads exactly `n` bytes, erroring on EOF.
+    async fn read_exact(&mut self, n: usize) -> io::Result<Vec<u8>> {
+        while self.read_buf.len() < n {
+            if self.fill().await? == 0 {
+                return Err(io::ErrorKind::UnexpectedEof.into());
+            }
+        }
+        Ok(self.read_buf.drain(..n).collect())
+    }
+
+    /// Reads exactly `n` bytes, returning `None` if the peer closes the
+    /// connection at a frame boundary (before any of the `n` bytes arrive) and
+    /// erroring on a partial (mid-frame) EOF.
+    async fn try_read_exact(&mut self, n: usize) -> io::Result<Option<Vec<u8>>> {
+        while self.read_buf.len() < n {
+            if self.fill().await? == 0 {
+                if self.read_buf.is_empty() {
+                    return Ok(None);
+                }
+                return Err(io::ErrorKind::UnexpectedEof.into());
+            }
+        }
+        Ok(Some(self.read_buf.drain(..n).collect()))
+    }
+
+    /// Writes a response frame: `status: u8`, `msg_len: u16` (LE), `msg`.
+    /// `None` means success; `Some(msg)` is a generic failure with diagnostic
+    /// text.
+    async fn write_response(&mut self, error: Option<&str>) -> io::Result<()> {
+        let (status, msg) = match error {
+            None => (0u8, ""),
+            Some(msg) => (1u8, msg),
+        };
+        let msg = msg.as_bytes();
+        let msg_len = msg.len().min(u16::MAX as usize);
+        let mut frame = Vec::with_capacity(3 + msg_len);
+        frame.push(status);
+        frame.extend_from_slice(&(msg_len as u16).to_le_bytes());
+        frame.extend_from_slice(&msg[..msg_len]);
+        self.write_all(&frame).await
+    }
+
+    async fn write_all(&mut self, buf: &[u8]) -> io::Result<()> {
+        use futures::AsyncWriteExt;
+        self.conn.write_all(buf).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::FdRegistry;
+    use super::protocol::HANDSHAKE_MAGIC;
+    use super::protocol::OPCODE_DEREGISTER;
+    use super::protocol::OPCODE_REGISTER;
+    use super::serve;
+    use pal_async::DefaultPool;
+    use pal_async::socket::PolledSocket;
+    use pal_async::task::Spawn;
+    use socket2::Domain;
+    use socket2::Socket;
+    use socket2::Type;
+    use std::io::IoSlice;
+    use std::io::Read as _;
+    use std::io::Write as _;
+    use std::os::fd::AsFd;
+    use std::os::fd::BorrowedFd;
+    use std::os::unix::net::UnixStream;
+
+    /// Creates a connected AF_UNIX stream socket pair.
+    fn socket_pair() -> (Socket, Socket) {
+        Socket::pair(Domain::UNIX, Type::STREAM, None).unwrap()
+    }
+
+    /// A blocking client for the fd-passing protocol, used to drive the server
+    /// over a real socket in tests.
+    struct TestClient {
+        sock: Socket,
+    }
+
+    impl TestClient {
+        fn handshake(&mut self) {
+            self.sock
+                .write_all(&[0xFD, b'F', b'D', 0x01, 0, 0, 0, 0])
+                .unwrap();
+            let mut buf = [0u8; 8];
+            self.sock.read_exact(&mut buf).unwrap();
+            assert_eq!(buf[..4], HANDSHAKE_MAGIC);
+        }
+
+        fn register(&mut self, name: &str, fd: BorrowedFd<'_>) -> (u8, String) {
+            let mut frame = vec![OPCODE_REGISTER, name.len() as u8];
+            frame.extend_from_slice(name.as_bytes());
+            unix_socket::send_with_fds(self.sock.as_fd(), &[IoSlice::new(&frame)], [fd]).unwrap();
+            self.read_response()
+        }
+
+        fn register_without_fd(&mut self, name: &str) -> (u8, String) {
+            let mut frame = vec![OPCODE_REGISTER, name.len() as u8];
+            frame.extend_from_slice(name.as_bytes());
+            self.sock.write_all(&frame).unwrap();
+            self.read_response()
+        }
+
+        fn deregister(&mut self, name: &str) -> (u8, String) {
+            let mut frame = vec![OPCODE_DEREGISTER, name.len() as u8];
+            frame.extend_from_slice(name.as_bytes());
+            self.sock.write_all(&frame).unwrap();
+            self.read_response()
+        }
+
+        fn deregister_with_fd(&mut self, name: &str, fd: BorrowedFd<'_>) -> (u8, String) {
+            let mut frame = vec![OPCODE_DEREGISTER, name.len() as u8];
+            frame.extend_from_slice(name.as_bytes());
+            unix_socket::send_with_fds(self.sock.as_fd(), &[IoSlice::new(&frame)], [fd]).unwrap();
+            self.read_response()
+        }
+
+        fn read_response(&mut self) -> (u8, String) {
+            let mut hdr = [0u8; 3];
+            self.sock.read_exact(&mut hdr).unwrap();
+            let status = hdr[0];
+            let msg_len = u16::from_le_bytes([hdr[1], hdr[2]]) as usize;
+            let mut msg = vec![0u8; msg_len];
+            self.sock.read_exact(&mut msg).unwrap();
+            (status, String::from_utf8(msg).unwrap())
+        }
+    }
+
+    #[test]
+    fn registry_semantics() {
+        let registry = FdRegistry::default();
+        let (a, mut b) = socket_pair();
+        registry.register("x".to_owned(), a.into()).unwrap();
+
+        // Registering an already-registered name fails.
+        let (c, _d) = socket_pair();
+        assert!(registry.register("x".to_owned(), c.into()).is_err());
+
+        // Resolving dups the descriptor; the dup refers to the same file, so it
+        // is still connected to peer `b`.
+        let dup = registry.resolve("x").unwrap();
+        Socket::from(dup).write_all(b"hi").unwrap();
+        let mut buf = [0u8; 2];
+        b.read_exact(&mut buf).unwrap();
+        assert_eq!(&buf, b"hi");
+
+        // Resolving an unknown name fails.
+        assert!(registry.resolve("nope").is_err());
+
+        // Deregistering drops the entry.
+        registry.deregister("x");
+        assert!(registry.resolve("x").is_err());
+    }
+
+    #[test]
+    fn end_to_end() {
+        let registry = FdRegistry::default();
+        let (server_sock, client_sock) = socket_pair();
+
+        // Run the server on its own pal_async pool so the blocking client below
+        // can drive it from this thread without deadlocking.
+        let (_thread, driver) = DefaultPool::spawn_on_thread("fd-passing-test");
+        let server = PolledSocket::new(&driver, UnixStream::from(server_sock)).unwrap();
+        let server_registry = registry.clone();
+        let task = driver.spawn(
+            "serve",
+            async move { serve(server, &server_registry).await },
+        );
+
+        let mut client = TestClient { sock: client_sock };
+        client.handshake();
+
+        // A second socket pair whose one end is registered; used to verify the
+        // resolved fd refers to the same file.
+        let (registered, mut peer) = socket_pair();
+
+        // Register succeeds.
+        let (status, msg) = client.register("t0", registered.as_fd());
+        assert_eq!(status, 0, "{msg}");
+
+        // The name now resolves; the dup talks to the same peer.
+        let dup = registry.resolve("t0").unwrap();
+        Socket::from(dup).write_all(b"ok").unwrap();
+        let mut buf = [0u8; 2];
+        peer.read_exact(&mut buf).unwrap();
+        assert_eq!(&buf, b"ok");
+
+        // Registering the same name again fails; the connection stays usable.
+        let (status, _) = client.register("t0", registered.as_fd());
+        assert_eq!(status, 1);
+
+        // Registering without an attached descriptor fails.
+        let (status, _) = client.register_without_fd("t2");
+        assert_eq!(status, 1);
+
+        // Deregistering an unknown name fails.
+        let (status, _) = client.deregister("nope");
+        assert_eq!(status, 1);
+
+        // Deregistering with an attached descriptor is malformed and fails; the
+        // connection stays usable.
+        let (status, _) = client.deregister_with_fd("t0", registered.as_fd());
+        assert_eq!(status, 1);
+
+        // Deregistering the real name succeeds and removes it.
+        let (status, _) = client.deregister("t0");
+        assert_eq!(status, 0);
+        assert!(registry.resolve("t0").is_err());
+
+        // Register again, then close the connection: per-connection cleanup
+        // must drop the name.
+        let (status, _) = client.register("t1", registered.as_fd());
+        assert_eq!(status, 0);
+        assert!(registry.resolve("t1").is_ok());
+        drop(client);
+
+        // serve() returns once the client closes; its cleanup drops t1.
+        futures::executor::block_on(task).unwrap();
+        assert!(registry.resolve("t1").is_err());
+    }
+}

--- a/openvmm/openvmm_entry/src/ttrpc/fd_passing.rs
+++ b/openvmm/openvmm_entry/src/ttrpc/fd_passing.rs
@@ -119,9 +119,11 @@ pub(super) async fn serve(
         anyhow::bail!("invalid fd-passing handshake magic");
     }
     // `features` (handshake[4..8]) is reserved and ignored in this revision.
-    // The handshake carries no descriptors; drop any a misbehaving client
-    // attached.
-    conn.fd = None;
+    // The handshake carries no ancillary data; a descriptor attached here is a
+    // protocol violation, so fail fast and close the connection.
+    if conn.fd.is_some() {
+        anyhow::bail!("fd-passing handshake must not carry a descriptor");
+    }
 
     let mut server_handshake = [0u8; 8];
     server_handshake[..4].copy_from_slice(&protocol::HANDSHAKE_MAGIC);

--- a/openvmm/openvmm_entry/src/ttrpc/fd_passing.rs
+++ b/openvmm/openvmm_entry/src/ttrpc/fd_passing.rs
@@ -91,6 +91,11 @@ impl FdRegistry {
 
     /// Resolves `name` to a freshly duplicated descriptor. The registry entry
     /// remains valid.
+    ///
+    /// Only the tap NIC backend (`cfg(target_os = "linux")`) and the unit tests
+    /// call this, so on other unix targets (e.g. macOS) it is otherwise
+    /// unused; suppress the resulting dead-code warning there.
+    #[cfg_attr(not(any(target_os = "linux", test)), expect(dead_code))]
     pub fn resolve(&self, name: &str) -> anyhow::Result<OwnedFd> {
         let map = self.inner.lock();
         let fd = map

--- a/openvmm/openvmm_entry/src/ttrpc/fd_passing.rs
+++ b/openvmm/openvmm_entry/src/ttrpc/fd_passing.rs
@@ -261,12 +261,22 @@ impl Connection {
         })
         .await?;
         self.read_buf.extend(&buf[..n]);
-        // Drain immediately: the next `recv` closes any fds still held. At most
-        // one arrives per `recv`, and the previous message's descriptor has
-        // already been consumed, so `fd` is empty here.
+        // Take the at-most-one descriptor that arrived with this `recv`. A
+        // conforming client attaches a descriptor only to a `Register` and
+        // reads the response before sending anything else, so the previous
+        // message's descriptor has already been consumed and `fd` is empty
+        // here. A misbehaving client can still attach descriptors to other
+        // bytes; since the protocol requires the server never panic on any
+        // input, treat an unconsumed descriptor as a protocol violation and
+        // error out (dropping both descriptors and closing the connection)
+        // rather than asserting.
         if let Some(fd) = self.receiver.drain().next() {
-            let prev = self.fd.replace(fd);
-            assert!(prev.is_none(), "a descriptor was left unconsumed");
+            if self.fd.replace(fd).is_some() {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "received a descriptor before the previous one was consumed",
+                ));
+            }
         }
         Ok(n)
     }

--- a/openvmm/openvmm_entry/src/ttrpc/fd_passing.rs
+++ b/openvmm/openvmm_entry/src/ttrpc/fd_passing.rs
@@ -129,20 +129,35 @@ pub(super) async fn serve(
         .await
         .context("failed to send fd-passing handshake")?;
 
-    // Track the names registered by this connection so they can be dropped when
-    // it closes.
-    let mut owned_names: Vec<String> = Vec::new();
-    let result = serve_requests(&mut conn, registry, &mut owned_names).await;
-    for name in owned_names {
-        registry.deregister(&name);
+    // Track the names registered by this connection so they are dropped when
+    // it closes. `OwnedNames` deregisters on drop, so cleanup runs even if this
+    // future is cancelled (dropped) before `serve_requests` returns.
+    let mut owned_names = OwnedNames {
+        registry,
+        names: Vec::new(),
+    };
+    serve_requests(&mut conn, &mut owned_names).await
+}
+
+/// Tracks the names a connection has registered and deregisters them on drop,
+/// so cleanup runs even if the serving future is dropped mid-flight (e.g. when
+/// the accept loop is cancelled) rather than leaking them into the registry.
+struct OwnedNames<'a> {
+    registry: &'a FdRegistry,
+    names: Vec<String>,
+}
+
+impl Drop for OwnedNames<'_> {
+    fn drop(&mut self) {
+        for name in self.names.drain(..) {
+            self.registry.deregister(&name);
+        }
     }
-    result
 }
 
 async fn serve_requests(
     conn: &mut Connection,
-    registry: &FdRegistry,
-    owned_names: &mut Vec<String>,
+    owned_names: &mut OwnedNames<'_>,
 ) -> anyhow::Result<()> {
     loop {
         // Read the request header (opcode + name length). A clean EOF here (at
@@ -170,9 +185,9 @@ async fn serve_requests(
         match opcode {
             protocol::OPCODE_REGISTER => match parse_name(&name_bytes) {
                 Some(name) => match fd {
-                    Some(fd) => match registry.register(name.clone(), fd) {
+                    Some(fd) => match owned_names.registry.register(name.clone(), fd) {
                         Ok(()) => {
-                            owned_names.push(name);
+                            owned_names.names.push(name);
                             conn.write_response(None).await?;
                         }
                         Err(err) => conn.write_response(Some(&err.to_string())).await?,
@@ -196,9 +211,9 @@ async fn serve_requests(
                         .await?
                 }
                 Some(name) => {
-                    if let Some(pos) = owned_names.iter().position(|n| *n == name) {
-                        owned_names.swap_remove(pos);
-                        registry.deregister(&name);
+                    if let Some(pos) = owned_names.names.iter().position(|n| *n == name) {
+                        owned_names.names.swap_remove(pos);
+                        owned_names.registry.deregister(&name);
                         conn.write_response(None).await?;
                     } else {
                         conn.write_response(Some("name not registered by this connection"))

--- a/openvmm/openvmm_entry/src/ttrpc/mod.rs
+++ b/openvmm/openvmm_entry/src/ttrpc/mod.rs
@@ -17,7 +17,7 @@ use fd_passing::FdRegistry;
 /// empty placeholder there; it is never populated or resolved.
 #[cfg(not(unix))]
 #[derive(Clone, Default)]
-struct FdRegistry;
+struct FdRegistry {}
 
 use crate::meshworker::VmmMesh;
 use crate::serial_io::bind_serial;

--- a/openvmm/openvmm_entry/src/ttrpc/mod.rs
+++ b/openvmm/openvmm_entry/src/ttrpc/mod.rs
@@ -5,6 +5,20 @@
 
 #![cfg(any(feature = "ttrpc", feature = "grpc"))]
 
+// The fd-passing protocol relies on `SCM_RIGHTS` and so exists only on unix.
+#[cfg(unix)]
+mod fd_passing;
+
+#[cfg(unix)]
+use fd_passing::FdRegistry;
+
+/// On non-unix platforms the fd-passing protocol does not exist. The registry
+/// is still threaded through the shared NIC configuration code, so provide an
+/// empty placeholder there; it is never populated or resolved.
+#[cfg(not(unix))]
+#[derive(Clone, Default)]
+struct FdRegistry;
+
 use crate::meshworker::VmmMesh;
 use crate::serial_io::bind_serial;
 use crate::serial_io::connect_serial;
@@ -97,6 +111,9 @@ pub struct Parameters {
 pub enum RpcTransport {
     Ttrpc,
     Grpc,
+    /// Auto-detect ttrpc vs. gRPC per connection, based on the first byte of
+    /// the stream.
+    Auto,
 }
 
 impl std::fmt::Display for RpcTransport {
@@ -104,6 +121,7 @@ impl std::fmt::Display for RpcTransport {
         f.pad(match self {
             RpcTransport::Ttrpc => "ttrpc",
             RpcTransport::Grpc => "grpc",
+            RpcTransport::Auto => "auto",
         })
     }
 }
@@ -114,6 +132,148 @@ enum ResolvedTransport {
     Ttrpc,
     #[cfg(feature = "grpc")]
     Grpc,
+    Auto,
+}
+
+impl ResolvedTransport {
+    /// Returns whether ttrpc connections are permitted in this mode.
+    #[cfg(feature = "ttrpc")]
+    fn allows_ttrpc(self) -> bool {
+        match self {
+            ResolvedTransport::Ttrpc => true,
+            #[cfg(feature = "grpc")]
+            ResolvedTransport::Grpc => false,
+            ResolvedTransport::Auto => true,
+        }
+    }
+
+    /// Returns whether gRPC connections are permitted in this mode.
+    #[cfg(feature = "grpc")]
+    fn allows_grpc(self) -> bool {
+        match self {
+            #[cfg(feature = "ttrpc")]
+            ResolvedTransport::Ttrpc => false,
+            ResolvedTransport::Grpc => true,
+            ResolvedTransport::Auto => true,
+        }
+    }
+}
+
+/// The RPC server accept loop.
+///
+/// This owns the accept loop rather than delegating to
+/// [`mesh_rpc::Server::run`], so that the protocol used for each connection can
+/// be chosen based on the compiled-in features and the configured transport,
+/// including auto-detecting ttrpc vs. gRPC from the first byte on the wire.
+///
+/// Neither ttrpc nor gRPC has an explicit negotiation phase, but their first
+/// byte on the wire is distinct, so a single non-consuming peek is enough to
+/// classify a connection:
+///
+/// * ttrpc frames begin with a big-endian `u32` length field whose most
+///   significant byte is always zero (messages are capped well under 16 MiB),
+///   so the first byte is `0x00`.
+/// * gRPC uses HTTP/2 cleartext, whose client connection preface begins with
+///   the ASCII bytes `"PRI "`, so the first byte is `b'P'`.
+/// * The OpenVMM fd-passing protocol (UNIX only) begins with a handshake whose
+///   first byte is `0xFD`, distinct from both of the above.
+mod dispatch {
+    use super::FdRegistry;
+    use super::ResolvedTransport;
+    use futures::FutureExt;
+    use pal_async::driver::Driver;
+    use pal_async::socket::AsSockRef;
+    use pal_async::socket::PolledSocket;
+    use std::io::Read;
+    use std::io::Write;
+    use unicycle::FuturesUnordered;
+    use unix_socket::UnixListener;
+    use unix_socket::UnixStream;
+
+    /// Runs the RPC server, listening on `listener` and servicing connections
+    /// until `cancel`, dispatching each connection according to `transport`.
+    pub(super) async fn run(
+        server: &mesh_rpc::Server,
+        driver: &(impl Driver + ?Sized),
+        listener: UnixListener,
+        cancel: mesh::OneshotReceiver<()>,
+        transport: ResolvedTransport,
+        registry: FdRegistry,
+    ) -> anyhow::Result<()> {
+        let mut listener = PolledSocket::new(driver, listener)?;
+        let mut tasks = FuturesUnordered::new();
+        let mut cancel = cancel.fuse();
+        loop {
+            let conn = futures::select! { // merge semantics
+                r = listener.accept().fuse() => r,
+                _ = tasks.next() => continue,
+                _ = cancel => break,
+            };
+            if let Ok(conn) = conn.and_then(|(conn, _)| PolledSocket::new(driver, conn)) {
+                let registry = registry.clone();
+                tasks.push(async move {
+                    let _ = serve(server, conn, transport, &registry)
+                        .await
+                        .map_err(|err| {
+                            tracing::error!(
+                                error = err.as_ref() as &dyn std::error::Error,
+                                "connection error"
+                            )
+                        });
+                });
+            }
+        }
+        Ok(())
+    }
+
+    /// Services a single connection.
+    ///
+    /// The protocol is always determined by peeking the first byte of the
+    /// stream; the configured `transport` only restricts which protocols are
+    /// permitted (e.g. a ttrpc-only server rejects a gRPC client).
+    async fn serve(
+        server: &mesh_rpc::Server,
+        mut conn: PolledSocket<UnixStream>,
+        transport: ResolvedTransport,
+        registry: &FdRegistry,
+    ) -> anyhow::Result<()> {
+        // Wait for the client to send data (returning early if it hangs up
+        // first) and classify the protocol from its first byte.
+        let Some(first_byte) = peek_first_byte(&mut conn).await? else {
+            return Ok(());
+        };
+
+        // The fd-passing protocol (UNIX only) is allowed in every transport
+        // mode; it shares the socket with ttrpc/gRPC and is selected by its
+        // distinct magic first byte.
+        #[cfg(not(unix))]
+        let _ = registry;
+
+        match first_byte {
+            #[cfg(feature = "ttrpc")]
+            0x00 if transport.allows_ttrpc() => server.serve_connection(conn).await,
+            #[cfg(feature = "grpc")]
+            b'P' if transport.allows_grpc() => server.serve_connection_grpc(conn).await,
+            #[cfg(unix)]
+            super::fd_passing::MAGIC_FIRST_BYTE => super::fd_passing::serve(conn, registry).await,
+            byte => {
+                anyhow::bail!("unrecognized or disallowed rpc protocol (first byte {byte:#04x})")
+            }
+        }
+    }
+
+    /// Waits for the first byte of the stream to be available and returns it
+    /// without consuming it, so the chosen protocol handler sees a pristine
+    /// stream.
+    ///
+    /// Returns `None` if the peer closed the connection before sending any data.
+    async fn peek_first_byte(
+        conn: &mut PolledSocket<impl AsSockRef + Read + Write>,
+    ) -> std::io::Result<Option<u8>> {
+        let mut buf = [0u8; 1];
+        let n = conn.peek(&mut buf).await?;
+        Ok((n != 0).then_some(buf[0]))
+    }
 }
 
 pub struct TtrpcWorker {
@@ -136,6 +296,7 @@ impl Worker for TtrpcWorker {
                 RpcTransport::Ttrpc => ResolvedTransport::Ttrpc,
                 #[cfg(feature = "grpc")]
                 RpcTransport::Grpc => ResolvedTransport::Grpc,
+                RpcTransport::Auto => ResolvedTransport::Auto,
                 #[expect(clippy::allow_attributes)]
                 #[allow(unreachable_patterns)]
                 transport => bail!("unsupported transport {transport}"),
@@ -159,6 +320,7 @@ impl Worker for TtrpcWorker {
                 lifecycle: VmLifecycle::Uninitialized,
                 rpc_tasks: Vec::new(),
                 transport: self.transport,
+                registry: FdRegistry::default(),
             };
             service.run(self.listener, recv).await?;
             Ok(())
@@ -177,18 +339,13 @@ impl VmService {
         let mut inspect_service_recv = server.add_service::<InspectService>();
 
         let transport = self.transport;
+        let registry = self.registry.clone();
         let (cancel_send, cancel_recv) = mesh::oneshot();
         let server_task = self.driver.spawn("ttrpc-server", {
             let driver = self.driver.clone();
             async move {
-                let r = match transport {
-                    #[cfg(feature = "ttrpc")]
-                    ResolvedTransport::Ttrpc => server.run(&driver, listener, cancel_recv).await,
-                    #[cfg(feature = "grpc")]
-                    ResolvedTransport::Grpc => {
-                        server.run_grpc(&driver, listener, cancel_recv).await
-                    }
-                };
+                let r = dispatch::run(&server, &driver, listener, cancel_recv, transport, registry)
+                    .await;
                 match &r {
                     Ok(()) => tracing::debug!("ttrpc server shutting down"),
                     Err(err) => tracing::error!(
@@ -368,6 +525,9 @@ struct VmService {
     lifecycle: VmLifecycle,
     rpc_tasks: Vec<Task<()>>,
     transport: ResolvedTransport,
+    /// Registry of file descriptors passed in over the fd-passing protocol,
+    /// resolvable by name (e.g. for tap NIC backends).
+    registry: FdRegistry,
 }
 
 fn grpc_error(err: anyhow::Error) -> Status {
@@ -528,6 +688,10 @@ impl VmService {
             bail!("VM already created");
         }
 
+        // Snapshot the fd registry so tap NIC backends can resolve descriptors
+        // passed in over the fd-passing protocol.
+        let registry = self.registry.clone();
+
         let load_mode = match req_config
             .boot_config
             .context("missing boot configuration")?
@@ -624,7 +788,7 @@ impl VmService {
         // attached behind their ports).
         let (pcie_root_complexes, pcie_switches, pcie_devices) =
             if let Some(pcie) = req_config.pcie.take() {
-                build_pcie_topology(pcie).await?
+                build_pcie_topology(pcie, &registry).await?
             } else {
                 (Vec::new(), Vec::new(), Vec::new())
             };
@@ -717,7 +881,9 @@ impl VmService {
                 } else {
                     None
                 };
-                config.vmbus_devices.push(parse_nic_config(nic, recv)?);
+                config
+                    .vmbus_devices
+                    .push(parse_nic_config(nic, recv, &registry)?);
             }
 
             for virtiofs in devices_config.virtiofs_config {
@@ -986,9 +1152,10 @@ impl VmService {
             .context("VM not created yet")?
             .worker_rpc
             .clone();
+        let registry = self.registry.clone();
         Ok(async move {
             let vmservice::AddPcieDeviceRequest { port_name, device } = request;
-            let resource = build_pcie_device(device.context("missing device")?).await?;
+            let resource = build_pcie_device(device.context("missing device")?, &registry).await?;
             worker_rpc
                 .call_failable(VmRpc::AddPcieDevice, (port_name, resource))
                 .await
@@ -1058,7 +1225,7 @@ impl VmService {
                              configure it at VM creation time"
                         );
                     }
-                    let config = parse_nic_config(nic, None)?;
+                    let config = parse_nic_config(nic, None, &self.registry)?;
                     let recv = vm.worker_rpc.call_failable(VmRpc::AddVmbusDevice, config);
                     Ok(async move { recv.await.map_err(anyhow::Error::from) }.boxed())
                 } else if request.r#type == vmservice::ModifyType::Update as i32 {
@@ -1159,8 +1326,11 @@ fn parse_port_config(port: vmservice::PortConfig) -> anyhow::Result<HostPortConf
 fn parse_nic_config(
     nic: vmservice::NicConfig,
     recv: Option<mesh::Receiver<ConsommeRequest>>,
+    registry: &FdRegistry,
 ) -> anyhow::Result<(DeviceVtl, Resource<VmbusDeviceHandleKind>)> {
     use self::vmservice::nic_config::Backend;
+    #[cfg(not(target_os = "linux"))]
+    let _ = registry;
     let endpoint = match nic.backend.context("missing backend")? {
         #[cfg(windows)]
         Backend::LegacyPortId(port_id) => net_backend_resources::dio::WindowsDirectIoHandle {
@@ -1179,11 +1349,7 @@ fn parse_nic_config(
         }
         .into_resource(),
         #[cfg(target_os = "linux")]
-        Backend::Tap(tap) => {
-            let fd = net_tap::tap::open_tap(&tap.name)
-                .with_context(|| format!("failed to open TAP device '{}'", tap.name))?;
-            net_backend_resources::tap::TapHandle { fd }.into_resource()
-        }
+        Backend::Tap(tap) => build_tap_backend(tap, registry)?,
         Backend::Consomme(consomme) => net_backend_resources::consomme::ConsommeHandle {
             cidr: if consomme.cidr.is_empty() {
                 None
@@ -1321,6 +1487,7 @@ fn pcie_mmio_range_config(size: u64, base: Option<u64>) -> anyhow::Result<PcieMm
 /// the port it sits behind).
 async fn build_pcie_topology(
     topology: vmservice::PcieTopologyConfig,
+    registry: &FdRegistry,
 ) -> anyhow::Result<(
     Vec<PcieRootComplexConfig>,
     Vec<PcieSwitchConfig>,
@@ -1389,7 +1556,7 @@ async fn build_pcie_topology(
 
     let mut devices = Vec::new();
     for (port_name, device) in pending_devices {
-        let resource = build_pcie_device(device).await?;
+        let resource = build_pcie_device(device, registry).await?;
         devices.push(PcieDeviceConfig {
             port_name,
             resource,
@@ -1456,12 +1623,13 @@ fn walk_pcie_attachment(
 /// function, an NVMe controller, or a VFIO-assigned host device).
 async fn build_pcie_device(
     device: vmservice::PcieDeviceKind,
+    registry: &FdRegistry,
 ) -> anyhow::Result<Resource<PciDeviceHandleKind>> {
     use vmservice::pcie_device_kind::Kind;
     let vmservice::PcieDeviceKind { kind } = device;
     Ok(match kind.context("missing PCIe device kind")? {
         Kind::Virtio(virtio) => {
-            let resource = build_virtio_device(virtio).await?;
+            let resource = build_virtio_device(virtio, registry).await?;
             VirtioPciDeviceHandle(resource).into_resource()
         }
         Kind::Nvme(nvme) => build_nvme_controller(nvme).await?,
@@ -1551,6 +1719,7 @@ async fn build_nvme_controller(
 /// `VirtioDevice`.
 async fn build_virtio_device(
     device: vmservice::VirtioDevice,
+    registry: &FdRegistry,
 ) -> anyhow::Result<Resource<VirtioDeviceHandle>> {
     use vmservice::virtio_device::Kind;
     let vmservice::VirtioDevice { kind } = device;
@@ -1565,7 +1734,7 @@ async fn build_virtio_device(
             backend,
             mac_address,
         }) => {
-            let endpoint = build_nic_backend(backend.context("missing net backend")?)?;
+            let endpoint = build_nic_backend(backend.context("missing net backend")?, registry)?;
             virtio_resources::net::VirtioNetHandle {
                 max_queues: max_queues
                     .map(|q| q.try_into().context("max_queues out of range"))
@@ -1618,8 +1787,11 @@ async fn build_disk_backend(
 /// Builds a host network endpoint resource from the proto `NicBackend`.
 fn build_nic_backend(
     backend: vmservice::NicBackend,
+    registry: &FdRegistry,
 ) -> anyhow::Result<Resource<NetEndpointHandleKind>> {
     use vmservice::nic_backend::Kind;
+    #[cfg(not(target_os = "linux"))]
+    let _ = registry;
     let vmservice::NicBackend { kind } = backend;
     Ok(match kind.context("missing network backend")? {
         Kind::Consomme(vmservice::ConsommeBackend { cidr, ports }) => {
@@ -1634,11 +1806,7 @@ fn build_nic_backend(
             .into_resource()
         }
         #[cfg(target_os = "linux")]
-        Kind::Tap(vmservice::TapBackend { name }) => {
-            let fd = net_tap::tap::open_tap(name.as_ref())
-                .with_context(|| format!("failed to open TAP device '{name}'"))?;
-            net_backend_resources::tap::TapHandle { fd }.into_resource()
-        }
+        Kind::Tap(tap) => build_tap_backend(tap, registry)?,
         #[cfg(windows)]
         Kind::Dio(vmservice::DioBackend { switch_id, port_id }) => {
             net_backend_resources::dio::WindowsDirectIoHandle {
@@ -1651,6 +1819,25 @@ fn build_nic_backend(
         }
         _ => anyhow::bail!("unsupported network backend"),
     })
+}
+
+/// Resolves a proto `TapBackend` into a tap NIC endpoint resource, either by
+/// opening `/dev/net/tun` by device name or by resolving a descriptor
+/// registered via the fd-passing protocol.
+#[cfg(target_os = "linux")]
+fn build_tap_backend(
+    tap: vmservice::TapBackend,
+    registry: &FdRegistry,
+) -> anyhow::Result<Resource<NetEndpointHandleKind>> {
+    use vmservice::tap_backend::Source;
+    let fd = match tap.source.context("missing tap source")? {
+        Source::Name(name) => net_tap::tap::open_tap(&name)
+            .with_context(|| format!("failed to open TAP device '{name}'"))?,
+        Source::FdName(fd_name) => registry
+            .resolve(&fd_name)
+            .with_context(|| format!("failed to resolve tap fd '{fd_name}'"))?,
+    };
+    Ok(net_backend_resources::tap::TapHandle { fd }.into_resource())
 }
 
 /// Builds a serial backend resource from the proto `SerialBackend`.

--- a/openvmm/openvmm_ttrpc_vmservice/src/fd_passing.md
+++ b/openvmm/openvmm_ttrpc_vmservice/src/fd_passing.md
@@ -1,0 +1,188 @@
+# OpenVMM fd-passing protocol
+
+The **fd-passing protocol** lets a client hand pre-opened file descriptors to
+the OpenVMM management server, each under a client-chosen name. A name can then
+be referenced from the ordinary ttrpc/gRPC API — for example a `TapBackend` may
+give an `fd_name` instead of a device `name`, so the server uses an already-open
+tap fd instead of opening `/dev/net/tun` itself.
+
+It runs over the **same `AF_UNIX` stream socket** as ttrpc and gRPC, and carries
+descriptors via `SCM_RIGHTS`. It is UNIX-only.
+
+Status: **revision 1** (handshake magic `0xFD 'F' 'D' 0x01`).
+
+## Conventions
+
+- Multi-byte integers are **little-endian**; `u8`/`u16`/`u32` are unsigned.
+- **MUST** / **MAY** mark normative requirements. Blocks labelled *Rationale*
+  are non-normative and explain intent only.
+- Descriptors are transferred with `SCM_RIGHTS` control messages on
+  `sendmsg`/`recvmsg` (see `unix(7)`, `cmsg(3)`).
+
+## Client procedure
+
+A client does the following, in order:
+
+1. **Connect** to the socket.
+2. **Send** the 8-byte handshake (see [Handshake](#handshake)), with
+   `features = 0` and no ancillary data.
+3. **Receive and validate** the server's 8-byte handshake. On magic mismatch or
+   EOF, abort — the server does not speak this revision.
+4. **For each descriptor:** send one `Register` request carrying the fd (see
+   [Requests](#requests)), then read exactly one response (see
+   [Responses](#responses)) before doing anything else.
+5. **Optionally** `Deregister` names no longer needed.
+6. **Close** the connection when done; any names still registered are dropped
+   automatically (see [Lifetime and cleanup](#lifetime-and-cleanup)).
+
+Requests and responses are strictly one-for-one: a client MUST read the response
+to a request before sending the next request.
+
+## Handshake
+
+Both sides send a fixed 8-byte handshake; the client sends first, then the
+server replies. Neither side sends anything else until both handshakes have been
+exchanged.
+
+```
+Handshake (8 bytes):
+  magic: [u8; 4]   // 0xFD, 0x46 'F', 0x44 'D', 0x01
+  features: u32    // 0 in this revision
+```
+
+- Both sides MUST send exactly these 8 bytes, with `features = 0` and **no
+  ancillary data**.
+- Each side MUST verify the received 4-byte magic and MUST close the connection
+  on any mismatch.
+- A client MUST ignore (not validate) the received `features` value.
+- If the server closes before sending its handshake (EOF), the client MUST treat
+  it as not supporting this revision.
+
+> *Rationale.* The leading `0xFD` differs from the ttrpc (`0x00`) and gRPC
+> (`'P'`) first bytes, letting the server route a connection by its first byte.
+> The 4-byte magic encodes both protocol and revision: a wire-incompatible
+> future revision uses a *different* magic (advertised out of band via ttrpc),
+> so there is no separate version field. `features` reserves room for optional,
+> backward-compatible capabilities; sending 0 and ignoring the peer's value lets
+> a newer peer advertise features without breaking an older one. Keeping the
+> handshake free of ancillary data means descriptors are only ever attached to
+> `Register`, with no ambiguity about which message carries an fd.
+
+## Requests
+
+After the handshake the connection is a synchronous request/response loop. Each
+request is a fixed frame:
+
+```
+opcode: u8            // 1 = Register, 2 = Deregister
+name_len: u8          // name length in bytes, 1..=255
+name: [u8; name_len]  // UTF-8 identifier chosen by the client
+```
+
+### Register (opcode 1)
+
+Registers one descriptor under `name`.
+
+- The request MUST attach **exactly one** descriptor, in a single `SCM_RIGHTS`
+  control message on the same `sendmsg` as the request bytes.
+- Registration fails if `name` is already registered by **any** connection
+  (names share one global namespace).
+- On success the server owns the descriptor; the client MAY close its own copy
+  once it has read the success response.
+
+### Deregister (opcode 2)
+
+Removes `name`. No descriptor is attached.
+
+- A connection MAY only deregister names it registered itself; deregistering an
+  unknown name, or a name owned by another connection, fails.
+- On success the server drops its descriptor for that name.
+
+## Responses
+
+The server sends exactly one response per request, in order:
+
+```
+status: u8          // 0 = ok; non-zero = failure
+msg_len: u16        // length of msg (0 on success)
+msg: [u8; msg_len]  // UTF-8 diagnostic text (empty on success)
+```
+
+- `status = 0` is success; any non-zero value is failure.
+- This revision emits only `status = 1` (**generic failure**). A client MUST
+  treat every non-zero value as a single failure.
+- `msg` is human-readable diagnostic text only; a client MUST NOT parse it.
+- The connection stays usable after a failure response.
+
+Failures include, at minimum: registering an already-registered name;
+registering with zero or more than one attached descriptor; an empty or
+non-UTF-8 name; deregistering a name this connection did not register.
+
+The server MUST NOT panic on any input. On a frame it cannot interpret — an
+unknown opcode, or a truncated request — it closes any received descriptors and
+closes the connection.
+
+> *Rationale.* Reserving the non-zero code space lets a future revision assign
+> specific codes while an older client keeps working by collapsing them to
+> "failure". An uninterpretable frame cannot be skipped (there is no length
+> prefix), so the byte stream cannot resynchronize and the connection must
+> close. That is acceptable because the opcode set is fixed for a given
+> handshake magic, and additive capabilities are negotiated via `features`, so a
+> conforming client never sends one.
+
+## Lifetime and cleanup
+
+- Names are **owned by the registering connection**: when that connection closes
+  (cleanly or not), the server drops every descriptor it registered.
+- The namespace is **global**: a name registered on one connection is resolvable
+  from a *different* connection.
+- Resolving a name **dups** the descriptor; the registry entry stays valid.
+  Deregistering, or closing the registering connection, does not invalidate a
+  descriptor already handed to a running VM.
+
+> *Rationale.* A global namespace is required because the ttrpc/gRPC connection
+> that creates a VM is separate from the fd-passing connection that registered
+> the fd. Per-connection ownership guarantees cleanup even if the client
+> crashes; dup-on-resolve lets a name be used more than once and decouples the
+> VM's lifetime from the registration's.
+
+## Referencing a registered fd
+
+A registered name is used from the ordinary ttrpc/gRPC API. The first consumer
+is the TAP backend:
+
+```proto
+message TapBackend {
+  oneof source {
+    string name    = 1;  // open /dev/net/tun by device name (existing behavior)
+    string fd_name = 2;  // use the fd registered under this name
+  }
+}
+```
+
+With `fd_name`, the server resolves the name (dup) and uses it as the tap
+backing fd; an unregistered name fails NIC creation.
+
+## Wire format examples
+
+Hex bytes; ancillary data is shown separately.
+
+| Message | Bytes | Ancillary |
+|---------|-------|-----------|
+| Handshake (either side) | `FD 46 44 01 00 00 00 00` | none |
+| `Register("t0", fd)` | `01 02 74 30` | one fd via `SCM_RIGHTS` |
+| `Deregister("t0")` | `02 02 74 30` | none |
+| Response, success | `00 00 00` | none |
+| Response, failure `"boom"` | `01 04 00 62 6F 6F 6D` | none |
+
+(`74 30` is the ASCII name `"t0"`; `04 00` is `msg_len = 4`, little-endian.)
+
+## Implementing a client
+
+Encoding and decoding are plain fixed byte buffers — `read_exact`/`write_all`,
+no library needed. The only OS-specific step is attaching the fd on `Register`:
+`std::os::unix::net::UnixStream` cannot pass a descriptor, so that one `sendmsg`
+must build an `SCM_RIGHTS` control message. Options: call `libc::sendmsg`
+directly; reuse OpenVMM's helper (the `SCM_RIGHTS` send/recv lives in the
+`unix_socket` crate); or use a crate such as `sendfd`/`passfd`. The handshake,
+`Deregister`, and all responses use no ancillary data.

--- a/openvmm/openvmm_ttrpc_vmservice/src/vmservice.proto
+++ b/openvmm/openvmm_ttrpc_vmservice/src/vmservice.proto
@@ -592,7 +592,13 @@ message DioBackend {
 }
 
 message TapBackend {
-    string name = 1;
+    oneof source {
+        // Open /dev/net/tun by this device name (existing behavior).
+        string name = 1;
+        // Use the file descriptor registered under this name via the
+        // fd-passing protocol (see fd_passing.md).
+        string fd_name = 2;
+    }
 }
 
 enum IpProtocol {

--- a/support/mesh/mesh_rpc/src/server.rs
+++ b/support/mesh/mesh_rpc/src/server.rs
@@ -135,7 +135,7 @@ impl Server {
             };
             if let Ok(conn) = conn.and_then(|(conn, _)| PolledSocket::new(driver, conn)) {
                 tasks.push(async {
-                    let _ = self.serve(conn).await.map_err(|err| {
+                    let _ = self.serve_connection(conn).await.map_err(|err| {
                         tracing::error!(
                             error = err.as_ref() as &dyn std::error::Error,
                             "connection error"
@@ -153,10 +153,16 @@ impl Server {
         driver: &(impl Driver + ?Sized),
         conn: impl AsSockRef + Read + Write,
     ) -> anyhow::Result<()> {
-        self.serve(PolledSocket::new(driver, conn)?).await
+        self.serve_connection(PolledSocket::new(driver, conn)?)
+            .await
     }
 
-    async fn serve(
+    /// Services a single, already-accepted connection using the ttrpc protocol.
+    ///
+    /// This is useful when the caller owns the accept loop, for example to
+    /// dispatch a connection to ttrpc or another protocol based on a sniffed
+    /// prefix byte.
+    pub async fn serve_connection(
         &self,
         stream: PolledSocket<impl AsSockRef + Read + Write>,
     ) -> anyhow::Result<()> {
@@ -351,7 +357,7 @@ mod grpc {
                 };
                 if let Ok(conn) = conn.and_then(|(conn, _)| PolledSocket::new(driver, conn)) {
                     tasks.push(async {
-                        let _ = self.serve_grpc(conn).await.map_err(|err| {
+                        let _ = self.serve_connection_grpc(conn).await.map_err(|err| {
                             tracing::error!(
                                 error = err.as_ref() as &dyn std::error::Error,
                                 "connection error"
@@ -363,7 +369,13 @@ mod grpc {
             Ok(())
         }
 
-        async fn serve_grpc(
+        /// Services a single, already-accepted connection using the gRPC
+        /// (HTTP/2) protocol.
+        ///
+        /// This is useful when the caller owns the accept loop, for example to
+        /// dispatch a connection to gRPC or another protocol based on a sniffed
+        /// prefix byte.
+        pub async fn serve_connection_grpc(
             &self,
             stream: PolledSocket<impl AsSockRef + Read + Write>,
         ) -> anyhow::Result<()> {

--- a/support/pal/pal_async/src/socket.rs
+++ b/support/pal/pal_async/src/socket.rs
@@ -125,6 +125,41 @@ impl<T: AsSockRef> PolledSocket<T> {
         sock_ref.set_nonblocking(false).unwrap();
         self.socket
     }
+
+    /// Polls for peeking at incoming data without consuming it.
+    ///
+    /// On success, the peeked bytes are written to the start of `buf` and the
+    /// number of bytes peeked is returned. A return value of `Ok(0)` indicates
+    /// that the peer has closed the connection (or that `buf` was empty).
+    ///
+    /// The peeked data remains in the socket's receive buffer, so a subsequent
+    /// read (or peek) will observe the same bytes.
+    // UNSAFETY: Reinterpreting an initialized `&mut [u8]` as
+    // `&mut [MaybeUninit<u8>]` to pass to `socket2::Socket::peek`.
+    #[expect(unsafe_code)]
+    pub fn poll_peek(&mut self, cx: &mut Context<'_>, buf: &mut [u8]) -> Poll<io::Result<usize>> {
+        self.poll_io(cx, InterestSlot::Read, PollEvents::IN, |this| {
+            // SAFETY: Reinterpreting an initialized `&mut [u8]` as
+            // `&mut [MaybeUninit<u8>]` is sound: every `u8` is a valid
+            // `MaybeUninit<u8>`, and `peek` only writes initialized bytes. The
+            // caller's buffer therefore remains fully initialized.
+            let uninit = unsafe {
+                std::slice::from_raw_parts_mut(
+                    buf.as_mut_ptr().cast::<std::mem::MaybeUninit<u8>>(),
+                    buf.len(),
+                )
+            };
+            this.socket.as_sock_ref().peek(uninit)
+        })
+    }
+
+    /// Peeks at incoming data without consuming it, waiting until at least one
+    /// byte is available or the peer closes the connection.
+    ///
+    /// See [`PolledSocket::poll_peek`] for details.
+    pub async fn peek(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        poll_fn(|cx| self.poll_peek(cx, buf)).await
+    }
 }
 
 impl<T> PolledSocket<T> {
@@ -643,5 +678,37 @@ mod tests {
             assert_eq!(&v, b"abcdef");
         };
         futures::future::join(copy, rest).await;
+    }
+
+    #[async_test]
+    async fn peek(driver: DefaultDriver) {
+        let (a, b) = UnixStream::pair().unwrap();
+        let mut a = PolledSocket::new(&driver, a).unwrap();
+        let mut b = PolledSocket::new(&driver, b).unwrap();
+
+        b.write_all(b"abc").await.unwrap();
+
+        // Peeking does not consume the data.
+        let mut buf = [0; 2];
+        let n = a.peek(&mut buf).await.unwrap();
+        assert_eq!(n, 2);
+        assert_eq!(&buf, b"ab");
+
+        // A second peek observes the same bytes.
+        let mut buf = [0; 3];
+        let n = a.peek(&mut buf).await.unwrap();
+        assert_eq!(n, 3);
+        assert_eq!(&buf, b"abc");
+
+        // A subsequent read still observes the peeked bytes.
+        let mut buf = [0; 3];
+        a.read_exact(&mut buf).await.unwrap();
+        assert_eq!(&buf, b"abc");
+
+        // Peeking after the peer closes returns 0.
+        drop(b);
+        let mut buf = [0; 1];
+        let n = a.peek(&mut buf).await.unwrap();
+        assert_eq!(n, 0);
     }
 }

--- a/support/pal/pal_async/src/socket.rs
+++ b/support/pal/pal_async/src/socket.rs
@@ -608,6 +608,11 @@ impl<T: AsSockRef> AsyncRead for ReadHalf<T> {
         cx: &mut Context<'_>,
         buf: &mut [u8],
     ) -> Poll<io::Result<usize>> {
+        // Short-circuit an empty buffer so the caller gets `Ok(0)`
+        // immediately, rather than blocking on read readiness.
+        if buf.is_empty() {
+            return Poll::Ready(Ok(0));
+        }
         self.poll_io(cx, |this| (&*this.inner.socket.as_sock_ref()).read(buf))
     }
 

--- a/support/pal/pal_async/src/socket.rs
+++ b/support/pal/pal_async/src/socket.rs
@@ -3,6 +3,10 @@
 
 //! Socket-related functionality.
 
+// UNSAFETY: Reinterpreting an initialized `&mut [u8]` as
+// `&mut [MaybeUninit<u8>]` to pass to `socket2::Socket::peek`.
+#![expect(unsafe_code)]
+
 #[cfg(unix)]
 use super::fd;
 use super::interest::InterestSlot;
@@ -134,10 +138,12 @@ impl<T: AsSockRef> PolledSocket<T> {
     ///
     /// The peeked data remains in the socket's receive buffer, so a subsequent
     /// read (or peek) will observe the same bytes.
-    // UNSAFETY: Reinterpreting an initialized `&mut [u8]` as
-    // `&mut [MaybeUninit<u8>]` to pass to `socket2::Socket::peek`.
-    #[expect(unsafe_code)]
     pub fn poll_peek(&mut self, cx: &mut Context<'_>, buf: &mut [u8]) -> Poll<io::Result<usize>> {
+        // Short-circuit an empty buffer so the caller gets the documented
+        // `Ok(0)` immediately, rather than blocking on read readiness.
+        if buf.is_empty() {
+            return Poll::Ready(Ok(0));
+        }
         self.poll_io(cx, InterestSlot::Read, PollEvents::IN, |this| {
             // SAFETY: Reinterpreting an initialized `&mut [u8]` as
             // `&mut [MaybeUninit<u8>]` is sound: every `u8` is a valid
@@ -353,6 +359,11 @@ impl<T: AsSockRef + Read> AsyncRead for PolledSocket<T> {
         cx: &mut Context<'_>,
         buf: &mut [u8],
     ) -> Poll<io::Result<usize>> {
+        // Short-circuit an empty buffer so the caller gets `Ok(0)`
+        // immediately, rather than blocking on read readiness.
+        if buf.is_empty() {
+            return Poll::Ready(Ok(0));
+        }
         self.poll_io(cx, InterestSlot::Read, PollEvents::IN, |this| {
             this.socket.read(buf)
         })

--- a/vmm_tests/vmm_tests/tests/tests/ttrpc.rs
+++ b/vmm_tests/vmm_tests/tests/tests/ttrpc.rs
@@ -623,9 +623,9 @@ fn virtio_device(kind: vmservice::virtio_device::Kind) -> vmservice::PcieDeviceK
     }
 }
 
-/// Spawns `openvmm --ttrpc <socket_path> --pidfile <pidfile_path>`, waits for it
-/// to signal readiness (by closing stdout), validates the pidfile, and connects
-/// a ttrpc client.
+/// Spawns `openvmm --rpc path=<socket_path>,transport=ttrpc --pidfile
+/// <pidfile_path>`, waits for it to signal readiness (by closing stdout),
+/// validates the pidfile, and connects a ttrpc client.
 ///
 /// Returns the child process, a connected ttrpc client, and the stderr-pump
 /// task (which must be kept alive for the child's lifetime).
@@ -645,8 +645,8 @@ async fn launch_openvmm(
     let (stderr_read, stderr_write) = pal::pipe_pair()?;
     let (stdout_read, stdout_write) = pal::pipe_pair()?;
     let child = std::process::Command::new(openvmm)
-        .arg("--ttrpc")
-        .arg(socket_path)
+        .arg("--rpc")
+        .arg(format!("path={},transport=ttrpc", socket_path.display()))
         .arg("--pidfile")
         .arg(pidfile_path)
         .stdin(Stdio::null())

--- a/vmm_tests/vmm_tests/tests/tests/ttrpc.rs
+++ b/vmm_tests/vmm_tests/tests/tests/ttrpc.rs
@@ -3,18 +3,27 @@
 
 //! Integration tests for OpenVMM's TTRPC interface.
 
+// Tests for the fd-passing protocol, which shares the TTRPC socket. It is
+// UNIX-only and tap `fd_name` resolution is Linux-only, so it only builds on
+// Linux.
+#[cfg(target_os = "linux")]
+mod fd_passing;
+
 use anyhow::Context;
 use futures::AsyncReadExt;
 use guid::Guid;
 use mesh::CancelContext;
 use openvmm_ttrpc_vmservice as vmservice;
+use pal_async::DefaultDriver;
 use pal_async::DefaultPool;
 use pal_async::pipe::PolledPipe;
 use pal_async::process::PolledChild;
 use pal_async::socket::PolledSocket;
 use pal_async::task::Spawn;
+use pal_async::task::Task;
 use petri::ResolvedArtifact;
 use petri_artifacts_vmm_test::artifacts;
+use std::path::Path;
 use std::process::Stdio;
 use std::time::Duration;
 use unix_socket::UnixListener;
@@ -45,78 +54,9 @@ fn test_ttrpc_interface(
         petri_artifacts_common::tags::MachineArch::Aarch64 => "ttyAMA0",
     };
 
-    tracing::info!(socket_path = %socket_path.display(), "launching OpenVMM with ttrpc");
-
-    let (stderr_read, stderr_write) = pal::pipe_pair()?;
-    let (stdout_read, stdout_write) = pal::pipe_pair()?;
-    let child = std::process::Command::new(openvmm)
-        .arg("--ttrpc")
-        .arg(&socket_path)
-        .arg("--pidfile")
-        .arg(&pidfile_path)
-        .stdin(Stdio::null())
-        .stdout(stdout_write)
-        .stderr(stderr_write)
-        .spawn()?;
-
     DefaultPool::run_with(async |driver| {
-        let mut child = PolledChild::<std::process::Child>::new(&driver, child)?;
-
-        // Start pumping stderr immediately so the pipe buffer doesn't fill
-        // up and block the child.
-        let stderr_task = driver.spawn(
-            "stderr",
-            petri::log_task(
-                params.logger.log_file("stderr")?,
-                PolledPipe::new(&driver, stderr_read)?,
-                "openvmm stderr",
-            ),
-        );
-
-        // Wait for stdout to close (readiness signal). If the child
-        // crashes at startup, stdout closes too and we detect the exit
-        // when the pidfile is missing.
-        let mut stdout = PolledPipe::new(&driver, stdout_read)?;
-        let mut buf = [0u8; 1];
-        let n = stdout
-            .read(&mut buf)
-            .await
-            .context("reading from openvmm stdout")?;
-        anyhow::ensure!(n == 0, "openvmm wrote unexpected data to stdout");
-        drop(stdout);
-
-        // Verify the pidfile was created with the correct PID. If it's
-        // missing, wait briefly for the child to exit (the PidfileGuard
-        // deletes it on drop) and report the exit status.
-        let pid_content = match std::fs::read_to_string(&pidfile_path) {
-            Ok(s) => s,
-            Err(e) => {
-                let wait_result = CancelContext::new()
-                    .with_timeout(Duration::from_secs(10))
-                    .until_cancelled(child.wait())
-                    .await;
-                match wait_result {
-                    Ok(Ok(status)) => {
-                        let _ = stderr_task.await;
-                        anyhow::bail!("openvmm exited with {status} before pidfile was created");
-                    }
-                    _ => {
-                        return Err(e).context("failed to read pidfile");
-                    }
-                }
-            }
-        };
-        assert_eq!(
-            pid_content,
-            format!("{}\n", child.get().id()),
-            "pidfile should contain the child PID"
-        );
-
-        let ttrpc_path = socket_path.clone();
-        let client = mesh_rpc::Client::new(
-            &driver,
-            mesh_rpc::client::UnixDialier::new(driver.clone(), ttrpc_path),
-        );
+        let (mut child, client, _stderr_task) =
+            launch_openvmm(&driver, &params, &openvmm, &socket_path, &pidfile_path).await?;
 
         let query_props = || {
             client.call().start(
@@ -683,8 +623,99 @@ fn virtio_device(kind: vmservice::virtio_device::Kind) -> vmservice::PcieDeviceK
     }
 }
 
+/// Spawns `openvmm --ttrpc <socket_path> --pidfile <pidfile_path>`, waits for it
+/// to signal readiness (by closing stdout), validates the pidfile, and connects
+/// a ttrpc client.
+///
+/// Returns the child process, a connected ttrpc client, and the stderr-pump
+/// task (which must be kept alive for the child's lifetime).
+async fn launch_openvmm(
+    driver: &DefaultDriver,
+    params: &petri::PetriTestParams<'_>,
+    openvmm: &ResolvedArtifact,
+    socket_path: &Path,
+    pidfile_path: &Path,
+) -> anyhow::Result<(
+    PolledChild<std::process::Child>,
+    mesh_rpc::Client,
+    Task<anyhow::Result<()>>,
+)> {
+    tracing::info!(socket_path = %socket_path.display(), "launching OpenVMM with ttrpc");
+
+    let (stderr_read, stderr_write) = pal::pipe_pair()?;
+    let (stdout_read, stdout_write) = pal::pipe_pair()?;
+    let child = std::process::Command::new(openvmm)
+        .arg("--ttrpc")
+        .arg(socket_path)
+        .arg("--pidfile")
+        .arg(pidfile_path)
+        .stdin(Stdio::null())
+        .stdout(stdout_write)
+        .stderr(stderr_write)
+        .spawn()?;
+
+    let mut child = PolledChild::<std::process::Child>::new(driver, child)?;
+
+    // Start pumping stderr immediately so the pipe buffer doesn't fill up and
+    // block the child.
+    let stderr_task = driver.spawn(
+        "stderr",
+        petri::log_task(
+            params.logger.log_file("stderr")?,
+            PolledPipe::new(driver, stderr_read)?,
+            "openvmm stderr",
+        ),
+    );
+
+    // Wait for stdout to close (readiness signal). If the child crashes at
+    // startup, stdout closes too and we detect the exit when the pidfile is
+    // missing.
+    let mut stdout = PolledPipe::new(driver, stdout_read)?;
+    let mut buf = [0u8; 1];
+    let n = stdout
+        .read(&mut buf)
+        .await
+        .context("reading from openvmm stdout")?;
+    anyhow::ensure!(n == 0, "openvmm wrote unexpected data to stdout");
+    drop(stdout);
+
+    // Verify the pidfile was created with the correct PID. If it's missing,
+    // wait briefly for the child to exit (the PidfileGuard deletes it on drop)
+    // and report the exit status.
+    let pid_content = match std::fs::read_to_string(pidfile_path) {
+        Ok(s) => s,
+        Err(e) => {
+            let wait_result = CancelContext::new()
+                .with_timeout(Duration::from_secs(10))
+                .until_cancelled(child.wait())
+                .await;
+            match wait_result {
+                Ok(Ok(status)) => {
+                    let _ = stderr_task.await;
+                    anyhow::bail!("openvmm exited with {status} before pidfile was created");
+                }
+                _ => {
+                    return Err(e).context("failed to read pidfile");
+                }
+            }
+        }
+    };
+    assert_eq!(
+        pid_content,
+        format!("{}\n", child.get().id()),
+        "pidfile should contain the child PID"
+    );
+
+    let client = mesh_rpc::Client::new(
+        driver,
+        mesh_rpc::client::UnixDialier::new(driver.clone(), socket_path.to_path_buf()),
+    );
+
+    Ok((child, client, stderr_task))
+}
+
 /// Builds a file-backed disk backend for the given path.
-fn file_disk(path: &std::path::Path) -> vmservice::DiskBackend {
+fn file_disk(path: &Path) -> vmservice::DiskBackend {
     vmservice::DiskBackend {
         kind: Some(vmservice::disk_backend::Kind::File(vmservice::FileDisk {
             path: path.to_string_lossy().into(),

--- a/vmm_tests/vmm_tests/tests/tests/ttrpc/fd_passing.rs
+++ b/vmm_tests/vmm_tests/tests/tests/ttrpc/fd_passing.rs
@@ -3,7 +3,7 @@
 
 //! Integration test for OpenVMM's fd-passing protocol on the TTRPC endpoint.
 //!
-//! This boots a real `openvmm --ttrpc` process and drives the bespoke
+//! This boots a real `openvmm --rpc` process and drives the bespoke
 //! fd-passing protocol (see `openvmm_ttrpc_vmservice/src/fd_passing.md`) over
 //! the same Unix socket, then confirms that a descriptor registered on the
 //! fd-passing connection is resolvable by name from a *separate* TTRPC

--- a/vmm_tests/vmm_tests/tests/tests/ttrpc/fd_passing.rs
+++ b/vmm_tests/vmm_tests/tests/tests/ttrpc/fd_passing.rs
@@ -14,17 +14,22 @@
 //! `ttrpc` module.
 
 use anyhow::Context;
+use futures::AsyncReadExt as _;
+use futures::AsyncWriteExt as _;
 use guid::Guid;
 use openvmm_ttrpc_vmservice as vmservice;
 use pal_async::DefaultPool;
+use pal_async::interest::InterestSlot;
+use pal_async::interest::PollEvents;
+use pal_async::socket::AsSockRef;
+use pal_async::socket::PolledSocket;
 use petri::ResolvedArtifact;
 use petri_artifacts_vmm_test::artifacts;
+use std::future::poll_fn;
 use std::io::IoSlice;
-use std::io::Read as _;
-use std::io::Write as _;
 use std::os::fd::AsFd;
 use std::os::fd::BorrowedFd;
-use std::os::unix::net::UnixStream;
+use unix_socket::UnixStream;
 
 /// The 4-byte fd-passing handshake magic: `0xFD 'F' 'D' 0x01`.
 const HANDSHAKE_MAGIC: [u8; 4] = [0xFD, b'F', b'D', 0x01];
@@ -58,10 +63,14 @@ fn fd_passing_tap(
             super::launch_openvmm(&driver, &params, &openvmm, &socket_path, &pidfile_path).await?;
 
         // Open a dedicated fd-passing connection and exercise the wire protocol
-        // against the live server.
-        let mut fd_conn =
-            UnixStream::connect(&socket_path).context("connecting fd-passing socket")?;
-        handshake(&mut fd_conn).context("fd-passing handshake")?;
+        // against the live server. Async IO keeps the single-threaded executor
+        // free to run co-scheduled tasks (e.g. the stderr pump).
+        let mut fd_conn = PolledSocket::connect_unix(&driver, &socket_path)
+            .await
+            .context("connecting fd-passing socket")?;
+        handshake(&mut fd_conn)
+            .await
+            .context("fd-passing handshake")?;
 
         // A real (but non-tap) descriptor to register: one end of a socket
         // pair. The other end is held open so the fd stays valid.
@@ -69,24 +78,24 @@ fn fd_passing_tap(
         let registered_fd = registered_fd.as_fd();
 
         // Register succeeds.
-        let (status, msg) = register(&mut fd_conn, "t0", registered_fd)?;
+        let (status, msg) = register(&mut fd_conn, "t0", registered_fd).await?;
         anyhow::ensure!(status == 0, "register 't0' failed: {msg}");
         // Registering the same name again fails; the connection stays usable.
-        let (status, _) = register(&mut fd_conn, "t0", registered_fd)?;
+        let (status, _) = register(&mut fd_conn, "t0", registered_fd).await?;
         anyhow::ensure!(status != 0, "duplicate register unexpectedly succeeded");
         // Registering without an attached descriptor fails.
-        let (status, _) = register_without_fd(&mut fd_conn, "t2")?;
+        let (status, _) = register_without_fd(&mut fd_conn, "t2").await?;
         anyhow::ensure!(status != 0, "register without fd unexpectedly succeeded");
         // Deregistering an unknown name fails.
-        let (status, _) = deregister(&mut fd_conn, "nope")?;
+        let (status, _) = deregister(&mut fd_conn, "nope").await?;
         anyhow::ensure!(
             status != 0,
             "deregister of unknown name unexpectedly succeeded"
         );
         // Deregister then re-register so 't0' is available for CreateVm below.
-        let (status, _) = deregister(&mut fd_conn, "t0")?;
+        let (status, _) = deregister(&mut fd_conn, "t0").await?;
         anyhow::ensure!(status == 0, "deregister 't0' failed");
-        let (status, msg) = register(&mut fd_conn, "t0", registered_fd)?;
+        let (status, msg) = register(&mut fd_conn, "t0", registered_fd).await?;
         anyhow::ensure!(status == 0, "re-register 't0' failed: {msg}");
         // NOTE: `fd_conn` is intentionally kept open for the rest of the test:
         // names are dropped when the registering connection closes.
@@ -150,12 +159,12 @@ fn fd_passing_tap(
 }
 
 /// Sends the client handshake and validates the server's reply.
-fn handshake(sock: &mut UnixStream) -> anyhow::Result<()> {
+async fn handshake(sock: &mut PolledSocket<UnixStream>) -> anyhow::Result<()> {
     let mut client_handshake = [0u8; 8];
     client_handshake[..4].copy_from_slice(&HANDSHAKE_MAGIC);
-    sock.write_all(&client_handshake)?;
+    sock.write_all(&client_handshake).await?;
     let mut server_handshake = [0u8; 8];
-    sock.read_exact(&mut server_handshake)?;
+    sock.read_exact(&mut server_handshake).await?;
     anyhow::ensure!(
         server_handshake[..4] == HANDSHAKE_MAGIC,
         "bad server handshake magic: {:x?}",
@@ -165,37 +174,79 @@ fn handshake(sock: &mut UnixStream) -> anyhow::Result<()> {
 }
 
 /// Sends a `Register` request carrying `fd` and returns the response.
-fn register(sock: &mut UnixStream, name: &str, fd: BorrowedFd<'_>) -> anyhow::Result<(u8, String)> {
+async fn register(
+    sock: &mut PolledSocket<UnixStream>,
+    name: &str,
+    fd: BorrowedFd<'_>,
+) -> anyhow::Result<(u8, String)> {
     let mut frame = vec![OPCODE_REGISTER, name.len() as u8];
     frame.extend_from_slice(name.as_bytes());
-    unix_socket::send_with_fds(sock.as_fd(), &[IoSlice::new(&frame)], [fd])?;
-    read_response(sock)
+    send_frame(sock, &frame, &[fd]).await?;
+    read_response(sock).await
 }
 
 /// Sends a `Register` request with no attached descriptor (an error case).
-fn register_without_fd(sock: &mut UnixStream, name: &str) -> anyhow::Result<(u8, String)> {
+async fn register_without_fd(
+    sock: &mut PolledSocket<UnixStream>,
+    name: &str,
+) -> anyhow::Result<(u8, String)> {
     let mut frame = vec![OPCODE_REGISTER, name.len() as u8];
     frame.extend_from_slice(name.as_bytes());
-    sock.write_all(&frame)?;
-    read_response(sock)
+    sock.write_all(&frame).await?;
+    read_response(sock).await
 }
 
 /// Sends a `Deregister` request and returns the response.
-fn deregister(sock: &mut UnixStream, name: &str) -> anyhow::Result<(u8, String)> {
+async fn deregister(
+    sock: &mut PolledSocket<UnixStream>,
+    name: &str,
+) -> anyhow::Result<(u8, String)> {
     let mut frame = vec![OPCODE_DEREGISTER, name.len() as u8];
     frame.extend_from_slice(name.as_bytes());
-    sock.write_all(&frame)?;
-    read_response(sock)
+    sock.write_all(&frame).await?;
+    read_response(sock).await
+}
+
+/// Sends `frame` with `fds` attached, awaiting write readiness so the executor
+/// thread is never blocked.
+///
+/// The descriptors ride on the first `sendmsg` only: once any bytes are
+/// accepted the kernel has taken the `SCM_RIGHTS`, so the remainder of a short
+/// write is sent with no ancillary data. This both guarantees the whole frame
+/// is written and that the fds are delivered exactly once.
+async fn send_frame(
+    sock: &mut PolledSocket<UnixStream>,
+    frame: &[u8],
+    fds: &[BorrowedFd<'_>],
+) -> anyhow::Result<()> {
+    let mut pos = 0;
+    while pos < frame.len() {
+        // Attach the fds only while nothing has been sent yet.
+        let fds: &[BorrowedFd<'_>] = if pos == 0 { fds } else { &[] };
+        let n = poll_fn(|cx| {
+            sock.poll_io(cx, InterestSlot::Write, PollEvents::OUT, |this| {
+                unix_socket::send_with_fds(
+                    this.get().as_sock_ref().as_fd(),
+                    &[IoSlice::new(&frame[pos..])],
+                    fds.iter().copied(),
+                )
+            })
+        })
+        .await?;
+        anyhow::ensure!(n > 0, "sendmsg accepted 0 bytes");
+        pos += n;
+    }
+    Ok(())
 }
 
 /// Reads one response frame: `status: u8`, `msg_len: u16` (LE), `msg`.
-fn read_response(sock: &mut UnixStream) -> anyhow::Result<(u8, String)> {
+async fn read_response(sock: &mut PolledSocket<UnixStream>) -> anyhow::Result<(u8, String)> {
     let mut hdr = [0u8; 3];
-    sock.read_exact(&mut hdr)?;
+    sock.read_exact(&mut hdr).await?;
     let status = hdr[0];
     let msg_len = u16::from_le_bytes([hdr[1], hdr[2]]) as usize;
     let mut msg = vec![0u8; msg_len];
-    sock.read_exact(&mut msg)?;
+    sock.read_exact(&mut msg).await?;
     Ok((status, String::from_utf8_lossy(&msg).into_owned()))
 }
 

--- a/vmm_tests/vmm_tests/tests/tests/ttrpc/fd_passing.rs
+++ b/vmm_tests/vmm_tests/tests/tests/ttrpc/fd_passing.rs
@@ -1,0 +1,242 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Integration test for OpenVMM's fd-passing protocol on the TTRPC endpoint.
+//!
+//! This boots a real `openvmm --ttrpc` process and drives the bespoke
+//! fd-passing protocol (see `openvmm_ttrpc_vmservice/src/fd_passing.md`) over
+//! the same Unix socket, then confirms that a descriptor registered on the
+//! fd-passing connection is resolvable by name from a *separate* TTRPC
+//! `CreateVm` connection via a `TapBackend { fd_name }` NIC.
+//!
+//! The feature is UNIX-only and tap `fd_name` resolution is Linux-only, so this
+//! test is gated to `target_os = "linux"` where it is declared in the parent
+//! `ttrpc` module.
+
+use anyhow::Context;
+use guid::Guid;
+use openvmm_ttrpc_vmservice as vmservice;
+use pal_async::DefaultPool;
+use petri::ResolvedArtifact;
+use petri_artifacts_vmm_test::artifacts;
+use std::io::IoSlice;
+use std::io::Read as _;
+use std::io::Write as _;
+use std::os::fd::AsFd;
+use std::os::fd::BorrowedFd;
+use std::os::unix::net::UnixStream;
+
+/// The 4-byte fd-passing handshake magic: `0xFD 'F' 'D' 0x01`.
+const HANDSHAKE_MAGIC: [u8; 4] = [0xFD, b'F', b'D', 0x01];
+
+const OPCODE_REGISTER: u8 = 1;
+const OPCODE_DEREGISTER: u8 = 2;
+
+petri::test!(fd_passing_tap, |resolver| {
+    // Only supported on x86_64 for now (matches the TTRPC interface test).
+    if petri_artifacts_common::tags::MachineArch::host()
+        != petri_artifacts_common::tags::MachineArch::X86_64
+    {
+        return None;
+    }
+    let openvmm = resolver.require(artifacts::OPENVMM_NATIVE);
+    let kernel = resolver.require(artifacts::loadable::LINUX_DIRECT_TEST_KERNEL_NATIVE);
+    let initrd = resolver.require(artifacts::loadable::LINUX_DIRECT_TEST_INITRD_NATIVE);
+    Some([openvmm.erase(), kernel.erase(), initrd.erase()])
+});
+
+fn fd_passing_tap(
+    params: petri::PetriTestParams<'_>,
+    [openvmm, kernel_path, initrd_path]: [ResolvedArtifact; 3],
+) -> anyhow::Result<()> {
+    let tempdir = tempfile::tempdir()?;
+    let socket_path = tempdir.path().join("ttrpc.sock");
+    let pidfile_path = tempdir.path().join("openvmm.pid");
+
+    DefaultPool::run_with(async |driver| {
+        let (mut child, client, _stderr_task) =
+            super::launch_openvmm(&driver, &params, &openvmm, &socket_path, &pidfile_path).await?;
+
+        // Open a dedicated fd-passing connection and exercise the wire protocol
+        // against the live server.
+        let mut fd_conn =
+            UnixStream::connect(&socket_path).context("connecting fd-passing socket")?;
+        handshake(&mut fd_conn).context("fd-passing handshake")?;
+
+        // A real (but non-tap) descriptor to register: one end of a socket
+        // pair. The other end is held open so the fd stays valid.
+        let (registered_fd, _keepalive) = UnixStream::pair()?;
+        let registered_fd = registered_fd.as_fd();
+
+        // Register succeeds.
+        let (status, msg) = register(&mut fd_conn, "t0", registered_fd)?;
+        anyhow::ensure!(status == 0, "register 't0' failed: {msg}");
+        // Registering the same name again fails; the connection stays usable.
+        let (status, _) = register(&mut fd_conn, "t0", registered_fd)?;
+        anyhow::ensure!(status != 0, "duplicate register unexpectedly succeeded");
+        // Registering without an attached descriptor fails.
+        let (status, _) = register_without_fd(&mut fd_conn, "t2")?;
+        anyhow::ensure!(status != 0, "register without fd unexpectedly succeeded");
+        // Deregistering an unknown name fails.
+        let (status, _) = deregister(&mut fd_conn, "nope")?;
+        anyhow::ensure!(
+            status != 0,
+            "deregister of unknown name unexpectedly succeeded"
+        );
+        // Deregister then re-register so 't0' is available for CreateVm below.
+        let (status, _) = deregister(&mut fd_conn, "t0")?;
+        anyhow::ensure!(status == 0, "deregister 't0' failed");
+        let (status, msg) = register(&mut fd_conn, "t0", registered_fd)?;
+        anyhow::ensure!(status == 0, "re-register 't0' failed: {msg}");
+        // NOTE: `fd_conn` is intentionally kept open for the rest of the test:
+        // names are dropped when the registering connection closes.
+
+        // Negative case: an unregistered `fd_name` fails to resolve during
+        // CreateVm, proving the proto -> registry resolution path is wired in.
+        let err = client
+            .call()
+            .start(
+                vmservice::Vm::CreateVm,
+                create_vm_request(&kernel_path, &initrd_path, "does-not-exist"),
+            )
+            .await
+            .unwrap_err();
+        assert!(
+            err.message.contains("failed to resolve tap fd"),
+            "expected an fd resolution error, got: {}",
+            err.message
+        );
+
+        // Positive case: a `fd_name` registered on the *fd-passing* connection
+        // resolves from this *separate* TTRPC connection, proving both share one
+        // global registry. The descriptor is a socket pair, not a real tap, so
+        // VM bring-up still fails -- but past resolution, with a different
+        // error (never the "failed to resolve" error above).
+        let result = client
+            .call()
+            .start(
+                vmservice::Vm::CreateVm,
+                create_vm_request(&kernel_path, &initrd_path, "t0"),
+            )
+            .await;
+        match result {
+            // Resolution succeeded and the VM was created; tear it back down.
+            Ok(()) => {
+                let _ = client.call().start(vmservice::Vm::TeardownVm, ()).await;
+            }
+            Err(err) => assert!(
+                !err.message.contains("failed to resolve tap fd"),
+                "registered fd_name should have resolved, got: {}",
+                err.message
+            ),
+        }
+
+        // Shut down openvmm and confirm a clean exit.
+        let _ = client.call().start(vmservice::Vm::Quit, ()).await;
+        drop(fd_conn);
+
+        let exit_status = child.wait().await?;
+        tracing::info!(?exit_status, "openvmm exited");
+        assert!(
+            exit_status.success(),
+            "openvmm exited abnormally: {exit_status:?}"
+        );
+        assert!(
+            !pidfile_path.exists(),
+            "pidfile should be removed after exit"
+        );
+        Ok(())
+    })
+}
+
+/// Sends the client handshake and validates the server's reply.
+fn handshake(sock: &mut UnixStream) -> anyhow::Result<()> {
+    let mut client_handshake = [0u8; 8];
+    client_handshake[..4].copy_from_slice(&HANDSHAKE_MAGIC);
+    sock.write_all(&client_handshake)?;
+    let mut server_handshake = [0u8; 8];
+    sock.read_exact(&mut server_handshake)?;
+    anyhow::ensure!(
+        server_handshake[..4] == HANDSHAKE_MAGIC,
+        "bad server handshake magic: {:x?}",
+        &server_handshake[..4]
+    );
+    Ok(())
+}
+
+/// Sends a `Register` request carrying `fd` and returns the response.
+fn register(sock: &mut UnixStream, name: &str, fd: BorrowedFd<'_>) -> anyhow::Result<(u8, String)> {
+    let mut frame = vec![OPCODE_REGISTER, name.len() as u8];
+    frame.extend_from_slice(name.as_bytes());
+    unix_socket::send_with_fds(sock.as_fd(), &[IoSlice::new(&frame)], [fd])?;
+    read_response(sock)
+}
+
+/// Sends a `Register` request with no attached descriptor (an error case).
+fn register_without_fd(sock: &mut UnixStream, name: &str) -> anyhow::Result<(u8, String)> {
+    let mut frame = vec![OPCODE_REGISTER, name.len() as u8];
+    frame.extend_from_slice(name.as_bytes());
+    sock.write_all(&frame)?;
+    read_response(sock)
+}
+
+/// Sends a `Deregister` request and returns the response.
+fn deregister(sock: &mut UnixStream, name: &str) -> anyhow::Result<(u8, String)> {
+    let mut frame = vec![OPCODE_DEREGISTER, name.len() as u8];
+    frame.extend_from_slice(name.as_bytes());
+    sock.write_all(&frame)?;
+    read_response(sock)
+}
+
+/// Reads one response frame: `status: u8`, `msg_len: u16` (LE), `msg`.
+fn read_response(sock: &mut UnixStream) -> anyhow::Result<(u8, String)> {
+    let mut hdr = [0u8; 3];
+    sock.read_exact(&mut hdr)?;
+    let status = hdr[0];
+    let msg_len = u16::from_le_bytes([hdr[1], hdr[2]]) as usize;
+    let mut msg = vec![0u8; msg_len];
+    sock.read_exact(&mut msg)?;
+    Ok((status, String::from_utf8_lossy(&msg).into_owned()))
+}
+
+/// Builds a minimal direct-boot `CreateVm` request with a single tap NIC whose
+/// backing descriptor is resolved by `fd_name`.
+fn create_vm_request(
+    kernel_path: &ResolvedArtifact,
+    initrd_path: &ResolvedArtifact,
+    fd_name: &str,
+) -> vmservice::CreateVmRequest {
+    vmservice::CreateVmRequest {
+        config: Some(vmservice::VmConfig {
+            memory_config: Some(vmservice::MemoryConfig {
+                memory_mb: 256,
+                ..Default::default()
+            }),
+            processor_config: Some(vmservice::ProcessorConfig {
+                processor_count: 1,
+                ..Default::default()
+            }),
+            boot_config: Some(vmservice::vm_config::BootConfig::DirectBoot(
+                vmservice::DirectBoot {
+                    kernel_path: kernel_path.get().to_string_lossy().to_string(),
+                    initrd_path: initrd_path.get().to_string_lossy().to_string(),
+                    kernel_cmdline: "console=ttyS0 rdinit=/bin/busybox panic=-1 -- poweroff -f"
+                        .to_string(),
+                },
+            )),
+            devices_config: Some(vmservice::DevicesConfig {
+                nic_config: vec![vmservice::NicConfig {
+                    nic_id: Guid::new_random().to_string(),
+                    mac_address: "00-15-5D-12-12-14".to_string(),
+                    backend: Some(vmservice::nic_config::Backend::Tap(vmservice::TapBackend {
+                        source: Some(vmservice::tap_backend::Source::FdName(fd_name.to_string())),
+                    })),
+                    ..Default::default()
+                }],
+                ..Default::default()
+            }),
+            ..Default::default()
+        }),
+        log_id: String::new(),
+    }
+}


### PR DESCRIPTION
OpenVMM's management server (ttrpc/gRPC over an AF_UNIX socket) could only open network backends itself — a TapBackend had to name a device that the server opened via /dev/net/tun. Callers that already hold an open tap descriptor (for example, a launcher that set up networking on the VM's behalf) had no way to hand it to OpenVMM.

Introduce an fd-passing protocol that shares the same Unix socket as ttrpc/gRPC and transfers descriptors via SCM_RIGHTS. A client performs a short handshake, then registers pre-opened descriptors under client-chosen names; those names can be referenced from the ordinary API, so a TapBackend may now supply an fd_name instead of a device name and the server will use the already-open fd. Registered names live in a global registry keyed by name and are dropped when the registering connection closes. The wire format is specified in fd_passing.md.

Because the three protocols share one socket, the server now owns its own accept loop and classifies each connection by peeking the first byte: ttrpc frames start with 0x00, the gRPC HTTP/2 preface with 'P', and the fd-passing handshake with 0xFD. This enables a new unified --rpc flag (path=<PATH>[,transport=auto|ttrpc|grpc]) that auto-detects the transport per connection by default. The old --ttrpc and --grpc flags are retained but deprecated, mapping to transport-restricted modes.

Supporting changes: mesh_rpc exposes serve_connection / serve_connection_grpc so callers can drive a single already-accepted connection, and pal_async gains PolledSocket::peek for the non-consuming first-byte classification. The fd-passing protocol and fd_name resolution are UNIX-only; a placeholder registry keeps the shared NIC configuration code compiling elsewhere.