### PR TITLE
pci_resource_assignment: enable ARI in downstream ports

### DIFF
--- a/vm/devices/pci/pci_core/src/spec.rs
+++ b/vm/devices/pci/pci_core/src/spec.rs
@@ -461,6 +461,7 @@ pub mod caps {
             SRIOV = 0x10,
             REBAR = 0x15,
             DVSEC = 0x23,
+            SIOV  = 0x38,
         }
     }
 
@@ -1246,27 +1247,70 @@ pub mod caps {
             /// | Offset    | Bits 31-16              | Bits 15-0               |
             /// |-----------|-------------------------|-------------------------|
             /// | Ext + 0x0 | Next Cap Ptr + Version  | Extended Capability ID  |
-            /// | Ext + 0x4 | SR-IOV Control          | SR-IOV Capabilities     |
-            /// | Ext + 0x8 | Total VFs               | Initial VFs             |
-            /// | Ext + 0xC | Num VFs                 | Function Dep Link       |
-            /// | Ext + 0x10| First VF Offset         | VF Stride               |
-            /// | Ext + 0x14| VF Device ID            | Reserved                |
-            /// | Ext + 0x18| Supported Page Sizes                              |
-            /// | Ext + 0x1C| System Page Size                                  |
-            /// | Ext + 0x20| VF BAR0                                           |
-            /// | Ext + 0x24| VF BAR1                                           |
-            /// | Ext + 0x28| VF BAR2                                           |
-            /// | Ext + 0x2C| VF BAR3                                           |
-            /// | Ext + 0x30| VF BAR4                                           |
-            /// | Ext + 0x34| VF BAR5                                           |
-            /// | Ext + 0x38| VF Migration State Array Offset                   |
+            /// | Ext + 0x4 | SR-IOV Capabilities                               |
+            /// | Ext + 0x8 | SR-IOV Status           | SR-IOV Control          |
+            /// | Ext + 0xC | Total VFs               | Initial VFs             |
+            /// | Ext + 0x10| Function Dep Link       | Num VFs                 |
+            /// | Ext + 0x14| VF Stride               | First VF Offset         |
+            /// | Ext + 0x18| VF Device ID            | Reserved                |
+            /// | Ext + 0x1C| Supported Page Sizes                              |
+            /// | Ext + 0x20| System Page Size                                  |
+            /// | Ext + 0x24| VF BAR0                                           |
+            /// | Ext + 0x28| VF BAR1                                           |
+            /// | Ext + 0x2C| VF BAR2                                           |
+            /// | Ext + 0x30| VF BAR3                                           |
+            /// | Ext + 0x34| VF BAR4                                           |
+            /// | Ext + 0x38| VF BAR5                                           |
+            /// | Ext + 0x3C| VF Migration State Array Offset                   |
             pub enum SriovExtendedCapabilityHeader: u16 {
                 HEADER = 0x00,
-                CAPS_CONTROL = 0x04,
+                CAPS = 0x04,
+                /// SR-IOV Control (bits 15:0) and SR-IOV Status (bits 31:16).
+                CONTROL_STATUS = 0x08,
                 INITIAL_TOTAL_VFS = 0x0C,
                 VF_OFFSET_STRIDE = 0x14,
                 VF_BAR0 = 0x24,
             }
         }
+
+        /// ARI Capable Hierarchy bit within the 16-bit SR-IOV Control register
+        /// (at [`SriovExtendedCapabilityHeader::CONTROL_STATUS`]).
+        ///
+        /// Source: PCI Express Base Specification §9.4.3.3.5. Present only in
+        /// the lowest-numbered PF of a device; Read Only Zero in other PFs.
+        /// When Set, it hints that ARI has been enabled in the Root Port or
+        /// Switch Downstream Port immediately above the device, allowing VFs to
+        /// be assigned Function Numbers greater than 7 to conserve Bus Numbers.
+        pub const SRIOV_CONTROL_ARI_CAPABLE_HIERARCHY: u16 = 1 << 4;
+    }
+
+    /// Source: PCI Express Base Specification §7.8.8, "ARI Extended Capability"
+    #[expect(missing_docs)] // primarily enums/structs with self-explanatory variants
+    pub mod ari {
+        open_enum::open_enum! {
+            /// Offsets into the ARI Extended Capability structure.
+            ///
+            /// | Offset    | Bits 31-16              | Bits 15-0               |
+            /// |-----------|-------------------------|-------------------------|
+            /// | Ext + 0x0 | Next Cap Ptr + Version  | Extended Capability ID  |
+            /// | Ext + 0x4 | ARI Control             | ARI Capability          |
+            ///
+            /// The ARI Capability register (bits 15:0 at Ext + 0x4) holds the
+            /// Next Function Number in bits 15:8; see
+            /// [`ARI_CAPABILITY_NEXT_FUNCTION_SHIFT`].
+            pub enum AriExtendedCapabilityHeader: u16 {
+                HEADER = 0x00,
+                CAPABILITY_CONTROL = 0x04,
+            }
+        }
+
+        /// Bit shift of the Next Function Number field within the ARI
+        /// Capability register (bits 15:8 of the 16-bit register at
+        /// [`AriExtendedCapabilityHeader::CAPABILITY_CONTROL`]).
+        ///
+        /// Source: PCI Express Base Specification §7.8.8.2. Function 0 is the
+        /// head of a linked list of Function Numbers; a value of 0 terminates
+        /// the list. Function Numbers may be sparse and non-sequential.
+        pub const ARI_CAPABILITY_NEXT_FUNCTION_SHIFT: u32 = 8;
     }
 }

--- a/vm/devices/pci/pci_resource_assignment/src/enumerate.rs
+++ b/vm/devices/pci/pci_resource_assignment/src/enumerate.rs
@@ -412,12 +412,21 @@ async fn scan_bus(
             devices.push(dev);
         }
 
-        // An ARI Device occupies the entire Function-Number space of Device 0
-        // on this bus (the Device Number field is eliminated). Traditional
-        // Device Numbers 1..31 alias to ARI Function Numbers >= 8, so stop
-        // scanning further Device Numbers to avoid re-enumerating the same
-        // Extended Functions.
-        if ari_cap_f0.is_some() {
+        // When ARI Forwarding is enabled in the downstream port above, that
+        // port stops enforcing the Device Number == 0 restriction when
+        // converting Type 1 Configuration Requests to Type 0 (PCIe Base 7.0
+        // §6.13). The ARI Device below then occupies the entire Function-Number
+        // space of Device 0, and traditional Device Numbers 1..31 alias to ARI
+        // Function Numbers >= 8 (already enumerated via the linked-list walk
+        // above). Stop scanning further Device Numbers to avoid re-enumerating
+        // those Extended Functions.
+        //
+        // This aliasing only occurs once ARI Forwarding is enabled. If it was
+        // not (e.g., the root bus has no upstream port, or the port does not
+        // support ARI Forwarding), Device Numbers 1..31 are either absent
+        // (point-to-point link below a downstream port) or real, independent
+        // devices (root/conventional bus) that must still be scanned.
+        if ari_forwarding_enabled {
             break;
         }
     }

--- a/vm/devices/pci/pci_resource_assignment/src/enumerate.rs
+++ b/vm/devices/pci/pci_resource_assignment/src/enumerate.rs
@@ -6,8 +6,15 @@
 use crate::AssignmentError;
 use crate::AssignmentParams;
 use crate::PciConfigAccess;
+use pci_core::spec::caps::CapabilityId;
 use pci_core::spec::caps::EXT_CAP_START;
 use pci_core::spec::caps::ExtendedCapabilityId;
+use pci_core::spec::caps::ari::ARI_CAPABILITY_NEXT_FUNCTION_SHIFT;
+use pci_core::spec::caps::ari::AriExtendedCapabilityHeader;
+use pci_core::spec::caps::pci_express::DeviceCapabilities2;
+use pci_core::spec::caps::pci_express::DeviceControl2;
+use pci_core::spec::caps::pci_express::PciExpressCapabilityHeader;
+use pci_core::spec::caps::sriov::SRIOV_CONTROL_ARI_CAPABLE_HIERARCHY;
 use pci_core::spec::caps::sriov::SriovExtendedCapabilityHeader;
 use pci_core::spec::cfg_space::BarEncodingBits;
 use pci_core::spec::cfg_space::BistHeader;
@@ -16,11 +23,21 @@ use pci_core::spec::cfg_space::CommonHeader;
 use pci_core::spec::cfg_space::HeaderType00;
 use pci_core::spec::cfg_space::HeaderType01;
 
+/// Status register bit 4: Capabilities List present.
+const STATUS_CAPABILITIES_LIST: u16 = 1 << 4;
+
 /// A discovered PCI device or bridge with probed BAR sizes.
 #[derive(Debug, Clone)]
 pub struct DiscoveredDevice {
     pub bus: u8,
     pub device: u8,
+    /// Function Number.
+    ///
+    /// For a traditional Function this is 0..7. For the Extended Functions of
+    /// an ARI Device the Device Number field is eliminated and this holds the
+    /// full 8-bit ARI Function Number (which may exceed 7); in that case
+    /// [`device`](Self::device) is 0, so the config-space devfn byte is still
+    /// `crate::devfn(device, function)`.
     pub function: u8,
     pub is_bridge: bool,
     pub bars: Vec<DiscoveredBar>,
@@ -78,6 +95,7 @@ pub async fn enumerate_and_probe(
     scan_bus(
         cfg,
         params.start_bus,
+        None,
         params.end_bus,
         &mut next_bus,
         params.preserve_bars,
@@ -88,9 +106,15 @@ pub async fn enumerate_and_probe(
 /// Scan a single bus (non-recursive helper that does DFS via inner calls).
 /// This is called for secondary buses behind bridges. It's not async-recursive
 /// itself because we use the pattern of scanning children inline.
+///
+/// `parent_port` is the `(bus, devfn)` of the bridge (Root Port or Switch
+/// Downstream Port) immediately above this bus, or `None` for the host
+/// bridge's root bus. It is used to enable ARI Forwarding in the downstream
+/// port above an ARI Device (see [`enable_ari_forwarding`]).
 async fn scan_bus(
     cfg: &mut impl PciConfigAccess,
     bus: u8,
+    parent_port: Option<(u8, u8)>,
     end_bus: u8,
     next_bus: &mut u16,
     preserve_bars: bool,
@@ -117,37 +141,167 @@ async fn scan_bus(
             )
             .await;
         let bist = BistHeader::from(bist_header_raw);
-        let header_type = bist.header_type();
+        let header_type0 = bist.header_type();
         let multi_function = bist.multi_function();
 
-        let max_func = if multi_function { 8 } else { 1 };
+        // An ARI Device is identified by an ARI Extended Capability structure
+        // in Function 0 (the head of the Extended-Function linked list). This
+        // is reachable without ARI Forwarding since it lives at devfn 0.
+        //
+        // ARI eliminates the Device Number field, so an ARI Device always
+        // occupies Device 0 on its bus. Only treat Device 0 as a possible ARI
+        // Device; this keeps `crate::devfn(device, function)` correct for
+        // Extended Function Numbers > 7 (since `device` is 0).
+        let ari_cap_f0 = if device_num == 0 {
+            find_ext_cap(
+                cfg,
+                bus,
+                crate::devfn(device_num, 0),
+                ExtendedCapabilityId::ARI,
+            )
+            .await
+        } else {
+            None
+        };
 
-        for function in 0..max_func {
-            let devfn = crate::devfn(device_num, function);
+        // If this is an ARI Device, enable ARI Forwarding in the downstream
+        // port above it *before* enumerating its Functions, so that Extended
+        // Functions (Function Numbers > 7) become reachable via Type 0
+        // Configuration Requests. See PCIe Base 7.0 §6.13.
+        let mut ari_forwarding_enabled = false;
+        if ari_cap_f0.is_some() {
+            if let Some((pbus, pdevfn)) = parent_port {
+                ari_forwarding_enabled = enable_ari_forwarding(cfg, pbus, pdevfn).await;
+            }
+        }
 
-            if function > 0 {
-                let vendor = cfg
-                    .read_u32(bus, devfn, CommonHeader::DEVICE_VENDOR.0)
-                    .await;
-                if vendor == !0u32 {
-                    continue;
+        // Build the list of Function Numbers to enumerate. For an ARI Device
+        // this walks the ARI Next-Function-Number linked list (§7.8.8.2),
+        // which may include sparse Function Numbers greater than 7. Otherwise
+        // scan the traditional Function Numbers 0..7.
+        let func_nums: Vec<u8> = if ari_cap_f0.is_some() {
+            ari_function_list(cfg, bus).await
+        } else if multi_function {
+            let mut v = Vec::new();
+            for f in 0..8u8 {
+                if f == 0
+                    || cfg
+                        .read_u32(
+                            bus,
+                            crate::devfn(device_num, f),
+                            CommonHeader::DEVICE_VENDOR.0,
+                        )
+                        .await
+                        != !0u32
+                {
+                    v.push(f);
                 }
             }
+            v
+        } else {
+            vec![0]
+        };
 
-            let func_header = if function > 0 {
-                let bh = cfg.read_u32(bus, devfn, HeaderType00::BIST_HEADER.0).await;
-                BistHeader::from(bh).header_type()
+        // Detect the header type and SR-IOV / SIOV capabilities of each
+        // Function. This is done before probing so that ARI Forwarding and
+        // ARI Capable Hierarchy can be configured before First VF Offset /
+        // VF Stride are read (their values may depend on ARI Capable
+        // Hierarchy — see §9.2.1.2).
+        struct FuncInfo {
+            func_num: u8,
+            devfn: u8,
+            is_bridge: bool,
+            sriov_off: Option<u16>,
+            is_siov: bool,
+        }
+        let mut funcs = Vec::new();
+        for &f in &func_nums {
+            // For an ARI Device the Device Number is eliminated, so the devfn
+            // byte is the raw Function Number. Since ARI Devices reside at
+            // Device 0, `devfn(0, f)` equals `f` for any `f`.
+            let devfn = crate::devfn(device_num, f);
+            let is_bridge = if f == 0 {
+                header_type0 == 1
             } else {
-                header_type
+                let bh = cfg.read_u32(bus, devfn, HeaderType00::BIST_HEADER.0).await;
+                BistHeader::from(bh).header_type() == 1
             };
+            // SR-IOV / SIOV Extended Capabilities only appear on endpoint
+            // (Type 0) Functions.
+            let (sriov_off, is_siov) = if is_bridge {
+                (None, false)
+            } else {
+                let sriov_off = find_ext_cap(cfg, bus, devfn, ExtendedCapabilityId::SRIOV).await;
+                let is_siov = find_ext_cap(cfg, bus, devfn, ExtendedCapabilityId::SIOV)
+                    .await
+                    .is_some();
+                (sriov_off, is_siov)
+            };
+            funcs.push(FuncInfo {
+                func_num: f,
+                devfn,
+                is_bridge,
+                sriov_off,
+                is_siov,
+            });
+        }
 
-            let is_bridge = func_header == 1;
+        let has_sriov = funcs.iter().any(|f| f.sriov_off.is_some());
+        let has_siov = funcs.iter().any(|f| f.is_siov);
+
+        // Enable ARI Forwarding in the downstream port above this device when
+        // it exposes SR-IOV or SIOV Functions (and it was not already enabled
+        // for an ARI Device above). SR-IOV VFs and SIOV SDIs may consume
+        // Function Numbers greater than 7 when ARI Capable Hierarchy is set.
+        if !ari_forwarding_enabled && (has_sriov || has_siov) {
+            if let Some((pbus, pdevfn)) = parent_port {
+                ari_forwarding_enabled = enable_ari_forwarding(cfg, pbus, pdevfn).await;
+            }
+        }
+
+        // Set ARI Capable Hierarchy in the lowest-numbered SR-IOV PF, but only
+        // when ARI Forwarding was actually enabled in the downstream port
+        // above: software should set this bit to *match* the port's ARI
+        // Forwarding Enable (§9.4.3.3.5). This bit is present only in the
+        // lowest-numbered PF and affects all PFs of the device; it must be set
+        // before First VF Offset / VF Stride are read below.
+        if ari_forwarding_enabled {
+            if let Some(pf) = funcs
+                .iter()
+                .filter(|f| f.sriov_off.is_some())
+                .min_by_key(|f| f.func_num)
+            {
+                set_ari_capable_hierarchy(cfg, bus, pf.devfn, pf.sriov_off.unwrap()).await;
+            }
+        }
+
+        if ari_forwarding_enabled {
+            tracing::debug!(
+                bus,
+                device = device_num,
+                is_ari_device = ari_cap_f0.is_some(),
+                has_sriov,
+                has_siov,
+                "enabled ARI forwarding in downstream port"
+            );
+        }
+
+        // Probe each Function and build its DiscoveredDevice.
+        for info in funcs {
+            let FuncInfo {
+                func_num,
+                devfn,
+                is_bridge,
+                sriov_off,
+                is_siov: _,
+            } = info;
+
             let bars = probe_bars(cfg, bus, devfn, is_bridge, preserve_bars).await;
 
             let mut dev = DiscoveredDevice {
                 bus,
                 device: device_num,
-                function,
+                function: func_num,
                 is_bridge,
                 bars,
                 children: Vec::new(),
@@ -162,7 +316,7 @@ async fn scan_bus(
                     return Err(AssignmentError::BusExhaustion {
                         bus,
                         device: device_num,
-                        function,
+                        function: func_num,
                     });
                 }
                 let secondary = *next_bus as u8;
@@ -176,9 +330,17 @@ async fn scan_bus(
                 // itself indirectly via this path), but the Rust compiler
                 // handles it because each call is a separate monomorphized
                 // async block that goes through the same function, and we
-                // box it to avoid infinite-size futures.
-                let children =
-                    Box::pin(scan_bus(cfg, secondary, end_bus, next_bus, preserve_bars)).await?;
+                // box it to avoid infinite-size futures. This bridge is the
+                // downstream port above the secondary bus.
+                let children = Box::pin(scan_bus(
+                    cfg,
+                    secondary,
+                    Some((bus, devfn)),
+                    end_bus,
+                    next_bus,
+                    preserve_bars,
+                ))
+                .await?;
 
                 let subordinate = (*next_bus - 1).max(secondary as u16) as u8;
                 let bus_reg =
@@ -193,20 +355,24 @@ async fn scan_bus(
                 tracing::debug!(
                     bus,
                     device = device_num,
-                    function,
+                    function = func_num,
                     secondary,
                     subordinate,
                     "bridge enumerated"
                 );
             } else {
                 // Probe SR-IOV capability for bus reservation and VF BAR sizes.
-                if let Some(sriov_result) = probe_sriov(cfg, bus, devfn, preserve_bars).await {
+                // First VF Offset / VF Stride now reflect ARI Capable
+                // Hierarchy, which was configured above.
+                if let Some(sriov_result) =
+                    probe_sriov(cfg, bus, devfn, sriov_off, preserve_bars).await
+                {
                     let max_vf_bus = sriov_result.max_vf_bus;
                     if max_vf_bus > end_bus as u16 {
                         return Err(AssignmentError::BusExhaustion {
                             bus,
                             device: device_num,
-                            function,
+                            function: func_num,
                         });
                     }
                     // VF bus numbers are fixed by the device's VF Offset
@@ -219,7 +385,7 @@ async fn scan_bus(
                             return Err(AssignmentError::SriovBusConflict {
                                 bus,
                                 device: device_num,
-                                function,
+                                function: func_num,
                                 max_vf_bus,
                                 next_bus: *next_bus,
                             });
@@ -237,7 +403,7 @@ async fn scan_bus(
                 tracing::debug!(
                     bus,
                     device = device_num,
-                    function,
+                    function = func_num,
                     bar_count = dev.bars.len(),
                     "endpoint enumerated"
                 );
@@ -245,9 +411,184 @@ async fn scan_bus(
 
             devices.push(dev);
         }
+
+        // An ARI Device occupies the entire Function-Number space of Device 0
+        // on this bus (the Device Number field is eliminated). Traditional
+        // Device Numbers 1..31 alias to ARI Function Numbers >= 8, so stop
+        // scanning further Device Numbers to avoid re-enumerating the same
+        // Extended Functions.
+        if ari_cap_f0.is_some() {
+            break;
+        }
     }
 
     Ok(devices)
+}
+
+/// Read a single byte from config space via a 32-bit aligned read.
+async fn read_config_u8(cfg: &mut impl PciConfigAccess, bus: u8, devfn: u8, offset: u16) -> u8 {
+    let dword = cfg.read_u32(bus, devfn, offset & !0x3).await;
+    (dword >> ((offset & 0x3) * 8)) as u8
+}
+
+/// Walk the standard (PCI-compatible) Capabilities List to find the PCI
+/// Express Capability (ID 0x10). Returns its config-space offset, or `None`
+/// if the Function has no Capabilities List or no PCI Express Capability.
+async fn find_pcie_cap(cfg: &mut impl PciConfigAccess, bus: u8, devfn: u8) -> Option<u16> {
+    let status = (cfg
+        .read_u32(bus, devfn, CommonHeader::STATUS_COMMAND.0)
+        .await
+        >> 16) as u16;
+    if status & STATUS_CAPABILITIES_LIST == 0 {
+        return None;
+    }
+    let mut ptr = read_config_u8(cfg, bus, devfn, CommonHeader::RESERVED_CAP_PTR.0).await as u16;
+    // Capabilities live in the range 0x40..0x100; bound the walk to that many
+    // entries to guard against malformed loops.
+    for _ in 0..48 {
+        if ptr < 0x40 || ptr == 0xFF {
+            break;
+        }
+        let cap_id = read_config_u8(cfg, bus, devfn, ptr).await;
+        if cap_id == CapabilityId::PCI_EXPRESS.0 {
+            return Some(ptr);
+        }
+        ptr = read_config_u8(cfg, bus, devfn, ptr + 1).await as u16;
+    }
+    None
+}
+
+/// Walk the PCIe Extended Capabilities list (starting at 0x100) to find the
+/// capability with the given ID. Returns its config-space offset, or `None`.
+async fn find_ext_cap(
+    cfg: &mut impl PciConfigAccess,
+    bus: u8,
+    devfn: u8,
+    cap_id: ExtendedCapabilityId,
+) -> Option<u16> {
+    let mut offset = EXT_CAP_START;
+    loop {
+        if offset < EXT_CAP_START || offset & 0x3 != 0 {
+            break;
+        }
+        let header = cfg.read_u32(bus, devfn, offset).await;
+        if header == 0 || header == !0u32 {
+            break;
+        }
+        let id = (header & 0xFFFF) as u16;
+        let next = ((header >> 20) & 0xFFC) as u16;
+        if id == cap_id.0 {
+            return Some(offset);
+        }
+        if next == 0 || next <= offset {
+            break;
+        }
+        offset = next;
+    }
+    None
+}
+
+/// Enable ARI Forwarding in a downstream port (Root Port or Switch Downstream
+/// Port), if the port supports it. Setting the ARI Forwarding Enable bit in
+/// the port's Device Control 2 register lets Configuration Requests reach
+/// Extended Functions (Function Numbers > 7) in the ARI Device below. Returns
+/// `true` if ARI Forwarding is enabled (either newly or already).
+///
+/// See PCIe Base 7.0 §6.13, §7.5.3.15 (ARI Forwarding Supported), and
+/// §7.5.3.16 (ARI Forwarding Enable).
+async fn enable_ari_forwarding(cfg: &mut impl PciConfigAccess, bus: u8, devfn: u8) -> bool {
+    let Some(pcie) = find_pcie_cap(cfg, bus, devfn).await else {
+        return false;
+    };
+    let dev_caps2 = DeviceCapabilities2::from(
+        cfg.read_u32(
+            bus,
+            devfn,
+            pcie + PciExpressCapabilityHeader::DEVICE_CAPS_2.0,
+        )
+        .await,
+    );
+    if !dev_caps2.ari_forwarding_supported() {
+        return false;
+    }
+    let ctl_sts_off = pcie + PciExpressCapabilityHeader::DEVICE_CTL_STS_2.0;
+    let ctl_sts = cfg.read_u32(bus, devfn, ctl_sts_off).await;
+    // Device Control 2 is the low 16 bits; Device Status 2 the high 16 bits.
+    let control = DeviceControl2::from(ctl_sts as u16);
+    if control.ari_forwarding_enable() {
+        return true;
+    }
+    let control = control.with_ari_forwarding_enable(true);
+    // Preserve the high 16 bits (Device Status 2, reserved) as read.
+    let new = (ctl_sts & 0xFFFF_0000) | control.into_bits() as u32;
+    cfg.write_u32(bus, devfn, ctl_sts_off, new).await;
+    true
+}
+
+/// Set the ARI Capable Hierarchy bit in a PF's SR-IOV Control register. This
+/// hints to the device that ARI has been enabled in the downstream port above
+/// it, allowing VFs to be packed into Function Numbers greater than 7 to
+/// conserve Bus Numbers. See PCIe Base 7.0 §9.4.3.3.5.
+async fn set_ari_capable_hierarchy(
+    cfg: &mut impl PciConfigAccess,
+    bus: u8,
+    devfn: u8,
+    sriov_offset: u16,
+) {
+    let off = sriov_offset + SriovExtendedCapabilityHeader::CONTROL_STATUS.0;
+    let control = cfg.read_u32(bus, devfn, off).await as u16;
+    if control & SRIOV_CONTROL_ARI_CAPABLE_HIERARCHY != 0 {
+        return;
+    }
+    // Write only the 16-bit SR-IOV Control field, leaving the SR-IOV Status
+    // field (high 16 bits, which contains W1C bits) as zero — a no-op.
+    let new = (control | SRIOV_CONTROL_ARI_CAPABLE_HIERARCHY) as u32;
+    cfg.write_u32(bus, devfn, off, new).await;
+}
+
+/// Enumerate an ARI Device's Function Numbers by walking the ARI Capability
+/// register's Next-Function-Number linked list. Function 0 is the head; each
+/// Function's ARI Capability register (bits 15:8) points to the next higher
+/// Function Number, or 0 to terminate. Function Numbers may be sparse and
+/// greater than 7. See PCIe Base 7.0 §6.13, §7.8.8.2.
+///
+/// Reaching Functions with Function Number > 7 requires ARI Forwarding to
+/// already be enabled in the downstream port above the device.
+async fn ari_function_list(cfg: &mut impl PciConfigAccess, bus: u8) -> Vec<u8> {
+    let mut funcs = Vec::new();
+    let mut func = 0u8;
+    // At most 256 Functions; bound the walk to guard against malformed lists.
+    for _ in 0..256 {
+        // For an ARI Device the devfn byte is the raw Function Number.
+        let devfn = func;
+        if cfg
+            .read_u32(bus, devfn, CommonHeader::DEVICE_VENDOR.0)
+            .await
+            == !0u32
+        {
+            break;
+        }
+        funcs.push(func);
+        let Some(ari_off) = find_ext_cap(cfg, bus, devfn, ExtendedCapabilityId::ARI).await else {
+            break;
+        };
+        let cap = cfg
+            .read_u32(
+                bus,
+                devfn,
+                ari_off + AriExtendedCapabilityHeader::CAPABILITY_CONTROL.0,
+            )
+            .await;
+        let next = (cap >> ARI_CAPABILITY_NEXT_FUNCTION_SHIFT) as u8;
+        // A Next Function Number of 0 terminates the list; it must strictly
+        // increase, so anything not greater than the current Function is
+        // treated as the end to avoid looping.
+        if next <= func {
+            break;
+        }
+        func = next;
+    }
+    funcs
 }
 
 /// Probe BAR sizes for a device by writing all-ones and reading back.
@@ -329,83 +670,67 @@ pub(crate) struct SriovProbeResult {
     pub vf_bars: Vec<DiscoveredBar>,
 }
 
-/// Probe SR-IOV capability to determine bus requirements and VF BAR sizes.
-/// Returns `None` if the device has no SR-IOV capability or has no VFs.
+/// Probe an SR-IOV capability (already located at `sriov_offset`) to determine
+/// bus requirements and VF BAR sizes. Returns `None` if the PF has no VFs.
+///
+/// This must be called *after* ARI Capable Hierarchy has been configured,
+/// since First VF Offset / VF Stride may depend on it (§9.2.1.2).
 async fn probe_sriov(
     cfg: &mut impl PciConfigAccess,
     bus: u8,
     devfn: u8,
+    sriov_offset: Option<u16>,
     preserve_bars: bool,
 ) -> Option<SriovProbeResult> {
-    // Walk extended capabilities starting at 0x100.
-    let mut offset = EXT_CAP_START;
-    loop {
-        if offset < EXT_CAP_START || offset & 0x3 != 0 {
-            break;
-        }
-        let header = cfg.read_u32(bus, devfn, offset).await;
-        if header == 0 || header == !0u32 {
-            break;
-        }
-        let cap_id = (header & 0xFFFF) as u16;
-        let next = ((header >> 20) & 0xFFC) as u16;
+    let offset = sriov_offset?;
 
-        if cap_id == ExtendedCapabilityId::SRIOV.0 {
-            // Read TotalVFs.
-            let vfs_dword = cfg
-                .read_u32(
-                    bus,
-                    devfn,
-                    offset + SriovExtendedCapabilityHeader::INITIAL_TOTAL_VFS.0,
-                )
-                .await;
-            let total_vfs = (vfs_dword >> 16) as u16;
-            if total_vfs == 0 {
-                return None;
-            }
-
-            // Read VF Offset and VF Stride.
-            let offset_stride = cfg
-                .read_u32(
-                    bus,
-                    devfn,
-                    offset + SriovExtendedCapabilityHeader::VF_OFFSET_STRIDE.0,
-                )
-                .await;
-            let vf_offset = offset_stride as u16;
-            let vf_stride = (offset_stride >> 16) as u16;
-
-            if vf_stride == 0 {
-                return None;
-            }
-
-            // Compute the BDF of the last VF. Use checked arithmetic
-            // since these values come from hardware and could overflow.
-            // A routing ID is 16 bits (bus:8 | devfn:8).
-            let pf_rid = (bus as u16) << 8 | devfn as u16;
-            let last_vf_rid = (total_vfs - 1)
-                .checked_mul(vf_stride)?
-                .checked_add(vf_offset)?
-                .checked_add(pf_rid)?;
-            let max_vf_bus = (last_vf_rid >> 8) as u16;
-
-            // Probe VF BAR sizes (same write-all-ones/readback technique).
-            let vf_bars = probe_vf_bars(cfg, bus, devfn, offset, preserve_bars).await;
-
-            return Some(SriovProbeResult {
-                cap_offset: offset,
-                max_vf_bus,
-                total_vfs,
-                vf_bars,
-            });
-        }
-
-        if next == 0 || next <= offset {
-            break;
-        }
-        offset = next;
+    // Read TotalVFs.
+    let vfs_dword = cfg
+        .read_u32(
+            bus,
+            devfn,
+            offset + SriovExtendedCapabilityHeader::INITIAL_TOTAL_VFS.0,
+        )
+        .await;
+    let total_vfs = (vfs_dword >> 16) as u16;
+    if total_vfs == 0 {
+        return None;
     }
-    None
+
+    // Read VF Offset and VF Stride.
+    let offset_stride = cfg
+        .read_u32(
+            bus,
+            devfn,
+            offset + SriovExtendedCapabilityHeader::VF_OFFSET_STRIDE.0,
+        )
+        .await;
+    let vf_offset = offset_stride as u16;
+    let vf_stride = (offset_stride >> 16) as u16;
+
+    if vf_stride == 0 {
+        return None;
+    }
+
+    // Compute the BDF of the last VF. Use checked arithmetic
+    // since these values come from hardware and could overflow.
+    // A routing ID is 16 bits (bus:8 | devfn:8).
+    let pf_rid = (bus as u16) << 8 | devfn as u16;
+    let last_vf_rid = (total_vfs - 1)
+        .checked_mul(vf_stride)?
+        .checked_add(vf_offset)?
+        .checked_add(pf_rid)?;
+    let max_vf_bus = (last_vf_rid >> 8) as u16;
+
+    // Probe VF BAR sizes (same write-all-ones/readback technique).
+    let vf_bars = probe_vf_bars(cfg, bus, devfn, offset, preserve_bars).await;
+
+    Some(SriovProbeResult {
+        cap_offset: offset,
+        max_vf_bus,
+        total_vfs,
+        vf_bars,
+    })
 }
 
 /// Probe BAR sizes for a range of BAR registers starting at `base_offset`.

--- a/vm/devices/pci/pci_resource_assignment/src/lib.rs
+++ b/vm/devices/pci/pci_resource_assignment/src/lib.rs
@@ -23,6 +23,10 @@ mod tests;
 /// Compute the devfn byte from a device number and function number.
 ///
 /// This is the standard PCI encoding: `(device << 3) | function`.
+///
+/// For an ARI Device the Device Number field is eliminated: `device` is 0 and
+/// `function` is the full 8-bit ARI Function Number, so this still yields the
+/// correct config-space devfn byte (`(0 << 3) | function == function`).
 pub fn devfn(device: u8, function: u8) -> u8 {
     (device << 3) | function
 }

--- a/vm/devices/pci/pci_resource_assignment/src/tests.rs
+++ b/vm/devices/pci/pci_resource_assignment/src/tests.rs
@@ -162,6 +162,10 @@ impl MockConfigSpace {
         let sriov_id: u16 = 0x10;
         inner.regs.insert(key(0x100), sriov_id as u32); // cap_id=0x10, version=0, next=0
 
+        // SR-IOV Control (low u16) | SR-IOV Status (high u16) at cap + 0x08,
+        // initialized to 0 (ARI Capable Hierarchy clear).
+        inner.regs.insert(key(0x100 + 0x08), 0);
+
         // InitialVFs (low u16) | TotalVFs (high u16) at cap + 0x0C.
         inner.regs.insert(
             key(0x100 + 0x0C),
@@ -195,6 +199,70 @@ impl MockConfigSpace {
                 inner.bar_masks.insert(key(upper_offset), upper_mask);
             }
         }
+    }
+
+    /// Write a raw extended-capability header dword at `at`, with the given
+    /// capability ID (version 1) and a pointer to the next capability (`next`,
+    /// 0 to terminate).
+    fn add_ext_cap_header(
+        &self,
+        bus: u8,
+        device: u8,
+        function: u8,
+        cap_id: u16,
+        at: u16,
+        next: u16,
+    ) {
+        let mut inner = self.inner.lock();
+        let header = (cap_id as u32) | (0x1u32 << 16) | ((next as u32) << 20);
+        inner.regs.insert((bus, device, function, at), header);
+    }
+
+    /// Add an ARI extended capability at `at` (chaining to `next`), advertising
+    /// `next_function_number` in bits 15:8 of its ARI Capability register.
+    fn add_ari_cap(
+        &self,
+        bus: u8,
+        device: u8,
+        function: u8,
+        at: u16,
+        next: u16,
+        next_function_number: u8,
+    ) {
+        self.add_ext_cap_header(bus, device, function, 0x0E, at, next);
+        let mut inner = self.inner.lock();
+        // ARI Capability register at at + 0x04; Next Function Number is bits 15:8.
+        inner.regs.insert(
+            (bus, device, function, at + 0x04),
+            (next_function_number as u32) << 8,
+        );
+    }
+
+    /// Add a PCI Express capability to a device's standard capability list at
+    /// offset 0x40, optionally advertising ARI Forwarding Supported in Device
+    /// Capabilities 2. Device Control 2 (which holds ARI Forwarding Enable) is
+    /// readable/writable at offset 0x68.
+    fn add_pcie_cap(&self, bus: u8, device: u8, function: u8, ari_forwarding_supported: bool) {
+        let mut inner = self.inner.lock();
+        let key = |off: u16| (bus, device, function, off);
+        // Set the Capabilities List bit (bit 4) in the Status register (high
+        // 16 bits of the Status/Command dword at 0x04).
+        let sc = inner.regs.get(&key(0x04)).copied().unwrap_or(0);
+        inner.regs.insert(key(0x04), sc | (1u32 << (16 + 4)));
+        // Capabilities Pointer (low byte of 0x34) -> 0x40.
+        inner.regs.insert(key(0x34), 0x40);
+        // PCI Express capability header at 0x40: cap id 0x10, next 0.
+        inner.regs.insert(key(0x40), 0x10);
+        // Device Capabilities 2 at 0x40 + 0x24 = 0x64: bit 5 = ARI Forwarding
+        // Supported.
+        let dev_caps2 = if ari_forwarding_supported {
+            1u32 << 5
+        } else {
+            0
+        };
+        inner.regs.insert(key(0x64), dev_caps2);
+        // Device Control/Status 2 at 0x40 + 0x28 = 0x68: initially 0.
+        inner.regs.insert(key(0x68), 0);
     }
 
     fn read_reg(&self, bus: u8, device: u8, function: u8, offset: u16) -> u32 {
@@ -310,6 +378,19 @@ fn read_vf_bar64(mock: &MockConfigSpace, bus: u8, dev: u8, func: u8, bar_idx: u8
 }
 
 // ---- Tests ----
+
+/// Read the ARI Forwarding Enable bit (Device Control 2, bit 5) from a
+/// bridge's PCI Express capability (located at offset 0x40, so Device
+/// Control 2 is at 0x68).
+fn ari_forwarding_enabled(mock: &MockConfigSpace, bus: u8, dev: u8, func: u8) -> bool {
+    mock.read_reg(bus, dev, func, 0x68) & (1 << 5) != 0
+}
+
+/// Read the ARI Capable Hierarchy bit (SR-IOV Control, bit 4) from a PF's
+/// SR-IOV capability (located at offset 0x100, so SR-IOV Control is at 0x108).
+fn ari_capable_hierarchy(mock: &MockConfigSpace, bus: u8, dev: u8, func: u8) -> bool {
+    mock.read_reg(bus, dev, func, 0x108) & (1 << 4) != 0
+}
 
 #[async_test]
 async fn single_endpoint_32bit_bar() {
@@ -2409,4 +2490,266 @@ async fn pinned_bar_near_u64_max_no_overflow() {
         matches!(err, crate::AssignmentError::PinnedBarOutOfAperture { .. }),
         "expected PinnedBarOutOfAperture, got {err}"
     );
+}
+
+// ---- ARI enablement tests ----
+
+/// An SR-IOV device behind a bridge that supports ARI Forwarding should get
+/// ARI Forwarding enabled in the bridge and ARI Capable Hierarchy set in its
+/// PF.
+#[async_test]
+async fn ari_enabled_for_sriov_device() {
+    let mock = MockConfigSpace::new();
+
+    // Bridge on bus 0 that supports ARI Forwarding.
+    mock.add_bridge(0, 0, 0);
+    mock.add_pcie_cap(0, 0, 0, true);
+
+    // SR-IOV endpoint on bus 1.
+    mock.add_endpoint(1, 0, 0, &[(0, 0x1000, false, false)]);
+    mock.add_sriov(1, 0, 0, 4, 1, 1);
+
+    let params = AssignmentParams {
+        start_bus: 0,
+        end_bus: 255,
+        low_mmio: MemoryRange::new(0x1000_0000..0x1000_0000 + 0x1000_0000),
+        high_mmio: MemoryRange::EMPTY,
+        preserve_bars: false,
+    };
+
+    let mut cfg = mock.clone();
+    assign_pci_resources(&mut cfg, &params).await.unwrap();
+
+    assert!(
+        ari_forwarding_enabled(&mock, 0, 0, 0),
+        "ARI Forwarding should be enabled in the bridge above an SR-IOV device"
+    );
+    assert!(
+        ari_capable_hierarchy(&mock, 1, 0, 0),
+        "ARI Capable Hierarchy should be set in the SR-IOV PF"
+    );
+}
+
+/// If the bridge does not advertise ARI Forwarding Supported, ARI Forwarding
+/// must not be enabled.
+#[async_test]
+async fn ari_not_enabled_when_unsupported() {
+    let mock = MockConfigSpace::new();
+
+    mock.add_bridge(0, 0, 0);
+    mock.add_pcie_cap(0, 0, 0, false); // ARI Forwarding NOT supported
+
+    mock.add_endpoint(1, 0, 0, &[(0, 0x1000, false, false)]);
+    mock.add_sriov(1, 0, 0, 4, 1, 1);
+
+    let params = AssignmentParams {
+        start_bus: 0,
+        end_bus: 255,
+        low_mmio: MemoryRange::new(0x1000_0000..0x1000_0000 + 0x1000_0000),
+        high_mmio: MemoryRange::EMPTY,
+        preserve_bars: false,
+    };
+
+    let mut cfg = mock.clone();
+    assign_pci_resources(&mut cfg, &params).await.unwrap();
+
+    assert!(
+        !ari_forwarding_enabled(&mock, 0, 0, 0),
+        "ARI Forwarding must not be enabled when the bridge does not support it"
+    );
+    assert!(
+        !ari_capable_hierarchy(&mock, 1, 0, 0),
+        "ARI Capable Hierarchy must not be set when ARI Forwarding is not enabled"
+    );
+}
+
+/// An SIOV device (SIOV Extended Capability, no SR-IOV) should still trigger
+/// ARI Forwarding in the bridge, but there is no ARI Capable Hierarchy to set.
+#[async_test]
+async fn ari_enabled_for_siov_device() {
+    let mock = MockConfigSpace::new();
+
+    mock.add_bridge(0, 0, 0);
+    mock.add_pcie_cap(0, 0, 0, true);
+
+    // SIOV endpoint on bus 1: SIOV Extended Capability (0x38) at 0x100.
+    mock.add_endpoint(1, 0, 0, &[(0, 0x1000, false, false)]);
+    mock.add_ext_cap_header(1, 0, 0, 0x38, 0x100, 0);
+
+    let params = AssignmentParams {
+        start_bus: 0,
+        end_bus: 255,
+        low_mmio: MemoryRange::new(0x1000_0000..0x1000_0000 + 0x1000_0000),
+        high_mmio: MemoryRange::EMPTY,
+        preserve_bars: false,
+    };
+
+    let mut cfg = mock.clone();
+    assign_pci_resources(&mut cfg, &params).await.unwrap();
+
+    assert!(
+        ari_forwarding_enabled(&mock, 0, 0, 0),
+        "ARI Forwarding should be enabled in the bridge above an SIOV device"
+    );
+}
+
+/// A device that only has an ARI Extended Capability (no SR-IOV / SIOV) still
+/// triggers ARI Forwarding in the bridge.
+#[async_test]
+async fn ari_enabled_for_ari_cap_only() {
+    let mock = MockConfigSpace::new();
+
+    mock.add_bridge(0, 0, 0);
+    mock.add_pcie_cap(0, 0, 0, true);
+
+    // Endpoint on bus 1 with a single Function and an ARI cap terminating the
+    // Function list (Next Function Number = 0).
+    mock.add_endpoint(1, 0, 0, &[(0, 0x1000, false, false)]);
+    mock.add_ari_cap(1, 0, 0, 0x100, 0, 0);
+
+    let params = AssignmentParams {
+        start_bus: 0,
+        end_bus: 255,
+        low_mmio: MemoryRange::new(0x1000_0000..0x1000_0000 + 0x1000_0000),
+        high_mmio: MemoryRange::EMPTY,
+        preserve_bars: false,
+    };
+
+    let mut cfg = mock.clone();
+    assign_pci_resources(&mut cfg, &params).await.unwrap();
+
+    assert!(
+        ari_forwarding_enabled(&mock, 0, 0, 0),
+        "ARI Forwarding should be enabled for a device with an ARI capability"
+    );
+}
+
+/// An ARI device with sparse Extended Functions (Function Numbers 0, 1, 8, 9)
+/// must be fully enumerated via the ARI Next-Function-Number linked list, and
+/// each Function's BAR programmed. Functions 8 and 9 (accessed via raw devfn
+/// bytes 8 and 9) map to mock (device 1, function 0/1).
+#[async_test]
+async fn ari_function_list_walk() {
+    let mock = MockConfigSpace::new();
+
+    mock.add_bridge(0, 0, 0);
+    mock.add_pcie_cap(0, 0, 0, true);
+
+    // Function 0 (devfn 0 -> mock 0,0): ARI cap, next function 1.
+    mock.add_endpoint(1, 0, 0, &[(0, 0x1000, false, false)]);
+    mock.set_multi_function(1, 0);
+    mock.add_ari_cap(1, 0, 0, 0x100, 0, 1);
+
+    // Function 1 (devfn 1 -> mock 0,1): ARI cap, next function 8.
+    mock.add_endpoint(1, 0, 1, &[(0, 0x1000, false, false)]);
+    mock.add_ari_cap(1, 0, 1, 0x100, 0, 8);
+
+    // Function 8 (devfn 8 -> mock 1,0): ARI cap, next function 9.
+    mock.add_endpoint(1, 1, 0, &[(0, 0x1000, false, false)]);
+    mock.add_ari_cap(1, 1, 0, 0x100, 0, 9);
+
+    // Function 9 (devfn 9 -> mock 1,1): ARI cap, terminates the list.
+    mock.add_endpoint(1, 1, 1, &[(0, 0x1000, false, false)]);
+    mock.add_ari_cap(1, 1, 1, 0x100, 0, 0);
+
+    let params = AssignmentParams {
+        start_bus: 0,
+        end_bus: 255,
+        low_mmio: MemoryRange::new(0x1000_0000..0x1000_0000 + 0x1000_0000),
+        high_mmio: MemoryRange::EMPTY,
+        preserve_bars: false,
+    };
+
+    let mut cfg = mock.clone();
+    assign_pci_resources(&mut cfg, &params).await.unwrap();
+
+    assert!(
+        ari_forwarding_enabled(&mock, 0, 0, 0),
+        "ARI Forwarding should be enabled for the ARI device"
+    );
+
+    // All four Extended Functions must have their BARs programmed to distinct,
+    // valid addresses. The raw devfn byte decomposes into the mock's
+    // (device, function): devfn 0->(0,0), 1->(0,1), 8->(1,0), 9->(1,1).
+    let f0 = read_bar32(&mock, 1, 0, 0, 0) & !0xF;
+    let f1 = read_bar32(&mock, 1, 0, 1, 0) & !0xF;
+    let f8 = read_bar32(&mock, 1, 1, 0, 0) & !0xF;
+    let f9 = read_bar32(&mock, 1, 1, 1, 0) & !0xF;
+    for (name, addr) in [("f0", f0), ("f1", f1), ("f8", f8), ("f9", f9)] {
+        assert!(addr >= 0x1000_0000, "{name} BAR not programmed: {addr:#x}");
+    }
+    let mut addrs = [f0, f1, f8, f9];
+    addrs.sort_unstable();
+    for w in addrs.windows(2) {
+        assert_ne!(w[0], w[1], "ARI function BARs must be distinct");
+    }
+}
+
+/// ARI Capable Hierarchy must be set in the lowest-numbered PF even when that
+/// PF is not Function 0. Here Function 0 has no SR-IOV; PFs are at Functions
+/// 2 and 4, so the lowest PF is Function 2.
+#[async_test]
+async fn ari_capable_hierarchy_lowest_pf() {
+    let mock = MockConfigSpace::new();
+
+    mock.add_bridge(0, 0, 0);
+    mock.add_pcie_cap(0, 0, 0, true);
+
+    // Multi-function device: Function 0 is a plain endpoint (no SR-IOV).
+    mock.add_endpoint(1, 0, 0, &[(0, 0x1000, false, false)]);
+    mock.set_multi_function(1, 0);
+    // Function 2: SR-IOV PF (lowest-numbered PF).
+    mock.add_endpoint(1, 0, 2, &[(0, 0x1000, false, false)]);
+    mock.add_sriov(1, 0, 2, 2, 1, 1);
+    // Function 4: another SR-IOV PF.
+    mock.add_endpoint(1, 0, 4, &[(0, 0x1000, false, false)]);
+    mock.add_sriov(1, 0, 4, 2, 1, 1);
+
+    let params = AssignmentParams {
+        start_bus: 0,
+        end_bus: 255,
+        low_mmio: MemoryRange::new(0x1000_0000..0x1000_0000 + 0x1000_0000),
+        high_mmio: MemoryRange::EMPTY,
+        preserve_bars: false,
+    };
+
+    let mut cfg = mock.clone();
+    assign_pci_resources(&mut cfg, &params).await.unwrap();
+
+    assert!(
+        ari_forwarding_enabled(&mock, 0, 0, 0),
+        "ARI Forwarding should be enabled"
+    );
+    assert!(
+        ari_capable_hierarchy(&mock, 1, 0, 2),
+        "ARI Capable Hierarchy should be set in the lowest-numbered PF (Function 2)"
+    );
+    assert!(
+        !ari_capable_hierarchy(&mock, 1, 0, 4),
+        "ARI Capable Hierarchy should not be set in the higher-numbered PF (Function 4)"
+    );
+}
+
+/// A top-level SR-IOV device directly on the root bus (no downstream port
+/// above) must not fault; there is no port on which to enable ARI Forwarding.
+#[async_test]
+async fn ari_no_port_at_root_bus() {
+    let mock = MockConfigSpace::new();
+
+    // SR-IOV endpoint directly on bus 0 (no bridge above).
+    mock.add_endpoint(0, 0, 0, &[(0, 0x1000, false, false)]);
+    mock.add_sriov(0, 0, 0, 2, 1, 1);
+
+    let params = AssignmentParams {
+        start_bus: 0,
+        end_bus: 255,
+        low_mmio: MemoryRange::new(0x1000_0000..0x1000_0000 + 0x1000_0000),
+        high_mmio: MemoryRange::EMPTY,
+        preserve_bars: false,
+    };
+
+    let mut cfg = mock.clone();
+    // Should succeed without attempting to enable ARI Forwarding on a
+    // non-existent downstream port.
+    assign_pci_resources(&mut cfg, &params).await.unwrap();
 }

--- a/vm/devices/pci/pci_resource_assignment/src/tests.rs
+++ b/vm/devices/pci/pci_resource_assignment/src/tests.rs
@@ -2753,3 +2753,39 @@ async fn ari_no_port_at_root_bus() {
     // non-existent downstream port.
     assign_pci_resources(&mut cfg, &params).await.unwrap();
 }
+
+/// An ARI-capable device at Device 0 on the root bus (no upstream port, so ARI
+/// Forwarding cannot be enabled) must not cause real, independent devices at
+/// higher Device Numbers to be skipped. The Device-Number -> Function-Number
+/// aliasing only applies once ARI Forwarding is enabled upstream.
+#[async_test]
+async fn ari_cap_without_forwarding_does_not_skip_real_devices() {
+    let mock = MockConfigSpace::new();
+
+    // Device 0 on the root bus: has an ARI capability but no upstream port to
+    // enable ARI Forwarding on. ARI cap terminates the Function list.
+    mock.add_endpoint(0, 0, 0, &[(0, 0x1000, false, false)]);
+    mock.add_ari_cap(0, 0, 0, 0x100, 0, 0);
+
+    // Device 1 on the root bus: a real, independent endpoint.
+    mock.add_endpoint(0, 1, 0, &[(0, 0x2000, false, false)]);
+
+    let params = AssignmentParams {
+        start_bus: 0,
+        end_bus: 255,
+        low_mmio: MemoryRange::new(0x1000_0000..0x1000_0000 + 0x1000_0000),
+        high_mmio: MemoryRange::EMPTY,
+        preserve_bars: false,
+    };
+
+    let mut cfg = mock.clone();
+    assign_pci_resources(&mut cfg, &params).await.unwrap();
+
+    // Device 1's BAR must have been programmed into the low MMIO aperture
+    // (it was not skipped). An unscanned device would leave its BAR at 0.
+    let dev1_bar = read_bar32(&mock, 0, 1, 0, 0) & !0xF;
+    assert!(
+        (0x1000_0000..0x2000_0000).contains(&dev1_bar),
+        "device 1 BAR should be programmed into the aperture, got {dev1_bar:#x}"
+    );
+}


### PR DESCRIPTION
## Summary

Teaches `pci_resource_assignment` enumeration to enable **ARI (Alternative Routing-ID Interpretation)** where appropriate, grounded in the PCI Express Base Specification 7.0.

During the enumeration/probe pass, for each device:

- **Enable ARI Forwarding** in the downstream port (Root Port or Switch Downstream Port) immediately above the device when the device exposes an **SR-IOV**, **SIOV**, or **ARI** Extended Capability — but only if the port advertises *ARI Forwarding Supported* (Device Capabilities 2 bit 5). This sets *ARI Forwarding Enable* in the port's Device Control 2 register (§6.13, §7.5.3.15–16).
- **Set ARI Capable Hierarchy** in the **lowest-numbered SR-IOV PF** (found by scanning — it need not be Function 0), and only when forwarding was actually enabled, so the bit *matches* the port's forwarding-enable per §9.4.3.3.5.
- **Enumerate ARI devices via the ARI Next-Function-Number linked list** (§7.8.8.2) when an ARI capability is present, supporting sparse Function Numbers > 7; otherwise scan Functions 0..7 traditionally.

Ordering matters and is enforced:
- ARI Forwarding is enabled **before** the Function walk, so Extended Functions (Function Number > 7) are reachable.
- ARI Capable Hierarchy is set **before** reading *First VF Offset* / *VF Stride*, whose values may depend on it (§9.2.1.2).

Because ARI eliminates the Device Number field, an ARI device always occupies Device 0 on its bus; detection is gated to Device 0, and traditional Device Numbers 1..31 (which alias to ARI Function Numbers ≥ 8) are skipped after an ARI device is enumerated.

### `pci_core` spec additions
- `ExtendedCapabilityId::SIOV = 0x38`
- SR-IOV Control register offset (`CONTROL_STATUS`) + `SRIOV_CONTROL_ARI_CAPABLE_HIERARCHY` (bit 4)
- New `ari` module: ARI Capability register offset + Next-Function-Number shift
- Corrected the previously misaligned SR-IOV offset documentation table

### SIOV note
The **SIOV Extended Capability is entirely read-only** (Capabilities/Status/Total SDIs/First SDI Offset/SDI Stride) and has **no ARI Capable Hierarchy analog or control register** — SDIs are enabled by device-specific means. So for SIOV only ARI Forwarding is enabled; there is nothing to set in the endpoint.

## Testing

- 7 new unit tests: forwarding enabled for SR-IOV; not enabled when the port is unsupported (and ARI Capable Hierarchy left clear); forwarding for SIOV; forwarding for an ARI-cap-only device; ARI linked-list walk with sparse Functions 0/1/8/9; ARI Capable Hierarchy set on the lowest PF when it is not Function 0; SR-IOV device on the root bus with no downstream port.
- Full crate suite: **58/58 pass**. `cargo clippy --all-targets`, `cargo doc --no-deps`, and `cargo xtask fmt --fix` all clean for `pci_core` and `pci_resource_assignment`.