### PR TITLE
consomme: fix DHCPv4 reply delivery and framing

### DIFF
--- a/vm/devices/net/net_consomme/consomme/src/dhcp.rs
+++ b/vm/devices/net/net_consomme/consomme/src/dhcp.rs
@@ -12,6 +12,7 @@ use smoltcp::wire::DHCP_MAX_DNS_SERVER_COUNT;
 use smoltcp::wire::DhcpMessageType;
 use smoltcp::wire::DhcpPacket;
 use smoltcp::wire::DhcpRepr;
+use smoltcp::wire::EthernetAddress;
 use smoltcp::wire::EthernetFrame;
 use smoltcp::wire::EthernetProtocol;
 use smoltcp::wire::EthernetRepr;
@@ -75,7 +76,7 @@ impl<T: Client> Access<'_, T> {
                 router: Some(self.inner.state.params.gateway_ip),
                 subnet_mask: Some(self.inner.state.params.net_mask),
                 relay_agent_ip: Ipv4Address::UNSPECIFIED,
-                broadcast: false,
+                broadcast: dhcp_req.broadcast,
                 requested_ip: None,
                 client_identifier: None,
                 server_identifier: Some(self.inner.state.params.gateway_ip),
@@ -94,15 +95,15 @@ impl<T: Client> Access<'_, T> {
                 secs: 0,
                 client_hardware_address: dhcp_req.client_hardware_address,
                 client_ip: Ipv4Address::UNSPECIFIED,
-                your_ip: Ipv4Address::BROADCAST,
-                server_ip: self.inner.state.params.gateway_ip,
+                your_ip: Ipv4Address::UNSPECIFIED,
+                server_ip: Ipv4Address::UNSPECIFIED,
                 router: None,
                 subnet_mask: None,
                 relay_agent_ip: Ipv4Address::UNSPECIFIED,
-                broadcast: false,
+                broadcast: dhcp_req.broadcast,
                 requested_ip: None,
                 client_identifier: None,
-                server_identifier: None,
+                server_identifier: Some(self.inner.state.params.gateway_ip),
                 parameter_request_list: None,
                 dns_servers: None,
                 max_size: None,
@@ -117,16 +118,22 @@ impl<T: Client> Access<'_, T> {
             src_port: DHCP_SERVER,
             dst_port: DHCP_CLIENT,
         };
+        // RFC 2131 section 4.1 requires consistent link- and network-layer
+        // destinations. A DHCPNAK is always broadcast when no relay is involved.
+        let (dst_hardware_address, dst_ip) = match (dhcp_req.broadcast, your_ip) {
+            (true, _) | (_, None) => (EthernetAddress::BROADCAST, Ipv4Address::BROADCAST),
+            (false, Some(ip)) => (dhcp_req.client_hardware_address, ip),
+        };
         let resp_ipv4 = Ipv4Repr {
             src_addr: self.inner.state.params.gateway_ip,
-            dst_addr: Ipv4Address::BROADCAST,
+            dst_addr: dst_ip,
             next_header: IpProtocol::Udp,
             payload_len: resp_udp.header_len() + resp_dhcp.buffer_len(),
             hop_limit: 64,
         };
         let resp_eth = EthernetRepr {
             src_addr: self.inner.state.params.gateway_mac,
-            dst_addr: dhcp_req.client_hardware_address,
+            dst_addr: dst_hardware_address,
             ethertype: EthernetProtocol::Ipv4,
         };
 
@@ -153,8 +160,174 @@ impl<T: Client> Access<'_, T> {
                 + resp_ipv4.buffer_len()
                 + resp_udp.header_len()
                 + resp_dhcp.buffer_len()],
-            &ChecksumState::IPV4_ONLY,
+            &ChecksumState::UDP4,
         );
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Consomme;
+    use crate::ConsommeParams;
+    use pal_async::DefaultDriver;
+    use pal_async::driver::Driver;
+
+    const CLIENT_MAC: EthernetAddress = EthernetAddress([0x00, 0x15, 0x5d, 0x12, 0x34, 0x56]);
+    const CLIENT_IP: Ipv4Address = Ipv4Address::new(10, 0, 0, 2);
+    const GATEWAY_IP: Ipv4Address = Ipv4Address::new(10, 0, 0, 1);
+
+    struct CaptureClient {
+        driver: DefaultDriver,
+        frames: Vec<(Vec<u8>, ChecksumState)>,
+    }
+
+    impl Client for CaptureClient {
+        fn driver(&self) -> &dyn Driver {
+            &self.driver
+        }
+
+        fn recv(&mut self, data: &[u8], checksum: &ChecksumState) {
+            self.frames.push((data.to_vec(), *checksum));
+        }
+
+        fn rx_mtu(&mut self) -> usize {
+            1514
+        }
+    }
+
+    fn request(
+        message_type: DhcpMessageType,
+        broadcast: bool,
+        requested_ip: Option<Ipv4Address>,
+    ) -> Vec<u8> {
+        let request = DhcpRepr {
+            message_type,
+            transaction_id: 0x1234_5678,
+            secs: 0,
+            client_hardware_address: CLIENT_MAC,
+            client_ip: Ipv4Address::UNSPECIFIED,
+            your_ip: Ipv4Address::UNSPECIFIED,
+            server_ip: Ipv4Address::UNSPECIFIED,
+            router: None,
+            subnet_mask: None,
+            relay_agent_ip: Ipv4Address::UNSPECIFIED,
+            broadcast,
+            requested_ip,
+            client_identifier: None,
+            server_identifier: None,
+            parameter_request_list: None,
+            dns_servers: None,
+            max_size: None,
+            lease_duration: None,
+            renew_duration: None,
+            rebind_duration: None,
+            additional_options: &[],
+        };
+        let mut payload = vec![0; request.buffer_len()];
+        request
+            .emit(&mut DhcpPacket::new_unchecked(&mut payload))
+            .unwrap();
+        payload
+    }
+
+    struct Reply {
+        message_type: DhcpMessageType,
+        ethernet_dst: EthernetAddress,
+        ip_dst: Ipv4Address,
+        your_ip: Ipv4Address,
+        server_ip: Ipv4Address,
+        server_identifier: Option<Ipv4Address>,
+        broadcast: bool,
+        checksum_state: ChecksumState,
+    }
+
+    fn reply(
+        driver: DefaultDriver,
+        message_type: DhcpMessageType,
+        broadcast: bool,
+        requested_ip: Option<Ipv4Address>,
+    ) -> Reply {
+        let mut params = ConsommeParams::new().unwrap();
+        params.client_mac = CLIENT_MAC;
+        let mut consomme = Consomme::new(params);
+        let mut client = CaptureClient {
+            driver,
+            frames: Vec::new(),
+        };
+        consomme
+            .access(&mut client)
+            .handle_dhcp(&request(message_type, broadcast, requested_ip))
+            .unwrap();
+
+        let (frame, checksum_state) = client.frames.last().expect("DHCP reply");
+        let ethernet = EthernetFrame::new_checked(frame.as_slice()).unwrap();
+        let ethernet_repr = EthernetRepr::parse(&ethernet).unwrap();
+        let ipv4 = Ipv4Packet::new_checked(ethernet.payload()).unwrap();
+        let ipv4_repr = Ipv4Repr::parse(&ipv4, &ChecksumCapabilities::default()).unwrap();
+        let udp = UdpPacket::new_checked(ipv4.payload()).unwrap();
+        let dhcp = DhcpPacket::new_checked(udp.payload()).unwrap();
+        let dhcp_repr = DhcpRepr::parse(&dhcp).unwrap();
+
+        Reply {
+            message_type: dhcp_repr.message_type,
+            ethernet_dst: ethernet_repr.dst_addr,
+            ip_dst: ipv4_repr.dst_addr,
+            your_ip: dhcp_repr.your_ip,
+            server_ip: dhcp_repr.server_ip,
+            server_identifier: dhcp_repr.server_identifier,
+            broadcast: dhcp_repr.broadcast,
+            checksum_state: *checksum_state,
+        }
+    }
+
+    fn assert_udp4(checksum_state: ChecksumState) {
+        assert!(checksum_state.ipv4);
+        assert!(checksum_state.udp);
+        assert!(!checksum_state.tcp);
+        assert_eq!(checksum_state.tso, None);
+        assert_eq!(checksum_state.gso, None);
+    }
+
+    #[pal_async::async_test]
+    async fn broadcasts_offer_when_requested(driver: DefaultDriver) {
+        let reply = reply(driver, DhcpMessageType::Discover, true, None);
+
+        assert_eq!(reply.message_type, DhcpMessageType::Offer);
+        assert_eq!(reply.ethernet_dst, EthernetAddress::BROADCAST);
+        assert_eq!(reply.ip_dst, Ipv4Address::BROADCAST);
+        assert!(reply.broadcast);
+        assert_udp4(reply.checksum_state);
+    }
+
+    #[pal_async::async_test]
+    async fn unicasts_offer_when_supported(driver: DefaultDriver) {
+        let reply = reply(driver, DhcpMessageType::Discover, false, None);
+
+        assert_eq!(reply.message_type, DhcpMessageType::Offer);
+        assert_eq!(reply.ethernet_dst, CLIENT_MAC);
+        assert_eq!(reply.ip_dst, CLIENT_IP);
+        assert!(!reply.broadcast);
+        assert_udp4(reply.checksum_state);
+    }
+
+    #[pal_async::async_test]
+    async fn broadcasts_nak_with_required_fields(driver: DefaultDriver) {
+        let reply = reply(
+            driver,
+            DhcpMessageType::Request,
+            false,
+            Some(Ipv4Address::new(10, 0, 0, 99)),
+        );
+
+        assert_eq!(reply.message_type, DhcpMessageType::Nak);
+        assert_eq!(reply.ethernet_dst, EthernetAddress::BROADCAST);
+        assert_eq!(reply.ip_dst, Ipv4Address::BROADCAST);
+        assert_eq!(reply.your_ip, Ipv4Address::UNSPECIFIED);
+        assert_eq!(reply.server_ip, Ipv4Address::UNSPECIFIED);
+        assert_eq!(reply.server_identifier, Some(GATEWAY_IP));
+        assert!(!reply.broadcast);
+        assert_udp4(reply.checksum_state);
     }
 }

--- a/vm/devices/net/net_consomme/consomme/src/dhcp.rs
+++ b/vm/devices/net/net_consomme/consomme/src/dhcp.rs
@@ -212,6 +212,7 @@ mod tests {
     const CLIENT_MAC: EthernetAddress = EthernetAddress([0x00, 0x15, 0x5d, 0x12, 0x34, 0x56]);
     const CLIENT_IP: Ipv4Address = Ipv4Address::new(10, 0, 0, 2);
     const GATEWAY_IP: Ipv4Address = Ipv4Address::new(10, 0, 0, 1);
+    const NET_MASK: Ipv4Address = Ipv4Address::new(255, 255, 255, 0);
 
     struct CaptureClient {
         driver: DefaultDriver,
@@ -228,7 +229,7 @@ mod tests {
         }
 
         fn rx_mtu(&mut self) -> usize {
-            1514
+            MIN_MTU
         }
     }
 
@@ -292,6 +293,9 @@ mod tests {
 
     fn capture(driver: DefaultDriver, request: &[u8]) -> Vec<(Vec<u8>, ChecksumState)> {
         let mut params = ConsommeParams::new().unwrap();
+        params.net_mask = NET_MASK;
+        params.gateway_ip = GATEWAY_IP;
+        params.client_ip = CLIENT_IP;
         params.client_mac = CLIENT_MAC;
         let mut consomme = Consomme::new(params);
         let mut client = CaptureClient {

--- a/vm/devices/net/net_consomme/consomme/src/dhcp.rs
+++ b/vm/devices/net/net_consomme/consomme/src/dhcp.rs
@@ -178,6 +178,7 @@ impl<T: Client> Access<'_, T> {
         let mut resp_ipv4_packet = Ipv4Packet::new_unchecked(resp_eth_packet.payload_mut());
         resp_ipv4.emit(&mut resp_ipv4_packet, &ChecksumCapabilities::default());
         let mut resp_udp_packet = UdpPacket::new_unchecked(resp_ipv4_packet.payload_mut());
+        let mut dhcp_emit_result = Ok(());
         resp_udp.emit(
             &mut resp_udp_packet,
             &IpAddress::Ipv4(resp_ipv4.src_addr),
@@ -185,10 +186,11 @@ impl<T: Client> Access<'_, T> {
             resp_dhcp_len,
             |udp_payload| {
                 let mut resp_dhcp_packet = DhcpPacket::new_unchecked(udp_payload);
-                resp_dhcp.emit(&mut resp_dhcp_packet).unwrap();
+                dhcp_emit_result = resp_dhcp.emit(&mut resp_dhcp_packet);
             },
             &ChecksumCapabilities::default(),
         );
+        dhcp_emit_result?;
 
         self.client.recv(
             &resp_buffer[..resp_eth.buffer_len()

--- a/vm/devices/net/net_consomme/consomme/src/dhcp.rs
+++ b/vm/devices/net/net_consomme/consomme/src/dhcp.rs
@@ -33,23 +33,51 @@ impl<T: Client> Access<'_, T> {
     pub(crate) fn handle_dhcp(&mut self, payload: &[u8]) -> Result<(), DropReason> {
         let dhcp_packet = DhcpPacket::new_checked(payload)?;
         let dhcp_req = DhcpRepr::parse(&dhcp_packet)?;
+        let gateway_ip = self.inner.state.params.gateway_ip;
+        let client_ip = self.inner.state.params.client_ip;
+
+        // Consomme has no relay-facing network path. Silently ignore relayed
+        // requests rather than emitting a direct-client reply with invalid
+        // giaddr and UDP destination fields.
+        if dhcp_req.relay_agent_ip != Ipv4Address::UNSPECIFIED {
+            return Ok(());
+        }
+
         let your_ip;
         let message_type;
         match dhcp_req.message_type {
             DhcpMessageType::Discover => {
-                your_ip = Some(self.inner.state.params.client_ip);
+                your_ip = Some(client_ip);
                 message_type = DhcpMessageType::Offer;
             }
             DhcpMessageType::Request => {
-                your_ip = match dhcp_req.requested_ip {
-                    Some(addr) if addr == self.inner.state.params.client_ip => Some(addr),
-                    None => Some(self.inner.state.params.client_ip),
+                // A SELECTING request identifies the chosen server. Other
+                // servers must treat it as declining their offers.
+                if dhcp_req
+                    .server_identifier
+                    .is_some_and(|server| server != gateway_ip)
+                {
+                    return Ok(());
+                }
+
+                let requested_ip = dhcp_req.requested_ip.or_else(|| {
+                    (dhcp_req.client_ip != Ipv4Address::UNSPECIFIED).then_some(dhcp_req.client_ip)
+                });
+                your_ip = match requested_ip {
+                    Some(addr) if addr == client_ip => Some(addr),
+                    None => return Ok(()),
                     Some(_) => None,
                 };
                 message_type = DhcpMessageType::Ack;
             }
             ty => return Err(DropReason::UnsupportedDhcp(ty)),
         }
+        let response_client_ip =
+            if message_type == DhcpMessageType::Ack && dhcp_req.requested_ip.is_none() {
+                dhcp_req.client_ip
+            } else {
+                Ipv4Address::UNSPECIFIED
+            };
 
         let mut dns_servers: HeaplessVec<Ipv4Address, DHCP_MAX_DNS_SERVER_COUNT> =
             HeaplessVec::new();
@@ -72,16 +100,16 @@ impl<T: Client> Access<'_, T> {
                 transaction_id: dhcp_req.transaction_id,
                 secs: 0,
                 client_hardware_address: dhcp_req.client_hardware_address,
-                client_ip: Ipv4Address::UNSPECIFIED,
+                client_ip: response_client_ip,
                 your_ip,
-                server_ip: self.inner.state.params.gateway_ip,
-                router: Some(self.inner.state.params.gateway_ip),
+                server_ip: Ipv4Address::UNSPECIFIED,
+                router: Some(gateway_ip),
                 subnet_mask: Some(self.inner.state.params.net_mask),
                 relay_agent_ip: Ipv4Address::UNSPECIFIED,
                 broadcast: dhcp_req.broadcast,
                 requested_ip: None,
                 client_identifier: None,
-                server_identifier: Some(self.inner.state.params.gateway_ip),
+                server_identifier: Some(gateway_ip),
                 parameter_request_list: None,
                 dns_servers: Some(dns_servers),
                 max_size: None,
@@ -105,7 +133,7 @@ impl<T: Client> Access<'_, T> {
                 broadcast: dhcp_req.broadcast,
                 requested_ip: None,
                 client_identifier: None,
-                server_identifier: Some(self.inner.state.params.gateway_ip),
+                server_identifier: Some(gateway_ip),
                 parameter_request_list: None,
                 dns_servers: None,
                 max_size: None,
@@ -123,12 +151,16 @@ impl<T: Client> Access<'_, T> {
         let resp_dhcp_len = resp_dhcp.buffer_len().max(BOOTP_MIN_MESSAGE_LEN);
         // RFC 2131 section 4.1 requires consistent link- and network-layer
         // destinations. A DHCPNAK is always broadcast when no relay is involved.
-        let (dst_hardware_address, dst_ip) = match (dhcp_req.broadcast, your_ip) {
-            (true, _) | (_, None) => (EthernetAddress::BROADCAST, Ipv4Address::BROADCAST),
-            (false, Some(ip)) => (dhcp_req.client_hardware_address, ip),
+        let (dst_hardware_address, dst_ip) = match your_ip {
+            None => (EthernetAddress::BROADCAST, Ipv4Address::BROADCAST),
+            Some(_) if dhcp_req.client_ip != Ipv4Address::UNSPECIFIED => {
+                (dhcp_req.client_hardware_address, dhcp_req.client_ip)
+            }
+            Some(_) if dhcp_req.broadcast => (EthernetAddress::BROADCAST, Ipv4Address::BROADCAST),
+            Some(ip) => (dhcp_req.client_hardware_address, ip),
         };
         let resp_ipv4 = Ipv4Repr {
-            src_addr: self.inner.state.params.gateway_ip,
+            src_addr: gateway_ip,
             dst_addr: dst_ip,
             next_header: IpProtocol::Udp,
             payload_len: resp_udp.header_len() + resp_dhcp_len,
@@ -200,12 +232,13 @@ mod tests {
         }
     }
 
-    fn request(
+    fn request_with(
         message_type: DhcpMessageType,
         broadcast: bool,
         requested_ip: Option<Ipv4Address>,
+        configure: impl FnOnce(&mut DhcpRepr<'_>),
     ) -> Vec<u8> {
-        let request = DhcpRepr {
+        let mut request = DhcpRepr {
             message_type,
             transaction_id: 0x1234_5678,
             secs: 0,
@@ -228,6 +261,7 @@ mod tests {
             rebind_duration: None,
             additional_options: &[],
         };
+        configure(&mut request);
         let mut payload = vec![0; request.buffer_len()];
         request
             .emit(&mut DhcpPacket::new_unchecked(&mut payload))
@@ -235,10 +269,19 @@ mod tests {
         payload
     }
 
+    fn request(
+        message_type: DhcpMessageType,
+        broadcast: bool,
+        requested_ip: Option<Ipv4Address>,
+    ) -> Vec<u8> {
+        request_with(message_type, broadcast, requested_ip, |_| {})
+    }
+
     struct Reply {
         message_type: DhcpMessageType,
         ethernet_dst: EthernetAddress,
         ip_dst: Ipv4Address,
+        client_ip: Ipv4Address,
         your_ip: Ipv4Address,
         server_ip: Ipv4Address,
         server_identifier: Option<Ipv4Address>,
@@ -247,12 +290,7 @@ mod tests {
         checksum_state: ChecksumState,
     }
 
-    fn reply(
-        driver: DefaultDriver,
-        message_type: DhcpMessageType,
-        broadcast: bool,
-        requested_ip: Option<Ipv4Address>,
-    ) -> Reply {
+    fn capture(driver: DefaultDriver, request: &[u8]) -> Vec<(Vec<u8>, ChecksumState)> {
         let mut params = ConsommeParams::new().unwrap();
         params.client_mac = CLIENT_MAC;
         let mut consomme = Consomme::new(params);
@@ -260,12 +298,14 @@ mod tests {
             driver,
             frames: Vec::new(),
         };
-        consomme
-            .access(&mut client)
-            .handle_dhcp(&request(message_type, broadcast, requested_ip))
-            .unwrap();
+        consomme.access(&mut client).handle_dhcp(request).unwrap();
+        client.frames
+    }
 
-        let (frame, checksum_state) = client.frames.last().expect("DHCP reply");
+    fn reply_from_request(driver: DefaultDriver, request: &[u8]) -> Reply {
+        let frames = capture(driver, request);
+
+        let (frame, checksum_state) = frames.last().expect("DHCP reply");
         let ethernet = EthernetFrame::new_checked(frame.as_slice()).unwrap();
         let ethernet_repr = EthernetRepr::parse(&ethernet).unwrap();
         let ipv4 = Ipv4Packet::new_checked(ethernet.payload()).unwrap();
@@ -278,6 +318,7 @@ mod tests {
             message_type: dhcp_repr.message_type,
             ethernet_dst: ethernet_repr.dst_addr,
             ip_dst: ipv4_repr.dst_addr,
+            client_ip: dhcp_repr.client_ip,
             your_ip: dhcp_repr.your_ip,
             server_ip: dhcp_repr.server_ip,
             server_identifier: dhcp_repr.server_identifier,
@@ -285,6 +326,15 @@ mod tests {
             dhcp_len: udp.payload().len(),
             checksum_state: *checksum_state,
         }
+    }
+
+    fn reply(
+        driver: DefaultDriver,
+        message_type: DhcpMessageType,
+        broadcast: bool,
+        requested_ip: Option<Ipv4Address>,
+    ) -> Reply {
+        reply_from_request(driver, &request(message_type, broadcast, requested_ip))
     }
 
     fn assert_udp4(checksum_state: ChecksumState) {
@@ -302,6 +352,7 @@ mod tests {
         assert_eq!(reply.message_type, DhcpMessageType::Offer);
         assert_eq!(reply.ethernet_dst, EthernetAddress::BROADCAST);
         assert_eq!(reply.ip_dst, Ipv4Address::BROADCAST);
+        assert_eq!(reply.server_ip, Ipv4Address::UNSPECIFIED);
         assert!(reply.broadcast);
         assert_udp4(reply.checksum_state);
     }
@@ -320,6 +371,7 @@ mod tests {
         assert_eq!(reply.message_type, DhcpMessageType::Offer);
         assert_eq!(reply.ethernet_dst, CLIENT_MAC);
         assert_eq!(reply.ip_dst, CLIENT_IP);
+        assert_eq!(reply.server_ip, Ipv4Address::UNSPECIFIED);
         assert!(!reply.broadcast);
         assert_udp4(reply.checksum_state);
     }
@@ -341,5 +393,76 @@ mod tests {
         assert_eq!(reply.server_identifier, Some(GATEWAY_IP));
         assert!(!reply.broadcast);
         assert_udp4(reply.checksum_state);
+    }
+
+    #[pal_async::async_test]
+    async fn acknowledges_selected_address(driver: DefaultDriver) {
+        let request = request_with(
+            DhcpMessageType::Request,
+            false,
+            Some(CLIENT_IP),
+            |request| request.server_identifier = Some(GATEWAY_IP),
+        );
+        let reply = reply_from_request(driver, &request);
+
+        assert_eq!(reply.message_type, DhcpMessageType::Ack);
+        assert_eq!(reply.ethernet_dst, CLIENT_MAC);
+        assert_eq!(reply.ip_dst, CLIENT_IP);
+        assert_eq!(reply.client_ip, Ipv4Address::UNSPECIFIED);
+        assert_eq!(reply.your_ip, CLIENT_IP);
+        assert_eq!(reply.server_ip, Ipv4Address::UNSPECIFIED);
+        assert_eq!(reply.server_identifier, Some(GATEWAY_IP));
+        assert_udp4(reply.checksum_state);
+    }
+
+    #[pal_async::async_test]
+    async fn ignores_request_for_another_server(driver: DefaultDriver) {
+        let request = request_with(DhcpMessageType::Request, true, Some(CLIENT_IP), |request| {
+            request.server_identifier = Some(Ipv4Address::new(10, 0, 0, 99));
+        });
+
+        assert!(capture(driver, &request).is_empty());
+    }
+
+    #[pal_async::async_test]
+    async fn acknowledges_renewal_at_ciaddr(driver: DefaultDriver) {
+        let request = request_with(DhcpMessageType::Request, true, None, |request| {
+            request.client_ip = CLIENT_IP;
+        });
+        let reply = reply_from_request(driver, &request);
+
+        assert_eq!(reply.message_type, DhcpMessageType::Ack);
+        assert_eq!(reply.ethernet_dst, CLIENT_MAC);
+        assert_eq!(reply.ip_dst, CLIENT_IP);
+        assert_eq!(reply.client_ip, CLIENT_IP);
+        assert_eq!(reply.your_ip, CLIENT_IP);
+        assert!(reply.broadcast);
+        assert_udp4(reply.checksum_state);
+    }
+
+    #[pal_async::async_test]
+    async fn broadcasts_nak_for_stale_ciaddr(driver: DefaultDriver) {
+        let stale_ip = Ipv4Address::new(10, 0, 0, 99);
+        let request = request_with(DhcpMessageType::Request, false, None, |request| {
+            request.client_ip = stale_ip;
+        });
+        let reply = reply_from_request(driver, &request);
+
+        assert_eq!(reply.message_type, DhcpMessageType::Nak);
+        assert_eq!(reply.ethernet_dst, EthernetAddress::BROADCAST);
+        assert_eq!(reply.ip_dst, Ipv4Address::BROADCAST);
+        assert_eq!(reply.client_ip, Ipv4Address::UNSPECIFIED);
+        assert_eq!(reply.your_ip, Ipv4Address::UNSPECIFIED);
+        assert_eq!(reply.server_identifier, Some(GATEWAY_IP));
+        assert_udp4(reply.checksum_state);
+    }
+
+    #[pal_async::async_test]
+    async fn ignores_request_from_unsupported_relay(driver: DefaultDriver) {
+        let request = request_with(DhcpMessageType::Discover, true, None, |request| {
+            request.relay_agent_ip = Ipv4Address::new(10, 0, 1, 1);
+        });
+
+        assert!(capture(driver, &request).is_empty());
     }
 }

--- a/vm/devices/net/net_consomme/consomme/src/dhcp.rs
+++ b/vm/devices/net/net_consomme/consomme/src/dhcp.rs
@@ -26,6 +26,8 @@ use smoltcp::wire::UdpRepr;
 
 pub const DHCP_SERVER: u16 = 67;
 pub const DHCP_CLIENT: u16 = 68;
+// RFC 1542 section 2.1 requires every BOOTP message to be at least 300 octets.
+const BOOTP_MIN_MESSAGE_LEN: usize = 300;
 
 impl<T: Client> Access<'_, T> {
     pub(crate) fn handle_dhcp(&mut self, payload: &[u8]) -> Result<(), DropReason> {
@@ -118,6 +120,7 @@ impl<T: Client> Access<'_, T> {
             src_port: DHCP_SERVER,
             dst_port: DHCP_CLIENT,
         };
+        let resp_dhcp_len = resp_dhcp.buffer_len().max(BOOTP_MIN_MESSAGE_LEN);
         // RFC 2131 section 4.1 requires consistent link- and network-layer
         // destinations. A DHCPNAK is always broadcast when no relay is involved.
         let (dst_hardware_address, dst_ip) = match (dhcp_req.broadcast, your_ip) {
@@ -128,7 +131,7 @@ impl<T: Client> Access<'_, T> {
             src_addr: self.inner.state.params.gateway_ip,
             dst_addr: dst_ip,
             next_header: IpProtocol::Udp,
-            payload_len: resp_udp.header_len() + resp_dhcp.buffer_len(),
+            payload_len: resp_udp.header_len() + resp_dhcp_len,
             hop_limit: 64,
         };
         let resp_eth = EthernetRepr {
@@ -147,7 +150,7 @@ impl<T: Client> Access<'_, T> {
             &mut resp_udp_packet,
             &IpAddress::Ipv4(resp_ipv4.src_addr),
             &IpAddress::Ipv4(resp_ipv4.dst_addr),
-            resp_dhcp.buffer_len(),
+            resp_dhcp_len,
             |udp_payload| {
                 let mut resp_dhcp_packet = DhcpPacket::new_unchecked(udp_payload);
                 resp_dhcp.emit(&mut resp_dhcp_packet).unwrap();
@@ -159,7 +162,7 @@ impl<T: Client> Access<'_, T> {
             &resp_buffer[..resp_eth.buffer_len()
                 + resp_ipv4.buffer_len()
                 + resp_udp.header_len()
-                + resp_dhcp.buffer_len()],
+                + resp_dhcp_len],
             &ChecksumState::UDP4,
         );
         Ok(())
@@ -240,6 +243,7 @@ mod tests {
         server_ip: Ipv4Address,
         server_identifier: Option<Ipv4Address>,
         broadcast: bool,
+        dhcp_len: usize,
         checksum_state: ChecksumState,
     }
 
@@ -278,6 +282,7 @@ mod tests {
             server_ip: dhcp_repr.server_ip,
             server_identifier: dhcp_repr.server_identifier,
             broadcast: dhcp_repr.broadcast,
+            dhcp_len: udp.payload().len(),
             checksum_state: *checksum_state,
         }
     }
@@ -299,6 +304,13 @@ mod tests {
         assert_eq!(reply.ip_dst, Ipv4Address::BROADCAST);
         assert!(reply.broadcast);
         assert_udp4(reply.checksum_state);
+    }
+
+    #[pal_async::async_test]
+    async fn pads_bootp_reply_to_minimum_length(driver: DefaultDriver) {
+        let reply = reply(driver, DhcpMessageType::Discover, false, None);
+
+        assert_eq!(reply.dhcp_len, BOOTP_MIN_MESSAGE_LEN);
     }
 
     #[pal_async::async_test]


### PR DESCRIPTION

## Summary

Correct Consomme’s direct-client DHCPv4 reply behavior.

Consomme previously emitted replies with inconsistent link- and network-layer destinations, incomplete DHCPNAK fields, under-reported checksum state, and BOOTP messages shorter than the required minimum.

Update the DHCPv4 path to:

- deliver OFFER and ACK replies using RFC 2131 `ciaddr`, broadcast, then `yiaddr` precedence;
- broadcast DHCPNAKs with zero `ciaddr`, `yiaddr`, and `siaddr`, plus option 54;
- copy and validate `ciaddr` for renewal and rebinding requests;
- ignore requests selecting another DHCP server;
- ignore relayed requests because Consomme has no relay-facing network path;
- keep `siaddr` zero unless a real bootstrap server is configured;
- report verified IPv4 and UDP checksums accurately;
- pad every BOOTP/DHCP payload to the RFC 1542 minimum of 300 octets.

This remains a deliberately narrow DHCP server for Consomme’s single-guest NAT topology. It does not add relay support, intercept arbitrary UDP/67 traffic, or change DHCPv6.

## Testing

All local and live validation was performed on a macOS ARM64 host.

- Added packet-level coverage for broadcast/unicast OFFER, ACK, renewal, stale-binding NAK, foreign-server silence, unsupported-relay silence, checksum state, and BOOTP padding.
- All 108 `consomme` tests passed.
- Clippy, docs, and formatting checks passed.
- AZL-3 ARM64 reached SSH and received `10.0.0.2/24` with gateway `10.0.0.1`.
- Windows ARM64 reached SSH and received `10.0.0.2/24`; gateway, DHCP server, and DNS server were `10.0.0.1`.
- Both guests shut down cleanly with OpenVMM exit code 0.