### PR TITLE
logview: upload runs keyed on run_id + attempt number

### DIFF
--- a/.github/workflows/upload-petri-results.yml
+++ b/.github/workflows/upload-petri-results.yml
@@ -99,8 +99,41 @@ jobs:
               "ghbranch=$SOURCE_BRANCH" \
               "ghpr=$SOURCE_PR" \
             --auth-mode login
+
+          # Attempt-keyed duplicate (new scheme).
+          #
+          # Re-running a workflow reuses the same run_id, so the legacy uploads
+          # above overwrite a previous attempt's logs (a flaky test that failed
+          # then passed loses its failure logs). To preserve every attempt we
+          # additionally upload the same data + metadata keyed on
+          # "<run_id>_<run_attempt>" (the first attempt is "_1").
+          #
+          # The data tree lives at the top level alongside the legacy tree
+          # (results/<run_id>_<attempt>/...); the metadata marker goes in a
+          # separate `attempts/` folder rather than `runs/` so the current
+          # site's `runs/` listing is unaffected during the transition. Once a
+          # full 30-day retention window has elapsed, the site can be switched
+          # to read from `attempts/` and the legacy uploads above removed.
+          run_key="${run_id}_${run_attempt}"
+
+          az storage blob upload-batch \
+            --destination "$BASE_URL/results" \
+            --destination-path "$run_key" \
+            --source results \
+            --auth-mode login
+
+          az storage blob upload \
+            --blob-url "$BASE_URL/results/attempts/$run_key" \
+            --file /dev/null \
+            --metadata \
+              "petrifailed=$FAIL_COUNT" \
+              "petripassed=$PASS_COUNT" \
+              "ghbranch=$SOURCE_BRANCH" \
+              "ghpr=$SOURCE_PR" \
+            --auth-mode login
         env:
           run_id: ${{ github.event.workflow_run.id }}
+          run_attempt: ${{ github.event.workflow_run.run_attempt }}
 
       - name: Upload to memory validation results to Azure Blob Storage
         run: |

--- a/.github/workflows/upload-petri-results.yml
+++ b/.github/workflows/upload-petri-results.yml
@@ -100,20 +100,10 @@ jobs:
               "ghpr=$SOURCE_PR" \
             --auth-mode login
 
-          # Attempt-keyed duplicate (new scheme).
-          #
-          # Re-running a workflow reuses the same run_id, so the legacy uploads
-          # above overwrite a previous attempt's logs (a flaky test that failed
-          # then passed loses its failure logs). To preserve every attempt we
-          # additionally upload the same data + metadata keyed on
-          # "<run_id>_<run_attempt>" (the first attempt is "_1").
-          #
-          # The data tree lives at the top level alongside the legacy tree
-          # (results/<run_id>_<attempt>/...); the metadata marker goes in a
-          # separate `attempts/` folder rather than `runs/` so the current
-          # site's `runs/` listing is unaffected during the transition. Once a
-          # full 30-day retention window has elapsed, the site can be switched
-          # to read from `attempts/` and the legacy uploads above removed.
+          # Run-and-attempt-keyed runs and details. For now, these will live alongside
+          # the legacy run-keyed uploads above, but the site will be switched to
+          # read from the attempt-keyed uploads once a full 30-day retention
+          # window has elapsed.
           run_key="${run_id}_${run_attempt}"
 
           az storage blob upload-batch \

--- a/petri/logview/src/utils/fetch_runs_data.ts
+++ b/petri/logview/src/utils/fetch_runs_data.ts
@@ -430,8 +430,7 @@ export async function fetchRunDetails(
     // Collect all XML data first in an array to avoid string concatenation overhead
     do {
       // Build URL with continuation token if we have one
-      // TODO: If hierarchical namespaces are supported this fetch call might go by much faster. Try this out in a non-prod environment first to try it out
-      let url = `https://openvmmghtestresults.blob.core.windows.net/results?restype=container&comp=list&showonly=files&prefix=${encodeURIComponent(runNumber)}`;
+      let url = `https://openvmmghtestresults.blob.core.windows.net/results?restype=container&comp=list&showonly=files&prefix=${encodeURIComponent(runNumber + "/")}`;
       if (continuationToken) {
         url += `&marker=${encodeURIComponent(continuationToken)}`;
       }


### PR DESCRIPTION
Fixes an existing bug where run information gets overwritten if the github workflow is restarted. Existing runs are not keyed on attempt numbers.

This PR fixes 2 things:
1. It now uploads runs to a folder along with the run number, separated by an underscore. For example: `221234_1` for attempt 1 and run number 221234.
2. Fixes a bug in the front end which would fetch all data starting with a run number instead of looking for the exact run folder. 

For now, this will just duplicate data in the storage account. Run metadata will be uploaded to the attempts folder (currently unread by the front end) and the run data itself will be uploaded to the <run_id>_<attempt_number> folder. Once 30 days have elapsed and we have enough data stored, the front end will be switched to query the `attempts` folder and read the `<run_id>_<attempt_number>` folder instead. ... This should allow for the cleanest switch