### PR TITLE
openvmm: extend --smmu with accel and OAS options

### DIFF
--- a/Guide/src/reference/openvmm/management/cli.md
+++ b/Guide/src/reference/openvmm/management/cli.md
@@ -412,21 +412,46 @@ For `--virtio-rng` and `--virtio-console`, use their separate PCIe port flags:
 
 ### SMMU (aarch64 only)
 
-`--smmu <RC_NAME>` enables an emulated Arm SMMUv3 IOMMU for the named
-root complex. The flag is repeatable — use one `--smmu` per root complex
-that should have an SMMU. Devices behind a covered root complex get
-software IOVA→GPA translation for DMA and MSI addresses.
+`--smmu` enables an emulated Arm SMMUv3 IOMMU for a named PCIe root
+complex. The flag is repeatable — use one `--smmu` per root complex that
+should have an SMMU. Devices behind a covered root complex get software
+IOVA→GPA translation for DMA and MSI addresses.
+
+The syntax is a comma-separated key/value list:
 
 ```sh
-# Enable SMMU on root complex rc0
---smmu rc0
-
-# Multiple root complexes
---smmu rc0 --smmu rc1
+--smmu rc=<name>[,accel][,oas=auto|N]
 ```
 
-VFIO devices cannot currently be placed behind an SMMU-covered root
-complex because iommufd nested translation is not yet available.
+- `rc=<name>` (required): the PCIe root complex this SMMU covers.
+- `accel` (optional): enable hardware-accelerated (iommufd-nested)
+  translation, delegating stage-1 walks to the host IOMMU. See the note
+  below — this is not yet wired up and currently fails at startup.
+- `oas=auto|N` (optional): the SMMU's output address size (OAS) in bits.
+  `auto` (the default) picks a fixed size large enough to cover any guest
+  physical address space. A fixed `N` must be one of the SMMUv3-legal
+  encodings: `32`, `36`, `40`, `42`, `44`, `48`, or `52`.
+
+```sh
+# Enable an emulated SMMU on root complex rc0
+--smmu rc=rc0
+
+# Multiple root complexes
+--smmu rc=rc0 --smmu rc=rc1
+
+# Pin the output address size to 48 bits
+--smmu rc=rc0,oas=48
+```
+
+```admonish warning
+`accel` is accepted by the parser but the acceleration backend is not yet
+implemented: requesting it fails during SMMU setup rather than silently
+falling back to emulated translation.
+
+VFIO devices therefore cannot currently be placed behind an SMMU-covered
+root complex, because host passthrough requires the (not-yet-available)
+iommufd nested translation path.
+```
 
 ### AMD IOMMU (x86_64 only)
 

--- a/Guide/src/reference/openvmm/management/cli.md
+++ b/Guide/src/reference/openvmm/management/cli.md
@@ -428,9 +428,11 @@ The syntax is a comma-separated key/value list:
   translation, delegating stage-1 walks to the host IOMMU. See the note
   below — this is not yet wired up and currently fails at startup.
 - `oas=auto|N` (optional): the SMMU's output address size (OAS) in bits.
-  `auto` (the default) picks a fixed size large enough to cover any guest
-  physical address space. A fixed `N` must be one of the SMMUv3-legal
-  encodings: `32`, `36`, `40`, `42`, `44`, `48`, or `52`.
+  `auto` (the default) advertises a fixed 48 bits, which covers typical
+  configurations. Very large RAM or an explicitly pinned high MMIO/ECAM
+  base can exceed this, requiring an explicit larger `oas=` (e.g. `oas=52`).
+  A fixed `N` must be one of the SMMUv3-legal encodings: `32`, `36`, `40`,
+  `42`, `44`, `48`, or `52`.
 
 ```sh
 # Enable an emulated SMMU on root complex rc0

--- a/openvmm/openvmm_core/src/worker/dispatch.rs
+++ b/openvmm/openvmm_core/src/worker/dispatch.rs
@@ -1018,7 +1018,7 @@ impl InitializedVm {
             let smmu_count = cfg
                 .pcie_root_complexes
                 .iter()
-                .filter(|rc| matches!(rc.iommu, Some(PcieIommuConfig::Smmu)))
+                .filter(|rc| matches!(rc.iommu, Some(PcieIommuConfig::Smmu { .. })))
                 .count();
             let result =
                 build_aarch64_topology(&cfg.processor_topology, &platform_info, smmu_count)?;

--- a/openvmm/openvmm_core/src/worker/dispatch/smmu_wiring.rs
+++ b/openvmm/openvmm_core/src/worker/dispatch/smmu_wiring.rs
@@ -15,6 +15,17 @@ use std::sync::Arc;
 use vm_topology::pcie::PcieHostBridge;
 use vmotherboard::ChipsetBuilder;
 
+/// Default advertised OAS (in bits) for an `oas=auto` SMMU.
+///
+/// 48 bits (256 TiB) comfortably covers any guest physical address space, so an
+/// `auto` SMMU advertises it as a fixed value rather than sizing it to the
+/// guest memory layout (matching the fixed-OAS approach taken by QEMU and
+/// Hyper-V's emulated SMMUs).
+const DEFAULT_AUTO_OAS_BITS: u8 = 48;
+
+/// Valid SMMUv3 output address sizes (IDR5.OAS encodings), in bits.
+const VALID_OAS_BITS: [u8; 7] = [32, 36, 40, 42, 44, 48, 52];
+
 /// Resolved resources for a single SMMUv3 instance, combining MMIO and SPI
 /// allocations.
 pub(super) struct ResolvedSmmuResources {
@@ -74,15 +85,44 @@ pub(super) fn setup_smmu(
     let smmu_rcs = root_complexes
         .iter()
         .enumerate()
-        .filter(|(_, rc)| matches!(rc.iommu, Some(openvmm_defs::config::PcieIommuConfig::Smmu)));
+        .filter_map(|(rc_pos, rc)| match &rc.iommu {
+            Some(openvmm_defs::config::PcieIommuConfig::Smmu { accel, oas }) => {
+                Some((rc_pos, rc, *accel, *oas))
+            }
+            _ => None,
+        });
 
-    for ((rc_pos, rc), smmu) in smmu_rcs.zip(resolved_smmu_resources) {
+    for ((rc_pos, rc, accel, oas), smmu) in smmu_rcs.zip(resolved_smmu_resources) {
+        // Accelerated (iommufd-nested) SMMUs are not yet wired up. Reject the
+        // request explicitly rather than silently falling back to emulated
+        // translation.
+        anyhow::ensure!(
+            !accel,
+            "SMMU on root complex {}: accelerated translation is not yet supported",
+            rc.name
+        );
+
+        // Resolve the requested OAS into a concrete advertised value.
+        let oas_bits = match oas {
+            openvmm_defs::config::SmmuOas::Auto => DEFAULT_AUTO_OAS_BITS,
+            openvmm_defs::config::SmmuOas::Fixed(bits) => {
+                anyhow::ensure!(
+                    VALID_OAS_BITS.contains(&bits),
+                    "SMMU on root complex {}: OAS {bits} is not a valid SMMUv3 output \
+                     address size (expected one of {:?})",
+                    rc.name,
+                    VALID_OAS_BITS
+                );
+                bits
+            }
+        };
+
         let evtq_irq_vector = smmu.evtq_intid - *vmm_core::emuplat::gic::SPI_RANGE.start();
         let gerror_irq_vector = smmu.gerr_intid - *vmm_core::emuplat::gic::SPI_RANGE.start();
         let device_name = format!("smmu:{}", rc.name);
         let smmu_config = smmu::SmmuConfig {
             sidsize: 16,
-            oas: 44,
+            oas: oas_bits,
         };
         let smmu_device =
             chipset_builder

--- a/openvmm/openvmm_core/src/worker/dispatch/smmu_wiring.rs
+++ b/openvmm/openvmm_core/src/worker/dispatch/smmu_wiring.rs
@@ -17,10 +17,18 @@ use vmotherboard::ChipsetBuilder;
 
 /// Default advertised OAS (in bits) for an `oas=auto` SMMU.
 ///
-/// 48 bits (256 TiB) comfortably covers any guest physical address space, so an
-/// `auto` SMMU advertises it as a fixed value rather than sizing it to the
-/// guest memory layout (matching the fixed-OAS approach taken by QEMU and
-/// Hyper-V's emulated SMMUs).
+/// This is a fixed sizing policy, not a computed maximum: rather than sizing
+/// the advertised OAS to the guest memory layout (or to the host's supported
+/// IPA width, which on aarch64/KVM can be up to 52 bits), an `auto` SMMU
+/// advertises a constant 48 bits. This matches the fixed-OAS approach taken by
+/// Hyper-V's emulated SMMU.
+///
+/// The memory-layout allocator packs high MMIO compactly bottom-up just above
+/// guest RAM, so for typical configurations every translatable address sits
+/// far below 48 bits (256 TiB). This is not a hard guarantee, though: a large
+/// enough RAM size, or an explicitly pinned high MMIO/ECAM base, can place
+/// addresses above 256 TiB (up to the host IPA width). Such a configuration
+/// must pass an explicit `oas=` (e.g. `oas=52`) rather than relying on `auto`.
 const DEFAULT_AUTO_OAS_BITS: u8 = 48;
 
 /// Valid SMMUv3 output address sizes (IDR5.OAS encodings), in bits.

--- a/openvmm/openvmm_core/src/worker/memory_layout.rs
+++ b/openvmm/openvmm_core/src/worker/memory_layout.rs
@@ -340,7 +340,7 @@ pub(super) fn resolve_memory_layout(
         );
         let (name, size) = match kind {
             // SMMUv3: 128 KiB region (two 64 KiB pages).
-            PcieIommuConfig::Smmu => ("smmu", SMMU_SIZE),
+            PcieIommuConfig::Smmu { .. } => ("smmu", SMMU_SIZE),
             // AMD IOMMU: 16 KiB per AMD IOMMU spec §3.4.
             PcieIommuConfig::AmdVi => ("amd-iommu", 0x4000),
             // Intel VT-d: 4 KiB per VT-d spec.
@@ -430,7 +430,7 @@ pub(super) fn resolve_memory_layout(
     // until `allocate`.
     let iommu_ranges = match iommu_kind {
         None => ResolvedIommuRanges::None,
-        Some(PcieIommuConfig::Smmu) => ResolvedIommuRanges::Smmu(iommu_ranges),
+        Some(PcieIommuConfig::Smmu { .. }) => ResolvedIommuRanges::Smmu(iommu_ranges),
         Some(PcieIommuConfig::AmdVi) => ResolvedIommuRanges::AmdVi(iommu_ranges),
         Some(PcieIommuConfig::IntelVtd) => ResolvedIommuRanges::IntelVtd(iommu_ranges),
     };

--- a/openvmm/openvmm_defs/src/config.rs
+++ b/openvmm/openvmm_defs/src/config.rs
@@ -372,9 +372,25 @@ pub enum PcieIommuConfig {
     /// AMD IOMMU (AMD-Vi) for x86_64 guests.
     AmdVi,
     /// Arm SMMUv3 for aarch64 guests.
-    Smmu,
+    Smmu {
+        /// Enable HW-accelerated nested translation (iommufd). Requires VFIO
+        /// devices with `iommu=` behind this SMMU.
+        accel: bool,
+        /// Output address size (OAS) resolution policy.
+        oas: SmmuOas,
+    },
     /// Intel VT-d for x86_64 guests.
     IntelVtd,
+}
+
+/// Output address size (OAS) policy for an emulated SMMUv3.
+#[derive(Debug, MeshPayload, Clone, Copy)]
+pub enum SmmuOas {
+    /// Resolve automatically to a fixed default that covers any guest physical
+    /// address space.
+    Auto,
+    /// Use a fixed OAS in bits (one of 32, 36, 40, 42, 44, 48, 52).
+    Fixed(u8),
 }
 
 #[derive(Debug, Protobuf, Default, Clone)]

--- a/openvmm/openvmm_defs/src/config.rs
+++ b/openvmm/openvmm_defs/src/config.rs
@@ -386,8 +386,8 @@ pub enum PcieIommuConfig {
 /// Output address size (OAS) policy for an emulated SMMUv3.
 #[derive(Debug, MeshPayload, Clone, Copy)]
 pub enum SmmuOas {
-    /// Resolve automatically to a fixed default that covers any guest physical
-    /// address space.
+    /// Advertise a fixed default OAS. See `DEFAULT_AUTO_OAS_BITS` for the
+    /// sizing policy and its limits.
     Auto,
     /// Use a fixed OAS in bits (one of 32, 36, 40, 42, 44, 48, 52).
     Fixed(u8),

--- a/openvmm/openvmm_entry/src/cli_args.rs
+++ b/openvmm/openvmm_entry/src/cli_args.rs
@@ -3534,8 +3534,8 @@ pub struct SmmuCli {
 #[cfg(guest_arch = "aarch64")]
 #[derive(Clone, Copy, Debug)]
 pub enum SmmuOasCli {
-    /// Resolve automatically to a fixed default covering the guest physical
-    /// address space.
+    /// Advertise a fixed default OAS (see the `--smmu` docs for the sizing
+    /// policy and when a larger fixed OAS is required).
     Auto,
     /// Fixed OAS in bits (one of 32, 36, 40, 42, 44, 48, 52).
     Fixed(u8),

--- a/openvmm/openvmm_entry/src/cli_args.rs
+++ b/openvmm/openvmm_entry/src/cli_args.rs
@@ -5635,4 +5635,53 @@ mod tests {
         assert!(parse_numa_distance("0:1").is_err());
         assert!(parse_numa_distance("0:1:20:extra").is_err());
     }
+
+    #[cfg(guest_arch = "aarch64")]
+    #[test]
+    fn test_smmu_cli_from_str() {
+        // Minimal: only rc=, oas defaults to auto, accel off.
+        let s = SmmuCli::from_str("rc=pcie0").unwrap();
+        assert_eq!(s.rc_name, "pcie0");
+        assert!(!s.accel);
+        assert!(matches!(s.oas, SmmuOasCli::Auto));
+
+        // accel flag.
+        let s = SmmuCli::from_str("rc=pcie0,accel").unwrap();
+        assert_eq!(s.rc_name, "pcie0");
+        assert!(s.accel);
+        assert!(matches!(s.oas, SmmuOasCli::Auto));
+
+        // Explicit oas=auto.
+        let s = SmmuCli::from_str("rc=pcie0,oas=auto").unwrap();
+        assert!(matches!(s.oas, SmmuOasCli::Auto));
+
+        // Fixed oas.
+        let s = SmmuCli::from_str("rc=pcie0,oas=52").unwrap();
+        assert!(matches!(s.oas, SmmuOasCli::Fixed(52)));
+
+        // All keys/flags together, order independent.
+        let s = SmmuCli::from_str("oas=48,accel,rc=pcie1").unwrap();
+        assert_eq!(s.rc_name, "pcie1");
+        assert!(s.accel);
+        assert!(matches!(s.oas, SmmuOasCli::Fixed(48)));
+
+        // Missing required rc=.
+        assert!(SmmuCli::from_str("accel").is_err());
+        assert!(SmmuCli::from_str("oas=52").is_err());
+
+        // Empty rc= value.
+        assert!(SmmuCli::from_str("rc=").is_err());
+
+        // Duplicate rc= key.
+        assert!(SmmuCli::from_str("rc=pcie0,rc=pcie1").is_err());
+
+        // Non-numeric oas value.
+        assert!(SmmuCli::from_str("rc=pcie0,oas=big").is_err());
+
+        // Unknown key.
+        assert!(SmmuCli::from_str("rc=pcie0,foo=bar").is_err());
+
+        // Unknown flag.
+        assert!(SmmuCli::from_str("rc=pcie0,turbo").is_err());
+    }
 }

--- a/openvmm/openvmm_entry/src/cli_args.rs
+++ b/openvmm/openvmm_entry/src/cli_args.rs
@@ -569,10 +569,12 @@ options:
     #[clap(long, default_value = "auto")]
     pub gic_msi: GicMsiCli,
 
-    /// enable SMMUv3 IOMMU for an aarch64 PCIe root complex (repeatable, e.g. --smmu rc0 --smmu rc1)
+    /// configure SMMUv3 IOMMU for an aarch64 PCIe root complex (repeatable).
+    ///
+    /// Syntax: `rc=<name>[,accel][,oas=auto|N]`.
     #[cfg(guest_arch = "aarch64")]
-    #[clap(long, value_name = "RC_NAME")]
-    pub smmu: Vec<String>,
+    #[clap(long, value_name = "SMMU_CONFIG")]
+    pub smmu: Vec<SmmuCli>,
 
     /// COM1 binding, optionally prefixed with `debugger-mode:` (see below)
     /// (console | stderr | listen=\<path\> | file=\<path\> (overwrites) | listen=tcp:\<ip\>:\<port\> | term[=\<program\>]\[,name=\<windowtitle\>\] | none)
@@ -3510,6 +3512,83 @@ impl FromStr for VfioDeviceCli {
             pci_id,
             iommu,
             bar_pt,
+        })
+    }
+}
+
+/// CLI configuration for an SMMUv3 instance.
+///
+/// Syntax: `rc=<name>[,accel][,oas=auto|N]`. `oas` defaults to `auto`.
+#[cfg(guest_arch = "aarch64")]
+#[derive(Clone, Debug)]
+pub struct SmmuCli {
+    /// Name of the PCIe root complex this SMMU covers.
+    pub rc_name: String,
+    /// Enable HW-accelerated nested translation (iommufd).
+    pub accel: bool,
+    /// Output address size policy.
+    pub oas: SmmuOasCli,
+}
+
+/// Output address size (OAS) policy parsed from `--smmu`.
+#[cfg(guest_arch = "aarch64")]
+#[derive(Clone, Copy, Debug)]
+pub enum SmmuOasCli {
+    /// Resolve automatically to a fixed default covering the guest physical
+    /// address space.
+    Auto,
+    /// Fixed OAS in bits (one of 32, 36, 40, 42, 44, 48, 52).
+    Fixed(u8),
+}
+
+#[cfg(guest_arch = "aarch64")]
+impl FromStr for SmmuCli {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let mut rc_name: Option<String> = None;
+        let mut accel = false;
+        let mut oas = SmmuOasCli::Auto;
+
+        for part in s.split(',') {
+            if let Some((key, value)) = part.split_once('=') {
+                match key {
+                    "rc" => {
+                        if rc_name.is_some() {
+                            anyhow::bail!("duplicate --smmu key: 'rc'");
+                        }
+                        if value.is_empty() {
+                            anyhow::bail!("--smmu: 'rc=' value cannot be empty");
+                        }
+                        rc_name = Some(value.to_string());
+                    }
+                    "oas" => {
+                        oas = if value == "auto" {
+                            SmmuOasCli::Auto
+                        } else {
+                            let bits: u8 = value
+                                .parse()
+                                .context("--smmu: oas must be 'auto' or a number")?;
+                            SmmuOasCli::Fixed(bits)
+                        };
+                    }
+                    _ => anyhow::bail!("unknown --smmu key: '{key}'"),
+                }
+            } else {
+                // Boolean flag (no '=')
+                match part {
+                    "accel" => accel = true,
+                    _ => anyhow::bail!("unknown --smmu flag: '{part}'"),
+                }
+            }
+        }
+
+        let rc_name = rc_name.context("--smmu: 'rc=' is required")?;
+
+        Ok(SmmuCli {
+            rc_name,
+            accel,
+            oas,
         })
     }
 }

--- a/openvmm/openvmm_entry/src/lib.rs
+++ b/openvmm/openvmm_entry/src/lib.rs
@@ -864,6 +864,23 @@ async fn vm_config_from_command_line(
     let mut vtd_names: std::collections::HashSet<&str> =
         opt.intel_vtd.iter().map(|s| s.as_str()).collect();
 
+    // Map each `--smmu` entry to its root complex, rejecting duplicate `rc=`
+    // entries up front. Entries are removed as they are matched to a root
+    // complex below; any left over refer to unknown root complexes.
+    #[cfg(guest_arch = "aarch64")]
+    let mut smmu_names: std::collections::HashMap<&str, &cli_args::SmmuCli> = {
+        let mut map = std::collections::HashMap::new();
+        for s in &opt.smmu {
+            if map.insert(s.rc_name.as_str(), s).is_some() {
+                anyhow::bail!(
+                    "--smmu specified multiple times for root complex '{}'",
+                    s.rc_name
+                );
+            }
+        }
+        map
+    };
+
     let mut pcie_root_complexes = Vec::new();
     for (i, rc_cli) in opt.pcie_root_complex.iter().enumerate() {
         let ports: Vec<PciePortConfig> = opt
@@ -927,7 +944,7 @@ async fn vm_config_from_command_line(
             cxl,
             ports,
             #[cfg(guest_arch = "aarch64")]
-            iommu: opt.smmu.iter().find(|s| s.rc_name == rc_cli.name).map(|s| {
+            iommu: smmu_names.remove(rc_cli.name.as_str()).map(|s| {
                 openvmm_defs::config::PcieIommuConfig::Smmu {
                     accel: s.accel,
                     oas: match s.oas {
@@ -952,12 +969,8 @@ async fn vm_config_from_command_line(
     }
 
     #[cfg(guest_arch = "aarch64")]
-    for s in &opt.smmu {
-        anyhow::ensure!(
-            pcie_root_complexes.iter().any(|rc| rc.name == s.rc_name),
-            "--smmu refers to unknown root complex '{}'",
-            s.rc_name
-        );
+    if let Some(name) = smmu_names.into_keys().next() {
+        anyhow::bail!("--smmu refers to unknown root complex '{name}'");
     }
     #[cfg(guest_arch = "x86_64")]
     if let Some(name) = amd_iommu_names.into_iter().next() {

--- a/openvmm/openvmm_entry/src/lib.rs
+++ b/openvmm/openvmm_entry/src/lib.rs
@@ -857,9 +857,6 @@ async fn vm_config_from_command_line(
         "--amd-iommu and --intel-vtd cannot both be used in the same VM"
     );
 
-    #[cfg(guest_arch = "aarch64")]
-    let mut smmu_names: std::collections::HashSet<&str> =
-        opt.smmu.iter().map(|s| s.as_str()).collect();
     #[cfg(guest_arch = "x86_64")]
     let mut amd_iommu_names: std::collections::HashSet<&str> =
         opt.amd_iommu.iter().map(|s| s.as_str()).collect();
@@ -930,9 +927,17 @@ async fn vm_config_from_command_line(
             cxl,
             ports,
             #[cfg(guest_arch = "aarch64")]
-            iommu: smmu_names
-                .remove(rc_cli.name.as_str())
-                .then_some(openvmm_defs::config::PcieIommuConfig::Smmu),
+            iommu: opt.smmu.iter().find(|s| s.rc_name == rc_cli.name).map(|s| {
+                openvmm_defs::config::PcieIommuConfig::Smmu {
+                    accel: s.accel,
+                    oas: match s.oas {
+                        cli_args::SmmuOasCli::Auto => openvmm_defs::config::SmmuOas::Auto,
+                        cli_args::SmmuOasCli::Fixed(bits) => {
+                            openvmm_defs::config::SmmuOas::Fixed(bits)
+                        }
+                    },
+                }
+            }),
             #[cfg(guest_arch = "x86_64")]
             iommu: if amd_iommu_names.remove(rc_cli.name.as_str()) {
                 Some(openvmm_defs::config::PcieIommuConfig::AmdVi)
@@ -947,8 +952,12 @@ async fn vm_config_from_command_line(
     }
 
     #[cfg(guest_arch = "aarch64")]
-    if let Some(name) = smmu_names.into_iter().next() {
-        anyhow::bail!("--smmu refers to unknown root complex '{name}'");
+    for s in &opt.smmu {
+        anyhow::ensure!(
+            pcie_root_complexes.iter().any(|rc| rc.name == s.rc_name),
+            "--smmu refers to unknown root complex '{}'",
+            s.rc_name
+        );
     }
     #[cfg(guest_arch = "x86_64")]
     if let Some(name) = amd_iommu_names.into_iter().next() {

--- a/petri/src/vm/openvmm/modify.rs
+++ b/petri/src/vm/openvmm/modify.rs
@@ -447,8 +447,13 @@ impl PetriVmConfigOpenVmm {
     /// complexes.
     pub fn with_smmu(mut self, rc_names: &[&str]) -> Self {
         for name in rc_names {
-            self.pending_iommu
-                .push((name.to_string(), PcieIommuConfig::Smmu));
+            self.pending_iommu.push((
+                name.to_string(),
+                PcieIommuConfig::Smmu {
+                    accel: false,
+                    oas: openvmm_defs::config::SmmuOas::Auto,
+                },
+            ));
         }
         self
     }


### PR DESCRIPTION
The emulated SMMUv3 is gaining a hardware-accelerated (iommufd-nested) translation mode, and its output address size needs to be configurable rather than hardcoded. This reshapes the SMMU configuration surface to carry both options up front so the CLI, config, and wiring layers agree on their representation before the acceleration backend lands.

The PcieIommuConfig::Smmu variant now carries an accel flag and an OAS policy, and --smmu takes an rc=<name>[,accel][,oas=auto|N] key/value syntax, replacing the old bare root-complex name. The wiring layer resolves the OAS policy to a concrete advertised value, validating fixed sizes against the legal SMMUv3 encodings and falling back to a default that covers any guest physical address space when auto is requested.

Acceleration is parsed and plumbed but not yet implemented: requesting accel fails during SMMU setup with a clear error rather than silently falling back to emulated translation. The remaining pieces (host IOMMU nesting, ACPI/DT reserved-region emission, and the VFIO backend) will be enabled in follow-up changes. The Guide's --smmu reference is updated to document the new syntax and the current acceleration limitation.