### PR TITLE
ide: fix drive head toctou bug on enlightened path (#3535)

### DIFF
--- a/vm/devices/storage/ide/src/lib.rs
+++ b/vm/devices/storage/ide/src/lib.rs
@@ -298,19 +298,6 @@ impl Channel {
             return IoResult::Err(IoError::InvalidAccessSize);
         }
 
-        if let Some(status) = self.current_drive_status() {
-            if status.err() {
-                tracelimit::warn_ratelimited!(
-                    "drive is in error state, ignoring enlightened command",
-                );
-                return IoResult::Ok;
-            } else if status.bsy() || status.drq() {
-                tracelimit::warn_ratelimited!(
-                    "command is already pending on this drive, ignoring enlightened command"
-                );
-                return IoResult::Ok;
-            }
-        }
         if self.enlightened_write.is_some() {
             tracelimit::error_ratelimited!("enlightened write while one is in progress, ignoring");
             return IoResult::Ok;
@@ -340,6 +327,20 @@ impl Channel {
             eint13_cmd.device_head.into(),
             bus_master_state,
         );
+
+        if let Some(status) = self.current_drive_status() {
+            if status.err() {
+                tracelimit::warn_ratelimited!(
+                    "drive is in error state, ignoring enlightened command",
+                );
+                return IoResult::Ok;
+            } else if status.bsy() || status.drq() {
+                tracelimit::warn_ratelimited!(
+                    "command is already pending on this drive, ignoring enlightened command"
+                );
+                return IoResult::Ok;
+            }
+        }
 
         let result = if let Some(drive_type) = self.current_drive_type() {
             match drive_type {


### PR DESCRIPTION
This is a clean cherry-pick of #3535

The enlightened path in the IDE implementation is supposed to check whether the drive is busy, and bail out if so.

We were checking if the drive is busy before switching the device head, meaning we could mistakenly go further down the enlightened path, even when the drive was busy. Fixed.