### PR TITLE
virtio_net: complete requests in order

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4836,6 +4836,7 @@ dependencies = [
  "net_backend_resources",
  "pal_async",
  "parking_lot",
+ "test_with_tracing",
  "thiserror 2.0.16",
  "tracing",
  "vm_resource",

--- a/vm/devices/net/net_backend/Cargo.toml
+++ b/vm/devices/net/net_backend/Cargo.toml
@@ -27,5 +27,8 @@ tracing.workspace = true
 thiserror.workspace = true
 inspect_counters.workspace = true
 
+[dev-dependencies]
+test_with_tracing.workspace = true
+
 [lints]
 workspace = true

--- a/vm/devices/net/net_backend/src/lib.rs
+++ b/vm/devices/net/net_backend/src/lib.rs
@@ -558,10 +558,20 @@ enum DisconnectableEndpointUpdate {
 
 pub struct DisconnectableEndpointControl {
     send_update: mesh::Sender<DisconnectableEndpointUpdate>,
+    is_ordered: Option<bool>,
 }
 
 impl DisconnectableEndpointControl {
     pub fn connect(&mut self, endpoint: Box<dyn Endpoint>) -> anyhow::Result<()> {
+        let new_is_ordered = endpoint.is_ordered();
+        if let Some(is_ordered) = self.is_ordered {
+            anyhow::ensure!(
+                !is_ordered || new_is_ordered,
+                "network endpoint cannot be reattached as unordered after being ordered"
+            );
+        } else {
+            self.is_ordered = Some(new_is_ordered);
+        }
         self.send_update
             .send(DisconnectableEndpointUpdate::EndpointConnected(endpoint));
         Ok(())
@@ -605,6 +615,7 @@ impl DisconnectableEndpoint {
         let (endpoint_tx, endpoint_rx) = mesh::channel();
         let control = DisconnectableEndpointControl {
             send_update: endpoint_tx,
+            is_ordered: None,
         };
         (
             Self {
@@ -722,13 +733,6 @@ impl Endpoint for DisconnectableEndpoint {
                 let old_endpoint = self.endpoint.take();
                 assert!(old_endpoint.is_none());
                 self.endpoint = Some(endpoint);
-                // Ordering is pinned at the first connect and reported
-                // unchanged for the endpoint's lifetime. Consumers bake the
-                // value into correctness decisions (e.g. virtio-net advertises
-                // VIRTIO_F_IN_ORDER to the guest based on it), so a reattach
-                // MUST NOT downgrade an ordered endpoint to an unordered one.
-                // Upgrading (unordered -> ordered) is harmless but we keep
-                // reporting the original conservative value for stability.
                 let new_is_ordered = self.current().is_ordered();
                 let is_ordered = if let Some(prev) = &self.cached_state {
                     assert!(
@@ -768,5 +772,64 @@ impl Endpoint for DisconnectableEndpoint {
             .as_ref()
             .expect("Endpoint needs connected at least once before use")
             .link_speed
+    }
+}
+
+#[cfg(test)]
+mod disconnectable_endpoint_tests {
+    use super::*;
+    use test_with_tracing::test;
+
+    #[derive(InspectMut)]
+    struct TestEndpoint {
+        is_ordered: bool,
+    }
+
+    #[async_trait]
+    impl Endpoint for TestEndpoint {
+        fn endpoint_type(&self) -> &'static str {
+            "test"
+        }
+
+        async fn get_queues(
+            &mut self,
+            _config: Vec<QueueConfig>,
+            _rss: Option<&RssConfig<'_>>,
+            _queues: &mut Vec<Box<dyn Queue>>,
+        ) -> anyhow::Result<()> {
+            unreachable!()
+        }
+
+        async fn stop(&mut self) {
+            unreachable!()
+        }
+
+        fn is_ordered(&self) -> bool {
+            self.is_ordered
+        }
+    }
+
+    #[test]
+    fn connect_pins_endpoint_ordering() {
+        let (_endpoint, mut control) = DisconnectableEndpoint::new();
+        control
+            .connect(Box::new(TestEndpoint { is_ordered: true }))
+            .unwrap();
+
+        let err = control
+            .connect(Box::new(TestEndpoint { is_ordered: false }))
+            .unwrap_err();
+        assert_eq!(
+            err.to_string(),
+            "network endpoint cannot be reattached as unordered after being ordered"
+        );
+
+        let (_endpoint, mut control) = DisconnectableEndpoint::new();
+        control
+            .connect(Box::new(TestEndpoint { is_ordered: false }))
+            .unwrap();
+        control
+            .connect(Box::new(TestEndpoint { is_ordered: true }))
+            .unwrap();
     }
 }

--- a/vm/devices/net/net_backend/src/lib.rs
+++ b/vm/devices/net/net_backend/src/lib.rs
@@ -97,10 +97,10 @@ pub trait Endpoint: Send + Sync + InspectMut {
     /// All queues returned via `get_queues` must have been dropped.
     async fn stop(&mut self);
 
-    /// Specifies whether packets are always completed in order.
-    fn is_ordered(&self) -> bool {
-        false
-    }
+    /// Whether the endpoint completes buffers in the order they were made
+    /// available (RX buffers returned from `rx_poll`, and TX packets completed,
+    /// in available-ring order).
+    fn is_ordered(&self) -> bool;
 
     /// Specifies the supported set of transmit offloads.
     fn tx_offload_support(&self) -> TxOffloadSupport {
@@ -722,8 +722,25 @@ impl Endpoint for DisconnectableEndpoint {
                 let old_endpoint = self.endpoint.take();
                 assert!(old_endpoint.is_none());
                 self.endpoint = Some(endpoint);
+                // Ordering is pinned at the first connect and reported
+                // unchanged for the endpoint's lifetime. Consumers bake the
+                // value into correctness decisions (e.g. virtio-net advertises
+                // VIRTIO_F_IN_ORDER to the guest based on it), so a reattach
+                // MUST NOT downgrade an ordered endpoint to an unordered one.
+                // Upgrading (unordered -> ordered) is harmless but we keep
+                // reporting the original conservative value for stability.
+                let new_is_ordered = self.current().is_ordered();
+                let is_ordered = if let Some(prev) = &self.cached_state {
+                    assert!(
+                        !prev.is_ordered || new_is_ordered,
+                        "network endpoint reattached as unordered after being ordered"
+                    );
+                    prev.is_ordered
+                } else {
+                    new_is_ordered
+                };
                 self.cached_state = Some(DisconnectableEndpointCachedState {
-                    is_ordered: self.current().is_ordered(),
+                    is_ordered,
                     tx_offload_support: self.current().tx_offload_support(),
                     multiqueue_support: self.current().multiqueue_support(),
                     tx_fast_completions: self.current().tx_fast_completions(),

--- a/vm/devices/net/net_dio/src/lib.rs
+++ b/vm/devices/net/net_dio/src/lib.rs
@@ -25,6 +25,7 @@ use net_backend::TxSegment;
 use net_backend::next_packet;
 use pal_async::driver::Driver;
 use parking_lot::Mutex;
+use std::collections::VecDeque;
 use std::io::ErrorKind;
 use std::sync::Arc;
 use std::task::Context;
@@ -72,13 +73,20 @@ impl Endpoint for DioEndpoint {
     async fn stop(&mut self) {
         assert!(self.nic.lock().is_some(), "the queue has not been dropped");
     }
+
+    fn is_ordered(&self) -> bool {
+        // RX buffers are filled and TX packets are completed in the order they
+        // were made available (see `DioQueue`: `free` is drained FIFO, and
+        // `tx_avail` completes synchronously in order).
+        true
+    }
 }
 
 /// A DirectIO queue.
 pub struct DioQueue {
     slot: Arc<Mutex<Option<dio::DioNic>>>,
     nic: Option<dio::DioQueue>,
-    free: Vec<RxId>,
+    free: VecDeque<RxId>,
 }
 
 impl InspectMut for DioQueue {
@@ -100,7 +108,7 @@ impl DioQueue {
         Self {
             slot,
             nic: nic.map(|nic| dio::DioQueue::new(driver, nic)),
-            free: Vec::new(),
+            free: VecDeque::new(),
         }
     }
 }
@@ -127,7 +135,7 @@ impl Queue for DioQueue {
         if let Some(nic) = &mut self.nic {
             // Transmit incoming packets to the guest until there are no more available.
             for done_id in packets {
-                let id = if let Some(&id) = self.free.last() {
+                let id = if let Some(&id) = self.free.front() {
                     id
                 } else {
                     break;
@@ -144,7 +152,7 @@ impl Queue for DioQueue {
                     );
                 });
                 match result {
-                    Ok(()) => self.free.pop(),
+                    Ok(()) => self.free.pop_front(),
                     Err(e) if e.kind() == ErrorKind::WouldBlock => break,
                     Err(e) => {
                         // The DIO endpoint is in a bad state.

--- a/vm/devices/virtio/virtio/src/common.rs
+++ b/vm/devices/virtio/virtio/src/common.rs
@@ -1,12 +1,12 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+use crate::queue::QueueCompletion;
 use crate::queue::QueueCoreCompleteWork;
 use crate::queue::QueueCoreGetWork;
 use crate::queue::QueueError;
 use crate::queue::QueueParams;
 use crate::queue::QueueState;
-use crate::queue::QueueWork;
 use crate::queue::VirtioQueuePayload;
 use crate::queue::new_queue;
 use crate::spec::VirtioDeviceFeatures;
@@ -104,18 +104,39 @@ fn read_from_payload_at_offset(
 /// and will not automatically post a completion.
 #[must_use]
 pub struct VirtioQueueCallbackWork {
-    work: QueueWork,
+    completion: QueueCompletion,
     pub payload: Vec<VirtioQueuePayload>,
 }
 
 impl VirtioQueueCallbackWork {
-    pub(crate) fn new(mut work: QueueWork) -> Self {
-        let payload = std::mem::take(&mut work.payload);
-        Self { work, payload }
+    pub(crate) fn from_parts(
+        completion: QueueCompletion,
+        payload: Vec<VirtioQueuePayload>,
+    ) -> Self {
+        Self {
+            completion,
+            payload,
+        }
+    }
+
+    /// Borrows the completion token, used internally to advance the available
+    /// index for a peeked descriptor.
+    pub(crate) fn completion(&self) -> &QueueCompletion {
+        &self.completion
     }
 
     pub fn descriptor_index(&self) -> u16 {
-        self.work.descriptor_index()
+        self.completion.descriptor_index()
+    }
+
+    /// Discards the payload buffer descriptors and returns the lightweight
+    /// [`QueueCompletion`] token, which carries only the state
+    /// [`VirtioQueue::complete_prepared`] needs to publish the used ring entry.
+    ///
+    /// Use this to buffer a completion (e.g. for in-order publication) without
+    /// retaining the full payload.
+    pub fn into_completion(self) -> QueueCompletion {
+        self.completion
     }
 
     // Determine the total size of all readable or all writeable payload buffers.
@@ -208,11 +229,11 @@ pub enum VirtioWriteError {
 /// available for the next peek/next call.
 pub struct PeekedWork<'a> {
     queue: &'a mut VirtioQueue,
-    work: QueueWork,
+    work: VirtioQueueCallbackWork,
 }
 
 impl<'a> PeekedWork<'a> {
-    fn new(queue: &'a mut VirtioQueue, work: QueueWork) -> Self {
+    fn new(queue: &'a mut VirtioQueue, work: VirtioQueueCallbackWork) -> Self {
         Self { queue, work }
     }
 
@@ -247,8 +268,8 @@ impl<'a> PeekedWork<'a> {
     /// Returns a [`VirtioQueueCallbackWork`] that must be explicitly
     /// completed via [`VirtioQueue::complete`].
     pub fn consume(self) -> VirtioQueueCallbackWork {
-        self.queue.core.advance(&self.work);
-        VirtioQueueCallbackWork::new(self.work)
+        self.queue.core.advance(self.work.completion());
+        self.work
     }
 }
 
@@ -312,11 +333,7 @@ impl VirtioQueue {
     /// used in a poll loop with [`poll_kick`](Self::poll_kick), the kick will
     /// be armed automatically before sleeping.
     pub fn try_next(&mut self) -> Result<Option<VirtioQueueCallbackWork>, Error> {
-        Ok(self
-            .core
-            .try_next_work()
-            .map_err(Error::other)?
-            .map(VirtioQueueCallbackWork::new))
+        self.core.try_next_work().map_err(Error::other)
     }
 
     /// Peek at the next available descriptor without advancing the available
@@ -364,7 +381,20 @@ impl VirtioQueue {
     /// Takes ownership of the work item, ensuring it can only be completed
     /// once.
     pub fn complete(&mut self, work: VirtioQueueCallbackWork, bytes_written: u32) {
-        match self.complete.complete_descriptor(&work.work, bytes_written) {
+        self.complete_prepared(work.into_completion(), bytes_written);
+    }
+
+    /// Completes a descriptor from a lightweight [`QueueCompletion`] token
+    /// previously obtained via [`VirtioQueueCallbackWork::into_completion`].
+    ///
+    /// Equivalent to [`complete`](Self::complete) but does not require holding
+    /// the payload, so callers that buffer completions can store only the
+    /// token.
+    pub fn complete_prepared(&mut self, completion: QueueCompletion, bytes_written: u32) {
+        match self
+            .complete
+            .complete_descriptor(&completion, bytes_written)
+        {
             Ok(true) => {
                 self.notify_guest.deliver();
             }

--- a/vm/devices/virtio/virtio/src/in_order.rs
+++ b/vm/devices/virtio/virtio/src/in_order.rs
@@ -99,16 +99,11 @@ impl InOrderCompletion {
     ///
     /// Use this in place of [`VirtioQueue::complete_prepared`].
     ///
-    /// # Panics
-    ///
-    /// Panics if `completion` was not produced by a descriptor from
-    /// [`try_next`](Self::try_next) on this tracker, or if the same descriptor
-    /// is completed more than once while outstanding. These are internal
-    /// invariant violations (a *guest*-induced duplicate is rejected upstream by
-    /// the device before it ever reaches here), and silently dropping the
-    /// completion would stall the used ring — hanging the guest and corrupting
-    /// the `[used_index, avail_index)` outstanding range — so we fail fast
-    /// instead.
+    /// Each `completion` must be for a descriptor still outstanding from
+    /// [`try_next`](Self::try_next), completed once. Some violations panic (an
+    /// out-of-range index, or a collision with a still-buffered slot); a
+    /// completion for a no-longer-outstanding descriptor is not caught and
+    /// would strand an entry in `completed`, eventually stalling publication.
     pub fn complete(
         &mut self,
         queue: &mut VirtioQueue,

--- a/vm/devices/virtio/virtio/src/in_order.rs
+++ b/vm/devices/virtio/virtio/src/in_order.rs
@@ -127,7 +127,9 @@ impl InOrderCompletion {
         if self.order.front() == Some(&idx) {
             self.order.pop_front();
             queue.complete_prepared(completion, bytes_written);
-            self.drain_completed_prefix(queue);
+            if !self.order.is_empty() {
+                self.drain_completed_prefix(queue);
+            }
             return;
         }
 

--- a/vm/devices/virtio/virtio/src/in_order.rs
+++ b/vm/devices/virtio/virtio/src/in_order.rs
@@ -1,0 +1,171 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! In-order completion discipline layered on top of a [`VirtioQueue`].
+//!
+//! Some devices (notably virtio-net) require that the used ring be published
+//! strictly in the order descriptors were consumed from the available ring,
+//! even though work may complete out of order (e.g. a network backend that
+//! finishes packets in a different order, or descriptors that are dropped
+//! early). This makes the outstanding set exactly the contiguous
+//! `[used_index, avail_index)` range, which enables a simple cursor-based
+//! save/restore.
+//!
+//! This is deliberately a *side* helper whose methods borrow a
+//! [`VirtioQueue`], rather than being baked into the queue itself. Devices that
+//! do not need in-order completion (virtio-blk, virtio-vsock, ...) never
+//! instantiate it and pay nothing — the queue's hot path is untouched. It uses
+//! only the queue's public API, mirroring QEMU's
+//! `virtqueue_ordered_fill`/`virtqueue_ordered_flush` (`used_elems`): consumed
+//! descriptors are recorded in consumption order, completions fill their slot
+//! (possibly out of order), and only the contiguous filled prefix is published
+//! to the used ring, in order.
+
+use crate::VirtioQueue;
+use crate::VirtioQueueCallbackWork;
+use crate::queue::QueueCompletion;
+use inspect::Inspect;
+use std::collections::VecDeque;
+use std::io::Error;
+
+/// Enforces in-order used-ring publication for a single [`VirtioQueue`].
+///
+/// Consume descriptors via [`try_next`](Self::try_next) and complete them via
+/// [`complete`](Self::complete) instead of calling the queue's methods
+/// directly. Completions may be issued in any order; the used ring is always
+/// published in consumption (available) order.
+#[derive(Inspect)]
+pub struct InOrderCompletion {
+    /// Descriptor indices of outstanding descriptors, in consumption order.
+    /// The front is the next descriptor eligible to be published.
+    #[inspect(with = "VecDeque::len")]
+    order: VecDeque<u16>,
+    /// Completed-but-not-yet-published work, indexed by descriptor index.
+    /// Bounded by the queue size, so a descriptor index (always
+    /// `< queue_size`) is a unique key for the outstanding set: a repeated
+    /// index while still outstanding is a guest protocol violation that the
+    /// device detects and treats as fatal.
+    #[inspect(skip)]
+    completed: Vec<Option<Completed>>,
+}
+
+struct Completed {
+    completion: QueueCompletion,
+    bytes_written: u32,
+}
+
+impl InOrderCompletion {
+    /// Creates an in-order completion tracker for a queue of the given size.
+    pub fn new(queue_size: u16) -> Self {
+        Self {
+            order: VecDeque::with_capacity(queue_size as usize),
+            completed: (0..queue_size).map(|_| None).collect(),
+        }
+    }
+
+    /// Consumes the next available descriptor from `queue`, recording it for
+    /// in-order completion. Returns `Ok(None)` if no work is available.
+    ///
+    /// Use this in place of [`VirtioQueue::try_next`].
+    pub fn try_next(
+        &mut self,
+        queue: &mut VirtioQueue,
+    ) -> Result<Option<VirtioQueueCallbackWork>, Error> {
+        let work = queue.try_next()?;
+        if let Some(work) = &work {
+            let idx = work.descriptor_index() as usize;
+            // The queue validates the descriptor index against the ring size
+            // when it reads the descriptor, so an out-of-range index fails
+            // above rather than reaching here. Assert the invariant so a
+            // violation fails fast at entry instead of corrupting later state.
+            assert!(
+                idx < self.completed.len(),
+                "descriptor index {idx} exceeds queue size {}",
+                self.completed.len()
+            );
+            self.order.push_back(work.descriptor_index());
+        }
+        Ok(work)
+    }
+
+    /// Records a completion for the descriptor identified by `completion` and
+    /// publishes the contiguous run of completed descriptors at the front of
+    /// the consumption order to the used ring, in order.
+    ///
+    /// `completion` is the lightweight token obtained from
+    /// [`VirtioQueueCallbackWork::into_completion`], so callers that buffer
+    /// outstanding descriptors can retain only the token rather than the full
+    /// work (and its payload).
+    ///
+    /// Use this in place of [`VirtioQueue::complete_prepared`].
+    ///
+    /// # Panics
+    ///
+    /// Panics if `completion` was not produced by a descriptor from
+    /// [`try_next`](Self::try_next) on this tracker, or if the same descriptor
+    /// is completed more than once while outstanding. These are internal
+    /// invariant violations (a *guest*-induced duplicate is rejected upstream by
+    /// the device before it ever reaches here), and silently dropping the
+    /// completion would stall the used ring — hanging the guest and corrupting
+    /// the `[used_index, avail_index)` outstanding range — so we fail fast
+    /// instead.
+    pub fn complete(
+        &mut self,
+        queue: &mut VirtioQueue,
+        completion: QueueCompletion,
+        bytes_written: u32,
+    ) {
+        let idx = completion.descriptor_index();
+
+        // Fast path: the completing descriptor is the one at the front of the
+        // consumption order — the overwhelmingly common case, since an ordered
+        // backend completes in the order buffers were posted. Publish it
+        // directly, with no `completed` slot write/read. (When `idx` is at the
+        // front, its slot is guaranteed empty: any completed front descriptor is
+        // published and popped immediately, so the front is always outstanding
+        // on entry.)
+        if self.order.front() == Some(&idx) {
+            self.order.pop_front();
+            queue.complete_prepared(completion, bytes_written);
+            self.drain_completed_prefix(queue);
+            return;
+        }
+
+        // Slow path: an out-of-order completion. Buffer it until the
+        // descriptors ahead of it have been published. Because `idx` is not at
+        // the front, nothing new can be published yet.
+        let slot = self
+            .completed
+            .get_mut(idx as usize)
+            .expect("completed descriptor index must be within the queue size");
+        assert!(
+            slot.is_none(),
+            "descriptor {idx} completed more than once while outstanding"
+        );
+        *slot = Some(Completed {
+            completion,
+            bytes_written,
+        });
+    }
+
+    /// Publishes the longest run of already-completed descriptors at the front
+    /// of the consumption order, in order.
+    fn drain_completed_prefix(&mut self, queue: &mut VirtioQueue) {
+        while let Some(&front) = self.order.front() {
+            let Some(Completed {
+                completion,
+                bytes_written,
+            }) = self.completed[front as usize].take()
+            else {
+                break;
+            };
+            self.order.pop_front();
+            queue.complete_prepared(completion, bytes_written);
+        }
+    }
+
+    /// Returns the number of descriptors consumed but not yet published.
+    pub fn outstanding(&self) -> usize {
+        self.order.len()
+    }
+}

--- a/vm/devices/virtio/virtio/src/lib.rs
+++ b/vm/devices/virtio/virtio/src/lib.rs
@@ -8,6 +8,7 @@
 
 mod common;
 pub mod device;
+pub mod in_order;
 pub mod queue;
 pub mod regions;
 pub mod resolve;
@@ -19,6 +20,7 @@ pub mod transport;
 pub use common::*;
 pub use device::DynVirtioDevice;
 pub use device::VirtioDevice;
+pub use in_order::InOrderCompletion;
 pub use transport::*;
 pub use virtio_spec as spec;
 

--- a/vm/devices/virtio/virtio/src/lib.rs
+++ b/vm/devices/virtio/virtio/src/lib.rs
@@ -20,7 +20,6 @@ pub mod transport;
 pub use common::*;
 pub use device::DynVirtioDevice;
 pub use device::VirtioDevice;
-pub use in_order::InOrderCompletion;
 pub use transport::*;
 pub use virtio_spec as spec;
 

--- a/vm/devices/virtio/virtio/src/queue.rs
+++ b/vm/devices/virtio/virtio/src/queue.rs
@@ -6,6 +6,7 @@
 
 mod packed;
 mod split;
+use crate::VirtioQueueCallbackWork;
 use crate::spec::VirtioDeviceFeatures;
 use crate::spec::queue as spec;
 use guestmem::GuestMemory;
@@ -64,26 +65,32 @@ pub enum QueueError {
     InvalidQueueSize(u16),
 }
 
-pub struct QueueDescriptor {
+struct QueueDescriptor {
     address: u64,
     length: u32,
     flags: DescriptorFlags,
-    pub(crate) buffer_id: Option<u16>,
+    buffer_id: Option<u16>,
     next: Option<u16>,
 }
 
-pub enum QueueCompletionContext {
+enum QueueCompletionContext {
     Split,
     Packed(PackedQueueCompletionContext),
 }
 
-pub struct QueueWork {
+/// The minimal state required to publish a completion to the used ring.
+///
+/// This is everything `complete_descriptor` needs — notably *not* the payload
+/// buffer descriptors, which are only used while the device is reading/writing
+/// guest memory. Devices that must buffer completions (e.g. in-order
+/// publication) can hold a `QueueCompletion` instead of a full
+/// `VirtioQueueCallbackWork` to avoid retaining the payload.
+pub struct QueueCompletion {
     context: QueueCompletionContext,
     descriptor_index: u16,
-    pub payload: Vec<VirtioQueuePayload>,
 }
 
-impl QueueWork {
+impl QueueCompletion {
     pub fn descriptor_index(&self) -> u16 {
         self.descriptor_index
     }
@@ -184,10 +191,10 @@ impl QueueCoreGetWork {
         })
     }
 
-    pub fn try_next_work(&mut self) -> Result<Option<QueueWork>, QueueError> {
+    pub fn try_next_work(&mut self) -> Result<Option<VirtioQueueCallbackWork>, QueueError> {
         match self.try_peek_work() {
             Ok(Some(work)) => {
-                self.advance(&work);
+                self.advance(work.completion());
                 Ok(Some(work))
             }
             r => r,
@@ -199,7 +206,7 @@ impl QueueCoreGetWork {
     /// consume the peeked descriptor and move to the next one. Calling this
     /// again without advancing will return the same descriptor, but note that
     /// the guest may have modified the descriptor memory in the meantime.
-    pub fn try_peek_work(&mut self) -> Result<Option<QueueWork>, QueueError> {
+    pub fn try_peek_work(&mut self) -> Result<Option<VirtioQueueCallbackWork>, QueueError> {
         let index = match &mut self.inner {
             QueueGetWorkInner::Split(split) => split.is_available()?,
             QueueGetWorkInner::Packed(packed) => packed.is_available()?,
@@ -263,11 +270,11 @@ impl QueueCoreGetWork {
 
     /// Advances the available index after a successful
     /// [`try_peek_work`](Self::try_peek_work) call.
-    pub fn advance(&mut self, work: &QueueWork) {
+    pub fn advance(&mut self, completion: &QueueCompletion) {
         match &mut self.inner {
             QueueGetWorkInner::Split(split) => split.advance(),
             QueueGetWorkInner::Packed(packed) => {
-                let QueueCompletionContext::Packed(ctx) = &work.context else {
+                let QueueCompletionContext::Packed(ctx) = &completion.context else {
                     unreachable!();
                 };
                 packed.advance(ctx.descriptor_count());
@@ -275,17 +282,19 @@ impl QueueCoreGetWork {
         }
     }
 
-    fn work_from_index(&mut self, index: u16) -> Result<QueueWork, QueueError> {
+    fn work_from_index(&mut self, index: u16) -> Result<VirtioQueueCallbackWork, QueueError> {
         if let QueueGetWorkInner::Split(split) = &mut self.inner {
             let descriptor_index = split.get_available_descriptor_index(index)?;
             let payload = self
                 .reader(descriptor_index)
                 .collect::<Result<Vec<_>, _>>()?;
-            Ok(QueueWork {
-                descriptor_index,
-                context: QueueCompletionContext::Split,
+            Ok(VirtioQueueCallbackWork::from_parts(
+                QueueCompletion {
+                    descriptor_index,
+                    context: QueueCompletionContext::Split,
+                },
                 payload,
-            })
+            ))
         } else {
             let (payload, last_primary_desc_index) = {
                 let mut reader = self.reader(index);
@@ -302,11 +311,13 @@ impl QueueCoreGetWork {
                 self.queue_size - index + last_primary_desc_index + 1
             };
             let completion_context = PackedQueueCompletionContext::new(&last, count);
-            Ok(QueueWork {
-                context: QueueCompletionContext::Packed(completion_context),
+            Ok(VirtioQueueCallbackWork::from_parts(
+                QueueCompletion {
+                    context: QueueCompletionContext::Packed(completion_context),
+                    descriptor_index: index,
+                },
                 payload,
-                descriptor_index: index,
-            })
+            ))
         }
     }
 
@@ -378,7 +389,7 @@ impl QueueCoreGetWork {
 }
 
 #[derive(Debug, Inspect)]
-pub struct QueueCoreCompleteWork {
+pub(crate) struct QueueCoreCompleteWork {
     #[inspect(flatten)]
     inner: QueueCompleteWorkInner,
 }
@@ -424,15 +435,15 @@ impl QueueCoreCompleteWork {
 
     pub fn complete_descriptor(
         &mut self,
-        work: &QueueWork,
+        completion: &QueueCompletion,
         bytes_written: u32,
     ) -> Result<bool, QueueError> {
         match &mut self.inner {
             QueueCompleteWorkInner::Split(split) => {
-                split.complete_descriptor(work.descriptor_index, bytes_written)
+                split.complete_descriptor(completion.descriptor_index, bytes_written)
             }
             QueueCompleteWorkInner::Packed(packed) => {
-                let QueueCompletionContext::Packed(context) = &work.context else {
+                let QueueCompletionContext::Packed(context) = &completion.context else {
                     panic!("mismatched queue completion context for packed queue");
                 };
                 packed.complete_descriptor(context, bytes_written)
@@ -452,7 +463,7 @@ pub(crate) fn new_queue(
     Ok((get_work, complete_work))
 }
 
-pub struct DescriptorReader<'a> {
+struct DescriptorReader<'a> {
     chain: DescriptorChain<'a>,
 }
 
@@ -482,7 +493,7 @@ impl Iterator for DescriptorReader<'_> {
     }
 }
 
-pub struct DescriptorChain<'a> {
+struct DescriptorChain<'a> {
     queue: &'a QueueCoreGetWork,
     /// Maximum chain length — always the original ring queue size (spec §2.7.5.3.1).
     queue_size: u16,

--- a/vm/devices/virtio/virtio/src/tests.rs
+++ b/vm/devices/virtio/virtio/src/tests.rs
@@ -5357,7 +5357,7 @@ async fn packed_full_ring_chain_toggles_wrap_counters(driver: DefaultDriver) {
 /// strictly in avail (consumption) order.
 #[async_test]
 async fn in_order_completion_publishes_in_avail_order(driver: DefaultDriver) {
-    use crate::InOrderCompletion;
+    use crate::in_order::InOrderCompletion;
     use crate::test_helpers::init_avail_ring;
     use crate::test_helpers::init_used_ring;
     use crate::test_helpers::make_available;
@@ -5448,7 +5448,7 @@ async fn in_order_completion_publishes_in_avail_order(driver: DefaultDriver) {
 #[async_test]
 #[should_panic(expected = "completed more than once")]
 async fn in_order_double_complete_panics(driver: DefaultDriver) {
-    use crate::InOrderCompletion;
+    use crate::in_order::InOrderCompletion;
     use crate::test_helpers::init_avail_ring;
     use crate::test_helpers::init_used_ring;
     use crate::test_helpers::make_available;

--- a/vm/devices/virtio/virtio/src/tests.rs
+++ b/vm/devices/virtio/virtio/src/tests.rs
@@ -5351,3 +5351,163 @@ async fn packed_full_ring_chain_toggles_wrap_counters(driver: DefaultDriver) {
         "used wrap counter must toggle after a full-ring lap"
     );
 }
+
+/// Directly exercises the in-order completion helper: with it in front of the
+/// queue, descriptors completed out of order are published to the used ring
+/// strictly in avail (consumption) order.
+#[async_test]
+async fn in_order_completion_publishes_in_avail_order(driver: DefaultDriver) {
+    use crate::InOrderCompletion;
+    use crate::test_helpers::init_avail_ring;
+    use crate::test_helpers::init_used_ring;
+    use crate::test_helpers::make_available;
+    use crate::test_helpers::read_used;
+    use crate::test_helpers::write_descriptor;
+
+    let mem = GuestMemory::allocate(0x10000);
+    let desc_addr = 0x1000;
+    let avail_addr = 0x2000;
+    let used_addr = 0x3000;
+    let data_addr = 0x4000;
+    let size: u16 = 8;
+
+    init_avail_ring(&mem, avail_addr);
+    init_used_ring(&mem, used_addr);
+
+    let params = QueueParams {
+        size,
+        enable: true,
+        desc_addr,
+        avail_addr,
+        used_addr,
+    };
+    let event = Event::new();
+    let interrupt_event = Event::new();
+    let notify = Interrupt::from_event(interrupt_event);
+    let queue_event = PolledWait::new(&driver, event).unwrap();
+    let mut queue = VirtioQueue::new(
+        VirtioDeviceFeatures::new(),
+        params,
+        mem.clone(),
+        notify,
+        queue_event,
+        None,
+    )
+    .unwrap();
+    let mut in_order = InOrderCompletion::new(size);
+
+    // Make three writeable descriptors available.
+    let mut avail_idx = 0;
+    for i in 0..3u16 {
+        write_descriptor(
+            &mem,
+            desc_addr,
+            i,
+            data_addr + i as u64 * 0x100,
+            0x100,
+            DescriptorFlags::new().with_write(true),
+            0,
+        );
+        make_available(&mem, avail_addr, size, i, &mut avail_idx);
+    }
+
+    let w0 = in_order.try_next(&mut queue).unwrap().unwrap();
+    let w1 = in_order.try_next(&mut queue).unwrap().unwrap();
+    let w2 = in_order.try_next(&mut queue).unwrap().unwrap();
+
+    let mut used_idx = 0;
+
+    // Complete the last descriptor first: nothing may be published yet.
+    in_order.complete(&mut queue, w2.into_completion(), 22);
+    assert!(read_used(&mem, used_addr, size, &mut used_idx).is_none());
+
+    // Complete descriptor 0: it publishes, but descriptor 2 must wait for 1.
+    in_order.complete(&mut queue, w0.into_completion(), 10);
+    assert_eq!(
+        read_used(&mem, used_addr, size, &mut used_idx),
+        Some((0, 10))
+    );
+    assert!(read_used(&mem, used_addr, size, &mut used_idx).is_none());
+
+    // Complete descriptor 1: now 1 and the already-filled 2 flush in order.
+    in_order.complete(&mut queue, w1.into_completion(), 11);
+    assert_eq!(
+        read_used(&mem, used_addr, size, &mut used_idx),
+        Some((1, 11))
+    );
+    assert_eq!(
+        read_used(&mem, used_addr, size, &mut used_idx),
+        Some((2, 22))
+    );
+}
+
+/// Completing the same descriptor twice while it is still outstanding is an
+/// internal invariant violation (the device rejects guest-induced duplicates
+/// upstream), so the in-order helper must fail fast rather than silently
+/// stalling the used ring.
+#[async_test]
+#[should_panic(expected = "completed more than once")]
+async fn in_order_double_complete_panics(driver: DefaultDriver) {
+    use crate::InOrderCompletion;
+    use crate::test_helpers::init_avail_ring;
+    use crate::test_helpers::init_used_ring;
+    use crate::test_helpers::make_available;
+    use crate::test_helpers::write_descriptor;
+
+    let mem = GuestMemory::allocate(0x10000);
+    let desc_addr = 0x1000;
+    let avail_addr = 0x2000;
+    let used_addr = 0x3000;
+    let data_addr = 0x4000;
+    let size: u16 = 8;
+
+    init_avail_ring(&mem, avail_addr);
+    init_used_ring(&mem, used_addr);
+
+    let params = QueueParams {
+        size,
+        enable: true,
+        desc_addr,
+        avail_addr,
+        used_addr,
+    };
+    let event = Event::new();
+    let notify = Interrupt::from_event(Event::new());
+    let queue_event = PolledWait::new(&driver, event).unwrap();
+    let mut queue = VirtioQueue::new(
+        VirtioDeviceFeatures::new(),
+        params,
+        mem.clone(),
+        notify,
+        queue_event,
+        None,
+    )
+    .unwrap();
+    let mut in_order = InOrderCompletion::new(size);
+
+    // Descriptors 0 and 1, with 1 made available twice so two works share
+    // descriptor index 1.
+    let mut avail_idx = 0;
+    for i in 0..2u16 {
+        write_descriptor(
+            &mem,
+            desc_addr,
+            i,
+            data_addr + i as u64 * 0x100,
+            0x100,
+            DescriptorFlags::new().with_write(true),
+            0,
+        );
+        make_available(&mem, avail_addr, size, i, &mut avail_idx);
+    }
+    make_available(&mem, avail_addr, size, 1, &mut avail_idx);
+
+    let _w0 = in_order.try_next(&mut queue).unwrap().unwrap();
+    let w1a = in_order.try_next(&mut queue).unwrap().unwrap();
+    let w1b = in_order.try_next(&mut queue).unwrap().unwrap();
+
+    // w0 (descriptor 0) is never completed, so descriptor 1 stays buffered
+    // behind it; completing index 1 twice while buffered must panic.
+    in_order.complete(&mut queue, w1a.into_completion(), 1);
+    in_order.complete(&mut queue, w1b.into_completion(), 1);
+}

--- a/vm/devices/virtio/virtio_net/src/buffers.rs
+++ b/vm/devices/virtio/virtio_net/src/buffers.rs
@@ -29,6 +29,18 @@ pub struct VirtioWorkPool {
     rx_packets: Vec<Option<RxPacket>>,
 }
 
+/// Reason a submitted RX buffer could not be queued to the backend, returned
+/// with the original work item so the caller can decide how to handle it.
+pub enum RxQueueError {
+    /// The descriptor index is already in use (duplicate guest submission).
+    /// This is a fatal protocol violation: the pool slot is already taken, so
+    /// the buffer cannot be tracked.
+    DuplicateIndex(VirtioQueueCallbackWork),
+    /// The buffer is smaller than the virtio-net header. It must be completed
+    /// (dropped) in avail order rather than posted to the backend.
+    TooSmall(VirtioQueueCallbackWork),
+}
+
 impl VirtioWorkPool {
     fn inspect_extra(&self, resp: &mut inspect::Response<'_>) {
         resp.field(
@@ -71,17 +83,15 @@ impl VirtioWorkPool {
 
     /// Add a virtio work instance to the buffers available for use.
     ///
-    /// Returns `Err` with the work item if the descriptor index is already in
-    /// use (duplicate submission by the guest).
-    pub fn queue_work(
-        &mut self,
-        work: VirtioQueueCallbackWork,
-    ) -> Result<RxId, VirtioQueueCallbackWork> {
+    /// Returns `Err` with the work item if the buffer cannot be posted to the
+    /// backend, distinguishing a fatal duplicate descriptor index from a
+    /// too-small buffer that should be dropped in order.
+    pub fn queue_work(&mut self, work: VirtioQueueCallbackWork) -> Result<RxId, RxQueueError> {
         let idx = work.descriptor_index();
         let packet = &mut self.rx_packets[idx as usize];
         if packet.is_some() {
             tracelimit::warn_ratelimited!("dropping RX buffer: descriptor index already in use");
-            return Err(work);
+            return Err(RxQueueError::DuplicateIndex(work));
         }
         let payload_length = work.get_payload_length(true) as u32;
         let Some(cap) = payload_length.checked_sub(header_size() as u32) else {
@@ -89,7 +99,7 @@ impl VirtioWorkPool {
                 len = payload_length,
                 "dropping RX buffer: payload length smaller than virtio-net header size"
             );
-            return Err(work);
+            return Err(RxQueueError::TooSmall(work));
         };
         *packet = Some(RxPacket { len: 0, cap, work });
         Ok(RxId(idx.into()))

--- a/vm/devices/virtio/virtio_net/src/lib.rs
+++ b/vm/devices/virtio/virtio_net/src/lib.rs
@@ -17,6 +17,7 @@ pub mod resolver;
 #[cfg(test)]
 mod tests;
 
+use crate::buffers::RxQueueError;
 use crate::buffers::VirtioWorkPool;
 use anyhow::Context as _;
 use bitfield_struct::bitfield;
@@ -48,10 +49,12 @@ use task_control::TaskControl;
 use thiserror::Error;
 use virtio::DeviceTraits;
 use virtio::DeviceTraitsSharedMemory;
+use virtio::InOrderCompletion;
 use virtio::QueueResources;
 use virtio::VirtioDevice;
 use virtio::VirtioQueue;
 use virtio::VirtioQueueCallbackWork;
+use virtio::queue::QueueCompletion;
 use virtio::queue::QueueState;
 use virtio::spec::VirtioDeviceFeatures;
 use vmcore::vm_task::VmTaskDriver;
@@ -281,7 +284,11 @@ impl VirtioDevice for Device {
                 .with_bank(1, features_bank1.into_bits())
                 .with_ring_event_idx(true)
                 .with_ring_indirect_desc(true)
-                .with_ring_packed(true),
+                .with_ring_packed(true)
+                // We guarantee in-order descriptor completion per queue. We
+                // don't yet take advantage of the ability to do batched
+                // completions, but we may in the future.
+                .with_in_order(true),
             max_queues: 2 * self.registers.max_virtqueue_pairs,
             device_register_length: size_of::<NetConfig>() as u32,
             shared_memory: DeviceTraitsSharedMemory { id: 0, size: 0 },
@@ -386,6 +393,8 @@ impl VirtioDevice for Device {
                     rx_queue_size,
                     tx_queue,
                     tx_queue_size,
+                    rx_in_order: InOrderCompletion::new(rx_queue_size),
+                    tx_in_order: InOrderCompletion::new(tx_queue_size),
                 };
                 self.insert_worker(
                     virtio_state,
@@ -518,7 +527,7 @@ impl ActiveState {
 
 /// The state for a tx packet that's currently pending in the backend endpoint.
 struct PendingTxPacket {
-    work: VirtioQueueCallbackWork,
+    completion: QueueCompletion,
 }
 
 pub struct NicBuilder {
@@ -532,12 +541,28 @@ impl NicBuilder {
     }
 
     /// Creates a new NIC.
+    ///
+    /// Fails if the network backend does not complete buffers in order.
+    /// virtio-net guarantees in-order descriptor completion per queue (so the
+    /// outstanding set is exactly the contiguous `[used_index, avail_index)`
+    /// range), which requires a backend that always completes in order. Every
+    /// real backend is ordered; this rejects the misconfiguration up front
+    /// rather than letting the device come up and wedge when the guest
+    /// activates it.
     pub fn build(
         self,
         driver_source: &VmTaskDriverSource,
         endpoint: Box<dyn Endpoint>,
         mac_address: MacAddress,
-    ) -> Device {
+    ) -> anyhow::Result<Device> {
+        if !endpoint.is_ordered() {
+            anyhow::bail!(
+                "network backend '{}' does not complete packets in order; \
+                 virtio-net requires an ordered backend",
+                endpoint.endpoint_type()
+            );
+        }
+
         // TODO: Implement VIRTIO_NET_F_MQ and VIRTIO_NET_F_RSS logic based on mulitqueue support.
         // let multiqueue = endpoint.multiqueue_support();
         // let max_queue_pairs = self.max_queue_pairs.clamp(1, multiqueue.max_queues.min(VIRTIO_NET_MAX_QUEUES));
@@ -570,7 +595,7 @@ impl NicBuilder {
             supported_hash_types: 0,
         };
 
-        Device {
+        Ok(Device {
             registers,
             coordinator,
             adapter,
@@ -578,7 +603,7 @@ impl NicBuilder {
             pairs: (0..max_queue_pairs)
                 .map(|_| QueuePairState::Empty)
                 .collect(),
-        }
+        })
     }
 }
 
@@ -798,6 +823,13 @@ struct VirtioState {
     rx_queue_size: u16,
     tx_queue: VirtioQueue,
     tx_queue_size: u16,
+    /// In-order completion discipline for the RX queue. virtio-net requires
+    /// the used ring to be published in avail order so the outstanding set is
+    /// exactly the contiguous `[used_index, avail_index)` range (see the
+    /// backend `is_ordered()` gate in `restart_queues`).
+    rx_in_order: InOrderCompletion,
+    /// In-order completion discipline for the TX queue.
+    tx_in_order: InOrderCompletion,
 }
 
 #[derive(Debug, Error)]
@@ -806,6 +838,8 @@ enum WorkerError {
     VirtioQueue(#[source] std::io::Error),
     #[error("endpoint")]
     Endpoint(#[source] anyhow::Error),
+    #[error("guest submitted duplicate descriptor index {0}")]
+    DuplicateDescriptor(u16),
     #[error("cancelled")]
     Cancelled(task_control::Cancelled),
 }
@@ -915,13 +949,13 @@ impl Worker {
             for _ in 0..8 {
                 let Some(work) = self
                     .virtio_state
-                    .tx_queue
-                    .try_next()
+                    .tx_in_order
+                    .try_next(&mut self.virtio_state.tx_queue)
                     .map_err(WorkerError::VirtioQueue)?
                 else {
                     break;
                 };
-                self.queue_tx_packet(work);
+                self.queue_tx_packet(work)?;
                 did_work = true;
             }
             if self.active_state.data.tx_segments.is_empty() {
@@ -931,11 +965,21 @@ impl Worker {
         Ok(did_work)
     }
 
-    fn queue_tx_packet(&mut self, work: VirtioQueueCallbackWork) {
+    fn queue_tx_packet(&mut self, work: VirtioQueueCallbackWork) -> Result<(), WorkerError> {
         let seg_start = self.active_state.data.tx_segments.len();
         match self.try_queue_tx_packet(&work) {
             Ok(idx) => {
-                self.active_state.pending_tx_packets[idx as usize] = Some(PendingTxPacket { work });
+                self.active_state.pending_tx_packets[idx as usize] = Some(PendingTxPacket {
+                    completion: work.into_completion(),
+                });
+            }
+            Err(TxPacketError::DuplicateIndex(idx)) => {
+                // A duplicate descriptor index cannot be tracked (the pending
+                // slot is already taken), so treat it as a fatal queue protocol
+                // violation rather than an out-of-order drop.
+                self.active_state.stats.tx_dropped.increment();
+                self.active_state.data.tx_segments.truncate(seg_start);
+                return Err(WorkerError::DuplicateDescriptor(idx));
             }
             Err(err) => {
                 tracelimit::warn_ratelimited!(
@@ -944,9 +988,16 @@ impl Worker {
                 );
                 self.active_state.stats.tx_dropped.increment();
                 self.active_state.data.tx_segments.truncate(seg_start);
-                self.virtio_state.tx_queue.complete(work, 0);
+                // Complete (drop) the packet in avail order via the in-order
+                // completion discipline.
+                self.virtio_state.tx_in_order.complete(
+                    &mut self.virtio_state.tx_queue,
+                    work.into_completion(),
+                    0,
+                );
             }
         }
+        Ok(())
     }
 
     /// Build TX segments and offload metadata for a packet.
@@ -1240,17 +1291,30 @@ impl Worker {
         let mut rx_ids = Vec::new();
         while let Some(work) = self
             .virtio_state
-            .rx_queue
-            .try_next()
+            .rx_in_order
+            .try_next(&mut self.virtio_state.rx_queue)
             .map_err(WorkerError::VirtioQueue)?
         {
             tracing::trace!("rx packet");
             match self.active_state.pending_rx_packets.queue_work(work) {
                 Ok(rx_id) => rx_ids.push(rx_id),
-                Err(work) => {
-                    // Reason has been traced by the callee.
+                Err(RxQueueError::TooSmall(work)) => {
+                    // Complete (drop) the buffer in avail order via the in-order
+                    // completion discipline. Reason traced by callee.
                     self.active_state.stats.rx_dropped.increment();
-                    self.virtio_state.rx_queue.complete(work, 0);
+                    self.virtio_state.rx_in_order.complete(
+                        &mut self.virtio_state.rx_queue,
+                        work.into_completion(),
+                        0,
+                    );
+                }
+                Err(RxQueueError::DuplicateIndex(work)) => {
+                    // A duplicate descriptor index cannot be tracked (the pool
+                    // slot is already taken), so treat it as a fatal queue
+                    // protocol violation rather than an out-of-order drop.
+                    let idx = work.descriptor_index();
+                    self.active_state.stats.rx_dropped.increment();
+                    return Err(WorkerError::DuplicateDescriptor(idx));
                 }
             }
         }
@@ -1277,7 +1341,11 @@ impl Worker {
         for ready_id in state.data.rx_ready[..n].iter() {
             state.stats.rx_packets.increment();
             let (work, bytes) = state.pending_rx_packets.take_rx_work(*ready_id);
-            self.virtio_state.rx_queue.complete(work, bytes);
+            self.virtio_state.rx_in_order.complete(
+                &mut self.virtio_state.rx_queue,
+                work.into_completion(),
+                bytes,
+            );
         }
 
         state.stats.rx_packets_per_wake.add_sample(n as u64);
@@ -1350,7 +1418,11 @@ impl Worker {
     fn complete_tx_packet(&mut self, id: TxId) -> Result<(), WorkerError> {
         let state = &mut self.active_state;
         let tx_packet = state.pending_tx_packets[id.0 as usize].take().unwrap();
-        self.virtio_state.tx_queue.complete(tx_packet.work, 0);
+        self.virtio_state.tx_in_order.complete(
+            &mut self.virtio_state.tx_queue,
+            tx_packet.completion,
+            0,
+        );
         self.active_state.stats.tx_packets.increment();
         Ok(())
     }

--- a/vm/devices/virtio/virtio_net/src/lib.rs
+++ b/vm/devices/virtio/virtio_net/src/lib.rs
@@ -49,11 +49,11 @@ use task_control::TaskControl;
 use thiserror::Error;
 use virtio::DeviceTraits;
 use virtio::DeviceTraitsSharedMemory;
-use virtio::InOrderCompletion;
 use virtio::QueueResources;
 use virtio::VirtioDevice;
 use virtio::VirtioQueue;
 use virtio::VirtioQueueCallbackWork;
+use virtio::in_order::InOrderCompletion;
 use virtio::queue::QueueCompletion;
 use virtio::queue::QueueState;
 use virtio::spec::VirtioDeviceFeatures;
@@ -825,8 +825,7 @@ struct VirtioState {
     tx_queue_size: u16,
     /// In-order completion discipline for the RX queue. virtio-net requires
     /// the used ring to be published in avail order so the outstanding set is
-    /// exactly the contiguous `[used_index, avail_index)` range (see the
-    /// backend `is_ordered()` gate in `restart_queues`).
+    /// exactly the contiguous `[used_index, avail_index)` range.
     rx_in_order: InOrderCompletion,
     /// In-order completion discipline for the TX queue.
     tx_in_order: InOrderCompletion,
@@ -973,21 +972,19 @@ impl Worker {
                     completion: work.into_completion(),
                 });
             }
-            Err(TxPacketError::DuplicateIndex(idx)) => {
-                // A duplicate descriptor index cannot be tracked (the pending
-                // slot is already taken), so treat it as a fatal queue protocol
-                // violation rather than an out-of-order drop.
+            Err(err) => {
                 self.active_state.stats.tx_dropped.increment();
                 self.active_state.data.tx_segments.truncate(seg_start);
-                return Err(WorkerError::DuplicateDescriptor(idx));
-            }
-            Err(err) => {
+                if let TxPacketError::DuplicateIndex(idx) = err {
+                    // A duplicate descriptor index cannot be tracked (the pending
+                    // slot is already taken), so treat it as a fatal queue protocol
+                    // violation rather than an out-of-order drop.
+                    return Err(WorkerError::DuplicateDescriptor(idx));
+                }
                 tracelimit::warn_ratelimited!(
                     error = &err as &dyn std::error::Error,
                     "dropping TX packet"
                 );
-                self.active_state.stats.tx_dropped.increment();
-                self.active_state.data.tx_segments.truncate(seg_start);
                 // Complete (drop) the packet in avail order via the in-order
                 // completion discipline.
                 self.virtio_state.tx_in_order.complete(

--- a/vm/devices/virtio/virtio_net/src/resolver.rs
+++ b/vm/devices/virtio/virtio_net/src/resolver.rs
@@ -47,7 +47,7 @@ impl AsyncResolveResource<VirtioDeviceHandle, VirtioNetHandle> for VirtioNetReso
             )
             .await?;
 
-        let device = builder.build(input.driver_source, endpoint.0, resource.mac_address);
+        let device = builder.build(input.driver_source, endpoint.0, resource.mac_address)?;
 
         Ok(device.into())
     }

--- a/vm/devices/virtio/virtio_net/src/tests.rs
+++ b/vm/devices/virtio/virtio_net/src/tests.rs
@@ -278,6 +278,31 @@ impl MockQueueHandle {
         }
     }
 
+    /// Inject an RX packet into a *specific* pending RX buffer, identified by
+    /// its `RxId`. Unlike [`inject_rx_packet`], which uses the oldest pending
+    /// buffer, this lets tests complete buffers out of order.
+    fn inject_rx_packet_for(&self, rx_id: RxId, data: &[u8]) {
+        let mut pending = self.rx_pending.lock();
+        let pos = pending
+            .iter()
+            .position(|id| id.0 == rx_id.0)
+            .expect("rx_id not pending");
+        pending.remove(pos);
+        drop(pending);
+        self.rx_ready.lock().push_back((
+            rx_id,
+            data.to_vec(),
+            RxMetadata {
+                offset: 0,
+                len: data.len(),
+                ..Default::default()
+            },
+        ));
+        if let Some(waker) = self.ready_waker.lock().take() {
+            waker.wake();
+        }
+    }
+
     /// Wait until the device has called `rx_avail` for at least one buffer.
     async fn wait_for_rx_pending(&mut self) {
         mesh::CancelContext::new()
@@ -336,6 +361,7 @@ fn new_mock_queue() -> (MockQueue, MockQueueHandle) {
 
 struct MockEndpoint {
     queue_tx: mesh::Sender<MockQueueHandle>,
+    is_ordered: bool,
 }
 
 impl InspectMut for MockEndpoint {
@@ -365,7 +391,7 @@ impl Endpoint for MockEndpoint {
     async fn stop(&mut self) {}
 
     fn is_ordered(&self) -> bool {
-        false
+        self.is_ordered
     }
 
     fn tx_offload_support(&self) -> TxOffloadSupport {
@@ -457,11 +483,16 @@ impl TestHarness {
 
         // Create mock endpoint with channel
         let (queue_tx, queue_handle_rx) = mesh::channel();
-        let endpoint = MockEndpoint { queue_tx };
+        let endpoint = MockEndpoint {
+            queue_tx,
+            is_ordered: true,
+        };
 
         let driver_source = VmTaskDriverSource::new(SingleDriverBackend::new(driver.clone()));
         let mac = MacAddress::new([0x00, 0x15, 0x5d, 0xaa, 0xbb, 0xcc]);
-        let device = Device::builder().build(&driver_source, Box::new(endpoint), mac);
+        let device = Device::builder()
+            .build(&driver_source, Box::new(endpoint), mac)
+            .unwrap();
 
         let rx_event = Event::new();
         let rx_interrupt_event = Event::new();
@@ -652,6 +683,25 @@ impl TestHarness {
         .await
     }
 
+    /// Non-blocking read of the next RX used ring entry, if any.
+    fn try_read_rx_used(&mut self) -> Option<(u16, u32)> {
+        read_used(&self.mem, RX_USED_ADDR, QUEUE_SIZE, &mut self.rx_used_idx)
+    }
+
+    /// Non-blocking read of the next TX used ring entry, if any.
+    fn try_read_tx_used(&mut self) -> Option<(u16, u32)> {
+        read_used(&self.mem, TX_USED_ADDR, QUEUE_SIZE, &mut self.tx_used_idx)
+    }
+
+    /// Sleep for a bounded duration to let the worker make progress. Used by
+    /// tests that assert a completion has *not* been published yet.
+    async fn settle(&self) {
+        let _ = mesh::CancelContext::new()
+            .with_timeout(Duration::from_millis(250))
+            .until_cancelled(pending::<()>())
+            .await;
+    }
+
     /// Disable the device (stops all queues).
     async fn disable(&mut self) {
         self.device.stop_queue(1).await;
@@ -755,10 +805,11 @@ async fn async_completion_single_packet(driver: DefaultDriver) {
 }
 
 /// Submit a descriptor index that is already in-flight (async completion
-/// pending). The duplicate should be dropped immediately and the original
-/// should still complete normally.
+/// pending). A duplicate descriptor index cannot be tracked (the pending slot
+/// is already taken), so the device treats it as a fatal protocol violation:
+/// the queue worker stops and no further completions are published.
 #[async_test]
-async fn duplicate_descriptor_index_dropped(driver: DefaultDriver) {
+async fn duplicate_descriptor_index_is_fatal(driver: DefaultDriver) {
     let mut harness = TestHarness::new(&driver);
     let mut handle = harness.enable_and_get_handle().await;
 
@@ -778,29 +829,172 @@ async fn duplicate_descriptor_index_dropped(driver: DefaultDriver) {
     assert_eq!(log.len(), 1);
 
     // Now post the same descriptor index again. The device should detect the
-    // duplicate and complete it immediately without forwarding to the backend.
+    // duplicate and treat it as a fatal queue protocol violation, stopping the
+    // worker.
     harness.post_tx_and_signal(desc_index, data_len);
+    harness.settle().await;
 
-    // The duplicate gets completed immediately (dropped).
-    let (used_id, used_len) = harness.wait_for_used().await;
-    assert_eq!(used_id, desc_index);
-    assert_eq!(used_len, 0);
+    // The duplicate must NOT be completed (old behavior dropped it with len 0).
+    assert_eq!(
+        harness.try_read_tx_used(),
+        None,
+        "duplicate descriptor must not produce a used ring entry"
+    );
 
-    // The backend should NOT have received a second tx_avail call for the
-    // duplicate packet's segments.
+    // The backend should NOT have received a second tx_avail call.
     let log = handle.take_tx_avail_log();
     assert!(
         log.is_empty(),
         "duplicate packet should not reach the backend"
     );
 
-    // Now complete the original packet.
+    // Because the worker stopped, even completing the original in-flight packet
+    // does not publish anything further.
     handle.complete_tx(vec![TxId(desc_index as u32)]);
+    harness.settle().await;
+    assert_eq!(
+        harness.try_read_tx_used(),
+        None,
+        "no completions should be published after the fatal violation"
+    );
+}
 
-    // The original completion should appear in the used ring.
-    let (used_id, used_len) = harness.wait_for_used().await;
-    assert_eq!(used_id, desc_index);
-    assert_eq!(used_len, 0);
+/// An unordered network backend is rejected at device creation with a clear
+/// error, rather than the device coming up and wedging when the guest activates
+/// it.
+#[async_test]
+async fn unordered_backend_rejected(driver: DefaultDriver) {
+    let driver_source = VmTaskDriverSource::new(SingleDriverBackend::new(driver));
+    let mac = MacAddress::new([0x00, 0x15, 0x5d, 0xaa, 0xbb, 0xcc]);
+    let (queue_tx, _queue_handle_rx) = mesh::channel();
+    let endpoint = MockEndpoint {
+        queue_tx,
+        is_ordered: false,
+    };
+
+    let err = Device::builder()
+        .build(&driver_source, Box::new(endpoint), mac)
+        .err()
+        .expect("build must fail on an unordered backend");
+    assert!(
+        err.to_string().contains("ordered backend"),
+        "unexpected error: {err}"
+    );
+}
+
+/// A backend that completes RX buffers out of order must still result in the
+/// used ring being published strictly in avail (consumption) order.
+#[async_test]
+async fn rx_out_of_order_completion_published_in_order(driver: DefaultDriver) {
+    let mut harness = TestHarness::new(&driver);
+    let mut handle = harness.enable_and_get_handle().await;
+
+    let buffer_size: u32 = 512;
+    let mut gpas = Vec::new();
+    for i in 0u16..3 {
+        gpas.push(harness.post_rx_buffer_and_signal(i, buffer_size));
+    }
+    for _ in 0..3 {
+        handle.wait_for_rx_pending().await;
+    }
+
+    let payloads: [&[u8]; 3] = [b"packet-zero", b"packet-one!!", b"pkt-two"];
+
+    // Complete the last buffer first. Because descriptor 0 (and 1) are still
+    // outstanding, nothing may be published yet.
+    handle.inject_rx_packet_for(RxId(2), payloads[2]);
+    harness.settle().await;
+    assert_eq!(
+        harness.try_read_rx_used(),
+        None,
+        "descriptor 2 must not be published ahead of earlier outstanding buffers"
+    );
+
+    // Complete descriptor 0: it publishes, but descriptor 1 is still
+    // outstanding so descriptor 2 must not follow yet.
+    handle.inject_rx_packet_for(RxId(0), payloads[0]);
+    let (id0, len0) = harness.wait_for_rx_used().await;
+    assert_eq!(id0, 0);
+    assert_eq!(len0, NET_HEADER_SIZE + payloads[0].len() as u32);
+    assert_eq!(
+        harness.try_read_rx_used(),
+        None,
+        "descriptor 2 must not be published while descriptor 1 is outstanding"
+    );
+
+    // Complete descriptor 1: now 1 and the already-filled 2 both flush in order.
+    handle.inject_rx_packet_for(RxId(1), payloads[1]);
+    let (id1, len1) = harness.wait_for_rx_used().await;
+    assert_eq!(id1, 1);
+    assert_eq!(len1, NET_HEADER_SIZE + payloads[1].len() as u32);
+    let (id2, len2) = harness.wait_for_rx_used().await;
+    assert_eq!(id2, 2);
+    assert_eq!(len2, NET_HEADER_SIZE + payloads[2].len() as u32);
+
+    // Verify data integrity for each buffer.
+    for (i, payload) in payloads.iter().enumerate() {
+        let mut readback = vec![0u8; payload.len()];
+        harness
+            .mem
+            .read_at(gpas[i] + NET_HEADER_SIZE as u64, &mut readback)
+            .unwrap();
+        assert_eq!(&readback, payload, "buffer {i} data mismatch");
+    }
+}
+
+/// A malformed (too-small) RX buffer in the middle of the avail ring is dropped,
+/// but its completion is published in its avail-order position — never ahead of
+/// an earlier still-outstanding buffer.
+#[async_test]
+async fn rx_malformed_completed_in_order(driver: DefaultDriver) {
+    let mut harness = TestHarness::new(&driver);
+    let mut handle = harness.enable_and_get_handle().await;
+
+    // Descriptor 0: normal. Descriptor 1: too small (< virtio-net header) and
+    // will be dropped. Descriptor 2: normal.
+    harness.post_rx_buffer_and_signal(0, 512);
+    harness.post_rx_buffer_and_signal(1, 4); // smaller than header_size()
+    harness.post_rx_buffer_and_signal(2, 512);
+
+    // Descriptors 0 and 2 are posted to the backend (descriptor 1 is dropped).
+    handle.wait_for_rx_pending().await;
+    handle.wait_for_rx_pending().await;
+    harness.settle().await;
+
+    // The malformed descriptor 1 has been completed internally but is held
+    // behind the still-outstanding descriptor 0, so nothing is published yet.
+    assert_eq!(
+        harness.try_read_rx_used(),
+        None,
+        "malformed descriptor must not be published ahead of descriptor 0"
+    );
+
+    // Complete descriptor 2 out of order — still nothing publishes.
+    handle.inject_rx_packet_for(RxId(2), b"pkt-two");
+    harness.settle().await;
+    assert_eq!(
+        harness.try_read_rx_used(),
+        None,
+        "descriptor 2 must not be published ahead of descriptors 0/1"
+    );
+
+    // Complete descriptor 0: now 0, the dropped 1 (len 0), and 2 flush in order.
+    handle.inject_rx_packet_for(RxId(0), b"packet-zero");
+
+    let (id0, len0) = harness.wait_for_rx_used().await;
+    assert_eq!(id0, 0);
+    assert_eq!(len0, NET_HEADER_SIZE + b"packet-zero".len() as u32);
+
+    let (id1, len1) = harness.wait_for_rx_used().await;
+    assert_eq!(
+        id1, 1,
+        "malformed descriptor completes in avail-order position"
+    );
+    assert_eq!(len1, 0, "malformed descriptor is dropped with len 0");
+
+    let (id2, len2) = harness.wait_for_rx_used().await;
+    assert_eq!(id2, 2);
+    assert_eq!(len2, NET_HEADER_SIZE + b"pkt-two".len() as u32);
 }
 
 /// Post 3 TX packets one at a time, each completing synchronously.
@@ -1695,7 +1889,9 @@ async fn feature_negotiation_with_offloads(driver: DefaultDriver) {
         },
     };
 
-    let device = Device::builder().build(&driver_source, Box::new(endpoint), mac);
+    let device = Device::builder()
+        .build(&driver_source, Box::new(endpoint), mac)
+        .unwrap();
     let traits = device.traits();
 
     let bank0 = NetworkFeaturesBank0::from(traits.device_features.bank(0));
@@ -1721,6 +1917,43 @@ async fn feature_negotiation_with_offloads(driver: DefaultDriver) {
     );
 }
 
+/// The device advertises VIRTIO_F_IN_ORDER, since it guarantees in-order
+/// descriptor completion per queue.
+#[async_test]
+async fn advertises_in_order(driver: DefaultDriver) {
+    let driver_source = VmTaskDriverSource::new(SingleDriverBackend::new(driver));
+    let mac = MacAddress::new([0x00, 0x15, 0x5d, 0x01, 0x02, 0x03]);
+    let endpoint = MockEndpointWithOffloads {
+        offloads: TxOffloadSupport::default(),
+    };
+    let device = Device::builder()
+        .build(&driver_source, Box::new(endpoint), mac)
+        .unwrap();
+    assert!(
+        device.traits().device_features.in_order(),
+        "VIRTIO_F_IN_ORDER must be advertised"
+    );
+}
+
+/// With VIRTIO_F_IN_ORDER negotiated, the RX path still round-trips a packet
+/// (negotiating the feature must not break queue setup or completion).
+#[async_test]
+async fn in_order_negotiated_rx_roundtrip(driver: DefaultDriver) {
+    let mut harness = TestHarness::new(&driver);
+    let mut handle = harness
+        .enable_and_get_handle_with_features(VirtioDeviceFeatures::new().with_in_order(true))
+        .await;
+
+    let _gpa = harness.post_rx_buffer_and_signal(0, 1500);
+    handle.wait_for_rx_pending().await;
+    let payload = b"in-order rx";
+    handle.inject_rx_packet(payload);
+
+    let (used_id, used_len) = harness.wait_for_rx_used().await;
+    assert_eq!(used_id, 0);
+    assert_eq!(used_len, NET_HEADER_SIZE + payload.len() as u32);
+}
+
 /// Verify that the device does NOT advertise offload features when the
 /// endpoint supports none.
 #[async_test]
@@ -1732,7 +1965,9 @@ async fn feature_negotiation_no_offloads(driver: DefaultDriver) {
         offloads: TxOffloadSupport::default(),
     };
 
-    let device = Device::builder().build(&driver_source, Box::new(endpoint), mac);
+    let device = Device::builder()
+        .build(&driver_source, Box::new(endpoint), mac)
+        .unwrap();
     let traits = device.traits();
 
     let bank0 = NetworkFeaturesBank0::from(traits.device_features.bank(0));
@@ -1782,6 +2017,10 @@ impl Endpoint for MockEndpointWithOffloads {
     }
 
     async fn stop(&mut self) {}
+
+    fn is_ordered(&self) -> bool {
+        true
+    }
 
     fn tx_offload_support(&self) -> TxOffloadSupport {
         self.offloads


### PR DESCRIPTION
Currently, virtio_net does not guarantee that it completes requests in order. This makes implementing save/restore or network endpoint restart annoying, since we have to remember exactly which transactions are yet to be completed, instead of just replaying transcations from the in-memory queues.

However, in practice, every network backend completes requests in order (with the exception of net_dio, which this PR fixes). And virtio_net completes requests in order with exceptions just for error cases.

Rather than complicate save/restore (which is coming in a separate change), just depend on this ordering behavior from the backends. To manage the error cases, keep a side buffer of requests that were completed out of order.

Additionally, advertise this in-order behavior to the guest. Very new Linux kernel virtio-net drivers can use this information to optimize the IO path for some modest performance gains.