### PR TITLE
virtio: preserve PCI config space across save/restore

### DIFF
--- a/petri/src/vm/mod.rs
+++ b/petri/src/vm/mod.rs
@@ -237,6 +237,8 @@ pub struct PetriVmConfig {
     pub vmbus_storage_controllers: HashMap<Guid, VmbusStorageController>,
     /// PCIe NVMe drives.
     pub pcie_nvme_drives: Vec<PcieNvmeDrive>,
+    /// PCIe virtio-blk drives.
+    pub pcie_virtio_blk_drives: Vec<PcieVirtioBlkDrive>,
     /// Physical NVMe devices to attach
     pub physical_nvme_devices: HashMap<Guid, PhysicalNvmeDevice>,
 }
@@ -248,6 +250,15 @@ pub struct PcieNvmeDrive {
     pub port_name: String,
     /// NVMe namespace ID.
     pub nsid: u32,
+    /// The drive to attach.
+    pub drive: Drive,
+}
+
+/// PCIe virtio-blk drive configuration.
+#[derive(Debug)]
+pub struct PcieVirtioBlkDrive {
+    /// PCIe root port name (e.g. "s0rc0rp0").
+    pub port_name: String,
     /// The drive to attach.
     pub drive: Drive,
 }
@@ -443,6 +454,7 @@ impl<T: PetriVmmBackend> PetriVmBuilder<T> {
                 tpm: None,
                 vmbus_storage_controllers: HashMap::new(),
                 pcie_nvme_drives: Vec::new(),
+                pcie_virtio_blk_drives: Vec::new(),
                 physical_nvme_devices: HashMap::new(),
             },
             modify_vmm_config: None,
@@ -520,6 +532,7 @@ impl<T: PetriVmmBackend> PetriVmBuilder<T> {
                 tpm: None,
                 vmbus_storage_controllers: HashMap::new(),
                 pcie_nvme_drives: Vec::new(),
+                pcie_virtio_blk_drives: Vec::new(),
                 physical_nvme_devices: HashMap::new(),
             },
             modify_vmm_config: None,
@@ -935,6 +948,13 @@ impl<T: PetriVmmBackend> PetriVmBuilder<T> {
                     self.config.pcie_nvme_drives.push(PcieNvmeDrive {
                         port_name,
                         nsid: 1,
+                        drive: boot_drive,
+                    });
+                    self
+                }
+                BootDeviceType::PcieVirtioBlk => {
+                    self.config.pcie_virtio_blk_drives.push(PcieVirtioBlkDrive {
+                        port_name: "s0rc0rp0".into(),
                         drive: boot_drive,
                     });
                     self
@@ -2623,6 +2643,8 @@ pub enum BootDeviceType {
     NvmeViaNvme,
     /// Boot from NVMe attached to a PCIe root port.
     PcieNvme,
+    /// Boot from virtio-blk attached to a PCIe root port.
+    PcieVirtioBlk,
 }
 
 impl BootDeviceType {
@@ -2632,7 +2654,8 @@ impl BootDeviceType {
             | BootDeviceType::Ide
             | BootDeviceType::Scsi
             | BootDeviceType::Nvme
-            | BootDeviceType::PcieNvme => false,
+            | BootDeviceType::PcieNvme
+            | BootDeviceType::PcieVirtioBlk => false,
             BootDeviceType::IdeViaScsi
             | BootDeviceType::IdeViaNvme
             | BootDeviceType::ScsiViaScsi
@@ -2651,7 +2674,10 @@ impl BootDeviceType {
 
     fn requires_vmbus(&self) -> bool {
         match self {
-            BootDeviceType::None | BootDeviceType::Ide | BootDeviceType::PcieNvme => false,
+            BootDeviceType::None
+            | BootDeviceType::Ide
+            | BootDeviceType::PcieNvme
+            | BootDeviceType::PcieVirtioBlk => false,
             BootDeviceType::IdeViaScsi
             | BootDeviceType::IdeViaNvme
             | BootDeviceType::Scsi

--- a/petri/src/vm/openvmm/construct.rs
+++ b/petri/src/vm/openvmm/construct.rs
@@ -13,6 +13,7 @@ use crate::IsolationType;
 use crate::MemoryConfig;
 use crate::OpenHclConfig;
 use crate::PcieNvmeDrive;
+use crate::PcieVirtioBlkDrive;
 use crate::PetriLogSource;
 use crate::PetriVmConfig;
 use crate::PetriVmResources;
@@ -121,6 +122,7 @@ impl PetriVmConfigOpenVmm {
             tpm: tpm_config,
             vmbus_storage_controllers,
             pcie_nvme_drives,
+            pcie_virtio_blk_drives,
             physical_nvme_devices,
         } = petri_vm_config;
 
@@ -247,6 +249,28 @@ impl PetriVmConfigOpenVmm {
                     }],
                     requests: None,
                 }
+                .into_resource(),
+            });
+        }
+
+        for PcieVirtioBlkDrive {
+            port_name,
+            drive: Drive { disk, .. },
+        } in pcie_virtio_blk_drives
+        {
+            let disk = disk.ok_or_else(|| {
+                anyhow::anyhow!("missing disk for PCIe virtio-blk drive on port '{port_name}'")
+            })?;
+            let disk = petri_disk_to_openvmm(&disk).await?;
+            pcie_devices.push(PcieDeviceConfig {
+                port_name,
+                resource: VirtioPciDeviceHandle(
+                    VirtioBlkHandle {
+                        disk,
+                        read_only: false,
+                    }
+                    .into_resource(),
+                )
                 .into_resource(),
             });
         }

--- a/vm/devices/virtio/virtio/src/transport/pci.rs
+++ b/vm/devices/virtio/virtio/src/transport/pci.rs
@@ -811,6 +811,8 @@ mod saved_state {
         use crate::transport::saved_state::state::CommonQueueState;
         use crate::transport::saved_state::state::CommonSavedState;
         use mesh::payload::Protobuf;
+        use pci_core::cfg_space_emu::ConfigSpaceType0Emulator;
+        use vmcore::save_restore::SaveRestore;
         use vmcore::save_restore::SavedStateRoot;
 
         #[derive(Protobuf)]
@@ -833,6 +835,11 @@ mod saved_state {
             pub queues: Vec<SavedQueueState>,
             #[mesh(4)]
             pub interrupt_status: u32,
+            /// PCI configuration space, including the BAR base addresses. This
+            /// must be preserved so that BARs pre-assigned by the host (before
+            /// the guest firmware runs) survive a save/restore cycle.
+            #[mesh(5)]
+            pub cfg_space: <ConfigSpaceType0Emulator as SaveRestore>::SavedState,
         }
 
         #[derive(Protobuf, SavedStateRoot)]
@@ -868,6 +875,7 @@ mod saved_state {
                     })
                     .collect(),
                 interrupt_status: *self.pci.interrupt_status.lock(),
+                cfg_space: self.pci.config_space.save()?,
             })
         }
 
@@ -889,6 +897,10 @@ mod saved_state {
                 line.set_level(state.interrupt_status != 0);
             }
             self.pci.msix_config_vector = state.msix_config_vector;
+
+            // Restore the PCI config space (BARs, command register, etc.) so
+            // that host pre-assigned BARs are preserved across the cycle.
+            self.pci.config_space.restore(state.cfg_space)?;
 
             Ok(())
         }

--- a/vmm_tests/vmm_tests/tests/tests/multiarch/pcie.rs
+++ b/vmm_tests/vmm_tests/tests/tests/multiarch/pcie.rs
@@ -525,6 +525,48 @@ async fn pcie_nvme_boot(config: PetriVmBuilder<OpenVmmPetriBackend>) -> anyhow::
     Ok(())
 }
 
+/// Boot a guest through UEFI from a virtio-blk device on an emulated PCIe root
+/// port. Exercises UEFI's virtio-blk driver stack (UEFI must read the OS off
+/// the device to load it) and confirms the guest's root filesystem lands on the
+/// virtio-blk disk.
+///
+/// Only Linux guests are covered: the base Windows images do not carry an inbox
+/// virtio-blk driver, so Windows cannot mount the OS volume from virtio-blk.
+#[openvmm_test(uefi_x64(vhd(alpine_3_23_x64)), uefi_aarch64(vhd(alpine_3_23_aarch64)))]
+async fn pcie_virtio_blk_boot(config: PetriVmBuilder<OpenVmmPetriBackend>) -> anyhow::Result<()> {
+    let (vm, agent) = config
+        .with_boot_device_type(petri::BootDeviceType::PcieVirtioBlk)
+        .with_default_boot_always_attempt(true)
+        .modify_backend(|b| b.with_pcie_root_topology(1, 1, 1))
+        .run()
+        .await?;
+
+    // Confirm we actually booted from virtio-blk. Linux only assigns the "vd"
+    // prefix to virtio-blk block devices (NVMe uses "nvme*", SCSI uses "sd*"),
+    // so a "/dev/vd*" root device proves the OS was loaded off the virtio-blk
+    // disk rather than some other device.
+    let mounts = String::from_utf8(agent.read_file("/proc/mounts").await?)
+        .context("/proc/mounts is not valid UTF-8")?;
+    let root_device = mounts
+        .lines()
+        .find_map(|line| {
+            let mut fields = line.split_whitespace();
+            let source = fields.next()?;
+            let target = fields.next()?;
+            (target == "/").then_some(source)
+        })
+        .context("no root mount found in /proc/mounts")?;
+    tracing::info!(root_device, "guest root device");
+    assert!(
+        root_device.starts_with("/dev/vd"),
+        "expected to boot from a virtio-blk device, but root is {root_device}"
+    );
+
+    agent.power_off().await?;
+    vm.wait_for_clean_teardown().await?;
+    Ok(())
+}
+
 /// Test SMMUv3 IOMMU emulation with a mixed topology:
 ///
 /// - Root complex s0rc0 (segment 0): SMMU enabled, virtio-net + NVMe behind it


### PR DESCRIPTION
Saving and restoring a virtio PCI device dropped its configuration space, so BARs pre-assigned by the host before guest firmware runs were lost across a save/restore cycle. The device's config space is now included in its saved state and restored, so the host-assigned BAR layout survives the round trip.

To validate this, add a test that boots a guest through UEFI off a virtio-blk device attached to an emulated PCIe root port. UEFI must drive the virtio-blk stack to read the OS image, exercising the config space that save/restore previously lost, and the test confirms the guest's root filesystem actually lands on the virtio-blk disk (Linux only, since the base Windows images lack an inbox virtio-blk driver). This also validates virtio-blk boot end to end, which required teaching petri to attach virtio-blk drives to PCIe root ports and to treat PcieVirtioBlk as a boot device that needs neither VTL2 nor vmbus.