### PR TITLE
vmm_cli: add declarative key=value CLI option parsing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5750,6 +5750,7 @@ dependencies = [
  "vmcore",
  "vmgs_format",
  "vmgs_resources",
+ "vmm_cli",
  "vmm_core_defs",
  "vmotherboard",
  "vmswitch",
@@ -10394,6 +10395,24 @@ checksum = "506c62fdf617a5176827c2f9afbcf1be155b03a9b4bf9617a60dbc07e3a1642f"
 dependencies = [
  "bitflags 1.3.2",
  "libc",
+]
+
+[[package]]
+name = "vmm_cli"
+version = "0.0.0"
+dependencies = [
+ "anyhow",
+ "vmm_cli_derive",
+]
+
+[[package]]
+name = "vmm_cli_derive"
+version = "0.0.0"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -437,6 +437,8 @@ virt_support_x86emu = { path = "vmm_core/virt_support_x86emu" }
 virt_whp = { path = "vmm_core/virt_whp" }
 vm_loader = { path = "vmm_core/vm_loader" }
 vm_manifest_builder = { path = "vmm_core/vm_manifest_builder" }
+vmm_cli = { path = "vmm_core/vmm_cli" }
+vmm_cli_derive = { path = "vmm_core/vmm_cli_derive" }
 vmm_core = { path = "vmm_core" }
 vmm_core_defs = { path = "vmm_core/vmm_core_defs" }
 vmotherboard = { path = "vmm_core/vmotherboard" }

--- a/Guide/src/reference/openvmm/management/cli.md
+++ b/Guide/src/reference/openvmm/management/cli.md
@@ -24,14 +24,14 @@ as well as the generated CLI help (via `cargo run -- --help`).
   Supported keys:
   * `size=<SIZE>` - guest RAM size. Sizes accept `K`, `M`, `G`, and
     `T` suffixes, optionally followed by `B`.
-  * `shared=on|off` - use shared file-backed guest RAM. The default is
+  * `shared[=on|off]` - use shared file-backed guest RAM. The default is
     `on`; `off` uses private anonymous memory.
-  * `prefetch=on|off` - pre-populate guest RAM mappings up front.
+  * `prefetch[=on|off]` - pre-populate guest RAM mappings up front.
     Only has an effect under WHP; a no-op on KVM/mshv.
-  * `thp=on|off` - mark guest RAM (shared or private) as Transparent Huge
+  * `thp[=on|off]` - mark guest RAM (shared or private) as Transparent Huge
     Page eligible. Linux-only, best-effort, and on by default; pass `thp=off` to
     opt out.
-  * `hugepages=on|off` - allocate guest RAM from explicit large/huge pages
+  * `hugepages[=on|off]` - allocate guest RAM from explicit large/huge pages
     (Linux hugetlb pages or a Windows `SEC_LARGE_PAGES` section). Requires
     shared memory.
   * `hugepage_size=<SIZE>` - request a specific large-page size, such

--- a/openvmm/openvmm_entry/Cargo.toml
+++ b/openvmm/openvmm_entry/Cargo.toml
@@ -80,6 +80,7 @@ sparse_mmap.workspace = true
 term.workspace = true
 tracelimit.workspace = true
 tracing_helpers.workspace = true
+vmm_cli.workspace = true
 
 anyhow.workspace = true
 clap = { workspace = true, features = ["derive", "string"] }

--- a/openvmm/openvmm_entry/src/cli_args.rs
+++ b/openvmm/openvmm_entry/src/cli_args.rs
@@ -4974,7 +4974,10 @@ mod tests {
     fn test_parse_vp_list() {
         use vmm_cli::BracketRangeList;
 
-        let parse = |s: &str| s.parse::<BracketRangeList>().map(|v| v.0);
+        let parse = |s: &str| {
+            s.parse::<BracketRangeList>()
+                .and_then(|v| v.expand_below(1024))
+        };
 
         // Individual indices.
         assert_eq!(parse("[0,1,2,3]").unwrap(), vec![0, 1, 2, 3]);
@@ -5044,11 +5047,11 @@ mod tests {
 
         // Node with bracket VP list.
         let n = parse_numa_node("size=1G,vps=[0,1,2,3]").unwrap();
-        assert_eq!(n.vps.unwrap().0, vec![0, 1, 2, 3]);
+        assert_eq!(n.vps.unwrap().expand_below(1024).unwrap(), [0, 1, 2, 3]);
 
         // Node with VP range in brackets.
         let n = parse_numa_node("size=1G,vps=[0-3]").unwrap();
-        assert_eq!(n.vps.unwrap().0, vec![0, 1, 2, 3]);
+        assert_eq!(n.vps.unwrap().expand_below(1024).unwrap(), [0, 1, 2, 3]);
 
         // Node with host_numa_node.
         let n = parse_numa_node("size=1G,host_numa_node=1").unwrap();
@@ -5056,7 +5059,7 @@ mod tests {
 
         // All options together.
         let n = parse_numa_node("size=1G,vps=[0,1],host_numa_node=0,hugepages=on").unwrap();
-        assert_eq!(n.vps.unwrap().0, vec![0, 1]);
+        assert_eq!(n.vps.unwrap().expand_below(1024).unwrap(), [0, 1]);
         assert_eq!(n.host_numa_node, Some(0));
         assert!(n.memory.hugepages);
 
@@ -5074,7 +5077,7 @@ mod tests {
 
         // Empty vps=[] for memory-only node.
         let n = parse_numa_node("size=1G,vps=[]").unwrap();
-        assert_eq!(n.vps.unwrap().0, Vec::<u32>::new());
+        assert!(n.vps.unwrap().0.is_empty());
     }
 
     #[test]

--- a/openvmm/openvmm_entry/src/cli_args.rs
+++ b/openvmm/openvmm_entry/src/cli_args.rs
@@ -67,34 +67,64 @@ pub(crate) fn parse_options() -> Options {
 
 const DEFAULT_MEMORY_SIZE: u64 = 1024 * 1024 * 1024;
 
-/// Guest memory configuration parsed from `--memory`.
-#[derive(Debug, Clone, PartialEq, Eq)]
+/// Guest memory configuration parsed from `--memory` (and, flattened, from
+/// `--numa`).
+///
+/// Fields are the raw parsed options; callers apply the defaults (`size`
+/// defaults to [`DEFAULT_MEMORY_SIZE`]; `transparent_hugepages` defaults to
+/// `!hugepages`). Cross-field validation lives in [`MemoryCli::validate`].
+#[derive(Debug, Clone, Default, PartialEq, Eq, vmm_cli::KeyValueArgs)]
 pub struct MemoryCli {
-    /// Guest RAM size in bytes.
-    pub mem_size: u64,
-    /// Whether shared file-backed memory was explicitly requested.
+    /// Guest RAM size. Defaults to [`DEFAULT_MEMORY_SIZE`] when unset.
+    pub size: Option<vmm_cli::MemorySize>,
+    /// Whether shared file-backed memory was explicitly requested (tri-state:
+    /// unset / `on` / `off`).
+    #[kv(flag)]
     pub shared: Option<bool>,
     /// Whether to prefetch guest RAM.
+    #[kv(flag)]
     pub prefetch: bool,
-    /// Whether to use transparent huge pages for guest RAM.
-    pub transparent_hugepages: bool,
+    /// Whether to use transparent huge pages. When unset, defaults to enabled
+    /// unless `hugepages` is set.
+    #[kv(flag, key = "thp")]
+    pub transparent_hugepages: Option<bool>,
     /// Whether to use explicit hugetlb memfd backing for guest RAM.
+    #[kv(flag)]
     pub hugepages: bool,
-    /// Explicit hugetlb page size in bytes.
-    pub hugepage_size: Option<u64>,
+    /// Explicit hugetlb page size.
+    pub hugepage_size: Option<vmm_cli::MemorySize>,
     /// File used to back guest RAM.
     pub file: Option<PathBuf>,
 }
 
+impl MemoryCli {
+    /// Validate cross-field constraints shared by `--memory` and `--numa`.
+    pub fn validate(&self) -> anyhow::Result<()> {
+        if self.hugepage_size.is_some() && !self.hugepages {
+            anyhow::bail!("hugepage_size requires hugepages=on");
+        }
+        if self.hugepages {
+            if self.shared == Some(false) {
+                anyhow::bail!("hugepages=on conflicts with shared=off");
+            }
+            if self.file.is_some() {
+                anyhow::bail!("hugepages=on conflicts with file=...");
+            }
+        }
+        Ok(())
+    }
+}
+
 /// NUMA node configuration parsed from `--numa`.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, vmm_cli::KeyValueArgs)]
 pub struct NumaNodeCli {
-    /// Memory configuration (size, shared, prefetch, hugepages, etc.)
+    /// Memory configuration (size, shared, prefetch, hugepages, etc.).
+    #[kv(flatten)]
     pub memory: MemoryCli,
     /// Host NUMA node to bind memory allocation to.
     pub host_numa_node: Option<u32>,
     /// Explicit VP indices for this node.
-    pub vps: Option<Vec<u32>>,
+    pub vps: Option<vmm_cli::BracketRangeList>,
 }
 
 /// NUMA distance parsed from `--numa-distance`.
@@ -1223,7 +1253,7 @@ Syntax: id=<name>
 impl Options {
     /// Returns the effective guest RAM size.
     pub fn memory_size(&self) -> u64 {
-        self.memory.mem_size
+        self.memory.size.map(|m| m.0).unwrap_or(DEFAULT_MEMORY_SIZE)
     }
 
     /// Returns whether guest RAM should be prefetched.
@@ -1238,7 +1268,10 @@ impl Options {
 
     /// Returns whether guest RAM should be marked THP-eligible.
     pub fn transparent_hugepages(&self) -> bool {
-        self.memory.transparent_hugepages || self.deprecated_thp
+        self.memory
+            .transparent_hugepages
+            .unwrap_or(!self.memory.hugepages)
+            || self.deprecated_thp
     }
 
     /// Returns the effective file backing path for guest RAM.
@@ -1457,223 +1490,32 @@ fn parse_acs_capability_mask(value: &str) -> anyhow::Result<u16> {
     }
 }
 
-fn parse_memory_toggle(key: &str, value: &str) -> anyhow::Result<bool> {
-    match value {
-        "on" => Ok(true),
-        "off" => Ok(false),
-        _ => anyhow::bail!("invalid {key} value '{value}', expected 'on' or 'off'"),
-    }
-}
-
-/// Accumulator for shared memory option parsing (size, shared, prefetch, thp,
-/// hugepages, hugepage_size). Used by both `parse_memory_config` and
-/// `parse_numa_node`.
-#[derive(Default)]
-struct MemoryOptionAccum {
-    mem_size: Option<u64>,
-    shared: Option<bool>,
-    prefetch: Option<bool>,
-    transparent_hugepages: Option<bool>,
-    hugepages: Option<bool>,
-    hugepage_size: Option<u64>,
-}
-
-impl MemoryOptionAccum {
-    /// Try to parse a key=value pair as a common memory option.
-    /// Returns `Ok(true)` if the key was recognized, `Ok(false)` if not.
-    fn try_parse(&mut self, key: &str, value: &str) -> anyhow::Result<bool> {
-        match key {
-            "size" => {
-                anyhow::ensure!(self.mem_size.is_none(), "duplicate option 'size'");
-                self.mem_size = Some(parse_memory(value)?);
-            }
-            "shared" => {
-                anyhow::ensure!(self.shared.is_none(), "duplicate option 'shared'");
-                self.shared = Some(parse_memory_toggle(key, value)?);
-            }
-            "prefetch" => {
-                anyhow::ensure!(self.prefetch.is_none(), "duplicate option 'prefetch'");
-                self.prefetch = Some(parse_memory_toggle(key, value)?);
-            }
-            "thp" => {
-                anyhow::ensure!(
-                    self.transparent_hugepages.is_none(),
-                    "duplicate option 'thp'"
-                );
-                self.transparent_hugepages = Some(parse_memory_toggle(key, value)?);
-            }
-            "hugepages" => {
-                anyhow::ensure!(self.hugepages.is_none(), "duplicate option 'hugepages'");
-                self.hugepages = Some(parse_memory_toggle(key, value)?);
-            }
-            "hugepage_size" => {
-                anyhow::ensure!(
-                    self.hugepage_size.is_none(),
-                    "duplicate option 'hugepage_size'"
-                );
-                self.hugepage_size = Some(parse_memory(value)?);
-            }
-            _ => return Ok(false),
-        }
-        Ok(true)
-    }
-
-    /// Validate common constraints and build a `MemoryCli`.
-    fn finish(self, default_size: u64, file: Option<PathBuf>) -> anyhow::Result<MemoryCli> {
-        if self.hugepage_size.is_some() && self.hugepages != Some(true) {
-            anyhow::bail!("hugepage_size requires hugepages=on");
-        }
-        if self.hugepages == Some(true) {
-            if self.shared == Some(false) {
-                anyhow::bail!("hugepages=on conflicts with shared=off");
-            }
-            if file.is_some() {
-                anyhow::bail!("hugepages=on conflicts with file=...");
-            }
-        }
-        Ok(MemoryCli {
-            mem_size: self.mem_size.unwrap_or(default_size),
-            shared: self.shared,
-            prefetch: self.prefetch.unwrap_or(false),
-            transparent_hugepages: self
-                .transparent_hugepages
-                .unwrap_or(self.hugepages != Some(true)),
-            hugepages: self.hugepages.unwrap_or(false),
-            hugepage_size: self.hugepage_size,
-            file,
-        })
-    }
-}
-
 fn parse_memory_config(s: &str) -> anyhow::Result<MemoryCli> {
-    if !s.contains('=') && !s.contains(',') {
-        return Ok(MemoryCli {
-            mem_size: parse_memory(s)?,
-            shared: None,
-            prefetch: false,
-            transparent_hugepages: true,
-            hugepages: false,
-            hugepage_size: None,
-            file: None,
-        });
-    }
-
-    let mut accum = MemoryOptionAccum::default();
-    let mut file = None;
-
-    for part in s.split(',') {
-        let (key, value) = part
-            .split_once('=')
-            .with_context(|| format!("invalid memory option '{part}', expected key=value"))?;
-        if key.is_empty() || value.is_empty() {
-            anyhow::bail!("invalid memory option '{part}', expected key=value");
+    // Bare shortcut: `--memory 64G` sets only the size.
+    let memory = if !s.contains('=') && !s.contains(',') {
+        MemoryCli {
+            size: Some(vmm_cli::MemorySize(parse_memory(s)?)),
+            ..Default::default()
         }
-
-        if accum.try_parse(key, value)? {
-            continue;
-        }
-        match key {
-            "file" => {
-                anyhow::ensure!(file.is_none(), "duplicate memory option 'file'");
-                file = Some(PathBuf::from(value));
-            }
-            _ => anyhow::bail!("unknown memory option '{key}'"),
-        }
-    }
-
-    accum.finish(DEFAULT_MEMORY_SIZE, file)
-}
-
-/// Split a comma-delimited option string, but skip commas inside `[]`.
-fn split_options(s: &str) -> anyhow::Result<Vec<&str>> {
-    let mut parts = Vec::new();
-    let mut depth = 0u32;
-    let mut start = 0;
-    for (i, c) in s.char_indices() {
-        match c {
-            '[' => depth += 1,
-            ']' => {
-                anyhow::ensure!(depth > 0, "unmatched ']' in '{s}'");
-                depth -= 1;
-            }
-            ',' if depth == 0 => {
-                parts.push(&s[start..i]);
-                start = i + 1;
-            }
-            _ => {}
-        }
-    }
-    anyhow::ensure!(depth == 0, "unmatched '[' in '{s}'");
-    parts.push(&s[start..]);
-    Ok(parts)
-}
-
-/// Parse a VP list value in bracket syntax: `[0,1,4-5]`.
-/// Returns individual VP indices.
-fn parse_vp_list(value: &str) -> anyhow::Result<Vec<u32>> {
-    let inner = value
-        .strip_prefix('[')
-        .and_then(|s| s.strip_suffix(']'))
-        .with_context(|| {
-            format!("vps value must use bracket syntax, e.g. [0,1,2-3], got '{value}'")
-        })?;
-
-    if inner.is_empty() {
-        return Ok(Vec::new());
-    }
-
-    let mut vps = Vec::new();
-    for item in inner.split(',') {
-        let item = item.trim();
-        if let Some((lo, hi)) = item.split_once('-') {
-            let lo = lo.trim().parse::<u32>().context("invalid vp index")?;
-            let hi = hi.trim().parse::<u32>().context("invalid vp index")?;
-            anyhow::ensure!(lo <= hi, "invalid vp range {lo}-{hi}");
-            vps.extend(lo..=hi);
-        } else {
-            vps.push(item.parse::<u32>().context("invalid vp index")?);
-        }
-    }
-    Ok(vps)
+    } else {
+        s.parse::<MemoryCli>()?
+    };
+    memory.validate()?;
+    Ok(memory)
 }
 
 fn parse_numa_node(s: &str) -> anyhow::Result<NumaNodeCli> {
-    let mut accum = MemoryOptionAccum::default();
-    let mut host_numa_node = None;
-    let mut vps: Option<Vec<u32>> = None;
-
-    for part in split_options(s)? {
-        let (key, value) = part
-            .split_once('=')
-            .with_context(|| format!("invalid numa option '{part}', expected key=value"))?;
-
-        if accum.try_parse(key, value)? {
-            continue;
-        }
-        match key {
-            "host_numa_node" => {
-                anyhow::ensure!(
-                    host_numa_node.is_none(),
-                    "duplicate numa option 'host_numa_node'"
-                );
-                host_numa_node = Some(value.parse::<u32>().context("invalid host_numa_node")?);
-            }
-            "vps" => {
-                anyhow::ensure!(vps.is_none(), "duplicate numa option 'vps'");
-                vps = Some(parse_vp_list(value)?);
-            }
-            _ => anyhow::bail!("unknown numa option '{key}'"),
-        }
-    }
-
-    anyhow::ensure!(accum.mem_size.is_some(), "numa node requires 'size' option");
-    let memory = accum.finish(0, None)?;
-
-    Ok(NumaNodeCli {
-        memory,
-        host_numa_node,
-        vps,
-    })
+    let node: NumaNodeCli = s.parse()?;
+    anyhow::ensure!(
+        node.memory.size.is_some(),
+        "numa node requires 'size' option"
+    );
+    anyhow::ensure!(
+        node.memory.file.is_none(),
+        "'file' is not supported in --numa"
+    );
+    node.memory.validate()?;
+    Ok(node)
 }
 
 fn parse_numa_distance(s: &str) -> anyhow::Result<NumaDistanceCli> {
@@ -2017,75 +1859,74 @@ pub enum UnderhillDiskSource {
     Nvme,
 }
 
+/// A `relay=<name>[:<location>]` target for an OpenHCL-managed controller.
+struct RelayTarget {
+    name: String,
+    location: Option<u32>,
+}
+
+impl FromStr for RelayTarget {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> anyhow::Result<Self> {
+        Ok(if let Some((name, loc)) = s.split_once(':') {
+            RelayTarget {
+                name: name.to_string(),
+                location: Some(loc.parse::<u32>().context("invalid relay location")?),
+            }
+        } else {
+            RelayTarget {
+                name: s.to_string(),
+                location: None,
+            }
+        })
+    }
+}
+
+/// Raw `--disk`/`--nvme`/`--virtio-blk` options, resolved and validated into a
+/// [`DiskCli`] by its `FromStr`.
+#[derive(vmm_cli::KeyValueArgs)]
+struct DiskArgs {
+    #[kv(positional)]
+    kind: DiskCliKind,
+    #[kv(flag)]
+    ro: bool,
+    #[kv(flag)]
+    dvd: bool,
+    #[kv(flag, key = "vtl2", present = DeviceVtl::Vtl2, absent = DeviceVtl::Vtl0)]
+    vtl: DeviceVtl,
+    #[kv(flag)]
+    uh: bool,
+    #[kv(flag, key = "uh-nvme")]
+    uh_nvme: bool,
+    pcie_port: Option<String>,
+    #[kv(key = "on")]
+    controller: Option<String>,
+    nsid: Option<u32>,
+    lun: Option<u8>,
+    relay: Option<RelayTarget>,
+}
+
 impl FromStr for DiskCli {
     type Err = anyhow::Error;
 
     fn from_str(s: &str) -> anyhow::Result<Self> {
-        let mut opts = s.split(',');
-        let kind = opts.next().unwrap().parse()?;
+        let args: DiskArgs = s.parse()?;
 
-        let mut read_only = false;
-        let mut is_dvd = false;
-        let mut underhill = None;
-        let mut vtl = DeviceVtl::Vtl0;
-        let mut pcie_port = None;
-        let mut controller = None;
-        let mut nsid = None;
-        let mut lun = None;
-        let mut relay = None;
-        for opt in opts {
-            let mut s = opt.split('=');
-            let opt = s.next().unwrap();
-            match opt {
-                "ro" => read_only = true,
-                "dvd" => {
-                    is_dvd = true;
-                    read_only = true;
-                }
-                "vtl2" => {
-                    vtl = DeviceVtl::Vtl2;
-                }
-                "uh" => underhill = Some(UnderhillDiskSource::Scsi),
-                "uh-nvme" => underhill = Some(UnderhillDiskSource::Nvme),
-                "pcie_port" => {
-                    let port = s.next();
-                    if port.is_none_or(|p| p.is_empty()) {
-                        anyhow::bail!("`pcie_port` requires a port name");
-                    }
-                    pcie_port = Some(String::from(port.unwrap()));
-                }
-                "on" => {
-                    let name = s.next();
-                    if name.is_none_or(|n| n.is_empty()) {
-                        anyhow::bail!("`on` requires a controller name");
-                    }
-                    controller = Some(String::from(name.unwrap()));
-                }
-                "nsid" => {
-                    let val = s.next().context("`nsid` requires a value")?;
-                    nsid = Some(val.parse::<u32>().context("invalid `nsid` value")?);
-                }
-                "lun" => {
-                    let val = s.next().context("`lun` requires a value")?;
-                    lun = Some(val.parse::<u8>().context("invalid `lun` value")?);
-                }
-                "relay" => {
-                    let val = s.next();
-                    if val.is_none_or(|v| v.is_empty()) {
-                        anyhow::bail!("`relay` requires a target controller name");
-                    }
-                    let val = val.unwrap();
-                    // Parse "name" or "name:location"
-                    if let Some((name, loc)) = val.split_once(':') {
-                        let loc = loc.parse::<u32>().context("invalid relay location")?;
-                        relay = Some((name.to_string(), Some(loc)));
-                    } else {
-                        relay = Some((val.to_string(), None));
-                    }
-                }
-                opt => anyhow::bail!("unknown option: '{opt}'"),
-            }
-        }
+        let underhill = match (args.uh, args.uh_nvme) {
+            (false, false) => None,
+            (true, false) => Some(UnderhillDiskSource::Scsi),
+            (false, true) => Some(UnderhillDiskSource::Nvme),
+            (true, true) => anyhow::bail!("`uh` and `uh-nvme` are mutually exclusive"),
+        };
+        let read_only = args.ro || args.dvd;
+        let is_dvd = args.dvd;
+        let vtl = args.vtl;
+        let pcie_port = args.pcie_port;
+        let controller = args.controller;
+        let nsid = args.nsid;
+        let lun = args.lun;
+        let relay = args.relay.map(|r| (r.name, r.location));
 
         if underhill.is_some() && vtl != DeviceVtl::Vtl0 {
             anyhow::bail!("`uh` or `uh-nvme` is incompatible with `vtl2`");
@@ -2131,7 +1972,7 @@ impl FromStr for DiskCli {
 
         Ok(DiskCli {
             vtl,
-            kind,
+            kind: args.kind,
             read_only,
             is_dvd,
             underhill,
@@ -2145,134 +1986,41 @@ impl FromStr for DiskCli {
 }
 
 /// The transport for a named NVMe controller.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, vmm_cli::KeyValueGroup)]
+#[kv(required)]
 pub enum NvmeControllerTransport {
     /// Present via PCIe on the specified root port.
+    #[kv(key = "pcie_port")]
     Pcie(String),
     /// Present via VPCI with an optional instance GUID.
+    #[kv(key = "vpci")]
     Vpci(Option<Guid>),
 }
 
 /// CLI arguments for a named NVMe controller.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, vmm_cli::KeyValueArgs)]
 pub struct NvmeControllerCli {
     /// Controller name, referenced by `--disk on=<name>`.
     pub id: String,
     /// Transport configuration.
+    #[kv(flatten)]
     pub transport: NvmeControllerTransport,
     /// VTL assignment (default VTL0).
+    #[kv(flag, key = "vtl2", present = DeviceVtl::Vtl2, absent = DeviceVtl::Vtl0)]
     pub vtl: DeviceVtl,
 }
 
-impl FromStr for NvmeControllerCli {
-    type Err = anyhow::Error;
-
-    fn from_str(s: &str) -> anyhow::Result<Self> {
-        let mut id = None;
-        let mut pcie_port = None;
-        let mut vpci = None;
-        let mut vpci_set = false;
-        let mut vtl = DeviceVtl::Vtl0;
-
-        for part in s.split(',') {
-            let mut kv = part.split('=');
-            let key = kv.next().unwrap();
-            match key {
-                "id" => {
-                    let val = kv.next();
-                    if val.is_none_or(|v| v.is_empty()) {
-                        anyhow::bail!("`id` requires a name");
-                    }
-                    id = Some(val.unwrap().to_string());
-                }
-                "pcie_port" => {
-                    let val = kv.next();
-                    if val.is_none_or(|v| v.is_empty()) {
-                        anyhow::bail!("`pcie_port` requires a port name");
-                    }
-                    pcie_port = Some(val.unwrap().to_string());
-                }
-                "vpci" => {
-                    vpci_set = true;
-                    if let Some(val) = kv.next() {
-                        if !val.is_empty() {
-                            vpci = Some(val.parse::<Guid>().context("invalid GUID for `vpci`")?);
-                        }
-                    }
-                }
-                "vtl2" => {
-                    vtl = DeviceVtl::Vtl2;
-                }
-                other => anyhow::bail!("unknown option: '{other}'"),
-            }
-        }
-
-        let id = id.context("`id` is required")?;
-
-        let transport = match (pcie_port, vpci_set) {
-            (Some(port), false) => NvmeControllerTransport::Pcie(port),
-            (None, true) => NvmeControllerTransport::Vpci(vpci),
-            (Some(_), true) => {
-                anyhow::bail!("`pcie_port` and `vpci` are mutually exclusive")
-            }
-            (None, false) => {
-                anyhow::bail!("one of `pcie_port` or `vpci` is required")
-            }
-        };
-
-        Ok(NvmeControllerCli { id, transport, vtl })
-    }
-}
-
 /// CLI arguments for a named VMBus SCSI controller.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, vmm_cli::KeyValueArgs)]
 pub struct ScsiControllerCli {
     /// Controller name, referenced by `--disk on=<name>`.
     pub id: String,
     /// Number of sub-channels.
+    #[kv(default)]
     pub sub_channels: u16,
     /// VTL assignment (default VTL0).
+    #[kv(flag, key = "vtl2", present = DeviceVtl::Vtl2, absent = DeviceVtl::Vtl0)]
     pub vtl: DeviceVtl,
-}
-
-impl FromStr for ScsiControllerCli {
-    type Err = anyhow::Error;
-
-    fn from_str(s: &str) -> anyhow::Result<Self> {
-        let mut id = None;
-        let mut sub_channels = 0u16;
-        let mut vtl = DeviceVtl::Vtl0;
-
-        for part in s.split(',') {
-            let mut kv = part.split('=');
-            let key = kv.next().unwrap();
-            match key {
-                "id" => {
-                    let val = kv.next();
-                    if val.is_none_or(|v| v.is_empty()) {
-                        anyhow::bail!("`id` requires a name");
-                    }
-                    id = Some(val.unwrap().to_string());
-                }
-                "sub_channels" => {
-                    let val = kv.next().context("`sub_channels` requires a value")?;
-                    sub_channels = val.parse().context("invalid `sub_channels` value")?;
-                }
-                "vtl2" => {
-                    vtl = DeviceVtl::Vtl2;
-                }
-                other => anyhow::bail!("unknown option: '{other}'"),
-            }
-        }
-
-        let id = id.context("`id` is required")?;
-
-        Ok(ScsiControllerCli {
-            id,
-            sub_channels,
-            vtl,
-        })
-    }
 }
 
 /// Protocol type for an OpenHCL-managed controller.
@@ -2283,58 +2031,25 @@ pub enum OpenhclControllerType {
 }
 
 /// CLI arguments for an OpenHCL-managed storage controller (relay target).
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, vmm_cli::KeyValueArgs)]
 pub struct OpenhclControllerCli {
     /// Controller name, referenced by `--disk ... relay=<name>`.
     pub id: String,
     /// Controller protocol.
+    #[kv(key = "type")]
     pub controller_type: OpenhclControllerType,
     /// Instance GUID (auto-derived from name if omitted).
     pub guid: Option<Guid>,
 }
 
-impl FromStr for OpenhclControllerCli {
+impl FromStr for OpenhclControllerType {
     type Err = anyhow::Error;
 
     fn from_str(s: &str) -> anyhow::Result<Self> {
-        let mut id = None;
-        let mut controller_type = None;
-        let mut guid = None;
-
-        for part in s.split(',') {
-            let mut kv = part.split('=');
-            let key = kv.next().unwrap();
-            match key {
-                "id" => {
-                    let val = kv.next();
-                    if val.is_none_or(|v| v.is_empty()) {
-                        anyhow::bail!("`id` requires a name");
-                    }
-                    id = Some(val.unwrap().to_string());
-                }
-                "type" => {
-                    let val = kv.next().context("`type` requires a value")?;
-                    controller_type = Some(match val {
-                        "scsi" => OpenhclControllerType::Scsi,
-                        "nvme" => OpenhclControllerType::Nvme,
-                        other => anyhow::bail!("unknown controller type: '{other}'"),
-                    });
-                }
-                "guid" => {
-                    let val = kv.next().context("`guid` requires a value")?;
-                    guid = Some(val.parse::<Guid>().context("invalid GUID")?);
-                }
-                other => anyhow::bail!("unknown option: '{other}'"),
-            }
-        }
-
-        let id = id.context("`id` is required")?;
-        let controller_type = controller_type.context("`type` is required")?;
-
-        Ok(OpenhclControllerCli {
-            id,
-            controller_type,
-            guid,
+        Ok(match s {
+            "scsi" => OpenhclControllerType::Scsi,
+            "nvme" => OpenhclControllerType::Nvme,
+            other => anyhow::bail!("unknown controller type: '{other}'"),
         })
     }
 }
@@ -2440,34 +2155,12 @@ impl FromStr for IdeDiskCli {
 }
 
 // <kind>[,ro]
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, vmm_cli::KeyValueArgs)]
 pub struct FloppyDiskCli {
+    #[kv(positional)]
     pub kind: DiskCliKind,
+    #[kv(flag, key = "ro")]
     pub read_only: bool,
-}
-
-impl FromStr for FloppyDiskCli {
-    type Err = anyhow::Error;
-
-    fn from_str(s: &str) -> anyhow::Result<Self> {
-        if s.is_empty() {
-            anyhow::bail!("empty disk spec");
-        }
-        let mut opts = s.split(',');
-        let kind = opts.next().unwrap().parse()?;
-
-        let mut read_only = false;
-        for opt in opts {
-            let mut s = opt.split('=');
-            let opt = s.next().unwrap();
-            match opt {
-                "ro" => read_only = true,
-                _ => anyhow::bail!("unknown option: '{opt}'"),
-            }
-        }
-
-        Ok(FloppyDiskCli { kind, read_only })
-    }
 }
 
 #[derive(Clone)]
@@ -2996,115 +2689,83 @@ pub struct PcieRootComplexCli {
     pub vnode: Option<u32>,
 }
 
+/// A `0x`-prefixed hexadecimal address, used for MMIO base overrides.
+struct HexAddress(u64);
+
+impl FromStr for HexAddress {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> anyhow::Result<Self> {
+        Ok(HexAddress(parse_address(s)?))
+    }
+}
+
+/// A CFMWS window-restrictions bitmask (`0x21` or `33`).
+struct CfmwsWindowRestrictionsCli(CfmwsWindowRestrictions);
+
+impl FromStr for CfmwsWindowRestrictionsCli {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> anyhow::Result<Self> {
+        Ok(CfmwsWindowRestrictionsCli(
+            parse_cxl_cfmws_window_restriction_u16_bitmask(s)?,
+        ))
+    }
+}
+
+/// Raw `--pcie-root-complex` options, parsed declaratively. Validated and
+/// mapped into the public [`PcieRootComplexCli`] by its `FromStr`.
+#[derive(vmm_cli::KeyValueArgs)]
+struct PcieRootComplexArgs {
+    #[kv(positional)]
+    name: String,
+    #[kv(default)]
+    segment: u16,
+    #[kv(default)]
+    start_bus: u8,
+    #[kv(default = 255)]
+    end_bus: u8,
+    #[kv(default = vmm_cli::MemorySize(64 * 1024 * 1024))]
+    low_mmio: vmm_cli::MemorySize,
+    #[kv(default = vmm_cli::MemorySize(1024 * 1024 * 1024))]
+    high_mmio: vmm_cli::MemorySize,
+    low_mmio_base: Option<HexAddress>,
+    high_mmio_base: Option<HexAddress>,
+    #[kv(flag)]
+    preserve_bars: bool,
+    #[kv(default = vmm_cli::MemorySize(1024 * 1024 * 1024))]
+    hdm: vmm_cli::MemorySize,
+    #[kv(default = CfmwsWindowRestrictionsCli(CfmwsWindowRestrictions::DEVICE_COHERENT))]
+    hdm_window_restrictions: CfmwsWindowRestrictionsCli,
+    #[kv(key = "node")]
+    vnode: Option<u32>,
+}
+
 impl FromStr for PcieRootComplexCli {
     type Err = anyhow::Error;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        const DEFAULT_PCIE_CRS_LOW_SIZE: u32 = 64 * 1024 * 1024; // 64M
-        const DEFAULT_PCIE_CRS_HIGH_SIZE: u64 = 1024 * 1024 * 1024; // 1G
-        const DEFAULT_PCIE_HDM_SIZE: u64 = 1024 * 1024 * 1024; // 1G
-        const DEFAULT_HDM_WINDOW_RESTRICTIONS: CfmwsWindowRestrictions =
-            CfmwsWindowRestrictions::DEVICE_COHERENT;
+        let args: PcieRootComplexArgs = s.parse()?;
 
-        let mut opts = s.split(',');
-        let name = opts.next().context("expected root complex name")?;
-        if name.is_empty() {
-            anyhow::bail!("must provide a root complex name");
-        }
-
-        let mut segment = 0;
-        let mut start_bus = 0;
-        let mut end_bus = 255;
-        let mut low_mmio = DEFAULT_PCIE_CRS_LOW_SIZE;
-        let mut high_mmio = DEFAULT_PCIE_CRS_HIGH_SIZE;
-        let mut low_mmio_base = None;
-        let mut high_mmio_base = None;
-        let mut preserve_bars = false;
-        let mut hdm = DEFAULT_PCIE_HDM_SIZE;
-        let mut hdm_window_restrictions = DEFAULT_HDM_WINDOW_RESTRICTIONS;
-        let mut vnode = None;
-        for opt in opts {
-            let mut s = opt.split('=');
-            let opt = s.next().context("expected option")?;
-            match opt {
-                "segment" => {
-                    let seg_str = s.next().context("expected segment number")?;
-                    segment = u16::from_str(seg_str).context("failed to parse segment number")?;
-                }
-                "start_bus" => {
-                    let bus_str = s.next().context("expected start bus number")?;
-                    start_bus =
-                        u8::from_str(bus_str).context("failed to parse start bus number")?;
-                }
-                "end_bus" => {
-                    let bus_str = s.next().context("expected end bus number")?;
-                    end_bus = u8::from_str(bus_str).context("failed to parse end bus number")?;
-                }
-                "low_mmio" => {
-                    let low_mmio_str = s.next().context("expected low MMIO size")?;
-                    low_mmio = parse_memory(low_mmio_str)
-                        .context("failed to parse low MMIO size")?
-                        .try_into()?;
-                }
-                "high_mmio" => {
-                    let high_mmio_str = s.next().context("expected high MMIO size")?;
-                    high_mmio =
-                        parse_memory(high_mmio_str).context("failed to parse high MMIO size")?;
-                }
-                "low_mmio_base" => {
-                    let base_str = s.next().context("expected low MMIO base address")?;
-                    low_mmio_base = Some(
-                        parse_address(base_str).context("failed to parse low MMIO base address")?,
-                    );
-                }
-                "high_mmio_base" => {
-                    let base_str = s.next().context("expected high MMIO base address")?;
-                    high_mmio_base = Some(
-                        parse_address(base_str)
-                            .context("failed to parse high MMIO base address")?,
-                    );
-                }
-                "preserve_bars" => {
-                    preserve_bars = true;
-                }
-                "hdm" => {
-                    let hdm_str = s.next().context("expected HDM decoder size")?;
-                    hdm = parse_memory(hdm_str).context("failed to parse HDM decoder size")?;
-                }
-                "hdm_window_restrictions" => {
-                    let mask_str = s
-                        .next()
-                        .context("expected HDM window restrictions bitmask")?;
-                    hdm_window_restrictions =
-                        parse_cxl_cfmws_window_restriction_u16_bitmask(mask_str)
-                            .context("failed to parse HDM window restrictions bitmask")?;
-                }
-                "node" => {
-                    let node_str = s.next().context("expected NUMA node number")?;
-                    vnode =
-                        Some(u32::from_str(node_str).context("failed to parse NUMA node number")?);
-                }
-                opt => anyhow::bail!("unknown option: '{opt}'"),
-            }
-        }
-
-        if start_bus >= end_bus {
+        if args.start_bus >= args.end_bus {
             anyhow::bail!("start_bus must be less than or equal to end_bus");
         }
 
+        let low_mmio = u32::try_from(args.low_mmio.0).context("low MMIO size exceeds 32 bits")?;
+
         Ok(PcieRootComplexCli {
-            name: name.to_string(),
-            segment,
-            start_bus,
-            end_bus,
+            name: args.name,
+            segment: args.segment,
+            start_bus: args.start_bus,
+            end_bus: args.end_bus,
             low_mmio,
-            high_mmio,
-            low_mmio_base,
-            high_mmio_base,
-            preserve_bars,
-            hdm,
-            hdm_window_restrictions,
-            vnode,
+            high_mmio: args.high_mmio.0,
+            low_mmio_base: args.low_mmio_base.map(|a| a.0),
+            high_mmio_base: args.high_mmio_base.map(|a| a.0),
+            preserve_bars: args.preserve_bars,
+            hdm: args.hdm.0,
+            hdm_window_restrictions: args.hdm_window_restrictions.0,
+            vnode: args.vnode,
         })
     }
 }
@@ -3132,73 +2793,81 @@ pub struct PcieRootPortCli {
     pub cxl: bool,
 }
 
+/// A colon-joined `parent:child` name pair used as the positional head of
+/// `--pcie-root-port` and `--pcie-switch`.
+struct PortNamePair {
+    parent: String,
+    child: String,
+}
+
+impl FromStr for PortNamePair {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> anyhow::Result<Self> {
+        let mut it = s.split(':');
+        let parent = it
+            .next()
+            .filter(|x| !x.is_empty())
+            .context("expected parent name")?;
+        let child = it
+            .next()
+            .filter(|x| !x.is_empty())
+            .context("expected child name")?;
+        anyhow::ensure!(it.next().is_none(), "unexpected token in '{s}'");
+        Ok(PortNamePair {
+            parent: parent.to_string(),
+            child: child.to_string(),
+        })
+    }
+}
+
+/// A PCIe device/function address (`XX[.Y]`) parsed into a devfn.
+struct PcieAddr(u8);
+
+impl FromStr for PcieAddr {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> anyhow::Result<Self> {
+        Ok(PcieAddr(parse_pcie_addr(s)?))
+    }
+}
+
+/// An ACS capability bitmask (hex `0x..` or decimal).
+struct AcsMask(u16);
+
+impl FromStr for AcsMask {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> anyhow::Result<Self> {
+        Ok(AcsMask(parse_acs_capability_mask(s)?))
+    }
+}
+
+/// Raw `--pcie-root-port` options, mapped into [`PcieRootPortCli`].
+#[derive(vmm_cli::KeyValueArgs)]
+struct RootPortArgs {
+    #[kv(positional)]
+    names: PortNamePair,
+    addr: Option<PcieAddr>,
+    #[kv(flag)]
+    hotplug: bool,
+    acs: Option<AcsMask>,
+    #[kv(flag)]
+    cxl: bool,
+}
+
 impl FromStr for PcieRootPortCli {
     type Err = anyhow::Error;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let mut opts = s.split(',');
-        let names = opts.next().context("expected root port identifiers")?;
-        if names.is_empty() {
-            anyhow::bail!("must provide root port identifiers");
-        }
-
-        let mut s = names.split(':');
-        let rc_name = s.next().context("expected name of parent root complex")?;
-        let rp_name = s.next().context("expected root port name")?;
-
-        if let Some(extra) = s.next() {
-            anyhow::bail!("unexpected token: '{extra}'")
-        }
-
-        let mut devfn = None;
-        let mut hotplug = false;
-        let mut acs_capabilities_supported = None;
-        let mut cxl = false;
-
-        // Parse optional flags
-        for opt in opts {
-            let mut kv = opt.split('=');
-            let key = kv.next().context("expected option name")?;
-            let value = kv.next();
-
-            match key {
-                "addr" => {
-                    let value = value.context("addr option requires a value")?;
-                    if kv.next().is_some() {
-                        anyhow::bail!("addr option expects a single value")
-                    }
-                    devfn = Some(parse_pcie_addr(value)?);
-                }
-                "hotplug" => {
-                    if value.is_some() {
-                        anyhow::bail!("hotplug option does not take a value")
-                    }
-                    hotplug = true;
-                }
-                "acs" => {
-                    let value = value.context("acs option requires a value")?;
-                    if kv.next().is_some() {
-                        anyhow::bail!("acs option expects a single value")
-                    }
-                    acs_capabilities_supported = Some(parse_acs_capability_mask(value)?);
-                }
-                "cxl" => {
-                    if value.is_some() {
-                        anyhow::bail!("cxl option does not take a value")
-                    }
-                    cxl = true;
-                }
-                _ => anyhow::bail!("unexpected option: '{opt}'"),
-            }
-        }
-
+        let args: RootPortArgs = s.parse()?;
         Ok(PcieRootPortCli {
-            root_complex_name: rc_name.to_string(),
-            name: rp_name.to_string(),
-            devfn,
-            hotplug,
-            acs_capabilities_supported,
-            cxl,
+            root_complex_name: args.names.parent,
+            name: args.names.child,
+            devfn: args.addr.map(|a| a.0),
+            hotplug: args.hotplug,
+            acs_capabilities_supported: args.acs.map(|a| a.0),
+            cxl: args.cxl,
         })
     }
 }
@@ -3242,186 +2911,59 @@ pub struct GenericPcieSwitchCli {
     pub acs_capabilities_supported: Option<u16>,
 }
 
+/// Raw `--pcie-switch` options, mapped into [`GenericPcieSwitchCli`].
+#[derive(vmm_cli::KeyValueArgs)]
+struct SwitchArgs {
+    #[kv(positional)]
+    names: PortNamePair,
+    #[kv(default = 4)]
+    num_downstream_ports: u8,
+    #[kv(flag)]
+    hotplug: bool,
+    acs: Option<AcsMask>,
+}
+
 impl FromStr for GenericPcieSwitchCli {
     type Err = anyhow::Error;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let mut opts = s.split(',');
-        let names = opts.next().context("expected switch identifiers")?;
-        if names.is_empty() {
-            anyhow::bail!("must provide switch identifiers");
-        }
-
-        let mut s = names.split(':');
-        let port_name = s.next().context("expected name of parent port")?;
-        let switch_name = s.next().context("expected switch name")?;
-
-        if let Some(extra) = s.next() {
-            anyhow::bail!("unexpected token: '{extra}'")
-        }
-
-        let mut num_downstream_ports = 4u8; // Default value
-        let mut hotplug = false;
-        let mut acs_capabilities_supported = None;
-
-        for opt in opts {
-            let mut kv = opt.split('=');
-            let key = kv.next().context("expected option name")?;
-
-            match key {
-                "num_downstream_ports" => {
-                    let value = kv.next().context("expected option value")?;
-                    if let Some(extra) = kv.next() {
-                        anyhow::bail!("unexpected token: '{extra}'")
-                    }
-                    num_downstream_ports = value.parse().context("invalid num_downstream_ports")?;
-                }
-                "hotplug" => {
-                    if kv.next().is_some() {
-                        anyhow::bail!("hotplug option does not take a value")
-                    }
-                    hotplug = true;
-                }
-                "acs" => {
-                    let value = kv.next().context("acs option requires a value")?;
-                    if kv.next().is_some() {
-                        anyhow::bail!("acs option expects a single value")
-                    }
-                    acs_capabilities_supported = Some(parse_acs_capability_mask(value)?);
-                }
-                _ => anyhow::bail!("unknown option: '{key}'"),
-            }
-        }
-
+        let args: SwitchArgs = s.parse()?;
         Ok(GenericPcieSwitchCli {
-            port_name: port_name.to_string(),
-            name: switch_name.to_string(),
-            num_downstream_ports,
-            hotplug,
-            acs_capabilities_supported,
+            port_name: args.names.parent,
+            name: args.names.child,
+            num_downstream_ports: args.num_downstream_ports,
+            hotplug: args.hotplug,
+            acs_capabilities_supported: args.acs.map(|a| a.0),
         })
     }
 }
 
 /// CLI configuration mapping a PCIe port name to a generic-initiator NUMA node.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, vmm_cli::KeyValueArgs)]
 pub struct PcieGenericInitiatorCli {
     /// Name of the PCIe port (root port or switch downstream port) behind
     /// which the generic-initiator device resides.
+    #[kv(key = "port")]
     pub port_name: String,
     /// NUMA node the device is a generic initiator for.
     pub node: u32,
 }
 
-impl FromStr for PcieGenericInitiatorCli {
-    type Err = anyhow::Error;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let mut port_name = None;
-        let mut node = None;
-
-        for opt in s.split(',') {
-            let mut kv = opt.split('=');
-            let key = kv.next().context("expected option name")?;
-            let value = kv.next();
-            if kv.next().is_some() {
-                anyhow::bail!("option '{key}' expects a single value")
-            }
-
-            match key {
-                "port" => {
-                    let value = value.context("port option requires a value")?;
-                    if value.is_empty() {
-                        anyhow::bail!("port option requires a value");
-                    }
-                    port_name = Some(value.to_string());
-                }
-                "node" => {
-                    let value = value.context("node option requires a value")?;
-                    node = Some(
-                        u32::from_str(value)
-                            .context("failed to parse generic initiator NUMA node")?,
-                    );
-                }
-                _ => anyhow::bail!("unexpected option: '{opt}'"),
-            }
-        }
-
-        Ok(PcieGenericInitiatorCli {
-            port_name: port_name.context("expected 'port=<name>'")?,
-            node: node.context("expected 'node=<node>'")?,
-        })
-    }
-}
-
 /// CLI configuration for a PCIe remote device.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, vmm_cli::KeyValueArgs)]
 pub struct PcieRemoteCli {
     /// Name of the PCIe downstream port to attach to.
+    #[kv(positional)]
     pub port_name: String,
     /// TCP socket address for the remote simulator.
+    #[kv(key = "socket")]
     pub socket_addr: Option<String>,
     /// Hardware unit identifier for plug request.
+    #[kv(default)]
     pub hu: u16,
     /// Controller identifier for plug request.
+    #[kv(default)]
     pub controller: u16,
-}
-
-impl FromStr for PcieRemoteCli {
-    type Err = anyhow::Error;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let mut opts = s.split(',');
-        let port_name = opts.next().context("expected port name")?;
-        if port_name.is_empty() {
-            anyhow::bail!("must provide a port name");
-        }
-
-        let mut socket_addr = None;
-        let mut hu = 0u16;
-        let mut controller = 0u16;
-
-        for opt in opts {
-            let mut kv = opt.split('=');
-            let key = kv.next().context("expected option name")?;
-            let value = kv.next();
-
-            match key {
-                "socket" => {
-                    let addr = value.context("socket requires an address")?;
-                    if let Some(extra) = kv.next() {
-                        anyhow::bail!("unexpected token: '{extra}'")
-                    }
-                    if addr.is_empty() {
-                        anyhow::bail!("socket address cannot be empty");
-                    }
-                    socket_addr = Some(addr.to_string());
-                }
-                "hu" => {
-                    let val = value.context("hu requires a value")?;
-                    if let Some(extra) = kv.next() {
-                        anyhow::bail!("unexpected token: '{extra}'")
-                    }
-                    hu = val.parse().context("failed to parse hu")?;
-                }
-                "controller" => {
-                    let val = value.context("controller requires a value")?;
-                    if let Some(extra) = kv.next() {
-                        anyhow::bail!("unexpected token: '{extra}'")
-                    }
-                    controller = val.parse().context("failed to parse controller")?;
-                }
-                _ => anyhow::bail!("unknown option: '{key}'"),
-            }
-        }
-
-        Ok(PcieRemoteCli {
-            port_name: port_name.to_string(),
-            socket_addr,
-            hu,
-            controller,
-        })
-    }
 }
 
 /// CLI configuration for a VFIO-assigned PCI device.
@@ -3442,65 +2984,70 @@ pub struct VfioDeviceCli {
     pub bar_pt: [bool; 6],
 }
 
+/// Marker for a BAR passthrough value; only `pt` is accepted.
+#[cfg(target_os = "linux")]
+struct Pt;
+
+#[cfg(target_os = "linux")]
+impl FromStr for Pt {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> anyhow::Result<Self> {
+        anyhow::ensure!(s == "pt", "expected 'pt'");
+        Ok(Pt)
+    }
+}
+
+/// Per-BAR passthrough flags (`bar0=pt` .. `bar5=pt`), flattened into
+/// [`VfioArgs`].
+#[cfg(target_os = "linux")]
+#[derive(vmm_cli::KeyValueArgs)]
+struct BarFlags {
+    bar0: Option<Pt>,
+    bar1: Option<Pt>,
+    bar2: Option<Pt>,
+    bar3: Option<Pt>,
+    bar4: Option<Pt>,
+    bar5: Option<Pt>,
+}
+
+/// Raw `--vfio` options, resolved and validated into a [`VfioDeviceCli`].
+#[cfg(target_os = "linux")]
+#[derive(vmm_cli::KeyValueArgs)]
+struct VfioArgs {
+    host: String,
+    port: String,
+    iommu: Option<String>,
+    #[kv(flatten)]
+    bars: BarFlags,
+}
+
 #[cfg(target_os = "linux")]
 impl FromStr for VfioDeviceCli {
     type Err = anyhow::Error;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let mut host: Option<String> = None;
-        let mut port: Option<String> = None;
-        let mut iommu: Option<String> = None;
-        let mut bar_pt = [false; 6];
-
-        for kv in s.split(',') {
-            let (key, value) = kv
-                .split_once('=')
-                .context("expected key=value pair (e.g., host=0000:01:00.0,port=rp0)")?;
-            if value.is_empty() {
-                anyhow::bail!("--vfio: '{key}=' value cannot be empty");
-            }
-            match key {
-                "host" => {
-                    if host.is_some() {
-                        anyhow::bail!("duplicate --vfio key: 'host'");
-                    }
-                    host = Some(value.to_string());
-                }
-                "port" => {
-                    if port.is_some() {
-                        anyhow::bail!("duplicate --vfio key: 'port'");
-                    }
-                    port = Some(value.to_string());
-                }
-                "iommu" => {
-                    if iommu.is_some() {
-                        anyhow::bail!("duplicate --vfio key: 'iommu'");
-                    }
-                    iommu = Some(value.to_string());
-                }
-                "bar0" | "bar1" | "bar2" | "bar3" | "bar4" | "bar5" => {
-                    if value != "pt" {
-                        anyhow::bail!("--vfio: '{key}' only accepts 'pt' as a value");
-                    }
-                    let idx: usize = key[3..].parse().unwrap();
-                    bar_pt[idx] = true;
-                }
-                _ => anyhow::bail!("unknown --vfio key: '{key}'"),
-            }
-        }
-
-        let pci_id = host.context("--vfio: 'host=' is required")?;
-        let port_name = port.context("--vfio: 'port=' is required")?;
+        let args: VfioArgs = s.parse()?;
 
         // Reject path separators to prevent sysfs path traversal via Path::join.
-        if pci_id.contains('/') || pci_id.contains("..") {
+        if args.host.contains('/') || args.host.contains("..") {
             anyhow::bail!("PCI address must not contain path separators");
         }
 
+        let bars = args.bars;
+        let bar_pt = [
+            bars.bar0.is_some(),
+            bars.bar1.is_some(),
+            bars.bar2.is_some(),
+            bars.bar3.is_some(),
+            bars.bar4.is_some(),
+            bars.bar5.is_some(),
+        ];
+
         Ok(VfioDeviceCli {
-            port_name,
-            pci_id,
-            iommu,
+            port_name: args.port,
+            pci_id: args.host,
+            iommu: args.iommu,
             bar_pt,
         })
     }
@@ -3510,75 +3057,40 @@ impl FromStr for VfioDeviceCli {
 ///
 /// Syntax: `rc=<name>[,accel][,oas=auto|N]`. `oas` defaults to `auto`.
 #[cfg(guest_arch = "aarch64")]
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, vmm_cli::KeyValueArgs)]
 pub struct SmmuCli {
     /// Name of the PCIe root complex this SMMU covers.
+    #[kv(key = "rc")]
     pub rc_name: String,
     /// Enable HW-accelerated nested translation (iommufd).
+    #[kv(flag)]
     pub accel: bool,
     /// Output address size policy.
+    #[kv(default)]
     pub oas: SmmuOasCli,
 }
 
 /// Output address size (OAS) policy parsed from `--smmu`.
 #[cfg(guest_arch = "aarch64")]
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, Default)]
 pub enum SmmuOasCli {
     /// Advertise a fixed default OAS (see the `--smmu` docs for the sizing
     /// policy and when a larger fixed OAS is required).
+    #[default]
     Auto,
     /// Fixed OAS in bits (one of 32, 36, 40, 42, 44, 48, 52).
     Fixed(u8),
 }
 
 #[cfg(guest_arch = "aarch64")]
-impl FromStr for SmmuCli {
+impl FromStr for SmmuOasCli {
     type Err = anyhow::Error;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let mut rc_name: Option<String> = None;
-        let mut accel = false;
-        let mut oas = SmmuOasCli::Auto;
-
-        for part in s.split(',') {
-            if let Some((key, value)) = part.split_once('=') {
-                match key {
-                    "rc" => {
-                        if rc_name.is_some() {
-                            anyhow::bail!("duplicate --smmu key: 'rc'");
-                        }
-                        if value.is_empty() {
-                            anyhow::bail!("--smmu: 'rc=' value cannot be empty");
-                        }
-                        rc_name = Some(value.to_string());
-                    }
-                    "oas" => {
-                        oas = if value == "auto" {
-                            SmmuOasCli::Auto
-                        } else {
-                            let bits: u8 = value
-                                .parse()
-                                .context("--smmu: oas must be 'auto' or a number")?;
-                            SmmuOasCli::Fixed(bits)
-                        };
-                    }
-                    _ => anyhow::bail!("unknown --smmu key: '{key}'"),
-                }
-            } else {
-                // Boolean flag (no '=')
-                match part {
-                    "accel" => accel = true,
-                    _ => anyhow::bail!("unknown --smmu flag: '{part}'"),
-                }
-            }
-        }
-
-        let rc_name = rc_name.context("--smmu: 'rc=' is required")?;
-
-        Ok(SmmuCli {
-            rc_name,
-            accel,
-            oas,
+        Ok(if s == "auto" {
+            SmmuOasCli::Auto
+        } else {
+            SmmuOasCli::Fixed(s.parse().context("oas must be 'auto' or a number")?)
         })
     }
 }
@@ -3587,30 +3099,10 @@ impl FromStr for SmmuCli {
 ///
 /// Syntax: `id=<name>`
 #[cfg(target_os = "linux")]
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, vmm_cli::KeyValueArgs)]
 pub struct IommuCli {
     /// Unique identifier for this iommufd context.
     pub id: String,
-}
-
-#[cfg(target_os = "linux")]
-impl FromStr for IommuCli {
-    type Err = anyhow::Error;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let (key, value) = s
-            .split_once('=')
-            .context("expected id=<name> (e.g., id=iommu0)")?;
-        if key != "id" {
-            anyhow::bail!("expected 'id=<name>', got '{key}=...'");
-        }
-        if value.is_empty() {
-            anyhow::bail!("iommu id cannot be empty");
-        }
-        Ok(IommuCli {
-            id: value.to_string(),
-        })
-    }
 }
 
 /// Read a environment variable that may / may-not have a target-specific
@@ -3674,31 +3166,21 @@ pub struct VhostUserCli {
     pub pcie_port: Option<String>,
 }
 
-/// Split a string on commas, but not inside `[…]` brackets.
-///
-/// Returns an error on mismatched brackets (unmatched `]` or unclosed `[`).
+/// Raw `--vhost-user` options, resolved into a [`VhostUserCli`] by its
+/// `FromStr`.
 #[cfg(target_os = "linux")]
-fn split_respecting_brackets(s: &str) -> anyhow::Result<Vec<&str>> {
-    let mut result = Vec::new();
-    let mut start = 0;
-    let mut depth: i32 = 0;
-    for (i, c) in s.char_indices() {
-        match c {
-            '[' => depth += 1,
-            ']' => {
-                depth -= 1;
-                anyhow::ensure!(depth >= 0, "unmatched ']' in option string");
-            }
-            ',' if depth == 0 => {
-                result.push(&s[start..i]);
-                start = i + 1;
-            }
-            _ => {}
-        }
-    }
-    anyhow::ensure!(depth == 0, "unclosed '[' in option string");
-    result.push(&s[start..]);
-    Ok(result)
+#[derive(vmm_cli::KeyValueArgs)]
+struct VhostUserArgs {
+    #[kv(positional)]
+    socket_path: String,
+    #[kv(key = "type")]
+    type_name: Option<String>,
+    device_id: Option<u16>,
+    tag: Option<String>,
+    pcie_port: Option<String>,
+    num_queues: Option<u16>,
+    queue_size: Option<u16>,
+    queue_sizes: Option<vmm_cli::BracketList<u16>>,
 }
 
 #[cfg(target_os = "linux")]
@@ -3706,105 +3188,56 @@ impl FromStr for VhostUserCli {
     type Err = anyhow::Error;
 
     fn from_str(s: &str) -> anyhow::Result<Self> {
-        // Split on commas, but not inside brackets (for queue_sizes=[N,N]).
-        let parts = split_respecting_brackets(s)?;
-        let mut parts_iter = parts.into_iter();
-        let socket_path = parts_iter
-            .next()
-            .context("missing socket path")?
-            .to_string();
+        let mut args: VhostUserArgs = s.parse()?;
+        let type_name = args.type_name.take();
 
-        let mut device_id: Option<u16> = None;
-        let mut tag: Option<String> = None;
-        let mut pcie_port: Option<String> = None;
-        let mut type_name = None;
-        let mut num_queues: Option<u16> = None;
-        let mut queue_size: Option<u16> = None;
-        let mut queue_sizes: Option<Vec<u16>> = None;
-        for opt in parts_iter {
-            let (key, val) = opt.split_once('=').context("expected key=value option")?;
-            match key {
-                "type" => {
-                    type_name = Some(val);
-                }
-                "device_id" => {
-                    device_id = Some(val.parse().context("invalid device_id")?);
-                }
-                "tag" => {
-                    tag = Some(val.to_string());
-                }
-                "pcie_port" => {
-                    pcie_port = Some(val.to_string());
-                }
-                "num_queues" => {
-                    num_queues = Some(val.parse().context("invalid num_queues")?);
-                }
-                "queue_size" => {
-                    queue_size = Some(val.parse().context("invalid queue_size")?);
-                }
-                "queue_sizes" => {
-                    // Parse bracket-delimited comma-separated list: [N,N,N]
-                    let trimmed = val
-                        .strip_prefix('[')
-                        .and_then(|v| v.strip_suffix(']'))
-                        .context("queue_sizes must be bracketed: [N,N,N]")?;
-                    let sizes: Vec<u16> = trimmed
-                        .split(',')
-                        .map(|s| s.parse().context("invalid queue size in queue_sizes"))
-                        .collect::<anyhow::Result<_>>()?;
-                    anyhow::ensure!(!sizes.is_empty(), "queue_sizes must be non-empty");
-                    queue_sizes = Some(sizes);
-                }
-                other => anyhow::bail!("unknown vhost-user option: '{other}'"),
-            }
-        }
-
-        if type_name.is_some() == device_id.is_some() {
+        if type_name.is_some() == args.device_id.is_some() {
             anyhow::bail!("must specify type=<name> or device_id=<N>");
         }
 
-        // Build the typed device variant.
-        let device_type = match type_name {
-            Some("fs") => {
-                let tag = tag.take().context("type=fs requires tag=<name>")?;
-                VhostUserDeviceTypeCli::Fs {
-                    tag,
-                    num_queues: num_queues.take(),
-                    queue_size: queue_size.take(),
-                }
-            }
+        // Each variant consumes the options it accepts; whatever is left over
+        // afterward was used with the wrong device type.
+        let device_type = match type_name.as_deref() {
+            Some("fs") => VhostUserDeviceTypeCli::Fs {
+                tag: args.tag.take().context("type=fs requires tag=<name>")?,
+                num_queues: args.num_queues.take(),
+                queue_size: args.queue_size.take(),
+            },
             Some("blk") => VhostUserDeviceTypeCli::Blk {
-                num_queues: num_queues.take(),
-                queue_size: queue_size.take(),
+                num_queues: args.num_queues.take(),
+                queue_size: args.queue_size.take(),
             },
             Some(ty) => anyhow::bail!("unknown vhost-user device type: '{ty}'"),
             None => {
-                let queue_sizes = queue_sizes
+                let queue_sizes = args
+                    .queue_sizes
                     .take()
-                    .context("device_id= requires queue_sizes=[N,N,...]")?;
+                    .context("device_id= requires queue_sizes=[N,N,...]")?
+                    .0;
+                anyhow::ensure!(!queue_sizes.is_empty(), "queue_sizes must be non-empty");
                 VhostUserDeviceTypeCli::Other {
-                    device_id: device_id.unwrap(),
+                    device_id: args.device_id.unwrap(),
                     queue_sizes,
                 }
             }
         };
 
-        if tag.is_some() {
+        if args.tag.is_some() {
             anyhow::bail!("tag= is only valid for type=fs");
         }
-        if queue_sizes.is_some() {
+        if args.queue_sizes.is_some() {
             anyhow::bail!("queue_sizes= is only valid for device_id=");
         }
-        if num_queues.is_some() || queue_size.is_some() {
+        if args.num_queues.is_some() || args.queue_size.is_some() {
             anyhow::bail!(
                 "num_queues= and queue_size= are not valid for device_id=; use queue_sizes="
             );
         }
 
         Ok(VhostUserCli {
-            socket_path,
+            socket_path: args.socket_path,
             device_type,
-            pcie_port,
+            pcie_port: args.pcie_port,
         })
     }
 }
@@ -5066,13 +4499,8 @@ mod tests {
         assert_eq!(
             parse_memory_config("64G").unwrap(),
             MemoryCli {
-                mem_size: 64 * 1024 * 1024 * 1024,
-                shared: None,
-                prefetch: false,
-                transparent_hugepages: true,
-                hugepages: false,
-                hugepage_size: None,
-                file: None,
+                size: Some(vmm_cli::MemorySize(64 * 1024 * 1024 * 1024)),
+                ..Default::default()
             }
         );
     }
@@ -5082,39 +4510,29 @@ mod tests {
         assert_eq!(
             parse_memory_config("size=2G,shared=off,prefetch=on,thp=on").unwrap(),
             MemoryCli {
-                mem_size: 2 * 1024 * 1024 * 1024,
+                size: Some(vmm_cli::MemorySize(2 * 1024 * 1024 * 1024)),
                 shared: Some(false),
                 prefetch: true,
-                transparent_hugepages: true,
-                hugepages: false,
-                hugepage_size: None,
-                file: None,
+                transparent_hugepages: Some(true),
+                ..Default::default()
             }
         );
 
         assert_eq!(
             parse_memory_config("size=4GB,hugepages=on,hugepage_size=2MB").unwrap(),
             MemoryCli {
-                mem_size: 4 * 1024 * 1024 * 1024,
-                shared: None,
-                prefetch: false,
-                transparent_hugepages: false,
+                size: Some(vmm_cli::MemorySize(4 * 1024 * 1024 * 1024)),
                 hugepages: true,
-                hugepage_size: Some(2 * 1024 * 1024),
-                file: None,
+                hugepage_size: Some(vmm_cli::MemorySize(2 * 1024 * 1024)),
+                ..Default::default()
             }
         );
 
         assert_eq!(
             parse_memory_config("file=/tmp/memory.bin").unwrap(),
             MemoryCli {
-                mem_size: DEFAULT_MEMORY_SIZE,
-                shared: None,
-                prefetch: false,
-                transparent_hugepages: true,
-                hugepages: false,
-                hugepage_size: None,
                 file: Some(PathBuf::from("/tmp/memory.bin")),
+                ..Default::default()
             }
         );
     }
@@ -5132,7 +4550,7 @@ mod tests {
             parse_memory_config("hugepages=on,hugepage_size=3MB")
                 .unwrap()
                 .hugepage_size,
-            Some(3 * 1024 * 1024)
+            Some(vmm_cli::MemorySize(3 * 1024 * 1024))
         );
     }
 
@@ -5281,6 +4699,14 @@ mod tests {
         assert_eq!(v.pci_id, "0000:02:00.0");
         assert_eq!(v.port_name, "rp1");
         assert_eq!(v.iommu.as_deref(), Some("iommu0"));
+
+        // BAR passthrough flags set the corresponding indices.
+        let v = VfioDeviceCli::from_str("host=0000:01:00.0,port=rp0,bar0=pt,bar2=pt").unwrap();
+        assert_eq!(v.bar_pt, [true, false, true, false, false, false]);
+
+        // A BAR flag only accepts `pt`, and requires a value.
+        assert!(VfioDeviceCli::from_str("host=0000:01:00.0,port=rp0,bar0=x").is_err());
+        assert!(VfioDeviceCli::from_str("host=0000:01:00.0,port=rp0,bar0").is_err());
     }
 
     #[cfg(target_os = "linux")]
@@ -5326,6 +4752,48 @@ mod tests {
 
         // Empty id.
         assert!(IommuCli::from_str("id=").is_err());
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn test_vhost_user_cli() {
+        // type=blk: socket is positional; num_queues/queue_size optional.
+        let v = VhostUserCli::from_str("/run/blk.sock,type=blk,num_queues=2").unwrap();
+        assert_eq!(v.socket_path, "/run/blk.sock");
+        assert!(matches!(
+            v.device_type,
+            VhostUserDeviceTypeCli::Blk {
+                num_queues: Some(2),
+                queue_size: None
+            }
+        ));
+        assert_eq!(v.pcie_port, None);
+
+        // type=fs requires a tag.
+        let v = VhostUserCli::from_str("/run/fs.sock,type=fs,tag=myfs,pcie_port=p0").unwrap();
+        assert!(matches!(
+            &v.device_type,
+            VhostUserDeviceTypeCli::Fs { tag, .. } if tag == "myfs"
+        ));
+        assert_eq!(v.pcie_port.as_deref(), Some("p0"));
+
+        // device_id with a bracketed queue_sizes list.
+        let v = VhostUserCli::from_str("/run/x.sock,device_id=9,queue_sizes=[16,32]").unwrap();
+        assert!(matches!(
+            &v.device_type,
+            VhostUserDeviceTypeCli::Other { device_id: 9, queue_sizes } if *queue_sizes == vec![16, 32]
+        ));
+
+        // Errors.
+        assert!(VhostUserCli::from_str("/run/x.sock").is_err()); // neither type nor device_id
+        assert!(VhostUserCli::from_str("/run/x.sock,type=blk,device_id=1").is_err()); // both
+        assert!(VhostUserCli::from_str("/run/x.sock,type=fs").is_err()); // fs without tag
+        assert!(VhostUserCli::from_str("/run/x.sock,type=zzz").is_err()); // unknown type
+        assert!(VhostUserCli::from_str("/run/x.sock,type=blk,tag=t").is_err()); // tag on non-fs
+        assert!(VhostUserCli::from_str("/run/x.sock,type=blk,queue_sizes=[1]").is_err()); // queue_sizes on non-device_id
+        assert!(VhostUserCli::from_str("/run/x.sock,device_id=1,num_queues=2").is_err()); // num_queues on device_id
+        assert!(VhostUserCli::from_str("/run/x.sock,device_id=1,queue_sizes=[]").is_err()); // empty list
+        assert!(VhostUserCli::from_str("/run/x.sock,device_id=1").is_err()); // device_id without queue_sizes
     }
 
     #[test]
@@ -5505,40 +4973,39 @@ mod tests {
 
     #[test]
     fn test_parse_vp_list() {
-        use super::parse_vp_list;
+        use vmm_cli::BracketRangeList;
+
+        let parse = |s: &str| s.parse::<BracketRangeList>().map(|v| v.0);
 
         // Individual indices.
-        assert_eq!(parse_vp_list("[0,1,2,3]").unwrap(), vec![0, 1, 2, 3]);
+        assert_eq!(parse("[0,1,2,3]").unwrap(), vec![0, 1, 2, 3]);
 
         // Single index.
-        assert_eq!(parse_vp_list("[5]").unwrap(), vec![5]);
+        assert_eq!(parse("[5]").unwrap(), vec![5]);
 
         // Dash range.
-        assert_eq!(parse_vp_list("[0-3]").unwrap(), vec![0, 1, 2, 3]);
+        assert_eq!(parse("[0-3]").unwrap(), vec![0, 1, 2, 3]);
 
         // Mixed indices and ranges.
-        assert_eq!(
-            parse_vp_list("[0,1,4-6,10]").unwrap(),
-            vec![0, 1, 4, 5, 6, 10]
-        );
+        assert_eq!(parse("[0,1,4-6,10]").unwrap(), vec![0, 1, 4, 5, 6, 10]);
 
         // Whitespace tolerance.
-        assert_eq!(parse_vp_list("[0, 1, 2-4]").unwrap(), vec![0, 1, 2, 3, 4]);
+        assert_eq!(parse("[0, 1, 2-4]").unwrap(), vec![0, 1, 2, 3, 4]);
 
         // Missing brackets.
-        assert!(parse_vp_list("0,1,2").is_err());
-        assert!(parse_vp_list("0-3").is_err());
+        assert!(parse("0,1,2").is_err());
+        assert!(parse("0-3").is_err());
 
         // Inverted range.
-        assert!(parse_vp_list("[3-0]").is_err());
+        assert!(parse("[3-0]").is_err());
 
         // Non-numeric.
-        assert!(parse_vp_list("[a,b]").is_err());
+        assert!(parse("[a,b]").is_err());
     }
 
     #[test]
     fn test_split_options_brackets() {
-        use super::split_options;
+        use vmm_cli::split_options;
 
         // No brackets — plain comma split.
         assert_eq!(
@@ -5569,17 +5036,20 @@ mod tests {
 
         // Basic node with size only.
         let n = parse_numa_node("size=2G").unwrap();
-        assert_eq!(n.memory.mem_size, 2 * 1024 * 1024 * 1024);
+        assert_eq!(
+            n.memory.size,
+            Some(vmm_cli::MemorySize(2 * 1024 * 1024 * 1024))
+        );
         assert!(n.vps.is_none());
         assert!(n.host_numa_node.is_none());
 
         // Node with bracket VP list.
         let n = parse_numa_node("size=1G,vps=[0,1,2,3]").unwrap();
-        assert_eq!(n.vps.unwrap(), vec![0, 1, 2, 3]);
+        assert_eq!(n.vps.unwrap().0, vec![0, 1, 2, 3]);
 
         // Node with VP range in brackets.
         let n = parse_numa_node("size=1G,vps=[0-3]").unwrap();
-        assert_eq!(n.vps.unwrap(), vec![0, 1, 2, 3]);
+        assert_eq!(n.vps.unwrap().0, vec![0, 1, 2, 3]);
 
         // Node with host_numa_node.
         let n = parse_numa_node("size=1G,host_numa_node=1").unwrap();
@@ -5587,7 +5057,7 @@ mod tests {
 
         // All options together.
         let n = parse_numa_node("size=1G,vps=[0,1],host_numa_node=0,hugepages=on").unwrap();
-        assert_eq!(n.vps.unwrap(), vec![0, 1]);
+        assert_eq!(n.vps.unwrap().0, vec![0, 1]);
         assert_eq!(n.host_numa_node, Some(0));
         assert!(n.memory.hugepages);
 
@@ -5600,9 +5070,12 @@ mod tests {
         // Duplicate vps.
         assert!(parse_numa_node("size=1G,vps=[0],vps=[1]").is_err());
 
+        // `file` is rejected for NUMA nodes.
+        assert!(parse_numa_node("size=1G,file=/tmp/x").is_err());
+
         // Empty vps=[] for memory-only node.
         let n = parse_numa_node("size=1G,vps=[]").unwrap();
-        assert_eq!(n.vps.unwrap(), Vec::<u32>::new());
+        assert_eq!(n.vps.unwrap().0, Vec::<u32>::new());
     }
 
     #[test]

--- a/openvmm/openvmm_entry/src/cli_args.rs
+++ b/openvmm/openvmm_entry/src/cli_args.rs
@@ -164,10 +164,10 @@ Size suffixes accept K, M, G, and T, optionally followed by B.
 
 Options:
     size=<SIZE>              guest RAM size, default 1GB
-    shared=on|off            use shared file-backed RAM, default on
-    prefetch=on|off          pre-populate guest RAM mappings
-    thp=on|off               mark guest RAM as THP-eligible (Linux), default on
-    hugepages=on|off         allocate RAM from hugetlb/large pages (Linux, Windows)
+    shared[=on|off]          use shared file-backed RAM, default on
+    prefetch[=on|off]        pre-populate guest RAM mappings
+    thp[=on|off]             mark guest RAM as THP-eligible (Linux), default on
+    hugepages[=on|off]       allocate RAM from hugetlb/large pages (Linux, Windows)
     hugepage_size=<SIZE>     hugepage size, default 2MB; requires hugepages=on
     file=<PATH>              use an existing file as guest RAM backing
 
@@ -194,10 +194,10 @@ Syntax: key=value[,key=value...]
 
 Options:
     size=<SIZE>              RAM for this node (required)
-    shared=on|off            use shared file-backed RAM, default on
-    prefetch=on|off          pre-populate guest RAM mappings
-    thp=on|off               mark node RAM as THP-eligible (Linux), default on
-    hugepages=on|off         allocate RAM from hugetlb/large pages (Linux, Windows)
+    shared[=on|off]          use shared file-backed RAM, default on
+    prefetch[=on|off]        pre-populate guest RAM mappings
+    thp[=on|off]             mark node RAM as THP-eligible (Linux), default on
+    hugepages[=on|off]       allocate RAM from hugetlb/large pages (Linux, Windows)
     hugepage_size=<SIZE>     hugepage size, default 2MB; requires hugepages=on
     host_numa_node=<N>       bind allocation to host NUMA node N
     vps=<LIST>               explicit VP indices (e.g. "[0,1,2,3]")
@@ -2746,8 +2746,8 @@ impl FromStr for PcieRootComplexCli {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let args: PcieRootComplexArgs = s.parse()?;
 
-        if args.start_bus >= args.end_bus {
-            anyhow::bail!("start_bus must be less than or equal to end_bus");
+        if args.start_bus > args.end_bus {
+            anyhow::bail!("start_bus must be <= end_bus");
         }
 
         let low_mmio = u32::try_from(args.low_mmio.0).context("low MMIO size exceeds 32 bits")?;

--- a/openvmm/openvmm_entry/src/cli_args.rs
+++ b/openvmm/openvmm_entry/src/cli_args.rs
@@ -5007,33 +5007,6 @@ mod tests {
     }
 
     #[test]
-    fn test_split_options_brackets() {
-        use vmm_cli::split_options;
-
-        // No brackets — plain comma split.
-        assert_eq!(
-            split_options("a=1,b=2,c=3").unwrap(),
-            vec!["a=1", "b=2", "c=3"]
-        );
-
-        // Brackets protect inner commas.
-        assert_eq!(
-            split_options("size=2G,vps=[0,1,2]").unwrap(),
-            vec!["size=2G", "vps=[0,1,2]"]
-        );
-
-        // Brackets with ranges and trailing option.
-        assert_eq!(
-            split_options("size=2G,vps=[0-1,4-5],host_numa_node=0").unwrap(),
-            vec!["size=2G", "vps=[0-1,4-5]", "host_numa_node=0"]
-        );
-
-        // Unmatched brackets.
-        assert!(split_options("vps=[0,1").is_err());
-        assert!(split_options("vps=0,1]").is_err());
-    }
-
-    #[test]
     fn test_parse_numa_node() {
         use super::parse_numa_node;
 

--- a/openvmm/openvmm_entry/src/cli_args.rs
+++ b/openvmm/openvmm_entry/src/cli_args.rs
@@ -1494,7 +1494,7 @@ fn parse_memory_config(s: &str) -> anyhow::Result<MemoryCli> {
     // Bare shortcut: `--memory 64G` sets only the size.
     let memory = if !s.contains('=') && !s.contains(',') {
         MemoryCli {
-            size: Some(vmm_cli::MemorySize(parse_memory(s)?)),
+            size: Some(s.parse::<vmm_cli::MemorySize>()?),
             ..Default::default()
         }
     } else {
@@ -1987,7 +1987,6 @@ impl FromStr for DiskCli {
 
 /// The transport for a named NVMe controller.
 #[derive(Clone, Debug, PartialEq, vmm_cli::KeyValueGroup)]
-#[kv(required)]
 pub enum NvmeControllerTransport {
     /// Present via PCIe on the specified root port.
     #[kv(key = "pcie_port")]

--- a/openvmm/openvmm_entry/src/cli_args.rs
+++ b/openvmm/openvmm_entry/src/cli_args.rs
@@ -4807,6 +4807,7 @@ mod tests {
         let c = NvmeControllerCli::from_str("id=nvme1,vpci").unwrap();
         assert_eq!(c.id, "nvme1");
         assert!(matches!(c.transport, NvmeControllerTransport::Vpci(None)));
+        assert!(NvmeControllerCli::from_str("id=nvme1,vpci=").is_err());
     }
 
     #[test]

--- a/openvmm/openvmm_entry/src/cli_args.rs
+++ b/openvmm/openvmm_entry/src/cli_args.rs
@@ -4835,7 +4835,8 @@ mod tests {
         // Empty pcie_port.
         assert!(NvmeControllerCli::from_str("id=nvme0,pcie_port=").is_err());
         // Invalid GUID.
-        assert!(NvmeControllerCli::from_str("id=nvme0,vpci=not-a-guid").is_err());
+        let err = NvmeControllerCli::from_str("id=nvme0,vpci=not-a-guid").unwrap_err();
+        assert!(err.to_string().contains("invalid value for option 'vpci'"));
     }
 
     #[test]

--- a/openvmm/openvmm_entry/src/lib.rs
+++ b/openvmm/openvmm_entry/src/lib.rs
@@ -1922,7 +1922,11 @@ async fn vm_config_from_command_line(
                             };
                             Ok(NumaNode {
                                 mem: Some(MemoryConfig {
-                                    mem_size: n.memory.size.map(|m| m.0).unwrap_or(0),
+                                    mem_size: n
+                                        .memory
+                                        .size
+                                        .expect("NUMA memory size was validated")
+                                        .0,
                                     prefetch_memory: n.memory.prefetch,
                                     private_memory: n.memory.shared == Some(false),
                                     transparent_hugepages: n

--- a/openvmm/openvmm_entry/src/lib.rs
+++ b/openvmm/openvmm_entry/src/lib.rs
@@ -1914,17 +1914,20 @@ async fn vm_config_from_command_line(
                         .iter()
                         .map(|n| NumaNode {
                             mem: Some(MemoryConfig {
-                                mem_size: n.memory.mem_size,
+                                mem_size: n.memory.size.map(|m| m.0).unwrap_or(0),
                                 prefetch_memory: n.memory.prefetch,
                                 private_memory: n.memory.shared == Some(false),
-                                transparent_hugepages: n.memory.transparent_hugepages,
+                                transparent_hugepages: n
+                                    .memory
+                                    .transparent_hugepages
+                                    .unwrap_or(!n.memory.hugepages),
                                 hugepages: n.memory.hugepages,
-                                hugepage_size: n.memory.hugepage_size,
+                                hugepage_size: n.memory.hugepage_size.map(|m| m.0),
                                 host_numa_node: n.host_numa_node,
                             }),
                             vps: match &n.vps {
-                                Some(vps) if vps.is_empty() => VpAssignment::Empty,
-                                Some(vps) => VpAssignment::Explicit(vps.clone()),
+                                Some(vps) if vps.0.is_empty() => VpAssignment::Empty,
+                                Some(vps) => VpAssignment::Explicit(vps.0.clone()),
                                 None => VpAssignment::FromTopology,
                             },
                         })
@@ -1951,7 +1954,7 @@ async fn vm_config_from_command_line(
                             private_memory: opt.private_memory(),
                             transparent_hugepages: opt.transparent_hugepages(),
                             hugepages: opt.memory.hugepages,
-                            hugepage_size: opt.memory.hugepage_size,
+                            hugepage_size: opt.memory.hugepage_size.map(|m| m.0),
                             host_numa_node: None,
                         }),
                         vps: VpAssignment::FromTopology,

--- a/openvmm/openvmm_entry/src/lib.rs
+++ b/openvmm/openvmm_entry/src/lib.rs
@@ -1912,26 +1912,31 @@ async fn vm_config_from_command_line(
                 NumaTopology {
                     nodes: nodes
                         .iter()
-                        .map(|n| NumaNode {
-                            mem: Some(MemoryConfig {
-                                mem_size: n.memory.size.map(|m| m.0).unwrap_or(0),
-                                prefetch_memory: n.memory.prefetch,
-                                private_memory: n.memory.shared == Some(false),
-                                transparent_hugepages: n
-                                    .memory
-                                    .transparent_hugepages
-                                    .unwrap_or(!n.memory.hugepages),
-                                hugepages: n.memory.hugepages,
-                                hugepage_size: n.memory.hugepage_size.map(|m| m.0),
-                                host_numa_node: n.host_numa_node,
-                            }),
-                            vps: match &n.vps {
+                        .map(|n| {
+                            let vps = match &n.vps {
                                 Some(vps) if vps.0.is_empty() => VpAssignment::Empty,
-                                Some(vps) => VpAssignment::Explicit(vps.0.clone()),
+                                Some(vps) => {
+                                    VpAssignment::Explicit(vps.expand_below(opt.processors)?)
+                                }
                                 None => VpAssignment::FromTopology,
-                            },
+                            };
+                            Ok(NumaNode {
+                                mem: Some(MemoryConfig {
+                                    mem_size: n.memory.size.map(|m| m.0).unwrap_or(0),
+                                    prefetch_memory: n.memory.prefetch,
+                                    private_memory: n.memory.shared == Some(false),
+                                    transparent_hugepages: n
+                                        .memory
+                                        .transparent_hugepages
+                                        .unwrap_or(!n.memory.hugepages),
+                                    hugepages: n.memory.hugepages,
+                                    hugepage_size: n.memory.hugepage_size.map(|m| m.0),
+                                    host_numa_node: n.host_numa_node,
+                                }),
+                                vps,
+                            })
                         })
-                        .collect(),
+                        .collect::<anyhow::Result<Vec<_>>>()?,
                     distances: opt
                         .numa_distance
                         .as_deref()

--- a/vmm_core/vmm_cli/Cargo.toml
+++ b/vmm_core/vmm_cli/Cargo.toml
@@ -1,0 +1,14 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+[package]
+name = "vmm_cli"
+edition.workspace = true
+rust-version.workspace = true
+
+[dependencies]
+vmm_cli_derive.workspace = true
+anyhow.workspace = true
+
+[lints]
+workspace = true

--- a/vmm_core/vmm_cli/src/lib.rs
+++ b/vmm_core/vmm_cli/src/lib.rs
@@ -67,6 +67,9 @@ pub use anyhow;
 pub use vmm_cli_derive::KeyValueArgs;
 pub use vmm_cli_derive::KeyValueGroup;
 
+#[doc(hidden)]
+pub mod private;
+
 /// The error type produced by generated parsers (an [`anyhow::Error`]).
 pub type Error = anyhow::Error;
 /// Result alias used by generated parsers.
@@ -95,145 +98,6 @@ pub trait KeyValueFields: Sized {
     fn finish(accum: Self::Accum) -> Result<Self>;
 }
 
-/// Construct an [`Error`] with the given message.
-///
-/// Used by generated code so it never has to reference `anyhow` macros
-/// directly.
-#[doc(hidden)]
-pub fn error(msg: impl Display) -> Error {
-    anyhow::Error::msg(msg.to_string())
-}
-
-/// Construct an unknown-option error listing all keys accepted by `T`.
-#[doc(hidden)]
-pub fn unknown_option<T: KeyValueFields>(key: &str) -> Error {
-    let mut keys = Vec::new();
-    T::append_keys(&mut keys);
-    error(format!(
-        "unknown option '{key}'; expected one of: {}",
-        keys.iter()
-            .map(|key| format!("'{key}'"))
-            .collect::<Vec<_>>()
-            .join(", ")
-    ))
-}
-
-/// Split a `key=value[,key=value...]` option string on top-level commas,
-/// honoring `[...]` nesting so that a bracketed list value containing commas
-/// (e.g. `vps=[0,1,4-5]`) is not split apart.
-pub fn split_options(s: &str) -> Result<Vec<&str>> {
-    let mut parts = Vec::new();
-    let mut depth = 0u32;
-    let mut start = 0;
-    for (i, c) in s.char_indices() {
-        match c {
-            '[' => depth += 1,
-            ']' => {
-                anyhow::ensure!(depth > 0, "unmatched ']' in '{s}'");
-                depth -= 1;
-            }
-            ',' if depth == 0 => {
-                parts.push(&s[start..i]);
-                start = i + 1;
-            }
-            _ => {}
-        }
-    }
-    anyhow::ensure!(depth == 0, "unmatched '[' in '{s}'");
-    parts.push(&s[start..]);
-    Ok(parts)
-}
-
-/// Split one option part into its key and optional value: `a=b` => `("a",
-/// Some("b"))`, `a` => `("a", None)`.
-pub fn split_kv(part: &str) -> (&str, Option<&str>) {
-    match part.split_once('=') {
-        Some((k, v)) => (k, Some(v)),
-        None => (part, None),
-    }
-}
-
-/// Parse a required, non-empty value for `key` via `T`'s [`FromStr`].
-///
-/// An absent or empty value is an error (empty is treated as "no value").
-pub fn parse_value<T>(key: &str, value: Option<&str>) -> Result<T>
-where
-    T: FromStr,
-    T::Err: Display,
-{
-    let value = match value {
-        Some(v) if !v.is_empty() => v,
-        _ => anyhow::bail!("option '{key}' requires a value"),
-    };
-    value
-        .parse::<T>()
-        .map_err(|e| error(format!("invalid value for option '{key}': {e}")))
-}
-
-/// Parse an optional value for `key`: a bare key or empty value yields `None`,
-/// otherwise the value is parsed via `T`'s [`FromStr`].
-pub fn parse_opt_value<T>(key: &str, value: Option<&str>) -> Result<Option<T>>
-where
-    T: FromStr,
-    T::Err: Display,
-{
-    match value {
-        Some(v) if !v.is_empty() => {
-            Ok(Some(v.parse::<T>().map_err(|e| {
-                error(format!("invalid value for option '{key}': {e}"))
-            })?))
-        }
-        _ => Ok(None),
-    }
-}
-
-/// Parse the leading positional token (the first comma-separated part, taken
-/// verbatim without splitting on `=`) via `T`'s [`FromStr`].
-///
-/// An absent or empty token is an error.
-pub fn parse_positional<T>(name: &str, value: Option<&str>) -> Result<T>
-where
-    T: FromStr,
-    T::Err: Display,
-{
-    let value = match value {
-        Some(v) if !v.is_empty() => v,
-        _ => anyhow::bail!("missing required '{name}'"),
-    };
-    value
-        .parse::<T>()
-        .map_err(|e| error(format!("invalid '{name}': {e}")))
-}
-
-/// Store a parsed value into `slot`, erroring if `key` was already seen.
-pub fn set_once<T>(slot: &mut Option<T>, key: &str, value: T) -> Result<()> {
-    if slot.is_some() {
-        anyhow::bail!("duplicate option '{key}'");
-    }
-    *slot = Some(value);
-    Ok(())
-}
-
-/// Parse a boolean flag/toggle into `slot`, erroring on duplicates.
-///
-/// Accepts three uniform spellings so callers never have to remember which
-/// booleans are bare and which take a value: bare presence (`foo`) and `foo=on`
-/// both mean `true`, and `foo=off` means `false`.
-pub fn set_toggle(slot: &mut Option<bool>, key: &str, value: Option<&str>) -> Result<()> {
-    let v = match value {
-        None | Some("on") => true,
-        Some("off") => false,
-        Some(other) => {
-            anyhow::bail!("flag '{key}' expects no value, 'on', or 'off', got '{other}'")
-        }
-    };
-    if slot.is_some() {
-        anyhow::bail!("duplicate flag '{key}'");
-    }
-    *slot = Some(v);
-    Ok(())
-}
-
 fn strip_brackets(s: &str) -> Result<&str> {
     s.strip_prefix('[')
         .and_then(|s| s.strip_suffix(']'))
@@ -243,8 +107,8 @@ fn strip_brackets(s: &str) -> Result<&str> {
 /// A bracket-delimited list value, e.g. `[a,b,c]` or the empty list `[]`.
 ///
 /// Implements [`FromStr`], so it composes directly as a `#[derive(KeyValueArgs)]`
-/// field type; because [`split_options`] is bracket-aware, a `BracketList`
-/// value may contain commas.
+/// field type; because option splitting is bracket-aware, a `BracketList` value
+/// may contain commas.
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct BracketList<T>(pub Vec<T>);
 
@@ -265,7 +129,7 @@ where
             let item = item.trim();
             items.push(
                 item.parse::<T>()
-                    .map_err(|e| error(format!("invalid list item '{item}': {e}")))?,
+                    .map_err(|e| private::error(format!("invalid list item '{item}': {e}")))?,
             );
         }
         Ok(Self(items))
@@ -373,13 +237,13 @@ mod tests {
 
     #[test]
     fn split_options_bracket_aware() {
-        assert_eq!(split_options("a=1,b=2").unwrap(), ["a=1", "b=2"]);
+        assert_eq!(private::split_options("a=1,b=2").unwrap(), ["a=1", "b=2"]);
         assert_eq!(
-            split_options("size=2G,vps=[0,1,4-5]").unwrap(),
+            private::split_options("size=2G,vps=[0,1,4-5]").unwrap(),
             ["size=2G", "vps=[0,1,4-5]"]
         );
-        assert!(split_options("a=[1,2").is_err());
-        assert!(split_options("a=1]").is_err());
+        assert!(private::split_options("a=[1,2").is_err());
+        assert!(private::split_options("a=1]").is_err());
     }
 
     #[test]

--- a/vmm_core/vmm_cli/src/lib.rs
+++ b/vmm_core/vmm_cli/src/lib.rs
@@ -1,0 +1,372 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Declarative parsing of the comma-separated `key=value` option strings used
+//! throughout the OpenVMM CLI (e.g. `--nvme id=nvme0,pcie_port=p0`).
+//!
+//! This crate is OpenVMM-specific by design, not a general-purpose argument
+//! parser: it is expected to accrete VMM-oriented value types and conventions
+//! (such as [`MemorySize`]) as more of the CLI moves onto it.
+//!
+//! Instead of hand-writing a `FromStr` impl that tokenizes the string, matches
+//! keys, and produces bespoke error messages, annotate a struct with
+//! [`macro@KeyValueArgs`] and let the derive generate a consistent parser:
+//!
+//! ```
+//! use vmm_cli::KeyValueArgs;
+//!
+//! #[derive(KeyValueArgs)]
+//! struct Example {
+//!     // required scalar; parsed via the field type's `FromStr`.
+//!     name: String,
+//!     // boolean flag: `fast`, `fast=on`, and `fast=off` are all accepted.
+//!     #[kv(flag)]
+//!     fast: bool,
+//!     // tri-state boolean: absent => None, `turbo`/`turbo=on` => Some(true),
+//!     // `turbo=off` => Some(false).
+//!     #[kv(flag)]
+//!     turbo: Option<bool>,
+//!     // optional scalar; absent => `None`.
+//!     count: Option<u32>,
+//!     // absent => `Default::default()`.
+//!     #[kv(default)]
+//!     level: u8,
+//! }
+//!
+//! let e: Example = "name=foo,fast,turbo=off,count=3".parse().unwrap();
+//! assert_eq!(e.name, "foo");
+//! assert!(e.fast);
+//! assert_eq!(e.turbo, Some(false));
+//! assert_eq!(e.count, Some(3));
+//! assert_eq!(e.level, 0);
+//! ```
+//!
+//! Booleans are spelled uniformly: any `#[kv(flag)]` field accepts bare
+//! presence, `=on`, or `=off`, so users never have to remember which options
+//! take a value.
+//!
+//! Mutually-exclusive keys that resolve to one enum variant ("one of"
+//! semantics) are expressed with [`macro@KeyValueGroup`] on an enum and a
+//! `#[kv(flatten)]` field in the parent struct.
+//!
+//! `#[kv(flatten)]` also merges a shared `#[derive(KeyValueArgs)]` sub-struct's
+//! keys into the parent, so common option sets can be defined once and reused
+//! across several parsers.
+//!
+//! A single leading positional token (the first comma-separated part, taken
+//! verbatim) can be captured with `#[kv(positional)]` on one field.
+
+#![forbid(unsafe_code)]
+
+use anyhow::Context;
+use std::fmt::Display;
+use std::str::FromStr;
+
+#[doc(hidden)]
+pub use anyhow;
+pub use vmm_cli_derive::KeyValueArgs;
+pub use vmm_cli_derive::KeyValueGroup;
+
+/// The error type produced by generated parsers (an [`anyhow::Error`]).
+pub type Error = anyhow::Error;
+/// Result alias used by generated parsers.
+pub type Result<T> = anyhow::Result<T>;
+
+/// A composable set of `key=value` fields that can be accumulated one token at
+/// a time and finished into a value.
+///
+/// Implemented by both `#[derive(KeyValueArgs)]` (a struct of fields) and
+/// `#[derive(KeyValueGroup)]` (an enum of mutually-exclusive keys). A parent
+/// struct field tagged `#[kv(flatten)]` merges the flattened type's keys into
+/// the parent's own.
+pub trait KeyValueFields: Sized {
+    /// Accumulator state threaded through parsing.
+    type Accum: Default;
+
+    /// Try to consume `key`; returns `Ok(true)` if it belongs to this type,
+    /// `Ok(false)` if the key is unknown to it.
+    fn accept(accum: &mut Self::Accum, key: &str, value: Option<&str>) -> Result<bool>;
+
+    /// Finish parsing, enforcing required/exclusivity constraints and applying
+    /// defaults.
+    fn finish(accum: Self::Accum) -> Result<Self>;
+}
+
+/// Construct an [`Error`] with the given message.
+///
+/// Used by generated code so it never has to reference `anyhow` macros
+/// directly.
+#[doc(hidden)]
+pub fn error(msg: impl Display) -> Error {
+    anyhow::Error::msg(msg.to_string())
+}
+
+/// Split a `key=value[,key=value...]` option string on top-level commas,
+/// honoring `[...]` nesting so that a bracketed list value containing commas
+/// (e.g. `vps=[0,1,4-5]`) is not split apart.
+pub fn split_options(s: &str) -> Result<Vec<&str>> {
+    let mut parts = Vec::new();
+    let mut depth = 0u32;
+    let mut start = 0;
+    for (i, c) in s.char_indices() {
+        match c {
+            '[' => depth += 1,
+            ']' => {
+                anyhow::ensure!(depth > 0, "unmatched ']' in '{s}'");
+                depth -= 1;
+            }
+            ',' if depth == 0 => {
+                parts.push(&s[start..i]);
+                start = i + 1;
+            }
+            _ => {}
+        }
+    }
+    anyhow::ensure!(depth == 0, "unmatched '[' in '{s}'");
+    parts.push(&s[start..]);
+    Ok(parts)
+}
+
+/// Split one option part into its key and optional value: `a=b` => `("a",
+/// Some("b"))`, `a` => `("a", None)`.
+pub fn split_kv(part: &str) -> (&str, Option<&str>) {
+    match part.split_once('=') {
+        Some((k, v)) => (k, Some(v)),
+        None => (part, None),
+    }
+}
+
+/// Parse a required, non-empty value for `key` via `T`'s [`FromStr`].
+///
+/// An absent or empty value is an error (empty is treated as "no value").
+pub fn parse_value<T>(key: &str, value: Option<&str>) -> Result<T>
+where
+    T: FromStr,
+    T::Err: Display,
+{
+    let value = match value {
+        Some(v) if !v.is_empty() => v,
+        _ => anyhow::bail!("option '{key}' requires a value"),
+    };
+    value
+        .parse::<T>()
+        .map_err(|e| error(format!("invalid value for option '{key}': {e}")))
+}
+
+/// Parse an optional value: a bare key or empty value yields `None`, otherwise
+/// the value is parsed via `T`'s [`FromStr`].
+pub fn parse_opt_value<T>(value: Option<&str>) -> Result<Option<T>>
+where
+    T: FromStr,
+    T::Err: Display,
+{
+    match value {
+        Some(v) if !v.is_empty() => Ok(Some(
+            v.parse::<T>()
+                .map_err(|e| error(format!("invalid value: {e}")))?,
+        )),
+        _ => Ok(None),
+    }
+}
+
+/// Parse the leading positional token (the first comma-separated part, taken
+/// verbatim without splitting on `=`) via `T`'s [`FromStr`].
+///
+/// An absent or empty token is an error.
+pub fn parse_positional<T>(name: &str, value: Option<&str>) -> Result<T>
+where
+    T: FromStr,
+    T::Err: Display,
+{
+    let value = match value {
+        Some(v) if !v.is_empty() => v,
+        _ => anyhow::bail!("missing required '{name}'"),
+    };
+    value
+        .parse::<T>()
+        .map_err(|e| error(format!("invalid '{name}': {e}")))
+}
+
+/// Store a parsed value into `slot`, erroring if `key` was already seen.
+pub fn set_once<T>(slot: &mut Option<T>, key: &str, value: T) -> Result<()> {
+    if slot.is_some() {
+        anyhow::bail!("duplicate option '{key}'");
+    }
+    *slot = Some(value);
+    Ok(())
+}
+
+/// Parse a boolean flag/toggle into `slot`, erroring on duplicates.
+///
+/// Accepts three uniform spellings so callers never have to remember which
+/// booleans are bare and which take a value: bare presence (`foo`) and `foo=on`
+/// both mean `true`, and `foo=off` means `false`.
+pub fn set_toggle(slot: &mut Option<bool>, key: &str, value: Option<&str>) -> Result<()> {
+    let v = match value {
+        None | Some("on") => true,
+        Some("off") => false,
+        Some(other) => {
+            anyhow::bail!("flag '{key}' expects no value, 'on', or 'off', got '{other}'")
+        }
+    };
+    if slot.is_some() {
+        anyhow::bail!("duplicate flag '{key}'");
+    }
+    *slot = Some(v);
+    Ok(())
+}
+
+fn strip_brackets(s: &str) -> Result<&str> {
+    s.strip_prefix('[')
+        .and_then(|s| s.strip_suffix(']'))
+        .with_context(|| format!("expected bracket syntax like [a,b,c], got '{s}'"))
+}
+
+/// A bracket-delimited list value, e.g. `[a,b,c]` or the empty list `[]`.
+///
+/// Implements [`FromStr`], so it composes directly as a `#[derive(KeyValueArgs)]`
+/// field type; because [`split_options`] is bracket-aware, a `BracketList`
+/// value may contain commas.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct BracketList<T>(pub Vec<T>);
+
+impl<T> FromStr for BracketList<T>
+where
+    T: FromStr,
+    T::Err: Display,
+{
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<Self> {
+        let inner = strip_brackets(s)?;
+        if inner.is_empty() {
+            return Ok(Self(Vec::new()));
+        }
+        let mut items = Vec::new();
+        for item in inner.split(',') {
+            let item = item.trim();
+            items.push(
+                item.parse::<T>()
+                    .map_err(|e| error(format!("invalid list item '{item}': {e}")))?,
+            );
+        }
+        Ok(Self(items))
+    }
+}
+
+/// A bracket-delimited list of unsigned integers that also accepts inclusive
+/// ranges, e.g. `[0,1,4-5]` expands to `[0, 1, 4, 5]`.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct BracketRangeList(pub Vec<u32>);
+
+impl FromStr for BracketRangeList {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<Self> {
+        let inner = strip_brackets(s)?;
+        if inner.is_empty() {
+            return Ok(Self(Vec::new()));
+        }
+        let mut items = Vec::new();
+        for item in inner.split(',') {
+            let item = item.trim();
+            if let Some((lo, hi)) = item.split_once('-') {
+                let lo = lo.trim().parse::<u32>().context("invalid range bound")?;
+                let hi = hi.trim().parse::<u32>().context("invalid range bound")?;
+                anyhow::ensure!(lo <= hi, "invalid range {lo}-{hi}");
+                items.extend(lo..=hi);
+            } else {
+                items.push(item.parse::<u32>().context("invalid list item")?);
+            }
+        }
+        Ok(Self(items))
+    }
+}
+
+/// A memory/byte size such as `2G`, `64M`, `512K`, `4T`, or a bare byte count
+/// like `1024`. Suffixes `K`/`M`/`G`/`T` are powers of 1024, and an optional
+/// trailing `B` is accepted (e.g. `64MB` == `64M`).
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord)]
+pub struct MemorySize(pub u64);
+
+impl FromStr for MemorySize {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<Self> {
+        let mut b = s.as_bytes();
+        if b.last() == Some(&b'B') {
+            b = &b[..b.len() - 1];
+        }
+        anyhow::ensure!(!b.is_empty(), "invalid memory size '{s}'");
+        let multiplier = match b[b.len() - 1] {
+            b'T' => Some(1024 * 1024 * 1024 * 1024),
+            b'G' => Some(1024 * 1024 * 1024),
+            b'M' => Some(1024 * 1024),
+            b'K' => Some(1024),
+            _ => None,
+        };
+        if multiplier.is_some() {
+            b = &b[..b.len() - 1];
+        }
+        let n: u64 = std::str::from_utf8(b)
+            .ok()
+            .and_then(|s| s.parse().ok())
+            .with_context(|| format!("invalid memory size '{s}'"))?;
+        let bytes = n
+            .checked_mul(multiplier.unwrap_or(1))
+            .with_context(|| format!("memory size '{s}' overflows"))?;
+        Ok(MemorySize(bytes))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn split_options_bracket_aware() {
+        assert_eq!(split_options("a=1,b=2").unwrap(), ["a=1", "b=2"]);
+        assert_eq!(
+            split_options("size=2G,vps=[0,1,4-5]").unwrap(),
+            ["size=2G", "vps=[0,1,4-5]"]
+        );
+        assert!(split_options("a=[1,2").is_err());
+        assert!(split_options("a=1]").is_err());
+    }
+
+    #[test]
+    fn bracket_list() {
+        assert_eq!(
+            "[a,b,c]".parse::<BracketList<String>>().unwrap().0,
+            ["a", "b", "c"]
+        );
+        assert_eq!("[]".parse::<BracketList<u32>>().unwrap().0, [] as [u32; 0]);
+        assert!("a,b".parse::<BracketList<String>>().is_err());
+        assert!("[1,x]".parse::<BracketList<u32>>().is_err());
+    }
+
+    #[test]
+    fn bracket_range_list() {
+        assert_eq!(
+            "[0,1,4-5]".parse::<BracketRangeList>().unwrap().0,
+            [0, 1, 4, 5]
+        );
+        assert_eq!("[]".parse::<BracketRangeList>().unwrap().0, [] as [u32; 0]);
+        assert!("[5-1]".parse::<BracketRangeList>().is_err());
+    }
+
+    #[test]
+    fn memory_size() {
+        assert_eq!("1024".parse::<MemorySize>().unwrap().0, 1024);
+        assert_eq!("512K".parse::<MemorySize>().unwrap().0, 512 * 1024);
+        assert_eq!("64M".parse::<MemorySize>().unwrap().0, 64 * 1024 * 1024);
+        assert_eq!(
+            "2G".parse::<MemorySize>().unwrap().0,
+            2 * 1024 * 1024 * 1024
+        );
+        assert_eq!("64MB".parse::<MemorySize>().unwrap().0, 64 * 1024 * 1024);
+        assert!("".parse::<MemorySize>().is_err());
+        assert!("aG".parse::<MemorySize>().is_err());
+        assert!("bad".parse::<MemorySize>().is_err());
+    }
+}

--- a/vmm_core/vmm_cli/src/lib.rs
+++ b/vmm_core/vmm_cli/src/lib.rs
@@ -254,10 +254,39 @@ where
     }
 }
 
-/// A bracket-delimited list of unsigned integers that also accepts inclusive
-/// ranges, e.g. `[0,1,4-5]` expands to `[0, 1, 4, 5]`.
+/// A bracket-delimited list of unsigned integers and inclusive ranges, e.g.
+/// `[0,1,4-5]`.
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
-pub struct BracketRangeList(pub Vec<u32>);
+pub struct BracketRangeList(pub Vec<std::ops::RangeInclusive<u32>>);
+
+impl BracketRangeList {
+    /// Expands the ranges after ensuring every value is below `upper_bound`.
+    pub fn expand_below(&self, upper_bound: u32) -> Result<Vec<u32>> {
+        let mut len = 0usize;
+        for range in &self.0 {
+            anyhow::ensure!(
+                range.end() < &upper_bound,
+                "list item {} must be less than {}",
+                range.end(),
+                upper_bound
+            );
+            let range_len = u64::from(*range.end()) - u64::from(*range.start()) + 1;
+            len = len
+                .checked_add(usize::try_from(range_len).context("range is too large")?)
+                .context("expanded list is too large")?;
+            anyhow::ensure!(
+                len <= upper_bound as usize,
+                "expanded list contains more than {upper_bound} items"
+            );
+        }
+
+        let mut items = Vec::with_capacity(len);
+        for range in &self.0 {
+            items.extend(range.clone());
+        }
+        Ok(items)
+    }
+}
 
 impl FromStr for BracketRangeList {
     type Err = Error;
@@ -267,19 +296,20 @@ impl FromStr for BracketRangeList {
         if inner.is_empty() {
             return Ok(Self(Vec::new()));
         }
-        let mut items = Vec::new();
+        let mut ranges = Vec::new();
         for item in inner.split(',') {
             let item = item.trim();
             if let Some((lo, hi)) = item.split_once('-') {
                 let lo = lo.trim().parse::<u32>().context("invalid range bound")?;
                 let hi = hi.trim().parse::<u32>().context("invalid range bound")?;
                 anyhow::ensure!(lo <= hi, "invalid range {lo}-{hi}");
-                items.extend(lo..=hi);
+                ranges.push(lo..=hi);
             } else {
-                items.push(item.parse::<u32>().context("invalid list item")?);
+                let value = item.parse::<u32>().context("invalid list item")?;
+                ranges.push(value..=value);
             }
         }
-        Ok(Self(items))
+        Ok(Self(ranges))
     }
 }
 
@@ -347,12 +377,20 @@ mod tests {
 
     #[test]
     fn bracket_range_list() {
-        assert_eq!(
-            "[0,1,4-5]".parse::<BracketRangeList>().unwrap().0,
-            [0, 1, 4, 5]
+        let list = "[0,1,4-5]".parse::<BracketRangeList>().unwrap();
+        assert_eq!(list.expand_below(6).unwrap(), [0, 1, 4, 5]);
+        assert!(
+            "[]".parse::<BracketRangeList>()
+                .unwrap()
+                .expand_below(0)
+                .unwrap()
+                .is_empty()
         );
-        assert_eq!("[]".parse::<BracketRangeList>().unwrap().0, [] as [u32; 0]);
         assert!("[5-1]".parse::<BracketRangeList>().is_err());
+
+        let huge = "[0-4000000000]".parse::<BracketRangeList>().unwrap();
+        assert_eq!(huge.0, [0..=4_000_000_000]);
+        assert!(huge.expand_below(1024).is_err());
     }
 
     #[test]

--- a/vmm_core/vmm_cli/src/lib.rs
+++ b/vmm_core/vmm_cli/src/lib.rs
@@ -83,6 +83,9 @@ pub trait KeyValueFields: Sized {
     /// Accumulator state threaded through parsing.
     type Accum: Default;
 
+    /// Append the option keys accepted by this type to `keys`.
+    fn append_keys(keys: &mut Vec<&'static str>);
+
     /// Try to consume `key`; returns `Ok(true)` if it belongs to this type,
     /// `Ok(false)` if the key is unknown to it.
     fn accept(accum: &mut Self::Accum, key: &str, value: Option<&str>) -> Result<bool>;
@@ -99,6 +102,20 @@ pub trait KeyValueFields: Sized {
 #[doc(hidden)]
 pub fn error(msg: impl Display) -> Error {
     anyhow::Error::msg(msg.to_string())
+}
+
+/// Construct an unknown-option error listing all keys accepted by `T`.
+#[doc(hidden)]
+pub fn unknown_option<T: KeyValueFields>(key: &str) -> Error {
+    let mut keys = Vec::new();
+    T::append_keys(&mut keys);
+    error(format!(
+        "unknown option '{key}'; expected one of: {}",
+        keys.iter()
+            .map(|key| format!("'{key}'"))
+            .collect::<Vec<_>>()
+            .join(", ")
+    ))
 }
 
 /// Split a `key=value[,key=value...]` option string on top-level commas,
@@ -153,18 +170,19 @@ where
         .map_err(|e| error(format!("invalid value for option '{key}': {e}")))
 }
 
-/// Parse an optional value: a bare key or empty value yields `None`, otherwise
-/// the value is parsed via `T`'s [`FromStr`].
-pub fn parse_opt_value<T>(value: Option<&str>) -> Result<Option<T>>
+/// Parse an optional value for `key`: a bare key or empty value yields `None`,
+/// otherwise the value is parsed via `T`'s [`FromStr`].
+pub fn parse_opt_value<T>(key: &str, value: Option<&str>) -> Result<Option<T>>
 where
     T: FromStr,
     T::Err: Display,
 {
     match value {
-        Some(v) if !v.is_empty() => Ok(Some(
-            v.parse::<T>()
-                .map_err(|e| error(format!("invalid value: {e}")))?,
-        )),
+        Some(v) if !v.is_empty() => {
+            Ok(Some(v.parse::<T>().map_err(|e| {
+                error(format!("invalid value for option '{key}': {e}"))
+            })?))
+        }
         _ => Ok(None),
     }
 }

--- a/vmm_core/vmm_cli/src/lib.rs
+++ b/vmm_core/vmm_cli/src/lib.rs
@@ -127,6 +127,7 @@ where
         let mut items = Vec::new();
         for item in inner.split(',') {
             let item = item.trim();
+            anyhow::ensure!(!item.is_empty(), "list item cannot be empty");
             items.push(
                 item.parse::<T>()
                     .map_err(|e| private::error(format!("invalid list item '{item}': {e}")))?,
@@ -255,6 +256,9 @@ mod tests {
         assert_eq!("[]".parse::<BracketList<u32>>().unwrap().0, [] as [u32; 0]);
         assert!("a,b".parse::<BracketList<String>>().is_err());
         assert!("[1,x]".parse::<BracketList<u32>>().is_err());
+        assert!("[a,,b]".parse::<BracketList<String>>().is_err());
+        assert!("[,]".parse::<BracketList<String>>().is_err());
+        assert!("[a, ,b]".parse::<BracketList<String>>().is_err());
     }
 
     #[test]

--- a/vmm_core/vmm_cli/src/private.rs
+++ b/vmm_core/vmm_cli/src/private.rs
@@ -1,0 +1,139 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+use crate::Error;
+use crate::KeyValueFields;
+use crate::Result;
+use std::fmt::Display;
+use std::str::FromStr;
+
+/// Construct an [`Error`] with the given message.
+pub fn error(msg: impl Display) -> Error {
+    anyhow::Error::msg(msg.to_string())
+}
+
+/// Construct an unknown-option error listing all keys accepted by `T`.
+pub fn unknown_option<T: KeyValueFields>(key: &str) -> Error {
+    let mut keys = Vec::new();
+    T::append_keys(&mut keys);
+    error(format!(
+        "unknown option '{key}'; expected one of: {}",
+        keys.iter()
+            .map(|key| format!("'{key}'"))
+            .collect::<Vec<_>>()
+            .join(", ")
+    ))
+}
+
+/// Split an option string on top-level commas, honoring `[...]` nesting.
+pub fn split_options(s: &str) -> Result<Vec<&str>> {
+    if s.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let mut parts = Vec::new();
+    let mut depth = 0u32;
+    let mut start = 0;
+    for (i, c) in s.char_indices() {
+        match c {
+            '[' => depth += 1,
+            ']' => {
+                anyhow::ensure!(depth > 0, "unmatched ']' in '{s}'");
+                depth -= 1;
+            }
+            ',' if depth == 0 => {
+                let part = &s[start..i];
+                anyhow::ensure!(!part.is_empty(), "empty option in '{s}'");
+                parts.push(part);
+                start = i + 1;
+            }
+            _ => {}
+        }
+    }
+    anyhow::ensure!(depth == 0, "unmatched '[' in '{s}'");
+    let part = &s[start..];
+    anyhow::ensure!(!part.is_empty(), "empty option in '{s}'");
+    parts.push(part);
+    Ok(parts)
+}
+
+/// Split one option into its non-empty key and optional value.
+pub fn split_kv(part: &str) -> Result<(&str, Option<&str>)> {
+    let (key, value) = match part.split_once('=') {
+        Some((key, value)) => (key, Some(value)),
+        None => (part, None),
+    };
+    anyhow::ensure!(!key.is_empty(), "option key cannot be empty");
+    Ok((key, value))
+}
+
+/// Parse a required, non-empty value for `key` via `T`'s [`FromStr`].
+pub fn parse_value<T>(key: &str, value: Option<&str>) -> Result<T>
+where
+    T: FromStr,
+    T::Err: Display,
+{
+    let value = match value {
+        Some(v) if !v.is_empty() => v,
+        _ => anyhow::bail!("option '{key}' requires a value"),
+    };
+    value
+        .parse::<T>()
+        .map_err(|e| error(format!("invalid value for option '{key}': {e}")))
+}
+
+/// Parse an optional value for `key`, returning `None` for no value.
+pub fn parse_opt_value<T>(key: &str, value: Option<&str>) -> Result<Option<T>>
+where
+    T: FromStr,
+    T::Err: Display,
+{
+    match value {
+        Some(v) if !v.is_empty() => {
+            Ok(Some(v.parse::<T>().map_err(|e| {
+                error(format!("invalid value for option '{key}': {e}"))
+            })?))
+        }
+        _ => Ok(None),
+    }
+}
+
+/// Parse the leading positional token via `T`'s [`FromStr`].
+pub fn parse_positional<T>(name: &str, value: Option<&str>) -> Result<T>
+where
+    T: FromStr,
+    T::Err: Display,
+{
+    let value = match value {
+        Some(v) if !v.is_empty() => v,
+        _ => anyhow::bail!("missing required '{name}'"),
+    };
+    value
+        .parse::<T>()
+        .map_err(|e| error(format!("invalid '{name}': {e}")))
+}
+
+/// Store a parsed value into `slot`, erroring if `key` was already seen.
+pub fn set_once<T>(slot: &mut Option<T>, key: &str, value: T) -> Result<()> {
+    if slot.is_some() {
+        anyhow::bail!("duplicate option '{key}'");
+    }
+    *slot = Some(value);
+    Ok(())
+}
+
+/// Parse a boolean flag/toggle into `slot`, erroring on duplicates.
+pub fn set_toggle(slot: &mut Option<bool>, key: &str, value: Option<&str>) -> Result<()> {
+    let v = match value {
+        None | Some("on") => true,
+        Some("off") => false,
+        Some(other) => {
+            anyhow::bail!("flag '{key}' expects no value, 'on', or 'off', got '{other}'")
+        }
+    };
+    if slot.is_some() {
+        anyhow::bail!("duplicate flag '{key}'");
+    }
+    *slot = Some(v);
+    Ok(())
+}

--- a/vmm_core/vmm_cli/src/private.rs
+++ b/vmm_core/vmm_cli/src/private.rs
@@ -82,19 +82,20 @@ where
         .map_err(|e| error(format!("invalid value for option '{key}': {e}")))
 }
 
-/// Parse an optional value for `key`, returning `None` for no value.
+/// Parse an optional value for `key`, returning `None` when `=` is omitted.
 pub fn parse_opt_value<T>(key: &str, value: Option<&str>) -> Result<Option<T>>
 where
     T: FromStr,
     T::Err: Display,
 {
     match value {
-        Some(v) if !v.is_empty() => {
-            Ok(Some(v.parse::<T>().map_err(|e| {
+        Some("") => anyhow::bail!("option '{key}' requires a value after '='"),
+        Some(value) => {
+            Ok(Some(value.parse::<T>().map_err(|e| {
                 error(format!("invalid value for option '{key}': {e}"))
             })?))
         }
-        _ => Ok(None),
+        None => Ok(None),
     }
 }
 

--- a/vmm_core/vmm_cli/tests/conformance.rs
+++ b/vmm_core/vmm_cli/tests/conformance.rs
@@ -88,6 +88,33 @@ fn unknown_key_is_rejected() {
 }
 
 #[test]
+fn malformed_options_are_rejected_clearly() {
+    assert_eq!(
+        "".parse::<Basic>().unwrap_err().to_string(),
+        "missing required option 'name'"
+    );
+    assert_eq!(
+        ",name=foo".parse::<Basic>().unwrap_err().to_string(),
+        "empty option in ',name=foo'"
+    );
+    assert_eq!(
+        "name=foo,".parse::<Basic>().unwrap_err().to_string(),
+        "empty option in 'name=foo,'"
+    );
+    assert_eq!(
+        "name=foo,,count=1"
+            .parse::<Basic>()
+            .unwrap_err()
+            .to_string(),
+        "empty option in 'name=foo,,count=1'"
+    );
+    assert_eq!(
+        "=foo".parse::<Basic>().unwrap_err().to_string(),
+        "option key cannot be empty"
+    );
+}
+
+#[test]
 fn duplicate_key_is_rejected() {
     assert!("name=foo,name=bar".parse::<Basic>().is_err());
     assert!("name=foo,count=1,count=2".parse::<Basic>().is_err());

--- a/vmm_core/vmm_cli/tests/conformance.rs
+++ b/vmm_core/vmm_cli/tests/conformance.rs
@@ -71,7 +71,7 @@ fn basic_happy_path() {
             fast: true,
             verbose: Some(false),
             size: Some(MemorySize(2 * 1024 * 1024)),
-            vps: Some(BracketRangeList(vec![0, 2, 3])),
+            vps: Some(BracketRangeList(vec![0..=0, 2..=3])),
         }
     );
 }

--- a/vmm_core/vmm_cli/tests/conformance.rs
+++ b/vmm_core/vmm_cli/tests/conformance.rs
@@ -187,7 +187,6 @@ fn positional_head() {
 }
 
 #[derive(KeyValueGroup, Debug, PartialEq)]
-#[kv(required)]
 enum Transport {
     #[kv(key = "tcp")]
     Tcp(String),

--- a/vmm_core/vmm_cli/tests/conformance.rs
+++ b/vmm_core/vmm_cli/tests/conformance.rs
@@ -1,0 +1,275 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Conformance tests for the `KeyValueArgs` / `KeyValueGroup` derives.
+//!
+//! These pin the *uniform mechanics* the derive guarantees for every generated
+//! parser — unknown/duplicate/empty/missing keys, the boolean flag spellings,
+//! tri-state flags, defaults, positional heads, bracket lists, "one of" groups,
+//! and struct flattening — so that individual `#[derive(KeyValueArgs)]` call
+//! sites don't each have to re-prove them.
+
+use vmm_cli::BracketRangeList;
+use vmm_cli::KeyValueArgs;
+use vmm_cli::KeyValueGroup;
+use vmm_cli::MemorySize;
+
+#[derive(KeyValueArgs, Debug, PartialEq)]
+struct Basic {
+    /// Required scalar.
+    name: String,
+    /// Optional scalar.
+    count: Option<u32>,
+    /// Absent => `Default::default()`.
+    #[kv(default)]
+    level: u8,
+    /// Absent => the given expression.
+    #[kv(default = 7)]
+    retries: u8,
+    /// Plain boolean flag.
+    #[kv(flag)]
+    fast: bool,
+    /// Tri-state boolean flag.
+    #[kv(flag)]
+    verbose: Option<bool>,
+    /// Renamed key + `FromStr` newtype value.
+    #[kv(key = "sz")]
+    size: Option<MemorySize>,
+    /// Bracket list value.
+    vps: Option<BracketRangeList>,
+}
+
+#[test]
+fn basic_happy_path() {
+    // Only the required field: everything else takes its default/None.
+    let b: Basic = "name=foo".parse().unwrap();
+    assert_eq!(
+        b,
+        Basic {
+            name: "foo".into(),
+            count: None,
+            level: 0,
+            retries: 7,
+            fast: false,
+            verbose: None,
+            size: None,
+            vps: None,
+        }
+    );
+
+    // Everything set, order-independent.
+    let b: Basic = "vps=[0,2-3],sz=2M,verbose=off,fast,retries=1,level=2,count=3,name=foo"
+        .parse()
+        .unwrap();
+    assert_eq!(
+        b,
+        Basic {
+            name: "foo".into(),
+            count: Some(3),
+            level: 2,
+            retries: 1,
+            fast: true,
+            verbose: Some(false),
+            size: Some(MemorySize(2 * 1024 * 1024)),
+            vps: Some(BracketRangeList(vec![0, 2, 3])),
+        }
+    );
+}
+
+#[test]
+fn unknown_key_is_rejected() {
+    assert!("name=foo,bogus=1".parse::<Basic>().is_err());
+    // A bare unknown token is also rejected.
+    assert!("name=foo,bogus".parse::<Basic>().is_err());
+}
+
+#[test]
+fn duplicate_key_is_rejected() {
+    assert!("name=foo,name=bar".parse::<Basic>().is_err());
+    assert!("name=foo,count=1,count=2".parse::<Basic>().is_err());
+}
+
+#[test]
+fn empty_value_is_rejected() {
+    // An empty value for a scalar is treated as "no value".
+    assert!("name=".parse::<Basic>().is_err());
+    assert!("name=foo,count=".parse::<Basic>().is_err());
+}
+
+#[test]
+fn missing_required_is_rejected() {
+    assert!("count=3".parse::<Basic>().is_err());
+}
+
+#[test]
+fn invalid_value_is_rejected() {
+    assert!("name=foo,count=abc".parse::<Basic>().is_err());
+    assert!("name=foo,sz=notasize".parse::<Basic>().is_err());
+    assert!("name=foo,vps=0,1".parse::<Basic>().is_err()); // missing brackets
+}
+
+#[test]
+fn flag_accepts_bare_on_off() {
+    assert!(!"name=x".parse::<Basic>().unwrap().fast);
+    assert!("name=x,fast".parse::<Basic>().unwrap().fast);
+    assert!("name=x,fast=on".parse::<Basic>().unwrap().fast);
+    assert!(!"name=x,fast=off".parse::<Basic>().unwrap().fast);
+}
+
+#[test]
+fn flag_rejects_garbage_and_duplicates() {
+    assert!("name=x,fast=yes".parse::<Basic>().is_err());
+    assert!("name=x,fast,fast".parse::<Basic>().is_err());
+    assert!("name=x,fast=on,fast=off".parse::<Basic>().is_err());
+}
+
+#[test]
+fn tristate_flag_distinguishes_all_three() {
+    assert_eq!("name=x".parse::<Basic>().unwrap().verbose, None);
+    assert_eq!(
+        "name=x,verbose".parse::<Basic>().unwrap().verbose,
+        Some(true)
+    );
+    assert_eq!(
+        "name=x,verbose=on".parse::<Basic>().unwrap().verbose,
+        Some(true)
+    );
+    assert_eq!(
+        "name=x,verbose=off".parse::<Basic>().unwrap().verbose,
+        Some(false)
+    );
+}
+
+#[derive(KeyValueArgs, Debug, PartialEq)]
+struct Flagged {
+    id: String,
+    /// A flag that maps presence to a chosen value.
+    #[kv(flag, present = 2u8, absent = 0u8)]
+    level: u8,
+}
+
+#[test]
+fn present_absent_flag_maps_values() {
+    assert_eq!("id=a".parse::<Flagged>().unwrap().level, 0);
+    assert_eq!("id=a,level".parse::<Flagged>().unwrap().level, 2);
+    assert_eq!("id=a,level=on".parse::<Flagged>().unwrap().level, 2);
+    assert_eq!("id=a,level=off".parse::<Flagged>().unwrap().level, 0);
+}
+
+#[derive(KeyValueArgs, Debug, PartialEq)]
+struct Positional {
+    #[kv(positional)]
+    head: String,
+    #[kv(flag)]
+    flag: bool,
+    opt: Option<u32>,
+}
+
+#[test]
+fn positional_head() {
+    let p: Positional = "myhead".parse().unwrap();
+    assert_eq!(p.head, "myhead");
+    assert!(!p.flag);
+    assert_eq!(p.opt, None);
+
+    let p: Positional = "myhead,flag,opt=3".parse().unwrap();
+    assert_eq!(p.head, "myhead");
+    assert!(p.flag);
+    assert_eq!(p.opt, Some(3));
+
+    // The head is taken verbatim (not split on '=').
+    let p: Positional = "a:b=c,flag".parse().unwrap();
+    assert_eq!(p.head, "a:b=c");
+
+    // A missing/empty head is rejected.
+    assert!("".parse::<Positional>().is_err());
+    assert!(",flag".parse::<Positional>().is_err());
+}
+
+#[derive(KeyValueGroup, Debug, PartialEq)]
+#[kv(required)]
+enum Transport {
+    #[kv(key = "tcp")]
+    Tcp(String),
+    #[kv(key = "unix")]
+    Unix(Option<String>),
+    #[kv(key = "none")]
+    None,
+}
+
+#[derive(KeyValueArgs, Debug, PartialEq)]
+struct WithGroup {
+    id: String,
+    #[kv(flatten)]
+    transport: Transport,
+}
+
+#[test]
+fn group_selects_one_variant() {
+    assert_eq!(
+        "id=a,tcp=1.2.3.4".parse::<WithGroup>().unwrap().transport,
+        Transport::Tcp("1.2.3.4".into())
+    );
+    // Optional-valued variant: bare and valued forms.
+    assert_eq!(
+        "id=a,unix".parse::<WithGroup>().unwrap().transport,
+        Transport::Unix(None)
+    );
+    assert_eq!(
+        "id=a,unix=/run/s".parse::<WithGroup>().unwrap().transport,
+        Transport::Unix(Some("/run/s".into()))
+    );
+    // Unit variant.
+    assert_eq!(
+        "id=a,none".parse::<WithGroup>().unwrap().transport,
+        Transport::None
+    );
+}
+
+#[test]
+fn group_required_and_exclusive() {
+    // Required: none of the group keys present.
+    assert!("id=a".parse::<WithGroup>().is_err());
+    // Mutually exclusive: two group keys present.
+    assert!("id=a,tcp=x,none".parse::<WithGroup>().is_err());
+    // Unknown key still errors even with a valid group key.
+    assert!("id=a,tcp=x,bogus".parse::<WithGroup>().is_err());
+}
+
+#[derive(KeyValueArgs, Debug, PartialEq)]
+struct Shared {
+    #[kv(flag)]
+    a: bool,
+    b: Option<u32>,
+}
+
+#[derive(KeyValueArgs, Debug, PartialEq)]
+struct Outer {
+    name: String,
+    #[kv(flatten)]
+    shared: Shared,
+    c: Option<u32>,
+}
+
+#[test]
+fn flatten_merges_struct_keys() {
+    let o: Outer = "name=x,a,b=1,c=2".parse().unwrap();
+    assert_eq!(
+        o,
+        Outer {
+            name: "x".into(),
+            shared: Shared {
+                a: true,
+                b: Some(1)
+            },
+            c: Some(2),
+        }
+    );
+
+    // Absent flattened keys take their defaults.
+    let o: Outer = "name=x".parse().unwrap();
+    assert_eq!(o.shared, Shared { a: false, b: None });
+
+    // Unknown keys still error at the top level.
+    assert!("name=x,bogus=1".parse::<Outer>().is_err());
+}

--- a/vmm_core/vmm_cli/tests/conformance.rs
+++ b/vmm_core/vmm_cli/tests/conformance.rs
@@ -78,7 +78,11 @@ fn basic_happy_path() {
 
 #[test]
 fn unknown_key_is_rejected() {
-    assert!("name=foo,bogus=1".parse::<Basic>().is_err());
+    let err = "name=foo,bogus=1".parse::<Basic>().unwrap_err();
+    assert_eq!(
+        err.to_string(),
+        "unknown option 'bogus'; expected one of: 'name', 'count', 'level', 'retries', 'fast', 'verbose', 'sz', 'vps'"
+    );
     // A bare unknown token is also rejected.
     assert!("name=foo,bogus".parse::<Basic>().is_err());
 }
@@ -232,7 +236,11 @@ fn group_required_and_exclusive() {
     // Mutually exclusive: two group keys present.
     assert!("id=a,tcp=x,none".parse::<WithGroup>().is_err());
     // Unknown key still errors even with a valid group key.
-    assert!("id=a,tcp=x,bogus".parse::<WithGroup>().is_err());
+    let err = "id=a,tcp=x,bogus".parse::<WithGroup>().unwrap_err();
+    assert_eq!(
+        err.to_string(),
+        "unknown option 'bogus'; expected one of: 'id', 'tcp', 'unix', 'none'"
+    );
 }
 
 #[derive(KeyValueArgs, Debug, PartialEq)]
@@ -270,5 +278,9 @@ fn flatten_merges_struct_keys() {
     assert_eq!(o.shared, Shared { a: false, b: None });
 
     // Unknown keys still error at the top level.
-    assert!("name=x,bogus=1".parse::<Outer>().is_err());
+    let err = "name=x,bogus=1".parse::<Outer>().unwrap_err();
+    assert_eq!(
+        err.to_string(),
+        "unknown option 'bogus'; expected one of: 'name', 'a', 'b', 'c'"
+    );
 }

--- a/vmm_core/vmm_cli/tests/conformance.rs
+++ b/vmm_core/vmm_cli/tests/conformance.rs
@@ -249,6 +249,7 @@ fn group_selects_one_variant() {
         "id=a,unix=/run/s".parse::<WithGroup>().unwrap().transport,
         Transport::Unix(Some("/run/s".into()))
     );
+    assert!("id=a,unix=".parse::<WithGroup>().is_err());
     // Unit variant.
     assert_eq!(
         "id=a,none".parse::<WithGroup>().unwrap().transport,

--- a/vmm_core/vmm_cli_derive/Cargo.toml
+++ b/vmm_core/vmm_cli_derive/Cargo.toml
@@ -1,0 +1,19 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+[package]
+name = "vmm_cli_derive"
+edition.workspace = true
+rust-version.workspace = true
+
+[lib]
+proc-macro = true
+
+[dependencies]
+heck.workspace = true
+proc-macro2.workspace = true
+quote.workspace = true
+syn = { workspace = true, features = ["extra-traits", "full"] }
+
+[lints]
+workspace = true

--- a/vmm_core/vmm_cli_derive/src/lib.rs
+++ b/vmm_core/vmm_cli_derive/src/lib.rs
@@ -121,6 +121,58 @@ fn is_bool(ty: &Type) -> bool {
     matches!(ty, Type::Path(tp) if tp.qself.is_none() && tp.path.is_ident("bool"))
 }
 
+fn validate_field_attr(field: &syn::Field, fa: &FieldAttr) -> syn::Result<()> {
+    if !fa.flag && (fa.present.is_some() || fa.absent.is_some()) {
+        return Err(syn::Error::new_spanned(
+            field,
+            "`present`/`absent` require `flag`",
+        ));
+    }
+    if fa.flatten
+        && (fa.key.is_some()
+            || fa.flag
+            || !matches!(fa.default, DefaultKind::None)
+            || fa.present.is_some()
+            || fa.absent.is_some())
+    {
+        return Err(syn::Error::new_spanned(
+            field,
+            "`flatten` cannot be combined with `key`, `flag`, `default`, `present`, or `absent`",
+        ));
+    }
+    if fa.positional
+        && (fa.key.is_some()
+            || fa.flag
+            || fa.flatten
+            || !matches!(fa.default, DefaultKind::None)
+            || fa.present.is_some()
+            || fa.absent.is_some())
+    {
+        return Err(syn::Error::new_spanned(
+            field,
+            "`positional` cannot be combined with `key`, `flag`, `flatten`, `default`, `present`, or `absent`",
+        ));
+    }
+    if fa.flag && !matches!(fa.default, DefaultKind::None) {
+        return Err(syn::Error::new_spanned(
+            field,
+            "`default` is not allowed on a `flag` field",
+        ));
+    }
+    if !fa.flag
+        && !fa.flatten
+        && !fa.positional
+        && option_inner(&field.ty).is_some()
+        && !matches!(fa.default, DefaultKind::None)
+    {
+        return Err(syn::Error::new_spanned(
+            field,
+            "`default` is not allowed on an `Option<T>` field",
+        ));
+    }
+    Ok(())
+}
+
 fn expand_struct(input: DeriveInput) -> syn::Result<TokenStream2> {
     let name = &input.ident;
     let vis = &input.vis;
@@ -150,15 +202,10 @@ fn expand_struct(input: DeriveInput) -> syn::Result<TokenStream2> {
         let fname = field.ident.as_ref().unwrap();
         let ty = &field.ty;
         let fa = parse_field_attr(field)?;
+        validate_field_attr(field, &fa)?;
         let key = fa.key.clone().unwrap_or_else(|| fname.to_string());
 
         if fa.positional {
-            if fa.flag || fa.flatten || !matches!(fa.default, DefaultKind::None) {
-                return Err(syn::Error::new_spanned(
-                    field,
-                    "`positional` cannot be combined with `flag`, `flatten`, or `default`",
-                ));
-            }
             if positional.is_some() {
                 return Err(syn::Error::new_spanned(
                     field,
@@ -471,4 +518,63 @@ fn expand_group(input: DeriveInput) -> syn::Result<TokenStream2> {
             }
         }
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use syn::parse_quote;
+
+    fn expansion_error(input: DeriveInput) -> String {
+        expand_struct(input).unwrap_err().to_string()
+    }
+
+    #[test]
+    fn rejects_attributes_without_meaning_for_field_kind() {
+        assert_eq!(
+            expansion_error(parse_quote! {
+                struct Args {
+                    #[kv(present = 1, absent = 0)]
+                    value: u8,
+                }
+            }),
+            "`present`/`absent` require `flag`"
+        );
+        assert_eq!(
+            expansion_error(parse_quote! {
+                struct Args {
+                    #[kv(default)]
+                    value: Option<u8>,
+                }
+            }),
+            "`default` is not allowed on an `Option<T>` field"
+        );
+        assert_eq!(
+            expansion_error(parse_quote! {
+                struct Args {
+                    #[kv(flag, default)]
+                    value: bool,
+                }
+            }),
+            "`default` is not allowed on a `flag` field"
+        );
+        assert_eq!(
+            expansion_error(parse_quote! {
+                struct Args {
+                    #[kv(flatten, key = "value")]
+                    value: Nested,
+                }
+            }),
+            "`flatten` cannot be combined with `key`, `flag`, `default`, `present`, or `absent`"
+        );
+        assert_eq!(
+            expansion_error(parse_quote! {
+                struct Args {
+                    #[kv(positional, key = "value")]
+                    value: String,
+                }
+            }),
+            "`positional` cannot be combined with `key`, `flag`, `flatten`, `default`, `present`, or `absent`"
+        );
+    }
 }

--- a/vmm_core/vmm_cli_derive/src/lib.rs
+++ b/vmm_core/vmm_cli_derive/src/lib.rs
@@ -142,6 +142,7 @@ fn expand_struct(input: DeriveInput) -> syn::Result<TokenStream2> {
     let mut accum_fields = Vec::new();
     let mut accept_arms = Vec::new();
     let mut flatten_accepts = Vec::new();
+    let mut append_keys = Vec::new();
     let mut finish_fields = Vec::new();
     let mut positional: Option<(syn::Ident, Type, String)> = None;
 
@@ -174,6 +175,9 @@ fn expand_struct(input: DeriveInput) -> syn::Result<TokenStream2> {
             positional = Some((fname.clone(), ty.clone(), pname));
         } else if fa.flatten {
             accum_fields.push(quote! { #fname: <#ty as ::vmm_cli::KeyValueFields>::Accum, });
+            append_keys.push(quote! {
+                <#ty as ::vmm_cli::KeyValueFields>::append_keys(__keys);
+            });
             flatten_accepts.push(quote! {
                 if <#ty as ::vmm_cli::KeyValueFields>::accept(&mut __a.#fname, __key, __value)? {
                     return ::core::result::Result::Ok(true);
@@ -183,6 +187,7 @@ fn expand_struct(input: DeriveInput) -> syn::Result<TokenStream2> {
                 #fname: <#ty as ::vmm_cli::KeyValueFields>::finish(__a.#fname)?,
             });
         } else if fa.flag {
+            append_keys.push(quote! { __keys.push(#key); });
             accum_fields.push(quote! { #fname: ::core::option::Option<bool>, });
             accept_arms.push(quote! {
                 #key => { ::vmm_cli::set_toggle(&mut __a.#fname, #key, __value)?; }
@@ -211,6 +216,7 @@ fn expand_struct(input: DeriveInput) -> syn::Result<TokenStream2> {
                 });
             }
         } else if let Some(inner) = option_inner(ty) {
+            append_keys.push(quote! { __keys.push(#key); });
             accum_fields.push(quote! { #fname: #ty, });
             accept_arms.push(quote! {
                 #key => {
@@ -219,6 +225,7 @@ fn expand_struct(input: DeriveInput) -> syn::Result<TokenStream2> {
             });
             finish_fields.push(quote! { #fname: __a.#fname, });
         } else {
+            append_keys.push(quote! { __keys.push(#key); });
             accum_fields.push(quote! { #fname: ::core::option::Option<#ty>, });
             accept_arms.push(quote! {
                 #key => {
@@ -271,9 +278,7 @@ fn expand_struct(input: DeriveInput) -> syn::Result<TokenStream2> {
             for __part in __parts {
                 let (__key, __value) = ::vmm_cli::split_kv(__part);
                 if !<#name as ::vmm_cli::KeyValueFields>::accept(&mut __a, __key, __value)? {
-                    return ::core::result::Result::Err(::vmm_cli::error(
-                        ::std::format!("unknown option '{}'", __key),
-                    ));
+                    return ::core::result::Result::Err(::vmm_cli::unknown_option::<#name>(__key));
                 }
             }
         }
@@ -282,9 +287,7 @@ fn expand_struct(input: DeriveInput) -> syn::Result<TokenStream2> {
             for __part in ::vmm_cli::split_options(s)? {
                 let (__key, __value) = ::vmm_cli::split_kv(__part);
                 if !<#name as ::vmm_cli::KeyValueFields>::accept(&mut __a, __key, __value)? {
-                    return ::core::result::Result::Err(::vmm_cli::error(
-                        ::std::format!("unknown option '{}'", __key),
-                    ));
+                    return ::core::result::Result::Err(::vmm_cli::unknown_option::<#name>(__key));
                 }
             }
         }
@@ -306,6 +309,10 @@ fn expand_struct(input: DeriveInput) -> syn::Result<TokenStream2> {
 
         impl ::vmm_cli::KeyValueFields for #name {
             type Accum = #accum_name;
+
+            fn append_keys(__keys: &mut ::std::vec::Vec<&'static str>) {
+                #(#append_keys)*
+            }
 
             fn accept(
                 __a: &mut Self::Accum,
@@ -367,12 +374,14 @@ fn expand_group(input: DeriveInput) -> syn::Result<TokenStream2> {
 
     let mut arms = Vec::new();
     let mut keys = Vec::new();
+    let mut append_keys = Vec::new();
     let mut default_variant = None;
 
     for variant in &data.variants {
         let vname = &variant.ident;
         let (key, is_default) = parse_variant_attr(variant)?;
         keys.push(format!("'{key}'"));
+        append_keys.push(quote! { __keys.push(#key); });
 
         let build = match &variant.fields {
             Fields::Unit => quote! {
@@ -388,7 +397,7 @@ fn expand_group(input: DeriveInput) -> syn::Result<TokenStream2> {
             Fields::Unnamed(f) if f.unnamed.len() == 1 => {
                 let fty = &f.unnamed.first().unwrap().ty;
                 if let Some(inner) = option_inner(fty) {
-                    quote! { #name::#vname(::vmm_cli::parse_opt_value::<#inner>(__value)?) }
+                    quote! { #name::#vname(::vmm_cli::parse_opt_value::<#inner>(#key, __value)?) }
                 } else {
                     quote! { #name::#vname(::vmm_cli::parse_value::<#fty>(#key, __value)?) }
                 }
@@ -431,6 +440,10 @@ fn expand_group(input: DeriveInput) -> syn::Result<TokenStream2> {
     Ok(quote! {
         impl ::vmm_cli::KeyValueFields for #name {
             type Accum = ::core::option::Option<#name>;
+
+            fn append_keys(__keys: &mut ::std::vec::Vec<&'static str>) {
+                #(#append_keys)*
+            }
 
             fn accept(
                 __accum: &mut Self::Accum,

--- a/vmm_core/vmm_cli_derive/src/lib.rs
+++ b/vmm_core/vmm_cli_derive/src/lib.rs
@@ -291,6 +291,13 @@ fn expand_struct(input: DeriveInput) -> syn::Result<TokenStream2> {
     };
 
     Ok(quote! {
+        // The accumulator inherits the parsed type's visibility (`#vis`) rather
+        // than being private. It is the value of the public
+        // `KeyValueFields::Accum` associated type, so for a `pub` parsed type it
+        // must be at least as visible as that type; making it private trips
+        // E0446 ("private type in public interface"). It also has to be nameable
+        // by other types that `#[kv(flatten)]` this one, potentially across
+        // crates. `#[doc(hidden)]` keeps it out of rustdoc regardless.
         #[doc(hidden)]
         #[derive(::core::default::Default)]
         #vis struct #accum_name {
@@ -358,21 +365,6 @@ fn expand_group(input: DeriveInput) -> syn::Result<TokenStream2> {
         ));
     };
 
-    let mut required = false;
-    for attr in &input.attrs {
-        if !attr.path().is_ident("kv") {
-            continue;
-        }
-        attr.parse_nested_meta(|meta| {
-            if meta.path.is_ident("required") {
-                required = true;
-                Ok(())
-            } else {
-                Err(meta.error("unknown `kv` attribute"))
-            }
-        })?;
-    }
-
     let mut arms = Vec::new();
     let mut keys = Vec::new();
     let mut default_variant = None;
@@ -410,14 +402,20 @@ fn expand_group(input: DeriveInput) -> syn::Result<TokenStream2> {
         };
         arms.push(quote! { #key => #build, });
         if is_default {
+            if default_variant.is_some() {
+                return Err(syn::Error::new_spanned(
+                    variant,
+                    "only one variant may be marked `#[kv(default)]`",
+                ));
+            }
             default_variant = Some(quote! { #name::#vname });
         }
     }
 
     let keys_desc = keys.join(", ");
-    let none_case = match (&default_variant, required) {
-        (Some(def), _) => quote! { ::core::result::Result::Ok(#def) },
-        (None, _) => quote! {
+    let none_case = match &default_variant {
+        Some(def) => quote! { ::core::result::Result::Ok(#def) },
+        None => quote! {
             ::core::result::Result::Err(::vmm_cli::error(
                 ::std::format!("one of {} is required", #keys_desc),
             ))

--- a/vmm_core/vmm_cli_derive/src/lib.rs
+++ b/vmm_core/vmm_cli_derive/src/lib.rs
@@ -402,6 +402,12 @@ fn expand_group(input: DeriveInput) -> syn::Result<TokenStream2> {
         };
         arms.push(quote! { #key => #build, });
         if is_default {
+            if !matches!(variant.fields, Fields::Unit) {
+                return Err(syn::Error::new_spanned(
+                    variant,
+                    "`#[kv(default)]` is only allowed on unit variants",
+                ));
+            }
             if default_variant.is_some() {
                 return Err(syn::Error::new_spanned(
                     variant,

--- a/vmm_core/vmm_cli_derive/src/lib.rs
+++ b/vmm_core/vmm_cli_derive/src/lib.rs
@@ -169,7 +169,7 @@ fn expand_struct(input: DeriveInput) -> syn::Result<TokenStream2> {
             let pname = fname.to_string();
             finish_fields.push(quote! {
                 #fname: __a.#fname.ok_or_else(
-                    || ::vmm_cli::error(::std::format!("missing required '{}'", #pname)),
+                    || ::vmm_cli::private::error(::std::format!("missing required '{}'", #pname)),
                 )?,
             });
             positional = Some((fname.clone(), ty.clone(), pname));
@@ -190,7 +190,7 @@ fn expand_struct(input: DeriveInput) -> syn::Result<TokenStream2> {
             append_keys.push(quote! { __keys.push(#key); });
             accum_fields.push(quote! { #fname: ::core::option::Option<bool>, });
             accept_arms.push(quote! {
-                #key => { ::vmm_cli::set_toggle(&mut __a.#fname, #key, __value)?; }
+                #key => { ::vmm_cli::private::set_toggle(&mut __a.#fname, #key, __value)?; }
             });
             if option_inner(ty).is_some_and(is_bool) {
                 if fa.present.is_some() || fa.absent.is_some() {
@@ -220,7 +220,7 @@ fn expand_struct(input: DeriveInput) -> syn::Result<TokenStream2> {
             accum_fields.push(quote! { #fname: #ty, });
             accept_arms.push(quote! {
                 #key => {
-                    ::vmm_cli::set_once(&mut __a.#fname, #key, ::vmm_cli::parse_value::<#inner>(#key, __value)?)?;
+                    ::vmm_cli::private::set_once(&mut __a.#fname, #key, ::vmm_cli::private::parse_value::<#inner>(#key, __value)?)?;
                 }
             });
             finish_fields.push(quote! { #fname: __a.#fname, });
@@ -229,7 +229,7 @@ fn expand_struct(input: DeriveInput) -> syn::Result<TokenStream2> {
             accum_fields.push(quote! { #fname: ::core::option::Option<#ty>, });
             accept_arms.push(quote! {
                 #key => {
-                    ::vmm_cli::set_once(&mut __a.#fname, #key, ::vmm_cli::parse_value::<#ty>(#key, __value)?)?;
+                    ::vmm_cli::private::set_once(&mut __a.#fname, #key, ::vmm_cli::private::parse_value::<#ty>(#key, __value)?)?;
                 }
             });
             match &fa.default {
@@ -241,7 +241,7 @@ fn expand_struct(input: DeriveInput) -> syn::Result<TokenStream2> {
                 }
                 DefaultKind::None => finish_fields.push(quote! {
                     #fname: __a.#fname.ok_or_else(
-                        || ::vmm_cli::error(::std::format!("missing required option '{}'", #key)),
+                        || ::vmm_cli::private::error(::std::format!("missing required option '{}'", #key)),
                     )?,
                 }),
             }
@@ -271,23 +271,23 @@ fn expand_struct(input: DeriveInput) -> syn::Result<TokenStream2> {
     // positional (if any), feed the rest through `accept`, then `finish`.
     let parse_loop = if let Some((pf, pty, pname)) = &positional {
         quote! {
-            let mut __parts = ::vmm_cli::split_options(s)?.into_iter();
+            let mut __parts = ::vmm_cli::private::split_options(s)?.into_iter();
             __a.#pf = ::core::option::Option::Some(
-                ::vmm_cli::parse_positional::<#pty>(#pname, __parts.next())?,
+                ::vmm_cli::private::parse_positional::<#pty>(#pname, __parts.next())?,
             );
             for __part in __parts {
-                let (__key, __value) = ::vmm_cli::split_kv(__part);
+                let (__key, __value) = ::vmm_cli::private::split_kv(__part)?;
                 if !<#name as ::vmm_cli::KeyValueFields>::accept(&mut __a, __key, __value)? {
-                    return ::core::result::Result::Err(::vmm_cli::unknown_option::<#name>(__key));
+                    return ::core::result::Result::Err(::vmm_cli::private::unknown_option::<#name>(__key));
                 }
             }
         }
     } else {
         quote! {
-            for __part in ::vmm_cli::split_options(s)? {
-                let (__key, __value) = ::vmm_cli::split_kv(__part);
+            for __part in ::vmm_cli::private::split_options(s)? {
+                let (__key, __value) = ::vmm_cli::private::split_kv(__part)?;
                 if !<#name as ::vmm_cli::KeyValueFields>::accept(&mut __a, __key, __value)? {
-                    return ::core::result::Result::Err(::vmm_cli::unknown_option::<#name>(__key));
+                    return ::core::result::Result::Err(::vmm_cli::private::unknown_option::<#name>(__key));
                 }
             }
         }
@@ -387,7 +387,7 @@ fn expand_group(input: DeriveInput) -> syn::Result<TokenStream2> {
             Fields::Unit => quote! {
                 {
                     if __value.is_some() {
-                        return ::core::result::Result::Err(::vmm_cli::error(
+                        return ::core::result::Result::Err(::vmm_cli::private::error(
                             ::std::format!("flag '{}' does not take a value", #key),
                         ));
                     }
@@ -397,9 +397,9 @@ fn expand_group(input: DeriveInput) -> syn::Result<TokenStream2> {
             Fields::Unnamed(f) if f.unnamed.len() == 1 => {
                 let fty = &f.unnamed.first().unwrap().ty;
                 if let Some(inner) = option_inner(fty) {
-                    quote! { #name::#vname(::vmm_cli::parse_opt_value::<#inner>(#key, __value)?) }
+                    quote! { #name::#vname(::vmm_cli::private::parse_opt_value::<#inner>(#key, __value)?) }
                 } else {
-                    quote! { #name::#vname(::vmm_cli::parse_value::<#fty>(#key, __value)?) }
+                    quote! { #name::#vname(::vmm_cli::private::parse_value::<#fty>(#key, __value)?) }
                 }
             }
             _ => {
@@ -431,7 +431,7 @@ fn expand_group(input: DeriveInput) -> syn::Result<TokenStream2> {
     let none_case = match &default_variant {
         Some(def) => quote! { ::core::result::Result::Ok(#def) },
         None => quote! {
-            ::core::result::Result::Err(::vmm_cli::error(
+            ::core::result::Result::Err(::vmm_cli::private::error(
                 ::std::format!("one of {} is required", #keys_desc),
             ))
         },
@@ -455,7 +455,7 @@ fn expand_group(input: DeriveInput) -> syn::Result<TokenStream2> {
                     _ => return ::core::result::Result::Ok(false),
                 };
                 if __accum.is_some() {
-                    return ::core::result::Result::Err(::vmm_cli::error(
+                    return ::core::result::Result::Err(::vmm_cli::private::error(
                         ::std::format!("only one of {} may be specified", #keys_desc),
                     ));
                 }

--- a/vmm_core/vmm_cli_derive/src/lib.rs
+++ b/vmm_core/vmm_cli_derive/src/lib.rs
@@ -1,0 +1,457 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Derive macros for the `vmm_cli` crate. See that crate for documentation.
+
+#![forbid(unsafe_code)]
+
+use heck::ToSnakeCase;
+use proc_macro::TokenStream;
+use proc_macro2::TokenStream as TokenStream2;
+use quote::format_ident;
+use quote::quote;
+use syn::Data;
+use syn::DeriveInput;
+use syn::Expr;
+use syn::Fields;
+use syn::LitStr;
+use syn::Token;
+use syn::Type;
+use syn::Variant;
+use syn::parse_macro_input;
+
+/// Derive a `FromStr` impl that parses a comma-separated `key=value` option
+/// string into this struct. Documented in the `vmm_cli` crate.
+#[proc_macro_derive(KeyValueArgs, attributes(kv))]
+pub fn derive_key_value_args(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+    expand_struct(input)
+        .unwrap_or_else(|e| e.to_compile_error())
+        .into()
+}
+
+/// Derive a `vmm_cli::KeyValueGroup` impl for an enum whose variants each
+/// correspond to a mutually-exclusive key. Documented in the `vmm_cli` crate.
+#[proc_macro_derive(KeyValueGroup, attributes(kv))]
+pub fn derive_key_value_group(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+    expand_group(input)
+        .unwrap_or_else(|e| e.to_compile_error())
+        .into()
+}
+
+/// How a scalar field is populated when its key is absent.
+#[derive(Default)]
+enum DefaultKind {
+    /// No default: the key is required.
+    #[default]
+    None,
+    /// `#[kv(default)]`: use `Default::default()`.
+    Auto,
+    /// `#[kv(default = expr)]`: use `expr`.
+    Expr(Expr),
+}
+
+#[derive(Default)]
+struct FieldAttr {
+    key: Option<String>,
+    flag: bool,
+    flatten: bool,
+    positional: bool,
+    default: DefaultKind,
+    present: Option<Expr>,
+    absent: Option<Expr>,
+}
+
+fn parse_field_attr(field: &syn::Field) -> syn::Result<FieldAttr> {
+    let mut fa = FieldAttr::default();
+    for attr in &field.attrs {
+        if !attr.path().is_ident("kv") {
+            continue;
+        }
+        attr.parse_nested_meta(|meta| {
+            if meta.path.is_ident("key") {
+                fa.key = Some(meta.value()?.parse::<LitStr>()?.value());
+            } else if meta.path.is_ident("flag") {
+                fa.flag = true;
+            } else if meta.path.is_ident("flatten") {
+                fa.flatten = true;
+            } else if meta.path.is_ident("positional") {
+                fa.positional = true;
+            } else if meta.path.is_ident("default") {
+                if meta.input.peek(Token![=]) {
+                    fa.default = DefaultKind::Expr(meta.value()?.parse()?);
+                } else {
+                    fa.default = DefaultKind::Auto;
+                }
+            } else if meta.path.is_ident("present") {
+                fa.present = Some(meta.value()?.parse()?);
+            } else if meta.path.is_ident("absent") {
+                fa.absent = Some(meta.value()?.parse()?);
+            } else {
+                return Err(meta.error("unknown `kv` attribute"));
+            }
+            Ok(())
+        })?;
+    }
+    Ok(fa)
+}
+
+/// If `ty` is `Option<T>`, return `T`.
+fn option_inner(ty: &Type) -> Option<&Type> {
+    let Type::Path(tp) = ty else { return None };
+    if tp.qself.is_some() {
+        return None;
+    }
+    let seg = tp.path.segments.last()?;
+    if seg.ident != "Option" {
+        return None;
+    }
+    let syn::PathArguments::AngleBracketed(args) = &seg.arguments else {
+        return None;
+    };
+    match args.args.first()? {
+        syn::GenericArgument::Type(t) => Some(t),
+        _ => None,
+    }
+}
+
+/// Whether `ty` is exactly `bool`.
+fn is_bool(ty: &Type) -> bool {
+    matches!(ty, Type::Path(tp) if tp.qself.is_none() && tp.path.is_ident("bool"))
+}
+
+fn expand_struct(input: DeriveInput) -> syn::Result<TokenStream2> {
+    let name = &input.ident;
+    let vis = &input.vis;
+    let Data::Struct(data) = &input.data else {
+        return Err(syn::Error::new_spanned(
+            &input,
+            "KeyValueArgs may only be derived for structs",
+        ));
+    };
+    let Fields::Named(named) = &data.fields else {
+        return Err(syn::Error::new_spanned(
+            &input,
+            "KeyValueArgs requires named fields",
+        ));
+    };
+
+    let accum_name = format_ident!("__{}Accum", name);
+
+    let mut accum_fields = Vec::new();
+    let mut accept_arms = Vec::new();
+    let mut flatten_accepts = Vec::new();
+    let mut finish_fields = Vec::new();
+    let mut positional: Option<(syn::Ident, Type, String)> = None;
+
+    for field in &named.named {
+        let fname = field.ident.as_ref().unwrap();
+        let ty = &field.ty;
+        let fa = parse_field_attr(field)?;
+        let key = fa.key.clone().unwrap_or_else(|| fname.to_string());
+
+        if fa.positional {
+            if fa.flag || fa.flatten || !matches!(fa.default, DefaultKind::None) {
+                return Err(syn::Error::new_spanned(
+                    field,
+                    "`positional` cannot be combined with `flag`, `flatten`, or `default`",
+                ));
+            }
+            if positional.is_some() {
+                return Err(syn::Error::new_spanned(
+                    field,
+                    "only one `positional` field is allowed",
+                ));
+            }
+            accum_fields.push(quote! { #fname: ::core::option::Option<#ty>, });
+            let pname = fname.to_string();
+            finish_fields.push(quote! {
+                #fname: __a.#fname.ok_or_else(
+                    || ::vmm_cli::error(::std::format!("missing required '{}'", #pname)),
+                )?,
+            });
+            positional = Some((fname.clone(), ty.clone(), pname));
+        } else if fa.flatten {
+            accum_fields.push(quote! { #fname: <#ty as ::vmm_cli::KeyValueFields>::Accum, });
+            flatten_accepts.push(quote! {
+                if <#ty as ::vmm_cli::KeyValueFields>::accept(&mut __a.#fname, __key, __value)? {
+                    return ::core::result::Result::Ok(true);
+                }
+            });
+            finish_fields.push(quote! {
+                #fname: <#ty as ::vmm_cli::KeyValueFields>::finish(__a.#fname)?,
+            });
+        } else if fa.flag {
+            accum_fields.push(quote! { #fname: ::core::option::Option<bool>, });
+            accept_arms.push(quote! {
+                #key => { ::vmm_cli::set_toggle(&mut __a.#fname, #key, __value)?; }
+            });
+            if option_inner(ty).is_some_and(is_bool) {
+                if fa.present.is_some() || fa.absent.is_some() {
+                    return Err(syn::Error::new_spanned(
+                        field,
+                        "`present`/`absent` are not allowed on an `Option<bool>` flag",
+                    ));
+                }
+                finish_fields.push(quote! { #fname: __a.#fname, });
+            } else {
+                let (present, absent) = match (&fa.present, &fa.absent) {
+                    (Some(p), Some(a)) => (quote!(#p), quote!(#a)),
+                    (None, None) => (quote!(true), quote!(false)),
+                    _ => {
+                        return Err(syn::Error::new_spanned(
+                            field,
+                            "`flag` requires both `present` and `absent` (for non-bool fields), or neither (for bool)",
+                        ));
+                    }
+                };
+                finish_fields.push(quote! {
+                    #fname: if __a.#fname.unwrap_or(false) { #present } else { #absent },
+                });
+            }
+        } else if let Some(inner) = option_inner(ty) {
+            accum_fields.push(quote! { #fname: #ty, });
+            accept_arms.push(quote! {
+                #key => {
+                    ::vmm_cli::set_once(&mut __a.#fname, #key, ::vmm_cli::parse_value::<#inner>(#key, __value)?)?;
+                }
+            });
+            finish_fields.push(quote! { #fname: __a.#fname, });
+        } else {
+            accum_fields.push(quote! { #fname: ::core::option::Option<#ty>, });
+            accept_arms.push(quote! {
+                #key => {
+                    ::vmm_cli::set_once(&mut __a.#fname, #key, ::vmm_cli::parse_value::<#ty>(#key, __value)?)?;
+                }
+            });
+            match &fa.default {
+                DefaultKind::Expr(expr) => {
+                    finish_fields.push(quote! { #fname: __a.#fname.unwrap_or_else(|| #expr), });
+                }
+                DefaultKind::Auto => {
+                    finish_fields.push(quote! { #fname: __a.#fname.unwrap_or_default(), });
+                }
+                DefaultKind::None => finish_fields.push(quote! {
+                    #fname: __a.#fname.ok_or_else(
+                        || ::vmm_cli::error(::std::format!("missing required option '{}'", #key)),
+                    )?,
+                }),
+            }
+        }
+    }
+
+    // Body of `KeyValueFields::accept`.
+    let accept_body = if accept_arms.is_empty() && flatten_accepts.is_empty() {
+        quote! {
+            let _ = (&mut *__a, __key, __value);
+            ::core::result::Result::Ok(false)
+        }
+    } else {
+        quote! {
+            match __key {
+                #(#accept_arms)*
+                _ => {
+                    #(#flatten_accepts)*
+                    return ::core::result::Result::Ok(false);
+                }
+            }
+            ::core::result::Result::Ok(true)
+        }
+    };
+
+    // Body of `FromStr::from_str`: seed the accumulator, consume the leading
+    // positional (if any), feed the rest through `accept`, then `finish`.
+    let parse_loop = if let Some((pf, pty, pname)) = &positional {
+        quote! {
+            let mut __parts = ::vmm_cli::split_options(s)?.into_iter();
+            __a.#pf = ::core::option::Option::Some(
+                ::vmm_cli::parse_positional::<#pty>(#pname, __parts.next())?,
+            );
+            for __part in __parts {
+                let (__key, __value) = ::vmm_cli::split_kv(__part);
+                if !<#name as ::vmm_cli::KeyValueFields>::accept(&mut __a, __key, __value)? {
+                    return ::core::result::Result::Err(::vmm_cli::error(
+                        ::std::format!("unknown option '{}'", __key),
+                    ));
+                }
+            }
+        }
+    } else {
+        quote! {
+            for __part in ::vmm_cli::split_options(s)? {
+                let (__key, __value) = ::vmm_cli::split_kv(__part);
+                if !<#name as ::vmm_cli::KeyValueFields>::accept(&mut __a, __key, __value)? {
+                    return ::core::result::Result::Err(::vmm_cli::error(
+                        ::std::format!("unknown option '{}'", __key),
+                    ));
+                }
+            }
+        }
+    };
+
+    Ok(quote! {
+        #[doc(hidden)]
+        #[derive(::core::default::Default)]
+        #vis struct #accum_name {
+            #(#accum_fields)*
+        }
+
+        impl ::vmm_cli::KeyValueFields for #name {
+            type Accum = #accum_name;
+
+            fn accept(
+                __a: &mut Self::Accum,
+                __key: &str,
+                __value: ::core::option::Option<&str>,
+            ) -> ::vmm_cli::Result<bool> {
+                #accept_body
+            }
+
+            fn finish(__a: Self::Accum) -> ::vmm_cli::Result<Self> {
+                ::core::result::Result::Ok(Self {
+                    #(#finish_fields)*
+                })
+            }
+        }
+
+        impl ::core::str::FromStr for #name {
+            type Err = ::vmm_cli::Error;
+
+            fn from_str(s: &str) -> ::vmm_cli::Result<Self> {
+                let mut __a = <#name as ::vmm_cli::KeyValueFields>::Accum::default();
+                #parse_loop
+                <#name as ::vmm_cli::KeyValueFields>::finish(__a)
+            }
+        }
+    })
+}
+
+fn parse_variant_attr(variant: &Variant) -> syn::Result<(String, bool)> {
+    let mut key = None;
+    let mut is_default = false;
+    for attr in &variant.attrs {
+        if !attr.path().is_ident("kv") {
+            continue;
+        }
+        attr.parse_nested_meta(|meta| {
+            if meta.path.is_ident("key") {
+                key = Some(meta.value()?.parse::<LitStr>()?.value());
+            } else if meta.path.is_ident("default") {
+                is_default = true;
+            } else {
+                return Err(meta.error("unknown `kv` attribute"));
+            }
+            Ok(())
+        })?;
+    }
+    let key = key.unwrap_or_else(|| variant.ident.to_string().to_snake_case());
+    Ok((key, is_default))
+}
+
+fn expand_group(input: DeriveInput) -> syn::Result<TokenStream2> {
+    let name = &input.ident;
+    let Data::Enum(data) = &input.data else {
+        return Err(syn::Error::new_spanned(
+            &input,
+            "KeyValueGroup may only be derived for enums",
+        ));
+    };
+
+    let mut required = false;
+    for attr in &input.attrs {
+        if !attr.path().is_ident("kv") {
+            continue;
+        }
+        attr.parse_nested_meta(|meta| {
+            if meta.path.is_ident("required") {
+                required = true;
+                Ok(())
+            } else {
+                Err(meta.error("unknown `kv` attribute"))
+            }
+        })?;
+    }
+
+    let mut arms = Vec::new();
+    let mut keys = Vec::new();
+    let mut default_variant = None;
+
+    for variant in &data.variants {
+        let vname = &variant.ident;
+        let (key, is_default) = parse_variant_attr(variant)?;
+        keys.push(format!("'{key}'"));
+
+        let build = match &variant.fields {
+            Fields::Unit => quote! {
+                {
+                    if __value.is_some() {
+                        return ::core::result::Result::Err(::vmm_cli::error(
+                            ::std::format!("flag '{}' does not take a value", #key),
+                        ));
+                    }
+                    #name::#vname
+                }
+            },
+            Fields::Unnamed(f) if f.unnamed.len() == 1 => {
+                let fty = &f.unnamed.first().unwrap().ty;
+                if let Some(inner) = option_inner(fty) {
+                    quote! { #name::#vname(::vmm_cli::parse_opt_value::<#inner>(__value)?) }
+                } else {
+                    quote! { #name::#vname(::vmm_cli::parse_value::<#fty>(#key, __value)?) }
+                }
+            }
+            _ => {
+                return Err(syn::Error::new_spanned(
+                    variant,
+                    "KeyValueGroup variants must be a unit or a single-field tuple",
+                ));
+            }
+        };
+        arms.push(quote! { #key => #build, });
+        if is_default {
+            default_variant = Some(quote! { #name::#vname });
+        }
+    }
+
+    let keys_desc = keys.join(", ");
+    let none_case = match (&default_variant, required) {
+        (Some(def), _) => quote! { ::core::result::Result::Ok(#def) },
+        (None, _) => quote! {
+            ::core::result::Result::Err(::vmm_cli::error(
+                ::std::format!("one of {} is required", #keys_desc),
+            ))
+        },
+    };
+
+    Ok(quote! {
+        impl ::vmm_cli::KeyValueFields for #name {
+            type Accum = ::core::option::Option<#name>;
+
+            fn accept(
+                __accum: &mut Self::Accum,
+                __key: &str,
+                __value: ::core::option::Option<&str>,
+            ) -> ::vmm_cli::Result<bool> {
+                let __v = match __key {
+                    #(#arms)*
+                    _ => return ::core::result::Result::Ok(false),
+                };
+                if __accum.is_some() {
+                    return ::core::result::Result::Err(::vmm_cli::error(
+                        ::std::format!("only one of {} may be specified", #keys_desc),
+                    ));
+                }
+                *__accum = ::core::option::Option::Some(__v);
+                ::core::result::Result::Ok(true)
+            }
+
+            fn finish(__accum: Self::Accum) -> ::vmm_cli::Result<Self> {
+                match __accum {
+                    ::core::option::Option::Some(__v) => ::core::result::Result::Ok(__v),
+                    ::core::option::Option::None => { #none_case }
+                }
+            }
+        }
+    })
+}


### PR DESCRIPTION
The OpenVMM command line uses a compact per-argument mini-language throughout — things like `--disk file:x,ro,on=nvme0` or `--memory size=2G,hugepages=on`. Each such argument had its own hand-written `FromStr` that re-implemented the same mechanics: splitting on commas, splitting on `=`, matching keys, rejecting unknown, duplicate, or empty options, and producing bespoke error messages. This was repetitive, easy to get subtly wrong, and inconsistent between arguments — most visibly, some booleans were bare flags while others required `=on`/`=off`, so users had to remember which was which.

This introduces `vmm_cli` and its companion `vmm_cli_derive`, a small internal framework for parsing these option strings. `#[derive(KeyValueArgs)]` generates the parser from an annotated struct, with attributes for renamed keys, defaults, a leading positional token, boolean flags (uniformly accepting bare presence, `=on`, or `=off`, plus tri-state `Option<bool>`), bracket-delimited lists, and a `#[kv(flatten)]` that merges a shared option struct into several parsers. A companion `#[derive(KeyValueGroup)]` expresses mutually-exclusive keys that resolve to a single enum variant. Reusable value types (`MemorySize`, `BracketList`, `BracketRangeList`) cover the common non-trivial value formats, and a conformance test pins the derive's guarantees in one place.

The modern comma-separated arguments in openvmm_entry are converted to use the derive. Public CLI types keep their existing shape: where an argument has context-dependent defaults or cross-field validation — disk placement rules, memory hugepage constraints, the vhost-user device-type discrimination — the derive produces a raw options struct and a thin hand-written wrapper applies the remaining semantics, so no downstream consumers change. Arguments built on a different grammar (colon-delimited or discriminated unions such as the serial and network backends) are left as they were.

A side benefit is that boolean options are now uniform: every flag accepts bare, `=on`, or `=off`.