### PR TITLE
openvmm: remove custom dsdt option

### DIFF
--- a/openvmm/openvmm_core/src/worker/dispatch.rs
+++ b/openvmm/openvmm_core/src/worker/dispatch.rs
@@ -3119,7 +3119,6 @@ impl LoadedVmInner {
                 ref initrd,
                 ref cmdline,
                 enable_serial,
-                ref custom_dsdt,
                 boot_mode,
             } => {
                 match boot_mode {
@@ -3136,23 +3135,19 @@ impl LoadedVmInner {
                     isolation: self.hypervisor_cfg.with_isolation,
                 };
                 super::vm_loaders::linux::load_linux_x86(&kernel_config, &self.gm, |gpa| {
-                    let tables = if let Some(dsdt) = custom_dsdt {
-                        acpi_builder.build_acpi_tables_custom_dsdt(gpa, dsdt)
-                    } else {
-                        acpi_builder.build_acpi_tables(gpa, |dsdt| {
-                            add_devices_to_dsdt_x64(
-                                dsdt,
-                                &self.chipset_cfg,
-                                &self.chipset_capabilities,
-                                enable_serial,
-                                self.vmbus_server.is_some(),
-                                &self.chipset_mmio,
-                                self.virtio_mmio_region,
-                                self.virtio_mmio_irq,
-                                &self.pci_legacy_interrupts,
-                            )
-                        })
-                    };
+                    let tables = acpi_builder.build_acpi_tables(gpa, |dsdt| {
+                        add_devices_to_dsdt_x64(
+                            dsdt,
+                            &self.chipset_cfg,
+                            &self.chipset_capabilities,
+                            enable_serial,
+                            self.vmbus_server.is_some(),
+                            &self.chipset_mmio,
+                            self.virtio_mmio_region,
+                            self.virtio_mmio_irq,
+                            &self.pci_legacy_interrupts,
+                        )
+                    });
 
                     loader::linux::AcpiTables {
                         rsdp: tables.rsdp,
@@ -3166,7 +3161,6 @@ impl LoadedVmInner {
                 ref initrd,
                 ref cmdline,
                 enable_serial,
-                custom_dsdt: _,
                 boot_mode,
             } => {
                 use openvmm_defs::config::LinuxDirectBootMode;

--- a/openvmm/openvmm_defs/src/config.rs
+++ b/openvmm/openvmm_defs/src/config.rs
@@ -130,7 +130,6 @@ pub enum LoadMode {
         initrd: Option<File>,
         cmdline: String,
         enable_serial: bool,
-        custom_dsdt: Option<Vec<u8>>,
         boot_mode: LinuxDirectBootMode,
     },
     Uefi {

--- a/openvmm/openvmm_entry/src/cli_args.rs
+++ b/openvmm/openvmm_entry/src/cli_args.rs
@@ -884,16 +884,6 @@ flags:
     #[clap(long)]
     pub nested_virt: bool,
 
-    /// (dev utility) boot linux using a custom (raw) DSDT table.
-    ///
-    /// This is a _very_ niche utility, and it's unlikely you'll need to use it.
-    ///
-    /// e.g: this flag helped bring up certain Hyper-V Generation 1 legacy
-    /// devices without needing to port the associated ACPI code into OpenVMM's
-    /// DSDT builder.
-    #[clap(long, value_name = "FILE", conflicts_with_all(&["uefi", "pcat", "igvm"]))]
-    pub custom_dsdt: Option<PathBuf>,
-
     /// attach an ide drive (can be passed multiple times)
     ///
     /// Each ide controller has two channels. Each channel can have up to two

--- a/openvmm/openvmm_entry/src/lib.rs
+++ b/openvmm/openvmm_entry/src/lib.rs
@@ -59,7 +59,6 @@ use gdma_resources::VportDefinition;
 use guid::Guid;
 use input_core::MultiplexedInputHandle;
 use inspect::InspectMut;
-use io::Read;
 use mesh::CancelContext;
 use mesh::CellUpdater;
 use mesh::rpc::RpcSend;
@@ -1344,23 +1343,10 @@ async fn vm_config_from_command_line(
             .transpose()
             .context("failed to open initrd")?;
 
-        let custom_dsdt = match &opt.custom_dsdt {
-            Some(path) => {
-                let mut v = Vec::new();
-                fs_err::File::open(path)
-                    .context("failed to open custom dsdt")?
-                    .read_to_end(&mut v)
-                    .context("failed to read custom dsdt")?;
-                Some(v)
-            }
-            None => None,
-        };
-
         load_mode = LoadMode::Linux {
             kernel: kernel.into(),
             initrd: initrd.map(Into::into),
             cmdline,
-            custom_dsdt,
             enable_serial: any_serial_configured,
             boot_mode: if opt.device_tree {
                 openvmm_defs::config::LinuxDirectBootMode::DeviceTree

--- a/openvmm/openvmm_entry/src/ttrpc/mod.rs
+++ b/openvmm/openvmm_entry/src/ttrpc/mod.rs
@@ -543,7 +543,6 @@ impl VmService {
                     kernel,
                     initrd,
                     cmdline: boot.kernel_cmdline,
-                    custom_dsdt: None,
                     enable_serial: true,
                     boot_mode: openvmm_defs::config::LinuxDirectBootMode::Acpi,
                 }

--- a/petri/src/vm/openvmm/construct.rs
+++ b/petri/src/vm/openvmm/construct.rs
@@ -862,7 +862,6 @@ impl PetriVmConfigSetupCore<'_> {
                     kernel,
                     initrd: Some(initrd),
                     cmdline,
-                    custom_dsdt: None,
                     enable_serial: self.enable_serial,
                     boot_mode: openvmm_defs::config::LinuxDirectBootMode::Acpi,
                 }

--- a/vmm_core/src/acpi_builder.rs
+++ b/vmm_core/src/acpi_builder.rs
@@ -1135,15 +1135,6 @@ impl<T: AcpiTopology> AcpiTablesBuilder<'_, T> {
         self.build_acpi_tables_inner(gpa, &dsdt_data.to_bytes())
     }
 
-    /// Build ACPI tables based on the supplied custom DSDT.
-    ///
-    /// The RSDP is assumed to take one whole page.
-    ///
-    /// Returns tables that should be loaded at the supplied gpa.
-    pub fn build_acpi_tables_custom_dsdt(&self, gpa: u64, dsdt: &[u8]) -> BuiltAcpiTables {
-        self.build_acpi_tables_inner(gpa, dsdt)
-    }
-
     fn build_acpi_tables_inner(&self, gpa: u64, dsdt: &[u8]) -> BuiltAcpiTables {
         let mut b = acpi::builder::Builder::new(gpa + 0x1000, OEM_INFO);
 


### PR DESCRIPTION
Remove this, as it was only used during pcat bringup and isn't needed anymore. 