### PR TITLE
openhcl: add direct TVM host certification flow

### DIFF
--- a/openhcl/tee_call/src/lib.rs
+++ b/openhcl/tee_call/src/lib.rs
@@ -274,3 +274,20 @@ impl TeeCall for HostCall {
         TeeType::Host
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::HostCall;
+    use super::TeeCall;
+    use super::TeeType;
+
+    #[test]
+    fn host_call_tee_type_is_host() {
+        assert!(matches!(HostCall.tee_type(), TeeType::Host));
+    }
+
+    #[test]
+    fn host_call_does_not_support_derived_key() {
+        assert!(HostCall.supports_get_derived_key().is_none());
+    }
+}

--- a/openhcl/tee_call/src/lib.rs
+++ b/openhcl/tee_call/src/lib.rs
@@ -40,11 +40,15 @@ pub const HW_DERIVED_KEY_LENGTH: usize = x86defs::snp::SNP_DERIVED_KEY_SIZE;
 // DEVNOTE: This value should be upper bound among all the supported TEE types.
 pub const REPORT_DATA_SIZE: usize = x86defs::snp::SNP_REPORT_DATA_SIZE;
 
+/// Size of `TVM_REPORT_V1`.
+pub const TVM_REPORT_SIZE: usize = 396;
+
 // TDX and SNP report data size are equal so we can use either of them
 static_assertions::const_assert_eq!(
     x86defs::snp::SNP_REPORT_DATA_SIZE,
     x86defs::tdx::TDX_REPORT_DATA_SIZE
 );
+static_assertions::const_assert!(TVM_REPORT_SIZE <= hvdef::hypercall::VBS_VM_MAX_REPORT_SIZE);
 
 /// Type of the TEE
 #[derive(Debug)]
@@ -57,6 +61,8 @@ pub enum TeeType {
     Cca,
     /// Virtualization-based Security (VBS)
     Vbs,
+    /// Trusted Launch host certification
+    Host,
 }
 
 /// The result of the `get_attestation_report`.
@@ -209,16 +215,22 @@ impl TeeCall for TdxCall {
 /// Implementation of [`TeeCall`] for VBS
 pub struct VbsCall;
 
+fn get_vbs_vm_report(
+    report_data: &[u8; REPORT_DATA_SIZE],
+) -> Result<[u8; hvdef::hypercall::VBS_VM_MAX_REPORT_SIZE], Error> {
+    let mshv_hvcall = MshvHvcall::new().map_err(Error::OpenDevVbsGuest)?;
+    mshv_hvcall.set_allowed_hypercalls(&[HypercallCode::HvCallVbsVmCallReport]);
+    mshv_hvcall
+        .vbs_vm_call_report(report_data)
+        .map_err(Error::GetVbsReport)
+}
+
 impl TeeCall for VbsCall {
     fn get_attestation_report(
         &self,
         report_data: &[u8; REPORT_DATA_SIZE],
     ) -> Result<GetAttestationReportResult, Error> {
-        let mshv_hvcall = MshvHvcall::new().map_err(Error::OpenDevVbsGuest)?;
-        mshv_hvcall.set_allowed_hypercalls(&[HypercallCode::HvCallVbsVmCallReport]);
-        let report = mshv_hvcall
-            .vbs_vm_call_report(report_data)
-            .map_err(Error::GetVbsReport)?;
+        let report = get_vbs_vm_report(report_data)?;
 
         Ok(GetAttestationReportResult {
             report: report[..hvdef::vbs::VBS_REPORT_SIZE].to_vec(),
@@ -235,5 +247,30 @@ impl TeeCall for VbsCall {
     /// Return TeeType::Vbs.
     fn tee_type(&self) -> TeeType {
         TeeType::Vbs
+    }
+}
+
+/// Implementation of [`TeeCall`] for Trusted Launch host certification.
+pub struct HostCall;
+
+impl TeeCall for HostCall {
+    fn get_attestation_report(
+        &self,
+        report_data: &[u8; REPORT_DATA_SIZE],
+    ) -> Result<GetAttestationReportResult, Error> {
+        let report = get_vbs_vm_report(report_data)?;
+
+        Ok(GetAttestationReportResult {
+            report: report[..TVM_REPORT_SIZE].to_vec(),
+            tcb_version: None,
+        })
+    }
+
+    fn supports_get_derived_key(&self) -> Option<&dyn TeeCallGetDerivedKey> {
+        None
+    }
+
+    fn tee_type(&self) -> TeeType {
+        TeeType::Host
     }
 }

--- a/openhcl/underhill_attestation/src/igvm_attest/mod.rs
+++ b/openhcl/underhill_attestation/src/igvm_attest/mod.rs
@@ -428,6 +428,166 @@ mod tests {
     }
 
     #[test]
+    fn test_tvm_host_certified_report_size_boundary_rejected() {
+        use openhcl_attestation_protocol::igvm_attest::get::IGVM_ATTEST_REQUEST_CURRENT_VERSION;
+
+        let too_small = create_request(
+            IGVM_ATTEST_REQUEST_CURRENT_VERSION,
+            IgvmAttestRequestType::AK_CERT_REQUEST,
+            &[],
+            &[0u8; tee_call::TVM_REPORT_SIZE - 1],
+            &ReportType::TvmHostCertified,
+            IgvmAttestHashType::SHA_256,
+        );
+        assert!(matches!(
+            too_small,
+            Err(Error::InvalidAttestationReportSize {
+                report_size,
+                expected_size,
+            }) if report_size == tee_call::TVM_REPORT_SIZE - 1
+                && expected_size == tee_call::TVM_REPORT_SIZE
+        ));
+
+        let too_large = create_request(
+            IGVM_ATTEST_REQUEST_CURRENT_VERSION,
+            IgvmAttestRequestType::AK_CERT_REQUEST,
+            &[],
+            &[0u8; tee_call::TVM_REPORT_SIZE + 1],
+            &ReportType::TvmHostCertified,
+            IgvmAttestHashType::SHA_256,
+        );
+        assert!(matches!(
+            too_large,
+            Err(Error::InvalidAttestationReportSize {
+                report_size,
+                expected_size,
+            }) if report_size == tee_call::TVM_REPORT_SIZE + 1
+                && expected_size == tee_call::TVM_REPORT_SIZE
+        ));
+    }
+
+    #[test]
+    fn test_tvm_host_certified_request_bytes() {
+        use openhcl_attestation_protocol::igvm_attest::get::IgvmAttestRequestBase;
+        use openhcl_attestation_protocol::igvm_attest::get::IgvmAttestRequestVersion;
+
+        let runtime_claims = vec![7u8, 8, 9];
+        let attestation_report: Vec<u8> = (0..tee_call::TVM_REPORT_SIZE).map(|i| i as u8).collect();
+
+        let buffer = create_request(
+            IgvmAttestRequestVersion::VERSION_2,
+            IgvmAttestRequestType::AK_CERT_REQUEST,
+            &runtime_claims,
+            &attestation_report,
+            &ReportType::TvmHostCertified,
+            IgvmAttestHashType::SHA_256,
+        )
+        .expect("request generation");
+
+        let (request, _) =
+            IgvmAttestRequestBase::read_from_prefix(&buffer).expect("parse IgvmAttestRequest");
+
+        assert_eq!(
+            request.header.report_size,
+            (size_of::<IgvmAttestRequestBase>()
+                + size_of::<openhcl_attestation_protocol::igvm_attest::get::IgvmAttestRequestDataExt>(
+                )
+                + runtime_claims.len()) as u32
+        );
+        assert_eq!(
+            &request.attestation_report[..tee_call::TVM_REPORT_SIZE],
+            attestation_report.as_slice()
+        );
+        assert!(
+            request.attestation_report[tee_call::TVM_REPORT_SIZE..]
+                .iter()
+                .all(|&b| b == 0)
+        );
+        assert_eq!(
+            request.request_data.report_type,
+            IgvmAttestReportType::TVM_REPORT
+        );
+        assert_eq!(
+            request.request_data.variable_data_size,
+            runtime_claims.len() as u32
+        );
+
+        let header_size = size_of::<IgvmAttestRequestBase>();
+        let extension_size =
+            size_of::<openhcl_attestation_protocol::igvm_attest::get::IgvmAttestRequestDataExt>();
+        assert_eq!(
+            &buffer[header_size + extension_size..],
+            runtime_claims.as_slice()
+        );
+    }
+
+    #[test]
+    fn test_prepare_ak_cert_request_host_report_size() {
+        use openhcl_attestation_protocol::igvm_attest::get::IGVM_ATTEST_REQUEST_CURRENT_VERSION;
+
+        let attestation_vm_config = AttestationVmConfig {
+            current_time: None,
+            root_cert_thumbprint: String::new(),
+            console_enabled: false,
+            interactive_console_enabled: false,
+            secure_boot: false,
+            tpm_enabled: false,
+            tpm_persisted: false,
+            hardware_sealing_policy: HardwareSealingPolicy::None,
+            filtered_vpci_devices_allowed: true,
+            vm_unique_id: String::new(),
+            vmgs_provisioner: None,
+        };
+
+        let host_report = [0u8; tee_call::TVM_REPORT_SIZE];
+
+        let host_helper = IgvmAttestRequestHelper::prepare_ak_cert_request(
+            Some(TeeType::Host),
+            &[],
+            &[],
+            &[],
+            &[],
+            &attestation_vm_config,
+            &[],
+        );
+        assert!(
+            host_helper
+                .create_request(IGVM_ATTEST_REQUEST_CURRENT_VERSION, &host_report)
+                .is_ok()
+        );
+
+        let legacy_helper = IgvmAttestRequestHelper::prepare_ak_cert_request(
+            None,
+            &[],
+            &[],
+            &[],
+            &[],
+            &attestation_vm_config,
+            &[],
+        );
+        assert!(
+            legacy_helper
+                .create_request(IGVM_ATTEST_REQUEST_CURRENT_VERSION, &host_report)
+                .is_err()
+        );
+
+        let vbs_helper = IgvmAttestRequestHelper::prepare_ak_cert_request(
+            Some(TeeType::Vbs),
+            &[],
+            &[],
+            &[],
+            &[],
+            &attestation_vm_config,
+            &[],
+        );
+        assert!(
+            vbs_helper
+                .create_request(IGVM_ATTEST_REQUEST_CURRENT_VERSION, &host_report)
+                .is_err()
+        );
+    }
+
+    #[test]
     fn test_create_request_version1_no_extension() {
         use openhcl_attestation_protocol::igvm_attest::get::IgvmAttestRequestBase;
         use openhcl_attestation_protocol::igvm_attest::get::IgvmAttestRequestVersion;

--- a/openhcl/underhill_attestation/src/igvm_attest/mod.rs
+++ b/openhcl/underhill_attestation/src/igvm_attest/mod.rs
@@ -76,6 +76,8 @@ pub enum ReportType {
     Cca,
     /// Trusted VM report
     Tvm,
+    /// Trusted VM report signed by the host IDK_S key
+    TvmHostCertified,
 }
 
 impl ReportType {
@@ -86,7 +88,7 @@ impl ReportType {
             Self::Snp => IgvmAttestReportType::SNP_VM_REPORT,
             Self::Tdx => IgvmAttestReportType::TDX_VM_REPORT,
             Self::Cca => IgvmAttestReportType::CCA_VM_REPORT,
-            Self::Tvm => IgvmAttestReportType::TVM_REPORT,
+            Self::Tvm | Self::TvmHostCertified => IgvmAttestReportType::TVM_REPORT,
         }
     }
 }
@@ -120,6 +122,7 @@ impl IgvmAttestRequestHelper {
             TeeType::Tdx => ReportType::Tdx,
             TeeType::Cca => ReportType::Cca,
             TeeType::Vbs => ReportType::Vbs,
+            TeeType::Host => ReportType::TvmHostCertified,
         };
 
         let attestation_vm_config =
@@ -157,6 +160,7 @@ impl IgvmAttestRequestHelper {
             Some(TeeType::Tdx) => ReportType::Tdx,
             Some(TeeType::Cca) => ReportType::Cca,
             Some(TeeType::Vbs) => ReportType::Vbs,
+            Some(TeeType::Host) => ReportType::TvmHostCertified,
             None => ReportType::Tvm,
         };
 
@@ -335,6 +339,7 @@ fn get_report_size(report_type: &ReportType) -> usize {
         ReportType::Snp => openhcl_attestation_protocol::igvm_attest::get::SNP_VM_REPORT_SIZE,
         ReportType::Tdx => openhcl_attestation_protocol::igvm_attest::get::TDX_VM_REPORT_SIZE,
         ReportType::Tvm => openhcl_attestation_protocol::igvm_attest::get::TVM_REPORT_SIZE,
+        ReportType::TvmHostCertified => tee_call::TVM_REPORT_SIZE,
         ReportType::Cca => todo!(),
     }
 }
@@ -385,6 +390,41 @@ mod tests {
             IgvmAttestHashType::SHA_256,
         );
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_create_tvm_requests() {
+        use openhcl_attestation_protocol::igvm_attest::get::IGVM_ATTEST_REQUEST_CURRENT_VERSION;
+
+        let legacy = create_request(
+            IGVM_ATTEST_REQUEST_CURRENT_VERSION,
+            IgvmAttestRequestType::AK_CERT_REQUEST,
+            &[],
+            &[],
+            &ReportType::Tvm,
+            IgvmAttestHashType::SHA_256,
+        );
+        assert!(legacy.is_ok());
+
+        let host_certified = create_request(
+            IGVM_ATTEST_REQUEST_CURRENT_VERSION,
+            IgvmAttestRequestType::AK_CERT_REQUEST,
+            &[],
+            &[0u8; tee_call::TVM_REPORT_SIZE],
+            &ReportType::TvmHostCertified,
+            IgvmAttestHashType::SHA_256,
+        );
+        assert!(host_certified.is_ok());
+
+        let missing_report = create_request(
+            IGVM_ATTEST_REQUEST_CURRENT_VERSION,
+            IgvmAttestRequestType::AK_CERT_REQUEST,
+            &[],
+            &[],
+            &ReportType::TvmHostCertified,
+            IgvmAttestHashType::SHA_256,
+        );
+        assert!(missing_report.is_err());
     }
 
     #[test]

--- a/openhcl/underhill_core/src/emuplat/tpm.rs
+++ b/openhcl/underhill_core/src/emuplat/tpm.rs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+use cvm_tracing::CVM_ALLOWED;
 use guest_emulation_transport::GuestEmulationTransportClient;
 use guest_emulation_transport::api::EventLogId;
 use openhcl_attestation_protocol::igvm_attest::get::AK_CERT_RESPONSE_BUFFER_SIZE;
@@ -63,6 +64,13 @@ impl RequestAkCert for TpmRequestAkCertHelper {
         guest_input: &[u8],
         is_attestation_report: bool,
     ) -> Result<Vec<u8>, Box<dyn std::error::Error + Send + Sync>> {
+        tracing::info!(
+            CVM_ALLOWED,
+            attestation_type = ?self.attestation_type,
+            tvm_host_certification = self.tvm_host_certification,
+            is_attestation_report,
+            "creating TPM AK certificate request"
+        );
         let tee_type = match self.attestation_type {
             AttestationType::Snp => Some(tee_call::TeeType::Snp),
             AttestationType::Tdx => Some(tee_call::TeeType::Tdx),
@@ -91,6 +99,12 @@ impl RequestAkCert for TpmRequestAkCertHelper {
         } else {
             vec![]
         };
+        tracing::info!(
+            CVM_ALLOWED,
+            attestation_type = ?self.attestation_type,
+            report_size = attestation_report.len(),
+            "attestation report generated for TPM request"
+        );
 
         let version = if is_attestation_report {
             // If this is an attestation report, use the version 1, the stable structure exposed
@@ -104,6 +118,14 @@ impl RequestAkCert for TpmRequestAkCertHelper {
         let request = ak_cert_request_helper
             .create_request(version, &attestation_report)
             .map_err(TpmAttestationError::CreateAkCertRequest)?;
+        tracing::info!(
+            CVM_ALLOWED,
+            attestation_type = ?self.attestation_type,
+            is_attestation_report,
+            report_size = attestation_report.len(),
+            request_size = request.len(),
+            "TPM request created"
+        );
 
         Ok(request)
     }
@@ -112,6 +134,11 @@ impl RequestAkCert for TpmRequestAkCertHelper {
         &self,
         request: Vec<u8>,
     ) -> Result<Vec<u8>, Box<dyn std::error::Error + Send + Sync + 'static>> {
+        tracing::info!(
+            CVM_ALLOWED,
+            request_size = request.len(),
+            "sending TPM AK certificate request to IGVM"
+        );
         let agent_data = self.attestation_agent_data.clone().unwrap_or_default();
         let result = self
             .get_client
@@ -123,6 +150,12 @@ impl RequestAkCert for TpmRequestAkCertHelper {
             // Let the caller to handle the empty response.
             vec![]
         };
+        tracing::info!(
+            CVM_ALLOWED,
+            response_size = result.response.len(),
+            payload_size = payload.len(),
+            "TPM AK certificate response received from IGVM"
+        );
 
         Ok(payload)
     }

--- a/openhcl/underhill_core/src/emuplat/tpm.rs
+++ b/openhcl/underhill_core/src/emuplat/tpm.rs
@@ -292,3 +292,125 @@ pub mod resources {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::TpmRequestAkCertHelper;
+    use openhcl_attestation_protocol::igvm_attest::get::IgvmAttestReportType;
+    use openhcl_attestation_protocol::igvm_attest::get::IgvmAttestRequestBase;
+    use openhcl_attestation_protocol::igvm_attest::get::runtime_claims::AttestationVmConfig;
+    use openhcl_attestation_protocol::igvm_attest::get::runtime_claims::HardwareSealingPolicy;
+    use pal_async::DefaultDriver;
+    use pal_async::async_test;
+    use std::sync::Arc;
+    use tpm_device::ak_cert::RequestAkCert;
+    use underhill_attestation::AttestationType;
+    use zerocopy::FromBytes;
+
+    struct TestHostCall;
+
+    impl tee_call::TeeCall for TestHostCall {
+        fn get_attestation_report(
+            &self,
+            _report_data: &[u8; tee_call::REPORT_DATA_SIZE],
+        ) -> Result<tee_call::GetAttestationReportResult, tee_call::Error> {
+            Ok(tee_call::GetAttestationReportResult {
+                report: vec![0x42; tee_call::TVM_REPORT_SIZE],
+                tcb_version: None,
+            })
+        }
+
+        fn supports_get_derived_key(&self) -> Option<&dyn tee_call::TeeCallGetDerivedKey> {
+            None
+        }
+
+        fn tee_type(&self) -> tee_call::TeeType {
+            tee_call::TeeType::Host
+        }
+    }
+
+    fn test_attestation_vm_config() -> AttestationVmConfig {
+        AttestationVmConfig {
+            current_time: None,
+            root_cert_thumbprint: String::new(),
+            console_enabled: false,
+            interactive_console_enabled: false,
+            secure_boot: false,
+            tpm_enabled: false,
+            tpm_persisted: false,
+            hardware_sealing_policy: HardwareSealingPolicy::None,
+            filtered_vpci_devices_allowed: true,
+            vm_unique_id: String::new(),
+            vmgs_provisioner: None,
+        }
+    }
+
+    #[async_test]
+    async fn host_certification_enabled_request_includes_396_byte_report(driver: DefaultDriver) {
+        let get_pair = guest_emulation_transport::test_utilities::new_transport_pair(
+            driver,
+            None,
+            get_protocol::ProtocolVersion::NICKEL_REV2,
+            None,
+            None,
+        )
+        .await;
+
+        let helper = TpmRequestAkCertHelper::new(
+            get_pair.client,
+            Some(Arc::new(TestHostCall)),
+            AttestationType::Host,
+            test_attestation_vm_config(),
+            None,
+            true,
+        );
+
+        let request = helper
+            .create_ak_cert_request(&[], &[], &[], &[], &[], false)
+            .expect("host-certified request generation");
+
+        let (parsed, _) =
+            IgvmAttestRequestBase::read_from_prefix(&request).expect("parse IgvmAttestRequest");
+        assert_eq!(
+            parsed.request_data.report_type,
+            IgvmAttestReportType::TVM_REPORT
+        );
+        assert_eq!(
+            &parsed.attestation_report[..tee_call::TVM_REPORT_SIZE],
+            [0x42; tee_call::TVM_REPORT_SIZE].as_slice()
+        );
+    }
+
+    #[async_test]
+    async fn host_certification_disabled_retains_zero_report_legacy_request(driver: DefaultDriver) {
+        let get_pair = guest_emulation_transport::test_utilities::new_transport_pair(
+            driver,
+            None,
+            get_protocol::ProtocolVersion::NICKEL_REV2,
+            None,
+            None,
+        )
+        .await;
+
+        let helper = TpmRequestAkCertHelper::new(
+            get_pair.client,
+            None,
+            AttestationType::Host,
+            test_attestation_vm_config(),
+            None,
+            false,
+        );
+
+        let request = helper
+            .create_ak_cert_request(&[], &[], &[], &[], &[], false)
+            .expect("legacy request generation");
+
+        let (parsed, _) =
+            IgvmAttestRequestBase::read_from_prefix(&request).expect("parse IgvmAttestRequest");
+        assert_eq!(
+            parsed.request_data.report_type,
+            IgvmAttestReportType::TVM_REPORT
+        );
+        assert!(parsed.attestation_report.iter().all(|&b| b == 0));
+    }
+}

--- a/openhcl/underhill_core/src/emuplat/tpm.rs
+++ b/openhcl/underhill_core/src/emuplat/tpm.rs
@@ -29,6 +29,7 @@ pub struct TpmRequestAkCertHelper {
     attestation_type: AttestationType,
     attestation_vm_config: AttestationVmConfig,
     attestation_agent_data: Option<Vec<u8>>,
+    tvm_host_certification: bool,
 }
 
 impl TpmRequestAkCertHelper {
@@ -38,6 +39,7 @@ impl TpmRequestAkCertHelper {
         attestation_type: AttestationType,
         attestation_vm_config: AttestationVmConfig,
         attestation_agent_data: Option<Vec<u8>>,
+        tvm_host_certification: bool,
     ) -> Self {
         Self {
             get_client,
@@ -45,6 +47,7 @@ impl TpmRequestAkCertHelper {
             attestation_type,
             attestation_vm_config,
             attestation_agent_data,
+            tvm_host_certification,
         }
     }
 }
@@ -65,7 +68,9 @@ impl RequestAkCert for TpmRequestAkCertHelper {
             AttestationType::Tdx => Some(tee_call::TeeType::Tdx),
             AttestationType::Cca => Some(tee_call::TeeType::Cca),
             AttestationType::Vbs => Some(tee_call::TeeType::Vbs),
-            AttestationType::Host => None,
+            AttestationType::Host => self
+                .tvm_host_certification
+                .then_some(tee_call::TeeType::Host),
         };
         let ak_cert_request_helper =
             underhill_attestation::IgvmAttestRequestHelper::prepare_ak_cert_request(
@@ -181,6 +186,7 @@ pub mod resources {
         attestation_type: AttestationType,
         attestation_vm_config: AttestationVmConfig,
         attestation_agent_data: Option<Vec<u8>>,
+        tvm_host_certification: bool,
     }
 
     impl GetTpmRequestAkCertHelperHandle {
@@ -188,11 +194,13 @@ pub mod resources {
             attestation_type: AttestationType,
             attestation_vm_config: AttestationVmConfig,
             attestation_agent_data: Option<Vec<u8>>,
+            tvm_host_certification: bool,
         ) -> Self {
             Self {
                 attestation_type,
                 attestation_vm_config,
                 attestation_agent_data,
+                tvm_host_certification,
             }
         }
     }
@@ -233,6 +241,9 @@ pub mod resources {
                     tracing::warn!("CCA: resolve: tee_call is not implemented yet");
                     None
                 }
+                AttestationType::Host if handle.tvm_host_certification => {
+                    Some(Arc::new(tee_call::HostCall))
+                }
                 AttestationType::Host => None,
             };
 
@@ -242,6 +253,7 @@ pub mod resources {
                 handle.attestation_type,
                 handle.attestation_vm_config,
                 handle.attestation_agent_data,
+                handle.tvm_host_certification,
             )
             .into())
         }

--- a/openhcl/underhill_core/src/lib.rs
+++ b/openhcl/underhill_core/src/lib.rs
@@ -355,6 +355,7 @@ async fn launch_workers(
         efi_diagnostics_rate_limit: opt.efi_diagnostics_rate_limit,
         strict_encryption_policy: opt.strict_encryption_policy,
         attempt_ak_cert_callback: opt.attempt_ak_cert_callback,
+        tvm_host_certification: opt.tvm_host_certification,
         enable_vpci_relay: opt.enable_vpci_relay,
         disable_proxy_redirect: opt.disable_proxy_redirect,
         disable_lower_vtl_timer_virt: opt.disable_lower_vtl_timer_virt,

--- a/openhcl/underhill_core/src/options.rs
+++ b/openhcl/underhill_core/src/options.rs
@@ -333,6 +333,9 @@ pub struct Options {
     /// If not specified, use the configuration in DPSv2 ManagementVtlFeatures.
     pub attempt_ak_cert_callback: Option<bool>,
 
+    /// (HCL_TVM_HOST_CERTIFICATION=1) Enable direct TVM host certification.
+    pub tvm_host_certification: Option<bool>,
+
     /// (OPENHCL_ENABLE_VPCI_RELAY=1) Enable the VPCI relay.
     pub enable_vpci_relay: Option<bool>,
 
@@ -539,6 +542,7 @@ impl Options {
             .transpose()?;
         let strict_encryption_policy = parse_env_bool_opt("HCL_STRICT_ENCRYPTION_POLICY");
         let attempt_ak_cert_callback = parse_env_bool_opt("HCL_ATTEMPT_AK_CERT_CALLBACK");
+        let tvm_host_certification = parse_env_bool_opt("HCL_TVM_HOST_CERTIFICATION");
         let enable_vpci_relay = parse_env_bool_opt("OPENHCL_ENABLE_VPCI_RELAY");
         let disable_proxy_redirect = parse_env_bool("OPENHCL_DISABLE_PROXY_REDIRECT");
         let disable_lower_vtl_timer_virt = parse_env_bool("OPENHCL_DISABLE_LOWER_VTL_TIMER_VIRT");
@@ -610,6 +614,7 @@ impl Options {
             efi_diagnostics_rate_limit,
             strict_encryption_policy,
             attempt_ak_cert_callback,
+            tvm_host_certification,
             enable_vpci_relay,
             disable_proxy_redirect,
             disable_lower_vtl_timer_virt,

--- a/openhcl/underhill_core/src/worker.rs
+++ b/openhcl/underhill_core/src/worker.rs
@@ -3043,7 +3043,7 @@ async fn new_underhill_vm(
             virt::IsolationType::None => AttestationType::Host,
         };
 
-        let ak_cert_type = {
+        let (ak_cert_type, ak_cert_mode) = {
             let tvm_host_certification = attestation_type == AttestationType::Host
                 && dps.general.management_vtl_features.tvm_host_certification();
             let request_ak_cert = GetTpmRequestAkCertHelperHandle::new(
@@ -3055,23 +3055,31 @@ async fn new_underhill_vm(
             .into_resource();
 
             match attestation_type {
-                AttestationType::Snp | AttestationType::Tdx => {
-                    TpmAkCertTypeResource::HwAttested(request_ak_cert)
-                }
-                AttestationType::Vbs => TpmAkCertTypeResource::SwAttested(request_ak_cert),
-                AttestationType::Host if tvm_host_certification => {
-                    TpmAkCertTypeResource::SwAttested(request_ak_cert)
-                }
-                AttestationType::Host => TpmAkCertTypeResource::Trusted(
-                    request_ak_cert,
-                    dps.general
-                        .management_vtl_features
-                        .control_ak_cert_provisioning()
-                        .then(|| {
-                            dps.general
-                                .management_vtl_features
-                                .attempt_ak_cert_callback()
-                        }),
+                AttestationType::Snp | AttestationType::Tdx => (
+                    TpmAkCertTypeResource::HwAttested(request_ak_cert),
+                    "HwAttested",
+                ),
+                AttestationType::Vbs => (
+                    TpmAkCertTypeResource::SwAttested(request_ak_cert),
+                    "SwAttested",
+                ),
+                AttestationType::Host if tvm_host_certification => (
+                    TpmAkCertTypeResource::SwAttested(request_ak_cert),
+                    "HostCertified",
+                ),
+                AttestationType::Host => (
+                    TpmAkCertTypeResource::Trusted(
+                        request_ak_cert,
+                        dps.general
+                            .management_vtl_features
+                            .control_ak_cert_provisioning()
+                            .then(|| {
+                                dps.general
+                                    .management_vtl_features
+                                    .attempt_ak_cert_callback()
+                            }),
+                    ),
+                    "Trusted",
                 ),
                 AttestationType::Cca => {
                     anyhow::bail!(
@@ -3080,6 +3088,13 @@ async fn new_underhill_vm(
                 }
             }
         };
+        tracing::info!(
+            CVM_ALLOWED,
+            attestation_type = ?attestation_type,
+            ak_cert_mode,
+            tvm_host_certification = dps.general.management_vtl_features.tvm_host_certification(),
+            "configured TPM AK certificate flow"
+        );
 
         let register_layout = if cfg!(guest_arch = "x86_64") {
             TpmRegisterLayout::IoPort

--- a/openhcl/underhill_core/src/worker.rs
+++ b/openhcl/underhill_core/src/worker.rs
@@ -310,6 +310,8 @@ pub struct UnderhillEnvCfg {
     pub strict_encryption_policy: Option<bool>,
     /// Attempt to renew the AK cert
     pub attempt_ak_cert_callback: Option<bool>,
+    /// Enable direct TVM host certification
+    pub tvm_host_certification: Option<bool>,
     /// Enable the VPCI relay
     pub enable_vpci_relay: Option<bool>,
     /// Disable proxy interrupt redirection
@@ -1607,6 +1609,13 @@ async fn new_underhill_vm(
             dps.general
                 .management_vtl_features
                 .set_attempt_ak_cert_callback(value);
+        }
+
+        if let Some(value) = env_cfg.tvm_host_certification {
+            tracing::info!("using HCL_TVM_HOST_CERTIFICATION={value} from cmdline");
+            dps.general
+                .management_vtl_features
+                .set_tvm_host_certification(value);
         }
 
         dps
@@ -3035,10 +3044,13 @@ async fn new_underhill_vm(
         };
 
         let ak_cert_type = {
+            let tvm_host_certification = attestation_type == AttestationType::Host
+                && dps.general.management_vtl_features.tvm_host_certification();
             let request_ak_cert = GetTpmRequestAkCertHelperHandle::new(
                 attestation_type,
                 attestation_vm_config,
                 platform_attestation_data.agent_data,
+                tvm_host_certification,
             )
             .into_resource();
 
@@ -3047,6 +3059,9 @@ async fn new_underhill_vm(
                     TpmAkCertTypeResource::HwAttested(request_ak_cert)
                 }
                 AttestationType::Vbs => TpmAkCertTypeResource::SwAttested(request_ak_cert),
+                AttestationType::Host if tvm_host_certification => {
+                    TpmAkCertTypeResource::SwAttested(request_ak_cert)
+                }
                 AttestationType::Host => TpmAkCertTypeResource::Trusted(
                     request_ak_cert,
                     dps.general

--- a/petri/src/vm/hyperv/powershell.rs
+++ b/petri/src/vm/hyperv/powershell.rs
@@ -237,7 +237,8 @@ pub struct HyperVManagementVtlFeatureFlags {
     pub control_ak_cert_provisioning: bool,
     pub attempt_ak_cert_callback: bool,
     pub tx_only_serial_port: bool,
-    #[bits(59)]
+    pub tvm_host_certification: bool,
+    #[bits(58)]
     pub _reserved2: u64,
 }
 

--- a/petri/src/vm/hyperv/powershell.rs
+++ b/petri/src/vm/hyperv/powershell.rs
@@ -248,6 +248,28 @@ impl ps::AsVal for HyperVManagementVtlFeatureFlags {
     }
 }
 
+fn apply_management_vtl_feature_flags_command_line(
+    firmware_parameters: &mut Option<String>,
+    management_vtl_feature_flags: HyperVManagementVtlFeatureFlags,
+) -> anyhow::Result<()> {
+    let supported_flags = HyperVManagementVtlFeatureFlags::new()
+        .with_strict_encryption_policy(true)
+        .with_tvm_host_certification(true);
+    if management_vtl_feature_flags.0 & !supported_flags.0 != 0 {
+        anyhow::bail!(
+            "not all ManagementVtlFeatureFlags can be set using the command line: {}",
+            management_vtl_feature_flags.0
+        )
+    }
+    if management_vtl_feature_flags.strict_encryption_policy() {
+        append_cmdline(firmware_parameters, "HCL_STRICT_ENCRYPTION_POLICY=1");
+    }
+    if management_vtl_feature_flags.tvm_host_certification() {
+        append_cmdline(firmware_parameters, "HCL_TVM_HOST_CERTIFICATION=1");
+    }
+    Ok(())
+}
+
 /// Arguments for the New-CustomVM powershell cmdlet
 pub struct HyperVNewCustomVMArgs {
     /// Name
@@ -398,20 +420,10 @@ impl HyperVNewCustomVMArgs {
                 anyhow::bail!("OpenHCL is required to set ManagementVtlFeatureFlags");
             }
 
-            let supported_flags =
-                HyperVManagementVtlFeatureFlags::new().with_strict_encryption_policy(true);
-            if management_vtl_feature_flags.0 & !supported_flags.0 != 0 {
-                anyhow::bail!(
-                    "not all ManagementVtlFeatureFlags can be set using the command line: {}",
-                    management_vtl_feature_flags.0
-                )
-            }
-            if management_vtl_feature_flags.strict_encryption_policy() {
-                append_cmdline(
-                    &mut self.firmware_parameters,
-                    "HCL_STRICT_ENCRYPTION_POLICY=1",
-                );
-            }
+            apply_management_vtl_feature_flags_command_line(
+                &mut self.firmware_parameters,
+                *management_vtl_feature_flags,
+            )?;
             self.management_vtl_feature_flags = None;
         }
 
@@ -2126,4 +2138,41 @@ pub async fn run_disable_vmtpm(vmid: &Guid) -> anyhow::Result<()> {
     .await
     .map(|_| ())
     .context("run_disable_vmtpm")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::HyperVManagementVtlFeatureFlags;
+    use super::apply_management_vtl_feature_flags_command_line;
+
+    #[test]
+    fn tvm_host_certification_is_default_off_at_bit_five() {
+        let flags = HyperVManagementVtlFeatureFlags::new();
+        assert!(!flags.tvm_host_certification());
+        assert_eq!(flags.with_tvm_host_certification(true).into_bits(), 1 << 5);
+    }
+
+    #[test]
+    fn command_line_fallback_sets_supported_flags() {
+        let flags = HyperVManagementVtlFeatureFlags::new()
+            .with_strict_encryption_policy(true)
+            .with_tvm_host_certification(true);
+
+        let mut command_line = Some("OPENHCL_TEST=1".to_owned());
+        apply_management_vtl_feature_flags_command_line(&mut command_line, flags).unwrap();
+
+        assert_eq!(
+            command_line.as_deref(),
+            Some("OPENHCL_TEST=1 HCL_STRICT_ENCRYPTION_POLICY=1 HCL_TVM_HOST_CERTIFICATION=1")
+        );
+    }
+
+    #[test]
+    fn command_line_fallback_rejects_unsupported_flags() {
+        let flags = HyperVManagementVtlFeatureFlags::new().with_control_ak_cert_provisioning(true);
+
+        let mut command_line = None;
+        assert!(apply_management_vtl_feature_flags_command_line(&mut command_line, flags).is_err());
+        assert!(command_line.is_none());
+    }
 }

--- a/vm/devices/get/get_protocol/src/dps_json.rs
+++ b/vm/devices/get/get_protocol/src/dps_json.rs
@@ -318,12 +318,74 @@ mod test {
     }
 
     #[test]
+    fn management_vtl_features_absent_defaults_tvm_host_certification_off() {
+        // Neither sample JSON payload includes a `ManagementVtlFeatures`
+        // field, so parsing them exercises the backward-compatible default
+        // for hosts that predate the field.
+        let sample = serde_json::from_slice::<DevicePlatformSettingsV2Json>(include_bytes!(
+            "dps_test_json.json"
+        ))
+        .unwrap();
+        assert!(
+            !sample
+                .v2
+                .r#static
+                .management_vtl_features
+                .tvm_host_certification()
+        );
+
+        let sample_with_vtl2settings = serde_json::from_slice::<DevicePlatformSettingsV2Json>(
+            include_bytes!("dps_test_json_with_vtl2settings.json"),
+        )
+        .unwrap();
+        assert!(
+            !sample_with_vtl2settings
+                .v2
+                .r#static
+                .management_vtl_features
+                .tvm_host_certification()
+        );
+    }
+
+    #[test]
+    fn management_vtl_features_roundtrip_with_tvm_host_certification_on() {
+        let features = ManagementVtlFeatures::new()
+            .with_strict_encryption_policy(true)
+            .with_control_ak_cert_provisioning(true)
+            .with_attempt_ak_cert_callback(false)
+            .with_tx_only_serial_port(true)
+            .with_tvm_host_certification(true);
+
+        let json = serde_json::to_string(&features).unwrap();
+        let roundtripped: ManagementVtlFeatures = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(roundtripped.into_bits(), features.into_bits());
+        assert!(roundtripped.strict_encryption_policy());
+        assert!(roundtripped.control_ak_cert_provisioning());
+        assert!(!roundtripped.attempt_ak_cert_callback());
+        assert!(roundtripped.tx_only_serial_port());
+        assert!(roundtripped.tvm_host_certification());
+    }
+
+    #[test]
     fn tvm_host_certification_is_default_off_at_bit_five() {
         let features = ManagementVtlFeatures::new();
         assert!(!features.tvm_host_certification());
         assert_eq!(
             features.with_tvm_host_certification(true).into_bits(),
             1 << 5
+        );
+
+        // Setting the bit must not disturb its neighbors, and clearing it
+        // must not leave any stray bits behind.
+        let neighbors = ManagementVtlFeatures::new()
+            .with_tx_only_serial_port(true)
+            .with_strict_encryption_policy(true);
+        let combined = neighbors.with_tvm_host_certification(true);
+        assert_eq!(combined.into_bits(), neighbors.into_bits() | (1 << 5));
+        assert_eq!(
+            combined.with_tvm_host_certification(false).into_bits(),
+            neighbors.into_bits()
         );
     }
 }

--- a/vm/devices/get/get_protocol/src/dps_json.rs
+++ b/vm/devices/get/get_protocol/src/dps_json.rs
@@ -181,7 +181,8 @@ pub struct ManagementVtlFeatures {
     pub control_ak_cert_provisioning: bool,
     pub attempt_ak_cert_callback: bool,
     pub tx_only_serial_port: bool,
-    #[bits(59)]
+    pub tvm_host_certification: bool,
+    #[bits(58)]
     pub _reserved2: u64,
 }
 
@@ -314,5 +315,15 @@ mod test {
             "dps_test_json_with_vtl2settings.json"
         ))
         .unwrap();
+    }
+
+    #[test]
+    fn tvm_host_certification_is_default_off_at_bit_five() {
+        let features = ManagementVtlFeatures::new();
+        assert!(!features.tvm_host_certification());
+        assert_eq!(
+            features.with_tvm_host_certification(true).into_bits(),
+            1 << 5
+        );
     }
 }

--- a/vm/devices/tpm/tpm_device/src/ak_cert.rs
+++ b/vm/devices/tpm/tpm_device/src/ak_cert.rs
@@ -80,3 +80,42 @@ pub trait RequestAkCert: Send + Sync {
         request: Vec<u8>,
     ) -> Result<Vec<u8>, Box<dyn std::error::Error + Send + Sync + 'static>>;
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct TestRequestAkCertHelper;
+
+    #[async_trait::async_trait]
+    impl RequestAkCert for TestRequestAkCertHelper {
+        fn create_ak_cert_request(
+            &self,
+            _ak_pub_modulus: &[u8],
+            _ak_pub_exponent: &[u8],
+            _ek_pub_modulus: &[u8],
+            _ek_pub_exponent: &[u8],
+            _guest_input: &[u8],
+            _is_attestation_report: bool,
+        ) -> Result<Vec<u8>, Box<dyn std::error::Error + Send + Sync>> {
+            Ok(Vec::new())
+        }
+
+        async fn request_ak_cert(
+            &self,
+            _request: Vec<u8>,
+        ) -> Result<Vec<u8>, Box<dyn std::error::Error + Send + Sync + 'static>> {
+            Ok(Vec::new())
+        }
+    }
+
+    #[test]
+    fn sw_attested_is_attested_and_trusted_is_not() {
+        let helper: Arc<dyn RequestAkCert> = Arc::new(TestRequestAkCertHelper);
+
+        assert!(TpmAkCertType::SwAttested(helper.clone()).attested());
+        assert!(TpmAkCertType::HwAttested(helper.clone()).attested());
+        assert!(!TpmAkCertType::Trusted(helper.clone(), None).attested());
+        assert!(!TpmAkCertType::None.attested());
+    }
+}

--- a/vm/devices/tpm/tpm_device/src/lib.rs
+++ b/vm/devices/tpm/tpm_device/src/lib.rs
@@ -2034,6 +2034,8 @@ mod tests {
     use vmcore::non_volatile_store::EphemeralNonVolatileStore;
     struct TestRequestAkCertHelper;
 
+    const TEST_ATTESTATION_REPORT: &[u8] = b"test attestation report";
+
     #[async_trait::async_trait]
     impl RequestAkCert for TestRequestAkCertHelper {
         fn create_ak_cert_request(
@@ -2043,9 +2045,13 @@ mod tests {
             _ek_pub_modulus: &[u8],
             _ek_pub_exponent: &[u8],
             _guest_input: &[u8],
-            _is_attestation_report: bool,
+            is_attestation_report: bool,
         ) -> Result<Vec<u8>, Box<dyn std::error::Error + Send + Sync>> {
-            Ok(Vec::new())
+            if is_attestation_report {
+                Ok(TEST_ATTESTATION_REPORT.to_vec())
+            } else {
+                Ok(Vec::new())
+            }
         }
 
         async fn request_ak_cert(
@@ -2099,5 +2105,68 @@ mod tests {
             .find_nv_index(TPM_NV_INDEX_MITIGATED)
             .expect("find_nv_index should succeed")
             .expect("mitigation marker NV index present");
+    }
+
+    async fn new_test_tpm(ak_cert_type: TpmAkCertType) -> Tpm {
+        let tpm_state_blob = include_bytes!("../../test_data/vTpmState.blob");
+        let mut store = EphemeralNonVolatileStore::new_boxed();
+        store.persist(tpm_state_blob.to_vec()).await.unwrap();
+
+        let ppi_store = EphemeralNonVolatileStore::new_boxed();
+        let gm = GuestMemory::allocate(0x10000);
+        let monotonic_timer = Box::new(|| std::time::Duration::new(0, 0));
+
+        Tpm::new(
+            TpmRegisterLayout::IoPort,
+            gm,
+            ppi_store,
+            store,
+            None,
+            monotonic_timer,
+            false,
+            false,
+            ak_cert_type,
+            None,
+            None,
+            false,
+            guid::guid!("00000000-0000-0000-0000-000000000000"),
+        )
+        .await
+        .unwrap()
+    }
+
+    #[async_test]
+    async fn sw_attested_creates_attestation_report_nv_index() {
+        let mut tpm =
+            new_test_tpm(TpmAkCertType::SwAttested(Arc::new(TestRequestAkCertHelper))).await;
+
+        let result = tpm
+            .tpm_engine_helper
+            .find_nv_index(TPM_NV_INDEX_ATTESTATION_REPORT)
+            .expect("find_nv_index should succeed");
+        assert!(result.is_some());
+
+        let mut report = [0; TEST_ATTESTATION_REPORT.len()];
+        let result = tpm
+            .tpm_engine_helper
+            .read_from_nv_index(TPM_NV_INDEX_ATTESTATION_REPORT, &mut report)
+            .expect("read_from_nv_index should succeed");
+        assert!(matches!(result, tpm_lib::NvIndexState::Available));
+        assert_eq!(report.as_slice(), TEST_ATTESTATION_REPORT);
+    }
+
+    #[async_test]
+    async fn trusted_does_not_create_attestation_report_nv_index() {
+        let mut tpm = new_test_tpm(TpmAkCertType::Trusted(
+            Arc::new(TestRequestAkCertHelper),
+            Some(true),
+        ))
+        .await;
+
+        let result = tpm
+            .tpm_engine_helper
+            .find_nv_index(TPM_NV_INDEX_ATTESTATION_REPORT)
+            .expect("find_nv_index should succeed");
+        assert!(result.is_none());
     }
 }

--- a/vm/devices/tpm/tpm_device/src/lib.rs
+++ b/vm/devices/tpm/tpm_device/src/lib.rs
@@ -774,6 +774,7 @@ impl Tpm {
             // Initialize `TPM_NV_INDEX_ATTESTATION_REPORT` if `ak_cert_type` supports attestation
             // report.
             if self.ak_cert_type.attested() {
+                tracing::info!(CVM_ALLOWED, "initializing TPM attestation report NV index");
                 self.renew_attestation_report()?;
             }
         }
@@ -1075,6 +1076,11 @@ impl Tpm {
                 &attestation_report,
             )
             .map_err(TpmErrorKind::WriteToNvIndex)?;
+        tracing::info!(
+            CVM_ALLOWED,
+            report_size = attestation_report.len(),
+            "TPM attestation report NV index renewed"
+        );
 
         self.attestation_report_renew_time = Some(std::time::SystemTime::now());
 
@@ -1292,7 +1298,7 @@ impl Tpm {
                     );
                 }
             } else {
-                tracing::warn!("Hardware attestation report generation was rate limited");
+                tracing::warn!("Attestation report generation was rate limited");
             }
         } else {
             // Renew AkCert if exceeds 24 hours since renewal, or not populated,


### PR DESCRIPTION
## Summary

- Adds a HostCall implementation over the existing VBS report hypercall.
- Requests the fixed 396-byte TVM host certification report only when the feature is enabled.
- Keeps legacy Trusted Launch requests at zero report bytes.
- Reuses the existing software-attested TPM lifecycle and attestation-report NV index.
- Gates the flow behind DPS bit 5 and HCL_TVM_HOST_CERTIFICATION, both off by default.

## Validation

- Rust formatting passed.
- Targeted Windows Cargo checks, Clippy, and tests passed.
- Linux Cargo checks and targeted tests passed.
- PR validation will rerun against the rebased head.

## Dependencies

Requires the matching os.2020 SVC and VID producer plus IGVM Agent, Provisioner, A-LPI, and MAA changes.