### PR TITLE
petri: Require a mac address for non-synth nics

### DIFF
--- a/petri/burette/src/tests/network.rs
+++ b/petri/burette/src/tests/network.rs
@@ -229,7 +229,7 @@ impl crate::harness::WarmPerfTest for NetworkTest {
                             }
                             NicBackend::VirtioNet => (
                                 c.with_pcie_root_topology(1, 1, 2)
-                                    .with_virtio_nic("s0rc0rp0"),
+                                    .with_virtio_nic("s0rc0rp0", petri::openvmm::NIC_MAC_ADDRESS),
                                 "s0rc0rp1",
                             ),
                         };
@@ -537,7 +537,7 @@ mod tap {
                 }
                 super::NicBackend::VirtioNet => (
                     c.with_pcie_root_topology(1, 1, 3)
-                        .with_virtio_nic("s0rc0rp0"),
+                        .with_virtio_nic("s0rc0rp0", petri::openvmm::NIC_MAC_ADDRESS),
                     "s0rc0rp2",
                 ),
             };

--- a/petri/src/vm/mod.rs
+++ b/petri/src/vm/mod.rs
@@ -654,8 +654,8 @@ impl<T: PetriVmmBackend> PetriVmBuilder<T> {
     /// This removes all VMBus storage controllers. For Linux guests,
     /// virtio-vsock is used for pipette communication. For Windows guests,
     /// the caller must also configure TCP pipette transport via
-    /// `modify_backend(|b| b.with_tcp_pipette_nic())`. The guest must boot
-    /// from a non-VMBus device (e.g. PCIe NVMe).
+    /// `modify_backend(|b| b.with_tcp_pipette_nic(port, mac_address))`. The
+    /// guest must boot from a non-VMBus device (e.g. PCIe NVMe).
     pub fn with_no_vmbus(mut self) -> Self {
         self.no_vmbus = true;
         if self.config.firmware.os_flavor() != OsFlavor::Windows {

--- a/petri/src/vm/openvmm/mod.rs
+++ b/petri/src/vm/openvmm/mod.rs
@@ -74,7 +74,7 @@ use vm_resource::kind::DiskHandleKind;
 use vmgs_resources::VmgsDisk;
 use vmgs_resources::VmgsResource;
 
-/// The instance guid for the MANA nic automatically added when specifying `PetriVmConfigOpenVmm::with_nic`
+/// The instance guid for the MANA nic automatically added when specifying [`PetriVmConfigOpenVmm::with_nic`]
 const MANA_INSTANCE: Guid = guid::guid!("f9641cf4-d915-4743-a7d8-efa75db7b85a");
 
 /// The MAC address used by the NIC assigned with [`PetriVmConfigOpenVmm::with_nic`].

--- a/petri/src/vm/openvmm/modify.rs
+++ b/petri/src/vm/openvmm/modify.rs
@@ -183,7 +183,7 @@ impl PetriVmConfigOpenVmm {
     ///
     /// This exposes a virtio-net device on a PCIe root port, suitable for
     /// guests running virtio drivers (e.g. Linux with UEFI boot).
-    pub fn with_virtio_nic(mut self, port_name: &str) -> Self {
+    pub fn with_virtio_nic(mut self, port_name: &str, mac_address: MacAddress) -> Self {
         let endpoint = net_backend_resources::consomme::ConsommeHandle {
             cidr: None,
             ports: Vec::new(),
@@ -196,7 +196,7 @@ impl PetriVmConfigOpenVmm {
             resource: virtio_resources::VirtioPciDeviceHandle(
                 virtio_resources::net::VirtioNetHandle {
                     max_queues: None,
-                    mac_address: NIC_MAC_ADDRESS,
+                    mac_address,
                     endpoint,
                 }
                 .into_resource(),
@@ -214,7 +214,7 @@ impl PetriVmConfigOpenVmm {
     /// This configures consomme to forward the pipette TCP port from the
     /// host into the guest, so the petri framework can connect to the
     /// pipette agent over TCP.
-    pub fn with_tcp_pipette_nic(mut self, port_name: &str) -> Self {
+    pub fn with_tcp_pipette_nic(mut self, port_name: &str, mac_address: MacAddress) -> Self {
         let (port_send, port_recv) = mesh::oneshot();
         let endpoint = net_backend_resources::consomme::ConsommeHandle {
             cidr: None,
@@ -234,7 +234,7 @@ impl PetriVmConfigOpenVmm {
             resource: virtio_resources::VirtioPciDeviceHandle(
                 virtio_resources::net::VirtioNetHandle {
                     max_queues: None,
-                    mac_address: NIC_MAC_ADDRESS,
+                    mac_address,
                     endpoint,
                 }
                 .into_resource(),

--- a/vmm_tests/vmm_tests/tests/tests/multiarch/hyperv_nested.rs
+++ b/vmm_tests/vmm_tests/tests/tests/multiarch/hyperv_nested.rs
@@ -59,7 +59,7 @@ async fn boot_hyperv_role(config: PetriVmBuilder<OpenVmmPetriBackend>) -> anyhow
                 "s0rc0rp3",
                 guid::guid!("a1b2c3d4-e5f6-7890-abcd-ef0123456789"),
             )
-            .with_tcp_pipette_nic("s0rc0rp2")
+            .with_tcp_pipette_nic("s0rc0rp2", petri::openvmm::NIC_MAC_ADDRESS)
             .with_custom_config(|c| {
                 // Set ACS capability bits on root ports for proper IOMMU
                 // group isolation (SV + RR + CR + UF).

--- a/vmm_tests/vmm_tests/tests/tests/multiarch/pcie.rs
+++ b/vmm_tests/vmm_tests/tests/tests/multiarch/pcie.rs
@@ -520,9 +520,9 @@ async fn smmu_mixed_topology(config: PetriVmBuilder<OpenVmmPetriBackend>) -> any
             b.with_pcie_root_topology(2, 1, 4) // 2 segments, 1 RC each, 4 ports each
                 .with_smmu(&["s0rc0"]) // SMMU only on segment 0's RC
                 .with_pcie_nvme("s0rc0rp0", PCIE_NVME_SUBSYSTEM_IDS[0])
-                .with_virtio_nic("s0rc0rp1")
+                .with_virtio_nic("s0rc0rp1", PCIE_NIC_MAC_ADDRESSES[0])
                 .with_pcie_nvme("s1rc0rp0", PCIE_NVME_SUBSYSTEM_IDS[1])
-                .with_virtio_nic("s1rc0rp1")
+                .with_virtio_nic("s1rc0rp1", PCIE_NIC_MAC_ADDRESSES[1])
                 // Set real ACS capability bits on root ports so Linux creates
                 // per-device IOMMU groups (SV + RR + CR + UF).
                 .with_custom_config(|c| {
@@ -600,9 +600,9 @@ async fn amd_iommu_mixed_topology(
             b.with_pcie_root_topology(2, 1, 4) // 2 segments, 1 RC each, 4 ports each
                 .with_amd_iommu(&["s0rc0"]) // IOMMU only on segment 0's RC
                 .with_pcie_nvme("s0rc0rp0", PCIE_NVME_SUBSYSTEM_IDS[0])
-                .with_virtio_nic("s0rc0rp1")
+                .with_virtio_nic("s0rc0rp1", PCIE_NIC_MAC_ADDRESSES[0])
                 .with_pcie_nvme("s1rc0rp0", PCIE_NVME_SUBSYSTEM_IDS[1])
-                .with_virtio_nic("s1rc0rp1")
+                .with_virtio_nic("s1rc0rp1", PCIE_NIC_MAC_ADDRESSES[1])
                 // Set real ACS capability bits on root ports so Linux creates
                 // per-device IOMMU groups (SV + RR + CR + UF).
                 .with_custom_config(|c| {
@@ -691,9 +691,9 @@ async fn intel_vtd_multi_segment(
             b.with_pcie_root_topology(2, 1, 4) // 2 segments, 1 RC each, 4 ports each
                 .with_intel_vtd(&["s0rc0", "s1rc0"]) // VT-d on every RC
                 .with_pcie_nvme("s0rc0rp0", PCIE_NVME_SUBSYSTEM_IDS[0])
-                .with_virtio_nic("s0rc0rp1")
+                .with_virtio_nic("s0rc0rp1", PCIE_NIC_MAC_ADDRESSES[0])
                 .with_pcie_nvme("s1rc0rp0", PCIE_NVME_SUBSYSTEM_IDS[1])
-                .with_virtio_nic("s1rc0rp1")
+                .with_virtio_nic("s1rc0rp1", PCIE_NIC_MAC_ADDRESSES[1])
                 // Linux's Intel IOMMU driver is off by default unless the
                 // kernel was built with CONFIG_INTEL_IOMMU_DEFAULT_ON.
                 // Also set real ACS capability bits on root ports so Linux
@@ -813,8 +813,8 @@ async fn verify_iommu_mixed_topology(
     // Verify NVMe DMA works through the IOMMU (segment 0 / PCI domain 0000).
     verify_nvme_dma_on_segment(sh, 2, "0000").await?;
 
-    // Verify network interfaces exist on both RCs.
-    verify_net_interface_count(sh, 2).await?;
+    // Verify the expected network interfaces exist with distinct MAC addresses.
+    verify_net_interfaces(sh, &PCIE_NIC_MAC_ADDRESSES).await?;
 
     // Verify no IOMMU faults — faults indicate broken device scope, missing
     // page table mappings, or devices not covered by the IOMMU. Re-read dmesg
@@ -955,19 +955,44 @@ async fn verify_nvme_dma_on_segment(
     Ok(())
 }
 
-/// Assert that the guest has at least `min_count` non-loopback network
-/// interfaces.
-async fn verify_net_interface_count(
+/// Assert that the guest has a non-loopback interface for every expected MAC.
+async fn verify_net_interfaces(
     sh: &pipette_client::shell::UnixShell<'_>,
-    min_count: usize,
+    expected_macs: &[MacAddress],
 ) -> anyhow::Result<()> {
+    let expected_mac_count = expected_macs.len();
+    let expected_macs = expected_macs
+        .iter()
+        .copied()
+        .collect::<std::collections::HashSet<_>>();
+    assert_eq!(
+        expected_macs.len(),
+        expected_mac_count,
+        "expected network interface MAC addresses must be unique"
+    );
+
     let net_devs = cmd!(sh, "ls /sys/class/net/").read().await?;
     let net_count = net_devs.split_whitespace().filter(|d| *d != "lo").count();
     tracing::info!(%net_devs, net_count, "network devices");
     assert!(
-        net_count >= min_count,
-        "expected at least {min_count} network interfaces, got {net_count}: {net_devs}"
+        net_count >= expected_mac_count,
+        "expected at least {} network interfaces, got {net_count}: {net_devs}",
+        expected_mac_count
     );
+
+    let guest_macs = cmd!(sh, "sh -c 'cat /sys/class/net/*/address'")
+        .read()
+        .await?
+        .lines()
+        .map(str::parse)
+        .collect::<Result<std::collections::HashSet<MacAddress>, _>>()?;
+    tracing::info!(?guest_macs, "network interface MAC addresses");
+    for expected_mac in &expected_macs {
+        assert!(
+            guest_macs.contains(expected_mac),
+            "expected network interface with MAC {expected_mac}; found {guest_macs:?}"
+        );
+    }
     Ok(())
 }
 
@@ -984,7 +1009,7 @@ async fn boot_no_vmbus_windows(config: PetriVmBuilder<OpenVmmPetriBackend>) -> a
         .with_default_boot_always_attempt(true)
         .modify_backend(|b| {
             b.with_pcie_root_topology(1, 1, 3)
-                .with_tcp_pipette_nic("s0rc0rp2")
+                .with_tcp_pipette_nic("s0rc0rp2", PCIE_NIC_MAC_ADDRESSES[0])
         })
         .run()
         .await?;
@@ -1010,7 +1035,7 @@ async fn virtio_net_windows(
     let (vm, agent) = config
         .modify_backend(|b| {
             b.with_pcie_root_topology(1, 1, 1)
-                .with_virtio_nic("s0rc0rp0")
+                .with_virtio_nic("s0rc0rp0", PCIE_NIC_MAC_ADDRESSES[0])
         })
         .run()
         .await?;

--- a/vmm_tests/vmm_tests/tests/tests/multiarch/pcie.rs
+++ b/vmm_tests/vmm_tests/tests/tests/multiarch/pcie.rs
@@ -984,8 +984,8 @@ async fn verify_net_interfaces(
         .read()
         .await?
         .lines()
-        .map(str::parse)
-        .collect::<Result<std::collections::HashSet<MacAddress>, _>>()?;
+        .filter_map(|address| address.parse().ok())
+        .collect::<std::collections::HashSet<MacAddress>>();
     tracing::info!(?guest_macs, "network interface MAC addresses");
     for expected_mac in &expected_macs {
         assert!(


### PR DESCRIPTION
VMs can have multiple non-synthetic nics attached to them. Attaching two or more with the same mac address can cause cloud-init to become confused. This confusion is recoverable, but it introduces a two minute timeout we can easily avoid. Require that a mac address is specified for all of these functions so that tests can ensure that no nic gets a duplicate mac.