### PR TITLE
petri: Create more windows tempfiles in temp dirs

### DIFF
--- a/petri/src/vm/hyperv/mod.rs
+++ b/petri/src/vm/hyperv/mod.rs
@@ -391,7 +391,10 @@ impl PetriVmmBackend for HyperVPetriBackend {
             && matches!(properties.os_flavor, OsFlavor::Windows)
             && !properties.is_isolated
         {
-            let mut imc_hive_file = tempfile::NamedTempFile::new().context("creating tempfile")?;
+            let mut imc_hive_file = tempfile::Builder::new()
+                .prefix("imc-")
+                .tempfile_in(temp_dir.path())
+                .context("creating IMC hive tempfile")?;
             imc_hive_file
                 .write_all(include_bytes!("../../../guest-bootstrap/imc.hiv"))
                 .context("failed to write imc hive")?;
@@ -405,8 +408,10 @@ impl PetriVmmBackend for HyperVPetriBackend {
             .openhcl_config()
             .and_then(|c| c.vtl2_settings.as_ref())
         {
-            let mut vtl2_settings_file =
-                tempfile::NamedTempFile::new().context("creating tempfile")?;
+            let mut vtl2_settings_file = tempfile::Builder::new()
+                .prefix("vtl2-settings-")
+                .tempfile_in(temp_dir.path())
+                .context("creating VTL2 settings tempfile")?;
             vtl2_settings_file
                 .write_all(serde_json::to_string(vtl2_settings)?.as_bytes())
                 .context("writing settings to tempfile")?;

--- a/petri/src/vm/hyperv/powershell.rs
+++ b/petri/src/vm/hyperv/powershell.rs
@@ -2020,7 +2020,11 @@ pub async fn run_set_base_vtl2_settings(
 ) -> anyhow::Result<()> {
     // Pass the settings via a file to avoid challenges escaping the string across
     // the command line.
-    let mut tempfile = NamedTempFile::new().context("creating tempfile")?;
+    let temp_dir = ps_mod.parent().unwrap();
+    let mut tempfile = tempfile::Builder::new()
+        .prefix("base-vtl2-settings-")
+        .tempfile_in(temp_dir)
+        .context("creating base VTL2 settings tempfile")?;
     tempfile
         .write_all(serde_json::to_string(vtl2_settings)?.as_bytes())
         .context("writing settings to tempfile")?;


### PR DESCRIPTION
We've seen a few runs where tempfile creation has failed with ACCESS_DENIED. I can't think of any reason for this other than colliding with another test's tempfile. This PR finds cases where we're not creating files in our per-test temp directory and fixes them to do so, which should make collisions impossible. If I'm wrong about the cause this shouldn't have any downsides, and we'll try something else.