### PR TITLE
openvmm: report a version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5698,6 +5698,7 @@ name = "openvmm_entry"
 version = "0.0.0"
 dependencies = [
  "anyhow",
+ "build_rs_git_info",
  "build_rs_guest_arch",
  "chipset_device_worker_defs",
  "chipset_resources",

--- a/openvmm/openvmm_entry/Cargo.toml
+++ b/openvmm/openvmm_entry/Cargo.toml
@@ -120,6 +120,7 @@ features = [
 ]
 
 [build-dependencies]
+build_rs_git_info.workspace = true
 build_rs_guest_arch.workspace = true
 
 [dev-dependencies]

--- a/openvmm/openvmm_entry/build.rs
+++ b/openvmm/openvmm_entry/build.rs
@@ -4,5 +4,9 @@
 #![expect(missing_docs)]
 
 fn main() {
-    build_rs_guest_arch::emit_guest_arch()
+    build_rs_guest_arch::emit_guest_arch();
+    // Ignore the error: a build from a release tarball or vendored sources has
+    // no repository to read, and must still compile. `--version` then reports
+    // the crate version alone.
+    let _ = build_rs_git_info::emit_git_info();
 }

--- a/openvmm/openvmm_entry/src/cli_args.rs
+++ b/openvmm/openvmm_entry/src/cli_args.rs
@@ -32,6 +32,7 @@ use std::ffi::OsString;
 use std::net::SocketAddr;
 use std::path::PathBuf;
 use std::str::FromStr;
+use std::sync::LazyLock;
 use thiserror::Error;
 
 /// Parse CLI options, using a thread with a larger stack on Windows to avoid
@@ -138,11 +139,29 @@ pub struct NumaDistanceCli {
     pub distance: u8,
 }
 
+/// Formats the `--version` output from the crate version and the git revision
+/// the build recorded, if any.
+fn version_string(pkg_version: &str, revision: Option<&str>) -> String {
+    match revision {
+        Some(revision) if !revision.is_empty() => format!("{pkg_version} ({revision})"),
+        _ => pkg_version.to_owned(),
+    }
+}
+
+static VERSION: LazyLock<String> =
+    LazyLock::new(|| version_string(env!("CARGO_PKG_VERSION"), option_env!("BUILD_GIT_SHA")));
+
+/// The `--version` text, built once on first use.
+fn version() -> &'static str {
+    VERSION.as_str()
+}
+
 /// OpenVMM virtual machine monitor.
 ///
 /// This is not yet a stable interface and may change radically between
 /// versions.
 #[derive(Parser)]
+#[command(name = "openvmm", version = version())]
 pub struct Options {
     /// processor count
     #[clap(short = 'p', long, value_name = "COUNT", default_value = "1")]
@@ -3362,6 +3381,24 @@ mod tests {
 
     use std::path::Path;
     use test_with_tracing::test;
+
+    #[test]
+    fn version_string_includes_the_revision_when_the_build_had_one() {
+        assert_eq!(version_string("1.2.3", Some("abc1234")), "1.2.3 (abc1234)");
+    }
+
+    #[test]
+    fn version_string_falls_back_to_the_crate_version_without_a_repository() {
+        // A source build outside a git checkout emits no revision. It has to
+        // produce a usable version rather than an empty or malformed one.
+        assert_eq!(version_string("1.2.3", None), "1.2.3");
+    }
+
+    #[test]
+    fn version_string_ignores_a_blank_revision() {
+        // `git` succeeding with empty output would otherwise render "1.2.3 ()".
+        assert_eq!(version_string("1.2.3", Some("")), "1.2.3");
+    }
 
     #[test]
     fn test_parse_rpc() {


### PR DESCRIPTION
`openvmm --version` did not exist, so a deployed binary could not identify itself. Today the only way to tell which revision a binary came from is to hash it and look that hash up in a record kept somewhere else, which answers "is this the same binary as before" but never "which revision is this one".

This wires up clap's version flag and builds the string from the crate version plus the git revision:

    $ openvmm --version
    openvmm 0.0.0 (3148a7cc9ea8eaa7b7c61cb59d26880f809fe5a6)

The revision comes from the existing `build_rs_git_info` helper, already used by build_info, burette and underhill_init. Unlike those, the error is ignored here rather than unwrapped: they are always built inside a checkout, while openvmm is also built from release tarballs and vendored sources, where a missing repository should degrade the version string rather than fail the build.

The command name is set explicitly. clap otherwise takes it from the crate and reports `openvmm_entry`, which is neither the binary name nor what the usage line already prints.

Every crate in the workspace is at 0.0.0, so the revision currently carries all of the information. The flag gets more useful for free if a real version is ever set.
