### PR TITLE
petri: enable THP for shared memory and on Windows

### DIFF
--- a/petri/src/vm/mod.rs
+++ b/petri/src/vm/mod.rs
@@ -2350,15 +2350,10 @@ pub struct MemoryConfig {
     ///
     /// Defaults to `true`. Applies to private anonymous guest RAM and to
     /// shared memfd-backed RAM, on Linux (via `madvise`) and on Windows (via
-    /// soft large pages).
-    ///
-    /// It has no effect where THP does not apply, and some backend helpers
-    /// force it off:
-    /// - [`with_hugepages`](crate::openvmm::PetriVmConfigOpenVmm::with_hugepages)
-    ///   uses explicit hugetlb/large pages, which are already huge.
-    /// - [`with_memory_backing_file`](crate::openvmm::PetriVmConfigOpenVmm::with_memory_backing_file)
-    ///   uses a file-backed mapping (for snapshot save/restore) rather than an
-    ///   anonymous memfd.
+    /// soft large pages). It has no effect on explicit hugetlb/large-page
+    /// backings (see
+    /// [`with_hugepages`](crate::openvmm::PetriVmConfigOpenVmm::with_hugepages)),
+    /// which are already huge.
     ///
     /// Only applies to the OpenVMM backend; ignored by Hyper-V.
     pub transparent_hugepages: bool,

--- a/petri/src/vm/mod.rs
+++ b/petri/src/vm/mod.rs
@@ -2348,11 +2348,17 @@ pub struct MemoryConfig {
     /// Mark guest RAM as eligible for Transparent Huge Pages (THP),
     /// improving performance for large allocations.
     ///
-    /// Defaults to `true`. Applies to both private anonymous and shared
-    /// (file/memfd) guest RAM, on Linux (via `madvise`) and on Windows (via
-    /// soft large pages). It is silently ignored where it does not apply, such
-    /// as explicit hugetlb/large-page (`with_hugepages`) backings, which are
-    /// already huge.
+    /// Defaults to `true`. Applies to private anonymous guest RAM and to
+    /// shared memfd-backed RAM, on Linux (via `madvise`) and on Windows (via
+    /// soft large pages).
+    ///
+    /// It has no effect where THP does not apply, and some backend helpers
+    /// force it off:
+    /// - [`with_hugepages`](crate::openvmm::PetriVmConfigOpenVmm::with_hugepages)
+    ///   uses explicit hugetlb/large pages, which are already huge.
+    /// - [`with_memory_backing_file`](crate::openvmm::PetriVmConfigOpenVmm::with_memory_backing_file)
+    ///   uses a file-backed mapping (for snapshot save/restore) rather than an
+    ///   anonymous memfd.
     ///
     /// Only applies to the OpenVMM backend; ignored by Hyper-V.
     pub transparent_hugepages: bool,

--- a/petri/src/vm/mod.rs
+++ b/petri/src/vm/mod.rs
@@ -2345,13 +2345,14 @@ pub struct MemoryConfig {
     ///
     /// Only applies to the OpenVMM backend; ignored by Hyper-V.
     pub private_memory: Option<bool>,
-    /// Mark private guest RAM as eligible for Transparent Huge Pages (THP),
+    /// Mark guest RAM as eligible for Transparent Huge Pages (THP),
     /// improving performance for large allocations.
     ///
-    /// Defaults to `true`. Only takes effect when the guest RAM is backed by
-    /// private anonymous memory (see [`Self::private_memory`]) and only on
-    /// Linux; it is silently ignored otherwise (shared memory, hugetlb/file
-    /// backing, OpenHCL, PCAT/Gen1, or non-Linux hosts).
+    /// Defaults to `true`. Applies to both private anonymous and shared
+    /// (file/memfd) guest RAM, on Linux (via `madvise`) and on Windows (via
+    /// soft large pages). It is silently ignored where it does not apply, such
+    /// as explicit hugetlb/large-page (`with_hugepages`) backings, which are
+    /// already huge.
     ///
     /// Only applies to the OpenVMM backend; ignored by Hyper-V.
     pub transparent_hugepages: bool,

--- a/petri/src/vm/openvmm/construct.rs
+++ b/petri/src/vm/openvmm/construct.rs
@@ -488,11 +488,11 @@ impl PetriVmConfigOpenVmm {
                 None => !private_incompatible,
             };
 
-            // THP is only valid for private anonymous memory and only on
-            // Linux; disable it otherwise to avoid a memory build error.
-            let transparent_hugepages =
-                transparent_hugepages && private_memory && cfg!(target_os = "linux");
-
+            // THP applies to both private anonymous and shared (file/memfd)
+            // guest RAM, and on both Linux (madvise-based) and Windows
+            // (soft large pages). The membacking layer suppresses it where it
+            // does not apply (e.g. explicit hugetlb backings), so pass the
+            // requested value through unchanged.
             let make_mem = |size: u64| openvmm_defs::config::MemoryConfig {
                 mem_size: size,
                 prefetch_memory: false,

--- a/petri/src/vm/openvmm/modify.rs
+++ b/petri/src/vm/openvmm/modify.rs
@@ -358,7 +358,6 @@ impl PetriVmConfigOpenVmm {
         for node in &mut self.config.numa.nodes {
             if let Some(mem) = &mut node.mem {
                 mem.private_memory = false;
-                mem.transparent_hugepages = false;
             }
         }
         self
@@ -383,7 +382,6 @@ impl PetriVmConfigOpenVmm {
                 mem.hugepages = true;
                 mem.hugepage_size = hugepage_size;
                 mem.private_memory = false;
-                mem.transparent_hugepages = false;
             }
         }
         self


### PR DESCRIPTION
Petri gated transparent huge pages behind private anonymous memory and a Linux host, since that was the only backing where THP had any effect. The membacking layer now marks shared (file/memfd) guest RAM as THP-eligible and implements Windows soft large pages, so those restrictions are stale and needlessly suppress THP for VMs backed by shared memory or running on Windows hosts.

Drop the private-memory and Linux-host conditions and pass the requested THP setting straight through; membacking already suppresses it where it genuinely does not apply, such as explicit hugetlb backings. Update the MemoryConfig docs to match.

This should improve test performance on Windows hosts.