### PR TITLE
flowey: disable redundant dev kernel builds

### DIFF
--- a/.github/workflows/openvmm-ci.yaml
+++ b/.github/workflows/openvmm-ci.yaml
@@ -434,10 +434,6 @@ jobs:
         echo "$AgentTempDirNormal/publish_artifacts/aarch64-openhcl-baseline" | flowey v 10 'artifact_publish_from_aarch64-openhcl-baseline' --is-raw-string update
         mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-openhcl-igvm"
         echo "$AgentTempDirNormal/publish_artifacts/aarch64-openhcl-igvm" | flowey v 10 'artifact_publish_from_aarch64-openhcl-igvm' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-openhcl-igvm-devkern"
-        echo "$AgentTempDirNormal/publish_artifacts/aarch64-openhcl-igvm-devkern" | flowey v 10 'artifact_publish_from_aarch64-openhcl-igvm-devkern' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-openhcl-igvm-devkern-extras"
-        echo "$AgentTempDirNormal/publish_artifacts/aarch64-openhcl-igvm-devkern-extras" | flowey v 10 'artifact_publish_from_aarch64-openhcl-igvm-devkern-extras' --is-raw-string update
         mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-openhcl-igvm-extras"
         echo "$AgentTempDirNormal/publish_artifacts/aarch64-openhcl-igvm-extras" | flowey v 10 'artifact_publish_from_aarch64-openhcl-igvm-extras' --is-raw-string update
       shell: bash
@@ -534,7 +530,7 @@ jobs:
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 10 flowey_lib_hvlite::run_split_debug_info 3
+        flowey e 10 flowey_lib_hvlite::run_split_debug_info 2
         flowey e 10 flowey_lib_hvlite::run_cargo_build 9
         flowey e 10 flowey_lib_hvlite::build_openvmm_hcl 0
         flowey e 10 flowey_lib_hvlite::_jobs::build_and_publish_openvmm_hcl_baseline 0
@@ -575,7 +571,7 @@ jobs:
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 10 flowey_lib_hvlite::run_split_debug_info 2
+        flowey e 10 flowey_lib_hvlite::run_split_debug_info 1
         flowey e 10 flowey_lib_hvlite::run_cargo_build 5
         flowey e 10 flowey_lib_hvlite::build_openhcl_boot 0
         flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 5
@@ -593,7 +589,7 @@ jobs:
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 10 flowey_lib_hvlite::run_split_debug_info 4
+        flowey e 10 flowey_lib_hvlite::run_split_debug_info 3
         flowey e 10 flowey_lib_hvlite::run_cargo_build 1
         flowey e 10 flowey_lib_hvlite::build_igvmfilegen 0
         flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 7
@@ -607,36 +603,6 @@ jobs:
         flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 9
         flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 10
         flowey e 10 flowey_core::pipeline::artifact::publish 2
-      shell: bash
-    - name: extract and resolve kernel package
-      run: |-
-        flowey e 10 flowey_lib_hvlite::resolve_openhcl_kernel_package 1
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 15
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 12
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 10 flowey_lib_hvlite::run_split_debug_info 1
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 13
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 14
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 16
-      shell: bash
-    - name: building openhcl initrd
-      run: |-
-        flowey e 10 flowey_lib_hvlite::build_openhcl_initrd 1
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 17
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 18
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 19
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 20
-      shell: bash
-    - name: building igvm file
-      run: |-
-        flowey e 10 flowey_lib_hvlite::run_igvmfilegen 1
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 23
-        flowey e 10 flowey_core::pipeline::artifact::publish 3
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 21
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 22
-        flowey e 10 flowey_core::pipeline::artifact::publish 4
       shell: bash
     - name: 'validate cache entry: gh-release-download'
       run: flowey e 10 flowey_lib_common::cache 3
@@ -652,18 +618,6 @@ jobs:
       with:
         name: aarch64-openhcl-igvm
         path: ${{ runner.temp }}/publish_artifacts/aarch64-openhcl-igvm/
-        include-hidden-files: true
-    - name: 🌼📦 Publish aarch64-openhcl-igvm-devkern
-      uses: actions/upload-artifact@v7
-      with:
-        name: aarch64-openhcl-igvm-devkern
-        path: ${{ runner.temp }}/publish_artifacts/aarch64-openhcl-igvm-devkern/
-        include-hidden-files: true
-    - name: 🌼📦 Publish aarch64-openhcl-igvm-devkern-extras
-      uses: actions/upload-artifact@v7
-      with:
-        name: aarch64-openhcl-igvm-devkern-extras
-        path: ${{ runner.temp }}/publish_artifacts/aarch64-openhcl-igvm-devkern-extras/
         include-hidden-files: true
     - name: 🌼📦 Publish aarch64-openhcl-igvm-extras
       uses: actions/upload-artifact@v7
@@ -757,18 +711,10 @@ jobs:
         echo "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-cvm" | flowey v 11 'artifact_publish_from_x64-openhcl-igvm-cvm' --is-raw-string update
         mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-cvm-extras"
         echo "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-cvm-extras" | flowey v 11 'artifact_publish_from_x64-openhcl-igvm-cvm-extras' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-devkern"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-devkern" | flowey v 11 'artifact_publish_from_x64-openhcl-igvm-devkern' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-devkern-extras"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-devkern-extras" | flowey v 11 'artifact_publish_from_x64-openhcl-igvm-devkern-extras' --is-raw-string update
         mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-extras"
         echo "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-extras" | flowey v 11 'artifact_publish_from_x64-openhcl-igvm-extras' --is-raw-string update
         mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-test-linux-direct"
         echo "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-test-linux-direct" | flowey v 11 'artifact_publish_from_x64-openhcl-igvm-test-linux-direct' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-test-linux-direct-devkern"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-test-linux-direct-devkern" | flowey v 11 'artifact_publish_from_x64-openhcl-igvm-test-linux-direct-devkern' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-test-linux-direct-devkern-extras"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-test-linux-direct-devkern-extras" | flowey v 11 'artifact_publish_from_x64-openhcl-igvm-test-linux-direct-devkern-extras' --is-raw-string update
         mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-test-linux-direct-extras"
         echo "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-test-linux-direct-extras" | flowey v 11 'artifact_publish_from_x64-openhcl-igvm-test-linux-direct-extras' --is-raw-string update
       shell: bash
@@ -865,7 +811,7 @@ jobs:
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 11 flowey_lib_hvlite::run_split_debug_info 6
+        flowey e 11 flowey_lib_hvlite::run_split_debug_info 4
         flowey e 11 flowey_lib_hvlite::run_cargo_build 9
         flowey e 11 flowey_lib_hvlite::build_openvmm_hcl 0
         flowey e 11 flowey_lib_hvlite::_jobs::build_and_publish_openvmm_hcl_baseline 0
@@ -894,7 +840,7 @@ jobs:
       shell: bash
     - name: building openhcl initrd
       run: |-
-        flowey e 11 flowey_lib_hvlite::build_openhcl_initrd 2
+        flowey e 11 flowey_lib_hvlite::build_openhcl_initrd 0
         flowey e 11 flowey_lib_hvlite::init_cross_build 0
         flowey e 11 flowey_lib_hvlite::run_cargo_build 13
         flowey e 11 flowey_lib_hvlite::run_cargo_build 14
@@ -906,7 +852,7 @@ jobs:
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 11 flowey_lib_hvlite::run_split_debug_info 7
+        flowey e 11 flowey_lib_hvlite::run_split_debug_info 5
         flowey e 11 flowey_lib_hvlite::run_cargo_build 16
         flowey e 11 flowey_lib_hvlite::build_sidecar 0
         flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 5
@@ -921,7 +867,7 @@ jobs:
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 11 flowey_lib_hvlite::run_split_debug_info 5
+        flowey e 11 flowey_lib_hvlite::run_split_debug_info 3
         flowey e 11 flowey_lib_hvlite::run_cargo_build 5
         flowey e 11 flowey_lib_hvlite::build_openhcl_boot 0
         flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 6
@@ -939,7 +885,7 @@ jobs:
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 11 flowey_lib_hvlite::run_split_debug_info 8
+        flowey e 11 flowey_lib_hvlite::run_split_debug_info 6
         flowey e 11 flowey_lib_hvlite::run_cargo_build 1
         flowey e 11 flowey_lib_hvlite::build_igvmfilegen 0
         flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 8
@@ -947,43 +893,14 @@ jobs:
       shell: bash
     - name: building igvm file
       run: |-
-        flowey e 11 flowey_lib_hvlite::run_igvmfilegen 2
+        flowey e 11 flowey_lib_hvlite::run_igvmfilegen 1
         flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 12
         flowey e 11 flowey_core::pipeline::artifact::publish 1
         flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 10
         flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 11
         flowey e 11 flowey_core::pipeline::artifact::publish 2
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 34
-      shell: bash
-    - name: extract and resolve kernel package
-      run: |-
-        flowey e 11 flowey_lib_hvlite::resolve_openhcl_kernel_package 2
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 28
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 25
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 11 flowey_lib_hvlite::run_split_debug_info 4
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 26
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 27
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 29
-      shell: bash
-    - name: building openhcl initrd
-      run: |-
-        flowey e 11 flowey_lib_hvlite::build_openhcl_initrd 4
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 30
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 31
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 32
         flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 33
-      shell: bash
-    - name: building igvm file
-      run: |-
-        flowey e 11 flowey_lib_hvlite::run_igvmfilegen 4
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 37
-        flowey e 11 flowey_core::pipeline::artifact::publish 3
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 35
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 36
-        flowey e 11 flowey_core::pipeline::artifact::publish 4
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 34
       shell: bash
     - name: unpack openvmm-test-linux archives
       run: flowey e 11 flowey_lib_hvlite::resolve_openvmm_test_linux_kernel 0
@@ -991,60 +908,31 @@ jobs:
     - name: unpack openvmm-test-initrd archives
       run: |-
         flowey e 11 flowey_lib_hvlite::resolve_openvmm_test_initrd 0
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 41
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 38
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 11 flowey_lib_hvlite::run_split_debug_info 1
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 39
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 40
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 42
-      shell: bash
-    - name: building openhcl initrd
-      run: |-
-        flowey e 11 flowey_lib_hvlite::build_openhcl_initrd 0
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 43
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 44
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 45
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 46
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 47
-      shell: bash
-    - name: building igvm file
-      run: |-
-        flowey e 11 flowey_lib_hvlite::run_igvmfilegen 0
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 50
-        flowey e 11 flowey_core::pipeline::artifact::publish 5
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 48
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 49
-        flowey e 11 flowey_core::pipeline::artifact::publish 6
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 54
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 51
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 28
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 25
       shell: bash
     - name: split debug symbols
       run: |-
         flowey e 11 flowey_lib_hvlite::run_split_debug_info 2
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 52
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 53
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 55
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 26
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 27
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 29
       shell: bash
     - name: building openhcl initrd
       run: |-
-        flowey e 11 flowey_lib_hvlite::build_openhcl_initrd 1
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 56
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 57
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 58
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 59
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 60
+        flowey e 11 flowey_lib_hvlite::build_openhcl_initrd 2
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 30
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 31
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 32
       shell: bash
     - name: building igvm file
       run: |-
-        flowey e 11 flowey_lib_hvlite::run_igvmfilegen 1
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 63
-        flowey e 11 flowey_core::pipeline::artifact::publish 7
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 61
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 62
-        flowey e 11 flowey_core::pipeline::artifact::publish 8
+        flowey e 11 flowey_lib_hvlite::run_igvmfilegen 0
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 37
+        flowey e 11 flowey_core::pipeline::artifact::publish 3
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 35
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 36
+        flowey e 11 flowey_core::pipeline::artifact::publish 4
       shell: bash
     - name: extract and resolve kernel package
       run: |-
@@ -1054,14 +942,14 @@ jobs:
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 11 flowey_lib_hvlite::run_split_debug_info 3
+        flowey e 11 flowey_lib_hvlite::run_split_debug_info 1
         flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 14
         flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 15
         flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 17
       shell: bash
     - name: building openhcl initrd
       run: |-
-        flowey e 11 flowey_lib_hvlite::build_openhcl_initrd 3
+        flowey e 11 flowey_lib_hvlite::build_openhcl_initrd 1
         flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 18
         flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 19
         flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 20
@@ -1069,12 +957,12 @@ jobs:
       shell: bash
     - name: building igvm file
       run: |-
-        flowey e 11 flowey_lib_hvlite::run_igvmfilegen 3
+        flowey e 11 flowey_lib_hvlite::run_igvmfilegen 2
         flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 24
-        flowey e 11 flowey_core::pipeline::artifact::publish 9
+        flowey e 11 flowey_core::pipeline::artifact::publish 5
         flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 22
         flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 23
-        flowey e 11 flowey_core::pipeline::artifact::publish 10
+        flowey e 11 flowey_core::pipeline::artifact::publish 6
       shell: bash
     - name: 'validate cache entry: gh-release-download'
       run: flowey e 11 flowey_lib_common::cache 3
@@ -1103,18 +991,6 @@ jobs:
         name: x64-openhcl-igvm-cvm-extras
         path: ${{ runner.temp }}/publish_artifacts/x64-openhcl-igvm-cvm-extras/
         include-hidden-files: true
-    - name: 🌼📦 Publish x64-openhcl-igvm-devkern
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-openhcl-igvm-devkern
-        path: ${{ runner.temp }}/publish_artifacts/x64-openhcl-igvm-devkern/
-        include-hidden-files: true
-    - name: 🌼📦 Publish x64-openhcl-igvm-devkern-extras
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-openhcl-igvm-devkern-extras
-        path: ${{ runner.temp }}/publish_artifacts/x64-openhcl-igvm-devkern-extras/
-        include-hidden-files: true
     - name: 🌼📦 Publish x64-openhcl-igvm-extras
       uses: actions/upload-artifact@v7
       with:
@@ -1126,18 +1002,6 @@ jobs:
       with:
         name: x64-openhcl-igvm-test-linux-direct
         path: ${{ runner.temp }}/publish_artifacts/x64-openhcl-igvm-test-linux-direct/
-        include-hidden-files: true
-    - name: 🌼📦 Publish x64-openhcl-igvm-test-linux-direct-devkern
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-openhcl-igvm-test-linux-direct-devkern
-        path: ${{ runner.temp }}/publish_artifacts/x64-openhcl-igvm-test-linux-direct-devkern/
-        include-hidden-files: true
-    - name: 🌼📦 Publish x64-openhcl-igvm-test-linux-direct-devkern-extras
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-openhcl-igvm-test-linux-direct-devkern-extras
-        path: ${{ runner.temp }}/publish_artifacts/x64-openhcl-igvm-test-linux-direct-devkern-extras/
         include-hidden-files: true
     - name: 🌼📦 Publish x64-openhcl-igvm-test-linux-direct-extras
       uses: actions/upload-artifact@v7
@@ -2934,6 +2798,23 @@ jobs:
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
       shell: bash
+    - name: add default cargo home to path
+      run: flowey e 17 flowey_lib_common::install_rust 0
+      shell: bash
+    - name: install Rust
+      run: flowey e 17 flowey_lib_common::install_rust 1
+      shell: bash
+    - name: detect active toolchain
+      run: |-
+        flowey e 17 flowey_lib_common::install_rust 2
+        flowey e 17 flowey_lib_common::cfg_cargo_common_flags 0
+      shell: bash
+    - name: checking if packages need to be installed
+      run: flowey e 17 flowey_lib_common::install_dist_pkg 0
+      shell: bash
+    - name: installing packages
+      run: flowey e 17 flowey_lib_common::install_dist_pkg 1
+      shell: bash
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 17 flowey_lib_common::git_checkout 0
@@ -2986,33 +2867,14 @@ jobs:
         flowey e 17 flowey_lib_common::cache 6
         flowey e 17 flowey_lib_common::download_gh_release 1
       shell: bash
-    - name: checking if packages need to be installed
-      run: flowey e 17 flowey_lib_common::install_dist_pkg 0
-      shell: bash
-    - name: installing packages
-      run: flowey e 17 flowey_lib_common::install_dist_pkg 1
-      shell: bash
     - name: unpack protoc
       run: |-
         flowey e 17 flowey_lib_common::resolve_protoc 0
         flowey e 17 flowey_lib_hvlite::cfg_openvmm_magicpath 0
       shell: bash
     - name: symlink protoc
-      run: flowey e 17 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-      shell: bash
-    - name: add default cargo home to path
-      run: flowey e 17 flowey_lib_common::install_rust 0
-      shell: bash
-    - name: install Rust
-      run: flowey e 17 flowey_lib_common::install_rust 1
-      shell: bash
-    - name: run doctests for aarch64-unknown-linux-gnu
-      run: flowey e 17 flowey_lib_hvlite::_jobs::build_and_run_doc_tests 0
-      shell: bash
-    - name: detect active toolchain
       run: |-
-        flowey e 17 flowey_lib_common::install_rust 2
-        flowey e 17 flowey_lib_common::cfg_cargo_common_flags 0
+        flowey e 17 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
         flowey e 17 flowey_lib_hvlite::init_cross_build 0
       shell: bash
     - name: cargo clippy
@@ -3201,6 +3063,9 @@ jobs:
       run: |-
         flowey e 17 flowey_lib_hvlite::build_nextest_unit_tests 6
         flowey e 17 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
+      shell: bash
+    - name: run doctests for aarch64-unknown-linux-gnu
+      run: flowey e 17 flowey_lib_hvlite::_jobs::build_and_run_doc_tests 0
       shell: bash
     - name: 'validate cache entry: cargo-nextest'
       run: flowey e 17 flowey_lib_common::cache 3
@@ -4174,11 +4039,6 @@ jobs:
         flowey.exe e 20 flowey_lib_common::system_info 0
         flowey.exe e 20 flowey_lib_hvlite::git_checkout_openvmm_repo 0
         flowey.exe e 20 flowey_lib_hvlite::run_cargo_nextest_run 0
-        flowey.exe e 20 flowey_core::pipeline::artifact::resolve 8
-        flowey.exe e 20 flowey_core::pipeline::artifact::resolve 9
-        flowey.exe e 20 flowey_core::pipeline::artifact::resolve 12
-        flowey.exe e 20 flowey_core::pipeline::artifact::resolve 14
-        flowey.exe e 20 flowey_core::pipeline::artifact::resolve 15
         flowey.exe e 20 flowey_core::pipeline::artifact::resolve 13
         flowey.exe e 20 flowey_core::pipeline::artifact::resolve 3
         flowey.exe e 20 flowey_core::pipeline::artifact::resolve 11
@@ -4189,6 +4049,11 @@ jobs:
         flowey.exe e 20 flowey_core::pipeline::artifact::resolve 2
         flowey.exe e 20 flowey_core::pipeline::artifact::resolve 0
         flowey.exe e 20 flowey_core::pipeline::artifact::resolve 7
+        flowey.exe e 20 flowey_core::pipeline::artifact::resolve 8
+        flowey.exe e 20 flowey_core::pipeline::artifact::resolve 9
+        flowey.exe e 20 flowey_core::pipeline::artifact::resolve 12
+        flowey.exe e 20 flowey_core::pipeline::artifact::resolve 14
+        flowey.exe e 20 flowey_core::pipeline::artifact::resolve 15
       shell: bash
     - name: creating new test content dir
       run: flowey.exe e 20 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0

--- a/.github/workflows/openvmm-pr-release.yaml
+++ b/.github/workflows/openvmm-pr-release.yaml
@@ -441,10 +441,6 @@ jobs:
         EOF
         mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-openhcl-igvm"
         echo "$AgentTempDirNormal/publish_artifacts/aarch64-openhcl-igvm" | flowey v 10 'artifact_publish_from_aarch64-openhcl-igvm' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-openhcl-igvm-devkern"
-        echo "$AgentTempDirNormal/publish_artifacts/aarch64-openhcl-igvm-devkern" | flowey v 10 'artifact_publish_from_aarch64-openhcl-igvm-devkern' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-openhcl-igvm-devkern-extras"
-        echo "$AgentTempDirNormal/publish_artifacts/aarch64-openhcl-igvm-devkern-extras" | flowey v 10 'artifact_publish_from_aarch64-openhcl-igvm-devkern-extras' --is-raw-string update
         mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-openhcl-igvm-extras"
         echo "$AgentTempDirNormal/publish_artifacts/aarch64-openhcl-igvm-extras" | flowey v 10 'artifact_publish_from_aarch64-openhcl-igvm-extras' --is-raw-string update
       shell: bash
@@ -566,7 +562,7 @@ jobs:
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 10 flowey_lib_hvlite::run_split_debug_info 2
+        flowey e 10 flowey_lib_hvlite::run_split_debug_info 1
         flowey e 10 flowey_lib_hvlite::run_cargo_build 5
         flowey e 10 flowey_lib_hvlite::build_openhcl_boot 0
         flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 5
@@ -584,7 +580,7 @@ jobs:
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 10 flowey_lib_hvlite::run_split_debug_info 3
+        flowey e 10 flowey_lib_hvlite::run_split_debug_info 2
         flowey e 10 flowey_lib_hvlite::run_cargo_build 1
         flowey e 10 flowey_lib_hvlite::build_igvmfilegen 0
         flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 7
@@ -599,36 +595,6 @@ jobs:
         flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 10
         flowey e 10 flowey_core::pipeline::artifact::publish 1
       shell: bash
-    - name: extract and resolve kernel package
-      run: |-
-        flowey e 10 flowey_lib_hvlite::resolve_openhcl_kernel_package 1
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 15
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 12
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 10 flowey_lib_hvlite::run_split_debug_info 1
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 13
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 14
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 16
-      shell: bash
-    - name: building openhcl initrd
-      run: |-
-        flowey e 10 flowey_lib_hvlite::build_openhcl_initrd 1
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 17
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 18
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 19
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 20
-      shell: bash
-    - name: building igvm file
-      run: |-
-        flowey e 10 flowey_lib_hvlite::run_igvmfilegen 1
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 23
-        flowey e 10 flowey_core::pipeline::artifact::publish 2
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 21
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 22
-        flowey e 10 flowey_core::pipeline::artifact::publish 3
-      shell: bash
     - name: 'validate cache entry: gh-release-download'
       run: flowey e 10 flowey_lib_common::cache 3
       shell: bash
@@ -637,18 +603,6 @@ jobs:
       with:
         name: aarch64-openhcl-igvm
         path: ${{ runner.temp }}/publish_artifacts/aarch64-openhcl-igvm/
-        include-hidden-files: true
-    - name: 🌼📦 Publish aarch64-openhcl-igvm-devkern
-      uses: actions/upload-artifact@v7
-      with:
-        name: aarch64-openhcl-igvm-devkern
-        path: ${{ runner.temp }}/publish_artifacts/aarch64-openhcl-igvm-devkern/
-        include-hidden-files: true
-    - name: 🌼📦 Publish aarch64-openhcl-igvm-devkern-extras
-      uses: actions/upload-artifact@v7
-      with:
-        name: aarch64-openhcl-igvm-devkern-extras
-        path: ${{ runner.temp }}/publish_artifacts/aarch64-openhcl-igvm-devkern-extras/
         include-hidden-files: true
     - name: 🌼📦 Publish aarch64-openhcl-igvm-extras
       uses: actions/upload-artifact@v7
@@ -698,18 +652,10 @@ jobs:
         echo "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-cvm" | flowey v 11 'artifact_publish_from_x64-openhcl-igvm-cvm' --is-raw-string update
         mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-cvm-extras"
         echo "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-cvm-extras" | flowey v 11 'artifact_publish_from_x64-openhcl-igvm-cvm-extras' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-devkern"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-devkern" | flowey v 11 'artifact_publish_from_x64-openhcl-igvm-devkern' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-devkern-extras"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-devkern-extras" | flowey v 11 'artifact_publish_from_x64-openhcl-igvm-devkern-extras' --is-raw-string update
         mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-extras"
         echo "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-extras" | flowey v 11 'artifact_publish_from_x64-openhcl-igvm-extras' --is-raw-string update
         mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-test-linux-direct"
         echo "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-test-linux-direct" | flowey v 11 'artifact_publish_from_x64-openhcl-igvm-test-linux-direct' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-test-linux-direct-devkern"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-test-linux-direct-devkern" | flowey v 11 'artifact_publish_from_x64-openhcl-igvm-test-linux-direct-devkern' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-test-linux-direct-devkern-extras"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-test-linux-direct-devkern-extras" | flowey v 11 'artifact_publish_from_x64-openhcl-igvm-test-linux-direct-devkern-extras' --is-raw-string update
         mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-test-linux-direct-extras"
         echo "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-test-linux-direct-extras" | flowey v 11 'artifact_publish_from_x64-openhcl-igvm-test-linux-direct-extras' --is-raw-string update
       shell: bash
@@ -819,7 +765,7 @@ jobs:
       shell: bash
     - name: building openhcl initrd
       run: |-
-        flowey e 11 flowey_lib_hvlite::build_openhcl_initrd 2
+        flowey e 11 flowey_lib_hvlite::build_openhcl_initrd 0
         flowey e 11 flowey_lib_hvlite::init_cross_build 0
         flowey e 11 flowey_lib_hvlite::run_cargo_build 9
         flowey e 11 flowey_lib_hvlite::run_cargo_build 10
@@ -831,7 +777,7 @@ jobs:
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 11 flowey_lib_hvlite::run_split_debug_info 6
+        flowey e 11 flowey_lib_hvlite::run_split_debug_info 4
         flowey e 11 flowey_lib_hvlite::run_cargo_build 12
         flowey e 11 flowey_lib_hvlite::build_sidecar 0
         flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 5
@@ -846,7 +792,7 @@ jobs:
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 11 flowey_lib_hvlite::run_split_debug_info 5
+        flowey e 11 flowey_lib_hvlite::run_split_debug_info 3
         flowey e 11 flowey_lib_hvlite::run_cargo_build 5
         flowey e 11 flowey_lib_hvlite::build_openhcl_boot 0
         flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 6
@@ -864,7 +810,7 @@ jobs:
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 11 flowey_lib_hvlite::run_split_debug_info 7
+        flowey e 11 flowey_lib_hvlite::run_split_debug_info 5
         flowey e 11 flowey_lib_hvlite::run_cargo_build 1
         flowey e 11 flowey_lib_hvlite::build_igvmfilegen 0
         flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 8
@@ -872,43 +818,14 @@ jobs:
       shell: bash
     - name: building igvm file
       run: |-
-        flowey e 11 flowey_lib_hvlite::run_igvmfilegen 2
+        flowey e 11 flowey_lib_hvlite::run_igvmfilegen 1
         flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 12
         flowey e 11 flowey_core::pipeline::artifact::publish 0
         flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 10
         flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 11
         flowey e 11 flowey_core::pipeline::artifact::publish 1
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 34
-      shell: bash
-    - name: extract and resolve kernel package
-      run: |-
-        flowey e 11 flowey_lib_hvlite::resolve_openhcl_kernel_package 2
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 28
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 25
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 11 flowey_lib_hvlite::run_split_debug_info 4
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 26
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 27
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 29
-      shell: bash
-    - name: building openhcl initrd
-      run: |-
-        flowey e 11 flowey_lib_hvlite::build_openhcl_initrd 4
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 30
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 31
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 32
         flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 33
-      shell: bash
-    - name: building igvm file
-      run: |-
-        flowey e 11 flowey_lib_hvlite::run_igvmfilegen 4
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 37
-        flowey e 11 flowey_core::pipeline::artifact::publish 2
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 35
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 36
-        flowey e 11 flowey_core::pipeline::artifact::publish 3
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 34
       shell: bash
     - name: unpack openvmm-test-linux archives
       run: flowey e 11 flowey_lib_hvlite::resolve_openvmm_test_linux_kernel 0
@@ -916,60 +833,31 @@ jobs:
     - name: unpack openvmm-test-initrd archives
       run: |-
         flowey e 11 flowey_lib_hvlite::resolve_openvmm_test_initrd 0
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 41
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 38
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 11 flowey_lib_hvlite::run_split_debug_info 1
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 39
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 40
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 42
-      shell: bash
-    - name: building openhcl initrd
-      run: |-
-        flowey e 11 flowey_lib_hvlite::build_openhcl_initrd 0
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 43
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 44
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 45
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 46
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 47
-      shell: bash
-    - name: building igvm file
-      run: |-
-        flowey e 11 flowey_lib_hvlite::run_igvmfilegen 0
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 50
-        flowey e 11 flowey_core::pipeline::artifact::publish 4
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 48
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 49
-        flowey e 11 flowey_core::pipeline::artifact::publish 5
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 54
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 51
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 28
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 25
       shell: bash
     - name: split debug symbols
       run: |-
         flowey e 11 flowey_lib_hvlite::run_split_debug_info 2
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 52
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 53
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 55
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 26
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 27
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 29
       shell: bash
     - name: building openhcl initrd
       run: |-
-        flowey e 11 flowey_lib_hvlite::build_openhcl_initrd 1
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 56
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 57
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 58
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 59
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 60
+        flowey e 11 flowey_lib_hvlite::build_openhcl_initrd 2
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 30
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 31
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 32
       shell: bash
     - name: building igvm file
       run: |-
-        flowey e 11 flowey_lib_hvlite::run_igvmfilegen 1
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 63
-        flowey e 11 flowey_core::pipeline::artifact::publish 6
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 61
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 62
-        flowey e 11 flowey_core::pipeline::artifact::publish 7
+        flowey e 11 flowey_lib_hvlite::run_igvmfilegen 0
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 37
+        flowey e 11 flowey_core::pipeline::artifact::publish 2
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 35
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 36
+        flowey e 11 flowey_core::pipeline::artifact::publish 3
       shell: bash
     - name: extract and resolve kernel package
       run: |-
@@ -979,14 +867,14 @@ jobs:
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 11 flowey_lib_hvlite::run_split_debug_info 3
+        flowey e 11 flowey_lib_hvlite::run_split_debug_info 1
         flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 14
         flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 15
         flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 17
       shell: bash
     - name: building openhcl initrd
       run: |-
-        flowey e 11 flowey_lib_hvlite::build_openhcl_initrd 3
+        flowey e 11 flowey_lib_hvlite::build_openhcl_initrd 1
         flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 18
         flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 19
         flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 20
@@ -994,12 +882,12 @@ jobs:
       shell: bash
     - name: building igvm file
       run: |-
-        flowey e 11 flowey_lib_hvlite::run_igvmfilegen 3
+        flowey e 11 flowey_lib_hvlite::run_igvmfilegen 2
         flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 24
-        flowey e 11 flowey_core::pipeline::artifact::publish 8
+        flowey e 11 flowey_core::pipeline::artifact::publish 4
         flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 22
         flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 23
-        flowey e 11 flowey_core::pipeline::artifact::publish 9
+        flowey e 11 flowey_core::pipeline::artifact::publish 5
       shell: bash
     - name: 'validate cache entry: gh-release-download'
       run: flowey e 11 flowey_lib_common::cache 3
@@ -1022,18 +910,6 @@ jobs:
         name: x64-openhcl-igvm-cvm-extras
         path: ${{ runner.temp }}/publish_artifacts/x64-openhcl-igvm-cvm-extras/
         include-hidden-files: true
-    - name: 🌼📦 Publish x64-openhcl-igvm-devkern
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-openhcl-igvm-devkern
-        path: ${{ runner.temp }}/publish_artifacts/x64-openhcl-igvm-devkern/
-        include-hidden-files: true
-    - name: 🌼📦 Publish x64-openhcl-igvm-devkern-extras
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-openhcl-igvm-devkern-extras
-        path: ${{ runner.temp }}/publish_artifacts/x64-openhcl-igvm-devkern-extras/
-        include-hidden-files: true
     - name: 🌼📦 Publish x64-openhcl-igvm-extras
       uses: actions/upload-artifact@v7
       with:
@@ -1045,18 +921,6 @@ jobs:
       with:
         name: x64-openhcl-igvm-test-linux-direct
         path: ${{ runner.temp }}/publish_artifacts/x64-openhcl-igvm-test-linux-direct/
-        include-hidden-files: true
-    - name: 🌼📦 Publish x64-openhcl-igvm-test-linux-direct-devkern
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-openhcl-igvm-test-linux-direct-devkern
-        path: ${{ runner.temp }}/publish_artifacts/x64-openhcl-igvm-test-linux-direct-devkern/
-        include-hidden-files: true
-    - name: 🌼📦 Publish x64-openhcl-igvm-test-linux-direct-devkern-extras
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-openhcl-igvm-test-linux-direct-devkern-extras
-        path: ${{ runner.temp }}/publish_artifacts/x64-openhcl-igvm-test-linux-direct-devkern-extras/
         include-hidden-files: true
     - name: 🌼📦 Publish x64-openhcl-igvm-test-linux-direct-extras
       uses: actions/upload-artifact@v7
@@ -3057,50 +2921,16 @@ jobs:
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
       shell: bash
-    - name: create cargo-nextest cache dir
-      run: |-
-        flowey e 18 flowey_lib_common::cfg_cargo_common_flags 0
-        flowey e 18 flowey_lib_common::download_cargo_nextest 0
-        flowey e 18 flowey_lib_common::download_cargo_nextest 1
-        flowey e 18 flowey_lib_common::download_cargo_nextest 2
-        flowey e 18 flowey_lib_common::download_cargo_nextest 3
-      shell: bash
-    - name: Pre-processing cache vars
-      run: |-
-        flowey e 18 flowey_lib_common::cache 0
-        flowey v 18 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar7
-        flowey v 18 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar8
-      shell: bash
-    - id: flowey_lib_common__cache__1
-      uses: actions/cache@v5
-      with:
-        key: ${{ env.floweyvar7 }}
-        path: ${{ env.floweyvar8 }}
-      name: 'Restore cache: cargo-nextest'
-    - name: downloading cargo-nextest
-      run: |-
-        flowey v 18 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
-        EOF
-        flowey e 18 flowey_lib_common::cache 2
-        flowey e 18 flowey_lib_common::download_cargo_nextest 4
-      shell: bash
     - name: add default cargo home to path
       run: flowey e 18 flowey_lib_common::install_rust 0
       shell: bash
     - name: install Rust
       run: flowey e 18 flowey_lib_common::install_rust 1
       shell: bash
-    - name: report $CARGO_HOME
-      run: flowey e 18 flowey_lib_common::install_rust 3
-      shell: bash
-    - name: installing cargo-nextest
-      run: flowey e 18 flowey_lib_common::install_cargo_nextest 0
-      shell: bash
     - name: detect active toolchain
       run: |-
         flowey e 18 flowey_lib_common::install_rust 2
-        flowey e 18 flowey_lib_hvlite::init_cross_build 3
+        flowey e 18 flowey_lib_common::cfg_cargo_common_flags 0
       shell: bash
     - name: check if openvmm needs to be cloned
       run: |-
@@ -3127,13 +2957,7 @@ jobs:
       run: |-
         flowey e 18 flowey_lib_common::system_info 0
         flowey e 18 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-        flowey e 18 flowey_lib_hvlite::run_cargo_nextest_run 0
-      shell: bash
-    - name: generate nextest command
-      run: flowey e 18 flowey_lib_common::gen_cargo_nextest_run_cmd 3
-      shell: bash
-    - name: set '-Dwarnings' in .cargo/config.toml
-      run: flowey e 18 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
+        flowey e 18 flowey_lib_hvlite::cfg_openvmm_magicpath 0
       shell: bash
     - name: create gh-release-download cache dir
       run: flowey e 18 flowey_lib_common::download_gh_release 0
@@ -3158,25 +2982,107 @@ jobs:
         flowey e 18 flowey_lib_common::cache 6
         flowey e 18 flowey_lib_common::download_gh_release 1
       shell: bash
+    - name: unpack openvmm-deps archive
+      run: flowey e 18 flowey_lib_hvlite::resolve_openvmm_deps 0
+      shell: bash
+    - name: extract Aarch64 sysroot.tar.gz
+      run: flowey e 18 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
+      shell: bash
     - name: checking if packages need to be installed
       run: flowey e 18 flowey_lib_common::install_dist_pkg 0
       shell: bash
     - name: installing packages
       run: flowey e 18 flowey_lib_common::install_dist_pkg 1
       shell: bash
+    - name: set '-Dwarnings' in .cargo/config.toml
+      run: flowey e 18 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
+      shell: bash
     - name: unpack protoc
-      run: |-
-        flowey e 18 flowey_lib_common::resolve_protoc 0
-        flowey e 18 flowey_lib_hvlite::cfg_openvmm_magicpath 0
+      run: flowey e 18 flowey_lib_common::resolve_protoc 0
       shell: bash
     - name: symlink protoc
-      run: flowey e 18 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
+      run: |-
+        flowey e 18 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
+        flowey e 18 flowey_lib_hvlite::init_cross_build 2
       shell: bash
-    - name: unpack openvmm-deps archive
-      run: flowey e 18 flowey_lib_hvlite::resolve_openvmm_deps 0
+    - name: cargo clippy
+      run: flowey e 18 flowey_lib_common::run_cargo_clippy 3
       shell: bash
-    - name: extract Aarch64 sysroot.tar.gz
-      run: flowey e 18 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
+    - name: cargo clippy
+      run: flowey e 18 flowey_lib_common::run_cargo_clippy 5
+      shell: bash
+    - name: cargo clippy
+      run: flowey e 18 flowey_lib_common::run_cargo_clippy 1
+      shell: bash
+    - name: cargo clippy
+      run: flowey e 18 flowey_lib_common::run_cargo_clippy 7
+      shell: bash
+    - name: cargo clippy
+      run: |-
+        flowey e 18 flowey_lib_common::run_cargo_clippy 6
+        flowey e 18 flowey_lib_hvlite::init_cross_build 0
+      shell: bash
+    - name: cargo build xtask
+      run: |-
+        flowey e 18 flowey_lib_common::run_cargo_build 0
+        flowey e 18 flowey_lib_hvlite::run_cargo_build 0
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 18 flowey_lib_hvlite::run_split_debug_info 1
+        flowey e 18 flowey_lib_hvlite::run_cargo_build 1
+        flowey e 18 flowey_lib_hvlite::build_xtask 0
+      shell: bash
+    - name: determine clippy exclusions
+      run: flowey e 18 flowey_lib_hvlite::_jobs::check_clippy 0
+      shell: bash
+    - name: cargo clippy
+      run: flowey e 18 flowey_lib_common::run_cargo_clippy 0
+      shell: bash
+    - name: cargo clippy
+      run: flowey e 18 flowey_lib_common::run_cargo_clippy 2
+      shell: bash
+    - name: cargo clippy
+      run: flowey e 18 flowey_lib_common::run_cargo_clippy 4
+      shell: bash
+    - name: create cargo-nextest cache dir
+      run: |-
+        flowey e 18 flowey_lib_common::download_cargo_nextest 0
+        flowey e 18 flowey_lib_common::download_cargo_nextest 1
+        flowey e 18 flowey_lib_common::download_cargo_nextest 2
+        flowey e 18 flowey_lib_common::download_cargo_nextest 3
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
+        flowey e 18 flowey_lib_common::cache 0
+        flowey v 18 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar7
+        flowey v 18 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar8
+      shell: bash
+    - id: flowey_lib_common__cache__1
+      uses: actions/cache@v5
+      with:
+        key: ${{ env.floweyvar7 }}
+        path: ${{ env.floweyvar8 }}
+      name: 'Restore cache: cargo-nextest'
+    - name: downloading cargo-nextest
+      run: |-
+        flowey v 18 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
+        EOF
+        flowey e 18 flowey_lib_common::cache 2
+        flowey e 18 flowey_lib_common::download_cargo_nextest 4
+      shell: bash
+    - name: report $CARGO_HOME
+      run: flowey e 18 flowey_lib_common::install_rust 3
+      shell: bash
+    - name: installing cargo-nextest
+      run: |-
+        flowey e 18 flowey_lib_common::install_cargo_nextest 0
+        flowey e 18 flowey_lib_hvlite::init_cross_build 3
+        flowey e 18 flowey_lib_hvlite::run_cargo_nextest_run 0
+      shell: bash
+    - name: generate nextest command
+      run: flowey e 18 flowey_lib_common::gen_cargo_nextest_run_cmd 3
       shell: bash
     - name: run 'aarch64-linux-musl-unit-tests-crypto-rust' nextest tests
       run: |-
@@ -3316,49 +3222,7 @@ jobs:
         flowey e 18 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
       shell: bash
     - name: run doctests for aarch64-unknown-linux-musl
-      run: |-
-        flowey e 18 flowey_lib_hvlite::_jobs::build_and_run_doc_tests 0
-        flowey e 18 flowey_lib_hvlite::init_cross_build 2
-      shell: bash
-    - name: cargo clippy
-      run: flowey e 18 flowey_lib_common::run_cargo_clippy 3
-      shell: bash
-    - name: cargo clippy
-      run: flowey e 18 flowey_lib_common::run_cargo_clippy 5
-      shell: bash
-    - name: cargo clippy
-      run: flowey e 18 flowey_lib_common::run_cargo_clippy 1
-      shell: bash
-    - name: cargo clippy
-      run: flowey e 18 flowey_lib_common::run_cargo_clippy 7
-      shell: bash
-    - name: cargo clippy
-      run: |-
-        flowey e 18 flowey_lib_common::run_cargo_clippy 6
-        flowey e 18 flowey_lib_hvlite::init_cross_build 0
-      shell: bash
-    - name: cargo build xtask
-      run: |-
-        flowey e 18 flowey_lib_common::run_cargo_build 0
-        flowey e 18 flowey_lib_hvlite::run_cargo_build 0
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 18 flowey_lib_hvlite::run_split_debug_info 1
-        flowey e 18 flowey_lib_hvlite::run_cargo_build 1
-        flowey e 18 flowey_lib_hvlite::build_xtask 0
-      shell: bash
-    - name: determine clippy exclusions
-      run: flowey e 18 flowey_lib_hvlite::_jobs::check_clippy 0
-      shell: bash
-    - name: cargo clippy
-      run: flowey e 18 flowey_lib_common::run_cargo_clippy 0
-      shell: bash
-    - name: cargo clippy
-      run: flowey e 18 flowey_lib_common::run_cargo_clippy 2
-      shell: bash
-    - name: cargo clippy
-      run: flowey e 18 flowey_lib_common::run_cargo_clippy 4
+      run: flowey e 18 flowey_lib_hvlite::_jobs::build_and_run_doc_tests 0
       shell: bash
     - name: 'validate cache entry: cargo-nextest'
       run: flowey e 18 flowey_lib_common::cache 3
@@ -3948,11 +3812,6 @@ jobs:
         flowey.exe e 20 flowey_lib_common::system_info 0
         flowey.exe e 20 flowey_lib_hvlite::git_checkout_openvmm_repo 0
         flowey.exe e 20 flowey_lib_hvlite::run_cargo_nextest_run 0
-        flowey.exe e 20 flowey_core::pipeline::artifact::resolve 12
-        flowey.exe e 20 flowey_core::pipeline::artifact::resolve 14
-        flowey.exe e 20 flowey_core::pipeline::artifact::resolve 15
-        flowey.exe e 20 flowey_core::pipeline::artifact::resolve 13
-        flowey.exe e 20 flowey_core::pipeline::artifact::resolve 3
         flowey.exe e 20 flowey_core::pipeline::artifact::resolve 11
         flowey.exe e 20 flowey_core::pipeline::artifact::resolve 4
         flowey.exe e 20 flowey_core::pipeline::artifact::resolve 5
@@ -3963,6 +3822,11 @@ jobs:
         flowey.exe e 20 flowey_core::pipeline::artifact::resolve 7
         flowey.exe e 20 flowey_core::pipeline::artifact::resolve 8
         flowey.exe e 20 flowey_core::pipeline::artifact::resolve 9
+        flowey.exe e 20 flowey_core::pipeline::artifact::resolve 12
+        flowey.exe e 20 flowey_core::pipeline::artifact::resolve 14
+        flowey.exe e 20 flowey_core::pipeline::artifact::resolve 15
+        flowey.exe e 20 flowey_core::pipeline::artifact::resolve 13
+        flowey.exe e 20 flowey_core::pipeline::artifact::resolve 3
       shell: bash
     - name: creating new test content dir
       run: flowey.exe e 20 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0

--- a/.github/workflows/openvmm-pr.yaml
+++ b/.github/workflows/openvmm-pr.yaml
@@ -440,10 +440,6 @@ jobs:
         EOF
         mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-openhcl-igvm"
         echo "$AgentTempDirNormal/publish_artifacts/aarch64-openhcl-igvm" | flowey v 10 'artifact_publish_from_aarch64-openhcl-igvm' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-openhcl-igvm-devkern"
-        echo "$AgentTempDirNormal/publish_artifacts/aarch64-openhcl-igvm-devkern" | flowey v 10 'artifact_publish_from_aarch64-openhcl-igvm-devkern' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-openhcl-igvm-devkern-extras"
-        echo "$AgentTempDirNormal/publish_artifacts/aarch64-openhcl-igvm-devkern-extras" | flowey v 10 'artifact_publish_from_aarch64-openhcl-igvm-devkern-extras' --is-raw-string update
         mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-openhcl-igvm-extras"
         echo "$AgentTempDirNormal/publish_artifacts/aarch64-openhcl-igvm-extras" | flowey v 10 'artifact_publish_from_aarch64-openhcl-igvm-extras' --is-raw-string update
       shell: bash
@@ -565,7 +561,7 @@ jobs:
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 10 flowey_lib_hvlite::run_split_debug_info 2
+        flowey e 10 flowey_lib_hvlite::run_split_debug_info 1
         flowey e 10 flowey_lib_hvlite::run_cargo_build 5
         flowey e 10 flowey_lib_hvlite::build_openhcl_boot 0
         flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 5
@@ -583,7 +579,7 @@ jobs:
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 10 flowey_lib_hvlite::run_split_debug_info 3
+        flowey e 10 flowey_lib_hvlite::run_split_debug_info 2
         flowey e 10 flowey_lib_hvlite::run_cargo_build 1
         flowey e 10 flowey_lib_hvlite::build_igvmfilegen 0
         flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 7
@@ -598,36 +594,6 @@ jobs:
         flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 10
         flowey e 10 flowey_core::pipeline::artifact::publish 1
       shell: bash
-    - name: extract and resolve kernel package
-      run: |-
-        flowey e 10 flowey_lib_hvlite::resolve_openhcl_kernel_package 1
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 15
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 12
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 10 flowey_lib_hvlite::run_split_debug_info 1
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 13
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 14
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 16
-      shell: bash
-    - name: building openhcl initrd
-      run: |-
-        flowey e 10 flowey_lib_hvlite::build_openhcl_initrd 1
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 17
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 18
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 19
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 20
-      shell: bash
-    - name: building igvm file
-      run: |-
-        flowey e 10 flowey_lib_hvlite::run_igvmfilegen 1
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 23
-        flowey e 10 flowey_core::pipeline::artifact::publish 2
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 21
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 22
-        flowey e 10 flowey_core::pipeline::artifact::publish 3
-      shell: bash
     - name: 'validate cache entry: gh-release-download'
       run: flowey e 10 flowey_lib_common::cache 3
       shell: bash
@@ -636,18 +602,6 @@ jobs:
       with:
         name: aarch64-openhcl-igvm
         path: ${{ runner.temp }}/publish_artifacts/aarch64-openhcl-igvm/
-        include-hidden-files: true
-    - name: 🌼📦 Publish aarch64-openhcl-igvm-devkern
-      uses: actions/upload-artifact@v7
-      with:
-        name: aarch64-openhcl-igvm-devkern
-        path: ${{ runner.temp }}/publish_artifacts/aarch64-openhcl-igvm-devkern/
-        include-hidden-files: true
-    - name: 🌼📦 Publish aarch64-openhcl-igvm-devkern-extras
-      uses: actions/upload-artifact@v7
-      with:
-        name: aarch64-openhcl-igvm-devkern-extras
-        path: ${{ runner.temp }}/publish_artifacts/aarch64-openhcl-igvm-devkern-extras/
         include-hidden-files: true
     - name: 🌼📦 Publish aarch64-openhcl-igvm-extras
       uses: actions/upload-artifact@v7
@@ -900,18 +854,10 @@ jobs:
         echo "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-cvm" | flowey v 12 'artifact_publish_from_x64-openhcl-igvm-cvm' --is-raw-string update
         mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-cvm-extras"
         echo "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-cvm-extras" | flowey v 12 'artifact_publish_from_x64-openhcl-igvm-cvm-extras' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-devkern"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-devkern" | flowey v 12 'artifact_publish_from_x64-openhcl-igvm-devkern' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-devkern-extras"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-devkern-extras" | flowey v 12 'artifact_publish_from_x64-openhcl-igvm-devkern-extras' --is-raw-string update
         mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-extras"
         echo "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-extras" | flowey v 12 'artifact_publish_from_x64-openhcl-igvm-extras' --is-raw-string update
         mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-test-linux-direct"
         echo "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-test-linux-direct" | flowey v 12 'artifact_publish_from_x64-openhcl-igvm-test-linux-direct' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-test-linux-direct-devkern"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-test-linux-direct-devkern" | flowey v 12 'artifact_publish_from_x64-openhcl-igvm-test-linux-direct-devkern' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-test-linux-direct-devkern-extras"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-test-linux-direct-devkern-extras" | flowey v 12 'artifact_publish_from_x64-openhcl-igvm-test-linux-direct-devkern-extras' --is-raw-string update
         mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-test-linux-direct-extras"
         echo "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-test-linux-direct-extras" | flowey v 12 'artifact_publish_from_x64-openhcl-igvm-test-linux-direct-extras' --is-raw-string update
       shell: bash
@@ -1021,7 +967,7 @@ jobs:
       shell: bash
     - name: building openhcl initrd
       run: |-
-        flowey e 12 flowey_lib_hvlite::build_openhcl_initrd 2
+        flowey e 12 flowey_lib_hvlite::build_openhcl_initrd 0
         flowey e 12 flowey_lib_hvlite::init_cross_build 0
         flowey e 12 flowey_lib_hvlite::run_cargo_build 9
         flowey e 12 flowey_lib_hvlite::run_cargo_build 10
@@ -1033,7 +979,7 @@ jobs:
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 12 flowey_lib_hvlite::run_split_debug_info 6
+        flowey e 12 flowey_lib_hvlite::run_split_debug_info 4
         flowey e 12 flowey_lib_hvlite::run_cargo_build 12
         flowey e 12 flowey_lib_hvlite::build_sidecar 0
         flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 5
@@ -1048,7 +994,7 @@ jobs:
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 12 flowey_lib_hvlite::run_split_debug_info 5
+        flowey e 12 flowey_lib_hvlite::run_split_debug_info 3
         flowey e 12 flowey_lib_hvlite::run_cargo_build 5
         flowey e 12 flowey_lib_hvlite::build_openhcl_boot 0
         flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 6
@@ -1066,7 +1012,7 @@ jobs:
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 12 flowey_lib_hvlite::run_split_debug_info 7
+        flowey e 12 flowey_lib_hvlite::run_split_debug_info 5
         flowey e 12 flowey_lib_hvlite::run_cargo_build 1
         flowey e 12 flowey_lib_hvlite::build_igvmfilegen 0
         flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 8
@@ -1074,43 +1020,14 @@ jobs:
       shell: bash
     - name: building igvm file
       run: |-
-        flowey e 12 flowey_lib_hvlite::run_igvmfilegen 2
+        flowey e 12 flowey_lib_hvlite::run_igvmfilegen 1
         flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 12
         flowey e 12 flowey_core::pipeline::artifact::publish 0
         flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 10
         flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 11
         flowey e 12 flowey_core::pipeline::artifact::publish 1
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 34
-      shell: bash
-    - name: extract and resolve kernel package
-      run: |-
-        flowey e 12 flowey_lib_hvlite::resolve_openhcl_kernel_package 2
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 28
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 25
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 12 flowey_lib_hvlite::run_split_debug_info 4
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 26
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 27
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 29
-      shell: bash
-    - name: building openhcl initrd
-      run: |-
-        flowey e 12 flowey_lib_hvlite::build_openhcl_initrd 4
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 30
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 31
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 32
         flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 33
-      shell: bash
-    - name: building igvm file
-      run: |-
-        flowey e 12 flowey_lib_hvlite::run_igvmfilegen 4
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 37
-        flowey e 12 flowey_core::pipeline::artifact::publish 2
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 35
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 36
-        flowey e 12 flowey_core::pipeline::artifact::publish 3
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 34
       shell: bash
     - name: unpack openvmm-test-linux archives
       run: flowey e 12 flowey_lib_hvlite::resolve_openvmm_test_linux_kernel 0
@@ -1118,60 +1035,31 @@ jobs:
     - name: unpack openvmm-test-initrd archives
       run: |-
         flowey e 12 flowey_lib_hvlite::resolve_openvmm_test_initrd 0
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 41
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 38
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 12 flowey_lib_hvlite::run_split_debug_info 1
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 39
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 40
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 42
-      shell: bash
-    - name: building openhcl initrd
-      run: |-
-        flowey e 12 flowey_lib_hvlite::build_openhcl_initrd 0
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 43
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 44
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 45
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 46
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 47
-      shell: bash
-    - name: building igvm file
-      run: |-
-        flowey e 12 flowey_lib_hvlite::run_igvmfilegen 0
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 50
-        flowey e 12 flowey_core::pipeline::artifact::publish 4
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 48
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 49
-        flowey e 12 flowey_core::pipeline::artifact::publish 5
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 54
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 51
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 28
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 25
       shell: bash
     - name: split debug symbols
       run: |-
         flowey e 12 flowey_lib_hvlite::run_split_debug_info 2
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 52
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 53
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 55
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 26
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 27
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 29
       shell: bash
     - name: building openhcl initrd
       run: |-
-        flowey e 12 flowey_lib_hvlite::build_openhcl_initrd 1
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 56
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 57
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 58
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 59
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 60
+        flowey e 12 flowey_lib_hvlite::build_openhcl_initrd 2
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 30
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 31
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 32
       shell: bash
     - name: building igvm file
       run: |-
-        flowey e 12 flowey_lib_hvlite::run_igvmfilegen 1
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 63
-        flowey e 12 flowey_core::pipeline::artifact::publish 6
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 61
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 62
-        flowey e 12 flowey_core::pipeline::artifact::publish 7
+        flowey e 12 flowey_lib_hvlite::run_igvmfilegen 0
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 37
+        flowey e 12 flowey_core::pipeline::artifact::publish 2
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 35
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 36
+        flowey e 12 flowey_core::pipeline::artifact::publish 3
       shell: bash
     - name: extract and resolve kernel package
       run: |-
@@ -1181,14 +1069,14 @@ jobs:
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 12 flowey_lib_hvlite::run_split_debug_info 3
+        flowey e 12 flowey_lib_hvlite::run_split_debug_info 1
         flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 14
         flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 15
         flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 17
       shell: bash
     - name: building openhcl initrd
       run: |-
-        flowey e 12 flowey_lib_hvlite::build_openhcl_initrd 3
+        flowey e 12 flowey_lib_hvlite::build_openhcl_initrd 1
         flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 18
         flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 19
         flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 20
@@ -1196,12 +1084,12 @@ jobs:
       shell: bash
     - name: building igvm file
       run: |-
-        flowey e 12 flowey_lib_hvlite::run_igvmfilegen 3
+        flowey e 12 flowey_lib_hvlite::run_igvmfilegen 2
         flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 24
-        flowey e 12 flowey_core::pipeline::artifact::publish 8
+        flowey e 12 flowey_core::pipeline::artifact::publish 4
         flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 22
         flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 23
-        flowey e 12 flowey_core::pipeline::artifact::publish 9
+        flowey e 12 flowey_core::pipeline::artifact::publish 5
       shell: bash
     - name: 'validate cache entry: gh-release-download'
       run: flowey e 12 flowey_lib_common::cache 3
@@ -1224,18 +1112,6 @@ jobs:
         name: x64-openhcl-igvm-cvm-extras
         path: ${{ runner.temp }}/publish_artifacts/x64-openhcl-igvm-cvm-extras/
         include-hidden-files: true
-    - name: 🌼📦 Publish x64-openhcl-igvm-devkern
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-openhcl-igvm-devkern
-        path: ${{ runner.temp }}/publish_artifacts/x64-openhcl-igvm-devkern/
-        include-hidden-files: true
-    - name: 🌼📦 Publish x64-openhcl-igvm-devkern-extras
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-openhcl-igvm-devkern-extras
-        path: ${{ runner.temp }}/publish_artifacts/x64-openhcl-igvm-devkern-extras/
-        include-hidden-files: true
     - name: 🌼📦 Publish x64-openhcl-igvm-extras
       uses: actions/upload-artifact@v7
       with:
@@ -1247,18 +1123,6 @@ jobs:
       with:
         name: x64-openhcl-igvm-test-linux-direct
         path: ${{ runner.temp }}/publish_artifacts/x64-openhcl-igvm-test-linux-direct/
-        include-hidden-files: true
-    - name: 🌼📦 Publish x64-openhcl-igvm-test-linux-direct-devkern
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-openhcl-igvm-test-linux-direct-devkern
-        path: ${{ runner.temp }}/publish_artifacts/x64-openhcl-igvm-test-linux-direct-devkern/
-        include-hidden-files: true
-    - name: 🌼📦 Publish x64-openhcl-igvm-test-linux-direct-devkern-extras
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-openhcl-igvm-test-linux-direct-devkern-extras
-        path: ${{ runner.temp }}/publish_artifacts/x64-openhcl-igvm-test-linux-direct-devkern-extras/
         include-hidden-files: true
     - name: 🌼📦 Publish x64-openhcl-igvm-test-linux-direct-extras
       uses: actions/upload-artifact@v7
@@ -3106,6 +2970,23 @@ jobs:
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
       shell: bash
+    - name: add default cargo home to path
+      run: flowey e 19 flowey_lib_common::install_rust 0
+      shell: bash
+    - name: install Rust
+      run: flowey e 19 flowey_lib_common::install_rust 1
+      shell: bash
+    - name: detect active toolchain
+      run: |-
+        flowey e 19 flowey_lib_common::install_rust 2
+        flowey e 19 flowey_lib_common::cfg_cargo_common_flags 0
+      shell: bash
+    - name: checking if packages need to be installed
+      run: flowey e 19 flowey_lib_common::install_dist_pkg 0
+      shell: bash
+    - name: installing packages
+      run: flowey e 19 flowey_lib_common::install_dist_pkg 1
+      shell: bash
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 19 flowey_lib_common::git_checkout 0
@@ -3158,33 +3039,14 @@ jobs:
         flowey e 19 flowey_lib_common::cache 6
         flowey e 19 flowey_lib_common::download_gh_release 1
       shell: bash
-    - name: checking if packages need to be installed
-      run: flowey e 19 flowey_lib_common::install_dist_pkg 0
-      shell: bash
-    - name: installing packages
-      run: flowey e 19 flowey_lib_common::install_dist_pkg 1
-      shell: bash
     - name: unpack protoc
       run: |-
         flowey e 19 flowey_lib_common::resolve_protoc 0
         flowey e 19 flowey_lib_hvlite::cfg_openvmm_magicpath 0
       shell: bash
     - name: symlink protoc
-      run: flowey e 19 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-      shell: bash
-    - name: add default cargo home to path
-      run: flowey e 19 flowey_lib_common::install_rust 0
-      shell: bash
-    - name: install Rust
-      run: flowey e 19 flowey_lib_common::install_rust 1
-      shell: bash
-    - name: run doctests for aarch64-unknown-linux-gnu
-      run: flowey e 19 flowey_lib_hvlite::_jobs::build_and_run_doc_tests 0
-      shell: bash
-    - name: detect active toolchain
       run: |-
-        flowey e 19 flowey_lib_common::install_rust 2
-        flowey e 19 flowey_lib_common::cfg_cargo_common_flags 0
+        flowey e 19 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
         flowey e 19 flowey_lib_hvlite::init_cross_build 0
       shell: bash
     - name: cargo clippy
@@ -3373,6 +3235,9 @@ jobs:
       run: |-
         flowey e 19 flowey_lib_hvlite::build_nextest_unit_tests 6
         flowey e 19 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
+      shell: bash
+    - name: run doctests for aarch64-unknown-linux-gnu
+      run: flowey e 19 flowey_lib_hvlite::_jobs::build_and_run_doc_tests 0
       shell: bash
     - name: 'validate cache entry: cargo-nextest'
       run: flowey e 19 flowey_lib_common::cache 3
@@ -4352,11 +4217,6 @@ jobs:
         flowey.exe e 22 flowey_lib_common::system_info 0
         flowey.exe e 22 flowey_lib_hvlite::git_checkout_openvmm_repo 0
         flowey.exe e 22 flowey_lib_hvlite::run_cargo_nextest_run 0
-        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 12
-        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 14
-        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 15
-        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 13
-        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 3
         flowey.exe e 22 flowey_core::pipeline::artifact::resolve 11
         flowey.exe e 22 flowey_core::pipeline::artifact::resolve 4
         flowey.exe e 22 flowey_core::pipeline::artifact::resolve 5
@@ -4367,6 +4227,11 @@ jobs:
         flowey.exe e 22 flowey_core::pipeline::artifact::resolve 7
         flowey.exe e 22 flowey_core::pipeline::artifact::resolve 8
         flowey.exe e 22 flowey_core::pipeline::artifact::resolve 9
+        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 12
+        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 14
+        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 15
+        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 13
+        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 3
       shell: bash
     - name: creating new test content dir
       run: flowey.exe e 22 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0

--- a/ci-flowey/openvmm-pr.yaml
+++ b/ci-flowey/openvmm-pr.yaml
@@ -1448,18 +1448,10 @@ jobs:
       echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/x64-openhcl-igvm-cvm" | $FLOWEY_BIN v 11 'artifact_publish_from_x64-openhcl-igvm-cvm' --is-raw-string update
       mkdir -p "$(AgentTempDirNormal)/publish_artifacts/x64-openhcl-igvm-cvm-extras"
       echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/x64-openhcl-igvm-cvm-extras" | $FLOWEY_BIN v 11 'artifact_publish_from_x64-openhcl-igvm-cvm-extras' --is-raw-string update
-      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/x64-openhcl-igvm-devkern"
-      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/x64-openhcl-igvm-devkern" | $FLOWEY_BIN v 11 'artifact_publish_from_x64-openhcl-igvm-devkern' --is-raw-string update
-      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/x64-openhcl-igvm-devkern-extras"
-      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/x64-openhcl-igvm-devkern-extras" | $FLOWEY_BIN v 11 'artifact_publish_from_x64-openhcl-igvm-devkern-extras' --is-raw-string update
       mkdir -p "$(AgentTempDirNormal)/publish_artifacts/x64-openhcl-igvm-extras"
       echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/x64-openhcl-igvm-extras" | $FLOWEY_BIN v 11 'artifact_publish_from_x64-openhcl-igvm-extras' --is-raw-string update
       mkdir -p "$(AgentTempDirNormal)/publish_artifacts/x64-openhcl-igvm-test-linux-direct"
       echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/x64-openhcl-igvm-test-linux-direct" | $FLOWEY_BIN v 11 'artifact_publish_from_x64-openhcl-igvm-test-linux-direct' --is-raw-string update
-      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/x64-openhcl-igvm-test-linux-direct-devkern"
-      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/x64-openhcl-igvm-test-linux-direct-devkern" | $FLOWEY_BIN v 11 'artifact_publish_from_x64-openhcl-igvm-test-linux-direct-devkern' --is-raw-string update
-      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/x64-openhcl-igvm-test-linux-direct-devkern-extras"
-      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/x64-openhcl-igvm-test-linux-direct-devkern-extras" | $FLOWEY_BIN v 11 'artifact_publish_from_x64-openhcl-igvm-test-linux-direct-devkern-extras' --is-raw-string update
       mkdir -p "$(AgentTempDirNormal)/publish_artifacts/x64-openhcl-igvm-test-linux-direct-extras"
       echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/x64-openhcl-igvm-test-linux-direct-extras" | $FLOWEY_BIN v 11 'artifact_publish_from_x64-openhcl-igvm-test-linux-direct-extras' --is-raw-string update
     displayName: 🌼🛫 Initialize job
@@ -1558,7 +1550,7 @@ jobs:
     displayName: extract and resolve kernel package
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_initrd 2
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_initrd 0
       $(FLOWEY_BIN) e 11 flowey_lib_hvlite::init_cross_build 0
       $(FLOWEY_BIN) e 11 flowey_lib_hvlite::run_cargo_build 9
       $(FLOWEY_BIN) e 11 flowey_lib_hvlite::run_cargo_build 10
@@ -1570,7 +1562,7 @@ jobs:
     displayName: cargo build sidecar
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::run_split_debug_info 6
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::run_split_debug_info 4
       $(FLOWEY_BIN) e 11 flowey_lib_hvlite::run_cargo_build 12
       $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_sidecar 0
       $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 5
@@ -1585,7 +1577,7 @@ jobs:
     displayName: cargo build openhcl_boot
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::run_split_debug_info 5
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::run_split_debug_info 3
       $(FLOWEY_BIN) e 11 flowey_lib_hvlite::run_cargo_build 5
       $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_boot 0
       $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 6
@@ -1603,7 +1595,7 @@ jobs:
     displayName: cargo build igvmfilegen
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::run_split_debug_info 7
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::run_split_debug_info 5
       $(FLOWEY_BIN) e 11 flowey_lib_hvlite::run_cargo_build 1
       $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_igvmfilegen 0
       $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 8
@@ -1611,103 +1603,45 @@ jobs:
     displayName: split debug symbols
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::run_igvmfilegen 2
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::run_igvmfilegen 1
       $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 12
       $(FLOWEY_BIN) e 11 flowey_core::pipeline::artifact::publish 0
       $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 10
       $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 11
       $(FLOWEY_BIN) e 11 flowey_core::pipeline::artifact::publish 1
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 34
-    displayName: building igvm file
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::resolve_openhcl_kernel_package 2
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 28
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 25
-    displayName: extract and resolve kernel package
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::run_split_debug_info 4
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 26
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 27
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 29
-    displayName: split debug symbols
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_initrd 4
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 30
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 31
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 32
       $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 33
-    displayName: building openhcl initrd
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::run_igvmfilegen 4
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 37
-      $(FLOWEY_BIN) e 11 flowey_core::pipeline::artifact::publish 2
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 35
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 36
-      $(FLOWEY_BIN) e 11 flowey_core::pipeline::artifact::publish 3
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 34
     displayName: building igvm file
   - bash: $(FLOWEY_BIN) e 11 flowey_lib_hvlite::resolve_openvmm_test_linux_kernel 0
     displayName: unpack openvmm-test-linux archives
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 11 flowey_lib_hvlite::resolve_openvmm_test_initrd 0
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 41
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 38
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 28
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 25
     displayName: unpack openvmm-test-initrd archives
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::run_split_debug_info 1
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 39
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 40
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 42
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::run_split_debug_info 2
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 26
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 27
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 29
     displayName: split debug symbols
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_initrd 0
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 43
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 44
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 45
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 46
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 47
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_initrd 2
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 30
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 31
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 32
     displayName: building openhcl initrd
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 11 flowey_lib_hvlite::run_igvmfilegen 0
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 50
-      $(FLOWEY_BIN) e 11 flowey_core::pipeline::artifact::publish 4
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 48
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 49
-      $(FLOWEY_BIN) e 11 flowey_core::pipeline::artifact::publish 5
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 54
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 51
-    displayName: building igvm file
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::run_split_debug_info 2
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 52
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 53
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 55
-    displayName: split debug symbols
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_initrd 1
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 56
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 57
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 58
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 59
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 60
-    displayName: building openhcl initrd
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::run_igvmfilegen 1
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 63
-      $(FLOWEY_BIN) e 11 flowey_core::pipeline::artifact::publish 6
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 61
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 62
-      $(FLOWEY_BIN) e 11 flowey_core::pipeline::artifact::publish 7
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 37
+      $(FLOWEY_BIN) e 11 flowey_core::pipeline::artifact::publish 2
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 35
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 36
+      $(FLOWEY_BIN) e 11 flowey_core::pipeline::artifact::publish 3
     displayName: building igvm file
   - bash: |-
       set -e
@@ -1717,14 +1651,14 @@ jobs:
     displayName: extract and resolve kernel package
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::run_split_debug_info 3
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::run_split_debug_info 1
       $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 14
       $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 15
       $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 17
     displayName: split debug symbols
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_initrd 3
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_initrd 1
       $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 18
       $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 19
       $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 20
@@ -1732,12 +1666,12 @@ jobs:
     displayName: building openhcl initrd
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::run_igvmfilegen 3
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::run_igvmfilegen 2
       $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 24
-      $(FLOWEY_BIN) e 11 flowey_core::pipeline::artifact::publish 8
+      $(FLOWEY_BIN) e 11 flowey_core::pipeline::artifact::publish 4
       $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 22
       $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 23
-      $(FLOWEY_BIN) e 11 flowey_core::pipeline::artifact::publish 9
+      $(FLOWEY_BIN) e 11 flowey_core::pipeline::artifact::publish 5
     displayName: building igvm file
   - bash: $(FLOWEY_BIN) e 11 flowey_lib_common::cache 3
     displayName: 'validate cache entry: gh-release-download'
@@ -1750,24 +1684,12 @@ jobs:
   - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/x64-openhcl-igvm-cvm-extras
     displayName: 🌼📦 Publish x64-openhcl-igvm-cvm-extras
     artifact: x64-openhcl-igvm-cvm-extras
-  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/x64-openhcl-igvm-devkern
-    displayName: 🌼📦 Publish x64-openhcl-igvm-devkern
-    artifact: x64-openhcl-igvm-devkern
-  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/x64-openhcl-igvm-devkern-extras
-    displayName: 🌼📦 Publish x64-openhcl-igvm-devkern-extras
-    artifact: x64-openhcl-igvm-devkern-extras
   - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/x64-openhcl-igvm-extras
     displayName: 🌼📦 Publish x64-openhcl-igvm-extras
     artifact: x64-openhcl-igvm-extras
   - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/x64-openhcl-igvm-test-linux-direct
     displayName: 🌼📦 Publish x64-openhcl-igvm-test-linux-direct
     artifact: x64-openhcl-igvm-test-linux-direct
-  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/x64-openhcl-igvm-test-linux-direct-devkern
-    displayName: 🌼📦 Publish x64-openhcl-igvm-test-linux-direct-devkern
-    artifact: x64-openhcl-igvm-test-linux-direct-devkern
-  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/x64-openhcl-igvm-test-linux-direct-devkern-extras
-    displayName: 🌼📦 Publish x64-openhcl-igvm-test-linux-direct-devkern-extras
-    artifact: x64-openhcl-igvm-test-linux-direct-devkern-extras
   - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/x64-openhcl-igvm-test-linux-direct-extras
     displayName: 🌼📦 Publish x64-openhcl-igvm-test-linux-direct-extras
     artifact: x64-openhcl-igvm-test-linux-direct-extras
@@ -1809,10 +1731,6 @@ jobs:
       EOF
       mkdir -p "$(AgentTempDirNormal)/publish_artifacts/aarch64-openhcl-igvm"
       echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-openhcl-igvm" | $FLOWEY_BIN v 10 'artifact_publish_from_aarch64-openhcl-igvm' --is-raw-string update
-      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/aarch64-openhcl-igvm-devkern"
-      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-openhcl-igvm-devkern" | $FLOWEY_BIN v 10 'artifact_publish_from_aarch64-openhcl-igvm-devkern' --is-raw-string update
-      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/aarch64-openhcl-igvm-devkern-extras"
-      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-openhcl-igvm-devkern-extras" | $FLOWEY_BIN v 10 'artifact_publish_from_aarch64-openhcl-igvm-devkern-extras' --is-raw-string update
       mkdir -p "$(AgentTempDirNormal)/publish_artifacts/aarch64-openhcl-igvm-extras"
       echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-openhcl-igvm-extras" | $FLOWEY_BIN v 10 'artifact_publish_from_aarch64-openhcl-igvm-extras' --is-raw-string update
     displayName: 🌼🛫 Initialize job
@@ -1923,7 +1841,7 @@ jobs:
     displayName: cargo build openhcl_boot
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::run_split_debug_info 2
+      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::run_split_debug_info 1
       $(FLOWEY_BIN) e 10 flowey_lib_hvlite::run_cargo_build 5
       $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_openhcl_boot 0
       $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 5
@@ -1941,7 +1859,7 @@ jobs:
     displayName: cargo build igvmfilegen
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::run_split_debug_info 3
+      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::run_split_debug_info 2
       $(FLOWEY_BIN) e 10 flowey_lib_hvlite::run_cargo_build 1
       $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_igvmfilegen 0
       $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 7
@@ -1956,47 +1874,11 @@ jobs:
       $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 10
       $(FLOWEY_BIN) e 10 flowey_core::pipeline::artifact::publish 1
     displayName: building igvm file
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::resolve_openhcl_kernel_package 1
-      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 15
-      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 12
-    displayName: extract and resolve kernel package
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::run_split_debug_info 1
-      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 13
-      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 14
-      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 16
-    displayName: split debug symbols
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_openhcl_initrd 1
-      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 17
-      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 18
-      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 19
-      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 20
-    displayName: building openhcl initrd
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::run_igvmfilegen 1
-      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 23
-      $(FLOWEY_BIN) e 10 flowey_core::pipeline::artifact::publish 2
-      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 21
-      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 22
-      $(FLOWEY_BIN) e 10 flowey_core::pipeline::artifact::publish 3
-    displayName: building igvm file
   - bash: $(FLOWEY_BIN) e 10 flowey_lib_common::cache 3
     displayName: 'validate cache entry: gh-release-download'
   - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-openhcl-igvm
     displayName: 🌼📦 Publish aarch64-openhcl-igvm
     artifact: aarch64-openhcl-igvm
-  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-openhcl-igvm-devkern
-    displayName: 🌼📦 Publish aarch64-openhcl-igvm-devkern
-    artifact: aarch64-openhcl-igvm-devkern
-  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-openhcl-igvm-devkern-extras
-    displayName: 🌼📦 Publish aarch64-openhcl-igvm-devkern-extras
-    artifact: aarch64-openhcl-igvm-devkern-extras
   - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-openhcl-igvm-extras
     displayName: 🌼📦 Publish aarch64-openhcl-igvm-extras
     artifact: aarch64-openhcl-igvm-extras
@@ -5194,11 +5076,6 @@ jobs:
       $(FLOWEY_BIN) e 17 flowey_lib_common::system_info 0
       $(FLOWEY_BIN) e 17 flowey_lib_hvlite::git_checkout_openvmm_repo 0
       $(FLOWEY_BIN) e 17 flowey_lib_hvlite::run_cargo_nextest_run 0
-      $(FLOWEY_BIN) e 17 flowey_core::pipeline::artifact::resolve 12
-      $(FLOWEY_BIN) e 17 flowey_core::pipeline::artifact::resolve 14
-      $(FLOWEY_BIN) e 17 flowey_core::pipeline::artifact::resolve 15
-      $(FLOWEY_BIN) e 17 flowey_core::pipeline::artifact::resolve 13
-      $(FLOWEY_BIN) e 17 flowey_core::pipeline::artifact::resolve 3
       $(FLOWEY_BIN) e 17 flowey_core::pipeline::artifact::resolve 11
       $(FLOWEY_BIN) e 17 flowey_core::pipeline::artifact::resolve 4
       $(FLOWEY_BIN) e 17 flowey_core::pipeline::artifact::resolve 5
@@ -5209,6 +5086,11 @@ jobs:
       $(FLOWEY_BIN) e 17 flowey_core::pipeline::artifact::resolve 7
       $(FLOWEY_BIN) e 17 flowey_core::pipeline::artifact::resolve 8
       $(FLOWEY_BIN) e 17 flowey_core::pipeline::artifact::resolve 9
+      $(FLOWEY_BIN) e 17 flowey_core::pipeline::artifact::resolve 12
+      $(FLOWEY_BIN) e 17 flowey_core::pipeline::artifact::resolve 14
+      $(FLOWEY_BIN) e 17 flowey_core::pipeline::artifact::resolve 15
+      $(FLOWEY_BIN) e 17 flowey_core::pipeline::artifact::resolve 13
+      $(FLOWEY_BIN) e 17 flowey_core::pipeline::artifact::resolve 3
     displayName: print system info
   - bash: $(FLOWEY_BIN) e 17 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
     displayName: creating new test content dir

--- a/flowey/flowey_hvlite/src/pipelines/checkin_gates.rs
+++ b/flowey/flowey_hvlite/src/pipelines/checkin_gates.rs
@@ -1030,7 +1030,7 @@ impl IntoPipeline for CheckinGatesCli {
                 OpenvmmHclBuildProfile::Debug
             };
 
-            let igvm_recipes = match (arch, mi_secure) {
+            let mut igvm_recipes = match (arch, mi_secure) {
                 (CommonArch::X86_64, false) => vec![
                     OpenhclIgvmRecipe::X64,
                     OpenhclIgvmRecipe::X64Devkern,
@@ -1051,6 +1051,9 @@ impl IntoPipeline for CheckinGatesCli {
                 }
                 _ => unreachable!(),
             };
+            if flowey_lib_hvlite::_jobs::cfg_versions::OPENHCL_KERNEL_DEV_VERSION.is_none() {
+                igvm_recipes.retain(|recipe| !recipe.uses_dev_kernel());
+            }
 
             let (mut pub_openhcl_igvms, use_openhcl_igvms) =
                 pipeline.new_typed_artifact_collection(igvm_recipes.clone(), additional_tag, None);

--- a/flowey/flowey_lib_hvlite/src/_jobs/cfg_versions.rs
+++ b/flowey/flowey_lib_hvlite/src/_jobs/cfg_versions.rs
@@ -27,10 +27,9 @@ pub const MDBOOK_MERMAID: &str = "0.14.0";
 pub const MU_MSVM: &str = "26.0.13";
 pub const NEXTEST: &str = "0.9.133";
 pub const NODEJS: &str = "24.x";
-// N.B. Kernel version numbers for dev and stable branches are not directly
-//      comparable. They originate from separate branches, and the fourth digit
-//      increases with each release from the respective branch.
-pub const OPENHCL_KERNEL_DEV_VERSION: &str = "6.18.37.1";
+// Set this to Some(version) when the hcl-dev branch is meaningfully different
+// from hcl-main and should be built and tested independently.
+pub const OPENHCL_KERNEL_DEV_VERSION: Option<&str> = None;
 pub const OPENHCL_KERNEL_STABLE_VERSION: &str = "6.18.37.1";
 pub const OPENVMM_DEPS: &str = "0.3.0-110";
 pub const PROTOC: &str = "27.1";
@@ -184,13 +183,22 @@ impl FlowNode for Node {
         // Only set kernel versions if we don't have local paths
         // (versions are only needed for downloading)
         if !has_local_kernel {
+            let mut versions = BTreeMap::from([
+                (
+                    OpenhclKernelPackageKind::Main,
+                    OPENHCL_KERNEL_STABLE_VERSION.into(),
+                ),
+                (
+                    OpenhclKernelPackageKind::Cvm,
+                    OPENHCL_KERNEL_STABLE_VERSION.into(),
+                ),
+            ]);
+            if let Some(version) = OPENHCL_KERNEL_DEV_VERSION {
+                versions.insert(OpenhclKernelPackageKind::Dev, version.into());
+                versions.insert(OpenhclKernelPackageKind::CvmDev, version.into());
+            }
             ctx.config(crate::resolve_openhcl_kernel_package::Config {
-                versions: [
-                    (OpenhclKernelPackageKind::Dev, OPENHCL_KERNEL_DEV_VERSION.into()),
-                    (OpenhclKernelPackageKind::Main, OPENHCL_KERNEL_STABLE_VERSION.into()),
-                    (OpenhclKernelPackageKind::Cvm, OPENHCL_KERNEL_STABLE_VERSION.into()),
-                    (OpenhclKernelPackageKind::CvmDev, OPENHCL_KERNEL_DEV_VERSION.into()),
-                ].into(),
+                versions,
                 ..Default::default()
             });
         }

--- a/flowey/flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs
+++ b/flowey/flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs
@@ -313,6 +313,16 @@ impl ArtifactType for OpenhclIgvmRecipe {
 }
 
 impl OpenhclIgvmRecipe {
+    pub fn uses_dev_kernel(&self) -> bool {
+        matches!(
+            self,
+            Self::X64Devkern
+                | Self::X64TestLinuxDirectDevkern
+                | Self::X64CvmDevkern
+                | Self::Aarch64Devkern
+        )
+    }
+
     pub fn non_production_tag(&self) -> String {
         let mut tag = self.arch().to_string();
         if let Some(flavor) = self.flavor() {

--- a/flowey/flowey_lib_hvlite/src/resolve_openhcl_kernel_package.rs
+++ b/flowey/flowey_lib_hvlite/src/resolve_openhcl_kernel_package.rs
@@ -16,6 +16,12 @@ pub enum OpenhclKernelPackageKind {
     CvmDev,
 }
 
+impl OpenhclKernelPackageKind {
+    pub fn is_dev(self) -> bool {
+        matches!(self, Self::Dev | Self::CvmDev)
+    }
+}
+
 flowey_config! {
     /// Config for the resolve_openhcl_kernel_package node.
     pub struct Config {
@@ -130,6 +136,13 @@ impl FlowNodeWithConfig for Node {
         // Verify we have either local paths or versions for each requested architecture
         for (kind, arch) in &all_reqs {
             if !local_paths.contains_key(arch) && !versions.contains_key(kind) {
+                if kind.is_dev() {
+                    anyhow::bail!(
+                        "OpenHCL dev kernel support is disabled; configure \
+                         OPENHCL_KERNEL_DEV_VERSION to enable {:?}",
+                        kind
+                    );
+                }
                 anyhow::bail!(
                     "Must provide either SetLocal for {:?} or SetVersion for {:?}",
                     arch,

--- a/shell.nix
+++ b/shell.nix
@@ -19,6 +19,9 @@ let
   mdbook_mermaid = pkgs.callPackage ./nix/mdbook_mermaid.nix { };
   protoc = pkgs.callPackage ./nix/protoc.nix { };
 
+  # Enable this when hcl-dev should be built independently.
+  enableDevKernel = false;
+
   # Helper to get openvmm_deps and uefi_mu_msvm by architecture
   mkBaseDepsForArch = arch: {
     openvmm_deps = pkgs.callPackage ./nix/openvmm_deps.nix { targetArch = arch; };
@@ -81,7 +84,7 @@ let
     let kernelFile = if arch == "x86_64" then "vmlinux" else "Image";
     in "--use-local-deps --custom-openvmm-deps ${baseDeps.openvmm_deps} --custom-uefi=${baseDeps.uefi_mu_msvm}/MSVM.fd --custom-kernel ${kernel}/${kernelFile} --custom-kernel-modules ${kernel}/modules --custom-protoc ${protoc}";
 
-in pkgs.mkShell {
+in pkgs.mkShell ({
   nativeBuildInputs = [
     rust
     mdbook
@@ -117,29 +120,12 @@ in pkgs.mkShell {
     baseDeps = x64BaseDeps;
     kernel = x64KernelCvm;
   };
-  CARGO_BUILD_ARGS_X64_DEVKERN = mkCargoBuildArgs {
-    arch = "x86_64";
-    baseDeps = x64BaseDeps;
-    kernel = x64KernelDev;
-  };
-  CARGO_BUILD_ARGS_X64_CVM_DEVKERN = mkCargoBuildArgs {
-    arch = "x86_64";
-    baseDeps = x64BaseDeps;
-    kernel = x64KernelCvmDev;
-  };
-
   # aarch64 recipe variants
   CARGO_BUILD_ARGS_AARCH64 = mkCargoBuildArgs {
     arch = "aarch64";
     baseDeps = aarch64BaseDeps;
     kernel = aarch64Kernel;
   };
-  CARGO_BUILD_ARGS_AARCH64_DEVKERN = mkCargoBuildArgs {
-    arch = "aarch64";
-    baseDeps = aarch64BaseDeps;
-    kernel = aarch64KernelDev;
-  };
-
   # Expose deps for reference in update-rootfs.py
   OPENVMM_DEPS_X64 = x64BaseDeps.openvmm_deps;
   OPENVMM_DEPS_AARCH64 = aarch64BaseDeps.openvmm_deps;
@@ -150,10 +136,7 @@ in pkgs.mkShell {
   NIX_UEFI_AARCH64 = "${aarch64BaseDeps.uefi_mu_msvm}/MSVM.fd";
   NIX_KERNEL_X64 = "${x64Kernel}";
   NIX_KERNEL_X64_CVM = "${x64KernelCvm}";
-  NIX_KERNEL_X64_DEV = "${x64KernelDev}";
-  NIX_KERNEL_X64_CVM_DEV = "${x64KernelCvmDev}";
   NIX_KERNEL_AARCH64 = "${aarch64Kernel}";
-  NIX_KERNEL_AARCH64_DEV = "${aarch64KernelDev}";
 
   RUST_BACKTRACE = 1;
   SOURCE_DATE_EPOCH = 12345;
@@ -189,4 +172,23 @@ in pkgs.mkShell {
     ''}
     export PATH="$NIX_CC_WRAPPER_DIR:$PATH"
   '';
-}
+} // pkgs.lib.optionalAttrs enableDevKernel {
+  CARGO_BUILD_ARGS_X64_DEVKERN = mkCargoBuildArgs {
+    arch = "x86_64";
+    baseDeps = x64BaseDeps;
+    kernel = x64KernelDev;
+  };
+  CARGO_BUILD_ARGS_X64_CVM_DEVKERN = mkCargoBuildArgs {
+    arch = "x86_64";
+    baseDeps = x64BaseDeps;
+    kernel = x64KernelCvmDev;
+  };
+  CARGO_BUILD_ARGS_AARCH64_DEVKERN = mkCargoBuildArgs {
+    arch = "aarch64";
+    baseDeps = aarch64BaseDeps;
+    kernel = aarch64KernelDev;
+  };
+  NIX_KERNEL_X64_DEV = "${x64KernelDev}";
+  NIX_KERNEL_X64_CVM_DEV = "${x64KernelCvmDev}";
+  NIX_KERNEL_AARCH64_DEV = "${aarch64KernelDev}";
+})


### PR DESCRIPTION
## Motivation

OpenHCL retains a separate dev Linux kernel channel, but the main and dev kernels are currently identical. The check-in pipelines still build and publish duplicate dev-kernel IGVM variants, and the Nix shell exposes duplicate dev-kernel packages, without providing distinct coverage.

## Changes

- Make the configured dev-kernel version optional and disable it by default.
- Omit dev-kernel recipes from the OSS check-in pipeline matrices while disabled.
- Stop exposing dev-kernel packages and build arguments from the Nix shell.
- Keep the existing kernel kinds, recipes, CLI values, resolver routing, and Petri artifact identities so the channel can be restored without reconstructing its plumbing.
- Return a clear error when a published dev kernel is explicitly requested while no dev version is configured. Custom local kernel packages continue to work.
- Regenerate the affected CI workflows.

## Re-enabling the dev channel

1. Set `OPENHCL_KERNEL_DEV_VERSION` to `Some("<VERSION>")`.
2. Set `enableDevKernel` in `shell.nix` to `true` and update the dev version and hashes in `nix/openhcl_kernel.nix`.
3. Regenerate the Flowey pipelines.
4. Restore or add targeted dev-kernel test coverage that justifies the separate channel.

## Validation

- `cargo clippy --all-targets -p flowey_lib_hvlite -p flowey_hvlite`
- `cargo doc --no-deps -p flowey_lib_hvlite -p flowey_hvlite`
- `cargo xtask fmt --fix`