### PR TITLE
flowey: Fail with a non-zero exit code when local vmm test runs fail

### DIFF
--- a/flowey/flowey_lib_hvlite/src/_jobs/local_build_and_run_nextest_vmm_tests.rs
+++ b/flowey/flowey_lib_hvlite/src/_jobs/local_build_and_run_nextest_vmm_tests.rs
@@ -989,7 +989,7 @@ impl SimpleFlowNode for Node {
                 if results.all_tests_passed {
                     log::info!("all tests passed!");
                 } else {
-                    log::error!("encountered test failures.");
+                    anyhow::bail!("encountered test failures.")
                 }
 
                 Ok(())


### PR DESCRIPTION
Easy fix, but makes it easier to detect failures from scripts.