### PR TITLE
guestmem: lock guest pages for the intended access type

### DIFF
--- a/openhcl/virt_mshv_vtl/src/processor/hardware_cvm/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/hardware_cvm/mod.rs
@@ -1951,7 +1951,20 @@ impl hv1_emulator::VtlProtectAccess for CvmVtlProtectAccess<'_> {
         // LockedPages, but that requires some refactoring. For now, we just use
         // guest memory to lock the pages. When this is cleaned up, don't forget
         // to also cleanup how underhill_mem handles locking overlay pages.
-        Ok(self.guest_memory.lock_gpns(false, &[gpn]).unwrap())
+        //
+        // Lock for read, not write, even though the paravisor writes these
+        // overlay pages. The paravisor writes them through a mapping that
+        // bypasses guest VTL protections, so the lock must not apply the guest's
+        // write permission. `register_overlay_page` above has already validated
+        // and set the required permissions; locking for write would instead
+        // re-check the guest write bitmap, which is deliberately cleared to
+        // read-only for pages made guest-read-only (e.g. the hypercall and
+        // reference TSC pages), and would spuriously fail with a VTL protection
+        // violation.
+        Ok(self
+            .guest_memory
+            .lock_gpns(guestmem::AccessType::Read, false, &[gpn])
+            .unwrap())
     }
 
     fn unlock_overlay_page(&mut self, gpn: u64) -> Result<(), HvError> {

--- a/openhcl/virt_mshv_vtl/src/processor/tdx/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/tdx/mod.rs
@@ -994,8 +994,10 @@ impl hv1_emulator::VtlProtectAccess for UntrustedSynicVtlProts<'_> {
         _check_perms: hvdef::HvMapGpaFlags,
         _new_perms: Option<hvdef::HvMapGpaFlags>,
     ) -> Result<guestmem::LockedPages, HvError> {
+        // Overlay pages are written through the returned locked pages, so lock
+        // them for write.
         self.0
-            .lock_gpns(false, &[gpn])
+            .lock_gpns(guestmem::AccessType::Write, false, &[gpn])
             .map_err(|_| HvError::OperationFailed)
     }
 

--- a/openvmm/membacking/src/memory_manager/mod.rs
+++ b/openvmm/membacking/src/memory_manager/mod.rs
@@ -1143,4 +1143,67 @@ mod tests {
             assert_eq!(buf, pattern_b);
         });
     }
+
+    /// Builds a manager with a single THP-enabled shared RAM backing and
+    /// returns a [`GuestMemory`] over the **primary** mapper. Soft large pages
+    /// (the Windows deferred-protect scheme that maps guest RAM read-only until
+    /// the first write) apply only to the primary mapper, so locking behavior
+    /// must be exercised through it rather than through
+    /// [`GuestMemoryClient::guest_memory`], which hands out a secondary mapper.
+    async fn build_thp_primary_memory(size: u64) -> (GuestMemoryManager, GuestMemory) {
+        let mgr = GuestMemoryBuilder::new()
+            .add_backing(
+                RamBackingRequest::new(vec![MemoryRange::new(0..size)]).transparent_hugepages(true),
+            )
+            .build(size)
+            .await
+            .unwrap();
+        let primary = GuestMemory::new("test-primary", mgr.va_mapper.clone());
+        (mgr, primary)
+    }
+
+    /// Locking guest RAM for write must make it writable through the returned
+    /// raw pointer, even when the backing is only lazily made writable on the
+    /// first write (Windows soft large pages map primary-mapper guest RAM
+    /// read-only until then). The write here goes through the locked pointer
+    /// directly, bypassing the fault-handling `write_*` path, so if the lock
+    /// had only faulted the page in for read the store would access-violate.
+    /// This is the regression guard for read-only-locking a page that is then
+    /// written via zero-copy DMA.
+    #[async_test]
+    async fn test_lock_for_write_makes_page_writable() {
+        use std::sync::atomic::Ordering;
+
+        const SIZE: u64 = 2 * 1024 * 1024;
+        let (_mgr, gm) = build_thp_primary_memory(SIZE).await;
+
+        let locked = gm
+            .lock_gpns(guestmem::AccessType::Write, false, &[0])
+            .unwrap();
+        // Store directly through the locked pointer (not via `write_at`, which
+        // would fault the page in on its own).
+        locked.pages()[0][0].store(0xAB, Ordering::SeqCst);
+        locked.pages()[0][1].store(0xCD, Ordering::SeqCst);
+        drop(locked);
+
+        // The stores must be visible through a normal read.
+        assert_eq!(gm.read_plain::<u8>(0).unwrap(), 0xAB);
+        assert_eq!(gm.read_plain::<u8>(1).unwrap(), 0xCD);
+    }
+
+    /// A read-only lock succeeds and reads back the freshly zeroed page without
+    /// forcing the page writable.
+    #[async_test]
+    async fn test_lock_for_read_succeeds() {
+        use std::sync::atomic::Ordering;
+
+        const SIZE: u64 = 2 * 1024 * 1024;
+        let (_mgr, gm) = build_thp_primary_memory(SIZE).await;
+
+        let locked = gm
+            .lock_gpns(guestmem::AccessType::Read, false, &[0])
+            .unwrap();
+        assert_eq!(locked.pages()[0][0].load(Ordering::SeqCst), 0);
+        drop(locked);
+    }
 }

--- a/vm/devices/net/netvsp/src/buffers.rs
+++ b/vm/devices/net/netvsp/src/buffers.rs
@@ -109,7 +109,7 @@ impl GuestBuffers {
 
         let gpns = gpadl.first().unwrap().gpns().to_vec();
         let locked_pages = mem
-            .lock_gpns(false, &gpns)
+            .lock_gpns(guestmem::AccessType::Write, false, &gpns)
             .map_err(GuestBuffersError::GpnLock)?;
         Ok(Self {
             mem,

--- a/vm/devices/storage/scsi_buffers/src/lib.rs
+++ b/vm/devices/storage/scsi_buffers/src/lib.rs
@@ -401,10 +401,15 @@ impl<'a> RequestBuffers<'a> {
         if for_write && !self.is_write {
             return Err(AccessError::ReadOnly);
         }
-        Ok(LockedIoBuffers(
-            self.guest_memory
-                .lock_range(self.range, LockedIoVecs::new())?,
-        ))
+        Ok(LockedIoBuffers(self.guest_memory.lock_range(
+            if for_write {
+                guestmem::AccessType::Write
+            } else {
+                guestmem::AccessType::Read
+            },
+            self.range,
+            LockedIoVecs::new(),
+        )?))
     }
 
     /// Returns a subrange of this set of buffers.

--- a/vm/devices/virtio/virtio_vsock/src/lib.rs
+++ b/vm/devices/virtio/virtio_vsock/src/lib.rs
@@ -614,7 +614,15 @@ fn lock_payload_data<'a, T: LockedRange<'a>>(
         }
         let paged_range =
             PagedRange::new(*offset, *len, gpns).expect("offset and len should be valid");
-        Some(mem.lock_range(paged_range, locked_range)?)
+        Some(mem.lock_range(
+            if writable {
+                guestmem::AccessType::Write
+            } else {
+                guestmem::AccessType::Read
+            },
+            paged_range,
+            locked_range,
+        )?)
     } else {
         tracing::trace!("payload data is not representable in a single PagedRange");
         None

--- a/vm/devices/vmbus/vmbus_channel/src/gpadl_ring.rs
+++ b/vm/devices/vmbus/vmbus_channel/src/gpadl_ring.rs
@@ -93,7 +93,7 @@ impl GpadlPagedMemory {
             .chain(gpadl.gpns().iter().skip(1))
             .copied()
             .collect();
-        let pages = mem.lock_gpns(false, &gpns)?;
+        let pages = mem.lock_gpns(guestmem::AccessType::Write, false, &gpns)?;
         Ok(Self {
             _gpadl: gpadl,
             pages,

--- a/vm/devices/vmbus/vmbus_server/src/lib.rs
+++ b/vm/devices/vmbus/vmbus_server/src/lib.rs
@@ -2166,9 +2166,11 @@ fn gpadl_ring_size(gpadl: &AlignedGpadlView) -> usize {
 /// This allows us to lock a page in a `GuestMemory` that doesn't have a full mapping, but can
 /// create one for a subrange.
 fn lock_page_with_subrange(gm: &GuestMemory, offset: u64) -> anyhow::Result<guestmem::LockedPages> {
-    Ok(gm
-        .lockable_subrange(offset, PAGE_SIZE as u64)?
-        .lock_gpns(false, &[0])?)
+    Ok(gm.lockable_subrange(offset, PAGE_SIZE as u64)?.lock_gpns(
+        guestmem::AccessType::Write,
+        false,
+        &[0],
+    )?)
 }
 
 /// Helper to create a subrange before locking a single page from a gpn.

--- a/vm/vmcore/guestmem/fuzz/fuzz_guestmem.rs
+++ b/vm/vmcore/guestmem/fuzz/fuzz_guestmem.rs
@@ -156,6 +156,7 @@ enum GuestMemAction {
         gpa: u64,
     },
     LockGpns {
+        write: bool,
         gpns: Vec<u64>,
     },
     ProbeGpns {
@@ -199,6 +200,7 @@ enum GuestMemAction {
         data: Vec<u8>,
     },
     LockRange {
+        write: bool,
         offset: usize,
         len: usize,
         gpns: Vec<u64>,
@@ -253,8 +255,13 @@ fn do_fuzz(input: FuzzCase) {
                 _ = gm.compare_exchange(gpa, current, new)
             }
             GuestMemAction::Iova { gpa } => _ = gm.iova(gpa),
-            GuestMemAction::LockGpns { gpns } => {
-                _ = gm.lock_gpns(true, &gpns);
+            GuestMemAction::LockGpns { write, gpns } => {
+                let access = if write {
+                    guestmem::AccessType::Write
+                } else {
+                    guestmem::AccessType::Read
+                };
+                _ = gm.lock_gpns(access, true, &gpns);
             }
             GuestMemAction::ProbeGpns { gpns } => {
                 _ = gm.probe_gpns(&gpns);
@@ -312,10 +319,20 @@ fn do_fuzz(input: FuzzCase) {
                     _ = gm.write_range_from_atomic(&range, &data_atomic);
                 }
             }
-            GuestMemAction::LockRange { offset, len, gpns } => {
+            GuestMemAction::LockRange {
+                write,
+                offset,
+                len,
+                gpns,
+            } => {
                 if let Some(range) = PagedRange::new(offset, len, &gpns) {
                     let locked_range = LockedIoVecs::new();
-                    _ = gm.lock_range(range, locked_range);
+                    let access = if write {
+                        guestmem::AccessType::Write
+                    } else {
+                        guestmem::AccessType::Read
+                    };
+                    _ = gm.lock_range(access, range, locked_range);
                 }
             }
         }

--- a/vm/vmcore/guestmem/src/lib.rs
+++ b/vm/vmcore/guestmem/src/lib.rs
@@ -1222,10 +1222,15 @@ struct MemoryRegion {
     base_iova: Option<u64>,
 }
 
-/// The access type. The values correspond to bitmap indexes.
+/// The type of access that guest memory will be used for.
+///
+/// The discriminants correspond to bitmap indexes (read = 0, write = 1) and
+/// must not be reordered.
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
-enum AccessType {
+pub enum AccessType {
+    /// Read access.
     Read = 0,
+    /// Write access.
     Write = 1,
 }
 
@@ -2024,6 +2029,7 @@ impl GuestMemory {
 
     fn probe_page_for_lock(
         &self,
+        access: AccessType,
         with_kernel_access: bool,
         gpa: u64,
     ) -> Result<*const AtomicU8, GuestMemoryBackingError> {
@@ -2035,17 +2041,80 @@ impl GuestMemory {
         if with_kernel_access {
             self.inner.imp.expose_va(gpa, 1)?;
         }
-        // FUTURE: check the correct bitmap for the access type, which needs to
-        // be passed in.
-        self.read_plain_inner::<u8>(gpa)?;
+        // Fault the page in for the access the caller will perform through the
+        // returned pointer. A write lock must fault for *write* so that a
+        // read-only-until-write backing (e.g. Windows soft large pages, which
+        // map guest RAM read-only until the first write raises it to
+        // read-write) is made writable before the caller writes; otherwise the
+        // write would hit a read-only page and access-violate. A read-only lock
+        // only faults for read, so it neither forces writability (which
+        // genuinely read-only memory would reject) nor needlessly promotes soft
+        // large pages.
+        match access {
+            AccessType::Read => {
+                self.read_plain_inner::<u8>(gpa)?;
+            }
+            AccessType::Write => {
+                self.probe_mapped_page_writable(gpa)?;
+            }
+        }
         // SAFETY: the read_at call includes a check that ensures that
         // `gpa` is in the VA range.
         let page = unsafe { ptr.as_ptr().add(offset as usize) };
         Ok(page.cast())
     }
 
+    /// Faults a single **mapped** guest page in for write without changing its
+    /// contents, so that a read-only-until-write backing (e.g. Windows soft
+    /// large pages) is raised to read-write before a write lock hands out a
+    /// pointer to it.
+    ///
+    /// This is a helper for the locking path and requires the page to be backed
+    /// by a host mapping. It works by performing a no-op compare-exchange
+    /// against the mapping: on a read-only page the locked read-modify-write
+    /// triggers the write fault handler (raising the window to read-write), and
+    /// once writable the exchange leaves the value unchanged (writing back the
+    /// same value on a match and nothing on a mismatch).
+    ///
+    /// It deliberately does **not** fall back to
+    /// [`GuestMemoryAccess::compare_exchange_fallback`]: the write-probe is
+    /// meaningless without a mapping (there is nothing to fault in), and not all
+    /// backings implement that fallback. Callers must only reach this after
+    /// confirming the page is mapped, as the lock path does via
+    /// [`GuestMemory::supports_locking`]. A non-mapping backing therefore fails
+    /// with a clear error rather than silently taking an unsupported path.
+    fn probe_mapped_page_writable(&self, gpa: u64) -> Result<(), GuestMemoryBackingError> {
+        self.run_on_mapping(
+            AccessType::Write,
+            gpa,
+            1,
+            (),
+            |(), dest| {
+                // SAFETY: dest points to a reserved VA range of at least one byte.
+                unsafe { trycopy::try_compare_exchange::<u8>(dest.cast(), 0, 0).map(|_| ()) }
+            },
+            |()| {
+                // Only reachable without a mapping (or if a backing's
+                // `page_fault` requests the fallback). The write-probe only
+                // makes sense for mapping-based backings, so fail clearly here
+                // instead of invoking `compare_exchange_fallback`, which many
+                // backings do not implement.
+                Err(GuestMemoryBackingError::other(gpa, NotLockable))
+            },
+        )
+    }
+
+    /// Locks the specified guest pages (by GPN), returning handles that expose
+    /// their host VA for zero-copy access.
+    ///
+    /// `access` selects whether the pages will be read from or written to: a
+    /// write lock faults each page in for write so that a
+    /// read-only-until-write backing (e.g. Windows soft large pages) is raised
+    /// to read-write before the caller writes through the returned pointer,
+    /// while a read-only lock (e.g. read-only DMA) only faults for read.
     pub fn lock_gpns(
         &self,
+        access: AccessType,
         with_kernel_access: bool,
         gpns: &[u64],
     ) -> Result<LockedPages, GuestMemoryError> {
@@ -2057,7 +2126,7 @@ impl GuestMemory {
             let mut pages = Vec::with_capacity(gpns.len());
             for &gpn in gpns {
                 let gpa = gpn_to_gpa(gpn).map_err(GuestMemoryBackingError::gpn)?;
-                let page = self.probe_page_for_lock(with_kernel_access, gpa)?;
+                let page = self.probe_page_for_lock(access, with_kernel_access, gpa)?;
                 pages.push(PagePtr(page));
             }
             let store_gpns = self.inner.imp.lock_gpns(gpns)?;
@@ -2221,11 +2290,17 @@ impl GuestMemory {
     /// Locks the guest pages spanned by the specified `PagedRange`.
     ///
     /// # Arguments
+    /// * 'access' - Whether the locked pages will be read from or written to.
+    ///   A write lock faults each page in for write so that a
+    ///   read-only-until-write backing (e.g. Windows soft large pages) is
+    ///   raised to read-write before the caller writes through the returned
+    ///   VA; a read-only lock (e.g. read-only DMA) only faults for read.
     /// * 'paged_range' - The guest memory range to lock.
     /// * 'locked_range' - Receives a list of VA ranges to which each contiguous physical sub-range in `paged_range`
     ///   has been mapped. Must be initially empty.
     pub fn lock_range<'a, T: LockedRange<'a>>(
         &'a self,
+        access: AccessType,
         paged_range: PagedRange<'_>,
         mut locked_range: T,
     ) -> Result<LockedRangeImpl<'a, T>, GuestMemoryError> {
@@ -2237,7 +2312,7 @@ impl GuestMemory {
             }
             for &gpn in gpns {
                 let gpa = gpn_to_gpa(gpn).map_err(GuestMemoryBackingError::gpn)?;
-                self.probe_page_for_lock(true, gpa)?;
+                self.probe_page_for_lock(access, true, gpa)?;
             }
             for range in paged_range.ranges() {
                 let range = range.map_err(GuestMemoryBackingError::gpn)?;
@@ -2949,7 +3024,7 @@ mod tests {
         // the backing's `lock_gpns`.
         let gm = GuestMemory::new("nolock", ToggleLockMapping::new(SIZE_1MB, false));
         assert!(!gm.supports_locking());
-        assert!(gm.lock_gpns(false, &[0]).is_err());
+        assert!(gm.lock_gpns(crate::AccessType::Write, false, &[0]).is_err());
 
         // Multi-region: locking is supported only when every present backing
         // supports it.

--- a/vmm_core/virt_hvf/src/hypercall.rs
+++ b/vmm_core/virt_hvf/src/hypercall.rs
@@ -168,7 +168,12 @@ impl<'a> hv1_emulator::VtlProtectAccess for HvfNoVtlProtections<'a> {
         _check_perms: hvdef::HvMapGpaFlags,
         _new_perms: Option<hvdef::HvMapGpaFlags>,
     ) -> Result<guestmem::LockedPages, HvError> {
-        Ok(self.0.lock_gpns(false, &[gpn]).unwrap())
+        // Overlay pages are written through the returned locked pages, so lock
+        // them for write.
+        Ok(self
+            .0
+            .lock_gpns(guestmem::AccessType::Write, false, &[gpn])
+            .unwrap())
     }
 
     fn unlock_overlay_page(&mut self, _gpn: u64) -> Result<(), HvError> {

--- a/vmm_core/virt_kvm/src/arch/x86_64/mod.rs
+++ b/vmm_core/virt_kvm/src/arch/x86_64/mod.rs
@@ -989,8 +989,10 @@ impl hv1_emulator::VtlProtectAccess for KvmNoVtlProtections<'_> {
         _check_perms: hvdef::HvMapGpaFlags,
         _new_perms: Option<hvdef::HvMapGpaFlags>,
     ) -> Result<guestmem::LockedPages, HvError> {
+        // Overlay pages are written through the returned locked pages, so lock
+        // them for write.
         self.0
-            .lock_gpns(false, &[gpn])
+            .lock_gpns(guestmem::AccessType::Write, false, &[gpn])
             .map_err(|_| HvError::OperationDenied)
     }
 

--- a/vmm_core/virt_whp/src/lib.rs
+++ b/vmm_core/virt_whp/src/lib.rs
@@ -1759,7 +1759,12 @@ impl<'a> hv1_emulator::VtlProtectAccess for WhpNoVtlProtections<'a> {
         _check_perms: hvdef::HvMapGpaFlags,
         _new_perms: Option<hvdef::HvMapGpaFlags>,
     ) -> Result<guestmem::LockedPages, hvdef::HvError> {
-        Ok(self.0.lock_gpns(false, &[gpn]).unwrap())
+        // Overlay pages are written through the returned locked pages, so lock
+        // them for write.
+        Ok(self
+            .0
+            .lock_gpns(guestmem::AccessType::Write, false, &[gpn])
+            .unwrap())
     }
 
     fn unlock_overlay_page(&mut self, _gpn: u64) -> Result<(), hvdef::HvError> {


### PR DESCRIPTION
Locking guest pages for zero-copy access only ever probed the page for read, then handed out a pointer the caller could write through. That is fine for a backing whose pages are always writable, but it breaks the Windows "soft large page" scheme, where primary-mapper guest RAM is mapped read-only until the first write fault raises a 2 MB window to read-write. A caller that locked a page and then wrote through the returned pointer -- device DMA into guest memory, vmbus rings, or synthetic-hypervisor overlay pages -- bypassed the fault-handling write path and hit the read-only page directly, taking an access violation and crashing the VMM. This brought down essentially every shared-memory VM on Windows hosts once THP was enabled there.

Give the lock APIs an explicit access type. A write lock faults each page in for write before returning, so a read-only-until-write backing is raised to read-write up front; a read lock keeps the cheaper read probe, which is what read-only DMA wants and what genuinely read-only memory requires. Callers pass the direction they actually use: DMA buffers thread through their existing read/write intent, while vmbus rings, monitor/interrupt pages, and overlay pages lock for write.

The confidential-VM overlay path is the exception and locks for read: the paravisor writes those pages through a mapping that bypasses guest VTL protections, and a write lock would re-check the guest write bitmap that register_overlay_page intentionally clears for guest-read-only pages, spuriously failing with a VTL protection violation.

Also add membacking tests that lock a page for write and store through the returned pointer, exercising the soft-large-page raise.