### PR TITLE
[WIP] Add Hyper-V Azure Disk Encryption (esqe) storage test

### DIFF
--- a/.github/workflows/openvmm-ci.yaml
+++ b/.github/workflows/openvmm-ci.yaml
@@ -4407,6 +4407,14 @@ jobs:
         flowey.exe e 21 flowey_lib_common::download_gh_artifact 0
         flowey.exe e 21 flowey_lib_hvlite::download_release_igvm_files_from_gh::resolve 0
       shell: bash
+    - name: get latest completed action id
+      run: flowey.exe e 21 flowey_lib_common::gh_latest_completed_workflow_id 1
+      shell: bash
+    - name: download artifacts from github actions run
+      run: |-
+        flowey.exe e 21 flowey_lib_common::download_gh_artifact 1
+        flowey.exe e 21 flowey_lib_hvlite::download_release_igvm_files_from_gh::resolve 1
+      shell: bash
     - name: unpack openvmm-test-initrd archives
       run: flowey.exe e 21 flowey_lib_hvlite::resolve_openvmm_test_initrd 0
       shell: bash

--- a/.github/workflows/openvmm-pr-release.yaml
+++ b/.github/workflows/openvmm-pr-release.yaml
@@ -4181,6 +4181,14 @@ jobs:
         flowey.exe e 21 flowey_lib_common::download_gh_artifact 0
         flowey.exe e 21 flowey_lib_hvlite::download_release_igvm_files_from_gh::resolve 0
       shell: bash
+    - name: get latest completed action id
+      run: flowey.exe e 21 flowey_lib_common::gh_latest_completed_workflow_id 1
+      shell: bash
+    - name: download artifacts from github actions run
+      run: |-
+        flowey.exe e 21 flowey_lib_common::download_gh_artifact 1
+        flowey.exe e 21 flowey_lib_hvlite::download_release_igvm_files_from_gh::resolve 1
+      shell: bash
     - name: unpack openvmm-test-initrd archives
       run: flowey.exe e 21 flowey_lib_hvlite::resolve_openvmm_test_initrd 0
       shell: bash

--- a/.github/workflows/openvmm-pr.yaml
+++ b/.github/workflows/openvmm-pr.yaml
@@ -4586,6 +4586,14 @@ jobs:
         flowey.exe e 23 flowey_lib_common::download_gh_artifact 0
         flowey.exe e 23 flowey_lib_hvlite::download_release_igvm_files_from_gh::resolve 0
       shell: bash
+    - name: get latest completed action id
+      run: flowey.exe e 23 flowey_lib_common::gh_latest_completed_workflow_id 1
+      shell: bash
+    - name: download artifacts from github actions run
+      run: |-
+        flowey.exe e 23 flowey_lib_common::download_gh_artifact 1
+        flowey.exe e 23 flowey_lib_hvlite::download_release_igvm_files_from_gh::resolve 1
+      shell: bash
     - name: unpack openvmm-test-initrd archives
       run: flowey.exe e 23 flowey_lib_hvlite::resolve_openvmm_test_initrd 0
       shell: bash

--- a/flowey/flowey_hvlite/src/pipelines/checkin_gates.rs
+++ b/flowey/flowey_hvlite/src/pipelines/checkin_gates.rs
@@ -1438,6 +1438,7 @@ impl IntoPipeline for CheckinGatesCli {
             /// the resolver to supply an incubator artifact.
             incubator_profile: Option<&'a str>,
             nextest_filter_expr: String,
+            needs_release_2505_igvm: bool,
             test_artifacts: Vec<KnownTestArtifacts>,
             prep_steps_variants: Vec<String>,
             hugetlb_2mb_overcommit_pages: Option<u64>,
@@ -1548,6 +1549,7 @@ impl IntoPipeline for CheckinGatesCli {
             resolve_vmm_tests_artifacts,
             incubator_profile,
             nextest_filter_expr,
+            needs_release_2505_igvm,
             test_artifacts,
             prep_steps_variants,
             hugetlb_2mb_overcommit_pages,
@@ -1562,6 +1564,7 @@ impl IntoPipeline for CheckinGatesCli {
                 resolve_vmm_tests_artifacts: vmm_tests_artifacts_windows_intel_x86,
                 incubator_profile: None,
                 nextest_filter_expr: standard_filter.clone(),
+                needs_release_2505_igvm: false,
                 test_artifacts: standard_x64_test_artifacts.clone(),
                 prep_steps_variants: standard_x64_prep_variants.clone(),
                 hugetlb_2mb_overcommit_pages: None,
@@ -1577,6 +1580,7 @@ impl IntoPipeline for CheckinGatesCli {
                 incubator_profile: None,
                 nextest_filter_expr: "test(openhcl) & !test(servicing) & !test(cvm) & !test(memory_validation) & !test(very_heavy) & !test(hyperv_openhcl_pcat) & !test(prepped_vbs) & !test(256mb)"
                     .to_string(),
+                needs_release_2505_igvm: false,
                 test_artifacts: standard_x64_test_artifacts.clone(),
                 prep_steps_variants: Vec::new(),
                 hugetlb_2mb_overcommit_pages: None,
@@ -1591,6 +1595,7 @@ impl IntoPipeline for CheckinGatesCli {
                 resolve_vmm_tests_artifacts: vmm_tests_artifacts_windows_intel_tdx_x86,
                 incubator_profile: None,
                 nextest_filter_expr: cvm_filter("tdx"),
+                needs_release_2505_igvm: true,
                 test_artifacts: cvm_x64_test_artifacts.clone(),
                 prep_steps_variants: vec!["standard".into()],
                 hugetlb_2mb_overcommit_pages: None,
@@ -1607,6 +1612,7 @@ impl IntoPipeline for CheckinGatesCli {
                 resolve_vmm_tests_artifacts: vmm_tests_artifacts_windows_amd_x86,
                 incubator_profile: None,
                 nextest_filter_expr: standard_filter.clone(),
+                needs_release_2505_igvm: false,
                 test_artifacts: standard_x64_test_artifacts.clone(),
                 prep_steps_variants: standard_x64_prep_variants.clone(),
                 hugetlb_2mb_overcommit_pages: None,
@@ -1621,6 +1627,7 @@ impl IntoPipeline for CheckinGatesCli {
                 resolve_vmm_tests_artifacts: vmm_tests_artifacts_windows_amd_snp_x86,
                 incubator_profile: None,
                 nextest_filter_expr: cvm_filter("snp"),
+                needs_release_2505_igvm: false,
                 test_artifacts: cvm_x64_test_artifacts,
                 prep_steps_variants: vec!["standard".into()],
                 hugetlb_2mb_overcommit_pages: None,
@@ -1636,6 +1643,7 @@ impl IntoPipeline for CheckinGatesCli {
                 incubator_profile: None,
                 // - No legal way to obtain gen1 pcat blobs on non-msft linux machines
                 nextest_filter_expr: format!("{standard_filter} & !test(pcat_x64)"),
+                needs_release_2505_igvm: false,
                 test_artifacts: standard_x64_test_artifacts.clone(),
                 prep_steps_variants: standard_x64_prep_variants.clone(),
                 hugetlb_2mb_overcommit_pages: Some(HUGETLB_2MB_OVERCOMMIT_PAGES),
@@ -1652,6 +1660,7 @@ impl IntoPipeline for CheckinGatesCli {
                 incubator_profile: None,
                 // - No legal way to obtain gen1 pcat blobs on non-msft linux machines
                 nextest_filter_expr: format!("{standard_filter} & !test(pcat_x64)"),
+                needs_release_2505_igvm: false,
                 test_artifacts: standard_x64_test_artifacts.clone(),
                 prep_steps_variants: standard_x64_prep_variants.clone(),
                 hugetlb_2mb_overcommit_pages: None,
@@ -1666,6 +1675,7 @@ impl IntoPipeline for CheckinGatesCli {
                 resolve_vmm_tests_artifacts: vmm_tests_artifacts_windows_aarch64,
                 incubator_profile: None,
                 nextest_filter_expr: "all()".to_string(),
+                needs_release_2505_igvm: false,
                 test_artifacts: vec![
                     KnownTestArtifacts::Alpine323Aarch64Vhd,
                     KnownTestArtifacts::Ubuntu2404ServerAarch64Vhd,
@@ -1688,6 +1698,7 @@ impl IntoPipeline for CheckinGatesCli {
                 // inside the QEMU TCG incubator rather than directly on the host.
                 incubator_profile: Some("aarch64-tcg-pcie"),
                 nextest_filter_expr: "test(aarch64_tcg)".to_string(),
+                needs_release_2505_igvm: false,
                 test_artifacts: vec![
                     KnownTestArtifacts::Alpine323Aarch64Vhd,
                     KnownTestArtifacts::Ubuntu2404ServerAarch64Vhd,
@@ -1734,6 +1745,7 @@ impl IntoPipeline for CheckinGatesCli {
                     target: target.as_triple(),
                     nextest_profile: flowey_lib_hvlite::run_cargo_nextest_run::NextestProfile::Ci,
                     nextest_filter_expr: Some(nextest_filter_expr),
+                    needs_release_2505_igvm,
                     dep_artifact_dirs: resolve_vmm_tests_artifacts(ctx),
                     test_artifacts,
                     incubator_profile: incubator_profile.map(Into::into),

--- a/flowey/flowey_hvlite/src/pipelines/vmm_tests_run.rs
+++ b/flowey/flowey_hvlite/src/pipelines/vmm_tests_run.rs
@@ -155,6 +155,8 @@ struct ResolvedArtifactSelections {
     force_downloads: BTreeSet<KnownTestArtifacts>,
     /// Whether any tests need release IGVM files from GitHub
     needs_release_igvm: bool,
+    /// Whether any tests need the OpenHCL release 2505 IGVM from GitHub
+    needs_release_2505_igvm: bool,
     /// Whether any of the tests require Hyper-V
     needs_hyperv: bool,
     /// Whether any of the tests require hardware isolation
@@ -733,6 +735,7 @@ fn selections_from_resolved(
             _ => unreachable!(),
         },
         needs_release_igvm: resolved.needs_release_igvm,
+        needs_release_2505_igvm: resolved.needs_release_2505_igvm,
     }
 }
 
@@ -782,6 +785,10 @@ impl ResolvedArtifactSelections {
             {
                 // These are downloaded from GitHub releases, not built
                 self.needs_release_igvm = true;
+            }
+            petri_artifacts_vmm_test::artifacts::openhcl_igvm::RELEASE_25_05_STANDARD_X64::GLOBAL_UNIQUE_ID =>
+            {
+                self.needs_release_2505_igvm = true;
             }
 
             // Guest test UEFI

--- a/flowey/flowey_lib_hvlite/src/_jobs/consume_and_test_nextest_vmm_tests_archive.rs
+++ b/flowey/flowey_lib_hvlite/src/_jobs/consume_and_test_nextest_vmm_tests_archive.rs
@@ -96,6 +96,8 @@ flowey_request! {
         pub nextest_profile: NextestProfile,
         /// Nextest test filter expression.
         pub nextest_filter_expr: Option<String>,
+        /// Whether the selected tests require the OpenHCL release 2505 IGVM.
+        pub needs_release_2505_igvm: bool,
         /// Artifacts corresponding to required test dependencies
         pub dep_artifact_dirs: VmmTestsDepArtifacts,
         /// Test artifacts to download
@@ -151,6 +153,7 @@ impl SimpleFlowNode for Node {
             target,
             nextest_profile,
             nextest_filter_expr,
+            needs_release_2505_igvm,
             dep_artifact_dirs,
             test_artifacts,
             fail_job_on_test_fail,
@@ -231,6 +234,20 @@ impl SimpleFlowNode for Node {
         } else {
             None
         };
+        let release_2505_igvm_files = if needs_release_2505_igvm
+            && !matches!(ctx.backend(), FlowBackend::Ado)
+        {
+            Some(ctx.reqv(
+                |v| crate::download_release_igvm_files_from_gh::resolve::Request {
+                    arch,
+                    release_igvm_files: v,
+                    release_version:
+                        crate::download_release_igvm_files_from_gh::OpenhclReleaseVersion::Release2505,
+                },
+            ))
+        } else {
+            None
+        };
 
         let mut pre_run_deps = vec![ctx.reqv(crate::install_vmm_tests_deps::Request::Install)];
 
@@ -257,6 +274,7 @@ impl SimpleFlowNode for Node {
             get_test_log_path: Some(get_test_log_path),
             get_env: v,
             release_igvm_files,
+            release_2505_igvm_files,
             use_relative_paths: false,
             disable_remote_artifacts: true,
             reuse_prepped_vhds: false,

--- a/flowey/flowey_lib_hvlite/src/_jobs/local_build_and_run_nextest_vmm_tests.rs
+++ b/flowey/flowey_lib_hvlite/src/_jobs/local_build_and_run_nextest_vmm_tests.rs
@@ -33,6 +33,8 @@ pub struct VmmTestSelections {
     pub deps: VmmTestsDepSelections,
     /// Whether to download release IGVM files from GitHub
     pub needs_release_igvm: bool,
+    /// Whether to download the OpenHCL release 2505 IGVM from GitHub
+    pub needs_release_2505_igvm: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
@@ -184,6 +186,7 @@ impl SimpleFlowNode for Node {
             build,
             deps,
             needs_release_igvm,
+            needs_release_2505_igvm,
         } = selections;
 
         let build_openhcl = build.openhcl_standard
@@ -704,6 +707,16 @@ impl SimpleFlowNode for Node {
                 },
             )
         });
+        let release_2505_igvm_files = needs_release_2505_igvm.then(|| {
+            ctx.reqv(
+                |v| crate::download_release_igvm_files_from_gh::resolve::Request {
+                    arch,
+                    release_igvm_files: v,
+                    release_version:
+                        crate::download_release_igvm_files_from_gh::OpenhclReleaseVersion::Release2505,
+                },
+            )
+        });
 
         let extra_env = ctx.reqv(|v| crate::init_vmm_tests_env::Request {
             test_content_dir: ReadVar::from_static(test_content_dir.clone()),
@@ -726,6 +739,7 @@ impl SimpleFlowNode for Node {
             get_test_log_path: None,
             get_env: v,
             release_igvm_files,
+            release_2505_igvm_files,
             use_relative_paths: build_only,
             disable_remote_artifacts: false,
             reuse_prepped_vhds,

--- a/flowey/flowey_lib_hvlite/src/_jobs/local_restore_packages.rs
+++ b/flowey/flowey_lib_hvlite/src/_jobs/local_restore_packages.rs
@@ -96,6 +96,21 @@ impl SimpleFlowNode for Node {
                     )
                     .into_side_effect(),
                 );
+
+                if arch == CommonArch::X86_64 {
+                    deps.push(
+                        ctx.reqv(
+                            |v| crate::init_openvmm_magicpath_release_openhcl_igvm::resolve::Request {
+                                arch,
+                                release_version:
+                                    crate::download_release_igvm_files_from_gh::OpenhclReleaseVersion::Release2505,
+                                release_artifact: release_artifact.clone(),
+                                done: v,
+                            },
+                        )
+                        .into_side_effect(),
+                    );
+                }
             }
         }
 

--- a/flowey/flowey_lib_hvlite/src/init_vmm_tests_env.rs
+++ b/flowey/flowey_lib_hvlite/src/init_vmm_tests_env.rs
@@ -61,6 +61,7 @@ flowey_request! {
         /// Get a map of env vars required to be set when running VMM tests
         pub get_env: WriteVar<BTreeMap<String, String>>,
         pub release_igvm_files: Option<ReadVar<crate::download_release_igvm_files_from_gh::ReleaseOutput>>,
+        pub release_2505_igvm_files: Option<ReadVar<crate::download_release_igvm_files_from_gh::ReleaseOutput>>,
         /// Use paths relative to `test_content_dir` for environment variables
         pub use_relative_paths: bool,
         /// Disable lazy remote artifact fetching (set PETRI_REMOTE_ARTIFACTS=0).
@@ -107,6 +108,7 @@ impl SimpleFlowNode for Node {
             get_test_log_path,
             get_env,
             release_igvm_files,
+            release_2505_igvm_files,
             use_relative_paths,
             disable_remote_artifacts,
             reuse_prepped_vhds,
@@ -173,12 +175,14 @@ impl SimpleFlowNode for Node {
             let uefi = uefi.claim(ctx);
             let virtio_win_dir = virtio_win_dir.claim(ctx);
             let release_igvm_files_dir = release_igvm_files.claim(ctx);
+            let release_2505_igvm_files_dir = release_2505_igvm_files.claim(ctx);
             move |rt| {
                 let test_linux_initrd = rt.read(test_linux_initrd);
                 let test_linux_kernel = rt.read(test_linux_kernel);
                 let test_linux_bzimage = test_linux_bzimage.map(|v| rt.read(v));
                 let uefi = rt.read(uefi);
                 let release_igvm_files_dir = rt.read(release_igvm_files_dir);
+                let release_2505_igvm_files_dir = rt.read(release_2505_igvm_files_dir);
                 let test_content_dir = rt.read(test_content_dir);
 
                 let mut env = BTreeMap::new();
@@ -446,6 +450,15 @@ impl SimpleFlowNode for Node {
 
                     if let Some(src) = &release_igvm_files.openhcl_direct {
                         let new_name = format!("{latest_release_version}-x64-direct-openhcl.bin");
+                        fs_err::copy(src, test_content_dir.join(new_name))?;
+                    }
+                }
+
+                if let Some(release_igvm_files) = release_2505_igvm_files_dir {
+                    let release_version = OpenhclReleaseVersion::Release2505;
+
+                    if let Some(src) = &release_igvm_files.openhcl {
+                        let new_name = format!("{release_version}-x64-openhcl.bin");
                         fs_err::copy(src, test_content_dir.join(new_name))?;
                     }
                 }

--- a/petri/src/vm/hyperv/mod.rs
+++ b/petri/src/vm/hyperv/mod.rs
@@ -432,7 +432,7 @@ impl PetriVmmBackend for HyperVPetriBackend {
             ..HyperVNewCustomVMArgs::from_config(&config, &properties)?
         };
 
-        let vm = HyperVVM::new(hyperv_args, log_source.clone(), driver.clone()).await?;
+        let mut vm = HyperVVM::new(hyperv_args, log_source.clone(), driver.clone()).await?;
 
         if properties.is_openhcl {
             // Copy the IGVM file locally, since it may not be accessible by
@@ -496,6 +496,12 @@ impl PetriVmmBackend for HyperVPetriBackend {
                 .firmware
                 .into_runtime_config(config.vmbus_storage_controllers),
         ))
+    }
+}
+
+impl HyperVPetriRuntime {
+    pub(crate) async fn start(&mut self) -> anyhow::Result<()> {
+        self.vm.start().await
     }
 }
 

--- a/petri/src/vm/hyperv/vm.rs
+++ b/petri/src/vm/hyperv/vm.rs
@@ -332,9 +332,11 @@ impl HyperVVM {
     }
 
     /// Start the VM
-    pub async fn start(&self) -> anyhow::Result<()> {
+    pub async fn start(&mut self) -> anyhow::Result<()> {
         self.check_state(VmState::Off).await?;
+        let start_time = Timestamp::now();
         hvc::hvc_start(&self.vmid).await?;
+        self.last_start_time = Some(start_time);
         Ok(())
     }
 

--- a/petri/src/vm/mod.rs
+++ b/petri/src/vm/mod.rs
@@ -861,20 +861,15 @@ impl<T: PetriVmmBackend> PetriVmBuilder<T> {
                         &PETRI_SCSI_VTL2_CONTROLLER,
                         Some(PETRI_SCSI_BOOT_LUN),
                     )
-                    .add_vtl2_storage_controller(
-                        Vtl2StorageControllerBuilder::new(ControllerType::Ide)
-                            .with_instance_id(PETRI_IDE_BOOT_CONTROLLER)
-                            .add_lun(
-                                Vtl2LunBuilder::disk()
-                                    .with_channel(PETRI_IDE_BOOT_CONTROLLER_NUMBER)
-                                    .with_location(PETRI_IDE_BOOT_LUN as u32)
-                                    .with_physical_device(Vtl2StorageBackingDeviceBuilder::new(
-                                        ControllerType::Scsi,
-                                        PETRI_SCSI_VTL2_CONTROLLER,
-                                        PETRI_SCSI_BOOT_LUN,
-                                    )),
-                            )
-                            .build(),
+                    .add_vtl2_ide_lun(
+                        Vtl2LunBuilder::disk()
+                            .with_channel(PETRI_IDE_BOOT_CONTROLLER_NUMBER)
+                            .with_location(PETRI_IDE_BOOT_LUN as u32)
+                            .with_physical_device(Vtl2StorageBackingDeviceBuilder::new(
+                                ControllerType::Scsi,
+                                PETRI_SCSI_VTL2_CONTROLLER,
+                                PETRI_SCSI_BOOT_LUN,
+                            )),
                     ),
                 BootDeviceType::IdeViaNvme => todo!(),
                 BootDeviceType::Scsi => self.add_vmbus_drive(
@@ -1611,6 +1606,11 @@ impl<T: PetriVmmBackend> PetriVmBuilder<T> {
         })
     }
 
+    /// Add a LUN to the IDE controller used by OpenHCL PCAT guests.
+    pub fn add_vtl2_ide_lun(self, lun: Vtl2LunBuilder) -> Self {
+        self.with_custom_vtl2_settings(move |settings| push_vtl2_ide_lun(settings, lun))
+    }
+
     /// Add an additional SCSI controller to the VM.
     pub fn add_vmbus_storage_controller(
         mut self,
@@ -2095,6 +2095,16 @@ impl<T: PetriVmmBackend> PetriVm<T> {
             .await
     }
 
+    /// Add a LUN to the IDE controller used by OpenHCL PCAT guests.
+    pub async fn add_vtl2_ide_lun(&mut self, lun: Vtl2LunBuilder) -> anyhow::Result<()> {
+        let settings = self
+            .config
+            .vtl2_settings
+            .get_or_insert_with(default_vtl2_settings);
+        push_vtl2_ide_lun(settings, lun);
+        self.runtime.set_vtl2_settings(settings).await
+    }
+
     /// Get the list of storage controllers added to this VM
     pub fn get_vmbus_storage_controllers(&self) -> &HashMap<Guid, VmbusStorageController> {
         &self.config.vmbus_storage_controllers
@@ -2121,6 +2131,16 @@ impl<T: PetriVmmBackend> PetriVm<T> {
             .await?;
 
         Ok(())
+    }
+}
+
+#[cfg(windows)]
+impl PetriVm<hyperv::HyperVPetriBackend> {
+    /// Start a powered-off Hyper-V VM and reconnect to the guest agent.
+    pub async fn start(&mut self) -> anyhow::Result<PipetteClient> {
+        self.runtime.start().await?;
+        self.wait_for_expected_boot_event().await?;
+        self.wait_for_agent().await
     }
 }
 
@@ -3445,6 +3465,25 @@ fn default_vtl2_settings() -> Vtl2Settings {
         fixed: None,
         dynamic: Some(Default::default()),
         namespace_settings: Default::default(),
+    }
+}
+
+fn push_vtl2_ide_lun(settings: &mut Vtl2Settings, lun: Vtl2LunBuilder) {
+    let storage_controllers = &mut settings.dynamic.as_mut().unwrap().storage_controllers;
+    let instance_id = PETRI_IDE_BOOT_CONTROLLER.to_string();
+
+    if let Some(controller) = storage_controllers
+        .iter_mut()
+        .find(|controller| controller.instance_id == instance_id)
+    {
+        controller.luns.push(lun.build());
+    } else {
+        storage_controllers.push(
+            Vtl2StorageControllerBuilder::new(ControllerType::Ide)
+                .with_instance_id(PETRI_IDE_BOOT_CONTROLLER)
+                .add_lun(lun)
+                .build(),
+        );
     }
 }
 

--- a/vmm_tests/petri_artifact_resolver_openvmm_known_paths/src/lib.rs
+++ b/vmm_tests/petri_artifact_resolver_openvmm_known_paths/src/lib.rs
@@ -91,6 +91,7 @@ impl petri_artifacts_core::ResolveTestArtifact for OpenvmmKnownPathsTestArtifact
             _ if id == openhcl_igvm::LATEST_RELEASE_STANDARD_X64 => openhcl_bin_path(MachineArch::X86_64, OpenhclVersion::Release2511, OpenhclFlavor::Standard),
             _ if id == openhcl_igvm::LATEST_RELEASE_LINUX_DIRECT_X64 => openhcl_bin_path(MachineArch::X86_64, OpenhclVersion::Release2511, OpenhclFlavor::LinuxDirect),
             _ if id == openhcl_igvm::LATEST_RELEASE_STANDARD_AARCH64 => openhcl_bin_path(MachineArch::Aarch64, OpenhclVersion::Release2511, OpenhclFlavor::Standard),
+            _ if id == openhcl_igvm::RELEASE_25_05_STANDARD_X64 => openhcl_bin_path(MachineArch::X86_64, OpenhclVersion::Release2505, OpenhclFlavor::Standard),
 
             _ if id == openhcl_igvm::um_bin::LATEST_LINUX_DIRECT_TEST_X64 => openhcl_extras_path(OpenhclVersion::Latest,OpenhclFlavor::LinuxDirect,OpenhclExtras::UmBin),
             _ if id == openhcl_igvm::um_dbg::LATEST_LINUX_DIRECT_TEST_X64 => openhcl_extras_path(OpenhclVersion::Latest,OpenhclFlavor::LinuxDirect,OpenhclExtras::UmDbg),
@@ -258,6 +259,7 @@ enum PipetteFlavor {
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 enum OpenhclVersion {
     Latest,
+    Release2505,
     Release2511,
 }
 
@@ -772,6 +774,14 @@ fn openhcl_bin_path(
             "release-2511-x64-direct-openhcl.bin",
             MissingCommand::XFlowey {
                 description: "Previous OpenHCL release IGVM file",
+                xflowey_args: &["restore-packages"],
+            },
+        ),
+        (MachineArch::X86_64, OpenhclVersion::Release2505, OpenhclFlavor::Standard) => (
+            "flowey-out/artifacts/last-release-igvm-files",
+            "release-2505-x64-openhcl.bin",
+            MissingCommand::XFlowey {
+                description: "OpenHCL release 2505 IGVM file",
                 xflowey_args: &["restore-packages"],
             },
         ),

--- a/vmm_tests/petri_artifacts_vmm_test/src/lib.rs
+++ b/vmm_tests/petri_artifacts_vmm_test/src/lib.rs
@@ -213,6 +213,8 @@ pub mod artifacts {
             LATEST_STANDARD_X64,
             /// OpenHCL IGVM last release (standard)
             LATEST_RELEASE_STANDARD_X64,
+            /// OpenHCL IGVM 2505 release (standard)
+            RELEASE_25_05_STANDARD_X64,
             /// OpenHCL IGVM (standard, with VTL2 dev kernel)
             LATEST_STANDARD_DEV_KERNEL_X64,
             /// OpenHCL IGVM (for CVM)
@@ -238,6 +240,11 @@ pub mod artifacts {
             const ARCH: MachineArch = MachineArch::X86_64;
         }
         impl IsOpenhclIgvm for LATEST_RELEASE_STANDARD_X64 {}
+
+        impl IsLoadable for RELEASE_25_05_STANDARD_X64 {
+            const ARCH: MachineArch = MachineArch::X86_64;
+        }
+        impl IsOpenhclIgvm for RELEASE_25_05_STANDARD_X64 {}
 
         impl IsLoadable for LATEST_STANDARD_DEV_KERNEL_X64 {
             const ARCH: MachineArch = MachineArch::X86_64;

--- a/vmm_tests/vmm_tests/tests/tests/x86_64/storage.rs
+++ b/vmm_tests/vmm_tests/tests/tests/x86_64/storage.rs
@@ -19,9 +19,15 @@ use nvme_resources::NamespaceDefinition;
 use nvme_resources::NvmeControllerHandle;
 use openvmm_defs::config::DeviceVtl;
 use openvmm_defs::config::VpciDeviceConfig;
+#[cfg(windows)]
+use petri::PetriGuestStateLifetime;
 use petri::PetriVmBuilder;
 #[cfg(windows)]
 use petri::PetriVmmBackend;
+#[cfg(windows)]
+use petri::ResolvedArtifact;
+#[cfg(windows)]
+use petri::hyperv::HyperVPetriBackend;
 use petri::openvmm::OpenVmmPetriBackend;
 use petri::pipette::PipetteClient;
 use petri::pipette::cmd;
@@ -30,6 +36,10 @@ use petri::vtl2_settings::Vtl2LunBuilder;
 use petri::vtl2_settings::Vtl2StorageBackingDeviceBuilder;
 use petri::vtl2_settings::Vtl2StorageControllerBuilder;
 use petri::vtl2_settings::build_vtl2_storage_backing_physical_devices;
+#[cfg(windows)]
+use petri_artifacts_vmm_test::artifacts::openhcl_igvm::LATEST_RELEASE_STANDARD_X64;
+#[cfg(windows)]
+use petri_artifacts_vmm_test::artifacts::openhcl_igvm::RELEASE_25_05_STANDARD_X64;
 use scsidisk_resources::SimpleScsiDiskHandle;
 use scsidisk_resources::SimpleScsiDvdHandle;
 use scsidisk_resources::SimpleScsiDvdRequest;
@@ -285,6 +295,490 @@ async fn storvsp(config: PetriVmBuilder<OpenVmmPetriBackend>) -> Result<(), anyh
         ],
     )
     .await?;
+
+    agent.power_off().await?;
+    vm.wait_for_clean_teardown().await?;
+
+    Ok(())
+}
+
+#[cfg(windows)]
+fn write_both_endian_u16(bytes: &mut [u8], value: u16) {
+    bytes[..2].copy_from_slice(&value.to_le_bytes());
+    bytes[2..].copy_from_slice(&value.to_be_bytes());
+}
+
+#[cfg(windows)]
+fn write_both_endian_u32(bytes: &mut [u8], value: u32) {
+    bytes[..4].copy_from_slice(&value.to_le_bytes());
+    bytes[4..].copy_from_slice(&value.to_be_bytes());
+}
+
+#[cfg(windows)]
+fn write_iso_directory_record(record: &mut [u8], extent: u32, data_length: u32, identifier: u8) {
+    record[0] = 34;
+    write_both_endian_u32(&mut record[2..10], extent);
+    write_both_endian_u32(&mut record[10..18], data_length);
+    record[18..25].copy_from_slice(&[126, 1, 1, 0, 0, 0, 0]);
+    record[25] = 2;
+    write_both_endian_u16(&mut record[28..32], 1);
+    record[32] = 1;
+    record[33] = identifier;
+}
+
+#[cfg(windows)]
+fn write_test_iso(file: &mut File, size: u64) -> anyhow::Result<()> {
+    const BLOCK_SIZE: usize = 2048;
+    const PRIMARY_VOLUME_DESCRIPTOR_BLOCK: usize = 16;
+    const TERMINATOR_BLOCK: usize = 17;
+    const LITTLE_ENDIAN_PATH_TABLE_BLOCK: usize = 18;
+    const BIG_ENDIAN_PATH_TABLE_BLOCK: usize = 19;
+    const ROOT_DIRECTORY_BLOCK: usize = 20;
+
+    anyhow::ensure!(
+        size >= (ROOT_DIRECTORY_BLOCK + 1) as u64 * BLOCK_SIZE as u64,
+        "test ISO is too small"
+    );
+    anyhow::ensure!(
+        size.is_multiple_of(BLOCK_SIZE as u64),
+        "test ISO size is not block aligned"
+    );
+
+    let block_count: u32 = (size / BLOCK_SIZE as u64).try_into()?;
+    let mut image = vec![0_u8; size.try_into()?];
+
+    let primary = &mut image[PRIMARY_VOLUME_DESCRIPTOR_BLOCK * BLOCK_SIZE
+        ..(PRIMARY_VOLUME_DESCRIPTOR_BLOCK + 1) * BLOCK_SIZE];
+    primary[0] = 1;
+    primary[1..6].copy_from_slice(b"CD001");
+    primary[6] = 1;
+    primary[8..40].fill(b' ');
+    primary[40..72].fill(b' ');
+    primary[40..48].copy_from_slice(b"ADE_TEST");
+    write_both_endian_u32(&mut primary[80..88], block_count);
+    write_both_endian_u16(&mut primary[120..124], 1);
+    write_both_endian_u16(&mut primary[124..128], 1);
+    write_both_endian_u16(&mut primary[128..132], BLOCK_SIZE as u16);
+    write_both_endian_u32(&mut primary[132..140], 10);
+    primary[140..144].copy_from_slice(&(LITTLE_ENDIAN_PATH_TABLE_BLOCK as u32).to_le_bytes());
+    primary[148..152].copy_from_slice(&(BIG_ENDIAN_PATH_TABLE_BLOCK as u32).to_be_bytes());
+    write_iso_directory_record(
+        &mut primary[156..190],
+        ROOT_DIRECTORY_BLOCK as u32,
+        BLOCK_SIZE as u32,
+        0,
+    );
+    primary[190..813].fill(b' ');
+    primary[813..830].copy_from_slice(b"2026072400000000\0");
+    primary[830..847].copy_from_slice(b"2026072400000000\0");
+    primary[847..864].copy_from_slice(b"0000000000000000\0");
+    primary[864..881].copy_from_slice(b"0000000000000000\0");
+    primary[881] = 1;
+
+    let terminator = &mut image[TERMINATOR_BLOCK * BLOCK_SIZE..(TERMINATOR_BLOCK + 1) * BLOCK_SIZE];
+    terminator[0] = 255;
+    terminator[1..6].copy_from_slice(b"CD001");
+    terminator[6] = 1;
+
+    let little_endian_path_table = &mut image[LITTLE_ENDIAN_PATH_TABLE_BLOCK * BLOCK_SIZE..];
+    little_endian_path_table[0] = 1;
+    little_endian_path_table[2..6].copy_from_slice(&(ROOT_DIRECTORY_BLOCK as u32).to_le_bytes());
+    little_endian_path_table[6..8].copy_from_slice(&1_u16.to_le_bytes());
+
+    let big_endian_path_table = &mut image[BIG_ENDIAN_PATH_TABLE_BLOCK * BLOCK_SIZE..];
+    big_endian_path_table[0] = 1;
+    big_endian_path_table[2..6].copy_from_slice(&(ROOT_DIRECTORY_BLOCK as u32).to_be_bytes());
+    big_endian_path_table[6..8].copy_from_slice(&1_u16.to_be_bytes());
+
+    let root_directory = &mut image[ROOT_DIRECTORY_BLOCK * BLOCK_SIZE..];
+    write_iso_directory_record(
+        &mut root_directory[..34],
+        ROOT_DIRECTORY_BLOCK as u32,
+        BLOCK_SIZE as u32,
+        0,
+    );
+    write_iso_directory_record(
+        &mut root_directory[34..68],
+        ROOT_DIRECTORY_BLOCK as u32,
+        BLOCK_SIZE as u32,
+        1,
+    );
+
+    file.write_all(&image).context("write test ISO")
+}
+
+/// Test the Azure Disk Encryption (ADE) scenario:
+/// Boot a Generation 1 Windows VM, the VTL storage should look like this:
+///  - IDE:
+///    0:0 - OS disk
+///    0:1 - <empty>
+///    1:0 - CD ROM ISO (with a disc initially)
+///    1:1 - BEK Volume (empty initially)
+///
+/// Sequence of events:
+///  1. Boot the VM, verify that the IDE devices are present and have the expected sizes.
+///  2. Eject the CD ROM from the guest (mirrors azure agent behavior)
+///  2. Power off the VM, and add a BEK volume
+///  3. Power on the VM
+///  4. Set up bitlocker in the guest, and verify that the BEK volume is populated with the expected data.
+///  5. Soft reboot the VM, ensure that it boots again successfully
+///
+/// Ideally the OS disk is backed by NVMe from the host to VTL2. The BEK volume should be backed by vSCSI on the host to VTL2, as would the CD-ROM. These can be on the same vSCSI controller.
+#[cfg(windows)]
+#[vmm_test(hyperv_openhcl_pcat_x64(vhd(windows_datacenter_core_2022_x64)))]
+async fn storvsp_hyperv_ade(
+    config: PetriVmBuilder<HyperVPetriBackend>,
+) -> Result<(), anyhow::Error> {
+    storvsp_hyperv_ade_core(config).await
+}
+
+/// Reproduce the ADE sequence using the latest release OpenHCL from the first
+/// boot through CD-ROM ejection, the power cycle, BitLocker setup, and the final
+/// guest reboot.
+#[cfg(windows)]
+#[vmm_test(
+    hyperv_openhcl_pcat_x64(vhd(windows_datacenter_core_2022_x64))[LATEST_RELEASE_STANDARD_X64]
+)]
+async fn storvsp_hyperv_ade_latest_release(
+    config: PetriVmBuilder<HyperVPetriBackend>,
+    (release_openhcl,): (ResolvedArtifact<LATEST_RELEASE_STANDARD_X64>,),
+) -> Result<(), anyhow::Error> {
+    storvsp_hyperv_ade_core(
+        config
+            .with_custom_openhcl(release_openhcl)
+            .with_guest_state_lifetime(PetriGuestStateLifetime::Disk),
+    )
+    .await
+}
+
+/// Reproduce the ADE sequence using OpenHCL release 2505 from the first boot
+/// through CD-ROM ejection, the power cycle, BitLocker setup, and the final
+/// guest reboot.
+#[cfg(windows)]
+#[vmm_test(
+    hyperv_openhcl_pcat_x64(vhd(windows_datacenter_core_2022_x64))[RELEASE_25_05_STANDARD_X64]
+)]
+async fn storvsp_hyperv_ade_release_2505(
+    config: PetriVmBuilder<HyperVPetriBackend>,
+    (release_openhcl,): (ResolvedArtifact<RELEASE_25_05_STANDARD_X64>,),
+) -> Result<(), anyhow::Error> {
+    storvsp_hyperv_ade_core(
+        config
+            .with_custom_openhcl(release_openhcl)
+            .with_guest_state_lifetime(PetriGuestStateLifetime::Disk),
+    )
+    .await
+}
+
+#[cfg(windows)]
+async fn storvsp_hyperv_ade_core(
+    config: PetriVmBuilder<HyperVPetriBackend>,
+) -> Result<(), anyhow::Error> {
+    use petri::Disk;
+    use petri::Drive;
+    use petri::VmbusStorageType;
+    use petri::Vtl;
+
+    const VTL2_CD_LUN: u32 = 0;
+    const VTL2_BEK_LUN: u32 = 1;
+    const IDE_SECONDARY_CHANNEL: u32 = 1;
+    const IDE_CD_LOCATION: u32 = 0;
+    const IDE_BEK_LOCATION: u32 = 1;
+    const OS_DISK_SIZE_BYTES: u64 = 32_210_196_480;
+    const CD_MEDIA_SIZE_BYTES: u64 = 4 * 1024 * 1024;
+    const BEK_DISK_SIZE_BYTES: u64 = 128 * 1024 * 1024;
+
+    let vtl2_storage_instance = Guid::new_random();
+
+    let mut cd_media = tempfile::NamedTempFile::with_suffix("provisioning.iso")
+        .context("create temporary fake provisioning CD media")?;
+    write_test_iso(cd_media.as_file_mut(), CD_MEDIA_SIZE_BYTES)?;
+    let cd_media_path = cd_media.into_temp_path();
+
+    let (mut vm, agent) = config
+        .with_vmbus_redirect(true)
+        .add_vmbus_storage_controller(&vtl2_storage_instance, Vtl::Vtl2, VmbusStorageType::Scsi)
+        .add_vmbus_drive(
+            Drive::new(Some(Disk::Persistent(cd_media_path.to_path_buf())), true),
+            &vtl2_storage_instance,
+            Some(VTL2_CD_LUN),
+        )
+        .add_vtl2_ide_lun(
+            Vtl2LunBuilder::dvd()
+                .with_channel(IDE_SECONDARY_CHANNEL)
+                .with_location(IDE_CD_LOCATION)
+                .with_physical_device(Vtl2StorageBackingDeviceBuilder::new(
+                    ControllerType::Scsi,
+                    vtl2_storage_instance,
+                    VTL2_CD_LUN,
+                )),
+        )
+        .run()
+        .await?;
+
+    let shell = agent.windows_shell();
+    let initial_storage_check = format!(
+        r#"
+$ErrorActionPreference = 'Stop'
+$ideDisks = @(Get-CimInstance Win32_DiskDrive | Where-Object {{ $_.InterfaceType -eq 'IDE' }})
+if ($ideDisks.Count -ne 1) {{
+    throw "Expected one IDE disk before adding the BEK volume, found $($ideDisks.Count)"
+}}
+if ([uint64]$ideDisks[0].Size -ne {OS_DISK_SIZE_BYTES}) {{
+    throw "Expected a {OS_DISK_SIZE_BYTES}-byte OS disk, found $($ideDisks[0].Size) bytes"
+}}
+
+$cdroms = @(Get-CimInstance Win32_CDROMDrive)
+if ($cdroms.Count -ne 1) {{
+    throw "Expected one IDE CD-ROM, found $($cdroms.Count)"
+}}
+if (-not $cdroms[0].MediaLoaded) {{
+    throw 'Expected the IDE CD-ROM to contain media'
+}}
+if ([uint64]$cdroms[0].Size -ne {CD_MEDIA_SIZE_BYTES}) {{
+    throw "Expected {CD_MEDIA_SIZE_BYTES} bytes of CD media, found $($cdroms[0].Size) bytes"
+}}
+"#
+    );
+    cmd!(shell, "powershell.exe")
+        .args([
+            "-NoProfile",
+            "-NonInteractive",
+            "-Command",
+            &initial_storage_check,
+        ])
+        .run()
+        .await
+        .context("verify initial ADE storage layout")?;
+
+    let eject_cdrom = r#"
+$ErrorActionPreference = 'Stop'
+$source = @'
+using System;
+using System.ComponentModel;
+using System.Runtime.InteropServices;
+using Microsoft.Win32.SafeHandles;
+
+public static class CdromEjector
+{
+    private const uint FsctlLockVolume = 0x00090018;
+    private const uint FsctlUnlockVolume = 0x0009001c;
+    private const uint IoctlStorageEjectMedia = 0x002d4808;
+
+    [DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+    private static extern SafeFileHandle CreateFile(
+        string fileName,
+        uint desiredAccess,
+        uint shareMode,
+        IntPtr securityAttributes,
+        uint creationDisposition,
+        uint flagsAndAttributes,
+        IntPtr templateFile);
+
+    [DllImport("kernel32.dll", SetLastError = true)]
+    private static extern bool DeviceIoControl(
+        SafeFileHandle device,
+        uint controlCode,
+        IntPtr inputBuffer,
+        uint inputBufferSize,
+        IntPtr outputBuffer,
+        uint outputBufferSize,
+        out uint bytesReturned,
+        IntPtr overlapped);
+
+    public static void Eject(string path)
+    {
+        using (SafeFileHandle device = CreateFile(
+            path,
+            0x80000000,
+            3,
+            IntPtr.Zero,
+            3,
+            0,
+            IntPtr.Zero))
+        {
+            if (device.IsInvalid)
+            {
+                throw new Win32Exception(Marshal.GetLastWin32Error());
+            }
+
+            uint bytesReturned;
+            if (!DeviceIoControl(device, FsctlLockVolume, IntPtr.Zero, 0, IntPtr.Zero, 0, out bytesReturned, IntPtr.Zero))
+            {
+                throw new Win32Exception(Marshal.GetLastWin32Error());
+            }
+
+            try
+            {
+                if (!DeviceIoControl(device, IoctlStorageEjectMedia, IntPtr.Zero, 0, IntPtr.Zero, 0, out bytesReturned, IntPtr.Zero))
+                {
+                    throw new Win32Exception(Marshal.GetLastWin32Error());
+                }
+            }
+            finally
+            {
+                DeviceIoControl(device, FsctlUnlockVolume, IntPtr.Zero, 0, IntPtr.Zero, 0, out bytesReturned, IntPtr.Zero);
+            }
+        }
+    }
+}
+'@
+
+Add-Type -TypeDefinition $source
+[CdromEjector]::Eject('\\.\CdRom0')
+
+$deadline = (Get-Date).AddSeconds(30)
+do {
+    $cdrom = Get-CimInstance Win32_CDROMDrive
+    if (-not $cdrom.MediaLoaded) {
+        exit 0
+    }
+    Start-Sleep -Seconds 1
+} while ((Get-Date) -lt $deadline)
+
+throw 'The IDE CD-ROM still reports loaded media after eject'
+"#;
+    cmd!(shell, "powershell.exe")
+        .args(["-NoProfile", "-NonInteractive", "-Command", eject_cdrom])
+        .run()
+        .await
+        .context("eject ADE CD media")?;
+
+    agent.power_off().await?;
+    vm.wait_for_clean_shutdown().await?;
+
+    let mut bek_vhd =
+        tempfile::NamedTempFile::with_suffix("ade-bek.vhd").context("create temporary BEK VHD")?;
+    bek_vhd
+        .as_file()
+        .set_len(BEK_DISK_SIZE_BYTES)
+        .context("set BEK VHD length")?;
+    disk_vhd1::Vhd1Disk::make_fixed(bek_vhd.as_file_mut()).context("make fixed BEK VHD")?;
+    let bek_vhd_path = bek_vhd.into_temp_path();
+
+    vm.set_vmbus_drive(
+        Drive::new(Some(Disk::Persistent(bek_vhd_path.to_path_buf())), false),
+        &vtl2_storage_instance,
+        Some(VTL2_BEK_LUN),
+    )
+    .await?;
+    vm.add_vtl2_ide_lun(
+        Vtl2LunBuilder::disk()
+            .with_channel(IDE_SECONDARY_CHANNEL)
+            .with_location(IDE_BEK_LOCATION)
+            .with_physical_device(Vtl2StorageBackingDeviceBuilder::new(
+                ControllerType::Scsi,
+                vtl2_storage_instance,
+                VTL2_BEK_LUN,
+            )),
+    )
+    .await?;
+
+    let agent = vm.start().await?;
+    let shell = agent.windows_shell();
+    let prepare_bek_volume = format!(
+        r#"
+$ErrorActionPreference = 'Stop'
+$ideDisks = @(Get-CimInstance Win32_DiskDrive | Where-Object {{ $_.InterfaceType -eq 'IDE' }})
+if ($ideDisks.Count -ne 2) {{
+    throw "Expected two IDE disks after adding the BEK volume, found $($ideDisks.Count)"
+}}
+
+$osDisk = @($ideDisks | Where-Object {{ [uint64]$_.Size -eq {OS_DISK_SIZE_BYTES} }})
+if ($osDisk.Count -ne 1) {{
+    throw "Expected one {OS_DISK_SIZE_BYTES}-byte OS disk, found $($osDisk.Count)"
+}}
+
+$bekDisk = @(Get-Disk | Where-Object {{ [uint64]$_.Size -eq {BEK_DISK_SIZE_BYTES} }})
+if ($bekDisk.Count -ne 1) {{
+    throw "Expected one {BEK_DISK_SIZE_BYTES}-byte BEK disk, found $($bekDisk.Count)"
+}}
+if ($bekDisk[0].PartitionStyle -ne 'RAW') {{
+    throw "Expected a raw BEK disk, found partition style $($bekDisk[0].PartitionStyle)"
+}}
+if (Get-Volume -DriveLetter B -ErrorAction SilentlyContinue) {{
+    throw 'Drive letter B is already in use'
+}}
+
+Initialize-Disk -Number $bekDisk[0].Number -PartitionStyle MBR
+$partition = New-Partition -DiskNumber $bekDisk[0].Number -UseMaximumSize -DriveLetter B
+$partition | Format-Volume -FileSystem FAT32 -NewFileSystemLabel BEK -Confirm:$false
+"#
+    );
+    cmd!(shell, "powershell.exe")
+        .args([
+            "-NoProfile",
+            "-NonInteractive",
+            "-Command",
+            &prepare_bek_volume,
+        ])
+        .run()
+        .await
+        .context("prepare BEK volume")?;
+
+    let enable_bitlocker = r#"
+$ErrorActionPreference = 'Stop'
+$policyPath = 'HKLM:\SOFTWARE\Policies\Microsoft\FVE'
+New-Item -Path $policyPath -Force | Out-Null
+New-ItemProperty -Path $policyPath -Name EnableBDEWithNoTPM -PropertyType DWord -Value 1 -Force | Out-Null
+New-ItemProperty -Path $policyPath -Name UseAdvancedStartup -PropertyType DWord -Value 1 -Force | Out-Null
+
+& manage-bde.exe -on C: -usedspaceonly -startupkey B:\ -skiphardwaretest
+if ($LASTEXITCODE -ne 0) {
+    throw "manage-bde -on failed with exit code $LASTEXITCODE"
+}
+
+$deadline = (Get-Date).AddMinutes(20)
+do {
+    $status = (& manage-bde.exe -status C: | Out-String)
+    if ($LASTEXITCODE -ne 0) {
+        throw "manage-bde -status failed with exit code $LASTEXITCODE"
+    }
+    if ($status -match 'Percentage Encrypted:\s+100(?:\.0+)?%') {
+        break
+    }
+    if ((Get-Date) -ge $deadline) {
+        throw "BitLocker encryption did not complete within 20 minutes:`n$status"
+    }
+    Start-Sleep -Seconds 5
+} while ($true)
+
+$protectors = (& manage-bde.exe -protectors -get C: -type ExternalKey | Out-String)
+if ($LASTEXITCODE -ne 0 -or $protectors -notmatch 'External Key') {
+    throw "Expected an external key protector:`n$protectors"
+}
+
+$bekFiles = @(Get-ChildItem -Path B:\ -Filter '*.BEK' -File -Force)
+if ($bekFiles.Count -ne 1) {
+    throw "Expected one BEK file, found $($bekFiles.Count)"
+}
+if ($bekFiles[0].Length -eq 0) {
+    throw 'The BEK file is empty'
+}
+"#;
+    cmd!(shell, "powershell.exe")
+        .args([
+            "-NoProfile",
+            "-NonInteractive",
+            "-Command",
+            enable_bitlocker,
+        ])
+        .run()
+        .await
+        .context("enable BitLocker with a BEK startup key")?;
+
+    agent.reboot().await?;
+    let agent = vm.wait_for_reset().await?;
+    let shell = agent.windows_shell();
+    let bitlocker_status = cmd!(shell, "manage-bde.exe")
+        .args(["-status", "C:"])
+        .read()
+        .await
+        .context("read BitLocker status after reboot")?;
+    anyhow::ensure!(
+        bitlocker_status.contains("Lock Status:") && bitlocker_status.contains("Unlocked"),
+        "OS volume did not unlock after reboot: {bitlocker_status}"
+    );
 
     agent.power_off().await?;
     vm.wait_for_clean_teardown().await?;


### PR DESCRIPTION
Why is this change being made?
- Cover the Generation 1 Windows Azure Disk Encryption (esqe) boot sequence through OpenHCL IDE storage.
- Reproduce guest reboot failures with candidate OpenHCL versions after ADE provisioning.

What changed?
- Added a PCAT storage test with valid ISO media, dynamic BEK VHD attachment, BitLocker setup, and reboot validation.
- Added variants that boot directly on the latest release and release 2505 OpenHCL candidates.
- Restored the release 2505 IGVM artifact and scoped its CI download to the Hyper-V PCAT test job.
- Added test infrastructure support for extending the PCAT IDE configuration and restarting a powered-off Hyper-V VM.

How was the change tested?
- ✅ `cargo clippy --all-targets -p flowey_hvlite -p flowey_lib_hvlite -p petri_artifacts_vmm_test -p petri_artifact_resolver_openvmm_known_paths -p vmm_tests`
- ✅ `cargo doc --no-deps -p flowey_hvlite -p flowey_lib_hvlite -p petri_artifacts_vmm_test -p petri_artifact_resolver_openvmm_known_paths -p vmm_tests`
- ✅ `. ./build_support/setup_windows_cross.sh && cargo xflowey vmm-tests-run --target windows-x64 --filter "test(storvsp_hyperv_ade)" --build-only --dir /mnt/c/vmm_tests --skip-vhd-prompt`
- ✅ `cargo xflowey vmm-tests-run --target windows-x64 --filter "test(storvsp_hyperv_ade_release_2505)" --dir /mnt/c/vmm_tests --skip-vhd-prompt` reproduced the final reboot hang.
- ✅ `cargo xtask fmt --fix`