### PR TITLE
pci: pcie: enforce device-number gating and advertise ARI Forwarding on downstream ports

### DIFF
--- a/vm/devices/pci/pci_core/src/capabilities/pci_express.rs
+++ b/vm/devices/pci/pci_core/src/capabilities/pci_express.rs
@@ -89,6 +89,17 @@ impl PciExpressCapability {
     /// * `typ` - The spec-defined device or port type.
     /// * `flr_handler` - Optional handler to be called when FLR is initiated. This emulator will report that FLR is supported if flr_handler = Some(_)
     pub fn new(typ: pci_express::DevicePortType, flr_handler: Option<Arc<dyn FlrHandler>>) -> Self {
+        // ARI Forwarding is only meaningful on downstream-facing ports (root port /
+        // switch downstream port) which turn Type 1 config requests into Type 0
+        // requests to the connected device. Advertising it as supported lets an
+        // ARI-aware guest enable ARI Forwarding so that endpoint functions numbered
+        // greater than 7 (e.g. SR-IOV VFs) enumerate correctly instead of being
+        // aliased under multiple device numbers. See PCIe Base Spec 7.0 §6.13.
+        let ari_forwarding_supported = matches!(
+            typ,
+            pci_express::DevicePortType::RootPort
+                | pci_express::DevicePortType::DownstreamSwitchPort
+        );
         Self {
             pcie_capabilities: pci_express::PciExpressCapabilities::new()
                 .with_capability_version(2)
@@ -100,7 +111,8 @@ impl PciExpressCapability {
                 .with_max_link_width(LinkWidth::X16.into_bits()), // x16 link width
             slot_capabilities: pci_express::SlotCapabilities::new(),
             root_capabilities: pci_express::RootCapabilities::new(),
-            device_capabilities_2: pci_express::DeviceCapabilities2::new(),
+            device_capabilities_2: pci_express::DeviceCapabilities2::new()
+                .with_ari_forwarding_supported(ari_forwarding_supported),
             link_capabilities_2: pci_express::LinkCapabilities2::new()
                 .with_supported_link_speeds_vector(SupportedLinkSpeedsVector::UpToGen5.into_bits()), // Support speeds up to PCIe Gen 5 (32.0 GT/s)
             slot_capabilities_2: pci_express::SlotCapabilities2::new(),
@@ -404,6 +416,17 @@ impl PciExpressCapability {
     /// Returns whether the hot plug interrupt is enabled in Slot Control.
     pub fn hot_plug_interrupt_enabled(&self) -> bool {
         self.state.lock().slot_control.hot_plug_interrupt_enable()
+    }
+
+    /// Returns whether ARI Forwarding is enabled in Device Control 2.
+    ///
+    /// When set on a downstream-facing port, the port no longer enforces the
+    /// requirement that the Device Number be 0 when turning a Type 1
+    /// configuration request into a Type 0 request, allowing the full 8-bit
+    /// ARI function number to reach the connected device. See PCIe Base Spec
+    /// 7.0 §6.13.
+    pub fn ari_forwarding_enable(&self) -> bool {
+        self.state.lock().device_control_2.ari_forwarding_enable()
     }
 
     /// Returns a reference to the slot capabilities register.
@@ -802,6 +825,41 @@ mod tests {
             req.respond()
                 .field("flr_initiated", self.flr_initiated.load(Ordering::Acquire));
         }
+    }
+
+    #[test]
+    fn test_ari_forwarding_supported_by_port_type() {
+        // ARI Forwarding Supported (Device Capabilities 2, bit 5 / 0x20) must be
+        // advertised on downstream-facing ports and never on endpoints/upstream ports.
+        for (typ, expected) in [
+            (DevicePortType::RootPort, true),
+            (DevicePortType::DownstreamSwitchPort, true),
+            (DevicePortType::UpstreamSwitchPort, false),
+            (DevicePortType::Endpoint, false),
+        ] {
+            let name = format!("{typ:?}");
+            let cap = PciExpressCapability::new(typ, None);
+            let device_caps_2 = read_cap_u32(&cap, 0x24);
+            let ari_supported = device_caps_2 & 0x20 != 0;
+            assert_eq!(ari_supported, expected, "unexpected ARI support for {name}");
+        }
+    }
+
+    #[test]
+    fn test_ari_forwarding_enable_is_guest_writable() {
+        let mut cap = PciExpressCapability::new(DevicePortType::RootPort, None);
+
+        // Enable bit starts cleared.
+        assert!(!cap.ari_forwarding_enable());
+
+        // Guest sets ARI Forwarding Enable (Device Control 2, bit 5 / 0x20).
+        write_cap_u32(&mut cap, 0x28, 0x0020);
+        assert!(cap.ari_forwarding_enable());
+        assert_eq!(read_cap_u32(&cap, 0x28) & 0x0020, 0x0020);
+
+        // Guest clears it again.
+        write_cap_u32(&mut cap, 0x28, 0x0000);
+        assert!(!cap.ari_forwarding_enable());
     }
 
     #[test]

--- a/vm/devices/pci/pcie/src/port.rs
+++ b/vm/devices/pci/pcie/src/port.rs
@@ -1294,7 +1294,8 @@ mod tests {
             None,
         );
 
-        // Set primary + secondary bus number to 1.
+        // Set the secondary and subordinate bus numbers to 1, giving the port an
+        // assigned (secondary) bus range of 1..=1. Primary bus number stays 0.
         port.cfg_space.write_u32(0x18, (1u32 << 16) | (1u32 << 8));
 
         let stats = Arc::new(Mutex::new(RoutingStats::default()));

--- a/vm/devices/pci/pcie/src/port.rs
+++ b/vm/devices/pci/pcie/src/port.rs
@@ -696,6 +696,15 @@ impl PcieDownstreamPort {
             return IoResult::Ok;
         }
 
+        // Read whether ARI Forwarding is enabled on this port before borrowing the
+        // connected device, to avoid overlapping borrows of `self`.
+        let ari_forwarding_enabled = self
+            .cfg_space
+            .capabilities()
+            .iter()
+            .find_map(|cap| cap.as_pci_express())
+            .is_some_and(|pcie| pcie.ari_forwarding_enable());
+
         // If there is no device connected to the port, then we should return all-1s.
         let Some((_, device)) = &mut self.link else {
             tracing::trace!("no device connected to port");
@@ -703,10 +712,24 @@ impl PcieDownstreamPort {
             return IoResult::Ok;
         };
 
-        // If the target bus number is the secondary bus number of this port, turn the type 1 access into
-        // a type 0 access to the connected device. Otherwise, forward the type 1 access as-is.
+        // Determine how to route the request. If the target bus is this port's secondary
+        // bus, the Type 1 access must be turned into a Type 0 access to the connected
+        // device. Per PCIe Base Spec 7.0 §7.3.3, a downstream port only decodes Device
+        // Number 0, so a request to a non-zero device number is an Unsupported Request --
+        // unless ARI Forwarding is enabled (§6.13), in which case the full 8-bit devfn
+        // carries an ARI function number and must be forwarded. Without this gate, an
+        // ARI endpoint's functions numbered > 7 are aliased under phantom device numbers.
         let new_access_type = if addr.bus == *bus_range.start() {
-            PciConfigAccessType::Type0
+            if addr.device() == 0 || ari_forwarding_enabled {
+                PciConfigAccessType::Type0
+            } else {
+                tracing::trace!(
+                    device = addr.device(),
+                    "config read to non-zero device below downstream port without ARI forwarding; unsupported request"
+                );
+                value.set(!0);
+                return IoResult::Ok;
+            }
         } else {
             PciConfigAccessType::Type1
         };
@@ -745,16 +768,38 @@ impl PcieDownstreamPort {
             return IoResult::Ok;
         }
 
+        // Read whether ARI Forwarding is enabled on this port before borrowing the
+        // connected device, to avoid overlapping borrows of `self`.
+        let ari_forwarding_enabled = self
+            .cfg_space
+            .capabilities()
+            .iter()
+            .find_map(|cap| cap.as_pci_express())
+            .is_some_and(|pcie| pcie.ari_forwarding_enable());
+
         // If there is no device connected to the port, then we should just drop the access.
         let Some((_, device)) = &mut self.link else {
             tracelimit::warn_ratelimited!("no device connected to port");
             return IoResult::Ok;
         };
 
-        // If the target bus number is the secondary bus number of this port, turn the type 1 access into
-        // a type 0 access to the connected device. Otherwise, forward the type 1 access as-is.
+        // Determine how to route the request. If the target bus is this port's secondary
+        // bus, the Type 1 access must be turned into a Type 0 access to the connected
+        // device. Per PCIe Base Spec 7.0 §7.3.3, a downstream port only decodes Device
+        // Number 0, so a request to a non-zero device number is an Unsupported Request --
+        // unless ARI Forwarding is enabled (§6.13), in which case the full 8-bit devfn
+        // carries an ARI function number and must be forwarded. Without this gate, an
+        // ARI endpoint's functions numbered > 7 are aliased under phantom device numbers.
         let new_access_type = if addr.bus == *bus_range.start() {
-            PciConfigAccessType::Type0
+            if addr.device() == 0 || ari_forwarding_enabled {
+                PciConfigAccessType::Type0
+            } else {
+                tracing::trace!(
+                    device = addr.device(),
+                    "config write to non-zero device below downstream port without ARI forwarding; unsupported request"
+                );
+                return IoResult::Ok;
+            }
         } else {
             PciConfigAccessType::Type1
         };
@@ -1218,6 +1263,142 @@ mod tests {
                 PciConfigAddress::new(1, 2, 0x14 / 4).unwrap()
             ]
         );
+    }
+
+    /// Builds a root port with secondary bus 1 and a linked mock device, returning
+    /// the port and a handle to the device's routing stats.
+    fn make_root_port_with_linked_device() -> (PcieDownstreamPort, Arc<Mutex<RoutingStats>>) {
+        use pci_core::spec::hwid::{ClassCode, ProgrammingInterface, Subclass};
+
+        let hardware_ids = HardwareIds {
+            vendor_id: 0x1234,
+            device_id: 0x5678,
+            revision_id: 0,
+            prog_if: ProgrammingInterface::NONE,
+            sub_class: Subclass::BRIDGE_PCI_TO_PCI,
+            base_class: ClassCode::BRIDGE,
+            type0_sub_vendor_id: 0,
+            type0_sub_system_id: 0,
+        };
+
+        let msi_target = MsiTarget::disconnected();
+        let mut port = PcieDownstreamPort::new(
+            "test-port",
+            hardware_ids,
+            DevicePortType::RootPort,
+            false,
+            None,
+            &msi_target,
+            PciePortSettings::default(),
+            None,
+            None,
+        );
+
+        // Set primary + secondary bus number to 1.
+        port.cfg_space.write_u32(0x18, (1u32 << 16) | (1u32 << 8));
+
+        let stats = Arc::new(Mutex::new(RoutingStats::default()));
+        port.link = Some((
+            "mf-device".into(),
+            Box::new(MultiFunctionMockDevice {
+                stats: Arc::clone(&stats),
+            }),
+        ));
+
+        (port, stats)
+    }
+
+    #[test]
+    fn test_secondary_bus_nonzero_device_without_ari_is_unsupported_request() {
+        let (mut port, stats) = make_root_port_with_linked_device();
+
+        // Device 0 (devfn 0x00) on the secondary bus converts to Type 0 and forwards.
+        let mut value = 0;
+        assert!(matches!(
+            port.forward_cfg_read_with_routing(
+                PciConfigAddress::new(1, 0x00, 0x10 / 4).unwrap(),
+                ByteEnabledDwordRead::with_all_bytes_enabled(&mut value)
+            ),
+            IoResult::Ok
+        ));
+        assert_eq!(value, 0x1234_5678);
+
+        // Device 1 (devfn 0x08) without ARI Forwarding is an Unsupported Request:
+        // all-ones is returned and the connected device is never reached.
+        let mut value = 0;
+        assert!(matches!(
+            port.forward_cfg_read_with_routing(
+                PciConfigAddress::new(1, 0x08, 0x14 / 4).unwrap(),
+                ByteEnabledDwordRead::with_all_bytes_enabled(&mut value)
+            ),
+            IoResult::Ok
+        ));
+        assert_eq!(value, !0);
+
+        // A write to the same non-zero device is silently dropped.
+        assert!(matches!(
+            port.forward_cfg_write_with_routing(
+                PciConfigAddress::new(1, 0x08, 0x14 / 4).unwrap(),
+                ByteEnabledDwordWrite::with_all_bytes_enabled(0xDEAD_BEEF)
+            ),
+            IoResult::Ok
+        ));
+
+        let stats = stats.lock().clone();
+        // Only the device-0 read reached the device; the non-zero device accesses did not.
+        assert_eq!(
+            stats.type0_reads,
+            vec![PciConfigAddress::new(1, 0x00, 0x10 / 4).unwrap()]
+        );
+        assert!(stats.type0_writes.is_empty());
+        assert!(stats.type1_reads.is_empty());
+        assert!(stats.type1_writes.is_empty());
+    }
+
+    #[test]
+    fn test_secondary_bus_nonzero_device_with_ari_forwards_full_devfn() {
+        let (mut port, stats) = make_root_port_with_linked_device();
+
+        // Enable ARI Forwarding in Device Control 2 (PCIe cap base 0x40 + 0x28),
+        // bit 5 (0x20).
+        port.cfg_space.write_u32(0x68, 0x0000_0020);
+        assert_eq!(
+            port.cfg_space.read_u32(0x68) & 0x20,
+            0x20,
+            "ARI Forwarding Enable should be set"
+        );
+
+        // ARI function 8 arrives as devfn 0x08 (device bits non-zero) and must be
+        // forwarded as a Type 0 access carrying the full 8-bit function number.
+        let mut value = 0;
+        assert!(matches!(
+            port.forward_cfg_read_with_routing(
+                PciConfigAddress::new(1, 0x08, 0x10 / 4).unwrap(),
+                ByteEnabledDwordRead::with_all_bytes_enabled(&mut value)
+            ),
+            IoResult::Ok
+        ));
+        assert_eq!(value, 0x1234_5678);
+
+        assert!(matches!(
+            port.forward_cfg_write_with_routing(
+                PciConfigAddress::new(1, 0x30, 0x14 / 4).unwrap(),
+                ByteEnabledDwordWrite::with_all_bytes_enabled(0xCAFE_0000)
+            ),
+            IoResult::Ok
+        ));
+
+        let stats = stats.lock().clone();
+        assert_eq!(
+            stats.type0_reads,
+            vec![PciConfigAddress::new(1, 0x08, 0x10 / 4).unwrap()]
+        );
+        assert_eq!(
+            stats.type0_writes,
+            vec![PciConfigAddress::new(1, 0x30, 0x14 / 4).unwrap()]
+        );
+        assert!(stats.type1_reads.is_empty());
+        assert!(stats.type1_writes.is_empty());
     }
 
     #[test]


### PR DESCRIPTION
## Problem

An emulated PCIe root/downstream port converts Type 1 configuration requests into Type 0 requests based on a **bus-number match alone**, without checking the request's **device number** or consulting **ARI Forwarding**.

Per PCIe Base Spec 7.0 §7.3.3, a downstream port only decodes **device number 0**. Because of the missing gate, an ARI endpoint's functions numbered greater than 7 (e.g. SR-IOV VFs on an ARI-capable endpoint) are **aliased under phantom device numbers** in the guest — the VFs show up as separate PCI devices at different device numbers, all function 0, instead of as ARI functions on device 0.

## Fix

**A — Gate the Type 1 → Type 0 conversion (stops aliasing).**
In both `forward_cfg_read_with_routing()` and `forward_cfg_write_with_routing()`, only convert to Type 0 when the **device number is 0** or **ARI Forwarding is enabled** on the port. Otherwise the access is an Unsupported Request: all-ones is returned on reads and writes are dropped, and the connected device is never reached. This also covers **switch downstream ports**, which delegate to these same functions.

**B — Advertise ARI Forwarding Supported.**
Set `DeviceCapabilities2.ari_forwarding_supported = true` for downstream-facing port types (root port / switch downstream port), and add an `ari_forwarding_enable()` accessor so the port can honor the guest-controlled **ARI Forwarding Enable** bit. The enable bit remains guest-controlled and is never forced on — an ARI-aware guest that sets it can then enumerate VFs correctly as ARI functions on device 0.

## Spec basis

- §7.3.3 Configuration Request Routing Rules — Type 1 → Type 0 only for decoded device numbers (0 for a downstream port); otherwise Unsupported Request.
- §6.13 Alternative Routing-ID Interpretation (ARI) — ARI Forwarding Enable lifts the device-0 restriction; by default it must be enforced.

## Testing

- `cargo test -p pci_core -p pcie` — all pass, including new tests:
  - device-number gate returns UR without ARI, and forwards the full 8-bit devfn (ARI function > 7) once ARI Forwarding is enabled (read + write paths);
  - `ari_forwarding_supported` advertised only on downstream-facing port types;
  - `ari_forwarding_enable` is guest-writable/clearable.
- `cargo clippy --all-targets`, `cargo doc --no-deps`, `cargo xtask fmt --fix` — clean.