### PR TITLE
membacking: back Windows guest RAM with soft large pages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4390,16 +4390,19 @@ dependencies = [
  "guestmem",
  "hvdef",
  "inspect",
+ "inspect_counters",
  "memory_range",
  "mesh",
  "pal_async",
  "parking_lot",
+ "range_map_vec",
  "slab",
  "sparse_mmap",
  "thiserror 2.0.16",
  "tracing",
  "virt",
  "vmcore",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]

--- a/openvmm/membacking/Cargo.toml
+++ b/openvmm/membacking/Cargo.toml
@@ -14,6 +14,7 @@ virt.workspace = true
 memory_range = { workspace = true, features = ["mesh"] }
 
 inspect = { workspace = true, features = ["defer"] }
+inspect_counters.workspace = true
 mesh.workspace = true
 pal_async.workspace = true
 sparse_mmap.workspace = true
@@ -22,9 +23,15 @@ anyhow.workspace = true
 futures.workspace = true
 getrandom.workspace = true
 parking_lot.workspace = true
+range_map_vec.workspace = true
 slab.workspace = true
 thiserror.workspace = true
 tracing.workspace = true
+
+[target.'cfg(windows)'.dependencies]
+windows-sys = { workspace = true, features = [
+    "Win32_System_Memory",
+]}
 
 [lints]
 workspace = true

--- a/openvmm/membacking/src/mapping_manager/manager.rs
+++ b/openvmm/membacking/src/mapping_manager/manager.rs
@@ -8,6 +8,7 @@
 use super::mappable::Mappable;
 use super::object_cache::ObjectCache;
 use super::object_cache::ObjectId;
+use super::va_mapper::MapperRole;
 use super::va_mapper::VaMapper;
 use super::va_mapper::VaMapperError;
 use crate::RemoteProcess;
@@ -42,15 +43,11 @@ pub struct MappingManager {
 impl MappingManager {
     /// Returns a new mapping manager that can map addresses up to `max_addr`.
     ///
-    /// Mappers created from this manager will use anonymous private memory for
-    /// guest RAM within `private_ranges` instead of using shared file-backed
-    /// memory.
-    pub fn new(
-        spawn: impl Spawn,
-        max_addr: u64,
-        private_ranges: Vec<MemoryRange>,
-        minimum_va_alignment: Option<usize>,
-    ) -> Self {
+    /// Private memory imposes a "single local eager mapper" restriction, but
+    /// that is enforced dynamically by the manager task as mappings and mappers
+    /// come and go (private RAM may be added later, e.g. via hotplug) rather
+    /// than captured here at construction time.
+    pub fn new(spawn: impl Spawn, max_addr: u64, minimum_va_alignment: Option<usize>) -> Self {
         let (req_send, mut req_recv) = mesh::mpsc_channel();
         spawn
             .spawn("mapping_manager", {
@@ -65,7 +62,6 @@ impl MappingManager {
                 id: ObjectId::new(),
                 req_send,
                 max_addr,
-                private_ranges,
                 minimum_va_alignment,
             },
         }
@@ -84,14 +80,15 @@ pub struct MappingManagerClient {
     req_send: mesh::Sender<MappingRequest>,
     id: ObjectId,
     max_addr: u64,
-    private_ranges: Vec<MemoryRange>,
     minimum_va_alignment: Option<usize>,
 }
 
 static MAPPER_CACHE: ObjectCache<VaMapper> = ObjectCache::new();
 
 impl MappingManagerClient {
-    /// Returns a VA mapper for this guest memory.
+    /// Returns a secondary VA mapper for this guest memory (host-side access
+    /// that is not the loader/partition mapper: `guest_memory()` in any process,
+    /// DMA targets, etc.).
     ///
     /// When `eager` is true, the mapper receives all existing mappings
     /// immediately and gets new ones pushed synchronously. File-backed
@@ -102,26 +99,47 @@ impl MappingManagerClient {
     /// When `eager` is false, the mapper is lazy: mappings are populated
     /// on demand via page faults. This avoids the cost of pushing every
     /// mapping change to processes that rarely access the mapped regions
-    /// (e.g., device-emulation processes with virtio-fs DAX). Lazy
-    /// mappers cannot be used with private memory mode.
+    /// (e.g., device-emulation processes with virtio-fs DAX).
     ///
     /// The mapper is single-instanced per process via a cache. If a lazy
     /// mapper was previously created and an eager one is now requested,
-    /// it is upgraded in place.
+    /// it is upgraded in place. In the process that owns the
+    /// [`GuestMemoryManager`](crate::MemoryManager), that cached instance is the
+    /// primary mapper created by [`new_primary_mapper`](Self::new_primary_mapper);
+    /// in other processes (device/DMA workers) this creates a fresh secondary
+    /// mapper.
     pub async fn new_mapper(&self, eager: bool) -> Result<Arc<VaMapper>, VaMapperError> {
+        self.get_or_create_mapper(eager, MapperRole::Secondary)
+            .await
+    }
+
+    /// Returns *the* primary VA mapper: the one the loader writes through and the
+    /// partition resolves faults against, and the only mapper for which soft
+    /// large pages are worthwhile.
+    ///
+    /// Must be called by exactly one caller
+    /// ([`GuestMemoryManager`](crate::MemoryManager) at build time), which is
+    /// necessarily the first mapper created in the owning process, so the shared
+    /// cache captures it and later [`new_mapper`](Self::new_mapper) calls in that
+    /// process return it. It is always eager.
+    pub async fn new_primary_mapper(&self) -> Result<Arc<VaMapper>, VaMapperError> {
+        self.get_or_create_mapper(true, MapperRole::Primary).await
+    }
+
+    async fn get_or_create_mapper(
+        &self,
+        eager: bool,
+        role: MapperRole,
+    ) -> Result<Arc<VaMapper>, VaMapperError> {
         let mapper = MAPPER_CACHE
             .get_or_insert_with(&self.id, async {
-                assert!(
-                    eager || self.private_ranges.is_empty(),
-                    "lazy mappers are not supported with private memory"
-                );
                 VaMapper::new(
                     self.req_send.clone(),
                     self.max_addr,
                     None,
-                    self.private_ranges.clone(),
                     self.minimum_va_alignment,
                     eager,
+                    role,
                 )
                 .await
             })
@@ -145,24 +163,26 @@ impl MappingManagerClient {
     ///
     /// Each call will allocate a new unique mapper.
     ///
-    /// Returns an error if private memory mode is enabled, since private
-    /// anonymous pages would be committed in the remote process and not
-    /// accessible locally.
+    /// If private memory is present, this fails at registration time because it
+    /// would be a second mapper (private RAM requires a single mapper); a remote
+    /// mapper is only rejected on that count, not for being remote.
     pub async fn new_remote_mapper(
         &self,
         process: RemoteProcess,
     ) -> Result<Arc<VaMapper>, VaMapperError> {
-        if !self.private_ranges.is_empty() {
-            return Err(VaMapperError::RemoteWithPrivateMemory);
-        }
         Ok(Arc::new(
             VaMapper::new(
                 self.req_send.clone(),
                 self.max_addr,
                 Some(process),
-                Vec::new(),
                 self.minimum_va_alignment,
                 true, // eager — remote mappers used for partition mappings
+                // Secondary: this backs a partition from a remote process, but
+                // the soft-large-page work (deferred protect, first-write 2 MB
+                // populate, fault resolution) runs on the single primary mapper
+                // in the owning process. This mapper shares the same section
+                // pages, so it just maps them plain read-write 4 KB.
+                MapperRole::Secondary,
             )
             .await?,
         ))
@@ -273,11 +293,13 @@ pub enum MappingBacking {
     /// other processes or programmed into DMA targets that require an fd; it is
     /// exposed to DMA targets purely by host VA.
     ///
-    /// Private memory is only valid with a single local eager mapper: lazy
-    /// mappers and remote mappers are rejected when any range is private (see
-    /// [`MappingManagerClient::new_mapper`] and
-    /// [`MappingManagerClient::new_remote_mapper`]). Committing anonymous pages
-    /// into multiple independent mappers would not share storage.
+    /// Private memory is only valid with a single mapper: its anonymous storage
+    /// lives in one mapper's address space, with no backing fd, so it cannot be
+    /// shared to a second mapper. The mapping manager rejects a second mapper
+    /// while private memory is present, and rejects adding private RAM while
+    /// more than one mapper exists (see the `AddMapper` handler and
+    /// [`MappingManagerTask::add_mapping`]). A lone remote mapper is fine — the
+    /// restriction is on mapper *count*, not on locality.
     ///
     /// Unlike file-backed memory, the storage *is* the VA mapping: there is no
     /// fd holding the pages. Tearing the mapping down (via the region manager's
@@ -321,6 +343,12 @@ pub struct MemoryPolicy {
     /// Whether the range is advised as Transparent Huge Page eligible (Linux
     /// `madvise(MADV_HUGEPAGE)`).
     pub transparent_hugepages: bool,
+    /// Whether this range is populated eagerly at build time (prefetch). On
+    /// Windows this selects the *eager* soft-large-page path: the range is
+    /// mapped read-write and its large pages are built up front by the
+    /// build-time populate, with its first-fault windows pre-marked attempted
+    /// (rather than the lazy deferred-protect, fault-time path).
+    pub prefetch: bool,
 }
 
 impl MemoryPolicy {
@@ -334,6 +362,7 @@ impl MemoryPolicy {
         Self {
             numa_node: None,
             transparent_hugepages: false,
+            prefetch: false,
         }
     }
 }
@@ -422,6 +451,21 @@ impl MappingManagerTask {
             match req {
                 MappingRequest::AddMapper(rpc) => {
                     rpc.handle_failable(async |params: AddMapperParams| {
+                        // Private memory is anonymous: its storage *is* a single
+                        // mapper's address space, with no backing fd to share, so
+                        // a second mapper would get its own incoherent copy.
+                        // Private RAM therefore requires at most one mapper.
+                        // Reject a new mapper if private memory is already
+                        // present; the reverse direction (private RAM added
+                        // later) is enforced in `add_mapping`.
+                        if !self.mappers.mappers.is_empty() && self.has_private_mapping() {
+                            return Err(MappingError::new(
+                                MemoryRange::EMPTY,
+                                std::io::Error::other(
+                                    "cannot add a second mapper while private memory is present",
+                                ),
+                            ));
+                        }
                         self.add_mapper(params.send, params.eager).await
                     })
                     .await
@@ -437,7 +481,7 @@ impl MappingManagerTask {
                         .await
                 }
                 MappingRequest::AddMapping(rpc) => {
-                    rpc.handle(async |params| self.add_mapping(params).await)
+                    rpc.handle_failable(async |params| self.add_mapping(params).await)
                         .await
                 }
                 MappingRequest::RemoveMappings(rpc) => {
@@ -620,8 +664,15 @@ impl MappingManagerTask {
         }
     }
 
-    async fn add_mapping(&mut self, params: MappingParams) -> Result<(), RemoteError> {
+    async fn add_mapping(&mut self, params: MappingParams) -> anyhow::Result<()> {
         tracing::debug!(range = %params.range, "adding mapping");
+
+        // Private memory is anonymous and lives in a single mapper's address
+        // space, so it requires at most one mapper. Reject adding private RAM
+        // (e.g. via hotplug) while more than one mapper is present.
+        if matches!(params.backing, MappingBacking::Private) && self.mappers.mappers.len() > 1 {
+            anyhow::bail!("cannot add private memory while multiple mappers are present");
+        }
 
         assert!(!self.mappings.iter().any(|m| m.params.range == params.range));
 
@@ -655,7 +706,7 @@ impl MappingManagerTask {
                             );
                         }
                     }
-                    return Err(e);
+                    return Err(e.into());
                 }
                 Err(_) => {
                     // Mapper gone, skip. VaMapper::drop sends RemoveMapper
@@ -670,6 +721,13 @@ impl MappingManagerTask {
             active_mappers,
         });
         Ok(())
+    }
+
+    /// Returns true if any current mapping is backed by private memory.
+    fn has_private_mapping(&self) -> bool {
+        self.mappings
+            .iter()
+            .any(|m| matches!(m.params.backing, MappingBacking::Private))
     }
 
     fn get_dma_target_mappings(&self) -> Vec<MappingParams> {
@@ -762,7 +820,7 @@ mod tests {
 
     #[pal_async::async_test]
     async fn test_dma_target_regions_returned(spawn: impl Spawn) {
-        let mm = MappingManager::new(&spawn, 0x200000, Vec::new(), None);
+        let mm = MappingManager::new(&spawn, 0x200000, None);
         let client = mm.client().clone();
 
         let ram: Mappable = sparse_mmap::alloc_shared_memory(0x100000, "test-ram")
@@ -814,7 +872,7 @@ mod tests {
 
     #[pal_async::async_test]
     async fn test_no_dma_targets_returns_empty(spawn: impl Spawn) {
-        let mm = MappingManager::new(&spawn, 0x100000, Vec::new(), None);
+        let mm = MappingManager::new(&spawn, 0x100000, None);
         let client = mm.client().clone();
 
         let mappable: Mappable = sparse_mmap::alloc_shared_memory(0x1000, "test")
@@ -1388,9 +1446,9 @@ mod tests {
             req_send,
             0x10000,
             None,
-            Vec::new(),
             None,
             true, // eager
+            MapperRole::Primary,
         );
         let (mapper, _) = futures::join!(mapper_future, async {
             let msg = req_recv.recv().await.unwrap();
@@ -1426,9 +1484,9 @@ mod tests {
             req_send,
             0x10000,
             None,
-            Vec::new(),
             None,
             true, // eager
+            MapperRole::Primary,
         );
         let (mapper, mapper_req_send) = futures::join!(mapper_future, async {
             let msg = req_recv.recv().await.unwrap();
@@ -1459,7 +1517,7 @@ mod tests {
         let _ = spawn;
         let (manager_thread, manager_driver) =
             pal_async::DefaultPool::spawn_on_thread("mapping-manager-test");
-        let mm = MappingManager::new(&manager_driver, 0x10000, Vec::new(), None);
+        let mm = MappingManager::new(&manager_driver, 0x10000, None);
         let client = mm.client().clone();
 
         // Add a mapping so the lazy mapper can find it.
@@ -1509,7 +1567,7 @@ mod tests {
         let _ = spawn;
         let (manager_thread, manager_driver) =
             pal_async::DefaultPool::spawn_on_thread("mapping-manager-test");
-        let mm = MappingManager::new(&manager_driver, 0x10000, Vec::new(), None);
+        let mm = MappingManager::new(&manager_driver, 0x10000, None);
         let client = mm.client().clone();
 
         // Add a mapping while no mappers exist — it is stored for replay.
@@ -1547,7 +1605,7 @@ mod tests {
         let _ = spawn;
         let (manager_thread, manager_driver) =
             pal_async::DefaultPool::spawn_on_thread("mapping-manager-test");
-        let mm = MappingManager::new(&manager_driver, 0x20000, Vec::new(), None);
+        let mm = MappingManager::new(&manager_driver, 0x20000, None);
         let client = mm.client().clone();
 
         // Add a mapping first so replay has something to push.

--- a/openvmm/membacking/src/mapping_manager/manager.rs
+++ b/openvmm/membacking/src/mapping_manager/manager.rs
@@ -41,13 +41,40 @@ pub struct MappingManager {
 }
 
 impl MappingManager {
-    /// Returns a new mapping manager that can map addresses up to `max_addr`.
+    /// Returns a new mapping manager (mapping addresses up to `max_addr`) and
+    /// its primary VA mapper.
+    ///
+    /// The primary mapper is created here, as part of construction, so it is
+    /// necessarily the first mapper in the owning process and is captured by the
+    /// shared cache: every later
+    /// [`new_mapper`](MappingManagerClient::new_mapper) in this process returns
+    /// it. It is the loader's write target and the partition's fault resolver,
+    /// and the only mapper eligible for soft large pages. It is always eager,
+    /// and starts empty — it receives mappings as regions are added.
     ///
     /// Private memory imposes a "single local eager mapper" restriction, but
     /// that is enforced dynamically by the manager task as mappings and mappers
     /// come and go (private RAM may be added later, e.g. via hotplug) rather
     /// than captured here at construction time.
-    pub fn new(spawn: impl Spawn, max_addr: u64, minimum_va_alignment: Option<usize>) -> Self {
+    pub async fn new(
+        spawn: impl Spawn,
+        max_addr: u64,
+        minimum_va_alignment: Option<usize>,
+    ) -> Result<(Self, Arc<VaMapper>), VaMapperError> {
+        let this = Self::new_bare(spawn, max_addr, minimum_va_alignment);
+        // Create the primary mapper as part of construction. Being first, it is
+        // the instance the shared cache hands to every later `new_mapper` in
+        // this process.
+        let primary = this
+            .client()
+            .get_or_create_mapper(true, MapperRole::Primary)
+            .await?;
+        Ok((this, primary))
+    }
+
+    /// Spawns the manager task and builds the client, without creating a primary
+    /// mapper.
+    fn new_bare(spawn: impl Spawn, max_addr: u64, minimum_va_alignment: Option<usize>) -> Self {
         let (req_send, mut req_recv) = mesh::mpsc_channel();
         spawn
             .spawn("mapping_manager", {
@@ -65,6 +92,18 @@ impl MappingManager {
                 minimum_va_alignment,
             },
         }
+    }
+
+    /// Test-only constructor that builds a manager with no primary mapper (an
+    /// empty mapper cache), so unit tests can exercise secondary/lazy mapper
+    /// mechanics directly. Production code must use [`new`](Self::new).
+    #[cfg(test)]
+    pub(crate) fn new_without_primary(
+        spawn: impl Spawn,
+        max_addr: u64,
+        minimum_va_alignment: Option<usize>,
+    ) -> Self {
+        Self::new_bare(spawn, max_addr, minimum_va_alignment)
     }
 
     /// Returns an object used to access the mapping manager, potentially from a
@@ -90,7 +129,7 @@ impl MappingManagerClient {
     ///
     /// A *secondary* mapper is any host-side view of guest memory other than the
     /// primary one that the loader writes through and the partition resolves
-    /// faults against (see [`new_primary_mapper`](Self::new_primary_mapper)).
+    /// faults against (created by [`MappingManager::new`](MappingManager::new)).
     /// Secondary mappers are additional, remote views: for example a mapper in
     /// the VP process for WHP VTL2 emulation, an out-of-process device that needs
     /// to touch guest memory, or a DMA target. They never own the memory, and
@@ -112,25 +151,12 @@ impl MappingManagerClient {
     /// mapper was previously created and an eager one is now requested,
     /// it is upgraded in place. In the process that owns the
     /// [`GuestMemoryManager`](crate::MemoryManager), that cached instance is the
-    /// primary mapper created by [`new_primary_mapper`](Self::new_primary_mapper);
+    /// primary mapper created by [`MappingManager::new`](MappingManager::new);
     /// in other processes (device/DMA workers) this creates a fresh secondary
     /// mapper.
     pub async fn new_mapper(&self, eager: bool) -> Result<Arc<VaMapper>, VaMapperError> {
         self.get_or_create_mapper(eager, MapperRole::Secondary)
             .await
-    }
-
-    /// Returns *the* primary VA mapper: the one the loader writes through and the
-    /// partition resolves faults against, and the only mapper for which soft
-    /// large pages are worthwhile.
-    ///
-    /// Must be called by exactly one caller
-    /// ([`GuestMemoryManager`](crate::MemoryManager) at build time), which is
-    /// necessarily the first mapper created in the owning process, so the shared
-    /// cache captures it and later [`new_mapper`](Self::new_mapper) calls in that
-    /// process return it. It is always eager.
-    pub async fn new_primary_mapper(&self) -> Result<Arc<VaMapper>, VaMapperError> {
-        self.get_or_create_mapper(true, MapperRole::Primary).await
     }
 
     async fn get_or_create_mapper(
@@ -827,7 +853,7 @@ mod tests {
 
     #[pal_async::async_test]
     async fn test_dma_target_regions_returned(spawn: impl Spawn) {
-        let mm = MappingManager::new(&spawn, 0x200000, None);
+        let mm = MappingManager::new_without_primary(&spawn, 0x200000, None);
         let client = mm.client().clone();
 
         let ram: Mappable = sparse_mmap::alloc_shared_memory(0x100000, "test-ram")
@@ -879,7 +905,7 @@ mod tests {
 
     #[pal_async::async_test]
     async fn test_no_dma_targets_returns_empty(spawn: impl Spawn) {
-        let mm = MappingManager::new(&spawn, 0x100000, None);
+        let mm = MappingManager::new_without_primary(&spawn, 0x100000, None);
         let client = mm.client().clone();
 
         let mappable: Mappable = sparse_mmap::alloc_shared_memory(0x1000, "test")
@@ -1524,7 +1550,7 @@ mod tests {
         let _ = spawn;
         let (manager_thread, manager_driver) =
             pal_async::DefaultPool::spawn_on_thread("mapping-manager-test");
-        let mm = MappingManager::new(&manager_driver, 0x10000, None);
+        let mm = MappingManager::new_without_primary(&manager_driver, 0x10000, None);
         let client = mm.client().clone();
 
         // Add a mapping so the lazy mapper can find it.
@@ -1574,7 +1600,7 @@ mod tests {
         let _ = spawn;
         let (manager_thread, manager_driver) =
             pal_async::DefaultPool::spawn_on_thread("mapping-manager-test");
-        let mm = MappingManager::new(&manager_driver, 0x10000, None);
+        let mm = MappingManager::new_without_primary(&manager_driver, 0x10000, None);
         let client = mm.client().clone();
 
         // Add a mapping while no mappers exist — it is stored for replay.
@@ -1612,7 +1638,7 @@ mod tests {
         let _ = spawn;
         let (manager_thread, manager_driver) =
             pal_async::DefaultPool::spawn_on_thread("mapping-manager-test");
-        let mm = MappingManager::new(&manager_driver, 0x20000, None);
+        let mm = MappingManager::new_without_primary(&manager_driver, 0x20000, None);
         let client = mm.client().clone();
 
         // Add a mapping first so replay has something to push.

--- a/openvmm/membacking/src/mapping_manager/manager.rs
+++ b/openvmm/membacking/src/mapping_manager/manager.rs
@@ -86,9 +86,16 @@ pub struct MappingManagerClient {
 static MAPPER_CACHE: ObjectCache<VaMapper> = ObjectCache::new();
 
 impl MappingManagerClient {
-    /// Returns a secondary VA mapper for this guest memory (host-side access
-    /// that is not the loader/partition mapper: `guest_memory()` in any process,
-    /// DMA targets, etc.).
+    /// Returns a secondary VA mapper for this guest memory.
+    ///
+    /// A *secondary* mapper is any host-side view of guest memory other than the
+    /// primary one that the loader writes through and the partition resolves
+    /// faults against (see [`new_primary_mapper`](Self::new_primary_mapper)).
+    /// Secondary mappers are additional, remote views: for example a mapper in
+    /// the VP process for WHP VTL2 emulation, an out-of-process device that needs
+    /// to touch guest memory, or a DMA target. They never own the memory, and
+    /// soft large pages are not applied to them: in soft-large-page mode a
+    /// secondary mapper only ever gets 4 KB pages.
     ///
     /// When `eager` is true, the mapper receives all existing mappings
     /// immediately and gets new ones pushed synchronously. File-backed

--- a/openvmm/membacking/src/mapping_manager/va_mapper.rs
+++ b/openvmm/membacking/src/mapping_manager/va_mapper.rs
@@ -131,53 +131,71 @@ pub(crate) enum MapperRole {
 /// Properties recorded for each active guest-memory mapping, used to answer
 /// per-address queries (private vs. shared, soft-large-page first-fault state)
 /// without a static snapshot of the RAM layout.
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 struct MappingProps {
     /// Backed by private anonymous memory (committed on fault) rather than a
     /// shared file/section mapping.
     private: bool,
+    /// General per-mapping fault counters, always present. See [`FaultStats`].
+    stats: FaultStats,
     /// Soft-large-page state for this range's 2 MB regions. `Some` only for
     /// writable THP-eligible ranges on the **primary** (local) mapper on Windows
     /// (soft large pages); `None` otherwise — non-primary (device/DMA) mappers,
-    /// non-THP ranges, and non-Windows hosts spend nothing. Shared via `Arc` so
-    /// the fault paths can claim a region, materialize backing, and bump
-    /// counters without holding the mapping-index lock.
+    /// non-THP ranges, and non-Windows hosts spend nothing. The fault paths
+    /// claim a region, materialize backing, and bump counters while holding the
+    /// mapping-index read lock.
     ///
     /// `Some` also marks the range (private or shared) as "deferred protect":
     /// committed/mapped read-only and upgraded to read-write — then materialized
     /// with a 2 MB prefetch — a window at a time on first write.
-    soft_lp: Option<Arc<SoftLp>>,
+    soft_lp: Option<SoftLp>,
 }
 
-/// Per-mapping soft-large-page state: the first-fault bitmap plus fault and
-/// promotion counters. Shared via `Arc` so the fault paths update it without
-/// holding the mapping-index lock.
+/// Per-mapping soft-large-page state: the first-fault bitmap plus the
+/// large-page prefetch/promotion counters. Stored inline in [`MappingProps`]
+/// and accessed by the fault paths under the mapping-index read lock.
 #[derive(Debug)]
 struct SoftLp {
     first_fault: FirstFault,
     stats: SoftLpStats,
 }
 
-/// Per-mapping counters for the soft-large-page paths, exposed via `Inspect`.
+/// Per-mapping counters for the soft-large-page (2 MB window) machinery,
+/// exposed via `Inspect`. These track only the large-page-specific work —
+/// prefetching and promoting 2 MB windows. General fault accounting (the faults
+/// that drive this work) lives in [`FaultStats`].
 ///
 /// Kept per mapping (one backing, and thus one set of counters, per NUMA node)
 /// so they scale for large multi-NUMA-node VMs rather than contending on a
 /// single global counter.
 #[derive(Debug, Default, Inspect)]
 struct SoftLpStats {
-    /// Host-side deferred-protect write faults (e.g. the loader's first write to
-    /// a window).
-    host_faults: SharedCounter,
     /// 2 MB windows prefetched on the host fault path.
     host_prefetches: SharedCounter,
-    /// Guest-side faults resolved for this mapping.
-    guest_faults: SharedCounter,
     /// 2 MB windows promoted (first-fault widen) on the guest fault path.
     guest_promotions: SharedCounter,
     /// 2 MB windows pre-populated eagerly at build time (prefetch).
     eager_promotions: SharedCounter,
     /// Best-effort prefetch failures (no free large page, or pre-Win11).
     prefetch_failures: SharedCounter,
+}
+
+/// Per-mapping fault counters, exposed via `Inspect`.
+///
+/// Recorded for every mapping regardless of host OS, role, or backing, so
+/// general fault accounting is available even on mappings that never use soft
+/// large pages. Kept per mapping — one set of counters per backing, and thus
+/// per NUMA node — so they scale for large multi-NUMA-node VMs rather than
+/// contending on a single global counter. The counters are plain atomics
+/// (`SharedCounter`), bumped in place under the mapping-index read lock.
+#[derive(Debug, Default, Inspect)]
+struct FaultStats {
+    /// Host write faults that raised a soft-large-page deferred-protect window
+    /// to read-write (e.g. the loader's first write to a window). Nonzero only
+    /// for soft-large-page mappings (Windows, primary mapper, THP-eligible).
+    deferred_protect_faults: SharedCounter,
+    /// Guest memory faults resolved for this mapping.
+    guest_faults: SharedCounter,
 }
 
 /// A virtual address space mapper for guest memory.
@@ -214,12 +232,12 @@ impl Drop for VaMapper {
 }
 
 impl Inspect for VaMapper {
-    /// Contributes each soft-large-page mapping's counters to the shared
-    /// `mappings` node, under a `soft_large_pages` child keyed by GPA range, so
-    /// the stats sit alongside the mapping they describe (the mapping-manager
-    /// entry with the same range merges with this one). Only soft-large-page
-    /// mappings (the primary mapper's writable THP ranges on Windows)
-    /// contribute; other mappers contribute nothing.
+    /// Contributes each mapping's counters to the shared `mappings` node, keyed
+    /// by GPA range, so the stats sit alongside the mapping they describe (the
+    /// mapping-manager entry with the same range merges with this one). Every
+    /// mapping contributes a `faults` child (general fault accounting); only
+    /// soft-large-page mappings (the primary mapper's writable THP ranges on
+    /// Windows) additionally contribute a `soft_large_pages` child.
     fn inspect(&self, req: inspect::Request<'_>) {
         req.respond().field(
             "mappings",
@@ -227,15 +245,17 @@ impl Inspect for VaMapper {
                 let mut resp = req.respond();
                 let mappings = self.inner.mappings.read();
                 for (range, props) in mappings.iter() {
-                    if let Some(sl) = &props.soft_lp {
-                        let range = MemoryRange::new(*range.start()..*range.end() + 1);
-                        resp.field(
-                            &range.to_string(),
-                            inspect::adhoc(|req| {
-                                req.respond().field("soft_large_pages", &sl.stats);
-                            }),
-                        );
-                    }
+                    let range = MemoryRange::new(*range.start()..*range.end() + 1);
+                    resp.field(
+                        &range.to_string(),
+                        inspect::adhoc(|req| {
+                            let mut resp = req.respond();
+                            resp.field("faults", &props.stats);
+                            if let Some(sl) = &props.soft_lp {
+                                resp.field("soft_large_pages", &sl.stats);
+                            }
+                        }),
+                    );
                 }
             }),
         );
@@ -395,6 +415,7 @@ impl MapperTask {
             params.range,
             MappingProps {
                 private,
+                stats: FaultStats::default(),
                 soft_lp: soft_lp.then(|| {
                     let regions = large_region_count(params.range);
                     let stats = SoftLpStats::default();
@@ -407,7 +428,7 @@ impl MapperTask {
                     } else {
                         FirstFault::new(regions)
                     };
-                    Arc::new(SoftLp { first_fault, stats })
+                    SoftLp { first_fault, stats }
                 }),
             },
         );
@@ -837,22 +858,6 @@ impl VaMapper {
             .is_some_and(|p| p.private)
     }
 
-    /// Returns `(start, inclusive_end, soft_lp)` for the soft-large-page
-    /// (deferred-protect) mapping covering `addr`, or `None` if `addr` is not in
-    /// such a range.
-    ///
-    /// Only the primary mapper's writable THP ranges carry soft-large-page
-    /// state, so this is always `None` for non-primary mappers, non-THP ranges,
-    /// and non-Windows hosts.
-    #[cfg(windows)]
-    fn soft_lp_range(&self, addr: u64) -> Option<(u64, u64, Arc<SoftLp>)> {
-        self.inner
-            .mappings
-            .read()
-            .get_entry(&addr)
-            .and_then(|&(start, end, ref p)| p.soft_lp.as_ref().map(|sl| (start, end, sl.clone())))
-    }
-
     /// Returns the base pointer of the VA reservation.
     pub fn as_ptr(&self) -> *mut u8 {
         self.inner.mapping.as_ptr().cast()
@@ -891,16 +896,16 @@ impl VaMapper {
         //
         // Ordering: the first-fault bits are a best-effort widening *hint*, not
         // a record of page state, so clearing them before the decommit syscall
-        // is safe. The read lock only guards index traversal; it does not
-        // serialize against `resolve`, which claims bits after dropping the
-        // lock. A concurrent `resolve` on the same region can thus interleave —
-        // committing a 2 MB window we then decommit, or leaving a bit set over
-        // freshly-decommitted pages — but both only cost a large page, never
-        // correctness, since the guest re-faults and repopulates. If the bitmap
-        // were ever repurposed to authoritatively mean "this 2 MB chunk is zero"
-        // (to skip zeroing / drive protections), this would have to flip and
-        // tighten: decommit first, then mark, with the page-state change and the
-        // bit update held under a lock shared with `resolve`.
+        // is safe. Both this path and `resolve` touch the bits under a *read*
+        // lock, which does not serialize them against each other. A concurrent
+        // `resolve` on the same region can thus interleave — committing a 2 MB
+        // window we then decommit, or leaving a bit set over freshly-decommitted
+        // pages — but both only cost a large page, never correctness, since the
+        // guest re-faults and repopulates. If the bitmap were ever repurposed to
+        // authoritatively mean "this 2 MB chunk is zero" (to skip zeroing / drive
+        // protections), this would have to flip and tighten: decommit first, then
+        // mark, with the page-state change and the bit update held under a write
+        // lock shared with `resolve`.
         {
             let mappings = self.inner.mappings.read();
             assert!(
@@ -946,39 +951,51 @@ unsafe impl GuestMemoryAccess for VaMapper {
         // path: raise the whole 2 MB window to read-write and prefetch it so the
         // OS can back it with a contiguous large page, then retry the write.
         // Applies to both private and shared (section) RAM.
+        //
+        // The mapping-index read lock is held across the protect/prefetch
+        // syscalls. This only blocks a concurrent *writer* (a structural
+        // map/unmap), which is rare; other faulting VPs are readers and proceed
+        // in parallel.
         #[cfg(windows)]
         if write {
-            if let Some((start, end, sl)) = self.soft_lp_range(address) {
-                sl.stats.host_faults.increment();
-                let win_base = address & !(LARGE_PAGE_SIZE - 1);
-                let prot_start = win_base.max(start);
-                let prot_end = (win_base + LARGE_PAGE_SIZE).min(end + 1);
-                let off = prot_start as usize;
-                let plen = (prot_end - prot_start) as usize;
-                // Raise to read-write (idempotent) so the write proceeds.
-                if let Err(err) = self.inner.mapping.protect(off, plen, PAGE_READWRITE) {
-                    return PageFaultAction::Fail(PageFaultError::new(
-                        GuestMemoryErrorKind::Other,
-                        FaultError::Protect(MemoryRange::new(off as u64..(off + plen) as u64), err),
-                    ));
+            let mappings = self.inner.mappings.read();
+            if let Some(&(start, end, ref props)) = mappings.get_entry(&address) {
+                if let Some(sl) = &props.soft_lp {
+                    // A hit on the write-fault path is a deferred-protect fault.
+                    props.stats.deferred_protect_faults.increment();
+                    let win_base = address & !(LARGE_PAGE_SIZE - 1);
+                    let prot_start = win_base.max(start);
+                    let prot_end = (win_base + LARGE_PAGE_SIZE).min(end + 1);
+                    let off = prot_start as usize;
+                    let plen = (prot_end - prot_start) as usize;
+                    // Raise to read-write (idempotent) so the write proceeds.
+                    if let Err(err) = self.inner.mapping.protect(off, plen, PAGE_READWRITE) {
+                        return PageFaultAction::Fail(PageFaultError::new(
+                            GuestMemoryErrorKind::Other,
+                            FaultError::Protect(
+                                MemoryRange::new(off as u64..(off + plen) as u64),
+                                err,
+                            ),
+                        ));
+                    }
+                    // Prefetch the whole window in one call so the OS can back it
+                    // with a contiguous large page. Best-effort: a failure
+                    // (pre-Win11, or no large page available) just leaves 4 KB
+                    // backing, so log and proceed. No first-fault claim here —
+                    // leave the guest-side 2 MB widen to `resolve`; a later
+                    // redundant prefetch over resident pages is harmless.
+                    if let Err(err) = self.inner.mapping.prefetch(off, plen) {
+                        sl.stats.prefetch_failures.increment();
+                        tracing::debug!(
+                            error = &err as &dyn std::error::Error,
+                            address,
+                            "soft large page prefetch failed"
+                        );
+                    } else {
+                        sl.stats.host_prefetches.increment();
+                    }
+                    return PageFaultAction::Retry;
                 }
-                // Prefetch the whole window in one call so the OS can back it
-                // with a contiguous large page. Best-effort: a failure (pre-Win11,
-                // or no large page available) just leaves 4 KB backing, so log
-                // and proceed. No first-fault claim here — leave the guest-side
-                // 2 MB widen to `resolve`; a later redundant prefetch over
-                // resident pages is harmless.
-                if let Err(err) = self.inner.mapping.prefetch(off, plen) {
-                    sl.stats.prefetch_failures.increment();
-                    tracing::debug!(
-                        error = &err as &dyn std::error::Error,
-                        address,
-                        "soft large page prefetch failed"
-                    );
-                } else {
-                    sl.stats.host_prefetches.increment();
-                }
-                return PageFaultAction::Retry;
             }
         }
 
@@ -1073,35 +1090,31 @@ impl ResolveMemoryFault for VaMapper {
         let base = fault.start() & !(LARGE_PAGE_SIZE - 1);
         let window_end = base + LARGE_PAGE_SIZE;
 
-        // Extract the mapping metadata and drop the index lock before the
-        // protection change below, matching `decommit`'s note that `resolve`
-        // acts on first-fault state without holding the lock. `end` is the
-        // inclusive last address of the mapping.
-        let (start, end, soft_lp) = {
-            let mappings = self.inner.mappings.read();
-            let Some(&(start, end, ref props)) = mappings.get_entry(&fault.start()) else {
-                return Err(GuestMemoryBackingError::new(
-                    GuestMemoryErrorKind::OutOfRange,
-                    fault.start(),
-                    UnexpectedPageFault,
-                ));
-            };
-            (start, end, props.soft_lp.clone())
+        // Hold the mapping-index read lock across the widen decision and the
+        // protect/prefetch syscalls below. This only blocks a concurrent
+        // *writer* (a structural map/unmap), which is rare; other faulting VPs
+        // are readers and proceed in parallel. `end` is the inclusive last
+        // address of the mapping.
+        let mappings = self.inner.mappings.read();
+        let Some(&(start, end, ref props)) = mappings.get_entry(&fault.start()) else {
+            return Err(GuestMemoryBackingError::new(
+                GuestMemoryErrorKind::OutOfRange,
+                fault.start(),
+                UnexpectedPageFault,
+            ));
         };
-
-        if let Some(sl) = &soft_lp {
-            sl.stats.guest_faults.increment();
-        }
+        props.stats.guest_faults.increment();
+        let soft_lp = props.soft_lp.as_ref();
 
         let full_window = fault.end() <= window_end && base >= start && window_end <= end + 1;
         let widen = full_window
-            && soft_lp.as_ref().is_some_and(|sl| {
+            && soft_lp.is_some_and(|sl| {
                 sl.first_fault
                     .try_claim(base / LARGE_PAGE_SIZE - start / LARGE_PAGE_SIZE)
             });
         if widen {
             // `widen` implies `soft_lp` is `Some`.
-            if let Some(sl) = &soft_lp {
+            if let Some(sl) = soft_lp {
                 sl.stats.guest_promotions.increment();
             }
         }
@@ -1116,7 +1129,7 @@ impl ResolveMemoryFault for VaMapper {
         // written working set.
         #[cfg(windows)]
         if write {
-            if let Some(sl) = &soft_lp {
+            if let Some(sl) = soft_lp {
                 let (prot_start, prot_end) = if full_window {
                     (base, window_end)
                 } else {

--- a/openvmm/membacking/src/mapping_manager/va_mapper.rs
+++ b/openvmm/membacking/src/mapping_manager/va_mapper.rs
@@ -20,6 +20,24 @@
 //!
 //! In both modes, private memory ranges use commit-on-fault (Windows) or are
 //! handled transparently by the kernel (Linux).
+//!
+//! On Windows, the **primary** (local) mapper's writable THP-eligible guest RAM
+//! (private *and* shared/section) additionally uses a "deferred protect" scheme
+//! for soft large pages: the range is committed/mapped read-only, and the first
+//! write fault upgrades a full 2 MB window to read-write and prefetches it (via
+//! `page_fault` for host-side writes such as the loader, or `resolve` for guest
+//! writes). Faulting a uniform 2 MB region in one operation gives the OS the
+//! opportunity to back it with a large page (which the hypervisor can map as a
+//! 2 MB SLAT entry) instead of the fragmented small pages that result from
+//! dribbled per-page writes. Non-primary (device/DMA) mappers use plain 4 KB
+//! read-write pages.
+//!
+//! When such a range is also *prefetched*, it is populated eagerly at build
+//! time instead: it stays read-write (the build-time populate cannot access a
+//! read-only mapping) and its per-window first-fault bitmap starts fully set, so
+//! `resolve` treats every window as already attempted. The bitmap is still
+//! allocated, so windows freed later (e.g. via free-page reporting, which clears
+//! their bits) re-fault and rebuild through the lazy path.
 
 // UNSAFETY: Implementing the unsafe GuestMemoryAccess trait by calling unsafe
 // low level memory manipulation functions.
@@ -36,25 +54,131 @@ use super::manager::MemoryPolicy;
 use crate::RemoteProcess;
 use futures::executor::block_on;
 use guestmem::GuestMemoryAccess;
+use guestmem::GuestMemoryBackingError;
+use guestmem::GuestMemoryErrorKind;
 use guestmem::GuestMemorySharing;
 use guestmem::PageFaultAction;
 use guestmem::PageFaultError;
+use inspect::Inspect;
+use inspect_counters::SharedCounter;
 use memory_range::MemoryRange;
 use mesh::error::RemoteError;
 use mesh::rpc::RpcError;
 use mesh::rpc::RpcSend;
 use parking_lot::Mutex;
+use parking_lot::RwLock;
+use range_map_vec::RangeMap;
 use sparse_mmap::SparseMapping;
 use std::ptr::NonNull;
 use std::sync::Arc;
 use std::sync::atomic::AtomicBool;
+use std::sync::atomic::AtomicU64;
 use std::sync::atomic::Ordering;
 use std::thread::JoinHandle;
 use thiserror::Error;
+use virt::ResolveMemoryFault;
+#[cfg(windows)]
+use windows_sys::Win32::System::Memory::PAGE_READONLY;
+#[cfg(windows)]
+use windows_sys::Win32::System::Memory::PAGE_READWRITE;
+#[cfg(windows)]
+use windows_sys::Win32::System::Memory::SECTION_MAP_READ;
+#[cfg(windows)]
+use windows_sys::Win32::System::Memory::SECTION_MAP_WRITE;
 
 #[derive(Debug, Error)]
 #[error("unexpected page fault")]
 struct UnexpectedPageFault;
+
+/// A failure in one of the steps the fault handler takes to service a guest-RAM
+/// fault on Windows. Each variant names the operation and carries the
+/// underlying OS error as its [`source`](std::error::Error::source), so a
+/// passed-up guest-memory error identifies the step that failed rather than
+/// surfacing a bare OS error code.
+#[cfg(windows)]
+#[derive(Debug, Error)]
+enum FaultError {
+    /// Raising a window to read-write failed (deferred protect / soft large
+    /// pages).
+    #[error("failed to raise window {0} to read-write")]
+    Protect(MemoryRange, #[source] std::io::Error),
+    /// Committing private RAM failed (e.g. recommit after decommit).
+    #[error("failed to commit private RAM window {0}")]
+    Commit(MemoryRange, #[source] std::io::Error),
+}
+
+/// The role of a [`VaMapper`].
+///
+/// Exactly one mapper per VM is [`Primary`](Self::Primary): the loader's write
+/// target and the partition's fault resolver, and the only mapper for which soft
+/// large pages (Windows) are worthwhile, since its host backing drives the
+/// guest's SLAT. All other guest-memory access — `guest_memory()` in any
+/// process, DMA mappers, and remote partition-backing mappers — is
+/// [`Secondary`](Self::Secondary) and uses plain read-write 4 KB pages.
+///
+/// This is a role, not a location: it is set explicitly at construction rather
+/// than inferred from whether the mapping is local, so a remote primary mapper
+/// or a local secondary mapper (e.g. a device process's own local mapper) is
+/// handled correctly.
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub(crate) enum MapperRole {
+    /// The single loader/partition mapper; eligible for soft large pages.
+    Primary,
+    /// Any other mapper; plain read-write 4 KB pages.
+    Secondary,
+}
+
+/// Properties recorded for each active guest-memory mapping, used to answer
+/// per-address queries (private vs. shared, soft-large-page first-fault state)
+/// without a static snapshot of the RAM layout.
+#[derive(Debug, Clone)]
+struct MappingProps {
+    /// Backed by private anonymous memory (committed on fault) rather than a
+    /// shared file/section mapping.
+    private: bool,
+    /// Soft-large-page state for this range's 2 MB regions. `Some` only for
+    /// writable THP-eligible ranges on the **primary** (local) mapper on Windows
+    /// (soft large pages); `None` otherwise — non-primary (device/DMA) mappers,
+    /// non-THP ranges, and non-Windows hosts spend nothing. Shared via `Arc` so
+    /// the fault paths can claim a region, materialize backing, and bump
+    /// counters without holding the mapping-index lock.
+    ///
+    /// `Some` also marks the range (private or shared) as "deferred protect":
+    /// committed/mapped read-only and upgraded to read-write — then materialized
+    /// with a 2 MB prefetch — a window at a time on first write.
+    soft_lp: Option<Arc<SoftLp>>,
+}
+
+/// Per-mapping soft-large-page state: the first-fault bitmap plus fault and
+/// promotion counters. Shared via `Arc` so the fault paths update it without
+/// holding the mapping-index lock.
+#[derive(Debug)]
+struct SoftLp {
+    first_fault: FirstFault,
+    stats: SoftLpStats,
+}
+
+/// Per-mapping counters for the soft-large-page paths, exposed via `Inspect`.
+///
+/// Kept per mapping (one backing, and thus one set of counters, per NUMA node)
+/// so they scale for large multi-NUMA-node VMs rather than contending on a
+/// single global counter.
+#[derive(Debug, Default, Inspect)]
+struct SoftLpStats {
+    /// Host-side deferred-protect write faults (e.g. the loader's first write to
+    /// a window).
+    host_faults: SharedCounter,
+    /// 2 MB windows prefetched on the host fault path.
+    host_prefetches: SharedCounter,
+    /// Guest-side faults resolved for this mapping.
+    guest_faults: SharedCounter,
+    /// 2 MB windows promoted (first-fault widen) on the guest fault path.
+    guest_promotions: SharedCounter,
+    /// 2 MB windows pre-populated eagerly at build time (prefetch).
+    eager_promotions: SharedCounter,
+    /// Best-effort prefetch failures (no free large page, or pre-Win11).
+    prefetch_failures: SharedCounter,
+}
 
 /// A virtual address space mapper for guest memory.
 ///
@@ -64,10 +188,6 @@ pub struct VaMapper {
     inner: Arc<MapperInner>,
     id: MapperId,
     process: Option<RemoteProcess>,
-    /// Ranges backed by private anonymous memory.
-    /// Page faults in these ranges commit pages directly instead of
-    /// requesting a file-backed mapping from the MappingManager.
-    private_ranges: Vec<MemoryRange>,
     _thread: JoinHandle<()>,
 }
 
@@ -93,11 +213,45 @@ impl Drop for VaMapper {
     }
 }
 
+impl Inspect for VaMapper {
+    /// Contributes each soft-large-page mapping's counters to the shared
+    /// `mappings` node, under a `soft_large_pages` child keyed by GPA range, so
+    /// the stats sit alongside the mapping they describe (the mapping-manager
+    /// entry with the same range merges with this one). Only soft-large-page
+    /// mappings (the primary mapper's writable THP ranges on Windows)
+    /// contribute; other mappers contribute nothing.
+    fn inspect(&self, req: inspect::Request<'_>) {
+        req.respond().field(
+            "mappings",
+            inspect::adhoc(|req| {
+                let mut resp = req.respond();
+                let mappings = self.inner.mappings.read();
+                for (range, props) in mappings.iter() {
+                    if let Some(sl) = &props.soft_lp {
+                        let range = MemoryRange::new(*range.start()..*range.end() + 1);
+                        resp.field(
+                            &range.to_string(),
+                            inspect::adhoc(|req| {
+                                req.respond().field("soft_large_pages", &sl.stats);
+                            }),
+                        );
+                    }
+                }
+            }),
+        );
+    }
+}
+
 #[derive(Debug)]
 struct MapperInner {
     mapping: SparseMapping,
     /// Waiters for lazy mapping requests. `None` after the mapper task exits.
     waiters: Mutex<Option<Vec<MapWaiter>>>,
+    /// Index of active mappings recorded as they are established, keyed by GPA.
+    /// Written by the mapper task on map/unmap and read by the page-fault and
+    /// fault-resolution paths. Replaces a static snapshot of the RAM layout, so
+    /// hot-added ranges populate it like any other mapping.
+    mappings: RwLock<RangeMap<u64, MappingProps>>,
     /// Whether this mapper receives mappings eagerly (pushed by the
     /// mapping manager) or lazily (on demand via page faults).
     /// Set by the mapping manager task after replay is complete.
@@ -108,6 +262,11 @@ struct MapperInner {
     /// succeeds because the mapping is already established. The flag
     /// is eventually updated after `SetEager` is processed.
     eager: AtomicBool,
+    /// Whether this is the **primary** mapper — the one the partition and the
+    /// loader run against. Soft large pages (Windows) are only worthwhile here,
+    /// since this is the mapping whose host backing drives the guest's SLAT.
+    /// Secondary mappers use plain read-write 4 KB pages. See [`MapperRole`].
+    primary: bool,
     req_send: mesh::Sender<MappingRequest>,
 }
 
@@ -155,6 +314,7 @@ impl MapperTask {
                         .mapping
                         .unmap(range.start() as usize, range.len() as usize)
                         .expect("invalidate request should be valid");
+                    self.inner.remove_mapping(range);
                 }),
                 MapperRequest::MapEager(rpc) => {
                     rpc.handle_failable_sync(|params| {
@@ -197,13 +357,61 @@ impl MapperTask {
 
     /// Establishes a mapping in the VA space, dispatching on how it is backed.
     fn map(&self, params: MappingParams) -> Result<(), MappingError> {
-        match &params.backing {
+        // Soft large pages are a Windows-only, THP-only feature that matters only
+        // on the **primary** mapper: the partition and the loader run against its
+        // VA, so that is the only place a large host backing yields a 2 MB SLAT
+        // entry. Non-primary (device/DMA) mappers, read-only mappings (e.g. ROM),
+        // non-THP ranges, and non-Windows hosts use plain read-write 4 KB pages.
+        let soft_lp = cfg!(windows)
+            && params.policy.transparent_hugepages
+            && params.writable
+            && self.inner.primary;
+
+        // Deferred protect (map read-only, populate lazily on the first write
+        // fault) drives the *lazy* soft-LP path. When the range is prefetched it
+        // is populated *eagerly* at build time instead, so it stays read-write
+        // (the build-time populate cannot access a read-only mapping) and its
+        // 2 MB windows start already-attempted. The first-fault bitmap is still
+        // allocated in the prefetch case, so windows freed later (e.g. via
+        // free-page reporting, which clears their bits) re-fault and rebuild
+        // through the lazy path.
+        let prefetch = soft_lp && params.policy.prefetch;
+        let deferred_protect = soft_lp && !prefetch;
+
+        let private = match &params.backing {
             MappingBacking::File {
                 mappable,
                 file_offset,
-            } => self.map_file(&params, mappable, *file_offset),
-            MappingBacking::Private => self.map_private(&params),
-        }
+            } => {
+                self.map_file(&params, mappable, *file_offset, deferred_protect)?;
+                false
+            }
+            MappingBacking::Private => {
+                self.map_private(&params, deferred_protect)?;
+                true
+            }
+        };
+        self.inner.record_mapping(
+            params.range,
+            MappingProps {
+                private,
+                soft_lp: soft_lp.then(|| {
+                    let regions = large_region_count(params.range);
+                    let stats = SoftLpStats::default();
+                    // Prefetched ranges are populated up front, so mark every
+                    // window attempted and count them as eager promotions; lazy
+                    // ranges start unattempted.
+                    let first_fault = if prefetch {
+                        stats.eager_promotions.add(regions);
+                        FirstFault::new_all_claimed(regions)
+                    } else {
+                        FirstFault::new(regions)
+                    };
+                    Arc::new(SoftLp { first_fault, stats })
+                }),
+            },
+        );
+        Ok(())
     }
 
     /// Maps a file-backed region into the VA space, applying NUMA policy where
@@ -213,6 +421,7 @@ impl MapperTask {
         params: &MappingParams,
         mappable: &super::mappable::Mappable,
         file_offset: u64,
+        deferred_protect: bool,
     ) -> Result<(), MappingError> {
         let &MappingParams {
             range,
@@ -223,16 +432,41 @@ impl MapperTask {
                 MemoryPolicy {
                     numa_node,
                     transparent_hugepages,
+                    prefetch: _,
                 },
         } = params;
+        // A deferred-protect range is mapped read-write (so the view has write
+        // access and its pages can be raised back to read-write on the first
+        // write fault) and then immediately protected down to read-only just
+        // below. Mapping the view read-only up front instead would create a view
+        // whose pages cannot be raised to read-write later (`VirtualProtect`
+        // fails with ERROR_INVALID_PARAMETER). Deferred protect implies
+        // `writable`.
+        #[cfg(windows)]
+        let (protect, access) = (
+            if writable {
+                PAGE_READWRITE
+            } else {
+                PAGE_READONLY
+            },
+            if writable {
+                SECTION_MAP_READ | SECTION_MAP_WRITE
+            } else {
+                SECTION_MAP_READ
+            },
+        );
+        // `deferred_protect` is only consulted on Windows below; keep it live on
+        // other targets so the shared parameter doesn't warn.
+        let _ = deferred_protect;
         let map_result = cfg_select! {
             windows => {
-                self.inner.mapping.map_file_numa(
+                self.inner.mapping.map_view_of_file_access(
                     range.start() as usize,
                     range.len() as usize,
                     mappable,
                     file_offset,
-                    writable,
+                    protect,
+                    access,
                     numa_node,
                 )
             }
@@ -249,6 +483,20 @@ impl MapperTask {
 
         if let Err(e) = map_result {
             return Err(MappingError::new(range, e));
+        }
+
+        // Deferred protect: lower the freshly-mapped writable view to read-only
+        // so the first write faults; `page_fault`/`resolve` then raise the
+        // touched 2 MB window back to read-write.
+        #[cfg(windows)]
+        if deferred_protect {
+            if let Err(e) = self.inner.mapping.protect(
+                range.start() as usize,
+                range.len() as usize,
+                PAGE_READONLY,
+            ) {
+                return Err(MappingError::new(range, e));
+            }
         }
 
         // Mark shared (file-backed) RAM as THP-eligible. This is advisory:
@@ -291,7 +539,7 @@ impl MapperTask {
                 }
             }
             windows => {
-                // NUMA handled by map_file_numa above.
+                // NUMA handled by the map_view_of_file_access call above.
                 let _ = numa_node;
             }
             _ => {
@@ -307,7 +555,11 @@ impl MapperTask {
     /// This replaces the reserved placeholder at `range` with committed
     /// anonymous pages, optionally bound to a host NUMA node and marked
     /// eligible for Transparent Huge Pages.
-    fn map_private(&self, params: &MappingParams) -> Result<(), MappingError> {
+    fn map_private(
+        &self,
+        params: &MappingParams,
+        deferred_protect: bool,
+    ) -> Result<(), MappingError> {
         let &MappingParams {
             range,
             backing: _,
@@ -317,12 +569,17 @@ impl MapperTask {
                 MemoryPolicy {
                     numa_node,
                     transparent_hugepages,
+                    prefetch: _,
                 },
         } = params;
         let offset = range.start() as usize;
         let len = range.len() as usize;
 
-        if let Err(e) = self.inner.alloc(offset, len, numa_node) {
+        // On Windows, deferred-protect private RAM commits read-only so the first
+        // write faults and a full 2 MB window can be raised to read-write and
+        // materialized at once, giving the loader (and guest) large pages.
+        // Elsewhere this flag is ignored.
+        if let Err(e) = self.inner.alloc(offset, len, numa_node, deferred_protect) {
             return Err(MappingError::new(range, e));
         }
 
@@ -370,8 +627,6 @@ pub enum VaMapperError {
     Registration(#[source] RemoteError),
     #[error("failed to reserve address space")]
     Reserve(#[source] std::io::Error),
-    #[error("remote mappers are not supported when any RAM backing uses private memory")]
-    RemoteWithPrivateMemory,
 }
 
 /// Error returned when a lazy mapping request cannot be fulfilled.
@@ -380,6 +635,31 @@ pub enum VaMapperError {
 pub struct NoMapping(MemoryRange);
 
 impl MapperInner {
+    /// Records an established mapping in the index, replacing any stale entry
+    /// for the same range.
+    fn record_mapping(&self, range: MemoryRange, props: MappingProps) {
+        if range.is_empty() {
+            return;
+        }
+        let mut mappings = self.mappings.write();
+        mappings.remove_range(range.start()..=range.end() - 1);
+        let inserted = mappings.insert(range.start()..=range.end() - 1, props);
+        assert!(
+            inserted,
+            "mapping index range should be clear after removal"
+        );
+    }
+
+    /// Removes a mapping from the index.
+    fn remove_mapping(&self, range: MemoryRange) {
+        if range.is_empty() {
+            return;
+        }
+        self.mappings
+            .write()
+            .remove_range(range.start()..=range.end() - 1);
+    }
+
     /// Request that the mapping manager send mappings for the given range.
     ///
     /// Registers a waiter, sends `SendMappings` (fire-and-forget), and
@@ -416,6 +696,11 @@ impl MapperInner {
     /// This replaces the placeholder at the given offset with committed
     /// anonymous memory.
     ///
+    /// When `deferred_protect` is set (Windows soft large pages), the memory is
+    /// committed read-only instead of read-write, so the first write faults and
+    /// [`VaMapper`] can upgrade a full 2 MB window to read-write at once. This
+    /// has no effect on other platforms.
+    ///
     /// Caution: on Linux, if NUMA binding fails, the allocation itself has
     /// still succeeded — the returned error does not imply the memory is
     /// unmapped.
@@ -424,12 +709,22 @@ impl MapperInner {
         offset: usize,
         len: usize,
         numa_node: Option<u32>,
+        deferred_protect: bool,
     ) -> Result<(), std::io::Error> {
         cfg_select! {
             windows => {
-                self.mapping.alloc_numa(offset, len, numa_node)
+                // Deferred protect (soft large pages): commit read-only so the
+                // first write faults and the 2 MB window can be raised +
+                // materialized as a large page; otherwise commit read-write.
+                let protect = if deferred_protect {
+                    PAGE_READONLY
+                } else {
+                    PAGE_READWRITE
+                };
+                self.mapping.virtual_alloc(offset, len, protect, numa_node)
             }
             target_os = "linux" => {
+                let _ = deferred_protect;
                 self.mapping.alloc(offset, len)?;
                 if let Some(node) = numa_node {
                     self.mapping.mbind_at(offset, len, node)?;
@@ -437,6 +732,7 @@ impl MapperInner {
                 Ok(())
             }
             _ => {
+                let _ = deferred_protect;
                 assert!(numa_node.is_none(), "NUMA not supported on this platform; should have been rejected at build time");
                 self.mapping.alloc(offset, len)
             }
@@ -449,9 +745,9 @@ impl VaMapper {
         req_send: mesh::Sender<MappingRequest>,
         len: u64,
         remote_process: Option<RemoteProcess>,
-        private_ranges: Vec<MemoryRange>,
         minimum_alignment: Option<usize>,
         eager: bool,
+        role: MapperRole,
     ) -> Result<Self, VaMapperError> {
         let mapping = match &remote_process {
             None => SparseMapping::new_with_minimum_alignment(
@@ -480,7 +776,9 @@ impl VaMapper {
         let inner = Arc::new(MapperInner {
             mapping,
             waiters: Mutex::new(Some(Vec::new())),
+            mappings: RwLock::new(RangeMap::new()),
             eager: AtomicBool::new(eager),
+            primary: role == MapperRole::Primary,
             req_send,
         });
 
@@ -526,14 +824,33 @@ impl VaMapper {
             inner,
             id,
             process: remote_process,
-            private_ranges,
             _thread: thread,
         })
     }
 
     /// Returns true if `addr` falls within a private range.
     fn is_private(&self, addr: u64) -> bool {
-        self.private_ranges.iter().any(|r| r.contains_addr(addr))
+        self.inner
+            .mappings
+            .read()
+            .get(&addr)
+            .is_some_and(|p| p.private)
+    }
+
+    /// Returns `(start, inclusive_end, soft_lp)` for the soft-large-page
+    /// (deferred-protect) mapping covering `addr`, or `None` if `addr` is not in
+    /// such a range.
+    ///
+    /// Only the primary mapper's writable THP ranges carry soft-large-page
+    /// state, so this is always `None` for non-primary mappers, non-THP ranges,
+    /// and non-Windows hosts.
+    #[cfg(windows)]
+    fn soft_lp_range(&self, addr: u64) -> Option<(u64, u64, Arc<SoftLp>)> {
+        self.inner
+            .mappings
+            .read()
+            .get_entry(&addr)
+            .and_then(|&(start, end, ref p)| p.soft_lp.as_ref().map(|sl| (start, end, sl.clone())))
     }
 
     /// Returns the base pointer of the VA reservation.
@@ -568,13 +885,32 @@ impl VaMapper {
     /// private anonymous memory.
     #[expect(dead_code)] // Will be used by ballooning / memory hot-remove.
     pub fn decommit(&self, offset: usize, len: usize) -> Result<(), std::io::Error> {
-        assert!(
-            self.private_ranges
-                .iter()
-                .any(|r| r.contains(&MemoryRange::new(offset as u64..offset as u64 + len as u64))),
-            "decommit called on non-private range"
-        );
-        self.inner.mapping.decommit(offset, len)
+        // Verify the range is private and reset its first-fault state (so the
+        // freed 2 MB regions can widen again on the next fault) under a single
+        // lock acquisition.
+        //
+        // Ordering: the first-fault bits are a best-effort widening *hint*, not
+        // a record of page state, so clearing them before the decommit syscall
+        // is safe. The read lock only guards index traversal; it does not
+        // serialize against `resolve`, which claims bits after dropping the
+        // lock. A concurrent `resolve` on the same region can thus interleave —
+        // committing a 2 MB window we then decommit, or leaving a bit set over
+        // freshly-decommitted pages — but both only cost a large page, never
+        // correctness, since the guest re-faults and repopulates. If the bitmap
+        // were ever repurposed to authoritatively mean "this 2 MB chunk is zero"
+        // (to skip zeroing / drive protections), this would have to flip and
+        // tighten: decommit first, then mark, with the page-state change and the
+        // bit update held under a lock shared with `resolve`.
+        {
+            let mappings = self.inner.mappings.read();
+            assert!(
+                mappings.get(&(offset as u64)).is_some_and(|p| p.private),
+                "decommit called on non-private range"
+            );
+            clear_first_fault(&mappings, offset as u64, len as u64);
+        }
+        self.inner.mapping.decommit(offset, len)?;
+        Ok(())
     }
 }
 
@@ -604,8 +940,51 @@ unsafe impl GuestMemoryAccess for VaMapper {
     ) -> PageFaultAction {
         assert!(!bitmap_failure, "bitmaps are not used");
 
+        // Soft large pages (Windows): THP-eligible ranges on the primary mapper
+        // are committed/mapped read-only, so the first *write* traps here (reads
+        // are served by the zero page and don't fault). This is the loader's
+        // path: raise the whole 2 MB window to read-write and prefetch it so the
+        // OS can back it with a contiguous large page, then retry the write.
+        // Applies to both private and shared (section) RAM.
+        #[cfg(windows)]
+        if write {
+            if let Some((start, end, sl)) = self.soft_lp_range(address) {
+                sl.stats.host_faults.increment();
+                let win_base = address & !(LARGE_PAGE_SIZE - 1);
+                let prot_start = win_base.max(start);
+                let prot_end = (win_base + LARGE_PAGE_SIZE).min(end + 1);
+                let off = prot_start as usize;
+                let plen = (prot_end - prot_start) as usize;
+                // Raise to read-write (idempotent) so the write proceeds.
+                if let Err(err) = self.inner.mapping.protect(off, plen, PAGE_READWRITE) {
+                    return PageFaultAction::Fail(PageFaultError::new(
+                        GuestMemoryErrorKind::Other,
+                        FaultError::Protect(MemoryRange::new(off as u64..(off + plen) as u64), err),
+                    ));
+                }
+                // Prefetch the whole window in one call so the OS can back it
+                // with a contiguous large page. Best-effort: a failure (pre-Win11,
+                // or no large page available) just leaves 4 KB backing, so log
+                // and proceed. No first-fault claim here — leave the guest-side
+                // 2 MB widen to `resolve`; a later redundant prefetch over
+                // resident pages is harmless.
+                if let Err(err) = self.inner.mapping.prefetch(off, plen) {
+                    sl.stats.prefetch_failures.increment();
+                    tracing::debug!(
+                        error = &err as &dyn std::error::Error,
+                        address,
+                        "soft large page prefetch failed"
+                    );
+                } else {
+                    sl.stats.host_prefetches.increment();
+                }
+                return PageFaultAction::Retry;
+            }
+        }
+
         if self.is_private(address) {
-            // Private RAM: commit the page(s) directly.
+            // Private RAM: commit the page(s) directly (e.g. recommit after
+            // decommit).
             #[cfg(windows)]
             {
                 // Commit in 64KB-aligned chunks to amortize overhead.
@@ -616,8 +995,8 @@ unsafe impl GuestMemoryAccess for VaMapper {
 
                 if let Err(err) = self.inner.mapping.commit(commit_start as usize, commit_len) {
                     return PageFaultAction::Fail(PageFaultError::new(
-                        guestmem::GuestMemoryErrorKind::Other,
-                        err,
+                        GuestMemoryErrorKind::Other,
+                        FaultError::Commit(MemoryRange::new(commit_start..commit_end), err),
                     ));
                 }
                 return PageFaultAction::Retry;
@@ -627,7 +1006,7 @@ unsafe impl GuestMemoryAccess for VaMapper {
                 // On Linux, the kernel handles page faults transparently.
                 // If we get here, something is wrong.
                 return PageFaultAction::Fail(PageFaultError::new(
-                    guestmem::GuestMemoryErrorKind::Other,
+                    GuestMemoryErrorKind::Other,
                     UnexpectedPageFault,
                 ));
             }
@@ -638,7 +1017,7 @@ unsafe impl GuestMemoryAccess for VaMapper {
             // If we get a page fault, the mapping was never set up or was
             // torn down.
             return PageFaultAction::Fail(PageFaultError::new(
-                guestmem::GuestMemoryErrorKind::OutOfRange,
+                GuestMemoryErrorKind::OutOfRange,
                 UnexpectedPageFault,
             ));
         }
@@ -647,7 +1026,7 @@ unsafe impl GuestMemoryAccess for VaMapper {
         let range = MemoryRange::bounding(address..address + len as u64);
         if let Err(err) = block_on(self.inner.request_mapping(self.id, range, write)) {
             return PageFaultAction::Fail(PageFaultError::new(
-                guestmem::GuestMemoryErrorKind::OutOfRange,
+                GuestMemoryErrorKind::OutOfRange,
                 err,
             ));
         }
@@ -655,12 +1034,218 @@ unsafe impl GuestMemoryAccess for VaMapper {
     }
 
     fn sharing(&self) -> Option<GuestMemorySharing> {
-        if !self.private_ranges.is_empty() {
+        // Private anonymous memory is committed on fault in the local process
+        // and cannot be shared to a remote DMA process, so disable DMA sharing
+        // whenever any recorded mapping is private. Derived from the mapping
+        // index rather than a static flag so it tracks the actual backings.
+        if self.inner.mappings.read().iter().any(|(_, p)| p.private) {
             return None;
         }
         Some(GuestMemorySharing::new(DmaRegionProvider {
             req_send: self.inner.req_send.clone(),
         }))
+    }
+}
+
+/// The soft-large-page granularity (2 MB) used for opportunistic large SLAT
+/// entries and the per-region first-fault bitmap.
+const LARGE_PAGE_SIZE: u64 = 2 * 1024 * 1024;
+
+impl ResolveMemoryFault for VaMapper {
+    fn resolve(
+        &self,
+        fault: MemoryRange,
+        write: bool,
+    ) -> Result<MemoryRange, GuestMemoryBackingError> {
+        if fault.end() > self.inner.mapping.len() as u64 {
+            return Err(GuestMemoryBackingError::new(
+                GuestMemoryErrorKind::OutOfRange,
+                fault.start(),
+                UnexpectedPageFault,
+            ));
+        }
+
+        // Widen to a 2 MB soft large page only on the first fault of a 2 MB
+        // window that both contains the whole fault and lies entirely within one
+        // THP-eligible mapping. Every re-fault of an already-attempted region
+        // (e.g. after the host trimmer reclaimed the pages) resolves to the
+        // caller's range to avoid a hard-fault storm.
+        let base = fault.start() & !(LARGE_PAGE_SIZE - 1);
+        let window_end = base + LARGE_PAGE_SIZE;
+
+        // Extract the mapping metadata and drop the index lock before the
+        // protection change below, matching `decommit`'s note that `resolve`
+        // acts on first-fault state without holding the lock. `end` is the
+        // inclusive last address of the mapping.
+        let (start, end, soft_lp) = {
+            let mappings = self.inner.mappings.read();
+            let Some(&(start, end, ref props)) = mappings.get_entry(&fault.start()) else {
+                return Err(GuestMemoryBackingError::new(
+                    GuestMemoryErrorKind::OutOfRange,
+                    fault.start(),
+                    UnexpectedPageFault,
+                ));
+            };
+            (start, end, props.soft_lp.clone())
+        };
+
+        if let Some(sl) = &soft_lp {
+            sl.stats.guest_faults.increment();
+        }
+
+        let full_window = fault.end() <= window_end && base >= start && window_end <= end + 1;
+        let widen = full_window
+            && soft_lp.as_ref().is_some_and(|sl| {
+                sl.first_fault
+                    .try_claim(base / LARGE_PAGE_SIZE - start / LARGE_PAGE_SIZE)
+            });
+        if widen {
+            // `widen` implies `soft_lp` is `Some`.
+            if let Some(sl) = &soft_lp {
+                sl.stats.guest_promotions.increment();
+            }
+        }
+
+        // Deferred protect (Windows soft large pages): the range (private or
+        // shared) is committed/mapped read-only, so a write fault must raise it
+        // to read-write before the guest can proceed. Raise the whole 2 MB window
+        // when it lies within the mapping and, on the window's first fault
+        // (`widen`), prefetch it so the OS can back it with a large page;
+        // otherwise raise just the faulting range. Read faults leave the range
+        // read-only (served by the zero page), spending a large page only on the
+        // written working set.
+        #[cfg(windows)]
+        if write {
+            if let Some(sl) = &soft_lp {
+                let (prot_start, prot_end) = if full_window {
+                    (base, window_end)
+                } else {
+                    // Clamp to the mapping (`end` is inclusive) so a fault range
+                    // that spills past the region never protects an adjacent one.
+                    (fault.start().max(start), fault.end().min(end + 1))
+                };
+                if let Err(err) = self.inner.mapping.protect(
+                    prot_start as usize,
+                    (prot_end - prot_start) as usize,
+                    PAGE_READWRITE,
+                ) {
+                    return Err(GuestMemoryBackingError::new(
+                        GuestMemoryErrorKind::Other,
+                        fault.start(),
+                        FaultError::Protect(MemoryRange::new(prot_start..prot_end), err),
+                    ));
+                }
+                if widen {
+                    // Prefetch the whole window in one call so the OS can back it
+                    // with a contiguous large page. Best-effort: a failure
+                    // (pre-Win11, or no large page available) just leaves 4 KB
+                    // backing.
+                    if let Err(err) = self
+                        .inner
+                        .mapping
+                        .prefetch(base as usize, LARGE_PAGE_SIZE as usize)
+                    {
+                        sl.stats.prefetch_failures.increment();
+                        tracing::debug!(
+                            error = &err as &dyn std::error::Error,
+                            gpa = fault.start(),
+                            "soft large page prefetch failed"
+                        );
+                    }
+                }
+            }
+        }
+        #[cfg(not(windows))]
+        let _ = write;
+
+        Ok(if widen {
+            MemoryRange::new(base..window_end)
+        } else {
+            fault
+        })
+    }
+}
+
+/// Number of aligned 2 MB regions spanned by `range` (by absolute 2 MB region
+/// index), used to size a per-range [`FirstFault`] bitmap.
+fn large_region_count(range: MemoryRange) -> u64 {
+    (range.end() - 1) / LARGE_PAGE_SIZE - range.start() / LARGE_PAGE_SIZE + 1
+}
+
+/// Clears the first-fault bits for all 2 MB regions overlapping
+/// `[offset, offset + len)`, so a re-populated region can widen again. Takes the
+/// already-locked mapping index so the caller can reuse a single acquisition.
+fn clear_first_fault(mappings: &RangeMap<u64, MappingProps>, offset: u64, len: u64) {
+    if len == 0 {
+        return;
+    }
+    let first = offset / LARGE_PAGE_SIZE;
+    let last = (offset + len - 1) / LARGE_PAGE_SIZE;
+    for region in first..=last {
+        if let Some(&(start, _, ref props)) = mappings.get_entry(&(region * LARGE_PAGE_SIZE)) {
+            if let Some(sl) = &props.soft_lp {
+                sl.first_fault.clear(region - start / LARGE_PAGE_SIZE);
+            }
+        }
+    }
+}
+
+/// Per-2 MB-region first-fault bitmap for a single THP-eligible mapping (Windows
+/// soft large pages). A set bit means the region has already made its one
+/// soft-large-page widening attempt; later faults resolve to a single page to
+/// avoid a hard-fault storm. Cleared by [`VaMapper::decommit`] so a re-populated
+/// region can widen again.
+///
+/// Allocated per range and only for THP RAM on Windows, so guests without THP —
+/// and every non-Windows guest — pay nothing.
+#[derive(Debug)]
+struct FirstFault(Box<[AtomicU64]>);
+
+impl FirstFault {
+    /// Allocates a bitmap covering `regions` 2 MB regions, all bits clear.
+    fn new(regions: u64) -> Self {
+        let words = regions.div_ceil(64);
+        Self(
+            (0..words)
+                .map(|_| AtomicU64::new(0))
+                .collect::<Vec<_>>()
+                .into_boxed_slice(),
+        )
+    }
+
+    /// Allocates a bitmap covering `regions` 2 MB regions with every window
+    /// already marked attempted. Used for prefetched ranges: the large pages
+    /// are built eagerly at build time, so the lazy `resolve` path should not
+    /// re-widen a window until it is freed and its bit reset. Bits past
+    /// `regions` in the final word are set too, but are never indexed.
+    fn new_all_claimed(regions: u64) -> Self {
+        let words = regions.div_ceil(64);
+        Self(
+            (0..words)
+                .map(|_| AtomicU64::new(!0))
+                .collect::<Vec<_>>()
+                .into_boxed_slice(),
+        )
+    }
+
+    /// Atomically tests and sets the bit for `region`. Returns true if this
+    /// call won the race (the bit was previously clear).
+    fn try_claim(&self, region: u64) -> bool {
+        let word = (region / 64) as usize;
+        let bit = 1u64 << (region % 64);
+        match self.0.get(word) {
+            Some(slot) => slot.fetch_or(bit, Ordering::Relaxed) & bit == 0,
+            None => false,
+        }
+    }
+
+    /// Clears the bit for `region`.
+    fn clear(&self, region: u64) {
+        let word = (region / 64) as usize;
+        let bit = 1u64 << (region % 64);
+        if let Some(slot) = self.0.get(word) {
+            slot.fetch_and(!bit, Ordering::Relaxed);
+        }
     }
 }
 

--- a/openvmm/membacking/src/mapping_manager/va_mapper.rs
+++ b/openvmm/membacking/src/mapping_manager/va_mapper.rs
@@ -18,7 +18,7 @@
 //!   of notifying processes that rarely access certain mappings (e.g.,
 //!   device-emulation processes with virtio-fs DAX).
 //!
-//! In both modes, private memory ranges use commit-on-fault (Windows) or are
+//! In both modes, private memory ranges are committed up front (Windows) or
 //! handled transparently by the kernel (Linux).
 //!
 //! On Windows, the **primary** (local) mapper's writable THP-eligible guest RAM
@@ -35,9 +35,7 @@
 //! When such a range is also *prefetched*, it is populated eagerly at build
 //! time instead: it stays read-write (the build-time populate cannot access a
 //! read-only mapping) and its per-window first-fault bitmap starts fully set, so
-//! `resolve` treats every window as already attempted. The bitmap is still
-//! allocated, so windows freed later (e.g. via free-page reporting, which clears
-//! their bits) re-fault and rebuild through the lazy path.
+//! `resolve` treats every window as already attempted.
 
 // UNSAFETY: Implementing the unsafe GuestMemoryAccess trait by calling unsafe
 // low level memory manipulation functions.
@@ -102,9 +100,6 @@ enum FaultError {
     /// pages).
     #[error("failed to raise window {0} to read-write")]
     Protect(MemoryRange, #[source] std::io::Error),
-    /// Committing private RAM failed (e.g. recommit after decommit).
-    #[error("failed to commit private RAM window {0}")]
-    Commit(MemoryRange, #[source] std::io::Error),
 }
 
 /// The role of a [`VaMapper`].
@@ -133,7 +128,7 @@ pub(crate) enum MapperRole {
 /// without a static snapshot of the RAM layout.
 #[derive(Debug)]
 struct MappingProps {
-    /// Backed by private anonymous memory (committed on fault) rather than a
+    /// Backed by private anonymous memory (committed up front) rather than a
     /// shared file/section mapping.
     private: bool,
     /// General per-mapping fault counters, always present. See [`FaultStats`].
@@ -391,10 +386,7 @@ impl MapperTask {
         // fault) drives the *lazy* soft-LP path. When the range is prefetched it
         // is populated *eagerly* at build time instead, so it stays read-write
         // (the build-time populate cannot access a read-only mapping) and its
-        // 2 MB windows start already-attempted. The first-fault bitmap is still
-        // allocated in the prefetch case, so windows freed later (e.g. via
-        // free-page reporting, which clears their bits) re-fault and rebuild
-        // through the lazy path.
+        // 2 MB windows start already-attempted.
         let prefetch = soft_lp && params.policy.prefetch;
         let deferred_protect = soft_lp && !prefetch;
 
@@ -849,15 +841,6 @@ impl VaMapper {
         })
     }
 
-    /// Returns true if `addr` falls within a private range.
-    fn is_private(&self, addr: u64) -> bool {
-        self.inner
-            .mappings
-            .read()
-            .get(&addr)
-            .is_some_and(|p| p.private)
-    }
-
     /// Returns the base pointer of the VA reservation.
     pub fn as_ptr(&self) -> *mut u8 {
         self.inner.mapping.as_ptr().cast()
@@ -881,41 +864,6 @@ impl VaMapper {
     /// Returns the remote process, if this mapper maps into a remote process.
     pub fn process(&self) -> Option<&RemoteProcess> {
         self.process.as_ref()
-    }
-
-    /// Decommits a range of private RAM, releasing physical pages back to the
-    /// host.
-    ///
-    /// The caller must ensure this is only called on ranges backed by
-    /// private anonymous memory.
-    #[expect(dead_code)] // Will be used by ballooning / memory hot-remove.
-    pub fn decommit(&self, offset: usize, len: usize) -> Result<(), std::io::Error> {
-        // Verify the range is private and reset its first-fault state (so the
-        // freed 2 MB regions can widen again on the next fault) under a single
-        // lock acquisition.
-        //
-        // Ordering: the first-fault bits are a best-effort widening *hint*, not
-        // a record of page state, so clearing them before the decommit syscall
-        // is safe. Both this path and `resolve` touch the bits under a *read*
-        // lock, which does not serialize them against each other. A concurrent
-        // `resolve` on the same region can thus interleave — committing a 2 MB
-        // window we then decommit, or leaving a bit set over freshly-decommitted
-        // pages — but both only cost a large page, never correctness, since the
-        // guest re-faults and repopulates. If the bitmap were ever repurposed to
-        // authoritatively mean "this 2 MB chunk is zero" (to skip zeroing / drive
-        // protections), this would have to flip and tighten: decommit first, then
-        // mark, with the page-state change and the bit update held under a write
-        // lock shared with `resolve`.
-        {
-            let mappings = self.inner.mappings.read();
-            assert!(
-                mappings.get(&(offset as u64)).is_some_and(|p| p.private),
-                "decommit called on non-private range"
-            );
-            clear_first_fault(&mappings, offset as u64, len as u64);
-        }
-        self.inner.mapping.decommit(offset, len)?;
-        Ok(())
     }
 }
 
@@ -996,36 +944,6 @@ unsafe impl GuestMemoryAccess for VaMapper {
                     }
                     return PageFaultAction::Retry;
                 }
-            }
-        }
-
-        if self.is_private(address) {
-            // Private RAM: commit the page(s) directly (e.g. recommit after
-            // decommit).
-            #[cfg(windows)]
-            {
-                // Commit in 64KB-aligned chunks to amortize overhead.
-                let commit_start = address & !0xFFFF; // round down to 64KB
-                let commit_end = ((address + len as u64) + 0xFFFF) & !0xFFFF; // round up
-                let commit_end = commit_end.min(self.inner.mapping.len() as u64);
-                let commit_len = (commit_end - commit_start) as usize;
-
-                if let Err(err) = self.inner.mapping.commit(commit_start as usize, commit_len) {
-                    return PageFaultAction::Fail(PageFaultError::new(
-                        GuestMemoryErrorKind::Other,
-                        FaultError::Commit(MemoryRange::new(commit_start..commit_end), err),
-                    ));
-                }
-                return PageFaultAction::Retry;
-            }
-            #[cfg(unix)]
-            {
-                // On Linux, the kernel handles page faults transparently.
-                // If we get here, something is wrong.
-                return PageFaultAction::Fail(PageFaultError::new(
-                    GuestMemoryErrorKind::Other,
-                    UnexpectedPageFault,
-                ));
             }
         }
 
@@ -1185,29 +1103,10 @@ fn large_region_count(range: MemoryRange) -> u64 {
     (range.end() - 1) / LARGE_PAGE_SIZE - range.start() / LARGE_PAGE_SIZE + 1
 }
 
-/// Clears the first-fault bits for all 2 MB regions overlapping
-/// `[offset, offset + len)`, so a re-populated region can widen again. Takes the
-/// already-locked mapping index so the caller can reuse a single acquisition.
-fn clear_first_fault(mappings: &RangeMap<u64, MappingProps>, offset: u64, len: u64) {
-    if len == 0 {
-        return;
-    }
-    let first = offset / LARGE_PAGE_SIZE;
-    let last = (offset + len - 1) / LARGE_PAGE_SIZE;
-    for region in first..=last {
-        if let Some(&(start, _, ref props)) = mappings.get_entry(&(region * LARGE_PAGE_SIZE)) {
-            if let Some(sl) = &props.soft_lp {
-                sl.first_fault.clear(region - start / LARGE_PAGE_SIZE);
-            }
-        }
-    }
-}
-
 /// Per-2 MB-region first-fault bitmap for a single THP-eligible mapping (Windows
 /// soft large pages). A set bit means the region has already made its one
 /// soft-large-page widening attempt; later faults resolve to a single page to
-/// avoid a hard-fault storm. Cleared by [`VaMapper::decommit`] so a re-populated
-/// region can widen again.
+/// avoid a hard-fault storm.
 ///
 /// Allocated per range and only for THP RAM on Windows, so guests without THP —
 /// and every non-Windows guest — pay nothing.
@@ -1228,9 +1127,9 @@ impl FirstFault {
 
     /// Allocates a bitmap covering `regions` 2 MB regions with every window
     /// already marked attempted. Used for prefetched ranges: the large pages
-    /// are built eagerly at build time, so the lazy `resolve` path should not
-    /// re-widen a window until it is freed and its bit reset. Bits past
-    /// `regions` in the final word are set too, but are never indexed.
+    /// are built eagerly at build time, so the lazy `resolve` path never
+    /// re-widens a window. Bits past `regions` in the final word are set too,
+    /// but are never indexed.
     fn new_all_claimed(regions: u64) -> Self {
         let words = regions.div_ceil(64);
         Self(
@@ -1249,15 +1148,6 @@ impl FirstFault {
         match self.0.get(word) {
             Some(slot) => slot.fetch_or(bit, Ordering::Relaxed) & bit == 0,
             None => false,
-        }
-    }
-
-    /// Clears the bit for `region`.
-    fn clear(&self, region: u64) {
-        let word = (region / 64) as usize;
-        let bit = 1u64 << (region % 64);
-        if let Some(slot) = self.0.get(word) {
-            slot.fetch_and(!bit, Ordering::Relaxed);
         }
     }
 }
@@ -1291,68 +1181,6 @@ mod tests {
             zero_buf.iter().all(|&b| b == 0),
             "untouched committed memory should be zeros"
         );
-    }
-
-    /// Tests that decommitting pages releases their contents (zeros on re-read on Linux).
-    #[test]
-    fn test_private_ram_decommit_zeros() {
-        let page_size = SparseMapping::page_size();
-        let mapping = SparseMapping::new(4 * page_size).unwrap();
-
-        // Commit and write data.
-        mapping.alloc(0, 2 * page_size).unwrap();
-        let pattern = vec![0xABu8; 64];
-        mapping.write_at(0, &pattern).unwrap();
-        mapping.write_at(page_size, &pattern).unwrap();
-
-        // Decommit first page.
-        mapping.decommit(0, page_size).unwrap();
-
-        // On Linux, decommitted pages read as zeros.
-        #[cfg(unix)]
-        {
-            let mut buf = vec![0xFFu8; 64];
-            mapping.read_at(0, &mut buf).unwrap();
-            assert!(
-                buf.iter().all(|&b| b == 0),
-                "decommitted page should be zeros on Linux"
-            );
-        }
-
-        // Second page should still have its data.
-        let mut buf2 = vec![0u8; 64];
-        mapping.read_at(page_size, &mut buf2).unwrap();
-        assert_eq!(buf2, pattern);
-    }
-
-    /// Tests that recommitting pages after decommit provides zeroed memory.
-    #[test]
-    fn test_private_ram_recommit_after_decommit() {
-        let page_size = SparseMapping::page_size();
-        let mapping = SparseMapping::new(4 * page_size).unwrap();
-
-        // Commit, write, decommit, recommit.
-        mapping.alloc(0, page_size).unwrap();
-        let pattern = vec![0xCDu8; 64];
-        mapping.write_at(0, &pattern).unwrap();
-
-        mapping.decommit(0, page_size).unwrap();
-        mapping.commit(0, page_size).unwrap();
-
-        // After recommit, the page should be zeros (old data is gone).
-        let mut buf = vec![0xFFu8; 64];
-        mapping.read_at(0, &mut buf).unwrap();
-        assert!(
-            buf.iter().all(|&b| b == 0),
-            "recommitted page should be zeros"
-        );
-
-        // Can write and read new data.
-        let new_data = vec![0xEFu8; 64];
-        mapping.write_at(0, &new_data).unwrap();
-        let mut buf2 = vec![0u8; 64];
-        mapping.read_at(0, &mut buf2).unwrap();
-        assert_eq!(buf2, new_data);
     }
 
     /// Tests that commit is idempotent (committing already-committed pages is

--- a/openvmm/membacking/src/mapping_manager/va_mapper.rs
+++ b/openvmm/membacking/src/mapping_manager/va_mapper.rs
@@ -1000,9 +1000,12 @@ impl ResolveMemoryFault for VaMapper {
             ));
         }
 
-        // Widen to a 2 MB soft large page only on the first fault of a 2 MB
-        // window that both contains the whole fault and lies entirely within one
-        // THP-eligible mapping. Every re-fault of an already-attempted region
+        // Widen to a 2 MB soft large page only on the first *write* fault of a
+        // 2 MB window that both contains the whole fault and lies entirely within
+        // one THP-eligible mapping. Read faults are served read-only from the
+        // zero page and must not claim the window, so that the later first write
+        // still gets its one widening attempt (spending a large page only on the
+        // written working set). Every re-fault of an already-attempted region
         // (e.g. after the host trimmer reclaimed the pages) resolves to the
         // caller's range to avoid a hard-fault storm.
         let base = fault.start() & !(LARGE_PAGE_SIZE - 1);
@@ -1021,11 +1024,27 @@ impl ResolveMemoryFault for VaMapper {
                 UnexpectedPageFault,
             ));
         };
+        // The trait contract requires the resolved range to stay within the
+        // single uniform RAM region that covers `fault.start()`. Today the only
+        // caller faults one page at a time, so a fault never spans two mappings;
+        // guard against a future caller passing a wider range that starts in this
+        // mapping but extends past its end (`end` is the inclusive last address).
+        if fault.end() > end + 1 {
+            return Err(GuestMemoryBackingError::new(
+                GuestMemoryErrorKind::OutOfRange,
+                fault.start(),
+                UnexpectedPageFault,
+            ));
+        }
         props.stats.guest_faults.increment();
         let soft_lp = props.soft_lp.as_ref();
 
         let full_window = fault.end() <= window_end && base >= start && window_end <= end + 1;
-        let widen = full_window
+        // Only a write fault claims the window (see the widen comment above); a
+        // read fault leaves `first_fault` clear so the first write can still
+        // widen.
+        let widen = write
+            && full_window
             && soft_lp.is_some_and(|sl| {
                 sl.first_fault
                     .try_claim(base / LARGE_PAGE_SIZE - start / LARGE_PAGE_SIZE)
@@ -1086,8 +1105,6 @@ impl ResolveMemoryFault for VaMapper {
                 }
             }
         }
-        #[cfg(not(windows))]
-        let _ = write;
 
         Ok(if widen {
             MemoryRange::new(base..window_end)
@@ -1154,7 +1171,9 @@ impl FirstFault {
 
 #[cfg(test)]
 mod tests {
-
+    use super::FirstFault;
+    use super::large_region_count;
+    use memory_range::MemoryRange;
     use sparse_mmap::SparseMapping;
 
     /// Tests that private RAM pages can be allocated, written to, and read from.
@@ -1201,5 +1220,85 @@ mod tests {
         let mut buf = vec![0u8; 64];
         mapping.read_at(0, &mut buf).unwrap();
         assert_eq!(buf, pattern);
+    }
+
+    /// `try_claim` is one-shot: the first claim of a region wins and every
+    /// subsequent claim of the same region loses until it is (never) cleared.
+    #[test]
+    fn first_fault_try_claim_is_one_shot() {
+        let ff = FirstFault::new(4);
+        // First claim of each region wins.
+        for region in 0..4 {
+            assert!(ff.try_claim(region), "first claim of region {region}");
+        }
+        // Repeat claims of the same regions all lose.
+        for region in 0..4 {
+            assert!(!ff.try_claim(region), "repeat claim of region {region}");
+        }
+    }
+
+    /// Claims are independent across regions, including across the 64-bit word
+    /// boundary of the underlying bitmap.
+    #[test]
+    fn first_fault_claims_are_independent() {
+        // Enough regions to span more than one 64-bit word.
+        let ff = FirstFault::new(130);
+        assert!(ff.try_claim(0));
+        assert!(ff.try_claim(63));
+        assert!(ff.try_claim(64));
+        assert!(ff.try_claim(129));
+        // Claiming one region does not claim its neighbors.
+        assert!(ff.try_claim(1));
+        assert!(ff.try_claim(65));
+        // But the already-claimed regions stay claimed.
+        assert!(!ff.try_claim(0));
+        assert!(!ff.try_claim(64));
+    }
+
+    /// Region indices past the end of the allocated bitmap return false rather
+    /// than panicking, so a stray claim can never index out of bounds. (The
+    /// bitmap rounds up to whole 64-bit words, so indices in the final word's
+    /// padding are still claimable; callers only ever pass valid region
+    /// indices.)
+    #[test]
+    fn first_fault_out_of_range_returns_false() {
+        // One region rounds up to a single 64-bit word, so word 1 and beyond are
+        // out of range.
+        let ff = FirstFault::new(1);
+        assert!(!ff.try_claim(64));
+        assert!(!ff.try_claim(1_000_000));
+    }
+
+    /// `new_all_claimed` starts fully claimed, so no in-range window is ever
+    /// widened (used for eagerly prefetched ranges).
+    #[test]
+    fn first_fault_new_all_claimed_prevents_widening() {
+        let regions = 100;
+        let ff = FirstFault::new_all_claimed(regions);
+        for region in 0..regions {
+            assert!(
+                !ff.try_claim(region),
+                "region {region} should already be claimed"
+            );
+        }
+    }
+
+    /// `large_region_count` counts the aligned 2 MB regions a range spans by
+    /// absolute region index, so a range that straddles a 2 MB boundary spans
+    /// two regions even when it is smaller than 2 MB.
+    #[test]
+    fn large_region_count_spans() {
+        const LP: u64 = super::LARGE_PAGE_SIZE;
+        // A single page at the start of a region spans one region.
+        assert_eq!(large_region_count(MemoryRange::new(0..0x1000)), 1);
+        // A full aligned region spans one region.
+        assert_eq!(large_region_count(MemoryRange::new(0..LP)), 1);
+        // A range straddling a 2 MB boundary spans two regions.
+        assert_eq!(
+            large_region_count(MemoryRange::new(LP - 0x1000..LP + 0x1000)),
+            2
+        );
+        // Two full aligned regions span two regions.
+        assert_eq!(large_region_count(MemoryRange::new(0..2 * LP)), 2);
     }
 }

--- a/openvmm/membacking/src/memory_manager/mod.rs
+++ b/openvmm/membacking/src/memory_manager/mod.rs
@@ -568,13 +568,12 @@ impl GuestMemoryBuilder {
             None
         };
 
-        let mapping_manager = MappingManager::new(&spawner, max_addr, max_hugepage_size);
-
-        let va_mapper = mapping_manager
-            .client()
-            .new_primary_mapper() // the loader's target and the partition's fault resolver
-            .await
-            .map_err(MemoryBuildError::VaMapper)?;
+        // The primary mapper is created as part of `MappingManager::new`: it is
+        // the loader's target and the partition's fault resolver.
+        let (mapping_manager, va_mapper) =
+            MappingManager::new(&spawner, max_addr, max_hugepage_size)
+                .await
+                .map_err(MemoryBuildError::VaMapper)?;
 
         let region_manager = RegionManager::new(&spawner, mapping_manager.client().clone());
 

--- a/openvmm/membacking/src/memory_manager/mod.rs
+++ b/openvmm/membacking/src/memory_manager/mod.rs
@@ -48,7 +48,7 @@ pub struct GuestMemoryManager {
     #[inspect(flatten)]
     region_manager: RegionManager,
 
-    #[inspect(skip)]
+    #[inspect(flatten)]
     va_mapper: Arc<VaMapper>,
 
     #[inspect(skip)]
@@ -56,6 +56,10 @@ pub struct GuestMemoryManager {
 
     vtl0_alias_map_offset: Option<u64>,
     pin_mappings: bool,
+    /// Whether the partition delivers guest-memory-access faults to the VMM,
+    /// enabling on-demand fault resolution via [`VaMapper`]. Recorded here for
+    /// lazy-commit gating.
+    supports_memory_fault_resolution: bool,
 }
 
 /// A single RAM backing allocation — one memfd or anonymous region.
@@ -343,6 +347,7 @@ pub struct GuestMemoryBuilder {
     vtl0_alias_map: Option<u64>,
     pin_mappings: bool,
     x86_legacy_support: bool,
+    supports_memory_fault_resolution: bool,
     backing_requests: Vec<RamBackingRequest>,
 }
 
@@ -353,6 +358,7 @@ impl GuestMemoryBuilder {
             vtl0_alias_map: None,
             pin_mappings: false,
             x86_legacy_support: false,
+            supports_memory_fault_resolution: false,
             backing_requests: Vec::new(),
         }
     }
@@ -387,6 +393,14 @@ impl GuestMemoryBuilder {
     /// these ranges.
     pub fn x86_legacy_support(mut self, enable: bool) -> Self {
         self.x86_legacy_support = enable;
+        self
+    }
+
+    /// Records whether the partition delivers guest-memory-access faults to the
+    /// VMM, enabling on-demand fault resolution (soft large pages, lazy commit)
+    /// via [`GuestMemoryManager::memory_fault_resolver`].
+    pub fn supports_memory_fault_resolution(mut self, enable: bool) -> Self {
+        self.supports_memory_fault_resolution = enable;
         self
     }
 
@@ -462,15 +476,13 @@ impl GuestMemoryBuilder {
             max
         };
 
-        // Allocate per-backing memory and collect private ranges.
+        // Allocate per-backing memory.
         let num_backings = backing_requests.len();
         let mut backings = Vec::with_capacity(num_backings);
-        let mut private_ranges = Vec::new();
         for (i, req) in backing_requests.into_iter().enumerate() {
             let size: u64 = req.ranges.iter().map(|r| r.len()).sum();
 
             if req.private_memory {
-                private_ranges.extend_from_slice(&req.ranges);
                 backings.push(RamBacking {
                     mappable: None,
                     ranges: req.ranges,
@@ -556,12 +568,11 @@ impl GuestMemoryBuilder {
             None
         };
 
-        let mapping_manager =
-            MappingManager::new(&spawner, max_addr, private_ranges, max_hugepage_size);
+        let mapping_manager = MappingManager::new(&spawner, max_addr, max_hugepage_size);
 
         let va_mapper = mapping_manager
             .client()
-            .new_mapper(true)
+            .new_primary_mapper() // the loader's target and the partition's fault resolver
             .await
             .map_err(MemoryBuildError::VaMapper)?;
 
@@ -625,6 +636,7 @@ impl GuestMemoryBuilder {
                             MemoryPolicy {
                                 numa_node: backing.host_numa_node,
                                 transparent_hugepages: backing.transparent_hugepages,
+                                prefetch: backing.prefetch,
                             },
                         )
                         .await
@@ -663,6 +675,7 @@ impl GuestMemoryBuilder {
             va_mapper,
             vtl0_alias_map_offset,
             pin_mappings: self.pin_mappings,
+            supports_memory_fault_resolution: self.supports_memory_fault_resolution,
         };
         Ok(gm)
     }
@@ -719,6 +732,17 @@ impl GuestMemoryManager {
         GuestMemoryClient {
             mapping_manager: self.mapping_manager.client().clone(),
         }
+    }
+
+    /// Returns a resolver that prepares guest-memory backing on demand in
+    /// response to partition memory-access faults (soft large pages, lazy
+    /// commit).
+    ///
+    /// Intended for backends that report
+    /// [`virt::ProtoPartition::supports_memory_fault_resolution`]; supply the
+    /// returned resolver via [`virt::PartitionConfig::fault_resolver`].
+    pub fn memory_fault_resolver(&self) -> Arc<dyn virt::ResolveMemoryFault> {
+        self.va_mapper.clone()
     }
 
     /// Returns an object to map device memory into the VM.

--- a/openvmm/membacking/src/region_manager.rs
+++ b/openvmm/membacking/src/region_manager.rs
@@ -1234,7 +1234,7 @@ mod tests {
             }
         }
 
-        let mm = MappingManager::new(spawn, 0x200000, Vec::new(), None);
+        let mm = MappingManager::new(spawn, 0x200000, None);
         let mut task = TestTask(RegionManagerTask::new(mm.client().clone()));
 
         let high = task.add(1, 0x1000..0x3000).await.unwrap();
@@ -1265,7 +1265,7 @@ mod tests {
 
     impl DmaTestTask {
         fn new(spawn: impl Spawn) -> Self {
-            let mm = MappingManager::new(spawn, 0x200000, Vec::new(), None);
+            let mm = MappingManager::new(spawn, 0x200000, None);
             Self {
                 task: RegionManagerTask::new(mm.client().clone()),
                 mappable: test_mappable(),

--- a/openvmm/membacking/src/region_manager.rs
+++ b/openvmm/membacking/src/region_manager.rs
@@ -1234,7 +1234,7 @@ mod tests {
             }
         }
 
-        let mm = MappingManager::new(spawn, 0x200000, None);
+        let mm = MappingManager::new_without_primary(spawn, 0x200000, None);
         let mut task = TestTask(RegionManagerTask::new(mm.client().clone()));
 
         let high = task.add(1, 0x1000..0x3000).await.unwrap();
@@ -1265,7 +1265,7 @@ mod tests {
 
     impl DmaTestTask {
         fn new(spawn: impl Spawn) -> Self {
-            let mm = MappingManager::new(spawn, 0x200000, None);
+            let mm = MappingManager::new_without_primary(spawn, 0x200000, None);
             Self {
                 task: RegionManagerTask::new(mm.client().clone()),
                 mappable: test_mappable(),

--- a/openvmm/openvmm_core/src/worker/dispatch.rs
+++ b/openvmm/openvmm_core/src/worker/dispatch.rs
@@ -1075,6 +1075,11 @@ impl InitializedVm {
 
         let physical_address_size = proto.max_physical_address_size();
 
+        // Whether the partition delivers guest memory-access faults to the VMM
+        // so the memory backing can resolve them on demand (soft large pages,
+        // lazy commit).
+        let supports_memory_fault_resolution = proto.supports_memory_fault_resolution();
+
         // Determine if a special vtl2 memory allocation should be used.
         let vtl2_layout = if let LoadMode::Igvm {
             vtl2_base_address, ..
@@ -1219,6 +1224,7 @@ impl InitializedVm {
         let mut memory_builder = GuestMemoryBuilder::new();
         memory_builder = memory_builder
             .vtl0_alias_map(vtl0_alias_map)
+            .supports_memory_fault_resolution(supports_memory_fault_resolution)
             .x86_legacy_support(
                 matches!(cfg.load_mode, LoadMode::Pcat { .. }) || cfg.chipset.with_hyperv_vga,
             );
@@ -1307,6 +1313,8 @@ impl InitializedVm {
                 guest_memory: &gm,
                 cpuid: &cpuid,
                 vtl0_alias_map,
+                fault_resolver: supports_memory_fault_resolution
+                    .then(|| memory_manager.memory_fault_resolver()),
             })
             .context("failed to create the partition")?;
 

--- a/support/sparse_mmap/src/windows.rs
+++ b/support/sparse_mmap/src/windows.rs
@@ -539,9 +539,6 @@ impl SparseMapping {
         }
     }
 
-    /// Materializes a committed range into the working set, faulting the whole
-    /// range in with a single call.
-    ///
     /// Prefetches a committed range into the working set, faulting the whole
     /// range in with a single call.
     ///

--- a/support/sparse_mmap/src/windows.rs
+++ b/support/sparse_mmap/src/windows.rs
@@ -22,6 +22,7 @@ use Memory::PAGE_NOACCESS;
 use Memory::PAGE_READONLY;
 use Memory::PAGE_READWRITE;
 use Memory::PAGE_WRITECOPY;
+use Memory::PrefetchVirtualMemory;
 use Memory::SEC_COMMIT;
 use Memory::SEC_LARGE_PAGES;
 use Memory::SECTION_MAP_READ;
@@ -29,6 +30,8 @@ use Memory::SECTION_MAP_WRITE;
 use Memory::UnmapViewOfFile2;
 use Memory::VirtualAlloc2;
 use Memory::VirtualFreeEx;
+use Memory::VirtualProtectEx;
+use Memory::WIN32_MEMORY_RANGE_ENTRY;
 use pal::windows::BorrowedHandleExt;
 use pal::windows::Process;
 use parking_lot::Mutex;
@@ -129,6 +132,30 @@ unsafe fn virtual_free(
     flags: u32,
 ) -> Result<(), Error> {
     if unsafe { VirtualFreeEx(process.handle(), address, size, flags) } == 0 {
+        return Err(Error::last_os_error());
+    }
+    Ok(())
+}
+
+unsafe fn virtual_protect(
+    process: Option<&Process>,
+    address: *mut c_void,
+    size: usize,
+    page_protection: u32,
+) -> Result<(), Error> {
+    let mut old_protection = 0;
+    // SAFETY: caller guarantees `address..address + size` is a committed range
+    // within a mapping owned by this `SparseMapping`.
+    if unsafe {
+        VirtualProtectEx(
+            process.handle(),
+            address,
+            size,
+            page_protection,
+            &mut old_protection,
+        )
+    } == 0
+    {
         return Err(Error::last_os_error());
     }
     Ok(())
@@ -490,6 +517,78 @@ impl SparseMapping {
         self.virtual_alloc(offset, len, PAGE_READWRITE, numa_node)
     }
 
+    /// Changes the page protection of a committed range to `protection` (a
+    /// `PAGE_*` flag).
+    ///
+    /// The range must be committed. This does not allocate physical pages; on
+    /// Windows those are still materialized on first write.
+    pub fn protect(&self, offset: usize, len: usize, protection: u32) -> Result<(), Error> {
+        let _ = self.validate_offset_len(offset, len)?;
+        if len == 0 {
+            return Ok(());
+        }
+        // SAFETY: `validate_offset_len` confirmed the range lies within the
+        // reservation.
+        unsafe {
+            virtual_protect(
+                self.process.as_ref(),
+                self.address.wrapping_add(offset),
+                len,
+                protection,
+            )
+        }
+    }
+
+    /// Materializes a committed range into the working set, faulting the whole
+    /// range in with a single call.
+    ///
+    /// Prefetches a committed range into the working set, faulting the whole
+    /// range in with a single call.
+    ///
+    /// This is the soft-large-page primitive: faulting an entire 2 MB-aligned,
+    /// read-write window in one operation gives the OS the opportunity to back
+    /// it with a large page, which in turn allows a large second-level address
+    /// translation (SLAT) entry for a guest. Faulting the pages individually
+    /// instead tends to leave the window backed by scattered small pages. This
+    /// is best-effort: if a large page is unavailable, the range is simply
+    /// backed by small pages. The range must already be **read-write** —
+    /// prefetching a read-only range only maps the shared zero page.
+    ///
+    /// Uses the documented `PrefetchVirtualMemory` API with a flag that brings
+    /// the pages fully into the working set. That flag requires Windows 11;
+    /// older releases fail the call, so callers must treat an error as a
+    /// best-effort miss (the range stays valid, just not necessarily large-page
+    /// backed).
+    pub fn prefetch(&self, offset: usize, len: usize) -> Result<(), Error> {
+        // `PrefetchVirtualMemory` flag (Windows 11+) that brings the pages fully
+        // into the working set rather than only paging in file backing. Not yet
+        // exposed as a named constant by the `windows-sys` bindings.
+        const VM_PREFETCH_TO_WORKING_SET: u32 = 0x1;
+
+        let _ = self.validate_offset_len(offset, len)?;
+        if len == 0 {
+            return Ok(());
+        }
+        let entry = WIN32_MEMORY_RANGE_ENTRY {
+            VirtualAddress: self.address.wrapping_add(offset),
+            NumberOfBytes: len,
+        };
+        // SAFETY: calling per the API contract; `entry` describes a range that
+        // `validate_offset_len` confirmed lies within this reservation.
+        let ret = unsafe {
+            PrefetchVirtualMemory(
+                self.process.as_ref().handle(),
+                1,
+                &entry,
+                VM_PREFETCH_TO_WORKING_SET,
+            )
+        };
+        if ret == 0 {
+            return Err(Error::last_os_error());
+        }
+        Ok(())
+    }
+
     /// Maps read-only zero pages at the given offset within the mapping.
     pub fn map_zero(&self, offset: usize, len: usize) -> Result<(), Error> {
         self.virtual_alloc(offset, len, PAGE_READONLY, None)
@@ -632,18 +731,48 @@ impl SparseMapping {
         protect: u32,
         numa_node: Option<u32>,
     ) -> Result<(), Error> {
+        let access = match protect & 0xff {
+            PAGE_NOACCESS => 0,
+            PAGE_READONLY
+            | PAGE_WRITECOPY
+            | PAGE_EXECUTE
+            | PAGE_EXECUTE_READ
+            | PAGE_EXECUTE_WRITECOPY => SECTION_MAP_READ,
+            PAGE_READWRITE | PAGE_EXECUTE_READWRITE => SECTION_MAP_READ | SECTION_MAP_WRITE,
+            p => panic!("unknown protection {:#x}", p),
+        };
+        self.map_view_of_file_access(
+            offset,
+            len,
+            file_mapping,
+            file_offset,
+            protect,
+            access,
+            numa_node,
+        )
+    }
+
+    /// Maps a portion of a file mapping with an explicit section `access`
+    /// (`SECTION_MAP_*`) and page `protect` (`PAGE_*`), optionally bound to a
+    /// specific host NUMA node.
+    ///
+    /// Unlike [`map_view_of_file`](Self::map_view_of_file), which derives the
+    /// section access from the page protection, this lets the caller request
+    /// broader section access than the initial protection — e.g. a read-only
+    /// view backed by a write-capable section, so the view can later be raised
+    /// to read-write via [`protect`](Self::protect).
+    pub fn map_view_of_file_access(
+        &self,
+        offset: usize,
+        len: usize,
+        file_mapping: impl AsHandle,
+        file_offset: u64,
+        protect: u32,
+        access: u32,
+        numa_node: Option<u32>,
+    ) -> Result<(), Error> {
         assert_ne!(len, 0);
         self.map(offset, len, |addr| unsafe {
-            let access = match protect & 0xff {
-                PAGE_NOACCESS => 0,
-                PAGE_READONLY
-                | PAGE_WRITECOPY
-                | PAGE_EXECUTE
-                | PAGE_EXECUTE_READ
-                | PAGE_EXECUTE_WRITECOPY => SECTION_MAP_READ,
-                PAGE_READWRITE | PAGE_EXECUTE_READWRITE => SECTION_MAP_READ | SECTION_MAP_WRITE,
-                p => panic!("unknown protection {:#x}", p),
-            };
             let section = file_mapping.as_handle().duplicate(false, Some(access))?;
             let mut param = numa_extended_param(numa_node);
             map_view_of_file(

--- a/support/sparse_mmap/src/windows.rs
+++ b/support/sparse_mmap/src/windows.rs
@@ -770,6 +770,10 @@ impl SparseMapping {
     ) -> Result<(), Error> {
         assert_ne!(len, 0);
         self.map(offset, len, |addr| unsafe {
+            // Keep a handle for the mapping's lifetime (unmap/split re-map
+            // through it), restricted to just `access` as mild defense in depth.
+            // Either handle works for the initial map below (same section), so
+            // use the caller's original.
             let section = file_mapping.as_handle().duplicate(false, Some(access))?;
             let mut param = numa_extended_param(numa_node);
             map_view_of_file(

--- a/tmk/tmk_vmm/src/host_vmm.rs
+++ b/tmk/tmk_vmm/src/host_vmm.rs
@@ -56,6 +56,7 @@ impl RunContext<'_> {
                 guest_memory: &guest_memory,
                 cpuid: &[],
                 vtl0_alias_map: None,
+                fault_resolver: None,
             })
             .context("failed to build partition")?;
 

--- a/vmm_core/virt/src/generic.rs
+++ b/vmm_core/virt/src/generic.rs
@@ -17,6 +17,7 @@ use crate::x86::DebugState;
 use crate::x86::HardwareBreakpoint;
 use guestmem::DoorbellRegistration;
 use guestmem::GuestMemory;
+use guestmem::GuestMemoryBackingError;
 use hvdef::Vtl;
 use inspect::Inspect;
 use inspect::InspectMut;
@@ -201,6 +202,41 @@ pub struct PartitionConfig<'a> {
     /// The offset of the VTL0 alias map. This maps VTL0's view of memory into
     /// VTL2 at the specified offset (which must be a power of 2).
     pub vtl0_alias_map: Option<u64>,
+    /// An optional resolver used to prepare guest-memory backing on demand when
+    /// the partition delivers memory-access faults back to the VMM.
+    ///
+    /// This is set only when the backend reports
+    /// [`ProtoPartition::supports_memory_fault_resolution`]. The backend calls
+    /// it from its memory-fault handler to commit lazily-backed pages and to
+    /// learn the (possibly widened) GPA range to map; the backend retains the
+    /// final per-page safety decision over the returned range.
+    pub fault_resolver: Option<Arc<dyn ResolveMemoryFault>>,
+}
+
+/// Prepares guest-memory backing to resolve a memory-access fault, and reports
+/// the GPA range the partition should map in response.
+///
+/// This is implemented by the memory backing and called by hypervisor backends
+/// (e.g. WHP) that forward guest memory-access faults to the VMM. It lets the
+/// backing commit lazily-backed pages and opportunistically widen the mapped
+/// range to a large page (soft large pages), while the backend keeps the final
+/// per-page safety decision over the returned range.
+pub trait ResolveMemoryFault: Send + Sync {
+    /// Prepares backing for the faulting range `fault` and returns the GPA range
+    /// the partition should map.
+    ///
+    /// The caller passes the range it needs backed (expressed in whatever page
+    /// granularity the backend uses), so this layer never needs to know the
+    /// guest page size. The returned range is always a superset of `fault`,
+    /// clamped to a single uniform RAM region. It is widened (e.g. to 2 MB) only
+    /// on the first fault of a large-page-eligible region that fully contains
+    /// `fault`; otherwise `fault` is returned unchanged. Subsequent faults of an
+    /// already-attempted region are not widened.
+    fn resolve(
+        &self,
+        fault: MemoryRange,
+        write: bool,
+    ) -> Result<MemoryRange, GuestMemoryBackingError>;
 }
 
 /// Trait for a prototype partition, one that is partially created but still
@@ -223,6 +259,18 @@ pub trait ProtoPartition {
     /// interfaces by default, and it may be larger or smaller than what the VMM
     /// ultimately chooses to report to the guest.
     fn max_physical_address_size(&self) -> u8;
+
+    /// Whether the partition delivers guest-memory-access faults back to the
+    /// VMM and resolves them through a [`ResolveMemoryFault`] supplied in
+    /// [`PartitionConfig::fault_resolver`].
+    ///
+    /// Defaults to `false`. A backend that forwards memory faults to the VMM
+    /// (e.g. WHP) overrides this to `true`. The code assembling
+    /// [`PartitionConfig`] uses it to decide whether to supply a resolver, and
+    /// the memory backing uses it to select a lazy commit strategy.
+    fn supports_memory_fault_resolution(&self) -> bool {
+        false
+    }
 
     /// Constructs the full partition.
     fn build(

--- a/vmm_core/virt_whp/src/lib.rs
+++ b/vmm_core/virt_whp/src/lib.rs
@@ -110,6 +110,13 @@ struct WhpPartitionInner {
     mem_layout: MemoryLayout,
     #[inspect(skip)]
     gm: GuestMemory,
+    /// Resolves guest-memory-access faults on demand, letting the memory
+    /// backing commit lazily-backed pages and opportunistically widen the
+    /// mapped range to a soft large page. Set when the memory backing supplies
+    /// one via [`virt::PartitionConfig::fault_resolver`].
+    #[inspect(skip)]
+    #[cfg_attr(guest_arch = "aarch64", expect(dead_code))]
+    fault_resolver: Option<Arc<dyn virt::ResolveMemoryFault>>,
     vtl2_emulation: Option<vtl2::Vtl2Emulation>,
     #[cfg(guest_arch = "x86_64")]
     irq_routes: virt::irqcon::IrqRoutes,
@@ -959,6 +966,13 @@ impl ProtoPartition for WhpProtoPartition<'_> {
             .unwrap()
     }
 
+    fn supports_memory_fault_resolution(&self) -> bool {
+        // WHP forwards guest memory-access faults back to the VMM, so the
+        // memory backing can resolve them on demand (soft large pages, lazy
+        // commit).
+        true
+    }
+
     fn build(
         self,
         config: PartitionConfig<'_>,
@@ -1279,6 +1293,7 @@ impl WhpPartitionInner {
             vps,
             mem_layout: config.mem_layout.clone(),
             gm: config.guest_memory.clone(),
+            fault_resolver: config.fault_resolver.clone(),
             vtl2_emulation,
             #[cfg(guest_arch = "x86_64")]
             irq_routes: Default::default(),

--- a/vmm_core/virt_whp/src/memory.rs
+++ b/vmm_core/virt_whp/src/memory.rs
@@ -781,6 +781,7 @@ pub(crate) mod x86 {
     use crate::WhpPartitionInner;
     use hvdef::HV_PAGE_SIZE;
     use hvdef::Vtl;
+    use memory_range::MemoryRange;
 
     /// Different backing types for a given GPA.
     #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -822,11 +823,67 @@ pub(crate) mod x86 {
                 self.vtlp(vtl).gpa_backing_type(gpa)
             }
         }
+
+        /// Returns whether all of `range` is backed uniformly as RAM (writable
+        /// per `writable`) with no per-page exceptions inside it — no monitor
+        /// page, no higher-VTL page protections, and (on isolated partitions) no
+        /// unaccepted pages. Used to decide whether a fault can be resolved by
+        /// mapping the whole range as one soft large page instead of 4 KB.
+        ///
+        /// This answers the question with a couple of range lookups rather than
+        /// probing every page, since the backing is stored as ranges.
+        pub(crate) fn is_uniform_ram(&self, vtl: Vtl, range: MemoryRange, writable: bool) -> bool {
+            // The monitor page is a single RAM page mapped read-only so that
+            // writes keep trapping; never fold it into a large page.
+            if self
+                .monitor_page
+                .gpa()
+                .is_some_and(|gpa| range.contains_addr(gpa))
+            {
+                return false;
+            }
+
+            // A higher VTL can protect individual pages within VTL0 RAM.
+            if vtl == Vtl::Vtl0 {
+                if let Some(emu) = self.vtl2_emulation.as_ref() {
+                    let (start, end) = (range.start_4k_gpn(), range.end_4k_gpn());
+                    if emu
+                        .protected_pages
+                        .read()
+                        .iter()
+                        .any(|(pages, _)| *pages.start() < end && start <= *pages.end())
+                    {
+                        return false;
+                    }
+                }
+            }
+
+            self.vtlp(vtl).is_uniform_ram(range, writable)
+        }
     }
 
     impl VtlPartition {
         pub fn in_deferred_range(&self, gpa: u64) -> bool {
             self.mapper.in_deferred_range(gpa)
+        }
+
+        /// Returns whether all of `range` is covered by a single mapped range
+        /// with the required writability and no page-acceptance requirement. See
+        /// [`WhpPartitionInner::is_uniform_ram`].
+        fn is_uniform_ram(&self, range: MemoryRange, writable: bool) -> bool {
+            // Isolated partitions accept pages individually, so uniformity can't
+            // be assumed across a large page; fall back to per-page population.
+            if self.mapper.page_acceptance_supported() {
+                return false;
+            }
+
+            // The whole range must sit within one mapped range with the required
+            // writability. Adjacent same-writability ranges that happen not to be
+            // merged conservatively fail this and fall back to 4 KB.
+            self.ranges
+                .read()
+                .iter()
+                .any(|r| r.writable == writable && r.range.contains(&range))
         }
 
         fn gpa_backing_type(&self, gpa: u64) -> GpaBackingType {

--- a/vmm_core/virt_whp/src/vp.rs
+++ b/vmm_core/virt_whp/src/vp.rs
@@ -512,6 +512,7 @@ mod x86 {
     use hvdef::HvVtlEntryReason;
     use hvdef::HvX64VpExecutionState;
     use hvdef::Vtl;
+    use memory_range::MemoryRange;
     use thiserror::Error;
     use virt::LateMapVtl0MemoryPolicy;
     use virt::VpHaltReason;
@@ -713,11 +714,58 @@ mod x86 {
             if !access.AccessInfo.GpaUnmapped() && should_populate {
                 // This is a mapped GPA that wasn't mapped in the SLAT. Tell the
                 // kernel to populate the SLAT.
+                //
+                // By default only the faulting page is populated. For VTL0 RAM
+                // faults, ask the memory backing's fault resolver whether the
+                // range can be widened to a soft large page (2 MB). The resolver
+                // only knows RAM-region granularity, so `is_uniform_ram`
+                // confirms the widened range holds no per-page exceptions (the
+                // monitor page, a VTL-protected page, or an unaccepted page)
+                // before it is mapped as one, since those are only tracked here.
+                let mut populate = whp::abi::WHV_MEMORY_RANGE_ENTRY {
+                    GuestAddress: access.Gpa,
+                    SizeInBytes: 1,
+                };
+
+                if self.state.active_vtl == Vtl::Vtl0 {
+                    if let Some(resolver) = self.vp.partition.fault_resolver.as_ref() {
+                        let page = access.Gpa & !(hvdef::HV_PAGE_SIZE - 1);
+                        let fault = MemoryRange::new(page..page + hvdef::HV_PAGE_SIZE);
+                        let write =
+                            access.AccessInfo.AccessType() == whp::abi::WHvMemoryAccessWrite;
+                        match resolver.resolve(fault, write) {
+                            Ok(resolved) if resolved.len() > fault.len() => {
+                                // The resolver widened to a soft large page but
+                                // only knows RAM-region granularity, so confirm
+                                // the whole widened range is uniform RAM here (no
+                                // monitor page, VTL protection, or unaccepted page
+                                // hidden inside) before mapping it as one.
+                                let GpaBackingType::Ram { writable } = backing_type else {
+                                    unreachable!("should_populate implies Ram")
+                                };
+                                if self.vp.partition.is_uniform_ram(
+                                    self.state.active_vtl,
+                                    resolved,
+                                    writable,
+                                ) {
+                                    populate.GuestAddress = resolved.start();
+                                    populate.SizeInBytes = resolved.len();
+                                }
+                            }
+                            Ok(_) => {}
+                            Err(err) => {
+                                tracing::warn!(
+                                    gpa = access.Gpa,
+                                    error = ?err,
+                                    "memory fault resolver failed; populating single page"
+                                );
+                            }
+                        }
+                    }
+                }
+
                 match self.current_vtlp().whp.populate_ranges(
-                    &[whp::abi::WHV_MEMORY_RANGE_ENTRY {
-                        GuestAddress: access.Gpa,
-                        SizeInBytes: 1,
-                    }],
+                    &[populate],
                     access.AccessInfo.AccessType(),
                     Default::default(),
                 ) {

--- a/vmm_core/virt_whp/src/vp.rs
+++ b/vmm_core/virt_whp/src/vp.rs
@@ -754,7 +754,7 @@ mod x86 {
                             }
                             Ok(_) => {}
                             Err(err) => {
-                                tracing::warn!(
+                                tracelimit::warn_ratelimited!(
                                     gpa = access.Gpa,
                                     error = ?err,
                                     "memory fault resolver failed; populating single page"
@@ -774,7 +774,7 @@ mod x86 {
                         return Ok(());
                     }
                     Err(err) => {
-                        tracing::warn!(
+                        tracelimit::warn_ratelimited!(
                             gpa = access.Gpa,
                             access = ?access.AccessInfo.AccessType(),
                             error = &err as &dyn std::error::Error,


### PR DESCRIPTION
On Windows the guest RAM host mapping is committed page-by-page as the loader and guest touch it. Dribbled per-page writes leave the region backed by scattered 4 KB host pages, which forces the hypervisor to install 4 KB second-level (SLAT) entries and pay the resulting TLB and page-walk cost. This change opportunistically backs writable guest RAM with 2 MB host large pages so the hypervisor can install 2 MB SLAT entries instead.

The core mechanism is a "deferred protect" scheme in the primary VA mapper: writable, THP-eligible guest RAM is mapped read-only, and the first write to a 2 MB-aligned window raises that whole window to read-write and prefetches it in a single operation. Faulting a uniform 2 MB window all at once gives the OS the opportunity to satisfy it with a contiguous large page, whereas per-page faults tend to leave the window fragmented. Host-side writes (e.g. the loader) drive this through the page-fault path; guest writes drive it through a new fault-resolution path. Ranges marked for prefetch are populated eagerly at build time instead of lazily on first fault.

To let a hypervisor that forwards guest memory-access faults back to the VMM participate, this adds a `ResolveMemoryFault` trait, a `PartitionConfig::fault_resolver`, and a `ProtoPartition::supports_memory_fault_resolution` gate. The memory backing supplies the resolver; the backend calls it from its memory-fault handler to commit lazily-backed pages and learn the possibly-widened GPA range to map. WHP opts in: on a VTL0 RAM fault it asks the resolver whether the range can be widened, then confirms via `is_uniform_ram` that the whole widened window holds no per-page exceptions (the monitor page, a VTL-protected page, or an unaccepted page) before mapping it as one large SLAT entry, keeping the final per-page safety decision on the backend.

Because only the single mapper that the loader writes through and the partition resolves faults against drives the guest's SLAT, mappers now carry an explicit primary/secondary role; secondary mappers (guest_memory access, DMA, remote partition backing) continue to use plain 4 KB read-write pages. The private-memory "single mapper" restriction is reworked to be enforced dynamically by the mapping manager as mappers and mappings come and go, rather than being captured at construction, so private RAM can be added later (e.g. hotplug).

Adds `protect`, `prefetch`, and `map_view_of_file_access` primitives to sparse_mmap on Windows to support the above.