### PR TITLE
virt_kvm: Rearm synthetic timers on simp enablement

### DIFF
--- a/vmm_core/virt_kvm/src/arch/x86_64/mod.rs
+++ b/vmm_core/virt_kvm/src/arch/x86_64/mod.rs
@@ -1512,7 +1512,7 @@ impl<'p> Processor for KvmProcessor<'p> {
                             self.kvm.get_msrs(&msrs, &mut values).map_err(|err| {
                                 dev.fatal_error(KvmRunVpError::RearmSyntheticTimers(err).into())
                             })?;
-                            let mut rearm = Vec::with_capacity(4);
+                            let mut rearm = Vec::with_capacity(hvdef::NUM_TIMERS);
                             for (index, timer) in values.chunks_exact(2).enumerate() {
                                 let config = hvdef::HvSynicStimerConfig::from(timer[0]);
                                 let count = timer[1];

--- a/vmm_core/virt_kvm/src/arch/x86_64/mod.rs
+++ b/vmm_core/virt_kvm/src/arch/x86_64/mod.rs
@@ -1489,6 +1489,7 @@ impl<'p> Processor for KvmProcessor<'p> {
                         siefp,
                         simp,
                     } => {
+                        let new_simp = HvSynicSimpSiefp::from(simp);
                         // Bring the overlay pages into agreement with the new
                         // SIMP/SIEFP values the guest just programmed. The
                         // overlays are owned by this processor; the save/restore
@@ -1499,9 +1500,43 @@ impl<'p> Processor for KvmProcessor<'p> {
                             siefp.into(),
                             &self.partition.gm,
                         );
+
+                        // KVM leaves a periodic message-mode STimer permanently
+                        // pending if it expires before SIMP is usable. Rewriting
+                        // the count clears that state now that delivery can work.
+                        if !self.simp.enabled() && new_simp.enabled() {
+                            let msrs: [u32; 8] = std::array::from_fn(|index| {
+                                hvdef::HV_X64_MSR_STIMER0_CONFIG + index as u32
+                            });
+                            let mut values = [0; 8];
+                            self.kvm.get_msrs(&msrs, &mut values).map_err(|err| {
+                                dev.fatal_error(KvmRunVpError::RearmSyntheticTimers(err).into())
+                            })?;
+                            let mut rearm = Vec::with_capacity(4);
+                            for (index, timer) in values.chunks_exact(2).enumerate() {
+                                let config = hvdef::HvSynicStimerConfig::from(timer[0]);
+                                let count = timer[1];
+                                if config.enabled()
+                                    && config.periodic()
+                                    && !config.direct_mode()
+                                    && count != 0
+                                {
+                                    rearm.push((
+                                        hvdef::HV_X64_MSR_STIMER0_COUNT + index as u32 * 2,
+                                        count,
+                                    ));
+                                }
+                            }
+                            if !rearm.is_empty() {
+                                self.kvm.set_msrs(&rearm).map_err(|err| {
+                                    dev.fatal_error(KvmRunVpError::RearmSyntheticTimers(err).into())
+                                })?;
+                            }
+                        }
+
                         self.scontrol = control.into();
                         self.siefp = siefp.into();
-                        self.simp = simp.into();
+                        self.simp = new_simp;
                         *self.inner.siefp.write() = if self.scontrol.enabled() {
                             siefp.into()
                         } else {

--- a/vmm_core/virt_kvm/src/arch/x86_64/mod.rs
+++ b/vmm_core/virt_kvm/src/arch/x86_64/mod.rs
@@ -1505,10 +1505,10 @@ impl<'p> Processor for KvmProcessor<'p> {
                         // pending if it expires before SIMP is usable. Rewriting
                         // the count clears that state now that delivery can work.
                         if !self.simp.enabled() && new_simp.enabled() {
-                            let msrs: [u32; 8] = std::array::from_fn(|index| {
+                            let msrs: [u32; hvdef::NUM_TIMERS * 2] = std::array::from_fn(|index| {
                                 hvdef::HV_X64_MSR_STIMER0_CONFIG + index as u32
                             });
-                            let mut values = [0; 8];
+                            let mut values = [0; hvdef::NUM_TIMERS * 2];
                             self.kvm.get_msrs(&msrs, &mut values).map_err(|err| {
                                 dev.fatal_error(KvmRunVpError::RearmSyntheticTimers(err).into())
                             })?;

--- a/vmm_core/virt_kvm/src/lib.rs
+++ b/vmm_core/virt_kvm/src/lib.rs
@@ -153,6 +153,9 @@ enum KvmRunVpError {
     #[cfg(guest_arch = "x86_64")]
     #[error("failed to inject an extint interrupt")]
     ExtintInterrupt(#[source] kvm::Error),
+    #[cfg(guest_arch = "x86_64")]
+    #[error("failed to rearm Hyper-V synthetic timers")]
+    RearmSyntheticTimers(#[source] kvm::Error),
 }
 
 pub struct KvmProcessorBinder {


### PR DESCRIPTION
We've had a recent few hits in CI of apparent stalls of VMs on KVM. Copilot analysis of them flagged that on all of them STimer0 was armed, but there was no pending message or interrupt from it for the rest of the 10 minute timeout. Copilot claims that the reason for this is that KVM's timer will not retry delivery if a timer fires before the SIMP is enabled, resulting in this hang. The supposed fix is to read the counts of these timers and write them back unchanged when the SIMP is enabled. This action causes KVM to reevaluate the timer and deliver a fresh interrupt, which will now succeed.

Alternatives:
* Switch from KVM's built in synic support to hv1_emulator, a much larger change
* Advertise direct mode synthetic timer support. In theory using direct mode timers instead of message mode timers would bypass this issue by signaling the APIC instead of a SINT. However, that relies on the guest choosing to use direct mode timers, which it may not want to. We could still do this in addition to this PR.

It is unclear to me if there really is a guest-side race condition that could result in an STimer being configured and firing while the SIMP is disabled, or if this is all a hallucination. However copilot has been very insistent over multiple runs that this is the issue. So if it is a hallucination it's at least a consistent one.