### PR TITLE
underhill_core: capture additional meminfo/status fields for OOM diagnosis

### DIFF
--- a/openhcl/underhill_core/src/inspect_proc.rs
+++ b/openhcl/underhill_core/src/inspect_proc.rs
@@ -15,12 +15,15 @@ fn inspect_meminfo(req: Request<'_>) {
     const FIELDS: &[&str] = &[
         "MemTotal",
         "MemFree",
+        "MemAvailable",
         "Mapped",
         "Slab",
         "AnonPages",
         "Active(anon)",
         "Inactive(anon)",
+        "SReclaimable",
         "SUnreclaim",
+        "Mlocked",
         "KernelStack",
         "PageTables",
         "Shmem",
@@ -117,7 +120,9 @@ fn inspect_interrupts(req: Request<'_>) {
 /// Writes inspection results based on the contents of /proc/<pid>/status for userspace processes
 fn inspect_userspace_procs(req: Request<'_>) {
     const KTHREADD_PID_STRING: &str = "2"; // String so we don't have to parse to check it
-    const FIELDS: &[&str] = &["VmSize", "VmPeak", "VmRSS", "VmHWM", "RssAnon"];
+    const FIELDS: &[&str] = &[
+        "VmSize", "VmPeak", "VmRSS", "VmHWM", "RssAnon", "RssFile", "RssShmem",
+    ];
     let mut resp = req.respond();
 
     fn inner(resp: &mut Response<'_>) -> anyhow::Result<()> {


### PR DESCRIPTION
adds a few more memory fields to the inspect_proc telemetry so OOM investigations have more to go on

/proc/meminfo now also captures MemAvailable, SReclaimable (the reclaimable counterpart to the SUnreclaim we already report) and Mlocked

/proc/<pid>/status now also captures RssFile and RssShmem, so RssAnon + RssFile + RssShmem lines up with VmRSS for the full per-process breakdown

no logic change, just additions to the field lists, and these are the fields smmalis37 signed off on in the issue

fixes #3182
