### PR TITLE
pci_core/pcie: allow advertising support for PASID (TLP prefixing) in ports/switches

### DIFF
--- a/Guide/src/reference/openvmm/management/cli.md
+++ b/Guide/src/reference/openvmm/management/cli.md
@@ -303,6 +303,8 @@ name:
   root port. The value can be decimal or hexadecimal. Default is `0x005f`.
   Use `acs=0` to disable ACS for a root port.
 - `cxl`: marks the root port as CXL-capable.
+- `pasid`: advertises support for TLP prefixing (such as for guest PASID
+  behind a virtual IOMMU)
 
 `--pcie-switch` accepts optional comma-separated options as well:
 
@@ -315,6 +317,8 @@ name:
 - `acs=<mask>`: ACS capability mask requested for downstream switch ports.
   The upstream switch port does not expose ACS. Default is `0x005f`.
   Use `acs=0` to disable ACS for switch downstream ports.
+- `pasid`: advertises support for TLP prefixing (such as for guest PASID
+  behind a virtual IOMMU)
 
 ### Generic initiators
 

--- a/openvmm/openvmm_core/src/worker/dispatch.rs
+++ b/openvmm/openvmm_core/src/worker/dispatch.rs
@@ -2091,7 +2091,7 @@ impl InitializedVm {
                             let root_port_definitions = rc
                                 .ports
                                 .iter()
-                                .map(pcie_topology::build_root_port_definition)
+                                .map(pcie_topology::build_port_definition)
                                 .collect();
                             GenericPcieRootComplex::builder(
                                 &mut services.register_mmio(),
@@ -2219,7 +2219,7 @@ impl InitializedVm {
                     let downstream_ports = switch
                         .ports
                         .iter()
-                        .map(pcie_topology::build_root_port_definition)
+                        .map(pcie_topology::build_port_definition)
                         .collect();
                     let definition = pcie::switch::GenericPcieSwitchDefinition {
                         name: switch.name.clone().into(),

--- a/openvmm/openvmm_core/src/worker/dispatch/pcie_topology.rs
+++ b/openvmm/openvmm_core/src/worker/dispatch/pcie_topology.rs
@@ -11,34 +11,39 @@ use cxl_spec::pci_registers::spec::flex_bus_port_dvsec::CxlFlexBusPortDvsecCapab
 use openvmm_defs::config::PciePortConfig;
 use openvmm_defs::config::PcieRootComplexConfig;
 use pci_core::spec::caps::acs::DEFAULT_ACS_CAP_MASK;
+use pci_core::spec::caps::pci_express::MaxEndEndTlpPrefixes;
 use pcie::GenericPciePortDefinition;
 use pcie::PciePortSettings;
 
-/// Builds root-port PCIe settings from manifest flags.
+/// Builds port PCIe settings from manifest flags.
 ///
 /// When CXL is enabled, emit a default Flex Bus capability advertising both
 /// cache and memory support.
-fn build_root_port_settings(rp_cfg: &PciePortConfig) -> PciePortSettings {
+///
+/// When PASID is enabled, advertise support for up to four TLP prefixes to
+/// work for both switch and root ports.
+fn build_port_settings(port_cfg: &PciePortConfig) -> PciePortSettings {
     PciePortSettings {
-        acs_capabilities_supported: rp_cfg
+        acs_capabilities_supported: port_cfg
             .acs_capabilities_supported
             .unwrap_or(DEFAULT_ACS_CAP_MASK),
-        cxl_flex_bus_port_capability: rp_cfg.cxl.then_some(
+        cxl_flex_bus_port_capability: port_cfg.cxl.then_some(
             CxlFlexBusPortDvsecCapability::new()
                 .with_cache_capable(true)
                 .with_mem_capable(true),
         ),
+        tlp_prefixing_supported: port_cfg.pasid.then_some(MaxEndEndTlpPrefixes::Four),
     }
 }
 
-/// Converts a manifest root-port entry into the runtime root-port definition.
-pub(super) fn build_root_port_definition(rp_cfg: &PciePortConfig) -> GenericPciePortDefinition {
-    let settings = build_root_port_settings(rp_cfg);
+/// Converts a manifest port entry into the runtime port definition.
+pub(super) fn build_port_definition(port_cfg: &PciePortConfig) -> GenericPciePortDefinition {
+    let settings = build_port_settings(port_cfg);
 
     GenericPciePortDefinition {
-        name: rp_cfg.name.as_str().into(),
-        devfn: rp_cfg.devfn,
-        hotplug: rp_cfg.hotplug,
+        name: port_cfg.name.as_str().into(),
+        devfn: port_cfg.devfn,
+        hotplug: port_cfg.hotplug,
         settings,
     }
 }

--- a/openvmm/openvmm_defs/src/config.rs
+++ b/openvmm/openvmm_defs/src/config.rs
@@ -263,6 +263,8 @@ pub struct PciePortConfig {
     /// Runtime port construction derives required BAR/subregion layout from
     /// this flag (currently CXL component registers for BAR0).
     pub cxl: bool,
+    /// Enables PASID support for functions downstream of this port.
+    pub pasid: bool,
 }
 
 #[derive(Debug, MeshPayload)]

--- a/openvmm/openvmm_entry/src/cli_args.rs
+++ b/openvmm/openvmm_entry/src/cli_args.rs
@@ -1120,6 +1120,7 @@ Options:
     `hotplug`                      enable hotplug support for this root port
     `acs=<mask>`                   ACS capability bitmask (u16, decimal or 0x-prefixed hex)
     `cxl`                          configure this root port as CXL-capable
+    `pasid`                        enables PASID for devices downstream of this port
 "#)]
     #[clap(long, conflicts_with("pcat"))]
     pub pcie_root_port: Vec<PcieRootPortCli>,
@@ -1143,6 +1144,9 @@ Examples:
     # Enable hotplug on all downstream switch ports of switch0
     --pcie-switch rp0:switch0,hotplug
 
+    # Enable PASID on all downstream switch ports of switch0
+    --pcie-switch rp0:switch0,pasid
+
 Syntax: <port_name>:<name>[,opt,opt=arg,...]
 
     port_name can be:
@@ -1153,6 +1157,7 @@ Options:
     `hotplug`                       enable hotplug support for all downstream switch ports
     `num_downstream_ports=<value>`  number of downstream ports, default 4
     `acs=<mask>`                    ACS capability bitmask for downstream switch ports
+    `pasid`                         enables PASID for devices downstream of this switch
 "#)]
     #[clap(long, conflicts_with("pcat"))]
     pub pcie_switch: Vec<GenericPcieSwitchCli>,
@@ -3221,6 +3226,7 @@ pub struct PcieRootPortCli {
     pub hotplug: bool,
     pub acs_capabilities_supported: Option<u16>,
     pub cxl: bool,
+    pub pasid: bool,
 }
 
 impl FromStr for PcieRootPortCli {
@@ -3245,6 +3251,7 @@ impl FromStr for PcieRootPortCli {
         let mut hotplug = false;
         let mut acs_capabilities_supported = None;
         let mut cxl = false;
+        let mut pasid = false;
 
         // Parse optional flags
         for opt in opts {
@@ -3279,6 +3286,12 @@ impl FromStr for PcieRootPortCli {
                     }
                     cxl = true;
                 }
+                "pasid" => {
+                    if value.is_some() {
+                        anyhow::bail!("pasid option does not take a value")
+                    }
+                    pasid = true;
+                }
                 _ => anyhow::bail!("unexpected option: '{opt}'"),
             }
         }
@@ -3290,6 +3303,7 @@ impl FromStr for PcieRootPortCli {
             hotplug,
             acs_capabilities_supported,
             cxl,
+            pasid,
         })
     }
 }
@@ -3331,6 +3345,7 @@ pub struct GenericPcieSwitchCli {
     pub num_downstream_ports: u8,
     pub hotplug: bool,
     pub acs_capabilities_supported: Option<u16>,
+    pub pasid: bool,
 }
 
 impl FromStr for GenericPcieSwitchCli {
@@ -3354,6 +3369,7 @@ impl FromStr for GenericPcieSwitchCli {
         let mut num_downstream_ports = 4u8; // Default value
         let mut hotplug = false;
         let mut acs_capabilities_supported = None;
+        let mut pasid = false;
 
         for opt in opts {
             let mut kv = opt.split('=');
@@ -3380,6 +3396,12 @@ impl FromStr for GenericPcieSwitchCli {
                     }
                     acs_capabilities_supported = Some(parse_acs_capability_mask(value)?);
                 }
+                "pasid" => {
+                    if kv.next().is_some() {
+                        anyhow::bail!("pasid option does not take a value")
+                    }
+                    pasid = true;
+                }
                 _ => anyhow::bail!("unknown option: '{key}'"),
             }
         }
@@ -3390,6 +3412,7 @@ impl FromStr for GenericPcieSwitchCli {
             num_downstream_ports,
             hotplug,
             acs_capabilities_supported,
+            pasid,
         })
     }
 }
@@ -4870,6 +4893,7 @@ mod tests {
                 hotplug: false,
                 acs_capabilities_supported: None,
                 cxl: false,
+                pasid: false,
             }
         );
 
@@ -4882,6 +4906,7 @@ mod tests {
                 hotplug: false,
                 acs_capabilities_supported: None,
                 cxl: false,
+                pasid: false,
             }
         );
 
@@ -4895,6 +4920,7 @@ mod tests {
                 hotplug: true,
                 acs_capabilities_supported: None,
                 cxl: false,
+                pasid: false,
             }
         );
 
@@ -4907,6 +4933,7 @@ mod tests {
                 hotplug: false,
                 acs_capabilities_supported: Some(0),
                 cxl: false,
+                pasid: false,
             }
         );
 
@@ -4919,6 +4946,7 @@ mod tests {
                 hotplug: false,
                 acs_capabilities_supported: Some(0x005f),
                 cxl: false,
+                pasid: false,
             }
         );
 
@@ -4931,6 +4959,7 @@ mod tests {
                 hotplug: false,
                 acs_capabilities_supported: None,
                 cxl: true,
+                pasid: false,
             }
         );
 
@@ -4944,6 +4973,7 @@ mod tests {
                 hotplug: false,
                 acs_capabilities_supported: None,
                 cxl: false,
+                pasid: false,
             }
         );
         assert_eq!(
@@ -4955,6 +4985,7 @@ mod tests {
                 hotplug: false,
                 acs_capabilities_supported: None,
                 cxl: false,
+                pasid: false,
             }
         );
         assert_eq!(
@@ -4966,6 +4997,20 @@ mod tests {
                 hotplug: false,
                 acs_capabilities_supported: None,
                 cxl: false,
+                pasid: false,
+            }
+        );
+
+        assert_eq!(
+            PcieRootPortCli::from_str("my_rc:port8,pasid").unwrap(),
+            PcieRootPortCli {
+                root_complex_name: "my_rc".to_string(),
+                name: "port8".to_string(),
+                devfn: None,
+                hotplug: false,
+                acs_capabilities_supported: None,
+                cxl: false,
+                pasid: true,
             }
         );
 
@@ -4980,6 +5025,7 @@ mod tests {
         assert!(PcieRootPortCli::from_str("rc0:rp0,addr=0.8").is_err());
         assert!(PcieRootPortCli::from_str("rc0:rp0,addr=1.2.3").is_err());
         assert!(PcieRootPortCli::from_str("rc0:rp0,addr").is_err());
+        assert!(PcieRootPortCli::from_str("rc0:rp0,pasid=foo").is_err());
     }
 
     #[test]
@@ -5021,6 +5067,7 @@ mod tests {
                 num_downstream_ports: 4,
                 hotplug: false,
                 acs_capabilities_supported: None,
+                pasid: false,
             }
         );
 
@@ -5032,6 +5079,7 @@ mod tests {
                 num_downstream_ports: 4,
                 hotplug: false,
                 acs_capabilities_supported: None,
+                pasid: false,
             }
         );
 
@@ -5043,6 +5091,7 @@ mod tests {
                 num_downstream_ports: 8,
                 hotplug: false,
                 acs_capabilities_supported: None,
+                pasid: false,
             }
         );
 
@@ -5055,6 +5104,7 @@ mod tests {
                 num_downstream_ports: 4,
                 hotplug: false,
                 acs_capabilities_supported: None,
+                pasid: false,
             }
         );
 
@@ -5067,6 +5117,7 @@ mod tests {
                 num_downstream_ports: 4,
                 hotplug: true,
                 acs_capabilities_supported: None,
+                pasid: false,
             }
         );
 
@@ -5079,6 +5130,7 @@ mod tests {
                 num_downstream_ports: 8,
                 hotplug: true,
                 acs_capabilities_supported: None,
+                pasid: false,
             }
         );
 
@@ -5090,6 +5142,7 @@ mod tests {
                 num_downstream_ports: 4,
                 hotplug: false,
                 acs_capabilities_supported: Some(0),
+                pasid: false,
             }
         );
 
@@ -5101,6 +5154,19 @@ mod tests {
                 num_downstream_ports: 4,
                 hotplug: false,
                 acs_capabilities_supported: Some(95),
+                pasid: false,
+            }
+        );
+
+        assert_eq!(
+            GenericPcieSwitchCli::from_str("rp0:switch0,pasid").unwrap(),
+            GenericPcieSwitchCli {
+                port_name: "rp0".to_string(),
+                name: "switch0".to_string(),
+                num_downstream_ports: 4,
+                hotplug: false,
+                acs_capabilities_supported: None,
+                pasid: true,
             }
         );
 
@@ -5112,6 +5178,7 @@ mod tests {
         assert!(GenericPcieSwitchCli::from_str("rp0:switch0,num_downstream_ports=bad").is_err());
         assert!(GenericPcieSwitchCli::from_str("rp0:switch0,num_downstream_ports=").is_err());
         assert!(GenericPcieSwitchCli::from_str("rp0:switch0,invalid_flag").is_err());
+        assert!(GenericPcieSwitchCli::from_str("rp0:switch0,pasid=bar").is_err());
     }
 
     #[test]

--- a/openvmm/openvmm_entry/src/cli_args.rs
+++ b/openvmm/openvmm_entry/src/cli_args.rs
@@ -1120,7 +1120,7 @@ Options:
     `hotplug`                      enable hotplug support for this root port
     `acs=<mask>`                   ACS capability bitmask (u16, decimal or 0x-prefixed hex)
     `cxl`                          configure this root port as CXL-capable
-    `pasid`                        enables PASID for devices downstream of this port
+    `pasid`                        configure this port to support PASID for downstream devices
 "#)]
     #[clap(long, conflicts_with("pcat"))]
     pub pcie_root_port: Vec<PcieRootPortCli>,
@@ -1157,7 +1157,7 @@ Options:
     `hotplug`                       enable hotplug support for all downstream switch ports
     `num_downstream_ports=<value>`  number of downstream ports, default 4
     `acs=<mask>`                    ACS capability bitmask for downstream switch ports
-    `pasid`                         enables PASID for devices downstream of this switch
+    `pasid`                         configure this port to support PASID for downstream devices
 "#)]
     #[clap(long, conflicts_with("pcat"))]
     pub pcie_switch: Vec<GenericPcieSwitchCli>,

--- a/openvmm/openvmm_entry/src/lib.rs
+++ b/openvmm/openvmm_entry/src/lib.rs
@@ -220,6 +220,7 @@ fn build_switch_list(all_switches: &[cli_args::GenericPcieSwitchCli]) -> Vec<Pci
                     hotplug: switch_cli.hotplug,
                     acs_capabilities_supported: switch_cli.acs_capabilities_supported,
                     cxl: false,
+                    pasid: switch_cli.pasid,
                 })
                 .collect(),
         })
@@ -891,6 +892,7 @@ async fn vm_config_from_command_line(
                 hotplug: port_cli.hotplug,
                 acs_capabilities_supported: port_cli.acs_capabilities_supported,
                 cxl: port_cli.cxl,
+                pasid: port_cli.pasid,
             })
             .collect();
 

--- a/openvmm/openvmm_entry/src/ttrpc/mod.rs
+++ b/openvmm/openvmm_entry/src/ttrpc/mod.rs
@@ -1531,6 +1531,7 @@ async fn build_pcie_topology(
                 hotplug,
                 acs_capabilities_supported: None,
                 cxl: false,
+                pasid: false,
             });
             if let Some(attached) = attached {
                 walk_pcie_attachment(port_name, attached, &mut switches, &mut pending_devices)?;
@@ -1600,6 +1601,7 @@ fn walk_pcie_attachment(
                     hotplug,
                     acs_capabilities_supported: None,
                     cxl: false,
+                    pasid: false,
                 });
                 if let Some(attached) = attached {
                     children.push((downstream_name, attached));

--- a/petri/src/vm/openvmm/modify.rs
+++ b/petri/src/vm/openvmm/modify.rs
@@ -420,6 +420,7 @@ impl PetriVmConfigOpenVmm {
                         hotplug: true,
                         acs_capabilities_supported: Some(0),
                         cxl: false,
+                        pasid: false,
                     })
                     .collect();
 
@@ -465,6 +466,7 @@ impl PetriVmConfigOpenVmm {
                     hotplug,
                     acs_capabilities_supported: Some(0),
                     cxl: false,
+                    pasid: false,
                 })
                 .collect(),
         });

--- a/vm/devices/pci/pci_core/src/capabilities/pci_express.rs
+++ b/vm/devices/pci/pci_core/src/capabilities/pci_express.rs
@@ -360,7 +360,7 @@ impl PciExpressCapability {
             .device_capabilities_2
             .with_extended_fmt_field_supported(true)
             .with_end_end_tlp_prefix_supported(true)
-            .with_max_end_end_tlp_prefixes(max_prefixes.into_bits());
+            .with_max_end_end_tlp_prefixes(max_prefixes);
         self
     }
 
@@ -877,6 +877,29 @@ mod tests {
         // Guest clears it again.
         write_cap_u32(&mut cap, 0x28, 0x0000);
         assert!(!cap.ari_forwarding_enable());
+    }
+
+    #[test]
+    fn test_tlp_prefixing_supported_max_prefixes() {
+        for max_prefixes in [
+            MaxEndEndTlpPrefixes::One,
+            MaxEndEndTlpPrefixes::Two,
+            MaxEndEndTlpPrefixes::Three,
+            MaxEndEndTlpPrefixes::Four,
+        ] {
+            let cap = PciExpressCapability::new(DevicePortType::Endpoint, None)
+                .with_tlp_prefixing_supported(max_prefixes);
+            let device_caps_2 =
+                pci_express::DeviceCapabilities2::from_bits(read_cap_u32(&cap, 0x24));
+
+            assert!(device_caps_2.extended_fmt_field_supported());
+            assert!(device_caps_2.end_end_tlp_prefix_supported());
+            assert_eq!(
+                device_caps_2.max_end_end_tlp_prefixes().into_bits(),
+                max_prefixes.into_bits(),
+                "unexpected max TLP prefix encoding for {max_prefixes:?}"
+            );
+        }
     }
 
     #[test]

--- a/vm/devices/pci/pci_core/src/capabilities/pci_express.rs
+++ b/vm/devices/pci/pci_core/src/capabilities/pci_express.rs
@@ -6,9 +6,11 @@
 use super::PciCapability;
 use crate::spec::caps::CapabilityId;
 use crate::spec::caps::pci_express;
-use crate::spec::caps::pci_express::{
-    LinkSpeed, LinkWidth, PciExpressCapabilityHeader, SupportedLinkSpeedsVector,
-};
+use crate::spec::caps::pci_express::LinkSpeed;
+use crate::spec::caps::pci_express::LinkWidth;
+use crate::spec::caps::pci_express::MaxEndEndTlpPrefixes;
+use crate::spec::caps::pci_express::PciExpressCapabilityHeader;
+use crate::spec::caps::pci_express::SupportedLinkSpeedsVector;
 use chipset_device::pci::ByteEnabledDwordRead;
 use chipset_device::pci::ByteEnabledDwordWrite;
 use inspect::Inspect;
@@ -344,6 +346,21 @@ impl PciExpressCapability {
             .link_capabilities
             .with_data_link_layer_link_active_reporting(true);
 
+        self
+    }
+
+    /// Enable TLP prefixing support for this PCIe capability.
+    ///
+    /// This configures the appropriate registers to indicate that the function supports
+    /// end-to-end TLP prefixes. We do not currently implement TLP prefixing in endpoint
+    /// DMA APIs but this still may be required for ports upstream of passthrough devices
+    /// that support TLP prefixing (ex. for guest controlled PASID with a virtual IOMMU).
+    pub fn with_tlp_prefixing_supported(mut self, max_prefixes: MaxEndEndTlpPrefixes) -> Self {
+        self.device_capabilities_2 = self
+            .device_capabilities_2
+            .with_extended_fmt_field_supported(true)
+            .with_end_end_tlp_prefix_supported(true)
+            .with_max_end_end_tlp_prefixes(max_prefixes.into_bits());
         self
     }
 

--- a/vm/devices/pci/pci_core/src/spec.rs
+++ b/vm/devices/pci/pci_core/src/spec.rs
@@ -638,7 +638,7 @@ pub mod caps {
         }
 
         impl MaxEndEndTlpPrefixes {
-            pub const fn from_bits(bits: u32) -> Self {
+            pub(crate) const fn from_bits(bits: u32) -> Self {
                 match bits {
                     0b01 => MaxEndEndTlpPrefixes::One,
                     0b10 => MaxEndEndTlpPrefixes::Two,
@@ -1023,7 +1023,7 @@ pub mod caps {
             pub extended_fmt_field_supported: bool,
             pub end_end_tlp_prefix_supported: bool,
             #[bits(2)]
-            pub max_end_end_tlp_prefixes: u32,
+            pub max_end_end_tlp_prefixes: MaxEndEndTlpPrefixes,
             #[bits(2)]
             pub emergency_power_reduction_supported: u32,
             pub emergency_power_reduction_init_required: bool,

--- a/vm/devices/pci/pci_core/src/spec.rs
+++ b/vm/devices/pci/pci_core/src/spec.rs
@@ -622,7 +622,7 @@ pub mod caps {
 
         /// PCIe max TLP prefix values for use in Device Capabilities 2.
         ///
-        /// Values are defined in PCIe Base Specification for the Max  End-End TLP Prefixes
+        /// Values are defined in PCIe Base Specification for the Max End-End TLP Prefixes
         /// field in Device Capabilities 2 Register and similar fields.
         #[derive(Copy, Clone, Debug)]
         #[repr(u32)]

--- a/vm/devices/pci/pci_core/src/spec.rs
+++ b/vm/devices/pci/pci_core/src/spec.rs
@@ -620,6 +620,39 @@ pub mod caps {
             }
         }
 
+        /// PCIe max TLP prefix values for use in Device Capabilities 2.
+        ///
+        /// Values are defined in PCIe Base Specification for the Max  End-End TLP Prefixes
+        /// field in Device Capabilities 2 Register and similar fields.
+        #[derive(Copy, Clone, Debug)]
+        #[repr(u32)]
+        pub enum MaxEndEndTlpPrefixes {
+            /// 1 End-End TLP Prefix / OHC-E1
+            One = 0b01,
+            /// 2 End-End TLP Prefixes / OHC-E2
+            Two = 0b10,
+            /// 3 End-End TLP Prefixes / OHC-E4
+            Three = 0b11,
+            /// 4 End-End TLP Prefixes / OHC-E4
+            Four = 0b00,
+        }
+
+        impl MaxEndEndTlpPrefixes {
+            pub const fn from_bits(bits: u32) -> Self {
+                match bits {
+                    0b01 => MaxEndEndTlpPrefixes::One,
+                    0b10 => MaxEndEndTlpPrefixes::Two,
+                    0b11 => MaxEndEndTlpPrefixes::Three,
+                    0b00 => MaxEndEndTlpPrefixes::Four,
+                    _ => unreachable!(),
+                }
+            }
+
+            pub const fn into_bits(self) -> u32 {
+                self as u32
+            }
+        }
+
         /// PCIe Link Width encoding values for use in Link Capabilities and other registers.
         ///
         /// Values are defined in PCIe Base Specification for the Max Link Width field

--- a/vm/devices/pci/pcie/src/port.rs
+++ b/vm/devices/pci/pcie/src/port.rs
@@ -31,6 +31,7 @@ use pci_core::cfg_space_emu::ConfigSpaceType1Emulator;
 use pci_core::cfg_space_emu::DeviceBars;
 use pci_core::msi::MsiTarget;
 use pci_core::spec::caps::pci_express::DevicePortType;
+use pci_core::spec::caps::pci_express::MaxEndEndTlpPrefixes;
 use pci_core::spec::hwid::HardwareIds;
 use std::sync::Arc;
 use vmcore::save_restore::RestoreError;
@@ -71,6 +72,11 @@ pub struct PciePortSettings {
     /// CXL DVSECs are added only when this is `Some` and either `cache_capable`
     /// or `mem_capable` is set.
     pub cxl_flex_bus_port_capability: Option<CxlFlexBusPortDvsecCapability>,
+
+    /// Whether End-to-End TLP prefixing is supported for this port.
+    ///
+    /// If supported, the max number of TLP prefixes to advertise.
+    pub tlp_prefixing_supported: Option<MaxEndEndTlpPrefixes>,
 }
 
 /// A description of a generic PCIe port (a root-complex root port or a switch
@@ -366,12 +372,15 @@ impl PcieDownstreamPort {
         let acs_supported =
             filter_acs_capabilities_for_bridge(&port_type, settings.acs_capabilities_supported);
 
-        let pcie_cap = if hotplug {
+        let mut pcie_cap = PciExpressCapability::new(port_type, None);
+        if hotplug {
             let slot_num = slot_number.unwrap_or(0);
-            PciExpressCapability::new(port_type, None).with_hotplug_support(slot_num)
-        } else {
-            PciExpressCapability::new(port_type, None)
-        };
+            pcie_cap = pcie_cap.with_hotplug_support(slot_num);
+        }
+
+        if let Some(max_prefixes) = settings.tlp_prefixing_supported {
+            pcie_cap = pcie_cap.with_tlp_prefixing_supported(max_prefixes);
+        }
 
         let extended_capabilities = if acs_supported != 0 {
             vec![
@@ -943,6 +952,7 @@ mod tests {
                 cxl_flex_bus_port_capability: Some(
                     CxlFlexBusPortDvsecCapability::new().with_mem_capable(true),
                 ),
+                tlp_prefixing_supported: None,
             },
             Some(&mut mmio),
             Some(PortBarDefinition {
@@ -1545,6 +1555,7 @@ mod tests {
                 cxl_flex_bus_port_capability: Some(
                     CxlFlexBusPortDvsecCapability::new().with_mem_capable(true),
                 ),
+                tlp_prefixing_supported: None,
             },
             None,
             Some(PortBarDefinition {

--- a/vm/devices/pci/pcie/src/switch.rs
+++ b/vm/devices/pci/pcie/src/switch.rs
@@ -34,6 +34,7 @@ use pci_core::capabilities::pci_express::PciExpressCapability;
 use pci_core::cfg_space_emu::ConfigSpaceType1Emulator;
 use pci_core::msi::MsiTarget;
 use pci_core::spec::caps::pci_express::DevicePortType;
+use pci_core::spec::caps::pci_express::MaxEndEndTlpPrefixes;
 use pci_core::spec::hwid::ClassCode;
 use pci_core::spec::hwid::HardwareIds;
 use pci_core::spec::hwid::ProgrammingInterface;
@@ -52,7 +53,13 @@ pub struct UpstreamSwitchPort {
 
 impl UpstreamSwitchPort {
     /// Constructs a new [`UpstreamSwitchPort`] emulator.
-    pub fn new() -> Self {
+    pub fn new(end_end_tlp_prefixing_supported: bool) -> Self {
+        let mut pcie_cap = PciExpressCapability::new(DevicePortType::UpstreamSwitchPort, None);
+
+        if end_end_tlp_prefixing_supported {
+            pcie_cap = pcie_cap.with_tlp_prefixing_supported(MaxEndEndTlpPrefixes::Four);
+        }
+
         let cfg_space = ConfigSpaceType1Emulator::new(
             HardwareIds {
                 vendor_id: VENDOR_ID,
@@ -64,10 +71,7 @@ impl UpstreamSwitchPort {
                 type0_sub_vendor_id: 0,
                 type0_sub_system_id: 0,
             },
-            vec![Box::new(PciExpressCapability::new(
-                DevicePortType::UpstreamSwitchPort,
-                None,
-            ))],
+            vec![Box::new(pcie_cap)],
             vec![],
         );
         Self { cfg_space }
@@ -178,6 +182,19 @@ pub enum InvalidSwitchError {
     /// A downstream port's devfn could not be assigned.
     #[error(transparent)]
     Devfn(#[from] PortDevfnError),
+    /// All ports within a switch have to expose the same value for TLP prefixing support.
+    #[error("End-to-End TLP prefixing support is inconsistent within the switch")]
+    InconsistentEndToEndTlpPrefixing,
+    /// If the switch supports End-to-End TLP Prefixing, all downstream ports must support up to 4 prefixes.
+    #[error(
+        "downstream port '{name}' has invalid max end-to-end TLP prefixing support ({supported_prefixes} != 0)"
+    )]
+    InvalidMaxEndToEndTlpPrefixing {
+        /// Name of the offending downstream port.
+        name: Arc<str>,
+        /// The encoded MaxEndToEndTlpPrefixes value read from the downstream port's config space.
+        supported_prefixes: u32,
+    },
 }
 
 /// A PCI Express switch emulator that implements a complete switch with upstream and downstream ports.
@@ -204,17 +221,41 @@ pub struct GenericPcieSwitch {
 impl GenericPcieSwitch {
     /// Constructs a new [`GenericPcieSwitch`] emulator.
     pub fn new(definition: GenericPcieSwitchDefinition) -> Result<Self, InvalidSwitchError> {
-        let upstream_port = UpstreamSwitchPort::new();
+        let any_port_supports_tlp_prefixing = definition
+            .downstream_ports
+            .iter()
+            .any(|port_def| port_def.settings.tlp_prefixing_supported.is_some());
 
-        // CXL is not supported on switch downstream ports (there is no CHBCR /
-        // component-register infrastructure behind a switch).
         for port_def in &definition.downstream_ports {
+            // CXL is not supported on switch downstream ports (there is no CHBCR /
+            // component-register infrastructure behind a switch).
             if port_def.settings.cxl_flex_bus_port_capability.is_some() {
                 return Err(InvalidSwitchError::CxlUnsupported {
                     name: port_def.name.clone(),
                 });
             }
+
+            // If any port supports End-to-End TLP prefixing, all ports must support it.
+            // See PCI Express Base Specification, Revision 7.0 Section 7.5.3.15
+            if any_port_supports_tlp_prefixing
+                != port_def.settings.tlp_prefixing_supported.is_some()
+            {
+                return Err(InvalidSwitchError::InconsistentEndToEndTlpPrefixing);
+            }
+
+            // If the switch supports End-to-End TLP prefixing, all downstream ports must support up to 4 prefixes.
+            // See PCI Express Base Specification, Revision 7.0 Section 7.5.3.15
+            if let Some(max_prefixes) = port_def.settings.tlp_prefixing_supported {
+                if max_prefixes.into_bits() != MaxEndEndTlpPrefixes::Four.into_bits() {
+                    return Err(InvalidSwitchError::InvalidMaxEndToEndTlpPrefixing {
+                        name: port_def.name.clone(),
+                        supported_prefixes: max_prefixes.into_bits(),
+                    });
+                }
+            }
         }
+
+        let upstream_port = UpstreamSwitchPort::new(any_port_supports_tlp_prefixing);
 
         // Assign each downstream port a devfn, shared with the root-complex
         // root-port assignment. Honors explicit devfns and packs the rest from
@@ -697,9 +738,13 @@ mod tests {
 
     #[test]
     fn test_upstream_switch_port_creation() {
-        let port = UpstreamSwitchPort::new();
-
         // Verify that we can read the vendor/device ID from config space
+        let port = UpstreamSwitchPort::new(false);
+        let vendor_device_id = port.cfg_space.read_u32(0x0);
+        let expected = (UPSTREAM_SWITCH_PORT_DEVICE_ID as u32) << 16 | (VENDOR_ID as u32);
+        assert_eq!(vendor_device_id, expected);
+
+        let port = UpstreamSwitchPort::new(true);
         let vendor_device_id = port.cfg_space.read_u32(0x0);
         let expected = (UPSTREAM_SWITCH_PORT_DEVICE_ID as u32) << 16 | (VENDOR_ID as u32);
         assert_eq!(vendor_device_id, expected);

--- a/vm/devices/pci/pcie/src/switch.rs
+++ b/vm/devices/pci/pcie/src/switch.rs
@@ -736,6 +736,13 @@ mod tests {
         GenericPcieSwitch::new(definition).unwrap()
     }
 
+    fn tlp_prefixing_settings(max_prefixes: MaxEndEndTlpPrefixes) -> PciePortSettings {
+        PciePortSettings {
+            tlp_prefixing_supported: Some(max_prefixes),
+            ..PciePortSettings::default()
+        }
+    }
+
     #[test]
     fn test_upstream_switch_port_creation() {
         // Verify that we can read the vendor/device ID from config space
@@ -748,6 +755,76 @@ mod tests {
         let vendor_device_id = port.cfg_space.read_u32(0x0);
         let expected = (UPSTREAM_SWITCH_PORT_DEVICE_ID as u32) << 16 | (VENDOR_ID as u32);
         assert_eq!(vendor_device_id, expected);
+    }
+
+    #[test]
+    fn test_switch_rejects_inconsistent_tlp_prefixing_support() {
+        let mut definition = switch_def(
+            "test-switch",
+            2,
+            false,
+            PciePortSettings::default(),
+            MsiTarget::disconnected(),
+        );
+        definition.downstream_ports[1].settings =
+            tlp_prefixing_settings(MaxEndEndTlpPrefixes::Four);
+
+        let Err(err) = GenericPcieSwitch::new(definition) else {
+            panic!("switch with inconsistent TLP prefixing support should fail");
+        };
+        assert!(matches!(
+            err,
+            InvalidSwitchError::InconsistentEndToEndTlpPrefixing
+        ));
+    }
+
+    #[test]
+    fn test_switch_rejects_non_four_tlp_prefixing_support() {
+        for max_prefixes in [
+            MaxEndEndTlpPrefixes::One,
+            MaxEndEndTlpPrefixes::Two,
+            MaxEndEndTlpPrefixes::Three,
+        ] {
+            let definition = switch_def(
+                "test-switch",
+                2,
+                false,
+                tlp_prefixing_settings(max_prefixes),
+                MsiTarget::disconnected(),
+            );
+
+            let Err(err) = GenericPcieSwitch::new(definition) else {
+                panic!("switch with {max_prefixes:?} TLP prefixes should fail");
+            };
+            assert!(matches!(
+                err,
+                InvalidSwitchError::InvalidMaxEndToEndTlpPrefixing {
+                    supported_prefixes,
+                    ..
+                } if supported_prefixes == max_prefixes.into_bits()
+            ));
+        }
+    }
+
+    #[test]
+    fn test_switch_with_four_tlp_prefixes_reports_upstream_support() {
+        let switch = build(switch_def(
+            "test-switch",
+            2,
+            false,
+            tlp_prefixing_settings(MaxEndEndTlpPrefixes::Four),
+            MsiTarget::disconnected(),
+        ));
+        let device_caps_2 = pci_core::spec::caps::pci_express::DeviceCapabilities2::from_bits(
+            switch.upstream_port.cfg_space().read_u32(0x64),
+        );
+
+        assert!(device_caps_2.extended_fmt_field_supported());
+        assert!(device_caps_2.end_end_tlp_prefix_supported());
+        assert_eq!(
+            device_caps_2.max_end_end_tlp_prefixes().into_bits(),
+            MaxEndEndTlpPrefixes::Four.into_bits()
+        );
     }
 
     #[test]

--- a/vm/devices/pci/pcie/src/switch.rs
+++ b/vm/devices/pci/pcie/src/switch.rs
@@ -192,7 +192,7 @@ pub enum InvalidSwitchError {
     InvalidMaxEndToEndTlpPrefixing {
         /// Name of the offending downstream port.
         name: Arc<str>,
-        /// The encoded MaxEndToEndTlpPrefixes value read from the downstream port's config space.
+        /// The MaxEndToEndTlpPrefixes value, encoded as defined by the PCIe specification.
         supported_prefixes: u32,
     },
 }

--- a/vmm_tests/vmm_tests/tests/tests/multiarch/numa.rs
+++ b/vmm_tests/vmm_tests/tests/tests/multiarch/numa.rs
@@ -348,6 +348,7 @@ async fn pcie_device_numa_affinity(
                         hotplug: false,
                         acs_capabilities_supported: None,
                         cxl: false,
+                        pasid: false,
                     }],
                     iommu: None,
                     vnode: Some(1),


### PR DESCRIPTION
This change allows PCIe root ports and switches to advertise support for TLP prefixing, which guest OSes (like Linux) require to enable guest-PASID for assigned devices behind virtual IOMMUs.

PASID, or "process address space ID", is a hardware feature for DMA isolation. It relies on a couple different things:
1. The endpoint device must expose a PASID capability structure in config space, and support generating PASID-tagged DMA
2. All PCIe ports on the path from endpoint device to root complex must support end-to-end TLP prefixes, or the ability to forward TLP prefixes transparently
3. The endpoint device must be behind an IOMMU that supports PASID

This change specifically addresses #2 in this list