### PR TITLE
virt_whp: Fix another lost interrupt delivery

### DIFF
--- a/vmm_core/virt_whp/src/lib.rs
+++ b/vmm_core/virt_whp/src/lib.rs
@@ -515,6 +515,7 @@ impl<'a> WhpVpRef<'a> {
         if request_notification {
             self.vplc(vtl).check_queues.store(true, Ordering::SeqCst);
             self.ensure_vtl_runnable(vtl);
+            self.whp(vtl).cancel_run().expect("can't fail");
             self.wake();
         }
     }


### PR DESCRIPTION
Fix a WHP SynIC message-delivery race where a message can arrive after the VP checks its pending queue but immediately before entering WHvRunVirtualProcessor. In that window, waking the async task is insufficient because the wake can be consumed before the blocking WHP run begins, leaving the message stranded indefinitely.

Cancel the target VTL’s WHP run after enqueueing its first pending message. This ensures the VP returns to the host loop and flushes the SynIC queue, whether the target VTL is currently running or runs later.

This addresses VMBus stalls observed during OpenHCL servicing and TTRPC guest startup.