### PR TITLE
vmm_tests: re-enable the storvsp OpenHCL UEFI test

### DIFF
--- a/vmm_tests/vmm_tests/tests/tests/x86_64/storage.rs
+++ b/vmm_tests/vmm_tests/tests/tests/x86_64/storage.rs
@@ -176,10 +176,7 @@ async fn test_storage_linux(
 /// vmbus relay. This should expose two disks to VTL0 via vmbus.
 #[openvmm_test(
     openhcl_linux_direct_x64,
-    ignore(
-        reason = "pipette issues on this config (microsoft/openvmm#2039)",
-        openhcl_uefi_x64(vhd(ubuntu_2504_server_x64))
-    )
+    openhcl_uefi_x64(vhd(ubuntu_2504_server_x64))
 )]
 async fn storvsp(config: PetriVmBuilder<OpenVmmPetriBackend>) -> Result<(), anyhow::Error> {
     const NVME_INSTANCE: Guid = guid::guid!("dce4ebad-182f-46c0-8d30-8446c1c62ab3");


### PR DESCRIPTION
The storvsp test's `openhcl_uefi_x64` Ubuntu config was ignored due to pipette issues (microsoft/openvmm#2039). That problem is now resolved, so drop the ignore wrapper to restore coverage for this configuration.
