### PR TITLE
xtask_fmt: warn on orphaned *.rs files

### DIFF
--- a/xtask/src/tasks/fmt/lints.rs
+++ b/xtask/src/tasks/fmt/lints.rs
@@ -6,6 +6,7 @@
 mod cfg_target_arch;
 mod copyright;
 mod crate_name_nodash;
+mod orphaned_rs;
 mod package_info;
 mod repr_packed;
 mod trailing_newline;
@@ -292,6 +293,7 @@ fn lint_workspace(
         Box::new(cfg_target_arch::CfgTargetArch::new(&lint_ctx)),
         Box::new(copyright::Copyright::new(&lint_ctx)),
         Box::new(crate_name_nodash::CrateNameNoDash::new(&lint_ctx)),
+        Box::new(orphaned_rs::OrphanedRustFiles::new(&lint_ctx)),
         Box::new(package_info::PackageInfo::new(&lint_ctx)),
         Box::new(repr_packed::ReprPacked::new(&lint_ctx)),
         Box::new(trailing_newline::TrailingNewline::new(&lint_ctx)),

--- a/xtask/src/tasks/fmt/lints.rs
+++ b/xtask/src/tasks/fmt/lints.rs
@@ -44,11 +44,6 @@ pub trait Lint {
     /// Begin processing a crate, given the parsed Cargo.toml of the crate root.
     fn enter_crate(&mut self, content: &Lintable<DocumentMut>);
 
-    /// Provide the files in the current crate, with paths relative to the workspace root.
-    fn enter_crate_files(&mut self, files: &[PathBuf]) {
-        let _ = files;
-    }
-
     /// Process a Rust source file in the current crate.
     fn visit_file(&mut self, content: &mut Lintable<String>);
 
@@ -324,27 +319,6 @@ fn lint_workspace(
     let mut any_failed = false;
 
     for crate_dir in crate_dirs {
-        // Collect nested crate dirs within this crate to avoid
-        // processing files that belong to a child crate.
-        let nested_crate_dirs: Vec<_> = crate_dirs
-            .iter()
-            .filter(|other| *other != crate_dir && other.starts_with(crate_dir))
-            .collect();
-        let crate_files: Vec<_> = all_files
-            .iter()
-            .copied()
-            .filter(|file| {
-                file.starts_with(crate_dir)
-                    && !nested_crate_dirs
-                        .iter()
-                        .any(|nested| file.starts_with(nested))
-            })
-            .collect();
-        let relative_crate_files: Vec<_> = crate_files
-            .iter()
-            .map(|file| file.strip_prefix(workspace_dir).unwrap().to_owned())
-            .collect();
-
         let manifest_path = crate_dir.join("Cargo.toml");
         let mut crate_manifest =
             Lintable::<DocumentMut>::from_file(&manifest_path, ctx, workspace_dir)?;
@@ -352,12 +326,21 @@ fn lint_workspace(
         log::debug!("Linting crate {}", crate_dir.display());
         for lint in lints.iter_mut() {
             lint.enter_crate(&crate_manifest);
-            lint.enter_crate_files(&relative_crate_files);
         }
+
+        // Collect nested crate dirs within this crate to avoid
+        // processing files that belong to a child crate.
+        let nested_crate_dirs: Vec<_> = crate_dirs
+            .iter()
+            .filter(|other| *other != crate_dir && other.starts_with(crate_dir))
+            .collect();
 
         // Use pre-collected file paths instead of walking the crate
         // directory again, avoiding redundant filesystem traversals.
-        for path in crate_files {
+        for path in all_files.iter().filter(|f| {
+            f.starts_with(crate_dir)
+                && !nested_crate_dirs.iter().any(|nested| f.starts_with(nested))
+        }) {
             let ext = path.extension().and_then(|e| e.to_str()).unwrap_or("");
             let Some(mut file) = Lintable::<String>::from_file(path, ctx, workspace_dir)? else {
                 // Skip binary files

--- a/xtask/src/tasks/fmt/lints.rs
+++ b/xtask/src/tasks/fmt/lints.rs
@@ -44,6 +44,11 @@ pub trait Lint {
     /// Begin processing a crate, given the parsed Cargo.toml of the crate root.
     fn enter_crate(&mut self, content: &Lintable<DocumentMut>);
 
+    /// Provide the files in the current crate, with paths relative to the workspace root.
+    fn enter_crate_files(&mut self, files: &[PathBuf]) {
+        let _ = files;
+    }
+
     /// Process a Rust source file in the current crate.
     fn visit_file(&mut self, content: &mut Lintable<String>);
 
@@ -319,6 +324,27 @@ fn lint_workspace(
     let mut any_failed = false;
 
     for crate_dir in crate_dirs {
+        // Collect nested crate dirs within this crate to avoid
+        // processing files that belong to a child crate.
+        let nested_crate_dirs: Vec<_> = crate_dirs
+            .iter()
+            .filter(|other| *other != crate_dir && other.starts_with(crate_dir))
+            .collect();
+        let crate_files: Vec<_> = all_files
+            .iter()
+            .copied()
+            .filter(|file| {
+                file.starts_with(crate_dir)
+                    && !nested_crate_dirs
+                        .iter()
+                        .any(|nested| file.starts_with(nested))
+            })
+            .collect();
+        let relative_crate_files: Vec<_> = crate_files
+            .iter()
+            .map(|file| file.strip_prefix(workspace_dir).unwrap().to_owned())
+            .collect();
+
         let manifest_path = crate_dir.join("Cargo.toml");
         let mut crate_manifest =
             Lintable::<DocumentMut>::from_file(&manifest_path, ctx, workspace_dir)?;
@@ -326,21 +352,12 @@ fn lint_workspace(
         log::debug!("Linting crate {}", crate_dir.display());
         for lint in lints.iter_mut() {
             lint.enter_crate(&crate_manifest);
+            lint.enter_crate_files(&relative_crate_files);
         }
-
-        // Collect nested crate dirs within this crate to avoid
-        // processing files that belong to a child crate.
-        let nested_crate_dirs: Vec<_> = crate_dirs
-            .iter()
-            .filter(|other| *other != crate_dir && other.starts_with(crate_dir))
-            .collect();
 
         // Use pre-collected file paths instead of walking the crate
         // directory again, avoiding redundant filesystem traversals.
-        for path in all_files.iter().filter(|f| {
-            f.starts_with(crate_dir)
-                && !nested_crate_dirs.iter().any(|nested| f.starts_with(nested))
-        }) {
+        for path in crate_files {
             let ext = path.extension().and_then(|e| e.to_str()).unwrap_or("");
             let Some(mut file) = Lintable::<String>::from_file(path, ctx, workspace_dir)? else {
                 // Skip binary files

--- a/xtask/src/tasks/fmt/lints/orphaned_rs.rs
+++ b/xtask/src/tasks/fmt/lints/orphaned_rs.rs
@@ -6,65 +6,56 @@
 use super::Lint;
 use super::LintCtx;
 use super::Lintable;
+use std::collections::HashSet;
 use std::path::Path;
 use std::path::PathBuf;
 use toml_edit::DocumentMut;
 
-struct RustFile {
-    path: PathBuf,
-    referenced: bool,
+#[derive(Default)]
+struct References {
+    file_names: HashSet<String>,
+    module_names: HashSet<String>,
 }
 
 pub struct OrphanedRustFiles {
-    files: Vec<RustFile>,
+    files: Vec<PathBuf>,
+    references: References,
 }
 
 impl Lint for OrphanedRustFiles {
     fn new(_ctx: &LintCtx) -> Self {
-        Self { files: Vec::new() }
+        Self {
+            files: Vec::new(),
+            references: References::default(),
+        }
     }
 
     fn enter_workspace(&mut self, _content: &Lintable<DocumentMut>) {}
 
     fn enter_crate(&mut self, _content: &Lintable<DocumentMut>) {
         self.files.clear();
-    }
-
-    fn enter_crate_files(&mut self, files: &[PathBuf]) {
-        self.files
-            .extend(files.iter().filter_map(|path| match path.extension() {
-                Some(extension) if extension == "rs" => Some(RustFile {
-                    path: path.clone(),
-                    referenced: false,
-                }),
-                _ => None,
-            }));
+        self.references.clear();
     }
 
     fn visit_file(&mut self, content: &mut Lintable<String>) {
-        for file in &mut self.files {
-            if !file.referenced && is_referenced(&file.path, content) {
-                file.referenced = true;
-            }
-        }
+        self.files.push(content.path().to_owned());
+        self.references.extend(content);
     }
 
     fn exit_crate(&mut self, content: &mut Lintable<DocumentMut>) {
         let crate_dir = content.path().parent().unwrap_or(Path::new(""));
         let manifest = content.raw().unwrap_or_default();
+        self.references.extend(manifest);
 
         for file in &self.files {
-            let relative_path = file.path.strip_prefix(crate_dir).unwrap();
-            if is_cargo_target(relative_path)
-                || is_referenced(relative_path, manifest)
-                || file.referenced
-            {
+            let relative_path = file.strip_prefix(crate_dir).unwrap();
+            if is_cargo_target(relative_path) || self.references.contains(relative_path) {
                 continue;
             }
 
             log::warn!(
                 "{}: Rust source file is not referenced by a Cargo target, module, or include",
-                file.path.display(),
+                file.display(),
             );
         }
     }
@@ -116,23 +107,74 @@ fn is_cargo_target(path: &Path) -> bool {
     }
 }
 
-fn is_referenced(path: &Path, references: &str) -> bool {
-    let file_name = path.file_name().unwrap().to_string_lossy();
-    if references.contains(file_name.as_ref()) {
-        return true;
+impl References {
+    fn clear(&mut self) {
+        self.file_names.clear();
+        self.module_names.clear();
     }
 
-    let module_name = if file_name == "mod.rs" {
+    fn extend(&mut self, content: &str) {
+        let mut remaining = content;
+        while let Some(index) = remaining.find(".rs") {
+            let end = index + ".rs".len();
+            let start = remaining[..index]
+                .char_indices()
+                .rfind(|(_, character)| !is_file_name_character(*character))
+                .map_or(0, |(index, character)| index + character.len_utf8());
+            self.file_names.insert(remaining[start..end].to_owned());
+            remaining = &remaining[end..];
+        }
+
+        for line in content.lines() {
+            let mut remaining = line;
+            while let Some(index) = remaining.find("mod ") {
+                remaining = &remaining[index + "mod ".len()..];
+                let Some(end) = remaining.find(';') else {
+                    break;
+                };
+                let module_name = &remaining[..end];
+                if !module_name.is_empty()
+                    && !module_name.chars().any(char::is_whitespace)
+                    && module_name
+                        .chars()
+                        .all(|character| is_file_name_character(character) || character == '#')
+                {
+                    self.module_names.insert(
+                        module_name
+                            .strip_prefix("r#")
+                            .unwrap_or(module_name)
+                            .to_owned(),
+                    );
+                }
+                remaining = &remaining[end + 1..];
+            }
+        }
+    }
+
+    fn contains(&self, path: &Path) -> bool {
+        let file_name = path.file_name().unwrap().to_string_lossy();
+        if self.file_names.contains(file_name.as_ref()) {
+            return true;
+        }
+
+        self.module_names.contains(module_name(path).as_ref())
+    }
+}
+
+fn is_file_name_character(character: char) -> bool {
+    character.is_alphanumeric() || matches!(character, '_' | '-' | '.')
+}
+
+fn module_name(path: &Path) -> std::borrow::Cow<'_, str> {
+    let file_name = path.file_name().unwrap().to_string_lossy();
+    if file_name == "mod.rs" {
         let Some(module_name) = path.parent().and_then(Path::file_name) else {
-            return false;
+            return "".into();
         };
         module_name.to_string_lossy()
     } else {
         path.file_stem().unwrap().to_string_lossy()
-    };
-
-    references.contains(&format!("mod {module_name};"))
-        || references.contains(&format!("mod r#{module_name};"))
+    }
 }
 
 #[cfg(test)]
@@ -161,23 +203,26 @@ mod tests {
 
     #[test]
     fn recognizes_module_and_path_references() {
-        assert!(is_referenced(
-            Path::new("src/device.rs"),
-            "pub(crate) mod device;"
-        ));
-        assert!(is_referenced(
-            Path::new("src/device/mod.rs"),
-            "pub mod device;"
-        ));
-        assert!(is_referenced(
-            Path::new("src/templates/device.template.rs"),
-            "include_str!(\"./templates/device.template.rs\")"
-        ));
-        assert!(!is_referenced(Path::new("src/device.rs"), "pub mod other;"));
+        let mut references = References::default();
+        references.extend(
+            r#"
+            //! Documentation about `mod service`.
+            pub(crate) mod device;
+            pub mod r#type;
+            include_str!("./templates/device.template.rs");
+            "#,
+        );
+
+        assert!(references.contains(Path::new("src/device.rs")));
+        assert!(references.contains(Path::new("src/device/mod.rs")));
+        assert!(references.contains(Path::new("src/type.rs")));
+        assert!(references.contains(Path::new("src/templates/device.template.rs")));
+        assert!(!references.contains(Path::new("src/other.rs")));
     }
 
     #[test]
     fn crate_root_mod_rs_is_unreferenced() {
-        assert!(!is_referenced(Path::new("mod.rs"), ""));
+        let references = References::default();
+        assert!(!references.contains(Path::new("mod.rs")));
     }
 }

--- a/xtask/src/tasks/fmt/lints/orphaned_rs.rs
+++ b/xtask/src/tasks/fmt/lints/orphaned_rs.rs
@@ -10,30 +10,43 @@ use std::path::Path;
 use std::path::PathBuf;
 use toml_edit::DocumentMut;
 
+struct RustFile {
+    path: PathBuf,
+    referenced: bool,
+}
+
 pub struct OrphanedRustFiles {
-    files: Vec<PathBuf>,
-    references: String,
+    files: Vec<RustFile>,
 }
 
 impl Lint for OrphanedRustFiles {
     fn new(_ctx: &LintCtx) -> Self {
-        Self {
-            files: Vec::new(),
-            references: String::new(),
-        }
+        Self { files: Vec::new() }
     }
 
     fn enter_workspace(&mut self, _content: &Lintable<DocumentMut>) {}
 
     fn enter_crate(&mut self, _content: &Lintable<DocumentMut>) {
         self.files.clear();
-        self.references.clear();
+    }
+
+    fn enter_crate_files(&mut self, files: &[PathBuf]) {
+        self.files
+            .extend(files.iter().filter_map(|path| match path.extension() {
+                Some(extension) if extension == "rs" => Some(RustFile {
+                    path: path.clone(),
+                    referenced: false,
+                }),
+                _ => None,
+            }));
     }
 
     fn visit_file(&mut self, content: &mut Lintable<String>) {
-        self.files.push(content.path().to_owned());
-        self.references.push_str(content);
-        self.references.push('\n');
+        for file in &mut self.files {
+            if !file.referenced && is_referenced(&file.path, content) {
+                file.referenced = true;
+            }
+        }
     }
 
     fn exit_crate(&mut self, content: &mut Lintable<DocumentMut>) {
@@ -41,17 +54,17 @@ impl Lint for OrphanedRustFiles {
         let manifest = content.raw().unwrap_or_default();
 
         for file in &self.files {
-            let relative_path = file.strip_prefix(crate_dir).unwrap();
+            let relative_path = file.path.strip_prefix(crate_dir).unwrap();
             if is_cargo_target(relative_path)
                 || is_referenced(relative_path, manifest)
-                || is_referenced(relative_path, &self.references)
+                || file.referenced
             {
                 continue;
             }
 
             log::warn!(
                 "{}: Rust source file is not referenced by a Cargo target, module, or include",
-                file.display(),
+                file.path.display(),
             );
         }
     }

--- a/xtask/src/tasks/fmt/lints/orphaned_rs.rs
+++ b/xtask/src/tasks/fmt/lints/orphaned_rs.rs
@@ -1,0 +1,179 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Warns about Rust source files that are not reachable from a Cargo target.
+
+use super::Lint;
+use super::LintCtx;
+use super::Lintable;
+use std::path::Path;
+use std::path::PathBuf;
+use toml_edit::DocumentMut;
+
+const SUPPRESS: &str = "xtask-fmt allow-orphaned-rust-file";
+
+struct RustFile {
+    path: PathBuf,
+    content: String,
+}
+
+pub struct OrphanedRustFiles {
+    crate_dir: PathBuf,
+    manifest: String,
+    files: Vec<RustFile>,
+}
+
+impl Lint for OrphanedRustFiles {
+    fn new(_ctx: &LintCtx) -> Self {
+        Self {
+            crate_dir: PathBuf::new(),
+            manifest: String::new(),
+            files: Vec::new(),
+        }
+    }
+
+    fn enter_workspace(&mut self, _content: &Lintable<DocumentMut>) {}
+
+    fn enter_crate(&mut self, content: &Lintable<DocumentMut>) {
+        self.crate_dir = content.path().parent().unwrap_or(Path::new("")).to_owned();
+        self.manifest = content.raw().unwrap_or_default().to_owned();
+        self.files.clear();
+    }
+
+    fn visit_file(&mut self, content: &mut Lintable<String>) {
+        self.files.push(RustFile {
+            path: content.path().to_owned(),
+            content: content.to_string(),
+        });
+    }
+
+    fn exit_crate(&mut self, _content: &mut Lintable<DocumentMut>) {
+        let mut references = self.manifest.clone();
+        for file in &self.files {
+            references.push_str(&file.content);
+        }
+
+        for file in &self.files {
+            let relative_path = file.path.strip_prefix(&self.crate_dir).unwrap();
+            if is_cargo_target(relative_path)
+                || file.content.contains(SUPPRESS)
+                || is_referenced(relative_path, &references)
+            {
+                continue;
+            }
+
+            log::warn!(
+                "{}: Rust source file is not referenced by a Cargo target, module, or include \
+                 (add `{SUPPRESS}` to suppress)",
+                file.path.display(),
+            );
+        }
+    }
+
+    fn exit_workspace(&mut self, _content: &mut Lintable<DocumentMut>) {}
+}
+
+fn is_cargo_target(path: &Path) -> bool {
+    let components: Vec<_> = path.components().collect();
+    match components.as_slice() {
+        [file] if file.as_os_str() == "build.rs" => true,
+        [src, file]
+            if src.as_os_str() == "src"
+                && matches!(file.as_os_str().to_str(), Some("lib.rs" | "main.rs")) =>
+        {
+            true
+        }
+        [directory, file]
+            if matches!(
+                directory.as_os_str().to_str(),
+                Some("examples" | "tests" | "benches")
+            ) && file.as_os_str().to_string_lossy().ends_with(".rs") =>
+        {
+            true
+        }
+        [src, bin, file]
+            if src.as_os_str() == "src"
+                && bin.as_os_str() == "bin"
+                && file.as_os_str().to_string_lossy().ends_with(".rs") =>
+        {
+            true
+        }
+        [directory, _, main]
+            if matches!(
+                directory.as_os_str().to_str(),
+                Some("examples" | "tests" | "benches")
+            ) && main.as_os_str() == "main.rs" =>
+        {
+            true
+        }
+        [src, bin, _, main]
+            if src.as_os_str() == "src"
+                && bin.as_os_str() == "bin"
+                && main.as_os_str() == "main.rs" =>
+        {
+            true
+        }
+        _ => false,
+    }
+}
+
+fn is_referenced(path: &Path, references: &str) -> bool {
+    let file_name = path.file_name().unwrap().to_string_lossy();
+    if references.contains(file_name.as_ref()) {
+        return true;
+    }
+
+    let module_name = if file_name == "mod.rs" {
+        path.parent()
+            .and_then(Path::file_name)
+            .unwrap()
+            .to_string_lossy()
+    } else {
+        path.file_stem().unwrap().to_string_lossy()
+    };
+
+    references.contains(&format!("mod {module_name};"))
+        || references.contains(&format!("mod r#{module_name};"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn recognizes_cargo_targets() {
+        for path in [
+            "build.rs",
+            "src/lib.rs",
+            "src/main.rs",
+            "src/bin/tool.rs",
+            "src/bin/tool/main.rs",
+            "examples/demo.rs",
+            "examples/demo/main.rs",
+            "tests/integration.rs",
+            "benches/benchmark.rs",
+        ] {
+            assert!(is_cargo_target(Path::new(path)), "{path}");
+        }
+
+        assert!(!is_cargo_target(Path::new("src/device.rs")));
+        assert!(!is_cargo_target(Path::new("tests/common/mod.rs")));
+    }
+
+    #[test]
+    fn recognizes_module_and_path_references() {
+        assert!(is_referenced(
+            Path::new("src/device.rs"),
+            "pub(crate) mod device;"
+        ));
+        assert!(is_referenced(
+            Path::new("src/device/mod.rs"),
+            "pub mod device;"
+        ));
+        assert!(is_referenced(
+            Path::new("src/templates/device.template.rs"),
+            "include_str!(\"./templates/device.template.rs\")"
+        ));
+        assert!(!is_referenced(Path::new("src/device.rs"), "pub mod other;"));
+    }
+}

--- a/xtask/src/tasks/fmt/lints/orphaned_rs.rs
+++ b/xtask/src/tasks/fmt/lints/orphaned_rs.rs
@@ -10,62 +10,48 @@ use std::path::Path;
 use std::path::PathBuf;
 use toml_edit::DocumentMut;
 
-const SUPPRESS: &str = "xtask-fmt allow-orphaned-rust-file";
-
-struct RustFile {
-    path: PathBuf,
-    content: String,
-}
-
 pub struct OrphanedRustFiles {
-    crate_dir: PathBuf,
-    manifest: String,
-    files: Vec<RustFile>,
+    files: Vec<PathBuf>,
+    references: String,
 }
 
 impl Lint for OrphanedRustFiles {
     fn new(_ctx: &LintCtx) -> Self {
         Self {
-            crate_dir: PathBuf::new(),
-            manifest: String::new(),
             files: Vec::new(),
+            references: String::new(),
         }
     }
 
     fn enter_workspace(&mut self, _content: &Lintable<DocumentMut>) {}
 
-    fn enter_crate(&mut self, content: &Lintable<DocumentMut>) {
-        self.crate_dir = content.path().parent().unwrap_or(Path::new("")).to_owned();
-        self.manifest = content.raw().unwrap_or_default().to_owned();
+    fn enter_crate(&mut self, _content: &Lintable<DocumentMut>) {
         self.files.clear();
+        self.references.clear();
     }
 
     fn visit_file(&mut self, content: &mut Lintable<String>) {
-        self.files.push(RustFile {
-            path: content.path().to_owned(),
-            content: content.to_string(),
-        });
+        self.files.push(content.path().to_owned());
+        self.references.push_str(content);
+        self.references.push('\n');
     }
 
-    fn exit_crate(&mut self, _content: &mut Lintable<DocumentMut>) {
-        let mut references = self.manifest.clone();
-        for file in &self.files {
-            references.push_str(&file.content);
-        }
+    fn exit_crate(&mut self, content: &mut Lintable<DocumentMut>) {
+        let crate_dir = content.path().parent().unwrap_or(Path::new(""));
+        let manifest = content.raw().unwrap_or_default();
 
         for file in &self.files {
-            let relative_path = file.path.strip_prefix(&self.crate_dir).unwrap();
+            let relative_path = file.strip_prefix(crate_dir).unwrap();
             if is_cargo_target(relative_path)
-                || file.content.contains(SUPPRESS)
-                || is_referenced(relative_path, &references)
+                || is_referenced(relative_path, manifest)
+                || is_referenced(relative_path, &self.references)
             {
                 continue;
             }
 
             log::warn!(
-                "{}: Rust source file is not referenced by a Cargo target, module, or include \
-                 (add `{SUPPRESS}` to suppress)",
-                file.path.display(),
+                "{}: Rust source file is not referenced by a Cargo target, module, or include",
+                file.display(),
             );
         }
     }
@@ -124,10 +110,10 @@ fn is_referenced(path: &Path, references: &str) -> bool {
     }
 
     let module_name = if file_name == "mod.rs" {
-        path.parent()
-            .and_then(Path::file_name)
-            .unwrap()
-            .to_string_lossy()
+        let Some(module_name) = path.parent().and_then(Path::file_name) else {
+            return false;
+        };
+        module_name.to_string_lossy()
     } else {
         path.file_stem().unwrap().to_string_lossy()
     };
@@ -175,5 +161,10 @@ mod tests {
             "include_str!(\"./templates/device.template.rs\")"
         ));
         assert!(!is_referenced(Path::new("src/device.rs"), "pub mod other;"));
+    }
+
+    #[test]
+    fn crate_root_mod_rs_is_unreferenced() {
+        assert!(!is_referenced(Path::new("mod.rs"), ""));
     }
 }


### PR DESCRIPTION
Generate warning when orphaned *.rs files are discovered. This does not come with an auto-fix option.