### PR TITLE
virtio: bound in-flight queue descriptors

### DIFF
--- a/vm/devices/virtio/virtio/src/common.rs
+++ b/vm/devices/virtio/virtio/src/common.rs
@@ -391,6 +391,9 @@ impl VirtioQueue {
     /// the payload, so callers that buffer completions can store only the
     /// token.
     pub fn complete_prepared(&mut self, completion: QueueCompletion, bytes_written: u32) {
+        // The completion token is consumed even if publishing it to the used ring
+        // fails, so release its in-flight capacity before attempting the write.
+        self.core.work_completed(&completion);
         match self
             .complete
             .complete_descriptor(&completion, bytes_written)

--- a/vm/devices/virtio/virtio/src/queue.rs
+++ b/vm/devices/virtio/virtio/src/queue.rs
@@ -39,6 +39,52 @@ pub(crate) fn read_descriptor<T: IntoBytes + FromBytes + Immutable + KnownLayout
         .map_err(QueueError::Memory)
 }
 
+/// In-flight (consumed-but-not-completed) buffers for a split queue: the
+/// difference of the free-running avail/used head counters.
+///
+/// Errors with [`QueueError::InvalidSavedState`] if that exceeds the queue size
+/// (a corrupt/malicious state — restore is a host trust boundary).
+fn split_in_flight(avail: u16, used: u16, queue_size: u16) -> Result<u16, QueueError> {
+    let in_flight = avail.wrapping_sub(used);
+    if in_flight > queue_size {
+        return Err(QueueError::InvalidSavedState {
+            avail_index: avail,
+            used_index: used,
+            queue_size,
+        });
+    }
+    Ok(in_flight)
+}
+
+/// In-flight (consumed-but-not-completed) descriptors for a packed queue, from
+/// its saved cursors (ring index in bits 0..14, lap/wrap bit in bit 15).
+/// Projecting each cursor onto a doubled ring `[0, 2 * queue_size)` turns the
+/// span from `used` to `avail` into a modular distance; the lap bit tells an
+/// empty ring from a full one.
+///
+/// Errors with [`QueueError::InvalidSavedState`] if the cursors imply more than a
+/// full ring in flight (a corrupt/malicious state — restore is a trust boundary).
+fn packed_in_flight(avail: u16, used: u16, queue_size: u16) -> Result<u16, QueueError> {
+    if avail & 0x7fff >= queue_size || used & 0x7fff >= queue_size {
+        return Err(QueueError::InvalidSavedState {
+            avail_index: avail,
+            used_index: used,
+            queue_size,
+        });
+    }
+    let ring = queue_size as i32;
+    let position = |cursor: u16| (cursor & 0x7FFF) as i32 + i32::from(cursor & 0x8000 != 0) * ring;
+    let in_flight = (position(avail) - position(used)).rem_euclid(2 * ring);
+    if in_flight > ring {
+        return Err(QueueError::InvalidSavedState {
+            avail_index: avail,
+            used_index: used,
+            queue_size,
+        });
+    }
+    Ok(in_flight as u16)
+}
+
 /// Saved progress state for a single virtio queue.
 ///
 /// For split queues: `avail_index` and `used_index` are plain ring indices.
@@ -63,6 +109,24 @@ pub enum QueueError {
     TooLong,
     #[error("Invalid queue size {0}. Must be a power of 2.")]
     InvalidQueueSize(u16),
+    #[error(
+        "guest oversubscribed queue size {queue_size}: {in_flight} already in flight, \
+         {requested} more requested"
+    )]
+    TooManyInFlightDescriptors {
+        in_flight: u16,
+        requested: u16,
+        queue_size: u16,
+    },
+    #[error(
+        "corrupt queue saved state: avail index {avail_index:#x}, used index {used_index:#x}, \
+         queue size {queue_size}"
+    )]
+    InvalidSavedState {
+        avail_index: u16,
+        used_index: u16,
+        queue_size: u16,
+    },
 }
 
 struct QueueDescriptor {
@@ -93,6 +157,13 @@ pub struct QueueCompletion {
 impl QueueCompletion {
     pub fn descriptor_index(&self) -> u16 {
         self.descriptor_index
+    }
+
+    fn in_flight_cost(&self) -> u16 {
+        match &self.context {
+            QueueCompletionContext::Split => 1,
+            QueueCompletionContext::Packed(context) => context.descriptor_count(),
+        }
     }
 }
 
@@ -132,6 +203,12 @@ pub(crate) struct QueueCoreGetWork {
     inner: QueueGetWorkInner,
     /// Whether kick notification is currently armed.
     armed: bool,
+    /// Consumed-but-not-completed ring capacity, in the format's native unit:
+    /// buffers (heads) for split, descriptors (slots) for packed — the two forms
+    /// of the virtio "Queue Size" limit (spec §2.7.1 vs §2.8.1).
+    /// [`try_peek_work`](Self::try_peek_work) rejects work that would push this
+    /// past the queue size, so it stays in `0..=queue_size`.
+    in_flight: u16,
 }
 
 impl QueueCoreGetWork {
@@ -148,7 +225,8 @@ impl QueueCoreGetWork {
         params: QueueParams,
         initial_state: Option<QueueState>,
     ) -> Result<Self, QueueError> {
-        if params.size == 0 {
+        // Both ring layouts cap queue size at 2^15 (spec §2.7.1, §2.8.1).
+        if params.size == 0 || params.size > 1 << 15 {
             return Err(QueueError::InvalidQueueSize(params.size));
         }
         let initial_avail = initial_state.map(|s| s.avail_index);
@@ -181,6 +259,17 @@ impl QueueCoreGetWork {
                 index,
             )?)
         };
+        // Seed from the restored cursors in the matching unit (heads for split,
+        // descriptors for packed) so the running count stays consistent; a fresh
+        // queue is zero. Both reject a state implying more than a full ring
+        // in flight, since restore is a host trust boundary.
+        let in_flight = match initial_state {
+            None => 0,
+            Some(state) if features.ring_packed() => {
+                packed_in_flight(state.avail_index, state.used_index, params.size)?
+            }
+            Some(state) => split_in_flight(state.avail_index, state.used_index, params.size)?,
+        };
         Ok(Self {
             queue_desc,
             queue_size: params.size,
@@ -188,6 +277,7 @@ impl QueueCoreGetWork {
             mem,
             inner,
             armed: false,
+            in_flight,
         })
     }
 
@@ -213,7 +303,24 @@ impl QueueCoreGetWork {
         };
         let Some(index) = index else { return Ok(None) };
         self.suppress_if_armed();
-        self.work_from_index(index).map(Some)
+        let work = self.work_from_index(index)?;
+
+        // Reject a guest that oversubscribes the ring: the whole chain must fit
+        // in the remaining capacity, not just "we aren't already full" (spec caps
+        // in flight at the queue size — §2.7.1/§2.8.1). A compliant guest,
+        // bounded by ring space, never trips this; a misbehaving one (split
+        // reusing avail slots, or packed re-stamping wrap flags early) is caught
+        // before it can grow host tracking or overlap in-flight descriptors.
+        let requested = work.completion().in_flight_cost();
+        if requested > self.queue_size - self.in_flight {
+            return Err(QueueError::TooManyInFlightDescriptors {
+                in_flight: self.in_flight,
+                requested,
+                queue_size: self.queue_size,
+            });
+        }
+
+        Ok(Some(work))
     }
 
     /// Arms kick notification so the guest will send a doorbell when new work
@@ -271,6 +378,7 @@ impl QueueCoreGetWork {
     /// Advances the available index after a successful
     /// [`try_peek_work`](Self::try_peek_work) call.
     pub fn advance(&mut self, completion: &QueueCompletion) {
+        let cost = completion.in_flight_cost();
         match &mut self.inner {
             QueueGetWorkInner::Split(split) => split.advance(),
             QueueGetWorkInner::Packed(packed) => {
@@ -280,6 +388,20 @@ impl QueueCoreGetWork {
                 packed.advance(ctx.descriptor_count());
             }
         }
+        // The chain-fits bound in [`try_peek_work`] keeps this within the queue
+        // size; `checked_add` only guards against corrupt accounting.
+        self.in_flight = self
+            .in_flight
+            .checked_add(cost)
+            .expect("in-flight count overflowed");
+    }
+
+    /// Releases the ring capacity held by a consumed work item.
+    pub fn work_completed(&mut self, completion: &QueueCompletion) {
+        self.in_flight = self
+            .in_flight
+            .checked_sub(completion.in_flight_cost())
+            .expect("completed more than was consumed");
     }
 
     fn work_from_index(&mut self, index: u16) -> Result<VirtioQueueCallbackWork, QueueError> {
@@ -574,5 +696,67 @@ impl Iterator for DescriptorChain<'_> {
 
     fn next(&mut self) -> Option<Self::Item> {
         self.next_descriptor().transpose()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::QueueError;
+    use super::packed_in_flight;
+
+    /// Encodes a packed cursor as it is stored in `QueueState`:
+    /// `index | (wrap_counter << 15)`.
+    fn cursor(index: u16, wrap: bool) -> u16 {
+        index | (u16::from(wrap) << 15)
+    }
+
+    #[test]
+    fn packed_in_flight_decode() {
+        let qs = 8;
+
+        // Empty ring: cursors equal, same wrap.
+        assert_eq!(
+            packed_in_flight(cursor(2, false), cursor(2, false), qs).unwrap(),
+            0
+        );
+        assert_eq!(
+            packed_in_flight(cursor(5, true), cursor(5, true), qs).unwrap(),
+            0
+        );
+
+        // Partial, same wrap: avail ahead of used within the same lap.
+        assert_eq!(
+            packed_in_flight(cursor(5, false), cursor(2, false), qs).unwrap(),
+            3
+        );
+
+        // Full ring: cursors equal index, opposite wrap.
+        assert_eq!(
+            packed_in_flight(cursor(3, true), cursor(3, false), qs).unwrap(),
+            8
+        );
+        assert_eq!(
+            packed_in_flight(cursor(0, false), cursor(0, true), qs).unwrap(),
+            8
+        );
+
+        // Avail has wrapped past the end while used trails in the prior lap.
+        // used at 6, avail at 1 (next lap) → slots 6, 7, 0 in flight.
+        assert_eq!(
+            packed_in_flight(cursor(1, true), cursor(6, false), qs).unwrap(),
+            3
+        );
+    }
+
+    #[test]
+    fn packed_in_flight_rejects_corrupt_state() {
+        // Same wrap but avail index behind used index implies more than a full
+        // ring in flight — an impossible, corrupt saved state. It must be
+        // rejected with an error rather than panicking, since the restore path
+        // is a host trust boundary.
+        assert!(matches!(
+            packed_in_flight(cursor(1, false), cursor(6, false), 8),
+            Err(QueueError::InvalidSavedState { queue_size: 8, .. })
+        ));
     }
 }

--- a/vm/devices/virtio/virtio/src/tests.rs
+++ b/vm/devices/virtio/virtio/src/tests.rs
@@ -13,6 +13,7 @@ use crate::QueueResources;
 use crate::VirtioDevice;
 use crate::VirtioQueue;
 use crate::VirtioQueueCallbackWork;
+use crate::queue::QueueError;
 use crate::queue::QueueParams;
 use crate::queue::QueueState;
 use crate::spec::pci::*;
@@ -5510,4 +5511,280 @@ async fn in_order_double_complete_panics(driver: DefaultDriver) {
     // behind it; completing index 1 twice while buffered must panic.
     in_order.complete(&mut queue, w1a.into_completion(), 1);
     in_order.complete(&mut queue, w1b.into_completion(), 1);
+}
+
+const BOUND_TEST_QUEUE_SIZE: u16 = 4;
+const BOUND_TEST_DESC_ADDR: u64 = 0x1000;
+const BOUND_TEST_AVAIL_ADDR: u64 = 0x2000;
+const BOUND_TEST_USED_ADDR: u64 = 0x3000;
+const BOUND_TEST_DATA_ADDR: u64 = 0x4000;
+
+fn bound_test_params(size: u16) -> QueueParams {
+    QueueParams {
+        size,
+        enable: true,
+        desc_addr: BOUND_TEST_DESC_ADDR,
+        avail_addr: BOUND_TEST_AVAIL_ADDR,
+        used_addr: BOUND_TEST_USED_ADDR,
+    }
+}
+
+fn new_bound_test_queue(
+    driver: &DefaultDriver,
+    packed: bool,
+    initial_state: Option<QueueState>,
+) -> (GuestMemory, VirtioQueue) {
+    new_bound_test_queue_result(driver, packed, initial_state).unwrap()
+}
+
+fn new_bound_test_queue_result(
+    driver: &DefaultDriver,
+    packed: bool,
+    initial_state: Option<QueueState>,
+) -> Result<(GuestMemory, VirtioQueue), QueueError> {
+    use crate::test_helpers::init_avail_ring;
+    use crate::test_helpers::init_used_ring;
+    use crate::test_helpers::write_descriptor;
+
+    let mem = GuestMemory::allocate(0x10000);
+    init_avail_ring(&mem, BOUND_TEST_AVAIL_ADDR);
+    init_used_ring(&mem, BOUND_TEST_USED_ADDR);
+    if !packed {
+        for index in 0..BOUND_TEST_QUEUE_SIZE {
+            write_descriptor(
+                &mem,
+                BOUND_TEST_DESC_ADDR,
+                index,
+                BOUND_TEST_DATA_ADDR + u64::from(index) * 0x100,
+                0x100,
+                DescriptorFlags::new().with_write(true),
+                0,
+            );
+        }
+    }
+    let features = if packed {
+        VirtioDeviceFeatures::new().with_bank(1, VIRTIO_F_VERSION_1 | VIRTIO_F_RING_PACKED)
+    } else {
+        VirtioDeviceFeatures::new()
+    };
+    let queue = VirtioQueue::new(
+        features,
+        bound_test_params(BOUND_TEST_QUEUE_SIZE),
+        mem.clone(),
+        Interrupt::from_event(Event::new()),
+        PolledWait::new(driver, Event::new()).unwrap(),
+        initial_state,
+    )?;
+    Ok((mem, queue))
+}
+
+fn assert_in_flight_error(error: io::Error, in_flight: u16, requested: u16) {
+    let error = error
+        .get_ref()
+        .and_then(|error| error.downcast_ref::<QueueError>());
+    assert!(matches!(
+        error,
+        Some(QueueError::TooManyInFlightDescriptors {
+            in_flight: actual_in_flight,
+            requested: actual_requested,
+            queue_size: BOUND_TEST_QUEUE_SIZE,
+        }) if *actual_in_flight == in_flight && *actual_requested == requested
+    ));
+}
+
+fn next_error(queue: &mut VirtioQueue) -> io::Error {
+    match queue.try_next() {
+        Err(error) => error,
+        Ok(_) => panic!("queue accepted too many in-flight descriptors"),
+    }
+}
+
+fn make_split_bound_test_work(mem: &GuestMemory, count: u16, initial_avail: u16) {
+    use crate::test_helpers::make_available;
+
+    let mut avail = initial_avail;
+    for index in 0..count {
+        make_available(
+            mem,
+            BOUND_TEST_AVAIL_ADDR,
+            BOUND_TEST_QUEUE_SIZE,
+            index % BOUND_TEST_QUEUE_SIZE,
+            &mut avail,
+        );
+    }
+}
+
+fn write_packed_descriptor(
+    mem: &GuestMemory,
+    index: u16,
+    addr: u64,
+    buffer_id: u16,
+    flags: DescriptorFlags,
+) {
+    let base = BOUND_TEST_DESC_ADDR + size_of::<PackedDescriptor>() as u64 * u64::from(index);
+    for (offset, bytes) in [
+        (
+            std::mem::offset_of!(PackedDescriptor, address),
+            addr.to_le_bytes().as_slice(),
+        ),
+        (
+            std::mem::offset_of!(PackedDescriptor, buffer_id),
+            buffer_id.to_le_bytes().as_slice(),
+        ),
+        (
+            std::mem::offset_of!(PackedDescriptor, flags_raw),
+            u16::from(flags).to_le_bytes().as_slice(),
+        ),
+    ] {
+        mem.write_at(base + offset as u64, bytes).unwrap();
+    }
+    mem.write_at(
+        base + std::mem::offset_of!(PackedDescriptor, length) as u64,
+        &0x100u32.to_le_bytes(),
+    )
+    .unwrap();
+}
+
+#[async_test]
+async fn split_queue_rejects_too_many_in_flight(driver: DefaultDriver) {
+    let (mem, mut queue) = new_bound_test_queue(&driver, false, None);
+    make_split_bound_test_work(&mem, BOUND_TEST_QUEUE_SIZE + 1, 0);
+
+    for _ in 0..BOUND_TEST_QUEUE_SIZE {
+        let _ = queue.try_next().unwrap().unwrap();
+    }
+    assert_in_flight_error(next_error(&mut queue), BOUND_TEST_QUEUE_SIZE, 1);
+}
+
+#[async_test]
+async fn packed_queue_rejects_restamped_slots(driver: DefaultDriver) {
+    let (mem, mut queue) = new_bound_test_queue(&driver, true, None);
+    let available = DescriptorFlags::new().with_write(true).with_available(true);
+    for index in 0..BOUND_TEST_QUEUE_SIZE {
+        write_packed_descriptor(
+            &mem,
+            index,
+            BOUND_TEST_DATA_ADDR + u64::from(index) * 0x100,
+            index,
+            available,
+        );
+        let _ = queue.try_next().unwrap().unwrap();
+    }
+
+    write_packed_descriptor(
+        &mem,
+        0,
+        BOUND_TEST_DATA_ADDR,
+        0,
+        DescriptorFlags::new().with_write(true).with_used(true),
+    );
+    assert_in_flight_error(next_error(&mut queue), BOUND_TEST_QUEUE_SIZE, 1);
+}
+
+#[async_test]
+async fn packed_queue_rejects_chain_exceeding_free_space(driver: DefaultDriver) {
+    let (mem, mut queue) = new_bound_test_queue(&driver, true, None);
+    let available = DescriptorFlags::new().with_write(true).with_available(true);
+    let write = |index, flags| {
+        write_packed_descriptor(
+            &mem,
+            index,
+            BOUND_TEST_DATA_ADDR + u64::from(index) * 0x100,
+            index,
+            flags,
+        );
+    };
+    write(0, available.with_next(true));
+    write(1, available);
+    let _ = queue.try_next().unwrap().unwrap();
+
+    write(2, available.with_next(true));
+    write(3, available.with_next(true));
+    write(0, available);
+    assert_in_flight_error(next_error(&mut queue), 2, 3);
+}
+
+#[async_test]
+async fn split_queue_capacity_recovers_after_completion(driver: DefaultDriver) {
+    let (mem, mut queue) = new_bound_test_queue(&driver, false, None);
+    make_split_bound_test_work(&mem, BOUND_TEST_QUEUE_SIZE + 1, 0);
+
+    let mut works = Vec::new();
+    for _ in 0..BOUND_TEST_QUEUE_SIZE {
+        works.push(queue.try_next().unwrap().expect("within queue size"));
+    }
+    assert_in_flight_error(next_error(&mut queue), BOUND_TEST_QUEUE_SIZE, 1);
+    queue.complete(works.remove(0), 1);
+    let _ = queue.try_next().unwrap().unwrap();
+}
+
+#[async_test]
+async fn split_queue_restore_seeds_in_flight(driver: DefaultDriver) {
+    let (mem, mut queue) = new_bound_test_queue(
+        &driver,
+        false,
+        Some(QueueState {
+            avail_index: 3,
+            used_index: 1,
+        }),
+    );
+    make_split_bound_test_work(&mem, 3, 3);
+
+    for _ in 0..2 {
+        let _ = queue.try_next().unwrap().unwrap();
+    }
+    assert_in_flight_error(next_error(&mut queue), 4, 1);
+}
+
+#[async_test]
+async fn packed_queue_new_rejects_oversized_size(driver: DefaultDriver) {
+    let mem = GuestMemory::allocate(0x110000);
+    let params = QueueParams {
+        size: (1 << 15) + 1,
+        enable: true,
+        desc_addr: 0x1000,
+        avail_addr: 0x100000,
+        used_addr: 0x101000,
+    };
+    let features =
+        VirtioDeviceFeatures::new().with_bank(1, VIRTIO_F_VERSION_1 | VIRTIO_F_RING_PACKED);
+    let queue_event = PolledWait::new(&driver, Event::new()).unwrap();
+    assert!(matches!(
+        VirtioQueue::new(
+            features,
+            params,
+            mem,
+            Interrupt::from_event(Event::new()),
+            queue_event,
+            None,
+        ),
+        Err(QueueError::InvalidQueueSize(size)) if size == (1 << 15) + 1
+    ));
+}
+
+#[async_test]
+async fn queue_new_rejects_corrupt_saved_state(driver: DefaultDriver) {
+    let cases = [
+        (false, 10, 0),
+        (true, 1, 6),
+        (true, BOUND_TEST_QUEUE_SIZE, 0),
+        (true, 0, BOUND_TEST_QUEUE_SIZE),
+    ];
+    for (packed, avail_index, used_index) in cases {
+        assert!(matches!(
+            new_bound_test_queue_result(
+                &driver,
+                packed,
+                Some(QueueState {
+                    avail_index,
+                    used_index,
+                }),
+            ),
+            Err(QueueError::InvalidSavedState {
+                avail_index: actual_avail,
+                used_index: actual_used,
+                queue_size: BOUND_TEST_QUEUE_SIZE,
+            }) if actual_avail == avail_index && actual_used == used_index
+        ));
+    }
 }


### PR DESCRIPTION
A misbehaving guest can reuse ring entries before previously consumed work is completed, allowing host-side tracking to exceed the queue size and packed descriptor chains to overlap work already in flight.

Track consumed capacity in each queue, reject work that would exceed the negotiated queue size, and restore the count from validated saved cursors. Release capacity as completion tokens are consumed so normal queue progress continues while malformed live and saved state is rejected.