### PR TITLE
flowey: disable unused dev kernel IGVM variants

### DIFF
--- a/.github/workflows/openvmm-ci.yaml
+++ b/.github/workflows/openvmm-ci.yaml
@@ -6363,7 +6363,6 @@ jobs:
     - job20
     - job21
     - job22
-    - job23
     - job24
     - job25
     - job26

--- a/.github/workflows/openvmm-ci.yaml
+++ b/.github/workflows/openvmm-ci.yaml
@@ -99,8 +99,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey.exe e 0 flowey_lib_common::git_checkout 0
-        flowey.exe v 0 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar1
-        flowey.exe v 0 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 0 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env github floweyvar1
+        flowey.exe v 0 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -112,7 +112,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey.exe v 0 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey.exe v 0 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
         flowey.exe e 0 flowey_lib_common::git_checkout 3
@@ -142,8 +142,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 0 flowey_lib_common::cache 0
-        flowey.exe v 0 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar2
-        flowey.exe v 0 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar3
+        flowey.exe v 0 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar2
+        flowey.exe v 0 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar3
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -153,7 +153,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 0 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey.exe v 0 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey.exe e 0 flowey_lib_common::cache 2
@@ -259,8 +259,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 1 flowey_lib_common::git_checkout 0
-        flowey v 1 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar1
-        flowey v 1 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
+        flowey v 1 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env github floweyvar1
+        flowey v 1 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -272,7 +272,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey v 1 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey v 1 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
         flowey e 1 flowey_lib_common::git_checkout 3
@@ -302,8 +302,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 1 flowey_lib_common::cache 0
-        flowey v 1 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar2
-        flowey v 1 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar3
+        flowey v 1 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar2
+        flowey v 1 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar3
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -313,7 +313,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 1 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey v 1 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey e 1 flowey_lib_common::cache 2
@@ -451,8 +451,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 10 flowey_lib_common::git_checkout 0
-        flowey v 10 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar3
-        flowey v 10 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
+        flowey v 10 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env github floweyvar3
+        flowey v 10 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -464,7 +464,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey v 10 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey v 10 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
         flowey e 10 flowey_lib_common::git_checkout 3
@@ -481,8 +481,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 10 flowey_lib_common::cache 0
-        flowey v 10 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar1
-        flowey v 10 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar2
+        flowey v 10 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar1
+        flowey v 10 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar2
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -492,7 +492,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 10 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey v 10 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey e 10 flowey_lib_common::cache 2
@@ -732,8 +732,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 11 flowey_lib_common::git_checkout 0
-        flowey v 11 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar3
-        flowey v 11 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
+        flowey v 11 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env github floweyvar3
+        flowey v 11 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -745,7 +745,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey v 11 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey v 11 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
         flowey e 11 flowey_lib_common::git_checkout 3
@@ -762,8 +762,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 11 flowey_lib_common::cache 0
-        flowey v 11 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar1
-        flowey v 11 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar2
+        flowey v 11 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar1
+        flowey v 11 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar2
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -773,7 +773,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 11 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey v 11 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey e 11 flowey_lib_common::cache 2
@@ -1103,8 +1103,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 12 flowey_lib_common::git_checkout 0
-        flowey v 12 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar3
-        flowey v 12 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
+        flowey v 12 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env github floweyvar3
+        flowey v 12 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -1116,7 +1116,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey v 12 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey v 12 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
         flowey e 12 flowey_lib_common::git_checkout 3
@@ -1145,8 +1145,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 12 flowey_lib_common::cache 0
-        flowey v 12 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar1
-        flowey v 12 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar2
+        flowey v 12 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar1
+        flowey v 12 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar2
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -1156,7 +1156,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 12 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey v 12 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey e 12 flowey_lib_common::cache 2
@@ -1462,8 +1462,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey.exe e 13 flowey_lib_common::git_checkout 0
-        flowey.exe v 13 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar8
-        flowey.exe v 13 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 13 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env github floweyvar8
+        flowey.exe v 13 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -1475,7 +1475,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey.exe v 13 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey.exe v 13 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
         flowey.exe e 13 flowey_lib_common::git_checkout 3
@@ -1494,8 +1494,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 13 flowey_lib_common::cache 4
-        flowey.exe v 13 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
-        flowey.exe v 13 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
+        flowey.exe v 13 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar6
+        flowey.exe v 13 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar7
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
@@ -1505,7 +1505,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 13 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        flowey.exe v 13 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
         flowey.exe e 13 flowey_lib_common::cache 6
@@ -1550,8 +1550,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 13 flowey_lib_common::cache 0
-        flowey.exe v 13 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
-        flowey.exe v 13 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
+        flowey.exe v 13 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar4
+        flowey.exe v 13 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar5
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -1561,7 +1561,7 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
-        flowey.exe v 13 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey.exe v 13 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey.exe e 13 flowey_lib_common::cache 2
@@ -1597,8 +1597,8 @@ jobs:
         flowey.exe e 13 flowey_lib_hvlite::build_nextest_unit_tests 1
         flowey.exe e 13 flowey_lib_common::publish_test_results 6
         flowey.exe e 13 flowey_lib_common::publish_test_results 7
-        flowey.exe v 13 'flowey_lib_common::publish_test_results:12:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs:94:51 write-to-env github floweyvar3
-        flowey.exe v 13 'flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs:94:51' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 13 'flowey_lib_common::publish_test_results:12:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar3
+        flowey.exe v 13 'flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__8
       uses: actions/upload-artifact@v7
@@ -1617,8 +1617,8 @@ jobs:
         flowey.exe e 13 flowey_lib_hvlite::build_nextest_unit_tests 2
         flowey.exe e 13 flowey_lib_common::publish_test_results 0
         flowey.exe e 13 flowey_lib_common::publish_test_results 1
-        flowey.exe v 13 'flowey_lib_common::publish_test_results:2:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:94:51 write-to-env github floweyvar1
-        flowey.exe v 13 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:94:51' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 13 'flowey_lib_common::publish_test_results:2:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar1
+        flowey.exe v 13 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__2
       uses: actions/upload-artifact@v7
@@ -1637,8 +1637,8 @@ jobs:
         flowey.exe e 13 flowey_lib_hvlite::build_nextest_unit_tests 3
         flowey.exe e 13 flowey_lib_common::publish_test_results 3
         flowey.exe e 13 flowey_lib_common::publish_test_results 4
-        flowey.exe v 13 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:94:51 write-to-env github floweyvar2
-        flowey.exe v 13 'flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:94:51' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 13 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar2
+        flowey.exe v 13 'flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__5
       uses: actions/upload-artifact@v7
@@ -1755,8 +1755,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 14 flowey_lib_common::git_checkout 0
-        flowey v 14 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar10
-        flowey v 14 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
+        flowey v 14 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env github floweyvar10
+        flowey v 14 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -1768,7 +1768,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey v 14 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey v 14 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
         flowey e 14 flowey_lib_common::git_checkout 3
@@ -1787,8 +1787,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 14 flowey_lib_common::cache 4
-        flowey v 14 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
-        flowey v 14 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
+        flowey v 14 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar8
+        flowey v 14 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar9
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
@@ -1798,7 +1798,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 14 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        flowey v 14 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
         flowey e 14 flowey_lib_common::cache 6
@@ -1884,8 +1884,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 14 flowey_lib_common::cache 0
-        flowey v 14 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
-        flowey v 14 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
+        flowey v 14 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar6
+        flowey v 14 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar7
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -1895,7 +1895,7 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
-        flowey v 14 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey v 14 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey e 14 flowey_lib_common::cache 2
@@ -1920,8 +1920,8 @@ jobs:
         flowey e 14 flowey_lib_hvlite::build_nextest_unit_tests 3
         flowey e 14 flowey_lib_common::publish_test_results 6
         flowey e 14 flowey_lib_common::publish_test_results 7
-        flowey v 14 'flowey_lib_common::publish_test_results:12:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs:94:51 write-to-env github floweyvar3
-        flowey v 14 'flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs:94:51' write-to-env github FLOWEY_CONDITION
+        flowey v 14 'flowey_lib_common::publish_test_results:12:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar3
+        flowey v 14 'flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__8
       uses: actions/upload-artifact@v7
@@ -1940,8 +1940,8 @@ jobs:
         flowey e 14 flowey_lib_hvlite::build_nextest_unit_tests 4
         flowey e 14 flowey_lib_common::publish_test_results 9
         flowey e 14 flowey_lib_common::publish_test_results 10
-        flowey v 14 'flowey_lib_common::publish_test_results:17:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:15:flowey_lib_common/src/publish_test_results.rs:94:51 write-to-env github floweyvar4
-        flowey v 14 'flowey_lib_common::publish_test_results:15:flowey_lib_common/src/publish_test_results.rs:94:51' write-to-env github FLOWEY_CONDITION
+        flowey v 14 'flowey_lib_common::publish_test_results:17:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:15:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar4
+        flowey v 14 'flowey_lib_common::publish_test_results:15:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__11
       uses: actions/upload-artifact@v7
@@ -1960,8 +1960,8 @@ jobs:
         flowey e 14 flowey_lib_hvlite::build_nextest_unit_tests 5
         flowey e 14 flowey_lib_common::publish_test_results 12
         flowey e 14 flowey_lib_common::publish_test_results 13
-        flowey v 14 'flowey_lib_common::publish_test_results:22:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:20:flowey_lib_common/src/publish_test_results.rs:94:51 write-to-env github floweyvar5
-        flowey v 14 'flowey_lib_common::publish_test_results:20:flowey_lib_common/src/publish_test_results.rs:94:51' write-to-env github FLOWEY_CONDITION
+        flowey v 14 'flowey_lib_common::publish_test_results:22:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:20:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar5
+        flowey v 14 'flowey_lib_common::publish_test_results:20:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__14
       uses: actions/upload-artifact@v7
@@ -1995,8 +1995,8 @@ jobs:
         flowey e 14 flowey_lib_hvlite::build_nextest_unit_tests 1
         flowey e 14 flowey_lib_common::publish_test_results 0
         flowey e 14 flowey_lib_common::publish_test_results 1
-        flowey v 14 'flowey_lib_common::publish_test_results:2:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:94:51 write-to-env github floweyvar1
-        flowey v 14 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:94:51' write-to-env github FLOWEY_CONDITION
+        flowey v 14 'flowey_lib_common::publish_test_results:2:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar1
+        flowey v 14 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__2
       uses: actions/upload-artifact@v7
@@ -2015,8 +2015,8 @@ jobs:
         flowey e 14 flowey_lib_hvlite::build_nextest_unit_tests 2
         flowey e 14 flowey_lib_common::publish_test_results 3
         flowey e 14 flowey_lib_common::publish_test_results 4
-        flowey v 14 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:94:51 write-to-env github floweyvar2
-        flowey v 14 'flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:94:51' write-to-env github FLOWEY_CONDITION
+        flowey v 14 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar2
+        flowey v 14 'flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__5
       uses: actions/upload-artifact@v7
@@ -2132,8 +2132,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 15 flowey_lib_common::git_checkout 0
-        flowey v 15 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar11
-        flowey v 15 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
+        flowey v 15 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env github floweyvar11
+        flowey v 15 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -2145,7 +2145,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey v 15 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey v 15 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
         flowey e 15 flowey_lib_common::git_checkout 3
@@ -2162,8 +2162,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 15 flowey_lib_common::cache 4
-        flowey v 15 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar9
-        flowey v 15 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar10
+        flowey v 15 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar9
+        flowey v 15 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar10
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
@@ -2173,7 +2173,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 15 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        flowey v 15 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
         flowey e 15 flowey_lib_common::cache 6
@@ -2252,8 +2252,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 15 flowey_lib_common::cache 0
-        flowey v 15 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar7
-        flowey v 15 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar8
+        flowey v 15 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar7
+        flowey v 15 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar8
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -2263,7 +2263,7 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
-        flowey v 15 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey v 15 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey e 15 flowey_lib_common::cache 2
@@ -2288,8 +2288,8 @@ jobs:
         flowey e 15 flowey_lib_hvlite::build_nextest_unit_tests 3
         flowey e 15 flowey_lib_common::publish_test_results 6
         flowey e 15 flowey_lib_common::publish_test_results 7
-        flowey v 15 'flowey_lib_common::publish_test_results:12:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs:94:51 write-to-env github floweyvar3
-        flowey v 15 'flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs:94:51' write-to-env github FLOWEY_CONDITION
+        flowey v 15 'flowey_lib_common::publish_test_results:12:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar3
+        flowey v 15 'flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__8
       uses: actions/upload-artifact@v7
@@ -2308,8 +2308,8 @@ jobs:
         flowey e 15 flowey_lib_hvlite::build_nextest_unit_tests 4
         flowey e 15 flowey_lib_common::publish_test_results 9
         flowey e 15 flowey_lib_common::publish_test_results 10
-        flowey v 15 'flowey_lib_common::publish_test_results:17:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:15:flowey_lib_common/src/publish_test_results.rs:94:51 write-to-env github floweyvar4
-        flowey v 15 'flowey_lib_common::publish_test_results:15:flowey_lib_common/src/publish_test_results.rs:94:51' write-to-env github FLOWEY_CONDITION
+        flowey v 15 'flowey_lib_common::publish_test_results:17:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:15:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar4
+        flowey v 15 'flowey_lib_common::publish_test_results:15:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__11
       uses: actions/upload-artifact@v7
@@ -2328,8 +2328,8 @@ jobs:
         flowey e 15 flowey_lib_hvlite::build_nextest_unit_tests 5
         flowey e 15 flowey_lib_common::publish_test_results 12
         flowey e 15 flowey_lib_common::publish_test_results 13
-        flowey v 15 'flowey_lib_common::publish_test_results:22:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:20:flowey_lib_common/src/publish_test_results.rs:94:51 write-to-env github floweyvar5
-        flowey v 15 'flowey_lib_common::publish_test_results:20:flowey_lib_common/src/publish_test_results.rs:94:51' write-to-env github FLOWEY_CONDITION
+        flowey v 15 'flowey_lib_common::publish_test_results:22:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:20:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar5
+        flowey v 15 'flowey_lib_common::publish_test_results:20:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__14
       uses: actions/upload-artifact@v7
@@ -2348,8 +2348,8 @@ jobs:
         flowey e 15 flowey_lib_hvlite::build_nextest_unit_tests 6
         flowey e 15 flowey_lib_common::publish_test_results 15
         flowey e 15 flowey_lib_common::publish_test_results 16
-        flowey v 15 'flowey_lib_common::publish_test_results:27:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:25:flowey_lib_common/src/publish_test_results.rs:94:51 write-to-env github floweyvar6
-        flowey v 15 'flowey_lib_common::publish_test_results:25:flowey_lib_common/src/publish_test_results.rs:94:51' write-to-env github FLOWEY_CONDITION
+        flowey v 15 'flowey_lib_common::publish_test_results:27:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:25:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar6
+        flowey v 15 'flowey_lib_common::publish_test_results:25:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__17
       uses: actions/upload-artifact@v7
@@ -2383,8 +2383,8 @@ jobs:
         flowey e 15 flowey_lib_hvlite::build_nextest_unit_tests 1
         flowey e 15 flowey_lib_common::publish_test_results 0
         flowey e 15 flowey_lib_common::publish_test_results 1
-        flowey v 15 'flowey_lib_common::publish_test_results:2:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:94:51 write-to-env github floweyvar1
-        flowey v 15 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:94:51' write-to-env github FLOWEY_CONDITION
+        flowey v 15 'flowey_lib_common::publish_test_results:2:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar1
+        flowey v 15 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__2
       uses: actions/upload-artifact@v7
@@ -2403,8 +2403,8 @@ jobs:
         flowey e 15 flowey_lib_hvlite::build_nextest_unit_tests 2
         flowey e 15 flowey_lib_common::publish_test_results 3
         flowey e 15 flowey_lib_common::publish_test_results 4
-        flowey v 15 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:94:51 write-to-env github floweyvar2
-        flowey v 15 'flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:94:51' write-to-env github FLOWEY_CONDITION
+        flowey v 15 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar2
+        flowey v 15 'flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__5
       uses: actions/upload-artifact@v7
@@ -2520,8 +2520,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey.exe e 16 flowey_lib_common::git_checkout 0
-        flowey.exe v 16 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar8
-        flowey.exe v 16 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 16 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env github floweyvar8
+        flowey.exe v 16 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -2533,7 +2533,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey.exe v 16 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey.exe v 16 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
         flowey.exe e 16 flowey_lib_common::git_checkout 3
@@ -2552,8 +2552,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 16 flowey_lib_common::cache 4
-        flowey.exe v 16 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
-        flowey.exe v 16 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
+        flowey.exe v 16 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar6
+        flowey.exe v 16 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar7
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
@@ -2563,7 +2563,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 16 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        flowey.exe v 16 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
         flowey.exe e 16 flowey_lib_common::cache 6
@@ -2608,8 +2608,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 16 flowey_lib_common::cache 0
-        flowey.exe v 16 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
-        flowey.exe v 16 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
+        flowey.exe v 16 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar4
+        flowey.exe v 16 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar5
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -2619,7 +2619,7 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
-        flowey.exe v 16 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey.exe v 16 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey.exe e 16 flowey_lib_common::cache 2
@@ -2655,8 +2655,8 @@ jobs:
         flowey.exe e 16 flowey_lib_hvlite::build_nextest_unit_tests 1
         flowey.exe e 16 flowey_lib_common::publish_test_results 6
         flowey.exe e 16 flowey_lib_common::publish_test_results 7
-        flowey.exe v 16 'flowey_lib_common::publish_test_results:12:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs:94:51 write-to-env github floweyvar3
-        flowey.exe v 16 'flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs:94:51' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 16 'flowey_lib_common::publish_test_results:12:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar3
+        flowey.exe v 16 'flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__8
       uses: actions/upload-artifact@v7
@@ -2675,8 +2675,8 @@ jobs:
         flowey.exe e 16 flowey_lib_hvlite::build_nextest_unit_tests 2
         flowey.exe e 16 flowey_lib_common::publish_test_results 0
         flowey.exe e 16 flowey_lib_common::publish_test_results 1
-        flowey.exe v 16 'flowey_lib_common::publish_test_results:2:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:94:51 write-to-env github floweyvar1
-        flowey.exe v 16 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:94:51' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 16 'flowey_lib_common::publish_test_results:2:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar1
+        flowey.exe v 16 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__2
       uses: actions/upload-artifact@v7
@@ -2695,8 +2695,8 @@ jobs:
         flowey.exe e 16 flowey_lib_hvlite::build_nextest_unit_tests 3
         flowey.exe e 16 flowey_lib_common::publish_test_results 3
         flowey.exe e 16 flowey_lib_common::publish_test_results 4
-        flowey.exe v 16 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:94:51 write-to-env github floweyvar2
-        flowey.exe v 16 'flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:94:51' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 16 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar2
+        flowey.exe v 16 'flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__5
       uses: actions/upload-artifact@v7
@@ -2818,8 +2818,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 17 flowey_lib_common::git_checkout 0
-        flowey v 17 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar10
-        flowey v 17 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
+        flowey v 17 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env github floweyvar10
+        flowey v 17 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -2831,7 +2831,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey v 17 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey v 17 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
         flowey e 17 flowey_lib_common::git_checkout 3
@@ -2850,8 +2850,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 17 flowey_lib_common::cache 4
-        flowey v 17 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
-        flowey v 17 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
+        flowey v 17 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar8
+        flowey v 17 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar9
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
@@ -2861,7 +2861,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 17 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        flowey v 17 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
         flowey e 17 flowey_lib_common::cache 6
@@ -2918,8 +2918,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 17 flowey_lib_common::cache 0
-        flowey v 17 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
-        flowey v 17 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
+        flowey v 17 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar6
+        flowey v 17 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar7
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -2929,7 +2929,7 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
-        flowey v 17 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey v 17 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey e 17 flowey_lib_common::cache 2
@@ -2954,8 +2954,8 @@ jobs:
         flowey e 17 flowey_lib_hvlite::build_nextest_unit_tests 3
         flowey e 17 flowey_lib_common::publish_test_results 6
         flowey e 17 flowey_lib_common::publish_test_results 7
-        flowey v 17 'flowey_lib_common::publish_test_results:12:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs:94:51 write-to-env github floweyvar3
-        flowey v 17 'flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs:94:51' write-to-env github FLOWEY_CONDITION
+        flowey v 17 'flowey_lib_common::publish_test_results:12:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar3
+        flowey v 17 'flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__8
       uses: actions/upload-artifact@v7
@@ -2974,8 +2974,8 @@ jobs:
         flowey e 17 flowey_lib_hvlite::build_nextest_unit_tests 4
         flowey e 17 flowey_lib_common::publish_test_results 9
         flowey e 17 flowey_lib_common::publish_test_results 10
-        flowey v 17 'flowey_lib_common::publish_test_results:17:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:15:flowey_lib_common/src/publish_test_results.rs:94:51 write-to-env github floweyvar4
-        flowey v 17 'flowey_lib_common::publish_test_results:15:flowey_lib_common/src/publish_test_results.rs:94:51' write-to-env github FLOWEY_CONDITION
+        flowey v 17 'flowey_lib_common::publish_test_results:17:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:15:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar4
+        flowey v 17 'flowey_lib_common::publish_test_results:15:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__11
       uses: actions/upload-artifact@v7
@@ -2994,8 +2994,8 @@ jobs:
         flowey e 17 flowey_lib_hvlite::build_nextest_unit_tests 5
         flowey e 17 flowey_lib_common::publish_test_results 12
         flowey e 17 flowey_lib_common::publish_test_results 13
-        flowey v 17 'flowey_lib_common::publish_test_results:22:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:20:flowey_lib_common/src/publish_test_results.rs:94:51 write-to-env github floweyvar5
-        flowey v 17 'flowey_lib_common::publish_test_results:20:flowey_lib_common/src/publish_test_results.rs:94:51' write-to-env github FLOWEY_CONDITION
+        flowey v 17 'flowey_lib_common::publish_test_results:22:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:20:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar5
+        flowey v 17 'flowey_lib_common::publish_test_results:20:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__14
       uses: actions/upload-artifact@v7
@@ -3029,8 +3029,8 @@ jobs:
         flowey e 17 flowey_lib_hvlite::build_nextest_unit_tests 1
         flowey e 17 flowey_lib_common::publish_test_results 0
         flowey e 17 flowey_lib_common::publish_test_results 1
-        flowey v 17 'flowey_lib_common::publish_test_results:2:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:94:51 write-to-env github floweyvar1
-        flowey v 17 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:94:51' write-to-env github FLOWEY_CONDITION
+        flowey v 17 'flowey_lib_common::publish_test_results:2:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar1
+        flowey v 17 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__2
       uses: actions/upload-artifact@v7
@@ -3049,8 +3049,8 @@ jobs:
         flowey e 17 flowey_lib_hvlite::build_nextest_unit_tests 2
         flowey e 17 flowey_lib_common::publish_test_results 3
         flowey e 17 flowey_lib_common::publish_test_results 4
-        flowey v 17 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:94:51 write-to-env github floweyvar2
-        flowey v 17 'flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:94:51' write-to-env github FLOWEY_CONDITION
+        flowey v 17 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar2
+        flowey v 17 'flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__5
       uses: actions/upload-artifact@v7
@@ -3166,8 +3166,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 18 flowey_lib_common::git_checkout 0
-        flowey v 18 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar11
-        flowey v 18 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
+        flowey v 18 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env github floweyvar11
+        flowey v 18 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -3179,7 +3179,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey v 18 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey v 18 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
         flowey e 18 flowey_lib_common::git_checkout 3
@@ -3196,8 +3196,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 18 flowey_lib_common::cache 4
-        flowey v 18 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar9
-        flowey v 18 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar10
+        flowey v 18 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar9
+        flowey v 18 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar10
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
@@ -3207,7 +3207,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 18 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        flowey v 18 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
         flowey e 18 flowey_lib_common::cache 6
@@ -3286,8 +3286,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 18 flowey_lib_common::cache 0
-        flowey v 18 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar7
-        flowey v 18 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar8
+        flowey v 18 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar7
+        flowey v 18 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar8
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -3297,7 +3297,7 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
-        flowey v 18 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey v 18 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey e 18 flowey_lib_common::cache 2
@@ -3322,8 +3322,8 @@ jobs:
         flowey e 18 flowey_lib_hvlite::build_nextest_unit_tests 3
         flowey e 18 flowey_lib_common::publish_test_results 6
         flowey e 18 flowey_lib_common::publish_test_results 7
-        flowey v 18 'flowey_lib_common::publish_test_results:12:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs:94:51 write-to-env github floweyvar3
-        flowey v 18 'flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs:94:51' write-to-env github FLOWEY_CONDITION
+        flowey v 18 'flowey_lib_common::publish_test_results:12:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar3
+        flowey v 18 'flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__8
       uses: actions/upload-artifact@v7
@@ -3342,8 +3342,8 @@ jobs:
         flowey e 18 flowey_lib_hvlite::build_nextest_unit_tests 4
         flowey e 18 flowey_lib_common::publish_test_results 9
         flowey e 18 flowey_lib_common::publish_test_results 10
-        flowey v 18 'flowey_lib_common::publish_test_results:17:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:15:flowey_lib_common/src/publish_test_results.rs:94:51 write-to-env github floweyvar4
-        flowey v 18 'flowey_lib_common::publish_test_results:15:flowey_lib_common/src/publish_test_results.rs:94:51' write-to-env github FLOWEY_CONDITION
+        flowey v 18 'flowey_lib_common::publish_test_results:17:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:15:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar4
+        flowey v 18 'flowey_lib_common::publish_test_results:15:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__11
       uses: actions/upload-artifact@v7
@@ -3362,8 +3362,8 @@ jobs:
         flowey e 18 flowey_lib_hvlite::build_nextest_unit_tests 5
         flowey e 18 flowey_lib_common::publish_test_results 12
         flowey e 18 flowey_lib_common::publish_test_results 13
-        flowey v 18 'flowey_lib_common::publish_test_results:22:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:20:flowey_lib_common/src/publish_test_results.rs:94:51 write-to-env github floweyvar5
-        flowey v 18 'flowey_lib_common::publish_test_results:20:flowey_lib_common/src/publish_test_results.rs:94:51' write-to-env github FLOWEY_CONDITION
+        flowey v 18 'flowey_lib_common::publish_test_results:22:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:20:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar5
+        flowey v 18 'flowey_lib_common::publish_test_results:20:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__14
       uses: actions/upload-artifact@v7
@@ -3382,8 +3382,8 @@ jobs:
         flowey e 18 flowey_lib_hvlite::build_nextest_unit_tests 6
         flowey e 18 flowey_lib_common::publish_test_results 15
         flowey e 18 flowey_lib_common::publish_test_results 16
-        flowey v 18 'flowey_lib_common::publish_test_results:27:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:25:flowey_lib_common/src/publish_test_results.rs:94:51 write-to-env github floweyvar6
-        flowey v 18 'flowey_lib_common::publish_test_results:25:flowey_lib_common/src/publish_test_results.rs:94:51' write-to-env github FLOWEY_CONDITION
+        flowey v 18 'flowey_lib_common::publish_test_results:27:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:25:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar6
+        flowey v 18 'flowey_lib_common::publish_test_results:25:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__17
       uses: actions/upload-artifact@v7
@@ -3417,8 +3417,8 @@ jobs:
         flowey e 18 flowey_lib_hvlite::build_nextest_unit_tests 1
         flowey e 18 flowey_lib_common::publish_test_results 0
         flowey e 18 flowey_lib_common::publish_test_results 1
-        flowey v 18 'flowey_lib_common::publish_test_results:2:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:94:51 write-to-env github floweyvar1
-        flowey v 18 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:94:51' write-to-env github FLOWEY_CONDITION
+        flowey v 18 'flowey_lib_common::publish_test_results:2:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar1
+        flowey v 18 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__2
       uses: actions/upload-artifact@v7
@@ -3437,8 +3437,8 @@ jobs:
         flowey e 18 flowey_lib_hvlite::build_nextest_unit_tests 2
         flowey e 18 flowey_lib_common::publish_test_results 3
         flowey e 18 flowey_lib_common::publish_test_results 4
-        flowey v 18 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:94:51 write-to-env github floweyvar2
-        flowey v 18 'flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:94:51' write-to-env github FLOWEY_CONDITION
+        flowey v 18 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar2
+        flowey v 18 'flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__5
       uses: actions/upload-artifact@v7
@@ -3528,8 +3528,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 19 flowey_lib_common::cache 0
-        flowey.exe v 19 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
-        flowey.exe v 19 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
+        flowey.exe v 19 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar4
+        flowey.exe v 19 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar5
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -3539,7 +3539,7 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
-        flowey.exe v 19 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey.exe v 19 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey.exe e 19 flowey_lib_common::cache 2
@@ -3548,8 +3548,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey.exe e 19 flowey_lib_common::git_checkout 0
-        flowey.exe v 19 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar3
-        flowey.exe v 19 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 19 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env github floweyvar3
+        flowey.exe v 19 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -3561,7 +3561,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey.exe v 19 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey.exe v 19 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
         flowey.exe e 19 flowey_lib_common::git_checkout 3
@@ -3596,8 +3596,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 19 flowey_lib_common::cache 8
-        flowey.exe v 19 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
-        flowey.exe v 19 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
+        flowey.exe v 19 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar8
+        flowey.exe v 19 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar9
       shell: bash
     - id: flowey_lib_common__cache__9
       uses: actions/cache@v5
@@ -3607,7 +3607,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 19 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
+        flowey.exe v 19 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
         EOF
         flowey.exe e 19 flowey_lib_common::cache 10
@@ -3630,8 +3630,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 19 flowey_lib_common::cache 4
-        flowey.exe v 19 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
-        flowey.exe v 19 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
+        flowey.exe v 19 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar6
+        flowey.exe v 19 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar7
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
@@ -3641,12 +3641,12 @@ jobs:
       name: 'Restore cache: gh-cli'
     - name: installing gh
       run: |-
-        flowey.exe v 19 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        flowey.exe v 19 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
         flowey.exe e 19 flowey_lib_common::cache 6
         flowey.exe e 19 flowey_lib_common::download_gh_cli 1
-        flowey.exe v 19 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
+        flowey.exe v 19 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.token <<EOF
         ${{ github.token }}
         EOF
       shell: bash
@@ -3706,8 +3706,8 @@ jobs:
         flowey.exe e 19 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
         flowey.exe e 19 flowey_lib_common::publish_test_results 0
         flowey.exe e 19 flowey_lib_common::publish_test_results 1
-        flowey.exe v 19 'flowey_lib_common::publish_test_results:2:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:94:51 write-to-env github floweyvar1
-        flowey.exe v 19 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:94:51' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 19 'flowey_lib_common::publish_test_results:2:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar1
+        flowey.exe v 19 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__2
       uses: actions/upload-artifact@v7
@@ -3721,8 +3721,8 @@ jobs:
         flowey.exe e 19 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
         flowey.exe e 19 flowey_lib_common::publish_test_results 3
         flowey.exe e 19 flowey_lib_common::publish_test_results 4
-        flowey.exe v 19 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:150:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:142:57 write-to-env github floweyvar2
-        flowey.exe v 19 'flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:142:57' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 19 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar2
+        flowey.exe v 19 'flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__5
       uses: actions/upload-artifact@v7
@@ -3840,8 +3840,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey.exe e 2 flowey_lib_common::git_checkout 0
-        flowey.exe v 2 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar1
-        flowey.exe v 2 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 2 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env github floweyvar1
+        flowey.exe v 2 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -3853,7 +3853,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey.exe v 2 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey.exe v 2 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
         flowey.exe e 2 flowey_lib_common::git_checkout 3
@@ -3872,8 +3872,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 2 flowey_lib_common::cache 0
-        flowey.exe v 2 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar2
-        flowey.exe v 2 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar3
+        flowey.exe v 2 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar2
+        flowey.exe v 2 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar3
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -3883,7 +3883,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 2 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey.exe v 2 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey.exe e 2 flowey_lib_common::cache 2
@@ -3996,8 +3996,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 20 flowey_lib_common::cache 0
-        flowey.exe v 20 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
-        flowey.exe v 20 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
+        flowey.exe v 20 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar4
+        flowey.exe v 20 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar5
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -4007,7 +4007,7 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
-        flowey.exe v 20 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey.exe v 20 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey.exe e 20 flowey_lib_common::cache 2
@@ -4016,8 +4016,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey.exe e 20 flowey_lib_common::git_checkout 0
-        flowey.exe v 20 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar3
-        flowey.exe v 20 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 20 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env github floweyvar3
+        flowey.exe v 20 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -4029,7 +4029,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey.exe v 20 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey.exe v 20 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
         flowey.exe e 20 flowey_lib_common::git_checkout 3
@@ -4064,8 +4064,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 20 flowey_lib_common::cache 8
-        flowey.exe v 20 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
-        flowey.exe v 20 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
+        flowey.exe v 20 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar8
+        flowey.exe v 20 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar9
       shell: bash
     - id: flowey_lib_common__cache__9
       uses: actions/cache@v5
@@ -4075,7 +4075,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 20 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
+        flowey.exe v 20 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
         EOF
         flowey.exe e 20 flowey_lib_common::cache 10
@@ -4098,8 +4098,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 20 flowey_lib_common::cache 4
-        flowey.exe v 20 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
-        flowey.exe v 20 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
+        flowey.exe v 20 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar6
+        flowey.exe v 20 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar7
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
@@ -4109,12 +4109,12 @@ jobs:
       name: 'Restore cache: gh-cli'
     - name: installing gh
       run: |-
-        flowey.exe v 20 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        flowey.exe v 20 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
         flowey.exe e 20 flowey_lib_common::cache 6
         flowey.exe e 20 flowey_lib_common::download_gh_cli 1
-        flowey.exe v 20 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
+        flowey.exe v 20 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.token <<EOF
         ${{ github.token }}
         EOF
       shell: bash
@@ -4169,8 +4169,8 @@ jobs:
         flowey.exe e 20 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
         flowey.exe e 20 flowey_lib_common::publish_test_results 0
         flowey.exe e 20 flowey_lib_common::publish_test_results 1
-        flowey.exe v 20 'flowey_lib_common::publish_test_results:2:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:94:51 write-to-env github floweyvar1
-        flowey.exe v 20 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:94:51' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 20 'flowey_lib_common::publish_test_results:2:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar1
+        flowey.exe v 20 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__2
       uses: actions/upload-artifact@v7
@@ -4184,8 +4184,8 @@ jobs:
         flowey.exe e 20 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
         flowey.exe e 20 flowey_lib_common::publish_test_results 3
         flowey.exe e 20 flowey_lib_common::publish_test_results 4
-        flowey.exe v 20 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:150:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:142:57 write-to-env github floweyvar2
-        flowey.exe v 20 'flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:142:57' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 20 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar2
+        flowey.exe v 20 'flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__5
       uses: actions/upload-artifact@v7
@@ -4274,8 +4274,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 21 flowey_lib_common::cache 0
-        flowey.exe v 21 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
-        flowey.exe v 21 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
+        flowey.exe v 21 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar4
+        flowey.exe v 21 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar5
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -4285,7 +4285,7 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
-        flowey.exe v 21 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey.exe v 21 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey.exe e 21 flowey_lib_common::cache 2
@@ -4294,8 +4294,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey.exe e 21 flowey_lib_common::git_checkout 0
-        flowey.exe v 21 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar3
-        flowey.exe v 21 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 21 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env github floweyvar3
+        flowey.exe v 21 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -4307,7 +4307,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey.exe v 21 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey.exe v 21 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
         flowey.exe e 21 flowey_lib_common::git_checkout 3
@@ -4342,8 +4342,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 21 flowey_lib_common::cache 8
-        flowey.exe v 21 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
-        flowey.exe v 21 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
+        flowey.exe v 21 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar8
+        flowey.exe v 21 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar9
       shell: bash
     - id: flowey_lib_common__cache__9
       uses: actions/cache@v5
@@ -4353,7 +4353,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 21 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
+        flowey.exe v 21 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
         EOF
         flowey.exe e 21 flowey_lib_common::cache 10
@@ -4376,8 +4376,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 21 flowey_lib_common::cache 4
-        flowey.exe v 21 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
-        flowey.exe v 21 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
+        flowey.exe v 21 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar6
+        flowey.exe v 21 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar7
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
@@ -4387,12 +4387,12 @@ jobs:
       name: 'Restore cache: gh-cli'
     - name: installing gh
       run: |-
-        flowey.exe v 21 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        flowey.exe v 21 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
         flowey.exe e 21 flowey_lib_common::cache 6
         flowey.exe e 21 flowey_lib_common::download_gh_cli 1
-        flowey.exe v 21 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
+        flowey.exe v 21 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.token <<EOF
         ${{ github.token }}
         EOF
       shell: bash
@@ -4452,8 +4452,8 @@ jobs:
         flowey.exe e 21 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
         flowey.exe e 21 flowey_lib_common::publish_test_results 0
         flowey.exe e 21 flowey_lib_common::publish_test_results 1
-        flowey.exe v 21 'flowey_lib_common::publish_test_results:2:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:94:51 write-to-env github floweyvar1
-        flowey.exe v 21 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:94:51' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 21 'flowey_lib_common::publish_test_results:2:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar1
+        flowey.exe v 21 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__2
       uses: actions/upload-artifact@v7
@@ -4467,8 +4467,8 @@ jobs:
         flowey.exe e 21 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
         flowey.exe e 21 flowey_lib_common::publish_test_results 3
         flowey.exe e 21 flowey_lib_common::publish_test_results 4
-        flowey.exe v 21 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:150:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:142:57 write-to-env github floweyvar2
-        flowey.exe v 21 'flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:142:57' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 21 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar2
+        flowey.exe v 21 'flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__5
       uses: actions/upload-artifact@v7
@@ -4556,8 +4556,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 22 flowey_lib_common::cache 0
-        flowey.exe v 22 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
-        flowey.exe v 22 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
+        flowey.exe v 22 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar4
+        flowey.exe v 22 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar5
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -4567,7 +4567,7 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
-        flowey.exe v 22 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey.exe v 22 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey.exe e 22 flowey_lib_common::cache 2
@@ -4576,8 +4576,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey.exe e 22 flowey_lib_common::git_checkout 0
-        flowey.exe v 22 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar3
-        flowey.exe v 22 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 22 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env github floweyvar3
+        flowey.exe v 22 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -4589,7 +4589,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey.exe v 22 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey.exe v 22 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
         flowey.exe e 22 flowey_lib_common::git_checkout 3
@@ -4624,8 +4624,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 22 flowey_lib_common::cache 8
-        flowey.exe v 22 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
-        flowey.exe v 22 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
+        flowey.exe v 22 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar8
+        flowey.exe v 22 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar9
       shell: bash
     - id: flowey_lib_common__cache__9
       uses: actions/cache@v5
@@ -4635,7 +4635,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 22 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
+        flowey.exe v 22 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
         EOF
         flowey.exe e 22 flowey_lib_common::cache 10
@@ -4658,8 +4658,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 22 flowey_lib_common::cache 4
-        flowey.exe v 22 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
-        flowey.exe v 22 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
+        flowey.exe v 22 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar6
+        flowey.exe v 22 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar7
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
@@ -4669,12 +4669,12 @@ jobs:
       name: 'Restore cache: gh-cli'
     - name: installing gh
       run: |-
-        flowey.exe v 22 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        flowey.exe v 22 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
         flowey.exe e 22 flowey_lib_common::cache 6
         flowey.exe e 22 flowey_lib_common::download_gh_cli 1
-        flowey.exe v 22 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
+        flowey.exe v 22 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.token <<EOF
         ${{ github.token }}
         EOF
       shell: bash
@@ -4734,8 +4734,8 @@ jobs:
         flowey.exe e 22 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
         flowey.exe e 22 flowey_lib_common::publish_test_results 0
         flowey.exe e 22 flowey_lib_common::publish_test_results 1
-        flowey.exe v 22 'flowey_lib_common::publish_test_results:2:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:94:51 write-to-env github floweyvar1
-        flowey.exe v 22 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:94:51' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 22 'flowey_lib_common::publish_test_results:2:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar1
+        flowey.exe v 22 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__2
       uses: actions/upload-artifact@v7
@@ -4749,8 +4749,8 @@ jobs:
         flowey.exe e 22 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
         flowey.exe e 22 flowey_lib_common::publish_test_results 3
         flowey.exe e 22 flowey_lib_common::publish_test_results 4
-        flowey.exe v 22 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:150:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:142:57 write-to-env github floweyvar2
-        flowey.exe v 22 'flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:142:57' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 22 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar2
+        flowey.exe v 22 'flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__5
       uses: actions/upload-artifact@v7
@@ -4839,8 +4839,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 23 flowey_lib_common::cache 0
-        flowey.exe v 23 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
-        flowey.exe v 23 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
+        flowey.exe v 23 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar4
+        flowey.exe v 23 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar5
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -4850,7 +4850,7 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
-        flowey.exe v 23 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey.exe v 23 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey.exe e 23 flowey_lib_common::cache 2
@@ -4859,8 +4859,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey.exe e 23 flowey_lib_common::git_checkout 0
-        flowey.exe v 23 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar3
-        flowey.exe v 23 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 23 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env github floweyvar3
+        flowey.exe v 23 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -4872,7 +4872,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey.exe v 23 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey.exe v 23 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
         flowey.exe e 23 flowey_lib_common::git_checkout 3
@@ -4907,8 +4907,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 23 flowey_lib_common::cache 8
-        flowey.exe v 23 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
-        flowey.exe v 23 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
+        flowey.exe v 23 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar8
+        flowey.exe v 23 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar9
       shell: bash
     - id: flowey_lib_common__cache__9
       uses: actions/cache@v5
@@ -4918,7 +4918,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 23 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
+        flowey.exe v 23 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
         EOF
         flowey.exe e 23 flowey_lib_common::cache 10
@@ -4941,8 +4941,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 23 flowey_lib_common::cache 4
-        flowey.exe v 23 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
-        flowey.exe v 23 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
+        flowey.exe v 23 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar6
+        flowey.exe v 23 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar7
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
@@ -4952,12 +4952,12 @@ jobs:
       name: 'Restore cache: gh-cli'
     - name: installing gh
       run: |-
-        flowey.exe v 23 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        flowey.exe v 23 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
         flowey.exe e 23 flowey_lib_common::cache 6
         flowey.exe e 23 flowey_lib_common::download_gh_cli 1
-        flowey.exe v 23 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
+        flowey.exe v 23 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.token <<EOF
         ${{ github.token }}
         EOF
       shell: bash
@@ -5017,8 +5017,8 @@ jobs:
         flowey.exe e 23 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
         flowey.exe e 23 flowey_lib_common::publish_test_results 0
         flowey.exe e 23 flowey_lib_common::publish_test_results 1
-        flowey.exe v 23 'flowey_lib_common::publish_test_results:2:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:94:51 write-to-env github floweyvar1
-        flowey.exe v 23 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:94:51' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 23 'flowey_lib_common::publish_test_results:2:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar1
+        flowey.exe v 23 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__2
       uses: actions/upload-artifact@v7
@@ -5032,8 +5032,8 @@ jobs:
         flowey.exe e 23 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
         flowey.exe e 23 flowey_lib_common::publish_test_results 3
         flowey.exe e 23 flowey_lib_common::publish_test_results 4
-        flowey.exe v 23 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:150:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:142:57 write-to-env github floweyvar2
-        flowey.exe v 23 'flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:142:57' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 23 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar2
+        flowey.exe v 23 'flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__5
       uses: actions/upload-artifact@v7
@@ -5118,8 +5118,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 24 flowey_lib_common::cache 0
-        flowey v 24 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
-        flowey v 24 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
+        flowey v 24 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar4
+        flowey v 24 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar5
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -5129,7 +5129,7 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
-        flowey v 24 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey v 24 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey e 24 flowey_lib_common::cache 2
@@ -5138,8 +5138,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 24 flowey_lib_common::git_checkout 0
-        flowey v 24 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar3
-        flowey v 24 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
+        flowey v 24 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env github floweyvar3
+        flowey v 24 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -5151,7 +5151,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey v 24 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey v 24 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
         flowey e 24 flowey_lib_common::git_checkout 3
@@ -5184,8 +5184,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 24 flowey_lib_common::cache 8
-        flowey v 24 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
-        flowey v 24 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
+        flowey v 24 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar8
+        flowey v 24 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar9
       shell: bash
     - id: flowey_lib_common__cache__9
       uses: actions/cache@v5
@@ -5195,7 +5195,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 24 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
+        flowey v 24 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
         EOF
         flowey e 24 flowey_lib_common::cache 10
@@ -5218,8 +5218,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 24 flowey_lib_common::cache 4
-        flowey v 24 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
-        flowey v 24 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
+        flowey v 24 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar6
+        flowey v 24 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar7
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
@@ -5229,12 +5229,12 @@ jobs:
       name: 'Restore cache: gh-cli'
     - name: installing gh
       run: |-
-        flowey v 24 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        flowey v 24 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
         flowey e 24 flowey_lib_common::cache 6
         flowey e 24 flowey_lib_common::download_gh_cli 1
-        flowey v 24 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
+        flowey v 24 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.token <<EOF
         ${{ github.token }}
         EOF
       shell: bash
@@ -5287,8 +5287,8 @@ jobs:
         flowey e 24 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
         flowey e 24 flowey_lib_common::publish_test_results 0
         flowey e 24 flowey_lib_common::publish_test_results 1
-        flowey v 24 'flowey_lib_common::publish_test_results:2:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:94:51 write-to-env github floweyvar1
-        flowey v 24 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:94:51' write-to-env github FLOWEY_CONDITION
+        flowey v 24 'flowey_lib_common::publish_test_results:2:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar1
+        flowey v 24 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__2
       uses: actions/upload-artifact@v7
@@ -5302,8 +5302,8 @@ jobs:
         flowey e 24 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
         flowey e 24 flowey_lib_common::publish_test_results 3
         flowey e 24 flowey_lib_common::publish_test_results 4
-        flowey v 24 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:150:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:142:57 write-to-env github floweyvar2
-        flowey v 24 'flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:142:57' write-to-env github FLOWEY_CONDITION
+        flowey v 24 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar2
+        flowey v 24 'flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__5
       uses: actions/upload-artifact@v7
@@ -5433,8 +5433,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 25 flowey_lib_common::cache 0
-        flowey v 25 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
-        flowey v 25 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
+        flowey v 25 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar4
+        flowey v 25 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar5
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -5444,7 +5444,7 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
-        flowey v 25 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey v 25 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey e 25 flowey_lib_common::cache 2
@@ -5453,8 +5453,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 25 flowey_lib_common::git_checkout 0
-        flowey v 25 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar3
-        flowey v 25 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
+        flowey v 25 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env github floweyvar3
+        flowey v 25 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -5466,7 +5466,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey v 25 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey v 25 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
         flowey e 25 flowey_lib_common::git_checkout 3
@@ -5499,8 +5499,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 25 flowey_lib_common::cache 8
-        flowey v 25 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
-        flowey v 25 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
+        flowey v 25 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar8
+        flowey v 25 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar9
       shell: bash
     - id: flowey_lib_common__cache__9
       uses: actions/cache@v5
@@ -5510,7 +5510,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 25 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
+        flowey v 25 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
         EOF
         flowey e 25 flowey_lib_common::cache 10
@@ -5533,8 +5533,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 25 flowey_lib_common::cache 4
-        flowey v 25 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
-        flowey v 25 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
+        flowey v 25 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar6
+        flowey v 25 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar7
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
@@ -5544,12 +5544,12 @@ jobs:
       name: 'Restore cache: gh-cli'
     - name: installing gh
       run: |-
-        flowey v 25 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        flowey v 25 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
         flowey e 25 flowey_lib_common::cache 6
         flowey e 25 flowey_lib_common::download_gh_cli 1
-        flowey v 25 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
+        flowey v 25 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.token <<EOF
         ${{ github.token }}
         EOF
       shell: bash
@@ -5601,8 +5601,8 @@ jobs:
         flowey e 25 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
         flowey e 25 flowey_lib_common::publish_test_results 0
         flowey e 25 flowey_lib_common::publish_test_results 1
-        flowey v 25 'flowey_lib_common::publish_test_results:2:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:94:51 write-to-env github floweyvar1
-        flowey v 25 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:94:51' write-to-env github FLOWEY_CONDITION
+        flowey v 25 'flowey_lib_common::publish_test_results:2:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar1
+        flowey v 25 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__2
       uses: actions/upload-artifact@v7
@@ -5616,8 +5616,8 @@ jobs:
         flowey e 25 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
         flowey e 25 flowey_lib_common::publish_test_results 3
         flowey e 25 flowey_lib_common::publish_test_results 4
-        flowey v 25 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:150:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:142:57 write-to-env github floweyvar2
-        flowey v 25 'flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:142:57' write-to-env github FLOWEY_CONDITION
+        flowey v 25 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar2
+        flowey v 25 'flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__5
       uses: actions/upload-artifact@v7
@@ -5748,8 +5748,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 26 flowey_lib_common::cache 0
-        flowey.exe v 26 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
-        flowey.exe v 26 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
+        flowey.exe v 26 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar4
+        flowey.exe v 26 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar5
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -5759,7 +5759,7 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
-        flowey.exe v 26 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey.exe v 26 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey.exe e 26 flowey_lib_common::cache 2
@@ -5768,8 +5768,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey.exe e 26 flowey_lib_common::git_checkout 0
-        flowey.exe v 26 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar3
-        flowey.exe v 26 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 26 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env github floweyvar3
+        flowey.exe v 26 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -5781,7 +5781,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey.exe v 26 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey.exe v 26 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
         flowey.exe e 26 flowey_lib_common::git_checkout 3
@@ -5811,8 +5811,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 26 flowey_lib_common::cache 8
-        flowey.exe v 26 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
-        flowey.exe v 26 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
+        flowey.exe v 26 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar8
+        flowey.exe v 26 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar9
       shell: bash
     - id: flowey_lib_common__cache__9
       uses: actions/cache@v5
@@ -5822,7 +5822,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 26 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
+        flowey.exe v 26 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
         EOF
         flowey.exe e 26 flowey_lib_common::cache 10
@@ -5845,8 +5845,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 26 flowey_lib_common::cache 4
-        flowey.exe v 26 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
-        flowey.exe v 26 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
+        flowey.exe v 26 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar6
+        flowey.exe v 26 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar7
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
@@ -5856,12 +5856,12 @@ jobs:
       name: 'Restore cache: gh-cli'
     - name: installing gh
       run: |-
-        flowey.exe v 26 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        flowey.exe v 26 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
         flowey.exe e 26 flowey_lib_common::cache 6
         flowey.exe e 26 flowey_lib_common::download_gh_cli 1
-        flowey.exe v 26 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
+        flowey.exe v 26 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.token <<EOF
         ${{ github.token }}
         EOF
       shell: bash
@@ -5916,8 +5916,8 @@ jobs:
         flowey.exe e 26 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
         flowey.exe e 26 flowey_lib_common::publish_test_results 0
         flowey.exe e 26 flowey_lib_common::publish_test_results 1
-        flowey.exe v 26 'flowey_lib_common::publish_test_results:2:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:94:51 write-to-env github floweyvar1
-        flowey.exe v 26 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:94:51' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 26 'flowey_lib_common::publish_test_results:2:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar1
+        flowey.exe v 26 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__2
       uses: actions/upload-artifact@v7
@@ -5931,8 +5931,8 @@ jobs:
         flowey.exe e 26 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
         flowey.exe e 26 flowey_lib_common::publish_test_results 3
         flowey.exe e 26 flowey_lib_common::publish_test_results 4
-        flowey.exe v 26 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:150:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:142:57 write-to-env github floweyvar2
-        flowey.exe v 26 'flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:142:57' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 26 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar2
+        flowey.exe v 26 'flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__5
       uses: actions/upload-artifact@v7
@@ -6011,8 +6011,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 27 flowey_lib_common::cache 0
-        flowey v 27 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
-        flowey v 27 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
+        flowey v 27 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar4
+        flowey v 27 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar5
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -6022,7 +6022,7 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
-        flowey v 27 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey v 27 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey e 27 flowey_lib_common::cache 2
@@ -6031,8 +6031,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 27 flowey_lib_common::git_checkout 0
-        flowey v 27 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar3
-        flowey v 27 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
+        flowey v 27 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env github floweyvar3
+        flowey v 27 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -6044,7 +6044,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey v 27 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey v 27 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
         flowey e 27 flowey_lib_common::git_checkout 3
@@ -6080,8 +6080,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 27 flowey_lib_common::cache 8
-        flowey v 27 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
-        flowey v 27 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
+        flowey v 27 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar8
+        flowey v 27 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar9
       shell: bash
     - id: flowey_lib_common__cache__9
       uses: actions/cache@v5
@@ -6091,7 +6091,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 27 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
+        flowey v 27 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
         EOF
         flowey e 27 flowey_lib_common::cache 10
@@ -6114,8 +6114,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 27 flowey_lib_common::cache 4
-        flowey v 27 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
-        flowey v 27 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
+        flowey v 27 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar6
+        flowey v 27 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar7
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
@@ -6125,12 +6125,12 @@ jobs:
       name: 'Restore cache: gh-cli'
     - name: installing gh
       run: |-
-        flowey v 27 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        flowey v 27 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
         flowey e 27 flowey_lib_common::cache 6
         flowey e 27 flowey_lib_common::download_gh_cli 1
-        flowey v 27 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
+        flowey v 27 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.token <<EOF
         ${{ github.token }}
         EOF
       shell: bash
@@ -6186,8 +6186,8 @@ jobs:
         flowey e 27 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 6
         flowey e 27 flowey_lib_common::publish_test_results 0
         flowey e 27 flowey_lib_common::publish_test_results 1
-        flowey v 27 'flowey_lib_common::publish_test_results:2:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:94:51 write-to-env github floweyvar1
-        flowey v 27 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:94:51' write-to-env github FLOWEY_CONDITION
+        flowey v 27 'flowey_lib_common::publish_test_results:2:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar1
+        flowey v 27 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__2
       uses: actions/upload-artifact@v7
@@ -6201,8 +6201,8 @@ jobs:
         flowey e 27 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 5
         flowey e 27 flowey_lib_common::publish_test_results 3
         flowey e 27 flowey_lib_common::publish_test_results 4
-        flowey v 27 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:150:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:142:57 write-to-env github floweyvar2
-        flowey v 27 'flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:142:57' write-to-env github FLOWEY_CONDITION
+        flowey v 27 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar2
+        flowey v 27 'flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__5
       uses: actions/upload-artifact@v7
@@ -6301,8 +6301,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 28 flowey_lib_common::git_checkout 0
-        flowey v 28 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar1
-        flowey v 28 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
+        flowey v 28 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env github floweyvar1
+        flowey v 28 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -6314,7 +6314,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey v 28 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey v 28 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
         flowey e 28 flowey_lib_common::git_checkout 3
@@ -6333,7 +6333,7 @@ jobs:
     - name: detect active toolchain
       run: |-
         flowey e 28 flowey_lib_common::install_rust 2
-        flowey v 28 'flowey_lib_hvlite::_jobs::test_local_flowey_build_igvm:3:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
+        flowey v 28 'flowey_lib_hvlite::_jobs::test_local_flowey_build_igvm:3:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.token <<EOF
         ${{ github.token }}
         EOF
       shell: bash
@@ -6410,8 +6410,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 29 flowey_lib_common::cache 0
-        flowey v 29 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar2
-        flowey v 29 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar3
+        flowey v 29 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar2
+        flowey v 29 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar3
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -6421,12 +6421,12 @@ jobs:
       name: 'Restore cache: gh-cli'
     - name: installing gh
       run: |-
-        flowey v 29 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey v 29 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey e 29 flowey_lib_common::cache 2
         flowey e 29 flowey_lib_common::download_gh_cli 1
-        flowey v 29 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
+        flowey v 29 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.token <<EOF
         ${{ github.token }}
         EOF
       shell: bash
@@ -6444,8 +6444,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 29 flowey_lib_common::git_checkout 0
-        flowey v 29 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar1
-        flowey v 29 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
+        flowey v 29 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env github floweyvar1
+        flowey v 29 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -6457,7 +6457,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey v 29 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey v 29 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
         flowey e 29 flowey_lib_common::git_checkout 3
@@ -6600,8 +6600,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 3 flowey_lib_common::git_checkout 0
-        flowey v 3 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar1
-        flowey v 3 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
+        flowey v 3 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env github floweyvar1
+        flowey v 3 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -6613,7 +6613,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey v 3 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey v 3 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
         flowey e 3 flowey_lib_common::git_checkout 3
@@ -6632,8 +6632,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 3 flowey_lib_common::cache 0
-        flowey v 3 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar2
-        flowey v 3 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar3
+        flowey v 3 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar2
+        flowey v 3 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar3
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -6643,7 +6643,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 3 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey v 3 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey e 3 flowey_lib_common::cache 2
@@ -6988,8 +6988,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey.exe e 4 flowey_lib_common::git_checkout 0
-        flowey.exe v 4 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar1
-        flowey.exe v 4 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 4 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env github floweyvar1
+        flowey.exe v 4 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -7001,7 +7001,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey.exe v 4 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey.exe v 4 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
         flowey.exe e 4 flowey_lib_common::git_checkout 3
@@ -7020,8 +7020,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 4 flowey_lib_common::cache 0
-        flowey.exe v 4 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar2
-        flowey.exe v 4 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar3
+        flowey.exe v 4 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar2
+        flowey.exe v 4 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar3
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -7031,7 +7031,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 4 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey.exe v 4 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey.exe e 4 flowey_lib_common::cache 2
@@ -7215,8 +7215,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey.exe e 5 flowey_lib_common::git_checkout 0
-        flowey.exe v 5 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar1
-        flowey.exe v 5 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 5 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env github floweyvar1
+        flowey.exe v 5 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -7228,7 +7228,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey.exe v 5 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey.exe v 5 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
         flowey.exe e 5 flowey_lib_common::git_checkout 3
@@ -7247,8 +7247,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 5 flowey_lib_common::cache 4
-        flowey.exe v 5 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
-        flowey.exe v 5 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
+        flowey.exe v 5 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar4
+        flowey.exe v 5 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar5
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
@@ -7258,7 +7258,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 5 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        flowey.exe v 5 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
         flowey.exe e 5 flowey_lib_common::cache 6
@@ -7343,8 +7343,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 5 flowey_lib_common::cache 0
-        flowey.exe v 5 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar2
-        flowey.exe v 5 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar3
+        flowey.exe v 5 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar2
+        flowey.exe v 5 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar3
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -7354,7 +7354,7 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
-        flowey.exe v 5 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey.exe v 5 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey.exe e 5 flowey_lib_common::cache 2
@@ -7529,8 +7529,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey.exe e 6 flowey_lib_common::git_checkout 0
-        flowey.exe v 6 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar1
-        flowey.exe v 6 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 6 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env github floweyvar1
+        flowey.exe v 6 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -7542,7 +7542,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey.exe v 6 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey.exe v 6 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
         flowey.exe e 6 flowey_lib_common::git_checkout 3
@@ -7561,8 +7561,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 6 flowey_lib_common::cache 0
-        flowey.exe v 6 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar2
-        flowey.exe v 6 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar3
+        flowey.exe v 6 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar2
+        flowey.exe v 6 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar3
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -7572,7 +7572,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 6 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey.exe v 6 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey.exe e 6 flowey_lib_common::cache 2
@@ -7760,8 +7760,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey.exe e 7 flowey_lib_common::git_checkout 0
-        flowey.exe v 7 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar1
-        flowey.exe v 7 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 7 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env github floweyvar1
+        flowey.exe v 7 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -7773,7 +7773,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey.exe v 7 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey.exe v 7 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
         flowey.exe e 7 flowey_lib_common::git_checkout 3
@@ -7792,8 +7792,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 7 flowey_lib_common::cache 4
-        flowey.exe v 7 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
-        flowey.exe v 7 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
+        flowey.exe v 7 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar4
+        flowey.exe v 7 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar5
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
@@ -7803,7 +7803,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 7 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        flowey.exe v 7 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
         flowey.exe e 7 flowey_lib_common::cache 6
@@ -7888,8 +7888,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 7 flowey_lib_common::cache 0
-        flowey.exe v 7 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar2
-        flowey.exe v 7 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar3
+        flowey.exe v 7 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar2
+        flowey.exe v 7 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar3
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -7899,7 +7899,7 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
-        flowey.exe v 7 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey.exe v 7 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey.exe e 7 flowey_lib_common::cache 2
@@ -8102,8 +8102,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 8 flowey_lib_common::git_checkout 0
-        flowey v 8 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar1
-        flowey v 8 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
+        flowey v 8 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env github floweyvar1
+        flowey v 8 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -8115,7 +8115,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey v 8 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey v 8 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
         flowey e 8 flowey_lib_common::git_checkout 3
@@ -8134,8 +8134,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 8 flowey_lib_common::cache 4
-        flowey v 8 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
-        flowey v 8 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
+        flowey v 8 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar4
+        flowey v 8 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar5
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
@@ -8145,7 +8145,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 8 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        flowey v 8 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
         flowey e 8 flowey_lib_common::cache 6
@@ -8303,8 +8303,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 8 flowey_lib_common::cache 0
-        flowey v 8 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar2
-        flowey v 8 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar3
+        flowey v 8 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar2
+        flowey v 8 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar3
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -8314,7 +8314,7 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
-        flowey v 8 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey v 8 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey e 8 flowey_lib_common::cache 2
@@ -8537,8 +8537,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 9 flowey_lib_common::git_checkout 0
-        flowey v 9 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar1
-        flowey v 9 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
+        flowey v 9 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env github floweyvar1
+        flowey v 9 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -8550,7 +8550,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey v 9 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey v 9 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
         flowey e 9 flowey_lib_common::git_checkout 3
@@ -8569,8 +8569,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 9 flowey_lib_common::cache 4
-        flowey v 9 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
-        flowey v 9 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
+        flowey v 9 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar4
+        flowey v 9 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar5
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
@@ -8580,7 +8580,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 9 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        flowey v 9 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
         flowey e 9 flowey_lib_common::cache 6
@@ -8742,8 +8742,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 9 flowey_lib_common::cache 0
-        flowey v 9 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar2
-        flowey v 9 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar3
+        flowey v 9 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar2
+        flowey v 9 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar3
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -8753,7 +8753,7 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
-        flowey v 9 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey v 9 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey e 9 flowey_lib_common::cache 2

--- a/.github/workflows/openvmm-ci.yaml
+++ b/.github/workflows/openvmm-ci.yaml
@@ -99,8 +99,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey.exe e 0 flowey_lib_common::git_checkout 0
-        flowey.exe v 0 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env github floweyvar1
-        flowey.exe v 0 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 0 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar1
+        flowey.exe v 0 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -112,7 +112,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey.exe v 0 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.workspace <<EOF
+        flowey.exe v 0 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
         flowey.exe e 0 flowey_lib_common::git_checkout 3
@@ -142,8 +142,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 0 flowey_lib_common::cache 0
-        flowey.exe v 0 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar2
-        flowey.exe v 0 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar3
+        flowey.exe v 0 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar2
+        flowey.exe v 0 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar3
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -153,7 +153,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 0 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey.exe v 0 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey.exe e 0 flowey_lib_common::cache 2
@@ -259,8 +259,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 1 flowey_lib_common::git_checkout 0
-        flowey v 1 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env github floweyvar1
-        flowey v 1 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env github FLOWEY_CONDITION
+        flowey v 1 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar1
+        flowey v 1 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -272,7 +272,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey v 1 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.workspace <<EOF
+        flowey v 1 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
         flowey e 1 flowey_lib_common::git_checkout 3
@@ -302,8 +302,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 1 flowey_lib_common::cache 0
-        flowey v 1 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar2
-        flowey v 1 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar3
+        flowey v 1 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar2
+        flowey v 1 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar3
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -313,7 +313,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 1 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey v 1 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey e 1 flowey_lib_common::cache 2
@@ -434,10 +434,6 @@ jobs:
         echo "$AgentTempDirNormal/publish_artifacts/aarch64-openhcl-baseline" | flowey v 10 'artifact_publish_from_aarch64-openhcl-baseline' --is-raw-string update
         mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-openhcl-igvm"
         echo "$AgentTempDirNormal/publish_artifacts/aarch64-openhcl-igvm" | flowey v 10 'artifact_publish_from_aarch64-openhcl-igvm' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-openhcl-igvm-devkern"
-        echo "$AgentTempDirNormal/publish_artifacts/aarch64-openhcl-igvm-devkern" | flowey v 10 'artifact_publish_from_aarch64-openhcl-igvm-devkern' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-openhcl-igvm-devkern-extras"
-        echo "$AgentTempDirNormal/publish_artifacts/aarch64-openhcl-igvm-devkern-extras" | flowey v 10 'artifact_publish_from_aarch64-openhcl-igvm-devkern-extras' --is-raw-string update
         mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-openhcl-igvm-extras"
         echo "$AgentTempDirNormal/publish_artifacts/aarch64-openhcl-igvm-extras" | flowey v 10 'artifact_publish_from_aarch64-openhcl-igvm-extras' --is-raw-string update
       shell: bash
@@ -455,8 +451,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 10 flowey_lib_common::git_checkout 0
-        flowey v 10 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env github floweyvar3
-        flowey v 10 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env github FLOWEY_CONDITION
+        flowey v 10 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar3
+        flowey v 10 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -468,7 +464,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey v 10 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.workspace <<EOF
+        flowey v 10 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
         flowey e 10 flowey_lib_common::git_checkout 3
@@ -485,8 +481,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 10 flowey_lib_common::cache 0
-        flowey v 10 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar1
-        flowey v 10 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar2
+        flowey v 10 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar1
+        flowey v 10 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar2
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -496,7 +492,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 10 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey v 10 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey e 10 flowey_lib_common::cache 2
@@ -534,7 +530,7 @@ jobs:
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 10 flowey_lib_hvlite::run_split_debug_info 3
+        flowey e 10 flowey_lib_hvlite::run_split_debug_info 2
         flowey e 10 flowey_lib_hvlite::run_cargo_build 9
         flowey e 10 flowey_lib_hvlite::build_openvmm_hcl 0
         flowey e 10 flowey_lib_hvlite::_jobs::build_and_publish_openvmm_hcl_baseline 0
@@ -575,7 +571,7 @@ jobs:
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 10 flowey_lib_hvlite::run_split_debug_info 2
+        flowey e 10 flowey_lib_hvlite::run_split_debug_info 1
         flowey e 10 flowey_lib_hvlite::run_cargo_build 5
         flowey e 10 flowey_lib_hvlite::build_openhcl_boot 0
         flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 5
@@ -593,7 +589,7 @@ jobs:
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 10 flowey_lib_hvlite::run_split_debug_info 4
+        flowey e 10 flowey_lib_hvlite::run_split_debug_info 3
         flowey e 10 flowey_lib_hvlite::run_cargo_build 1
         flowey e 10 flowey_lib_hvlite::build_igvmfilegen 0
         flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 7
@@ -607,36 +603,6 @@ jobs:
         flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 9
         flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 10
         flowey e 10 flowey_core::pipeline::artifact::publish 2
-      shell: bash
-    - name: extract and resolve kernel package
-      run: |-
-        flowey e 10 flowey_lib_hvlite::resolve_openhcl_kernel_package 1
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 15
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 12
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 10 flowey_lib_hvlite::run_split_debug_info 1
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 13
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 14
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 16
-      shell: bash
-    - name: building openhcl initrd
-      run: |-
-        flowey e 10 flowey_lib_hvlite::build_openhcl_initrd 1
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 17
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 18
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 19
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 20
-      shell: bash
-    - name: building igvm file
-      run: |-
-        flowey e 10 flowey_lib_hvlite::run_igvmfilegen 1
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 23
-        flowey e 10 flowey_core::pipeline::artifact::publish 3
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 21
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 22
-        flowey e 10 flowey_core::pipeline::artifact::publish 4
       shell: bash
     - name: 'validate cache entry: gh-release-download'
       run: flowey e 10 flowey_lib_common::cache 3
@@ -652,18 +618,6 @@ jobs:
       with:
         name: aarch64-openhcl-igvm
         path: ${{ runner.temp }}/publish_artifacts/aarch64-openhcl-igvm/
-        include-hidden-files: true
-    - name: 🌼📦 Publish aarch64-openhcl-igvm-devkern
-      uses: actions/upload-artifact@v7
-      with:
-        name: aarch64-openhcl-igvm-devkern
-        path: ${{ runner.temp }}/publish_artifacts/aarch64-openhcl-igvm-devkern/
-        include-hidden-files: true
-    - name: 🌼📦 Publish aarch64-openhcl-igvm-devkern-extras
-      uses: actions/upload-artifact@v7
-      with:
-        name: aarch64-openhcl-igvm-devkern-extras
-        path: ${{ runner.temp }}/publish_artifacts/aarch64-openhcl-igvm-devkern-extras/
         include-hidden-files: true
     - name: 🌼📦 Publish aarch64-openhcl-igvm-extras
       uses: actions/upload-artifact@v7
@@ -757,18 +711,10 @@ jobs:
         echo "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-cvm" | flowey v 11 'artifact_publish_from_x64-openhcl-igvm-cvm' --is-raw-string update
         mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-cvm-extras"
         echo "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-cvm-extras" | flowey v 11 'artifact_publish_from_x64-openhcl-igvm-cvm-extras' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-devkern"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-devkern" | flowey v 11 'artifact_publish_from_x64-openhcl-igvm-devkern' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-devkern-extras"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-devkern-extras" | flowey v 11 'artifact_publish_from_x64-openhcl-igvm-devkern-extras' --is-raw-string update
         mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-extras"
         echo "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-extras" | flowey v 11 'artifact_publish_from_x64-openhcl-igvm-extras' --is-raw-string update
         mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-test-linux-direct"
         echo "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-test-linux-direct" | flowey v 11 'artifact_publish_from_x64-openhcl-igvm-test-linux-direct' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-test-linux-direct-devkern"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-test-linux-direct-devkern" | flowey v 11 'artifact_publish_from_x64-openhcl-igvm-test-linux-direct-devkern' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-test-linux-direct-devkern-extras"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-test-linux-direct-devkern-extras" | flowey v 11 'artifact_publish_from_x64-openhcl-igvm-test-linux-direct-devkern-extras' --is-raw-string update
         mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-test-linux-direct-extras"
         echo "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-test-linux-direct-extras" | flowey v 11 'artifact_publish_from_x64-openhcl-igvm-test-linux-direct-extras' --is-raw-string update
       shell: bash
@@ -786,8 +732,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 11 flowey_lib_common::git_checkout 0
-        flowey v 11 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env github floweyvar3
-        flowey v 11 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env github FLOWEY_CONDITION
+        flowey v 11 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar3
+        flowey v 11 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -799,7 +745,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey v 11 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.workspace <<EOF
+        flowey v 11 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
         flowey e 11 flowey_lib_common::git_checkout 3
@@ -816,8 +762,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 11 flowey_lib_common::cache 0
-        flowey v 11 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar1
-        flowey v 11 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar2
+        flowey v 11 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar1
+        flowey v 11 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar2
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -827,7 +773,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 11 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey v 11 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey e 11 flowey_lib_common::cache 2
@@ -865,7 +811,7 @@ jobs:
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 11 flowey_lib_hvlite::run_split_debug_info 6
+        flowey e 11 flowey_lib_hvlite::run_split_debug_info 4
         flowey e 11 flowey_lib_hvlite::run_cargo_build 9
         flowey e 11 flowey_lib_hvlite::build_openvmm_hcl 0
         flowey e 11 flowey_lib_hvlite::_jobs::build_and_publish_openvmm_hcl_baseline 0
@@ -894,7 +840,7 @@ jobs:
       shell: bash
     - name: building openhcl initrd
       run: |-
-        flowey e 11 flowey_lib_hvlite::build_openhcl_initrd 2
+        flowey e 11 flowey_lib_hvlite::build_openhcl_initrd 0
         flowey e 11 flowey_lib_hvlite::init_cross_build 0
         flowey e 11 flowey_lib_hvlite::run_cargo_build 13
         flowey e 11 flowey_lib_hvlite::run_cargo_build 14
@@ -906,7 +852,7 @@ jobs:
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 11 flowey_lib_hvlite::run_split_debug_info 7
+        flowey e 11 flowey_lib_hvlite::run_split_debug_info 5
         flowey e 11 flowey_lib_hvlite::run_cargo_build 16
         flowey e 11 flowey_lib_hvlite::build_sidecar 0
         flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 5
@@ -921,7 +867,7 @@ jobs:
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 11 flowey_lib_hvlite::run_split_debug_info 5
+        flowey e 11 flowey_lib_hvlite::run_split_debug_info 3
         flowey e 11 flowey_lib_hvlite::run_cargo_build 5
         flowey e 11 flowey_lib_hvlite::build_openhcl_boot 0
         flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 6
@@ -939,7 +885,7 @@ jobs:
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 11 flowey_lib_hvlite::run_split_debug_info 8
+        flowey e 11 flowey_lib_hvlite::run_split_debug_info 6
         flowey e 11 flowey_lib_hvlite::run_cargo_build 1
         flowey e 11 flowey_lib_hvlite::build_igvmfilegen 0
         flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 8
@@ -947,43 +893,14 @@ jobs:
       shell: bash
     - name: building igvm file
       run: |-
-        flowey e 11 flowey_lib_hvlite::run_igvmfilegen 2
+        flowey e 11 flowey_lib_hvlite::run_igvmfilegen 1
         flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 12
         flowey e 11 flowey_core::pipeline::artifact::publish 1
         flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 10
         flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 11
         flowey e 11 flowey_core::pipeline::artifact::publish 2
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 34
-      shell: bash
-    - name: extract and resolve kernel package
-      run: |-
-        flowey e 11 flowey_lib_hvlite::resolve_openhcl_kernel_package 2
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 28
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 25
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 11 flowey_lib_hvlite::run_split_debug_info 4
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 26
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 27
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 29
-      shell: bash
-    - name: building openhcl initrd
-      run: |-
-        flowey e 11 flowey_lib_hvlite::build_openhcl_initrd 4
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 30
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 31
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 32
         flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 33
-      shell: bash
-    - name: building igvm file
-      run: |-
-        flowey e 11 flowey_lib_hvlite::run_igvmfilegen 4
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 37
-        flowey e 11 flowey_core::pipeline::artifact::publish 3
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 35
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 36
-        flowey e 11 flowey_core::pipeline::artifact::publish 4
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 34
       shell: bash
     - name: unpack openvmm-test-linux archives
       run: flowey e 11 flowey_lib_hvlite::resolve_openvmm_test_linux_kernel 0
@@ -991,60 +908,31 @@ jobs:
     - name: unpack openvmm-test-initrd archives
       run: |-
         flowey e 11 flowey_lib_hvlite::resolve_openvmm_test_initrd 0
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 41
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 38
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 11 flowey_lib_hvlite::run_split_debug_info 1
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 39
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 40
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 42
-      shell: bash
-    - name: building openhcl initrd
-      run: |-
-        flowey e 11 flowey_lib_hvlite::build_openhcl_initrd 0
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 43
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 44
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 45
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 46
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 47
-      shell: bash
-    - name: building igvm file
-      run: |-
-        flowey e 11 flowey_lib_hvlite::run_igvmfilegen 0
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 50
-        flowey e 11 flowey_core::pipeline::artifact::publish 5
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 48
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 49
-        flowey e 11 flowey_core::pipeline::artifact::publish 6
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 54
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 51
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 28
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 25
       shell: bash
     - name: split debug symbols
       run: |-
         flowey e 11 flowey_lib_hvlite::run_split_debug_info 2
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 52
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 53
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 55
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 26
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 27
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 29
       shell: bash
     - name: building openhcl initrd
       run: |-
-        flowey e 11 flowey_lib_hvlite::build_openhcl_initrd 1
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 56
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 57
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 58
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 59
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 60
+        flowey e 11 flowey_lib_hvlite::build_openhcl_initrd 2
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 30
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 31
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 32
       shell: bash
     - name: building igvm file
       run: |-
-        flowey e 11 flowey_lib_hvlite::run_igvmfilegen 1
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 63
-        flowey e 11 flowey_core::pipeline::artifact::publish 7
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 61
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 62
-        flowey e 11 flowey_core::pipeline::artifact::publish 8
+        flowey e 11 flowey_lib_hvlite::run_igvmfilegen 0
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 37
+        flowey e 11 flowey_core::pipeline::artifact::publish 3
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 35
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 36
+        flowey e 11 flowey_core::pipeline::artifact::publish 4
       shell: bash
     - name: extract and resolve kernel package
       run: |-
@@ -1054,14 +942,14 @@ jobs:
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 11 flowey_lib_hvlite::run_split_debug_info 3
+        flowey e 11 flowey_lib_hvlite::run_split_debug_info 1
         flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 14
         flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 15
         flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 17
       shell: bash
     - name: building openhcl initrd
       run: |-
-        flowey e 11 flowey_lib_hvlite::build_openhcl_initrd 3
+        flowey e 11 flowey_lib_hvlite::build_openhcl_initrd 1
         flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 18
         flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 19
         flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 20
@@ -1069,12 +957,12 @@ jobs:
       shell: bash
     - name: building igvm file
       run: |-
-        flowey e 11 flowey_lib_hvlite::run_igvmfilegen 3
+        flowey e 11 flowey_lib_hvlite::run_igvmfilegen 2
         flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 24
-        flowey e 11 flowey_core::pipeline::artifact::publish 9
+        flowey e 11 flowey_core::pipeline::artifact::publish 5
         flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 22
         flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 23
-        flowey e 11 flowey_core::pipeline::artifact::publish 10
+        flowey e 11 flowey_core::pipeline::artifact::publish 6
       shell: bash
     - name: 'validate cache entry: gh-release-download'
       run: flowey e 11 flowey_lib_common::cache 3
@@ -1103,18 +991,6 @@ jobs:
         name: x64-openhcl-igvm-cvm-extras
         path: ${{ runner.temp }}/publish_artifacts/x64-openhcl-igvm-cvm-extras/
         include-hidden-files: true
-    - name: 🌼📦 Publish x64-openhcl-igvm-devkern
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-openhcl-igvm-devkern
-        path: ${{ runner.temp }}/publish_artifacts/x64-openhcl-igvm-devkern/
-        include-hidden-files: true
-    - name: 🌼📦 Publish x64-openhcl-igvm-devkern-extras
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-openhcl-igvm-devkern-extras
-        path: ${{ runner.temp }}/publish_artifacts/x64-openhcl-igvm-devkern-extras/
-        include-hidden-files: true
     - name: 🌼📦 Publish x64-openhcl-igvm-extras
       uses: actions/upload-artifact@v7
       with:
@@ -1126,18 +1002,6 @@ jobs:
       with:
         name: x64-openhcl-igvm-test-linux-direct
         path: ${{ runner.temp }}/publish_artifacts/x64-openhcl-igvm-test-linux-direct/
-        include-hidden-files: true
-    - name: 🌼📦 Publish x64-openhcl-igvm-test-linux-direct-devkern
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-openhcl-igvm-test-linux-direct-devkern
-        path: ${{ runner.temp }}/publish_artifacts/x64-openhcl-igvm-test-linux-direct-devkern/
-        include-hidden-files: true
-    - name: 🌼📦 Publish x64-openhcl-igvm-test-linux-direct-devkern-extras
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-openhcl-igvm-test-linux-direct-devkern-extras
-        path: ${{ runner.temp }}/publish_artifacts/x64-openhcl-igvm-test-linux-direct-devkern-extras/
         include-hidden-files: true
     - name: 🌼📦 Publish x64-openhcl-igvm-test-linux-direct-extras
       uses: actions/upload-artifact@v7
@@ -1239,8 +1103,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 12 flowey_lib_common::git_checkout 0
-        flowey v 12 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env github floweyvar3
-        flowey v 12 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env github FLOWEY_CONDITION
+        flowey v 12 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar3
+        flowey v 12 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -1252,7 +1116,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey v 12 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.workspace <<EOF
+        flowey v 12 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
         flowey e 12 flowey_lib_common::git_checkout 3
@@ -1281,8 +1145,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 12 flowey_lib_common::cache 0
-        flowey v 12 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar1
-        flowey v 12 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar2
+        flowey v 12 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar1
+        flowey v 12 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar2
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -1292,7 +1156,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 12 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey v 12 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey e 12 flowey_lib_common::cache 2
@@ -1598,8 +1462,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey.exe e 13 flowey_lib_common::git_checkout 0
-        flowey.exe v 13 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env github floweyvar8
-        flowey.exe v 13 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 13 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar8
+        flowey.exe v 13 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -1611,7 +1475,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey.exe v 13 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.workspace <<EOF
+        flowey.exe v 13 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
         flowey.exe e 13 flowey_lib_common::git_checkout 3
@@ -1630,8 +1494,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 13 flowey_lib_common::cache 4
-        flowey.exe v 13 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar6
-        flowey.exe v 13 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar7
+        flowey.exe v 13 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
+        flowey.exe v 13 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
@@ -1641,7 +1505,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 13 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        flowey.exe v 13 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
         flowey.exe e 13 flowey_lib_common::cache 6
@@ -1686,8 +1550,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 13 flowey_lib_common::cache 0
-        flowey.exe v 13 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar4
-        flowey.exe v 13 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar5
+        flowey.exe v 13 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
+        flowey.exe v 13 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -1697,7 +1561,7 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
-        flowey.exe v 13 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey.exe v 13 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey.exe e 13 flowey_lib_common::cache 2
@@ -1733,8 +1597,8 @@ jobs:
         flowey.exe e 13 flowey_lib_hvlite::build_nextest_unit_tests 1
         flowey.exe e 13 flowey_lib_common::publish_test_results 6
         flowey.exe e 13 flowey_lib_common::publish_test_results 7
-        flowey.exe v 13 'flowey_lib_common::publish_test_results:12:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar3
-        flowey.exe v 13 'flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 13 'flowey_lib_common::publish_test_results:12:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs:94:51 write-to-env github floweyvar3
+        flowey.exe v 13 'flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs:94:51' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__8
       uses: actions/upload-artifact@v7
@@ -1753,8 +1617,8 @@ jobs:
         flowey.exe e 13 flowey_lib_hvlite::build_nextest_unit_tests 2
         flowey.exe e 13 flowey_lib_common::publish_test_results 0
         flowey.exe e 13 flowey_lib_common::publish_test_results 1
-        flowey.exe v 13 'flowey_lib_common::publish_test_results:2:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar1
-        flowey.exe v 13 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 13 'flowey_lib_common::publish_test_results:2:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:94:51 write-to-env github floweyvar1
+        flowey.exe v 13 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:94:51' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__2
       uses: actions/upload-artifact@v7
@@ -1773,8 +1637,8 @@ jobs:
         flowey.exe e 13 flowey_lib_hvlite::build_nextest_unit_tests 3
         flowey.exe e 13 flowey_lib_common::publish_test_results 3
         flowey.exe e 13 flowey_lib_common::publish_test_results 4
-        flowey.exe v 13 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar2
-        flowey.exe v 13 'flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 13 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:94:51 write-to-env github floweyvar2
+        flowey.exe v 13 'flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:94:51' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__5
       uses: actions/upload-artifact@v7
@@ -1891,8 +1755,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 14 flowey_lib_common::git_checkout 0
-        flowey v 14 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env github floweyvar10
-        flowey v 14 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env github FLOWEY_CONDITION
+        flowey v 14 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar10
+        flowey v 14 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -1904,7 +1768,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey v 14 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.workspace <<EOF
+        flowey v 14 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
         flowey e 14 flowey_lib_common::git_checkout 3
@@ -1923,8 +1787,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 14 flowey_lib_common::cache 4
-        flowey v 14 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar8
-        flowey v 14 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar9
+        flowey v 14 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
+        flowey v 14 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
@@ -1934,7 +1798,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 14 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        flowey v 14 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
         flowey e 14 flowey_lib_common::cache 6
@@ -2020,8 +1884,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 14 flowey_lib_common::cache 0
-        flowey v 14 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar6
-        flowey v 14 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar7
+        flowey v 14 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
+        flowey v 14 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -2031,7 +1895,7 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
-        flowey v 14 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey v 14 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey e 14 flowey_lib_common::cache 2
@@ -2056,8 +1920,8 @@ jobs:
         flowey e 14 flowey_lib_hvlite::build_nextest_unit_tests 3
         flowey e 14 flowey_lib_common::publish_test_results 6
         flowey e 14 flowey_lib_common::publish_test_results 7
-        flowey v 14 'flowey_lib_common::publish_test_results:12:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar3
-        flowey v 14 'flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
+        flowey v 14 'flowey_lib_common::publish_test_results:12:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs:94:51 write-to-env github floweyvar3
+        flowey v 14 'flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs:94:51' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__8
       uses: actions/upload-artifact@v7
@@ -2076,8 +1940,8 @@ jobs:
         flowey e 14 flowey_lib_hvlite::build_nextest_unit_tests 4
         flowey e 14 flowey_lib_common::publish_test_results 9
         flowey e 14 flowey_lib_common::publish_test_results 10
-        flowey v 14 'flowey_lib_common::publish_test_results:17:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:15:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar4
-        flowey v 14 'flowey_lib_common::publish_test_results:15:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
+        flowey v 14 'flowey_lib_common::publish_test_results:17:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:15:flowey_lib_common/src/publish_test_results.rs:94:51 write-to-env github floweyvar4
+        flowey v 14 'flowey_lib_common::publish_test_results:15:flowey_lib_common/src/publish_test_results.rs:94:51' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__11
       uses: actions/upload-artifact@v7
@@ -2096,8 +1960,8 @@ jobs:
         flowey e 14 flowey_lib_hvlite::build_nextest_unit_tests 5
         flowey e 14 flowey_lib_common::publish_test_results 12
         flowey e 14 flowey_lib_common::publish_test_results 13
-        flowey v 14 'flowey_lib_common::publish_test_results:22:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:20:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar5
-        flowey v 14 'flowey_lib_common::publish_test_results:20:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
+        flowey v 14 'flowey_lib_common::publish_test_results:22:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:20:flowey_lib_common/src/publish_test_results.rs:94:51 write-to-env github floweyvar5
+        flowey v 14 'flowey_lib_common::publish_test_results:20:flowey_lib_common/src/publish_test_results.rs:94:51' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__14
       uses: actions/upload-artifact@v7
@@ -2131,8 +1995,8 @@ jobs:
         flowey e 14 flowey_lib_hvlite::build_nextest_unit_tests 1
         flowey e 14 flowey_lib_common::publish_test_results 0
         flowey e 14 flowey_lib_common::publish_test_results 1
-        flowey v 14 'flowey_lib_common::publish_test_results:2:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar1
-        flowey v 14 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
+        flowey v 14 'flowey_lib_common::publish_test_results:2:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:94:51 write-to-env github floweyvar1
+        flowey v 14 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:94:51' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__2
       uses: actions/upload-artifact@v7
@@ -2151,8 +2015,8 @@ jobs:
         flowey e 14 flowey_lib_hvlite::build_nextest_unit_tests 2
         flowey e 14 flowey_lib_common::publish_test_results 3
         flowey e 14 flowey_lib_common::publish_test_results 4
-        flowey v 14 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar2
-        flowey v 14 'flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
+        flowey v 14 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:94:51 write-to-env github floweyvar2
+        flowey v 14 'flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:94:51' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__5
       uses: actions/upload-artifact@v7
@@ -2268,8 +2132,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 15 flowey_lib_common::git_checkout 0
-        flowey v 15 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env github floweyvar11
-        flowey v 15 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env github FLOWEY_CONDITION
+        flowey v 15 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar11
+        flowey v 15 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -2281,7 +2145,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey v 15 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.workspace <<EOF
+        flowey v 15 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
         flowey e 15 flowey_lib_common::git_checkout 3
@@ -2298,8 +2162,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 15 flowey_lib_common::cache 4
-        flowey v 15 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar9
-        flowey v 15 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar10
+        flowey v 15 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar9
+        flowey v 15 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar10
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
@@ -2309,7 +2173,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 15 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        flowey v 15 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
         flowey e 15 flowey_lib_common::cache 6
@@ -2388,8 +2252,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 15 flowey_lib_common::cache 0
-        flowey v 15 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar7
-        flowey v 15 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar8
+        flowey v 15 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar7
+        flowey v 15 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar8
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -2399,7 +2263,7 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
-        flowey v 15 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey v 15 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey e 15 flowey_lib_common::cache 2
@@ -2424,8 +2288,8 @@ jobs:
         flowey e 15 flowey_lib_hvlite::build_nextest_unit_tests 3
         flowey e 15 flowey_lib_common::publish_test_results 6
         flowey e 15 flowey_lib_common::publish_test_results 7
-        flowey v 15 'flowey_lib_common::publish_test_results:12:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar3
-        flowey v 15 'flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
+        flowey v 15 'flowey_lib_common::publish_test_results:12:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs:94:51 write-to-env github floweyvar3
+        flowey v 15 'flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs:94:51' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__8
       uses: actions/upload-artifact@v7
@@ -2444,8 +2308,8 @@ jobs:
         flowey e 15 flowey_lib_hvlite::build_nextest_unit_tests 4
         flowey e 15 flowey_lib_common::publish_test_results 9
         flowey e 15 flowey_lib_common::publish_test_results 10
-        flowey v 15 'flowey_lib_common::publish_test_results:17:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:15:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar4
-        flowey v 15 'flowey_lib_common::publish_test_results:15:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
+        flowey v 15 'flowey_lib_common::publish_test_results:17:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:15:flowey_lib_common/src/publish_test_results.rs:94:51 write-to-env github floweyvar4
+        flowey v 15 'flowey_lib_common::publish_test_results:15:flowey_lib_common/src/publish_test_results.rs:94:51' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__11
       uses: actions/upload-artifact@v7
@@ -2464,8 +2328,8 @@ jobs:
         flowey e 15 flowey_lib_hvlite::build_nextest_unit_tests 5
         flowey e 15 flowey_lib_common::publish_test_results 12
         flowey e 15 flowey_lib_common::publish_test_results 13
-        flowey v 15 'flowey_lib_common::publish_test_results:22:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:20:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar5
-        flowey v 15 'flowey_lib_common::publish_test_results:20:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
+        flowey v 15 'flowey_lib_common::publish_test_results:22:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:20:flowey_lib_common/src/publish_test_results.rs:94:51 write-to-env github floweyvar5
+        flowey v 15 'flowey_lib_common::publish_test_results:20:flowey_lib_common/src/publish_test_results.rs:94:51' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__14
       uses: actions/upload-artifact@v7
@@ -2484,8 +2348,8 @@ jobs:
         flowey e 15 flowey_lib_hvlite::build_nextest_unit_tests 6
         flowey e 15 flowey_lib_common::publish_test_results 15
         flowey e 15 flowey_lib_common::publish_test_results 16
-        flowey v 15 'flowey_lib_common::publish_test_results:27:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:25:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar6
-        flowey v 15 'flowey_lib_common::publish_test_results:25:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
+        flowey v 15 'flowey_lib_common::publish_test_results:27:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:25:flowey_lib_common/src/publish_test_results.rs:94:51 write-to-env github floweyvar6
+        flowey v 15 'flowey_lib_common::publish_test_results:25:flowey_lib_common/src/publish_test_results.rs:94:51' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__17
       uses: actions/upload-artifact@v7
@@ -2519,8 +2383,8 @@ jobs:
         flowey e 15 flowey_lib_hvlite::build_nextest_unit_tests 1
         flowey e 15 flowey_lib_common::publish_test_results 0
         flowey e 15 flowey_lib_common::publish_test_results 1
-        flowey v 15 'flowey_lib_common::publish_test_results:2:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar1
-        flowey v 15 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
+        flowey v 15 'flowey_lib_common::publish_test_results:2:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:94:51 write-to-env github floweyvar1
+        flowey v 15 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:94:51' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__2
       uses: actions/upload-artifact@v7
@@ -2539,8 +2403,8 @@ jobs:
         flowey e 15 flowey_lib_hvlite::build_nextest_unit_tests 2
         flowey e 15 flowey_lib_common::publish_test_results 3
         flowey e 15 flowey_lib_common::publish_test_results 4
-        flowey v 15 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar2
-        flowey v 15 'flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
+        flowey v 15 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:94:51 write-to-env github floweyvar2
+        flowey v 15 'flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:94:51' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__5
       uses: actions/upload-artifact@v7
@@ -2656,8 +2520,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey.exe e 16 flowey_lib_common::git_checkout 0
-        flowey.exe v 16 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env github floweyvar8
-        flowey.exe v 16 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 16 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar8
+        flowey.exe v 16 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -2669,7 +2533,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey.exe v 16 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.workspace <<EOF
+        flowey.exe v 16 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
         flowey.exe e 16 flowey_lib_common::git_checkout 3
@@ -2688,8 +2552,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 16 flowey_lib_common::cache 4
-        flowey.exe v 16 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar6
-        flowey.exe v 16 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar7
+        flowey.exe v 16 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
+        flowey.exe v 16 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
@@ -2699,7 +2563,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 16 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        flowey.exe v 16 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
         flowey.exe e 16 flowey_lib_common::cache 6
@@ -2744,8 +2608,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 16 flowey_lib_common::cache 0
-        flowey.exe v 16 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar4
-        flowey.exe v 16 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar5
+        flowey.exe v 16 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
+        flowey.exe v 16 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -2755,7 +2619,7 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
-        flowey.exe v 16 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey.exe v 16 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey.exe e 16 flowey_lib_common::cache 2
@@ -2791,8 +2655,8 @@ jobs:
         flowey.exe e 16 flowey_lib_hvlite::build_nextest_unit_tests 1
         flowey.exe e 16 flowey_lib_common::publish_test_results 6
         flowey.exe e 16 flowey_lib_common::publish_test_results 7
-        flowey.exe v 16 'flowey_lib_common::publish_test_results:12:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar3
-        flowey.exe v 16 'flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 16 'flowey_lib_common::publish_test_results:12:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs:94:51 write-to-env github floweyvar3
+        flowey.exe v 16 'flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs:94:51' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__8
       uses: actions/upload-artifact@v7
@@ -2811,8 +2675,8 @@ jobs:
         flowey.exe e 16 flowey_lib_hvlite::build_nextest_unit_tests 2
         flowey.exe e 16 flowey_lib_common::publish_test_results 0
         flowey.exe e 16 flowey_lib_common::publish_test_results 1
-        flowey.exe v 16 'flowey_lib_common::publish_test_results:2:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar1
-        flowey.exe v 16 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 16 'flowey_lib_common::publish_test_results:2:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:94:51 write-to-env github floweyvar1
+        flowey.exe v 16 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:94:51' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__2
       uses: actions/upload-artifact@v7
@@ -2831,8 +2695,8 @@ jobs:
         flowey.exe e 16 flowey_lib_hvlite::build_nextest_unit_tests 3
         flowey.exe e 16 flowey_lib_common::publish_test_results 3
         flowey.exe e 16 flowey_lib_common::publish_test_results 4
-        flowey.exe v 16 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar2
-        flowey.exe v 16 'flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 16 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:94:51 write-to-env github floweyvar2
+        flowey.exe v 16 'flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:94:51' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__5
       uses: actions/upload-artifact@v7
@@ -2934,11 +2798,28 @@ jobs:
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
       shell: bash
+    - name: add default cargo home to path
+      run: flowey e 17 flowey_lib_common::install_rust 0
+      shell: bash
+    - name: install Rust
+      run: flowey e 17 flowey_lib_common::install_rust 1
+      shell: bash
+    - name: detect active toolchain
+      run: |-
+        flowey e 17 flowey_lib_common::install_rust 2
+        flowey e 17 flowey_lib_common::cfg_cargo_common_flags 0
+      shell: bash
+    - name: checking if packages need to be installed
+      run: flowey e 17 flowey_lib_common::install_dist_pkg 0
+      shell: bash
+    - name: installing packages
+      run: flowey e 17 flowey_lib_common::install_dist_pkg 1
+      shell: bash
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 17 flowey_lib_common::git_checkout 0
-        flowey v 17 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env github floweyvar10
-        flowey v 17 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env github FLOWEY_CONDITION
+        flowey v 17 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar10
+        flowey v 17 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -2950,7 +2831,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey v 17 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.workspace <<EOF
+        flowey v 17 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
         flowey e 17 flowey_lib_common::git_checkout 3
@@ -2969,8 +2850,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 17 flowey_lib_common::cache 4
-        flowey v 17 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar8
-        flowey v 17 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar9
+        flowey v 17 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
+        flowey v 17 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
@@ -2980,17 +2861,11 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 17 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        flowey v 17 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
         flowey e 17 flowey_lib_common::cache 6
         flowey e 17 flowey_lib_common::download_gh_release 1
-      shell: bash
-    - name: checking if packages need to be installed
-      run: flowey e 17 flowey_lib_common::install_dist_pkg 0
-      shell: bash
-    - name: installing packages
-      run: flowey e 17 flowey_lib_common::install_dist_pkg 1
       shell: bash
     - name: unpack protoc
       run: |-
@@ -2998,21 +2873,8 @@ jobs:
         flowey e 17 flowey_lib_hvlite::cfg_openvmm_magicpath 0
       shell: bash
     - name: symlink protoc
-      run: flowey e 17 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-      shell: bash
-    - name: add default cargo home to path
-      run: flowey e 17 flowey_lib_common::install_rust 0
-      shell: bash
-    - name: install Rust
-      run: flowey e 17 flowey_lib_common::install_rust 1
-      shell: bash
-    - name: run doctests for aarch64-unknown-linux-gnu
-      run: flowey e 17 flowey_lib_hvlite::_jobs::build_and_run_doc_tests 0
-      shell: bash
-    - name: detect active toolchain
       run: |-
-        flowey e 17 flowey_lib_common::install_rust 2
-        flowey e 17 flowey_lib_common::cfg_cargo_common_flags 0
+        flowey e 17 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
         flowey e 17 flowey_lib_hvlite::init_cross_build 0
       shell: bash
     - name: cargo clippy
@@ -3056,8 +2918,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 17 flowey_lib_common::cache 0
-        flowey v 17 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar6
-        flowey v 17 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar7
+        flowey v 17 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
+        flowey v 17 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -3067,7 +2929,7 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
-        flowey v 17 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey v 17 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey e 17 flowey_lib_common::cache 2
@@ -3092,8 +2954,8 @@ jobs:
         flowey e 17 flowey_lib_hvlite::build_nextest_unit_tests 3
         flowey e 17 flowey_lib_common::publish_test_results 6
         flowey e 17 flowey_lib_common::publish_test_results 7
-        flowey v 17 'flowey_lib_common::publish_test_results:12:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar3
-        flowey v 17 'flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
+        flowey v 17 'flowey_lib_common::publish_test_results:12:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs:94:51 write-to-env github floweyvar3
+        flowey v 17 'flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs:94:51' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__8
       uses: actions/upload-artifact@v7
@@ -3112,8 +2974,8 @@ jobs:
         flowey e 17 flowey_lib_hvlite::build_nextest_unit_tests 4
         flowey e 17 flowey_lib_common::publish_test_results 9
         flowey e 17 flowey_lib_common::publish_test_results 10
-        flowey v 17 'flowey_lib_common::publish_test_results:17:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:15:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar4
-        flowey v 17 'flowey_lib_common::publish_test_results:15:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
+        flowey v 17 'flowey_lib_common::publish_test_results:17:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:15:flowey_lib_common/src/publish_test_results.rs:94:51 write-to-env github floweyvar4
+        flowey v 17 'flowey_lib_common::publish_test_results:15:flowey_lib_common/src/publish_test_results.rs:94:51' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__11
       uses: actions/upload-artifact@v7
@@ -3132,8 +2994,8 @@ jobs:
         flowey e 17 flowey_lib_hvlite::build_nextest_unit_tests 5
         flowey e 17 flowey_lib_common::publish_test_results 12
         flowey e 17 flowey_lib_common::publish_test_results 13
-        flowey v 17 'flowey_lib_common::publish_test_results:22:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:20:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar5
-        flowey v 17 'flowey_lib_common::publish_test_results:20:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
+        flowey v 17 'flowey_lib_common::publish_test_results:22:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:20:flowey_lib_common/src/publish_test_results.rs:94:51 write-to-env github floweyvar5
+        flowey v 17 'flowey_lib_common::publish_test_results:20:flowey_lib_common/src/publish_test_results.rs:94:51' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__14
       uses: actions/upload-artifact@v7
@@ -3167,8 +3029,8 @@ jobs:
         flowey e 17 flowey_lib_hvlite::build_nextest_unit_tests 1
         flowey e 17 flowey_lib_common::publish_test_results 0
         flowey e 17 flowey_lib_common::publish_test_results 1
-        flowey v 17 'flowey_lib_common::publish_test_results:2:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar1
-        flowey v 17 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
+        flowey v 17 'flowey_lib_common::publish_test_results:2:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:94:51 write-to-env github floweyvar1
+        flowey v 17 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:94:51' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__2
       uses: actions/upload-artifact@v7
@@ -3187,8 +3049,8 @@ jobs:
         flowey e 17 flowey_lib_hvlite::build_nextest_unit_tests 2
         flowey e 17 flowey_lib_common::publish_test_results 3
         flowey e 17 flowey_lib_common::publish_test_results 4
-        flowey v 17 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar2
-        flowey v 17 'flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
+        flowey v 17 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:94:51 write-to-env github floweyvar2
+        flowey v 17 'flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:94:51' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__5
       uses: actions/upload-artifact@v7
@@ -3201,6 +3063,9 @@ jobs:
       run: |-
         flowey e 17 flowey_lib_hvlite::build_nextest_unit_tests 6
         flowey e 17 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
+      shell: bash
+    - name: run doctests for aarch64-unknown-linux-gnu
+      run: flowey e 17 flowey_lib_hvlite::_jobs::build_and_run_doc_tests 0
       shell: bash
     - name: 'validate cache entry: cargo-nextest'
       run: flowey e 17 flowey_lib_common::cache 3
@@ -3301,8 +3166,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 18 flowey_lib_common::git_checkout 0
-        flowey v 18 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env github floweyvar11
-        flowey v 18 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env github FLOWEY_CONDITION
+        flowey v 18 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar11
+        flowey v 18 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -3314,7 +3179,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey v 18 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.workspace <<EOF
+        flowey v 18 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
         flowey e 18 flowey_lib_common::git_checkout 3
@@ -3331,8 +3196,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 18 flowey_lib_common::cache 4
-        flowey v 18 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar9
-        flowey v 18 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar10
+        flowey v 18 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar9
+        flowey v 18 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar10
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
@@ -3342,7 +3207,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 18 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        flowey v 18 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
         flowey e 18 flowey_lib_common::cache 6
@@ -3421,8 +3286,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 18 flowey_lib_common::cache 0
-        flowey v 18 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar7
-        flowey v 18 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar8
+        flowey v 18 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar7
+        flowey v 18 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar8
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -3432,7 +3297,7 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
-        flowey v 18 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey v 18 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey e 18 flowey_lib_common::cache 2
@@ -3457,8 +3322,8 @@ jobs:
         flowey e 18 flowey_lib_hvlite::build_nextest_unit_tests 3
         flowey e 18 flowey_lib_common::publish_test_results 6
         flowey e 18 flowey_lib_common::publish_test_results 7
-        flowey v 18 'flowey_lib_common::publish_test_results:12:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar3
-        flowey v 18 'flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
+        flowey v 18 'flowey_lib_common::publish_test_results:12:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs:94:51 write-to-env github floweyvar3
+        flowey v 18 'flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs:94:51' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__8
       uses: actions/upload-artifact@v7
@@ -3477,8 +3342,8 @@ jobs:
         flowey e 18 flowey_lib_hvlite::build_nextest_unit_tests 4
         flowey e 18 flowey_lib_common::publish_test_results 9
         flowey e 18 flowey_lib_common::publish_test_results 10
-        flowey v 18 'flowey_lib_common::publish_test_results:17:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:15:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar4
-        flowey v 18 'flowey_lib_common::publish_test_results:15:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
+        flowey v 18 'flowey_lib_common::publish_test_results:17:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:15:flowey_lib_common/src/publish_test_results.rs:94:51 write-to-env github floweyvar4
+        flowey v 18 'flowey_lib_common::publish_test_results:15:flowey_lib_common/src/publish_test_results.rs:94:51' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__11
       uses: actions/upload-artifact@v7
@@ -3497,8 +3362,8 @@ jobs:
         flowey e 18 flowey_lib_hvlite::build_nextest_unit_tests 5
         flowey e 18 flowey_lib_common::publish_test_results 12
         flowey e 18 flowey_lib_common::publish_test_results 13
-        flowey v 18 'flowey_lib_common::publish_test_results:22:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:20:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar5
-        flowey v 18 'flowey_lib_common::publish_test_results:20:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
+        flowey v 18 'flowey_lib_common::publish_test_results:22:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:20:flowey_lib_common/src/publish_test_results.rs:94:51 write-to-env github floweyvar5
+        flowey v 18 'flowey_lib_common::publish_test_results:20:flowey_lib_common/src/publish_test_results.rs:94:51' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__14
       uses: actions/upload-artifact@v7
@@ -3517,8 +3382,8 @@ jobs:
         flowey e 18 flowey_lib_hvlite::build_nextest_unit_tests 6
         flowey e 18 flowey_lib_common::publish_test_results 15
         flowey e 18 flowey_lib_common::publish_test_results 16
-        flowey v 18 'flowey_lib_common::publish_test_results:27:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:25:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar6
-        flowey v 18 'flowey_lib_common::publish_test_results:25:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
+        flowey v 18 'flowey_lib_common::publish_test_results:27:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:25:flowey_lib_common/src/publish_test_results.rs:94:51 write-to-env github floweyvar6
+        flowey v 18 'flowey_lib_common::publish_test_results:25:flowey_lib_common/src/publish_test_results.rs:94:51' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__17
       uses: actions/upload-artifact@v7
@@ -3552,8 +3417,8 @@ jobs:
         flowey e 18 flowey_lib_hvlite::build_nextest_unit_tests 1
         flowey e 18 flowey_lib_common::publish_test_results 0
         flowey e 18 flowey_lib_common::publish_test_results 1
-        flowey v 18 'flowey_lib_common::publish_test_results:2:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar1
-        flowey v 18 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
+        flowey v 18 'flowey_lib_common::publish_test_results:2:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:94:51 write-to-env github floweyvar1
+        flowey v 18 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:94:51' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__2
       uses: actions/upload-artifact@v7
@@ -3572,8 +3437,8 @@ jobs:
         flowey e 18 flowey_lib_hvlite::build_nextest_unit_tests 2
         flowey e 18 flowey_lib_common::publish_test_results 3
         flowey e 18 flowey_lib_common::publish_test_results 4
-        flowey v 18 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar2
-        flowey v 18 'flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
+        flowey v 18 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:94:51 write-to-env github floweyvar2
+        flowey v 18 'flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:94:51' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__5
       uses: actions/upload-artifact@v7
@@ -3663,8 +3528,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 19 flowey_lib_common::cache 0
-        flowey.exe v 19 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar4
-        flowey.exe v 19 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar5
+        flowey.exe v 19 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
+        flowey.exe v 19 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -3674,7 +3539,7 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
-        flowey.exe v 19 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey.exe v 19 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey.exe e 19 flowey_lib_common::cache 2
@@ -3683,8 +3548,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey.exe e 19 flowey_lib_common::git_checkout 0
-        flowey.exe v 19 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env github floweyvar3
-        flowey.exe v 19 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 19 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar3
+        flowey.exe v 19 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -3696,7 +3561,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey.exe v 19 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.workspace <<EOF
+        flowey.exe v 19 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
         flowey.exe e 19 flowey_lib_common::git_checkout 3
@@ -3731,8 +3596,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 19 flowey_lib_common::cache 8
-        flowey.exe v 19 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar8
-        flowey.exe v 19 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar9
+        flowey.exe v 19 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
+        flowey.exe v 19 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
       shell: bash
     - id: flowey_lib_common__cache__9
       uses: actions/cache@v5
@@ -3742,7 +3607,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 19 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
+        flowey.exe v 19 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
         EOF
         flowey.exe e 19 flowey_lib_common::cache 10
@@ -3765,8 +3630,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 19 flowey_lib_common::cache 4
-        flowey.exe v 19 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar6
-        flowey.exe v 19 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar7
+        flowey.exe v 19 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
+        flowey.exe v 19 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
@@ -3776,12 +3641,12 @@ jobs:
       name: 'Restore cache: gh-cli'
     - name: installing gh
       run: |-
-        flowey.exe v 19 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        flowey.exe v 19 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
         flowey.exe e 19 flowey_lib_common::cache 6
         flowey.exe e 19 flowey_lib_common::download_gh_cli 1
-        flowey.exe v 19 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.token <<EOF
+        flowey.exe v 19 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
         ${{ github.token }}
         EOF
       shell: bash
@@ -3841,8 +3706,8 @@ jobs:
         flowey.exe e 19 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
         flowey.exe e 19 flowey_lib_common::publish_test_results 0
         flowey.exe e 19 flowey_lib_common::publish_test_results 1
-        flowey.exe v 19 'flowey_lib_common::publish_test_results:2:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar1
-        flowey.exe v 19 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 19 'flowey_lib_common::publish_test_results:2:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:94:51 write-to-env github floweyvar1
+        flowey.exe v 19 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:94:51' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__2
       uses: actions/upload-artifact@v7
@@ -3856,8 +3721,8 @@ jobs:
         flowey.exe e 19 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
         flowey.exe e 19 flowey_lib_common::publish_test_results 3
         flowey.exe e 19 flowey_lib_common::publish_test_results 4
-        flowey.exe v 19 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar2
-        flowey.exe v 19 'flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 19 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:150:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:142:57 write-to-env github floweyvar2
+        flowey.exe v 19 'flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:142:57' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__5
       uses: actions/upload-artifact@v7
@@ -3975,8 +3840,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey.exe e 2 flowey_lib_common::git_checkout 0
-        flowey.exe v 2 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env github floweyvar1
-        flowey.exe v 2 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 2 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar1
+        flowey.exe v 2 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -3988,7 +3853,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey.exe v 2 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.workspace <<EOF
+        flowey.exe v 2 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
         flowey.exe e 2 flowey_lib_common::git_checkout 3
@@ -4007,8 +3872,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 2 flowey_lib_common::cache 0
-        flowey.exe v 2 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar2
-        flowey.exe v 2 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar3
+        flowey.exe v 2 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar2
+        flowey.exe v 2 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar3
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -4018,7 +3883,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 2 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey.exe v 2 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey.exe e 2 flowey_lib_common::cache 2
@@ -4131,8 +3996,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 20 flowey_lib_common::cache 0
-        flowey.exe v 20 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar4
-        flowey.exe v 20 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar5
+        flowey.exe v 20 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
+        flowey.exe v 20 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -4142,7 +4007,7 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
-        flowey.exe v 20 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey.exe v 20 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey.exe e 20 flowey_lib_common::cache 2
@@ -4151,8 +4016,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey.exe e 20 flowey_lib_common::git_checkout 0
-        flowey.exe v 20 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env github floweyvar3
-        flowey.exe v 20 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 20 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar3
+        flowey.exe v 20 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -4164,7 +4029,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey.exe v 20 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.workspace <<EOF
+        flowey.exe v 20 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
         flowey.exe e 20 flowey_lib_common::git_checkout 3
@@ -4174,11 +4039,6 @@ jobs:
         flowey.exe e 20 flowey_lib_common::system_info 0
         flowey.exe e 20 flowey_lib_hvlite::git_checkout_openvmm_repo 0
         flowey.exe e 20 flowey_lib_hvlite::run_cargo_nextest_run 0
-        flowey.exe e 20 flowey_core::pipeline::artifact::resolve 8
-        flowey.exe e 20 flowey_core::pipeline::artifact::resolve 9
-        flowey.exe e 20 flowey_core::pipeline::artifact::resolve 12
-        flowey.exe e 20 flowey_core::pipeline::artifact::resolve 14
-        flowey.exe e 20 flowey_core::pipeline::artifact::resolve 15
         flowey.exe e 20 flowey_core::pipeline::artifact::resolve 13
         flowey.exe e 20 flowey_core::pipeline::artifact::resolve 3
         flowey.exe e 20 flowey_core::pipeline::artifact::resolve 11
@@ -4189,6 +4049,11 @@ jobs:
         flowey.exe e 20 flowey_core::pipeline::artifact::resolve 2
         flowey.exe e 20 flowey_core::pipeline::artifact::resolve 0
         flowey.exe e 20 flowey_core::pipeline::artifact::resolve 7
+        flowey.exe e 20 flowey_core::pipeline::artifact::resolve 8
+        flowey.exe e 20 flowey_core::pipeline::artifact::resolve 9
+        flowey.exe e 20 flowey_core::pipeline::artifact::resolve 12
+        flowey.exe e 20 flowey_core::pipeline::artifact::resolve 14
+        flowey.exe e 20 flowey_core::pipeline::artifact::resolve 15
       shell: bash
     - name: creating new test content dir
       run: flowey.exe e 20 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
@@ -4199,8 +4064,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 20 flowey_lib_common::cache 8
-        flowey.exe v 20 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar8
-        flowey.exe v 20 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar9
+        flowey.exe v 20 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
+        flowey.exe v 20 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
       shell: bash
     - id: flowey_lib_common__cache__9
       uses: actions/cache@v5
@@ -4210,7 +4075,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 20 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
+        flowey.exe v 20 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
         EOF
         flowey.exe e 20 flowey_lib_common::cache 10
@@ -4233,8 +4098,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 20 flowey_lib_common::cache 4
-        flowey.exe v 20 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar6
-        flowey.exe v 20 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar7
+        flowey.exe v 20 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
+        flowey.exe v 20 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
@@ -4244,12 +4109,12 @@ jobs:
       name: 'Restore cache: gh-cli'
     - name: installing gh
       run: |-
-        flowey.exe v 20 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        flowey.exe v 20 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
         flowey.exe e 20 flowey_lib_common::cache 6
         flowey.exe e 20 flowey_lib_common::download_gh_cli 1
-        flowey.exe v 20 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.token <<EOF
+        flowey.exe v 20 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
         ${{ github.token }}
         EOF
       shell: bash
@@ -4304,8 +4169,8 @@ jobs:
         flowey.exe e 20 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
         flowey.exe e 20 flowey_lib_common::publish_test_results 0
         flowey.exe e 20 flowey_lib_common::publish_test_results 1
-        flowey.exe v 20 'flowey_lib_common::publish_test_results:2:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar1
-        flowey.exe v 20 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 20 'flowey_lib_common::publish_test_results:2:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:94:51 write-to-env github floweyvar1
+        flowey.exe v 20 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:94:51' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__2
       uses: actions/upload-artifact@v7
@@ -4319,8 +4184,8 @@ jobs:
         flowey.exe e 20 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
         flowey.exe e 20 flowey_lib_common::publish_test_results 3
         flowey.exe e 20 flowey_lib_common::publish_test_results 4
-        flowey.exe v 20 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar2
-        flowey.exe v 20 'flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 20 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:150:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:142:57 write-to-env github floweyvar2
+        flowey.exe v 20 'flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:142:57' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__5
       uses: actions/upload-artifact@v7
@@ -4409,8 +4274,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 21 flowey_lib_common::cache 0
-        flowey.exe v 21 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar4
-        flowey.exe v 21 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar5
+        flowey.exe v 21 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
+        flowey.exe v 21 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -4420,7 +4285,7 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
-        flowey.exe v 21 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey.exe v 21 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey.exe e 21 flowey_lib_common::cache 2
@@ -4429,8 +4294,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey.exe e 21 flowey_lib_common::git_checkout 0
-        flowey.exe v 21 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env github floweyvar3
-        flowey.exe v 21 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 21 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar3
+        flowey.exe v 21 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -4442,7 +4307,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey.exe v 21 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.workspace <<EOF
+        flowey.exe v 21 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
         flowey.exe e 21 flowey_lib_common::git_checkout 3
@@ -4477,8 +4342,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 21 flowey_lib_common::cache 8
-        flowey.exe v 21 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar8
-        flowey.exe v 21 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar9
+        flowey.exe v 21 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
+        flowey.exe v 21 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
       shell: bash
     - id: flowey_lib_common__cache__9
       uses: actions/cache@v5
@@ -4488,7 +4353,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 21 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
+        flowey.exe v 21 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
         EOF
         flowey.exe e 21 flowey_lib_common::cache 10
@@ -4511,8 +4376,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 21 flowey_lib_common::cache 4
-        flowey.exe v 21 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar6
-        flowey.exe v 21 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar7
+        flowey.exe v 21 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
+        flowey.exe v 21 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
@@ -4522,12 +4387,12 @@ jobs:
       name: 'Restore cache: gh-cli'
     - name: installing gh
       run: |-
-        flowey.exe v 21 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        flowey.exe v 21 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
         flowey.exe e 21 flowey_lib_common::cache 6
         flowey.exe e 21 flowey_lib_common::download_gh_cli 1
-        flowey.exe v 21 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.token <<EOF
+        flowey.exe v 21 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
         ${{ github.token }}
         EOF
       shell: bash
@@ -4587,8 +4452,8 @@ jobs:
         flowey.exe e 21 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
         flowey.exe e 21 flowey_lib_common::publish_test_results 0
         flowey.exe e 21 flowey_lib_common::publish_test_results 1
-        flowey.exe v 21 'flowey_lib_common::publish_test_results:2:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar1
-        flowey.exe v 21 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 21 'flowey_lib_common::publish_test_results:2:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:94:51 write-to-env github floweyvar1
+        flowey.exe v 21 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:94:51' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__2
       uses: actions/upload-artifact@v7
@@ -4602,8 +4467,8 @@ jobs:
         flowey.exe e 21 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
         flowey.exe e 21 flowey_lib_common::publish_test_results 3
         flowey.exe e 21 flowey_lib_common::publish_test_results 4
-        flowey.exe v 21 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar2
-        flowey.exe v 21 'flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 21 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:150:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:142:57 write-to-env github floweyvar2
+        flowey.exe v 21 'flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:142:57' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__5
       uses: actions/upload-artifact@v7
@@ -4691,8 +4556,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 22 flowey_lib_common::cache 0
-        flowey.exe v 22 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar4
-        flowey.exe v 22 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar5
+        flowey.exe v 22 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
+        flowey.exe v 22 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -4702,7 +4567,7 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
-        flowey.exe v 22 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey.exe v 22 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey.exe e 22 flowey_lib_common::cache 2
@@ -4711,8 +4576,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey.exe e 22 flowey_lib_common::git_checkout 0
-        flowey.exe v 22 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env github floweyvar3
-        flowey.exe v 22 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 22 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar3
+        flowey.exe v 22 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -4724,7 +4589,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey.exe v 22 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.workspace <<EOF
+        flowey.exe v 22 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
         flowey.exe e 22 flowey_lib_common::git_checkout 3
@@ -4759,8 +4624,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 22 flowey_lib_common::cache 8
-        flowey.exe v 22 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar8
-        flowey.exe v 22 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar9
+        flowey.exe v 22 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
+        flowey.exe v 22 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
       shell: bash
     - id: flowey_lib_common__cache__9
       uses: actions/cache@v5
@@ -4770,7 +4635,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 22 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
+        flowey.exe v 22 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
         EOF
         flowey.exe e 22 flowey_lib_common::cache 10
@@ -4793,8 +4658,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 22 flowey_lib_common::cache 4
-        flowey.exe v 22 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar6
-        flowey.exe v 22 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar7
+        flowey.exe v 22 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
+        flowey.exe v 22 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
@@ -4804,12 +4669,12 @@ jobs:
       name: 'Restore cache: gh-cli'
     - name: installing gh
       run: |-
-        flowey.exe v 22 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        flowey.exe v 22 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
         flowey.exe e 22 flowey_lib_common::cache 6
         flowey.exe e 22 flowey_lib_common::download_gh_cli 1
-        flowey.exe v 22 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.token <<EOF
+        flowey.exe v 22 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
         ${{ github.token }}
         EOF
       shell: bash
@@ -4869,8 +4734,8 @@ jobs:
         flowey.exe e 22 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
         flowey.exe e 22 flowey_lib_common::publish_test_results 0
         flowey.exe e 22 flowey_lib_common::publish_test_results 1
-        flowey.exe v 22 'flowey_lib_common::publish_test_results:2:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar1
-        flowey.exe v 22 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 22 'flowey_lib_common::publish_test_results:2:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:94:51 write-to-env github floweyvar1
+        flowey.exe v 22 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:94:51' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__2
       uses: actions/upload-artifact@v7
@@ -4884,8 +4749,8 @@ jobs:
         flowey.exe e 22 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
         flowey.exe e 22 flowey_lib_common::publish_test_results 3
         flowey.exe e 22 flowey_lib_common::publish_test_results 4
-        flowey.exe v 22 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar2
-        flowey.exe v 22 'flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 22 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:150:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:142:57 write-to-env github floweyvar2
+        flowey.exe v 22 'flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:142:57' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__5
       uses: actions/upload-artifact@v7
@@ -4974,8 +4839,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 23 flowey_lib_common::cache 0
-        flowey.exe v 23 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar4
-        flowey.exe v 23 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar5
+        flowey.exe v 23 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
+        flowey.exe v 23 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -4985,7 +4850,7 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
-        flowey.exe v 23 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey.exe v 23 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey.exe e 23 flowey_lib_common::cache 2
@@ -4994,8 +4859,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey.exe e 23 flowey_lib_common::git_checkout 0
-        flowey.exe v 23 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env github floweyvar3
-        flowey.exe v 23 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 23 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar3
+        flowey.exe v 23 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -5007,7 +4872,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey.exe v 23 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.workspace <<EOF
+        flowey.exe v 23 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
         flowey.exe e 23 flowey_lib_common::git_checkout 3
@@ -5042,8 +4907,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 23 flowey_lib_common::cache 8
-        flowey.exe v 23 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar8
-        flowey.exe v 23 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar9
+        flowey.exe v 23 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
+        flowey.exe v 23 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
       shell: bash
     - id: flowey_lib_common__cache__9
       uses: actions/cache@v5
@@ -5053,7 +4918,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 23 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
+        flowey.exe v 23 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
         EOF
         flowey.exe e 23 flowey_lib_common::cache 10
@@ -5076,8 +4941,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 23 flowey_lib_common::cache 4
-        flowey.exe v 23 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar6
-        flowey.exe v 23 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar7
+        flowey.exe v 23 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
+        flowey.exe v 23 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
@@ -5087,12 +4952,12 @@ jobs:
       name: 'Restore cache: gh-cli'
     - name: installing gh
       run: |-
-        flowey.exe v 23 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        flowey.exe v 23 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
         flowey.exe e 23 flowey_lib_common::cache 6
         flowey.exe e 23 flowey_lib_common::download_gh_cli 1
-        flowey.exe v 23 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.token <<EOF
+        flowey.exe v 23 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
         ${{ github.token }}
         EOF
       shell: bash
@@ -5152,8 +5017,8 @@ jobs:
         flowey.exe e 23 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
         flowey.exe e 23 flowey_lib_common::publish_test_results 0
         flowey.exe e 23 flowey_lib_common::publish_test_results 1
-        flowey.exe v 23 'flowey_lib_common::publish_test_results:2:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar1
-        flowey.exe v 23 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 23 'flowey_lib_common::publish_test_results:2:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:94:51 write-to-env github floweyvar1
+        flowey.exe v 23 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:94:51' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__2
       uses: actions/upload-artifact@v7
@@ -5167,8 +5032,8 @@ jobs:
         flowey.exe e 23 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
         flowey.exe e 23 flowey_lib_common::publish_test_results 3
         flowey.exe e 23 flowey_lib_common::publish_test_results 4
-        flowey.exe v 23 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar2
-        flowey.exe v 23 'flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 23 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:150:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:142:57 write-to-env github floweyvar2
+        flowey.exe v 23 'flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:142:57' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__5
       uses: actions/upload-artifact@v7
@@ -5253,8 +5118,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 24 flowey_lib_common::cache 0
-        flowey v 24 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar4
-        flowey v 24 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar5
+        flowey v 24 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
+        flowey v 24 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -5264,7 +5129,7 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
-        flowey v 24 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey v 24 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey e 24 flowey_lib_common::cache 2
@@ -5273,8 +5138,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 24 flowey_lib_common::git_checkout 0
-        flowey v 24 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env github floweyvar3
-        flowey v 24 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env github FLOWEY_CONDITION
+        flowey v 24 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar3
+        flowey v 24 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -5286,7 +5151,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey v 24 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.workspace <<EOF
+        flowey v 24 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
         flowey e 24 flowey_lib_common::git_checkout 3
@@ -5319,8 +5184,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 24 flowey_lib_common::cache 8
-        flowey v 24 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar8
-        flowey v 24 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar9
+        flowey v 24 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
+        flowey v 24 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
       shell: bash
     - id: flowey_lib_common__cache__9
       uses: actions/cache@v5
@@ -5330,7 +5195,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 24 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
+        flowey v 24 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
         EOF
         flowey e 24 flowey_lib_common::cache 10
@@ -5353,8 +5218,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 24 flowey_lib_common::cache 4
-        flowey v 24 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar6
-        flowey v 24 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar7
+        flowey v 24 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
+        flowey v 24 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
@@ -5364,12 +5229,12 @@ jobs:
       name: 'Restore cache: gh-cli'
     - name: installing gh
       run: |-
-        flowey v 24 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        flowey v 24 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
         flowey e 24 flowey_lib_common::cache 6
         flowey e 24 flowey_lib_common::download_gh_cli 1
-        flowey v 24 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.token <<EOF
+        flowey v 24 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
         ${{ github.token }}
         EOF
       shell: bash
@@ -5422,8 +5287,8 @@ jobs:
         flowey e 24 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
         flowey e 24 flowey_lib_common::publish_test_results 0
         flowey e 24 flowey_lib_common::publish_test_results 1
-        flowey v 24 'flowey_lib_common::publish_test_results:2:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar1
-        flowey v 24 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
+        flowey v 24 'flowey_lib_common::publish_test_results:2:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:94:51 write-to-env github floweyvar1
+        flowey v 24 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:94:51' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__2
       uses: actions/upload-artifact@v7
@@ -5437,8 +5302,8 @@ jobs:
         flowey e 24 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
         flowey e 24 flowey_lib_common::publish_test_results 3
         flowey e 24 flowey_lib_common::publish_test_results 4
-        flowey v 24 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar2
-        flowey v 24 'flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
+        flowey v 24 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:150:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:142:57 write-to-env github floweyvar2
+        flowey v 24 'flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:142:57' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__5
       uses: actions/upload-artifact@v7
@@ -5568,8 +5433,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 25 flowey_lib_common::cache 0
-        flowey v 25 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar4
-        flowey v 25 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar5
+        flowey v 25 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
+        flowey v 25 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -5579,7 +5444,7 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
-        flowey v 25 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey v 25 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey e 25 flowey_lib_common::cache 2
@@ -5588,8 +5453,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 25 flowey_lib_common::git_checkout 0
-        flowey v 25 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env github floweyvar3
-        flowey v 25 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env github FLOWEY_CONDITION
+        flowey v 25 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar3
+        flowey v 25 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -5601,7 +5466,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey v 25 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.workspace <<EOF
+        flowey v 25 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
         flowey e 25 flowey_lib_common::git_checkout 3
@@ -5634,8 +5499,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 25 flowey_lib_common::cache 8
-        flowey v 25 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar8
-        flowey v 25 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar9
+        flowey v 25 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
+        flowey v 25 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
       shell: bash
     - id: flowey_lib_common__cache__9
       uses: actions/cache@v5
@@ -5645,7 +5510,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 25 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
+        flowey v 25 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
         EOF
         flowey e 25 flowey_lib_common::cache 10
@@ -5668,8 +5533,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 25 flowey_lib_common::cache 4
-        flowey v 25 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar6
-        flowey v 25 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar7
+        flowey v 25 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
+        flowey v 25 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
@@ -5679,12 +5544,12 @@ jobs:
       name: 'Restore cache: gh-cli'
     - name: installing gh
       run: |-
-        flowey v 25 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        flowey v 25 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
         flowey e 25 flowey_lib_common::cache 6
         flowey e 25 flowey_lib_common::download_gh_cli 1
-        flowey v 25 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.token <<EOF
+        flowey v 25 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
         ${{ github.token }}
         EOF
       shell: bash
@@ -5736,8 +5601,8 @@ jobs:
         flowey e 25 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
         flowey e 25 flowey_lib_common::publish_test_results 0
         flowey e 25 flowey_lib_common::publish_test_results 1
-        flowey v 25 'flowey_lib_common::publish_test_results:2:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar1
-        flowey v 25 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
+        flowey v 25 'flowey_lib_common::publish_test_results:2:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:94:51 write-to-env github floweyvar1
+        flowey v 25 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:94:51' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__2
       uses: actions/upload-artifact@v7
@@ -5751,8 +5616,8 @@ jobs:
         flowey e 25 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
         flowey e 25 flowey_lib_common::publish_test_results 3
         flowey e 25 flowey_lib_common::publish_test_results 4
-        flowey v 25 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar2
-        flowey v 25 'flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
+        flowey v 25 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:150:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:142:57 write-to-env github floweyvar2
+        flowey v 25 'flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:142:57' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__5
       uses: actions/upload-artifact@v7
@@ -5883,8 +5748,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 26 flowey_lib_common::cache 0
-        flowey.exe v 26 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar4
-        flowey.exe v 26 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar5
+        flowey.exe v 26 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
+        flowey.exe v 26 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -5894,7 +5759,7 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
-        flowey.exe v 26 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey.exe v 26 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey.exe e 26 flowey_lib_common::cache 2
@@ -5903,8 +5768,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey.exe e 26 flowey_lib_common::git_checkout 0
-        flowey.exe v 26 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env github floweyvar3
-        flowey.exe v 26 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 26 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar3
+        flowey.exe v 26 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -5916,7 +5781,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey.exe v 26 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.workspace <<EOF
+        flowey.exe v 26 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
         flowey.exe e 26 flowey_lib_common::git_checkout 3
@@ -5946,8 +5811,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 26 flowey_lib_common::cache 8
-        flowey.exe v 26 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar8
-        flowey.exe v 26 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar9
+        flowey.exe v 26 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
+        flowey.exe v 26 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
       shell: bash
     - id: flowey_lib_common__cache__9
       uses: actions/cache@v5
@@ -5957,7 +5822,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 26 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
+        flowey.exe v 26 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
         EOF
         flowey.exe e 26 flowey_lib_common::cache 10
@@ -5980,8 +5845,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 26 flowey_lib_common::cache 4
-        flowey.exe v 26 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar6
-        flowey.exe v 26 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar7
+        flowey.exe v 26 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
+        flowey.exe v 26 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
@@ -5991,12 +5856,12 @@ jobs:
       name: 'Restore cache: gh-cli'
     - name: installing gh
       run: |-
-        flowey.exe v 26 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        flowey.exe v 26 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
         flowey.exe e 26 flowey_lib_common::cache 6
         flowey.exe e 26 flowey_lib_common::download_gh_cli 1
-        flowey.exe v 26 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.token <<EOF
+        flowey.exe v 26 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
         ${{ github.token }}
         EOF
       shell: bash
@@ -6051,8 +5916,8 @@ jobs:
         flowey.exe e 26 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
         flowey.exe e 26 flowey_lib_common::publish_test_results 0
         flowey.exe e 26 flowey_lib_common::publish_test_results 1
-        flowey.exe v 26 'flowey_lib_common::publish_test_results:2:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar1
-        flowey.exe v 26 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 26 'flowey_lib_common::publish_test_results:2:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:94:51 write-to-env github floweyvar1
+        flowey.exe v 26 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:94:51' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__2
       uses: actions/upload-artifact@v7
@@ -6066,8 +5931,8 @@ jobs:
         flowey.exe e 26 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
         flowey.exe e 26 flowey_lib_common::publish_test_results 3
         flowey.exe e 26 flowey_lib_common::publish_test_results 4
-        flowey.exe v 26 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar2
-        flowey.exe v 26 'flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 26 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:150:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:142:57 write-to-env github floweyvar2
+        flowey.exe v 26 'flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:142:57' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__5
       uses: actions/upload-artifact@v7
@@ -6146,8 +6011,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 27 flowey_lib_common::cache 0
-        flowey v 27 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar4
-        flowey v 27 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar5
+        flowey v 27 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
+        flowey v 27 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -6157,7 +6022,7 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
-        flowey v 27 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey v 27 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey e 27 flowey_lib_common::cache 2
@@ -6166,8 +6031,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 27 flowey_lib_common::git_checkout 0
-        flowey v 27 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env github floweyvar3
-        flowey v 27 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env github FLOWEY_CONDITION
+        flowey v 27 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar3
+        flowey v 27 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -6179,7 +6044,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey v 27 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.workspace <<EOF
+        flowey v 27 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
         flowey e 27 flowey_lib_common::git_checkout 3
@@ -6215,8 +6080,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 27 flowey_lib_common::cache 8
-        flowey v 27 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar8
-        flowey v 27 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar9
+        flowey v 27 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
+        flowey v 27 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
       shell: bash
     - id: flowey_lib_common__cache__9
       uses: actions/cache@v5
@@ -6226,7 +6091,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 27 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
+        flowey v 27 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
         EOF
         flowey e 27 flowey_lib_common::cache 10
@@ -6249,8 +6114,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 27 flowey_lib_common::cache 4
-        flowey v 27 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar6
-        flowey v 27 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar7
+        flowey v 27 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
+        flowey v 27 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
@@ -6260,12 +6125,12 @@ jobs:
       name: 'Restore cache: gh-cli'
     - name: installing gh
       run: |-
-        flowey v 27 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        flowey v 27 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
         flowey e 27 flowey_lib_common::cache 6
         flowey e 27 flowey_lib_common::download_gh_cli 1
-        flowey v 27 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.token <<EOF
+        flowey v 27 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
         ${{ github.token }}
         EOF
       shell: bash
@@ -6321,8 +6186,8 @@ jobs:
         flowey e 27 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 6
         flowey e 27 flowey_lib_common::publish_test_results 0
         flowey e 27 flowey_lib_common::publish_test_results 1
-        flowey v 27 'flowey_lib_common::publish_test_results:2:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar1
-        flowey v 27 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
+        flowey v 27 'flowey_lib_common::publish_test_results:2:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:94:51 write-to-env github floweyvar1
+        flowey v 27 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:94:51' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__2
       uses: actions/upload-artifact@v7
@@ -6336,8 +6201,8 @@ jobs:
         flowey e 27 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 5
         flowey e 27 flowey_lib_common::publish_test_results 3
         flowey e 27 flowey_lib_common::publish_test_results 4
-        flowey v 27 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar2
-        flowey v 27 'flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
+        flowey v 27 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:150:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:142:57 write-to-env github floweyvar2
+        flowey v 27 'flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:142:57' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__5
       uses: actions/upload-artifact@v7
@@ -6436,8 +6301,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 28 flowey_lib_common::git_checkout 0
-        flowey v 28 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env github floweyvar1
-        flowey v 28 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env github FLOWEY_CONDITION
+        flowey v 28 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar1
+        flowey v 28 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -6449,7 +6314,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey v 28 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.workspace <<EOF
+        flowey v 28 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
         flowey e 28 flowey_lib_common::git_checkout 3
@@ -6468,7 +6333,7 @@ jobs:
     - name: detect active toolchain
       run: |-
         flowey e 28 flowey_lib_common::install_rust 2
-        flowey v 28 'flowey_lib_hvlite::_jobs::test_local_flowey_build_igvm:3:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.token <<EOF
+        flowey v 28 'flowey_lib_hvlite::_jobs::test_local_flowey_build_igvm:3:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
         ${{ github.token }}
         EOF
       shell: bash
@@ -6498,6 +6363,7 @@ jobs:
     - job20
     - job21
     - job22
+    - job23
     - job24
     - job25
     - job26
@@ -6545,8 +6411,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 29 flowey_lib_common::cache 0
-        flowey v 29 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar2
-        flowey v 29 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar3
+        flowey v 29 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar2
+        flowey v 29 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar3
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -6556,12 +6422,12 @@ jobs:
       name: 'Restore cache: gh-cli'
     - name: installing gh
       run: |-
-        flowey v 29 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey v 29 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey e 29 flowey_lib_common::cache 2
         flowey e 29 flowey_lib_common::download_gh_cli 1
-        flowey v 29 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.token <<EOF
+        flowey v 29 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
         ${{ github.token }}
         EOF
       shell: bash
@@ -6579,8 +6445,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 29 flowey_lib_common::git_checkout 0
-        flowey v 29 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env github floweyvar1
-        flowey v 29 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env github FLOWEY_CONDITION
+        flowey v 29 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar1
+        flowey v 29 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -6592,7 +6458,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey v 29 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.workspace <<EOF
+        flowey v 29 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
         flowey e 29 flowey_lib_common::git_checkout 3
@@ -6735,8 +6601,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 3 flowey_lib_common::git_checkout 0
-        flowey v 3 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env github floweyvar1
-        flowey v 3 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env github FLOWEY_CONDITION
+        flowey v 3 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar1
+        flowey v 3 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -6748,7 +6614,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey v 3 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.workspace <<EOF
+        flowey v 3 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
         flowey e 3 flowey_lib_common::git_checkout 3
@@ -6767,8 +6633,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 3 flowey_lib_common::cache 0
-        flowey v 3 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar2
-        flowey v 3 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar3
+        flowey v 3 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar2
+        flowey v 3 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar3
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -6778,7 +6644,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 3 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey v 3 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey e 3 flowey_lib_common::cache 2
@@ -7123,8 +6989,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey.exe e 4 flowey_lib_common::git_checkout 0
-        flowey.exe v 4 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env github floweyvar1
-        flowey.exe v 4 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 4 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar1
+        flowey.exe v 4 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -7136,7 +7002,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey.exe v 4 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.workspace <<EOF
+        flowey.exe v 4 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
         flowey.exe e 4 flowey_lib_common::git_checkout 3
@@ -7155,8 +7021,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 4 flowey_lib_common::cache 0
-        flowey.exe v 4 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar2
-        flowey.exe v 4 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar3
+        flowey.exe v 4 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar2
+        flowey.exe v 4 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar3
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -7166,7 +7032,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 4 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey.exe v 4 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey.exe e 4 flowey_lib_common::cache 2
@@ -7350,8 +7216,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey.exe e 5 flowey_lib_common::git_checkout 0
-        flowey.exe v 5 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env github floweyvar1
-        flowey.exe v 5 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 5 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar1
+        flowey.exe v 5 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -7363,7 +7229,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey.exe v 5 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.workspace <<EOF
+        flowey.exe v 5 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
         flowey.exe e 5 flowey_lib_common::git_checkout 3
@@ -7382,8 +7248,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 5 flowey_lib_common::cache 4
-        flowey.exe v 5 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar4
-        flowey.exe v 5 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar5
+        flowey.exe v 5 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
+        flowey.exe v 5 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
@@ -7393,7 +7259,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 5 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        flowey.exe v 5 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
         flowey.exe e 5 flowey_lib_common::cache 6
@@ -7478,8 +7344,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 5 flowey_lib_common::cache 0
-        flowey.exe v 5 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar2
-        flowey.exe v 5 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar3
+        flowey.exe v 5 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar2
+        flowey.exe v 5 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar3
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -7489,7 +7355,7 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
-        flowey.exe v 5 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey.exe v 5 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey.exe e 5 flowey_lib_common::cache 2
@@ -7664,8 +7530,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey.exe e 6 flowey_lib_common::git_checkout 0
-        flowey.exe v 6 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env github floweyvar1
-        flowey.exe v 6 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 6 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar1
+        flowey.exe v 6 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -7677,7 +7543,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey.exe v 6 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.workspace <<EOF
+        flowey.exe v 6 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
         flowey.exe e 6 flowey_lib_common::git_checkout 3
@@ -7696,8 +7562,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 6 flowey_lib_common::cache 0
-        flowey.exe v 6 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar2
-        flowey.exe v 6 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar3
+        flowey.exe v 6 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar2
+        flowey.exe v 6 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar3
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -7707,7 +7573,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 6 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey.exe v 6 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey.exe e 6 flowey_lib_common::cache 2
@@ -7895,8 +7761,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey.exe e 7 flowey_lib_common::git_checkout 0
-        flowey.exe v 7 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env github floweyvar1
-        flowey.exe v 7 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 7 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar1
+        flowey.exe v 7 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -7908,7 +7774,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey.exe v 7 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.workspace <<EOF
+        flowey.exe v 7 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
         flowey.exe e 7 flowey_lib_common::git_checkout 3
@@ -7927,8 +7793,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 7 flowey_lib_common::cache 4
-        flowey.exe v 7 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar4
-        flowey.exe v 7 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar5
+        flowey.exe v 7 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
+        flowey.exe v 7 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
@@ -7938,7 +7804,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 7 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        flowey.exe v 7 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
         flowey.exe e 7 flowey_lib_common::cache 6
@@ -8023,8 +7889,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 7 flowey_lib_common::cache 0
-        flowey.exe v 7 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar2
-        flowey.exe v 7 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar3
+        flowey.exe v 7 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar2
+        flowey.exe v 7 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar3
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -8034,7 +7900,7 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
-        flowey.exe v 7 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey.exe v 7 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey.exe e 7 flowey_lib_common::cache 2
@@ -8237,8 +8103,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 8 flowey_lib_common::git_checkout 0
-        flowey v 8 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env github floweyvar1
-        flowey v 8 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env github FLOWEY_CONDITION
+        flowey v 8 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar1
+        flowey v 8 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -8250,7 +8116,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey v 8 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.workspace <<EOF
+        flowey v 8 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
         flowey e 8 flowey_lib_common::git_checkout 3
@@ -8269,8 +8135,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 8 flowey_lib_common::cache 4
-        flowey v 8 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar4
-        flowey v 8 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar5
+        flowey v 8 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
+        flowey v 8 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
@@ -8280,7 +8146,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 8 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        flowey v 8 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
         flowey e 8 flowey_lib_common::cache 6
@@ -8438,8 +8304,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 8 flowey_lib_common::cache 0
-        flowey v 8 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar2
-        flowey v 8 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar3
+        flowey v 8 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar2
+        flowey v 8 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar3
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -8449,7 +8315,7 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
-        flowey v 8 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey v 8 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey e 8 flowey_lib_common::cache 2
@@ -8672,8 +8538,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 9 flowey_lib_common::git_checkout 0
-        flowey v 9 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env github floweyvar1
-        flowey v 9 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env github FLOWEY_CONDITION
+        flowey v 9 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar1
+        flowey v 9 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -8685,7 +8551,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey v 9 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.workspace <<EOF
+        flowey v 9 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
         flowey e 9 flowey_lib_common::git_checkout 3
@@ -8704,8 +8570,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 9 flowey_lib_common::cache 4
-        flowey v 9 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar4
-        flowey v 9 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar5
+        flowey v 9 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
+        flowey v 9 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
@@ -8715,7 +8581,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 9 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        flowey v 9 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
         flowey e 9 flowey_lib_common::cache 6
@@ -8877,8 +8743,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 9 flowey_lib_common::cache 0
-        flowey v 9 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar2
-        flowey v 9 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar3
+        flowey v 9 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar2
+        flowey v 9 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar3
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -8888,7 +8754,7 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
-        flowey v 9 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey v 9 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey e 9 flowey_lib_common::cache 2

--- a/.github/workflows/openvmm-pr-release.yaml
+++ b/.github/workflows/openvmm-pr-release.yaml
@@ -4558,7 +4558,6 @@ jobs:
       contents: read
       id-token: write
     needs:
-    - job0
     - job11
     - job2
     - job3

--- a/.github/workflows/openvmm-pr-release.yaml
+++ b/.github/workflows/openvmm-pr-release.yaml
@@ -107,8 +107,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 0 flowey_lib_common::git_checkout 0
-        flowey v 0 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar1
-        flowey v 0 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
+        flowey v 0 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env github floweyvar1
+        flowey v 0 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -120,7 +120,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey v 0 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey v 0 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
         flowey e 0 flowey_lib_common::git_checkout 3
@@ -150,8 +150,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 0 flowey_lib_common::cache 0
-        flowey v 0 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar2
-        flowey v 0 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar3
+        flowey v 0 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar2
+        flowey v 0 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar3
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -161,7 +161,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 0 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey v 0 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey e 0 flowey_lib_common::cache 2
@@ -321,8 +321,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey.exe e 1 flowey_lib_common::git_checkout 0
-        flowey.exe v 1 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar1
-        flowey.exe v 1 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 1 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env github floweyvar1
+        flowey.exe v 1 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -334,7 +334,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey.exe v 1 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey.exe v 1 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
         flowey.exe e 1 flowey_lib_common::git_checkout 3
@@ -364,8 +364,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 1 flowey_lib_common::cache 0
-        flowey.exe v 1 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar2
-        flowey.exe v 1 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar3
+        flowey.exe v 1 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar2
+        flowey.exe v 1 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar3
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -375,7 +375,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 1 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey.exe v 1 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey.exe e 1 flowey_lib_common::cache 2
@@ -447,8 +447,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 10 flowey_lib_common::git_checkout 0
-        flowey v 10 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar3
-        flowey v 10 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
+        flowey v 10 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env github floweyvar3
+        flowey v 10 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -460,7 +460,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey v 10 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey v 10 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
         flowey e 10 flowey_lib_common::git_checkout 3
@@ -489,8 +489,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 10 flowey_lib_common::cache 0
-        flowey v 10 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar1
-        flowey v 10 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar2
+        flowey v 10 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar1
+        flowey v 10 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar2
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -500,7 +500,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 10 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey v 10 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey e 10 flowey_lib_common::cache 2
@@ -662,8 +662,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 11 flowey_lib_common::git_checkout 0
-        flowey v 11 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar3
-        flowey v 11 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
+        flowey v 11 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env github floweyvar3
+        flowey v 11 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -675,7 +675,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey v 11 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey v 11 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
         flowey e 11 flowey_lib_common::git_checkout 3
@@ -704,8 +704,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 11 flowey_lib_common::cache 0
-        flowey v 11 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar1
-        flowey v 11 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar2
+        flowey v 11 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar1
+        flowey v 11 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar2
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -715,7 +715,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 11 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey v 11 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey e 11 flowey_lib_common::cache 2
@@ -980,8 +980,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 12 flowey_lib_common::git_checkout 0
-        flowey v 12 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar3
-        flowey v 12 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
+        flowey v 12 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env github floweyvar3
+        flowey v 12 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -993,7 +993,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey v 12 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey v 12 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
         flowey e 12 flowey_lib_common::git_checkout 3
@@ -1022,8 +1022,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 12 flowey_lib_common::cache 0
-        flowey v 12 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar1
-        flowey v 12 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar2
+        flowey v 12 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar1
+        flowey v 12 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar2
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -1033,7 +1033,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 12 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey v 12 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey e 12 flowey_lib_common::cache 2
@@ -1341,8 +1341,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey.exe e 13 flowey_lib_common::git_checkout 0
-        flowey.exe v 13 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar8
-        flowey.exe v 13 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 13 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env github floweyvar8
+        flowey.exe v 13 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -1354,7 +1354,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey.exe v 13 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey.exe v 13 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
         flowey.exe e 13 flowey_lib_common::git_checkout 3
@@ -1373,8 +1373,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 13 flowey_lib_common::cache 4
-        flowey.exe v 13 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
-        flowey.exe v 13 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
+        flowey.exe v 13 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar6
+        flowey.exe v 13 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar7
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
@@ -1384,7 +1384,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 13 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        flowey.exe v 13 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
         flowey.exe e 13 flowey_lib_common::cache 6
@@ -1429,8 +1429,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 13 flowey_lib_common::cache 0
-        flowey.exe v 13 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
-        flowey.exe v 13 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
+        flowey.exe v 13 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar4
+        flowey.exe v 13 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar5
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -1440,7 +1440,7 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
-        flowey.exe v 13 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey.exe v 13 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey.exe e 13 flowey_lib_common::cache 2
@@ -1476,8 +1476,8 @@ jobs:
         flowey.exe e 13 flowey_lib_hvlite::build_nextest_unit_tests 1
         flowey.exe e 13 flowey_lib_common::publish_test_results 6
         flowey.exe e 13 flowey_lib_common::publish_test_results 7
-        flowey.exe v 13 'flowey_lib_common::publish_test_results:12:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs:94:51 write-to-env github floweyvar3
-        flowey.exe v 13 'flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs:94:51' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 13 'flowey_lib_common::publish_test_results:12:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar3
+        flowey.exe v 13 'flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__8
       uses: actions/upload-artifact@v7
@@ -1496,8 +1496,8 @@ jobs:
         flowey.exe e 13 flowey_lib_hvlite::build_nextest_unit_tests 2
         flowey.exe e 13 flowey_lib_common::publish_test_results 0
         flowey.exe e 13 flowey_lib_common::publish_test_results 1
-        flowey.exe v 13 'flowey_lib_common::publish_test_results:2:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:94:51 write-to-env github floweyvar1
-        flowey.exe v 13 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:94:51' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 13 'flowey_lib_common::publish_test_results:2:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar1
+        flowey.exe v 13 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__2
       uses: actions/upload-artifact@v7
@@ -1516,8 +1516,8 @@ jobs:
         flowey.exe e 13 flowey_lib_hvlite::build_nextest_unit_tests 3
         flowey.exe e 13 flowey_lib_common::publish_test_results 3
         flowey.exe e 13 flowey_lib_common::publish_test_results 4
-        flowey.exe v 13 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:94:51 write-to-env github floweyvar2
-        flowey.exe v 13 'flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:94:51' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 13 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar2
+        flowey.exe v 13 'flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__5
       uses: actions/upload-artifact@v7
@@ -1597,8 +1597,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 14 flowey_lib_common::git_checkout 0
-        flowey v 14 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar10
-        flowey v 14 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
+        flowey v 14 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env github floweyvar10
+        flowey v 14 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -1610,7 +1610,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey v 14 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey v 14 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
         flowey e 14 flowey_lib_common::git_checkout 3
@@ -1629,8 +1629,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 14 flowey_lib_common::cache 4
-        flowey v 14 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
-        flowey v 14 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
+        flowey v 14 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar8
+        flowey v 14 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar9
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
@@ -1640,7 +1640,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 14 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        flowey v 14 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
         flowey e 14 flowey_lib_common::cache 6
@@ -1689,8 +1689,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 14 flowey_lib_common::cache 0
-        flowey v 14 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
-        flowey v 14 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
+        flowey v 14 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar6
+        flowey v 14 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar7
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -1700,7 +1700,7 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
-        flowey v 14 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey v 14 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey e 14 flowey_lib_common::cache 2
@@ -1725,8 +1725,8 @@ jobs:
         flowey e 14 flowey_lib_hvlite::build_nextest_unit_tests 3
         flowey e 14 flowey_lib_common::publish_test_results 6
         flowey e 14 flowey_lib_common::publish_test_results 7
-        flowey v 14 'flowey_lib_common::publish_test_results:12:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs:94:51 write-to-env github floweyvar3
-        flowey v 14 'flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs:94:51' write-to-env github FLOWEY_CONDITION
+        flowey v 14 'flowey_lib_common::publish_test_results:12:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar3
+        flowey v 14 'flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__8
       uses: actions/upload-artifact@v7
@@ -1745,8 +1745,8 @@ jobs:
         flowey e 14 flowey_lib_hvlite::build_nextest_unit_tests 4
         flowey e 14 flowey_lib_common::publish_test_results 9
         flowey e 14 flowey_lib_common::publish_test_results 10
-        flowey v 14 'flowey_lib_common::publish_test_results:17:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:15:flowey_lib_common/src/publish_test_results.rs:94:51 write-to-env github floweyvar4
-        flowey v 14 'flowey_lib_common::publish_test_results:15:flowey_lib_common/src/publish_test_results.rs:94:51' write-to-env github FLOWEY_CONDITION
+        flowey v 14 'flowey_lib_common::publish_test_results:17:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:15:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar4
+        flowey v 14 'flowey_lib_common::publish_test_results:15:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__11
       uses: actions/upload-artifact@v7
@@ -1765,8 +1765,8 @@ jobs:
         flowey e 14 flowey_lib_hvlite::build_nextest_unit_tests 5
         flowey e 14 flowey_lib_common::publish_test_results 12
         flowey e 14 flowey_lib_common::publish_test_results 13
-        flowey v 14 'flowey_lib_common::publish_test_results:22:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:20:flowey_lib_common/src/publish_test_results.rs:94:51 write-to-env github floweyvar5
-        flowey v 14 'flowey_lib_common::publish_test_results:20:flowey_lib_common/src/publish_test_results.rs:94:51' write-to-env github FLOWEY_CONDITION
+        flowey v 14 'flowey_lib_common::publish_test_results:22:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:20:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar5
+        flowey v 14 'flowey_lib_common::publish_test_results:20:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__14
       uses: actions/upload-artifact@v7
@@ -1800,8 +1800,8 @@ jobs:
         flowey e 14 flowey_lib_hvlite::build_nextest_unit_tests 1
         flowey e 14 flowey_lib_common::publish_test_results 0
         flowey e 14 flowey_lib_common::publish_test_results 1
-        flowey v 14 'flowey_lib_common::publish_test_results:2:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:94:51 write-to-env github floweyvar1
-        flowey v 14 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:94:51' write-to-env github FLOWEY_CONDITION
+        flowey v 14 'flowey_lib_common::publish_test_results:2:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar1
+        flowey v 14 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__2
       uses: actions/upload-artifact@v7
@@ -1820,8 +1820,8 @@ jobs:
         flowey e 14 flowey_lib_hvlite::build_nextest_unit_tests 2
         flowey e 14 flowey_lib_common::publish_test_results 3
         flowey e 14 flowey_lib_common::publish_test_results 4
-        flowey v 14 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:94:51 write-to-env github floweyvar2
-        flowey v 14 'flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:94:51' write-to-env github FLOWEY_CONDITION
+        flowey v 14 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar2
+        flowey v 14 'flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__5
       uses: actions/upload-artifact@v7
@@ -1895,8 +1895,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 15 flowey_lib_common::git_checkout 0
-        flowey v 15 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar11
-        flowey v 15 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
+        flowey v 15 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env github floweyvar11
+        flowey v 15 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -1908,7 +1908,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey v 15 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey v 15 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
         flowey e 15 flowey_lib_common::git_checkout 3
@@ -1925,8 +1925,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 15 flowey_lib_common::cache 4
-        flowey v 15 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar9
-        flowey v 15 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar10
+        flowey v 15 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar9
+        flowey v 15 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar10
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
@@ -1936,7 +1936,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 15 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        flowey v 15 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
         flowey e 15 flowey_lib_common::cache 6
@@ -2015,8 +2015,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 15 flowey_lib_common::cache 0
-        flowey v 15 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar7
-        flowey v 15 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar8
+        flowey v 15 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar7
+        flowey v 15 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar8
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -2026,7 +2026,7 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
-        flowey v 15 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey v 15 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey e 15 flowey_lib_common::cache 2
@@ -2051,8 +2051,8 @@ jobs:
         flowey e 15 flowey_lib_hvlite::build_nextest_unit_tests 3
         flowey e 15 flowey_lib_common::publish_test_results 6
         flowey e 15 flowey_lib_common::publish_test_results 7
-        flowey v 15 'flowey_lib_common::publish_test_results:12:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs:94:51 write-to-env github floweyvar3
-        flowey v 15 'flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs:94:51' write-to-env github FLOWEY_CONDITION
+        flowey v 15 'flowey_lib_common::publish_test_results:12:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar3
+        flowey v 15 'flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__8
       uses: actions/upload-artifact@v7
@@ -2071,8 +2071,8 @@ jobs:
         flowey e 15 flowey_lib_hvlite::build_nextest_unit_tests 4
         flowey e 15 flowey_lib_common::publish_test_results 9
         flowey e 15 flowey_lib_common::publish_test_results 10
-        flowey v 15 'flowey_lib_common::publish_test_results:17:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:15:flowey_lib_common/src/publish_test_results.rs:94:51 write-to-env github floweyvar4
-        flowey v 15 'flowey_lib_common::publish_test_results:15:flowey_lib_common/src/publish_test_results.rs:94:51' write-to-env github FLOWEY_CONDITION
+        flowey v 15 'flowey_lib_common::publish_test_results:17:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:15:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar4
+        flowey v 15 'flowey_lib_common::publish_test_results:15:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__11
       uses: actions/upload-artifact@v7
@@ -2091,8 +2091,8 @@ jobs:
         flowey e 15 flowey_lib_hvlite::build_nextest_unit_tests 5
         flowey e 15 flowey_lib_common::publish_test_results 12
         flowey e 15 flowey_lib_common::publish_test_results 13
-        flowey v 15 'flowey_lib_common::publish_test_results:22:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:20:flowey_lib_common/src/publish_test_results.rs:94:51 write-to-env github floweyvar5
-        flowey v 15 'flowey_lib_common::publish_test_results:20:flowey_lib_common/src/publish_test_results.rs:94:51' write-to-env github FLOWEY_CONDITION
+        flowey v 15 'flowey_lib_common::publish_test_results:22:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:20:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar5
+        flowey v 15 'flowey_lib_common::publish_test_results:20:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__14
       uses: actions/upload-artifact@v7
@@ -2111,8 +2111,8 @@ jobs:
         flowey e 15 flowey_lib_hvlite::build_nextest_unit_tests 6
         flowey e 15 flowey_lib_common::publish_test_results 15
         flowey e 15 flowey_lib_common::publish_test_results 16
-        flowey v 15 'flowey_lib_common::publish_test_results:27:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:25:flowey_lib_common/src/publish_test_results.rs:94:51 write-to-env github floweyvar6
-        flowey v 15 'flowey_lib_common::publish_test_results:25:flowey_lib_common/src/publish_test_results.rs:94:51' write-to-env github FLOWEY_CONDITION
+        flowey v 15 'flowey_lib_common::publish_test_results:27:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:25:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar6
+        flowey v 15 'flowey_lib_common::publish_test_results:25:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__17
       uses: actions/upload-artifact@v7
@@ -2146,8 +2146,8 @@ jobs:
         flowey e 15 flowey_lib_hvlite::build_nextest_unit_tests 1
         flowey e 15 flowey_lib_common::publish_test_results 0
         flowey e 15 flowey_lib_common::publish_test_results 1
-        flowey v 15 'flowey_lib_common::publish_test_results:2:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:94:51 write-to-env github floweyvar1
-        flowey v 15 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:94:51' write-to-env github FLOWEY_CONDITION
+        flowey v 15 'flowey_lib_common::publish_test_results:2:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar1
+        flowey v 15 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__2
       uses: actions/upload-artifact@v7
@@ -2166,8 +2166,8 @@ jobs:
         flowey e 15 flowey_lib_hvlite::build_nextest_unit_tests 2
         flowey e 15 flowey_lib_common::publish_test_results 3
         flowey e 15 flowey_lib_common::publish_test_results 4
-        flowey v 15 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:94:51 write-to-env github floweyvar2
-        flowey v 15 'flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:94:51' write-to-env github FLOWEY_CONDITION
+        flowey v 15 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar2
+        flowey v 15 'flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__5
       uses: actions/upload-artifact@v7
@@ -2285,8 +2285,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey.exe e 16 flowey_lib_common::git_checkout 0
-        flowey.exe v 16 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar8
-        flowey.exe v 16 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 16 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env github floweyvar8
+        flowey.exe v 16 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -2298,7 +2298,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey.exe v 16 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey.exe v 16 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
         flowey.exe e 16 flowey_lib_common::git_checkout 3
@@ -2317,8 +2317,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 16 flowey_lib_common::cache 4
-        flowey.exe v 16 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
-        flowey.exe v 16 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
+        flowey.exe v 16 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar6
+        flowey.exe v 16 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar7
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
@@ -2328,7 +2328,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 16 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        flowey.exe v 16 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
         flowey.exe e 16 flowey_lib_common::cache 6
@@ -2373,8 +2373,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 16 flowey_lib_common::cache 0
-        flowey.exe v 16 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
-        flowey.exe v 16 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
+        flowey.exe v 16 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar4
+        flowey.exe v 16 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar5
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -2384,7 +2384,7 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
-        flowey.exe v 16 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey.exe v 16 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey.exe e 16 flowey_lib_common::cache 2
@@ -2420,8 +2420,8 @@ jobs:
         flowey.exe e 16 flowey_lib_hvlite::build_nextest_unit_tests 1
         flowey.exe e 16 flowey_lib_common::publish_test_results 6
         flowey.exe e 16 flowey_lib_common::publish_test_results 7
-        flowey.exe v 16 'flowey_lib_common::publish_test_results:12:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs:94:51 write-to-env github floweyvar3
-        flowey.exe v 16 'flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs:94:51' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 16 'flowey_lib_common::publish_test_results:12:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar3
+        flowey.exe v 16 'flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__8
       uses: actions/upload-artifact@v7
@@ -2440,8 +2440,8 @@ jobs:
         flowey.exe e 16 flowey_lib_hvlite::build_nextest_unit_tests 2
         flowey.exe e 16 flowey_lib_common::publish_test_results 0
         flowey.exe e 16 flowey_lib_common::publish_test_results 1
-        flowey.exe v 16 'flowey_lib_common::publish_test_results:2:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:94:51 write-to-env github floweyvar1
-        flowey.exe v 16 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:94:51' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 16 'flowey_lib_common::publish_test_results:2:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar1
+        flowey.exe v 16 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__2
       uses: actions/upload-artifact@v7
@@ -2460,8 +2460,8 @@ jobs:
         flowey.exe e 16 flowey_lib_hvlite::build_nextest_unit_tests 3
         flowey.exe e 16 flowey_lib_common::publish_test_results 3
         flowey.exe e 16 flowey_lib_common::publish_test_results 4
-        flowey.exe v 16 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:94:51 write-to-env github floweyvar2
-        flowey.exe v 16 'flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:94:51' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 16 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar2
+        flowey.exe v 16 'flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__5
       uses: actions/upload-artifact@v7
@@ -2585,8 +2585,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 17 flowey_lib_common::git_checkout 0
-        flowey v 17 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar10
-        flowey v 17 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
+        flowey v 17 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env github floweyvar10
+        flowey v 17 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -2598,7 +2598,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey v 17 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey v 17 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
         flowey e 17 flowey_lib_common::git_checkout 3
@@ -2617,8 +2617,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 17 flowey_lib_common::cache 4
-        flowey v 17 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
-        flowey v 17 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
+        flowey v 17 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar8
+        flowey v 17 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar9
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
@@ -2628,7 +2628,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 17 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        flowey v 17 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
         flowey e 17 flowey_lib_common::cache 6
@@ -2685,8 +2685,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 17 flowey_lib_common::cache 0
-        flowey v 17 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
-        flowey v 17 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
+        flowey v 17 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar6
+        flowey v 17 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar7
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -2696,7 +2696,7 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
-        flowey v 17 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey v 17 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey e 17 flowey_lib_common::cache 2
@@ -2721,8 +2721,8 @@ jobs:
         flowey e 17 flowey_lib_hvlite::build_nextest_unit_tests 3
         flowey e 17 flowey_lib_common::publish_test_results 6
         flowey e 17 flowey_lib_common::publish_test_results 7
-        flowey v 17 'flowey_lib_common::publish_test_results:12:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs:94:51 write-to-env github floweyvar3
-        flowey v 17 'flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs:94:51' write-to-env github FLOWEY_CONDITION
+        flowey v 17 'flowey_lib_common::publish_test_results:12:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar3
+        flowey v 17 'flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__8
       uses: actions/upload-artifact@v7
@@ -2741,8 +2741,8 @@ jobs:
         flowey e 17 flowey_lib_hvlite::build_nextest_unit_tests 4
         flowey e 17 flowey_lib_common::publish_test_results 9
         flowey e 17 flowey_lib_common::publish_test_results 10
-        flowey v 17 'flowey_lib_common::publish_test_results:17:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:15:flowey_lib_common/src/publish_test_results.rs:94:51 write-to-env github floweyvar4
-        flowey v 17 'flowey_lib_common::publish_test_results:15:flowey_lib_common/src/publish_test_results.rs:94:51' write-to-env github FLOWEY_CONDITION
+        flowey v 17 'flowey_lib_common::publish_test_results:17:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:15:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar4
+        flowey v 17 'flowey_lib_common::publish_test_results:15:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__11
       uses: actions/upload-artifact@v7
@@ -2761,8 +2761,8 @@ jobs:
         flowey e 17 flowey_lib_hvlite::build_nextest_unit_tests 5
         flowey e 17 flowey_lib_common::publish_test_results 12
         flowey e 17 flowey_lib_common::publish_test_results 13
-        flowey v 17 'flowey_lib_common::publish_test_results:22:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:20:flowey_lib_common/src/publish_test_results.rs:94:51 write-to-env github floweyvar5
-        flowey v 17 'flowey_lib_common::publish_test_results:20:flowey_lib_common/src/publish_test_results.rs:94:51' write-to-env github FLOWEY_CONDITION
+        flowey v 17 'flowey_lib_common::publish_test_results:22:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:20:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar5
+        flowey v 17 'flowey_lib_common::publish_test_results:20:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__14
       uses: actions/upload-artifact@v7
@@ -2796,8 +2796,8 @@ jobs:
         flowey e 17 flowey_lib_hvlite::build_nextest_unit_tests 1
         flowey e 17 flowey_lib_common::publish_test_results 0
         flowey e 17 flowey_lib_common::publish_test_results 1
-        flowey v 17 'flowey_lib_common::publish_test_results:2:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:94:51 write-to-env github floweyvar1
-        flowey v 17 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:94:51' write-to-env github FLOWEY_CONDITION
+        flowey v 17 'flowey_lib_common::publish_test_results:2:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar1
+        flowey v 17 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__2
       uses: actions/upload-artifact@v7
@@ -2816,8 +2816,8 @@ jobs:
         flowey e 17 flowey_lib_hvlite::build_nextest_unit_tests 2
         flowey e 17 flowey_lib_common::publish_test_results 3
         flowey e 17 flowey_lib_common::publish_test_results 4
-        flowey v 17 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:94:51 write-to-env github floweyvar2
-        flowey v 17 'flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:94:51' write-to-env github FLOWEY_CONDITION
+        flowey v 17 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar2
+        flowey v 17 'flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__5
       uses: actions/upload-artifact@v7
@@ -2935,8 +2935,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 18 flowey_lib_common::git_checkout 0
-        flowey v 18 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar11
-        flowey v 18 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
+        flowey v 18 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env github floweyvar11
+        flowey v 18 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -2948,7 +2948,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey v 18 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey v 18 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
         flowey e 18 flowey_lib_common::git_checkout 3
@@ -2965,8 +2965,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 18 flowey_lib_common::cache 4
-        flowey v 18 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar9
-        flowey v 18 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar10
+        flowey v 18 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar9
+        flowey v 18 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar10
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
@@ -2976,7 +2976,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 18 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        flowey v 18 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
         flowey e 18 flowey_lib_common::cache 6
@@ -3055,8 +3055,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 18 flowey_lib_common::cache 0
-        flowey v 18 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar7
-        flowey v 18 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar8
+        flowey v 18 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar7
+        flowey v 18 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar8
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -3066,7 +3066,7 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
-        flowey v 18 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey v 18 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey e 18 flowey_lib_common::cache 2
@@ -3091,8 +3091,8 @@ jobs:
         flowey e 18 flowey_lib_hvlite::build_nextest_unit_tests 3
         flowey e 18 flowey_lib_common::publish_test_results 6
         flowey e 18 flowey_lib_common::publish_test_results 7
-        flowey v 18 'flowey_lib_common::publish_test_results:12:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs:94:51 write-to-env github floweyvar3
-        flowey v 18 'flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs:94:51' write-to-env github FLOWEY_CONDITION
+        flowey v 18 'flowey_lib_common::publish_test_results:12:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar3
+        flowey v 18 'flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__8
       uses: actions/upload-artifact@v7
@@ -3111,8 +3111,8 @@ jobs:
         flowey e 18 flowey_lib_hvlite::build_nextest_unit_tests 4
         flowey e 18 flowey_lib_common::publish_test_results 9
         flowey e 18 flowey_lib_common::publish_test_results 10
-        flowey v 18 'flowey_lib_common::publish_test_results:17:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:15:flowey_lib_common/src/publish_test_results.rs:94:51 write-to-env github floweyvar4
-        flowey v 18 'flowey_lib_common::publish_test_results:15:flowey_lib_common/src/publish_test_results.rs:94:51' write-to-env github FLOWEY_CONDITION
+        flowey v 18 'flowey_lib_common::publish_test_results:17:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:15:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar4
+        flowey v 18 'flowey_lib_common::publish_test_results:15:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__11
       uses: actions/upload-artifact@v7
@@ -3131,8 +3131,8 @@ jobs:
         flowey e 18 flowey_lib_hvlite::build_nextest_unit_tests 5
         flowey e 18 flowey_lib_common::publish_test_results 12
         flowey e 18 flowey_lib_common::publish_test_results 13
-        flowey v 18 'flowey_lib_common::publish_test_results:22:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:20:flowey_lib_common/src/publish_test_results.rs:94:51 write-to-env github floweyvar5
-        flowey v 18 'flowey_lib_common::publish_test_results:20:flowey_lib_common/src/publish_test_results.rs:94:51' write-to-env github FLOWEY_CONDITION
+        flowey v 18 'flowey_lib_common::publish_test_results:22:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:20:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar5
+        flowey v 18 'flowey_lib_common::publish_test_results:20:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__14
       uses: actions/upload-artifact@v7
@@ -3151,8 +3151,8 @@ jobs:
         flowey e 18 flowey_lib_hvlite::build_nextest_unit_tests 6
         flowey e 18 flowey_lib_common::publish_test_results 15
         flowey e 18 flowey_lib_common::publish_test_results 16
-        flowey v 18 'flowey_lib_common::publish_test_results:27:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:25:flowey_lib_common/src/publish_test_results.rs:94:51 write-to-env github floweyvar6
-        flowey v 18 'flowey_lib_common::publish_test_results:25:flowey_lib_common/src/publish_test_results.rs:94:51' write-to-env github FLOWEY_CONDITION
+        flowey v 18 'flowey_lib_common::publish_test_results:27:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:25:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar6
+        flowey v 18 'flowey_lib_common::publish_test_results:25:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__17
       uses: actions/upload-artifact@v7
@@ -3186,8 +3186,8 @@ jobs:
         flowey e 18 flowey_lib_hvlite::build_nextest_unit_tests 1
         flowey e 18 flowey_lib_common::publish_test_results 0
         flowey e 18 flowey_lib_common::publish_test_results 1
-        flowey v 18 'flowey_lib_common::publish_test_results:2:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:94:51 write-to-env github floweyvar1
-        flowey v 18 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:94:51' write-to-env github FLOWEY_CONDITION
+        flowey v 18 'flowey_lib_common::publish_test_results:2:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar1
+        flowey v 18 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__2
       uses: actions/upload-artifact@v7
@@ -3206,8 +3206,8 @@ jobs:
         flowey e 18 flowey_lib_hvlite::build_nextest_unit_tests 2
         flowey e 18 flowey_lib_common::publish_test_results 3
         flowey e 18 flowey_lib_common::publish_test_results 4
-        flowey v 18 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:94:51 write-to-env github floweyvar2
-        flowey v 18 'flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:94:51' write-to-env github FLOWEY_CONDITION
+        flowey v 18 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar2
+        flowey v 18 'flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__5
       uses: actions/upload-artifact@v7
@@ -3298,8 +3298,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 19 flowey_lib_common::cache 0
-        flowey.exe v 19 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
-        flowey.exe v 19 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
+        flowey.exe v 19 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar4
+        flowey.exe v 19 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar5
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -3309,7 +3309,7 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
-        flowey.exe v 19 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey.exe v 19 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey.exe e 19 flowey_lib_common::cache 2
@@ -3318,8 +3318,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey.exe e 19 flowey_lib_common::git_checkout 0
-        flowey.exe v 19 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar3
-        flowey.exe v 19 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 19 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env github floweyvar3
+        flowey.exe v 19 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -3331,7 +3331,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey.exe v 19 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey.exe v 19 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
         flowey.exe e 19 flowey_lib_common::git_checkout 3
@@ -3366,8 +3366,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 19 flowey_lib_common::cache 8
-        flowey.exe v 19 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
-        flowey.exe v 19 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
+        flowey.exe v 19 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar8
+        flowey.exe v 19 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar9
       shell: bash
     - id: flowey_lib_common__cache__9
       uses: actions/cache@v5
@@ -3377,7 +3377,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 19 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
+        flowey.exe v 19 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
         EOF
         flowey.exe e 19 flowey_lib_common::cache 10
@@ -3400,8 +3400,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 19 flowey_lib_common::cache 4
-        flowey.exe v 19 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
-        flowey.exe v 19 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
+        flowey.exe v 19 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar6
+        flowey.exe v 19 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar7
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
@@ -3411,12 +3411,12 @@ jobs:
       name: 'Restore cache: gh-cli'
     - name: installing gh
       run: |-
-        flowey.exe v 19 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        flowey.exe v 19 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
         flowey.exe e 19 flowey_lib_common::cache 6
         flowey.exe e 19 flowey_lib_common::download_gh_cli 1
-        flowey.exe v 19 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
+        flowey.exe v 19 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.token <<EOF
         ${{ github.token }}
         EOF
       shell: bash
@@ -3476,8 +3476,8 @@ jobs:
         flowey.exe e 19 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
         flowey.exe e 19 flowey_lib_common::publish_test_results 0
         flowey.exe e 19 flowey_lib_common::publish_test_results 1
-        flowey.exe v 19 'flowey_lib_common::publish_test_results:2:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:94:51 write-to-env github floweyvar1
-        flowey.exe v 19 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:94:51' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 19 'flowey_lib_common::publish_test_results:2:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar1
+        flowey.exe v 19 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__2
       uses: actions/upload-artifact@v7
@@ -3491,8 +3491,8 @@ jobs:
         flowey.exe e 19 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
         flowey.exe e 19 flowey_lib_common::publish_test_results 3
         flowey.exe e 19 flowey_lib_common::publish_test_results 4
-        flowey.exe v 19 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:150:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:142:57 write-to-env github floweyvar2
-        flowey.exe v 19 'flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:142:57' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 19 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar2
+        flowey.exe v 19 'flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__5
       uses: actions/upload-artifact@v7
@@ -3612,8 +3612,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey.exe e 2 flowey_lib_common::git_checkout 0
-        flowey.exe v 2 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar1
-        flowey.exe v 2 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 2 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env github floweyvar1
+        flowey.exe v 2 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -3625,7 +3625,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey.exe v 2 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey.exe v 2 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
         flowey.exe e 2 flowey_lib_common::git_checkout 3
@@ -3644,8 +3644,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 2 flowey_lib_common::cache 0
-        flowey.exe v 2 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar2
-        flowey.exe v 2 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar3
+        flowey.exe v 2 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar2
+        flowey.exe v 2 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar3
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -3655,7 +3655,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 2 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey.exe v 2 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey.exe e 2 flowey_lib_common::cache 2
@@ -3769,8 +3769,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 20 flowey_lib_common::cache 0
-        flowey.exe v 20 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
-        flowey.exe v 20 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
+        flowey.exe v 20 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar4
+        flowey.exe v 20 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar5
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -3780,7 +3780,7 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
-        flowey.exe v 20 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey.exe v 20 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey.exe e 20 flowey_lib_common::cache 2
@@ -3789,8 +3789,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey.exe e 20 flowey_lib_common::git_checkout 0
-        flowey.exe v 20 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar3
-        flowey.exe v 20 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 20 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env github floweyvar3
+        flowey.exe v 20 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -3802,7 +3802,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey.exe v 20 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey.exe v 20 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
         flowey.exe e 20 flowey_lib_common::git_checkout 3
@@ -3837,8 +3837,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 20 flowey_lib_common::cache 8
-        flowey.exe v 20 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
-        flowey.exe v 20 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
+        flowey.exe v 20 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar8
+        flowey.exe v 20 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar9
       shell: bash
     - id: flowey_lib_common__cache__9
       uses: actions/cache@v5
@@ -3848,7 +3848,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 20 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
+        flowey.exe v 20 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
         EOF
         flowey.exe e 20 flowey_lib_common::cache 10
@@ -3871,8 +3871,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 20 flowey_lib_common::cache 4
-        flowey.exe v 20 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
-        flowey.exe v 20 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
+        flowey.exe v 20 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar6
+        flowey.exe v 20 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar7
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
@@ -3882,12 +3882,12 @@ jobs:
       name: 'Restore cache: gh-cli'
     - name: installing gh
       run: |-
-        flowey.exe v 20 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        flowey.exe v 20 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
         flowey.exe e 20 flowey_lib_common::cache 6
         flowey.exe e 20 flowey_lib_common::download_gh_cli 1
-        flowey.exe v 20 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
+        flowey.exe v 20 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.token <<EOF
         ${{ github.token }}
         EOF
       shell: bash
@@ -3942,8 +3942,8 @@ jobs:
         flowey.exe e 20 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
         flowey.exe e 20 flowey_lib_common::publish_test_results 0
         flowey.exe e 20 flowey_lib_common::publish_test_results 1
-        flowey.exe v 20 'flowey_lib_common::publish_test_results:2:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:94:51 write-to-env github floweyvar1
-        flowey.exe v 20 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:94:51' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 20 'flowey_lib_common::publish_test_results:2:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar1
+        flowey.exe v 20 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__2
       uses: actions/upload-artifact@v7
@@ -3957,8 +3957,8 @@ jobs:
         flowey.exe e 20 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
         flowey.exe e 20 flowey_lib_common::publish_test_results 3
         flowey.exe e 20 flowey_lib_common::publish_test_results 4
-        flowey.exe v 20 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:150:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:142:57 write-to-env github floweyvar2
-        flowey.exe v 20 'flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:142:57' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 20 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar2
+        flowey.exe v 20 'flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__5
       uses: actions/upload-artifact@v7
@@ -4048,8 +4048,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 21 flowey_lib_common::cache 0
-        flowey.exe v 21 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
-        flowey.exe v 21 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
+        flowey.exe v 21 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar4
+        flowey.exe v 21 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar5
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -4059,7 +4059,7 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
-        flowey.exe v 21 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey.exe v 21 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey.exe e 21 flowey_lib_common::cache 2
@@ -4068,8 +4068,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey.exe e 21 flowey_lib_common::git_checkout 0
-        flowey.exe v 21 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar3
-        flowey.exe v 21 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 21 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env github floweyvar3
+        flowey.exe v 21 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -4081,7 +4081,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey.exe v 21 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey.exe v 21 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
         flowey.exe e 21 flowey_lib_common::git_checkout 3
@@ -4116,8 +4116,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 21 flowey_lib_common::cache 8
-        flowey.exe v 21 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
-        flowey.exe v 21 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
+        flowey.exe v 21 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar8
+        flowey.exe v 21 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar9
       shell: bash
     - id: flowey_lib_common__cache__9
       uses: actions/cache@v5
@@ -4127,7 +4127,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 21 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
+        flowey.exe v 21 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
         EOF
         flowey.exe e 21 flowey_lib_common::cache 10
@@ -4150,8 +4150,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 21 flowey_lib_common::cache 4
-        flowey.exe v 21 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
-        flowey.exe v 21 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
+        flowey.exe v 21 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar6
+        flowey.exe v 21 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar7
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
@@ -4161,12 +4161,12 @@ jobs:
       name: 'Restore cache: gh-cli'
     - name: installing gh
       run: |-
-        flowey.exe v 21 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        flowey.exe v 21 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
         flowey.exe e 21 flowey_lib_common::cache 6
         flowey.exe e 21 flowey_lib_common::download_gh_cli 1
-        flowey.exe v 21 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
+        flowey.exe v 21 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.token <<EOF
         ${{ github.token }}
         EOF
       shell: bash
@@ -4226,8 +4226,8 @@ jobs:
         flowey.exe e 21 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
         flowey.exe e 21 flowey_lib_common::publish_test_results 0
         flowey.exe e 21 flowey_lib_common::publish_test_results 1
-        flowey.exe v 21 'flowey_lib_common::publish_test_results:2:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:94:51 write-to-env github floweyvar1
-        flowey.exe v 21 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:94:51' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 21 'flowey_lib_common::publish_test_results:2:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar1
+        flowey.exe v 21 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__2
       uses: actions/upload-artifact@v7
@@ -4241,8 +4241,8 @@ jobs:
         flowey.exe e 21 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
         flowey.exe e 21 flowey_lib_common::publish_test_results 3
         flowey.exe e 21 flowey_lib_common::publish_test_results 4
-        flowey.exe v 21 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:150:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:142:57 write-to-env github floweyvar2
-        flowey.exe v 21 'flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:142:57' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 21 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar2
+        flowey.exe v 21 'flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__5
       uses: actions/upload-artifact@v7
@@ -4331,8 +4331,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 22 flowey_lib_common::cache 0
-        flowey.exe v 22 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
-        flowey.exe v 22 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
+        flowey.exe v 22 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar4
+        flowey.exe v 22 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar5
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -4342,7 +4342,7 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
-        flowey.exe v 22 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey.exe v 22 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey.exe e 22 flowey_lib_common::cache 2
@@ -4351,8 +4351,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey.exe e 22 flowey_lib_common::git_checkout 0
-        flowey.exe v 22 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar3
-        flowey.exe v 22 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 22 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env github floweyvar3
+        flowey.exe v 22 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -4364,7 +4364,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey.exe v 22 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey.exe v 22 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
         flowey.exe e 22 flowey_lib_common::git_checkout 3
@@ -4399,8 +4399,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 22 flowey_lib_common::cache 8
-        flowey.exe v 22 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
-        flowey.exe v 22 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
+        flowey.exe v 22 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar8
+        flowey.exe v 22 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar9
       shell: bash
     - id: flowey_lib_common__cache__9
       uses: actions/cache@v5
@@ -4410,7 +4410,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 22 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
+        flowey.exe v 22 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
         EOF
         flowey.exe e 22 flowey_lib_common::cache 10
@@ -4433,8 +4433,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 22 flowey_lib_common::cache 4
-        flowey.exe v 22 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
-        flowey.exe v 22 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
+        flowey.exe v 22 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar6
+        flowey.exe v 22 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar7
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
@@ -4444,12 +4444,12 @@ jobs:
       name: 'Restore cache: gh-cli'
     - name: installing gh
       run: |-
-        flowey.exe v 22 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        flowey.exe v 22 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
         flowey.exe e 22 flowey_lib_common::cache 6
         flowey.exe e 22 flowey_lib_common::download_gh_cli 1
-        flowey.exe v 22 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
+        flowey.exe v 22 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.token <<EOF
         ${{ github.token }}
         EOF
       shell: bash
@@ -4509,8 +4509,8 @@ jobs:
         flowey.exe e 22 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
         flowey.exe e 22 flowey_lib_common::publish_test_results 0
         flowey.exe e 22 flowey_lib_common::publish_test_results 1
-        flowey.exe v 22 'flowey_lib_common::publish_test_results:2:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:94:51 write-to-env github floweyvar1
-        flowey.exe v 22 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:94:51' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 22 'flowey_lib_common::publish_test_results:2:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar1
+        flowey.exe v 22 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__2
       uses: actions/upload-artifact@v7
@@ -4524,8 +4524,8 @@ jobs:
         flowey.exe e 22 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
         flowey.exe e 22 flowey_lib_common::publish_test_results 3
         flowey.exe e 22 flowey_lib_common::publish_test_results 4
-        flowey.exe v 22 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:150:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:142:57 write-to-env github floweyvar2
-        flowey.exe v 22 'flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:142:57' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 22 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar2
+        flowey.exe v 22 'flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__5
       uses: actions/upload-artifact@v7
@@ -4614,8 +4614,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 23 flowey_lib_common::cache 0
-        flowey.exe v 23 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
-        flowey.exe v 23 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
+        flowey.exe v 23 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar4
+        flowey.exe v 23 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar5
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -4625,7 +4625,7 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
-        flowey.exe v 23 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey.exe v 23 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey.exe e 23 flowey_lib_common::cache 2
@@ -4634,8 +4634,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey.exe e 23 flowey_lib_common::git_checkout 0
-        flowey.exe v 23 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar3
-        flowey.exe v 23 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 23 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env github floweyvar3
+        flowey.exe v 23 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -4647,7 +4647,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey.exe v 23 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey.exe v 23 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
         flowey.exe e 23 flowey_lib_common::git_checkout 3
@@ -4682,8 +4682,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 23 flowey_lib_common::cache 8
-        flowey.exe v 23 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
-        flowey.exe v 23 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
+        flowey.exe v 23 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar8
+        flowey.exe v 23 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar9
       shell: bash
     - id: flowey_lib_common__cache__9
       uses: actions/cache@v5
@@ -4693,7 +4693,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 23 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
+        flowey.exe v 23 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
         EOF
         flowey.exe e 23 flowey_lib_common::cache 10
@@ -4716,8 +4716,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 23 flowey_lib_common::cache 4
-        flowey.exe v 23 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
-        flowey.exe v 23 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
+        flowey.exe v 23 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar6
+        flowey.exe v 23 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar7
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
@@ -4727,12 +4727,12 @@ jobs:
       name: 'Restore cache: gh-cli'
     - name: installing gh
       run: |-
-        flowey.exe v 23 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        flowey.exe v 23 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
         flowey.exe e 23 flowey_lib_common::cache 6
         flowey.exe e 23 flowey_lib_common::download_gh_cli 1
-        flowey.exe v 23 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
+        flowey.exe v 23 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.token <<EOF
         ${{ github.token }}
         EOF
       shell: bash
@@ -4792,8 +4792,8 @@ jobs:
         flowey.exe e 23 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
         flowey.exe e 23 flowey_lib_common::publish_test_results 0
         flowey.exe e 23 flowey_lib_common::publish_test_results 1
-        flowey.exe v 23 'flowey_lib_common::publish_test_results:2:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:94:51 write-to-env github floweyvar1
-        flowey.exe v 23 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:94:51' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 23 'flowey_lib_common::publish_test_results:2:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar1
+        flowey.exe v 23 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__2
       uses: actions/upload-artifact@v7
@@ -4807,8 +4807,8 @@ jobs:
         flowey.exe e 23 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
         flowey.exe e 23 flowey_lib_common::publish_test_results 3
         flowey.exe e 23 flowey_lib_common::publish_test_results 4
-        flowey.exe v 23 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:150:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:142:57 write-to-env github floweyvar2
-        flowey.exe v 23 'flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:142:57' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 23 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar2
+        flowey.exe v 23 'flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__5
       uses: actions/upload-artifact@v7
@@ -4894,8 +4894,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 24 flowey_lib_common::cache 0
-        flowey v 24 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
-        flowey v 24 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
+        flowey v 24 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar4
+        flowey v 24 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar5
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -4905,7 +4905,7 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
-        flowey v 24 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey v 24 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey e 24 flowey_lib_common::cache 2
@@ -4914,8 +4914,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 24 flowey_lib_common::git_checkout 0
-        flowey v 24 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar3
-        flowey v 24 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
+        flowey v 24 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env github floweyvar3
+        flowey v 24 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -4927,7 +4927,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey v 24 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey v 24 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
         flowey e 24 flowey_lib_common::git_checkout 3
@@ -4960,8 +4960,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 24 flowey_lib_common::cache 8
-        flowey v 24 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
-        flowey v 24 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
+        flowey v 24 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar8
+        flowey v 24 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar9
       shell: bash
     - id: flowey_lib_common__cache__9
       uses: actions/cache@v5
@@ -4971,7 +4971,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 24 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
+        flowey v 24 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
         EOF
         flowey e 24 flowey_lib_common::cache 10
@@ -4994,8 +4994,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 24 flowey_lib_common::cache 4
-        flowey v 24 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
-        flowey v 24 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
+        flowey v 24 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar6
+        flowey v 24 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar7
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
@@ -5005,12 +5005,12 @@ jobs:
       name: 'Restore cache: gh-cli'
     - name: installing gh
       run: |-
-        flowey v 24 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        flowey v 24 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
         flowey e 24 flowey_lib_common::cache 6
         flowey e 24 flowey_lib_common::download_gh_cli 1
-        flowey v 24 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
+        flowey v 24 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.token <<EOF
         ${{ github.token }}
         EOF
       shell: bash
@@ -5063,8 +5063,8 @@ jobs:
         flowey e 24 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
         flowey e 24 flowey_lib_common::publish_test_results 0
         flowey e 24 flowey_lib_common::publish_test_results 1
-        flowey v 24 'flowey_lib_common::publish_test_results:2:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:94:51 write-to-env github floweyvar1
-        flowey v 24 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:94:51' write-to-env github FLOWEY_CONDITION
+        flowey v 24 'flowey_lib_common::publish_test_results:2:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar1
+        flowey v 24 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__2
       uses: actions/upload-artifact@v7
@@ -5078,8 +5078,8 @@ jobs:
         flowey e 24 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
         flowey e 24 flowey_lib_common::publish_test_results 3
         flowey e 24 flowey_lib_common::publish_test_results 4
-        flowey v 24 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:150:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:142:57 write-to-env github floweyvar2
-        flowey v 24 'flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:142:57' write-to-env github FLOWEY_CONDITION
+        flowey v 24 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar2
+        flowey v 24 'flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__5
       uses: actions/upload-artifact@v7
@@ -5210,8 +5210,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 25 flowey_lib_common::cache 0
-        flowey v 25 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
-        flowey v 25 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
+        flowey v 25 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar4
+        flowey v 25 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar5
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -5221,7 +5221,7 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
-        flowey v 25 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey v 25 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey e 25 flowey_lib_common::cache 2
@@ -5230,8 +5230,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 25 flowey_lib_common::git_checkout 0
-        flowey v 25 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar3
-        flowey v 25 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
+        flowey v 25 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env github floweyvar3
+        flowey v 25 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -5243,7 +5243,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey v 25 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey v 25 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
         flowey e 25 flowey_lib_common::git_checkout 3
@@ -5276,8 +5276,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 25 flowey_lib_common::cache 8
-        flowey v 25 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
-        flowey v 25 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
+        flowey v 25 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar8
+        flowey v 25 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar9
       shell: bash
     - id: flowey_lib_common__cache__9
       uses: actions/cache@v5
@@ -5287,7 +5287,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 25 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
+        flowey v 25 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
         EOF
         flowey e 25 flowey_lib_common::cache 10
@@ -5310,8 +5310,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 25 flowey_lib_common::cache 4
-        flowey v 25 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
-        flowey v 25 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
+        flowey v 25 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar6
+        flowey v 25 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar7
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
@@ -5321,12 +5321,12 @@ jobs:
       name: 'Restore cache: gh-cli'
     - name: installing gh
       run: |-
-        flowey v 25 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        flowey v 25 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
         flowey e 25 flowey_lib_common::cache 6
         flowey e 25 flowey_lib_common::download_gh_cli 1
-        flowey v 25 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
+        flowey v 25 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.token <<EOF
         ${{ github.token }}
         EOF
       shell: bash
@@ -5378,8 +5378,8 @@ jobs:
         flowey e 25 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
         flowey e 25 flowey_lib_common::publish_test_results 0
         flowey e 25 flowey_lib_common::publish_test_results 1
-        flowey v 25 'flowey_lib_common::publish_test_results:2:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:94:51 write-to-env github floweyvar1
-        flowey v 25 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:94:51' write-to-env github FLOWEY_CONDITION
+        flowey v 25 'flowey_lib_common::publish_test_results:2:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar1
+        flowey v 25 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__2
       uses: actions/upload-artifact@v7
@@ -5393,8 +5393,8 @@ jobs:
         flowey e 25 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
         flowey e 25 flowey_lib_common::publish_test_results 3
         flowey e 25 flowey_lib_common::publish_test_results 4
-        flowey v 25 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:150:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:142:57 write-to-env github floweyvar2
-        flowey v 25 'flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:142:57' write-to-env github FLOWEY_CONDITION
+        flowey v 25 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar2
+        flowey v 25 'flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__5
       uses: actions/upload-artifact@v7
@@ -5526,8 +5526,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 26 flowey_lib_common::cache 0
-        flowey.exe v 26 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
-        flowey.exe v 26 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
+        flowey.exe v 26 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar4
+        flowey.exe v 26 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar5
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -5537,7 +5537,7 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
-        flowey.exe v 26 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey.exe v 26 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey.exe e 26 flowey_lib_common::cache 2
@@ -5546,8 +5546,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey.exe e 26 flowey_lib_common::git_checkout 0
-        flowey.exe v 26 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar3
-        flowey.exe v 26 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 26 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env github floweyvar3
+        flowey.exe v 26 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -5559,7 +5559,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey.exe v 26 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey.exe v 26 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
         flowey.exe e 26 flowey_lib_common::git_checkout 3
@@ -5589,8 +5589,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 26 flowey_lib_common::cache 8
-        flowey.exe v 26 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
-        flowey.exe v 26 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
+        flowey.exe v 26 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar8
+        flowey.exe v 26 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar9
       shell: bash
     - id: flowey_lib_common__cache__9
       uses: actions/cache@v5
@@ -5600,7 +5600,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 26 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
+        flowey.exe v 26 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
         EOF
         flowey.exe e 26 flowey_lib_common::cache 10
@@ -5623,8 +5623,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 26 flowey_lib_common::cache 4
-        flowey.exe v 26 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
-        flowey.exe v 26 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
+        flowey.exe v 26 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar6
+        flowey.exe v 26 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar7
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
@@ -5634,12 +5634,12 @@ jobs:
       name: 'Restore cache: gh-cli'
     - name: installing gh
       run: |-
-        flowey.exe v 26 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        flowey.exe v 26 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
         flowey.exe e 26 flowey_lib_common::cache 6
         flowey.exe e 26 flowey_lib_common::download_gh_cli 1
-        flowey.exe v 26 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
+        flowey.exe v 26 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.token <<EOF
         ${{ github.token }}
         EOF
       shell: bash
@@ -5694,8 +5694,8 @@ jobs:
         flowey.exe e 26 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
         flowey.exe e 26 flowey_lib_common::publish_test_results 0
         flowey.exe e 26 flowey_lib_common::publish_test_results 1
-        flowey.exe v 26 'flowey_lib_common::publish_test_results:2:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:94:51 write-to-env github floweyvar1
-        flowey.exe v 26 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:94:51' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 26 'flowey_lib_common::publish_test_results:2:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar1
+        flowey.exe v 26 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__2
       uses: actions/upload-artifact@v7
@@ -5709,8 +5709,8 @@ jobs:
         flowey.exe e 26 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
         flowey.exe e 26 flowey_lib_common::publish_test_results 3
         flowey.exe e 26 flowey_lib_common::publish_test_results 4
-        flowey.exe v 26 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:150:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:142:57 write-to-env github floweyvar2
-        flowey.exe v 26 'flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:142:57' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 26 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar2
+        flowey.exe v 26 'flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__5
       uses: actions/upload-artifact@v7
@@ -5790,8 +5790,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 27 flowey_lib_common::cache 0
-        flowey v 27 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
-        flowey v 27 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
+        flowey v 27 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar4
+        flowey v 27 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar5
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -5801,7 +5801,7 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
-        flowey v 27 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey v 27 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey e 27 flowey_lib_common::cache 2
@@ -5810,8 +5810,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 27 flowey_lib_common::git_checkout 0
-        flowey v 27 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar3
-        flowey v 27 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
+        flowey v 27 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env github floweyvar3
+        flowey v 27 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -5823,7 +5823,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey v 27 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey v 27 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
         flowey e 27 flowey_lib_common::git_checkout 3
@@ -5859,8 +5859,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 27 flowey_lib_common::cache 8
-        flowey v 27 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
-        flowey v 27 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
+        flowey v 27 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar8
+        flowey v 27 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar9
       shell: bash
     - id: flowey_lib_common__cache__9
       uses: actions/cache@v5
@@ -5870,7 +5870,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 27 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
+        flowey v 27 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
         EOF
         flowey e 27 flowey_lib_common::cache 10
@@ -5893,8 +5893,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 27 flowey_lib_common::cache 4
-        flowey v 27 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
-        flowey v 27 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
+        flowey v 27 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar6
+        flowey v 27 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar7
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
@@ -5904,12 +5904,12 @@ jobs:
       name: 'Restore cache: gh-cli'
     - name: installing gh
       run: |-
-        flowey v 27 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        flowey v 27 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
         flowey e 27 flowey_lib_common::cache 6
         flowey e 27 flowey_lib_common::download_gh_cli 1
-        flowey v 27 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
+        flowey v 27 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.token <<EOF
         ${{ github.token }}
         EOF
       shell: bash
@@ -5965,8 +5965,8 @@ jobs:
         flowey e 27 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 6
         flowey e 27 flowey_lib_common::publish_test_results 0
         flowey e 27 flowey_lib_common::publish_test_results 1
-        flowey v 27 'flowey_lib_common::publish_test_results:2:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:94:51 write-to-env github floweyvar1
-        flowey v 27 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:94:51' write-to-env github FLOWEY_CONDITION
+        flowey v 27 'flowey_lib_common::publish_test_results:2:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar1
+        flowey v 27 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__2
       uses: actions/upload-artifact@v7
@@ -5980,8 +5980,8 @@ jobs:
         flowey e 27 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 5
         flowey e 27 flowey_lib_common::publish_test_results 3
         flowey e 27 flowey_lib_common::publish_test_results 4
-        flowey v 27 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:150:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:142:57 write-to-env github floweyvar2
-        flowey v 27 'flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:142:57' write-to-env github FLOWEY_CONDITION
+        flowey v 27 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar2
+        flowey v 27 'flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__5
       uses: actions/upload-artifact@v7
@@ -6038,8 +6038,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 28 flowey_lib_common::git_checkout 0
-        flowey v 28 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar1
-        flowey v 28 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
+        flowey v 28 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env github floweyvar1
+        flowey v 28 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -6051,7 +6051,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey v 28 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey v 28 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
         flowey e 28 flowey_lib_common::git_checkout 3
@@ -6070,7 +6070,7 @@ jobs:
     - name: detect active toolchain
       run: |-
         flowey e 28 flowey_lib_common::install_rust 2
-        flowey v 28 'flowey_lib_hvlite::_jobs::test_local_flowey_build_igvm:3:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
+        flowey v 28 'flowey_lib_hvlite::_jobs::test_local_flowey_build_igvm:3:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.token <<EOF
         ${{ github.token }}
         EOF
       shell: bash
@@ -6150,8 +6150,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 3 flowey_lib_common::git_checkout 0
-        flowey v 3 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar1
-        flowey v 3 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
+        flowey v 3 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env github floweyvar1
+        flowey v 3 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -6163,7 +6163,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey v 3 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey v 3 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
         flowey e 3 flowey_lib_common::git_checkout 3
@@ -6182,8 +6182,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 3 flowey_lib_common::cache 0
-        flowey v 3 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar2
-        flowey v 3 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar3
+        flowey v 3 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar2
+        flowey v 3 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar3
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -6193,7 +6193,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 3 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey v 3 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey e 3 flowey_lib_common::cache 2
@@ -6539,8 +6539,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey.exe e 4 flowey_lib_common::git_checkout 0
-        flowey.exe v 4 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar1
-        flowey.exe v 4 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 4 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env github floweyvar1
+        flowey.exe v 4 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -6552,7 +6552,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey.exe v 4 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey.exe v 4 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
         flowey.exe e 4 flowey_lib_common::git_checkout 3
@@ -6571,8 +6571,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 4 flowey_lib_common::cache 0
-        flowey.exe v 4 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar2
-        flowey.exe v 4 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar3
+        flowey.exe v 4 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar2
+        flowey.exe v 4 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar3
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -6582,7 +6582,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 4 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey.exe v 4 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey.exe e 4 flowey_lib_common::cache 2
@@ -6768,8 +6768,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey.exe e 5 flowey_lib_common::git_checkout 0
-        flowey.exe v 5 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar1
-        flowey.exe v 5 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 5 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env github floweyvar1
+        flowey.exe v 5 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -6781,7 +6781,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey.exe v 5 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey.exe v 5 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
         flowey.exe e 5 flowey_lib_common::git_checkout 3
@@ -6800,8 +6800,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 5 flowey_lib_common::cache 4
-        flowey.exe v 5 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
-        flowey.exe v 5 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
+        flowey.exe v 5 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar4
+        flowey.exe v 5 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar5
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
@@ -6811,7 +6811,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 5 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        flowey.exe v 5 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
         flowey.exe e 5 flowey_lib_common::cache 6
@@ -6896,8 +6896,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 5 flowey_lib_common::cache 0
-        flowey.exe v 5 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar2
-        flowey.exe v 5 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar3
+        flowey.exe v 5 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar2
+        flowey.exe v 5 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar3
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -6907,7 +6907,7 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
-        flowey.exe v 5 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey.exe v 5 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey.exe e 5 flowey_lib_common::cache 2
@@ -7084,8 +7084,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey.exe e 6 flowey_lib_common::git_checkout 0
-        flowey.exe v 6 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar1
-        flowey.exe v 6 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 6 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env github floweyvar1
+        flowey.exe v 6 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -7097,7 +7097,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey.exe v 6 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey.exe v 6 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
         flowey.exe e 6 flowey_lib_common::git_checkout 3
@@ -7116,8 +7116,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 6 flowey_lib_common::cache 0
-        flowey.exe v 6 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar2
-        flowey.exe v 6 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar3
+        flowey.exe v 6 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar2
+        flowey.exe v 6 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar3
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -7127,7 +7127,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 6 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey.exe v 6 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey.exe e 6 flowey_lib_common::cache 2
@@ -7317,8 +7317,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey.exe e 7 flowey_lib_common::git_checkout 0
-        flowey.exe v 7 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar1
-        flowey.exe v 7 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 7 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env github floweyvar1
+        flowey.exe v 7 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -7330,7 +7330,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey.exe v 7 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey.exe v 7 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
         flowey.exe e 7 flowey_lib_common::git_checkout 3
@@ -7349,8 +7349,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 7 flowey_lib_common::cache 4
-        flowey.exe v 7 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
-        flowey.exe v 7 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
+        flowey.exe v 7 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar4
+        flowey.exe v 7 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar5
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
@@ -7360,7 +7360,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 7 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        flowey.exe v 7 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
         flowey.exe e 7 flowey_lib_common::cache 6
@@ -7445,8 +7445,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 7 flowey_lib_common::cache 0
-        flowey.exe v 7 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar2
-        flowey.exe v 7 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar3
+        flowey.exe v 7 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar2
+        flowey.exe v 7 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar3
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -7456,7 +7456,7 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
-        flowey.exe v 7 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey.exe v 7 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey.exe e 7 flowey_lib_common::cache 2
@@ -7617,8 +7617,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 8 flowey_lib_common::git_checkout 0
-        flowey v 8 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar1
-        flowey v 8 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
+        flowey v 8 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env github floweyvar1
+        flowey v 8 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -7630,7 +7630,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey v 8 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey v 8 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
         flowey e 8 flowey_lib_common::git_checkout 3
@@ -7649,8 +7649,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 8 flowey_lib_common::cache 4
-        flowey v 8 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
-        flowey v 8 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
+        flowey v 8 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar4
+        flowey v 8 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar5
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
@@ -7660,7 +7660,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 8 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        flowey v 8 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
         flowey e 8 flowey_lib_common::cache 6
@@ -7818,8 +7818,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 8 flowey_lib_common::cache 0
-        flowey v 8 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar2
-        flowey v 8 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar3
+        flowey v 8 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar2
+        flowey v 8 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar3
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -7829,7 +7829,7 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
-        flowey v 8 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey v 8 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey e 8 flowey_lib_common::cache 2
@@ -8002,8 +8002,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 9 flowey_lib_common::git_checkout 0
-        flowey v 9 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar1
-        flowey v 9 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
+        flowey v 9 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env github floweyvar1
+        flowey v 9 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -8015,7 +8015,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey v 9 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey v 9 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
         flowey e 9 flowey_lib_common::git_checkout 3
@@ -8034,8 +8034,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 9 flowey_lib_common::cache 4
-        flowey v 9 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
-        flowey v 9 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
+        flowey v 9 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar4
+        flowey v 9 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar5
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
@@ -8045,7 +8045,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 9 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        flowey v 9 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
         flowey e 9 flowey_lib_common::cache 6
@@ -8207,8 +8207,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 9 flowey_lib_common::cache 0
-        flowey v 9 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar2
-        flowey v 9 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar3
+        flowey v 9 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar2
+        flowey v 9 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar3
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -8218,7 +8218,7 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
-        flowey v 9 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey v 9 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey e 9 flowey_lib_common::cache 2

--- a/.github/workflows/openvmm-pr-release.yaml
+++ b/.github/workflows/openvmm-pr-release.yaml
@@ -107,8 +107,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 0 flowey_lib_common::git_checkout 0
-        flowey v 0 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env github floweyvar1
-        flowey v 0 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env github FLOWEY_CONDITION
+        flowey v 0 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar1
+        flowey v 0 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -120,7 +120,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey v 0 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.workspace <<EOF
+        flowey v 0 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
         flowey e 0 flowey_lib_common::git_checkout 3
@@ -150,8 +150,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 0 flowey_lib_common::cache 0
-        flowey v 0 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar2
-        flowey v 0 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar3
+        flowey v 0 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar2
+        flowey v 0 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar3
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -161,7 +161,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 0 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey v 0 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey e 0 flowey_lib_common::cache 2
@@ -321,8 +321,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey.exe e 1 flowey_lib_common::git_checkout 0
-        flowey.exe v 1 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env github floweyvar1
-        flowey.exe v 1 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 1 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar1
+        flowey.exe v 1 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -334,7 +334,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey.exe v 1 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.workspace <<EOF
+        flowey.exe v 1 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
         flowey.exe e 1 flowey_lib_common::git_checkout 3
@@ -364,8 +364,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 1 flowey_lib_common::cache 0
-        flowey.exe v 1 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar2
-        flowey.exe v 1 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar3
+        flowey.exe v 1 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar2
+        flowey.exe v 1 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar3
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -375,7 +375,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 1 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey.exe v 1 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey.exe e 1 flowey_lib_common::cache 2
@@ -441,18 +441,14 @@ jobs:
         EOF
         mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-openhcl-igvm"
         echo "$AgentTempDirNormal/publish_artifacts/aarch64-openhcl-igvm" | flowey v 10 'artifact_publish_from_aarch64-openhcl-igvm' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-openhcl-igvm-devkern"
-        echo "$AgentTempDirNormal/publish_artifacts/aarch64-openhcl-igvm-devkern" | flowey v 10 'artifact_publish_from_aarch64-openhcl-igvm-devkern' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-openhcl-igvm-devkern-extras"
-        echo "$AgentTempDirNormal/publish_artifacts/aarch64-openhcl-igvm-devkern-extras" | flowey v 10 'artifact_publish_from_aarch64-openhcl-igvm-devkern-extras' --is-raw-string update
         mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-openhcl-igvm-extras"
         echo "$AgentTempDirNormal/publish_artifacts/aarch64-openhcl-igvm-extras" | flowey v 10 'artifact_publish_from_aarch64-openhcl-igvm-extras' --is-raw-string update
       shell: bash
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 10 flowey_lib_common::git_checkout 0
-        flowey v 10 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env github floweyvar3
-        flowey v 10 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env github FLOWEY_CONDITION
+        flowey v 10 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar3
+        flowey v 10 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -464,7 +460,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey v 10 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.workspace <<EOF
+        flowey v 10 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
         flowey e 10 flowey_lib_common::git_checkout 3
@@ -493,8 +489,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 10 flowey_lib_common::cache 0
-        flowey v 10 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar1
-        flowey v 10 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar2
+        flowey v 10 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar1
+        flowey v 10 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar2
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -504,7 +500,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 10 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey v 10 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey e 10 flowey_lib_common::cache 2
@@ -566,7 +562,7 @@ jobs:
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 10 flowey_lib_hvlite::run_split_debug_info 2
+        flowey e 10 flowey_lib_hvlite::run_split_debug_info 1
         flowey e 10 flowey_lib_hvlite::run_cargo_build 5
         flowey e 10 flowey_lib_hvlite::build_openhcl_boot 0
         flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 5
@@ -584,7 +580,7 @@ jobs:
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 10 flowey_lib_hvlite::run_split_debug_info 3
+        flowey e 10 flowey_lib_hvlite::run_split_debug_info 2
         flowey e 10 flowey_lib_hvlite::run_cargo_build 1
         flowey e 10 flowey_lib_hvlite::build_igvmfilegen 0
         flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 7
@@ -599,36 +595,6 @@ jobs:
         flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 10
         flowey e 10 flowey_core::pipeline::artifact::publish 1
       shell: bash
-    - name: extract and resolve kernel package
-      run: |-
-        flowey e 10 flowey_lib_hvlite::resolve_openhcl_kernel_package 1
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 15
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 12
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 10 flowey_lib_hvlite::run_split_debug_info 1
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 13
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 14
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 16
-      shell: bash
-    - name: building openhcl initrd
-      run: |-
-        flowey e 10 flowey_lib_hvlite::build_openhcl_initrd 1
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 17
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 18
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 19
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 20
-      shell: bash
-    - name: building igvm file
-      run: |-
-        flowey e 10 flowey_lib_hvlite::run_igvmfilegen 1
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 23
-        flowey e 10 flowey_core::pipeline::artifact::publish 2
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 21
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 22
-        flowey e 10 flowey_core::pipeline::artifact::publish 3
-      shell: bash
     - name: 'validate cache entry: gh-release-download'
       run: flowey e 10 flowey_lib_common::cache 3
       shell: bash
@@ -637,18 +603,6 @@ jobs:
       with:
         name: aarch64-openhcl-igvm
         path: ${{ runner.temp }}/publish_artifacts/aarch64-openhcl-igvm/
-        include-hidden-files: true
-    - name: 🌼📦 Publish aarch64-openhcl-igvm-devkern
-      uses: actions/upload-artifact@v7
-      with:
-        name: aarch64-openhcl-igvm-devkern
-        path: ${{ runner.temp }}/publish_artifacts/aarch64-openhcl-igvm-devkern/
-        include-hidden-files: true
-    - name: 🌼📦 Publish aarch64-openhcl-igvm-devkern-extras
-      uses: actions/upload-artifact@v7
-      with:
-        name: aarch64-openhcl-igvm-devkern-extras
-        path: ${{ runner.temp }}/publish_artifacts/aarch64-openhcl-igvm-devkern-extras/
         include-hidden-files: true
     - name: 🌼📦 Publish aarch64-openhcl-igvm-extras
       uses: actions/upload-artifact@v7
@@ -698,26 +652,18 @@ jobs:
         echo "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-cvm" | flowey v 11 'artifact_publish_from_x64-openhcl-igvm-cvm' --is-raw-string update
         mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-cvm-extras"
         echo "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-cvm-extras" | flowey v 11 'artifact_publish_from_x64-openhcl-igvm-cvm-extras' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-devkern"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-devkern" | flowey v 11 'artifact_publish_from_x64-openhcl-igvm-devkern' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-devkern-extras"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-devkern-extras" | flowey v 11 'artifact_publish_from_x64-openhcl-igvm-devkern-extras' --is-raw-string update
         mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-extras"
         echo "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-extras" | flowey v 11 'artifact_publish_from_x64-openhcl-igvm-extras' --is-raw-string update
         mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-test-linux-direct"
         echo "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-test-linux-direct" | flowey v 11 'artifact_publish_from_x64-openhcl-igvm-test-linux-direct' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-test-linux-direct-devkern"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-test-linux-direct-devkern" | flowey v 11 'artifact_publish_from_x64-openhcl-igvm-test-linux-direct-devkern' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-test-linux-direct-devkern-extras"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-test-linux-direct-devkern-extras" | flowey v 11 'artifact_publish_from_x64-openhcl-igvm-test-linux-direct-devkern-extras' --is-raw-string update
         mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-test-linux-direct-extras"
         echo "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-test-linux-direct-extras" | flowey v 11 'artifact_publish_from_x64-openhcl-igvm-test-linux-direct-extras' --is-raw-string update
       shell: bash
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 11 flowey_lib_common::git_checkout 0
-        flowey v 11 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env github floweyvar3
-        flowey v 11 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env github FLOWEY_CONDITION
+        flowey v 11 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar3
+        flowey v 11 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -729,7 +675,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey v 11 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.workspace <<EOF
+        flowey v 11 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
         flowey e 11 flowey_lib_common::git_checkout 3
@@ -758,8 +704,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 11 flowey_lib_common::cache 0
-        flowey v 11 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar1
-        flowey v 11 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar2
+        flowey v 11 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar1
+        flowey v 11 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar2
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -769,7 +715,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 11 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey v 11 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey e 11 flowey_lib_common::cache 2
@@ -819,7 +765,7 @@ jobs:
       shell: bash
     - name: building openhcl initrd
       run: |-
-        flowey e 11 flowey_lib_hvlite::build_openhcl_initrd 2
+        flowey e 11 flowey_lib_hvlite::build_openhcl_initrd 0
         flowey e 11 flowey_lib_hvlite::init_cross_build 0
         flowey e 11 flowey_lib_hvlite::run_cargo_build 9
         flowey e 11 flowey_lib_hvlite::run_cargo_build 10
@@ -831,7 +777,7 @@ jobs:
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 11 flowey_lib_hvlite::run_split_debug_info 6
+        flowey e 11 flowey_lib_hvlite::run_split_debug_info 4
         flowey e 11 flowey_lib_hvlite::run_cargo_build 12
         flowey e 11 flowey_lib_hvlite::build_sidecar 0
         flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 5
@@ -846,7 +792,7 @@ jobs:
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 11 flowey_lib_hvlite::run_split_debug_info 5
+        flowey e 11 flowey_lib_hvlite::run_split_debug_info 3
         flowey e 11 flowey_lib_hvlite::run_cargo_build 5
         flowey e 11 flowey_lib_hvlite::build_openhcl_boot 0
         flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 6
@@ -864,7 +810,7 @@ jobs:
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 11 flowey_lib_hvlite::run_split_debug_info 7
+        flowey e 11 flowey_lib_hvlite::run_split_debug_info 5
         flowey e 11 flowey_lib_hvlite::run_cargo_build 1
         flowey e 11 flowey_lib_hvlite::build_igvmfilegen 0
         flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 8
@@ -872,43 +818,14 @@ jobs:
       shell: bash
     - name: building igvm file
       run: |-
-        flowey e 11 flowey_lib_hvlite::run_igvmfilegen 2
+        flowey e 11 flowey_lib_hvlite::run_igvmfilegen 1
         flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 12
         flowey e 11 flowey_core::pipeline::artifact::publish 0
         flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 10
         flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 11
         flowey e 11 flowey_core::pipeline::artifact::publish 1
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 34
-      shell: bash
-    - name: extract and resolve kernel package
-      run: |-
-        flowey e 11 flowey_lib_hvlite::resolve_openhcl_kernel_package 2
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 28
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 25
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 11 flowey_lib_hvlite::run_split_debug_info 4
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 26
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 27
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 29
-      shell: bash
-    - name: building openhcl initrd
-      run: |-
-        flowey e 11 flowey_lib_hvlite::build_openhcl_initrd 4
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 30
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 31
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 32
         flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 33
-      shell: bash
-    - name: building igvm file
-      run: |-
-        flowey e 11 flowey_lib_hvlite::run_igvmfilegen 4
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 37
-        flowey e 11 flowey_core::pipeline::artifact::publish 2
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 35
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 36
-        flowey e 11 flowey_core::pipeline::artifact::publish 3
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 34
       shell: bash
     - name: unpack openvmm-test-linux archives
       run: flowey e 11 flowey_lib_hvlite::resolve_openvmm_test_linux_kernel 0
@@ -916,60 +833,31 @@ jobs:
     - name: unpack openvmm-test-initrd archives
       run: |-
         flowey e 11 flowey_lib_hvlite::resolve_openvmm_test_initrd 0
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 41
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 38
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 11 flowey_lib_hvlite::run_split_debug_info 1
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 39
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 40
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 42
-      shell: bash
-    - name: building openhcl initrd
-      run: |-
-        flowey e 11 flowey_lib_hvlite::build_openhcl_initrd 0
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 43
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 44
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 45
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 46
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 47
-      shell: bash
-    - name: building igvm file
-      run: |-
-        flowey e 11 flowey_lib_hvlite::run_igvmfilegen 0
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 50
-        flowey e 11 flowey_core::pipeline::artifact::publish 4
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 48
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 49
-        flowey e 11 flowey_core::pipeline::artifact::publish 5
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 54
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 51
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 28
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 25
       shell: bash
     - name: split debug symbols
       run: |-
         flowey e 11 flowey_lib_hvlite::run_split_debug_info 2
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 52
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 53
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 55
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 26
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 27
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 29
       shell: bash
     - name: building openhcl initrd
       run: |-
-        flowey e 11 flowey_lib_hvlite::build_openhcl_initrd 1
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 56
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 57
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 58
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 59
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 60
+        flowey e 11 flowey_lib_hvlite::build_openhcl_initrd 2
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 30
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 31
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 32
       shell: bash
     - name: building igvm file
       run: |-
-        flowey e 11 flowey_lib_hvlite::run_igvmfilegen 1
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 63
-        flowey e 11 flowey_core::pipeline::artifact::publish 6
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 61
-        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 62
-        flowey e 11 flowey_core::pipeline::artifact::publish 7
+        flowey e 11 flowey_lib_hvlite::run_igvmfilegen 0
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 37
+        flowey e 11 flowey_core::pipeline::artifact::publish 2
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 35
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 36
+        flowey e 11 flowey_core::pipeline::artifact::publish 3
       shell: bash
     - name: extract and resolve kernel package
       run: |-
@@ -979,14 +867,14 @@ jobs:
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 11 flowey_lib_hvlite::run_split_debug_info 3
+        flowey e 11 flowey_lib_hvlite::run_split_debug_info 1
         flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 14
         flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 15
         flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 17
       shell: bash
     - name: building openhcl initrd
       run: |-
-        flowey e 11 flowey_lib_hvlite::build_openhcl_initrd 3
+        flowey e 11 flowey_lib_hvlite::build_openhcl_initrd 1
         flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 18
         flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 19
         flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 20
@@ -994,12 +882,12 @@ jobs:
       shell: bash
     - name: building igvm file
       run: |-
-        flowey e 11 flowey_lib_hvlite::run_igvmfilegen 3
+        flowey e 11 flowey_lib_hvlite::run_igvmfilegen 2
         flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 24
-        flowey e 11 flowey_core::pipeline::artifact::publish 8
+        flowey e 11 flowey_core::pipeline::artifact::publish 4
         flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 22
         flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 23
-        flowey e 11 flowey_core::pipeline::artifact::publish 9
+        flowey e 11 flowey_core::pipeline::artifact::publish 5
       shell: bash
     - name: 'validate cache entry: gh-release-download'
       run: flowey e 11 flowey_lib_common::cache 3
@@ -1022,18 +910,6 @@ jobs:
         name: x64-openhcl-igvm-cvm-extras
         path: ${{ runner.temp }}/publish_artifacts/x64-openhcl-igvm-cvm-extras/
         include-hidden-files: true
-    - name: 🌼📦 Publish x64-openhcl-igvm-devkern
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-openhcl-igvm-devkern
-        path: ${{ runner.temp }}/publish_artifacts/x64-openhcl-igvm-devkern/
-        include-hidden-files: true
-    - name: 🌼📦 Publish x64-openhcl-igvm-devkern-extras
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-openhcl-igvm-devkern-extras
-        path: ${{ runner.temp }}/publish_artifacts/x64-openhcl-igvm-devkern-extras/
-        include-hidden-files: true
     - name: 🌼📦 Publish x64-openhcl-igvm-extras
       uses: actions/upload-artifact@v7
       with:
@@ -1045,18 +921,6 @@ jobs:
       with:
         name: x64-openhcl-igvm-test-linux-direct
         path: ${{ runner.temp }}/publish_artifacts/x64-openhcl-igvm-test-linux-direct/
-        include-hidden-files: true
-    - name: 🌼📦 Publish x64-openhcl-igvm-test-linux-direct-devkern
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-openhcl-igvm-test-linux-direct-devkern
-        path: ${{ runner.temp }}/publish_artifacts/x64-openhcl-igvm-test-linux-direct-devkern/
-        include-hidden-files: true
-    - name: 🌼📦 Publish x64-openhcl-igvm-test-linux-direct-devkern-extras
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-openhcl-igvm-test-linux-direct-devkern-extras
-        path: ${{ runner.temp }}/publish_artifacts/x64-openhcl-igvm-test-linux-direct-devkern-extras/
         include-hidden-files: true
     - name: 🌼📦 Publish x64-openhcl-igvm-test-linux-direct-extras
       uses: actions/upload-artifact@v7
@@ -1116,8 +980,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 12 flowey_lib_common::git_checkout 0
-        flowey v 12 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env github floweyvar3
-        flowey v 12 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env github FLOWEY_CONDITION
+        flowey v 12 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar3
+        flowey v 12 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -1129,7 +993,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey v 12 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.workspace <<EOF
+        flowey v 12 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
         flowey e 12 flowey_lib_common::git_checkout 3
@@ -1158,8 +1022,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 12 flowey_lib_common::cache 0
-        flowey v 12 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar1
-        flowey v 12 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar2
+        flowey v 12 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar1
+        flowey v 12 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar2
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -1169,7 +1033,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 12 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey v 12 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey e 12 flowey_lib_common::cache 2
@@ -1477,8 +1341,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey.exe e 13 flowey_lib_common::git_checkout 0
-        flowey.exe v 13 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env github floweyvar8
-        flowey.exe v 13 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 13 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar8
+        flowey.exe v 13 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -1490,7 +1354,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey.exe v 13 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.workspace <<EOF
+        flowey.exe v 13 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
         flowey.exe e 13 flowey_lib_common::git_checkout 3
@@ -1509,8 +1373,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 13 flowey_lib_common::cache 4
-        flowey.exe v 13 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar6
-        flowey.exe v 13 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar7
+        flowey.exe v 13 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
+        flowey.exe v 13 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
@@ -1520,7 +1384,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 13 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        flowey.exe v 13 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
         flowey.exe e 13 flowey_lib_common::cache 6
@@ -1565,8 +1429,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 13 flowey_lib_common::cache 0
-        flowey.exe v 13 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar4
-        flowey.exe v 13 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar5
+        flowey.exe v 13 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
+        flowey.exe v 13 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -1576,7 +1440,7 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
-        flowey.exe v 13 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey.exe v 13 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey.exe e 13 flowey_lib_common::cache 2
@@ -1612,8 +1476,8 @@ jobs:
         flowey.exe e 13 flowey_lib_hvlite::build_nextest_unit_tests 1
         flowey.exe e 13 flowey_lib_common::publish_test_results 6
         flowey.exe e 13 flowey_lib_common::publish_test_results 7
-        flowey.exe v 13 'flowey_lib_common::publish_test_results:12:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar3
-        flowey.exe v 13 'flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 13 'flowey_lib_common::publish_test_results:12:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs:94:51 write-to-env github floweyvar3
+        flowey.exe v 13 'flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs:94:51' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__8
       uses: actions/upload-artifact@v7
@@ -1632,8 +1496,8 @@ jobs:
         flowey.exe e 13 flowey_lib_hvlite::build_nextest_unit_tests 2
         flowey.exe e 13 flowey_lib_common::publish_test_results 0
         flowey.exe e 13 flowey_lib_common::publish_test_results 1
-        flowey.exe v 13 'flowey_lib_common::publish_test_results:2:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar1
-        flowey.exe v 13 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 13 'flowey_lib_common::publish_test_results:2:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:94:51 write-to-env github floweyvar1
+        flowey.exe v 13 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:94:51' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__2
       uses: actions/upload-artifact@v7
@@ -1652,8 +1516,8 @@ jobs:
         flowey.exe e 13 flowey_lib_hvlite::build_nextest_unit_tests 3
         flowey.exe e 13 flowey_lib_common::publish_test_results 3
         flowey.exe e 13 flowey_lib_common::publish_test_results 4
-        flowey.exe v 13 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar2
-        flowey.exe v 13 'flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 13 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:94:51 write-to-env github floweyvar2
+        flowey.exe v 13 'flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:94:51' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__5
       uses: actions/upload-artifact@v7
@@ -1733,8 +1597,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 14 flowey_lib_common::git_checkout 0
-        flowey v 14 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env github floweyvar10
-        flowey v 14 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env github FLOWEY_CONDITION
+        flowey v 14 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar10
+        flowey v 14 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -1746,7 +1610,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey v 14 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.workspace <<EOF
+        flowey v 14 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
         flowey e 14 flowey_lib_common::git_checkout 3
@@ -1765,8 +1629,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 14 flowey_lib_common::cache 4
-        flowey v 14 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar8
-        flowey v 14 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar9
+        flowey v 14 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
+        flowey v 14 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
@@ -1776,7 +1640,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 14 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        flowey v 14 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
         flowey e 14 flowey_lib_common::cache 6
@@ -1825,8 +1689,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 14 flowey_lib_common::cache 0
-        flowey v 14 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar6
-        flowey v 14 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar7
+        flowey v 14 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
+        flowey v 14 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -1836,7 +1700,7 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
-        flowey v 14 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey v 14 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey e 14 flowey_lib_common::cache 2
@@ -1861,8 +1725,8 @@ jobs:
         flowey e 14 flowey_lib_hvlite::build_nextest_unit_tests 3
         flowey e 14 flowey_lib_common::publish_test_results 6
         flowey e 14 flowey_lib_common::publish_test_results 7
-        flowey v 14 'flowey_lib_common::publish_test_results:12:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar3
-        flowey v 14 'flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
+        flowey v 14 'flowey_lib_common::publish_test_results:12:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs:94:51 write-to-env github floweyvar3
+        flowey v 14 'flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs:94:51' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__8
       uses: actions/upload-artifact@v7
@@ -1881,8 +1745,8 @@ jobs:
         flowey e 14 flowey_lib_hvlite::build_nextest_unit_tests 4
         flowey e 14 flowey_lib_common::publish_test_results 9
         flowey e 14 flowey_lib_common::publish_test_results 10
-        flowey v 14 'flowey_lib_common::publish_test_results:17:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:15:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar4
-        flowey v 14 'flowey_lib_common::publish_test_results:15:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
+        flowey v 14 'flowey_lib_common::publish_test_results:17:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:15:flowey_lib_common/src/publish_test_results.rs:94:51 write-to-env github floweyvar4
+        flowey v 14 'flowey_lib_common::publish_test_results:15:flowey_lib_common/src/publish_test_results.rs:94:51' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__11
       uses: actions/upload-artifact@v7
@@ -1901,8 +1765,8 @@ jobs:
         flowey e 14 flowey_lib_hvlite::build_nextest_unit_tests 5
         flowey e 14 flowey_lib_common::publish_test_results 12
         flowey e 14 flowey_lib_common::publish_test_results 13
-        flowey v 14 'flowey_lib_common::publish_test_results:22:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:20:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar5
-        flowey v 14 'flowey_lib_common::publish_test_results:20:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
+        flowey v 14 'flowey_lib_common::publish_test_results:22:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:20:flowey_lib_common/src/publish_test_results.rs:94:51 write-to-env github floweyvar5
+        flowey v 14 'flowey_lib_common::publish_test_results:20:flowey_lib_common/src/publish_test_results.rs:94:51' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__14
       uses: actions/upload-artifact@v7
@@ -1936,8 +1800,8 @@ jobs:
         flowey e 14 flowey_lib_hvlite::build_nextest_unit_tests 1
         flowey e 14 flowey_lib_common::publish_test_results 0
         flowey e 14 flowey_lib_common::publish_test_results 1
-        flowey v 14 'flowey_lib_common::publish_test_results:2:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar1
-        flowey v 14 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
+        flowey v 14 'flowey_lib_common::publish_test_results:2:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:94:51 write-to-env github floweyvar1
+        flowey v 14 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:94:51' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__2
       uses: actions/upload-artifact@v7
@@ -1956,8 +1820,8 @@ jobs:
         flowey e 14 flowey_lib_hvlite::build_nextest_unit_tests 2
         flowey e 14 flowey_lib_common::publish_test_results 3
         flowey e 14 flowey_lib_common::publish_test_results 4
-        flowey v 14 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar2
-        flowey v 14 'flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
+        flowey v 14 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:94:51 write-to-env github floweyvar2
+        flowey v 14 'flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:94:51' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__5
       uses: actions/upload-artifact@v7
@@ -2031,8 +1895,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 15 flowey_lib_common::git_checkout 0
-        flowey v 15 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env github floweyvar11
-        flowey v 15 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env github FLOWEY_CONDITION
+        flowey v 15 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar11
+        flowey v 15 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -2044,7 +1908,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey v 15 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.workspace <<EOF
+        flowey v 15 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
         flowey e 15 flowey_lib_common::git_checkout 3
@@ -2061,8 +1925,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 15 flowey_lib_common::cache 4
-        flowey v 15 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar9
-        flowey v 15 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar10
+        flowey v 15 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar9
+        flowey v 15 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar10
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
@@ -2072,7 +1936,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 15 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        flowey v 15 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
         flowey e 15 flowey_lib_common::cache 6
@@ -2151,8 +2015,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 15 flowey_lib_common::cache 0
-        flowey v 15 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar7
-        flowey v 15 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar8
+        flowey v 15 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar7
+        flowey v 15 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar8
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -2162,7 +2026,7 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
-        flowey v 15 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey v 15 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey e 15 flowey_lib_common::cache 2
@@ -2187,8 +2051,8 @@ jobs:
         flowey e 15 flowey_lib_hvlite::build_nextest_unit_tests 3
         flowey e 15 flowey_lib_common::publish_test_results 6
         flowey e 15 flowey_lib_common::publish_test_results 7
-        flowey v 15 'flowey_lib_common::publish_test_results:12:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar3
-        flowey v 15 'flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
+        flowey v 15 'flowey_lib_common::publish_test_results:12:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs:94:51 write-to-env github floweyvar3
+        flowey v 15 'flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs:94:51' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__8
       uses: actions/upload-artifact@v7
@@ -2207,8 +2071,8 @@ jobs:
         flowey e 15 flowey_lib_hvlite::build_nextest_unit_tests 4
         flowey e 15 flowey_lib_common::publish_test_results 9
         flowey e 15 flowey_lib_common::publish_test_results 10
-        flowey v 15 'flowey_lib_common::publish_test_results:17:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:15:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar4
-        flowey v 15 'flowey_lib_common::publish_test_results:15:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
+        flowey v 15 'flowey_lib_common::publish_test_results:17:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:15:flowey_lib_common/src/publish_test_results.rs:94:51 write-to-env github floweyvar4
+        flowey v 15 'flowey_lib_common::publish_test_results:15:flowey_lib_common/src/publish_test_results.rs:94:51' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__11
       uses: actions/upload-artifact@v7
@@ -2227,8 +2091,8 @@ jobs:
         flowey e 15 flowey_lib_hvlite::build_nextest_unit_tests 5
         flowey e 15 flowey_lib_common::publish_test_results 12
         flowey e 15 flowey_lib_common::publish_test_results 13
-        flowey v 15 'flowey_lib_common::publish_test_results:22:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:20:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar5
-        flowey v 15 'flowey_lib_common::publish_test_results:20:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
+        flowey v 15 'flowey_lib_common::publish_test_results:22:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:20:flowey_lib_common/src/publish_test_results.rs:94:51 write-to-env github floweyvar5
+        flowey v 15 'flowey_lib_common::publish_test_results:20:flowey_lib_common/src/publish_test_results.rs:94:51' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__14
       uses: actions/upload-artifact@v7
@@ -2247,8 +2111,8 @@ jobs:
         flowey e 15 flowey_lib_hvlite::build_nextest_unit_tests 6
         flowey e 15 flowey_lib_common::publish_test_results 15
         flowey e 15 flowey_lib_common::publish_test_results 16
-        flowey v 15 'flowey_lib_common::publish_test_results:27:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:25:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar6
-        flowey v 15 'flowey_lib_common::publish_test_results:25:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
+        flowey v 15 'flowey_lib_common::publish_test_results:27:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:25:flowey_lib_common/src/publish_test_results.rs:94:51 write-to-env github floweyvar6
+        flowey v 15 'flowey_lib_common::publish_test_results:25:flowey_lib_common/src/publish_test_results.rs:94:51' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__17
       uses: actions/upload-artifact@v7
@@ -2282,8 +2146,8 @@ jobs:
         flowey e 15 flowey_lib_hvlite::build_nextest_unit_tests 1
         flowey e 15 flowey_lib_common::publish_test_results 0
         flowey e 15 flowey_lib_common::publish_test_results 1
-        flowey v 15 'flowey_lib_common::publish_test_results:2:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar1
-        flowey v 15 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
+        flowey v 15 'flowey_lib_common::publish_test_results:2:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:94:51 write-to-env github floweyvar1
+        flowey v 15 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:94:51' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__2
       uses: actions/upload-artifact@v7
@@ -2302,8 +2166,8 @@ jobs:
         flowey e 15 flowey_lib_hvlite::build_nextest_unit_tests 2
         flowey e 15 flowey_lib_common::publish_test_results 3
         flowey e 15 flowey_lib_common::publish_test_results 4
-        flowey v 15 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar2
-        flowey v 15 'flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
+        flowey v 15 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:94:51 write-to-env github floweyvar2
+        flowey v 15 'flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:94:51' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__5
       uses: actions/upload-artifact@v7
@@ -2421,8 +2285,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey.exe e 16 flowey_lib_common::git_checkout 0
-        flowey.exe v 16 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env github floweyvar8
-        flowey.exe v 16 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 16 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar8
+        flowey.exe v 16 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -2434,7 +2298,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey.exe v 16 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.workspace <<EOF
+        flowey.exe v 16 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
         flowey.exe e 16 flowey_lib_common::git_checkout 3
@@ -2453,8 +2317,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 16 flowey_lib_common::cache 4
-        flowey.exe v 16 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar6
-        flowey.exe v 16 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar7
+        flowey.exe v 16 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
+        flowey.exe v 16 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
@@ -2464,7 +2328,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 16 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        flowey.exe v 16 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
         flowey.exe e 16 flowey_lib_common::cache 6
@@ -2509,8 +2373,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 16 flowey_lib_common::cache 0
-        flowey.exe v 16 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar4
-        flowey.exe v 16 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar5
+        flowey.exe v 16 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
+        flowey.exe v 16 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -2520,7 +2384,7 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
-        flowey.exe v 16 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey.exe v 16 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey.exe e 16 flowey_lib_common::cache 2
@@ -2556,8 +2420,8 @@ jobs:
         flowey.exe e 16 flowey_lib_hvlite::build_nextest_unit_tests 1
         flowey.exe e 16 flowey_lib_common::publish_test_results 6
         flowey.exe e 16 flowey_lib_common::publish_test_results 7
-        flowey.exe v 16 'flowey_lib_common::publish_test_results:12:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar3
-        flowey.exe v 16 'flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 16 'flowey_lib_common::publish_test_results:12:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs:94:51 write-to-env github floweyvar3
+        flowey.exe v 16 'flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs:94:51' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__8
       uses: actions/upload-artifact@v7
@@ -2576,8 +2440,8 @@ jobs:
         flowey.exe e 16 flowey_lib_hvlite::build_nextest_unit_tests 2
         flowey.exe e 16 flowey_lib_common::publish_test_results 0
         flowey.exe e 16 flowey_lib_common::publish_test_results 1
-        flowey.exe v 16 'flowey_lib_common::publish_test_results:2:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar1
-        flowey.exe v 16 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 16 'flowey_lib_common::publish_test_results:2:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:94:51 write-to-env github floweyvar1
+        flowey.exe v 16 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:94:51' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__2
       uses: actions/upload-artifact@v7
@@ -2596,8 +2460,8 @@ jobs:
         flowey.exe e 16 flowey_lib_hvlite::build_nextest_unit_tests 3
         flowey.exe e 16 flowey_lib_common::publish_test_results 3
         flowey.exe e 16 flowey_lib_common::publish_test_results 4
-        flowey.exe v 16 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar2
-        flowey.exe v 16 'flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 16 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:94:51 write-to-env github floweyvar2
+        flowey.exe v 16 'flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:94:51' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__5
       uses: actions/upload-artifact@v7
@@ -2721,8 +2585,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 17 flowey_lib_common::git_checkout 0
-        flowey v 17 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env github floweyvar10
-        flowey v 17 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env github FLOWEY_CONDITION
+        flowey v 17 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar10
+        flowey v 17 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -2734,7 +2598,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey v 17 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.workspace <<EOF
+        flowey v 17 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
         flowey e 17 flowey_lib_common::git_checkout 3
@@ -2753,8 +2617,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 17 flowey_lib_common::cache 4
-        flowey v 17 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar8
-        flowey v 17 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar9
+        flowey v 17 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
+        flowey v 17 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
@@ -2764,7 +2628,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 17 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        flowey v 17 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
         flowey e 17 flowey_lib_common::cache 6
@@ -2821,8 +2685,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 17 flowey_lib_common::cache 0
-        flowey v 17 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar6
-        flowey v 17 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar7
+        flowey v 17 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
+        flowey v 17 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -2832,7 +2696,7 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
-        flowey v 17 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey v 17 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey e 17 flowey_lib_common::cache 2
@@ -2857,8 +2721,8 @@ jobs:
         flowey e 17 flowey_lib_hvlite::build_nextest_unit_tests 3
         flowey e 17 flowey_lib_common::publish_test_results 6
         flowey e 17 flowey_lib_common::publish_test_results 7
-        flowey v 17 'flowey_lib_common::publish_test_results:12:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar3
-        flowey v 17 'flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
+        flowey v 17 'flowey_lib_common::publish_test_results:12:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs:94:51 write-to-env github floweyvar3
+        flowey v 17 'flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs:94:51' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__8
       uses: actions/upload-artifact@v7
@@ -2877,8 +2741,8 @@ jobs:
         flowey e 17 flowey_lib_hvlite::build_nextest_unit_tests 4
         flowey e 17 flowey_lib_common::publish_test_results 9
         flowey e 17 flowey_lib_common::publish_test_results 10
-        flowey v 17 'flowey_lib_common::publish_test_results:17:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:15:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar4
-        flowey v 17 'flowey_lib_common::publish_test_results:15:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
+        flowey v 17 'flowey_lib_common::publish_test_results:17:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:15:flowey_lib_common/src/publish_test_results.rs:94:51 write-to-env github floweyvar4
+        flowey v 17 'flowey_lib_common::publish_test_results:15:flowey_lib_common/src/publish_test_results.rs:94:51' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__11
       uses: actions/upload-artifact@v7
@@ -2897,8 +2761,8 @@ jobs:
         flowey e 17 flowey_lib_hvlite::build_nextest_unit_tests 5
         flowey e 17 flowey_lib_common::publish_test_results 12
         flowey e 17 flowey_lib_common::publish_test_results 13
-        flowey v 17 'flowey_lib_common::publish_test_results:22:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:20:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar5
-        flowey v 17 'flowey_lib_common::publish_test_results:20:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
+        flowey v 17 'flowey_lib_common::publish_test_results:22:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:20:flowey_lib_common/src/publish_test_results.rs:94:51 write-to-env github floweyvar5
+        flowey v 17 'flowey_lib_common::publish_test_results:20:flowey_lib_common/src/publish_test_results.rs:94:51' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__14
       uses: actions/upload-artifact@v7
@@ -2932,8 +2796,8 @@ jobs:
         flowey e 17 flowey_lib_hvlite::build_nextest_unit_tests 1
         flowey e 17 flowey_lib_common::publish_test_results 0
         flowey e 17 flowey_lib_common::publish_test_results 1
-        flowey v 17 'flowey_lib_common::publish_test_results:2:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar1
-        flowey v 17 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
+        flowey v 17 'flowey_lib_common::publish_test_results:2:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:94:51 write-to-env github floweyvar1
+        flowey v 17 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:94:51' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__2
       uses: actions/upload-artifact@v7
@@ -2952,8 +2816,8 @@ jobs:
         flowey e 17 flowey_lib_hvlite::build_nextest_unit_tests 2
         flowey e 17 flowey_lib_common::publish_test_results 3
         flowey e 17 flowey_lib_common::publish_test_results 4
-        flowey v 17 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar2
-        flowey v 17 'flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
+        flowey v 17 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:94:51 write-to-env github floweyvar2
+        flowey v 17 'flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:94:51' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__5
       uses: actions/upload-artifact@v7
@@ -3057,56 +2921,22 @@ jobs:
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
       shell: bash
-    - name: create cargo-nextest cache dir
-      run: |-
-        flowey e 18 flowey_lib_common::cfg_cargo_common_flags 0
-        flowey e 18 flowey_lib_common::download_cargo_nextest 0
-        flowey e 18 flowey_lib_common::download_cargo_nextest 1
-        flowey e 18 flowey_lib_common::download_cargo_nextest 2
-        flowey e 18 flowey_lib_common::download_cargo_nextest 3
-      shell: bash
-    - name: Pre-processing cache vars
-      run: |-
-        flowey e 18 flowey_lib_common::cache 0
-        flowey v 18 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar7
-        flowey v 18 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar8
-      shell: bash
-    - id: flowey_lib_common__cache__1
-      uses: actions/cache@v5
-      with:
-        key: ${{ env.floweyvar7 }}
-        path: ${{ env.floweyvar8 }}
-      name: 'Restore cache: cargo-nextest'
-    - name: downloading cargo-nextest
-      run: |-
-        flowey v 18 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
-        EOF
-        flowey e 18 flowey_lib_common::cache 2
-        flowey e 18 flowey_lib_common::download_cargo_nextest 4
-      shell: bash
     - name: add default cargo home to path
       run: flowey e 18 flowey_lib_common::install_rust 0
       shell: bash
     - name: install Rust
       run: flowey e 18 flowey_lib_common::install_rust 1
       shell: bash
-    - name: report $CARGO_HOME
-      run: flowey e 18 flowey_lib_common::install_rust 3
-      shell: bash
-    - name: installing cargo-nextest
-      run: flowey e 18 flowey_lib_common::install_cargo_nextest 0
-      shell: bash
     - name: detect active toolchain
       run: |-
         flowey e 18 flowey_lib_common::install_rust 2
-        flowey e 18 flowey_lib_hvlite::init_cross_build 3
+        flowey e 18 flowey_lib_common::cfg_cargo_common_flags 0
       shell: bash
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 18 flowey_lib_common::git_checkout 0
-        flowey v 18 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env github floweyvar11
-        flowey v 18 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env github FLOWEY_CONDITION
+        flowey v 18 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar11
+        flowey v 18 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -3118,7 +2948,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey v 18 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.workspace <<EOF
+        flowey v 18 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
         flowey e 18 flowey_lib_common::git_checkout 3
@@ -3127,13 +2957,7 @@ jobs:
       run: |-
         flowey e 18 flowey_lib_common::system_info 0
         flowey e 18 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-        flowey e 18 flowey_lib_hvlite::run_cargo_nextest_run 0
-      shell: bash
-    - name: generate nextest command
-      run: flowey e 18 flowey_lib_common::gen_cargo_nextest_run_cmd 3
-      shell: bash
-    - name: set '-Dwarnings' in .cargo/config.toml
-      run: flowey e 18 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
+        flowey e 18 flowey_lib_hvlite::cfg_openvmm_magicpath 0
       shell: bash
     - name: create gh-release-download cache dir
       run: flowey e 18 flowey_lib_common::download_gh_release 0
@@ -3141,8 +2965,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 18 flowey_lib_common::cache 4
-        flowey v 18 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar9
-        flowey v 18 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar10
+        flowey v 18 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar9
+        flowey v 18 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar10
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
@@ -3152,25 +2976,11 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 18 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        flowey v 18 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
         flowey e 18 flowey_lib_common::cache 6
         flowey e 18 flowey_lib_common::download_gh_release 1
-      shell: bash
-    - name: checking if packages need to be installed
-      run: flowey e 18 flowey_lib_common::install_dist_pkg 0
-      shell: bash
-    - name: installing packages
-      run: flowey e 18 flowey_lib_common::install_dist_pkg 1
-      shell: bash
-    - name: unpack protoc
-      run: |-
-        flowey e 18 flowey_lib_common::resolve_protoc 0
-        flowey e 18 flowey_lib_hvlite::cfg_openvmm_magicpath 0
-      shell: bash
-    - name: symlink protoc
-      run: flowey e 18 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
       shell: bash
     - name: unpack openvmm-deps archive
       run: flowey e 18 flowey_lib_hvlite::resolve_openvmm_deps 0
@@ -3178,146 +2988,21 @@ jobs:
     - name: extract Aarch64 sysroot.tar.gz
       run: flowey e 18 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
       shell: bash
-    - name: run 'aarch64-linux-musl-unit-tests-crypto-rust' nextest tests
+    - name: checking if packages need to be installed
+      run: flowey e 18 flowey_lib_common::install_dist_pkg 0
+      shell: bash
+    - name: installing packages
+      run: flowey e 18 flowey_lib_common::install_dist_pkg 1
+      shell: bash
+    - name: set '-Dwarnings' in .cargo/config.toml
+      run: flowey e 18 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
+      shell: bash
+    - name: unpack protoc
+      run: flowey e 18 flowey_lib_common::resolve_protoc 0
+      shell: bash
+    - name: symlink protoc
       run: |-
-        flowey e 18 flowey_lib_common::run_cargo_nextest_run 8
-        flowey e 18 flowey_lib_common::run_cargo_nextest_run 9
-        flowey e 18 flowey_lib_hvlite::build_nextest_unit_tests 3
-        flowey e 18 flowey_lib_common::publish_test_results 6
-        flowey e 18 flowey_lib_common::publish_test_results 7
-        flowey v 18 'flowey_lib_common::publish_test_results:12:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar3
-        flowey v 18 'flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__publish_test_results__8
-      uses: actions/upload-artifact@v7
-      with:
-        name: aarch64-linux-musl-unit-tests-crypto-rust-junit-xml
-        path: ${{ env.floweyvar3 }}
-      name: 'publish test results: aarch64-linux-musl-unit-tests-crypto-rust (JUnit XML)'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: generate nextest command
-      run: flowey e 18 flowey_lib_common::gen_cargo_nextest_run_cmd 2
-      shell: bash
-    - name: run 'aarch64-linux-musl-unit-tests-crypto-openssl' nextest tests
-      run: |-
-        flowey e 18 flowey_lib_common::run_cargo_nextest_run 6
-        flowey e 18 flowey_lib_common::run_cargo_nextest_run 7
-        flowey e 18 flowey_lib_hvlite::build_nextest_unit_tests 4
-        flowey e 18 flowey_lib_common::publish_test_results 9
-        flowey e 18 flowey_lib_common::publish_test_results 10
-        flowey v 18 'flowey_lib_common::publish_test_results:17:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:15:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar4
-        flowey v 18 'flowey_lib_common::publish_test_results:15:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__publish_test_results__11
-      uses: actions/upload-artifact@v7
-      with:
-        name: aarch64-linux-musl-unit-tests-crypto-openssl-junit-xml
-        path: ${{ env.floweyvar4 }}
-      name: 'publish test results: aarch64-linux-musl-unit-tests-crypto-openssl (JUnit XML)'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: generate nextest command
-      run: flowey e 18 flowey_lib_common::gen_cargo_nextest_run_cmd 4
-      shell: bash
-    - name: run 'aarch64-linux-musl-unit-tests-crypto-symcrypt' nextest tests
-      run: |-
-        flowey e 18 flowey_lib_common::run_cargo_nextest_run 10
-        flowey e 18 flowey_lib_common::run_cargo_nextest_run 11
-        flowey e 18 flowey_lib_hvlite::build_nextest_unit_tests 5
-        flowey e 18 flowey_lib_common::publish_test_results 12
-        flowey e 18 flowey_lib_common::publish_test_results 13
-        flowey v 18 'flowey_lib_common::publish_test_results:22:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:20:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar5
-        flowey v 18 'flowey_lib_common::publish_test_results:20:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__publish_test_results__14
-      uses: actions/upload-artifact@v7
-      with:
-        name: aarch64-linux-musl-unit-tests-crypto-symcrypt-junit-xml
-        path: ${{ env.floweyvar5 }}
-      name: 'publish test results: aarch64-linux-musl-unit-tests-crypto-symcrypt (JUnit XML)'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: generate nextest command
-      run: flowey e 18 flowey_lib_common::gen_cargo_nextest_run_cmd 0
-      shell: bash
-    - name: run 'aarch64-linux-musl-unit-tests-crypto-all' nextest tests
-      run: |-
-        flowey e 18 flowey_lib_common::run_cargo_nextest_run 2
-        flowey e 18 flowey_lib_common::run_cargo_nextest_run 3
-        flowey e 18 flowey_lib_hvlite::build_nextest_unit_tests 6
-        flowey e 18 flowey_lib_common::publish_test_results 15
-        flowey e 18 flowey_lib_common::publish_test_results 16
-        flowey v 18 'flowey_lib_common::publish_test_results:27:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:25:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar6
-        flowey v 18 'flowey_lib_common::publish_test_results:25:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__publish_test_results__17
-      uses: actions/upload-artifact@v7
-      with:
-        name: aarch64-linux-musl-unit-tests-crypto-all-junit-xml
-        path: ${{ env.floweyvar6 }}
-      name: 'publish test results: aarch64-linux-musl-unit-tests-crypto-all (JUnit XML)'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: cargo build xtask
-      run: |-
-        flowey e 18 flowey_lib_hvlite::init_cross_build 1
-        flowey e 18 flowey_lib_common::run_cargo_build 1
-        flowey e 18 flowey_lib_hvlite::run_cargo_build 2
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 18 flowey_lib_hvlite::run_split_debug_info 0
-        flowey e 18 flowey_lib_hvlite::run_cargo_build 3
-        flowey e 18 flowey_lib_hvlite::build_xtask 1
-      shell: bash
-    - name: determine unit test exclusions
-      run: flowey e 18 flowey_lib_hvlite::build_nextest_unit_tests 0
-      shell: bash
-    - name: generate nextest command
-      run: flowey e 18 flowey_lib_common::gen_cargo_nextest_run_cmd 5
-      shell: bash
-    - name: run 'aarch64-linux-musl-unit-tests-base' nextest tests
-      run: |-
-        flowey e 18 flowey_lib_common::run_cargo_nextest_run 0
-        flowey e 18 flowey_lib_common::run_cargo_nextest_run 1
-        flowey e 18 flowey_lib_hvlite::build_nextest_unit_tests 1
-        flowey e 18 flowey_lib_common::publish_test_results 0
-        flowey e 18 flowey_lib_common::publish_test_results 1
-        flowey v 18 'flowey_lib_common::publish_test_results:2:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar1
-        flowey v 18 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__publish_test_results__2
-      uses: actions/upload-artifact@v7
-      with:
-        name: aarch64-linux-musl-unit-tests-base-junit-xml
-        path: ${{ env.floweyvar1 }}
-      name: 'publish test results: aarch64-linux-musl-unit-tests-base (JUnit XML)'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: generate nextest command
-      run: flowey e 18 flowey_lib_common::gen_cargo_nextest_run_cmd 1
-      shell: bash
-    - name: run 'aarch64-linux-musl-unit-tests-crypto-native' nextest tests
-      run: |-
-        flowey e 18 flowey_lib_common::run_cargo_nextest_run 4
-        flowey e 18 flowey_lib_common::run_cargo_nextest_run 5
-        flowey e 18 flowey_lib_hvlite::build_nextest_unit_tests 2
-        flowey e 18 flowey_lib_common::publish_test_results 3
-        flowey e 18 flowey_lib_common::publish_test_results 4
-        flowey v 18 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar2
-        flowey v 18 'flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__publish_test_results__5
-      uses: actions/upload-artifact@v7
-      with:
-        name: aarch64-linux-musl-unit-tests-crypto-native-junit-xml
-        path: ${{ env.floweyvar2 }}
-      name: 'publish test results: aarch64-linux-musl-unit-tests-crypto-native (JUnit XML)'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: report test results to overall pipeline status
-      run: |-
-        flowey e 18 flowey_lib_hvlite::build_nextest_unit_tests 7
-        flowey e 18 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
-      shell: bash
-    - name: run doctests for aarch64-unknown-linux-musl
-      run: |-
-        flowey e 18 flowey_lib_hvlite::_jobs::build_and_run_doc_tests 0
+        flowey e 18 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
         flowey e 18 flowey_lib_hvlite::init_cross_build 2
       shell: bash
     - name: cargo clippy
@@ -3359,6 +3044,185 @@ jobs:
       shell: bash
     - name: cargo clippy
       run: flowey e 18 flowey_lib_common::run_cargo_clippy 4
+      shell: bash
+    - name: create cargo-nextest cache dir
+      run: |-
+        flowey e 18 flowey_lib_common::download_cargo_nextest 0
+        flowey e 18 flowey_lib_common::download_cargo_nextest 1
+        flowey e 18 flowey_lib_common::download_cargo_nextest 2
+        flowey e 18 flowey_lib_common::download_cargo_nextest 3
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
+        flowey e 18 flowey_lib_common::cache 0
+        flowey v 18 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar7
+        flowey v 18 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar8
+      shell: bash
+    - id: flowey_lib_common__cache__1
+      uses: actions/cache@v5
+      with:
+        key: ${{ env.floweyvar7 }}
+        path: ${{ env.floweyvar8 }}
+      name: 'Restore cache: cargo-nextest'
+    - name: downloading cargo-nextest
+      run: |-
+        flowey v 18 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
+        EOF
+        flowey e 18 flowey_lib_common::cache 2
+        flowey e 18 flowey_lib_common::download_cargo_nextest 4
+      shell: bash
+    - name: report $CARGO_HOME
+      run: flowey e 18 flowey_lib_common::install_rust 3
+      shell: bash
+    - name: installing cargo-nextest
+      run: |-
+        flowey e 18 flowey_lib_common::install_cargo_nextest 0
+        flowey e 18 flowey_lib_hvlite::init_cross_build 3
+        flowey e 18 flowey_lib_hvlite::run_cargo_nextest_run 0
+      shell: bash
+    - name: generate nextest command
+      run: flowey e 18 flowey_lib_common::gen_cargo_nextest_run_cmd 3
+      shell: bash
+    - name: run 'aarch64-linux-musl-unit-tests-crypto-rust' nextest tests
+      run: |-
+        flowey e 18 flowey_lib_common::run_cargo_nextest_run 8
+        flowey e 18 flowey_lib_common::run_cargo_nextest_run 9
+        flowey e 18 flowey_lib_hvlite::build_nextest_unit_tests 3
+        flowey e 18 flowey_lib_common::publish_test_results 6
+        flowey e 18 flowey_lib_common::publish_test_results 7
+        flowey v 18 'flowey_lib_common::publish_test_results:12:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs:94:51 write-to-env github floweyvar3
+        flowey v 18 'flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs:94:51' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__publish_test_results__8
+      uses: actions/upload-artifact@v7
+      with:
+        name: aarch64-linux-musl-unit-tests-crypto-rust-junit-xml
+        path: ${{ env.floweyvar3 }}
+      name: 'publish test results: aarch64-linux-musl-unit-tests-crypto-rust (JUnit XML)'
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: generate nextest command
+      run: flowey e 18 flowey_lib_common::gen_cargo_nextest_run_cmd 2
+      shell: bash
+    - name: run 'aarch64-linux-musl-unit-tests-crypto-openssl' nextest tests
+      run: |-
+        flowey e 18 flowey_lib_common::run_cargo_nextest_run 6
+        flowey e 18 flowey_lib_common::run_cargo_nextest_run 7
+        flowey e 18 flowey_lib_hvlite::build_nextest_unit_tests 4
+        flowey e 18 flowey_lib_common::publish_test_results 9
+        flowey e 18 flowey_lib_common::publish_test_results 10
+        flowey v 18 'flowey_lib_common::publish_test_results:17:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:15:flowey_lib_common/src/publish_test_results.rs:94:51 write-to-env github floweyvar4
+        flowey v 18 'flowey_lib_common::publish_test_results:15:flowey_lib_common/src/publish_test_results.rs:94:51' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__publish_test_results__11
+      uses: actions/upload-artifact@v7
+      with:
+        name: aarch64-linux-musl-unit-tests-crypto-openssl-junit-xml
+        path: ${{ env.floweyvar4 }}
+      name: 'publish test results: aarch64-linux-musl-unit-tests-crypto-openssl (JUnit XML)'
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: generate nextest command
+      run: flowey e 18 flowey_lib_common::gen_cargo_nextest_run_cmd 4
+      shell: bash
+    - name: run 'aarch64-linux-musl-unit-tests-crypto-symcrypt' nextest tests
+      run: |-
+        flowey e 18 flowey_lib_common::run_cargo_nextest_run 10
+        flowey e 18 flowey_lib_common::run_cargo_nextest_run 11
+        flowey e 18 flowey_lib_hvlite::build_nextest_unit_tests 5
+        flowey e 18 flowey_lib_common::publish_test_results 12
+        flowey e 18 flowey_lib_common::publish_test_results 13
+        flowey v 18 'flowey_lib_common::publish_test_results:22:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:20:flowey_lib_common/src/publish_test_results.rs:94:51 write-to-env github floweyvar5
+        flowey v 18 'flowey_lib_common::publish_test_results:20:flowey_lib_common/src/publish_test_results.rs:94:51' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__publish_test_results__14
+      uses: actions/upload-artifact@v7
+      with:
+        name: aarch64-linux-musl-unit-tests-crypto-symcrypt-junit-xml
+        path: ${{ env.floweyvar5 }}
+      name: 'publish test results: aarch64-linux-musl-unit-tests-crypto-symcrypt (JUnit XML)'
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: generate nextest command
+      run: flowey e 18 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      shell: bash
+    - name: run 'aarch64-linux-musl-unit-tests-crypto-all' nextest tests
+      run: |-
+        flowey e 18 flowey_lib_common::run_cargo_nextest_run 2
+        flowey e 18 flowey_lib_common::run_cargo_nextest_run 3
+        flowey e 18 flowey_lib_hvlite::build_nextest_unit_tests 6
+        flowey e 18 flowey_lib_common::publish_test_results 15
+        flowey e 18 flowey_lib_common::publish_test_results 16
+        flowey v 18 'flowey_lib_common::publish_test_results:27:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:25:flowey_lib_common/src/publish_test_results.rs:94:51 write-to-env github floweyvar6
+        flowey v 18 'flowey_lib_common::publish_test_results:25:flowey_lib_common/src/publish_test_results.rs:94:51' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__publish_test_results__17
+      uses: actions/upload-artifact@v7
+      with:
+        name: aarch64-linux-musl-unit-tests-crypto-all-junit-xml
+        path: ${{ env.floweyvar6 }}
+      name: 'publish test results: aarch64-linux-musl-unit-tests-crypto-all (JUnit XML)'
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: cargo build xtask
+      run: |-
+        flowey e 18 flowey_lib_hvlite::init_cross_build 1
+        flowey e 18 flowey_lib_common::run_cargo_build 1
+        flowey e 18 flowey_lib_hvlite::run_cargo_build 2
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 18 flowey_lib_hvlite::run_split_debug_info 0
+        flowey e 18 flowey_lib_hvlite::run_cargo_build 3
+        flowey e 18 flowey_lib_hvlite::build_xtask 1
+      shell: bash
+    - name: determine unit test exclusions
+      run: flowey e 18 flowey_lib_hvlite::build_nextest_unit_tests 0
+      shell: bash
+    - name: generate nextest command
+      run: flowey e 18 flowey_lib_common::gen_cargo_nextest_run_cmd 5
+      shell: bash
+    - name: run 'aarch64-linux-musl-unit-tests-base' nextest tests
+      run: |-
+        flowey e 18 flowey_lib_common::run_cargo_nextest_run 0
+        flowey e 18 flowey_lib_common::run_cargo_nextest_run 1
+        flowey e 18 flowey_lib_hvlite::build_nextest_unit_tests 1
+        flowey e 18 flowey_lib_common::publish_test_results 0
+        flowey e 18 flowey_lib_common::publish_test_results 1
+        flowey v 18 'flowey_lib_common::publish_test_results:2:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:94:51 write-to-env github floweyvar1
+        flowey v 18 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:94:51' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__publish_test_results__2
+      uses: actions/upload-artifact@v7
+      with:
+        name: aarch64-linux-musl-unit-tests-base-junit-xml
+        path: ${{ env.floweyvar1 }}
+      name: 'publish test results: aarch64-linux-musl-unit-tests-base (JUnit XML)'
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: generate nextest command
+      run: flowey e 18 flowey_lib_common::gen_cargo_nextest_run_cmd 1
+      shell: bash
+    - name: run 'aarch64-linux-musl-unit-tests-crypto-native' nextest tests
+      run: |-
+        flowey e 18 flowey_lib_common::run_cargo_nextest_run 4
+        flowey e 18 flowey_lib_common::run_cargo_nextest_run 5
+        flowey e 18 flowey_lib_hvlite::build_nextest_unit_tests 2
+        flowey e 18 flowey_lib_common::publish_test_results 3
+        flowey e 18 flowey_lib_common::publish_test_results 4
+        flowey v 18 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:94:51 write-to-env github floweyvar2
+        flowey v 18 'flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:94:51' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__publish_test_results__5
+      uses: actions/upload-artifact@v7
+      with:
+        name: aarch64-linux-musl-unit-tests-crypto-native-junit-xml
+        path: ${{ env.floweyvar2 }}
+      name: 'publish test results: aarch64-linux-musl-unit-tests-crypto-native (JUnit XML)'
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: report test results to overall pipeline status
+      run: |-
+        flowey e 18 flowey_lib_hvlite::build_nextest_unit_tests 7
+        flowey e 18 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
+      shell: bash
+    - name: run doctests for aarch64-unknown-linux-musl
+      run: flowey e 18 flowey_lib_hvlite::_jobs::build_and_run_doc_tests 0
       shell: bash
     - name: 'validate cache entry: cargo-nextest'
       run: flowey e 18 flowey_lib_common::cache 3
@@ -3434,8 +3298,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 19 flowey_lib_common::cache 0
-        flowey.exe v 19 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar4
-        flowey.exe v 19 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar5
+        flowey.exe v 19 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
+        flowey.exe v 19 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -3445,7 +3309,7 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
-        flowey.exe v 19 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey.exe v 19 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey.exe e 19 flowey_lib_common::cache 2
@@ -3454,8 +3318,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey.exe e 19 flowey_lib_common::git_checkout 0
-        flowey.exe v 19 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env github floweyvar3
-        flowey.exe v 19 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 19 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar3
+        flowey.exe v 19 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -3467,7 +3331,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey.exe v 19 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.workspace <<EOF
+        flowey.exe v 19 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
         flowey.exe e 19 flowey_lib_common::git_checkout 3
@@ -3502,8 +3366,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 19 flowey_lib_common::cache 8
-        flowey.exe v 19 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar8
-        flowey.exe v 19 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar9
+        flowey.exe v 19 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
+        flowey.exe v 19 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
       shell: bash
     - id: flowey_lib_common__cache__9
       uses: actions/cache@v5
@@ -3513,7 +3377,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 19 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
+        flowey.exe v 19 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
         EOF
         flowey.exe e 19 flowey_lib_common::cache 10
@@ -3536,8 +3400,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 19 flowey_lib_common::cache 4
-        flowey.exe v 19 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar6
-        flowey.exe v 19 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar7
+        flowey.exe v 19 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
+        flowey.exe v 19 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
@@ -3547,12 +3411,12 @@ jobs:
       name: 'Restore cache: gh-cli'
     - name: installing gh
       run: |-
-        flowey.exe v 19 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        flowey.exe v 19 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
         flowey.exe e 19 flowey_lib_common::cache 6
         flowey.exe e 19 flowey_lib_common::download_gh_cli 1
-        flowey.exe v 19 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.token <<EOF
+        flowey.exe v 19 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
         ${{ github.token }}
         EOF
       shell: bash
@@ -3612,8 +3476,8 @@ jobs:
         flowey.exe e 19 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
         flowey.exe e 19 flowey_lib_common::publish_test_results 0
         flowey.exe e 19 flowey_lib_common::publish_test_results 1
-        flowey.exe v 19 'flowey_lib_common::publish_test_results:2:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar1
-        flowey.exe v 19 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 19 'flowey_lib_common::publish_test_results:2:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:94:51 write-to-env github floweyvar1
+        flowey.exe v 19 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:94:51' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__2
       uses: actions/upload-artifact@v7
@@ -3627,8 +3491,8 @@ jobs:
         flowey.exe e 19 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
         flowey.exe e 19 flowey_lib_common::publish_test_results 3
         flowey.exe e 19 flowey_lib_common::publish_test_results 4
-        flowey.exe v 19 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar2
-        flowey.exe v 19 'flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 19 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:150:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:142:57 write-to-env github floweyvar2
+        flowey.exe v 19 'flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:142:57' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__5
       uses: actions/upload-artifact@v7
@@ -3748,8 +3612,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey.exe e 2 flowey_lib_common::git_checkout 0
-        flowey.exe v 2 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env github floweyvar1
-        flowey.exe v 2 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 2 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar1
+        flowey.exe v 2 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -3761,7 +3625,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey.exe v 2 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.workspace <<EOF
+        flowey.exe v 2 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
         flowey.exe e 2 flowey_lib_common::git_checkout 3
@@ -3780,8 +3644,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 2 flowey_lib_common::cache 0
-        flowey.exe v 2 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar2
-        flowey.exe v 2 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar3
+        flowey.exe v 2 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar2
+        flowey.exe v 2 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar3
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -3791,7 +3655,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 2 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey.exe v 2 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey.exe e 2 flowey_lib_common::cache 2
@@ -3905,8 +3769,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 20 flowey_lib_common::cache 0
-        flowey.exe v 20 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar4
-        flowey.exe v 20 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar5
+        flowey.exe v 20 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
+        flowey.exe v 20 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -3916,7 +3780,7 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
-        flowey.exe v 20 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey.exe v 20 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey.exe e 20 flowey_lib_common::cache 2
@@ -3925,8 +3789,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey.exe e 20 flowey_lib_common::git_checkout 0
-        flowey.exe v 20 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env github floweyvar3
-        flowey.exe v 20 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 20 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar3
+        flowey.exe v 20 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -3938,7 +3802,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey.exe v 20 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.workspace <<EOF
+        flowey.exe v 20 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
         flowey.exe e 20 flowey_lib_common::git_checkout 3
@@ -3948,11 +3812,6 @@ jobs:
         flowey.exe e 20 flowey_lib_common::system_info 0
         flowey.exe e 20 flowey_lib_hvlite::git_checkout_openvmm_repo 0
         flowey.exe e 20 flowey_lib_hvlite::run_cargo_nextest_run 0
-        flowey.exe e 20 flowey_core::pipeline::artifact::resolve 12
-        flowey.exe e 20 flowey_core::pipeline::artifact::resolve 14
-        flowey.exe e 20 flowey_core::pipeline::artifact::resolve 15
-        flowey.exe e 20 flowey_core::pipeline::artifact::resolve 13
-        flowey.exe e 20 flowey_core::pipeline::artifact::resolve 3
         flowey.exe e 20 flowey_core::pipeline::artifact::resolve 11
         flowey.exe e 20 flowey_core::pipeline::artifact::resolve 4
         flowey.exe e 20 flowey_core::pipeline::artifact::resolve 5
@@ -3963,6 +3822,11 @@ jobs:
         flowey.exe e 20 flowey_core::pipeline::artifact::resolve 7
         flowey.exe e 20 flowey_core::pipeline::artifact::resolve 8
         flowey.exe e 20 flowey_core::pipeline::artifact::resolve 9
+        flowey.exe e 20 flowey_core::pipeline::artifact::resolve 12
+        flowey.exe e 20 flowey_core::pipeline::artifact::resolve 14
+        flowey.exe e 20 flowey_core::pipeline::artifact::resolve 15
+        flowey.exe e 20 flowey_core::pipeline::artifact::resolve 13
+        flowey.exe e 20 flowey_core::pipeline::artifact::resolve 3
       shell: bash
     - name: creating new test content dir
       run: flowey.exe e 20 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
@@ -3973,8 +3837,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 20 flowey_lib_common::cache 8
-        flowey.exe v 20 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar8
-        flowey.exe v 20 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar9
+        flowey.exe v 20 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
+        flowey.exe v 20 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
       shell: bash
     - id: flowey_lib_common__cache__9
       uses: actions/cache@v5
@@ -3984,7 +3848,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 20 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
+        flowey.exe v 20 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
         EOF
         flowey.exe e 20 flowey_lib_common::cache 10
@@ -4007,8 +3871,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 20 flowey_lib_common::cache 4
-        flowey.exe v 20 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar6
-        flowey.exe v 20 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar7
+        flowey.exe v 20 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
+        flowey.exe v 20 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
@@ -4018,12 +3882,12 @@ jobs:
       name: 'Restore cache: gh-cli'
     - name: installing gh
       run: |-
-        flowey.exe v 20 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        flowey.exe v 20 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
         flowey.exe e 20 flowey_lib_common::cache 6
         flowey.exe e 20 flowey_lib_common::download_gh_cli 1
-        flowey.exe v 20 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.token <<EOF
+        flowey.exe v 20 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
         ${{ github.token }}
         EOF
       shell: bash
@@ -4078,8 +3942,8 @@ jobs:
         flowey.exe e 20 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
         flowey.exe e 20 flowey_lib_common::publish_test_results 0
         flowey.exe e 20 flowey_lib_common::publish_test_results 1
-        flowey.exe v 20 'flowey_lib_common::publish_test_results:2:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar1
-        flowey.exe v 20 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 20 'flowey_lib_common::publish_test_results:2:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:94:51 write-to-env github floweyvar1
+        flowey.exe v 20 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:94:51' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__2
       uses: actions/upload-artifact@v7
@@ -4093,8 +3957,8 @@ jobs:
         flowey.exe e 20 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
         flowey.exe e 20 flowey_lib_common::publish_test_results 3
         flowey.exe e 20 flowey_lib_common::publish_test_results 4
-        flowey.exe v 20 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar2
-        flowey.exe v 20 'flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 20 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:150:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:142:57 write-to-env github floweyvar2
+        flowey.exe v 20 'flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:142:57' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__5
       uses: actions/upload-artifact@v7
@@ -4184,8 +4048,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 21 flowey_lib_common::cache 0
-        flowey.exe v 21 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar4
-        flowey.exe v 21 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar5
+        flowey.exe v 21 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
+        flowey.exe v 21 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -4195,7 +4059,7 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
-        flowey.exe v 21 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey.exe v 21 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey.exe e 21 flowey_lib_common::cache 2
@@ -4204,8 +4068,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey.exe e 21 flowey_lib_common::git_checkout 0
-        flowey.exe v 21 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env github floweyvar3
-        flowey.exe v 21 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 21 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar3
+        flowey.exe v 21 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -4217,7 +4081,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey.exe v 21 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.workspace <<EOF
+        flowey.exe v 21 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
         flowey.exe e 21 flowey_lib_common::git_checkout 3
@@ -4252,8 +4116,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 21 flowey_lib_common::cache 8
-        flowey.exe v 21 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar8
-        flowey.exe v 21 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar9
+        flowey.exe v 21 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
+        flowey.exe v 21 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
       shell: bash
     - id: flowey_lib_common__cache__9
       uses: actions/cache@v5
@@ -4263,7 +4127,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 21 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
+        flowey.exe v 21 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
         EOF
         flowey.exe e 21 flowey_lib_common::cache 10
@@ -4286,8 +4150,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 21 flowey_lib_common::cache 4
-        flowey.exe v 21 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar6
-        flowey.exe v 21 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar7
+        flowey.exe v 21 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
+        flowey.exe v 21 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
@@ -4297,12 +4161,12 @@ jobs:
       name: 'Restore cache: gh-cli'
     - name: installing gh
       run: |-
-        flowey.exe v 21 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        flowey.exe v 21 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
         flowey.exe e 21 flowey_lib_common::cache 6
         flowey.exe e 21 flowey_lib_common::download_gh_cli 1
-        flowey.exe v 21 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.token <<EOF
+        flowey.exe v 21 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
         ${{ github.token }}
         EOF
       shell: bash
@@ -4362,8 +4226,8 @@ jobs:
         flowey.exe e 21 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
         flowey.exe e 21 flowey_lib_common::publish_test_results 0
         flowey.exe e 21 flowey_lib_common::publish_test_results 1
-        flowey.exe v 21 'flowey_lib_common::publish_test_results:2:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar1
-        flowey.exe v 21 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 21 'flowey_lib_common::publish_test_results:2:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:94:51 write-to-env github floweyvar1
+        flowey.exe v 21 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:94:51' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__2
       uses: actions/upload-artifact@v7
@@ -4377,8 +4241,8 @@ jobs:
         flowey.exe e 21 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
         flowey.exe e 21 flowey_lib_common::publish_test_results 3
         flowey.exe e 21 flowey_lib_common::publish_test_results 4
-        flowey.exe v 21 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar2
-        flowey.exe v 21 'flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 21 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:150:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:142:57 write-to-env github floweyvar2
+        flowey.exe v 21 'flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:142:57' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__5
       uses: actions/upload-artifact@v7
@@ -4467,8 +4331,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 22 flowey_lib_common::cache 0
-        flowey.exe v 22 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar4
-        flowey.exe v 22 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar5
+        flowey.exe v 22 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
+        flowey.exe v 22 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -4478,7 +4342,7 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
-        flowey.exe v 22 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey.exe v 22 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey.exe e 22 flowey_lib_common::cache 2
@@ -4487,8 +4351,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey.exe e 22 flowey_lib_common::git_checkout 0
-        flowey.exe v 22 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env github floweyvar3
-        flowey.exe v 22 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 22 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar3
+        flowey.exe v 22 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -4500,7 +4364,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey.exe v 22 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.workspace <<EOF
+        flowey.exe v 22 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
         flowey.exe e 22 flowey_lib_common::git_checkout 3
@@ -4535,8 +4399,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 22 flowey_lib_common::cache 8
-        flowey.exe v 22 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar8
-        flowey.exe v 22 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar9
+        flowey.exe v 22 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
+        flowey.exe v 22 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
       shell: bash
     - id: flowey_lib_common__cache__9
       uses: actions/cache@v5
@@ -4546,7 +4410,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 22 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
+        flowey.exe v 22 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
         EOF
         flowey.exe e 22 flowey_lib_common::cache 10
@@ -4569,8 +4433,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 22 flowey_lib_common::cache 4
-        flowey.exe v 22 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar6
-        flowey.exe v 22 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar7
+        flowey.exe v 22 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
+        flowey.exe v 22 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
@@ -4580,12 +4444,12 @@ jobs:
       name: 'Restore cache: gh-cli'
     - name: installing gh
       run: |-
-        flowey.exe v 22 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        flowey.exe v 22 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
         flowey.exe e 22 flowey_lib_common::cache 6
         flowey.exe e 22 flowey_lib_common::download_gh_cli 1
-        flowey.exe v 22 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.token <<EOF
+        flowey.exe v 22 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
         ${{ github.token }}
         EOF
       shell: bash
@@ -4645,8 +4509,8 @@ jobs:
         flowey.exe e 22 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
         flowey.exe e 22 flowey_lib_common::publish_test_results 0
         flowey.exe e 22 flowey_lib_common::publish_test_results 1
-        flowey.exe v 22 'flowey_lib_common::publish_test_results:2:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar1
-        flowey.exe v 22 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 22 'flowey_lib_common::publish_test_results:2:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:94:51 write-to-env github floweyvar1
+        flowey.exe v 22 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:94:51' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__2
       uses: actions/upload-artifact@v7
@@ -4660,8 +4524,8 @@ jobs:
         flowey.exe e 22 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
         flowey.exe e 22 flowey_lib_common::publish_test_results 3
         flowey.exe e 22 flowey_lib_common::publish_test_results 4
-        flowey.exe v 22 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar2
-        flowey.exe v 22 'flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 22 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:150:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:142:57 write-to-env github floweyvar2
+        flowey.exe v 22 'flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:142:57' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__5
       uses: actions/upload-artifact@v7
@@ -4694,6 +4558,7 @@ jobs:
       contents: read
       id-token: write
     needs:
+    - job0
     - job11
     - job2
     - job3
@@ -4750,8 +4615,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 23 flowey_lib_common::cache 0
-        flowey.exe v 23 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar4
-        flowey.exe v 23 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar5
+        flowey.exe v 23 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
+        flowey.exe v 23 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -4761,7 +4626,7 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
-        flowey.exe v 23 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey.exe v 23 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey.exe e 23 flowey_lib_common::cache 2
@@ -4770,8 +4635,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey.exe e 23 flowey_lib_common::git_checkout 0
-        flowey.exe v 23 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env github floweyvar3
-        flowey.exe v 23 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 23 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar3
+        flowey.exe v 23 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -4783,7 +4648,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey.exe v 23 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.workspace <<EOF
+        flowey.exe v 23 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
         flowey.exe e 23 flowey_lib_common::git_checkout 3
@@ -4818,8 +4683,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 23 flowey_lib_common::cache 8
-        flowey.exe v 23 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar8
-        flowey.exe v 23 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar9
+        flowey.exe v 23 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
+        flowey.exe v 23 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
       shell: bash
     - id: flowey_lib_common__cache__9
       uses: actions/cache@v5
@@ -4829,7 +4694,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 23 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
+        flowey.exe v 23 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
         EOF
         flowey.exe e 23 flowey_lib_common::cache 10
@@ -4852,8 +4717,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 23 flowey_lib_common::cache 4
-        flowey.exe v 23 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar6
-        flowey.exe v 23 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar7
+        flowey.exe v 23 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
+        flowey.exe v 23 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
@@ -4863,12 +4728,12 @@ jobs:
       name: 'Restore cache: gh-cli'
     - name: installing gh
       run: |-
-        flowey.exe v 23 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        flowey.exe v 23 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
         flowey.exe e 23 flowey_lib_common::cache 6
         flowey.exe e 23 flowey_lib_common::download_gh_cli 1
-        flowey.exe v 23 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.token <<EOF
+        flowey.exe v 23 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
         ${{ github.token }}
         EOF
       shell: bash
@@ -4928,8 +4793,8 @@ jobs:
         flowey.exe e 23 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
         flowey.exe e 23 flowey_lib_common::publish_test_results 0
         flowey.exe e 23 flowey_lib_common::publish_test_results 1
-        flowey.exe v 23 'flowey_lib_common::publish_test_results:2:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar1
-        flowey.exe v 23 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 23 'flowey_lib_common::publish_test_results:2:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:94:51 write-to-env github floweyvar1
+        flowey.exe v 23 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:94:51' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__2
       uses: actions/upload-artifact@v7
@@ -4943,8 +4808,8 @@ jobs:
         flowey.exe e 23 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
         flowey.exe e 23 flowey_lib_common::publish_test_results 3
         flowey.exe e 23 flowey_lib_common::publish_test_results 4
-        flowey.exe v 23 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar2
-        flowey.exe v 23 'flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 23 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:150:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:142:57 write-to-env github floweyvar2
+        flowey.exe v 23 'flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:142:57' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__5
       uses: actions/upload-artifact@v7
@@ -5030,8 +4895,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 24 flowey_lib_common::cache 0
-        flowey v 24 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar4
-        flowey v 24 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar5
+        flowey v 24 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
+        flowey v 24 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -5041,7 +4906,7 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
-        flowey v 24 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey v 24 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey e 24 flowey_lib_common::cache 2
@@ -5050,8 +4915,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 24 flowey_lib_common::git_checkout 0
-        flowey v 24 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env github floweyvar3
-        flowey v 24 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env github FLOWEY_CONDITION
+        flowey v 24 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar3
+        flowey v 24 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -5063,7 +4928,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey v 24 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.workspace <<EOF
+        flowey v 24 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
         flowey e 24 flowey_lib_common::git_checkout 3
@@ -5096,8 +4961,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 24 flowey_lib_common::cache 8
-        flowey v 24 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar8
-        flowey v 24 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar9
+        flowey v 24 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
+        flowey v 24 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
       shell: bash
     - id: flowey_lib_common__cache__9
       uses: actions/cache@v5
@@ -5107,7 +4972,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 24 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
+        flowey v 24 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
         EOF
         flowey e 24 flowey_lib_common::cache 10
@@ -5130,8 +4995,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 24 flowey_lib_common::cache 4
-        flowey v 24 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar6
-        flowey v 24 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar7
+        flowey v 24 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
+        flowey v 24 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
@@ -5141,12 +5006,12 @@ jobs:
       name: 'Restore cache: gh-cli'
     - name: installing gh
       run: |-
-        flowey v 24 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        flowey v 24 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
         flowey e 24 flowey_lib_common::cache 6
         flowey e 24 flowey_lib_common::download_gh_cli 1
-        flowey v 24 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.token <<EOF
+        flowey v 24 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
         ${{ github.token }}
         EOF
       shell: bash
@@ -5199,8 +5064,8 @@ jobs:
         flowey e 24 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
         flowey e 24 flowey_lib_common::publish_test_results 0
         flowey e 24 flowey_lib_common::publish_test_results 1
-        flowey v 24 'flowey_lib_common::publish_test_results:2:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar1
-        flowey v 24 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
+        flowey v 24 'flowey_lib_common::publish_test_results:2:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:94:51 write-to-env github floweyvar1
+        flowey v 24 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:94:51' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__2
       uses: actions/upload-artifact@v7
@@ -5214,8 +5079,8 @@ jobs:
         flowey e 24 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
         flowey e 24 flowey_lib_common::publish_test_results 3
         flowey e 24 flowey_lib_common::publish_test_results 4
-        flowey v 24 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar2
-        flowey v 24 'flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
+        flowey v 24 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:150:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:142:57 write-to-env github floweyvar2
+        flowey v 24 'flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:142:57' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__5
       uses: actions/upload-artifact@v7
@@ -5346,8 +5211,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 25 flowey_lib_common::cache 0
-        flowey v 25 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar4
-        flowey v 25 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar5
+        flowey v 25 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
+        flowey v 25 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -5357,7 +5222,7 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
-        flowey v 25 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey v 25 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey e 25 flowey_lib_common::cache 2
@@ -5366,8 +5231,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 25 flowey_lib_common::git_checkout 0
-        flowey v 25 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env github floweyvar3
-        flowey v 25 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env github FLOWEY_CONDITION
+        flowey v 25 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar3
+        flowey v 25 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -5379,7 +5244,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey v 25 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.workspace <<EOF
+        flowey v 25 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
         flowey e 25 flowey_lib_common::git_checkout 3
@@ -5412,8 +5277,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 25 flowey_lib_common::cache 8
-        flowey v 25 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar8
-        flowey v 25 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar9
+        flowey v 25 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
+        flowey v 25 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
       shell: bash
     - id: flowey_lib_common__cache__9
       uses: actions/cache@v5
@@ -5423,7 +5288,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 25 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
+        flowey v 25 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
         EOF
         flowey e 25 flowey_lib_common::cache 10
@@ -5446,8 +5311,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 25 flowey_lib_common::cache 4
-        flowey v 25 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar6
-        flowey v 25 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar7
+        flowey v 25 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
+        flowey v 25 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
@@ -5457,12 +5322,12 @@ jobs:
       name: 'Restore cache: gh-cli'
     - name: installing gh
       run: |-
-        flowey v 25 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        flowey v 25 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
         flowey e 25 flowey_lib_common::cache 6
         flowey e 25 flowey_lib_common::download_gh_cli 1
-        flowey v 25 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.token <<EOF
+        flowey v 25 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
         ${{ github.token }}
         EOF
       shell: bash
@@ -5514,8 +5379,8 @@ jobs:
         flowey e 25 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
         flowey e 25 flowey_lib_common::publish_test_results 0
         flowey e 25 flowey_lib_common::publish_test_results 1
-        flowey v 25 'flowey_lib_common::publish_test_results:2:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar1
-        flowey v 25 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
+        flowey v 25 'flowey_lib_common::publish_test_results:2:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:94:51 write-to-env github floweyvar1
+        flowey v 25 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:94:51' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__2
       uses: actions/upload-artifact@v7
@@ -5529,8 +5394,8 @@ jobs:
         flowey e 25 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
         flowey e 25 flowey_lib_common::publish_test_results 3
         flowey e 25 flowey_lib_common::publish_test_results 4
-        flowey v 25 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar2
-        flowey v 25 'flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
+        flowey v 25 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:150:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:142:57 write-to-env github floweyvar2
+        flowey v 25 'flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:142:57' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__5
       uses: actions/upload-artifact@v7
@@ -5662,8 +5527,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 26 flowey_lib_common::cache 0
-        flowey.exe v 26 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar4
-        flowey.exe v 26 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar5
+        flowey.exe v 26 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
+        flowey.exe v 26 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -5673,7 +5538,7 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
-        flowey.exe v 26 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey.exe v 26 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey.exe e 26 flowey_lib_common::cache 2
@@ -5682,8 +5547,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey.exe e 26 flowey_lib_common::git_checkout 0
-        flowey.exe v 26 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env github floweyvar3
-        flowey.exe v 26 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 26 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar3
+        flowey.exe v 26 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -5695,7 +5560,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey.exe v 26 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.workspace <<EOF
+        flowey.exe v 26 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
         flowey.exe e 26 flowey_lib_common::git_checkout 3
@@ -5725,8 +5590,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 26 flowey_lib_common::cache 8
-        flowey.exe v 26 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar8
-        flowey.exe v 26 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar9
+        flowey.exe v 26 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
+        flowey.exe v 26 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
       shell: bash
     - id: flowey_lib_common__cache__9
       uses: actions/cache@v5
@@ -5736,7 +5601,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 26 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
+        flowey.exe v 26 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
         EOF
         flowey.exe e 26 flowey_lib_common::cache 10
@@ -5759,8 +5624,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 26 flowey_lib_common::cache 4
-        flowey.exe v 26 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar6
-        flowey.exe v 26 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar7
+        flowey.exe v 26 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
+        flowey.exe v 26 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
@@ -5770,12 +5635,12 @@ jobs:
       name: 'Restore cache: gh-cli'
     - name: installing gh
       run: |-
-        flowey.exe v 26 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        flowey.exe v 26 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
         flowey.exe e 26 flowey_lib_common::cache 6
         flowey.exe e 26 flowey_lib_common::download_gh_cli 1
-        flowey.exe v 26 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.token <<EOF
+        flowey.exe v 26 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
         ${{ github.token }}
         EOF
       shell: bash
@@ -5830,8 +5695,8 @@ jobs:
         flowey.exe e 26 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
         flowey.exe e 26 flowey_lib_common::publish_test_results 0
         flowey.exe e 26 flowey_lib_common::publish_test_results 1
-        flowey.exe v 26 'flowey_lib_common::publish_test_results:2:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar1
-        flowey.exe v 26 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 26 'flowey_lib_common::publish_test_results:2:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:94:51 write-to-env github floweyvar1
+        flowey.exe v 26 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:94:51' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__2
       uses: actions/upload-artifact@v7
@@ -5845,8 +5710,8 @@ jobs:
         flowey.exe e 26 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
         flowey.exe e 26 flowey_lib_common::publish_test_results 3
         flowey.exe e 26 flowey_lib_common::publish_test_results 4
-        flowey.exe v 26 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar2
-        flowey.exe v 26 'flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 26 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:150:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:142:57 write-to-env github floweyvar2
+        flowey.exe v 26 'flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:142:57' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__5
       uses: actions/upload-artifact@v7
@@ -5926,8 +5791,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 27 flowey_lib_common::cache 0
-        flowey v 27 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar4
-        flowey v 27 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar5
+        flowey v 27 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
+        flowey v 27 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -5937,7 +5802,7 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
-        flowey v 27 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey v 27 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey e 27 flowey_lib_common::cache 2
@@ -5946,8 +5811,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 27 flowey_lib_common::git_checkout 0
-        flowey v 27 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env github floweyvar3
-        flowey v 27 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env github FLOWEY_CONDITION
+        flowey v 27 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar3
+        flowey v 27 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -5959,7 +5824,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey v 27 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.workspace <<EOF
+        flowey v 27 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
         flowey e 27 flowey_lib_common::git_checkout 3
@@ -5995,8 +5860,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 27 flowey_lib_common::cache 8
-        flowey v 27 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar8
-        flowey v 27 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar9
+        flowey v 27 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
+        flowey v 27 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
       shell: bash
     - id: flowey_lib_common__cache__9
       uses: actions/cache@v5
@@ -6006,7 +5871,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 27 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
+        flowey v 27 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
         EOF
         flowey e 27 flowey_lib_common::cache 10
@@ -6029,8 +5894,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 27 flowey_lib_common::cache 4
-        flowey v 27 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar6
-        flowey v 27 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar7
+        flowey v 27 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
+        flowey v 27 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
@@ -6040,12 +5905,12 @@ jobs:
       name: 'Restore cache: gh-cli'
     - name: installing gh
       run: |-
-        flowey v 27 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        flowey v 27 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
         flowey e 27 flowey_lib_common::cache 6
         flowey e 27 flowey_lib_common::download_gh_cli 1
-        flowey v 27 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.token <<EOF
+        flowey v 27 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
         ${{ github.token }}
         EOF
       shell: bash
@@ -6101,8 +5966,8 @@ jobs:
         flowey e 27 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 6
         flowey e 27 flowey_lib_common::publish_test_results 0
         flowey e 27 flowey_lib_common::publish_test_results 1
-        flowey v 27 'flowey_lib_common::publish_test_results:2:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar1
-        flowey v 27 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
+        flowey v 27 'flowey_lib_common::publish_test_results:2:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:94:51 write-to-env github floweyvar1
+        flowey v 27 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:94:51' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__2
       uses: actions/upload-artifact@v7
@@ -6116,8 +5981,8 @@ jobs:
         flowey e 27 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 5
         flowey e 27 flowey_lib_common::publish_test_results 3
         flowey e 27 flowey_lib_common::publish_test_results 4
-        flowey v 27 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar2
-        flowey v 27 'flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
+        flowey v 27 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:150:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:142:57 write-to-env github floweyvar2
+        flowey v 27 'flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:142:57' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__5
       uses: actions/upload-artifact@v7
@@ -6174,8 +6039,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 28 flowey_lib_common::git_checkout 0
-        flowey v 28 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env github floweyvar1
-        flowey v 28 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env github FLOWEY_CONDITION
+        flowey v 28 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar1
+        flowey v 28 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -6187,7 +6052,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey v 28 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.workspace <<EOF
+        flowey v 28 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
         flowey e 28 flowey_lib_common::git_checkout 3
@@ -6206,7 +6071,7 @@ jobs:
     - name: detect active toolchain
       run: |-
         flowey e 28 flowey_lib_common::install_rust 2
-        flowey v 28 'flowey_lib_hvlite::_jobs::test_local_flowey_build_igvm:3:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.token <<EOF
+        flowey v 28 'flowey_lib_hvlite::_jobs::test_local_flowey_build_igvm:3:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
         ${{ github.token }}
         EOF
       shell: bash
@@ -6286,8 +6151,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 3 flowey_lib_common::git_checkout 0
-        flowey v 3 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env github floweyvar1
-        flowey v 3 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env github FLOWEY_CONDITION
+        flowey v 3 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar1
+        flowey v 3 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -6299,7 +6164,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey v 3 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.workspace <<EOF
+        flowey v 3 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
         flowey e 3 flowey_lib_common::git_checkout 3
@@ -6318,8 +6183,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 3 flowey_lib_common::cache 0
-        flowey v 3 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar2
-        flowey v 3 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar3
+        flowey v 3 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar2
+        flowey v 3 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar3
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -6329,7 +6194,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 3 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey v 3 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey e 3 flowey_lib_common::cache 2
@@ -6675,8 +6540,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey.exe e 4 flowey_lib_common::git_checkout 0
-        flowey.exe v 4 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env github floweyvar1
-        flowey.exe v 4 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 4 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar1
+        flowey.exe v 4 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -6688,7 +6553,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey.exe v 4 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.workspace <<EOF
+        flowey.exe v 4 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
         flowey.exe e 4 flowey_lib_common::git_checkout 3
@@ -6707,8 +6572,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 4 flowey_lib_common::cache 0
-        flowey.exe v 4 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar2
-        flowey.exe v 4 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar3
+        flowey.exe v 4 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar2
+        flowey.exe v 4 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar3
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -6718,7 +6583,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 4 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey.exe v 4 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey.exe e 4 flowey_lib_common::cache 2
@@ -6904,8 +6769,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey.exe e 5 flowey_lib_common::git_checkout 0
-        flowey.exe v 5 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env github floweyvar1
-        flowey.exe v 5 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 5 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar1
+        flowey.exe v 5 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -6917,7 +6782,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey.exe v 5 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.workspace <<EOF
+        flowey.exe v 5 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
         flowey.exe e 5 flowey_lib_common::git_checkout 3
@@ -6936,8 +6801,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 5 flowey_lib_common::cache 4
-        flowey.exe v 5 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar4
-        flowey.exe v 5 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar5
+        flowey.exe v 5 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
+        flowey.exe v 5 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
@@ -6947,7 +6812,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 5 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        flowey.exe v 5 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
         flowey.exe e 5 flowey_lib_common::cache 6
@@ -7032,8 +6897,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 5 flowey_lib_common::cache 0
-        flowey.exe v 5 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar2
-        flowey.exe v 5 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar3
+        flowey.exe v 5 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar2
+        flowey.exe v 5 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar3
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -7043,7 +6908,7 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
-        flowey.exe v 5 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey.exe v 5 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey.exe e 5 flowey_lib_common::cache 2
@@ -7220,8 +7085,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey.exe e 6 flowey_lib_common::git_checkout 0
-        flowey.exe v 6 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env github floweyvar1
-        flowey.exe v 6 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 6 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar1
+        flowey.exe v 6 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -7233,7 +7098,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey.exe v 6 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.workspace <<EOF
+        flowey.exe v 6 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
         flowey.exe e 6 flowey_lib_common::git_checkout 3
@@ -7252,8 +7117,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 6 flowey_lib_common::cache 0
-        flowey.exe v 6 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar2
-        flowey.exe v 6 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar3
+        flowey.exe v 6 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar2
+        flowey.exe v 6 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar3
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -7263,7 +7128,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 6 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey.exe v 6 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey.exe e 6 flowey_lib_common::cache 2
@@ -7453,8 +7318,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey.exe e 7 flowey_lib_common::git_checkout 0
-        flowey.exe v 7 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env github floweyvar1
-        flowey.exe v 7 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 7 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar1
+        flowey.exe v 7 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -7466,7 +7331,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey.exe v 7 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.workspace <<EOF
+        flowey.exe v 7 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
         flowey.exe e 7 flowey_lib_common::git_checkout 3
@@ -7485,8 +7350,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 7 flowey_lib_common::cache 4
-        flowey.exe v 7 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar4
-        flowey.exe v 7 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar5
+        flowey.exe v 7 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
+        flowey.exe v 7 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
@@ -7496,7 +7361,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 7 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        flowey.exe v 7 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
         flowey.exe e 7 flowey_lib_common::cache 6
@@ -7581,8 +7446,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 7 flowey_lib_common::cache 0
-        flowey.exe v 7 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar2
-        flowey.exe v 7 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar3
+        flowey.exe v 7 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar2
+        flowey.exe v 7 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar3
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -7592,7 +7457,7 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
-        flowey.exe v 7 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey.exe v 7 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey.exe e 7 flowey_lib_common::cache 2
@@ -7753,8 +7618,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 8 flowey_lib_common::git_checkout 0
-        flowey v 8 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env github floweyvar1
-        flowey v 8 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env github FLOWEY_CONDITION
+        flowey v 8 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar1
+        flowey v 8 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -7766,7 +7631,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey v 8 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.workspace <<EOF
+        flowey v 8 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
         flowey e 8 flowey_lib_common::git_checkout 3
@@ -7785,8 +7650,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 8 flowey_lib_common::cache 4
-        flowey v 8 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar4
-        flowey v 8 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar5
+        flowey v 8 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
+        flowey v 8 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
@@ -7796,7 +7661,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 8 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        flowey v 8 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
         flowey e 8 flowey_lib_common::cache 6
@@ -7954,8 +7819,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 8 flowey_lib_common::cache 0
-        flowey v 8 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar2
-        flowey v 8 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar3
+        flowey v 8 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar2
+        flowey v 8 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar3
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -7965,7 +7830,7 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
-        flowey v 8 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey v 8 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey e 8 flowey_lib_common::cache 2
@@ -8138,8 +8003,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 9 flowey_lib_common::git_checkout 0
-        flowey v 9 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env github floweyvar1
-        flowey v 9 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env github FLOWEY_CONDITION
+        flowey v 9 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar1
+        flowey v 9 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -8151,7 +8016,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey v 9 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.workspace <<EOF
+        flowey v 9 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
         flowey e 9 flowey_lib_common::git_checkout 3
@@ -8170,8 +8035,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 9 flowey_lib_common::cache 4
-        flowey v 9 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar4
-        flowey v 9 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar5
+        flowey v 9 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
+        flowey v 9 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
@@ -8181,7 +8046,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 9 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        flowey v 9 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
         flowey e 9 flowey_lib_common::cache 6
@@ -8343,8 +8208,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 9 flowey_lib_common::cache 0
-        flowey v 9 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar2
-        flowey v 9 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar3
+        flowey v 9 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar2
+        flowey v 9 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar3
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -8354,7 +8219,7 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
-        flowey v 9 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey v 9 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey e 9 flowey_lib_common::cache 2

--- a/.github/workflows/openvmm-pr.yaml
+++ b/.github/workflows/openvmm-pr.yaml
@@ -106,8 +106,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 0 flowey_lib_common::git_checkout 0
-        flowey v 0 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env github floweyvar1
-        flowey v 0 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env github FLOWEY_CONDITION
+        flowey v 0 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar1
+        flowey v 0 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -119,7 +119,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey v 0 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.workspace <<EOF
+        flowey v 0 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
         flowey e 0 flowey_lib_common::git_checkout 3
@@ -149,8 +149,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 0 flowey_lib_common::cache 0
-        flowey v 0 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar2
-        flowey v 0 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar3
+        flowey v 0 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar2
+        flowey v 0 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar3
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -160,7 +160,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 0 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey v 0 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey e 0 flowey_lib_common::cache 2
@@ -320,8 +320,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey.exe e 1 flowey_lib_common::git_checkout 0
-        flowey.exe v 1 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env github floweyvar1
-        flowey.exe v 1 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 1 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar1
+        flowey.exe v 1 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -333,7 +333,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey.exe v 1 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.workspace <<EOF
+        flowey.exe v 1 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
         flowey.exe e 1 flowey_lib_common::git_checkout 3
@@ -363,8 +363,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 1 flowey_lib_common::cache 0
-        flowey.exe v 1 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar2
-        flowey.exe v 1 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar3
+        flowey.exe v 1 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar2
+        flowey.exe v 1 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar3
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -374,7 +374,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 1 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey.exe v 1 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey.exe e 1 flowey_lib_common::cache 2
@@ -440,18 +440,14 @@ jobs:
         EOF
         mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-openhcl-igvm"
         echo "$AgentTempDirNormal/publish_artifacts/aarch64-openhcl-igvm" | flowey v 10 'artifact_publish_from_aarch64-openhcl-igvm' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-openhcl-igvm-devkern"
-        echo "$AgentTempDirNormal/publish_artifacts/aarch64-openhcl-igvm-devkern" | flowey v 10 'artifact_publish_from_aarch64-openhcl-igvm-devkern' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-openhcl-igvm-devkern-extras"
-        echo "$AgentTempDirNormal/publish_artifacts/aarch64-openhcl-igvm-devkern-extras" | flowey v 10 'artifact_publish_from_aarch64-openhcl-igvm-devkern-extras' --is-raw-string update
         mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-openhcl-igvm-extras"
         echo "$AgentTempDirNormal/publish_artifacts/aarch64-openhcl-igvm-extras" | flowey v 10 'artifact_publish_from_aarch64-openhcl-igvm-extras' --is-raw-string update
       shell: bash
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 10 flowey_lib_common::git_checkout 0
-        flowey v 10 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env github floweyvar3
-        flowey v 10 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env github FLOWEY_CONDITION
+        flowey v 10 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar3
+        flowey v 10 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -463,7 +459,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey v 10 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.workspace <<EOF
+        flowey v 10 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
         flowey e 10 flowey_lib_common::git_checkout 3
@@ -492,8 +488,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 10 flowey_lib_common::cache 0
-        flowey v 10 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar1
-        flowey v 10 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar2
+        flowey v 10 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar1
+        flowey v 10 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar2
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -503,7 +499,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 10 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey v 10 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey e 10 flowey_lib_common::cache 2
@@ -565,7 +561,7 @@ jobs:
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 10 flowey_lib_hvlite::run_split_debug_info 2
+        flowey e 10 flowey_lib_hvlite::run_split_debug_info 1
         flowey e 10 flowey_lib_hvlite::run_cargo_build 5
         flowey e 10 flowey_lib_hvlite::build_openhcl_boot 0
         flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 5
@@ -583,7 +579,7 @@ jobs:
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 10 flowey_lib_hvlite::run_split_debug_info 3
+        flowey e 10 flowey_lib_hvlite::run_split_debug_info 2
         flowey e 10 flowey_lib_hvlite::run_cargo_build 1
         flowey e 10 flowey_lib_hvlite::build_igvmfilegen 0
         flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 7
@@ -598,36 +594,6 @@ jobs:
         flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 10
         flowey e 10 flowey_core::pipeline::artifact::publish 1
       shell: bash
-    - name: extract and resolve kernel package
-      run: |-
-        flowey e 10 flowey_lib_hvlite::resolve_openhcl_kernel_package 1
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 15
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 12
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 10 flowey_lib_hvlite::run_split_debug_info 1
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 13
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 14
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 16
-      shell: bash
-    - name: building openhcl initrd
-      run: |-
-        flowey e 10 flowey_lib_hvlite::build_openhcl_initrd 1
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 17
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 18
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 19
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 20
-      shell: bash
-    - name: building igvm file
-      run: |-
-        flowey e 10 flowey_lib_hvlite::run_igvmfilegen 1
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 23
-        flowey e 10 flowey_core::pipeline::artifact::publish 2
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 21
-        flowey e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 22
-        flowey e 10 flowey_core::pipeline::artifact::publish 3
-      shell: bash
     - name: 'validate cache entry: gh-release-download'
       run: flowey e 10 flowey_lib_common::cache 3
       shell: bash
@@ -636,18 +602,6 @@ jobs:
       with:
         name: aarch64-openhcl-igvm
         path: ${{ runner.temp }}/publish_artifacts/aarch64-openhcl-igvm/
-        include-hidden-files: true
-    - name: 🌼📦 Publish aarch64-openhcl-igvm-devkern
-      uses: actions/upload-artifact@v7
-      with:
-        name: aarch64-openhcl-igvm-devkern
-        path: ${{ runner.temp }}/publish_artifacts/aarch64-openhcl-igvm-devkern/
-        include-hidden-files: true
-    - name: 🌼📦 Publish aarch64-openhcl-igvm-devkern-extras
-      uses: actions/upload-artifact@v7
-      with:
-        name: aarch64-openhcl-igvm-devkern-extras
-        path: ${{ runner.temp }}/publish_artifacts/aarch64-openhcl-igvm-devkern-extras/
         include-hidden-files: true
     - name: 🌼📦 Publish aarch64-openhcl-igvm-extras
       uses: actions/upload-artifact@v7
@@ -702,8 +656,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 11 flowey_lib_common::git_checkout 0
-        flowey v 11 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env github floweyvar2
-        flowey v 11 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env github FLOWEY_CONDITION
+        flowey v 11 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar2
+        flowey v 11 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -715,7 +669,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey v 11 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.workspace <<EOF
+        flowey v 11 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
         flowey e 11 flowey_lib_common::git_checkout 3
@@ -732,8 +686,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 11 flowey_lib_common::cache 4
-        flowey v 11 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar5
-        flowey v 11 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar6
+        flowey v 11 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar5
+        flowey v 11 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar6
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
@@ -743,7 +697,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 11 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        flowey v 11 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
         flowey e 11 flowey_lib_common::cache 6
@@ -789,7 +743,7 @@ jobs:
     - name: collect openvmm_hcl files for analysis
       run: |-
         flowey e 11 flowey_lib_hvlite::_jobs::check_openvmm_hcl_size 1
-        flowey v 11 'flowey_lib_hvlite::_jobs::check_openvmm_hcl_size:8:flowey_lib_hvlite/src/_jobs/check_openvmm_hcl_size.rs' --is-raw-string write-to-env github floweyvar1
+        flowey v 11 'flowey_lib_hvlite::_jobs::check_openvmm_hcl_size:8:flowey_lib_hvlite/src/_jobs/check_openvmm_hcl_size.rs:113:27' --is-raw-string write-to-env github floweyvar1
       shell: bash
     - id: flowey_lib_hvlite___jobs__check_openvmm_hcl_size__2
       uses: actions/upload-artifact@v7
@@ -815,8 +769,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 11 flowey_lib_common::cache 0
-        flowey v 11 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar3
-        flowey v 11 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar4
+        flowey v 11 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar3
+        flowey v 11 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar4
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -826,12 +780,12 @@ jobs:
       name: 'Restore cache: gh-cli'
     - name: installing gh
       run: |-
-        flowey v 11 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey v 11 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey e 11 flowey_lib_common::cache 2
         flowey e 11 flowey_lib_common::download_gh_cli 1
-        flowey v 11 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.token <<EOF
+        flowey v 11 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
         ${{ github.token }}
         EOF
       shell: bash
@@ -900,26 +854,18 @@ jobs:
         echo "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-cvm" | flowey v 12 'artifact_publish_from_x64-openhcl-igvm-cvm' --is-raw-string update
         mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-cvm-extras"
         echo "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-cvm-extras" | flowey v 12 'artifact_publish_from_x64-openhcl-igvm-cvm-extras' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-devkern"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-devkern" | flowey v 12 'artifact_publish_from_x64-openhcl-igvm-devkern' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-devkern-extras"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-devkern-extras" | flowey v 12 'artifact_publish_from_x64-openhcl-igvm-devkern-extras' --is-raw-string update
         mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-extras"
         echo "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-extras" | flowey v 12 'artifact_publish_from_x64-openhcl-igvm-extras' --is-raw-string update
         mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-test-linux-direct"
         echo "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-test-linux-direct" | flowey v 12 'artifact_publish_from_x64-openhcl-igvm-test-linux-direct' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-test-linux-direct-devkern"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-test-linux-direct-devkern" | flowey v 12 'artifact_publish_from_x64-openhcl-igvm-test-linux-direct-devkern' --is-raw-string update
-        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-test-linux-direct-devkern-extras"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-test-linux-direct-devkern-extras" | flowey v 12 'artifact_publish_from_x64-openhcl-igvm-test-linux-direct-devkern-extras' --is-raw-string update
         mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-test-linux-direct-extras"
         echo "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-test-linux-direct-extras" | flowey v 12 'artifact_publish_from_x64-openhcl-igvm-test-linux-direct-extras' --is-raw-string update
       shell: bash
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 12 flowey_lib_common::git_checkout 0
-        flowey v 12 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env github floweyvar3
-        flowey v 12 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env github FLOWEY_CONDITION
+        flowey v 12 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar3
+        flowey v 12 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -931,7 +877,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey v 12 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.workspace <<EOF
+        flowey v 12 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
         flowey e 12 flowey_lib_common::git_checkout 3
@@ -960,8 +906,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 12 flowey_lib_common::cache 0
-        flowey v 12 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar1
-        flowey v 12 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar2
+        flowey v 12 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar1
+        flowey v 12 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar2
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -971,7 +917,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 12 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey v 12 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey e 12 flowey_lib_common::cache 2
@@ -1021,7 +967,7 @@ jobs:
       shell: bash
     - name: building openhcl initrd
       run: |-
-        flowey e 12 flowey_lib_hvlite::build_openhcl_initrd 2
+        flowey e 12 flowey_lib_hvlite::build_openhcl_initrd 0
         flowey e 12 flowey_lib_hvlite::init_cross_build 0
         flowey e 12 flowey_lib_hvlite::run_cargo_build 9
         flowey e 12 flowey_lib_hvlite::run_cargo_build 10
@@ -1033,7 +979,7 @@ jobs:
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 12 flowey_lib_hvlite::run_split_debug_info 6
+        flowey e 12 flowey_lib_hvlite::run_split_debug_info 4
         flowey e 12 flowey_lib_hvlite::run_cargo_build 12
         flowey e 12 flowey_lib_hvlite::build_sidecar 0
         flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 5
@@ -1048,7 +994,7 @@ jobs:
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 12 flowey_lib_hvlite::run_split_debug_info 5
+        flowey e 12 flowey_lib_hvlite::run_split_debug_info 3
         flowey e 12 flowey_lib_hvlite::run_cargo_build 5
         flowey e 12 flowey_lib_hvlite::build_openhcl_boot 0
         flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 6
@@ -1066,7 +1012,7 @@ jobs:
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 12 flowey_lib_hvlite::run_split_debug_info 7
+        flowey e 12 flowey_lib_hvlite::run_split_debug_info 5
         flowey e 12 flowey_lib_hvlite::run_cargo_build 1
         flowey e 12 flowey_lib_hvlite::build_igvmfilegen 0
         flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 8
@@ -1074,43 +1020,14 @@ jobs:
       shell: bash
     - name: building igvm file
       run: |-
-        flowey e 12 flowey_lib_hvlite::run_igvmfilegen 2
+        flowey e 12 flowey_lib_hvlite::run_igvmfilegen 1
         flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 12
         flowey e 12 flowey_core::pipeline::artifact::publish 0
         flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 10
         flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 11
         flowey e 12 flowey_core::pipeline::artifact::publish 1
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 34
-      shell: bash
-    - name: extract and resolve kernel package
-      run: |-
-        flowey e 12 flowey_lib_hvlite::resolve_openhcl_kernel_package 2
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 28
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 25
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 12 flowey_lib_hvlite::run_split_debug_info 4
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 26
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 27
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 29
-      shell: bash
-    - name: building openhcl initrd
-      run: |-
-        flowey e 12 flowey_lib_hvlite::build_openhcl_initrd 4
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 30
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 31
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 32
         flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 33
-      shell: bash
-    - name: building igvm file
-      run: |-
-        flowey e 12 flowey_lib_hvlite::run_igvmfilegen 4
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 37
-        flowey e 12 flowey_core::pipeline::artifact::publish 2
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 35
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 36
-        flowey e 12 flowey_core::pipeline::artifact::publish 3
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 34
       shell: bash
     - name: unpack openvmm-test-linux archives
       run: flowey e 12 flowey_lib_hvlite::resolve_openvmm_test_linux_kernel 0
@@ -1118,60 +1035,31 @@ jobs:
     - name: unpack openvmm-test-initrd archives
       run: |-
         flowey e 12 flowey_lib_hvlite::resolve_openvmm_test_initrd 0
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 41
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 38
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 12 flowey_lib_hvlite::run_split_debug_info 1
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 39
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 40
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 42
-      shell: bash
-    - name: building openhcl initrd
-      run: |-
-        flowey e 12 flowey_lib_hvlite::build_openhcl_initrd 0
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 43
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 44
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 45
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 46
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 47
-      shell: bash
-    - name: building igvm file
-      run: |-
-        flowey e 12 flowey_lib_hvlite::run_igvmfilegen 0
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 50
-        flowey e 12 flowey_core::pipeline::artifact::publish 4
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 48
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 49
-        flowey e 12 flowey_core::pipeline::artifact::publish 5
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 54
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 51
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 28
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 25
       shell: bash
     - name: split debug symbols
       run: |-
         flowey e 12 flowey_lib_hvlite::run_split_debug_info 2
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 52
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 53
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 55
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 26
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 27
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 29
       shell: bash
     - name: building openhcl initrd
       run: |-
-        flowey e 12 flowey_lib_hvlite::build_openhcl_initrd 1
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 56
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 57
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 58
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 59
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 60
+        flowey e 12 flowey_lib_hvlite::build_openhcl_initrd 2
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 30
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 31
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 32
       shell: bash
     - name: building igvm file
       run: |-
-        flowey e 12 flowey_lib_hvlite::run_igvmfilegen 1
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 63
-        flowey e 12 flowey_core::pipeline::artifact::publish 6
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 61
-        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 62
-        flowey e 12 flowey_core::pipeline::artifact::publish 7
+        flowey e 12 flowey_lib_hvlite::run_igvmfilegen 0
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 37
+        flowey e 12 flowey_core::pipeline::artifact::publish 2
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 35
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 36
+        flowey e 12 flowey_core::pipeline::artifact::publish 3
       shell: bash
     - name: extract and resolve kernel package
       run: |-
@@ -1181,14 +1069,14 @@ jobs:
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 12 flowey_lib_hvlite::run_split_debug_info 3
+        flowey e 12 flowey_lib_hvlite::run_split_debug_info 1
         flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 14
         flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 15
         flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 17
       shell: bash
     - name: building openhcl initrd
       run: |-
-        flowey e 12 flowey_lib_hvlite::build_openhcl_initrd 3
+        flowey e 12 flowey_lib_hvlite::build_openhcl_initrd 1
         flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 18
         flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 19
         flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 20
@@ -1196,12 +1084,12 @@ jobs:
       shell: bash
     - name: building igvm file
       run: |-
-        flowey e 12 flowey_lib_hvlite::run_igvmfilegen 3
+        flowey e 12 flowey_lib_hvlite::run_igvmfilegen 2
         flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 24
-        flowey e 12 flowey_core::pipeline::artifact::publish 8
+        flowey e 12 flowey_core::pipeline::artifact::publish 4
         flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 22
         flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 23
-        flowey e 12 flowey_core::pipeline::artifact::publish 9
+        flowey e 12 flowey_core::pipeline::artifact::publish 5
       shell: bash
     - name: 'validate cache entry: gh-release-download'
       run: flowey e 12 flowey_lib_common::cache 3
@@ -1224,18 +1112,6 @@ jobs:
         name: x64-openhcl-igvm-cvm-extras
         path: ${{ runner.temp }}/publish_artifacts/x64-openhcl-igvm-cvm-extras/
         include-hidden-files: true
-    - name: 🌼📦 Publish x64-openhcl-igvm-devkern
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-openhcl-igvm-devkern
-        path: ${{ runner.temp }}/publish_artifacts/x64-openhcl-igvm-devkern/
-        include-hidden-files: true
-    - name: 🌼📦 Publish x64-openhcl-igvm-devkern-extras
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-openhcl-igvm-devkern-extras
-        path: ${{ runner.temp }}/publish_artifacts/x64-openhcl-igvm-devkern-extras/
-        include-hidden-files: true
     - name: 🌼📦 Publish x64-openhcl-igvm-extras
       uses: actions/upload-artifact@v7
       with:
@@ -1247,18 +1123,6 @@ jobs:
       with:
         name: x64-openhcl-igvm-test-linux-direct
         path: ${{ runner.temp }}/publish_artifacts/x64-openhcl-igvm-test-linux-direct/
-        include-hidden-files: true
-    - name: 🌼📦 Publish x64-openhcl-igvm-test-linux-direct-devkern
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-openhcl-igvm-test-linux-direct-devkern
-        path: ${{ runner.temp }}/publish_artifacts/x64-openhcl-igvm-test-linux-direct-devkern/
-        include-hidden-files: true
-    - name: 🌼📦 Publish x64-openhcl-igvm-test-linux-direct-devkern-extras
-      uses: actions/upload-artifact@v7
-      with:
-        name: x64-openhcl-igvm-test-linux-direct-devkern-extras
-        path: ${{ runner.temp }}/publish_artifacts/x64-openhcl-igvm-test-linux-direct-devkern-extras/
         include-hidden-files: true
     - name: 🌼📦 Publish x64-openhcl-igvm-test-linux-direct-extras
       uses: actions/upload-artifact@v7
@@ -1313,8 +1177,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 13 flowey_lib_common::git_checkout 0
-        flowey v 13 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env github floweyvar2
-        flowey v 13 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env github FLOWEY_CONDITION
+        flowey v 13 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar2
+        flowey v 13 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -1326,7 +1190,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey v 13 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.workspace <<EOF
+        flowey v 13 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
         flowey e 13 flowey_lib_common::git_checkout 3
@@ -1343,8 +1207,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 13 flowey_lib_common::cache 4
-        flowey v 13 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar5
-        flowey v 13 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar6
+        flowey v 13 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar5
+        flowey v 13 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar6
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
@@ -1354,7 +1218,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 13 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        flowey v 13 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
         flowey e 13 flowey_lib_common::cache 6
@@ -1400,7 +1264,7 @@ jobs:
     - name: collect openvmm_hcl files for analysis
       run: |-
         flowey e 13 flowey_lib_hvlite::_jobs::check_openvmm_hcl_size 1
-        flowey v 13 'flowey_lib_hvlite::_jobs::check_openvmm_hcl_size:8:flowey_lib_hvlite/src/_jobs/check_openvmm_hcl_size.rs' --is-raw-string write-to-env github floweyvar1
+        flowey v 13 'flowey_lib_hvlite::_jobs::check_openvmm_hcl_size:8:flowey_lib_hvlite/src/_jobs/check_openvmm_hcl_size.rs:113:27' --is-raw-string write-to-env github floweyvar1
       shell: bash
     - id: flowey_lib_hvlite___jobs__check_openvmm_hcl_size__2
       uses: actions/upload-artifact@v7
@@ -1426,8 +1290,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 13 flowey_lib_common::cache 0
-        flowey v 13 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar3
-        flowey v 13 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar4
+        flowey v 13 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar3
+        flowey v 13 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar4
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -1437,12 +1301,12 @@ jobs:
       name: 'Restore cache: gh-cli'
     - name: installing gh
       run: |-
-        flowey v 13 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey v 13 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey e 13 flowey_lib_common::cache 2
         flowey e 13 flowey_lib_common::download_gh_cli 1
-        flowey v 13 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.token <<EOF
+        flowey v 13 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
         ${{ github.token }}
         EOF
       shell: bash
@@ -1521,8 +1385,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 14 flowey_lib_common::git_checkout 0
-        flowey v 14 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env github floweyvar3
-        flowey v 14 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env github FLOWEY_CONDITION
+        flowey v 14 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar3
+        flowey v 14 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -1534,7 +1398,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey v 14 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.workspace <<EOF
+        flowey v 14 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
         flowey e 14 flowey_lib_common::git_checkout 3
@@ -1563,8 +1427,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 14 flowey_lib_common::cache 0
-        flowey v 14 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar1
-        flowey v 14 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar2
+        flowey v 14 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar1
+        flowey v 14 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar2
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -1574,7 +1438,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 14 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey v 14 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey e 14 flowey_lib_common::cache 2
@@ -1882,8 +1746,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey.exe e 15 flowey_lib_common::git_checkout 0
-        flowey.exe v 15 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env github floweyvar8
-        flowey.exe v 15 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 15 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar8
+        flowey.exe v 15 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -1895,7 +1759,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey.exe v 15 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.workspace <<EOF
+        flowey.exe v 15 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
         flowey.exe e 15 flowey_lib_common::git_checkout 3
@@ -1914,8 +1778,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 15 flowey_lib_common::cache 4
-        flowey.exe v 15 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar6
-        flowey.exe v 15 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar7
+        flowey.exe v 15 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
+        flowey.exe v 15 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
@@ -1925,7 +1789,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 15 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        flowey.exe v 15 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
         flowey.exe e 15 flowey_lib_common::cache 6
@@ -1970,8 +1834,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 15 flowey_lib_common::cache 0
-        flowey.exe v 15 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar4
-        flowey.exe v 15 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar5
+        flowey.exe v 15 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
+        flowey.exe v 15 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -1981,7 +1845,7 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
-        flowey.exe v 15 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey.exe v 15 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey.exe e 15 flowey_lib_common::cache 2
@@ -2017,8 +1881,8 @@ jobs:
         flowey.exe e 15 flowey_lib_hvlite::build_nextest_unit_tests 1
         flowey.exe e 15 flowey_lib_common::publish_test_results 6
         flowey.exe e 15 flowey_lib_common::publish_test_results 7
-        flowey.exe v 15 'flowey_lib_common::publish_test_results:12:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar3
-        flowey.exe v 15 'flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 15 'flowey_lib_common::publish_test_results:12:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs:94:51 write-to-env github floweyvar3
+        flowey.exe v 15 'flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs:94:51' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__8
       uses: actions/upload-artifact@v7
@@ -2037,8 +1901,8 @@ jobs:
         flowey.exe e 15 flowey_lib_hvlite::build_nextest_unit_tests 2
         flowey.exe e 15 flowey_lib_common::publish_test_results 0
         flowey.exe e 15 flowey_lib_common::publish_test_results 1
-        flowey.exe v 15 'flowey_lib_common::publish_test_results:2:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar1
-        flowey.exe v 15 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 15 'flowey_lib_common::publish_test_results:2:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:94:51 write-to-env github floweyvar1
+        flowey.exe v 15 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:94:51' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__2
       uses: actions/upload-artifact@v7
@@ -2057,8 +1921,8 @@ jobs:
         flowey.exe e 15 flowey_lib_hvlite::build_nextest_unit_tests 3
         flowey.exe e 15 flowey_lib_common::publish_test_results 3
         flowey.exe e 15 flowey_lib_common::publish_test_results 4
-        flowey.exe v 15 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar2
-        flowey.exe v 15 'flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 15 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:94:51 write-to-env github floweyvar2
+        flowey.exe v 15 'flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:94:51' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__5
       uses: actions/upload-artifact@v7
@@ -2138,8 +2002,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 16 flowey_lib_common::git_checkout 0
-        flowey v 16 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env github floweyvar10
-        flowey v 16 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env github FLOWEY_CONDITION
+        flowey v 16 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar10
+        flowey v 16 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -2151,7 +2015,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey v 16 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.workspace <<EOF
+        flowey v 16 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
         flowey e 16 flowey_lib_common::git_checkout 3
@@ -2170,8 +2034,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 16 flowey_lib_common::cache 4
-        flowey v 16 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar8
-        flowey v 16 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar9
+        flowey v 16 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
+        flowey v 16 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
@@ -2181,7 +2045,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 16 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        flowey v 16 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
         flowey e 16 flowey_lib_common::cache 6
@@ -2230,8 +2094,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 16 flowey_lib_common::cache 0
-        flowey v 16 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar6
-        flowey v 16 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar7
+        flowey v 16 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
+        flowey v 16 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -2241,7 +2105,7 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
-        flowey v 16 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey v 16 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey e 16 flowey_lib_common::cache 2
@@ -2266,8 +2130,8 @@ jobs:
         flowey e 16 flowey_lib_hvlite::build_nextest_unit_tests 3
         flowey e 16 flowey_lib_common::publish_test_results 6
         flowey e 16 flowey_lib_common::publish_test_results 7
-        flowey v 16 'flowey_lib_common::publish_test_results:12:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar3
-        flowey v 16 'flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
+        flowey v 16 'flowey_lib_common::publish_test_results:12:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs:94:51 write-to-env github floweyvar3
+        flowey v 16 'flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs:94:51' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__8
       uses: actions/upload-artifact@v7
@@ -2286,8 +2150,8 @@ jobs:
         flowey e 16 flowey_lib_hvlite::build_nextest_unit_tests 4
         flowey e 16 flowey_lib_common::publish_test_results 9
         flowey e 16 flowey_lib_common::publish_test_results 10
-        flowey v 16 'flowey_lib_common::publish_test_results:17:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:15:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar4
-        flowey v 16 'flowey_lib_common::publish_test_results:15:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
+        flowey v 16 'flowey_lib_common::publish_test_results:17:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:15:flowey_lib_common/src/publish_test_results.rs:94:51 write-to-env github floweyvar4
+        flowey v 16 'flowey_lib_common::publish_test_results:15:flowey_lib_common/src/publish_test_results.rs:94:51' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__11
       uses: actions/upload-artifact@v7
@@ -2306,8 +2170,8 @@ jobs:
         flowey e 16 flowey_lib_hvlite::build_nextest_unit_tests 5
         flowey e 16 flowey_lib_common::publish_test_results 12
         flowey e 16 flowey_lib_common::publish_test_results 13
-        flowey v 16 'flowey_lib_common::publish_test_results:22:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:20:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar5
-        flowey v 16 'flowey_lib_common::publish_test_results:20:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
+        flowey v 16 'flowey_lib_common::publish_test_results:22:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:20:flowey_lib_common/src/publish_test_results.rs:94:51 write-to-env github floweyvar5
+        flowey v 16 'flowey_lib_common::publish_test_results:20:flowey_lib_common/src/publish_test_results.rs:94:51' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__14
       uses: actions/upload-artifact@v7
@@ -2341,8 +2205,8 @@ jobs:
         flowey e 16 flowey_lib_hvlite::build_nextest_unit_tests 1
         flowey e 16 flowey_lib_common::publish_test_results 0
         flowey e 16 flowey_lib_common::publish_test_results 1
-        flowey v 16 'flowey_lib_common::publish_test_results:2:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar1
-        flowey v 16 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
+        flowey v 16 'flowey_lib_common::publish_test_results:2:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:94:51 write-to-env github floweyvar1
+        flowey v 16 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:94:51' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__2
       uses: actions/upload-artifact@v7
@@ -2361,8 +2225,8 @@ jobs:
         flowey e 16 flowey_lib_hvlite::build_nextest_unit_tests 2
         flowey e 16 flowey_lib_common::publish_test_results 3
         flowey e 16 flowey_lib_common::publish_test_results 4
-        flowey v 16 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar2
-        flowey v 16 'flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
+        flowey v 16 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:94:51 write-to-env github floweyvar2
+        flowey v 16 'flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:94:51' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__5
       uses: actions/upload-artifact@v7
@@ -2436,8 +2300,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 17 flowey_lib_common::git_checkout 0
-        flowey v 17 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env github floweyvar11
-        flowey v 17 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env github FLOWEY_CONDITION
+        flowey v 17 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar11
+        flowey v 17 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -2449,7 +2313,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey v 17 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.workspace <<EOF
+        flowey v 17 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
         flowey e 17 flowey_lib_common::git_checkout 3
@@ -2466,8 +2330,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 17 flowey_lib_common::cache 4
-        flowey v 17 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar9
-        flowey v 17 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar10
+        flowey v 17 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar9
+        flowey v 17 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar10
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
@@ -2477,7 +2341,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 17 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        flowey v 17 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
         flowey e 17 flowey_lib_common::cache 6
@@ -2556,8 +2420,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 17 flowey_lib_common::cache 0
-        flowey v 17 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar7
-        flowey v 17 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar8
+        flowey v 17 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar7
+        flowey v 17 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar8
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -2567,7 +2431,7 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
-        flowey v 17 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey v 17 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey e 17 flowey_lib_common::cache 2
@@ -2592,8 +2456,8 @@ jobs:
         flowey e 17 flowey_lib_hvlite::build_nextest_unit_tests 3
         flowey e 17 flowey_lib_common::publish_test_results 6
         flowey e 17 flowey_lib_common::publish_test_results 7
-        flowey v 17 'flowey_lib_common::publish_test_results:12:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar3
-        flowey v 17 'flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
+        flowey v 17 'flowey_lib_common::publish_test_results:12:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs:94:51 write-to-env github floweyvar3
+        flowey v 17 'flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs:94:51' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__8
       uses: actions/upload-artifact@v7
@@ -2612,8 +2476,8 @@ jobs:
         flowey e 17 flowey_lib_hvlite::build_nextest_unit_tests 4
         flowey e 17 flowey_lib_common::publish_test_results 9
         flowey e 17 flowey_lib_common::publish_test_results 10
-        flowey v 17 'flowey_lib_common::publish_test_results:17:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:15:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar4
-        flowey v 17 'flowey_lib_common::publish_test_results:15:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
+        flowey v 17 'flowey_lib_common::publish_test_results:17:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:15:flowey_lib_common/src/publish_test_results.rs:94:51 write-to-env github floweyvar4
+        flowey v 17 'flowey_lib_common::publish_test_results:15:flowey_lib_common/src/publish_test_results.rs:94:51' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__11
       uses: actions/upload-artifact@v7
@@ -2632,8 +2496,8 @@ jobs:
         flowey e 17 flowey_lib_hvlite::build_nextest_unit_tests 5
         flowey e 17 flowey_lib_common::publish_test_results 12
         flowey e 17 flowey_lib_common::publish_test_results 13
-        flowey v 17 'flowey_lib_common::publish_test_results:22:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:20:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar5
-        flowey v 17 'flowey_lib_common::publish_test_results:20:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
+        flowey v 17 'flowey_lib_common::publish_test_results:22:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:20:flowey_lib_common/src/publish_test_results.rs:94:51 write-to-env github floweyvar5
+        flowey v 17 'flowey_lib_common::publish_test_results:20:flowey_lib_common/src/publish_test_results.rs:94:51' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__14
       uses: actions/upload-artifact@v7
@@ -2652,8 +2516,8 @@ jobs:
         flowey e 17 flowey_lib_hvlite::build_nextest_unit_tests 6
         flowey e 17 flowey_lib_common::publish_test_results 15
         flowey e 17 flowey_lib_common::publish_test_results 16
-        flowey v 17 'flowey_lib_common::publish_test_results:27:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:25:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar6
-        flowey v 17 'flowey_lib_common::publish_test_results:25:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
+        flowey v 17 'flowey_lib_common::publish_test_results:27:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:25:flowey_lib_common/src/publish_test_results.rs:94:51 write-to-env github floweyvar6
+        flowey v 17 'flowey_lib_common::publish_test_results:25:flowey_lib_common/src/publish_test_results.rs:94:51' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__17
       uses: actions/upload-artifact@v7
@@ -2687,8 +2551,8 @@ jobs:
         flowey e 17 flowey_lib_hvlite::build_nextest_unit_tests 1
         flowey e 17 flowey_lib_common::publish_test_results 0
         flowey e 17 flowey_lib_common::publish_test_results 1
-        flowey v 17 'flowey_lib_common::publish_test_results:2:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar1
-        flowey v 17 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
+        flowey v 17 'flowey_lib_common::publish_test_results:2:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:94:51 write-to-env github floweyvar1
+        flowey v 17 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:94:51' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__2
       uses: actions/upload-artifact@v7
@@ -2707,8 +2571,8 @@ jobs:
         flowey e 17 flowey_lib_hvlite::build_nextest_unit_tests 2
         flowey e 17 flowey_lib_common::publish_test_results 3
         flowey e 17 flowey_lib_common::publish_test_results 4
-        flowey v 17 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar2
-        flowey v 17 'flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
+        flowey v 17 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:94:51 write-to-env github floweyvar2
+        flowey v 17 'flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:94:51' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__5
       uses: actions/upload-artifact@v7
@@ -2826,8 +2690,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey.exe e 18 flowey_lib_common::git_checkout 0
-        flowey.exe v 18 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env github floweyvar8
-        flowey.exe v 18 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 18 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar8
+        flowey.exe v 18 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -2839,7 +2703,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey.exe v 18 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.workspace <<EOF
+        flowey.exe v 18 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
         flowey.exe e 18 flowey_lib_common::git_checkout 3
@@ -2858,8 +2722,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 18 flowey_lib_common::cache 4
-        flowey.exe v 18 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar6
-        flowey.exe v 18 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar7
+        flowey.exe v 18 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
+        flowey.exe v 18 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
@@ -2869,7 +2733,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 18 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        flowey.exe v 18 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
         flowey.exe e 18 flowey_lib_common::cache 6
@@ -2914,8 +2778,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 18 flowey_lib_common::cache 0
-        flowey.exe v 18 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar4
-        flowey.exe v 18 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar5
+        flowey.exe v 18 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
+        flowey.exe v 18 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -2925,7 +2789,7 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
-        flowey.exe v 18 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey.exe v 18 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey.exe e 18 flowey_lib_common::cache 2
@@ -2961,8 +2825,8 @@ jobs:
         flowey.exe e 18 flowey_lib_hvlite::build_nextest_unit_tests 1
         flowey.exe e 18 flowey_lib_common::publish_test_results 6
         flowey.exe e 18 flowey_lib_common::publish_test_results 7
-        flowey.exe v 18 'flowey_lib_common::publish_test_results:12:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar3
-        flowey.exe v 18 'flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 18 'flowey_lib_common::publish_test_results:12:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs:94:51 write-to-env github floweyvar3
+        flowey.exe v 18 'flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs:94:51' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__8
       uses: actions/upload-artifact@v7
@@ -2981,8 +2845,8 @@ jobs:
         flowey.exe e 18 flowey_lib_hvlite::build_nextest_unit_tests 2
         flowey.exe e 18 flowey_lib_common::publish_test_results 0
         flowey.exe e 18 flowey_lib_common::publish_test_results 1
-        flowey.exe v 18 'flowey_lib_common::publish_test_results:2:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar1
-        flowey.exe v 18 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 18 'flowey_lib_common::publish_test_results:2:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:94:51 write-to-env github floweyvar1
+        flowey.exe v 18 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:94:51' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__2
       uses: actions/upload-artifact@v7
@@ -3001,8 +2865,8 @@ jobs:
         flowey.exe e 18 flowey_lib_hvlite::build_nextest_unit_tests 3
         flowey.exe e 18 flowey_lib_common::publish_test_results 3
         flowey.exe e 18 flowey_lib_common::publish_test_results 4
-        flowey.exe v 18 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar2
-        flowey.exe v 18 'flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 18 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:94:51 write-to-env github floweyvar2
+        flowey.exe v 18 'flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:94:51' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__5
       uses: actions/upload-artifact@v7
@@ -3106,11 +2970,28 @@ jobs:
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
       shell: bash
+    - name: add default cargo home to path
+      run: flowey e 19 flowey_lib_common::install_rust 0
+      shell: bash
+    - name: install Rust
+      run: flowey e 19 flowey_lib_common::install_rust 1
+      shell: bash
+    - name: detect active toolchain
+      run: |-
+        flowey e 19 flowey_lib_common::install_rust 2
+        flowey e 19 flowey_lib_common::cfg_cargo_common_flags 0
+      shell: bash
+    - name: checking if packages need to be installed
+      run: flowey e 19 flowey_lib_common::install_dist_pkg 0
+      shell: bash
+    - name: installing packages
+      run: flowey e 19 flowey_lib_common::install_dist_pkg 1
+      shell: bash
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 19 flowey_lib_common::git_checkout 0
-        flowey v 19 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env github floweyvar10
-        flowey v 19 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env github FLOWEY_CONDITION
+        flowey v 19 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar10
+        flowey v 19 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -3122,7 +3003,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey v 19 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.workspace <<EOF
+        flowey v 19 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
         flowey e 19 flowey_lib_common::git_checkout 3
@@ -3141,8 +3022,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 19 flowey_lib_common::cache 4
-        flowey v 19 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar8
-        flowey v 19 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar9
+        flowey v 19 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
+        flowey v 19 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
@@ -3152,17 +3033,11 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 19 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        flowey v 19 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
         flowey e 19 flowey_lib_common::cache 6
         flowey e 19 flowey_lib_common::download_gh_release 1
-      shell: bash
-    - name: checking if packages need to be installed
-      run: flowey e 19 flowey_lib_common::install_dist_pkg 0
-      shell: bash
-    - name: installing packages
-      run: flowey e 19 flowey_lib_common::install_dist_pkg 1
       shell: bash
     - name: unpack protoc
       run: |-
@@ -3170,21 +3045,8 @@ jobs:
         flowey e 19 flowey_lib_hvlite::cfg_openvmm_magicpath 0
       shell: bash
     - name: symlink protoc
-      run: flowey e 19 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-      shell: bash
-    - name: add default cargo home to path
-      run: flowey e 19 flowey_lib_common::install_rust 0
-      shell: bash
-    - name: install Rust
-      run: flowey e 19 flowey_lib_common::install_rust 1
-      shell: bash
-    - name: run doctests for aarch64-unknown-linux-gnu
-      run: flowey e 19 flowey_lib_hvlite::_jobs::build_and_run_doc_tests 0
-      shell: bash
-    - name: detect active toolchain
       run: |-
-        flowey e 19 flowey_lib_common::install_rust 2
-        flowey e 19 flowey_lib_common::cfg_cargo_common_flags 0
+        flowey e 19 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
         flowey e 19 flowey_lib_hvlite::init_cross_build 0
       shell: bash
     - name: cargo clippy
@@ -3228,8 +3090,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 19 flowey_lib_common::cache 0
-        flowey v 19 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar6
-        flowey v 19 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar7
+        flowey v 19 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
+        flowey v 19 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -3239,7 +3101,7 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
-        flowey v 19 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey v 19 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey e 19 flowey_lib_common::cache 2
@@ -3264,8 +3126,8 @@ jobs:
         flowey e 19 flowey_lib_hvlite::build_nextest_unit_tests 3
         flowey e 19 flowey_lib_common::publish_test_results 6
         flowey e 19 flowey_lib_common::publish_test_results 7
-        flowey v 19 'flowey_lib_common::publish_test_results:12:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar3
-        flowey v 19 'flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
+        flowey v 19 'flowey_lib_common::publish_test_results:12:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs:94:51 write-to-env github floweyvar3
+        flowey v 19 'flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs:94:51' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__8
       uses: actions/upload-artifact@v7
@@ -3284,8 +3146,8 @@ jobs:
         flowey e 19 flowey_lib_hvlite::build_nextest_unit_tests 4
         flowey e 19 flowey_lib_common::publish_test_results 9
         flowey e 19 flowey_lib_common::publish_test_results 10
-        flowey v 19 'flowey_lib_common::publish_test_results:17:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:15:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar4
-        flowey v 19 'flowey_lib_common::publish_test_results:15:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
+        flowey v 19 'flowey_lib_common::publish_test_results:17:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:15:flowey_lib_common/src/publish_test_results.rs:94:51 write-to-env github floweyvar4
+        flowey v 19 'flowey_lib_common::publish_test_results:15:flowey_lib_common/src/publish_test_results.rs:94:51' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__11
       uses: actions/upload-artifact@v7
@@ -3304,8 +3166,8 @@ jobs:
         flowey e 19 flowey_lib_hvlite::build_nextest_unit_tests 5
         flowey e 19 flowey_lib_common::publish_test_results 12
         flowey e 19 flowey_lib_common::publish_test_results 13
-        flowey v 19 'flowey_lib_common::publish_test_results:22:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:20:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar5
-        flowey v 19 'flowey_lib_common::publish_test_results:20:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
+        flowey v 19 'flowey_lib_common::publish_test_results:22:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:20:flowey_lib_common/src/publish_test_results.rs:94:51 write-to-env github floweyvar5
+        flowey v 19 'flowey_lib_common::publish_test_results:20:flowey_lib_common/src/publish_test_results.rs:94:51' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__14
       uses: actions/upload-artifact@v7
@@ -3339,8 +3201,8 @@ jobs:
         flowey e 19 flowey_lib_hvlite::build_nextest_unit_tests 1
         flowey e 19 flowey_lib_common::publish_test_results 0
         flowey e 19 flowey_lib_common::publish_test_results 1
-        flowey v 19 'flowey_lib_common::publish_test_results:2:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar1
-        flowey v 19 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
+        flowey v 19 'flowey_lib_common::publish_test_results:2:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:94:51 write-to-env github floweyvar1
+        flowey v 19 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:94:51' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__2
       uses: actions/upload-artifact@v7
@@ -3359,8 +3221,8 @@ jobs:
         flowey e 19 flowey_lib_hvlite::build_nextest_unit_tests 2
         flowey e 19 flowey_lib_common::publish_test_results 3
         flowey e 19 flowey_lib_common::publish_test_results 4
-        flowey v 19 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar2
-        flowey v 19 'flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
+        flowey v 19 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:94:51 write-to-env github floweyvar2
+        flowey v 19 'flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:94:51' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__5
       uses: actions/upload-artifact@v7
@@ -3373,6 +3235,9 @@ jobs:
       run: |-
         flowey e 19 flowey_lib_hvlite::build_nextest_unit_tests 6
         flowey e 19 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
+      shell: bash
+    - name: run doctests for aarch64-unknown-linux-gnu
+      run: flowey e 19 flowey_lib_hvlite::_jobs::build_and_run_doc_tests 0
       shell: bash
     - name: 'validate cache entry: cargo-nextest'
       run: flowey e 19 flowey_lib_common::cache 3
@@ -3479,8 +3344,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey.exe e 2 flowey_lib_common::git_checkout 0
-        flowey.exe v 2 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env github floweyvar1
-        flowey.exe v 2 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 2 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar1
+        flowey.exe v 2 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -3492,7 +3357,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey.exe v 2 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.workspace <<EOF
+        flowey.exe v 2 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
         flowey.exe e 2 flowey_lib_common::git_checkout 3
@@ -3511,8 +3376,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 2 flowey_lib_common::cache 0
-        flowey.exe v 2 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar2
-        flowey.exe v 2 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar3
+        flowey.exe v 2 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar2
+        flowey.exe v 2 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar3
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -3522,7 +3387,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 2 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey.exe v 2 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey.exe e 2 flowey_lib_common::cache 2
@@ -3663,8 +3528,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 20 flowey_lib_common::git_checkout 0
-        flowey v 20 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env github floweyvar11
-        flowey v 20 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env github FLOWEY_CONDITION
+        flowey v 20 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar11
+        flowey v 20 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -3676,7 +3541,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey v 20 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.workspace <<EOF
+        flowey v 20 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
         flowey e 20 flowey_lib_common::git_checkout 3
@@ -3693,8 +3558,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 20 flowey_lib_common::cache 4
-        flowey v 20 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar9
-        flowey v 20 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar10
+        flowey v 20 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar9
+        flowey v 20 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar10
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
@@ -3704,7 +3569,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 20 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        flowey v 20 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
         flowey e 20 flowey_lib_common::cache 6
@@ -3783,8 +3648,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 20 flowey_lib_common::cache 0
-        flowey v 20 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar7
-        flowey v 20 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar8
+        flowey v 20 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar7
+        flowey v 20 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar8
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -3794,7 +3659,7 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
-        flowey v 20 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey v 20 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey e 20 flowey_lib_common::cache 2
@@ -3819,8 +3684,8 @@ jobs:
         flowey e 20 flowey_lib_hvlite::build_nextest_unit_tests 3
         flowey e 20 flowey_lib_common::publish_test_results 6
         flowey e 20 flowey_lib_common::publish_test_results 7
-        flowey v 20 'flowey_lib_common::publish_test_results:12:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar3
-        flowey v 20 'flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
+        flowey v 20 'flowey_lib_common::publish_test_results:12:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs:94:51 write-to-env github floweyvar3
+        flowey v 20 'flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs:94:51' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__8
       uses: actions/upload-artifact@v7
@@ -3839,8 +3704,8 @@ jobs:
         flowey e 20 flowey_lib_hvlite::build_nextest_unit_tests 4
         flowey e 20 flowey_lib_common::publish_test_results 9
         flowey e 20 flowey_lib_common::publish_test_results 10
-        flowey v 20 'flowey_lib_common::publish_test_results:17:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:15:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar4
-        flowey v 20 'flowey_lib_common::publish_test_results:15:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
+        flowey v 20 'flowey_lib_common::publish_test_results:17:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:15:flowey_lib_common/src/publish_test_results.rs:94:51 write-to-env github floweyvar4
+        flowey v 20 'flowey_lib_common::publish_test_results:15:flowey_lib_common/src/publish_test_results.rs:94:51' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__11
       uses: actions/upload-artifact@v7
@@ -3859,8 +3724,8 @@ jobs:
         flowey e 20 flowey_lib_hvlite::build_nextest_unit_tests 5
         flowey e 20 flowey_lib_common::publish_test_results 12
         flowey e 20 flowey_lib_common::publish_test_results 13
-        flowey v 20 'flowey_lib_common::publish_test_results:22:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:20:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar5
-        flowey v 20 'flowey_lib_common::publish_test_results:20:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
+        flowey v 20 'flowey_lib_common::publish_test_results:22:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:20:flowey_lib_common/src/publish_test_results.rs:94:51 write-to-env github floweyvar5
+        flowey v 20 'flowey_lib_common::publish_test_results:20:flowey_lib_common/src/publish_test_results.rs:94:51' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__14
       uses: actions/upload-artifact@v7
@@ -3879,8 +3744,8 @@ jobs:
         flowey e 20 flowey_lib_hvlite::build_nextest_unit_tests 6
         flowey e 20 flowey_lib_common::publish_test_results 15
         flowey e 20 flowey_lib_common::publish_test_results 16
-        flowey v 20 'flowey_lib_common::publish_test_results:27:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:25:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar6
-        flowey v 20 'flowey_lib_common::publish_test_results:25:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
+        flowey v 20 'flowey_lib_common::publish_test_results:27:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:25:flowey_lib_common/src/publish_test_results.rs:94:51 write-to-env github floweyvar6
+        flowey v 20 'flowey_lib_common::publish_test_results:25:flowey_lib_common/src/publish_test_results.rs:94:51' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__17
       uses: actions/upload-artifact@v7
@@ -3914,8 +3779,8 @@ jobs:
         flowey e 20 flowey_lib_hvlite::build_nextest_unit_tests 1
         flowey e 20 flowey_lib_common::publish_test_results 0
         flowey e 20 flowey_lib_common::publish_test_results 1
-        flowey v 20 'flowey_lib_common::publish_test_results:2:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar1
-        flowey v 20 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
+        flowey v 20 'flowey_lib_common::publish_test_results:2:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:94:51 write-to-env github floweyvar1
+        flowey v 20 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:94:51' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__2
       uses: actions/upload-artifact@v7
@@ -3934,8 +3799,8 @@ jobs:
         flowey e 20 flowey_lib_hvlite::build_nextest_unit_tests 2
         flowey e 20 flowey_lib_common::publish_test_results 3
         flowey e 20 flowey_lib_common::publish_test_results 4
-        flowey v 20 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar2
-        flowey v 20 'flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
+        flowey v 20 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:94:51 write-to-env github floweyvar2
+        flowey v 20 'flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:94:51' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__5
       uses: actions/upload-artifact@v7
@@ -4026,8 +3891,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 21 flowey_lib_common::cache 0
-        flowey.exe v 21 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar4
-        flowey.exe v 21 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar5
+        flowey.exe v 21 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
+        flowey.exe v 21 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -4037,7 +3902,7 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
-        flowey.exe v 21 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey.exe v 21 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey.exe e 21 flowey_lib_common::cache 2
@@ -4046,8 +3911,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey.exe e 21 flowey_lib_common::git_checkout 0
-        flowey.exe v 21 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env github floweyvar3
-        flowey.exe v 21 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 21 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar3
+        flowey.exe v 21 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -4059,7 +3924,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey.exe v 21 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.workspace <<EOF
+        flowey.exe v 21 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
         flowey.exe e 21 flowey_lib_common::git_checkout 3
@@ -4094,8 +3959,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 21 flowey_lib_common::cache 8
-        flowey.exe v 21 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar8
-        flowey.exe v 21 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar9
+        flowey.exe v 21 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
+        flowey.exe v 21 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
       shell: bash
     - id: flowey_lib_common__cache__9
       uses: actions/cache@v5
@@ -4105,7 +3970,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 21 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
+        flowey.exe v 21 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
         EOF
         flowey.exe e 21 flowey_lib_common::cache 10
@@ -4128,8 +3993,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 21 flowey_lib_common::cache 4
-        flowey.exe v 21 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar6
-        flowey.exe v 21 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar7
+        flowey.exe v 21 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
+        flowey.exe v 21 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
@@ -4139,12 +4004,12 @@ jobs:
       name: 'Restore cache: gh-cli'
     - name: installing gh
       run: |-
-        flowey.exe v 21 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        flowey.exe v 21 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
         flowey.exe e 21 flowey_lib_common::cache 6
         flowey.exe e 21 flowey_lib_common::download_gh_cli 1
-        flowey.exe v 21 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.token <<EOF
+        flowey.exe v 21 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
         ${{ github.token }}
         EOF
       shell: bash
@@ -4204,8 +4069,8 @@ jobs:
         flowey.exe e 21 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
         flowey.exe e 21 flowey_lib_common::publish_test_results 0
         flowey.exe e 21 flowey_lib_common::publish_test_results 1
-        flowey.exe v 21 'flowey_lib_common::publish_test_results:2:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar1
-        flowey.exe v 21 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 21 'flowey_lib_common::publish_test_results:2:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:94:51 write-to-env github floweyvar1
+        flowey.exe v 21 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:94:51' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__2
       uses: actions/upload-artifact@v7
@@ -4219,8 +4084,8 @@ jobs:
         flowey.exe e 21 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
         flowey.exe e 21 flowey_lib_common::publish_test_results 3
         flowey.exe e 21 flowey_lib_common::publish_test_results 4
-        flowey.exe v 21 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar2
-        flowey.exe v 21 'flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 21 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:150:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:142:57 write-to-env github floweyvar2
+        flowey.exe v 21 'flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:142:57' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__5
       uses: actions/upload-artifact@v7
@@ -4309,8 +4174,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 22 flowey_lib_common::cache 0
-        flowey.exe v 22 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar4
-        flowey.exe v 22 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar5
+        flowey.exe v 22 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
+        flowey.exe v 22 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -4320,7 +4185,7 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
-        flowey.exe v 22 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey.exe v 22 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey.exe e 22 flowey_lib_common::cache 2
@@ -4329,8 +4194,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey.exe e 22 flowey_lib_common::git_checkout 0
-        flowey.exe v 22 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env github floweyvar3
-        flowey.exe v 22 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 22 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar3
+        flowey.exe v 22 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -4342,7 +4207,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey.exe v 22 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.workspace <<EOF
+        flowey.exe v 22 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
         flowey.exe e 22 flowey_lib_common::git_checkout 3
@@ -4352,11 +4217,6 @@ jobs:
         flowey.exe e 22 flowey_lib_common::system_info 0
         flowey.exe e 22 flowey_lib_hvlite::git_checkout_openvmm_repo 0
         flowey.exe e 22 flowey_lib_hvlite::run_cargo_nextest_run 0
-        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 12
-        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 14
-        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 15
-        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 13
-        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 3
         flowey.exe e 22 flowey_core::pipeline::artifact::resolve 11
         flowey.exe e 22 flowey_core::pipeline::artifact::resolve 4
         flowey.exe e 22 flowey_core::pipeline::artifact::resolve 5
@@ -4367,6 +4227,11 @@ jobs:
         flowey.exe e 22 flowey_core::pipeline::artifact::resolve 7
         flowey.exe e 22 flowey_core::pipeline::artifact::resolve 8
         flowey.exe e 22 flowey_core::pipeline::artifact::resolve 9
+        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 12
+        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 14
+        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 15
+        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 13
+        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 3
       shell: bash
     - name: creating new test content dir
       run: flowey.exe e 22 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
@@ -4377,8 +4242,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 22 flowey_lib_common::cache 8
-        flowey.exe v 22 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar8
-        flowey.exe v 22 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar9
+        flowey.exe v 22 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
+        flowey.exe v 22 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
       shell: bash
     - id: flowey_lib_common__cache__9
       uses: actions/cache@v5
@@ -4388,7 +4253,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 22 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
+        flowey.exe v 22 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
         EOF
         flowey.exe e 22 flowey_lib_common::cache 10
@@ -4411,8 +4276,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 22 flowey_lib_common::cache 4
-        flowey.exe v 22 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar6
-        flowey.exe v 22 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar7
+        flowey.exe v 22 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
+        flowey.exe v 22 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
@@ -4422,12 +4287,12 @@ jobs:
       name: 'Restore cache: gh-cli'
     - name: installing gh
       run: |-
-        flowey.exe v 22 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        flowey.exe v 22 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
         flowey.exe e 22 flowey_lib_common::cache 6
         flowey.exe e 22 flowey_lib_common::download_gh_cli 1
-        flowey.exe v 22 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.token <<EOF
+        flowey.exe v 22 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
         ${{ github.token }}
         EOF
       shell: bash
@@ -4482,8 +4347,8 @@ jobs:
         flowey.exe e 22 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
         flowey.exe e 22 flowey_lib_common::publish_test_results 0
         flowey.exe e 22 flowey_lib_common::publish_test_results 1
-        flowey.exe v 22 'flowey_lib_common::publish_test_results:2:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar1
-        flowey.exe v 22 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 22 'flowey_lib_common::publish_test_results:2:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:94:51 write-to-env github floweyvar1
+        flowey.exe v 22 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:94:51' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__2
       uses: actions/upload-artifact@v7
@@ -4497,8 +4362,8 @@ jobs:
         flowey.exe e 22 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
         flowey.exe e 22 flowey_lib_common::publish_test_results 3
         flowey.exe e 22 flowey_lib_common::publish_test_results 4
-        flowey.exe v 22 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar2
-        flowey.exe v 22 'flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 22 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:150:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:142:57 write-to-env github floweyvar2
+        flowey.exe v 22 'flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:142:57' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__5
       uses: actions/upload-artifact@v7
@@ -4588,8 +4453,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 23 flowey_lib_common::cache 0
-        flowey.exe v 23 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar4
-        flowey.exe v 23 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar5
+        flowey.exe v 23 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
+        flowey.exe v 23 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -4599,7 +4464,7 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
-        flowey.exe v 23 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey.exe v 23 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey.exe e 23 flowey_lib_common::cache 2
@@ -4608,8 +4473,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey.exe e 23 flowey_lib_common::git_checkout 0
-        flowey.exe v 23 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env github floweyvar3
-        flowey.exe v 23 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 23 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar3
+        flowey.exe v 23 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -4621,7 +4486,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey.exe v 23 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.workspace <<EOF
+        flowey.exe v 23 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
         flowey.exe e 23 flowey_lib_common::git_checkout 3
@@ -4656,8 +4521,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 23 flowey_lib_common::cache 8
-        flowey.exe v 23 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar8
-        flowey.exe v 23 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar9
+        flowey.exe v 23 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
+        flowey.exe v 23 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
       shell: bash
     - id: flowey_lib_common__cache__9
       uses: actions/cache@v5
@@ -4667,7 +4532,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 23 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
+        flowey.exe v 23 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
         EOF
         flowey.exe e 23 flowey_lib_common::cache 10
@@ -4690,8 +4555,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 23 flowey_lib_common::cache 4
-        flowey.exe v 23 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar6
-        flowey.exe v 23 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar7
+        flowey.exe v 23 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
+        flowey.exe v 23 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
@@ -4701,12 +4566,12 @@ jobs:
       name: 'Restore cache: gh-cli'
     - name: installing gh
       run: |-
-        flowey.exe v 23 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        flowey.exe v 23 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
         flowey.exe e 23 flowey_lib_common::cache 6
         flowey.exe e 23 flowey_lib_common::download_gh_cli 1
-        flowey.exe v 23 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.token <<EOF
+        flowey.exe v 23 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
         ${{ github.token }}
         EOF
       shell: bash
@@ -4766,8 +4631,8 @@ jobs:
         flowey.exe e 23 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
         flowey.exe e 23 flowey_lib_common::publish_test_results 0
         flowey.exe e 23 flowey_lib_common::publish_test_results 1
-        flowey.exe v 23 'flowey_lib_common::publish_test_results:2:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar1
-        flowey.exe v 23 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 23 'flowey_lib_common::publish_test_results:2:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:94:51 write-to-env github floweyvar1
+        flowey.exe v 23 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:94:51' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__2
       uses: actions/upload-artifact@v7
@@ -4781,8 +4646,8 @@ jobs:
         flowey.exe e 23 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
         flowey.exe e 23 flowey_lib_common::publish_test_results 3
         flowey.exe e 23 flowey_lib_common::publish_test_results 4
-        flowey.exe v 23 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar2
-        flowey.exe v 23 'flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 23 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:150:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:142:57 write-to-env github floweyvar2
+        flowey.exe v 23 'flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:142:57' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__5
       uses: actions/upload-artifact@v7
@@ -4871,8 +4736,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 24 flowey_lib_common::cache 0
-        flowey.exe v 24 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar4
-        flowey.exe v 24 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar5
+        flowey.exe v 24 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
+        flowey.exe v 24 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -4882,7 +4747,7 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
-        flowey.exe v 24 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey.exe v 24 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey.exe e 24 flowey_lib_common::cache 2
@@ -4891,8 +4756,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey.exe e 24 flowey_lib_common::git_checkout 0
-        flowey.exe v 24 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env github floweyvar3
-        flowey.exe v 24 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 24 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar3
+        flowey.exe v 24 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -4904,7 +4769,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey.exe v 24 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.workspace <<EOF
+        flowey.exe v 24 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
         flowey.exe e 24 flowey_lib_common::git_checkout 3
@@ -4939,8 +4804,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 24 flowey_lib_common::cache 8
-        flowey.exe v 24 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar8
-        flowey.exe v 24 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar9
+        flowey.exe v 24 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
+        flowey.exe v 24 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
       shell: bash
     - id: flowey_lib_common__cache__9
       uses: actions/cache@v5
@@ -4950,7 +4815,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 24 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
+        flowey.exe v 24 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
         EOF
         flowey.exe e 24 flowey_lib_common::cache 10
@@ -4973,8 +4838,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 24 flowey_lib_common::cache 4
-        flowey.exe v 24 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar6
-        flowey.exe v 24 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar7
+        flowey.exe v 24 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
+        flowey.exe v 24 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
@@ -4984,12 +4849,12 @@ jobs:
       name: 'Restore cache: gh-cli'
     - name: installing gh
       run: |-
-        flowey.exe v 24 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        flowey.exe v 24 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
         flowey.exe e 24 flowey_lib_common::cache 6
         flowey.exe e 24 flowey_lib_common::download_gh_cli 1
-        flowey.exe v 24 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.token <<EOF
+        flowey.exe v 24 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
         ${{ github.token }}
         EOF
       shell: bash
@@ -5049,8 +4914,8 @@ jobs:
         flowey.exe e 24 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
         flowey.exe e 24 flowey_lib_common::publish_test_results 0
         flowey.exe e 24 flowey_lib_common::publish_test_results 1
-        flowey.exe v 24 'flowey_lib_common::publish_test_results:2:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar1
-        flowey.exe v 24 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 24 'flowey_lib_common::publish_test_results:2:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:94:51 write-to-env github floweyvar1
+        flowey.exe v 24 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:94:51' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__2
       uses: actions/upload-artifact@v7
@@ -5064,8 +4929,8 @@ jobs:
         flowey.exe e 24 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
         flowey.exe e 24 flowey_lib_common::publish_test_results 3
         flowey.exe e 24 flowey_lib_common::publish_test_results 4
-        flowey.exe v 24 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar2
-        flowey.exe v 24 'flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 24 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:150:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:142:57 write-to-env github floweyvar2
+        flowey.exe v 24 'flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:142:57' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__5
       uses: actions/upload-artifact@v7
@@ -5098,6 +4963,7 @@ jobs:
       contents: read
       id-token: write
     needs:
+    - job0
     - job12
     - job2
     - job3
@@ -5154,8 +5020,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 25 flowey_lib_common::cache 0
-        flowey.exe v 25 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar4
-        flowey.exe v 25 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar5
+        flowey.exe v 25 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
+        flowey.exe v 25 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -5165,7 +5031,7 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
-        flowey.exe v 25 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey.exe v 25 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey.exe e 25 flowey_lib_common::cache 2
@@ -5174,8 +5040,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey.exe e 25 flowey_lib_common::git_checkout 0
-        flowey.exe v 25 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env github floweyvar3
-        flowey.exe v 25 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 25 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar3
+        flowey.exe v 25 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -5187,7 +5053,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey.exe v 25 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.workspace <<EOF
+        flowey.exe v 25 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
         flowey.exe e 25 flowey_lib_common::git_checkout 3
@@ -5222,8 +5088,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 25 flowey_lib_common::cache 8
-        flowey.exe v 25 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar8
-        flowey.exe v 25 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar9
+        flowey.exe v 25 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
+        flowey.exe v 25 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
       shell: bash
     - id: flowey_lib_common__cache__9
       uses: actions/cache@v5
@@ -5233,7 +5099,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 25 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
+        flowey.exe v 25 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
         EOF
         flowey.exe e 25 flowey_lib_common::cache 10
@@ -5256,8 +5122,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 25 flowey_lib_common::cache 4
-        flowey.exe v 25 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar6
-        flowey.exe v 25 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar7
+        flowey.exe v 25 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
+        flowey.exe v 25 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
@@ -5267,12 +5133,12 @@ jobs:
       name: 'Restore cache: gh-cli'
     - name: installing gh
       run: |-
-        flowey.exe v 25 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        flowey.exe v 25 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
         flowey.exe e 25 flowey_lib_common::cache 6
         flowey.exe e 25 flowey_lib_common::download_gh_cli 1
-        flowey.exe v 25 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.token <<EOF
+        flowey.exe v 25 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
         ${{ github.token }}
         EOF
       shell: bash
@@ -5332,8 +5198,8 @@ jobs:
         flowey.exe e 25 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
         flowey.exe e 25 flowey_lib_common::publish_test_results 0
         flowey.exe e 25 flowey_lib_common::publish_test_results 1
-        flowey.exe v 25 'flowey_lib_common::publish_test_results:2:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar1
-        flowey.exe v 25 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 25 'flowey_lib_common::publish_test_results:2:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:94:51 write-to-env github floweyvar1
+        flowey.exe v 25 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:94:51' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__2
       uses: actions/upload-artifact@v7
@@ -5347,8 +5213,8 @@ jobs:
         flowey.exe e 25 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
         flowey.exe e 25 flowey_lib_common::publish_test_results 3
         flowey.exe e 25 flowey_lib_common::publish_test_results 4
-        flowey.exe v 25 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar2
-        flowey.exe v 25 'flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 25 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:150:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:142:57 write-to-env github floweyvar2
+        flowey.exe v 25 'flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:142:57' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__5
       uses: actions/upload-artifact@v7
@@ -5434,8 +5300,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 26 flowey_lib_common::cache 0
-        flowey v 26 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar4
-        flowey v 26 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar5
+        flowey v 26 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
+        flowey v 26 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -5445,7 +5311,7 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
-        flowey v 26 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey v 26 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey e 26 flowey_lib_common::cache 2
@@ -5454,8 +5320,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 26 flowey_lib_common::git_checkout 0
-        flowey v 26 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env github floweyvar3
-        flowey v 26 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env github FLOWEY_CONDITION
+        flowey v 26 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar3
+        flowey v 26 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -5467,7 +5333,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey v 26 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.workspace <<EOF
+        flowey v 26 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
         flowey e 26 flowey_lib_common::git_checkout 3
@@ -5500,8 +5366,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 26 flowey_lib_common::cache 8
-        flowey v 26 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar8
-        flowey v 26 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar9
+        flowey v 26 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
+        flowey v 26 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
       shell: bash
     - id: flowey_lib_common__cache__9
       uses: actions/cache@v5
@@ -5511,7 +5377,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 26 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
+        flowey v 26 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
         EOF
         flowey e 26 flowey_lib_common::cache 10
@@ -5534,8 +5400,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 26 flowey_lib_common::cache 4
-        flowey v 26 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar6
-        flowey v 26 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar7
+        flowey v 26 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
+        flowey v 26 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
@@ -5545,12 +5411,12 @@ jobs:
       name: 'Restore cache: gh-cli'
     - name: installing gh
       run: |-
-        flowey v 26 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        flowey v 26 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
         flowey e 26 flowey_lib_common::cache 6
         flowey e 26 flowey_lib_common::download_gh_cli 1
-        flowey v 26 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.token <<EOF
+        flowey v 26 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
         ${{ github.token }}
         EOF
       shell: bash
@@ -5603,8 +5469,8 @@ jobs:
         flowey e 26 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
         flowey e 26 flowey_lib_common::publish_test_results 0
         flowey e 26 flowey_lib_common::publish_test_results 1
-        flowey v 26 'flowey_lib_common::publish_test_results:2:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar1
-        flowey v 26 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
+        flowey v 26 'flowey_lib_common::publish_test_results:2:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:94:51 write-to-env github floweyvar1
+        flowey v 26 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:94:51' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__2
       uses: actions/upload-artifact@v7
@@ -5618,8 +5484,8 @@ jobs:
         flowey e 26 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
         flowey e 26 flowey_lib_common::publish_test_results 3
         flowey e 26 flowey_lib_common::publish_test_results 4
-        flowey v 26 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar2
-        flowey v 26 'flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
+        flowey v 26 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:150:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:142:57 write-to-env github floweyvar2
+        flowey v 26 'flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:142:57' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__5
       uses: actions/upload-artifact@v7
@@ -5750,8 +5616,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 27 flowey_lib_common::cache 0
-        flowey v 27 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar4
-        flowey v 27 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar5
+        flowey v 27 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
+        flowey v 27 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -5761,7 +5627,7 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
-        flowey v 27 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey v 27 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey e 27 flowey_lib_common::cache 2
@@ -5770,8 +5636,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 27 flowey_lib_common::git_checkout 0
-        flowey v 27 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env github floweyvar3
-        flowey v 27 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env github FLOWEY_CONDITION
+        flowey v 27 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar3
+        flowey v 27 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -5783,7 +5649,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey v 27 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.workspace <<EOF
+        flowey v 27 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
         flowey e 27 flowey_lib_common::git_checkout 3
@@ -5816,8 +5682,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 27 flowey_lib_common::cache 8
-        flowey v 27 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar8
-        flowey v 27 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar9
+        flowey v 27 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
+        flowey v 27 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
       shell: bash
     - id: flowey_lib_common__cache__9
       uses: actions/cache@v5
@@ -5827,7 +5693,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 27 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
+        flowey v 27 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
         EOF
         flowey e 27 flowey_lib_common::cache 10
@@ -5850,8 +5716,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 27 flowey_lib_common::cache 4
-        flowey v 27 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar6
-        flowey v 27 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar7
+        flowey v 27 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
+        flowey v 27 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
@@ -5861,12 +5727,12 @@ jobs:
       name: 'Restore cache: gh-cli'
     - name: installing gh
       run: |-
-        flowey v 27 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        flowey v 27 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
         flowey e 27 flowey_lib_common::cache 6
         flowey e 27 flowey_lib_common::download_gh_cli 1
-        flowey v 27 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.token <<EOF
+        flowey v 27 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
         ${{ github.token }}
         EOF
       shell: bash
@@ -5918,8 +5784,8 @@ jobs:
         flowey e 27 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
         flowey e 27 flowey_lib_common::publish_test_results 0
         flowey e 27 flowey_lib_common::publish_test_results 1
-        flowey v 27 'flowey_lib_common::publish_test_results:2:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar1
-        flowey v 27 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
+        flowey v 27 'flowey_lib_common::publish_test_results:2:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:94:51 write-to-env github floweyvar1
+        flowey v 27 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:94:51' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__2
       uses: actions/upload-artifact@v7
@@ -5933,8 +5799,8 @@ jobs:
         flowey e 27 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
         flowey e 27 flowey_lib_common::publish_test_results 3
         flowey e 27 flowey_lib_common::publish_test_results 4
-        flowey v 27 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar2
-        flowey v 27 'flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
+        flowey v 27 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:150:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:142:57 write-to-env github floweyvar2
+        flowey v 27 'flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:142:57' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__5
       uses: actions/upload-artifact@v7
@@ -6066,8 +5932,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 28 flowey_lib_common::cache 0
-        flowey.exe v 28 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar4
-        flowey.exe v 28 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar5
+        flowey.exe v 28 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
+        flowey.exe v 28 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -6077,7 +5943,7 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
-        flowey.exe v 28 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey.exe v 28 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey.exe e 28 flowey_lib_common::cache 2
@@ -6086,8 +5952,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey.exe e 28 flowey_lib_common::git_checkout 0
-        flowey.exe v 28 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env github floweyvar3
-        flowey.exe v 28 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 28 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar3
+        flowey.exe v 28 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -6099,7 +5965,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey.exe v 28 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.workspace <<EOF
+        flowey.exe v 28 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
         flowey.exe e 28 flowey_lib_common::git_checkout 3
@@ -6129,8 +5995,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 28 flowey_lib_common::cache 8
-        flowey.exe v 28 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar8
-        flowey.exe v 28 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar9
+        flowey.exe v 28 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
+        flowey.exe v 28 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
       shell: bash
     - id: flowey_lib_common__cache__9
       uses: actions/cache@v5
@@ -6140,7 +6006,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 28 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
+        flowey.exe v 28 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
         EOF
         flowey.exe e 28 flowey_lib_common::cache 10
@@ -6163,8 +6029,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 28 flowey_lib_common::cache 4
-        flowey.exe v 28 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar6
-        flowey.exe v 28 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar7
+        flowey.exe v 28 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
+        flowey.exe v 28 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
@@ -6174,12 +6040,12 @@ jobs:
       name: 'Restore cache: gh-cli'
     - name: installing gh
       run: |-
-        flowey.exe v 28 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        flowey.exe v 28 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
         flowey.exe e 28 flowey_lib_common::cache 6
         flowey.exe e 28 flowey_lib_common::download_gh_cli 1
-        flowey.exe v 28 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.token <<EOF
+        flowey.exe v 28 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
         ${{ github.token }}
         EOF
       shell: bash
@@ -6234,8 +6100,8 @@ jobs:
         flowey.exe e 28 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
         flowey.exe e 28 flowey_lib_common::publish_test_results 0
         flowey.exe e 28 flowey_lib_common::publish_test_results 1
-        flowey.exe v 28 'flowey_lib_common::publish_test_results:2:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar1
-        flowey.exe v 28 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 28 'flowey_lib_common::publish_test_results:2:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:94:51 write-to-env github floweyvar1
+        flowey.exe v 28 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:94:51' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__2
       uses: actions/upload-artifact@v7
@@ -6249,8 +6115,8 @@ jobs:
         flowey.exe e 28 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
         flowey.exe e 28 flowey_lib_common::publish_test_results 3
         flowey.exe e 28 flowey_lib_common::publish_test_results 4
-        flowey.exe v 28 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar2
-        flowey.exe v 28 'flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 28 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:150:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:142:57 write-to-env github floweyvar2
+        flowey.exe v 28 'flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:142:57' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__5
       uses: actions/upload-artifact@v7
@@ -6330,8 +6196,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 29 flowey_lib_common::cache 0
-        flowey v 29 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar4
-        flowey v 29 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar5
+        flowey v 29 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
+        flowey v 29 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -6341,7 +6207,7 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
-        flowey v 29 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey v 29 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey e 29 flowey_lib_common::cache 2
@@ -6350,8 +6216,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 29 flowey_lib_common::git_checkout 0
-        flowey v 29 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env github floweyvar3
-        flowey v 29 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env github FLOWEY_CONDITION
+        flowey v 29 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar3
+        flowey v 29 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -6363,7 +6229,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey v 29 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.workspace <<EOF
+        flowey v 29 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
         flowey e 29 flowey_lib_common::git_checkout 3
@@ -6399,8 +6265,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 29 flowey_lib_common::cache 8
-        flowey v 29 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar8
-        flowey v 29 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar9
+        flowey v 29 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
+        flowey v 29 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
       shell: bash
     - id: flowey_lib_common__cache__9
       uses: actions/cache@v5
@@ -6410,7 +6276,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 29 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
+        flowey v 29 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
         EOF
         flowey e 29 flowey_lib_common::cache 10
@@ -6433,8 +6299,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 29 flowey_lib_common::cache 4
-        flowey v 29 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar6
-        flowey v 29 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar7
+        flowey v 29 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
+        flowey v 29 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
@@ -6444,12 +6310,12 @@ jobs:
       name: 'Restore cache: gh-cli'
     - name: installing gh
       run: |-
-        flowey v 29 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        flowey v 29 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
         flowey e 29 flowey_lib_common::cache 6
         flowey e 29 flowey_lib_common::download_gh_cli 1
-        flowey v 29 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.token <<EOF
+        flowey v 29 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
         ${{ github.token }}
         EOF
       shell: bash
@@ -6505,8 +6371,8 @@ jobs:
         flowey e 29 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 6
         flowey e 29 flowey_lib_common::publish_test_results 0
         flowey e 29 flowey_lib_common::publish_test_results 1
-        flowey v 29 'flowey_lib_common::publish_test_results:2:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar1
-        flowey v 29 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
+        flowey v 29 'flowey_lib_common::publish_test_results:2:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:94:51 write-to-env github floweyvar1
+        flowey v 29 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:94:51' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__2
       uses: actions/upload-artifact@v7
@@ -6520,8 +6386,8 @@ jobs:
         flowey e 29 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 5
         flowey e 29 flowey_lib_common::publish_test_results 3
         flowey e 29 flowey_lib_common::publish_test_results 4
-        flowey v 29 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar2
-        flowey v 29 'flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
+        flowey v 29 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:150:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:142:57 write-to-env github floweyvar2
+        flowey v 29 'flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:142:57' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__5
       uses: actions/upload-artifact@v7
@@ -6615,8 +6481,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 3 flowey_lib_common::git_checkout 0
-        flowey v 3 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env github floweyvar1
-        flowey v 3 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env github FLOWEY_CONDITION
+        flowey v 3 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar1
+        flowey v 3 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -6628,7 +6494,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey v 3 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.workspace <<EOF
+        flowey v 3 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
         flowey e 3 flowey_lib_common::git_checkout 3
@@ -6647,8 +6513,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 3 flowey_lib_common::cache 0
-        flowey v 3 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar2
-        flowey v 3 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar3
+        flowey v 3 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar2
+        flowey v 3 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar3
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -6658,7 +6524,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 3 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey v 3 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey e 3 flowey_lib_common::cache 2
@@ -6937,8 +6803,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 30 flowey_lib_common::git_checkout 0
-        flowey v 30 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env github floweyvar1
-        flowey v 30 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env github FLOWEY_CONDITION
+        flowey v 30 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar1
+        flowey v 30 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -6950,7 +6816,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey v 30 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.workspace <<EOF
+        flowey v 30 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
         flowey e 30 flowey_lib_common::git_checkout 3
@@ -6969,7 +6835,7 @@ jobs:
     - name: detect active toolchain
       run: |-
         flowey e 30 flowey_lib_common::install_rust 2
-        flowey v 30 'flowey_lib_hvlite::_jobs::test_local_flowey_build_igvm:3:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.token <<EOF
+        flowey v 30 'flowey_lib_hvlite::_jobs::test_local_flowey_build_igvm:3:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
         ${{ github.token }}
         EOF
       shell: bash
@@ -7001,6 +6867,7 @@ jobs:
     - job22
     - job23
     - job24
+    - job25
     - job26
     - job27
     - job28
@@ -7146,8 +7013,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey.exe e 4 flowey_lib_common::git_checkout 0
-        flowey.exe v 4 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env github floweyvar1
-        flowey.exe v 4 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 4 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar1
+        flowey.exe v 4 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -7159,7 +7026,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey.exe v 4 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.workspace <<EOF
+        flowey.exe v 4 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
         flowey.exe e 4 flowey_lib_common::git_checkout 3
@@ -7178,8 +7045,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 4 flowey_lib_common::cache 0
-        flowey.exe v 4 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar2
-        flowey.exe v 4 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar3
+        flowey.exe v 4 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar2
+        flowey.exe v 4 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar3
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -7189,7 +7056,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 4 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey.exe v 4 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey.exe e 4 flowey_lib_common::cache 2
@@ -7375,8 +7242,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey.exe e 5 flowey_lib_common::git_checkout 0
-        flowey.exe v 5 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env github floweyvar1
-        flowey.exe v 5 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 5 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar1
+        flowey.exe v 5 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -7388,7 +7255,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey.exe v 5 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.workspace <<EOF
+        flowey.exe v 5 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
         flowey.exe e 5 flowey_lib_common::git_checkout 3
@@ -7407,8 +7274,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 5 flowey_lib_common::cache 4
-        flowey.exe v 5 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar4
-        flowey.exe v 5 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar5
+        flowey.exe v 5 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
+        flowey.exe v 5 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
@@ -7418,7 +7285,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 5 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        flowey.exe v 5 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
         flowey.exe e 5 flowey_lib_common::cache 6
@@ -7503,8 +7370,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 5 flowey_lib_common::cache 0
-        flowey.exe v 5 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar2
-        flowey.exe v 5 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar3
+        flowey.exe v 5 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar2
+        flowey.exe v 5 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar3
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -7514,7 +7381,7 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
-        flowey.exe v 5 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey.exe v 5 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey.exe e 5 flowey_lib_common::cache 2
@@ -7691,8 +7558,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey.exe e 6 flowey_lib_common::git_checkout 0
-        flowey.exe v 6 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env github floweyvar1
-        flowey.exe v 6 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 6 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar1
+        flowey.exe v 6 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -7704,7 +7571,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey.exe v 6 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.workspace <<EOF
+        flowey.exe v 6 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
         flowey.exe e 6 flowey_lib_common::git_checkout 3
@@ -7723,8 +7590,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 6 flowey_lib_common::cache 0
-        flowey.exe v 6 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar2
-        flowey.exe v 6 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar3
+        flowey.exe v 6 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar2
+        flowey.exe v 6 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar3
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -7734,7 +7601,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 6 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey.exe v 6 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey.exe e 6 flowey_lib_common::cache 2
@@ -7924,8 +7791,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey.exe e 7 flowey_lib_common::git_checkout 0
-        flowey.exe v 7 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env github floweyvar1
-        flowey.exe v 7 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 7 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar1
+        flowey.exe v 7 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -7937,7 +7804,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey.exe v 7 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.workspace <<EOF
+        flowey.exe v 7 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
         flowey.exe e 7 flowey_lib_common::git_checkout 3
@@ -7956,8 +7823,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 7 flowey_lib_common::cache 4
-        flowey.exe v 7 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar4
-        flowey.exe v 7 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar5
+        flowey.exe v 7 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
+        flowey.exe v 7 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
@@ -7967,7 +7834,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 7 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        flowey.exe v 7 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
         flowey.exe e 7 flowey_lib_common::cache 6
@@ -8052,8 +7919,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 7 flowey_lib_common::cache 0
-        flowey.exe v 7 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar2
-        flowey.exe v 7 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar3
+        flowey.exe v 7 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar2
+        flowey.exe v 7 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar3
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -8063,7 +7930,7 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
-        flowey.exe v 7 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey.exe v 7 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey.exe e 7 flowey_lib_common::cache 2
@@ -8224,8 +8091,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 8 flowey_lib_common::git_checkout 0
-        flowey v 8 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env github floweyvar1
-        flowey v 8 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env github FLOWEY_CONDITION
+        flowey v 8 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar1
+        flowey v 8 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -8237,7 +8104,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey v 8 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.workspace <<EOF
+        flowey v 8 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
         flowey e 8 flowey_lib_common::git_checkout 3
@@ -8256,8 +8123,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 8 flowey_lib_common::cache 4
-        flowey v 8 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar4
-        flowey v 8 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar5
+        flowey v 8 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
+        flowey v 8 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
@@ -8267,7 +8134,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 8 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        flowey v 8 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
         flowey e 8 flowey_lib_common::cache 6
@@ -8425,8 +8292,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 8 flowey_lib_common::cache 0
-        flowey v 8 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar2
-        flowey v 8 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar3
+        flowey v 8 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar2
+        flowey v 8 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar3
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -8436,7 +8303,7 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
-        flowey v 8 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey v 8 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey e 8 flowey_lib_common::cache 2
@@ -8609,8 +8476,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 9 flowey_lib_common::git_checkout 0
-        flowey v 9 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env github floweyvar1
-        flowey v 9 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env github FLOWEY_CONDITION
+        flowey v 9 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar1
+        flowey v 9 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -8622,7 +8489,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey v 9 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.workspace <<EOF
+        flowey v 9 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
         flowey e 9 flowey_lib_common::git_checkout 3
@@ -8641,8 +8508,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 9 flowey_lib_common::cache 4
-        flowey v 9 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar4
-        flowey v 9 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar5
+        flowey v 9 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
+        flowey v 9 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
@@ -8652,7 +8519,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 9 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        flowey v 9 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
         flowey e 9 flowey_lib_common::cache 6
@@ -8814,8 +8681,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 9 flowey_lib_common::cache 0
-        flowey v 9 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar2
-        flowey v 9 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar3
+        flowey v 9 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar2
+        flowey v 9 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar3
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -8825,7 +8692,7 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
-        flowey v 9 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey v 9 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey e 9 flowey_lib_common::cache 2

--- a/.github/workflows/openvmm-pr.yaml
+++ b/.github/workflows/openvmm-pr.yaml
@@ -4963,7 +4963,6 @@ jobs:
       contents: read
       id-token: write
     needs:
-    - job0
     - job12
     - job2
     - job3
@@ -6867,7 +6866,6 @@ jobs:
     - job22
     - job23
     - job24
-    - job25
     - job26
     - job27
     - job28

--- a/.github/workflows/openvmm-pr.yaml
+++ b/.github/workflows/openvmm-pr.yaml
@@ -106,8 +106,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 0 flowey_lib_common::git_checkout 0
-        flowey v 0 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar1
-        flowey v 0 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
+        flowey v 0 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env github floweyvar1
+        flowey v 0 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -119,7 +119,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey v 0 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey v 0 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
         flowey e 0 flowey_lib_common::git_checkout 3
@@ -149,8 +149,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 0 flowey_lib_common::cache 0
-        flowey v 0 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar2
-        flowey v 0 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar3
+        flowey v 0 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar2
+        flowey v 0 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar3
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -160,7 +160,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 0 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey v 0 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey e 0 flowey_lib_common::cache 2
@@ -320,8 +320,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey.exe e 1 flowey_lib_common::git_checkout 0
-        flowey.exe v 1 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar1
-        flowey.exe v 1 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 1 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env github floweyvar1
+        flowey.exe v 1 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -333,7 +333,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey.exe v 1 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey.exe v 1 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
         flowey.exe e 1 flowey_lib_common::git_checkout 3
@@ -363,8 +363,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 1 flowey_lib_common::cache 0
-        flowey.exe v 1 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar2
-        flowey.exe v 1 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar3
+        flowey.exe v 1 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar2
+        flowey.exe v 1 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar3
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -374,7 +374,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 1 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey.exe v 1 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey.exe e 1 flowey_lib_common::cache 2
@@ -446,8 +446,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 10 flowey_lib_common::git_checkout 0
-        flowey v 10 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar3
-        flowey v 10 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
+        flowey v 10 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env github floweyvar3
+        flowey v 10 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -459,7 +459,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey v 10 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey v 10 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
         flowey e 10 flowey_lib_common::git_checkout 3
@@ -488,8 +488,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 10 flowey_lib_common::cache 0
-        flowey v 10 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar1
-        flowey v 10 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar2
+        flowey v 10 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar1
+        flowey v 10 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar2
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -499,7 +499,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 10 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey v 10 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey e 10 flowey_lib_common::cache 2
@@ -656,8 +656,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 11 flowey_lib_common::git_checkout 0
-        flowey v 11 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar2
-        flowey v 11 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
+        flowey v 11 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env github floweyvar2
+        flowey v 11 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -669,7 +669,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey v 11 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey v 11 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
         flowey e 11 flowey_lib_common::git_checkout 3
@@ -686,8 +686,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 11 flowey_lib_common::cache 4
-        flowey v 11 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar5
-        flowey v 11 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar6
+        flowey v 11 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar5
+        flowey v 11 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar6
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
@@ -697,7 +697,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 11 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        flowey v 11 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
         flowey e 11 flowey_lib_common::cache 6
@@ -743,7 +743,7 @@ jobs:
     - name: collect openvmm_hcl files for analysis
       run: |-
         flowey e 11 flowey_lib_hvlite::_jobs::check_openvmm_hcl_size 1
-        flowey v 11 'flowey_lib_hvlite::_jobs::check_openvmm_hcl_size:8:flowey_lib_hvlite/src/_jobs/check_openvmm_hcl_size.rs:113:27' --is-raw-string write-to-env github floweyvar1
+        flowey v 11 'flowey_lib_hvlite::_jobs::check_openvmm_hcl_size:8:flowey_lib_hvlite/src/_jobs/check_openvmm_hcl_size.rs' --is-raw-string write-to-env github floweyvar1
       shell: bash
     - id: flowey_lib_hvlite___jobs__check_openvmm_hcl_size__2
       uses: actions/upload-artifact@v7
@@ -769,8 +769,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 11 flowey_lib_common::cache 0
-        flowey v 11 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar3
-        flowey v 11 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar4
+        flowey v 11 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar3
+        flowey v 11 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar4
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -780,12 +780,12 @@ jobs:
       name: 'Restore cache: gh-cli'
     - name: installing gh
       run: |-
-        flowey v 11 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey v 11 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey e 11 flowey_lib_common::cache 2
         flowey e 11 flowey_lib_common::download_gh_cli 1
-        flowey v 11 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
+        flowey v 11 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.token <<EOF
         ${{ github.token }}
         EOF
       shell: bash
@@ -864,8 +864,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 12 flowey_lib_common::git_checkout 0
-        flowey v 12 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar3
-        flowey v 12 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
+        flowey v 12 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env github floweyvar3
+        flowey v 12 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -877,7 +877,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey v 12 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey v 12 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
         flowey e 12 flowey_lib_common::git_checkout 3
@@ -906,8 +906,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 12 flowey_lib_common::cache 0
-        flowey v 12 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar1
-        flowey v 12 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar2
+        flowey v 12 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar1
+        flowey v 12 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar2
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -917,7 +917,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 12 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey v 12 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey e 12 flowey_lib_common::cache 2
@@ -1177,8 +1177,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 13 flowey_lib_common::git_checkout 0
-        flowey v 13 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar2
-        flowey v 13 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
+        flowey v 13 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env github floweyvar2
+        flowey v 13 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -1190,7 +1190,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey v 13 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey v 13 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
         flowey e 13 flowey_lib_common::git_checkout 3
@@ -1207,8 +1207,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 13 flowey_lib_common::cache 4
-        flowey v 13 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar5
-        flowey v 13 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar6
+        flowey v 13 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar5
+        flowey v 13 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar6
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
@@ -1218,7 +1218,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 13 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        flowey v 13 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
         flowey e 13 flowey_lib_common::cache 6
@@ -1264,7 +1264,7 @@ jobs:
     - name: collect openvmm_hcl files for analysis
       run: |-
         flowey e 13 flowey_lib_hvlite::_jobs::check_openvmm_hcl_size 1
-        flowey v 13 'flowey_lib_hvlite::_jobs::check_openvmm_hcl_size:8:flowey_lib_hvlite/src/_jobs/check_openvmm_hcl_size.rs:113:27' --is-raw-string write-to-env github floweyvar1
+        flowey v 13 'flowey_lib_hvlite::_jobs::check_openvmm_hcl_size:8:flowey_lib_hvlite/src/_jobs/check_openvmm_hcl_size.rs' --is-raw-string write-to-env github floweyvar1
       shell: bash
     - id: flowey_lib_hvlite___jobs__check_openvmm_hcl_size__2
       uses: actions/upload-artifact@v7
@@ -1290,8 +1290,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 13 flowey_lib_common::cache 0
-        flowey v 13 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar3
-        flowey v 13 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar4
+        flowey v 13 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar3
+        flowey v 13 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar4
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -1301,12 +1301,12 @@ jobs:
       name: 'Restore cache: gh-cli'
     - name: installing gh
       run: |-
-        flowey v 13 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey v 13 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey e 13 flowey_lib_common::cache 2
         flowey e 13 flowey_lib_common::download_gh_cli 1
-        flowey v 13 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
+        flowey v 13 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.token <<EOF
         ${{ github.token }}
         EOF
       shell: bash
@@ -1385,8 +1385,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 14 flowey_lib_common::git_checkout 0
-        flowey v 14 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar3
-        flowey v 14 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
+        flowey v 14 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env github floweyvar3
+        flowey v 14 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -1398,7 +1398,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey v 14 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey v 14 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
         flowey e 14 flowey_lib_common::git_checkout 3
@@ -1427,8 +1427,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 14 flowey_lib_common::cache 0
-        flowey v 14 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar1
-        flowey v 14 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar2
+        flowey v 14 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar1
+        flowey v 14 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar2
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -1438,7 +1438,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 14 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey v 14 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey e 14 flowey_lib_common::cache 2
@@ -1746,8 +1746,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey.exe e 15 flowey_lib_common::git_checkout 0
-        flowey.exe v 15 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar8
-        flowey.exe v 15 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 15 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env github floweyvar8
+        flowey.exe v 15 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -1759,7 +1759,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey.exe v 15 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey.exe v 15 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
         flowey.exe e 15 flowey_lib_common::git_checkout 3
@@ -1778,8 +1778,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 15 flowey_lib_common::cache 4
-        flowey.exe v 15 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
-        flowey.exe v 15 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
+        flowey.exe v 15 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar6
+        flowey.exe v 15 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar7
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
@@ -1789,7 +1789,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 15 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        flowey.exe v 15 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
         flowey.exe e 15 flowey_lib_common::cache 6
@@ -1834,8 +1834,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 15 flowey_lib_common::cache 0
-        flowey.exe v 15 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
-        flowey.exe v 15 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
+        flowey.exe v 15 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar4
+        flowey.exe v 15 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar5
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -1845,7 +1845,7 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
-        flowey.exe v 15 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey.exe v 15 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey.exe e 15 flowey_lib_common::cache 2
@@ -1881,8 +1881,8 @@ jobs:
         flowey.exe e 15 flowey_lib_hvlite::build_nextest_unit_tests 1
         flowey.exe e 15 flowey_lib_common::publish_test_results 6
         flowey.exe e 15 flowey_lib_common::publish_test_results 7
-        flowey.exe v 15 'flowey_lib_common::publish_test_results:12:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs:94:51 write-to-env github floweyvar3
-        flowey.exe v 15 'flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs:94:51' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 15 'flowey_lib_common::publish_test_results:12:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar3
+        flowey.exe v 15 'flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__8
       uses: actions/upload-artifact@v7
@@ -1901,8 +1901,8 @@ jobs:
         flowey.exe e 15 flowey_lib_hvlite::build_nextest_unit_tests 2
         flowey.exe e 15 flowey_lib_common::publish_test_results 0
         flowey.exe e 15 flowey_lib_common::publish_test_results 1
-        flowey.exe v 15 'flowey_lib_common::publish_test_results:2:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:94:51 write-to-env github floweyvar1
-        flowey.exe v 15 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:94:51' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 15 'flowey_lib_common::publish_test_results:2:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar1
+        flowey.exe v 15 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__2
       uses: actions/upload-artifact@v7
@@ -1921,8 +1921,8 @@ jobs:
         flowey.exe e 15 flowey_lib_hvlite::build_nextest_unit_tests 3
         flowey.exe e 15 flowey_lib_common::publish_test_results 3
         flowey.exe e 15 flowey_lib_common::publish_test_results 4
-        flowey.exe v 15 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:94:51 write-to-env github floweyvar2
-        flowey.exe v 15 'flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:94:51' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 15 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar2
+        flowey.exe v 15 'flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__5
       uses: actions/upload-artifact@v7
@@ -2002,8 +2002,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 16 flowey_lib_common::git_checkout 0
-        flowey v 16 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar10
-        flowey v 16 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
+        flowey v 16 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env github floweyvar10
+        flowey v 16 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -2015,7 +2015,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey v 16 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey v 16 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
         flowey e 16 flowey_lib_common::git_checkout 3
@@ -2034,8 +2034,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 16 flowey_lib_common::cache 4
-        flowey v 16 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
-        flowey v 16 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
+        flowey v 16 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar8
+        flowey v 16 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar9
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
@@ -2045,7 +2045,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 16 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        flowey v 16 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
         flowey e 16 flowey_lib_common::cache 6
@@ -2094,8 +2094,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 16 flowey_lib_common::cache 0
-        flowey v 16 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
-        flowey v 16 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
+        flowey v 16 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar6
+        flowey v 16 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar7
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -2105,7 +2105,7 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
-        flowey v 16 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey v 16 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey e 16 flowey_lib_common::cache 2
@@ -2130,8 +2130,8 @@ jobs:
         flowey e 16 flowey_lib_hvlite::build_nextest_unit_tests 3
         flowey e 16 flowey_lib_common::publish_test_results 6
         flowey e 16 flowey_lib_common::publish_test_results 7
-        flowey v 16 'flowey_lib_common::publish_test_results:12:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs:94:51 write-to-env github floweyvar3
-        flowey v 16 'flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs:94:51' write-to-env github FLOWEY_CONDITION
+        flowey v 16 'flowey_lib_common::publish_test_results:12:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar3
+        flowey v 16 'flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__8
       uses: actions/upload-artifact@v7
@@ -2150,8 +2150,8 @@ jobs:
         flowey e 16 flowey_lib_hvlite::build_nextest_unit_tests 4
         flowey e 16 flowey_lib_common::publish_test_results 9
         flowey e 16 flowey_lib_common::publish_test_results 10
-        flowey v 16 'flowey_lib_common::publish_test_results:17:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:15:flowey_lib_common/src/publish_test_results.rs:94:51 write-to-env github floweyvar4
-        flowey v 16 'flowey_lib_common::publish_test_results:15:flowey_lib_common/src/publish_test_results.rs:94:51' write-to-env github FLOWEY_CONDITION
+        flowey v 16 'flowey_lib_common::publish_test_results:17:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:15:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar4
+        flowey v 16 'flowey_lib_common::publish_test_results:15:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__11
       uses: actions/upload-artifact@v7
@@ -2170,8 +2170,8 @@ jobs:
         flowey e 16 flowey_lib_hvlite::build_nextest_unit_tests 5
         flowey e 16 flowey_lib_common::publish_test_results 12
         flowey e 16 flowey_lib_common::publish_test_results 13
-        flowey v 16 'flowey_lib_common::publish_test_results:22:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:20:flowey_lib_common/src/publish_test_results.rs:94:51 write-to-env github floweyvar5
-        flowey v 16 'flowey_lib_common::publish_test_results:20:flowey_lib_common/src/publish_test_results.rs:94:51' write-to-env github FLOWEY_CONDITION
+        flowey v 16 'flowey_lib_common::publish_test_results:22:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:20:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar5
+        flowey v 16 'flowey_lib_common::publish_test_results:20:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__14
       uses: actions/upload-artifact@v7
@@ -2205,8 +2205,8 @@ jobs:
         flowey e 16 flowey_lib_hvlite::build_nextest_unit_tests 1
         flowey e 16 flowey_lib_common::publish_test_results 0
         flowey e 16 flowey_lib_common::publish_test_results 1
-        flowey v 16 'flowey_lib_common::publish_test_results:2:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:94:51 write-to-env github floweyvar1
-        flowey v 16 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:94:51' write-to-env github FLOWEY_CONDITION
+        flowey v 16 'flowey_lib_common::publish_test_results:2:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar1
+        flowey v 16 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__2
       uses: actions/upload-artifact@v7
@@ -2225,8 +2225,8 @@ jobs:
         flowey e 16 flowey_lib_hvlite::build_nextest_unit_tests 2
         flowey e 16 flowey_lib_common::publish_test_results 3
         flowey e 16 flowey_lib_common::publish_test_results 4
-        flowey v 16 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:94:51 write-to-env github floweyvar2
-        flowey v 16 'flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:94:51' write-to-env github FLOWEY_CONDITION
+        flowey v 16 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar2
+        flowey v 16 'flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__5
       uses: actions/upload-artifact@v7
@@ -2300,8 +2300,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 17 flowey_lib_common::git_checkout 0
-        flowey v 17 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar11
-        flowey v 17 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
+        flowey v 17 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env github floweyvar11
+        flowey v 17 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -2313,7 +2313,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey v 17 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey v 17 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
         flowey e 17 flowey_lib_common::git_checkout 3
@@ -2330,8 +2330,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 17 flowey_lib_common::cache 4
-        flowey v 17 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar9
-        flowey v 17 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar10
+        flowey v 17 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar9
+        flowey v 17 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar10
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
@@ -2341,7 +2341,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 17 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        flowey v 17 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
         flowey e 17 flowey_lib_common::cache 6
@@ -2420,8 +2420,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 17 flowey_lib_common::cache 0
-        flowey v 17 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar7
-        flowey v 17 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar8
+        flowey v 17 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar7
+        flowey v 17 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar8
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -2431,7 +2431,7 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
-        flowey v 17 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey v 17 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey e 17 flowey_lib_common::cache 2
@@ -2456,8 +2456,8 @@ jobs:
         flowey e 17 flowey_lib_hvlite::build_nextest_unit_tests 3
         flowey e 17 flowey_lib_common::publish_test_results 6
         flowey e 17 flowey_lib_common::publish_test_results 7
-        flowey v 17 'flowey_lib_common::publish_test_results:12:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs:94:51 write-to-env github floweyvar3
-        flowey v 17 'flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs:94:51' write-to-env github FLOWEY_CONDITION
+        flowey v 17 'flowey_lib_common::publish_test_results:12:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar3
+        flowey v 17 'flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__8
       uses: actions/upload-artifact@v7
@@ -2476,8 +2476,8 @@ jobs:
         flowey e 17 flowey_lib_hvlite::build_nextest_unit_tests 4
         flowey e 17 flowey_lib_common::publish_test_results 9
         flowey e 17 flowey_lib_common::publish_test_results 10
-        flowey v 17 'flowey_lib_common::publish_test_results:17:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:15:flowey_lib_common/src/publish_test_results.rs:94:51 write-to-env github floweyvar4
-        flowey v 17 'flowey_lib_common::publish_test_results:15:flowey_lib_common/src/publish_test_results.rs:94:51' write-to-env github FLOWEY_CONDITION
+        flowey v 17 'flowey_lib_common::publish_test_results:17:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:15:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar4
+        flowey v 17 'flowey_lib_common::publish_test_results:15:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__11
       uses: actions/upload-artifact@v7
@@ -2496,8 +2496,8 @@ jobs:
         flowey e 17 flowey_lib_hvlite::build_nextest_unit_tests 5
         flowey e 17 flowey_lib_common::publish_test_results 12
         flowey e 17 flowey_lib_common::publish_test_results 13
-        flowey v 17 'flowey_lib_common::publish_test_results:22:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:20:flowey_lib_common/src/publish_test_results.rs:94:51 write-to-env github floweyvar5
-        flowey v 17 'flowey_lib_common::publish_test_results:20:flowey_lib_common/src/publish_test_results.rs:94:51' write-to-env github FLOWEY_CONDITION
+        flowey v 17 'flowey_lib_common::publish_test_results:22:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:20:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar5
+        flowey v 17 'flowey_lib_common::publish_test_results:20:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__14
       uses: actions/upload-artifact@v7
@@ -2516,8 +2516,8 @@ jobs:
         flowey e 17 flowey_lib_hvlite::build_nextest_unit_tests 6
         flowey e 17 flowey_lib_common::publish_test_results 15
         flowey e 17 flowey_lib_common::publish_test_results 16
-        flowey v 17 'flowey_lib_common::publish_test_results:27:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:25:flowey_lib_common/src/publish_test_results.rs:94:51 write-to-env github floweyvar6
-        flowey v 17 'flowey_lib_common::publish_test_results:25:flowey_lib_common/src/publish_test_results.rs:94:51' write-to-env github FLOWEY_CONDITION
+        flowey v 17 'flowey_lib_common::publish_test_results:27:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:25:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar6
+        flowey v 17 'flowey_lib_common::publish_test_results:25:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__17
       uses: actions/upload-artifact@v7
@@ -2551,8 +2551,8 @@ jobs:
         flowey e 17 flowey_lib_hvlite::build_nextest_unit_tests 1
         flowey e 17 flowey_lib_common::publish_test_results 0
         flowey e 17 flowey_lib_common::publish_test_results 1
-        flowey v 17 'flowey_lib_common::publish_test_results:2:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:94:51 write-to-env github floweyvar1
-        flowey v 17 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:94:51' write-to-env github FLOWEY_CONDITION
+        flowey v 17 'flowey_lib_common::publish_test_results:2:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar1
+        flowey v 17 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__2
       uses: actions/upload-artifact@v7
@@ -2571,8 +2571,8 @@ jobs:
         flowey e 17 flowey_lib_hvlite::build_nextest_unit_tests 2
         flowey e 17 flowey_lib_common::publish_test_results 3
         flowey e 17 flowey_lib_common::publish_test_results 4
-        flowey v 17 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:94:51 write-to-env github floweyvar2
-        flowey v 17 'flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:94:51' write-to-env github FLOWEY_CONDITION
+        flowey v 17 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar2
+        flowey v 17 'flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__5
       uses: actions/upload-artifact@v7
@@ -2690,8 +2690,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey.exe e 18 flowey_lib_common::git_checkout 0
-        flowey.exe v 18 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar8
-        flowey.exe v 18 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 18 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env github floweyvar8
+        flowey.exe v 18 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -2703,7 +2703,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey.exe v 18 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey.exe v 18 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
         flowey.exe e 18 flowey_lib_common::git_checkout 3
@@ -2722,8 +2722,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 18 flowey_lib_common::cache 4
-        flowey.exe v 18 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
-        flowey.exe v 18 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
+        flowey.exe v 18 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar6
+        flowey.exe v 18 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar7
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
@@ -2733,7 +2733,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 18 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        flowey.exe v 18 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
         flowey.exe e 18 flowey_lib_common::cache 6
@@ -2778,8 +2778,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 18 flowey_lib_common::cache 0
-        flowey.exe v 18 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
-        flowey.exe v 18 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
+        flowey.exe v 18 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar4
+        flowey.exe v 18 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar5
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -2789,7 +2789,7 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
-        flowey.exe v 18 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey.exe v 18 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey.exe e 18 flowey_lib_common::cache 2
@@ -2825,8 +2825,8 @@ jobs:
         flowey.exe e 18 flowey_lib_hvlite::build_nextest_unit_tests 1
         flowey.exe e 18 flowey_lib_common::publish_test_results 6
         flowey.exe e 18 flowey_lib_common::publish_test_results 7
-        flowey.exe v 18 'flowey_lib_common::publish_test_results:12:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs:94:51 write-to-env github floweyvar3
-        flowey.exe v 18 'flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs:94:51' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 18 'flowey_lib_common::publish_test_results:12:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar3
+        flowey.exe v 18 'flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__8
       uses: actions/upload-artifact@v7
@@ -2845,8 +2845,8 @@ jobs:
         flowey.exe e 18 flowey_lib_hvlite::build_nextest_unit_tests 2
         flowey.exe e 18 flowey_lib_common::publish_test_results 0
         flowey.exe e 18 flowey_lib_common::publish_test_results 1
-        flowey.exe v 18 'flowey_lib_common::publish_test_results:2:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:94:51 write-to-env github floweyvar1
-        flowey.exe v 18 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:94:51' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 18 'flowey_lib_common::publish_test_results:2:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar1
+        flowey.exe v 18 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__2
       uses: actions/upload-artifact@v7
@@ -2865,8 +2865,8 @@ jobs:
         flowey.exe e 18 flowey_lib_hvlite::build_nextest_unit_tests 3
         flowey.exe e 18 flowey_lib_common::publish_test_results 3
         flowey.exe e 18 flowey_lib_common::publish_test_results 4
-        flowey.exe v 18 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:94:51 write-to-env github floweyvar2
-        flowey.exe v 18 'flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:94:51' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 18 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar2
+        flowey.exe v 18 'flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__5
       uses: actions/upload-artifact@v7
@@ -2990,8 +2990,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 19 flowey_lib_common::git_checkout 0
-        flowey v 19 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar10
-        flowey v 19 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
+        flowey v 19 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env github floweyvar10
+        flowey v 19 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -3003,7 +3003,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey v 19 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey v 19 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
         flowey e 19 flowey_lib_common::git_checkout 3
@@ -3022,8 +3022,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 19 flowey_lib_common::cache 4
-        flowey v 19 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
-        flowey v 19 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
+        flowey v 19 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar8
+        flowey v 19 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar9
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
@@ -3033,7 +3033,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 19 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        flowey v 19 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
         flowey e 19 flowey_lib_common::cache 6
@@ -3090,8 +3090,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 19 flowey_lib_common::cache 0
-        flowey v 19 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
-        flowey v 19 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
+        flowey v 19 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar6
+        flowey v 19 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar7
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -3101,7 +3101,7 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
-        flowey v 19 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey v 19 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey e 19 flowey_lib_common::cache 2
@@ -3126,8 +3126,8 @@ jobs:
         flowey e 19 flowey_lib_hvlite::build_nextest_unit_tests 3
         flowey e 19 flowey_lib_common::publish_test_results 6
         flowey e 19 flowey_lib_common::publish_test_results 7
-        flowey v 19 'flowey_lib_common::publish_test_results:12:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs:94:51 write-to-env github floweyvar3
-        flowey v 19 'flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs:94:51' write-to-env github FLOWEY_CONDITION
+        flowey v 19 'flowey_lib_common::publish_test_results:12:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar3
+        flowey v 19 'flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__8
       uses: actions/upload-artifact@v7
@@ -3146,8 +3146,8 @@ jobs:
         flowey e 19 flowey_lib_hvlite::build_nextest_unit_tests 4
         flowey e 19 flowey_lib_common::publish_test_results 9
         flowey e 19 flowey_lib_common::publish_test_results 10
-        flowey v 19 'flowey_lib_common::publish_test_results:17:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:15:flowey_lib_common/src/publish_test_results.rs:94:51 write-to-env github floweyvar4
-        flowey v 19 'flowey_lib_common::publish_test_results:15:flowey_lib_common/src/publish_test_results.rs:94:51' write-to-env github FLOWEY_CONDITION
+        flowey v 19 'flowey_lib_common::publish_test_results:17:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:15:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar4
+        flowey v 19 'flowey_lib_common::publish_test_results:15:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__11
       uses: actions/upload-artifact@v7
@@ -3166,8 +3166,8 @@ jobs:
         flowey e 19 flowey_lib_hvlite::build_nextest_unit_tests 5
         flowey e 19 flowey_lib_common::publish_test_results 12
         flowey e 19 flowey_lib_common::publish_test_results 13
-        flowey v 19 'flowey_lib_common::publish_test_results:22:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:20:flowey_lib_common/src/publish_test_results.rs:94:51 write-to-env github floweyvar5
-        flowey v 19 'flowey_lib_common::publish_test_results:20:flowey_lib_common/src/publish_test_results.rs:94:51' write-to-env github FLOWEY_CONDITION
+        flowey v 19 'flowey_lib_common::publish_test_results:22:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:20:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar5
+        flowey v 19 'flowey_lib_common::publish_test_results:20:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__14
       uses: actions/upload-artifact@v7
@@ -3201,8 +3201,8 @@ jobs:
         flowey e 19 flowey_lib_hvlite::build_nextest_unit_tests 1
         flowey e 19 flowey_lib_common::publish_test_results 0
         flowey e 19 flowey_lib_common::publish_test_results 1
-        flowey v 19 'flowey_lib_common::publish_test_results:2:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:94:51 write-to-env github floweyvar1
-        flowey v 19 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:94:51' write-to-env github FLOWEY_CONDITION
+        flowey v 19 'flowey_lib_common::publish_test_results:2:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar1
+        flowey v 19 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__2
       uses: actions/upload-artifact@v7
@@ -3221,8 +3221,8 @@ jobs:
         flowey e 19 flowey_lib_hvlite::build_nextest_unit_tests 2
         flowey e 19 flowey_lib_common::publish_test_results 3
         flowey e 19 flowey_lib_common::publish_test_results 4
-        flowey v 19 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:94:51 write-to-env github floweyvar2
-        flowey v 19 'flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:94:51' write-to-env github FLOWEY_CONDITION
+        flowey v 19 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar2
+        flowey v 19 'flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__5
       uses: actions/upload-artifact@v7
@@ -3344,8 +3344,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey.exe e 2 flowey_lib_common::git_checkout 0
-        flowey.exe v 2 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar1
-        flowey.exe v 2 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 2 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env github floweyvar1
+        flowey.exe v 2 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -3357,7 +3357,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey.exe v 2 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey.exe v 2 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
         flowey.exe e 2 flowey_lib_common::git_checkout 3
@@ -3376,8 +3376,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 2 flowey_lib_common::cache 0
-        flowey.exe v 2 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar2
-        flowey.exe v 2 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar3
+        flowey.exe v 2 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar2
+        flowey.exe v 2 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar3
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -3387,7 +3387,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 2 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey.exe v 2 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey.exe e 2 flowey_lib_common::cache 2
@@ -3528,8 +3528,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 20 flowey_lib_common::git_checkout 0
-        flowey v 20 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar11
-        flowey v 20 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
+        flowey v 20 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env github floweyvar11
+        flowey v 20 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -3541,7 +3541,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey v 20 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey v 20 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
         flowey e 20 flowey_lib_common::git_checkout 3
@@ -3558,8 +3558,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 20 flowey_lib_common::cache 4
-        flowey v 20 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar9
-        flowey v 20 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar10
+        flowey v 20 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar9
+        flowey v 20 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar10
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
@@ -3569,7 +3569,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 20 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        flowey v 20 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
         flowey e 20 flowey_lib_common::cache 6
@@ -3648,8 +3648,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 20 flowey_lib_common::cache 0
-        flowey v 20 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar7
-        flowey v 20 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar8
+        flowey v 20 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar7
+        flowey v 20 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar8
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -3659,7 +3659,7 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
-        flowey v 20 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey v 20 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey e 20 flowey_lib_common::cache 2
@@ -3684,8 +3684,8 @@ jobs:
         flowey e 20 flowey_lib_hvlite::build_nextest_unit_tests 3
         flowey e 20 flowey_lib_common::publish_test_results 6
         flowey e 20 flowey_lib_common::publish_test_results 7
-        flowey v 20 'flowey_lib_common::publish_test_results:12:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs:94:51 write-to-env github floweyvar3
-        flowey v 20 'flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs:94:51' write-to-env github FLOWEY_CONDITION
+        flowey v 20 'flowey_lib_common::publish_test_results:12:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar3
+        flowey v 20 'flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__8
       uses: actions/upload-artifact@v7
@@ -3704,8 +3704,8 @@ jobs:
         flowey e 20 flowey_lib_hvlite::build_nextest_unit_tests 4
         flowey e 20 flowey_lib_common::publish_test_results 9
         flowey e 20 flowey_lib_common::publish_test_results 10
-        flowey v 20 'flowey_lib_common::publish_test_results:17:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:15:flowey_lib_common/src/publish_test_results.rs:94:51 write-to-env github floweyvar4
-        flowey v 20 'flowey_lib_common::publish_test_results:15:flowey_lib_common/src/publish_test_results.rs:94:51' write-to-env github FLOWEY_CONDITION
+        flowey v 20 'flowey_lib_common::publish_test_results:17:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:15:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar4
+        flowey v 20 'flowey_lib_common::publish_test_results:15:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__11
       uses: actions/upload-artifact@v7
@@ -3724,8 +3724,8 @@ jobs:
         flowey e 20 flowey_lib_hvlite::build_nextest_unit_tests 5
         flowey e 20 flowey_lib_common::publish_test_results 12
         flowey e 20 flowey_lib_common::publish_test_results 13
-        flowey v 20 'flowey_lib_common::publish_test_results:22:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:20:flowey_lib_common/src/publish_test_results.rs:94:51 write-to-env github floweyvar5
-        flowey v 20 'flowey_lib_common::publish_test_results:20:flowey_lib_common/src/publish_test_results.rs:94:51' write-to-env github FLOWEY_CONDITION
+        flowey v 20 'flowey_lib_common::publish_test_results:22:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:20:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar5
+        flowey v 20 'flowey_lib_common::publish_test_results:20:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__14
       uses: actions/upload-artifact@v7
@@ -3744,8 +3744,8 @@ jobs:
         flowey e 20 flowey_lib_hvlite::build_nextest_unit_tests 6
         flowey e 20 flowey_lib_common::publish_test_results 15
         flowey e 20 flowey_lib_common::publish_test_results 16
-        flowey v 20 'flowey_lib_common::publish_test_results:27:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:25:flowey_lib_common/src/publish_test_results.rs:94:51 write-to-env github floweyvar6
-        flowey v 20 'flowey_lib_common::publish_test_results:25:flowey_lib_common/src/publish_test_results.rs:94:51' write-to-env github FLOWEY_CONDITION
+        flowey v 20 'flowey_lib_common::publish_test_results:27:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:25:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar6
+        flowey v 20 'flowey_lib_common::publish_test_results:25:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__17
       uses: actions/upload-artifact@v7
@@ -3779,8 +3779,8 @@ jobs:
         flowey e 20 flowey_lib_hvlite::build_nextest_unit_tests 1
         flowey e 20 flowey_lib_common::publish_test_results 0
         flowey e 20 flowey_lib_common::publish_test_results 1
-        flowey v 20 'flowey_lib_common::publish_test_results:2:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:94:51 write-to-env github floweyvar1
-        flowey v 20 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:94:51' write-to-env github FLOWEY_CONDITION
+        flowey v 20 'flowey_lib_common::publish_test_results:2:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar1
+        flowey v 20 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__2
       uses: actions/upload-artifact@v7
@@ -3799,8 +3799,8 @@ jobs:
         flowey e 20 flowey_lib_hvlite::build_nextest_unit_tests 2
         flowey e 20 flowey_lib_common::publish_test_results 3
         flowey e 20 flowey_lib_common::publish_test_results 4
-        flowey v 20 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:94:51 write-to-env github floweyvar2
-        flowey v 20 'flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:94:51' write-to-env github FLOWEY_CONDITION
+        flowey v 20 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar2
+        flowey v 20 'flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__5
       uses: actions/upload-artifact@v7
@@ -3891,8 +3891,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 21 flowey_lib_common::cache 0
-        flowey.exe v 21 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
-        flowey.exe v 21 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
+        flowey.exe v 21 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar4
+        flowey.exe v 21 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar5
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -3902,7 +3902,7 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
-        flowey.exe v 21 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey.exe v 21 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey.exe e 21 flowey_lib_common::cache 2
@@ -3911,8 +3911,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey.exe e 21 flowey_lib_common::git_checkout 0
-        flowey.exe v 21 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar3
-        flowey.exe v 21 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 21 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env github floweyvar3
+        flowey.exe v 21 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -3924,7 +3924,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey.exe v 21 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey.exe v 21 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
         flowey.exe e 21 flowey_lib_common::git_checkout 3
@@ -3959,8 +3959,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 21 flowey_lib_common::cache 8
-        flowey.exe v 21 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
-        flowey.exe v 21 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
+        flowey.exe v 21 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar8
+        flowey.exe v 21 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar9
       shell: bash
     - id: flowey_lib_common__cache__9
       uses: actions/cache@v5
@@ -3970,7 +3970,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 21 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
+        flowey.exe v 21 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
         EOF
         flowey.exe e 21 flowey_lib_common::cache 10
@@ -3993,8 +3993,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 21 flowey_lib_common::cache 4
-        flowey.exe v 21 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
-        flowey.exe v 21 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
+        flowey.exe v 21 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar6
+        flowey.exe v 21 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar7
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
@@ -4004,12 +4004,12 @@ jobs:
       name: 'Restore cache: gh-cli'
     - name: installing gh
       run: |-
-        flowey.exe v 21 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        flowey.exe v 21 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
         flowey.exe e 21 flowey_lib_common::cache 6
         flowey.exe e 21 flowey_lib_common::download_gh_cli 1
-        flowey.exe v 21 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
+        flowey.exe v 21 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.token <<EOF
         ${{ github.token }}
         EOF
       shell: bash
@@ -4069,8 +4069,8 @@ jobs:
         flowey.exe e 21 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
         flowey.exe e 21 flowey_lib_common::publish_test_results 0
         flowey.exe e 21 flowey_lib_common::publish_test_results 1
-        flowey.exe v 21 'flowey_lib_common::publish_test_results:2:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:94:51 write-to-env github floweyvar1
-        flowey.exe v 21 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:94:51' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 21 'flowey_lib_common::publish_test_results:2:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar1
+        flowey.exe v 21 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__2
       uses: actions/upload-artifact@v7
@@ -4084,8 +4084,8 @@ jobs:
         flowey.exe e 21 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
         flowey.exe e 21 flowey_lib_common::publish_test_results 3
         flowey.exe e 21 flowey_lib_common::publish_test_results 4
-        flowey.exe v 21 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:150:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:142:57 write-to-env github floweyvar2
-        flowey.exe v 21 'flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:142:57' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 21 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar2
+        flowey.exe v 21 'flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__5
       uses: actions/upload-artifact@v7
@@ -4174,8 +4174,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 22 flowey_lib_common::cache 0
-        flowey.exe v 22 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
-        flowey.exe v 22 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
+        flowey.exe v 22 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar4
+        flowey.exe v 22 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar5
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -4185,7 +4185,7 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
-        flowey.exe v 22 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey.exe v 22 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey.exe e 22 flowey_lib_common::cache 2
@@ -4194,8 +4194,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey.exe e 22 flowey_lib_common::git_checkout 0
-        flowey.exe v 22 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar3
-        flowey.exe v 22 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 22 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env github floweyvar3
+        flowey.exe v 22 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -4207,7 +4207,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey.exe v 22 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey.exe v 22 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
         flowey.exe e 22 flowey_lib_common::git_checkout 3
@@ -4242,8 +4242,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 22 flowey_lib_common::cache 8
-        flowey.exe v 22 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
-        flowey.exe v 22 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
+        flowey.exe v 22 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar8
+        flowey.exe v 22 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar9
       shell: bash
     - id: flowey_lib_common__cache__9
       uses: actions/cache@v5
@@ -4253,7 +4253,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 22 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
+        flowey.exe v 22 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
         EOF
         flowey.exe e 22 flowey_lib_common::cache 10
@@ -4276,8 +4276,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 22 flowey_lib_common::cache 4
-        flowey.exe v 22 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
-        flowey.exe v 22 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
+        flowey.exe v 22 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar6
+        flowey.exe v 22 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar7
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
@@ -4287,12 +4287,12 @@ jobs:
       name: 'Restore cache: gh-cli'
     - name: installing gh
       run: |-
-        flowey.exe v 22 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        flowey.exe v 22 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
         flowey.exe e 22 flowey_lib_common::cache 6
         flowey.exe e 22 flowey_lib_common::download_gh_cli 1
-        flowey.exe v 22 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
+        flowey.exe v 22 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.token <<EOF
         ${{ github.token }}
         EOF
       shell: bash
@@ -4347,8 +4347,8 @@ jobs:
         flowey.exe e 22 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
         flowey.exe e 22 flowey_lib_common::publish_test_results 0
         flowey.exe e 22 flowey_lib_common::publish_test_results 1
-        flowey.exe v 22 'flowey_lib_common::publish_test_results:2:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:94:51 write-to-env github floweyvar1
-        flowey.exe v 22 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:94:51' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 22 'flowey_lib_common::publish_test_results:2:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar1
+        flowey.exe v 22 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__2
       uses: actions/upload-artifact@v7
@@ -4362,8 +4362,8 @@ jobs:
         flowey.exe e 22 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
         flowey.exe e 22 flowey_lib_common::publish_test_results 3
         flowey.exe e 22 flowey_lib_common::publish_test_results 4
-        flowey.exe v 22 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:150:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:142:57 write-to-env github floweyvar2
-        flowey.exe v 22 'flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:142:57' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 22 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar2
+        flowey.exe v 22 'flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__5
       uses: actions/upload-artifact@v7
@@ -4453,8 +4453,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 23 flowey_lib_common::cache 0
-        flowey.exe v 23 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
-        flowey.exe v 23 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
+        flowey.exe v 23 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar4
+        flowey.exe v 23 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar5
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -4464,7 +4464,7 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
-        flowey.exe v 23 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey.exe v 23 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey.exe e 23 flowey_lib_common::cache 2
@@ -4473,8 +4473,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey.exe e 23 flowey_lib_common::git_checkout 0
-        flowey.exe v 23 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar3
-        flowey.exe v 23 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 23 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env github floweyvar3
+        flowey.exe v 23 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -4486,7 +4486,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey.exe v 23 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey.exe v 23 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
         flowey.exe e 23 flowey_lib_common::git_checkout 3
@@ -4521,8 +4521,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 23 flowey_lib_common::cache 8
-        flowey.exe v 23 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
-        flowey.exe v 23 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
+        flowey.exe v 23 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar8
+        flowey.exe v 23 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar9
       shell: bash
     - id: flowey_lib_common__cache__9
       uses: actions/cache@v5
@@ -4532,7 +4532,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 23 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
+        flowey.exe v 23 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
         EOF
         flowey.exe e 23 flowey_lib_common::cache 10
@@ -4555,8 +4555,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 23 flowey_lib_common::cache 4
-        flowey.exe v 23 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
-        flowey.exe v 23 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
+        flowey.exe v 23 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar6
+        flowey.exe v 23 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar7
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
@@ -4566,12 +4566,12 @@ jobs:
       name: 'Restore cache: gh-cli'
     - name: installing gh
       run: |-
-        flowey.exe v 23 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        flowey.exe v 23 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
         flowey.exe e 23 flowey_lib_common::cache 6
         flowey.exe e 23 flowey_lib_common::download_gh_cli 1
-        flowey.exe v 23 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
+        flowey.exe v 23 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.token <<EOF
         ${{ github.token }}
         EOF
       shell: bash
@@ -4631,8 +4631,8 @@ jobs:
         flowey.exe e 23 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
         flowey.exe e 23 flowey_lib_common::publish_test_results 0
         flowey.exe e 23 flowey_lib_common::publish_test_results 1
-        flowey.exe v 23 'flowey_lib_common::publish_test_results:2:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:94:51 write-to-env github floweyvar1
-        flowey.exe v 23 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:94:51' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 23 'flowey_lib_common::publish_test_results:2:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar1
+        flowey.exe v 23 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__2
       uses: actions/upload-artifact@v7
@@ -4646,8 +4646,8 @@ jobs:
         flowey.exe e 23 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
         flowey.exe e 23 flowey_lib_common::publish_test_results 3
         flowey.exe e 23 flowey_lib_common::publish_test_results 4
-        flowey.exe v 23 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:150:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:142:57 write-to-env github floweyvar2
-        flowey.exe v 23 'flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:142:57' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 23 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar2
+        flowey.exe v 23 'flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__5
       uses: actions/upload-artifact@v7
@@ -4736,8 +4736,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 24 flowey_lib_common::cache 0
-        flowey.exe v 24 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
-        flowey.exe v 24 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
+        flowey.exe v 24 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar4
+        flowey.exe v 24 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar5
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -4747,7 +4747,7 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
-        flowey.exe v 24 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey.exe v 24 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey.exe e 24 flowey_lib_common::cache 2
@@ -4756,8 +4756,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey.exe e 24 flowey_lib_common::git_checkout 0
-        flowey.exe v 24 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar3
-        flowey.exe v 24 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 24 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env github floweyvar3
+        flowey.exe v 24 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -4769,7 +4769,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey.exe v 24 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey.exe v 24 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
         flowey.exe e 24 flowey_lib_common::git_checkout 3
@@ -4804,8 +4804,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 24 flowey_lib_common::cache 8
-        flowey.exe v 24 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
-        flowey.exe v 24 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
+        flowey.exe v 24 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar8
+        flowey.exe v 24 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar9
       shell: bash
     - id: flowey_lib_common__cache__9
       uses: actions/cache@v5
@@ -4815,7 +4815,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 24 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
+        flowey.exe v 24 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
         EOF
         flowey.exe e 24 flowey_lib_common::cache 10
@@ -4838,8 +4838,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 24 flowey_lib_common::cache 4
-        flowey.exe v 24 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
-        flowey.exe v 24 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
+        flowey.exe v 24 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar6
+        flowey.exe v 24 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar7
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
@@ -4849,12 +4849,12 @@ jobs:
       name: 'Restore cache: gh-cli'
     - name: installing gh
       run: |-
-        flowey.exe v 24 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        flowey.exe v 24 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
         flowey.exe e 24 flowey_lib_common::cache 6
         flowey.exe e 24 flowey_lib_common::download_gh_cli 1
-        flowey.exe v 24 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
+        flowey.exe v 24 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.token <<EOF
         ${{ github.token }}
         EOF
       shell: bash
@@ -4914,8 +4914,8 @@ jobs:
         flowey.exe e 24 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
         flowey.exe e 24 flowey_lib_common::publish_test_results 0
         flowey.exe e 24 flowey_lib_common::publish_test_results 1
-        flowey.exe v 24 'flowey_lib_common::publish_test_results:2:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:94:51 write-to-env github floweyvar1
-        flowey.exe v 24 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:94:51' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 24 'flowey_lib_common::publish_test_results:2:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar1
+        flowey.exe v 24 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__2
       uses: actions/upload-artifact@v7
@@ -4929,8 +4929,8 @@ jobs:
         flowey.exe e 24 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
         flowey.exe e 24 flowey_lib_common::publish_test_results 3
         flowey.exe e 24 flowey_lib_common::publish_test_results 4
-        flowey.exe v 24 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:150:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:142:57 write-to-env github floweyvar2
-        flowey.exe v 24 'flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:142:57' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 24 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar2
+        flowey.exe v 24 'flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__5
       uses: actions/upload-artifact@v7
@@ -5019,8 +5019,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 25 flowey_lib_common::cache 0
-        flowey.exe v 25 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
-        flowey.exe v 25 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
+        flowey.exe v 25 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar4
+        flowey.exe v 25 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar5
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -5030,7 +5030,7 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
-        flowey.exe v 25 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey.exe v 25 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey.exe e 25 flowey_lib_common::cache 2
@@ -5039,8 +5039,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey.exe e 25 flowey_lib_common::git_checkout 0
-        flowey.exe v 25 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar3
-        flowey.exe v 25 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 25 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env github floweyvar3
+        flowey.exe v 25 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -5052,7 +5052,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey.exe v 25 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey.exe v 25 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
         flowey.exe e 25 flowey_lib_common::git_checkout 3
@@ -5087,8 +5087,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 25 flowey_lib_common::cache 8
-        flowey.exe v 25 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
-        flowey.exe v 25 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
+        flowey.exe v 25 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar8
+        flowey.exe v 25 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar9
       shell: bash
     - id: flowey_lib_common__cache__9
       uses: actions/cache@v5
@@ -5098,7 +5098,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 25 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
+        flowey.exe v 25 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
         EOF
         flowey.exe e 25 flowey_lib_common::cache 10
@@ -5121,8 +5121,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 25 flowey_lib_common::cache 4
-        flowey.exe v 25 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
-        flowey.exe v 25 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
+        flowey.exe v 25 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar6
+        flowey.exe v 25 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar7
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
@@ -5132,12 +5132,12 @@ jobs:
       name: 'Restore cache: gh-cli'
     - name: installing gh
       run: |-
-        flowey.exe v 25 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        flowey.exe v 25 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
         flowey.exe e 25 flowey_lib_common::cache 6
         flowey.exe e 25 flowey_lib_common::download_gh_cli 1
-        flowey.exe v 25 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
+        flowey.exe v 25 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.token <<EOF
         ${{ github.token }}
         EOF
       shell: bash
@@ -5197,8 +5197,8 @@ jobs:
         flowey.exe e 25 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
         flowey.exe e 25 flowey_lib_common::publish_test_results 0
         flowey.exe e 25 flowey_lib_common::publish_test_results 1
-        flowey.exe v 25 'flowey_lib_common::publish_test_results:2:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:94:51 write-to-env github floweyvar1
-        flowey.exe v 25 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:94:51' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 25 'flowey_lib_common::publish_test_results:2:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar1
+        flowey.exe v 25 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__2
       uses: actions/upload-artifact@v7
@@ -5212,8 +5212,8 @@ jobs:
         flowey.exe e 25 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
         flowey.exe e 25 flowey_lib_common::publish_test_results 3
         flowey.exe e 25 flowey_lib_common::publish_test_results 4
-        flowey.exe v 25 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:150:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:142:57 write-to-env github floweyvar2
-        flowey.exe v 25 'flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:142:57' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 25 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar2
+        flowey.exe v 25 'flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__5
       uses: actions/upload-artifact@v7
@@ -5299,8 +5299,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 26 flowey_lib_common::cache 0
-        flowey v 26 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
-        flowey v 26 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
+        flowey v 26 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar4
+        flowey v 26 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar5
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -5310,7 +5310,7 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
-        flowey v 26 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey v 26 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey e 26 flowey_lib_common::cache 2
@@ -5319,8 +5319,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 26 flowey_lib_common::git_checkout 0
-        flowey v 26 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar3
-        flowey v 26 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
+        flowey v 26 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env github floweyvar3
+        flowey v 26 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -5332,7 +5332,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey v 26 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey v 26 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
         flowey e 26 flowey_lib_common::git_checkout 3
@@ -5365,8 +5365,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 26 flowey_lib_common::cache 8
-        flowey v 26 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
-        flowey v 26 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
+        flowey v 26 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar8
+        flowey v 26 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar9
       shell: bash
     - id: flowey_lib_common__cache__9
       uses: actions/cache@v5
@@ -5376,7 +5376,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 26 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
+        flowey v 26 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
         EOF
         flowey e 26 flowey_lib_common::cache 10
@@ -5399,8 +5399,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 26 flowey_lib_common::cache 4
-        flowey v 26 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
-        flowey v 26 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
+        flowey v 26 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar6
+        flowey v 26 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar7
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
@@ -5410,12 +5410,12 @@ jobs:
       name: 'Restore cache: gh-cli'
     - name: installing gh
       run: |-
-        flowey v 26 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        flowey v 26 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
         flowey e 26 flowey_lib_common::cache 6
         flowey e 26 flowey_lib_common::download_gh_cli 1
-        flowey v 26 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
+        flowey v 26 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.token <<EOF
         ${{ github.token }}
         EOF
       shell: bash
@@ -5468,8 +5468,8 @@ jobs:
         flowey e 26 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
         flowey e 26 flowey_lib_common::publish_test_results 0
         flowey e 26 flowey_lib_common::publish_test_results 1
-        flowey v 26 'flowey_lib_common::publish_test_results:2:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:94:51 write-to-env github floweyvar1
-        flowey v 26 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:94:51' write-to-env github FLOWEY_CONDITION
+        flowey v 26 'flowey_lib_common::publish_test_results:2:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar1
+        flowey v 26 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__2
       uses: actions/upload-artifact@v7
@@ -5483,8 +5483,8 @@ jobs:
         flowey e 26 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
         flowey e 26 flowey_lib_common::publish_test_results 3
         flowey e 26 flowey_lib_common::publish_test_results 4
-        flowey v 26 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:150:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:142:57 write-to-env github floweyvar2
-        flowey v 26 'flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:142:57' write-to-env github FLOWEY_CONDITION
+        flowey v 26 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar2
+        flowey v 26 'flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__5
       uses: actions/upload-artifact@v7
@@ -5615,8 +5615,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 27 flowey_lib_common::cache 0
-        flowey v 27 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
-        flowey v 27 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
+        flowey v 27 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar4
+        flowey v 27 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar5
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -5626,7 +5626,7 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
-        flowey v 27 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey v 27 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey e 27 flowey_lib_common::cache 2
@@ -5635,8 +5635,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 27 flowey_lib_common::git_checkout 0
-        flowey v 27 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar3
-        flowey v 27 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
+        flowey v 27 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env github floweyvar3
+        flowey v 27 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -5648,7 +5648,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey v 27 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey v 27 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
         flowey e 27 flowey_lib_common::git_checkout 3
@@ -5681,8 +5681,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 27 flowey_lib_common::cache 8
-        flowey v 27 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
-        flowey v 27 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
+        flowey v 27 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar8
+        flowey v 27 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar9
       shell: bash
     - id: flowey_lib_common__cache__9
       uses: actions/cache@v5
@@ -5692,7 +5692,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 27 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
+        flowey v 27 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
         EOF
         flowey e 27 flowey_lib_common::cache 10
@@ -5715,8 +5715,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 27 flowey_lib_common::cache 4
-        flowey v 27 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
-        flowey v 27 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
+        flowey v 27 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar6
+        flowey v 27 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar7
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
@@ -5726,12 +5726,12 @@ jobs:
       name: 'Restore cache: gh-cli'
     - name: installing gh
       run: |-
-        flowey v 27 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        flowey v 27 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
         flowey e 27 flowey_lib_common::cache 6
         flowey e 27 flowey_lib_common::download_gh_cli 1
-        flowey v 27 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
+        flowey v 27 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.token <<EOF
         ${{ github.token }}
         EOF
       shell: bash
@@ -5783,8 +5783,8 @@ jobs:
         flowey e 27 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
         flowey e 27 flowey_lib_common::publish_test_results 0
         flowey e 27 flowey_lib_common::publish_test_results 1
-        flowey v 27 'flowey_lib_common::publish_test_results:2:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:94:51 write-to-env github floweyvar1
-        flowey v 27 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:94:51' write-to-env github FLOWEY_CONDITION
+        flowey v 27 'flowey_lib_common::publish_test_results:2:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar1
+        flowey v 27 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__2
       uses: actions/upload-artifact@v7
@@ -5798,8 +5798,8 @@ jobs:
         flowey e 27 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
         flowey e 27 flowey_lib_common::publish_test_results 3
         flowey e 27 flowey_lib_common::publish_test_results 4
-        flowey v 27 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:150:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:142:57 write-to-env github floweyvar2
-        flowey v 27 'flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:142:57' write-to-env github FLOWEY_CONDITION
+        flowey v 27 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar2
+        flowey v 27 'flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__5
       uses: actions/upload-artifact@v7
@@ -5931,8 +5931,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 28 flowey_lib_common::cache 0
-        flowey.exe v 28 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
-        flowey.exe v 28 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
+        flowey.exe v 28 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar4
+        flowey.exe v 28 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar5
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -5942,7 +5942,7 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
-        flowey.exe v 28 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey.exe v 28 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey.exe e 28 flowey_lib_common::cache 2
@@ -5951,8 +5951,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey.exe e 28 flowey_lib_common::git_checkout 0
-        flowey.exe v 28 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar3
-        flowey.exe v 28 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 28 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env github floweyvar3
+        flowey.exe v 28 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -5964,7 +5964,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey.exe v 28 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey.exe v 28 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
         flowey.exe e 28 flowey_lib_common::git_checkout 3
@@ -5994,8 +5994,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 28 flowey_lib_common::cache 8
-        flowey.exe v 28 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
-        flowey.exe v 28 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
+        flowey.exe v 28 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar8
+        flowey.exe v 28 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar9
       shell: bash
     - id: flowey_lib_common__cache__9
       uses: actions/cache@v5
@@ -6005,7 +6005,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 28 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
+        flowey.exe v 28 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
         EOF
         flowey.exe e 28 flowey_lib_common::cache 10
@@ -6028,8 +6028,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 28 flowey_lib_common::cache 4
-        flowey.exe v 28 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
-        flowey.exe v 28 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
+        flowey.exe v 28 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar6
+        flowey.exe v 28 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar7
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
@@ -6039,12 +6039,12 @@ jobs:
       name: 'Restore cache: gh-cli'
     - name: installing gh
       run: |-
-        flowey.exe v 28 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        flowey.exe v 28 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
         flowey.exe e 28 flowey_lib_common::cache 6
         flowey.exe e 28 flowey_lib_common::download_gh_cli 1
-        flowey.exe v 28 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
+        flowey.exe v 28 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.token <<EOF
         ${{ github.token }}
         EOF
       shell: bash
@@ -6099,8 +6099,8 @@ jobs:
         flowey.exe e 28 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
         flowey.exe e 28 flowey_lib_common::publish_test_results 0
         flowey.exe e 28 flowey_lib_common::publish_test_results 1
-        flowey.exe v 28 'flowey_lib_common::publish_test_results:2:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:94:51 write-to-env github floweyvar1
-        flowey.exe v 28 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:94:51' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 28 'flowey_lib_common::publish_test_results:2:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar1
+        flowey.exe v 28 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__2
       uses: actions/upload-artifact@v7
@@ -6114,8 +6114,8 @@ jobs:
         flowey.exe e 28 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
         flowey.exe e 28 flowey_lib_common::publish_test_results 3
         flowey.exe e 28 flowey_lib_common::publish_test_results 4
-        flowey.exe v 28 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:150:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:142:57 write-to-env github floweyvar2
-        flowey.exe v 28 'flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:142:57' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 28 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar2
+        flowey.exe v 28 'flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__5
       uses: actions/upload-artifact@v7
@@ -6195,8 +6195,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 29 flowey_lib_common::cache 0
-        flowey v 29 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
-        flowey v 29 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
+        flowey v 29 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar4
+        flowey v 29 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar5
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -6206,7 +6206,7 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
-        flowey v 29 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey v 29 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey e 29 flowey_lib_common::cache 2
@@ -6215,8 +6215,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 29 flowey_lib_common::git_checkout 0
-        flowey v 29 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar3
-        flowey v 29 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
+        flowey v 29 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env github floweyvar3
+        flowey v 29 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -6228,7 +6228,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey v 29 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey v 29 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
         flowey e 29 flowey_lib_common::git_checkout 3
@@ -6264,8 +6264,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 29 flowey_lib_common::cache 8
-        flowey v 29 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
-        flowey v 29 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
+        flowey v 29 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar8
+        flowey v 29 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar9
       shell: bash
     - id: flowey_lib_common__cache__9
       uses: actions/cache@v5
@@ -6275,7 +6275,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 29 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
+        flowey v 29 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
         EOF
         flowey e 29 flowey_lib_common::cache 10
@@ -6298,8 +6298,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 29 flowey_lib_common::cache 4
-        flowey v 29 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
-        flowey v 29 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
+        flowey v 29 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar6
+        flowey v 29 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar7
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
@@ -6309,12 +6309,12 @@ jobs:
       name: 'Restore cache: gh-cli'
     - name: installing gh
       run: |-
-        flowey v 29 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        flowey v 29 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
         flowey e 29 flowey_lib_common::cache 6
         flowey e 29 flowey_lib_common::download_gh_cli 1
-        flowey v 29 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
+        flowey v 29 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.token <<EOF
         ${{ github.token }}
         EOF
       shell: bash
@@ -6370,8 +6370,8 @@ jobs:
         flowey e 29 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 6
         flowey e 29 flowey_lib_common::publish_test_results 0
         flowey e 29 flowey_lib_common::publish_test_results 1
-        flowey v 29 'flowey_lib_common::publish_test_results:2:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:94:51 write-to-env github floweyvar1
-        flowey v 29 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:94:51' write-to-env github FLOWEY_CONDITION
+        flowey v 29 'flowey_lib_common::publish_test_results:2:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar1
+        flowey v 29 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__2
       uses: actions/upload-artifact@v7
@@ -6385,8 +6385,8 @@ jobs:
         flowey e 29 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 5
         flowey e 29 flowey_lib_common::publish_test_results 3
         flowey e 29 flowey_lib_common::publish_test_results 4
-        flowey v 29 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:150:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:142:57 write-to-env github floweyvar2
-        flowey v 29 'flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:142:57' write-to-env github FLOWEY_CONDITION
+        flowey v 29 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar2
+        flowey v 29 'flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__5
       uses: actions/upload-artifact@v7
@@ -6480,8 +6480,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 3 flowey_lib_common::git_checkout 0
-        flowey v 3 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar1
-        flowey v 3 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
+        flowey v 3 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env github floweyvar1
+        flowey v 3 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -6493,7 +6493,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey v 3 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey v 3 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
         flowey e 3 flowey_lib_common::git_checkout 3
@@ -6512,8 +6512,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 3 flowey_lib_common::cache 0
-        flowey v 3 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar2
-        flowey v 3 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar3
+        flowey v 3 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar2
+        flowey v 3 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar3
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -6523,7 +6523,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 3 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey v 3 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey e 3 flowey_lib_common::cache 2
@@ -6802,8 +6802,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 30 flowey_lib_common::git_checkout 0
-        flowey v 30 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar1
-        flowey v 30 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
+        flowey v 30 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env github floweyvar1
+        flowey v 30 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -6815,7 +6815,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey v 30 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey v 30 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
         flowey e 30 flowey_lib_common::git_checkout 3
@@ -6834,7 +6834,7 @@ jobs:
     - name: detect active toolchain
       run: |-
         flowey e 30 flowey_lib_common::install_rust 2
-        flowey v 30 'flowey_lib_hvlite::_jobs::test_local_flowey_build_igvm:3:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.token <<EOF
+        flowey v 30 'flowey_lib_hvlite::_jobs::test_local_flowey_build_igvm:3:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.token <<EOF
         ${{ github.token }}
         EOF
       shell: bash
@@ -7011,8 +7011,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey.exe e 4 flowey_lib_common::git_checkout 0
-        flowey.exe v 4 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar1
-        flowey.exe v 4 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 4 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env github floweyvar1
+        flowey.exe v 4 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -7024,7 +7024,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey.exe v 4 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey.exe v 4 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
         flowey.exe e 4 flowey_lib_common::git_checkout 3
@@ -7043,8 +7043,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 4 flowey_lib_common::cache 0
-        flowey.exe v 4 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar2
-        flowey.exe v 4 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar3
+        flowey.exe v 4 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar2
+        flowey.exe v 4 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar3
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -7054,7 +7054,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 4 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey.exe v 4 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey.exe e 4 flowey_lib_common::cache 2
@@ -7240,8 +7240,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey.exe e 5 flowey_lib_common::git_checkout 0
-        flowey.exe v 5 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar1
-        flowey.exe v 5 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 5 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env github floweyvar1
+        flowey.exe v 5 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -7253,7 +7253,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey.exe v 5 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey.exe v 5 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
         flowey.exe e 5 flowey_lib_common::git_checkout 3
@@ -7272,8 +7272,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 5 flowey_lib_common::cache 4
-        flowey.exe v 5 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
-        flowey.exe v 5 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
+        flowey.exe v 5 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar4
+        flowey.exe v 5 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar5
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
@@ -7283,7 +7283,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 5 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        flowey.exe v 5 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
         flowey.exe e 5 flowey_lib_common::cache 6
@@ -7368,8 +7368,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 5 flowey_lib_common::cache 0
-        flowey.exe v 5 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar2
-        flowey.exe v 5 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar3
+        flowey.exe v 5 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar2
+        flowey.exe v 5 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar3
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -7379,7 +7379,7 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
-        flowey.exe v 5 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey.exe v 5 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey.exe e 5 flowey_lib_common::cache 2
@@ -7556,8 +7556,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey.exe e 6 flowey_lib_common::git_checkout 0
-        flowey.exe v 6 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar1
-        flowey.exe v 6 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 6 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env github floweyvar1
+        flowey.exe v 6 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -7569,7 +7569,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey.exe v 6 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey.exe v 6 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
         flowey.exe e 6 flowey_lib_common::git_checkout 3
@@ -7588,8 +7588,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 6 flowey_lib_common::cache 0
-        flowey.exe v 6 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar2
-        flowey.exe v 6 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar3
+        flowey.exe v 6 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar2
+        flowey.exe v 6 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar3
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -7599,7 +7599,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 6 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey.exe v 6 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey.exe e 6 flowey_lib_common::cache 2
@@ -7789,8 +7789,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey.exe e 7 flowey_lib_common::git_checkout 0
-        flowey.exe v 7 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar1
-        flowey.exe v 7 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
+        flowey.exe v 7 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env github floweyvar1
+        flowey.exe v 7 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -7802,7 +7802,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey.exe v 7 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey.exe v 7 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
         flowey.exe e 7 flowey_lib_common::git_checkout 3
@@ -7821,8 +7821,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 7 flowey_lib_common::cache 4
-        flowey.exe v 7 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
-        flowey.exe v 7 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
+        flowey.exe v 7 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar4
+        flowey.exe v 7 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar5
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
@@ -7832,7 +7832,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 7 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        flowey.exe v 7 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
         flowey.exe e 7 flowey_lib_common::cache 6
@@ -7917,8 +7917,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 7 flowey_lib_common::cache 0
-        flowey.exe v 7 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar2
-        flowey.exe v 7 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar3
+        flowey.exe v 7 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar2
+        flowey.exe v 7 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar3
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -7928,7 +7928,7 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
-        flowey.exe v 7 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey.exe v 7 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey.exe e 7 flowey_lib_common::cache 2
@@ -8089,8 +8089,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 8 flowey_lib_common::git_checkout 0
-        flowey v 8 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar1
-        flowey v 8 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
+        flowey v 8 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env github floweyvar1
+        flowey v 8 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -8102,7 +8102,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey v 8 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey v 8 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
         flowey e 8 flowey_lib_common::git_checkout 3
@@ -8121,8 +8121,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 8 flowey_lib_common::cache 4
-        flowey v 8 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
-        flowey v 8 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
+        flowey v 8 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar4
+        flowey v 8 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar5
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
@@ -8132,7 +8132,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 8 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        flowey v 8 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
         flowey e 8 flowey_lib_common::cache 6
@@ -8290,8 +8290,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 8 flowey_lib_common::cache 0
-        flowey v 8 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar2
-        flowey v 8 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar3
+        flowey v 8 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar2
+        flowey v 8 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar3
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -8301,7 +8301,7 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
-        flowey v 8 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey v 8 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey e 8 flowey_lib_common::cache 2
@@ -8474,8 +8474,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 9 flowey_lib_common::git_checkout 0
-        flowey v 9 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:487:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46 write-to-env github floweyvar1
-        flowey v 9 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:488:46' write-to-env github FLOWEY_CONDITION
+        flowey v 9 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env github floweyvar1
+        flowey v 9 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v6
@@ -8487,7 +8487,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey v 9 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
+        flowey v 9 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
         flowey e 9 flowey_lib_common::git_checkout 3
@@ -8506,8 +8506,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 9 flowey_lib_common::cache 4
-        flowey v 9 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
-        flowey v 9 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
+        flowey v 9 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar4
+        flowey v 9 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar5
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v5
@@ -8517,7 +8517,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 9 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
+        flowey v 9 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
         flowey e 9 flowey_lib_common::cache 6
@@ -8679,8 +8679,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 9 flowey_lib_common::cache 0
-        flowey v 9 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar2
-        flowey v 9 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar3
+        flowey v 9 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar2
+        flowey v 9 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar3
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v5
@@ -8690,7 +8690,7 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: downloading cargo-nextest
       run: |-
-        flowey v 9 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        flowey v 9 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey e 9 flowey_lib_common::cache 2

--- a/Guide/src/dev_guide/dev_tools/flowey/nix.md
+++ b/Guide/src/dev_guide/dev_tools/flowey/nix.md
@@ -59,6 +59,21 @@ error: hash mismatch in fixed-output derivation '/nix/store/...-source.drv':
 
 Use the `got:` value in the `.nix` file.
 
+### OpenHCL dev kernel packages
+
+The Nix shell does not evaluate or export OpenHCL dev kernel packages by
+default. The main and dev kernels often contain the same promoted changes, so
+building both variants adds unnecessary download and build work.
+
+To restore the dev kernel packages when the branches diverge:
+
+1. Set `enableDevKernel` to `true` in `shell.nix`.
+2. Update the dev version in `nix/openhcl_kernel.nix`.
+3. Clear and replace the dev hashes using the procedure above.
+This restores the `NIX_KERNEL_*_DEV` paths and
+`CARGO_BUILD_ARGS_*_DEVKERN` arguments in the Nix shell.
+`CARGO_BUILD_ARGS_*_DEVKERN` arguments in the Nix shell.
+
 ## Updating the Rust Version
 
 The Nix shell derives its Rust toolchain version from `rust-version` in the root `Cargo.toml` and resolves it against a pinned [rust-overlay](https://github.com/oxalica/rust-overlay) commit in `shell.nix`. When `rust-version` is bumped in `Cargo.toml`, the pinned rust-overlay may not yet include the new version, causing an error like:

--- a/Guide/src/dev_guide/dev_tools/flowey/nix.md
+++ b/Guide/src/dev_guide/dev_tools/flowey/nix.md
@@ -70,8 +70,8 @@ To restore the dev kernel packages when the branches diverge:
 1. Set `enableDevKernel` to `true` in `shell.nix`.
 2. Update the dev version in `nix/openhcl_kernel.nix`.
 3. Clear and replace the dev hashes using the procedure above.
+
 This restores the `NIX_KERNEL_*_DEV` paths and
-`CARGO_BUILD_ARGS_*_DEVKERN` arguments in the Nix shell.
 `CARGO_BUILD_ARGS_*_DEVKERN` arguments in the Nix shell.
 
 ## Updating the Rust Version

--- a/Guide/src/dev_guide/getting_started/build_openhcl.md
+++ b/Guide/src/dev_guide/getting_started/build_openhcl.md
@@ -152,12 +152,16 @@ Some examples of potentially useful customization include:
     cargo xflowey build-igvm x64 --custom-openvmm-hcl target/x86_64-unknown-linux-musl/debug/openvmm_hcl
     ```
 
-- Specify a custom VTL2 kernel `vmlinux` / `Image`, instead of using a
-    pre-packed stable/dev kernel.
+- Specify a custom VTL2 kernel `vmlinux` / `Image`, instead of using the
+    packaged main kernel.
 
     ```bash
     cargo xflowey build-igvm x64 --custom-kernel path/to/my/prebuilt/vmlinux
     ```
+
+    The packaged dev kernel variants are disabled by default. A custom kernel
+    remains available for local kernel development without enabling those
+    variants.
 
 For a full list of available customizations, refer to `build-igvm --help`.
 

--- a/ci-flowey/openvmm-pr.yaml
+++ b/ci-flowey/openvmm-pr.yaml
@@ -105,8 +105,8 @@ jobs:
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 0 flowey_lib_common::git_checkout 0
-      $FLOWEY_BIN v 0 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env ado floweyvar1
-      $FLOWEY_BIN v 0 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env ado FLOWEY_CONDITION
+      $FLOWEY_BIN v 0 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:319:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46 write-to-env ado floweyvar1
+      $FLOWEY_BIN v 0 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46' write-to-env ado FLOWEY_CONDITION
     displayName: check if openvmm needs to be cloned
   - checkout: self
     path: repo0
@@ -118,7 +118,7 @@ jobs:
     condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
   - bash: |-
       set -e
-      $FLOWEY_BIN v 0 'flowey_lib_common::git_checkout:4:flowey_lib_common/src/git_checkout.rs' --is-raw-string update --env-source Pipeline.Workspace <<'EOF'
+      $FLOWEY_BIN v 0 'flowey_lib_common::git_checkout:4:flowey_lib_common/src/git_checkout.rs:402:29' --is-raw-string update --env-source Pipeline.Workspace <<'EOF'
       $(Pipeline.Workspace)
       EOF
       $(FLOWEY_BIN) e 0 flowey_lib_common::git_checkout 3
@@ -142,8 +142,8 @@ jobs:
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 0 flowey_lib_common::cache 0
-      $FLOWEY_BIN v 0 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env ado floweyvar2
-      $FLOWEY_BIN v 0 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env ado floweyvar3
+      $FLOWEY_BIN v 0 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar2
+      $FLOWEY_BIN v 0 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar3
     displayName: Pre-processing cache vars
   - task: Cache@2
     inputs:
@@ -153,7 +153,7 @@ jobs:
     displayName: 'Restore cache: gh-release-download'
   - bash: |-
       set -e
-      $FLOWEY_BIN v 0 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
+      $FLOWEY_BIN v 0 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:300:70' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
       $(FLOWEY_CACHE_HITVAR)
       EOF
       $(FLOWEY_BIN) e 0 flowey_lib_common::cache 2
@@ -270,8 +270,8 @@ jobs:
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 15 flowey_lib_common::git_checkout 0
-      $FLOWEY_BIN v 15 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env ado floweyvar11
-      $FLOWEY_BIN v 15 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env ado FLOWEY_CONDITION
+      $FLOWEY_BIN v 15 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:319:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46 write-to-env ado floweyvar11
+      $FLOWEY_BIN v 15 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46' write-to-env ado FLOWEY_CONDITION
     displayName: check if openvmm needs to be cloned
   - checkout: self
     path: repo0
@@ -283,7 +283,7 @@ jobs:
     condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
   - bash: |-
       set -e
-      $FLOWEY_BIN v 15 'flowey_lib_common::git_checkout:4:flowey_lib_common/src/git_checkout.rs' --is-raw-string update --env-source Pipeline.Workspace <<'EOF'
+      $FLOWEY_BIN v 15 'flowey_lib_common::git_checkout:4:flowey_lib_common/src/git_checkout.rs:402:29' --is-raw-string update --env-source Pipeline.Workspace <<'EOF'
       $(Pipeline.Workspace)
       EOF
       $(FLOWEY_BIN) e 15 flowey_lib_common::git_checkout 3
@@ -299,8 +299,8 @@ jobs:
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 15 flowey_lib_common::cache 4
-      $FLOWEY_BIN v 15 'flowey_lib_common::cache:8:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env ado floweyvar9
-      $FLOWEY_BIN v 15 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env ado floweyvar10
+      $FLOWEY_BIN v 15 'flowey_lib_common::cache:8:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar9
+      $FLOWEY_BIN v 15 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar10
     displayName: Pre-processing cache vars
   - task: Cache@2
     inputs:
@@ -310,7 +310,7 @@ jobs:
     displayName: 'Restore cache: gh-release-download'
   - bash: |-
       set -e
-      $FLOWEY_BIN v 15 'flowey_lib_common::cache:11:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
+      $FLOWEY_BIN v 15 'flowey_lib_common::cache:11:flowey_lib_common/src/cache.rs:300:70' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
       $(FLOWEY_CACHE_HITVAR)
       EOF
       $(FLOWEY_BIN) e 15 flowey_lib_common::cache 6
@@ -376,8 +376,8 @@ jobs:
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 15 flowey_lib_common::cache 0
-      $FLOWEY_BIN v 15 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env ado floweyvar7
-      $FLOWEY_BIN v 15 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env ado floweyvar8
+      $FLOWEY_BIN v 15 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar7
+      $FLOWEY_BIN v 15 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar8
     displayName: Pre-processing cache vars
   - task: Cache@2
     inputs:
@@ -387,7 +387,7 @@ jobs:
     displayName: 'Restore cache: cargo-nextest'
   - bash: |-
       set -e
-      $FLOWEY_BIN v 15 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
+      $FLOWEY_BIN v 15 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:300:70' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
       $(FLOWEY_CACHE_HITVAR)
       EOF
       $(FLOWEY_BIN) e 15 flowey_lib_common::cache 2
@@ -412,8 +412,8 @@ jobs:
       $(FLOWEY_BIN) e 15 flowey_lib_common::publish_test_results 5
       $(FLOWEY_BIN) e 15 flowey_lib_common::ado_task_publish_test_results 8
       $(FLOWEY_BIN) e 15 flowey_lib_common::publish_test_results 4
-      $FLOWEY_BIN v 15 'flowey_lib_common::ado_task_publish_test_results:8:flowey_lib_common/src/ado_task_publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs write-to-env ado floweyvar5
-      $FLOWEY_BIN v 15 'flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs' write-to-env ado FLOWEY_CONDITION
+      $FLOWEY_BIN v 15 'flowey_lib_common::ado_task_publish_test_results:8:flowey_lib_common/src/ado_task_publish_test_results.rs:57:45' --is-raw-string --condvar flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs:79:51 write-to-env ado floweyvar5
+      $FLOWEY_BIN v 15 'flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs:79:51' write-to-env ado FLOWEY_CONDITION
     displayName: run 'x64-linux-musl-unit-tests-crypto-rust' nextest tests
   - task: PublishTestResults@2
     inputs:
@@ -432,8 +432,8 @@ jobs:
       $(FLOWEY_BIN) e 15 flowey_lib_common::publish_test_results 7
       $(FLOWEY_BIN) e 15 flowey_lib_common::ado_task_publish_test_results 6
       $(FLOWEY_BIN) e 15 flowey_lib_common::publish_test_results 6
-      $FLOWEY_BIN v 15 'flowey_lib_common::ado_task_publish_test_results:6:flowey_lib_common/src/ado_task_publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:15:flowey_lib_common/src/publish_test_results.rs write-to-env ado floweyvar4
-      $FLOWEY_BIN v 15 'flowey_lib_common::publish_test_results:15:flowey_lib_common/src/publish_test_results.rs' write-to-env ado FLOWEY_CONDITION
+      $FLOWEY_BIN v 15 'flowey_lib_common::ado_task_publish_test_results:6:flowey_lib_common/src/ado_task_publish_test_results.rs:57:45' --is-raw-string --condvar flowey_lib_common::publish_test_results:15:flowey_lib_common/src/publish_test_results.rs:79:51 write-to-env ado floweyvar4
+      $FLOWEY_BIN v 15 'flowey_lib_common::publish_test_results:15:flowey_lib_common/src/publish_test_results.rs:79:51' write-to-env ado FLOWEY_CONDITION
     displayName: run 'x64-linux-musl-unit-tests-crypto-openssl' nextest tests
   - task: PublishTestResults@2
     inputs:
@@ -452,8 +452,8 @@ jobs:
       $(FLOWEY_BIN) e 15 flowey_lib_common::publish_test_results 9
       $(FLOWEY_BIN) e 15 flowey_lib_common::ado_task_publish_test_results 10
       $(FLOWEY_BIN) e 15 flowey_lib_common::publish_test_results 8
-      $FLOWEY_BIN v 15 'flowey_lib_common::ado_task_publish_test_results:10:flowey_lib_common/src/ado_task_publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:20:flowey_lib_common/src/publish_test_results.rs write-to-env ado floweyvar6
-      $FLOWEY_BIN v 15 'flowey_lib_common::publish_test_results:20:flowey_lib_common/src/publish_test_results.rs' write-to-env ado FLOWEY_CONDITION
+      $FLOWEY_BIN v 15 'flowey_lib_common::ado_task_publish_test_results:10:flowey_lib_common/src/ado_task_publish_test_results.rs:57:45' --is-raw-string --condvar flowey_lib_common::publish_test_results:20:flowey_lib_common/src/publish_test_results.rs:79:51 write-to-env ado floweyvar6
+      $FLOWEY_BIN v 15 'flowey_lib_common::publish_test_results:20:flowey_lib_common/src/publish_test_results.rs:79:51' write-to-env ado FLOWEY_CONDITION
     displayName: run 'x64-linux-musl-unit-tests-crypto-symcrypt' nextest tests
   - task: PublishTestResults@2
     inputs:
@@ -472,8 +472,8 @@ jobs:
       $(FLOWEY_BIN) e 15 flowey_lib_common::publish_test_results 11
       $(FLOWEY_BIN) e 15 flowey_lib_common::ado_task_publish_test_results 2
       $(FLOWEY_BIN) e 15 flowey_lib_common::publish_test_results 10
-      $FLOWEY_BIN v 15 'flowey_lib_common::ado_task_publish_test_results:2:flowey_lib_common/src/ado_task_publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:25:flowey_lib_common/src/publish_test_results.rs write-to-env ado floweyvar2
-      $FLOWEY_BIN v 15 'flowey_lib_common::publish_test_results:25:flowey_lib_common/src/publish_test_results.rs' write-to-env ado FLOWEY_CONDITION
+      $FLOWEY_BIN v 15 'flowey_lib_common::ado_task_publish_test_results:2:flowey_lib_common/src/ado_task_publish_test_results.rs:57:45' --is-raw-string --condvar flowey_lib_common::publish_test_results:25:flowey_lib_common/src/publish_test_results.rs:79:51 write-to-env ado floweyvar2
+      $FLOWEY_BIN v 15 'flowey_lib_common::publish_test_results:25:flowey_lib_common/src/publish_test_results.rs:79:51' write-to-env ado FLOWEY_CONDITION
     displayName: run 'x64-linux-musl-unit-tests-crypto-all' nextest tests
   - task: PublishTestResults@2
     inputs:
@@ -506,8 +506,8 @@ jobs:
       $(FLOWEY_BIN) e 15 flowey_lib_common::publish_test_results 1
       $(FLOWEY_BIN) e 15 flowey_lib_common::ado_task_publish_test_results 0
       $(FLOWEY_BIN) e 15 flowey_lib_common::publish_test_results 0
-      $FLOWEY_BIN v 15 'flowey_lib_common::ado_task_publish_test_results:0:flowey_lib_common/src/ado_task_publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs write-to-env ado floweyvar1
-      $FLOWEY_BIN v 15 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs' write-to-env ado FLOWEY_CONDITION
+      $FLOWEY_BIN v 15 'flowey_lib_common::ado_task_publish_test_results:0:flowey_lib_common/src/ado_task_publish_test_results.rs:57:45' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:79:51 write-to-env ado floweyvar1
+      $FLOWEY_BIN v 15 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:79:51' write-to-env ado FLOWEY_CONDITION
     displayName: run 'x64-linux-musl-unit-tests-base' nextest tests
   - task: PublishTestResults@2
     inputs:
@@ -526,8 +526,8 @@ jobs:
       $(FLOWEY_BIN) e 15 flowey_lib_common::publish_test_results 3
       $(FLOWEY_BIN) e 15 flowey_lib_common::ado_task_publish_test_results 4
       $(FLOWEY_BIN) e 15 flowey_lib_common::publish_test_results 2
-      $FLOWEY_BIN v 15 'flowey_lib_common::ado_task_publish_test_results:4:flowey_lib_common/src/ado_task_publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs write-to-env ado floweyvar3
-      $FLOWEY_BIN v 15 'flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs' write-to-env ado FLOWEY_CONDITION
+      $FLOWEY_BIN v 15 'flowey_lib_common::ado_task_publish_test_results:4:flowey_lib_common/src/ado_task_publish_test_results.rs:57:45' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:79:51 write-to-env ado floweyvar3
+      $FLOWEY_BIN v 15 'flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:79:51' write-to-env ado FLOWEY_CONDITION
     displayName: run 'x64-linux-musl-unit-tests-crypto-native' nextest tests
   - task: PublishTestResults@2
     inputs:
@@ -598,8 +598,8 @@ jobs:
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 14 flowey_lib_common::git_checkout 0
-      $FLOWEY_BIN v 14 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env ado floweyvar10
-      $FLOWEY_BIN v 14 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env ado FLOWEY_CONDITION
+      $FLOWEY_BIN v 14 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:319:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46 write-to-env ado floweyvar10
+      $FLOWEY_BIN v 14 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46' write-to-env ado FLOWEY_CONDITION
     displayName: check if openvmm needs to be cloned
   - checkout: self
     path: repo0
@@ -611,7 +611,7 @@ jobs:
     condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
   - bash: |-
       set -e
-      $FLOWEY_BIN v 14 'flowey_lib_common::git_checkout:4:flowey_lib_common/src/git_checkout.rs' --is-raw-string update --env-source Pipeline.Workspace <<'EOF'
+      $FLOWEY_BIN v 14 'flowey_lib_common::git_checkout:4:flowey_lib_common/src/git_checkout.rs:402:29' --is-raw-string update --env-source Pipeline.Workspace <<'EOF'
       $(Pipeline.Workspace)
       EOF
       $(FLOWEY_BIN) e 14 flowey_lib_common::git_checkout 3
@@ -628,8 +628,8 @@ jobs:
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 14 flowey_lib_common::cache 4
-      $FLOWEY_BIN v 14 'flowey_lib_common::cache:8:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env ado floweyvar8
-      $FLOWEY_BIN v 14 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env ado floweyvar9
+      $FLOWEY_BIN v 14 'flowey_lib_common::cache:8:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar8
+      $FLOWEY_BIN v 14 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar9
     displayName: Pre-processing cache vars
   - task: Cache@2
     inputs:
@@ -639,7 +639,7 @@ jobs:
     displayName: 'Restore cache: gh-release-download'
   - bash: |-
       set -e
-      $FLOWEY_BIN v 14 'flowey_lib_common::cache:11:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
+      $FLOWEY_BIN v 14 'flowey_lib_common::cache:11:flowey_lib_common/src/cache.rs:300:70' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
       $(FLOWEY_CACHE_HITVAR)
       EOF
       $(FLOWEY_BIN) e 14 flowey_lib_common::cache 6
@@ -685,8 +685,8 @@ jobs:
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 14 flowey_lib_common::cache 0
-      $FLOWEY_BIN v 14 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env ado floweyvar6
-      $FLOWEY_BIN v 14 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env ado floweyvar7
+      $FLOWEY_BIN v 14 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar6
+      $FLOWEY_BIN v 14 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar7
     displayName: Pre-processing cache vars
   - task: Cache@2
     inputs:
@@ -696,7 +696,7 @@ jobs:
     displayName: 'Restore cache: cargo-nextest'
   - bash: |-
       set -e
-      $FLOWEY_BIN v 14 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
+      $FLOWEY_BIN v 14 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:300:70' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
       $(FLOWEY_CACHE_HITVAR)
       EOF
       $(FLOWEY_BIN) e 14 flowey_lib_common::cache 2
@@ -721,8 +721,8 @@ jobs:
       $(FLOWEY_BIN) e 14 flowey_lib_common::publish_test_results 5
       $(FLOWEY_BIN) e 14 flowey_lib_common::ado_task_publish_test_results 8
       $(FLOWEY_BIN) e 14 flowey_lib_common::publish_test_results 4
-      $FLOWEY_BIN v 14 'flowey_lib_common::ado_task_publish_test_results:8:flowey_lib_common/src/ado_task_publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs write-to-env ado floweyvar5
-      $FLOWEY_BIN v 14 'flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs' write-to-env ado FLOWEY_CONDITION
+      $FLOWEY_BIN v 14 'flowey_lib_common::ado_task_publish_test_results:8:flowey_lib_common/src/ado_task_publish_test_results.rs:57:45' --is-raw-string --condvar flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs:79:51 write-to-env ado floweyvar5
+      $FLOWEY_BIN v 14 'flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs:79:51' write-to-env ado FLOWEY_CONDITION
     displayName: run 'x64-linux-unit-tests-crypto-rust' nextest tests
   - task: PublishTestResults@2
     inputs:
@@ -741,8 +741,8 @@ jobs:
       $(FLOWEY_BIN) e 14 flowey_lib_common::publish_test_results 7
       $(FLOWEY_BIN) e 14 flowey_lib_common::ado_task_publish_test_results 6
       $(FLOWEY_BIN) e 14 flowey_lib_common::publish_test_results 6
-      $FLOWEY_BIN v 14 'flowey_lib_common::ado_task_publish_test_results:6:flowey_lib_common/src/ado_task_publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:15:flowey_lib_common/src/publish_test_results.rs write-to-env ado floweyvar4
-      $FLOWEY_BIN v 14 'flowey_lib_common::publish_test_results:15:flowey_lib_common/src/publish_test_results.rs' write-to-env ado FLOWEY_CONDITION
+      $FLOWEY_BIN v 14 'flowey_lib_common::ado_task_publish_test_results:6:flowey_lib_common/src/ado_task_publish_test_results.rs:57:45' --is-raw-string --condvar flowey_lib_common::publish_test_results:15:flowey_lib_common/src/publish_test_results.rs:79:51 write-to-env ado floweyvar4
+      $FLOWEY_BIN v 14 'flowey_lib_common::publish_test_results:15:flowey_lib_common/src/publish_test_results.rs:79:51' write-to-env ado FLOWEY_CONDITION
     displayName: run 'x64-linux-unit-tests-crypto-openssl' nextest tests
   - task: PublishTestResults@2
     inputs:
@@ -761,8 +761,8 @@ jobs:
       $(FLOWEY_BIN) e 14 flowey_lib_common::publish_test_results 9
       $(FLOWEY_BIN) e 14 flowey_lib_common::ado_task_publish_test_results 2
       $(FLOWEY_BIN) e 14 flowey_lib_common::publish_test_results 8
-      $FLOWEY_BIN v 14 'flowey_lib_common::ado_task_publish_test_results:2:flowey_lib_common/src/ado_task_publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:20:flowey_lib_common/src/publish_test_results.rs write-to-env ado floweyvar2
-      $FLOWEY_BIN v 14 'flowey_lib_common::publish_test_results:20:flowey_lib_common/src/publish_test_results.rs' write-to-env ado FLOWEY_CONDITION
+      $FLOWEY_BIN v 14 'flowey_lib_common::ado_task_publish_test_results:2:flowey_lib_common/src/ado_task_publish_test_results.rs:57:45' --is-raw-string --condvar flowey_lib_common::publish_test_results:20:flowey_lib_common/src/publish_test_results.rs:79:51 write-to-env ado floweyvar2
+      $FLOWEY_BIN v 14 'flowey_lib_common::publish_test_results:20:flowey_lib_common/src/publish_test_results.rs:79:51' write-to-env ado FLOWEY_CONDITION
     displayName: run 'x64-linux-unit-tests-crypto-all' nextest tests
   - task: PublishTestResults@2
     inputs:
@@ -795,8 +795,8 @@ jobs:
       $(FLOWEY_BIN) e 14 flowey_lib_common::publish_test_results 1
       $(FLOWEY_BIN) e 14 flowey_lib_common::ado_task_publish_test_results 0
       $(FLOWEY_BIN) e 14 flowey_lib_common::publish_test_results 0
-      $FLOWEY_BIN v 14 'flowey_lib_common::ado_task_publish_test_results:0:flowey_lib_common/src/ado_task_publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs write-to-env ado floweyvar1
-      $FLOWEY_BIN v 14 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs' write-to-env ado FLOWEY_CONDITION
+      $FLOWEY_BIN v 14 'flowey_lib_common::ado_task_publish_test_results:0:flowey_lib_common/src/ado_task_publish_test_results.rs:57:45' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:79:51 write-to-env ado floweyvar1
+      $FLOWEY_BIN v 14 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:79:51' write-to-env ado FLOWEY_CONDITION
     displayName: run 'x64-linux-unit-tests-base' nextest tests
   - task: PublishTestResults@2
     inputs:
@@ -815,8 +815,8 @@ jobs:
       $(FLOWEY_BIN) e 14 flowey_lib_common::publish_test_results 3
       $(FLOWEY_BIN) e 14 flowey_lib_common::ado_task_publish_test_results 4
       $(FLOWEY_BIN) e 14 flowey_lib_common::publish_test_results 2
-      $FLOWEY_BIN v 14 'flowey_lib_common::ado_task_publish_test_results:4:flowey_lib_common/src/ado_task_publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs write-to-env ado floweyvar3
-      $FLOWEY_BIN v 14 'flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs' write-to-env ado FLOWEY_CONDITION
+      $FLOWEY_BIN v 14 'flowey_lib_common::ado_task_publish_test_results:4:flowey_lib_common/src/ado_task_publish_test_results.rs:57:45' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:79:51 write-to-env ado floweyvar3
+      $FLOWEY_BIN v 14 'flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:79:51' write-to-env ado FLOWEY_CONDITION
     displayName: run 'x64-linux-unit-tests-crypto-native' nextest tests
   - task: PublishTestResults@2
     inputs:
@@ -928,8 +928,8 @@ jobs:
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 13 flowey_lib_common::git_checkout 0
-      $FLOWEY_BIN v 13 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env ado floweyvar8
-      $FLOWEY_BIN v 13 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env ado FLOWEY_CONDITION
+      $FLOWEY_BIN v 13 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:319:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46 write-to-env ado floweyvar8
+      $FLOWEY_BIN v 13 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46' write-to-env ado FLOWEY_CONDITION
     displayName: check if openvmm needs to be cloned
   - checkout: self
     path: repo0
@@ -941,7 +941,7 @@ jobs:
     condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
   - bash: |-
       set -e
-      $FLOWEY_BIN v 13 'flowey_lib_common::git_checkout:4:flowey_lib_common/src/git_checkout.rs' --is-raw-string update --env-source Pipeline.Workspace <<'EOF'
+      $FLOWEY_BIN v 13 'flowey_lib_common::git_checkout:4:flowey_lib_common/src/git_checkout.rs:402:29' --is-raw-string update --env-source Pipeline.Workspace <<'EOF'
       $(Pipeline.Workspace)
       EOF
       $(FLOWEY_BIN) e 13 flowey_lib_common::git_checkout 3
@@ -958,8 +958,8 @@ jobs:
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 13 flowey_lib_common::cache 4
-      $FLOWEY_BIN v 13 'flowey_lib_common::cache:8:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env ado floweyvar6
-      $FLOWEY_BIN v 13 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env ado floweyvar7
+      $FLOWEY_BIN v 13 'flowey_lib_common::cache:8:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar6
+      $FLOWEY_BIN v 13 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar7
     displayName: Pre-processing cache vars
   - task: Cache@2
     inputs:
@@ -969,7 +969,7 @@ jobs:
     displayName: 'Restore cache: gh-release-download'
   - bash: |-
       set -e
-      $FLOWEY_BIN v 13 'flowey_lib_common::cache:11:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
+      $FLOWEY_BIN v 13 'flowey_lib_common::cache:11:flowey_lib_common/src/cache.rs:300:70' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
       $(FLOWEY_CACHE_HITVAR)
       EOF
       $(FLOWEY_BIN) e 13 flowey_lib_common::cache 6
@@ -1011,8 +1011,8 @@ jobs:
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 13 flowey_lib_common::cache 0
-      $FLOWEY_BIN v 13 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env ado floweyvar4
-      $FLOWEY_BIN v 13 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env ado floweyvar5
+      $FLOWEY_BIN v 13 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar4
+      $FLOWEY_BIN v 13 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar5
     displayName: Pre-processing cache vars
   - task: Cache@2
     inputs:
@@ -1022,7 +1022,7 @@ jobs:
     displayName: 'Restore cache: cargo-nextest'
   - bash: |-
       set -e
-      $FLOWEY_BIN v 13 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
+      $FLOWEY_BIN v 13 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:300:70' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
       $(FLOWEY_CACHE_HITVAR)
       EOF
       $(FLOWEY_BIN) e 13 flowey_lib_common::cache 2
@@ -1058,8 +1058,8 @@ jobs:
       $(FLOWEY_BIN) e 13 flowey_lib_common::publish_test_results 5
       $(FLOWEY_BIN) e 13 flowey_lib_common::ado_task_publish_test_results 0
       $(FLOWEY_BIN) e 13 flowey_lib_common::publish_test_results 4
-      $FLOWEY_BIN v 13 'flowey_lib_common::ado_task_publish_test_results:0:flowey_lib_common/src/ado_task_publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs write-to-env ado floweyvar1
-      $FLOWEY_BIN v 13 'flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs' write-to-env ado FLOWEY_CONDITION
+      $FLOWEY_BIN v 13 'flowey_lib_common::ado_task_publish_test_results:0:flowey_lib_common/src/ado_task_publish_test_results.rs:57:45' --is-raw-string --condvar flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs:79:51 write-to-env ado floweyvar1
+      $FLOWEY_BIN v 13 'flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs:79:51' write-to-env ado FLOWEY_CONDITION
     displayName: run 'x64-windows-unit-tests-base' nextest tests
   - task: PublishTestResults@2
     inputs:
@@ -1078,8 +1078,8 @@ jobs:
       $(FLOWEY_BIN) e 13 flowey_lib_common::publish_test_results 1
       $(FLOWEY_BIN) e 13 flowey_lib_common::ado_task_publish_test_results 2
       $(FLOWEY_BIN) e 13 flowey_lib_common::publish_test_results 0
-      $FLOWEY_BIN v 13 'flowey_lib_common::ado_task_publish_test_results:2:flowey_lib_common/src/ado_task_publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs write-to-env ado floweyvar2
-      $FLOWEY_BIN v 13 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs' write-to-env ado FLOWEY_CONDITION
+      $FLOWEY_BIN v 13 'flowey_lib_common::ado_task_publish_test_results:2:flowey_lib_common/src/ado_task_publish_test_results.rs:57:45' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:79:51 write-to-env ado floweyvar2
+      $FLOWEY_BIN v 13 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:79:51' write-to-env ado FLOWEY_CONDITION
     displayName: run 'x64-windows-unit-tests-crypto-native' nextest tests
   - task: PublishTestResults@2
     inputs:
@@ -1098,8 +1098,8 @@ jobs:
       $(FLOWEY_BIN) e 13 flowey_lib_common::publish_test_results 3
       $(FLOWEY_BIN) e 13 flowey_lib_common::ado_task_publish_test_results 4
       $(FLOWEY_BIN) e 13 flowey_lib_common::publish_test_results 2
-      $FLOWEY_BIN v 13 'flowey_lib_common::ado_task_publish_test_results:4:flowey_lib_common/src/ado_task_publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs write-to-env ado floweyvar3
-      $FLOWEY_BIN v 13 'flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs' write-to-env ado FLOWEY_CONDITION
+      $FLOWEY_BIN v 13 'flowey_lib_common::ado_task_publish_test_results:4:flowey_lib_common/src/ado_task_publish_test_results.rs:57:45' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:79:51 write-to-env ado floweyvar3
+      $FLOWEY_BIN v 13 'flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:79:51' write-to-env ado FLOWEY_CONDITION
     displayName: run 'x64-windows-unit-tests-crypto-rust' nextest tests
   - task: PublishTestResults@2
     inputs:
@@ -1171,8 +1171,8 @@ jobs:
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 12 flowey_lib_common::git_checkout 0
-      $FLOWEY_BIN v 12 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env ado floweyvar3
-      $FLOWEY_BIN v 12 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env ado FLOWEY_CONDITION
+      $FLOWEY_BIN v 12 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:319:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46 write-to-env ado floweyvar3
+      $FLOWEY_BIN v 12 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46' write-to-env ado FLOWEY_CONDITION
     displayName: check if openvmm needs to be cloned
   - checkout: self
     path: repo0
@@ -1184,7 +1184,7 @@ jobs:
     condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
   - bash: |-
       set -e
-      $FLOWEY_BIN v 12 'flowey_lib_common::git_checkout:4:flowey_lib_common/src/git_checkout.rs' --is-raw-string update --env-source Pipeline.Workspace <<'EOF'
+      $FLOWEY_BIN v 12 'flowey_lib_common::git_checkout:4:flowey_lib_common/src/git_checkout.rs:402:29' --is-raw-string update --env-source Pipeline.Workspace <<'EOF'
       $(Pipeline.Workspace)
       EOF
       $(FLOWEY_BIN) e 12 flowey_lib_common::git_checkout 3
@@ -1208,8 +1208,8 @@ jobs:
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 12 flowey_lib_common::cache 0
-      $FLOWEY_BIN v 12 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env ado floweyvar1
-      $FLOWEY_BIN v 12 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env ado floweyvar2
+      $FLOWEY_BIN v 12 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar1
+      $FLOWEY_BIN v 12 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar2
     displayName: Pre-processing cache vars
   - task: Cache@2
     inputs:
@@ -1219,7 +1219,7 @@ jobs:
     displayName: 'Restore cache: gh-release-download'
   - bash: |-
       set -e
-      $FLOWEY_BIN v 12 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
+      $FLOWEY_BIN v 12 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:300:70' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
       $(FLOWEY_CACHE_HITVAR)
       EOF
       $(FLOWEY_BIN) e 12 flowey_lib_common::cache 2
@@ -1448,26 +1448,18 @@ jobs:
       echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/x64-openhcl-igvm-cvm" | $FLOWEY_BIN v 11 'artifact_publish_from_x64-openhcl-igvm-cvm' --is-raw-string update
       mkdir -p "$(AgentTempDirNormal)/publish_artifacts/x64-openhcl-igvm-cvm-extras"
       echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/x64-openhcl-igvm-cvm-extras" | $FLOWEY_BIN v 11 'artifact_publish_from_x64-openhcl-igvm-cvm-extras' --is-raw-string update
-      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/x64-openhcl-igvm-devkern"
-      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/x64-openhcl-igvm-devkern" | $FLOWEY_BIN v 11 'artifact_publish_from_x64-openhcl-igvm-devkern' --is-raw-string update
-      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/x64-openhcl-igvm-devkern-extras"
-      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/x64-openhcl-igvm-devkern-extras" | $FLOWEY_BIN v 11 'artifact_publish_from_x64-openhcl-igvm-devkern-extras' --is-raw-string update
       mkdir -p "$(AgentTempDirNormal)/publish_artifacts/x64-openhcl-igvm-extras"
       echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/x64-openhcl-igvm-extras" | $FLOWEY_BIN v 11 'artifact_publish_from_x64-openhcl-igvm-extras' --is-raw-string update
       mkdir -p "$(AgentTempDirNormal)/publish_artifacts/x64-openhcl-igvm-test-linux-direct"
       echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/x64-openhcl-igvm-test-linux-direct" | $FLOWEY_BIN v 11 'artifact_publish_from_x64-openhcl-igvm-test-linux-direct' --is-raw-string update
-      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/x64-openhcl-igvm-test-linux-direct-devkern"
-      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/x64-openhcl-igvm-test-linux-direct-devkern" | $FLOWEY_BIN v 11 'artifact_publish_from_x64-openhcl-igvm-test-linux-direct-devkern' --is-raw-string update
-      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/x64-openhcl-igvm-test-linux-direct-devkern-extras"
-      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/x64-openhcl-igvm-test-linux-direct-devkern-extras" | $FLOWEY_BIN v 11 'artifact_publish_from_x64-openhcl-igvm-test-linux-direct-devkern-extras' --is-raw-string update
       mkdir -p "$(AgentTempDirNormal)/publish_artifacts/x64-openhcl-igvm-test-linux-direct-extras"
       echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/x64-openhcl-igvm-test-linux-direct-extras" | $FLOWEY_BIN v 11 'artifact_publish_from_x64-openhcl-igvm-test-linux-direct-extras' --is-raw-string update
     displayName: 🌼🛫 Initialize job
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 11 flowey_lib_common::git_checkout 0
-      $FLOWEY_BIN v 11 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env ado floweyvar3
-      $FLOWEY_BIN v 11 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env ado FLOWEY_CONDITION
+      $FLOWEY_BIN v 11 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:319:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46 write-to-env ado floweyvar3
+      $FLOWEY_BIN v 11 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46' write-to-env ado FLOWEY_CONDITION
     displayName: check if openvmm needs to be cloned
   - checkout: self
     path: repo0
@@ -1479,7 +1471,7 @@ jobs:
     condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
   - bash: |-
       set -e
-      $FLOWEY_BIN v 11 'flowey_lib_common::git_checkout:4:flowey_lib_common/src/git_checkout.rs' --is-raw-string update --env-source Pipeline.Workspace <<'EOF'
+      $FLOWEY_BIN v 11 'flowey_lib_common::git_checkout:4:flowey_lib_common/src/git_checkout.rs:402:29' --is-raw-string update --env-source Pipeline.Workspace <<'EOF'
       $(Pipeline.Workspace)
       EOF
       $(FLOWEY_BIN) e 11 flowey_lib_common::git_checkout 3
@@ -1503,8 +1495,8 @@ jobs:
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 11 flowey_lib_common::cache 0
-      $FLOWEY_BIN v 11 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env ado floweyvar1
-      $FLOWEY_BIN v 11 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env ado floweyvar2
+      $FLOWEY_BIN v 11 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar1
+      $FLOWEY_BIN v 11 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar2
     displayName: Pre-processing cache vars
   - task: Cache@2
     inputs:
@@ -1514,7 +1506,7 @@ jobs:
     displayName: 'Restore cache: gh-release-download'
   - bash: |-
       set -e
-      $FLOWEY_BIN v 11 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
+      $FLOWEY_BIN v 11 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:300:70' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
       $(FLOWEY_CACHE_HITVAR)
       EOF
       $(FLOWEY_BIN) e 11 flowey_lib_common::cache 2
@@ -1558,7 +1550,7 @@ jobs:
     displayName: extract and resolve kernel package
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_initrd 2
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_initrd 0
       $(FLOWEY_BIN) e 11 flowey_lib_hvlite::init_cross_build 0
       $(FLOWEY_BIN) e 11 flowey_lib_hvlite::run_cargo_build 9
       $(FLOWEY_BIN) e 11 flowey_lib_hvlite::run_cargo_build 10
@@ -1570,7 +1562,7 @@ jobs:
     displayName: cargo build sidecar
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::run_split_debug_info 6
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::run_split_debug_info 4
       $(FLOWEY_BIN) e 11 flowey_lib_hvlite::run_cargo_build 12
       $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_sidecar 0
       $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 5
@@ -1585,7 +1577,7 @@ jobs:
     displayName: cargo build openhcl_boot
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::run_split_debug_info 5
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::run_split_debug_info 3
       $(FLOWEY_BIN) e 11 flowey_lib_hvlite::run_cargo_build 5
       $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_boot 0
       $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 6
@@ -1603,7 +1595,7 @@ jobs:
     displayName: cargo build igvmfilegen
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::run_split_debug_info 7
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::run_split_debug_info 5
       $(FLOWEY_BIN) e 11 flowey_lib_hvlite::run_cargo_build 1
       $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_igvmfilegen 0
       $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 8
@@ -1611,103 +1603,45 @@ jobs:
     displayName: split debug symbols
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::run_igvmfilegen 2
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::run_igvmfilegen 1
       $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 12
       $(FLOWEY_BIN) e 11 flowey_core::pipeline::artifact::publish 0
       $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 10
       $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 11
       $(FLOWEY_BIN) e 11 flowey_core::pipeline::artifact::publish 1
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 34
-    displayName: building igvm file
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::resolve_openhcl_kernel_package 2
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 28
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 25
-    displayName: extract and resolve kernel package
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::run_split_debug_info 4
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 26
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 27
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 29
-    displayName: split debug symbols
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_initrd 4
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 30
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 31
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 32
       $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 33
-    displayName: building openhcl initrd
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::run_igvmfilegen 4
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 37
-      $(FLOWEY_BIN) e 11 flowey_core::pipeline::artifact::publish 2
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 35
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 36
-      $(FLOWEY_BIN) e 11 flowey_core::pipeline::artifact::publish 3
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 34
     displayName: building igvm file
   - bash: $(FLOWEY_BIN) e 11 flowey_lib_hvlite::resolve_openvmm_test_linux_kernel 0
     displayName: unpack openvmm-test-linux archives
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 11 flowey_lib_hvlite::resolve_openvmm_test_initrd 0
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 41
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 38
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 28
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 25
     displayName: unpack openvmm-test-initrd archives
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::run_split_debug_info 1
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 39
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 40
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 42
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::run_split_debug_info 2
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 26
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 27
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 29
     displayName: split debug symbols
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_initrd 0
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 43
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 44
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 45
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 46
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 47
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_initrd 2
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 30
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 31
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 32
     displayName: building openhcl initrd
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 11 flowey_lib_hvlite::run_igvmfilegen 0
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 50
-      $(FLOWEY_BIN) e 11 flowey_core::pipeline::artifact::publish 4
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 48
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 49
-      $(FLOWEY_BIN) e 11 flowey_core::pipeline::artifact::publish 5
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 54
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 51
-    displayName: building igvm file
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::run_split_debug_info 2
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 52
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 53
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 55
-    displayName: split debug symbols
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_initrd 1
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 56
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 57
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 58
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 59
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 60
-    displayName: building openhcl initrd
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::run_igvmfilegen 1
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 63
-      $(FLOWEY_BIN) e 11 flowey_core::pipeline::artifact::publish 6
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 61
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 62
-      $(FLOWEY_BIN) e 11 flowey_core::pipeline::artifact::publish 7
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 37
+      $(FLOWEY_BIN) e 11 flowey_core::pipeline::artifact::publish 2
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 35
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 36
+      $(FLOWEY_BIN) e 11 flowey_core::pipeline::artifact::publish 3
     displayName: building igvm file
   - bash: |-
       set -e
@@ -1717,14 +1651,14 @@ jobs:
     displayName: extract and resolve kernel package
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::run_split_debug_info 3
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::run_split_debug_info 1
       $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 14
       $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 15
       $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 17
     displayName: split debug symbols
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_initrd 3
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_initrd 1
       $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 18
       $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 19
       $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 20
@@ -1732,12 +1666,12 @@ jobs:
     displayName: building openhcl initrd
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::run_igvmfilegen 3
+      $(FLOWEY_BIN) e 11 flowey_lib_hvlite::run_igvmfilegen 2
       $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 24
-      $(FLOWEY_BIN) e 11 flowey_core::pipeline::artifact::publish 8
+      $(FLOWEY_BIN) e 11 flowey_core::pipeline::artifact::publish 4
       $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 22
       $(FLOWEY_BIN) e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 23
-      $(FLOWEY_BIN) e 11 flowey_core::pipeline::artifact::publish 9
+      $(FLOWEY_BIN) e 11 flowey_core::pipeline::artifact::publish 5
     displayName: building igvm file
   - bash: $(FLOWEY_BIN) e 11 flowey_lib_common::cache 3
     displayName: 'validate cache entry: gh-release-download'
@@ -1750,24 +1684,12 @@ jobs:
   - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/x64-openhcl-igvm-cvm-extras
     displayName: 🌼📦 Publish x64-openhcl-igvm-cvm-extras
     artifact: x64-openhcl-igvm-cvm-extras
-  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/x64-openhcl-igvm-devkern
-    displayName: 🌼📦 Publish x64-openhcl-igvm-devkern
-    artifact: x64-openhcl-igvm-devkern
-  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/x64-openhcl-igvm-devkern-extras
-    displayName: 🌼📦 Publish x64-openhcl-igvm-devkern-extras
-    artifact: x64-openhcl-igvm-devkern-extras
   - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/x64-openhcl-igvm-extras
     displayName: 🌼📦 Publish x64-openhcl-igvm-extras
     artifact: x64-openhcl-igvm-extras
   - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/x64-openhcl-igvm-test-linux-direct
     displayName: 🌼📦 Publish x64-openhcl-igvm-test-linux-direct
     artifact: x64-openhcl-igvm-test-linux-direct
-  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/x64-openhcl-igvm-test-linux-direct-devkern
-    displayName: 🌼📦 Publish x64-openhcl-igvm-test-linux-direct-devkern
-    artifact: x64-openhcl-igvm-test-linux-direct-devkern
-  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/x64-openhcl-igvm-test-linux-direct-devkern-extras
-    displayName: 🌼📦 Publish x64-openhcl-igvm-test-linux-direct-devkern-extras
-    artifact: x64-openhcl-igvm-test-linux-direct-devkern-extras
   - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/x64-openhcl-igvm-test-linux-direct-extras
     displayName: 🌼📦 Publish x64-openhcl-igvm-test-linux-direct-extras
     artifact: x64-openhcl-igvm-test-linux-direct-extras
@@ -1809,18 +1731,14 @@ jobs:
       EOF
       mkdir -p "$(AgentTempDirNormal)/publish_artifacts/aarch64-openhcl-igvm"
       echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-openhcl-igvm" | $FLOWEY_BIN v 10 'artifact_publish_from_aarch64-openhcl-igvm' --is-raw-string update
-      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/aarch64-openhcl-igvm-devkern"
-      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-openhcl-igvm-devkern" | $FLOWEY_BIN v 10 'artifact_publish_from_aarch64-openhcl-igvm-devkern' --is-raw-string update
-      mkdir -p "$(AgentTempDirNormal)/publish_artifacts/aarch64-openhcl-igvm-devkern-extras"
-      echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-openhcl-igvm-devkern-extras" | $FLOWEY_BIN v 10 'artifact_publish_from_aarch64-openhcl-igvm-devkern-extras' --is-raw-string update
       mkdir -p "$(AgentTempDirNormal)/publish_artifacts/aarch64-openhcl-igvm-extras"
       echo "$(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-openhcl-igvm-extras" | $FLOWEY_BIN v 10 'artifact_publish_from_aarch64-openhcl-igvm-extras' --is-raw-string update
     displayName: 🌼🛫 Initialize job
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 10 flowey_lib_common::git_checkout 0
-      $FLOWEY_BIN v 10 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env ado floweyvar3
-      $FLOWEY_BIN v 10 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env ado FLOWEY_CONDITION
+      $FLOWEY_BIN v 10 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:319:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46 write-to-env ado floweyvar3
+      $FLOWEY_BIN v 10 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46' write-to-env ado FLOWEY_CONDITION
     displayName: check if openvmm needs to be cloned
   - checkout: self
     path: repo0
@@ -1832,7 +1750,7 @@ jobs:
     condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
   - bash: |-
       set -e
-      $FLOWEY_BIN v 10 'flowey_lib_common::git_checkout:4:flowey_lib_common/src/git_checkout.rs' --is-raw-string update --env-source Pipeline.Workspace <<'EOF'
+      $FLOWEY_BIN v 10 'flowey_lib_common::git_checkout:4:flowey_lib_common/src/git_checkout.rs:402:29' --is-raw-string update --env-source Pipeline.Workspace <<'EOF'
       $(Pipeline.Workspace)
       EOF
       $(FLOWEY_BIN) e 10 flowey_lib_common::git_checkout 3
@@ -1856,8 +1774,8 @@ jobs:
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 10 flowey_lib_common::cache 0
-      $FLOWEY_BIN v 10 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env ado floweyvar1
-      $FLOWEY_BIN v 10 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env ado floweyvar2
+      $FLOWEY_BIN v 10 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar1
+      $FLOWEY_BIN v 10 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar2
     displayName: Pre-processing cache vars
   - task: Cache@2
     inputs:
@@ -1867,7 +1785,7 @@ jobs:
     displayName: 'Restore cache: gh-release-download'
   - bash: |-
       set -e
-      $FLOWEY_BIN v 10 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
+      $FLOWEY_BIN v 10 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:300:70' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
       $(FLOWEY_CACHE_HITVAR)
       EOF
       $(FLOWEY_BIN) e 10 flowey_lib_common::cache 2
@@ -1923,7 +1841,7 @@ jobs:
     displayName: cargo build openhcl_boot
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::run_split_debug_info 2
+      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::run_split_debug_info 1
       $(FLOWEY_BIN) e 10 flowey_lib_hvlite::run_cargo_build 5
       $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_openhcl_boot 0
       $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 5
@@ -1941,7 +1859,7 @@ jobs:
     displayName: cargo build igvmfilegen
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::run_split_debug_info 3
+      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::run_split_debug_info 2
       $(FLOWEY_BIN) e 10 flowey_lib_hvlite::run_cargo_build 1
       $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_igvmfilegen 0
       $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 7
@@ -1956,47 +1874,11 @@ jobs:
       $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 10
       $(FLOWEY_BIN) e 10 flowey_core::pipeline::artifact::publish 1
     displayName: building igvm file
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::resolve_openhcl_kernel_package 1
-      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 15
-      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 12
-    displayName: extract and resolve kernel package
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::run_split_debug_info 1
-      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 13
-      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 14
-      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 16
-    displayName: split debug symbols
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_openhcl_initrd 1
-      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 17
-      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 18
-      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 19
-      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 20
-    displayName: building openhcl initrd
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::run_igvmfilegen 1
-      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 23
-      $(FLOWEY_BIN) e 10 flowey_core::pipeline::artifact::publish 2
-      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 21
-      $(FLOWEY_BIN) e 10 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 22
-      $(FLOWEY_BIN) e 10 flowey_core::pipeline::artifact::publish 3
-    displayName: building igvm file
   - bash: $(FLOWEY_BIN) e 10 flowey_lib_common::cache 3
     displayName: 'validate cache entry: gh-release-download'
   - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-openhcl-igvm
     displayName: 🌼📦 Publish aarch64-openhcl-igvm
     artifact: aarch64-openhcl-igvm
-  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-openhcl-igvm-devkern
-    displayName: 🌼📦 Publish aarch64-openhcl-igvm-devkern
-    artifact: aarch64-openhcl-igvm-devkern
-  - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-openhcl-igvm-devkern-extras
-    displayName: 🌼📦 Publish aarch64-openhcl-igvm-devkern-extras
-    artifact: aarch64-openhcl-igvm-devkern-extras
   - publish: $(FLOWEY_TEMP_DIR)/publish_artifacts/aarch64-openhcl-igvm-extras
     displayName: 🌼📦 Publish aarch64-openhcl-igvm-extras
     artifact: aarch64-openhcl-igvm-extras
@@ -2075,8 +1957,8 @@ jobs:
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 9 flowey_lib_common::git_checkout 0
-      $FLOWEY_BIN v 9 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env ado floweyvar1
-      $FLOWEY_BIN v 9 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env ado FLOWEY_CONDITION
+      $FLOWEY_BIN v 9 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:319:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46 write-to-env ado floweyvar1
+      $FLOWEY_BIN v 9 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46' write-to-env ado FLOWEY_CONDITION
     displayName: check if openvmm needs to be cloned
   - checkout: self
     path: repo0
@@ -2088,7 +1970,7 @@ jobs:
     condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
   - bash: |-
       set -e
-      $FLOWEY_BIN v 9 'flowey_lib_common::git_checkout:4:flowey_lib_common/src/git_checkout.rs' --is-raw-string update --env-source Pipeline.Workspace <<'EOF'
+      $FLOWEY_BIN v 9 'flowey_lib_common::git_checkout:4:flowey_lib_common/src/git_checkout.rs:402:29' --is-raw-string update --env-source Pipeline.Workspace <<'EOF'
       $(Pipeline.Workspace)
       EOF
       $(FLOWEY_BIN) e 9 flowey_lib_common::git_checkout 3
@@ -2105,8 +1987,8 @@ jobs:
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 9 flowey_lib_common::cache 4
-      $FLOWEY_BIN v 9 'flowey_lib_common::cache:8:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env ado floweyvar4
-      $FLOWEY_BIN v 9 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env ado floweyvar5
+      $FLOWEY_BIN v 9 'flowey_lib_common::cache:8:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar4
+      $FLOWEY_BIN v 9 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar5
     displayName: Pre-processing cache vars
   - task: Cache@2
     inputs:
@@ -2116,7 +1998,7 @@ jobs:
     displayName: 'Restore cache: gh-release-download'
   - bash: |-
       set -e
-      $FLOWEY_BIN v 9 'flowey_lib_common::cache:11:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
+      $FLOWEY_BIN v 9 'flowey_lib_common::cache:11:flowey_lib_common/src/cache.rs:300:70' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
       $(FLOWEY_CACHE_HITVAR)
       EOF
       $(FLOWEY_BIN) e 9 flowey_lib_common::cache 6
@@ -2278,8 +2160,8 @@ jobs:
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 9 flowey_lib_common::cache 0
-      $FLOWEY_BIN v 9 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env ado floweyvar2
-      $FLOWEY_BIN v 9 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env ado floweyvar3
+      $FLOWEY_BIN v 9 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar2
+      $FLOWEY_BIN v 9 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar3
     displayName: Pre-processing cache vars
   - task: Cache@2
     inputs:
@@ -2289,7 +2171,7 @@ jobs:
     displayName: 'Restore cache: cargo-nextest'
   - bash: |-
       set -e
-      $FLOWEY_BIN v 9 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
+      $FLOWEY_BIN v 9 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:300:70' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
       $(FLOWEY_CACHE_HITVAR)
       EOF
       $(FLOWEY_BIN) e 9 flowey_lib_common::cache 2
@@ -2429,8 +2311,8 @@ jobs:
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 8 flowey_lib_common::git_checkout 0
-      $FLOWEY_BIN v 8 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env ado floweyvar1
-      $FLOWEY_BIN v 8 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env ado FLOWEY_CONDITION
+      $FLOWEY_BIN v 8 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:319:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46 write-to-env ado floweyvar1
+      $FLOWEY_BIN v 8 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46' write-to-env ado FLOWEY_CONDITION
     displayName: check if openvmm needs to be cloned
   - checkout: self
     path: repo0
@@ -2442,7 +2324,7 @@ jobs:
     condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
   - bash: |-
       set -e
-      $FLOWEY_BIN v 8 'flowey_lib_common::git_checkout:4:flowey_lib_common/src/git_checkout.rs' --is-raw-string update --env-source Pipeline.Workspace <<'EOF'
+      $FLOWEY_BIN v 8 'flowey_lib_common::git_checkout:4:flowey_lib_common/src/git_checkout.rs:402:29' --is-raw-string update --env-source Pipeline.Workspace <<'EOF'
       $(Pipeline.Workspace)
       EOF
       $(FLOWEY_BIN) e 8 flowey_lib_common::git_checkout 3
@@ -2459,8 +2341,8 @@ jobs:
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 8 flowey_lib_common::cache 4
-      $FLOWEY_BIN v 8 'flowey_lib_common::cache:8:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env ado floweyvar4
-      $FLOWEY_BIN v 8 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env ado floweyvar5
+      $FLOWEY_BIN v 8 'flowey_lib_common::cache:8:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar4
+      $FLOWEY_BIN v 8 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar5
     displayName: Pre-processing cache vars
   - task: Cache@2
     inputs:
@@ -2470,7 +2352,7 @@ jobs:
     displayName: 'Restore cache: gh-release-download'
   - bash: |-
       set -e
-      $FLOWEY_BIN v 8 'flowey_lib_common::cache:11:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
+      $FLOWEY_BIN v 8 'flowey_lib_common::cache:11:flowey_lib_common/src/cache.rs:300:70' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
       $(FLOWEY_CACHE_HITVAR)
       EOF
       $(FLOWEY_BIN) e 8 flowey_lib_common::cache 6
@@ -2628,8 +2510,8 @@ jobs:
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 8 flowey_lib_common::cache 0
-      $FLOWEY_BIN v 8 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env ado floweyvar2
-      $FLOWEY_BIN v 8 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env ado floweyvar3
+      $FLOWEY_BIN v 8 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar2
+      $FLOWEY_BIN v 8 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar3
     displayName: Pre-processing cache vars
   - task: Cache@2
     inputs:
@@ -2639,7 +2521,7 @@ jobs:
     displayName: 'Restore cache: cargo-nextest'
   - bash: |-
       set -e
-      $FLOWEY_BIN v 8 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
+      $FLOWEY_BIN v 8 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:300:70' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
       $(FLOWEY_CACHE_HITVAR)
       EOF
       $(FLOWEY_BIN) e 8 flowey_lib_common::cache 2
@@ -2804,8 +2686,8 @@ jobs:
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 7 flowey_lib_common::git_checkout 0
-      $FLOWEY_BIN v 7 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env ado floweyvar1
-      $FLOWEY_BIN v 7 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env ado FLOWEY_CONDITION
+      $FLOWEY_BIN v 7 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:319:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46 write-to-env ado floweyvar1
+      $FLOWEY_BIN v 7 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46' write-to-env ado FLOWEY_CONDITION
     displayName: check if openvmm needs to be cloned
   - checkout: self
     path: repo0
@@ -2817,7 +2699,7 @@ jobs:
     condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
   - bash: |-
       set -e
-      $FLOWEY_BIN v 7 'flowey_lib_common::git_checkout:4:flowey_lib_common/src/git_checkout.rs' --is-raw-string update --env-source Pipeline.Workspace <<'EOF'
+      $FLOWEY_BIN v 7 'flowey_lib_common::git_checkout:4:flowey_lib_common/src/git_checkout.rs:402:29' --is-raw-string update --env-source Pipeline.Workspace <<'EOF'
       $(Pipeline.Workspace)
       EOF
       $(FLOWEY_BIN) e 7 flowey_lib_common::git_checkout 3
@@ -2834,8 +2716,8 @@ jobs:
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 7 flowey_lib_common::cache 4
-      $FLOWEY_BIN v 7 'flowey_lib_common::cache:8:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env ado floweyvar4
-      $FLOWEY_BIN v 7 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env ado floweyvar5
+      $FLOWEY_BIN v 7 'flowey_lib_common::cache:8:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar4
+      $FLOWEY_BIN v 7 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar5
     displayName: Pre-processing cache vars
   - task: Cache@2
     inputs:
@@ -2845,7 +2727,7 @@ jobs:
     displayName: 'Restore cache: gh-release-download'
   - bash: |-
       set -e
-      $FLOWEY_BIN v 7 'flowey_lib_common::cache:11:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
+      $FLOWEY_BIN v 7 'flowey_lib_common::cache:11:flowey_lib_common/src/cache.rs:300:70' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
       $(FLOWEY_CACHE_HITVAR)
       EOF
       $(FLOWEY_BIN) e 7 flowey_lib_common::cache 6
@@ -2931,8 +2813,8 @@ jobs:
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 7 flowey_lib_common::cache 0
-      $FLOWEY_BIN v 7 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env ado floweyvar2
-      $FLOWEY_BIN v 7 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env ado floweyvar3
+      $FLOWEY_BIN v 7 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar2
+      $FLOWEY_BIN v 7 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar3
     displayName: Pre-processing cache vars
   - task: Cache@2
     inputs:
@@ -2942,7 +2824,7 @@ jobs:
     displayName: 'Restore cache: cargo-nextest'
   - bash: |-
       set -e
-      $FLOWEY_BIN v 7 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
+      $FLOWEY_BIN v 7 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:300:70' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
       $(FLOWEY_CACHE_HITVAR)
       EOF
       $(FLOWEY_BIN) e 7 flowey_lib_common::cache 2
@@ -3095,8 +2977,8 @@ jobs:
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 6 flowey_lib_common::git_checkout 0
-      $FLOWEY_BIN v 6 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env ado floweyvar1
-      $FLOWEY_BIN v 6 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env ado FLOWEY_CONDITION
+      $FLOWEY_BIN v 6 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:319:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46 write-to-env ado floweyvar1
+      $FLOWEY_BIN v 6 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46' write-to-env ado FLOWEY_CONDITION
     displayName: check if openvmm needs to be cloned
   - checkout: self
     path: repo0
@@ -3108,7 +2990,7 @@ jobs:
     condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
   - bash: |-
       set -e
-      $FLOWEY_BIN v 6 'flowey_lib_common::git_checkout:4:flowey_lib_common/src/git_checkout.rs' --is-raw-string update --env-source Pipeline.Workspace <<'EOF'
+      $FLOWEY_BIN v 6 'flowey_lib_common::git_checkout:4:flowey_lib_common/src/git_checkout.rs:402:29' --is-raw-string update --env-source Pipeline.Workspace <<'EOF'
       $(Pipeline.Workspace)
       EOF
       $(FLOWEY_BIN) e 6 flowey_lib_common::git_checkout 3
@@ -3125,8 +3007,8 @@ jobs:
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 6 flowey_lib_common::cache 0
-      $FLOWEY_BIN v 6 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env ado floweyvar2
-      $FLOWEY_BIN v 6 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env ado floweyvar3
+      $FLOWEY_BIN v 6 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar2
+      $FLOWEY_BIN v 6 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar3
     displayName: Pre-processing cache vars
   - task: Cache@2
     inputs:
@@ -3136,7 +3018,7 @@ jobs:
     displayName: 'Restore cache: gh-release-download'
   - bash: |-
       set -e
-      $FLOWEY_BIN v 6 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
+      $FLOWEY_BIN v 6 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:300:70' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
       $(FLOWEY_CACHE_HITVAR)
       EOF
       $(FLOWEY_BIN) e 6 flowey_lib_common::cache 2
@@ -3311,8 +3193,8 @@ jobs:
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 5 flowey_lib_common::git_checkout 0
-      $FLOWEY_BIN v 5 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env ado floweyvar1
-      $FLOWEY_BIN v 5 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env ado FLOWEY_CONDITION
+      $FLOWEY_BIN v 5 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:319:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46 write-to-env ado floweyvar1
+      $FLOWEY_BIN v 5 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46' write-to-env ado FLOWEY_CONDITION
     displayName: check if openvmm needs to be cloned
   - checkout: self
     path: repo0
@@ -3324,7 +3206,7 @@ jobs:
     condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
   - bash: |-
       set -e
-      $FLOWEY_BIN v 5 'flowey_lib_common::git_checkout:4:flowey_lib_common/src/git_checkout.rs' --is-raw-string update --env-source Pipeline.Workspace <<'EOF'
+      $FLOWEY_BIN v 5 'flowey_lib_common::git_checkout:4:flowey_lib_common/src/git_checkout.rs:402:29' --is-raw-string update --env-source Pipeline.Workspace <<'EOF'
       $(Pipeline.Workspace)
       EOF
       $(FLOWEY_BIN) e 5 flowey_lib_common::git_checkout 3
@@ -3341,8 +3223,8 @@ jobs:
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 5 flowey_lib_common::cache 4
-      $FLOWEY_BIN v 5 'flowey_lib_common::cache:8:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env ado floweyvar4
-      $FLOWEY_BIN v 5 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env ado floweyvar5
+      $FLOWEY_BIN v 5 'flowey_lib_common::cache:8:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar4
+      $FLOWEY_BIN v 5 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar5
     displayName: Pre-processing cache vars
   - task: Cache@2
     inputs:
@@ -3352,7 +3234,7 @@ jobs:
     displayName: 'Restore cache: gh-release-download'
   - bash: |-
       set -e
-      $FLOWEY_BIN v 5 'flowey_lib_common::cache:11:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
+      $FLOWEY_BIN v 5 'flowey_lib_common::cache:11:flowey_lib_common/src/cache.rs:300:70' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
       $(FLOWEY_CACHE_HITVAR)
       EOF
       $(FLOWEY_BIN) e 5 flowey_lib_common::cache 6
@@ -3438,8 +3320,8 @@ jobs:
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 5 flowey_lib_common::cache 0
-      $FLOWEY_BIN v 5 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env ado floweyvar2
-      $FLOWEY_BIN v 5 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env ado floweyvar3
+      $FLOWEY_BIN v 5 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar2
+      $FLOWEY_BIN v 5 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar3
     displayName: Pre-processing cache vars
   - task: Cache@2
     inputs:
@@ -3449,7 +3331,7 @@ jobs:
     displayName: 'Restore cache: cargo-nextest'
   - bash: |-
       set -e
-      $FLOWEY_BIN v 5 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
+      $FLOWEY_BIN v 5 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:300:70' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
       $(FLOWEY_CACHE_HITVAR)
       EOF
       $(FLOWEY_BIN) e 5 flowey_lib_common::cache 2
@@ -3597,8 +3479,8 @@ jobs:
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 4 flowey_lib_common::git_checkout 0
-      $FLOWEY_BIN v 4 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env ado floweyvar1
-      $FLOWEY_BIN v 4 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env ado FLOWEY_CONDITION
+      $FLOWEY_BIN v 4 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:319:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46 write-to-env ado floweyvar1
+      $FLOWEY_BIN v 4 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46' write-to-env ado FLOWEY_CONDITION
     displayName: check if openvmm needs to be cloned
   - checkout: self
     path: repo0
@@ -3610,7 +3492,7 @@ jobs:
     condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
   - bash: |-
       set -e
-      $FLOWEY_BIN v 4 'flowey_lib_common::git_checkout:4:flowey_lib_common/src/git_checkout.rs' --is-raw-string update --env-source Pipeline.Workspace <<'EOF'
+      $FLOWEY_BIN v 4 'flowey_lib_common::git_checkout:4:flowey_lib_common/src/git_checkout.rs:402:29' --is-raw-string update --env-source Pipeline.Workspace <<'EOF'
       $(Pipeline.Workspace)
       EOF
       $(FLOWEY_BIN) e 4 flowey_lib_common::git_checkout 3
@@ -3627,8 +3509,8 @@ jobs:
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 4 flowey_lib_common::cache 0
-      $FLOWEY_BIN v 4 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env ado floweyvar2
-      $FLOWEY_BIN v 4 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env ado floweyvar3
+      $FLOWEY_BIN v 4 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar2
+      $FLOWEY_BIN v 4 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar3
     displayName: Pre-processing cache vars
   - task: Cache@2
     inputs:
@@ -3638,7 +3520,7 @@ jobs:
     displayName: 'Restore cache: gh-release-download'
   - bash: |-
       set -e
-      $FLOWEY_BIN v 4 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
+      $FLOWEY_BIN v 4 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:300:70' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
       $(FLOWEY_CACHE_HITVAR)
       EOF
       $(FLOWEY_BIN) e 4 flowey_lib_common::cache 2
@@ -3770,8 +3652,8 @@ jobs:
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 3 flowey_lib_common::git_checkout 0
-      $FLOWEY_BIN v 3 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env ado floweyvar1
-      $FLOWEY_BIN v 3 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env ado FLOWEY_CONDITION
+      $FLOWEY_BIN v 3 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:319:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46 write-to-env ado floweyvar1
+      $FLOWEY_BIN v 3 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46' write-to-env ado FLOWEY_CONDITION
     displayName: check if openvmm needs to be cloned
   - checkout: self
     path: repo0
@@ -3783,7 +3665,7 @@ jobs:
     condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
   - bash: |-
       set -e
-      $FLOWEY_BIN v 3 'flowey_lib_common::git_checkout:4:flowey_lib_common/src/git_checkout.rs' --is-raw-string update --env-source Pipeline.Workspace <<'EOF'
+      $FLOWEY_BIN v 3 'flowey_lib_common::git_checkout:4:flowey_lib_common/src/git_checkout.rs:402:29' --is-raw-string update --env-source Pipeline.Workspace <<'EOF'
       $(Pipeline.Workspace)
       EOF
       $(FLOWEY_BIN) e 3 flowey_lib_common::git_checkout 3
@@ -3800,8 +3682,8 @@ jobs:
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 3 flowey_lib_common::cache 0
-      $FLOWEY_BIN v 3 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env ado floweyvar2
-      $FLOWEY_BIN v 3 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env ado floweyvar3
+      $FLOWEY_BIN v 3 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar2
+      $FLOWEY_BIN v 3 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar3
     displayName: Pre-processing cache vars
   - task: Cache@2
     inputs:
@@ -3811,7 +3693,7 @@ jobs:
     displayName: 'Restore cache: gh-release-download'
   - bash: |-
       set -e
-      $FLOWEY_BIN v 3 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
+      $FLOWEY_BIN v 3 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:300:70' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
       $(FLOWEY_CACHE_HITVAR)
       EOF
       $(FLOWEY_BIN) e 3 flowey_lib_common::cache 2
@@ -4110,8 +3992,8 @@ jobs:
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 20 flowey_lib_common::cache 0
-      $FLOWEY_BIN v 20 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env ado floweyvar3
-      $FLOWEY_BIN v 20 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env ado floweyvar4
+      $FLOWEY_BIN v 20 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar3
+      $FLOWEY_BIN v 20 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar4
     displayName: Pre-processing cache vars
   - task: Cache@2
     inputs:
@@ -4121,7 +4003,7 @@ jobs:
     displayName: 'Restore cache: cargo-nextest'
   - bash: |-
       set -e
-      $FLOWEY_BIN v 20 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
+      $FLOWEY_BIN v 20 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:300:70' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
       $(FLOWEY_CACHE_HITVAR)
       EOF
       $(FLOWEY_BIN) e 20 flowey_lib_common::cache 2
@@ -4131,8 +4013,8 @@ jobs:
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 20 flowey_lib_common::git_checkout 0
-      $FLOWEY_BIN v 20 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env ado floweyvar2
-      $FLOWEY_BIN v 20 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env ado FLOWEY_CONDITION
+      $FLOWEY_BIN v 20 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:319:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46 write-to-env ado floweyvar2
+      $FLOWEY_BIN v 20 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46' write-to-env ado FLOWEY_CONDITION
     displayName: check if openvmm needs to be cloned
   - checkout: self
     path: repo0
@@ -4144,7 +4026,7 @@ jobs:
     condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
   - bash: |-
       set -e
-      $FLOWEY_BIN v 20 'flowey_lib_common::git_checkout:4:flowey_lib_common/src/git_checkout.rs' --is-raw-string update --env-source Pipeline.Workspace <<'EOF'
+      $FLOWEY_BIN v 20 'flowey_lib_common::git_checkout:4:flowey_lib_common/src/git_checkout.rs:402:29' --is-raw-string update --env-source Pipeline.Workspace <<'EOF'
       $(Pipeline.Workspace)
       EOF
       $(FLOWEY_BIN) e 20 flowey_lib_common::git_checkout 3
@@ -4177,8 +4059,8 @@ jobs:
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 20 flowey_lib_common::cache 4
-      $FLOWEY_BIN v 20 'flowey_lib_common::cache:8:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env ado floweyvar5
-      $FLOWEY_BIN v 20 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env ado floweyvar6
+      $FLOWEY_BIN v 20 'flowey_lib_common::cache:8:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar5
+      $FLOWEY_BIN v 20 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar6
     displayName: Pre-processing cache vars
   - task: Cache@2
     inputs:
@@ -4188,7 +4070,7 @@ jobs:
     displayName: 'Restore cache: gh-release-download'
   - bash: |-
       set -e
-      $FLOWEY_BIN v 20 'flowey_lib_common::cache:11:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
+      $FLOWEY_BIN v 20 'flowey_lib_common::cache:11:flowey_lib_common/src/cache.rs:300:70' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
       $(FLOWEY_CACHE_HITVAR)
       EOF
       $(FLOWEY_BIN) e 20 flowey_lib_common::cache 6
@@ -4240,8 +4122,8 @@ jobs:
       $(FLOWEY_BIN) e 20 flowey_lib_common::publish_test_results 1
       $(FLOWEY_BIN) e 20 flowey_lib_common::ado_task_publish_test_results 0
       $(FLOWEY_BIN) e 20 flowey_lib_common::publish_test_results 0
-      $FLOWEY_BIN v 20 'flowey_lib_common::ado_task_publish_test_results:0:flowey_lib_common/src/ado_task_publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs write-to-env ado floweyvar1
-      $FLOWEY_BIN v 20 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs' write-to-env ado FLOWEY_CONDITION
+      $FLOWEY_BIN v 20 'flowey_lib_common::ado_task_publish_test_results:0:flowey_lib_common/src/ado_task_publish_test_results.rs:57:45' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:79:51 write-to-env ado floweyvar1
+      $FLOWEY_BIN v 20 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:79:51' write-to-env ado FLOWEY_CONDITION
     displayName: run 'vmm_tests' nextest tests
   - task: PublishTestResults@2
     inputs:
@@ -4357,8 +4239,8 @@ jobs:
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 2 flowey_lib_common::git_checkout 0
-      $FLOWEY_BIN v 2 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env ado floweyvar1
-      $FLOWEY_BIN v 2 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env ado FLOWEY_CONDITION
+      $FLOWEY_BIN v 2 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:319:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46 write-to-env ado floweyvar1
+      $FLOWEY_BIN v 2 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46' write-to-env ado FLOWEY_CONDITION
     displayName: check if openvmm needs to be cloned
   - checkout: self
     path: repo0
@@ -4370,7 +4252,7 @@ jobs:
     condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
   - bash: |-
       set -e
-      $FLOWEY_BIN v 2 'flowey_lib_common::git_checkout:4:flowey_lib_common/src/git_checkout.rs' --is-raw-string update --env-source Pipeline.Workspace <<'EOF'
+      $FLOWEY_BIN v 2 'flowey_lib_common::git_checkout:4:flowey_lib_common/src/git_checkout.rs:402:29' --is-raw-string update --env-source Pipeline.Workspace <<'EOF'
       $(Pipeline.Workspace)
       EOF
       $(FLOWEY_BIN) e 2 flowey_lib_common::git_checkout 3
@@ -4387,8 +4269,8 @@ jobs:
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 2 flowey_lib_common::cache 0
-      $FLOWEY_BIN v 2 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env ado floweyvar2
-      $FLOWEY_BIN v 2 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env ado floweyvar3
+      $FLOWEY_BIN v 2 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar2
+      $FLOWEY_BIN v 2 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar3
     displayName: Pre-processing cache vars
   - task: Cache@2
     inputs:
@@ -4398,7 +4280,7 @@ jobs:
     displayName: 'Restore cache: gh-release-download'
   - bash: |-
       set -e
-      $FLOWEY_BIN v 2 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
+      $FLOWEY_BIN v 2 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:300:70' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
       $(FLOWEY_CACHE_HITVAR)
       EOF
       $(FLOWEY_BIN) e 2 flowey_lib_common::cache 2
@@ -4546,8 +4428,8 @@ jobs:
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 19 flowey_lib_common::cache 0
-      $FLOWEY_BIN v 19 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env ado floweyvar3
-      $FLOWEY_BIN v 19 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env ado floweyvar4
+      $FLOWEY_BIN v 19 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar3
+      $FLOWEY_BIN v 19 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar4
     displayName: Pre-processing cache vars
   - task: Cache@2
     inputs:
@@ -4557,7 +4439,7 @@ jobs:
     displayName: 'Restore cache: cargo-nextest'
   - bash: |-
       set -e
-      $FLOWEY_BIN v 19 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
+      $FLOWEY_BIN v 19 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:300:70' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
       $(FLOWEY_CACHE_HITVAR)
       EOF
       $(FLOWEY_BIN) e 19 flowey_lib_common::cache 2
@@ -4567,8 +4449,8 @@ jobs:
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 19 flowey_lib_common::git_checkout 0
-      $FLOWEY_BIN v 19 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env ado floweyvar2
-      $FLOWEY_BIN v 19 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env ado FLOWEY_CONDITION
+      $FLOWEY_BIN v 19 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:319:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46 write-to-env ado floweyvar2
+      $FLOWEY_BIN v 19 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46' write-to-env ado FLOWEY_CONDITION
     displayName: check if openvmm needs to be cloned
   - checkout: self
     path: repo0
@@ -4580,7 +4462,7 @@ jobs:
     condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
   - bash: |-
       set -e
-      $FLOWEY_BIN v 19 'flowey_lib_common::git_checkout:4:flowey_lib_common/src/git_checkout.rs' --is-raw-string update --env-source Pipeline.Workspace <<'EOF'
+      $FLOWEY_BIN v 19 'flowey_lib_common::git_checkout:4:flowey_lib_common/src/git_checkout.rs:402:29' --is-raw-string update --env-source Pipeline.Workspace <<'EOF'
       $(Pipeline.Workspace)
       EOF
       $(FLOWEY_BIN) e 19 flowey_lib_common::git_checkout 3
@@ -4609,8 +4491,8 @@ jobs:
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 19 flowey_lib_common::cache 4
-      $FLOWEY_BIN v 19 'flowey_lib_common::cache:8:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env ado floweyvar5
-      $FLOWEY_BIN v 19 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env ado floweyvar6
+      $FLOWEY_BIN v 19 'flowey_lib_common::cache:8:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar5
+      $FLOWEY_BIN v 19 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar6
     displayName: Pre-processing cache vars
   - task: Cache@2
     inputs:
@@ -4620,7 +4502,7 @@ jobs:
     displayName: 'Restore cache: gh-release-download'
   - bash: |-
       set -e
-      $FLOWEY_BIN v 19 'flowey_lib_common::cache:11:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
+      $FLOWEY_BIN v 19 'flowey_lib_common::cache:11:flowey_lib_common/src/cache.rs:300:70' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
       $(FLOWEY_CACHE_HITVAR)
       EOF
       $(FLOWEY_BIN) e 19 flowey_lib_common::cache 6
@@ -4669,8 +4551,8 @@ jobs:
       $(FLOWEY_BIN) e 19 flowey_lib_common::publish_test_results 1
       $(FLOWEY_BIN) e 19 flowey_lib_common::ado_task_publish_test_results 0
       $(FLOWEY_BIN) e 19 flowey_lib_common::publish_test_results 0
-      $FLOWEY_BIN v 19 'flowey_lib_common::ado_task_publish_test_results:0:flowey_lib_common/src/ado_task_publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs write-to-env ado floweyvar1
-      $FLOWEY_BIN v 19 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs' write-to-env ado FLOWEY_CONDITION
+      $FLOWEY_BIN v 19 'flowey_lib_common::ado_task_publish_test_results:0:flowey_lib_common/src/ado_task_publish_test_results.rs:57:45' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:79:51 write-to-env ado floweyvar1
+      $FLOWEY_BIN v 19 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:79:51' write-to-env ado FLOWEY_CONDITION
     displayName: run 'vmm_tests' nextest tests
   - task: PublishTestResults@2
     inputs:
@@ -4843,8 +4725,8 @@ jobs:
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 18 flowey_lib_common::cache 0
-      $FLOWEY_BIN v 18 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env ado floweyvar3
-      $FLOWEY_BIN v 18 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env ado floweyvar4
+      $FLOWEY_BIN v 18 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar3
+      $FLOWEY_BIN v 18 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar4
     displayName: Pre-processing cache vars
   - task: Cache@2
     inputs:
@@ -4854,7 +4736,7 @@ jobs:
     displayName: 'Restore cache: cargo-nextest'
   - bash: |-
       set -e
-      $FLOWEY_BIN v 18 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
+      $FLOWEY_BIN v 18 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:300:70' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
       $(FLOWEY_CACHE_HITVAR)
       EOF
       $(FLOWEY_BIN) e 18 flowey_lib_common::cache 2
@@ -4864,8 +4746,8 @@ jobs:
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 18 flowey_lib_common::git_checkout 0
-      $FLOWEY_BIN v 18 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env ado floweyvar2
-      $FLOWEY_BIN v 18 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env ado FLOWEY_CONDITION
+      $FLOWEY_BIN v 18 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:319:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46 write-to-env ado floweyvar2
+      $FLOWEY_BIN v 18 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46' write-to-env ado FLOWEY_CONDITION
     displayName: check if openvmm needs to be cloned
   - checkout: self
     path: repo0
@@ -4877,7 +4759,7 @@ jobs:
     condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
   - bash: |-
       set -e
-      $FLOWEY_BIN v 18 'flowey_lib_common::git_checkout:4:flowey_lib_common/src/git_checkout.rs' --is-raw-string update --env-source Pipeline.Workspace <<'EOF'
+      $FLOWEY_BIN v 18 'flowey_lib_common::git_checkout:4:flowey_lib_common/src/git_checkout.rs:402:29' --is-raw-string update --env-source Pipeline.Workspace <<'EOF'
       $(Pipeline.Workspace)
       EOF
       $(FLOWEY_BIN) e 18 flowey_lib_common::git_checkout 3
@@ -4910,8 +4792,8 @@ jobs:
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 18 flowey_lib_common::cache 4
-      $FLOWEY_BIN v 18 'flowey_lib_common::cache:8:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env ado floweyvar5
-      $FLOWEY_BIN v 18 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env ado floweyvar6
+      $FLOWEY_BIN v 18 'flowey_lib_common::cache:8:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar5
+      $FLOWEY_BIN v 18 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar6
     displayName: Pre-processing cache vars
   - task: Cache@2
     inputs:
@@ -4921,7 +4803,7 @@ jobs:
     displayName: 'Restore cache: gh-release-download'
   - bash: |-
       set -e
-      $FLOWEY_BIN v 18 'flowey_lib_common::cache:11:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
+      $FLOWEY_BIN v 18 'flowey_lib_common::cache:11:flowey_lib_common/src/cache.rs:300:70' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
       $(FLOWEY_CACHE_HITVAR)
       EOF
       $(FLOWEY_BIN) e 18 flowey_lib_common::cache 6
@@ -4976,8 +4858,8 @@ jobs:
       $(FLOWEY_BIN) e 18 flowey_lib_common::publish_test_results 1
       $(FLOWEY_BIN) e 18 flowey_lib_common::ado_task_publish_test_results 0
       $(FLOWEY_BIN) e 18 flowey_lib_common::publish_test_results 0
-      $FLOWEY_BIN v 18 'flowey_lib_common::ado_task_publish_test_results:0:flowey_lib_common/src/ado_task_publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs write-to-env ado floweyvar1
-      $FLOWEY_BIN v 18 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs' write-to-env ado FLOWEY_CONDITION
+      $FLOWEY_BIN v 18 'flowey_lib_common::ado_task_publish_test_results:0:flowey_lib_common/src/ado_task_publish_test_results.rs:57:45' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:79:51 write-to-env ado floweyvar1
+      $FLOWEY_BIN v 18 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:79:51' write-to-env ado FLOWEY_CONDITION
     displayName: stopping test_igvm_agent_rpc_server
   - task: PublishTestResults@2
     inputs:
@@ -5150,8 +5032,8 @@ jobs:
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 17 flowey_lib_common::cache 0
-      $FLOWEY_BIN v 17 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env ado floweyvar3
-      $FLOWEY_BIN v 17 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env ado floweyvar4
+      $FLOWEY_BIN v 17 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar3
+      $FLOWEY_BIN v 17 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar4
     displayName: Pre-processing cache vars
   - task: Cache@2
     inputs:
@@ -5161,7 +5043,7 @@ jobs:
     displayName: 'Restore cache: cargo-nextest'
   - bash: |-
       set -e
-      $FLOWEY_BIN v 17 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
+      $FLOWEY_BIN v 17 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:300:70' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
       $(FLOWEY_CACHE_HITVAR)
       EOF
       $(FLOWEY_BIN) e 17 flowey_lib_common::cache 2
@@ -5171,8 +5053,8 @@ jobs:
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 17 flowey_lib_common::git_checkout 0
-      $FLOWEY_BIN v 17 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env ado floweyvar2
-      $FLOWEY_BIN v 17 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env ado FLOWEY_CONDITION
+      $FLOWEY_BIN v 17 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:319:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46 write-to-env ado floweyvar2
+      $FLOWEY_BIN v 17 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46' write-to-env ado FLOWEY_CONDITION
     displayName: check if openvmm needs to be cloned
   - checkout: self
     path: repo0
@@ -5184,7 +5066,7 @@ jobs:
     condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
   - bash: |-
       set -e
-      $FLOWEY_BIN v 17 'flowey_lib_common::git_checkout:4:flowey_lib_common/src/git_checkout.rs' --is-raw-string update --env-source Pipeline.Workspace <<'EOF'
+      $FLOWEY_BIN v 17 'flowey_lib_common::git_checkout:4:flowey_lib_common/src/git_checkout.rs:402:29' --is-raw-string update --env-source Pipeline.Workspace <<'EOF'
       $(Pipeline.Workspace)
       EOF
       $(FLOWEY_BIN) e 17 flowey_lib_common::git_checkout 3
@@ -5194,11 +5076,6 @@ jobs:
       $(FLOWEY_BIN) e 17 flowey_lib_common::system_info 0
       $(FLOWEY_BIN) e 17 flowey_lib_hvlite::git_checkout_openvmm_repo 0
       $(FLOWEY_BIN) e 17 flowey_lib_hvlite::run_cargo_nextest_run 0
-      $(FLOWEY_BIN) e 17 flowey_core::pipeline::artifact::resolve 12
-      $(FLOWEY_BIN) e 17 flowey_core::pipeline::artifact::resolve 14
-      $(FLOWEY_BIN) e 17 flowey_core::pipeline::artifact::resolve 15
-      $(FLOWEY_BIN) e 17 flowey_core::pipeline::artifact::resolve 13
-      $(FLOWEY_BIN) e 17 flowey_core::pipeline::artifact::resolve 3
       $(FLOWEY_BIN) e 17 flowey_core::pipeline::artifact::resolve 11
       $(FLOWEY_BIN) e 17 flowey_core::pipeline::artifact::resolve 4
       $(FLOWEY_BIN) e 17 flowey_core::pipeline::artifact::resolve 5
@@ -5209,6 +5086,11 @@ jobs:
       $(FLOWEY_BIN) e 17 flowey_core::pipeline::artifact::resolve 7
       $(FLOWEY_BIN) e 17 flowey_core::pipeline::artifact::resolve 8
       $(FLOWEY_BIN) e 17 flowey_core::pipeline::artifact::resolve 9
+      $(FLOWEY_BIN) e 17 flowey_core::pipeline::artifact::resolve 12
+      $(FLOWEY_BIN) e 17 flowey_core::pipeline::artifact::resolve 14
+      $(FLOWEY_BIN) e 17 flowey_core::pipeline::artifact::resolve 15
+      $(FLOWEY_BIN) e 17 flowey_core::pipeline::artifact::resolve 13
+      $(FLOWEY_BIN) e 17 flowey_core::pipeline::artifact::resolve 3
     displayName: print system info
   - bash: $(FLOWEY_BIN) e 17 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
     displayName: creating new test content dir
@@ -5217,8 +5099,8 @@ jobs:
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 17 flowey_lib_common::cache 4
-      $FLOWEY_BIN v 17 'flowey_lib_common::cache:8:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env ado floweyvar5
-      $FLOWEY_BIN v 17 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env ado floweyvar6
+      $FLOWEY_BIN v 17 'flowey_lib_common::cache:8:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar5
+      $FLOWEY_BIN v 17 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar6
     displayName: Pre-processing cache vars
   - task: Cache@2
     inputs:
@@ -5228,7 +5110,7 @@ jobs:
     displayName: 'Restore cache: gh-release-download'
   - bash: |-
       set -e
-      $FLOWEY_BIN v 17 'flowey_lib_common::cache:11:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
+      $FLOWEY_BIN v 17 'flowey_lib_common::cache:11:flowey_lib_common/src/cache.rs:300:70' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
       $(FLOWEY_CACHE_HITVAR)
       EOF
       $(FLOWEY_BIN) e 17 flowey_lib_common::cache 6
@@ -5273,8 +5155,8 @@ jobs:
       $(FLOWEY_BIN) e 17 flowey_lib_common::publish_test_results 1
       $(FLOWEY_BIN) e 17 flowey_lib_common::ado_task_publish_test_results 0
       $(FLOWEY_BIN) e 17 flowey_lib_common::publish_test_results 0
-      $FLOWEY_BIN v 17 'flowey_lib_common::ado_task_publish_test_results:0:flowey_lib_common/src/ado_task_publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs write-to-env ado floweyvar1
-      $FLOWEY_BIN v 17 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs' write-to-env ado FLOWEY_CONDITION
+      $FLOWEY_BIN v 17 'flowey_lib_common::ado_task_publish_test_results:0:flowey_lib_common/src/ado_task_publish_test_results.rs:57:45' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:79:51 write-to-env ado floweyvar1
+      $FLOWEY_BIN v 17 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:79:51' write-to-env ado FLOWEY_CONDITION
     displayName: run 'vmm_tests' nextest tests
   - task: PublishTestResults@2
     inputs:
@@ -5450,8 +5332,8 @@ jobs:
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 16 flowey_lib_common::cache 0
-      $FLOWEY_BIN v 16 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env ado floweyvar3
-      $FLOWEY_BIN v 16 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env ado floweyvar4
+      $FLOWEY_BIN v 16 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar3
+      $FLOWEY_BIN v 16 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar4
     displayName: Pre-processing cache vars
   - task: Cache@2
     inputs:
@@ -5461,7 +5343,7 @@ jobs:
     displayName: 'Restore cache: cargo-nextest'
   - bash: |-
       set -e
-      $FLOWEY_BIN v 16 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
+      $FLOWEY_BIN v 16 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:300:70' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
       $(FLOWEY_CACHE_HITVAR)
       EOF
       $(FLOWEY_BIN) e 16 flowey_lib_common::cache 2
@@ -5471,8 +5353,8 @@ jobs:
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 16 flowey_lib_common::git_checkout 0
-      $FLOWEY_BIN v 16 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env ado floweyvar2
-      $FLOWEY_BIN v 16 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env ado FLOWEY_CONDITION
+      $FLOWEY_BIN v 16 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:319:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46 write-to-env ado floweyvar2
+      $FLOWEY_BIN v 16 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46' write-to-env ado FLOWEY_CONDITION
     displayName: check if openvmm needs to be cloned
   - checkout: self
     path: repo0
@@ -5484,7 +5366,7 @@ jobs:
     condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
   - bash: |-
       set -e
-      $FLOWEY_BIN v 16 'flowey_lib_common::git_checkout:4:flowey_lib_common/src/git_checkout.rs' --is-raw-string update --env-source Pipeline.Workspace <<'EOF'
+      $FLOWEY_BIN v 16 'flowey_lib_common::git_checkout:4:flowey_lib_common/src/git_checkout.rs:402:29' --is-raw-string update --env-source Pipeline.Workspace <<'EOF'
       $(Pipeline.Workspace)
       EOF
       $(FLOWEY_BIN) e 16 flowey_lib_common::git_checkout 3
@@ -5517,8 +5399,8 @@ jobs:
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 16 flowey_lib_common::cache 4
-      $FLOWEY_BIN v 16 'flowey_lib_common::cache:8:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env ado floweyvar5
-      $FLOWEY_BIN v 16 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env ado floweyvar6
+      $FLOWEY_BIN v 16 'flowey_lib_common::cache:8:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar5
+      $FLOWEY_BIN v 16 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar6
     displayName: Pre-processing cache vars
   - task: Cache@2
     inputs:
@@ -5528,7 +5410,7 @@ jobs:
     displayName: 'Restore cache: gh-release-download'
   - bash: |-
       set -e
-      $FLOWEY_BIN v 16 'flowey_lib_common::cache:11:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
+      $FLOWEY_BIN v 16 'flowey_lib_common::cache:11:flowey_lib_common/src/cache.rs:300:70' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
       $(FLOWEY_CACHE_HITVAR)
       EOF
       $(FLOWEY_BIN) e 16 flowey_lib_common::cache 6
@@ -5583,8 +5465,8 @@ jobs:
       $(FLOWEY_BIN) e 16 flowey_lib_common::publish_test_results 1
       $(FLOWEY_BIN) e 16 flowey_lib_common::ado_task_publish_test_results 0
       $(FLOWEY_BIN) e 16 flowey_lib_common::publish_test_results 0
-      $FLOWEY_BIN v 16 'flowey_lib_common::ado_task_publish_test_results:0:flowey_lib_common/src/ado_task_publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs write-to-env ado floweyvar1
-      $FLOWEY_BIN v 16 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs' write-to-env ado FLOWEY_CONDITION
+      $FLOWEY_BIN v 16 'flowey_lib_common::ado_task_publish_test_results:0:flowey_lib_common/src/ado_task_publish_test_results.rs:57:45' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:79:51 write-to-env ado floweyvar1
+      $FLOWEY_BIN v 16 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:79:51' write-to-env ado FLOWEY_CONDITION
     displayName: stopping test_igvm_agent_rpc_server
   - task: PublishTestResults@2
     inputs:
@@ -5689,8 +5571,8 @@ jobs:
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 1 flowey_lib_common::git_checkout 0
-      $FLOWEY_BIN v 1 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env ado floweyvar1
-      $FLOWEY_BIN v 1 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env ado FLOWEY_CONDITION
+      $FLOWEY_BIN v 1 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:319:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46 write-to-env ado floweyvar1
+      $FLOWEY_BIN v 1 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46' write-to-env ado FLOWEY_CONDITION
     displayName: check if openvmm needs to be cloned
   - checkout: self
     path: repo0
@@ -5702,7 +5584,7 @@ jobs:
     condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
   - bash: |-
       set -e
-      $FLOWEY_BIN v 1 'flowey_lib_common::git_checkout:4:flowey_lib_common/src/git_checkout.rs' --is-raw-string update --env-source Pipeline.Workspace <<'EOF'
+      $FLOWEY_BIN v 1 'flowey_lib_common::git_checkout:4:flowey_lib_common/src/git_checkout.rs:402:29' --is-raw-string update --env-source Pipeline.Workspace <<'EOF'
       $(Pipeline.Workspace)
       EOF
       $(FLOWEY_BIN) e 1 flowey_lib_common::git_checkout 3
@@ -5726,8 +5608,8 @@ jobs:
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 1 flowey_lib_common::cache 0
-      $FLOWEY_BIN v 1 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env ado floweyvar2
-      $FLOWEY_BIN v 1 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env ado floweyvar3
+      $FLOWEY_BIN v 1 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar2
+      $FLOWEY_BIN v 1 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar3
     displayName: Pre-processing cache vars
   - task: Cache@2
     inputs:
@@ -5737,7 +5619,7 @@ jobs:
     displayName: 'Restore cache: gh-release-download'
   - bash: |-
       set -e
-      $FLOWEY_BIN v 1 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
+      $FLOWEY_BIN v 1 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:300:70' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
       $(FLOWEY_CACHE_HITVAR)
       EOF
       $(FLOWEY_BIN) e 1 flowey_lib_common::cache 2

--- a/ci-flowey/openvmm-pr.yaml
+++ b/ci-flowey/openvmm-pr.yaml
@@ -105,8 +105,8 @@ jobs:
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 0 flowey_lib_common::git_checkout 0
-      $FLOWEY_BIN v 0 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:319:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46 write-to-env ado floweyvar1
-      $FLOWEY_BIN v 0 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46' write-to-env ado FLOWEY_CONDITION
+      $FLOWEY_BIN v 0 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env ado floweyvar1
+      $FLOWEY_BIN v 0 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env ado FLOWEY_CONDITION
     displayName: check if openvmm needs to be cloned
   - checkout: self
     path: repo0
@@ -118,7 +118,7 @@ jobs:
     condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
   - bash: |-
       set -e
-      $FLOWEY_BIN v 0 'flowey_lib_common::git_checkout:4:flowey_lib_common/src/git_checkout.rs:402:29' --is-raw-string update --env-source Pipeline.Workspace <<'EOF'
+      $FLOWEY_BIN v 0 'flowey_lib_common::git_checkout:4:flowey_lib_common/src/git_checkout.rs' --is-raw-string update --env-source Pipeline.Workspace <<'EOF'
       $(Pipeline.Workspace)
       EOF
       $(FLOWEY_BIN) e 0 flowey_lib_common::git_checkout 3
@@ -142,8 +142,8 @@ jobs:
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 0 flowey_lib_common::cache 0
-      $FLOWEY_BIN v 0 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar2
-      $FLOWEY_BIN v 0 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar3
+      $FLOWEY_BIN v 0 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env ado floweyvar2
+      $FLOWEY_BIN v 0 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env ado floweyvar3
     displayName: Pre-processing cache vars
   - task: Cache@2
     inputs:
@@ -153,7 +153,7 @@ jobs:
     displayName: 'Restore cache: gh-release-download'
   - bash: |-
       set -e
-      $FLOWEY_BIN v 0 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:300:70' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
+      $FLOWEY_BIN v 0 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
       $(FLOWEY_CACHE_HITVAR)
       EOF
       $(FLOWEY_BIN) e 0 flowey_lib_common::cache 2
@@ -270,8 +270,8 @@ jobs:
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 15 flowey_lib_common::git_checkout 0
-      $FLOWEY_BIN v 15 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:319:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46 write-to-env ado floweyvar11
-      $FLOWEY_BIN v 15 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46' write-to-env ado FLOWEY_CONDITION
+      $FLOWEY_BIN v 15 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env ado floweyvar11
+      $FLOWEY_BIN v 15 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env ado FLOWEY_CONDITION
     displayName: check if openvmm needs to be cloned
   - checkout: self
     path: repo0
@@ -283,7 +283,7 @@ jobs:
     condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
   - bash: |-
       set -e
-      $FLOWEY_BIN v 15 'flowey_lib_common::git_checkout:4:flowey_lib_common/src/git_checkout.rs:402:29' --is-raw-string update --env-source Pipeline.Workspace <<'EOF'
+      $FLOWEY_BIN v 15 'flowey_lib_common::git_checkout:4:flowey_lib_common/src/git_checkout.rs' --is-raw-string update --env-source Pipeline.Workspace <<'EOF'
       $(Pipeline.Workspace)
       EOF
       $(FLOWEY_BIN) e 15 flowey_lib_common::git_checkout 3
@@ -299,8 +299,8 @@ jobs:
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 15 flowey_lib_common::cache 4
-      $FLOWEY_BIN v 15 'flowey_lib_common::cache:8:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar9
-      $FLOWEY_BIN v 15 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar10
+      $FLOWEY_BIN v 15 'flowey_lib_common::cache:8:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env ado floweyvar9
+      $FLOWEY_BIN v 15 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env ado floweyvar10
     displayName: Pre-processing cache vars
   - task: Cache@2
     inputs:
@@ -310,7 +310,7 @@ jobs:
     displayName: 'Restore cache: gh-release-download'
   - bash: |-
       set -e
-      $FLOWEY_BIN v 15 'flowey_lib_common::cache:11:flowey_lib_common/src/cache.rs:300:70' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
+      $FLOWEY_BIN v 15 'flowey_lib_common::cache:11:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
       $(FLOWEY_CACHE_HITVAR)
       EOF
       $(FLOWEY_BIN) e 15 flowey_lib_common::cache 6
@@ -376,8 +376,8 @@ jobs:
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 15 flowey_lib_common::cache 0
-      $FLOWEY_BIN v 15 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar7
-      $FLOWEY_BIN v 15 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar8
+      $FLOWEY_BIN v 15 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env ado floweyvar7
+      $FLOWEY_BIN v 15 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env ado floweyvar8
     displayName: Pre-processing cache vars
   - task: Cache@2
     inputs:
@@ -387,7 +387,7 @@ jobs:
     displayName: 'Restore cache: cargo-nextest'
   - bash: |-
       set -e
-      $FLOWEY_BIN v 15 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:300:70' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
+      $FLOWEY_BIN v 15 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
       $(FLOWEY_CACHE_HITVAR)
       EOF
       $(FLOWEY_BIN) e 15 flowey_lib_common::cache 2
@@ -412,8 +412,8 @@ jobs:
       $(FLOWEY_BIN) e 15 flowey_lib_common::publish_test_results 5
       $(FLOWEY_BIN) e 15 flowey_lib_common::ado_task_publish_test_results 8
       $(FLOWEY_BIN) e 15 flowey_lib_common::publish_test_results 4
-      $FLOWEY_BIN v 15 'flowey_lib_common::ado_task_publish_test_results:8:flowey_lib_common/src/ado_task_publish_test_results.rs:57:45' --is-raw-string --condvar flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs:79:51 write-to-env ado floweyvar5
-      $FLOWEY_BIN v 15 'flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs:79:51' write-to-env ado FLOWEY_CONDITION
+      $FLOWEY_BIN v 15 'flowey_lib_common::ado_task_publish_test_results:8:flowey_lib_common/src/ado_task_publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs write-to-env ado floweyvar5
+      $FLOWEY_BIN v 15 'flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs' write-to-env ado FLOWEY_CONDITION
     displayName: run 'x64-linux-musl-unit-tests-crypto-rust' nextest tests
   - task: PublishTestResults@2
     inputs:
@@ -432,8 +432,8 @@ jobs:
       $(FLOWEY_BIN) e 15 flowey_lib_common::publish_test_results 7
       $(FLOWEY_BIN) e 15 flowey_lib_common::ado_task_publish_test_results 6
       $(FLOWEY_BIN) e 15 flowey_lib_common::publish_test_results 6
-      $FLOWEY_BIN v 15 'flowey_lib_common::ado_task_publish_test_results:6:flowey_lib_common/src/ado_task_publish_test_results.rs:57:45' --is-raw-string --condvar flowey_lib_common::publish_test_results:15:flowey_lib_common/src/publish_test_results.rs:79:51 write-to-env ado floweyvar4
-      $FLOWEY_BIN v 15 'flowey_lib_common::publish_test_results:15:flowey_lib_common/src/publish_test_results.rs:79:51' write-to-env ado FLOWEY_CONDITION
+      $FLOWEY_BIN v 15 'flowey_lib_common::ado_task_publish_test_results:6:flowey_lib_common/src/ado_task_publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:15:flowey_lib_common/src/publish_test_results.rs write-to-env ado floweyvar4
+      $FLOWEY_BIN v 15 'flowey_lib_common::publish_test_results:15:flowey_lib_common/src/publish_test_results.rs' write-to-env ado FLOWEY_CONDITION
     displayName: run 'x64-linux-musl-unit-tests-crypto-openssl' nextest tests
   - task: PublishTestResults@2
     inputs:
@@ -452,8 +452,8 @@ jobs:
       $(FLOWEY_BIN) e 15 flowey_lib_common::publish_test_results 9
       $(FLOWEY_BIN) e 15 flowey_lib_common::ado_task_publish_test_results 10
       $(FLOWEY_BIN) e 15 flowey_lib_common::publish_test_results 8
-      $FLOWEY_BIN v 15 'flowey_lib_common::ado_task_publish_test_results:10:flowey_lib_common/src/ado_task_publish_test_results.rs:57:45' --is-raw-string --condvar flowey_lib_common::publish_test_results:20:flowey_lib_common/src/publish_test_results.rs:79:51 write-to-env ado floweyvar6
-      $FLOWEY_BIN v 15 'flowey_lib_common::publish_test_results:20:flowey_lib_common/src/publish_test_results.rs:79:51' write-to-env ado FLOWEY_CONDITION
+      $FLOWEY_BIN v 15 'flowey_lib_common::ado_task_publish_test_results:10:flowey_lib_common/src/ado_task_publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:20:flowey_lib_common/src/publish_test_results.rs write-to-env ado floweyvar6
+      $FLOWEY_BIN v 15 'flowey_lib_common::publish_test_results:20:flowey_lib_common/src/publish_test_results.rs' write-to-env ado FLOWEY_CONDITION
     displayName: run 'x64-linux-musl-unit-tests-crypto-symcrypt' nextest tests
   - task: PublishTestResults@2
     inputs:
@@ -472,8 +472,8 @@ jobs:
       $(FLOWEY_BIN) e 15 flowey_lib_common::publish_test_results 11
       $(FLOWEY_BIN) e 15 flowey_lib_common::ado_task_publish_test_results 2
       $(FLOWEY_BIN) e 15 flowey_lib_common::publish_test_results 10
-      $FLOWEY_BIN v 15 'flowey_lib_common::ado_task_publish_test_results:2:flowey_lib_common/src/ado_task_publish_test_results.rs:57:45' --is-raw-string --condvar flowey_lib_common::publish_test_results:25:flowey_lib_common/src/publish_test_results.rs:79:51 write-to-env ado floweyvar2
-      $FLOWEY_BIN v 15 'flowey_lib_common::publish_test_results:25:flowey_lib_common/src/publish_test_results.rs:79:51' write-to-env ado FLOWEY_CONDITION
+      $FLOWEY_BIN v 15 'flowey_lib_common::ado_task_publish_test_results:2:flowey_lib_common/src/ado_task_publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:25:flowey_lib_common/src/publish_test_results.rs write-to-env ado floweyvar2
+      $FLOWEY_BIN v 15 'flowey_lib_common::publish_test_results:25:flowey_lib_common/src/publish_test_results.rs' write-to-env ado FLOWEY_CONDITION
     displayName: run 'x64-linux-musl-unit-tests-crypto-all' nextest tests
   - task: PublishTestResults@2
     inputs:
@@ -506,8 +506,8 @@ jobs:
       $(FLOWEY_BIN) e 15 flowey_lib_common::publish_test_results 1
       $(FLOWEY_BIN) e 15 flowey_lib_common::ado_task_publish_test_results 0
       $(FLOWEY_BIN) e 15 flowey_lib_common::publish_test_results 0
-      $FLOWEY_BIN v 15 'flowey_lib_common::ado_task_publish_test_results:0:flowey_lib_common/src/ado_task_publish_test_results.rs:57:45' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:79:51 write-to-env ado floweyvar1
-      $FLOWEY_BIN v 15 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:79:51' write-to-env ado FLOWEY_CONDITION
+      $FLOWEY_BIN v 15 'flowey_lib_common::ado_task_publish_test_results:0:flowey_lib_common/src/ado_task_publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs write-to-env ado floweyvar1
+      $FLOWEY_BIN v 15 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs' write-to-env ado FLOWEY_CONDITION
     displayName: run 'x64-linux-musl-unit-tests-base' nextest tests
   - task: PublishTestResults@2
     inputs:
@@ -526,8 +526,8 @@ jobs:
       $(FLOWEY_BIN) e 15 flowey_lib_common::publish_test_results 3
       $(FLOWEY_BIN) e 15 flowey_lib_common::ado_task_publish_test_results 4
       $(FLOWEY_BIN) e 15 flowey_lib_common::publish_test_results 2
-      $FLOWEY_BIN v 15 'flowey_lib_common::ado_task_publish_test_results:4:flowey_lib_common/src/ado_task_publish_test_results.rs:57:45' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:79:51 write-to-env ado floweyvar3
-      $FLOWEY_BIN v 15 'flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:79:51' write-to-env ado FLOWEY_CONDITION
+      $FLOWEY_BIN v 15 'flowey_lib_common::ado_task_publish_test_results:4:flowey_lib_common/src/ado_task_publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs write-to-env ado floweyvar3
+      $FLOWEY_BIN v 15 'flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs' write-to-env ado FLOWEY_CONDITION
     displayName: run 'x64-linux-musl-unit-tests-crypto-native' nextest tests
   - task: PublishTestResults@2
     inputs:
@@ -598,8 +598,8 @@ jobs:
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 14 flowey_lib_common::git_checkout 0
-      $FLOWEY_BIN v 14 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:319:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46 write-to-env ado floweyvar10
-      $FLOWEY_BIN v 14 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46' write-to-env ado FLOWEY_CONDITION
+      $FLOWEY_BIN v 14 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env ado floweyvar10
+      $FLOWEY_BIN v 14 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env ado FLOWEY_CONDITION
     displayName: check if openvmm needs to be cloned
   - checkout: self
     path: repo0
@@ -611,7 +611,7 @@ jobs:
     condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
   - bash: |-
       set -e
-      $FLOWEY_BIN v 14 'flowey_lib_common::git_checkout:4:flowey_lib_common/src/git_checkout.rs:402:29' --is-raw-string update --env-source Pipeline.Workspace <<'EOF'
+      $FLOWEY_BIN v 14 'flowey_lib_common::git_checkout:4:flowey_lib_common/src/git_checkout.rs' --is-raw-string update --env-source Pipeline.Workspace <<'EOF'
       $(Pipeline.Workspace)
       EOF
       $(FLOWEY_BIN) e 14 flowey_lib_common::git_checkout 3
@@ -628,8 +628,8 @@ jobs:
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 14 flowey_lib_common::cache 4
-      $FLOWEY_BIN v 14 'flowey_lib_common::cache:8:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar8
-      $FLOWEY_BIN v 14 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar9
+      $FLOWEY_BIN v 14 'flowey_lib_common::cache:8:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env ado floweyvar8
+      $FLOWEY_BIN v 14 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env ado floweyvar9
     displayName: Pre-processing cache vars
   - task: Cache@2
     inputs:
@@ -639,7 +639,7 @@ jobs:
     displayName: 'Restore cache: gh-release-download'
   - bash: |-
       set -e
-      $FLOWEY_BIN v 14 'flowey_lib_common::cache:11:flowey_lib_common/src/cache.rs:300:70' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
+      $FLOWEY_BIN v 14 'flowey_lib_common::cache:11:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
       $(FLOWEY_CACHE_HITVAR)
       EOF
       $(FLOWEY_BIN) e 14 flowey_lib_common::cache 6
@@ -685,8 +685,8 @@ jobs:
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 14 flowey_lib_common::cache 0
-      $FLOWEY_BIN v 14 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar6
-      $FLOWEY_BIN v 14 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar7
+      $FLOWEY_BIN v 14 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env ado floweyvar6
+      $FLOWEY_BIN v 14 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env ado floweyvar7
     displayName: Pre-processing cache vars
   - task: Cache@2
     inputs:
@@ -696,7 +696,7 @@ jobs:
     displayName: 'Restore cache: cargo-nextest'
   - bash: |-
       set -e
-      $FLOWEY_BIN v 14 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:300:70' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
+      $FLOWEY_BIN v 14 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
       $(FLOWEY_CACHE_HITVAR)
       EOF
       $(FLOWEY_BIN) e 14 flowey_lib_common::cache 2
@@ -721,8 +721,8 @@ jobs:
       $(FLOWEY_BIN) e 14 flowey_lib_common::publish_test_results 5
       $(FLOWEY_BIN) e 14 flowey_lib_common::ado_task_publish_test_results 8
       $(FLOWEY_BIN) e 14 flowey_lib_common::publish_test_results 4
-      $FLOWEY_BIN v 14 'flowey_lib_common::ado_task_publish_test_results:8:flowey_lib_common/src/ado_task_publish_test_results.rs:57:45' --is-raw-string --condvar flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs:79:51 write-to-env ado floweyvar5
-      $FLOWEY_BIN v 14 'flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs:79:51' write-to-env ado FLOWEY_CONDITION
+      $FLOWEY_BIN v 14 'flowey_lib_common::ado_task_publish_test_results:8:flowey_lib_common/src/ado_task_publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs write-to-env ado floweyvar5
+      $FLOWEY_BIN v 14 'flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs' write-to-env ado FLOWEY_CONDITION
     displayName: run 'x64-linux-unit-tests-crypto-rust' nextest tests
   - task: PublishTestResults@2
     inputs:
@@ -741,8 +741,8 @@ jobs:
       $(FLOWEY_BIN) e 14 flowey_lib_common::publish_test_results 7
       $(FLOWEY_BIN) e 14 flowey_lib_common::ado_task_publish_test_results 6
       $(FLOWEY_BIN) e 14 flowey_lib_common::publish_test_results 6
-      $FLOWEY_BIN v 14 'flowey_lib_common::ado_task_publish_test_results:6:flowey_lib_common/src/ado_task_publish_test_results.rs:57:45' --is-raw-string --condvar flowey_lib_common::publish_test_results:15:flowey_lib_common/src/publish_test_results.rs:79:51 write-to-env ado floweyvar4
-      $FLOWEY_BIN v 14 'flowey_lib_common::publish_test_results:15:flowey_lib_common/src/publish_test_results.rs:79:51' write-to-env ado FLOWEY_CONDITION
+      $FLOWEY_BIN v 14 'flowey_lib_common::ado_task_publish_test_results:6:flowey_lib_common/src/ado_task_publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:15:flowey_lib_common/src/publish_test_results.rs write-to-env ado floweyvar4
+      $FLOWEY_BIN v 14 'flowey_lib_common::publish_test_results:15:flowey_lib_common/src/publish_test_results.rs' write-to-env ado FLOWEY_CONDITION
     displayName: run 'x64-linux-unit-tests-crypto-openssl' nextest tests
   - task: PublishTestResults@2
     inputs:
@@ -761,8 +761,8 @@ jobs:
       $(FLOWEY_BIN) e 14 flowey_lib_common::publish_test_results 9
       $(FLOWEY_BIN) e 14 flowey_lib_common::ado_task_publish_test_results 2
       $(FLOWEY_BIN) e 14 flowey_lib_common::publish_test_results 8
-      $FLOWEY_BIN v 14 'flowey_lib_common::ado_task_publish_test_results:2:flowey_lib_common/src/ado_task_publish_test_results.rs:57:45' --is-raw-string --condvar flowey_lib_common::publish_test_results:20:flowey_lib_common/src/publish_test_results.rs:79:51 write-to-env ado floweyvar2
-      $FLOWEY_BIN v 14 'flowey_lib_common::publish_test_results:20:flowey_lib_common/src/publish_test_results.rs:79:51' write-to-env ado FLOWEY_CONDITION
+      $FLOWEY_BIN v 14 'flowey_lib_common::ado_task_publish_test_results:2:flowey_lib_common/src/ado_task_publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:20:flowey_lib_common/src/publish_test_results.rs write-to-env ado floweyvar2
+      $FLOWEY_BIN v 14 'flowey_lib_common::publish_test_results:20:flowey_lib_common/src/publish_test_results.rs' write-to-env ado FLOWEY_CONDITION
     displayName: run 'x64-linux-unit-tests-crypto-all' nextest tests
   - task: PublishTestResults@2
     inputs:
@@ -795,8 +795,8 @@ jobs:
       $(FLOWEY_BIN) e 14 flowey_lib_common::publish_test_results 1
       $(FLOWEY_BIN) e 14 flowey_lib_common::ado_task_publish_test_results 0
       $(FLOWEY_BIN) e 14 flowey_lib_common::publish_test_results 0
-      $FLOWEY_BIN v 14 'flowey_lib_common::ado_task_publish_test_results:0:flowey_lib_common/src/ado_task_publish_test_results.rs:57:45' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:79:51 write-to-env ado floweyvar1
-      $FLOWEY_BIN v 14 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:79:51' write-to-env ado FLOWEY_CONDITION
+      $FLOWEY_BIN v 14 'flowey_lib_common::ado_task_publish_test_results:0:flowey_lib_common/src/ado_task_publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs write-to-env ado floweyvar1
+      $FLOWEY_BIN v 14 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs' write-to-env ado FLOWEY_CONDITION
     displayName: run 'x64-linux-unit-tests-base' nextest tests
   - task: PublishTestResults@2
     inputs:
@@ -815,8 +815,8 @@ jobs:
       $(FLOWEY_BIN) e 14 flowey_lib_common::publish_test_results 3
       $(FLOWEY_BIN) e 14 flowey_lib_common::ado_task_publish_test_results 4
       $(FLOWEY_BIN) e 14 flowey_lib_common::publish_test_results 2
-      $FLOWEY_BIN v 14 'flowey_lib_common::ado_task_publish_test_results:4:flowey_lib_common/src/ado_task_publish_test_results.rs:57:45' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:79:51 write-to-env ado floweyvar3
-      $FLOWEY_BIN v 14 'flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:79:51' write-to-env ado FLOWEY_CONDITION
+      $FLOWEY_BIN v 14 'flowey_lib_common::ado_task_publish_test_results:4:flowey_lib_common/src/ado_task_publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs write-to-env ado floweyvar3
+      $FLOWEY_BIN v 14 'flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs' write-to-env ado FLOWEY_CONDITION
     displayName: run 'x64-linux-unit-tests-crypto-native' nextest tests
   - task: PublishTestResults@2
     inputs:
@@ -928,8 +928,8 @@ jobs:
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 13 flowey_lib_common::git_checkout 0
-      $FLOWEY_BIN v 13 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:319:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46 write-to-env ado floweyvar8
-      $FLOWEY_BIN v 13 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46' write-to-env ado FLOWEY_CONDITION
+      $FLOWEY_BIN v 13 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env ado floweyvar8
+      $FLOWEY_BIN v 13 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env ado FLOWEY_CONDITION
     displayName: check if openvmm needs to be cloned
   - checkout: self
     path: repo0
@@ -941,7 +941,7 @@ jobs:
     condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
   - bash: |-
       set -e
-      $FLOWEY_BIN v 13 'flowey_lib_common::git_checkout:4:flowey_lib_common/src/git_checkout.rs:402:29' --is-raw-string update --env-source Pipeline.Workspace <<'EOF'
+      $FLOWEY_BIN v 13 'flowey_lib_common::git_checkout:4:flowey_lib_common/src/git_checkout.rs' --is-raw-string update --env-source Pipeline.Workspace <<'EOF'
       $(Pipeline.Workspace)
       EOF
       $(FLOWEY_BIN) e 13 flowey_lib_common::git_checkout 3
@@ -958,8 +958,8 @@ jobs:
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 13 flowey_lib_common::cache 4
-      $FLOWEY_BIN v 13 'flowey_lib_common::cache:8:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar6
-      $FLOWEY_BIN v 13 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar7
+      $FLOWEY_BIN v 13 'flowey_lib_common::cache:8:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env ado floweyvar6
+      $FLOWEY_BIN v 13 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env ado floweyvar7
     displayName: Pre-processing cache vars
   - task: Cache@2
     inputs:
@@ -969,7 +969,7 @@ jobs:
     displayName: 'Restore cache: gh-release-download'
   - bash: |-
       set -e
-      $FLOWEY_BIN v 13 'flowey_lib_common::cache:11:flowey_lib_common/src/cache.rs:300:70' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
+      $FLOWEY_BIN v 13 'flowey_lib_common::cache:11:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
       $(FLOWEY_CACHE_HITVAR)
       EOF
       $(FLOWEY_BIN) e 13 flowey_lib_common::cache 6
@@ -1011,8 +1011,8 @@ jobs:
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 13 flowey_lib_common::cache 0
-      $FLOWEY_BIN v 13 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar4
-      $FLOWEY_BIN v 13 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar5
+      $FLOWEY_BIN v 13 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env ado floweyvar4
+      $FLOWEY_BIN v 13 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env ado floweyvar5
     displayName: Pre-processing cache vars
   - task: Cache@2
     inputs:
@@ -1022,7 +1022,7 @@ jobs:
     displayName: 'Restore cache: cargo-nextest'
   - bash: |-
       set -e
-      $FLOWEY_BIN v 13 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:300:70' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
+      $FLOWEY_BIN v 13 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
       $(FLOWEY_CACHE_HITVAR)
       EOF
       $(FLOWEY_BIN) e 13 flowey_lib_common::cache 2
@@ -1058,8 +1058,8 @@ jobs:
       $(FLOWEY_BIN) e 13 flowey_lib_common::publish_test_results 5
       $(FLOWEY_BIN) e 13 flowey_lib_common::ado_task_publish_test_results 0
       $(FLOWEY_BIN) e 13 flowey_lib_common::publish_test_results 4
-      $FLOWEY_BIN v 13 'flowey_lib_common::ado_task_publish_test_results:0:flowey_lib_common/src/ado_task_publish_test_results.rs:57:45' --is-raw-string --condvar flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs:79:51 write-to-env ado floweyvar1
-      $FLOWEY_BIN v 13 'flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs:79:51' write-to-env ado FLOWEY_CONDITION
+      $FLOWEY_BIN v 13 'flowey_lib_common::ado_task_publish_test_results:0:flowey_lib_common/src/ado_task_publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs write-to-env ado floweyvar1
+      $FLOWEY_BIN v 13 'flowey_lib_common::publish_test_results:10:flowey_lib_common/src/publish_test_results.rs' write-to-env ado FLOWEY_CONDITION
     displayName: run 'x64-windows-unit-tests-base' nextest tests
   - task: PublishTestResults@2
     inputs:
@@ -1078,8 +1078,8 @@ jobs:
       $(FLOWEY_BIN) e 13 flowey_lib_common::publish_test_results 1
       $(FLOWEY_BIN) e 13 flowey_lib_common::ado_task_publish_test_results 2
       $(FLOWEY_BIN) e 13 flowey_lib_common::publish_test_results 0
-      $FLOWEY_BIN v 13 'flowey_lib_common::ado_task_publish_test_results:2:flowey_lib_common/src/ado_task_publish_test_results.rs:57:45' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:79:51 write-to-env ado floweyvar2
-      $FLOWEY_BIN v 13 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:79:51' write-to-env ado FLOWEY_CONDITION
+      $FLOWEY_BIN v 13 'flowey_lib_common::ado_task_publish_test_results:2:flowey_lib_common/src/ado_task_publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs write-to-env ado floweyvar2
+      $FLOWEY_BIN v 13 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs' write-to-env ado FLOWEY_CONDITION
     displayName: run 'x64-windows-unit-tests-crypto-native' nextest tests
   - task: PublishTestResults@2
     inputs:
@@ -1098,8 +1098,8 @@ jobs:
       $(FLOWEY_BIN) e 13 flowey_lib_common::publish_test_results 3
       $(FLOWEY_BIN) e 13 flowey_lib_common::ado_task_publish_test_results 4
       $(FLOWEY_BIN) e 13 flowey_lib_common::publish_test_results 2
-      $FLOWEY_BIN v 13 'flowey_lib_common::ado_task_publish_test_results:4:flowey_lib_common/src/ado_task_publish_test_results.rs:57:45' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:79:51 write-to-env ado floweyvar3
-      $FLOWEY_BIN v 13 'flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs:79:51' write-to-env ado FLOWEY_CONDITION
+      $FLOWEY_BIN v 13 'flowey_lib_common::ado_task_publish_test_results:4:flowey_lib_common/src/ado_task_publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs write-to-env ado floweyvar3
+      $FLOWEY_BIN v 13 'flowey_lib_common::publish_test_results:5:flowey_lib_common/src/publish_test_results.rs' write-to-env ado FLOWEY_CONDITION
     displayName: run 'x64-windows-unit-tests-crypto-rust' nextest tests
   - task: PublishTestResults@2
     inputs:
@@ -1171,8 +1171,8 @@ jobs:
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 12 flowey_lib_common::git_checkout 0
-      $FLOWEY_BIN v 12 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:319:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46 write-to-env ado floweyvar3
-      $FLOWEY_BIN v 12 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46' write-to-env ado FLOWEY_CONDITION
+      $FLOWEY_BIN v 12 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env ado floweyvar3
+      $FLOWEY_BIN v 12 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env ado FLOWEY_CONDITION
     displayName: check if openvmm needs to be cloned
   - checkout: self
     path: repo0
@@ -1184,7 +1184,7 @@ jobs:
     condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
   - bash: |-
       set -e
-      $FLOWEY_BIN v 12 'flowey_lib_common::git_checkout:4:flowey_lib_common/src/git_checkout.rs:402:29' --is-raw-string update --env-source Pipeline.Workspace <<'EOF'
+      $FLOWEY_BIN v 12 'flowey_lib_common::git_checkout:4:flowey_lib_common/src/git_checkout.rs' --is-raw-string update --env-source Pipeline.Workspace <<'EOF'
       $(Pipeline.Workspace)
       EOF
       $(FLOWEY_BIN) e 12 flowey_lib_common::git_checkout 3
@@ -1208,8 +1208,8 @@ jobs:
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 12 flowey_lib_common::cache 0
-      $FLOWEY_BIN v 12 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar1
-      $FLOWEY_BIN v 12 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar2
+      $FLOWEY_BIN v 12 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env ado floweyvar1
+      $FLOWEY_BIN v 12 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env ado floweyvar2
     displayName: Pre-processing cache vars
   - task: Cache@2
     inputs:
@@ -1219,7 +1219,7 @@ jobs:
     displayName: 'Restore cache: gh-release-download'
   - bash: |-
       set -e
-      $FLOWEY_BIN v 12 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:300:70' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
+      $FLOWEY_BIN v 12 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
       $(FLOWEY_CACHE_HITVAR)
       EOF
       $(FLOWEY_BIN) e 12 flowey_lib_common::cache 2
@@ -1458,8 +1458,8 @@ jobs:
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 11 flowey_lib_common::git_checkout 0
-      $FLOWEY_BIN v 11 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:319:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46 write-to-env ado floweyvar3
-      $FLOWEY_BIN v 11 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46' write-to-env ado FLOWEY_CONDITION
+      $FLOWEY_BIN v 11 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env ado floweyvar3
+      $FLOWEY_BIN v 11 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env ado FLOWEY_CONDITION
     displayName: check if openvmm needs to be cloned
   - checkout: self
     path: repo0
@@ -1471,7 +1471,7 @@ jobs:
     condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
   - bash: |-
       set -e
-      $FLOWEY_BIN v 11 'flowey_lib_common::git_checkout:4:flowey_lib_common/src/git_checkout.rs:402:29' --is-raw-string update --env-source Pipeline.Workspace <<'EOF'
+      $FLOWEY_BIN v 11 'flowey_lib_common::git_checkout:4:flowey_lib_common/src/git_checkout.rs' --is-raw-string update --env-source Pipeline.Workspace <<'EOF'
       $(Pipeline.Workspace)
       EOF
       $(FLOWEY_BIN) e 11 flowey_lib_common::git_checkout 3
@@ -1495,8 +1495,8 @@ jobs:
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 11 flowey_lib_common::cache 0
-      $FLOWEY_BIN v 11 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar1
-      $FLOWEY_BIN v 11 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar2
+      $FLOWEY_BIN v 11 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env ado floweyvar1
+      $FLOWEY_BIN v 11 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env ado floweyvar2
     displayName: Pre-processing cache vars
   - task: Cache@2
     inputs:
@@ -1506,7 +1506,7 @@ jobs:
     displayName: 'Restore cache: gh-release-download'
   - bash: |-
       set -e
-      $FLOWEY_BIN v 11 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:300:70' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
+      $FLOWEY_BIN v 11 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
       $(FLOWEY_CACHE_HITVAR)
       EOF
       $(FLOWEY_BIN) e 11 flowey_lib_common::cache 2
@@ -1737,8 +1737,8 @@ jobs:
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 10 flowey_lib_common::git_checkout 0
-      $FLOWEY_BIN v 10 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:319:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46 write-to-env ado floweyvar3
-      $FLOWEY_BIN v 10 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46' write-to-env ado FLOWEY_CONDITION
+      $FLOWEY_BIN v 10 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env ado floweyvar3
+      $FLOWEY_BIN v 10 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env ado FLOWEY_CONDITION
     displayName: check if openvmm needs to be cloned
   - checkout: self
     path: repo0
@@ -1750,7 +1750,7 @@ jobs:
     condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
   - bash: |-
       set -e
-      $FLOWEY_BIN v 10 'flowey_lib_common::git_checkout:4:flowey_lib_common/src/git_checkout.rs:402:29' --is-raw-string update --env-source Pipeline.Workspace <<'EOF'
+      $FLOWEY_BIN v 10 'flowey_lib_common::git_checkout:4:flowey_lib_common/src/git_checkout.rs' --is-raw-string update --env-source Pipeline.Workspace <<'EOF'
       $(Pipeline.Workspace)
       EOF
       $(FLOWEY_BIN) e 10 flowey_lib_common::git_checkout 3
@@ -1774,8 +1774,8 @@ jobs:
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 10 flowey_lib_common::cache 0
-      $FLOWEY_BIN v 10 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar1
-      $FLOWEY_BIN v 10 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar2
+      $FLOWEY_BIN v 10 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env ado floweyvar1
+      $FLOWEY_BIN v 10 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env ado floweyvar2
     displayName: Pre-processing cache vars
   - task: Cache@2
     inputs:
@@ -1785,7 +1785,7 @@ jobs:
     displayName: 'Restore cache: gh-release-download'
   - bash: |-
       set -e
-      $FLOWEY_BIN v 10 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:300:70' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
+      $FLOWEY_BIN v 10 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
       $(FLOWEY_CACHE_HITVAR)
       EOF
       $(FLOWEY_BIN) e 10 flowey_lib_common::cache 2
@@ -1957,8 +1957,8 @@ jobs:
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 9 flowey_lib_common::git_checkout 0
-      $FLOWEY_BIN v 9 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:319:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46 write-to-env ado floweyvar1
-      $FLOWEY_BIN v 9 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46' write-to-env ado FLOWEY_CONDITION
+      $FLOWEY_BIN v 9 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env ado floweyvar1
+      $FLOWEY_BIN v 9 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env ado FLOWEY_CONDITION
     displayName: check if openvmm needs to be cloned
   - checkout: self
     path: repo0
@@ -1970,7 +1970,7 @@ jobs:
     condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
   - bash: |-
       set -e
-      $FLOWEY_BIN v 9 'flowey_lib_common::git_checkout:4:flowey_lib_common/src/git_checkout.rs:402:29' --is-raw-string update --env-source Pipeline.Workspace <<'EOF'
+      $FLOWEY_BIN v 9 'flowey_lib_common::git_checkout:4:flowey_lib_common/src/git_checkout.rs' --is-raw-string update --env-source Pipeline.Workspace <<'EOF'
       $(Pipeline.Workspace)
       EOF
       $(FLOWEY_BIN) e 9 flowey_lib_common::git_checkout 3
@@ -1987,8 +1987,8 @@ jobs:
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 9 flowey_lib_common::cache 4
-      $FLOWEY_BIN v 9 'flowey_lib_common::cache:8:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar4
-      $FLOWEY_BIN v 9 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar5
+      $FLOWEY_BIN v 9 'flowey_lib_common::cache:8:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env ado floweyvar4
+      $FLOWEY_BIN v 9 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env ado floweyvar5
     displayName: Pre-processing cache vars
   - task: Cache@2
     inputs:
@@ -1998,7 +1998,7 @@ jobs:
     displayName: 'Restore cache: gh-release-download'
   - bash: |-
       set -e
-      $FLOWEY_BIN v 9 'flowey_lib_common::cache:11:flowey_lib_common/src/cache.rs:300:70' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
+      $FLOWEY_BIN v 9 'flowey_lib_common::cache:11:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
       $(FLOWEY_CACHE_HITVAR)
       EOF
       $(FLOWEY_BIN) e 9 flowey_lib_common::cache 6
@@ -2160,8 +2160,8 @@ jobs:
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 9 flowey_lib_common::cache 0
-      $FLOWEY_BIN v 9 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar2
-      $FLOWEY_BIN v 9 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar3
+      $FLOWEY_BIN v 9 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env ado floweyvar2
+      $FLOWEY_BIN v 9 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env ado floweyvar3
     displayName: Pre-processing cache vars
   - task: Cache@2
     inputs:
@@ -2171,7 +2171,7 @@ jobs:
     displayName: 'Restore cache: cargo-nextest'
   - bash: |-
       set -e
-      $FLOWEY_BIN v 9 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:300:70' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
+      $FLOWEY_BIN v 9 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
       $(FLOWEY_CACHE_HITVAR)
       EOF
       $(FLOWEY_BIN) e 9 flowey_lib_common::cache 2
@@ -2311,8 +2311,8 @@ jobs:
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 8 flowey_lib_common::git_checkout 0
-      $FLOWEY_BIN v 8 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:319:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46 write-to-env ado floweyvar1
-      $FLOWEY_BIN v 8 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46' write-to-env ado FLOWEY_CONDITION
+      $FLOWEY_BIN v 8 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env ado floweyvar1
+      $FLOWEY_BIN v 8 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env ado FLOWEY_CONDITION
     displayName: check if openvmm needs to be cloned
   - checkout: self
     path: repo0
@@ -2324,7 +2324,7 @@ jobs:
     condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
   - bash: |-
       set -e
-      $FLOWEY_BIN v 8 'flowey_lib_common::git_checkout:4:flowey_lib_common/src/git_checkout.rs:402:29' --is-raw-string update --env-source Pipeline.Workspace <<'EOF'
+      $FLOWEY_BIN v 8 'flowey_lib_common::git_checkout:4:flowey_lib_common/src/git_checkout.rs' --is-raw-string update --env-source Pipeline.Workspace <<'EOF'
       $(Pipeline.Workspace)
       EOF
       $(FLOWEY_BIN) e 8 flowey_lib_common::git_checkout 3
@@ -2341,8 +2341,8 @@ jobs:
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 8 flowey_lib_common::cache 4
-      $FLOWEY_BIN v 8 'flowey_lib_common::cache:8:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar4
-      $FLOWEY_BIN v 8 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar5
+      $FLOWEY_BIN v 8 'flowey_lib_common::cache:8:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env ado floweyvar4
+      $FLOWEY_BIN v 8 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env ado floweyvar5
     displayName: Pre-processing cache vars
   - task: Cache@2
     inputs:
@@ -2352,7 +2352,7 @@ jobs:
     displayName: 'Restore cache: gh-release-download'
   - bash: |-
       set -e
-      $FLOWEY_BIN v 8 'flowey_lib_common::cache:11:flowey_lib_common/src/cache.rs:300:70' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
+      $FLOWEY_BIN v 8 'flowey_lib_common::cache:11:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
       $(FLOWEY_CACHE_HITVAR)
       EOF
       $(FLOWEY_BIN) e 8 flowey_lib_common::cache 6
@@ -2510,8 +2510,8 @@ jobs:
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 8 flowey_lib_common::cache 0
-      $FLOWEY_BIN v 8 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar2
-      $FLOWEY_BIN v 8 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar3
+      $FLOWEY_BIN v 8 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env ado floweyvar2
+      $FLOWEY_BIN v 8 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env ado floweyvar3
     displayName: Pre-processing cache vars
   - task: Cache@2
     inputs:
@@ -2521,7 +2521,7 @@ jobs:
     displayName: 'Restore cache: cargo-nextest'
   - bash: |-
       set -e
-      $FLOWEY_BIN v 8 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:300:70' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
+      $FLOWEY_BIN v 8 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
       $(FLOWEY_CACHE_HITVAR)
       EOF
       $(FLOWEY_BIN) e 8 flowey_lib_common::cache 2
@@ -2686,8 +2686,8 @@ jobs:
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 7 flowey_lib_common::git_checkout 0
-      $FLOWEY_BIN v 7 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:319:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46 write-to-env ado floweyvar1
-      $FLOWEY_BIN v 7 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46' write-to-env ado FLOWEY_CONDITION
+      $FLOWEY_BIN v 7 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env ado floweyvar1
+      $FLOWEY_BIN v 7 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env ado FLOWEY_CONDITION
     displayName: check if openvmm needs to be cloned
   - checkout: self
     path: repo0
@@ -2699,7 +2699,7 @@ jobs:
     condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
   - bash: |-
       set -e
-      $FLOWEY_BIN v 7 'flowey_lib_common::git_checkout:4:flowey_lib_common/src/git_checkout.rs:402:29' --is-raw-string update --env-source Pipeline.Workspace <<'EOF'
+      $FLOWEY_BIN v 7 'flowey_lib_common::git_checkout:4:flowey_lib_common/src/git_checkout.rs' --is-raw-string update --env-source Pipeline.Workspace <<'EOF'
       $(Pipeline.Workspace)
       EOF
       $(FLOWEY_BIN) e 7 flowey_lib_common::git_checkout 3
@@ -2716,8 +2716,8 @@ jobs:
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 7 flowey_lib_common::cache 4
-      $FLOWEY_BIN v 7 'flowey_lib_common::cache:8:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar4
-      $FLOWEY_BIN v 7 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar5
+      $FLOWEY_BIN v 7 'flowey_lib_common::cache:8:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env ado floweyvar4
+      $FLOWEY_BIN v 7 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env ado floweyvar5
     displayName: Pre-processing cache vars
   - task: Cache@2
     inputs:
@@ -2727,7 +2727,7 @@ jobs:
     displayName: 'Restore cache: gh-release-download'
   - bash: |-
       set -e
-      $FLOWEY_BIN v 7 'flowey_lib_common::cache:11:flowey_lib_common/src/cache.rs:300:70' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
+      $FLOWEY_BIN v 7 'flowey_lib_common::cache:11:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
       $(FLOWEY_CACHE_HITVAR)
       EOF
       $(FLOWEY_BIN) e 7 flowey_lib_common::cache 6
@@ -2813,8 +2813,8 @@ jobs:
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 7 flowey_lib_common::cache 0
-      $FLOWEY_BIN v 7 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar2
-      $FLOWEY_BIN v 7 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar3
+      $FLOWEY_BIN v 7 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env ado floweyvar2
+      $FLOWEY_BIN v 7 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env ado floweyvar3
     displayName: Pre-processing cache vars
   - task: Cache@2
     inputs:
@@ -2824,7 +2824,7 @@ jobs:
     displayName: 'Restore cache: cargo-nextest'
   - bash: |-
       set -e
-      $FLOWEY_BIN v 7 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:300:70' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
+      $FLOWEY_BIN v 7 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
       $(FLOWEY_CACHE_HITVAR)
       EOF
       $(FLOWEY_BIN) e 7 flowey_lib_common::cache 2
@@ -2977,8 +2977,8 @@ jobs:
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 6 flowey_lib_common::git_checkout 0
-      $FLOWEY_BIN v 6 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:319:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46 write-to-env ado floweyvar1
-      $FLOWEY_BIN v 6 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46' write-to-env ado FLOWEY_CONDITION
+      $FLOWEY_BIN v 6 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env ado floweyvar1
+      $FLOWEY_BIN v 6 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env ado FLOWEY_CONDITION
     displayName: check if openvmm needs to be cloned
   - checkout: self
     path: repo0
@@ -2990,7 +2990,7 @@ jobs:
     condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
   - bash: |-
       set -e
-      $FLOWEY_BIN v 6 'flowey_lib_common::git_checkout:4:flowey_lib_common/src/git_checkout.rs:402:29' --is-raw-string update --env-source Pipeline.Workspace <<'EOF'
+      $FLOWEY_BIN v 6 'flowey_lib_common::git_checkout:4:flowey_lib_common/src/git_checkout.rs' --is-raw-string update --env-source Pipeline.Workspace <<'EOF'
       $(Pipeline.Workspace)
       EOF
       $(FLOWEY_BIN) e 6 flowey_lib_common::git_checkout 3
@@ -3007,8 +3007,8 @@ jobs:
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 6 flowey_lib_common::cache 0
-      $FLOWEY_BIN v 6 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar2
-      $FLOWEY_BIN v 6 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar3
+      $FLOWEY_BIN v 6 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env ado floweyvar2
+      $FLOWEY_BIN v 6 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env ado floweyvar3
     displayName: Pre-processing cache vars
   - task: Cache@2
     inputs:
@@ -3018,7 +3018,7 @@ jobs:
     displayName: 'Restore cache: gh-release-download'
   - bash: |-
       set -e
-      $FLOWEY_BIN v 6 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:300:70' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
+      $FLOWEY_BIN v 6 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
       $(FLOWEY_CACHE_HITVAR)
       EOF
       $(FLOWEY_BIN) e 6 flowey_lib_common::cache 2
@@ -3193,8 +3193,8 @@ jobs:
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 5 flowey_lib_common::git_checkout 0
-      $FLOWEY_BIN v 5 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:319:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46 write-to-env ado floweyvar1
-      $FLOWEY_BIN v 5 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46' write-to-env ado FLOWEY_CONDITION
+      $FLOWEY_BIN v 5 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env ado floweyvar1
+      $FLOWEY_BIN v 5 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env ado FLOWEY_CONDITION
     displayName: check if openvmm needs to be cloned
   - checkout: self
     path: repo0
@@ -3206,7 +3206,7 @@ jobs:
     condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
   - bash: |-
       set -e
-      $FLOWEY_BIN v 5 'flowey_lib_common::git_checkout:4:flowey_lib_common/src/git_checkout.rs:402:29' --is-raw-string update --env-source Pipeline.Workspace <<'EOF'
+      $FLOWEY_BIN v 5 'flowey_lib_common::git_checkout:4:flowey_lib_common/src/git_checkout.rs' --is-raw-string update --env-source Pipeline.Workspace <<'EOF'
       $(Pipeline.Workspace)
       EOF
       $(FLOWEY_BIN) e 5 flowey_lib_common::git_checkout 3
@@ -3223,8 +3223,8 @@ jobs:
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 5 flowey_lib_common::cache 4
-      $FLOWEY_BIN v 5 'flowey_lib_common::cache:8:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar4
-      $FLOWEY_BIN v 5 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar5
+      $FLOWEY_BIN v 5 'flowey_lib_common::cache:8:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env ado floweyvar4
+      $FLOWEY_BIN v 5 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env ado floweyvar5
     displayName: Pre-processing cache vars
   - task: Cache@2
     inputs:
@@ -3234,7 +3234,7 @@ jobs:
     displayName: 'Restore cache: gh-release-download'
   - bash: |-
       set -e
-      $FLOWEY_BIN v 5 'flowey_lib_common::cache:11:flowey_lib_common/src/cache.rs:300:70' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
+      $FLOWEY_BIN v 5 'flowey_lib_common::cache:11:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
       $(FLOWEY_CACHE_HITVAR)
       EOF
       $(FLOWEY_BIN) e 5 flowey_lib_common::cache 6
@@ -3320,8 +3320,8 @@ jobs:
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 5 flowey_lib_common::cache 0
-      $FLOWEY_BIN v 5 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar2
-      $FLOWEY_BIN v 5 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar3
+      $FLOWEY_BIN v 5 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env ado floweyvar2
+      $FLOWEY_BIN v 5 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env ado floweyvar3
     displayName: Pre-processing cache vars
   - task: Cache@2
     inputs:
@@ -3331,7 +3331,7 @@ jobs:
     displayName: 'Restore cache: cargo-nextest'
   - bash: |-
       set -e
-      $FLOWEY_BIN v 5 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:300:70' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
+      $FLOWEY_BIN v 5 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
       $(FLOWEY_CACHE_HITVAR)
       EOF
       $(FLOWEY_BIN) e 5 flowey_lib_common::cache 2
@@ -3479,8 +3479,8 @@ jobs:
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 4 flowey_lib_common::git_checkout 0
-      $FLOWEY_BIN v 4 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:319:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46 write-to-env ado floweyvar1
-      $FLOWEY_BIN v 4 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46' write-to-env ado FLOWEY_CONDITION
+      $FLOWEY_BIN v 4 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env ado floweyvar1
+      $FLOWEY_BIN v 4 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env ado FLOWEY_CONDITION
     displayName: check if openvmm needs to be cloned
   - checkout: self
     path: repo0
@@ -3492,7 +3492,7 @@ jobs:
     condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
   - bash: |-
       set -e
-      $FLOWEY_BIN v 4 'flowey_lib_common::git_checkout:4:flowey_lib_common/src/git_checkout.rs:402:29' --is-raw-string update --env-source Pipeline.Workspace <<'EOF'
+      $FLOWEY_BIN v 4 'flowey_lib_common::git_checkout:4:flowey_lib_common/src/git_checkout.rs' --is-raw-string update --env-source Pipeline.Workspace <<'EOF'
       $(Pipeline.Workspace)
       EOF
       $(FLOWEY_BIN) e 4 flowey_lib_common::git_checkout 3
@@ -3509,8 +3509,8 @@ jobs:
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 4 flowey_lib_common::cache 0
-      $FLOWEY_BIN v 4 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar2
-      $FLOWEY_BIN v 4 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar3
+      $FLOWEY_BIN v 4 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env ado floweyvar2
+      $FLOWEY_BIN v 4 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env ado floweyvar3
     displayName: Pre-processing cache vars
   - task: Cache@2
     inputs:
@@ -3520,7 +3520,7 @@ jobs:
     displayName: 'Restore cache: gh-release-download'
   - bash: |-
       set -e
-      $FLOWEY_BIN v 4 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:300:70' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
+      $FLOWEY_BIN v 4 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
       $(FLOWEY_CACHE_HITVAR)
       EOF
       $(FLOWEY_BIN) e 4 flowey_lib_common::cache 2
@@ -3652,8 +3652,8 @@ jobs:
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 3 flowey_lib_common::git_checkout 0
-      $FLOWEY_BIN v 3 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:319:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46 write-to-env ado floweyvar1
-      $FLOWEY_BIN v 3 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46' write-to-env ado FLOWEY_CONDITION
+      $FLOWEY_BIN v 3 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env ado floweyvar1
+      $FLOWEY_BIN v 3 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env ado FLOWEY_CONDITION
     displayName: check if openvmm needs to be cloned
   - checkout: self
     path: repo0
@@ -3665,7 +3665,7 @@ jobs:
     condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
   - bash: |-
       set -e
-      $FLOWEY_BIN v 3 'flowey_lib_common::git_checkout:4:flowey_lib_common/src/git_checkout.rs:402:29' --is-raw-string update --env-source Pipeline.Workspace <<'EOF'
+      $FLOWEY_BIN v 3 'flowey_lib_common::git_checkout:4:flowey_lib_common/src/git_checkout.rs' --is-raw-string update --env-source Pipeline.Workspace <<'EOF'
       $(Pipeline.Workspace)
       EOF
       $(FLOWEY_BIN) e 3 flowey_lib_common::git_checkout 3
@@ -3682,8 +3682,8 @@ jobs:
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 3 flowey_lib_common::cache 0
-      $FLOWEY_BIN v 3 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar2
-      $FLOWEY_BIN v 3 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar3
+      $FLOWEY_BIN v 3 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env ado floweyvar2
+      $FLOWEY_BIN v 3 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env ado floweyvar3
     displayName: Pre-processing cache vars
   - task: Cache@2
     inputs:
@@ -3693,7 +3693,7 @@ jobs:
     displayName: 'Restore cache: gh-release-download'
   - bash: |-
       set -e
-      $FLOWEY_BIN v 3 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:300:70' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
+      $FLOWEY_BIN v 3 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
       $(FLOWEY_CACHE_HITVAR)
       EOF
       $(FLOWEY_BIN) e 3 flowey_lib_common::cache 2
@@ -3992,8 +3992,8 @@ jobs:
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 20 flowey_lib_common::cache 0
-      $FLOWEY_BIN v 20 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar3
-      $FLOWEY_BIN v 20 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar4
+      $FLOWEY_BIN v 20 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env ado floweyvar3
+      $FLOWEY_BIN v 20 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env ado floweyvar4
     displayName: Pre-processing cache vars
   - task: Cache@2
     inputs:
@@ -4003,7 +4003,7 @@ jobs:
     displayName: 'Restore cache: cargo-nextest'
   - bash: |-
       set -e
-      $FLOWEY_BIN v 20 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:300:70' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
+      $FLOWEY_BIN v 20 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
       $(FLOWEY_CACHE_HITVAR)
       EOF
       $(FLOWEY_BIN) e 20 flowey_lib_common::cache 2
@@ -4013,8 +4013,8 @@ jobs:
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 20 flowey_lib_common::git_checkout 0
-      $FLOWEY_BIN v 20 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:319:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46 write-to-env ado floweyvar2
-      $FLOWEY_BIN v 20 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46' write-to-env ado FLOWEY_CONDITION
+      $FLOWEY_BIN v 20 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env ado floweyvar2
+      $FLOWEY_BIN v 20 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env ado FLOWEY_CONDITION
     displayName: check if openvmm needs to be cloned
   - checkout: self
     path: repo0
@@ -4026,7 +4026,7 @@ jobs:
     condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
   - bash: |-
       set -e
-      $FLOWEY_BIN v 20 'flowey_lib_common::git_checkout:4:flowey_lib_common/src/git_checkout.rs:402:29' --is-raw-string update --env-source Pipeline.Workspace <<'EOF'
+      $FLOWEY_BIN v 20 'flowey_lib_common::git_checkout:4:flowey_lib_common/src/git_checkout.rs' --is-raw-string update --env-source Pipeline.Workspace <<'EOF'
       $(Pipeline.Workspace)
       EOF
       $(FLOWEY_BIN) e 20 flowey_lib_common::git_checkout 3
@@ -4059,8 +4059,8 @@ jobs:
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 20 flowey_lib_common::cache 4
-      $FLOWEY_BIN v 20 'flowey_lib_common::cache:8:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar5
-      $FLOWEY_BIN v 20 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar6
+      $FLOWEY_BIN v 20 'flowey_lib_common::cache:8:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env ado floweyvar5
+      $FLOWEY_BIN v 20 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env ado floweyvar6
     displayName: Pre-processing cache vars
   - task: Cache@2
     inputs:
@@ -4070,7 +4070,7 @@ jobs:
     displayName: 'Restore cache: gh-release-download'
   - bash: |-
       set -e
-      $FLOWEY_BIN v 20 'flowey_lib_common::cache:11:flowey_lib_common/src/cache.rs:300:70' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
+      $FLOWEY_BIN v 20 'flowey_lib_common::cache:11:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
       $(FLOWEY_CACHE_HITVAR)
       EOF
       $(FLOWEY_BIN) e 20 flowey_lib_common::cache 6
@@ -4122,8 +4122,8 @@ jobs:
       $(FLOWEY_BIN) e 20 flowey_lib_common::publish_test_results 1
       $(FLOWEY_BIN) e 20 flowey_lib_common::ado_task_publish_test_results 0
       $(FLOWEY_BIN) e 20 flowey_lib_common::publish_test_results 0
-      $FLOWEY_BIN v 20 'flowey_lib_common::ado_task_publish_test_results:0:flowey_lib_common/src/ado_task_publish_test_results.rs:57:45' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:79:51 write-to-env ado floweyvar1
-      $FLOWEY_BIN v 20 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:79:51' write-to-env ado FLOWEY_CONDITION
+      $FLOWEY_BIN v 20 'flowey_lib_common::ado_task_publish_test_results:0:flowey_lib_common/src/ado_task_publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs write-to-env ado floweyvar1
+      $FLOWEY_BIN v 20 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs' write-to-env ado FLOWEY_CONDITION
     displayName: run 'vmm_tests' nextest tests
   - task: PublishTestResults@2
     inputs:
@@ -4239,8 +4239,8 @@ jobs:
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 2 flowey_lib_common::git_checkout 0
-      $FLOWEY_BIN v 2 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:319:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46 write-to-env ado floweyvar1
-      $FLOWEY_BIN v 2 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46' write-to-env ado FLOWEY_CONDITION
+      $FLOWEY_BIN v 2 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env ado floweyvar1
+      $FLOWEY_BIN v 2 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env ado FLOWEY_CONDITION
     displayName: check if openvmm needs to be cloned
   - checkout: self
     path: repo0
@@ -4252,7 +4252,7 @@ jobs:
     condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
   - bash: |-
       set -e
-      $FLOWEY_BIN v 2 'flowey_lib_common::git_checkout:4:flowey_lib_common/src/git_checkout.rs:402:29' --is-raw-string update --env-source Pipeline.Workspace <<'EOF'
+      $FLOWEY_BIN v 2 'flowey_lib_common::git_checkout:4:flowey_lib_common/src/git_checkout.rs' --is-raw-string update --env-source Pipeline.Workspace <<'EOF'
       $(Pipeline.Workspace)
       EOF
       $(FLOWEY_BIN) e 2 flowey_lib_common::git_checkout 3
@@ -4269,8 +4269,8 @@ jobs:
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 2 flowey_lib_common::cache 0
-      $FLOWEY_BIN v 2 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar2
-      $FLOWEY_BIN v 2 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar3
+      $FLOWEY_BIN v 2 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env ado floweyvar2
+      $FLOWEY_BIN v 2 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env ado floweyvar3
     displayName: Pre-processing cache vars
   - task: Cache@2
     inputs:
@@ -4280,7 +4280,7 @@ jobs:
     displayName: 'Restore cache: gh-release-download'
   - bash: |-
       set -e
-      $FLOWEY_BIN v 2 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:300:70' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
+      $FLOWEY_BIN v 2 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
       $(FLOWEY_CACHE_HITVAR)
       EOF
       $(FLOWEY_BIN) e 2 flowey_lib_common::cache 2
@@ -4428,8 +4428,8 @@ jobs:
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 19 flowey_lib_common::cache 0
-      $FLOWEY_BIN v 19 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar3
-      $FLOWEY_BIN v 19 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar4
+      $FLOWEY_BIN v 19 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env ado floweyvar3
+      $FLOWEY_BIN v 19 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env ado floweyvar4
     displayName: Pre-processing cache vars
   - task: Cache@2
     inputs:
@@ -4439,7 +4439,7 @@ jobs:
     displayName: 'Restore cache: cargo-nextest'
   - bash: |-
       set -e
-      $FLOWEY_BIN v 19 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:300:70' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
+      $FLOWEY_BIN v 19 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
       $(FLOWEY_CACHE_HITVAR)
       EOF
       $(FLOWEY_BIN) e 19 flowey_lib_common::cache 2
@@ -4449,8 +4449,8 @@ jobs:
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 19 flowey_lib_common::git_checkout 0
-      $FLOWEY_BIN v 19 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:319:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46 write-to-env ado floweyvar2
-      $FLOWEY_BIN v 19 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46' write-to-env ado FLOWEY_CONDITION
+      $FLOWEY_BIN v 19 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env ado floweyvar2
+      $FLOWEY_BIN v 19 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env ado FLOWEY_CONDITION
     displayName: check if openvmm needs to be cloned
   - checkout: self
     path: repo0
@@ -4462,7 +4462,7 @@ jobs:
     condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
   - bash: |-
       set -e
-      $FLOWEY_BIN v 19 'flowey_lib_common::git_checkout:4:flowey_lib_common/src/git_checkout.rs:402:29' --is-raw-string update --env-source Pipeline.Workspace <<'EOF'
+      $FLOWEY_BIN v 19 'flowey_lib_common::git_checkout:4:flowey_lib_common/src/git_checkout.rs' --is-raw-string update --env-source Pipeline.Workspace <<'EOF'
       $(Pipeline.Workspace)
       EOF
       $(FLOWEY_BIN) e 19 flowey_lib_common::git_checkout 3
@@ -4491,8 +4491,8 @@ jobs:
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 19 flowey_lib_common::cache 4
-      $FLOWEY_BIN v 19 'flowey_lib_common::cache:8:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar5
-      $FLOWEY_BIN v 19 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar6
+      $FLOWEY_BIN v 19 'flowey_lib_common::cache:8:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env ado floweyvar5
+      $FLOWEY_BIN v 19 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env ado floweyvar6
     displayName: Pre-processing cache vars
   - task: Cache@2
     inputs:
@@ -4502,7 +4502,7 @@ jobs:
     displayName: 'Restore cache: gh-release-download'
   - bash: |-
       set -e
-      $FLOWEY_BIN v 19 'flowey_lib_common::cache:11:flowey_lib_common/src/cache.rs:300:70' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
+      $FLOWEY_BIN v 19 'flowey_lib_common::cache:11:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
       $(FLOWEY_CACHE_HITVAR)
       EOF
       $(FLOWEY_BIN) e 19 flowey_lib_common::cache 6
@@ -4551,8 +4551,8 @@ jobs:
       $(FLOWEY_BIN) e 19 flowey_lib_common::publish_test_results 1
       $(FLOWEY_BIN) e 19 flowey_lib_common::ado_task_publish_test_results 0
       $(FLOWEY_BIN) e 19 flowey_lib_common::publish_test_results 0
-      $FLOWEY_BIN v 19 'flowey_lib_common::ado_task_publish_test_results:0:flowey_lib_common/src/ado_task_publish_test_results.rs:57:45' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:79:51 write-to-env ado floweyvar1
-      $FLOWEY_BIN v 19 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:79:51' write-to-env ado FLOWEY_CONDITION
+      $FLOWEY_BIN v 19 'flowey_lib_common::ado_task_publish_test_results:0:flowey_lib_common/src/ado_task_publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs write-to-env ado floweyvar1
+      $FLOWEY_BIN v 19 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs' write-to-env ado FLOWEY_CONDITION
     displayName: run 'vmm_tests' nextest tests
   - task: PublishTestResults@2
     inputs:
@@ -4725,8 +4725,8 @@ jobs:
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 18 flowey_lib_common::cache 0
-      $FLOWEY_BIN v 18 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar3
-      $FLOWEY_BIN v 18 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar4
+      $FLOWEY_BIN v 18 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env ado floweyvar3
+      $FLOWEY_BIN v 18 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env ado floweyvar4
     displayName: Pre-processing cache vars
   - task: Cache@2
     inputs:
@@ -4736,7 +4736,7 @@ jobs:
     displayName: 'Restore cache: cargo-nextest'
   - bash: |-
       set -e
-      $FLOWEY_BIN v 18 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:300:70' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
+      $FLOWEY_BIN v 18 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
       $(FLOWEY_CACHE_HITVAR)
       EOF
       $(FLOWEY_BIN) e 18 flowey_lib_common::cache 2
@@ -4746,8 +4746,8 @@ jobs:
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 18 flowey_lib_common::git_checkout 0
-      $FLOWEY_BIN v 18 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:319:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46 write-to-env ado floweyvar2
-      $FLOWEY_BIN v 18 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46' write-to-env ado FLOWEY_CONDITION
+      $FLOWEY_BIN v 18 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env ado floweyvar2
+      $FLOWEY_BIN v 18 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env ado FLOWEY_CONDITION
     displayName: check if openvmm needs to be cloned
   - checkout: self
     path: repo0
@@ -4759,7 +4759,7 @@ jobs:
     condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
   - bash: |-
       set -e
-      $FLOWEY_BIN v 18 'flowey_lib_common::git_checkout:4:flowey_lib_common/src/git_checkout.rs:402:29' --is-raw-string update --env-source Pipeline.Workspace <<'EOF'
+      $FLOWEY_BIN v 18 'flowey_lib_common::git_checkout:4:flowey_lib_common/src/git_checkout.rs' --is-raw-string update --env-source Pipeline.Workspace <<'EOF'
       $(Pipeline.Workspace)
       EOF
       $(FLOWEY_BIN) e 18 flowey_lib_common::git_checkout 3
@@ -4792,8 +4792,8 @@ jobs:
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 18 flowey_lib_common::cache 4
-      $FLOWEY_BIN v 18 'flowey_lib_common::cache:8:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar5
-      $FLOWEY_BIN v 18 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar6
+      $FLOWEY_BIN v 18 'flowey_lib_common::cache:8:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env ado floweyvar5
+      $FLOWEY_BIN v 18 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env ado floweyvar6
     displayName: Pre-processing cache vars
   - task: Cache@2
     inputs:
@@ -4803,7 +4803,7 @@ jobs:
     displayName: 'Restore cache: gh-release-download'
   - bash: |-
       set -e
-      $FLOWEY_BIN v 18 'flowey_lib_common::cache:11:flowey_lib_common/src/cache.rs:300:70' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
+      $FLOWEY_BIN v 18 'flowey_lib_common::cache:11:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
       $(FLOWEY_CACHE_HITVAR)
       EOF
       $(FLOWEY_BIN) e 18 flowey_lib_common::cache 6
@@ -4858,8 +4858,8 @@ jobs:
       $(FLOWEY_BIN) e 18 flowey_lib_common::publish_test_results 1
       $(FLOWEY_BIN) e 18 flowey_lib_common::ado_task_publish_test_results 0
       $(FLOWEY_BIN) e 18 flowey_lib_common::publish_test_results 0
-      $FLOWEY_BIN v 18 'flowey_lib_common::ado_task_publish_test_results:0:flowey_lib_common/src/ado_task_publish_test_results.rs:57:45' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:79:51 write-to-env ado floweyvar1
-      $FLOWEY_BIN v 18 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:79:51' write-to-env ado FLOWEY_CONDITION
+      $FLOWEY_BIN v 18 'flowey_lib_common::ado_task_publish_test_results:0:flowey_lib_common/src/ado_task_publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs write-to-env ado floweyvar1
+      $FLOWEY_BIN v 18 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs' write-to-env ado FLOWEY_CONDITION
     displayName: stopping test_igvm_agent_rpc_server
   - task: PublishTestResults@2
     inputs:
@@ -5032,8 +5032,8 @@ jobs:
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 17 flowey_lib_common::cache 0
-      $FLOWEY_BIN v 17 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar3
-      $FLOWEY_BIN v 17 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar4
+      $FLOWEY_BIN v 17 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env ado floweyvar3
+      $FLOWEY_BIN v 17 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env ado floweyvar4
     displayName: Pre-processing cache vars
   - task: Cache@2
     inputs:
@@ -5043,7 +5043,7 @@ jobs:
     displayName: 'Restore cache: cargo-nextest'
   - bash: |-
       set -e
-      $FLOWEY_BIN v 17 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:300:70' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
+      $FLOWEY_BIN v 17 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
       $(FLOWEY_CACHE_HITVAR)
       EOF
       $(FLOWEY_BIN) e 17 flowey_lib_common::cache 2
@@ -5053,8 +5053,8 @@ jobs:
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 17 flowey_lib_common::git_checkout 0
-      $FLOWEY_BIN v 17 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:319:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46 write-to-env ado floweyvar2
-      $FLOWEY_BIN v 17 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46' write-to-env ado FLOWEY_CONDITION
+      $FLOWEY_BIN v 17 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env ado floweyvar2
+      $FLOWEY_BIN v 17 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env ado FLOWEY_CONDITION
     displayName: check if openvmm needs to be cloned
   - checkout: self
     path: repo0
@@ -5066,7 +5066,7 @@ jobs:
     condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
   - bash: |-
       set -e
-      $FLOWEY_BIN v 17 'flowey_lib_common::git_checkout:4:flowey_lib_common/src/git_checkout.rs:402:29' --is-raw-string update --env-source Pipeline.Workspace <<'EOF'
+      $FLOWEY_BIN v 17 'flowey_lib_common::git_checkout:4:flowey_lib_common/src/git_checkout.rs' --is-raw-string update --env-source Pipeline.Workspace <<'EOF'
       $(Pipeline.Workspace)
       EOF
       $(FLOWEY_BIN) e 17 flowey_lib_common::git_checkout 3
@@ -5099,8 +5099,8 @@ jobs:
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 17 flowey_lib_common::cache 4
-      $FLOWEY_BIN v 17 'flowey_lib_common::cache:8:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar5
-      $FLOWEY_BIN v 17 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar6
+      $FLOWEY_BIN v 17 'flowey_lib_common::cache:8:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env ado floweyvar5
+      $FLOWEY_BIN v 17 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env ado floweyvar6
     displayName: Pre-processing cache vars
   - task: Cache@2
     inputs:
@@ -5110,7 +5110,7 @@ jobs:
     displayName: 'Restore cache: gh-release-download'
   - bash: |-
       set -e
-      $FLOWEY_BIN v 17 'flowey_lib_common::cache:11:flowey_lib_common/src/cache.rs:300:70' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
+      $FLOWEY_BIN v 17 'flowey_lib_common::cache:11:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
       $(FLOWEY_CACHE_HITVAR)
       EOF
       $(FLOWEY_BIN) e 17 flowey_lib_common::cache 6
@@ -5155,8 +5155,8 @@ jobs:
       $(FLOWEY_BIN) e 17 flowey_lib_common::publish_test_results 1
       $(FLOWEY_BIN) e 17 flowey_lib_common::ado_task_publish_test_results 0
       $(FLOWEY_BIN) e 17 flowey_lib_common::publish_test_results 0
-      $FLOWEY_BIN v 17 'flowey_lib_common::ado_task_publish_test_results:0:flowey_lib_common/src/ado_task_publish_test_results.rs:57:45' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:79:51 write-to-env ado floweyvar1
-      $FLOWEY_BIN v 17 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:79:51' write-to-env ado FLOWEY_CONDITION
+      $FLOWEY_BIN v 17 'flowey_lib_common::ado_task_publish_test_results:0:flowey_lib_common/src/ado_task_publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs write-to-env ado floweyvar1
+      $FLOWEY_BIN v 17 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs' write-to-env ado FLOWEY_CONDITION
     displayName: run 'vmm_tests' nextest tests
   - task: PublishTestResults@2
     inputs:
@@ -5332,8 +5332,8 @@ jobs:
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 16 flowey_lib_common::cache 0
-      $FLOWEY_BIN v 16 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar3
-      $FLOWEY_BIN v 16 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar4
+      $FLOWEY_BIN v 16 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env ado floweyvar3
+      $FLOWEY_BIN v 16 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env ado floweyvar4
     displayName: Pre-processing cache vars
   - task: Cache@2
     inputs:
@@ -5343,7 +5343,7 @@ jobs:
     displayName: 'Restore cache: cargo-nextest'
   - bash: |-
       set -e
-      $FLOWEY_BIN v 16 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:300:70' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
+      $FLOWEY_BIN v 16 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
       $(FLOWEY_CACHE_HITVAR)
       EOF
       $(FLOWEY_BIN) e 16 flowey_lib_common::cache 2
@@ -5353,8 +5353,8 @@ jobs:
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 16 flowey_lib_common::git_checkout 0
-      $FLOWEY_BIN v 16 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:319:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46 write-to-env ado floweyvar2
-      $FLOWEY_BIN v 16 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46' write-to-env ado FLOWEY_CONDITION
+      $FLOWEY_BIN v 16 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env ado floweyvar2
+      $FLOWEY_BIN v 16 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env ado FLOWEY_CONDITION
     displayName: check if openvmm needs to be cloned
   - checkout: self
     path: repo0
@@ -5366,7 +5366,7 @@ jobs:
     condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
   - bash: |-
       set -e
-      $FLOWEY_BIN v 16 'flowey_lib_common::git_checkout:4:flowey_lib_common/src/git_checkout.rs:402:29' --is-raw-string update --env-source Pipeline.Workspace <<'EOF'
+      $FLOWEY_BIN v 16 'flowey_lib_common::git_checkout:4:flowey_lib_common/src/git_checkout.rs' --is-raw-string update --env-source Pipeline.Workspace <<'EOF'
       $(Pipeline.Workspace)
       EOF
       $(FLOWEY_BIN) e 16 flowey_lib_common::git_checkout 3
@@ -5399,8 +5399,8 @@ jobs:
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 16 flowey_lib_common::cache 4
-      $FLOWEY_BIN v 16 'flowey_lib_common::cache:8:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar5
-      $FLOWEY_BIN v 16 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar6
+      $FLOWEY_BIN v 16 'flowey_lib_common::cache:8:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env ado floweyvar5
+      $FLOWEY_BIN v 16 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env ado floweyvar6
     displayName: Pre-processing cache vars
   - task: Cache@2
     inputs:
@@ -5410,7 +5410,7 @@ jobs:
     displayName: 'Restore cache: gh-release-download'
   - bash: |-
       set -e
-      $FLOWEY_BIN v 16 'flowey_lib_common::cache:11:flowey_lib_common/src/cache.rs:300:70' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
+      $FLOWEY_BIN v 16 'flowey_lib_common::cache:11:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
       $(FLOWEY_CACHE_HITVAR)
       EOF
       $(FLOWEY_BIN) e 16 flowey_lib_common::cache 6
@@ -5465,8 +5465,8 @@ jobs:
       $(FLOWEY_BIN) e 16 flowey_lib_common::publish_test_results 1
       $(FLOWEY_BIN) e 16 flowey_lib_common::ado_task_publish_test_results 0
       $(FLOWEY_BIN) e 16 flowey_lib_common::publish_test_results 0
-      $FLOWEY_BIN v 16 'flowey_lib_common::ado_task_publish_test_results:0:flowey_lib_common/src/ado_task_publish_test_results.rs:57:45' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:79:51 write-to-env ado floweyvar1
-      $FLOWEY_BIN v 16 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:79:51' write-to-env ado FLOWEY_CONDITION
+      $FLOWEY_BIN v 16 'flowey_lib_common::ado_task_publish_test_results:0:flowey_lib_common/src/ado_task_publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs write-to-env ado floweyvar1
+      $FLOWEY_BIN v 16 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs' write-to-env ado FLOWEY_CONDITION
     displayName: stopping test_igvm_agent_rpc_server
   - task: PublishTestResults@2
     inputs:
@@ -5571,8 +5571,8 @@ jobs:
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 1 flowey_lib_common::git_checkout 0
-      $FLOWEY_BIN v 1 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:319:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46 write-to-env ado floweyvar1
-      $FLOWEY_BIN v 1 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:320:46' write-to-env ado FLOWEY_CONDITION
+      $FLOWEY_BIN v 1 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env ado floweyvar1
+      $FLOWEY_BIN v 1 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env ado FLOWEY_CONDITION
     displayName: check if openvmm needs to be cloned
   - checkout: self
     path: repo0
@@ -5584,7 +5584,7 @@ jobs:
     condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
   - bash: |-
       set -e
-      $FLOWEY_BIN v 1 'flowey_lib_common::git_checkout:4:flowey_lib_common/src/git_checkout.rs:402:29' --is-raw-string update --env-source Pipeline.Workspace <<'EOF'
+      $FLOWEY_BIN v 1 'flowey_lib_common::git_checkout:4:flowey_lib_common/src/git_checkout.rs' --is-raw-string update --env-source Pipeline.Workspace <<'EOF'
       $(Pipeline.Workspace)
       EOF
       $(FLOWEY_BIN) e 1 flowey_lib_common::git_checkout 3
@@ -5608,8 +5608,8 @@ jobs:
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 1 flowey_lib_common::cache 0
-      $FLOWEY_BIN v 1 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:236:72' --is-raw-string write-to-env ado floweyvar2
-      $FLOWEY_BIN v 1 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:237:72' --is-raw-string write-to-env ado floweyvar3
+      $FLOWEY_BIN v 1 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env ado floweyvar2
+      $FLOWEY_BIN v 1 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env ado floweyvar3
     displayName: Pre-processing cache vars
   - task: Cache@2
     inputs:
@@ -5619,7 +5619,7 @@ jobs:
     displayName: 'Restore cache: gh-release-download'
   - bash: |-
       set -e
-      $FLOWEY_BIN v 1 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:300:70' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
+      $FLOWEY_BIN v 1 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
       $(FLOWEY_CACHE_HITVAR)
       EOF
       $(FLOWEY_BIN) e 1 flowey_lib_common::cache 2

--- a/flowey/flowey_hvlite/src/pipelines/checkin_gates.rs
+++ b/flowey/flowey_hvlite/src/pipelines/checkin_gates.rs
@@ -1030,7 +1030,7 @@ impl IntoPipeline for CheckinGatesCli {
                 OpenvmmHclBuildProfile::Debug
             };
 
-            let igvm_recipes = match (arch, mi_secure) {
+            let mut igvm_recipes = match (arch, mi_secure) {
                 (CommonArch::X86_64, false) => vec![
                     OpenhclIgvmRecipe::X64,
                     OpenhclIgvmRecipe::X64Devkern,
@@ -1051,6 +1051,9 @@ impl IntoPipeline for CheckinGatesCli {
                 }
                 _ => unreachable!(),
             };
+            if flowey_lib_hvlite::_jobs::cfg_versions::OPENHCL_KERNEL_DEV_VERSION.is_none() {
+                igvm_recipes.retain(|recipe| !recipe.uses_dev_kernel());
+            }
 
             let (mut pub_openhcl_igvms, use_openhcl_igvms) =
                 pipeline.new_typed_artifact_collection(igvm_recipes.clone(), additional_tag, None);

--- a/flowey/flowey_lib_hvlite/src/_jobs/cfg_versions.rs
+++ b/flowey/flowey_lib_hvlite/src/_jobs/cfg_versions.rs
@@ -27,8 +27,7 @@ pub const MDBOOK_MERMAID: &str = "0.14.0";
 pub const MU_MSVM: &str = "26.0.19";
 pub const NEXTEST: &str = "0.9.133";
 pub const NODEJS: &str = "24.x";
-// Set this to Some(version) when the hcl-dev branch is meaningfully different
-// from hcl-main and should be built and tested independently.
+// None disables hcl-dev builds and tests; Some(version) enables them.
 pub const OPENHCL_KERNEL_DEV_VERSION: Option<&str> = None;
 pub const OPENHCL_KERNEL_STABLE_VERSION: &str = "6.18.37.2";
 pub const OPENVMM_DEPS: &str = "0.3.0-110";

--- a/flowey/flowey_lib_hvlite/src/_jobs/cfg_versions.rs
+++ b/flowey/flowey_lib_hvlite/src/_jobs/cfg_versions.rs
@@ -27,10 +27,9 @@ pub const MDBOOK_MERMAID: &str = "0.14.0";
 pub const MU_MSVM: &str = "26.0.19";
 pub const NEXTEST: &str = "0.9.133";
 pub const NODEJS: &str = "24.x";
-// N.B. Kernel version numbers for dev and stable branches are not directly
-//      comparable. They originate from separate branches, and the fourth digit
-//      increases with each release from the respective branch.
-pub const OPENHCL_KERNEL_DEV_VERSION: &str = "6.18.37.3";
+// Set this to Some(version) when the hcl-dev branch is meaningfully different
+// from hcl-main and should be built and tested independently.
+pub const OPENHCL_KERNEL_DEV_VERSION: Option<&str> = None;
 pub const OPENHCL_KERNEL_STABLE_VERSION: &str = "6.18.37.2";
 pub const OPENVMM_DEPS: &str = "0.3.0-110";
 pub const PROTOC: &str = "27.1";
@@ -184,13 +183,22 @@ impl FlowNode for Node {
         // Only set kernel versions if we don't have local paths
         // (versions are only needed for downloading)
         if !has_local_kernel {
+            let mut versions = BTreeMap::from([
+                (
+                    OpenhclKernelPackageKind::Main,
+                    OPENHCL_KERNEL_STABLE_VERSION.into(),
+                ),
+                (
+                    OpenhclKernelPackageKind::Cvm,
+                    OPENHCL_KERNEL_STABLE_VERSION.into(),
+                ),
+            ]);
+            if let Some(version) = OPENHCL_KERNEL_DEV_VERSION {
+                versions.insert(OpenhclKernelPackageKind::Dev, version.into());
+                versions.insert(OpenhclKernelPackageKind::CvmDev, version.into());
+            }
             ctx.config(crate::resolve_openhcl_kernel_package::Config {
-                versions: [
-                    (OpenhclKernelPackageKind::Dev, OPENHCL_KERNEL_DEV_VERSION.into()),
-                    (OpenhclKernelPackageKind::Main, OPENHCL_KERNEL_STABLE_VERSION.into()),
-                    (OpenhclKernelPackageKind::Cvm, OPENHCL_KERNEL_STABLE_VERSION.into()),
-                    (OpenhclKernelPackageKind::CvmDev, OPENHCL_KERNEL_DEV_VERSION.into()),
-                ].into(),
+                versions,
                 ..Default::default()
             });
         }

--- a/flowey/flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs
+++ b/flowey/flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs
@@ -355,13 +355,13 @@ impl ArtifactType for OpenhclIgvmRecipe {
 
 impl OpenhclIgvmRecipe {
     pub fn uses_dev_kernel(&self) -> bool {
-        matches!(
-            self,
+        match self {
+            Self::X64 | Self::X64TestLinuxDirect | Self::X64Cvm | Self::Aarch64 => false,
             Self::X64Devkern
-                | Self::X64TestLinuxDirectDevkern
-                | Self::X64CvmDevkern
-                | Self::Aarch64Devkern
-        )
+            | Self::X64TestLinuxDirectDevkern
+            | Self::X64CvmDevkern
+            | Self::Aarch64Devkern => true,
+        }
     }
 
     pub fn non_production_tag(&self) -> String {

--- a/flowey/flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs
+++ b/flowey/flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs
@@ -354,6 +354,16 @@ impl ArtifactType for OpenhclIgvmRecipe {
 }
 
 impl OpenhclIgvmRecipe {
+    pub fn uses_dev_kernel(&self) -> bool {
+        matches!(
+            self,
+            Self::X64Devkern
+                | Self::X64TestLinuxDirectDevkern
+                | Self::X64CvmDevkern
+                | Self::Aarch64Devkern
+        )
+    }
+
     pub fn non_production_tag(&self) -> String {
         let mut tag = self.arch().to_string();
         if let Some(flavor) = self.flavor() {

--- a/flowey/flowey_lib_hvlite/src/resolve_openhcl_kernel_package.rs
+++ b/flowey/flowey_lib_hvlite/src/resolve_openhcl_kernel_package.rs
@@ -139,8 +139,10 @@ impl FlowNodeWithConfig for Node {
                 if kind.is_dev() {
                     anyhow::bail!(
                         "OpenHCL dev kernel support is disabled; configure \
-                         OPENHCL_KERNEL_DEV_VERSION to enable {:?}",
-                        kind
+                         OPENHCL_KERNEL_DEV_VERSION or provide local kernel paths for {:?} to \
+                         enable {:?}",
+                        arch,
+                        kind,
                     );
                 }
                 anyhow::bail!(

--- a/flowey/flowey_lib_hvlite/src/resolve_openhcl_kernel_package.rs
+++ b/flowey/flowey_lib_hvlite/src/resolve_openhcl_kernel_package.rs
@@ -138,9 +138,8 @@ impl FlowNodeWithConfig for Node {
             if !local_paths.contains_key(arch) && !versions.contains_key(kind) {
                 if kind.is_dev() {
                     anyhow::bail!(
-                        "OpenHCL dev kernel support is disabled; configure \
-                         OPENHCL_KERNEL_DEV_VERSION or provide local kernel paths for {:?} to \
-                         enable {:?}",
+                        "OpenHCL dev kernel support is disabled; provide local kernel paths for \
+                         {:?} to enable {:?}",
                         arch,
                         kind,
                     );

--- a/flowey/flowey_lib_hvlite/src/resolve_openhcl_kernel_package.rs
+++ b/flowey/flowey_lib_hvlite/src/resolve_openhcl_kernel_package.rs
@@ -18,7 +18,10 @@ pub enum OpenhclKernelPackageKind {
 
 impl OpenhclKernelPackageKind {
     pub fn is_dev(self) -> bool {
-        matches!(self, Self::Dev | Self::CvmDev)
+        match self {
+            Self::Main | Self::Cvm => false,
+            Self::Dev | Self::CvmDev => true,
+        }
     }
 }
 

--- a/flowey/flowey_lib_hvlite/src/resolve_openhcl_kernel_package.rs
+++ b/flowey/flowey_lib_hvlite/src/resolve_openhcl_kernel_package.rs
@@ -16,6 +16,12 @@ pub enum OpenhclKernelPackageKind {
     CvmDev,
 }
 
+impl OpenhclKernelPackageKind {
+    pub fn is_dev(self) -> bool {
+        matches!(self, Self::Dev | Self::CvmDev)
+    }
+}
+
 flowey_config! {
     /// Config for the resolve_openhcl_kernel_package node.
     pub struct Config {
@@ -130,6 +136,13 @@ impl FlowNodeWithConfig for Node {
         // Verify we have either local paths or versions for each requested architecture
         for (kind, arch) in &all_reqs {
             if !local_paths.contains_key(arch) && !versions.contains_key(kind) {
+                if kind.is_dev() {
+                    anyhow::bail!(
+                        "OpenHCL dev kernel support is disabled; configure \
+                         OPENHCL_KERNEL_DEV_VERSION to enable {:?}",
+                        kind
+                    );
+                }
                 anyhow::bail!(
                     "Must provide either SetLocal for {:?} or SetVersion for {:?}",
                     arch,

--- a/shell.nix
+++ b/shell.nix
@@ -19,6 +19,9 @@ let
   mdbook_mermaid = pkgs.callPackage ./nix/mdbook_mermaid.nix { };
   protoc = pkgs.callPackage ./nix/protoc.nix { };
 
+  # Enable this when hcl-dev should be built independently.
+  enableDevKernel = false;
+
   # Helper to get openvmm_deps and uefi_mu_msvm by architecture
   mkBaseDepsForArch = arch: {
     openvmm_deps = pkgs.callPackage ./nix/openvmm_deps.nix { targetArch = arch; };
@@ -81,7 +84,7 @@ let
     let kernelFile = if arch == "x86_64" then "vmlinux" else "Image";
     in "--use-local-deps --custom-openvmm-deps ${baseDeps.openvmm_deps} --custom-uefi=${baseDeps.uefi_mu_msvm}/MSVM.fd --custom-kernel ${kernel}/${kernelFile} --custom-kernel-modules ${kernel}/modules --custom-protoc ${protoc}";
 
-in pkgs.mkShell {
+in pkgs.mkShell ({
   nativeBuildInputs = [
     rust
     mdbook
@@ -117,29 +120,12 @@ in pkgs.mkShell {
     baseDeps = x64BaseDeps;
     kernel = x64KernelCvm;
   };
-  CARGO_BUILD_ARGS_X64_DEVKERN = mkCargoBuildArgs {
-    arch = "x86_64";
-    baseDeps = x64BaseDeps;
-    kernel = x64KernelDev;
-  };
-  CARGO_BUILD_ARGS_X64_CVM_DEVKERN = mkCargoBuildArgs {
-    arch = "x86_64";
-    baseDeps = x64BaseDeps;
-    kernel = x64KernelCvmDev;
-  };
-
   # aarch64 recipe variants
   CARGO_BUILD_ARGS_AARCH64 = mkCargoBuildArgs {
     arch = "aarch64";
     baseDeps = aarch64BaseDeps;
     kernel = aarch64Kernel;
   };
-  CARGO_BUILD_ARGS_AARCH64_DEVKERN = mkCargoBuildArgs {
-    arch = "aarch64";
-    baseDeps = aarch64BaseDeps;
-    kernel = aarch64KernelDev;
-  };
-
   # Expose deps for reference in update-rootfs.py
   OPENVMM_DEPS_X64 = x64BaseDeps.openvmm_deps;
   OPENVMM_DEPS_AARCH64 = aarch64BaseDeps.openvmm_deps;
@@ -150,10 +136,7 @@ in pkgs.mkShell {
   NIX_UEFI_AARCH64 = "${aarch64BaseDeps.uefi_mu_msvm}/MSVM.fd";
   NIX_KERNEL_X64 = "${x64Kernel}";
   NIX_KERNEL_X64_CVM = "${x64KernelCvm}";
-  NIX_KERNEL_X64_DEV = "${x64KernelDev}";
-  NIX_KERNEL_X64_CVM_DEV = "${x64KernelCvmDev}";
   NIX_KERNEL_AARCH64 = "${aarch64Kernel}";
-  NIX_KERNEL_AARCH64_DEV = "${aarch64KernelDev}";
 
   RUST_BACKTRACE = 1;
   SOURCE_DATE_EPOCH = 12345;
@@ -189,4 +172,23 @@ in pkgs.mkShell {
     ''}
     export PATH="$NIX_CC_WRAPPER_DIR:$PATH"
   '';
-}
+} // pkgs.lib.optionalAttrs enableDevKernel {
+  CARGO_BUILD_ARGS_X64_DEVKERN = mkCargoBuildArgs {
+    arch = "x86_64";
+    baseDeps = x64BaseDeps;
+    kernel = x64KernelDev;
+  };
+  CARGO_BUILD_ARGS_X64_CVM_DEVKERN = mkCargoBuildArgs {
+    arch = "x86_64";
+    baseDeps = x64BaseDeps;
+    kernel = x64KernelCvmDev;
+  };
+  CARGO_BUILD_ARGS_AARCH64_DEVKERN = mkCargoBuildArgs {
+    arch = "aarch64";
+    baseDeps = aarch64BaseDeps;
+    kernel = aarch64KernelDev;
+  };
+  NIX_KERNEL_X64_DEV = "${x64KernelDev}";
+  NIX_KERNEL_X64_CVM_DEV = "${x64KernelCvmDev}";
+  NIX_KERNEL_AARCH64_DEV = "${aarch64KernelDev}";
+})


### PR DESCRIPTION
## Motivation

OpenHCL retains separate dev Linux kernel IGVM recipe variants, but the dev branch no longer represents long-lived feature work that needs a permanently separate set of OpenVMM artifacts. Kernel changes are promoted to main, and the current VMM test pipelines do not consume the dev-kernel IGVM artifacts.

The check-in pipelines nevertheless build and publish dev variants for standard x64, Linux-direct, CVM, and aarch64 configurations. These builds add cost without providing distinct test coverage.

## Changes

- Make the configured dev-kernel version optional and disable it by default.
- Omit dev-kernel recipes from the OSS check-in pipeline matrices while disabled.
- Stop exposing dev-kernel packages and build arguments from the Nix shell.
- Keep the existing kernel kinds, recipes, CLI values, resolver routing, and Petri artifact identities so the variants can be restored without reconstructing their plumbing.
- Return a clear error when a published dev kernel is explicitly requested while no dev version is configured. Custom local kernel packages continue to work.
- Regenerate the affected CI workflows.

## Re-enabling the dev variants

1. Set `OPENHCL_KERNEL_DEV_VERSION` to `Some("<VERSION>")`.
2. Set `enableDevKernel` in `shell.nix` to `true` and update the dev version and hashes in `nix/openhcl_kernel.nix`.
3. Regenerate the Flowey pipelines.
4. Restore or add targeted dev-kernel test coverage that justifies the separate variants.

## Validation

- `cargo clippy --all-targets -p flowey_lib_hvlite -p flowey_hvlite`
- `cargo doc --no-deps -p flowey_lib_hvlite -p flowey_hvlite`
- `cargo xtask fmt --fix`