### PR TITLE
nvme: keepalive fixups

### DIFF
--- a/vm/devices/storage/disk_nvme/nvme_driver/src/driver.rs
+++ b/vm/devices/storage/disk_nvme/nvme_driver/src/driver.rs
@@ -900,12 +900,20 @@ impl<D: DeviceBacking> NvmeDriver<D> {
             .admin
             .as_ref()
             .map(|a| {
+                let pending_commands_count = a.handler_data.pending_cmds.commands.len();
                 tracing::info!(
                     id = a.qid,
-                    pending_commands_count = a.handler_data.pending_cmds.commands.len(),
+                    pending_commands_count,
                     ?pci_id,
                     "restoring admin queue",
                 );
+                if fused_keepalive_device && pending_commands_count > 0 {
+                    panic!(
+                        "fused keepalive device {pci_id} restored with a non-empty admin \
+                         queue ({pending_commands_count} pending commands); fused devices \
+                         must not issue admin commands after init"
+                    );
+                }
                 // Restore memory block for admin queue pair.
                 let mem_block = restored_memory
                     .iter()

--- a/vm/devices/storage/disk_nvme/nvme_driver/src/driver.rs
+++ b/vm/devices/storage/disk_nvme/nvme_driver/src/driver.rs
@@ -1117,7 +1117,7 @@ impl<D: DeviceBacking> NvmeDriver<D> {
                     q.queue_data.qid == 1
                         || !q.queue_data.handler_data.pending_cmds.commands.is_empty()
                 })
-                .flat_map(|q| -> Result<IoQueue<D>, anyhow::Error> {
+                .map(|q| -> Result<IoQueue<D>, anyhow::Error> {
                     let qid = q.queue_data.qid;
                     let cpu = q.cpu;
                     tracing::info!(qid, cpu, ?pci_id, "restoring queue");
@@ -1172,7 +1172,7 @@ impl<D: DeviceBacking> NvmeDriver<D> {
                     }
                     Ok(q)
                 })
-                .collect();
+                .collect::<anyhow::Result<Vec<_>>>()?;
 
             // Create prototype entries for any queues that don't currently have
             // outstanding commands. They will be restored on demand later.
@@ -1228,7 +1228,7 @@ impl<D: DeviceBacking> NvmeDriver<D> {
 
             worker.io = sorted_io
                 .into_iter()
-                .flat_map(|q| -> Result<IoQueue<D>, anyhow::Error> {
+                .map(|q| -> Result<IoQueue<D>, anyhow::Error> {
                     let qid = q.queue_data.qid;
                     let cpu = q.cpu;
                     tracing::info!(qid, cpu, iv = q.iv, ?pci_id, "restoring queue");
@@ -1288,7 +1288,7 @@ impl<D: DeviceBacking> NvmeDriver<D> {
                     }
                     Ok(q)
                 })
-                .collect();
+                .collect::<anyhow::Result<Vec<_>>>()?;
         }
 
         // Update next_ioq_id to avoid reusing qids.

--- a/vmm_tests/vmm_tests/tests/tests/multiarch/openhcl_servicing.rs
+++ b/vmm_tests/vmm_tests/tests/tests/multiarch/openhcl_servicing.rs
@@ -1322,10 +1322,13 @@ async fn servicing_keepalive_slow_create_io_queue_with_inspect(
 /// Boots a frontpage OpenHCL VM with two VTL2 NVMe -> VTL0 SCSI relays: one
 /// controller forced into fused keepalive mode (VendorID=0x1414/DeviceID=0xb111)
 /// and one normal controller. Verifies the fused device eagerly pre-creates its
-/// IO queues at init while the normal device creates them lazily.
-#[openvmm_test(openhcl_linux_direct_x64)]
-async fn nvme_fused_keepalive_enablement(
+/// IO queues at init while the normal device creates them lazily, then services
+/// the VM with NVMe keepalive. Re-verifies that the fused device is still fused
+/// and the normal device is still non-fused after the service boundary.
+#[openvmm_test(openhcl_linux_direct_x64 [LATEST_LINUX_DIRECT_TEST_X64])]
+async fn nvme_fused_keepalive_servicing(
     config: PetriVmBuilder<OpenVmmPetriBackend>,
+    (igvm_file,): (ResolvedArtifact<LATEST_LINUX_DIRECT_TEST_X64>,),
 ) -> Result<(), anyhow::Error> {
     const VP_COUNT: u32 = 4;
     const MSIX_COUNT: u16 = 10;
@@ -1339,6 +1342,9 @@ async fn nvme_fused_keepalive_enablement(
     const NORMAL_LUN: u32 = VTL0_NVME_LUN + 1;
 
     let eager_count = (VP_COUNT as usize).min(MAX_IO_QUEUES as usize);
+
+    let mut flags = config.default_servicing_flags();
+    flags.enable_nvme_keepalive = true;
 
     let run_vm = async || -> Result<PetriVm<OpenVmmPetriBackend>, anyhow::Error> {
         let mut fused_updater = CellUpdater::new(false);
@@ -1460,49 +1466,68 @@ async fn nvme_fused_keepalive_enablement(
                 .collect()
         };
 
-    let vm = run_vm().await?;
+    // Asserts the per-device fused/non-fused and IO-queue invariants. `phase` is
+    // used only to make failures clear about whether they occurred before or
+    // after servicing.
+    let assert_devices = |devices: &[(bool, Vec<bool>)], phase: &str| {
+        assert_eq!(devices.len(), 2, "[{phase}] expected two VTL2 NVMe devices");
+
+        let (_, fused_io) = devices
+            .iter()
+            .find(|(fused, _)| *fused)
+            .unwrap_or_else(|| panic!("[{phase}] expected one device in fused keepalive mode"));
+        let (_, normal_io) = devices
+            .iter()
+            .find(|(fused, _)| !*fused)
+            .unwrap_or_else(|| panic!("[{phase}] expected one device in normal (non-fused) mode"));
+
+        assert_eq!(
+            fused_io.len(),
+            eager_count,
+            "[{phase}] fused keepalive device should have min(max_io_queues, vp_count) = \
+             {eager_count} IO queues, but found {}",
+            fused_io.len()
+        );
+        assert!(
+            fused_io.iter().filter(|&&unmapped| unmapped).count() >= 1,
+            "[{phase}] fused keepalive device should have eagerly pre-created unmapped IO \
+             queues, but all {} queues were mapped",
+            fused_io.len()
+        );
+
+        assert!(
+            !normal_io.is_empty(),
+            "[{phase}] the normal NVMe driver should have at least one IO queue"
+        );
+        assert_eq!(
+            normal_io.iter().filter(|&&unmapped| unmapped).count(),
+            0,
+            "[{phase}] a normal (non-fused) device must never have unmapped IO queues"
+        );
+        assert!(
+            normal_io.len() < eager_count,
+            "[{phase}] a normal device creates IO queues lazily, so it should have fewer than \
+             the fused eager count ({eager_count}), but found {}",
+            normal_io.len()
+        );
+    };
+
+    let mut vm = run_vm().await?;
+
+    // Before servicing: the fused device eagerly pre-creates unmapped IO queues
+    // while the normal device creates them lazily.
     let devices = inspect_devices(&vm).await?;
+    assert_devices(&devices, "pre-servicing");
 
-    assert_eq!(devices.len(), 2, "expected two VTL2 NVMe devices");
+    // Exercise servicing with NVMe keepalive enabled.
+    vm.restart_openhcl(igvm_file, flags).await?;
 
-    let (_, fused_io) = devices
-        .iter()
-        .find(|(fused, _)| *fused)
-        .expect("expected one device in fused keepalive mode");
-    let (_, normal_io) = devices
-        .iter()
-        .find(|(fused, _)| !*fused)
-        .expect("expected one device in normal (non-fused) mode");
+    // After servicing: the fused flag is recomputed on the restore path, so the
+    // fused device must still be fused and the normal device must still be
+    // non-fused, with IO-queue state consistent with each mode.
+    let devices = inspect_devices(&vm).await?;
+    assert_devices(&devices, "post-servicing");
 
-    assert_eq!(
-        fused_io.len(),
-        eager_count,
-        "fused keepalive device should eagerly pre-create min(max_io_queues, vp_count) = \
-         {eager_count} IO queues at init, but found {}",
-        fused_io.len()
-    );
-    assert!(
-        fused_io.iter().filter(|&&unmapped| unmapped).count() >= 1,
-        "fused keepalive device should have eagerly pre-created unmapped IO queues, \
-         but all {} queues were mapped",
-        fused_io.len()
-    );
-
-    assert!(
-        !normal_io.is_empty(),
-        "the normal NVMe driver should have come up with at least one IO queue"
-    );
-    assert_eq!(
-        normal_io.iter().filter(|&&unmapped| unmapped).count(),
-        0,
-        "a normal (non-fused) device must never eagerly pre-create unmapped IO queues"
-    );
-    assert!(
-        normal_io.len() < eager_count,
-        "a normal device creates IO queues lazily, so it should have fewer than the \
-         fused eager count ({eager_count}), but found {}",
-        normal_io.len()
-    );
     Ok(())
 }
 

--- a/vmm_tests/vmm_tests/tests/tests/multiarch/openhcl_servicing.rs
+++ b/vmm_tests/vmm_tests/tests/tests/multiarch/openhcl_servicing.rs
@@ -1466,12 +1466,12 @@ async fn nvme_fused_keepalive_servicing(
                 .collect()
         };
 
-    // Asserts the per-device fused/non-fused and IO-queue invariants. `phase` is
+    // Asserts exactly one fused and one non-fused device are present, returning
+    // their IO-queue `unmapped` vectors as `(fused_io, normal_io)`. `phase` is
     // used only to make failures clear about whether they occurred before or
     // after servicing.
-    let assert_devices = |devices: &[(bool, Vec<bool>)], phase: &str| {
+    let split_fused = |devices: &[(bool, Vec<bool>)], phase: &str| -> (Vec<bool>, Vec<bool>) {
         assert_eq!(devices.len(), 2, "[{phase}] expected two VTL2 NVMe devices");
-
         let (_, fused_io) = devices
             .iter()
             .find(|(fused, _)| *fused)
@@ -1480,53 +1480,55 @@ async fn nvme_fused_keepalive_servicing(
             .iter()
             .find(|(fused, _)| !*fused)
             .unwrap_or_else(|| panic!("[{phase}] expected one device in normal (non-fused) mode"));
-
-        assert_eq!(
-            fused_io.len(),
-            eager_count,
-            "[{phase}] fused keepalive device should have min(max_io_queues, vp_count) = \
-             {eager_count} IO queues, but found {}",
-            fused_io.len()
-        );
-        assert!(
-            fused_io.iter().filter(|&&unmapped| unmapped).count() >= 1,
-            "[{phase}] fused keepalive device should have eagerly pre-created unmapped IO \
-             queues, but all {} queues were mapped",
-            fused_io.len()
-        );
-
-        assert!(
-            !normal_io.is_empty(),
-            "[{phase}] the normal NVMe driver should have at least one IO queue"
-        );
-        assert_eq!(
-            normal_io.iter().filter(|&&unmapped| unmapped).count(),
-            0,
-            "[{phase}] a normal (non-fused) device must never have unmapped IO queues"
-        );
-        assert!(
-            normal_io.len() < eager_count,
-            "[{phase}] a normal device creates IO queues lazily, so it should have fewer than \
-             the fused eager count ({eager_count}), but found {}",
-            normal_io.len()
-        );
+        (fused_io.clone(), normal_io.clone())
     };
 
     let mut vm = run_vm().await?;
 
-    // Before servicing: the fused device eagerly pre-creates unmapped IO queues
-    // while the normal device creates them lazily.
-    let devices = inspect_devices(&vm).await?;
-    assert_devices(&devices, "pre-servicing");
+    // Before servicing: the fused device eagerly pre-creates its full set of
+    // unmapped IO queues while the normal device creates them lazily.
+    let (fused_io, normal_io) = split_fused(&inspect_devices(&vm).await?, "pre-servicing");
+    assert_eq!(
+        fused_io.len(),
+        eager_count,
+        "[pre-servicing] fused keepalive device should have min(max_io_queues, vp_count) = \
+         {eager_count} IO queues, but found {}",
+        fused_io.len()
+    );
+    assert!(
+        fused_io.iter().filter(|&&unmapped| unmapped).count() >= 1,
+        "[pre-servicing] fused keepalive device should have eagerly pre-created unmapped IO \
+         queues, but all {} queues were mapped",
+        fused_io.len()
+    );
+    assert!(
+        !normal_io.is_empty(),
+        "[pre-servicing] the normal NVMe driver should have at least one IO queue"
+    );
+    assert_eq!(
+        normal_io.iter().filter(|&&unmapped| unmapped).count(),
+        0,
+        "[pre-servicing] a normal (non-fused) device must never have unmapped IO queues"
+    );
+    assert!(
+        normal_io.len() < eager_count,
+        "[pre-servicing] a normal device creates IO queues lazily, so it should have fewer than \
+         the fused eager count ({eager_count}), but found {}",
+        normal_io.len()
+    );
 
     // Exercise servicing with NVMe keepalive enabled.
     vm.restart_openhcl(igvm_file, flags).await?;
 
     // After servicing: the fused flag is recomputed on the restore path, so the
     // fused device must still be fused and the normal device must still be
-    // non-fused, with IO-queue state consistent with each mode.
-    let devices = inspect_devices(&vm).await?;
-    assert_devices(&devices, "post-servicing");
+    // non-fused. The `split_fused` call fails if either determination changed.
+    let (_fused_io, normal_io) = split_fused(&inspect_devices(&vm).await?, "post-servicing");
+    assert_eq!(
+        normal_io.iter().filter(|&&unmapped| unmapped).count(),
+        0,
+        "[post-servicing] a normal (non-fused) device must never have unmapped IO queues"
+    );
 
     Ok(())
 }


### PR DESCRIPTION
Improves the keepalive tests to actually run servicing, and adds a panic when there is a write to the admin queue in fused mode