### PR TITLE
membacking: fix Windows soft large page fault storm

### DIFF
--- a/openvmm/membacking/src/mapping_manager/manager.rs
+++ b/openvmm/membacking/src/mapping_manager/manager.rs
@@ -60,6 +60,7 @@ impl MappingManager {
         spawn: impl Spawn,
         max_addr: u64,
         minimum_va_alignment: Option<usize>,
+        supports_memory_fault_resolution: bool,
     ) -> Result<(Self, Arc<VaMapper>), VaMapperError> {
         let this = Self::new_bare(spawn, max_addr, minimum_va_alignment);
         // Create the primary mapper as part of construction. Being first, it is
@@ -67,7 +68,12 @@ impl MappingManager {
         // this process.
         let primary = this
             .client()
-            .get_or_create_mapper(true, MapperRole::Primary)
+            .get_or_create_mapper(
+                true,
+                MapperRole::Primary {
+                    supports_memory_fault_resolution,
+                },
+            )
             .await?;
         Ok((this, primary))
     }
@@ -1481,7 +1487,9 @@ mod tests {
             None,
             None,
             true, // eager
-            MapperRole::Primary,
+            MapperRole::Primary {
+                supports_memory_fault_resolution: false,
+            },
         );
         let (mapper, _) = futures::join!(mapper_future, async {
             let msg = req_recv.recv().await.unwrap();
@@ -1519,7 +1527,9 @@ mod tests {
             None,
             None,
             true, // eager
-            MapperRole::Primary,
+            MapperRole::Primary {
+                supports_memory_fault_resolution: false,
+            },
         );
         let (mapper, mapper_req_send) = futures::join!(mapper_future, async {
             let msg = req_recv.recv().await.unwrap();

--- a/openvmm/membacking/src/mapping_manager/va_mapper.rs
+++ b/openvmm/membacking/src/mapping_manager/va_mapper.rs
@@ -41,6 +41,13 @@
 // low level memory manipulation functions.
 #![expect(unsafe_code)]
 
+// Soft large pages are a Windows-only optimization; other targets get an
+// uninhabited stub with the same interface (`SoftLp::new` returns `None`) so the
+// fault paths compile without per-item `cfg`s.
+#[cfg_attr(not(windows), path = "va_mapper/soft_lp_stub.rs")]
+mod soft_lp;
+
+use self::soft_lp::SoftLp;
 use super::manager::DmaRegionProvider;
 use super::manager::MapperId;
 use super::manager::MapperRequest;
@@ -70,7 +77,6 @@ use sparse_mmap::SparseMapping;
 use std::ptr::NonNull;
 use std::sync::Arc;
 use std::sync::atomic::AtomicBool;
-use std::sync::atomic::AtomicU64;
 use std::sync::atomic::Ordering;
 use std::thread::JoinHandle;
 use thiserror::Error;
@@ -88,20 +94,6 @@ use windows_sys::Win32::System::Memory::SECTION_MAP_WRITE;
 #[error("unexpected page fault")]
 struct UnexpectedPageFault;
 
-/// A failure in one of the steps the fault handler takes to service a guest-RAM
-/// fault on Windows. Each variant names the operation and carries the
-/// underlying OS error as its [`source`](std::error::Error::source), so a
-/// passed-up guest-memory error identifies the step that failed rather than
-/// surfacing a bare OS error code.
-#[cfg(windows)]
-#[derive(Debug, Error)]
-enum FaultError {
-    /// Raising a window to read-write failed (deferred protect / soft large
-    /// pages).
-    #[error("failed to raise window {0} to read-write")]
-    Protect(MemoryRange, #[source] std::io::Error),
-}
-
 /// The role of a [`VaMapper`].
 ///
 /// Exactly one mapper per VM is [`Primary`](Self::Primary): the loader's write
@@ -118,14 +110,21 @@ enum FaultError {
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub(crate) enum MapperRole {
     /// The single loader/partition mapper; eligible for soft large pages.
-    Primary,
+    Primary {
+        /// Whether the partition delivers guest-memory-access faults to the
+        /// VMM. Soft large pages map a window read-only and rely on the
+        /// resulting write fault being resolved to raise it, so they are only
+        /// enabled when this is set. Carried on the `Primary` variant because it
+        /// is meaningless for a secondary mapper.
+        supports_memory_fault_resolution: bool,
+    },
     /// Any other mapper; plain read-write 4 KB pages.
     Secondary,
 }
 
 /// Properties recorded for each active guest-memory mapping, used to answer
-/// per-address queries (private vs. shared, soft-large-page first-fault state)
-/// without a static snapshot of the RAM layout.
+/// per-address queries (private vs. shared, soft-large-page state) without a
+/// static snapshot of the RAM layout.
 #[derive(Debug)]
 struct MappingProps {
     /// Backed by private anonymous memory (committed up front) rather than a
@@ -133,46 +132,10 @@ struct MappingProps {
     private: bool,
     /// General per-mapping fault counters, always present. See [`FaultStats`].
     stats: FaultStats,
-    /// Soft-large-page state for this range's 2 MB regions. `Some` only for
-    /// writable THP-eligible ranges on the **primary** (local) mapper on Windows
-    /// (soft large pages); `None` otherwise — non-primary (device/DMA) mappers,
-    /// non-THP ranges, and non-Windows hosts spend nothing. The fault paths
-    /// claim a region, materialize backing, and bump counters while holding the
-    /// mapping-index read lock.
-    ///
-    /// `Some` also marks the range (private or shared) as "deferred protect":
-    /// committed/mapped read-only and upgraded to read-write — then materialized
-    /// with a 2 MB prefetch — a window at a time on first write.
+    /// Soft-large-page (Windows THP) state, or `None` when the scheme does not
+    /// apply (non-primary/device mappers, read-only or non-THP ranges, and every
+    /// non-Windows host). See the [`soft_lp`] module.
     soft_lp: Option<SoftLp>,
-}
-
-/// Per-mapping soft-large-page state: the first-fault bitmap plus the
-/// large-page prefetch/promotion counters. Stored inline in [`MappingProps`]
-/// and accessed by the fault paths under the mapping-index read lock.
-#[derive(Debug)]
-struct SoftLp {
-    first_fault: FirstFault,
-    stats: SoftLpStats,
-}
-
-/// Per-mapping counters for the soft-large-page (2 MB window) machinery,
-/// exposed via `Inspect`. These track only the large-page-specific work —
-/// prefetching and promoting 2 MB windows. General fault accounting (the faults
-/// that drive this work) lives in [`FaultStats`].
-///
-/// Kept per mapping (one backing, and thus one set of counters, per NUMA node)
-/// so they scale for large multi-NUMA-node VMs rather than contending on a
-/// single global counter.
-#[derive(Debug, Default, Inspect)]
-struct SoftLpStats {
-    /// 2 MB windows prefetched on the host fault path.
-    host_prefetches: SharedCounter,
-    /// 2 MB windows promoted (first-fault widen) on the guest fault path.
-    guest_promotions: SharedCounter,
-    /// 2 MB windows pre-populated eagerly at build time (prefetch).
-    eager_promotions: SharedCounter,
-    /// Best-effort prefetch failures (no free large page, or pre-Win11).
-    prefetch_failures: SharedCounter,
 }
 
 /// Per-mapping fault counters, exposed via `Inspect`.
@@ -185,10 +148,6 @@ struct SoftLpStats {
 /// (`SharedCounter`), bumped in place under the mapping-index read lock.
 #[derive(Debug, Default, Inspect)]
 struct FaultStats {
-    /// Host write faults that raised a soft-large-page deferred-protect window
-    /// to read-write (e.g. the loader's first write to a window). Nonzero only
-    /// for soft-large-page mappings (Windows, primary mapper, THP-eligible).
-    deferred_protect_faults: SharedCounter,
     /// Guest memory faults resolved for this mapping.
     guest_faults: SharedCounter,
 }
@@ -247,7 +206,7 @@ impl Inspect for VaMapper {
                             let mut resp = req.respond();
                             resp.field("faults", &props.stats);
                             if let Some(sl) = &props.soft_lp {
-                                resp.field("soft_large_pages", &sl.stats);
+                                resp.field("soft_large_pages", sl);
                             }
                         }),
                     );
@@ -282,6 +241,12 @@ struct MapperInner {
     /// since this is the mapping whose host backing drives the guest's SLAT.
     /// Secondary mappers use plain read-write 4 KB pages. See [`MapperRole`].
     primary: bool,
+    /// Whether the partition delivers guest-memory-access faults to the VMM.
+    /// Soft large pages map a window read-only and rely on the resulting write
+    /// fault being resolved to raise it, so without fault resolution they would
+    /// wedge on the first guest write; the primary mapper only enables them when
+    /// this is set.
+    supports_memory_fault_resolution: bool,
     req_send: mesh::Sender<MappingRequest>,
 }
 
@@ -372,23 +337,26 @@ impl MapperTask {
 
     /// Establishes a mapping in the VA space, dispatching on how it is backed.
     fn map(&self, params: MappingParams) -> Result<(), MappingError> {
-        // Soft large pages are a Windows-only, THP-only feature that matters only
-        // on the **primary** mapper: the partition and the loader run against its
-        // VA, so that is the only place a large host backing yields a 2 MB SLAT
-        // entry. Non-primary (device/DMA) mappers, read-only mappings (e.g. ROM),
-        // non-THP ranges, and non-Windows hosts use plain read-write 4 KB pages.
-        let soft_lp = cfg!(windows)
-            && params.policy.transparent_hugepages
-            && params.writable
-            && self.inner.primary;
+        // Soft large pages apply only to writable THP-eligible RAM on the primary
+        // mapper (Windows); `SoftLp::new` returns `None` otherwise. See the
+        // `soft_lp` module. They also depend on the partition delivering write
+        // faults to raise deferred-protect windows, so don't even build one when
+        // the partition can't resolve faults.
+        let soft_lp = if self.inner.supports_memory_fault_resolution {
+            SoftLp::new(
+                params.range,
+                &params.policy,
+                params.writable,
+                self.inner.primary,
+            )
+        } else {
+            None
+        };
 
-        // Deferred protect (map read-only, populate lazily on the first write
-        // fault) drives the *lazy* soft-LP path. When the range is prefetched it
-        // is populated *eagerly* at build time instead, so it stays read-write
-        // (the build-time populate cannot access a read-only mapping) and its
-        // 2 MB windows start already-attempted.
-        let prefetch = soft_lp && params.policy.prefetch;
-        let deferred_protect = soft_lp && !prefetch;
+        // Deferred protect (map read-only, raise on the first write fault) drives
+        // the lazy soft-LP path; prefetched ranges are populated read-write
+        // eagerly at build time instead.
+        let deferred_protect = soft_lp.as_ref().is_some_and(SoftLp::deferred_protect);
 
         let private = match &params.backing {
             MappingBacking::File {
@@ -408,20 +376,7 @@ impl MapperTask {
             MappingProps {
                 private,
                 stats: FaultStats::default(),
-                soft_lp: soft_lp.then(|| {
-                    let regions = large_region_count(params.range);
-                    let stats = SoftLpStats::default();
-                    // Prefetched ranges are populated up front, so mark every
-                    // window attempted and count them as eager promotions; lazy
-                    // ranges start unattempted.
-                    let first_fault = if prefetch {
-                        stats.eager_promotions.add(regions);
-                        FirstFault::new_all_claimed(regions)
-                    } else {
-                        FirstFault::new(regions)
-                    };
-                    SoftLp { first_fault, stats }
-                }),
+                soft_lp,
             },
         );
         Ok(())
@@ -762,6 +717,15 @@ impl VaMapper {
         eager: bool,
         role: MapperRole,
     ) -> Result<Self, VaMapperError> {
+        // Soft large pages apply only to the primary mapper, and only when the
+        // partition resolves faults; `supports_memory_fault_resolution` rides on
+        // the `Primary` variant.
+        let (primary, supports_memory_fault_resolution) = match role {
+            MapperRole::Primary {
+                supports_memory_fault_resolution,
+            } => (true, supports_memory_fault_resolution),
+            MapperRole::Secondary => (false, false),
+        };
         let mapping = match &remote_process {
             None => SparseMapping::new_with_minimum_alignment(
                 len as usize,
@@ -791,7 +755,8 @@ impl VaMapper {
             waiters: Mutex::new(Some(Vec::new())),
             mappings: RwLock::new(RangeMap::new()),
             eager: AtomicBool::new(eager),
-            primary: role == MapperRole::Primary,
+            primary,
+            supports_memory_fault_resolution,
             req_send,
         });
 
@@ -896,53 +861,22 @@ unsafe impl GuestMemoryAccess for VaMapper {
         // Soft large pages (Windows): THP-eligible ranges on the primary mapper
         // are committed/mapped read-only, so the first *write* traps here (reads
         // are served by the zero page and don't fault). This is the loader's
-        // path: raise the whole 2 MB window to read-write and prefetch it so the
-        // OS can back it with a contiguous large page, then retry the write.
-        // Applies to both private and shared (section) RAM.
-        //
-        // The mapping-index read lock is held across the protect/prefetch
-        // syscalls. This only blocks a concurrent *writer* (a structural
-        // map/unmap), which is rare; other faulting VPs are readers and proceed
-        // in parallel.
+        // path; `SoftLp::on_host_write` raises (and prefetches) the covering
+        // 2 MB window, then the write is retried. The mapping-index read lock is
+        // held across the raise; it only blocks a concurrent *writer* (a
+        // structural map/unmap), which is rare.
         #[cfg(windows)]
         if write {
             let mappings = self.inner.mappings.read();
             if let Some(&(start, end, ref props)) = mappings.get_entry(&address) {
                 if let Some(sl) = &props.soft_lp {
-                    // A hit on the write-fault path is a deferred-protect fault.
-                    props.stats.deferred_protect_faults.increment();
-                    let win_base = address & !(LARGE_PAGE_SIZE - 1);
-                    let prot_start = win_base.max(start);
-                    let prot_end = (win_base + LARGE_PAGE_SIZE).min(end + 1);
-                    let off = prot_start as usize;
-                    let plen = (prot_end - prot_start) as usize;
-                    // Raise to read-write (idempotent) so the write proceeds.
-                    if let Err(err) = self.inner.mapping.protect(off, plen, PAGE_READWRITE) {
-                        return PageFaultAction::Fail(PageFaultError::new(
+                    return match sl.on_host_write(&self.inner.mapping, address, start, end) {
+                        Ok(()) => PageFaultAction::Retry,
+                        Err(err) => PageFaultAction::Fail(PageFaultError::new(
                             GuestMemoryErrorKind::Other,
-                            FaultError::Protect(
-                                MemoryRange::new(off as u64..(off + plen) as u64),
-                                err,
-                            ),
-                        ));
-                    }
-                    // Prefetch the whole window in one call so the OS can back it
-                    // with a contiguous large page. Best-effort: a failure
-                    // (pre-Win11, or no large page available) just leaves 4 KB
-                    // backing, so log and proceed. No first-fault claim here —
-                    // leave the guest-side 2 MB widen to `resolve`; a later
-                    // redundant prefetch over resident pages is harmless.
-                    if let Err(err) = self.inner.mapping.prefetch(off, plen) {
-                        sl.stats.prefetch_failures.increment();
-                        tracing::debug!(
-                            error = &err as &dyn std::error::Error,
-                            address,
-                            "soft large page prefetch failed"
-                        );
-                    } else {
-                        sl.stats.host_prefetches.increment();
-                    }
-                    return PageFaultAction::Retry;
+                            err,
+                        )),
+                    };
                 }
             }
         }
@@ -982,10 +916,6 @@ unsafe impl GuestMemoryAccess for VaMapper {
     }
 }
 
-/// The soft-large-page granularity (2 MB) used for opportunistic large SLAT
-/// entries and the per-region first-fault bitmap.
-const LARGE_PAGE_SIZE: u64 = 2 * 1024 * 1024;
-
 impl ResolveMemoryFault for VaMapper {
     fn resolve(
         &self,
@@ -1000,22 +930,10 @@ impl ResolveMemoryFault for VaMapper {
             ));
         }
 
-        // Widen to a 2 MB soft large page only on the first *write* fault of a
-        // 2 MB window that both contains the whole fault and lies entirely within
-        // one THP-eligible mapping. Read faults are served read-only from the
-        // zero page and must not claim the window, so that the later first write
-        // still gets its one widening attempt (spending a large page only on the
-        // written working set). Every re-fault of an already-attempted region
-        // (e.g. after the host trimmer reclaimed the pages) resolves to the
-        // caller's range to avoid a hard-fault storm.
-        let base = fault.start() & !(LARGE_PAGE_SIZE - 1);
-        let window_end = base + LARGE_PAGE_SIZE;
-
-        // Hold the mapping-index read lock across the widen decision and the
-        // protect/prefetch syscalls below. This only blocks a concurrent
-        // *writer* (a structural map/unmap), which is rare; other faulting VPs
-        // are readers and proceed in parallel. `end` is the inclusive last
-        // address of the mapping.
+        // Hold the mapping-index read lock across the fault resolution. This only
+        // blocks a concurrent *writer* (a structural map/unmap), which is rare;
+        // other faulting VPs are readers and proceed in parallel. `end` is the
+        // inclusive last address of the mapping.
         let mappings = self.inner.mappings.read();
         let Some(&(start, end, ref props)) = mappings.get_entry(&fault.start()) else {
             return Err(GuestMemoryBackingError::new(
@@ -1037,143 +955,23 @@ impl ResolveMemoryFault for VaMapper {
             ));
         }
         props.stats.guest_faults.increment();
-        let soft_lp = props.soft_lp.as_ref();
 
-        let full_window = fault.end() <= window_end && base >= start && window_end <= end + 1;
-        // Only a write fault claims the window (see the widen comment above); a
-        // read fault leaves `first_fault` clear so the first write can still
-        // widen.
-        let widen = write
-            && full_window
-            && soft_lp.is_some_and(|sl| {
-                sl.first_fault
-                    .try_claim(base / LARGE_PAGE_SIZE - start / LARGE_PAGE_SIZE)
-            });
-        if widen {
-            // `widen` implies `soft_lp` is `Some`.
-            if let Some(sl) = soft_lp {
-                sl.stats.guest_promotions.increment();
-            }
-        }
-
-        // Deferred protect (Windows soft large pages): the range (private or
-        // shared) is committed/mapped read-only, so a write fault must raise it
-        // to read-write before the guest can proceed. Raise the whole 2 MB window
-        // when it lies within the mapping and, on the window's first fault
-        // (`widen`), prefetch it so the OS can back it with a large page;
-        // otherwise raise just the faulting range. Read faults leave the range
-        // read-only (served by the zero page), spending a large page only on the
-        // written working set.
-        #[cfg(windows)]
-        if write {
-            if let Some(sl) = soft_lp {
-                let (prot_start, prot_end) = if full_window {
-                    (base, window_end)
-                } else {
-                    // Clamp to the mapping (`end` is inclusive) so a fault range
-                    // that spills past the region never protects an adjacent one.
-                    (fault.start().max(start), fault.end().min(end + 1))
-                };
-                if let Err(err) = self.inner.mapping.protect(
-                    prot_start as usize,
-                    (prot_end - prot_start) as usize,
-                    PAGE_READWRITE,
-                ) {
-                    return Err(GuestMemoryBackingError::new(
-                        GuestMemoryErrorKind::Other,
-                        fault.start(),
-                        FaultError::Protect(MemoryRange::new(prot_start..prot_end), err),
-                    ));
-                }
-                if widen {
-                    // Prefetch the whole window in one call so the OS can back it
-                    // with a contiguous large page. Best-effort: a failure
-                    // (pre-Win11, or no large page available) just leaves 4 KB
-                    // backing.
-                    if let Err(err) = self
-                        .inner
-                        .mapping
-                        .prefetch(base as usize, LARGE_PAGE_SIZE as usize)
-                    {
-                        sl.stats.prefetch_failures.increment();
-                        tracing::debug!(
-                            error = &err as &dyn std::error::Error,
-                            gpa = fault.start(),
-                            "soft large page prefetch failed"
-                        );
-                    }
-                }
-            }
-        }
-
-        Ok(if widen {
-            MemoryRange::new(base..window_end)
-        } else {
-            fault
-        })
-    }
-}
-
-/// Number of aligned 2 MB regions spanned by `range` (by absolute 2 MB region
-/// index), used to size a per-range [`FirstFault`] bitmap.
-fn large_region_count(range: MemoryRange) -> u64 {
-    (range.end() - 1) / LARGE_PAGE_SIZE - range.start() / LARGE_PAGE_SIZE + 1
-}
-
-/// Per-2 MB-region first-fault bitmap for a single THP-eligible mapping (Windows
-/// soft large pages). A set bit means the region has already made its one
-/// soft-large-page widening attempt; later faults resolve to a single page to
-/// avoid a hard-fault storm.
-///
-/// Allocated per range and only for THP RAM on Windows, so guests without THP —
-/// and every non-Windows guest — pay nothing.
-#[derive(Debug)]
-struct FirstFault(Box<[AtomicU64]>);
-
-impl FirstFault {
-    /// Allocates a bitmap covering `regions` 2 MB regions, all bits clear.
-    fn new(regions: u64) -> Self {
-        let words = regions.div_ceil(64);
-        Self(
-            (0..words)
-                .map(|_| AtomicU64::new(0))
-                .collect::<Vec<_>>()
-                .into_boxed_slice(),
-        )
-    }
-
-    /// Allocates a bitmap covering `regions` 2 MB regions with every window
-    /// already marked attempted. Used for prefetched ranges: the large pages
-    /// are built eagerly at build time, so the lazy `resolve` path never
-    /// re-widens a window. Bits past `regions` in the final word are set too,
-    /// but are never indexed.
-    fn new_all_claimed(regions: u64) -> Self {
-        let words = regions.div_ceil(64);
-        Self(
-            (0..words)
-                .map(|_| AtomicU64::new(!0))
-                .collect::<Vec<_>>()
-                .into_boxed_slice(),
-        )
-    }
-
-    /// Atomically tests and sets the bit for `region`. Returns true if this
-    /// call won the race (the bit was previously clear).
-    fn try_claim(&self, region: u64) -> bool {
-        let word = (region / 64) as usize;
-        let bit = 1u64 << (region % 64);
-        match self.0.get(word) {
-            Some(slot) => slot.fetch_or(bit, Ordering::Relaxed) & bit == 0,
-            None => false,
+        // Soft large pages (Windows) raise the covering 2 MB window on the first
+        // write and may resolve to the whole window; every other mapping (and
+        // every non-Windows host) resolves to the single faulting page.
+        match &props.soft_lp {
+            Some(sl) => sl
+                .resolve(&self.inner.mapping, fault, write, start, end)
+                .map_err(|err| {
+                    GuestMemoryBackingError::new(GuestMemoryErrorKind::Other, fault.start(), err)
+                }),
+            None => Ok(fault),
         }
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::FirstFault;
-    use super::large_region_count;
-    use memory_range::MemoryRange;
     use sparse_mmap::SparseMapping;
 
     /// Tests that private RAM pages can be allocated, written to, and read from.
@@ -1220,85 +1018,5 @@ mod tests {
         let mut buf = vec![0u8; 64];
         mapping.read_at(0, &mut buf).unwrap();
         assert_eq!(buf, pattern);
-    }
-
-    /// `try_claim` is one-shot: the first claim of a region wins and every
-    /// subsequent claim of the same region loses until it is (never) cleared.
-    #[test]
-    fn first_fault_try_claim_is_one_shot() {
-        let ff = FirstFault::new(4);
-        // First claim of each region wins.
-        for region in 0..4 {
-            assert!(ff.try_claim(region), "first claim of region {region}");
-        }
-        // Repeat claims of the same regions all lose.
-        for region in 0..4 {
-            assert!(!ff.try_claim(region), "repeat claim of region {region}");
-        }
-    }
-
-    /// Claims are independent across regions, including across the 64-bit word
-    /// boundary of the underlying bitmap.
-    #[test]
-    fn first_fault_claims_are_independent() {
-        // Enough regions to span more than one 64-bit word.
-        let ff = FirstFault::new(130);
-        assert!(ff.try_claim(0));
-        assert!(ff.try_claim(63));
-        assert!(ff.try_claim(64));
-        assert!(ff.try_claim(129));
-        // Claiming one region does not claim its neighbors.
-        assert!(ff.try_claim(1));
-        assert!(ff.try_claim(65));
-        // But the already-claimed regions stay claimed.
-        assert!(!ff.try_claim(0));
-        assert!(!ff.try_claim(64));
-    }
-
-    /// Region indices past the end of the allocated bitmap return false rather
-    /// than panicking, so a stray claim can never index out of bounds. (The
-    /// bitmap rounds up to whole 64-bit words, so indices in the final word's
-    /// padding are still claimable; callers only ever pass valid region
-    /// indices.)
-    #[test]
-    fn first_fault_out_of_range_returns_false() {
-        // One region rounds up to a single 64-bit word, so word 1 and beyond are
-        // out of range.
-        let ff = FirstFault::new(1);
-        assert!(!ff.try_claim(64));
-        assert!(!ff.try_claim(1_000_000));
-    }
-
-    /// `new_all_claimed` starts fully claimed, so no in-range window is ever
-    /// widened (used for eagerly prefetched ranges).
-    #[test]
-    fn first_fault_new_all_claimed_prevents_widening() {
-        let regions = 100;
-        let ff = FirstFault::new_all_claimed(regions);
-        for region in 0..regions {
-            assert!(
-                !ff.try_claim(region),
-                "region {region} should already be claimed"
-            );
-        }
-    }
-
-    /// `large_region_count` counts the aligned 2 MB regions a range spans by
-    /// absolute region index, so a range that straddles a 2 MB boundary spans
-    /// two regions even when it is smaller than 2 MB.
-    #[test]
-    fn large_region_count_spans() {
-        const LP: u64 = super::LARGE_PAGE_SIZE;
-        // A single page at the start of a region spans one region.
-        assert_eq!(large_region_count(MemoryRange::new(0..0x1000)), 1);
-        // A full aligned region spans one region.
-        assert_eq!(large_region_count(MemoryRange::new(0..LP)), 1);
-        // A range straddling a 2 MB boundary spans two regions.
-        assert_eq!(
-            large_region_count(MemoryRange::new(LP - 0x1000..LP + 0x1000)),
-            2
-        );
-        // Two full aligned regions span two regions.
-        assert_eq!(large_region_count(MemoryRange::new(0..2 * LP)), 2);
     }
 }

--- a/openvmm/membacking/src/mapping_manager/va_mapper/soft_lp.rs
+++ b/openvmm/membacking/src/mapping_manager/va_mapper/soft_lp.rs
@@ -1,0 +1,421 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Windows "soft large pages" (Transparent Huge Pages) for the primary VA
+//! mapper.
+//!
+//! THP-eligible, writable guest RAM on the primary mapper is committed/mapped
+//! **read-only** (see [`SoftLp::deferred_protect`]); the first *write* to a
+//! 2 MB window raises it to read-write and prefetches it, so the OS can back it
+//! with a contiguous large page that the hypervisor maps as a single 2 MB SLAT
+//! entry instead of the 512 fragmented 4 KB entries that dribbled per-page
+//! writes would produce. Both fault paths funnel through the same
+//! [`raise_window`](SoftLp::raise_window):
+//!
+//! - [`SoftLp::resolve`] — a guest access forwarded by the hypervisor; it also
+//!   decides the range to hand back so a full window populates the SLAT as one
+//!   2 MB entry.
+//! - [`SoftLp::on_host_write`] — a host-side write (e.g. the loader) that traps
+//!   through the VA mapper's `page_fault`.
+//!
+//! Funneling through one routine means each window is protected and prefetched
+//! exactly once regardless of which side touches it first.
+//!
+//! `protect` invalidates the partition's SLAT mapping of the affected range
+//! (splitting any large page and forcing every page in it to re-fault), so it
+//! must run exactly once per window: re-protecting an already-raised window
+//! would invalidate all ~512 of its pages, each re-faulting and re-protecting —
+//! a self-sustaining fault storm. A lock-free "raised" bitmap ([`FirstFault`])
+//! is the fast path, and a per-mapping [`raise_lock`](SoftLp::raise_lock) elects
+//! a single protector so concurrent faulters of the same still-read-only window
+//! sleep on the lock rather than re-fault.
+//!
+//! This module is compiled only on Windows; other targets get an uninhabited
+//! stub (see the non-Windows `soft_lp` module) so the fault paths need no
+//! per-item `cfg`s. Even on Windows, [`SoftLp::new`] returns `None` for
+//! non-THP, read-only, or non-primary mappings, so those pay nothing.
+
+use super::super::manager::MemoryPolicy;
+use inspect::Inspect;
+use inspect_counters::SharedCounter;
+use memory_range::MemoryRange;
+use parking_lot::Mutex;
+use sparse_mmap::SparseMapping;
+use std::sync::atomic::AtomicU64;
+use std::sync::atomic::Ordering;
+use thiserror::Error;
+use windows_sys::Win32::System::Memory::PAGE_READWRITE;
+
+/// The soft-large-page granularity (2 MB), used for opportunistic large SLAT
+/// entries and the per-region raised bitmap.
+pub(super) const LARGE_PAGE_SIZE: u64 = 2 * 1024 * 1024;
+
+/// Failure raising a 2 MB window to read-write. Carries the range and the
+/// underlying OS error as its [`source`](std::error::Error::source), so the
+/// passed-up guest-memory error identifies the failed operation rather than
+/// surfacing a bare OS error code.
+#[derive(Debug, Error)]
+#[error("failed to raise window {0} to read-write")]
+pub(super) struct RaiseError(MemoryRange, #[source] std::io::Error);
+
+/// Per-mapping soft-large-page state and logic.
+///
+/// Constructed (via [`SoftLp::new`]) only for THP-eligible, writable
+/// primary-mapper RAM on Windows; stored inline in the VA mapper's per-mapping
+/// properties and driven by the guest ([`resolve`](Self::resolve)) and host
+/// ([`on_host_write`](Self::on_host_write)) fault paths.
+#[derive(Debug)]
+pub(super) struct SoftLp {
+    /// Per-2 MB-window "raised" bitmap, the lock-free fast path for the raise.
+    raised: FirstFault,
+    /// Serializes raising a window to read-write within this mapping. Each
+    /// mapping is a single VAD, so `protect` already takes that VAD's exclusive
+    /// lock in the kernel; this userspace lock therefore adds no serialization
+    /// the kernel would not already impose, and lets a concurrent faulter of the
+    /// same (still-read-only) window sleep here until the winner's `protect`
+    /// lands rather than re-faulting in a tight loop. Only the raise takes it;
+    /// the already-raised fast path is lock-free.
+    raise_lock: Mutex<()>,
+    /// Whether the mapping is committed/mapped read-only at build time (so the
+    /// first write faults and raises the window). False for prefetched ranges,
+    /// which are populated read-write eagerly.
+    deferred_protect: bool,
+    stats: SoftLpStats,
+}
+
+impl SoftLp {
+    /// Creates soft-LP state for a mapping, or `None` if soft large pages do not
+    /// apply: a non-Windows host, THP disabled, or a read-only / non-primary
+    /// mapping. (Only the **primary** mapper matters — the partition and loader
+    /// run against its VA, so it is the only place a large host backing yields a
+    /// 2 MB SLAT entry.)
+    ///
+    /// `prefetch` marks a range populated read-write eagerly at build time: its
+    /// windows start already raised and it is not deferred-protected.
+    pub(super) fn new(
+        range: MemoryRange,
+        policy: &MemoryPolicy,
+        writable: bool,
+        primary: bool,
+    ) -> Option<Self> {
+        // Soft large pages are THP-only and matter only on the writable primary
+        // mapper (the partition and loader run against its VA).
+        let applies = policy.transparent_hugepages && writable && primary;
+        if !applies {
+            return None;
+        }
+        let regions = large_region_count(range);
+        let stats = SoftLpStats::default();
+        // Prefetched ranges are populated up front, so mark every window raised
+        // and count them as eager promotions; lazy ranges start unraised.
+        let raised = if policy.prefetch {
+            stats.eager_promotions.add(regions);
+            FirstFault::new_all_raised(regions)
+        } else {
+            FirstFault::new(regions)
+        };
+        Some(Self {
+            raised,
+            raise_lock: Mutex::new(()),
+            deferred_protect: !policy.prefetch,
+            stats,
+        })
+    }
+
+    /// Whether the mapping should be committed/mapped read-only at build time so
+    /// the first write faults and raises the covering window. False for
+    /// prefetched (eagerly populated read-write) ranges.
+    pub(super) fn deferred_protect(&self) -> bool {
+        self.deferred_protect
+    }
+
+    /// Resolves a guest fault against this mapping.
+    ///
+    /// The first *write* to a window raises it to read-write (a read is served
+    /// read-only from the zero page, spending a large page only on the written
+    /// working set). Returns the range the hypervisor should map: the whole
+    /// 2 MB window when a write lands on a full aligned window (so it maps as one
+    /// large SLAT entry, whether this fault or an earlier host write raised it),
+    /// otherwise the single faulting page. `start`/`end` are the mapping's first
+    /// and inclusive-last addresses.
+    pub(super) fn resolve(
+        &self,
+        mapping: &SparseMapping,
+        fault: MemoryRange,
+        write: bool,
+        start: u64,
+        end: u64,
+    ) -> Result<MemoryRange, RaiseError> {
+        let base = fault.start() & !(LARGE_PAGE_SIZE - 1);
+        let window_end = base + LARGE_PAGE_SIZE;
+        let full_window = fault.end() <= window_end && base >= start && window_end <= end + 1;
+        if write {
+            let region = base / LARGE_PAGE_SIZE - start / LARGE_PAGE_SIZE;
+            // Whole 2 MB window clamped to the mapping; for a full window this is
+            // exactly `base..window_end`.
+            let prot = MemoryRange::new(base.max(start)..window_end.min(end + 1));
+            if self.raise_window(mapping, region, prot, full_window)? && full_window {
+                self.stats.guest_promotions.increment();
+            }
+            if full_window {
+                // The window is now read-write across its whole span; map it as
+                // one 2 MB SLAT entry.
+                return Ok(MemoryRange::new(base..window_end));
+            }
+        }
+        Ok(fault)
+    }
+
+    /// Raises the 2 MB window covering a host write fault (e.g. the loader or a
+    /// device DMA writing guest RAM through the VA mapping). `start`/`end` are
+    /// the mapping's first and inclusive-last addresses.
+    pub(super) fn on_host_write(
+        &self,
+        mapping: &SparseMapping,
+        address: u64,
+        start: u64,
+        end: u64,
+    ) -> Result<(), RaiseError> {
+        self.stats.deferred_protect_faults.increment();
+        let win_base = address & !(LARGE_PAGE_SIZE - 1);
+        let full_window = win_base >= start && win_base + LARGE_PAGE_SIZE <= end + 1;
+        let region = win_base / LARGE_PAGE_SIZE - start / LARGE_PAGE_SIZE;
+        // Whole 2 MB window clamped to the mapping.
+        let prot = MemoryRange::new(win_base.max(start)..(win_base + LARGE_PAGE_SIZE).min(end + 1));
+        if self.raise_window(mapping, region, prot, full_window)? && full_window {
+            self.stats.host_promotions.increment();
+        }
+        Ok(())
+    }
+
+    /// Raises a window to read-write exactly once, serialized by
+    /// [`raise_lock`](Self::raise_lock), and — for a full 2 MB window —
+    /// prefetches it so the OS can back it with a contiguous large page.
+    ///
+    /// A lock-free `is_raised` fast path skips the raise for already-read-write
+    /// windows; otherwise the lock elects a single protector (the losers sleep
+    /// on the lock, not re-fault, and find the window raised on wake). The bit
+    /// is set only after a successful `protect`, so a failed protect leaves the
+    /// window unraised for a later fault to retry. `prot` must be the whole 2 MB
+    /// window clamped to the mapping, never just the faulting page: a later write
+    /// to any other page in the window finds it raised and skips the protect, so
+    /// every page must already be read-write.
+    ///
+    /// Returns `Ok(true)` if this call performed the raise, `Ok(false)` if the
+    /// window was already raised (read-write on return either way).
+    fn raise_window(
+        &self,
+        mapping: &SparseMapping,
+        region: u64,
+        prot: MemoryRange,
+        full_window: bool,
+    ) -> Result<bool, RaiseError> {
+        // Fast path: already raised, no lock.
+        if self.raised.is_raised(region) {
+            return Ok(false);
+        }
+        {
+            let _guard = self.raise_lock.lock();
+            // Re-check under the lock: a concurrent winner may have raised it
+            // while we waited.
+            if self.raised.is_raised(region) {
+                return Ok(false);
+            }
+            mapping
+                .protect(prot.start() as usize, prot.len() as usize, PAGE_READWRITE)
+                .map_err(|e| RaiseError(prot, e))?;
+            self.raised.set_raised(region);
+        }
+        // Prefetch outside the lock (best-effort): only a full window can be
+        // backed by a large page. A failure (pre-Win11, or no large page free)
+        // just leaves 4 KB backing.
+        if full_window {
+            if let Err(err) = mapping.prefetch(prot.start() as usize, prot.len() as usize) {
+                self.stats.prefetch_failures.increment();
+                tracing::debug!(
+                    error = &err as &dyn std::error::Error,
+                    gpa = prot.start(),
+                    "soft large page prefetch failed"
+                );
+            }
+        }
+        Ok(true)
+    }
+}
+
+impl Inspect for SoftLp {
+    fn inspect(&self, req: inspect::Request<'_>) {
+        self.stats.inspect(req);
+    }
+}
+
+/// Per-mapping counters for the soft-large-page (2 MB window) machinery,
+/// exposed via `Inspect`.
+///
+/// Kept per mapping (one backing, and thus one set of counters, per NUMA node)
+/// so they scale for large multi-NUMA-node VMs rather than contending on a
+/// single global counter.
+#[derive(Debug, Default, Inspect)]
+struct SoftLpStats {
+    /// 2 MB windows raised + prefetched on the host (loader/DMA) fault path.
+    host_promotions: SharedCounter,
+    /// 2 MB windows raised + prefetched on the guest fault path.
+    guest_promotions: SharedCounter,
+    /// 2 MB windows pre-populated eagerly at build time (prefetch).
+    eager_promotions: SharedCounter,
+    /// Best-effort prefetch failures (no free large page, or pre-Win11).
+    prefetch_failures: SharedCounter,
+    /// Host write faults that trapped into a deferred-protect (read-only)
+    /// window (e.g. the loader's first write to a window).
+    deferred_protect_faults: SharedCounter,
+}
+
+/// Number of aligned 2 MB regions spanned by `range` (by absolute 2 MB region
+/// index), used to size a per-range [`FirstFault`] bitmap.
+fn large_region_count(range: MemoryRange) -> u64 {
+    (range.end() - 1) / LARGE_PAGE_SIZE - range.start() / LARGE_PAGE_SIZE + 1
+}
+
+/// Per-2 MB-region "raised" bitmap for a single THP-eligible mapping. A set bit
+/// means the region has been raised to read-write (its deferred protect has been
+/// applied). The bit is set only *after* the `protect` succeeds and while
+/// holding the mapping's `raise_lock`, so a failed raise leaves it clear (and is
+/// retried by a later fault); a lock-free reader uses it as the fast path that
+/// skips the raise for already-read-write windows.
+#[derive(Debug)]
+struct FirstFault(Box<[AtomicU64]>);
+
+impl FirstFault {
+    /// Allocates a bitmap covering `regions` 2 MB regions, all bits clear (no
+    /// window raised yet).
+    fn new(regions: u64) -> Self {
+        let words = regions.div_ceil(64);
+        Self(
+            (0..words)
+                .map(|_| AtomicU64::new(0))
+                .collect::<Vec<_>>()
+                .into_boxed_slice(),
+        )
+    }
+
+    /// Allocates a bitmap covering `regions` 2 MB regions with every window
+    /// already marked raised. Used for prefetched ranges: they are populated
+    /// read-write eagerly at build time, so the lazy `resolve` path never needs
+    /// to raise them. Bits past `regions` in the final word are set too, but are
+    /// never indexed.
+    fn new_all_raised(regions: u64) -> Self {
+        let words = regions.div_ceil(64);
+        Self(
+            (0..words)
+                .map(|_| AtomicU64::new(!0))
+                .collect::<Vec<_>>()
+                .into_boxed_slice(),
+        )
+    }
+
+    /// Returns whether `region` has been raised. Lock-free (`Acquire`), used as
+    /// the fast path before taking the raise lock.
+    fn is_raised(&self, region: u64) -> bool {
+        let word = (region / 64) as usize;
+        let bit = 1u64 << (region % 64);
+        match self.0.get(word) {
+            Some(slot) => slot.load(Ordering::Acquire) & bit != 0,
+            None => false,
+        }
+    }
+
+    /// Marks `region` raised. Called under the mapping's `raise_lock` after the
+    /// `protect` succeeds; the `Release` pairs with [`FirstFault::is_raised`]'s
+    /// `Acquire` so a fast-path reader that sees the bit also sees the protect.
+    fn set_raised(&self, region: u64) {
+        let word = (region / 64) as usize;
+        let bit = 1u64 << (region % 64);
+        if let Some(slot) = self.0.get(word) {
+            slot.fetch_or(bit, Ordering::Release);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::FirstFault;
+    use super::LARGE_PAGE_SIZE;
+    use super::large_region_count;
+    use memory_range::MemoryRange;
+
+    /// A window starts unraised and, once `set_raised`, reads back raised.
+    #[test]
+    fn raise_is_sticky() {
+        let ff = FirstFault::new(4);
+        // Every region starts unraised.
+        for region in 0..4 {
+            assert!(!ff.is_raised(region), "region {region} starts unraised");
+        }
+        // Raising a region sticks.
+        for region in 0..4 {
+            ff.set_raised(region);
+            assert!(ff.is_raised(region), "region {region} raised");
+        }
+    }
+
+    /// Raises are independent across regions, including across the 64-bit word
+    /// boundary of the underlying bitmap.
+    #[test]
+    fn raises_are_independent() {
+        // Enough regions to span more than one 64-bit word.
+        let ff = FirstFault::new(130);
+        ff.set_raised(0);
+        ff.set_raised(64);
+        // Raising one region does not raise its neighbors.
+        assert!(ff.is_raised(0));
+        assert!(!ff.is_raised(1));
+        assert!(ff.is_raised(64));
+        assert!(!ff.is_raised(63));
+        assert!(!ff.is_raised(65));
+        assert!(!ff.is_raised(129));
+    }
+
+    /// Region indices past the end of the allocated bitmap report unraised
+    /// rather than panicking, so a stray query can never index out of bounds.
+    #[test]
+    fn out_of_range_returns_false() {
+        // One region rounds up to a single 64-bit word, so word 1 and beyond are
+        // out of range.
+        let ff = FirstFault::new(1);
+        assert!(!ff.is_raised(64));
+        assert!(!ff.is_raised(1_000_000));
+        // Setting an out-of-range region is a no-op, not a panic.
+        ff.set_raised(1_000_000);
+        assert!(!ff.is_raised(1_000_000));
+    }
+
+    /// `new_all_raised` starts fully raised, so no in-range window is ever
+    /// raised again (used for eagerly prefetched ranges).
+    #[test]
+    fn new_all_raised_is_fully_raised() {
+        let regions = 100;
+        let ff = FirstFault::new_all_raised(regions);
+        for region in 0..regions {
+            assert!(ff.is_raised(region), "region {region} should be raised");
+        }
+    }
+
+    /// `large_region_count` counts the aligned 2 MB regions a range spans by
+    /// absolute region index, so a range that straddles a 2 MB boundary spans
+    /// two regions even when it is smaller than 2 MB.
+    #[test]
+    fn large_region_count_spans() {
+        const LP: u64 = LARGE_PAGE_SIZE;
+        // A single page at the start of a region spans one region.
+        assert_eq!(large_region_count(MemoryRange::new(0..0x1000)), 1);
+        // A full aligned region spans one region.
+        assert_eq!(large_region_count(MemoryRange::new(0..LP)), 1);
+        // A range straddling a 2 MB boundary spans two regions.
+        assert_eq!(
+            large_region_count(MemoryRange::new(LP - 0x1000..LP + 0x1000)),
+            2
+        );
+        // Two full aligned regions span two regions.
+        assert_eq!(large_region_count(MemoryRange::new(0..2 * LP)), 2);
+    }
+}

--- a/openvmm/membacking/src/mapping_manager/va_mapper/soft_lp_stub.rs
+++ b/openvmm/membacking/src/mapping_manager/va_mapper/soft_lp_stub.rs
@@ -1,0 +1,69 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Non-Windows stub for the [`soft_lp`](super::soft_lp) module.
+//!
+//! Soft large pages are a Windows-only optimization (see the Windows module for
+//! the full scheme), so on every other target [`SoftLp`] is uninhabited:
+//! [`SoftLp::new`] always returns `None`, so the value is named in the VA
+//! mapper's per-mapping properties (`Option<SoftLp>`) but never constructed, and
+//! every method is statically unreachable. Providing this stub — rather than
+//! `cfg`-ing each use site — keeps the parent module free of platform gates.
+
+use super::super::manager::MemoryPolicy;
+use inspect::Inspect;
+use memory_range::MemoryRange;
+use sparse_mmap::SparseMapping;
+
+/// Uninhabited stand-in for the Windows `SoftLp`: never constructed off Windows.
+#[derive(Debug)]
+pub(super) enum SoftLp {}
+
+impl SoftLp {
+    /// Soft large pages never apply off Windows, so this always returns `None`.
+    pub(super) fn new(
+        _range: MemoryRange,
+        _policy: &MemoryPolicy,
+        _writable: bool,
+        _primary: bool,
+    ) -> Option<Self> {
+        None
+    }
+
+    /// Unreachable: `SoftLp` is never constructed off Windows.
+    pub(super) fn deferred_protect(&self) -> bool {
+        match *self {}
+    }
+
+    /// Unreachable: `SoftLp` is never constructed off Windows.
+    pub(super) fn resolve(
+        &self,
+        _mapping: &SparseMapping,
+        _fault: MemoryRange,
+        _write: bool,
+        _start: u64,
+        _end: u64,
+    ) -> Result<MemoryRange, RaiseError> {
+        match *self {}
+    }
+}
+
+impl Inspect for SoftLp {
+    fn inspect(&self, _req: inspect::Request<'_>) {
+        match *self {}
+    }
+}
+
+/// Uninhabited error mirror: the stub's [`SoftLp::resolve`] is unreachable, so a
+/// `RaiseError` is never produced, but the VA mapper's fault path names the type
+/// in its error mapping.
+#[derive(Debug)]
+pub(super) enum RaiseError {}
+
+impl std::fmt::Display for RaiseError {
+    fn fmt(&self, _f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match *self {}
+    }
+}
+
+impl std::error::Error for RaiseError {}

--- a/openvmm/membacking/src/memory_manager/mod.rs
+++ b/openvmm/membacking/src/memory_manager/mod.rs
@@ -570,10 +570,14 @@ impl GuestMemoryBuilder {
 
         // The primary mapper is created as part of `MappingManager::new`: it is
         // the loader's target and the partition's fault resolver.
-        let (mapping_manager, va_mapper) =
-            MappingManager::new(&spawner, max_addr, max_hugepage_size)
-                .await
-                .map_err(MemoryBuildError::VaMapper)?;
+        let (mapping_manager, va_mapper) = MappingManager::new(
+            &spawner,
+            max_addr,
+            max_hugepage_size,
+            self.supports_memory_fault_resolution,
+        )
+        .await
+        .map_err(MemoryBuildError::VaMapper)?;
 
         let region_manager = RegionManager::new(&spawner, mapping_manager.client().clone());
 

--- a/vmm_core/virt_whp/src/lib.rs
+++ b/vmm_core/virt_whp/src/lib.rs
@@ -966,10 +966,11 @@ impl ProtoPartition for WhpProtoPartition<'_> {
     }
 
     fn supports_memory_fault_resolution(&self) -> bool {
-        // WHP forwards guest memory-access faults back to the VMM, so the
-        // memory backing can resolve them on demand (soft large pages, lazy
-        // commit).
-        true
+        // On x86-64, WHP forwards guest memory-access faults back to the VMM, so
+        // the memory backing can resolve them on demand (soft large pages, lazy
+        // commit). WHP on aarch64 does not deliver these faults, so the backing
+        // must not defer any commit or protection to a fault.
+        cfg!(guest_arch = "x86_64")
     }
 
     fn build(


### PR DESCRIPTION
Windows soft large pages map a THP-eligible writable window read-only and raise it to read-write on the first write, so the OS can back it with a contiguous large page that the hypervisor maps as one 2 MB SLAT entry. The fault-resolution path did the raise on every write fault, re-running VirtualProtect on windows that were already read-write. On a WHP-mapped host VA, VirtualProtect invalidates the partition's SLAT mapping of the affected range, splitting the large page and forcing every 4 KB page in the window to re-fault — each of which re-protected the window again, a self-sustaining fault storm that stalled boots.

Raise each window exactly once instead. A lock-free "raised" bitmap is the fast path, and a per-mapping lock elects a single protector so concurrent faulters of a still-read-only window sleep rather than re-fault; the bit is set only after a successful protect, so a failed protect is retried by a later fault. Once a window is raised, later faults skip the protect entirely, leaving the large SLAT entry intact.

Soft large pages also only work when the partition delivers write faults back to the VMM to resolve. Don't even build the deferred-protect state unless the partition supports memory fault resolution; otherwise the first guest write to a read-only window would wedge with no one to raise it. Relatedly, correct WHP on aarch64 to report that it does not support memory fault resolution, since it does not deliver these faults.

While here, lift the whole scheme out of the VA mapper into a soft_lp submodule: a Windows implementation plus an uninhabited non-Windows stub, so the mapper's fault paths no longer carry per-item platform cfgs.