### PR TITLE
pal_async: fix macOS panic when awaiting an exited child

### DIFF
--- a/support/pal/pal_async/src/process.rs
+++ b/support/pal/pal_async/src/process.rs
@@ -372,20 +372,16 @@ mod tests {
         std::process::ExitStatus::from_raw(0)
     }
 
-    /// macOS `NOTE_EXIT` can fire before `waitpid` can reap. A latched-ready
-    /// backend with a transient-`None` reap must re-poll to completion, never
-    /// panic; re-polling the backend (calls == 2) guards the latching invariant.
+    /// macOS `NOTE_EXIT` can fire before `waitpid` can reap, so `try_wait`
+    /// transiently returns `None`. The shared poll must re-poll (Pending +
+    /// wake) rather than panic, then complete once the reap succeeds.
     #[test]
     fn macos_reap_race_repolls_then_completes() {
         let waker = Arc::new(CountingWaker(AtomicUsize::new(0)));
-        let raw_waker: Waker = waker.clone().into();
-        let mut cx = Context::from_waker(&raw_waker);
+        let task_waker: Waker = waker.clone().into();
+        let mut cx = Context::from_waker(&task_waker);
 
-        let poll_exit_calls = AtomicUsize::new(0);
-        let mut poll_exit = |_: &mut Context<'_>| {
-            poll_exit_calls.fetch_add(1, Ordering::Relaxed);
-            Poll::Ready(Ok(()))
-        };
+        let mut poll_exit = |_: &mut Context<'_>| Poll::Ready(Ok(()));
         let mut try_calls = 0;
         let mut try_wait = || {
             try_calls += 1;
@@ -401,11 +397,6 @@ mod tests {
             Poll::Ready(Ok(status)) => assert!(status.success()),
             other => panic!("expected ready success, got {other:?}"),
         }
-        assert_eq!(
-            poll_exit_calls.load(Ordering::Relaxed),
-            2,
-            "backend must be re-polled on retry (latching invariant)"
-        );
     }
 
     /// Linux/Windows: ready implies reapable, so this completes on the first
@@ -413,8 +404,8 @@ mod tests {
     #[test]
     fn ready_and_reapable_completes_without_repoll() {
         let waker = Arc::new(CountingWaker(AtomicUsize::new(0)));
-        let raw_waker: Waker = waker.clone().into();
-        let mut cx = Context::from_waker(&raw_waker);
+        let task_waker: Waker = waker.clone().into();
+        let mut cx = Context::from_waker(&task_waker);
 
         let mut poll_exit = |_: &mut Context<'_>| Poll::Ready(Ok(()));
         let mut try_wait = || Ok(Some(success_status()));
@@ -435,8 +426,8 @@ mod tests {
     #[test]
     fn pending_before_exit_does_not_reap() {
         let waker = Arc::new(CountingWaker(AtomicUsize::new(0)));
-        let raw_waker: Waker = waker.clone().into();
-        let mut cx = Context::from_waker(&raw_waker);
+        let task_waker: Waker = waker.clone().into();
+        let mut cx = Context::from_waker(&task_waker);
 
         let mut poll_exit = |_: &mut Context<'_>| Poll::Pending;
         let try_calls = AtomicUsize::new(0);

--- a/support/pal/pal_async/src/process.rs
+++ b/support/pal/pal_async/src/process.rs
@@ -58,19 +58,66 @@ impl<C> PolledChild<C> {
     }
 }
 
-/// Polls the wait backend for process exit, then calls `try_wait`.
+/// Polls the wait backend for exit, then reaps via `try_wait`.
 ///
-/// This is the shared implementation of `PolledChild::poll_wait` for all
-/// child-process types.
+/// Backend readiness does not universally imply reapability:
+/// - Linux (pidfd) and Windows (handle) report ready only once reapable.
+/// - macOS (kqueue `NOTE_EXIT`) can fire *before* the child is reapable via
+///   `waitpid`, so `try_wait` briefly returns `None`.
+///
+/// Backends latch their one-shot exit event, so on that race we re-poll to
+/// completion rather than panicking.
 fn poll_child_exit(
     cx: &mut Context<'_>,
-    wait: &mut Option<crate::sys::process::WaitInner>,
+    mut poll_exit: impl FnMut(&mut Context<'_>) -> Poll<io::Result<()>>,
     mut try_wait: impl FnMut() -> io::Result<Option<std::process::ExitStatus>>,
 ) -> Poll<io::Result<std::process::ExitStatus>> {
-    if let Some(w) = wait {
-        ready!(w.poll_exit(cx))?;
+    ready!(poll_exit(cx))?;
+    match try_wait()? {
+        Some(status) => Poll::Ready(Ok(status)),
+        // macOS: signaled but not yet reapable; re-poll (the backend stays latched).
+        None => {
+            cx.waker().wake_by_ref();
+            Poll::Pending
+        }
     }
-    Ok(try_wait()?.expect("wait backend signaled readiness but process has not exited")).into()
+}
+
+/// Generates the `poll_wait`/`wait` surface for a concrete child type.
+///
+/// `PolledChild<C>` is generic, but its two child types --
+/// [`std::process::Child`] and `pal::unix::process::Child` -- share only a
+/// compatible inherent `try_wait`, not a common trait, so the (otherwise
+/// identical) wait logic is stamped out per type rather than written
+/// generically.
+macro_rules! impl_polled_child_wait {
+    ($child:ty) => {
+        impl PolledChild<$child> {
+            /// Polls for the child process to exit.
+            pub fn poll_wait(
+                &mut self,
+                cx: &mut Context<'_>,
+            ) -> Poll<io::Result<std::process::ExitStatus>> {
+                let wait = &mut self.wait;
+                let child = &mut self.child;
+                poll_child_exit(
+                    cx,
+                    |cx| match wait {
+                        Some(w) => w.poll_exit(cx),
+                        None => Poll::Ready(Ok(())),
+                    },
+                    || child.try_wait(),
+                )
+            }
+
+            /// Waits for the child process to exit.
+            pub fn wait(
+                &mut self,
+            ) -> impl '_ + Unpin + Future<Output = io::Result<std::process::ExitStatus>> {
+                poll_fn(move |cx| self.poll_wait(cx))
+            }
+        }
+    };
 }
 
 // --- std::process::Child ---
@@ -80,22 +127,9 @@ impl PolledChild<std::process::Child> {
     pub fn new(driver: &(impl ?Sized + Driver), child: std::process::Child) -> io::Result<Self> {
         Self::new_inner(driver, child)
     }
-
-    /// Polls for the child process to exit.
-    pub fn poll_wait(
-        &mut self,
-        cx: &mut Context<'_>,
-    ) -> Poll<io::Result<std::process::ExitStatus>> {
-        poll_child_exit(cx, &mut self.wait, || self.child.try_wait())
-    }
-
-    /// Waits for the child process to exit.
-    pub fn wait(
-        &mut self,
-    ) -> impl '_ + Unpin + Future<Output = io::Result<std::process::ExitStatus>> {
-        poll_fn(move |cx| self.poll_wait(cx))
-    }
 }
+
+impl_polled_child_wait!(std::process::Child);
 
 // --- pal::unix::process::Child ---
 
@@ -108,22 +142,10 @@ impl PolledChild<pal::unix::process::Child> {
     ) -> io::Result<Self> {
         Self::new_inner(driver, child)
     }
-
-    /// Polls for the child process to exit.
-    pub fn poll_wait(
-        &mut self,
-        cx: &mut Context<'_>,
-    ) -> Poll<io::Result<std::process::ExitStatus>> {
-        poll_child_exit(cx, &mut self.wait, || self.child.try_wait())
-    }
-
-    /// Waits for the child process to exit.
-    pub fn wait(
-        &mut self,
-    ) -> impl '_ + Unpin + Future<Output = io::Result<std::process::ExitStatus>> {
-        poll_fn(move |cx| self.poll_wait(cx))
-    }
 }
+
+#[cfg(unix)]
+impl_polled_child_wait!(pal::unix::process::Child);
 
 // --- pal::windows::Process ---
 
@@ -317,5 +339,122 @@ mod windows {
                 child,
             })
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Arc;
+    use std::sync::atomic::AtomicUsize;
+    use std::sync::atomic::Ordering;
+    use std::task::Wake;
+    use std::task::Waker;
+
+    struct CountingWaker(AtomicUsize);
+
+    impl Wake for CountingWaker {
+        fn wake(self: Arc<Self>) {
+            self.wake_by_ref();
+        }
+        fn wake_by_ref(self: &Arc<Self>) {
+            self.0.fetch_add(1, Ordering::Relaxed);
+        }
+    }
+
+    /// A successful `ExitStatus` without spawning a process: `from_raw(0)` is a
+    /// zero wait-status on unix and exit code 0 on windows.
+    fn success_status() -> std::process::ExitStatus {
+        #[cfg(unix)]
+        use std::os::unix::process::ExitStatusExt;
+        #[cfg(windows)]
+        use std::os::windows::process::ExitStatusExt;
+        std::process::ExitStatus::from_raw(0)
+    }
+
+    /// macOS `NOTE_EXIT` can fire before `waitpid` can reap. A latched-ready
+    /// backend with a transient-`None` reap must re-poll to completion, never
+    /// panic; re-polling the backend (calls == 2) guards the latching invariant.
+    #[test]
+    fn macos_reap_race_repolls_then_completes() {
+        let waker = Arc::new(CountingWaker(AtomicUsize::new(0)));
+        let raw_waker: Waker = waker.clone().into();
+        let mut cx = Context::from_waker(&raw_waker);
+
+        let poll_exit_calls = AtomicUsize::new(0);
+        let mut poll_exit = |_: &mut Context<'_>| {
+            poll_exit_calls.fetch_add(1, Ordering::Relaxed);
+            Poll::Ready(Ok(()))
+        };
+        let mut try_calls = 0;
+        let mut try_wait = || {
+            try_calls += 1;
+            Ok((try_calls > 1).then(success_status))
+        };
+
+        // First poll: signaled but not yet reapable -> Pending + wake.
+        assert!(poll_child_exit(&mut cx, &mut poll_exit, &mut try_wait).is_pending());
+        assert_eq!(waker.0.load(Ordering::Relaxed), 1);
+
+        // Second poll: reap now succeeds.
+        match poll_child_exit(&mut cx, &mut poll_exit, &mut try_wait) {
+            Poll::Ready(Ok(status)) => assert!(status.success()),
+            other => panic!("expected ready success, got {other:?}"),
+        }
+        assert_eq!(
+            poll_exit_calls.load(Ordering::Relaxed),
+            2,
+            "backend must be re-polled on retry (latching invariant)"
+        );
+    }
+
+    /// Linux/Windows: ready implies reapable, so this completes on the first
+    /// poll with no self-wake.
+    #[test]
+    fn ready_and_reapable_completes_without_repoll() {
+        let waker = Arc::new(CountingWaker(AtomicUsize::new(0)));
+        let raw_waker: Waker = waker.clone().into();
+        let mut cx = Context::from_waker(&raw_waker);
+
+        let mut poll_exit = |_: &mut Context<'_>| Poll::Ready(Ok(()));
+        let mut try_wait = || Ok(Some(success_status()));
+
+        match poll_child_exit(&mut cx, &mut poll_exit, &mut try_wait) {
+            Poll::Ready(Ok(status)) => assert!(status.success()),
+            other => panic!("expected ready success, got {other:?}"),
+        }
+        assert_eq!(
+            waker.0.load(Ordering::Relaxed),
+            0,
+            "a reapable child must not trigger a re-poll"
+        );
+    }
+
+    /// Until the backend signals exit, poll stays Pending: no reap is attempted
+    /// and the task is not self-woken (the backend owns the wakeup).
+    #[test]
+    fn pending_before_exit_does_not_reap() {
+        let waker = Arc::new(CountingWaker(AtomicUsize::new(0)));
+        let raw_waker: Waker = waker.clone().into();
+        let mut cx = Context::from_waker(&raw_waker);
+
+        let mut poll_exit = |_: &mut Context<'_>| Poll::Pending;
+        let try_calls = AtomicUsize::new(0);
+        let mut try_wait = || {
+            try_calls.fetch_add(1, Ordering::Relaxed);
+            Ok(Some(success_status()))
+        };
+
+        assert!(poll_child_exit(&mut cx, &mut poll_exit, &mut try_wait).is_pending());
+        assert_eq!(
+            try_calls.load(Ordering::Relaxed),
+            0,
+            "must not reap before the backend signals exit"
+        );
+        assert_eq!(
+            waker.0.load(Ordering::Relaxed),
+            0,
+            "the backend owns the wakeup while pending"
+        );
     }
 }

--- a/support/pal/pal_async/src/process.rs
+++ b/support/pal/pal_async/src/process.rs
@@ -376,7 +376,7 @@ mod tests {
     /// transiently returns `None`. The shared poll must re-poll (Pending +
     /// wake) rather than panic, then complete once the reap succeeds.
     #[test]
-    fn macos_reap_race_repolls_then_completes() {
+    fn ready_but_unreapable_repolls_then_completes() {
         let waker = Arc::new(CountingWaker(AtomicUsize::new(0)));
         let task_waker: Waker = waker.clone().into();
         let mut cx = Context::from_waker(&task_waker);

--- a/support/pal/pal_async/src/process.rs
+++ b/support/pal/pal_async/src/process.rs
@@ -58,66 +58,27 @@ impl<C> PolledChild<C> {
     }
 }
 
-/// Polls the wait backend for exit, then reaps via `try_wait`.
+/// Polls the wait backend for the exit notification, then reaps the child.
 ///
-/// Backend readiness does not universally imply reapability:
-/// - Linux (pidfd) and Windows (handle) report ready only once reapable.
-/// - macOS (kqueue `NOTE_EXIT`) can fire *before* the child is reapable via
-///   `waitpid`, so `try_wait` briefly returns `None`.
+/// `reap` performs a *blocking* wait. On Linux (pidfd) and Windows (handle)
+/// the backend only signals once the child is reapable, so the wait returns
+/// immediately. On macOS the kqueue `NOTE_EXIT` notification can arrive a few
+/// microseconds before `waitpid` can reap the child, so the wait blocks for
+/// that brief, kernel-bounded window (XNU delivers `NOTE_EXIT` while the
+/// process is exiting, with only a few non-blocking teardown steps remaining)
+/// rather than spinning on a non-blocking `try_wait`.
 ///
-/// Backends latch their one-shot exit event, so on that race we re-poll to
-/// completion rather than panicking.
+/// This is the shared implementation of `PolledChild::poll_wait` for all
+/// child-process types.
 fn poll_child_exit(
     cx: &mut Context<'_>,
-    mut poll_exit: impl FnMut(&mut Context<'_>) -> Poll<io::Result<()>>,
-    mut try_wait: impl FnMut() -> io::Result<Option<std::process::ExitStatus>>,
+    wait: &mut Option<crate::sys::process::WaitInner>,
+    reap: impl FnOnce() -> io::Result<std::process::ExitStatus>,
 ) -> Poll<io::Result<std::process::ExitStatus>> {
-    ready!(poll_exit(cx))?;
-    match try_wait()? {
-        Some(status) => Poll::Ready(Ok(status)),
-        // macOS: signaled but not yet reapable; re-poll (the backend stays latched).
-        None => {
-            cx.waker().wake_by_ref();
-            Poll::Pending
-        }
+    if let Some(w) = wait {
+        ready!(w.poll_exit(cx))?;
     }
-}
-
-/// Generates the `poll_wait`/`wait` surface for a concrete child type.
-///
-/// `PolledChild<C>` is generic, but its two child types --
-/// [`std::process::Child`] and `pal::unix::process::Child` -- share only a
-/// compatible inherent `try_wait`, not a common trait, so the (otherwise
-/// identical) wait logic is stamped out per type rather than written
-/// generically.
-macro_rules! impl_polled_child_wait {
-    ($child:ty) => {
-        impl PolledChild<$child> {
-            /// Polls for the child process to exit.
-            pub fn poll_wait(
-                &mut self,
-                cx: &mut Context<'_>,
-            ) -> Poll<io::Result<std::process::ExitStatus>> {
-                let wait = &mut self.wait;
-                let child = &mut self.child;
-                poll_child_exit(
-                    cx,
-                    |cx| match wait {
-                        Some(w) => w.poll_exit(cx),
-                        None => Poll::Ready(Ok(())),
-                    },
-                    || child.try_wait(),
-                )
-            }
-
-            /// Waits for the child process to exit.
-            pub fn wait(
-                &mut self,
-            ) -> impl '_ + Unpin + Future<Output = io::Result<std::process::ExitStatus>> {
-                poll_fn(move |cx| self.poll_wait(cx))
-            }
-        }
-    };
+    Poll::Ready(reap())
 }
 
 // --- std::process::Child ---
@@ -127,9 +88,22 @@ impl PolledChild<std::process::Child> {
     pub fn new(driver: &(impl ?Sized + Driver), child: std::process::Child) -> io::Result<Self> {
         Self::new_inner(driver, child)
     }
-}
 
-impl_polled_child_wait!(std::process::Child);
+    /// Polls for the child process to exit.
+    pub fn poll_wait(
+        &mut self,
+        cx: &mut Context<'_>,
+    ) -> Poll<io::Result<std::process::ExitStatus>> {
+        poll_child_exit(cx, &mut self.wait, || self.child.wait())
+    }
+
+    /// Waits for the child process to exit.
+    pub fn wait(
+        &mut self,
+    ) -> impl '_ + Unpin + Future<Output = io::Result<std::process::ExitStatus>> {
+        poll_fn(move |cx| self.poll_wait(cx))
+    }
+}
 
 // --- pal::unix::process::Child ---
 
@@ -142,10 +116,22 @@ impl PolledChild<pal::unix::process::Child> {
     ) -> io::Result<Self> {
         Self::new_inner(driver, child)
     }
-}
 
-#[cfg(unix)]
-impl_polled_child_wait!(pal::unix::process::Child);
+    /// Polls for the child process to exit.
+    pub fn poll_wait(
+        &mut self,
+        cx: &mut Context<'_>,
+    ) -> Poll<io::Result<std::process::ExitStatus>> {
+        poll_child_exit(cx, &mut self.wait, || self.child.wait())
+    }
+
+    /// Waits for the child process to exit.
+    pub fn wait(
+        &mut self,
+    ) -> impl '_ + Unpin + Future<Output = io::Result<std::process::ExitStatus>> {
+        poll_fn(move |cx| self.poll_wait(cx))
+    }
+}
 
 // --- pal::windows::Process ---
 
@@ -339,113 +325,5 @@ mod windows {
                 child,
             })
         }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use std::sync::Arc;
-    use std::sync::atomic::AtomicUsize;
-    use std::sync::atomic::Ordering;
-    use std::task::Wake;
-    use std::task::Waker;
-
-    struct CountingWaker(AtomicUsize);
-
-    impl Wake for CountingWaker {
-        fn wake(self: Arc<Self>) {
-            self.wake_by_ref();
-        }
-        fn wake_by_ref(self: &Arc<Self>) {
-            self.0.fetch_add(1, Ordering::Relaxed);
-        }
-    }
-
-    /// A successful `ExitStatus` without spawning a process: `from_raw(0)` is a
-    /// zero wait-status on unix and exit code 0 on windows.
-    fn success_status() -> std::process::ExitStatus {
-        #[cfg(unix)]
-        use std::os::unix::process::ExitStatusExt;
-        #[cfg(windows)]
-        use std::os::windows::process::ExitStatusExt;
-        std::process::ExitStatus::from_raw(0)
-    }
-
-    /// macOS `NOTE_EXIT` can fire before `waitpid` can reap, so `try_wait`
-    /// transiently returns `None`. The shared poll must re-poll (Pending +
-    /// wake) rather than panic, then complete once the reap succeeds.
-    #[test]
-    fn ready_but_unreapable_repolls_then_completes() {
-        let waker = Arc::new(CountingWaker(AtomicUsize::new(0)));
-        let task_waker: Waker = waker.clone().into();
-        let mut cx = Context::from_waker(&task_waker);
-
-        let mut poll_exit = |_: &mut Context<'_>| Poll::Ready(Ok(()));
-        let mut try_calls = 0;
-        let mut try_wait = || {
-            try_calls += 1;
-            Ok((try_calls > 1).then(success_status))
-        };
-
-        // First poll: signaled but not yet reapable -> Pending + wake.
-        assert!(poll_child_exit(&mut cx, &mut poll_exit, &mut try_wait).is_pending());
-        assert_eq!(waker.0.load(Ordering::Relaxed), 1);
-
-        // Second poll: reap now succeeds.
-        match poll_child_exit(&mut cx, &mut poll_exit, &mut try_wait) {
-            Poll::Ready(Ok(status)) => assert!(status.success()),
-            other => panic!("expected ready success, got {other:?}"),
-        }
-    }
-
-    /// Linux/Windows: ready implies reapable, so this completes on the first
-    /// poll with no self-wake.
-    #[test]
-    fn ready_and_reapable_completes_without_repoll() {
-        let waker = Arc::new(CountingWaker(AtomicUsize::new(0)));
-        let task_waker: Waker = waker.clone().into();
-        let mut cx = Context::from_waker(&task_waker);
-
-        let mut poll_exit = |_: &mut Context<'_>| Poll::Ready(Ok(()));
-        let mut try_wait = || Ok(Some(success_status()));
-
-        match poll_child_exit(&mut cx, &mut poll_exit, &mut try_wait) {
-            Poll::Ready(Ok(status)) => assert!(status.success()),
-            other => panic!("expected ready success, got {other:?}"),
-        }
-        assert_eq!(
-            waker.0.load(Ordering::Relaxed),
-            0,
-            "a reapable child must not trigger a re-poll"
-        );
-    }
-
-    /// Until the backend signals exit, poll stays Pending: no reap is attempted
-    /// and the task is not self-woken (the backend owns the wakeup).
-    #[test]
-    fn pending_before_exit_does_not_reap() {
-        let waker = Arc::new(CountingWaker(AtomicUsize::new(0)));
-        let task_waker: Waker = waker.clone().into();
-        let mut cx = Context::from_waker(&task_waker);
-
-        let mut poll_exit = |_: &mut Context<'_>| Poll::Pending;
-        let try_calls = AtomicUsize::new(0);
-        let mut try_wait = || {
-            try_calls.fetch_add(1, Ordering::Relaxed);
-            Ok(Some(success_status()))
-        };
-
-        assert!(poll_child_exit(&mut cx, &mut poll_exit, &mut try_wait).is_pending());
-        assert_eq!(
-            try_calls.load(Ordering::Relaxed),
-            0,
-            "must not reap before the backend signals exit"
-        );
-        assert_eq!(
-            waker.0.load(Ordering::Relaxed),
-            0,
-            "the backend owns the wakeup while pending"
-        );
     }
 }


### PR DESCRIPTION
## Symptom
On macOS, awaiting a spawned child process can panic and abort the whole
process when the child exits.

## Root cause
`poll_child_exit` awaits the platform exit notification, then reaps the child.
It assumed that once the backend signals exit the child is immediately
reapable, and `.expect()`-ed the reap. That holds on Linux (pidfd) and Windows
(handle), but on macOS the kqueue `EVFILT_PROC`/`NOTE_EXIT` notification can be
delivered a few microseconds before `waitpid` can reap the child, so a
non-blocking `try_wait()` transiently returns `Ok(None)` — tripping the
`.expect()` and aborting.

## Fix
After the exit notification, reap with a blocking `wait()` rather than a
non-blocking `try_wait()`. On Linux/Windows the backend only signals once the
child is reapable, so the wait returns immediately; on macOS it blocks only for
XNU's brief, bounded post-`NOTE_EXIT` cleanup window.

This is correct by construction — a blocking `wait()` cannot observe the
not-yet-reapable state the old `.expect()` aborted on. The reap is a cold path
(once per child, at exit, gated behind the async notification), so a brief
bounded block there is preferable to spinning.

Thanks to @jstarks for the review suggestion to use a blocking wait.

## Testing
`cargo test -p pal_async` — including the cross-backend `process_tests`, which
exercise `PolledChild` reap on every executor backend (kqueue/macOS,
epoll & io_uring/Linux, IOCP/Windows) — plus `cargo clippy --all-targets` and
`cargo xtask fmt`.
