### PR TITLE
openhcl_boot: handle multi-NUMA private pool fallback

### DIFF
--- a/openhcl/openhcl_boot/src/cmdline.rs
+++ b/openhcl/openhcl_boot/src/cmdline.rs
@@ -34,6 +34,13 @@ const SIDECAR: &str = "OPENHCL_SIDECAR=";
 /// Disable NVME keep alive regardless if the host supports it.
 const DISABLE_NVME_KEEP_ALIVE: &str = "OPENHCL_DISABLE_NVME_KEEP_ALIVE=";
 
+/// Control NUMA allocation behavior for the VTL2 GPA pool.
+///
+/// * `split`: Force the pool to be split evenly across NUMA nodes, skipping
+///   the default "try node 0 first" fast path. Useful for testing multi-range
+///   pool allocation.
+const VTL2_GPA_POOL_NUMA: &str = "OPENHCL_VTL2_GPA_POOL_NUMA=";
+
 /// Lookup table to use for VTL2 GPA pool size heuristics.
 #[derive(Debug, PartialEq, Clone, Copy)]
 pub enum Vtl2GpaPoolLookupTable {
@@ -115,6 +122,9 @@ pub struct BootCommandLineOptions {
     pub enable_vtl2_gpa_pool: Vtl2GpaPoolConfig,
     pub sidecar: SidecarOptions,
     pub disable_nvme_keep_alive: bool,
+    /// When true, force the VTL2 GPA pool to be split evenly across NUMA
+    /// nodes instead of trying to allocate entirely on node 0 first.
+    pub vtl2_gpa_pool_numa_split: bool,
 }
 
 impl BootCommandLineOptions {
@@ -124,6 +134,7 @@ impl BootCommandLineOptions {
             enable_vtl2_gpa_pool: Vtl2GpaPoolConfig::Heuristics(Vtl2GpaPoolLookupTable::Release), // use the release config by default
             sidecar: SidecarOptions::default(),
             disable_nvme_keep_alive: false,
+            vtl2_gpa_pool_numa_split: false,
         }
     }
 }
@@ -175,6 +186,13 @@ impl BootCommandLineOptions {
                 let arg = arg.split_once('=').map(|(_, arg)| arg);
                 if arg.is_some_and(|a| a != "0") {
                     self.disable_nvme_keep_alive = true;
+                }
+            } else if arg.starts_with(VTL2_GPA_POOL_NUMA) {
+                if let Some((_, arg)) = arg.split_once('=') {
+                    match arg {
+                        "split" => self.vtl2_gpa_pool_numa_split = true,
+                        _ => log!("WARNING: Unknown value for OPENHCL_VTL2_GPA_POOL_NUMA: {arg}"),
+                    }
                 }
             }
         }

--- a/openhcl/openhcl_boot/src/host_params/dt/mod.rs
+++ b/openhcl/openhcl_boot/src/host_params/dt/mod.rs
@@ -26,6 +26,7 @@ use crate::memory::AllocationType;
 use crate::single_threaded::OffStackRef;
 use crate::single_threaded::off_stack;
 use alloc::vec::Vec;
+use arrayvec::ArrayString;
 use arrayvec::ArrayVec;
 use bump_alloc::ALLOCATOR;
 use core::cmp::max;
@@ -73,6 +74,146 @@ pub enum DtError {
     /// Host provided MMIO range is insufficient to cover VTL2.
     #[error("host provided MMIO range is insufficient to cover VTL2")]
     NotEnoughVtl2Mmio,
+}
+
+/// Allocate the private pool across NUMA nodes.
+///
+/// By default, tries to allocate the entire pool on NUMA node 0 (preserving
+/// previous behavior). If that fails, or if `force_numa_split` is true, the
+/// pool is split evenly across all available NUMA nodes (one range per node).
+fn allocate_private_pool(
+    address_space: &mut AddressSpaceManager,
+    vtl2_ram: &[MemoryEntry],
+    pool_size_bytes: u64,
+    force_numa_split: bool,
+    enable_vtl2_gpa_pool: crate::cmdline::Vtl2GpaPoolConfig,
+    device_dma_page_count: Option<u64>,
+    vp_count: usize,
+    mem_size: u64,
+) {
+    // Try allocating the entire pool on node 0 first. We do this to maintain
+    // compatibility with older openhcl_boot images that do not understand how
+    // to handle a split private pool, and to maintain previous behavior where
+    // the pool was completely allocated on numa node 0.
+    //
+    // Allocate from high memory downward to avoid overlapping any used ranges
+    // in low memory when openhcl's usage gets bigger, as otherwise the
+    // used_range by the bootshim could overlap the pool range chosen when
+    // servicing to a new image.
+    if !force_numa_split {
+        if let Some(pool) = address_space.allocate(
+            Some(0),
+            pool_size_bytes,
+            AllocationType::GpaPool,
+            AllocationPolicy::HighMemory,
+        ) {
+            log!("allocated VTL2 pool at {:#x?}", pool.range);
+            return;
+        }
+        log!("node 0 cannot fit full pool, splitting across NUMA nodes");
+    } else {
+        log!("forcing VTL2 pool NUMA split across nodes");
+    }
+
+    // Enumerate unique NUMA nodes from VTL2 RAM.
+    //
+    // FUTURE: Handle cases where the are CPU only or RAM only numa nodes.
+    let mut numa_nodes = off_stack!(ArrayVec<u32, MAX_NUMA_NODES>, ArrayVec::new_const());
+    for entry in vtl2_ram.iter() {
+        match numa_nodes.binary_search(&entry.vnode) {
+            Ok(_) => {}
+            Err(index) => {
+                numa_nodes.insert(index, entry.vnode);
+            }
+        }
+    }
+
+    let num_nodes = numa_nodes.len() as u64;
+    // Split the per node size to page size aligned chunks, and give the
+    // remainder to the last node.
+    let per_node_size = (pool_size_bytes / num_nodes) & !(HV_PAGE_SIZE - 1);
+    let last_node_size = pool_size_bytes - per_node_size * (num_nodes - 1);
+    let mut remaining = pool_size_bytes;
+
+    // If per-node-size is zero, we're in some strange configuration. We should
+    // have been able to allocate this from a single node, as this would mean
+    // the number of nodes is larger than the number of pages requested for the
+    // pool, so fail explicitly.
+    if per_node_size == 0 {
+        panic!(
+            "cannot split VTL2 pool of size {pool_size_bytes:#x} bytes across \
+            {num_nodes} nodes, per node size {per_node_size:#x} bytes; \
+            enable_vtl2_gpa_pool={enable_vtl2_gpa_pool:?}, \
+            device_dma_page_count={device_dma_page_count:#x?}, \
+            vp_count={vp_count}, mem_size={mem_size:#x}"
+        );
+    }
+
+    for (i, vnode) in numa_nodes.iter().enumerate() {
+        if remaining == 0 {
+            break;
+        }
+
+        let is_last = i == numa_nodes.len() - 1;
+        let alloc_size = if is_last {
+            last_node_size
+        } else {
+            per_node_size
+        };
+
+        // Make sure to allocate high memory downward, for the same reason as
+        // described in the numa 0 case.
+        match address_space.allocate(
+            Some(*vnode),
+            alloc_size,
+            AllocationType::GpaPool,
+            AllocationPolicy::HighMemory,
+        ) {
+            Some(pool) => {
+                remaining -= pool.range.len();
+                log!(
+                    "allocated VTL2 pool on node {} at {:#x?}",
+                    vnode,
+                    pool.range
+                );
+            }
+            None => {
+                let mut free_ranges = off_stack!(ArrayString<2048>, ArrayString::new_const());
+                for node in numa_nodes.iter() {
+                    for range in address_space.free_ranges(*node) {
+                        if write!(
+                            free_ranges,
+                            "n{}:[{:#x?}, {:#x?}) ",
+                            node,
+                            range.start(),
+                            range.end()
+                        )
+                        .is_err()
+                        {
+                            let _ = write!(free_ranges, "...");
+                            break;
+                        }
+                    }
+                }
+                let highest_numa_node = vtl2_ram.iter().map(|e| e.vnode).max().unwrap_or(0);
+                panic!(
+                    "failed to allocate VTL2 pool on node {vnode}: \
+                     need {alloc_size:#x} bytes, pool total {pool_size_bytes:#x} bytes \
+                     (enable_vtl2_gpa_pool={enable_vtl2_gpa_pool:?}, \
+                     device_dma_page_count={device_dma_page_count:#x?}, \
+                     vp_count={vp_count}, mem_size={mem_size:#x}), \
+                     highest_numa_node={highest_numa_node}, \
+                     free_ranges=[ {}]",
+                    free_ranges.as_str()
+                );
+            }
+        }
+    }
+
+    assert_eq!(
+        remaining, 0,
+        "pool allocation arithmetic error: {remaining:#x} bytes unallocated"
+    );
 }
 
 /// Allocate VTL2 ram from the partition's memory map.
@@ -575,27 +716,16 @@ fn topology_from_host_dt(
             // ranges to figure out which VTL2 memory is free to allocate from.
             let pool_size_bytes = vtl2_gpa_pool_size * HV_PAGE_SIZE;
 
-            // NOTE: For now, allocate all the private pool on NUMA node 0 to
-            // match previous behavior. Allocate from high memory downward to
-            // avoid overlapping any used ranges in low memory when openhcl's
-            // usage gets bigger, as otherwise the used_range by the bootshim
-            // could overlap the pool range chosen, when servicing to a new
-            // image.
-            match address_space.allocate(
-                Some(0),
+            allocate_private_pool(
+                address_space,
+                &vtl2_ram,
                 pool_size_bytes,
-                AllocationType::GpaPool,
-                AllocationPolicy::HighMemory,
-            ) {
-                Some(pool) => {
-                    log!("allocated VTL2 pool at {:#x?}", pool.range);
-                }
-                None => {
-                    panic!(
-                        "failed to allocate VTL2 pool of size {pool_size_bytes:#x} bytes (enable_vtl2_gpa_pool={enable_vtl2_gpa_pool:?}, device_dma_page_count={device_dma_page_count:#x?}, vp_count={vp_count}, mem_size={mem_size:#x})"
-                    );
-                }
-            };
+                options.vtl2_gpa_pool_numa_split,
+                enable_vtl2_gpa_pool,
+                device_dma_page_count,
+                vp_count,
+                mem_size,
+            );
         }
     }
 
@@ -750,22 +880,15 @@ fn topology_from_persisted_state(
     // allocated vtl2 pool. Today, we do not allocate a new/larger pool if the
     // command line arguments or host device tree changed, as that's not
     // something we expect to happen in practice.
-    let mut pool_ranges = partition_memory.iter().filter_map(|entry| {
+    let pool_ranges = partition_memory.iter().filter_map(|entry| {
         if entry.vtl_type == MemoryVtlType::VTL2_GPA_POOL {
             Some(entry.range)
         } else {
             None
         }
     });
-    let pool_range = pool_ranges.next();
-    assert!(
-        pool_ranges.next().is_none(),
-        "previous instance had multiple pool ranges"
-    );
 
-    if let Some(pool_range) = pool_range {
-        address_space_builder = address_space_builder.with_pool_range(pool_range);
-    }
+    address_space_builder = address_space_builder.with_pool_ranges(pool_ranges);
 
     // As described above, other ranges come from this current boot.
     address_space_builder = add_common_ranges(params, address_space_builder);

--- a/openhcl/openhcl_boot/src/memory.rs
+++ b/openhcl/openhcl_boot/src/memory.rs
@@ -3,7 +3,9 @@
 
 //! Address space allocator for VTL2 memory used by the bootshim.
 
+use crate::host_params::MAX_NUMA_NODES;
 use crate::host_params::MAX_VTL2_RAM_RANGES;
+use crate::single_threaded::off_stack;
 use arrayvec::ArrayVec;
 use host_fdt_parser::MemoryEntry;
 #[cfg(test)]
@@ -39,7 +41,6 @@ pub enum ReservedMemoryType {
     SidecarNode,
     /// Persistent VTL2 memory used for page allocations in usermode. This
     /// memory is persisted, both location and contents, across servicing.
-    /// Today, we only support a single range.
     Vtl2GpaPool,
     /// Page tables that are used for AP startup, on TDX.
     TdxPageTables,
@@ -138,7 +139,7 @@ pub struct AddressSpaceManagerBuilder<'a, I: Iterator<Item = MemoryRange>> {
     sidecar_image: Option<MemoryRange>,
     page_tables: Option<MemoryRange>,
     log_buffer: Option<MemoryRange>,
-    pool_range: Option<MemoryRange>,
+    pool_ranges: ArrayVec<MemoryRange, MAX_NUMA_NODES>,
 }
 
 impl<'a, I: Iterator<Item = MemoryRange>> AddressSpaceManagerBuilder<'a, I> {
@@ -171,7 +172,7 @@ impl<'a, I: Iterator<Item = MemoryRange>> AddressSpaceManagerBuilder<'a, I> {
             sidecar_image: None,
             page_tables: None,
             log_buffer: None,
-            pool_range: None,
+            pool_ranges: ArrayVec::new(),
         }
     }
 
@@ -194,8 +195,16 @@ impl<'a, I: Iterator<Item = MemoryRange>> AddressSpaceManagerBuilder<'a, I> {
     }
 
     /// Existing VTL2 GPA pool ranges, reported as type [`MemoryVtlType::VTL2_GPA_POOL`].
-    pub fn with_pool_range(mut self, pool_range: MemoryRange) -> Self {
-        self.pool_range = Some(pool_range);
+    ///
+    /// # Panics
+    ///
+    /// Panics if called more than once.
+    pub fn with_pool_ranges(mut self, pool_ranges: impl Iterator<Item = MemoryRange>) -> Self {
+        assert!(
+            self.pool_ranges.is_empty(),
+            "pool ranges already set on builder"
+        );
+        self.pool_ranges.extend(pool_ranges);
         self
     }
 
@@ -211,7 +220,7 @@ impl<'a, I: Iterator<Item = MemoryRange>> AddressSpaceManagerBuilder<'a, I> {
             sidecar_image,
             page_tables,
             log_buffer,
-            pool_range,
+            pool_ranges,
         } = self;
 
         if vtl2_ram.len() > MAX_VTL2_RAM_RANGES {
@@ -232,7 +241,9 @@ impl<'a, I: Iterator<Item = MemoryRange>> AddressSpaceManagerBuilder<'a, I> {
             persisted_state_region.split_at_offset(PAGE_SIZE_4K);
 
         // The other ranges are reserved, and must overlap with the used range.
-        let mut reserved: ArrayVec<(MemoryRange, ReservedMemoryType), 20> = ArrayVec::new();
+        const MAX_RESERVED_RANGES: usize = 20;
+        let mut reserved = off_stack!(ArrayVec<(MemoryRange, ReservedMemoryType), MAX_RESERVED_RANGES>, ArrayVec::new_const());
+        reserved.clear();
         reserved.push((persisted_header, ReservedMemoryType::PersistedStateHeader));
         reserved.push((persisted_payload, ReservedMemoryType::PersistedStatePayload));
         reserved.extend(vtl2_config.map(|r| (r, ReservedMemoryType::Vtl2Config)));
@@ -258,7 +269,11 @@ impl<'a, I: Iterator<Item = MemoryRange>> AddressSpaceManagerBuilder<'a, I> {
         );
         reserved.sort_unstable_by_key(|(r, _)| r.start());
 
-        let mut used_ranges: ArrayVec<(MemoryRange, AddressUsage), 13> = ArrayVec::new();
+        // Maximum number of used ranges is reserved ranges, plus any allocated
+        // pool ranges (one per node maximally).
+        const MAX_USED_RANGES: usize = MAX_RESERVED_RANGES + MAX_NUMA_NODES;
+        let mut used_ranges = off_stack!(ArrayVec<(MemoryRange, AddressUsage), MAX_USED_RANGES>, ArrayVec::new_const());
+        used_ranges.clear();
 
         // Construct initial used ranges by walking both the bootshim_used range
         // and all reserved ranges that overlap.
@@ -284,8 +299,8 @@ impl<'a, I: Iterator<Item = MemoryRange>> AddressSpaceManagerBuilder<'a, I> {
             }
         }
 
-        // Add any existing pool range as reserved.
-        if let Some(range) = pool_range {
+        // Add any existing pool ranges as reserved.
+        for range in pool_ranges {
             used_ranges.push((
                 range,
                 AddressUsage::Reserved(ReservedMemoryType::Vtl2GpaPool),
@@ -334,6 +349,16 @@ impl AddressSpaceManager {
             address_space: ArrayVec::new_const(),
             vtl2_pool: false,
         }
+    }
+
+    pub fn free_ranges(&self, vnode: u32) -> impl Iterator<Item = MemoryRange> + use<'_> {
+        self.address_space.iter().filter_map(move |r| {
+            if r.usage == AddressUsage::Free && r.vnode == vnode {
+                Some(r.range)
+            } else {
+                None
+            }
+        })
     }
 
     /// Split a free range into two, with allocation policy deciding if we
@@ -1025,5 +1050,210 @@ mod tests {
         }
     }
 
-    // FIXME: test pool ranges
+    // Tests for multi-NUMA pool range support in the builder.
+
+    #[test]
+    fn test_single_pool_range() {
+        let mut address_space = AddressSpaceManager::new_const();
+        let vtl2_ram = &[MemoryEntry {
+            range: MemoryRange::new(0x0..0x20000),
+            vnode: 0,
+            mem_type: MemoryMapEntryType::MEMORY,
+        }];
+
+        AddressSpaceManagerBuilder::new(
+            &mut address_space,
+            vtl2_ram,
+            MemoryRange::new(0x0..0x4000),
+            MemoryRange::new(0x0..0x2000),
+            core::iter::empty(),
+        )
+        .with_pool_ranges([MemoryRange::new(0x10000..0x18000)].into_iter())
+        .init()
+        .unwrap();
+
+        assert!(address_space.has_vtl2_pool());
+
+        // Pool range should be reserved.
+        let reserved: Vec<_> = address_space.reserved_vtl2_ranges().collect();
+        assert!(
+            reserved
+                .iter()
+                .any(|(r, t)| *r == MemoryRange::new(0x10000..0x18000)
+                    && *t == ReservedMemoryType::Vtl2GpaPool)
+        );
+    }
+
+    #[test]
+    fn test_multiple_pool_ranges() {
+        let mut address_space = AddressSpaceManager::new_const();
+        let vtl2_ram = &[
+            MemoryEntry {
+                range: MemoryRange::new(0x0..0x20000),
+                vnode: 0,
+                mem_type: MemoryMapEntryType::MEMORY,
+            },
+            MemoryEntry {
+                range: MemoryRange::new(0x100000..0x120000),
+                vnode: 1,
+                mem_type: MemoryMapEntryType::MEMORY,
+            },
+        ];
+
+        AddressSpaceManagerBuilder::new(
+            &mut address_space,
+            vtl2_ram,
+            MemoryRange::new(0x0..0x4000),
+            MemoryRange::new(0x0..0x2000),
+            core::iter::empty(),
+        )
+        .with_pool_ranges(
+            [
+                MemoryRange::new(0x10000..0x18000),
+                MemoryRange::new(0x110000..0x118000),
+            ]
+            .into_iter(),
+        )
+        .init()
+        .unwrap();
+
+        assert!(address_space.has_vtl2_pool());
+
+        // Both pool ranges should be reserved.
+        let reserved: Vec<_> = address_space
+            .reserved_vtl2_ranges()
+            .filter(|(_, t)| *t == ReservedMemoryType::Vtl2GpaPool)
+            .collect();
+        assert_eq!(reserved.len(), 2);
+        assert_eq!(reserved[0].0, MemoryRange::new(0x10000..0x18000));
+        assert_eq!(reserved[1].0, MemoryRange::new(0x110000..0x118000));
+    }
+
+    #[test]
+    fn test_allocate_pool_single_numa_node() {
+        // With a single NUMA node, pool should be allocated as one range on
+        // node 0 (regardless of force_split, since there's only one node).
+        let mut address_space = AddressSpaceManager::new_const();
+        let vtl2_ram = &[MemoryEntry {
+            range: MemoryRange::new(0x0..0x100000),
+            vnode: 0,
+            mem_type: MemoryMapEntryType::MEMORY,
+        }];
+
+        AddressSpaceManagerBuilder::new(
+            &mut address_space,
+            vtl2_ram,
+            MemoryRange::new(0x0..0x4000),
+            MemoryRange::new(0x0..0x2000),
+            core::iter::empty(),
+        )
+        .init()
+        .unwrap();
+
+        // Allocate pool on node 0.
+        let pool = address_space
+            .allocate(
+                Some(0),
+                0x10000,
+                AllocationType::GpaPool,
+                AllocationPolicy::HighMemory,
+            )
+            .unwrap();
+        assert_eq!(pool.vnode, 0);
+        assert_eq!(pool.range.len(), 0x10000);
+        assert!(address_space.has_vtl2_pool());
+    }
+
+    #[test]
+    fn test_allocate_pool_two_numa_nodes_node0_fits() {
+        // With 2 NUMA nodes and enough space on node 0, pool should be
+        // allocated entirely on node 0.
+        let mut address_space = AddressSpaceManager::new_const();
+        let vtl2_ram = &[
+            MemoryEntry {
+                range: MemoryRange::new(0x0..0x100000),
+                vnode: 0,
+                mem_type: MemoryMapEntryType::MEMORY,
+            },
+            MemoryEntry {
+                range: MemoryRange::new(0x200000..0x300000),
+                vnode: 1,
+                mem_type: MemoryMapEntryType::MEMORY,
+            },
+        ];
+
+        AddressSpaceManagerBuilder::new(
+            &mut address_space,
+            vtl2_ram,
+            MemoryRange::new(0x0..0x4000),
+            MemoryRange::new(0x0..0x2000),
+            core::iter::empty(),
+        )
+        .init()
+        .unwrap();
+
+        // Node 0 has plenty of free space, so the pool fits entirely on node 0.
+        let pool = address_space
+            .allocate(
+                Some(0),
+                0x10000,
+                AllocationType::GpaPool,
+                AllocationPolicy::HighMemory,
+            )
+            .unwrap();
+        assert_eq!(pool.vnode, 0);
+        assert_eq!(pool.range.len(), 0x10000);
+    }
+
+    #[test]
+    fn test_allocate_pool_two_numa_nodes_node0_exhausted() {
+        // Node 0 has no free space after bootshim. Pool must come from node 1.
+        let mut address_space = AddressSpaceManager::new_const();
+        let vtl2_ram = &[
+            MemoryEntry {
+                range: MemoryRange::new(0x0..0x4000),
+                vnode: 0,
+                mem_type: MemoryMapEntryType::MEMORY,
+            },
+            MemoryEntry {
+                range: MemoryRange::new(0x200000..0x300000),
+                vnode: 1,
+                mem_type: MemoryMapEntryType::MEMORY,
+            },
+        ];
+
+        AddressSpaceManagerBuilder::new(
+            &mut address_space,
+            vtl2_ram,
+            MemoryRange::new(0x0..0x4000),
+            MemoryRange::new(0x0..0x2000),
+            core::iter::empty(),
+        )
+        .init()
+        .unwrap();
+
+        // Node 0 allocation should fail (all used by bootshim).
+        assert!(
+            address_space
+                .allocate(
+                    Some(0),
+                    0x10000,
+                    AllocationType::GpaPool,
+                    AllocationPolicy::HighMemory,
+                )
+                .is_none()
+        );
+
+        // Node 1 should succeed.
+        let pool = address_space
+            .allocate(
+                Some(1),
+                0x10000,
+                AllocationType::GpaPool,
+                AllocationPolicy::HighMemory,
+            )
+            .unwrap();
+        assert_eq!(pool.vnode, 1);
+        assert_eq!(pool.range.len(), 0x10000);
+    }
 }


### PR DESCRIPTION
Backport the openhcl_boot changes from #3312 only.

Tested via the vmm_tests numa_private_pool_split on main with the igvm file built from this commit.