### PR TITLE
logview: add a column for github run links in the test details page and the run details page

### DIFF
--- a/petri/logview/src/run_details.tsx
+++ b/petri/logview/src/run_details.tsx
@@ -109,6 +109,14 @@ function RunDetailsHeader({
         )}
       </div>
       <div className="common-header-right">
+        <a
+          href={`https://github.com/microsoft/openvmm/actions/runs/${runId}`}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="common-table-link"
+        >
+          GH Run
+        </a>
         <SearchInput value={searchFilter} onChange={setSearchFilter} />
         <span className="common-result-count">{resultCount} tests</span>
       </div>

--- a/petri/logview/src/table_defs/test_details.tsx
+++ b/petri/logview/src/table_defs/test_details.tsx
@@ -12,7 +12,8 @@ export const defaultSorting = [
 
 export const columnWidthMap = {
     creationTime: 210,
-    status: 60
+    status: 60,
+    runNumber: 120
 };
 
 // Define the columns for the test details table
@@ -67,6 +68,30 @@ export const createColumns = (testName?: string): ColumnDef<TestRunInfo>[] => {
                     <Link to={`/runs/${runNumber}${searchParams}`} className="common-table-link" title={runNumber}>
                         {runNumber}
                     </Link>
+                );
+            },
+            sortingFn: (rowA, rowB, columnId) => {
+                const a = rowA.getValue(columnId) as string;
+                const b = rowB.getValue(columnId) as string;
+                return a.localeCompare(b);
+            },
+        },
+        {
+            id: 'ghRun',
+            accessorKey: 'runNumber',
+            header: 'GH Run',
+            enableSorting: true,
+            cell: (info) => {
+                const runNumber = info.getValue() as string;
+                return (
+                    <a
+                        href={`https://github.com/microsoft/openvmm/actions/runs/${runNumber}`}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="common-table-link"
+                    >
+                        {runNumber}
+                    </a>
                 );
             },
             sortingFn: (rowA, rowB, columnId) => {


### PR DESCRIPTION
Adding feature based on demand. Now has a github run column in the run-details page:
<img width="1902" height="117" alt="image" src="https://github.com/user-attachments/assets/3220cbf2-68c2-4126-a947-b6a633ed9301" />

And also a link in the test-details page:
<img width="1089" height="277" alt="image" src="https://github.com/user-attachments/assets/aa1ea685-8854-4cc7-b940-80e5d52e9578" />
