### PR TITLE
CVM register validation

### DIFF
--- a/openhcl/virt_mshv_vtl/src/processor/hardware_cvm/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/hardware_cvm/mod.rs
@@ -62,8 +62,22 @@ use virt_support_x86emu::translate::TranslationRegisters;
 use vm_topology::memory::AddressType;
 use vmcore::vmtime::VmTime;
 use vmcore::vmtime::VmTimeAccess;
+use x86defs::X64_CR0_CD;
+use x86defs::X64_CR0_NW;
+use x86defs::X64_CR0_PE;
+use x86defs::X64_CR0_PG;
+use x86defs::X64_CR4_LA57;
+use x86defs::X64_EFER_LMA;
+use x86defs::X64_EFER_LME;
+use x86defs::X64_EFER_NXE;
+use x86defs::X64_EFER_SCE;
+use x86defs::X64_EFER_SVME;
+use x86defs::X64_EFER_TCE;
 use x86defs::cpuid;
 use x86defs::cpuid::CpuidFunction;
+use x86defs::xsave::XSAVE_SUPERVISOR_FEATURE_CET_S;
+use x86defs::xsave::XSAVE_SUPERVISOR_FEATURE_CET_U;
+use x86defs::xsave::XSAVE_SUPERVISOR_FEATURE_PASID;
 use zerocopy::FromZeros;
 use zerocopy::IntoBytes;
 
@@ -123,6 +137,136 @@ impl Drop for RedirectedVectorMapping<'_> {
             ),
         }
     }
+}
+
+const CVM_GUEST_VA_BITS_48: u32 = 48;
+const CVM_GUEST_VA_BITS_57: u32 = 57;
+const X64_CR0_RESERVED_BITS_MASK_LOW32: u64 = 0x1FFA_FF80;
+const X64_CR0_RSVDZ1_MASK: u64 = 1 << 6;
+
+/// CR4 bits that are either reserved or unsupported for CVM guests, so must
+/// be zero.
+///
+/// - Bit 13 (VMXE), 14 (SMXE): Intel VMX / SMX, not permitted in a CVM guest.
+/// - Bit 19 (KL): Key Locker.
+/// - Bit 22 (PKE), 24 (PKS): protection keys, not supported.
+/// - Bit 25 (UINTR): user interrupts.
+/// - Bit 27 (LASS): linear-address space separation.
+/// - Bit 32 (FRED): flexible return and event delivery.
+/// - Bits 15, 26, 28-31, 33-63: architecturally reserved.
+const X64_CR4_INVALID_MASK: u64 = 0xFFFF_FFFF_FF48_E000;
+
+const X64_EFER_VALID_MASK: u64 =
+    X64_EFER_SCE | X64_EFER_LME | X64_EFER_LMA | X64_EFER_NXE | X64_EFER_SVME | X64_EFER_TCE;
+
+const SFMASK_MSR_RESERVED_MASK: u64 = 0xFFFF_FFFF_0000_0000;
+const PLX_SSP_MSR_RESERVED_MASK: u64 = 0x3;
+
+/// Corresponds to PASID (bit 10), CET_U (bit 11), and CET_S (bit 12).
+const XSS_VALID_MASK: u64 = XSAVE_SUPERVISOR_FEATURE_PASID
+    | XSAVE_SUPERVISOR_FEATURE_CET_U
+    | XSAVE_SUPERVISOR_FEATURE_CET_S;
+
+fn is_canonical(v: u64, bits: u32) -> bool {
+    let high = (v as i64) >> (bits - 1);
+    high == 0 || high == -1
+}
+
+/// Returns true if `v` is a valid linear address to load into a currently-in-
+/// use paging state whose EFER.LMA / CR4.LA57 bits are as given.
+pub(crate) fn validate_canonical_address(v: u64, efer: u64, cr4: u64) -> bool {
+    if !is_canonical(v, CVM_GUEST_VA_BITS_57) {
+        return false;
+    }
+    if is_canonical(v, CVM_GUEST_VA_BITS_48) {
+        return true;
+    }
+    (efer & X64_EFER_LMA) != 0 && (cr4 & X64_CR4_LA57) != 0
+}
+
+/// Validates a PAT MSR value: each of the 8 entries must be a valid memory
+/// type (0=UC, 1=WC, 4=WT, 5=WP, 6=WB, 7=UC-), with the top 5 bits of each
+/// byte zero.
+fn is_valid_pat(pat: u64) -> bool {
+    for i in 0..8 {
+        let byte = ((pat >> (i * 8)) & 0xFF) as u8;
+        // Top 5 bits reserved.
+        if byte & 0xF8 != 0 {
+            return false;
+        }
+        // Values 2 and 3 are reserved.
+        if byte == 2 || byte == 3 {
+            return false;
+        }
+    }
+    true
+}
+
+/// Validates a PLx_SSP MSR value: no reserved bits set, and the value is a
+/// canonical linear address.
+fn is_valid_ssp_msr(v: u64) -> bool {
+    if v & PLX_SSP_MSR_RESERVED_MASK != 0 {
+        return false;
+    }
+    is_canonical(v, CVM_GUEST_VA_BITS_57)
+}
+
+/// Validates the value being written to `msr` per the architectural
+/// constraints of the target MSR.
+///
+/// Callers must also validate MSRs that need the guest's current paging
+/// state (i.e. `MSR_FS_BASE`, `MSR_GS_BASE`) via
+/// [`validate_canonical_address`], since that check requires reading the
+/// guest's live EFER and CR4 from the backing.
+pub(crate) fn validate_cvm_msr_write(
+    msr: u32,
+    value: u64,
+    xsave: &virt::x86::XsaveCapabilities,
+) -> Result<(), MsrError> {
+    match msr {
+        x86defs::X64_MSR_KERNEL_GS_BASE
+        | x86defs::X86X_MSR_STAR
+        | x86defs::X86X_MSR_LSTAR
+        | x86defs::X86X_MSR_CSTAR
+        | x86defs::X86X_MSR_SYSENTER_EIP
+        | x86defs::X86X_MSR_SYSENTER_ESP
+        | x86defs::X86X_MSR_INTERRUPT_SSP_TABLE_ADDR => {
+            if !is_canonical(value, CVM_GUEST_VA_BITS_57) {
+                return Err(MsrError::InvalidAccess);
+            }
+        }
+        x86defs::X86X_MSR_EFER => {
+            if value & !X64_EFER_VALID_MASK != 0 {
+                return Err(MsrError::InvalidAccess);
+            }
+        }
+        x86defs::X86X_MSR_CR_PAT => {
+            if !is_valid_pat(value) {
+                return Err(MsrError::InvalidAccess);
+            }
+        }
+        x86defs::X86X_MSR_SFMASK => {
+            if value & SFMASK_MSR_RESERVED_MASK != 0 {
+                return Err(MsrError::InvalidAccess);
+            }
+        }
+        x86defs::X86X_MSR_XSS => {
+            let max_xss = (xsave.features | xsave.supervisor_features) & XSS_VALID_MASK;
+            if value & !max_xss != 0 {
+                return Err(MsrError::InvalidAccess);
+            }
+        }
+        x86defs::X86X_MSR_PL0_SSP
+        | x86defs::X86X_MSR_PL1_SSP
+        | x86defs::X86X_MSR_PL2_SSP
+        | x86defs::X86X_MSR_PL3_SSP => {
+            if !is_valid_ssp_msr(value) {
+                return Err(MsrError::InvalidAccess);
+            }
+        }
+        _ => {}
+    }
+    Ok(())
 }
 
 impl<B: HardwareIsolatedBacking> UhHypercallHandler<'_, '_, B> {
@@ -495,19 +639,107 @@ impl<B: HardwareIsolatedBacking> UhHypercallHandler<'_, '_, B> {
         }
     }
 
+    fn validate_set_vp_register_value(
+        &self,
+        vtl: GuestVtl,
+        reg: &mut hvdef::hypercall::HvRegisterAssoc,
+    ) -> HvResult<()> {
+        match HvX64RegisterName::from(reg.name) {
+            HvX64RegisterName::SysenterEsp
+            | HvX64RegisterName::SysenterEip
+            | HvX64RegisterName::Star
+            | HvX64RegisterName::Lstar
+            | HvX64RegisterName::Cstar
+            | HvX64RegisterName::KernelGsBase
+            | HvX64RegisterName::InterruptSspTableAddr => {
+                if !is_canonical(reg.value.as_u64(), CVM_GUEST_VA_BITS_57) {
+                    return Err(HvError::InvalidRegisterValue);
+                }
+            }
+
+            HvX64RegisterName::Efer => {
+                if reg.value.as_u64() & !X64_EFER_VALID_MASK != 0 {
+                    return Err(HvError::InvalidRegisterValue);
+                }
+            }
+
+            HvX64RegisterName::Pat => {
+                if !is_valid_pat(reg.value.as_u64()) {
+                    return Err(HvError::InvalidRegisterValue);
+                }
+            }
+
+            HvX64RegisterName::Sfmask => {
+                if reg.value.as_u64() & SFMASK_MSR_RESERVED_MASK != 0 {
+                    return Err(HvError::InvalidRegisterValue);
+                }
+            }
+
+            HvX64RegisterName::Xss => {
+                let xsave = &self.vp.partition.caps.xsave;
+                let max_xss = (xsave.features | xsave.supervisor_features) & XSS_VALID_MASK;
+                if reg.value.as_u64() & !max_xss != 0 {
+                    return Err(HvError::InvalidRegisterValue);
+                }
+            }
+
+            HvX64RegisterName::Pl0Ssp
+            | HvX64RegisterName::Pl1Ssp
+            | HvX64RegisterName::Pl2Ssp
+            | HvX64RegisterName::Pl3Ssp => {
+                if !is_valid_ssp_msr(reg.value.as_u64()) {
+                    return Err(HvError::InvalidRegisterValue);
+                }
+            }
+
+            HvX64RegisterName::Fs | HvX64RegisterName::Gs => {
+                let seg = hvdef::HvX64SegmentRegister::from(reg.value);
+                let regs = self.vp.backing.translation_registers(self.vp, vtl);
+                if !validate_canonical_address(seg.base, regs.efer, regs.cr4) {
+                    return Err(HvError::InvalidRegisterValue);
+                }
+            }
+
+            HvX64RegisterName::Cr0 | HvX64RegisterName::IntermediateCr0 => {
+                let mut cr0 = reg.value.as_u64();
+                cr0 &= !X64_CR0_RESERVED_BITS_MASK_LOW32;
+                // Bit 6 must be zero; PG requires PE; NW requires CD.
+                if cr0 & X64_CR0_RSVDZ1_MASK != 0
+                    || (cr0 & X64_CR0_PG != 0 && cr0 & X64_CR0_PE == 0)
+                    || (cr0 & X64_CR0_NW != 0 && cr0 & X64_CR0_CD == 0)
+                {
+                    return Err(HvError::InvalidRegisterValue);
+                }
+                reg.value = HvRegisterValue::from(cr0);
+            }
+
+            HvX64RegisterName::Cr4 | HvX64RegisterName::IntermediateCr4 => {
+                if reg.value.as_u64() & X64_CR4_INVALID_MASK != 0 {
+                    return Err(HvError::InvalidRegisterValue);
+                }
+            }
+
+            _ => {}
+        }
+
+        Ok(())
+    }
+
     fn set_vp_register(
         &mut self,
         vtl: GuestVtl,
         reg: &hvdef::hypercall::HvRegisterAssoc,
     ) -> HvResult<()> {
         self.validate_register_access(vtl, reg.name)?;
-        // TODO CVM:
-        // - when access vp state has support for single registers, clean this
-        //   up.
-        // - validate the values being set, e.g. that addresses are canonical,
-        //   that efer and pat make sense, etc. Similar validation is needed in
-        //   the write_msr path.
 
+        // Validate (and possibly normalize) the value against the target
+        // register's architectural constraints.
+        let mut reg = *reg;
+        self.validate_set_vp_register_value(vtl, &mut reg)?;
+        let reg = &reg;
+
+        // TODO CVM: when access vp state has support for single registers,
+        // clean this up.
         match HvX64RegisterName::from(reg.name) {
             HvX64RegisterName::VsmPartitionConfig => self.vp.set_vsm_partition_config(
                 HvRegisterVsmPartitionConfig::from(reg.value.as_u64()),
@@ -748,6 +980,7 @@ impl<B: HardwareIsolatedBacking> UhHypercallHandler<'_, '_, B> {
                 tracing::error!(
                     CVM_ALLOWED,
                     reg = ?reg.name,
+                    value = ?reg.value,
                     "guest invoked SetVpRegisters with unsupported register",
                 );
                 Err(HvError::InvalidParameter)
@@ -3004,5 +3237,153 @@ impl<T: HardwareIsolatedBacking> HardwareIsolatedGuestTimer<T> for VmTimeGuestTi
 
     fn sync_deadline_state(&self, _vp: &mut UhProcessor<'_, T>) {
         // No-op for software timers
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn canonical_va_check() {
+        // 48-bit canonical: also 57-bit canonical.
+        assert!(is_canonical(0, CVM_GUEST_VA_BITS_57));
+        assert!(is_canonical(0x0000_7FFF_FFFF_FFFF, CVM_GUEST_VA_BITS_57));
+        assert!(is_canonical(0xFFFF_8000_0000_0000, CVM_GUEST_VA_BITS_57));
+        assert!(is_canonical(u64::MAX, CVM_GUEST_VA_BITS_57));
+        // 57-bit canonical only (upper-half boundary of 5-level paging).
+        assert!(is_canonical(0x0000_8000_0000_0000, CVM_GUEST_VA_BITS_57));
+        assert!(is_canonical(0x00FF_FFFF_FFFF_FFFF, CVM_GUEST_VA_BITS_57));
+        assert!(is_canonical(0xFF00_0000_0000_0000, CVM_GUEST_VA_BITS_57));
+        // Not even 57-bit canonical.
+        assert!(!is_canonical(0x0100_0000_0000_0000, CVM_GUEST_VA_BITS_57));
+        assert!(!is_canonical(0xFC00_0000_0000_0000, CVM_GUEST_VA_BITS_57));
+    }
+
+    #[test]
+    fn canonical_current_paging_mode() {
+        let lma_la57 = X64_EFER_LMA;
+        let cr4_la57 = X64_CR4_LA57;
+        let cr4_no_la57 = 0;
+        // 48-bit canonical: always OK.
+        assert!(validate_canonical_address(
+            0x0000_7FFF_FFFF_FFFF,
+            lma_la57,
+            cr4_no_la57,
+        ));
+        // 57-bit canonical only, with LA57 enabled: OK.
+        assert!(validate_canonical_address(
+            0x0000_8000_0000_0000,
+            lma_la57,
+            cr4_la57,
+        ));
+        // 57-bit canonical only, with LA57 disabled: rejected.
+        assert!(!validate_canonical_address(
+            0x0000_8000_0000_0000,
+            lma_la57,
+            cr4_no_la57,
+        ));
+        // 57-bit canonical only, LA57 set but not in long mode: rejected.
+        assert!(!validate_canonical_address(
+            0x0000_8000_0000_0000,
+            0,
+            cr4_la57,
+        ));
+        // Not 57-bit canonical: always rejected.
+        assert!(!validate_canonical_address(
+            0x0100_0000_0000_0000,
+            lma_la57,
+            cr4_la57,
+        ));
+    }
+
+    #[test]
+    fn pat_validation() {
+        // Default PAT: {WB, WT, UC-, UC, WB, WT, UC-, UC}.
+        assert!(is_valid_pat(0x0007_0406_0007_0406));
+        // WC (1) and WP (5) are valid.
+        assert!(is_valid_pat(0x0505_0505_0101_0101));
+        // Reserved memory type (2).
+        assert!(!is_valid_pat(0x0000_0000_0000_0002));
+        // Reserved memory type (3).
+        assert!(!is_valid_pat(0x0000_0000_0000_0003));
+        // Top 5 bits of any byte must be zero.
+        assert!(!is_valid_pat(0x0000_0000_0000_0080));
+    }
+
+    #[test]
+    fn efer_valid_mask_covers_expected_bits() {
+        // Baseline long-mode EFER bits: LME | LMA | NXE | SCE.
+        assert_eq!(
+            (X64_EFER_SCE | X64_EFER_LME | X64_EFER_LMA | X64_EFER_NXE) & !X64_EFER_VALID_MASK,
+            0
+        );
+        // SVME is permitted (required by SNP).
+        assert_eq!(X64_EFER_SVME & !X64_EFER_VALID_MASK, 0);
+        // TCE (bit 15) is permitted, matching the Windows HCL allowlist.
+        assert_eq!(X64_EFER_TCE & !X64_EFER_VALID_MASK, 0);
+        // FFXSR (bit 14) is not permitted.
+        assert_ne!((1u64 << 14) & !X64_EFER_VALID_MASK, 0);
+        // LMSLE (bit 13) is not permitted.
+        assert_ne!((1u64 << 13) & !X64_EFER_VALID_MASK, 0);
+        // Reserved bits (bit 1) must be zero.
+        assert_ne!((1u64 << 1) & !X64_EFER_VALID_MASK, 0);
+    }
+
+    #[test]
+    fn ssp_msr_validation() {
+        assert!(is_valid_ssp_msr(0));
+        assert!(is_valid_ssp_msr(0x1000));
+        // 57-bit canonical addresses in the LA57 upper half are OK for SSPs,
+        // even though they aren't 48-bit canonical, because SSPs use the
+        // permissive `CurrentPagingMode = FALSE` variant.
+        assert!(is_valid_ssp_msr(0x0000_8000_0000_0000));
+        // Not 4-byte aligned.
+        assert!(!is_valid_ssp_msr(0x1001));
+        assert!(!is_valid_ssp_msr(0x1002));
+        // Not even 57-bit canonical.
+        assert!(!is_valid_ssp_msr(0x0100_0000_0000_0000));
+    }
+
+    #[test]
+    fn cr4_invalid_mask_covers_expected_bits() {
+        // Reserved and unsupported bits per the Windows reference:
+        // 13 VMXE, 14 SMXE, 15 rsvd, 19 KL, 22 PKE, 24 PKS, 25 UINTR,
+        // 26 rsvd, 27 LASS, 28-31 rsvd, 32 FRED, 33-63 rsvd.
+        for bit in [
+            13, 14, 15, 19, 22, 24, 25, 26, 27, 28, 29, 30, 31, 32, 47, 63,
+        ] {
+            assert!(
+                X64_CR4_INVALID_MASK & (1u64 << bit) != 0,
+                "expected CR4 bit {bit} to be invalid"
+            );
+        }
+        // Bits that CVMs must allow.
+        for bit in [0, 1, 4, 5, 7, 9, 10, 11, 16, 17, 18, 20, 21, 23] {
+            assert!(
+                X64_CR4_INVALID_MASK & (1u64 << bit) == 0,
+                "did not expect CR4 bit {bit} to be invalid"
+            );
+        }
+    }
+
+    #[test]
+    fn cr0_reserved_low32_mask_covers_expected_bits() {
+        // Silently-masked reserved bits: 7-15, 17, 19-28.
+        for bit in [7, 8, 15, 17, 19, 28] {
+            assert!(
+                X64_CR0_RESERVED_BITS_MASK_LOW32 & (1u64 << bit) != 0,
+                "expected CR0 bit {bit} to be silently masked"
+            );
+        }
+        // Bit 6 is checked separately, not silently masked.
+        assert_eq!(X64_CR0_RESERVED_BITS_MASK_LOW32 & (1u64 << 6), 0);
+        // Live bits must not be masked.
+        for bit in [0, 1, 2, 3, 4, 5, 16, 18, 29, 30, 31] {
+            assert!(
+                X64_CR0_RESERVED_BITS_MASK_LOW32 & (1u64 << bit) == 0,
+                "did not expect CR0 bit {bit} to be masked"
+            );
+        }
     }
 }

--- a/openhcl/virt_mshv_vtl/src/processor/hardware_cvm/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/hardware_cvm/mod.rs
@@ -978,7 +978,6 @@ impl<B: HardwareIsolatedBacking> UhHypercallHandler<'_, '_, B> {
                 tracing::error!(
                     CVM_ALLOWED,
                     reg = ?reg.name,
-                    value = ?reg.value,
                     "guest invoked SetVpRegisters with unsupported register",
                 );
                 Err(HvError::InvalidParameter)

--- a/openhcl/virt_mshv_vtl/src/processor/hardware_cvm/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/hardware_cvm/mod.rs
@@ -66,7 +66,9 @@ use x86defs::X64_CR0_CD;
 use x86defs::X64_CR0_NW;
 use x86defs::X64_CR0_PE;
 use x86defs::X64_CR0_PG;
+use x86defs::X64_CR0_RSVDZ_MASK;
 use x86defs::X64_CR4_LA57;
+use x86defs::X64_EFER_FFXSR;
 use x86defs::X64_EFER_LMA;
 use x86defs::X64_EFER_LME;
 use x86defs::X64_EFER_NXE;
@@ -142,8 +144,6 @@ impl Drop for RedirectedVectorMapping<'_> {
 
 const CVM_GUEST_VA_BITS_48: u32 = 48;
 const CVM_GUEST_VA_BITS_57: u32 = 57;
-const X64_CR0_RESERVED_BITS_MASK_LOW32: u64 = 0x1FFA_FF80;
-const X64_CR0_RSVDZ1_MASK: u64 = 1 << 6;
 
 /// CR4 bits that are either reserved or unsupported for CVM guests, so must
 /// be zero.
@@ -157,10 +157,19 @@ const X64_CR0_RSVDZ1_MASK: u64 = 1 << 6;
 /// - Bits 15, 26, 28-31, 33-63: architecturally reserved.
 const X64_CR4_INVALID_MASK: u64 = 0xFFFF_FFFF_FF48_E000;
 
-const X64_EFER_VALID_MASK: u64 =
-    X64_EFER_SCE | X64_EFER_LME | X64_EFER_LMA | X64_EFER_NXE | X64_EFER_SVME | X64_EFER_TCE;
+/// EFER bits allowed for a CVM guest.
+const X64_EFER_VALID_MASK: u64 = X64_EFER_SCE
+    | X64_EFER_LME
+    | X64_EFER_LMA
+    | X64_EFER_NXE
+    | X64_EFER_SVME
+    | X64_EFER_FFXSR
+    | X64_EFER_TCE;
 
+/// `IA32_FMASK` reserved bits (only low 32 are defined).
 const SFMASK_MSR_RESERVED_MASK: u64 = 0xFFFF_FFFF_0000_0000;
+
+/// `IA32_PLx_SSP` reserved bits (SSPs are 4-byte aligned).
 const PLX_SSP_MSR_RESERVED_MASK: u64 = 0x3;
 
 /// Corresponds to PASID (bit 10), CET_U (bit 11), and CET_S (bit 12).
@@ -171,13 +180,13 @@ const XSS_VALID_MASK: u64 = XSAVE_SUPERVISOR_FEATURE_PASID
 /// Returns true if `v` is a valid linear address to load into a currently-in-
 /// use paging state whose EFER.LMA / CR4.LA57 bits are as given.
 pub(crate) fn validate_canonical_address(v: u64, efer: u64, cr4: u64) -> bool {
-    if !is_canonical_address(v, CVM_GUEST_VA_BITS_57) {
-        return false;
-    }
-    if is_canonical_address(v, CVM_GUEST_VA_BITS_48) {
-        return true;
-    }
-    (efer & X64_EFER_LMA) != 0 && (cr4 & X64_CR4_LA57) != 0
+    let la57_active = (efer & X64_EFER_LMA) != 0 && (cr4 & X64_CR4_LA57) != 0;
+    let bits = if la57_active {
+        CVM_GUEST_VA_BITS_57
+    } else {
+        CVM_GUEST_VA_BITS_48
+    };
+    is_canonical_address(v, bits)
 }
 
 /// Validates a PAT MSR value: each of the 8 entries must be a valid memory
@@ -634,6 +643,10 @@ impl<B: HardwareIsolatedBacking> UhHypercallHandler<'_, '_, B> {
         }
     }
 
+    /// Validates (and possibly normalizes) the value being written to `reg`
+    /// against the target register's architectural constraints, returning the
+    /// (possibly modified) register-value pair on success. Some registers
+    /// (e.g. CR0) silently mask reserved bits matching hypervisor behavior.
     fn validate_set_vp_register_value(
         &self,
         vtl: GuestVtl,
@@ -695,10 +708,10 @@ impl<B: HardwareIsolatedBacking> UhHypercallHandler<'_, '_, B> {
             }
 
             HvX64RegisterName::Cr0 | HvX64RegisterName::IntermediateCr0 => {
+                // Writes to CR0 reserved bits in the Low 32 are silently ignored.
                 let mut cr0 = reg.value.as_u64();
-                cr0 &= !X64_CR0_RESERVED_BITS_MASK_LOW32;
-                // Bit 6 must be zero; PG requires PE; NW requires CD.
-                if cr0 & X64_CR0_RSVDZ1_MASK != 0
+                cr0 &= !X64_CR0_RSVDZ_MASK;
+                if cr0 & 0xFFFF_FFFF_0000_0000 != 0
                     || (cr0 & X64_CR0_PG != 0 && cr0 & X64_CR0_PE == 0)
                     || (cr0 & X64_CR0_NW != 0 && cr0 & X64_CR0_CD == 0)
                 {
@@ -725,11 +738,7 @@ impl<B: HardwareIsolatedBacking> UhHypercallHandler<'_, '_, B> {
         reg: &hvdef::hypercall::HvRegisterAssoc,
     ) -> HvResult<()> {
         self.validate_register_access(vtl, reg.name)?;
-
-        // Validate (and possibly normalize) the value against the target
-        // register's architectural constraints.
         let reg = self.validate_set_vp_register_value(vtl, *reg)?;
-        let reg = &reg;
 
         match HvX64RegisterName::from(reg.name) {
             HvX64RegisterName::VsmPartitionConfig => self.vp.set_vsm_partition_config(
@@ -3296,8 +3305,9 @@ mod tests {
         assert_eq!(X64_EFER_SVME & !X64_EFER_VALID_MASK, 0);
         // TCE (bit 15) is permitted, matching the Windows HCL allowlist.
         assert_eq!(X64_EFER_TCE & !X64_EFER_VALID_MASK, 0);
-        // FFXSR (bit 14) is not permitted.
-        assert_ne!((1u64 << 14) & !X64_EFER_VALID_MASK, 0);
+        // FFXSR (bit 14) is permitted (allowed by HCL on SEV; TDX rejects it
+        // separately in `write_efer`).
+        assert_eq!(X64_EFER_FFXSR & !X64_EFER_VALID_MASK, 0);
         // LMSLE (bit 13) is not permitted.
         assert_ne!((1u64 << 13) & !X64_EFER_VALID_MASK, 0);
         // Reserved bits (bit 1) must be zero.
@@ -3343,21 +3353,21 @@ mod tests {
 
     #[test]
     fn cr0_reserved_low32_mask_covers_expected_bits() {
-        // Silently-masked reserved bits: 7-15, 17, 19-28.
-        for bit in [7, 8, 15, 17, 19, 28] {
+        // Silently-masked reserved bits per the CR0 layout: 6-15, 17, 19-28.
+        for bit in [6, 7, 8, 15, 17, 19, 28] {
             assert!(
-                X64_CR0_RESERVED_BITS_MASK_LOW32 & (1u64 << bit) != 0,
+                X64_CR0_RSVDZ_MASK & (1u64 << bit) != 0,
                 "expected CR0 bit {bit} to be silently masked"
             );
         }
-        // Bit 6 is checked separately, not silently masked.
-        assert_eq!(X64_CR0_RESERVED_BITS_MASK_LOW32 & (1u64 << 6), 0);
         // Live bits must not be masked.
         for bit in [0, 1, 2, 3, 4, 5, 16, 18, 29, 30, 31] {
             assert!(
-                X64_CR0_RESERVED_BITS_MASK_LOW32 & (1u64 << bit) == 0,
+                X64_CR0_RSVDZ_MASK & (1u64 << bit) == 0,
                 "did not expect CR0 bit {bit} to be masked"
             );
         }
+        // The mask only covers the low 32 bits — the upper 32 are hard-rejected.
+        assert_eq!(X64_CR0_RSVDZ_MASK & 0xFFFF_FFFF_0000_0000, 0);
     }
 }

--- a/openhcl/virt_mshv_vtl/src/processor/hardware_cvm/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/hardware_cvm/mod.rs
@@ -75,6 +75,7 @@ use x86defs::X64_EFER_SVME;
 use x86defs::X64_EFER_TCE;
 use x86defs::cpuid;
 use x86defs::cpuid::CpuidFunction;
+use x86defs::is_canonical_address;
 use x86defs::xsave::XSAVE_SUPERVISOR_FEATURE_CET_S;
 use x86defs::xsave::XSAVE_SUPERVISOR_FEATURE_CET_U;
 use x86defs::xsave::XSAVE_SUPERVISOR_FEATURE_PASID;
@@ -167,18 +168,13 @@ const XSS_VALID_MASK: u64 = XSAVE_SUPERVISOR_FEATURE_PASID
     | XSAVE_SUPERVISOR_FEATURE_CET_U
     | XSAVE_SUPERVISOR_FEATURE_CET_S;
 
-fn is_canonical(v: u64, bits: u32) -> bool {
-    let high = (v as i64) >> (bits - 1);
-    high == 0 || high == -1
-}
-
 /// Returns true if `v` is a valid linear address to load into a currently-in-
 /// use paging state whose EFER.LMA / CR4.LA57 bits are as given.
 pub(crate) fn validate_canonical_address(v: u64, efer: u64, cr4: u64) -> bool {
-    if !is_canonical(v, CVM_GUEST_VA_BITS_57) {
+    if !is_canonical_address(v, CVM_GUEST_VA_BITS_57) {
         return false;
     }
-    if is_canonical(v, CVM_GUEST_VA_BITS_48) {
+    if is_canonical_address(v, CVM_GUEST_VA_BITS_48) {
         return true;
     }
     (efer & X64_EFER_LMA) != 0 && (cr4 & X64_CR4_LA57) != 0
@@ -208,7 +204,7 @@ fn is_valid_ssp_msr(v: u64) -> bool {
     if v & PLX_SSP_MSR_RESERVED_MASK != 0 {
         return false;
     }
-    is_canonical(v, CVM_GUEST_VA_BITS_57)
+    is_canonical_address(v, CVM_GUEST_VA_BITS_57)
 }
 
 /// Validates the value being written to `msr` per the architectural
@@ -230,7 +226,7 @@ pub(crate) fn validate_cvm_msr_write(
         | x86defs::X86X_MSR_SYSENTER_EIP
         | x86defs::X86X_MSR_SYSENTER_ESP
         | x86defs::X86X_MSR_INTERRUPT_SSP_TABLE_ADDR => {
-            if !is_canonical(value, CVM_GUEST_VA_BITS_57) {
+            if !is_canonical_address(value, CVM_GUEST_VA_BITS_57) {
                 return Err(MsrError::InvalidAccess);
             }
         }
@@ -641,8 +637,8 @@ impl<B: HardwareIsolatedBacking> UhHypercallHandler<'_, '_, B> {
     fn validate_set_vp_register_value(
         &self,
         vtl: GuestVtl,
-        reg: &mut hvdef::hypercall::HvRegisterAssoc,
-    ) -> HvResult<()> {
+        mut reg: hvdef::hypercall::HvRegisterAssoc,
+    ) -> HvResult<hvdef::hypercall::HvRegisterAssoc> {
         match HvX64RegisterName::from(reg.name) {
             HvX64RegisterName::SysenterEsp
             | HvX64RegisterName::SysenterEip
@@ -650,7 +646,7 @@ impl<B: HardwareIsolatedBacking> UhHypercallHandler<'_, '_, B> {
             | HvX64RegisterName::Cstar
             | HvX64RegisterName::KernelGsBase
             | HvX64RegisterName::InterruptSspTableAddr => {
-                if !is_canonical(reg.value.as_u64(), CVM_GUEST_VA_BITS_57) {
+                if !is_canonical_address(reg.value.as_u64(), CVM_GUEST_VA_BITS_57) {
                     return Err(HvError::InvalidRegisterValue);
                 }
             }
@@ -720,7 +716,7 @@ impl<B: HardwareIsolatedBacking> UhHypercallHandler<'_, '_, B> {
             _ => {}
         }
 
-        Ok(())
+        Ok(reg)
     }
 
     fn set_vp_register(
@@ -732,8 +728,7 @@ impl<B: HardwareIsolatedBacking> UhHypercallHandler<'_, '_, B> {
 
         // Validate (and possibly normalize) the value against the target
         // register's architectural constraints.
-        let mut reg = *reg;
-        self.validate_set_vp_register_value(vtl, &mut reg)?;
+        let reg = self.validate_set_vp_register_value(vtl, *reg)?;
         let reg = &reg;
 
         match HvX64RegisterName::from(reg.name) {
@@ -3238,22 +3233,6 @@ impl<T: HardwareIsolatedBacking> HardwareIsolatedGuestTimer<T> for VmTimeGuestTi
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn canonical_va_check() {
-        // 48-bit canonical: also 57-bit canonical.
-        assert!(is_canonical(0, CVM_GUEST_VA_BITS_57));
-        assert!(is_canonical(0x0000_7FFF_FFFF_FFFF, CVM_GUEST_VA_BITS_57));
-        assert!(is_canonical(0xFFFF_8000_0000_0000, CVM_GUEST_VA_BITS_57));
-        assert!(is_canonical(u64::MAX, CVM_GUEST_VA_BITS_57));
-        // 57-bit canonical only (upper-half boundary of 5-level paging).
-        assert!(is_canonical(0x0000_8000_0000_0000, CVM_GUEST_VA_BITS_57));
-        assert!(is_canonical(0x00FF_FFFF_FFFF_FFFF, CVM_GUEST_VA_BITS_57));
-        assert!(is_canonical(0xFF00_0000_0000_0000, CVM_GUEST_VA_BITS_57));
-        // Not even 57-bit canonical.
-        assert!(!is_canonical(0x0100_0000_0000_0000, CVM_GUEST_VA_BITS_57));
-        assert!(!is_canonical(0xFC00_0000_0000_0000, CVM_GUEST_VA_BITS_57));
-    }
 
     #[test]
     fn canonical_current_paging_mode() {

--- a/openhcl/virt_mshv_vtl/src/processor/hardware_cvm/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/hardware_cvm/mod.rs
@@ -738,8 +738,6 @@ impl<B: HardwareIsolatedBacking> UhHypercallHandler<'_, '_, B> {
         self.validate_set_vp_register_value(vtl, &mut reg)?;
         let reg = &reg;
 
-        // TODO CVM: when access vp state has support for single registers,
-        // clean this up.
         match HvX64RegisterName::from(reg.name) {
             HvX64RegisterName::VsmPartitionConfig => self.vp.set_vsm_partition_config(
                 HvRegisterVsmPartitionConfig::from(reg.value.as_u64()),

--- a/openhcl/virt_mshv_vtl/src/processor/hardware_cvm/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/hardware_cvm/mod.rs
@@ -225,7 +225,6 @@ pub(crate) fn validate_cvm_msr_write(
 ) -> Result<(), MsrError> {
     match msr {
         x86defs::X64_MSR_KERNEL_GS_BASE
-        | x86defs::X86X_MSR_STAR
         | x86defs::X86X_MSR_LSTAR
         | x86defs::X86X_MSR_CSTAR
         | x86defs::X86X_MSR_SYSENTER_EIP
@@ -647,7 +646,6 @@ impl<B: HardwareIsolatedBacking> UhHypercallHandler<'_, '_, B> {
         match HvX64RegisterName::from(reg.name) {
             HvX64RegisterName::SysenterEsp
             | HvX64RegisterName::SysenterEip
-            | HvX64RegisterName::Star
             | HvX64RegisterName::Lstar
             | HvX64RegisterName::Cstar
             | HvX64RegisterName::KernelGsBase

--- a/openhcl/virt_mshv_vtl/src/processor/snp/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/snp/mod.rs
@@ -3069,19 +3069,15 @@ impl UhProcessor<'_, SnpBacked> {
         vtl: GuestVtl,
     ) -> Result<(), MsrError> {
         hardware_cvm::validate_cvm_msr_write(msr, value, &self.partition.caps.xsave)?;
-        // MSR_FS_BASE and MSR_GS_BASE go into segment.base and are loaded on
-        // the very next VMRUN, so they need the paging-mode-aware canonical
-        // check against the guest's live EFER/CR4.
-        if matches!(msr, x86defs::X64_MSR_FS_BASE | x86defs::X64_MSR_GS_BASE) {
-            let vmsa = self.runner.vmsa(vtl);
-            if !hardware_cvm::validate_canonical_address(value, vmsa.efer(), vmsa.cr4()) {
-                return Err(MsrError::InvalidAccess);
-            }
-        }
 
         let mut vmsa = self.runner.vmsa_mut(vtl);
         match msr {
             x86defs::X64_MSR_FS_BASE => {
+                // The FS base is loaded on the very next VMRUN, so it must
+                // be canonical in the guest's current paging mode.
+                if !hardware_cvm::validate_canonical_address(value, vmsa.efer(), vmsa.cr4()) {
+                    return Err(MsrError::InvalidAccess);
+                }
                 let fs = vmsa.fs();
                 vmsa.set_fs(SevSelector {
                     attrib: fs.attrib,
@@ -3091,6 +3087,11 @@ impl UhProcessor<'_, SnpBacked> {
                 });
             }
             x86defs::X64_MSR_GS_BASE => {
+                // The GS base is loaded on the very next VMRUN, so it must
+                // be canonical in the guest's current paging mode.
+                if !hardware_cvm::validate_canonical_address(value, vmsa.efer(), vmsa.cr4()) {
+                    return Err(MsrError::InvalidAccess);
+                }
                 let gs = vmsa.gs();
                 vmsa.set_gs(SevSelector {
                     attrib: gs.attrib,

--- a/openhcl/virt_mshv_vtl/src/processor/snp/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/snp/mod.rs
@@ -3068,8 +3068,17 @@ impl UhProcessor<'_, SnpBacked> {
         value: u64,
         vtl: GuestVtl,
     ) -> Result<(), MsrError> {
-        // TODO SNP: validation on the values being set, e.g. checking addresses
-        // are canonical, etc.
+        hardware_cvm::validate_cvm_msr_write(msr, value, &self.partition.caps.xsave)?;
+        // MSR_FS_BASE and MSR_GS_BASE go into segment.base and are loaded on
+        // the very next VMRUN, so they need the paging-mode-aware canonical
+        // check against the guest's live EFER/CR4.
+        if matches!(msr, x86defs::X64_MSR_FS_BASE | x86defs::X64_MSR_GS_BASE) {
+            let vmsa = self.runner.vmsa(vtl);
+            if !hardware_cvm::validate_canonical_address(value, vmsa.efer(), vmsa.cr4()) {
+                return Err(MsrError::InvalidAccess);
+            }
+        }
+
         let mut vmsa = self.runner.vmsa_mut(vtl);
         match msr {
             x86defs::X64_MSR_FS_BASE => {

--- a/openhcl/virt_mshv_vtl/src/processor/tdx/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/tdx/mod.rs
@@ -2840,6 +2840,8 @@ impl UhProcessor<'_, TdxBacked> {
     }
 
     fn write_msr_tdx(&mut self, msr: u32, value: u64, vtl: GuestVtl) -> Result<(), MsrError> {
+        hardware_cvm::validate_cvm_msr_write(msr, value, &self.partition.caps.xsave)?;
+
         let state = &mut self.backing.vtls[vtl].private_regs;
 
         match msr {

--- a/openhcl/virt_mshv_vtl/src/processor/tdx/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/tdx/mod.rs
@@ -95,6 +95,7 @@ use x86defs::X64_EFER_LMA;
 use x86defs::X64_EFER_LME;
 use x86defs::X64_EFER_NXE;
 use x86defs::X64_EFER_SVME;
+use x86defs::X64_EFER_TCE;
 use x86defs::X86X_MSR_EFER;
 use x86defs::apic::X2APIC_MSR_BASE;
 use x86defs::tdx::TdCallResultCode;
@@ -3269,11 +3270,11 @@ impl UhProcessor<'_, TdxBacked> {
     /// Note that a caller must also call [`Self::update_execution_mode`] after
     /// updating EFER.
     fn write_efer(&mut self, vtl: GuestVtl, efer: u64) -> Result<(), vp_state::Error> {
-        if efer & (X64_EFER_SVME | X64_EFER_FFXSR) != 0 {
+        if efer & (X64_EFER_SVME | X64_EFER_FFXSR | X64_EFER_TCE) != 0 {
             return Err(vp_state::Error::InvalidValue(
                 efer,
                 "EFER",
-                "SVME or FFXSR set",
+                "SVME, FFXSR, or TCE set",
             ));
         }
 

--- a/openhcl/virt_mshv_vtl/src/processor/tdx/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/tdx/mod.rs
@@ -95,7 +95,6 @@ use x86defs::X64_EFER_LMA;
 use x86defs::X64_EFER_LME;
 use x86defs::X64_EFER_NXE;
 use x86defs::X64_EFER_SVME;
-use x86defs::X64_EFER_TCE;
 use x86defs::X86X_MSR_EFER;
 use x86defs::apic::X2APIC_MSR_BASE;
 use x86defs::tdx::TdCallResultCode;
@@ -3270,11 +3269,11 @@ impl UhProcessor<'_, TdxBacked> {
     /// Note that a caller must also call [`Self::update_execution_mode`] after
     /// updating EFER.
     fn write_efer(&mut self, vtl: GuestVtl, efer: u64) -> Result<(), vp_state::Error> {
-        if efer & (X64_EFER_SVME | X64_EFER_FFXSR | X64_EFER_TCE) != 0 {
+        if efer & (X64_EFER_SVME | X64_EFER_FFXSR) != 0 {
             return Err(vp_state::Error::InvalidValue(
                 efer,
                 "EFER",
-                "SVME, FFXSR, or TCE set",
+                "SVME or FFXSR set",
             ));
         }
 

--- a/vm/x86/x86defs/src/lib.rs
+++ b/vm/x86/x86defs/src/lib.rs
@@ -36,6 +36,9 @@ pub const X64_CR0_NW: u64 = 0x0000000020000000; // not write-through
 pub const X64_CR0_CD: u64 = 0x0000000040000000; // cache disable
 pub const X64_CR0_PG: u64 = 0x0000000080000000; // paging
 
+/// Reserved bits in the low 32 of CR0 (bits 6-15, 17, 19-28).
+pub const X64_CR0_RSVDZ_MASK: u64 = 0x1FFA_FFC0;
+
 pub const X64_CR4_VME: u64 = 0x0000000000000001; // Virtual 8086 mode extensions
 pub const X64_CR4_PVI: u64 = 0x0000000000000002; // Protected mode virtual interrupts
 pub const X64_CR4_TSD: u64 = 0x0000000000000004; // Time stamp disable

--- a/vm/x86/x86defs/src/lib.rs
+++ b/vm/x86/x86defs/src/lib.rs
@@ -63,6 +63,7 @@ pub const X64_EFER_LMA: u64 = 0x0000000000000400; // Long Mode Active
 pub const X64_EFER_NXE: u64 = 0x0000000000000800; // No-execute Enable
 pub const X64_EFER_SVME: u64 = 0x0000000000001000; // SVM enable
 pub const X64_EFER_FFXSR: u64 = 0x0000000000004000; // Fast save/restore enabled
+pub const X64_EFER_TCE: u64 = 0x0000000000008000; // Translation Cache Extension enable
 
 pub const X86X_MSR_DEFAULT_PAT: u64 = 0x0007040600070406;
 pub const X64_EMPTY_DR7: u64 = 0x0000000000000400;

--- a/vm/x86/x86defs/src/lib.rs
+++ b/vm/x86/x86defs/src/lib.rs
@@ -70,6 +70,14 @@ pub const X64_EMPTY_DR7: u64 = 0x0000000000000400;
 
 pub const USER_MODE_DPL: u8 = 3;
 
+/// Returns true if `v` is a canonical linear address for a paging mode with
+/// `bits` effective virtual address bits (48 or 57): the top `64 - bits` bits
+/// must be a sign-extension of the highest used bit.
+pub fn is_canonical_address(v: u64, bits: u32) -> bool {
+    let high = (v as i64) >> (bits - 1);
+    high == 0 || high == -1
+}
+
 pub const X64_DEFAULT_CODE_SEGMENT_ATTRIBUTES: SegmentAttributes = SegmentAttributes::new()
     .with_granularity(true)
     .with_long(true)

--- a/vmm_core/virt_support_x86emu/src/translate.rs
+++ b/vmm_core/virt_support_x86emu/src/translate.rs
@@ -21,6 +21,7 @@ use x86defs::X64_CR4_SMAP;
 use x86defs::X64_CR4_SMEP;
 use x86defs::X64_EFER_LMA;
 use x86defs::X64_EFER_NXE;
+use x86defs::is_canonical_address;
 
 /// Registers needed to walk the page table.
 #[derive(Debug, Clone)]
@@ -411,18 +412,10 @@ pub fn translate_gva_to_gpa(
     })
 }
 
-/// Returns whether a virtual address is canonical. On x86-64, this means that
-/// the N top unused bits are equal to the top used bit, where N is 64 minus the
-/// number of effective address bits (48 or 57).
-fn is_canonical_address(gva: u64, address_bits: u32) -> bool {
-    // Shift out the address bits that aren't part of the check, sign extending.
-    // This makes the subsequent check an easy comparison.
-    let high_bits = (gva as i64) >> (address_bits - 1);
-    high_bits == 0 || high_bits == -1
-}
-
 #[cfg(test)]
 mod tests {
+    use x86defs::is_canonical_address;
+
     #[test]
     fn test_canonical() {
         let cases = &[
@@ -441,7 +434,7 @@ mod tests {
 
         for &(addr, bits, is_canonical) in cases {
             assert_eq!(
-                super::is_canonical_address(addr, bits),
+                is_canonical_address(addr, bits),
                 is_canonical,
                 "{addr:#x} {bits}"
             );


### PR DESCRIPTION
Add per-register / per-MSR validation on the SetVpRegisters and WRMSR paths to help prevent invalid VMSA state which cause failures at VMRUN