### PR TITLE
virt_kvm: Set flags to accept values in set_activity

### DIFF
--- a/vmm_core/virt_kvm/src/arch/x86_64/vp_state.rs
+++ b/vmm_core/virt_kvm/src/arch/x86_64/vp_state.rs
@@ -349,7 +349,7 @@ impl AccessVpState for KvmVpStateAccess<'_, '_> {
                 pad: 0,
             },
             sipi_vector: 0,
-            flags: 0,
+            flags: kvm::KVM_VCPUEVENT_VALID_NMI_PENDING | kvm::KVM_VCPUEVENT_VALID_SHADOW,
             exception_has_payload: 0,
             exception_payload: 0,
             ..Default::default()

--- a/vmm_core/virt_kvm/src/arch/x86_64/vp_state.rs
+++ b/vmm_core/virt_kvm/src/arch/x86_64/vp_state.rs
@@ -328,6 +328,14 @@ impl AccessVpState for KvmVpStateAccess<'_, '_> {
         };
         self.kvm().set_mp_state(state)?;
 
+        let mut event_flags = 0;
+        if value.nmi_pending {
+            event_flags |= kvm::KVM_VCPUEVENT_VALID_NMI_PENDING;
+        }
+        if value.interrupt_shadow {
+            event_flags |= kvm::KVM_VCPUEVENT_VALID_SHADOW;
+        }
+
         let mut events = kvm::kvm_vcpu_events {
             exception: kvm::kvm_vcpu_events__bindgen_ty_1 {
                 injected: 0,
@@ -349,7 +357,7 @@ impl AccessVpState for KvmVpStateAccess<'_, '_> {
                 pad: 0,
             },
             sipi_vector: 0,
-            flags: kvm::KVM_VCPUEVENT_VALID_NMI_PENDING | kvm::KVM_VCPUEVENT_VALID_SHADOW,
+            flags: event_flags,
             exception_has_payload: 0,
             exception_payload: 0,
             ..Default::default()

--- a/vmm_core/virt_kvm/src/arch/x86_64/vp_state.rs
+++ b/vmm_core/virt_kvm/src/arch/x86_64/vp_state.rs
@@ -318,7 +318,16 @@ impl AccessVpState for KvmVpStateAccess<'_, '_> {
     }
 
     fn set_activity(&mut self, value: &vp::Activity) -> Result<(), Self::Error> {
-        let state = match value.mp_state {
+        let vp::Activity {
+            mp_state,
+            nmi_pending,
+            nmi_masked,
+            interrupt_shadow,
+            pending_event,
+            pending_interruption,
+        } = *value;
+
+        let state = match mp_state {
             vp::MpState::Running => kvm::KVM_MP_STATE_RUNNABLE,
             vp::MpState::WaitForSipi => kvm::KVM_MP_STATE_INIT_RECEIVED,
             vp::MpState::Halted => kvm::KVM_MP_STATE_HALTED,
@@ -329,10 +338,10 @@ impl AccessVpState for KvmVpStateAccess<'_, '_> {
         self.kvm().set_mp_state(state)?;
 
         let mut event_flags = 0;
-        if value.nmi_pending {
+        if nmi_pending {
             event_flags |= kvm::KVM_VCPUEVENT_VALID_NMI_PENDING;
         }
-        if value.interrupt_shadow {
+        if interrupt_shadow {
             event_flags |= kvm::KVM_VCPUEVENT_VALID_SHADOW;
         }
 
@@ -348,12 +357,12 @@ impl AccessVpState for KvmVpStateAccess<'_, '_> {
                 injected: 0,
                 nr: 0,
                 soft: 0,
-                shadow: value.interrupt_shadow.into(),
+                shadow: interrupt_shadow.into(),
             },
             nmi: kvm::kvm_vcpu_events__bindgen_ty_3 {
                 injected: 0,
-                pending: value.nmi_pending.into(),
-                masked: value.nmi_masked.into(),
+                pending: nmi_pending.into(),
+                masked: nmi_masked.into(),
                 pad: 0,
             },
             sipi_vector: 0,
@@ -363,7 +372,7 @@ impl AccessVpState for KvmVpStateAccess<'_, '_> {
             ..Default::default()
         };
 
-        match value.pending_event {
+        match pending_event {
             Some(vp::PendingEvent::Exception {
                 vector,
                 error_code,
@@ -384,7 +393,7 @@ impl AccessVpState for KvmVpStateAccess<'_, '_> {
             None => {}
         }
 
-        match value.pending_interruption {
+        match pending_interruption {
             Some(vp::PendingInterruption::Exception { vector, error_code }) => {
                 events.exception.injected = true.into();
                 events.exception.nr = vector;


### PR DESCRIPTION
On KVM the nmi_pending and interrupt_shadow values ignored by set_vcpu_events unless flags are specified saying to accept them. This is because these values can be modified by other processors asynchronously, and the caller may not want to accidentally overwrite these. In our case when these values are true we do in fact want them to be set, so pass in the flags to do so. However when they're false, we don't want to accidentally clear a signal from another VP, so check first.