### PR TITLE
openvmm_entry/ttrpc: expose PCIe NUMA and ACS config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10546,6 +10546,7 @@ dependencies = [
  "get_resources",
  "guid",
  "hyperv_ic_resources",
+ "initrd_cpio",
  "inspect",
  "jiff",
  "kmsg",

--- a/openvmm/openvmm_entry/src/ttrpc/mod.rs
+++ b/openvmm/openvmm_entry/src/ttrpc/mod.rs
@@ -62,6 +62,7 @@ use openvmm_defs::config::NumaDistance;
 use openvmm_defs::config::NumaNode;
 use openvmm_defs::config::NumaTopology;
 use openvmm_defs::config::PcieDeviceConfig;
+use openvmm_defs::config::PcieGenericInitiatorConfig;
 use openvmm_defs::config::PcieMmioRangeConfig;
 use openvmm_defs::config::PciePortConfig;
 use openvmm_defs::config::PcieRootComplexConfig;
@@ -785,22 +786,21 @@ impl VmService {
 
         // Build the PCIe topology (root complexes, switches, and the devices
         // attached behind their ports).
-        let (pcie_root_complexes, pcie_switches, pcie_devices) =
-            if let Some(pcie) = req_config.pcie.take() {
-                build_pcie_topology(pcie, &registry).await?
-            } else {
-                (Vec::new(), Vec::new(), Vec::new())
-            };
+        let pcie = if let Some(pcie) = req_config.pcie.take() {
+            build_pcie_topology(pcie, &registry).await?
+        } else {
+            BuiltPcieTopology::default()
+        };
 
         let mut config = Config {
             // TODO: devices, other stuff
             load_mode,
             ide_disks: vec![],
             floppy_disks: vec![],
-            pcie_root_complexes,
-            pcie_devices,
-            pcie_switches,
-            pcie_generic_initiators: vec![],
+            pcie_root_complexes: pcie.root_complexes,
+            pcie_devices: pcie.devices,
+            pcie_switches: pcie.switches,
+            pcie_generic_initiators: pcie.generic_initiators,
             vpci_devices: vec![],
             numa,
             chipset: chipset.chipset,
@@ -1484,16 +1484,21 @@ fn pcie_mmio_range_config(size: u64, base: Option<u64>) -> anyhow::Result<PcieMm
 /// a list of root complexes (each carrying its root ports), a list of switches
 /// (each referencing its parent port), and a list of devices (each referencing
 /// the port it sits behind).
+#[derive(Default)]
+struct BuiltPcieTopology {
+    root_complexes: Vec<PcieRootComplexConfig>,
+    switches: Vec<PcieSwitchConfig>,
+    devices: Vec<PcieDeviceConfig>,
+    generic_initiators: Vec<PcieGenericInitiatorConfig>,
+}
+
 async fn build_pcie_topology(
     topology: vmservice::PcieTopologyConfig,
     registry: &FdRegistry,
-) -> anyhow::Result<(
-    Vec<PcieRootComplexConfig>,
-    Vec<PcieSwitchConfig>,
-    Vec<PcieDeviceConfig>,
-)> {
+) -> anyhow::Result<BuiltPcieTopology> {
     let vmservice::PcieTopologyConfig {
         root_complexes: proto_root_complexes,
+        generic_initiators,
     } = topology;
     let mut root_complexes = Vec::new();
     let mut switches = Vec::new();
@@ -1522,6 +1527,7 @@ async fn build_pcie_topology(
                 hotplug,
                 attached,
                 devfn,
+                acs_capabilities_supported,
             } = root_port;
             ports.push(PciePortConfig {
                 name: port_name.clone(),
@@ -1529,7 +1535,9 @@ async fn build_pcie_topology(
                     .map(|d| d.try_into().context("devfn out of range"))
                     .transpose()?,
                 hotplug,
-                acs_capabilities_supported: None,
+                acs_capabilities_supported: acs_capabilities_supported
+                    .map(|acs| acs.try_into().context("ACS capability mask out of range"))
+                    .transpose()?,
                 cxl: false,
             });
             if let Some(attached) = attached {
@@ -1562,7 +1570,20 @@ async fn build_pcie_topology(
         });
     }
 
-    Ok((root_complexes, switches, devices))
+    let generic_initiators = generic_initiators
+        .into_iter()
+        .map(|initiator| PcieGenericInitiatorConfig {
+            port_name: initiator.port_name,
+            node: initiator.node,
+        })
+        .collect();
+
+    Ok(BuiltPcieTopology {
+        root_complexes,
+        switches,
+        devices,
+        generic_initiators,
+    })
 }
 
 /// Walks a single proto `PcieAttachment` (the thing behind one port): either an
@@ -1591,6 +1612,7 @@ fn walk_pcie_attachment(
                     hotplug,
                     attached,
                     devfn,
+                    acs_capabilities_supported,
                 } = downstream;
                 ports.push(PciePortConfig {
                     name: downstream_name.clone(),
@@ -1598,7 +1620,9 @@ fn walk_pcie_attachment(
                         .map(|d| d.try_into().context("devfn out of range"))
                         .transpose()?,
                     hotplug,
-                    acs_capabilities_supported: None,
+                    acs_capabilities_supported: acs_capabilities_supported
+                        .map(|acs| acs.try_into().context("ACS capability mask out of range"))
+                        .transpose()?,
                     cxl: false,
                 });
                 if let Some(attached) = attached {

--- a/openvmm/openvmm_ttrpc_vmservice/src/vmservice.proto
+++ b/openvmm/openvmm_ttrpc_vmservice/src/vmservice.proto
@@ -370,6 +370,16 @@ message NumaDistance {
 message PcieTopologyConfig {
     // The PCIe root complexes in the VM.
     repeated PcieRootComplex root_complexes = 1;
+    // Devices that act as initiators for device-only NUMA nodes.
+    repeated PcieGenericInitiator generic_initiators = 2;
+}
+
+// Associates the device behind a PCIe port with a NUMA proximity domain.
+message PcieGenericInitiator {
+    // Port directly upstream of the initiator device.
+    string port_name = 1;
+    // NUMA node for which the device is an initiator.
+    uint32 node = 2;
 }
 
 // A PCIe root complex.
@@ -411,6 +421,8 @@ message PciePort {
     // Device/function (`device << 3 | function`) to place this port at on its
     // bus. Absent => lowest available devfn.
     optional uint32 devfn = 4;
+    // ACS capability bits exposed by this port. Absent => default capabilities.
+    optional uint32 acs_capabilities_supported = 5;
 }
 
 // A PCIe switch: a set of downstream ports, each of which may have its own

--- a/vmm_tests/vmm_tests/Cargo.toml
+++ b/vmm_tests/vmm_tests/Cargo.toml
@@ -28,6 +28,7 @@ tmk_tests.workspace = true
 petri_artifacts_common.workspace = true
 petri.workspace = true
 inspect.workspace = true
+initrd_cpio.workspace = true
 
 get_resources.workspace = true
 openvmm_defs.workspace = true

--- a/vmm_tests/vmm_tests/tests/tests/ttrpc.rs
+++ b/vmm_tests/vmm_tests/tests/tests/ttrpc.rs
@@ -61,8 +61,11 @@ fn test_ttrpc_interface(
     let pipette = std::fs::read(pipette_path.get()).context("failed to read pipette")?;
     let pipette_initrd = initrd_cpio::inject_into_initrd(&initrd, "pipette", &pipette, 0o100755)
         .context("failed to inject pipette into test initrd")?;
-    let mut pipette_initrd_file = tempfile::NamedTempFile::new()?;
-    pipette_initrd_file.write_all(&pipette_initrd)?;
+    let mut pipette_initrd_file = tempfile::NamedTempFile::new_in(tempdir.path())
+        .context("failed to create initrd temp file")?;
+    pipette_initrd_file
+        .write_all(&pipette_initrd)
+        .context("failed to write initrd temp file")?;
 
     // The serial console device differs by architecture: x86 exposes a 16550
     // UART as `ttyS0`, while aarch64 exposes a PL011 UART as `ttyAMA0`.

--- a/vmm_tests/vmm_tests/tests/tests/ttrpc.rs
+++ b/vmm_tests/vmm_tests/tests/tests/ttrpc.rs
@@ -22,7 +22,9 @@ use pal_async::socket::PolledSocket;
 use pal_async::task::Spawn;
 use pal_async::task::Task;
 use petri::ResolvedArtifact;
+use petri::pipette::cmd;
 use petri_artifacts_vmm_test::artifacts;
+use std::io::Write;
 use std::path::Path;
 use std::process::Stdio;
 use std::time::Duration;
@@ -33,12 +35,20 @@ petri::test!(test_ttrpc_interface, |resolver| {
     let openvmm = resolver.require(artifacts::OPENVMM_NATIVE);
     let kernel = resolver.require(artifacts::loadable::LINUX_DIRECT_TEST_KERNEL_NATIVE);
     let initrd = resolver.require(artifacts::loadable::LINUX_DIRECT_TEST_INITRD_NATIVE);
-    Some([openvmm.erase(), kernel.erase(), initrd.erase()])
+    let pipette = match petri_artifacts_common::tags::MachineArch::host() {
+        petri_artifacts_common::tags::MachineArch::X86_64 => resolver
+            .require(petri_artifacts_common::artifacts::PIPETTE_LINUX_X64)
+            .erase(),
+        petri_artifacts_common::tags::MachineArch::Aarch64 => resolver
+            .require(petri_artifacts_common::artifacts::PIPETTE_LINUX_AARCH64)
+            .erase(),
+    };
+    Some([openvmm.erase(), kernel.erase(), initrd.erase(), pipette])
 });
 
 fn test_ttrpc_interface(
     params: petri::PetriTestParams<'_>,
-    [openvmm, kernel_path, initrd_path]: [ResolvedArtifact; 3],
+    [openvmm, kernel_path, initrd_path, pipette_path]: [ResolvedArtifact; 4],
 ) -> anyhow::Result<()> {
     // All temporary files for this test live under a single temp directory
     // that is cleaned up automatically when it is dropped at the end of the
@@ -46,6 +56,13 @@ fn test_ttrpc_interface(
     let tempdir = tempfile::tempdir()?;
     let socket_path = tempdir.path().join("ttrpc.sock");
     let pidfile_path = tempdir.path().join("openvmm.pid");
+
+    let initrd = std::fs::read(initrd_path.get()).context("failed to read test initrd")?;
+    let pipette = std::fs::read(pipette_path.get()).context("failed to read pipette")?;
+    let pipette_initrd = initrd_cpio::inject_into_initrd(&initrd, "pipette", &pipette, 0o100755)
+        .context("failed to inject pipette into test initrd")?;
+    let mut pipette_initrd_file = tempfile::NamedTempFile::new()?;
+    pipette_initrd_file.write_all(&pipette_initrd)?;
 
     // The serial console device differs by architecture: x86 exposes a 16550
     // UART as `ttyS0`, while aarch64 exposes a PL011 UART as `ttyAMA0`.
@@ -128,6 +145,17 @@ fn test_ttrpc_interface(
             let console_path = tempdir.path().join(format!("console-{i}.sock"));
             let virtiofs_root = tempdir.path().join(format!("virtiofs-{i}"));
             std::fs::create_dir_all(&virtiofs_root)?;
+            let hvsocket_path = tempdir.path().join(format!("hvsocket-{i}"));
+            let pipette_listener = if i == 0 {
+                let path = format!(
+                    "{}_{}",
+                    hvsocket_path.to_string_lossy(),
+                    pipette_client::PIPETTE_PORT
+                );
+                Some(UnixListener::bind(path)?)
+            } else {
+                None
+            };
 
             let consomme_nic_id = Guid::new_random().to_string();
 
@@ -166,6 +194,7 @@ fn test_ttrpc_interface(
                                     read_only: false,
                                 }),
                             ))),
+                            acs_capabilities_supported: Some(1),
                             devfn: None,
                         },
                         vmservice::PciePort {
@@ -173,6 +202,7 @@ fn test_ttrpc_interface(
                             hotplug: false,
                             attached: None,
                             devfn: None,
+                            acs_capabilities_supported: None,
                         },
                     ],
                 };
@@ -267,6 +297,10 @@ fn test_ttrpc_interface(
                     }),
                     Some(vmservice::PcieTopologyConfig {
                         root_complexes: vec![root_complex],
+                        generic_initiators: vec![vmservice::PcieGenericInitiator {
+                            port_name: "sw0-dp0".to_string(),
+                            node: 1,
+                        }],
                     }),
                 )
             } else {
@@ -284,7 +318,20 @@ fn test_ttrpc_interface(
                 )
             };
 
-            let guest_command = if i == 1 { "sleep 30" } else { "poweroff -f" };
+            let (boot_initrd_path, kernel_cmdline) = if i == 0 {
+                (
+                    pipette_initrd_file.path(),
+                    format!(
+                        "console={console} rdinit=/pipette panic=-1 initcall_blacklist=virtio_vsock_init"
+                    ),
+                )
+            } else {
+                let guest_command = if i == 1 { "sleep 30" } else { "poweroff -f" };
+                (
+                    initrd_path.get(),
+                    format!("console={console} rdinit=/bin/busybox panic=-1 -- {guest_command}"),
+                )
+            };
 
             client
                 .call()
@@ -299,10 +346,8 @@ fn test_ttrpc_interface(
                             boot_config: Some(vmservice::vm_config::BootConfig::DirectBoot(
                                 vmservice::DirectBoot {
                                     kernel_path: kernel_path.get().to_string_lossy().to_string(),
-                                    initrd_path: initrd_path.get().to_string_lossy().to_string(),
-                                    kernel_cmdline: format!(
-                                        "console={console} rdinit=/bin/busybox panic=-1 -- {guest_command}"
-                                    ),
+                                    initrd_path: boot_initrd_path.to_string_lossy().to_string(),
+                                    kernel_cmdline,
                                 },
                             )),
                             serial_config: Some(vmservice::SerialConfig {
@@ -333,6 +378,9 @@ fn test_ttrpc_interface(
                                     root_path: virtiofs_root.to_string_lossy().into(),
                                 }],
                                 ..Default::default()
+                            }),
+                            hvsocket_config: (i == 0).then(|| vmservice::HvSocketConfig {
+                                path: hvsocket_path.to_string_lossy().to_string(),
                             }),
                             ..Default::default()
                         }),
@@ -484,6 +532,20 @@ fn test_ttrpc_interface(
                         "after ResumeVm, expected RUNNING"
                     );
 
+                    if let Some(listener) = pipette_listener {
+                        let mut listener = PolledSocket::new(&driver, listener)?;
+                        let (conn, _) = listener.accept().await?;
+                        let conn = PolledSocket::new(&driver, conn)?;
+                        let agent = pipette_client::PipetteClient::new(
+                            &driver,
+                            conn,
+                            params.logger.output_dir(),
+                        )
+                        .await?;
+                        validate_pcie_config(&agent).await?;
+                        agent.power_off().await?;
+                    }
+
                     waiter.await.unwrap();
 
                     let props = query_props().await.unwrap();
@@ -611,6 +673,7 @@ fn pcie_root_port(
         hotplug,
         attached,
         devfn: None,
+        acs_capabilities_supported: None,
     }
 }
 
@@ -722,4 +785,109 @@ fn file_disk(path: &Path) -> vmservice::DiskBackend {
             direct: false,
         })),
     }
+}
+
+async fn validate_pcie_config(agent: &pipette_client::PipetteClient) -> anyhow::Result<()> {
+    let sh = agent.unix_shell();
+    let devices = cmd!(sh, "ls /sys/bus/pci/devices").read().await?;
+    let mut device = None;
+    for bdf in devices.split_whitespace() {
+        let class = sh
+            .read_file(format!("/sys/bus/pci/devices/{bdf}/class"))
+            .await?;
+        if class.trim() == "0x010000" {
+            device = Some(bdf);
+            break;
+        }
+    }
+    let device = device.context("virtio-blk PCI device not found")?;
+
+    let mut bdf = device.split([':', '.']);
+    let segment = u16::from_str_radix(bdf.next().context("missing PCI segment")?, 16)?;
+    let bus = u8::from_str_radix(bdf.next().context("missing PCI bus")?, 16)?;
+    let device_number = u8::from_str_radix(bdf.next().context("missing PCI device")?, 16)?;
+    let function = u8::from_str_radix(bdf.next().context("missing PCI function")?, 16)?;
+    anyhow::ensure!(bdf.next().is_none(), "invalid PCI BDF {device}");
+
+    let srat = agent.read_file("/sys/firmware/acpi/tables/SRAT").await?;
+    anyhow::ensure!(
+        srat.get(..4) == Some(b"SRAT"),
+        "guest SRAT has an invalid signature"
+    );
+    let mut offset = 48;
+    let mut found_generic_initiator = false;
+    while offset + 2 <= srat.len() {
+        let entry_len = srat[offset + 1] as usize;
+        anyhow::ensure!(
+            entry_len >= 2 && offset + entry_len <= srat.len(),
+            "guest SRAT contains an invalid entry at offset {offset:#x}"
+        );
+        if srat[offset] == 5 && entry_len == 32 {
+            let proximity_domain =
+                u32::from_le_bytes(srat[offset + 4..offset + 8].try_into().unwrap());
+            let entry_segment =
+                u16::from_le_bytes(srat[offset + 8..offset + 10].try_into().unwrap());
+            let entry_bus = srat[offset + 10];
+            let entry_devfn = srat[offset + 11];
+            let flags = u32::from_le_bytes(srat[offset + 24..offset + 28].try_into().unwrap());
+            if srat[offset + 3] == 1
+                && proximity_domain == 1
+                && entry_segment == segment
+                && entry_bus == bus
+                && entry_devfn == (device_number << 3) | function
+                && flags & 1 != 0
+            {
+                found_generic_initiator = true;
+                break;
+            }
+        }
+        offset += entry_len;
+    }
+    anyhow::ensure!(
+        found_generic_initiator,
+        "guest SRAT has no enabled Generic Initiator entry for {device} on NUMA node 1"
+    );
+
+    let device_path = cmd!(sh, "readlink -f /sys/bus/pci/devices/{device}")
+        .read()
+        .await?;
+    let port_path = Path::new(device_path.trim())
+        .parent()
+        .and_then(Path::to_str)
+        .context("PCI device has no parent port")?;
+    let config = sh.read_file_raw(format!("{port_path}/config")).await?;
+    let mut capability_offset = 0x100;
+    let acs_offset = loop {
+        let header = u32::from_le_bytes(
+            config
+                .get(capability_offset..capability_offset + 4)
+                .context("invalid PCIe extended capability offset")?
+                .try_into()
+                .unwrap(),
+        );
+        let capability_id = header as u16;
+        if capability_id == 0x000d {
+            break capability_offset;
+        }
+
+        let next_offset = (header >> 20) as usize;
+        anyhow::ensure!(
+            next_offset > capability_offset && next_offset % 4 == 0,
+            "parent port has no ACS capability"
+        );
+        capability_offset = next_offset;
+    };
+    let acs_capabilities = u16::from_le_bytes(
+        config
+            .get(acs_offset + 4..acs_offset + 6)
+            .context("parent port has no ACS capability register")?
+            .try_into()
+            .unwrap(),
+    );
+    anyhow::ensure!(
+        acs_capabilities == 1,
+        "expected ACS capability mask 0x0001, got {acs_capabilities:#06x}"
+    );
+
+    Ok(())
 }

--- a/vmm_tests/vmm_tests/tests/tests/ttrpc.rs
+++ b/vmm_tests/vmm_tests/tests/tests/ttrpc.rs
@@ -872,7 +872,7 @@ async fn validate_pcie_config(agent: &pipette_client::PipetteClient) -> anyhow::
 
         let next_offset = (header >> 20) as usize;
         anyhow::ensure!(
-            next_offset > capability_offset && next_offset % 4 == 0,
+            next_offset > capability_offset && next_offset.is_multiple_of(4),
             "parent port has no ACS capability"
         );
         capability_offset = next_offset;


### PR DESCRIPTION
GB200-style device topologies need the management interface to describe PCIe devices as ACPI Generic Initiators and control the ACS capabilities advertised by individual ports. Extend the VM service schema and topology conversion so these settings reach the canonical OpenVMM configuration.

Use pipette in the ttrpc integration test to verify the resulting SRAT Generic Initiator entry and ACS capability directly from inside the guest.