### PR TITLE
virt_kvm: Fix synic message delivery check

### DIFF
--- a/vmm_core/virt_kvm/src/arch/x86_64/mod.rs
+++ b/vmm_core/virt_kvm/src/arch/x86_64/mod.rs
@@ -905,7 +905,7 @@ impl KvmProcessor<'_> {
 
     /// Tries to deliver any pending synic messages for a VP.
     fn try_deliver_synic_messages(&mut self) -> Option<VmTime> {
-        if !self.scontrol.enabled() && self.simp.enabled() {
+        if !(self.scontrol.enabled() && self.simp.enabled()) {
             return None;
         }
         self.inner


### PR DESCRIPTION
I think it's unlikely this ever matters, since these two flags probably always get changed together, but just to be safe, fix this check.