### PR TITLE
pci_core: model DmaTarget host-passthrough disposition as an enum

### DIFF
--- a/vm/devices/iommu/iommu_common/src/lib.rs
+++ b/vm/devices/iommu/iommu_common/src/lib.rs
@@ -367,6 +367,38 @@ where
     pci_core::dma::DmaTarget::with_iommu(bus_range, devfn, iommu, msi)
 }
 
+/// Build a hardware-nestable [`DmaTarget`](pci_core::dma::DmaTarget) backed by
+/// an IOMMU translator.
+///
+/// Like [`new_dma_target`], but hands the resulting factory to
+/// [`DmaTarget::with_nestable_iommu`](pci_core::dma::DmaTarget::with_nestable_iommu)
+/// along with an opaque nesting `handle`, marking the device
+/// [`DmaPassthrough::HardwareNestable`](pci_core::dma::DmaPassthrough::HardwareNestable).
+/// Accel-capable IOMMUs (e.g. an SMMU programming the host IOMMU for nested
+/// stage-1 translation) call this so the device may be VFIO-assigned; the
+/// assignment backend downcasts `handle` to wire the device into the emulated
+/// IOMMU.
+pub fn new_nestable_dma_target<T>(
+    label: &str,
+    translator: T,
+    bus_range: AssignedBusRange,
+    devfn: u8,
+    guest_memory: GuestMemory,
+    handle: Arc<dyn std::any::Any + Send + Sync>,
+    msi: &pci_core::msi::MsiConnection,
+) -> pci_core::dma::DmaTarget
+where
+    T: IommuTranslator + Clone,
+{
+    let iommu = Arc::new(TranslatingDmaTarget::new(
+        format!("{label}-translating"),
+        translator,
+        bus_range.clone(),
+        guest_memory,
+    ));
+    pci_core::dma::DmaTarget::with_nestable_iommu(bus_range, devfn, iommu, handle, msi)
+}
+
 // =============================================================================
 // Interrupt Remapping Infrastructure
 // =============================================================================

--- a/vm/devices/pci/pci_core/src/dma.rs
+++ b/vm/devices/pci/pci_core/src/dma.rs
@@ -39,7 +39,7 @@ pub trait DmaTargetIommu: Send + Sync + 'static {
 ///
 /// This is the only IOMMU-related view exposed to consumers of
 /// [`DmaTarget`]. It deliberately says nothing about how guest memory is
-/// translated (that is the private [`DmaTargetIommu`] factory); it only
+/// translated (that is the underlying [`DmaTargetIommu`] factory); it only
 /// answers "can this device be handed to the host for passthrough, and if
 /// so, how does the assignment backend attach to the IOMMU?".
 pub enum DmaPassthrough<'a> {
@@ -112,17 +112,65 @@ impl DmaTarget {
         }
     }
 
-    /// Creates a DMA target backed by an IOMMU.
+    /// Creates a DMA target backed by a software/emulated IOMMU.
     ///
     /// The base (function-`devfn`) translating guest memory is derived from
     /// `iommu`; per-VF memory is produced by
     /// [`with_rid_offset`](Self::with_rid_offset). The MSI backend is taken
     /// (late-bound) from `msi`.
+    ///
+    /// The device is marked [`DmaPassthrough::SoftwareBlocked`]: a
+    /// software/emulated IOMMU cannot program the host IOMMU, so host
+    /// passthrough (VFIO assignment) is rejected. Use
+    /// [`with_nestable_iommu`](Self::with_nestable_iommu) for a
+    /// hardware-nestable IOMMU that permits passthrough.
     pub fn with_iommu(
         bus_range: AssignedBusRange,
         devfn: u8,
         iommu: Arc<dyn DmaTargetIommu>,
         msi: &MsiConnection,
+    ) -> Self {
+        Self::iommu_backed(bus_range, devfn, iommu, msi, Passthrough::SoftwareBlocked)
+    }
+
+    /// Creates a DMA target backed by a hardware-nestable IOMMU.
+    ///
+    /// Like [`with_iommu`](Self::with_iommu), but marks the device
+    /// [`DmaPassthrough::HardwareNestable`] with an opaque `handle` that the
+    /// host-assignment backend downcasts to its arch-specific nesting context.
+    /// Accel-capable IOMMUs (e.g. an SMMU that programs the host IOMMU for
+    /// nested stage-1 translation) use this to permit VFIO passthrough despite
+    /// wrapping guest memory with a translating target; the `handle` carries
+    /// everything the backend needs to wire the device into the emulated IOMMU.
+    ///
+    /// Supplying the nesting `handle` together with the `iommu` is what makes a
+    /// [`DmaPassthrough::HardwareNestable`] target impossible to construct
+    /// without a backing IOMMU.
+    pub fn with_nestable_iommu(
+        bus_range: AssignedBusRange,
+        devfn: u8,
+        iommu: Arc<dyn DmaTargetIommu>,
+        handle: Arc<dyn Any + Send + Sync>,
+        msi: &MsiConnection,
+    ) -> Self {
+        Self::iommu_backed(
+            bus_range,
+            devfn,
+            iommu,
+            msi,
+            Passthrough::HardwareNestable(handle),
+        )
+    }
+
+    /// Shared constructor for the IOMMU-backed cases: derives the base
+    /// translating memory and MSI identity, then stamps the passthrough
+    /// disposition.
+    fn iommu_backed(
+        bus_range: AssignedBusRange,
+        devfn: u8,
+        iommu: Arc<dyn DmaTargetIommu>,
+        msi: &MsiConnection,
+        passthrough: Passthrough,
     ) -> Self {
         let guest_memory = iommu.guest_memory_for_rid_offset(devfn as u16);
         let msi_target = msi.msi_target(bus_range, devfn);
@@ -131,7 +179,7 @@ impl DmaTarget {
             guest_memory,
             msi_target,
             iommu: Some(iommu),
-            passthrough: Passthrough::SoftwareBlocked,
+            passthrough,
         }
     }
 
@@ -159,20 +207,6 @@ impl DmaTarget {
                 DmaPassthrough::HardwareNestable(handle.as_ref())
             }
         }
-    }
-
-    /// Marks this target as behind a hardware-nestable IOMMU, attaching an
-    /// opaque `handle` that the assignment backend downcasts to its
-    /// arch-specific nesting context.
-    ///
-    /// Accel-capable IOMMUs (e.g. an SMMU that programs the host IOMMU for
-    /// nested stage-1 translation) call this to permit VFIO passthrough
-    /// despite wrapping guest memory with a translating target. The handle
-    /// carries everything the backend needs to wire the device into the
-    /// emulated IOMMU.
-    pub fn with_hardware_nesting(mut self, handle: Arc<dyn Any + Send + Sync>) -> Self {
-        self.passthrough = Passthrough::HardwareNestable(handle);
-        self
     }
 
     /// Derives a DMA target offset by `delta` from this one in RID space.
@@ -379,14 +413,19 @@ mod tests {
     }
 
     #[test]
-    fn with_hardware_nesting_exposes_downcastable_handle() {
+    fn with_nestable_iommu_exposes_downcastable_handle() {
         let bus_range = AssignedBusRange::new();
         bus_range.set_bus_range(5, 10);
         let msi_conn = MsiConnection::new();
 
         let iommu = RecordingIommu::new();
-        let target = DmaTarget::with_iommu(bus_range.clone(), 0, iommu, &msi_conn)
-            .with_hardware_nesting(Arc::new(FakeNestingContext { id: 0x1234 }));
+        let target = DmaTarget::with_nestable_iommu(
+            bus_range.clone(),
+            0,
+            iommu,
+            Arc::new(FakeNestingContext { id: 0x1234 }),
+            &msi_conn,
+        );
 
         // The base target accepts passthrough and hands back the context.
         match target.passthrough() {

--- a/vm/devices/pci/pci_core/src/dma.rs
+++ b/vm/devices/pci/pci_core/src/dma.rs
@@ -17,6 +17,7 @@ use crate::bus_range::AssignedBusRange;
 use crate::msi::MsiConnection;
 use crate::msi::MsiTarget;
 use guestmem::GuestMemory;
+use std::any::Any;
 use std::sync::Arc;
 
 /// A trait for IOMMU backends that produce per-device guest memory.
@@ -32,6 +33,38 @@ pub trait DmaTargetIommu: Send + Sync + 'static {
     /// offset in `0..=0xff`; SR-IOV VFs use larger offsets that carry into
     /// the bus byte.
     fn guest_memory_for_rid_offset(&self, rid_offset: u16) -> GuestMemory;
+}
+
+/// How a device's DMA relates to host passthrough (VFIO assignment).
+///
+/// This is the only IOMMU-related view exposed to consumers of
+/// [`DmaTarget`]. It deliberately says nothing about how guest memory is
+/// translated (that is the private [`DmaTargetIommu`] factory); it only
+/// answers "can this device be handed to the host for passthrough, and if
+/// so, how does the assignment backend attach to the IOMMU?".
+pub enum DmaPassthrough<'a> {
+    /// No IOMMU, or none relevant to passthrough — host assignment allowed.
+    Allowed,
+    /// Behind a software/emulated IOMMU that cannot program the host IOMMU
+    /// for passthrough DMA — host assignment rejected.
+    SoftwareBlocked,
+    /// Behind a hardware-nestable IOMMU — host assignment allowed. The
+    /// opaque handle lets the assignment backend (which knows the concrete
+    /// IOMMU type) downcast and attach to the emulated IOMMU for nested
+    /// stage-1 translation.
+    HardwareNestable(&'a (dyn Any + Send + Sync)),
+}
+
+/// Private representation of a [`DmaTarget`]'s passthrough disposition.
+#[derive(Clone)]
+enum Passthrough {
+    /// Host assignment allowed (no IOMMU, or none relevant).
+    Allowed,
+    /// Behind a software/emulated IOMMU — host assignment rejected.
+    SoftwareBlocked,
+    /// Behind a hardware-nestable IOMMU — the opaque handle is downcast by
+    /// the assignment backend to its arch-specific nesting context.
+    HardwareNestable(Arc<dyn Any + Send + Sync>),
 }
 
 /// Everything a PCI device needs for bus-mastered transactions: DMA
@@ -51,9 +84,8 @@ pub struct DmaTarget {
     /// When an IOMMU is present, produces per-device GuestMemory
     /// instances with distinct stream/context table entries.
     iommu: Option<Arc<dyn DmaTargetIommu>>,
-    /// Whether the device is behind a software IOMMU (e.g., emulated
-    /// SMMU) that cannot program the host IOMMU for passthrough DMA.
-    software_iommu: bool,
+    /// The device's host-passthrough disposition (see [`DmaPassthrough`]).
+    passthrough: Passthrough,
 }
 
 impl DmaTarget {
@@ -76,7 +108,7 @@ impl DmaTarget {
             guest_memory,
             msi_target,
             iommu: None,
-            software_iommu: false,
+            passthrough: Passthrough::Allowed,
         }
     }
 
@@ -99,7 +131,7 @@ impl DmaTarget {
             guest_memory,
             msi_target,
             iommu: Some(iommu),
-            software_iommu: true,
+            passthrough: Passthrough::SoftwareBlocked,
         }
     }
 
@@ -113,10 +145,34 @@ impl DmaTarget {
         &self.msi_target
     }
 
-    /// Whether the device is behind a software IOMMU that cannot
-    /// program the host IOMMU for passthrough DMA.
-    pub fn software_iommu(&self) -> bool {
-        self.software_iommu
+    /// The device's host-passthrough disposition.
+    ///
+    /// Used by host-assignment backends (e.g. the VFIO resolver) to decide
+    /// whether the device may be passed through and, when it is behind a
+    /// hardware-nestable IOMMU, to obtain the opaque handle they downcast to
+    /// attach to the emulated IOMMU.
+    pub fn passthrough(&self) -> DmaPassthrough<'_> {
+        match &self.passthrough {
+            Passthrough::Allowed => DmaPassthrough::Allowed,
+            Passthrough::SoftwareBlocked => DmaPassthrough::SoftwareBlocked,
+            Passthrough::HardwareNestable(handle) => {
+                DmaPassthrough::HardwareNestable(handle.as_ref())
+            }
+        }
+    }
+
+    /// Marks this target as behind a hardware-nestable IOMMU, attaching an
+    /// opaque `handle` that the assignment backend downcasts to its
+    /// arch-specific nesting context.
+    ///
+    /// Accel-capable IOMMUs (e.g. an SMMU that programs the host IOMMU for
+    /// nested stage-1 translation) call this to permit VFIO passthrough
+    /// despite wrapping guest memory with a translating target. The handle
+    /// carries everything the backend needs to wire the device into the
+    /// emulated IOMMU.
+    pub fn with_hardware_nesting(mut self, handle: Arc<dyn Any + Send + Sync>) -> Self {
+        self.passthrough = Passthrough::HardwareNestable(handle);
+        self
     }
 
     /// Derives a DMA target offset by `delta` from this one in RID space.
@@ -137,7 +193,7 @@ impl DmaTarget {
             },
             msi_target: self.msi_target.with_rid_offset(rid_offset),
             iommu: self.iommu.clone(),
-            software_iommu: self.software_iommu,
+            passthrough: self.passthrough.clone(),
         }
     }
 }
@@ -202,7 +258,7 @@ mod tests {
     fn new_has_no_iommu() {
         let msi_conn = MsiConnection::new();
         let target = DmaTarget::new(AssignedBusRange::new(), 0, GuestMemory::empty(), &msi_conn);
-        assert!(!target.software_iommu());
+        assert!(matches!(target.passthrough(), DmaPassthrough::Allowed));
         assert!(target.iommu.is_none());
     }
 
@@ -227,7 +283,7 @@ mod tests {
         assert_eq!(buf[0], 0xAB);
 
         // The MSI identity is derived from the offset: bus 5 (secondary) | offset.
-        assert!(!derived.software_iommu());
+        assert!(matches!(derived.passthrough(), DmaPassthrough::Allowed));
         derived.msi_target().signal_msi(0xFEE0_0000, 0);
         assert_eq!(recorder.pop().unwrap(), (5 << 8) | 0x18);
     }
@@ -258,7 +314,10 @@ mod tests {
 
         let iommu = RecordingIommu::new();
         let target = DmaTarget::with_iommu(bus_range.clone(), 0, iommu.clone(), &msi_conn);
-        assert!(target.software_iommu());
+        assert!(matches!(
+            target.passthrough(),
+            DmaPassthrough::SoftwareBlocked
+        ));
 
         let derived = target.with_rid_offset(0x18);
 
@@ -271,7 +330,10 @@ mod tests {
         let mut buf = [0u8];
         derived.guest_memory().read_at(0x1500, &mut buf).unwrap();
         assert_eq!(buf[0], 0xCD);
-        assert!(derived.software_iommu());
+        assert!(matches!(
+            derived.passthrough(),
+            DmaPassthrough::SoftwareBlocked
+        ));
 
         derived.msi_target().signal_msi(0xFEE0_0000, 0);
         assert_eq!(recorder.pop().unwrap(), (5 << 8) | 0x18);
@@ -300,9 +362,51 @@ mod tests {
         let mut buf = [0u8];
         derived.guest_memory().read_at(0x1500, &mut buf).unwrap();
         assert_eq!(buf[0], 0xCD);
-        assert!(derived.software_iommu());
+        assert!(matches!(
+            derived.passthrough(),
+            DmaPassthrough::SoftwareBlocked
+        ));
 
         derived.msi_target().signal_msi(0xFEE0_0000, 0);
         assert_eq!(recorder.pop().unwrap(), (7 << 8) | 0x0A);
+    }
+
+    /// An opaque nesting context behind the `HardwareNestable` handle, of the
+    /// kind an IOMMU backend crate would define.
+    #[derive(Debug, PartialEq)]
+    struct FakeNestingContext {
+        id: u32,
+    }
+
+    #[test]
+    fn with_hardware_nesting_exposes_downcastable_handle() {
+        let bus_range = AssignedBusRange::new();
+        bus_range.set_bus_range(5, 10);
+        let msi_conn = MsiConnection::new();
+
+        let iommu = RecordingIommu::new();
+        let target = DmaTarget::with_iommu(bus_range.clone(), 0, iommu, &msi_conn)
+            .with_hardware_nesting(Arc::new(FakeNestingContext { id: 0x1234 }));
+
+        // The base target accepts passthrough and hands back the context.
+        match target.passthrough() {
+            DmaPassthrough::HardwareNestable(handle) => {
+                let ctx = handle.downcast_ref::<FakeNestingContext>().unwrap();
+                assert_eq!(ctx, &FakeNestingContext { id: 0x1234 });
+            }
+            _ => panic!("expected HardwareNestable"),
+        }
+
+        // The nesting disposition (and handle) survives VF derivation.
+        let derived = target.with_rid_offset(0x18);
+        match derived.passthrough() {
+            DmaPassthrough::HardwareNestable(handle) => {
+                assert_eq!(
+                    handle.downcast_ref::<FakeNestingContext>().unwrap().id,
+                    0x1234
+                );
+            }
+            _ => panic!("expected HardwareNestable on derived target"),
+        }
     }
 }

--- a/vm/devices/pci/vfio_assigned_device/src/resolver.rs
+++ b/vm/devices/pci/vfio_assigned_device/src/resolver.rs
@@ -67,13 +67,17 @@ impl AsyncResolveResource<PciDeviceHandleKind, VfioDeviceHandle> for VfioDeviceR
             bar_pt,
         } = resource;
 
-        if let pci_core::dma::DmaPassthrough::SoftwareBlocked = input.dma_target.passthrough() {
-            anyhow::bail!(
-                "VFIO device {pci_id} is behind a software IOMMU that cannot \
-                 program the host IOMMU for passthrough DMA. Place the device \
-                 on a root complex without a software IOMMU, or wait for \
-                 iommufd nested translation support."
-            );
+        // The legacy VFIO group/type1 path can only do identity DMA, so only a
+        // device with no relevant IOMMU may be passed through here. Match
+        // exhaustively so a new disposition can't silently slip through.
+        match input.dma_target.passthrough() {
+            pci_core::dma::DmaPassthrough::Allowed => {}
+            pci_core::dma::DmaPassthrough::SoftwareBlocked => {
+                anyhow::bail!("VFIO device {pci_id} is behind a software IOMMU")
+            }
+            pci_core::dma::DmaPassthrough::HardwareNestable(_) => anyhow::bail!(
+                "VFIO device {pci_id} needs a hardware-nestable IOMMU: use the cdev path"
+            ),
         }
 
         tracing::info!(pci_id, "opening VFIO device");
@@ -154,6 +158,19 @@ impl AsyncResolveResource<PciDeviceHandleKind, VfioCdevDeviceHandle> for VfioCde
             iommu_id,
             bar_pt,
         } = resource;
+
+        // The cdev/iommufd path currently attaches devices to an identity
+        // IOAS; nested stage-1 translation is not yet wired up here. Match
+        // exhaustively so a new disposition can't silently slip through.
+        match input.dma_target.passthrough() {
+            pci_core::dma::DmaPassthrough::Allowed => {}
+            pci_core::dma::DmaPassthrough::SoftwareBlocked => {
+                anyhow::bail!("VFIO device {pci_id} is behind a software IOMMU")
+            }
+            pci_core::dma::DmaPassthrough::HardwareNestable(_) => {
+                anyhow::bail!("VFIO device {pci_id}: iommufd nested translation not yet supported")
+            }
+        }
 
         tracing::info!(pci_id, iommu_id, "opening VFIO cdev device with iommufd");
 

--- a/vm/devices/pci/vfio_assigned_device/src/resolver.rs
+++ b/vm/devices/pci/vfio_assigned_device/src/resolver.rs
@@ -67,7 +67,7 @@ impl AsyncResolveResource<PciDeviceHandleKind, VfioDeviceHandle> for VfioDeviceR
             bar_pt,
         } = resource;
 
-        if input.dma_target.software_iommu() {
+        if let pci_core::dma::DmaPassthrough::SoftwareBlocked = input.dma_target.passthrough() {
             anyhow::bail!(
                 "VFIO device {pci_id} is behind a software IOMMU that cannot \
                  program the host IOMMU for passthrough DMA. Place the device \


### PR DESCRIPTION
Replaces the `DmaTarget` `software_iommu: bool` with a three-state `DmaPassthrough` disposition so that assignment backends can distinguish between:

- **`Allowed`** — no relevant IOMMU; host passthrough allowed.
- **`SoftwareBlocked`** — behind a software/emulated IOMMU that cannot program the host IOMMU; passthrough rejected.
- **`HardwareNestable(handle)`** — behind a hardware-nestable IOMMU; passthrough allowed, carrying an opaque handle the backend downcasts to attach the device for nested translation.

The bool only distinguished the first two cases. A `HardwareNestable` target is produced only via the `DmaTarget::with_nestable_iommu` constructor (and the `iommu_common::new_nestable_dma_target` helper), which take the IOMMU and the nesting handle together — so the disposition can never exist without a backing IOMMU. There are **no production call sites** for the nestable constructor yet; it establishes the API an accel-capable emulated IOMMU will use (in a later PR) to opt a translating `DmaTarget` into host passthrough.

Both VFIO resolvers (group and cdev) now match `DmaPassthrough` exhaustively and accept only `Allowed`, since neither path can honor a software or hardware-nestable IOMMU today. The cdev `HardwareNestable` arm becomes the nested-translation setup in the follow-on PR.