### PR TITLE
fix(ohcldiag-dev): treat GUID-shaped VM args as names, not IDs

### DIFF
--- a/openhcl/ohcldiag-dev/src/main.rs
+++ b/openhcl/ohcldiag-dev/src/main.rs
@@ -24,7 +24,6 @@ use pal_async::driver::Driver;
 use pal_async::socket::PolledSocket;
 use pal_async::task::Spawn;
 use pal_async::timer::PolledTimer;
-use std::convert::Infallible;
 use std::ffi::OsStr;
 use std::io::ErrorKind;
 use std::io::IsTerminal;
@@ -331,13 +330,13 @@ pub struct VmArg {
     )]
     #[cfg_attr(
         windows,
-        doc = "* hyperv:GUID - A Hyper-V VM ID (with or without braces)
+        doc = "* hyperv-id:GUID - A Hyper-V VM ID (with or without braces)
 
     "
     )]
     #[cfg_attr(
         windows,
-        doc = "* NAME_OR_GUID_OR_PATH - Either a Hyper-V VM name or GUID, or a path as in vsock:PATH"
+        doc = "* NAME_OR_PATH - Either a Hyper-V VM name, or a path as in vsock:PATH"
     )]
     #[cfg_attr(not(windows), doc = "* PATH - A path as in vsock:PATH")]
     #[clap(name = "VM")]
@@ -354,7 +353,7 @@ enum VmId {
 }
 
 impl FromStr for VmId {
-    type Err = Infallible;
+    type Err = ParseVmIdError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         if let Some(s) = s.strip_prefix("vsock:") {
@@ -362,19 +361,19 @@ impl FromStr for VmId {
         } else {
             #[cfg(windows)]
             {
-                let (value, had_prefix) = match s.strip_prefix("hyperv:") {
-                    Some(rest) => (rest, true),
-                    None => (s, false),
-                };
-
-                // Try parsing as a GUID first (with or without braces).
-                if let Ok(guid) = value.parse::<guid::Guid>() {
+                if let Some(rest) = s.strip_prefix("hyperv-id:") {
+                    let guid = rest
+                        .parse::<guid::Guid>()
+                        .map_err(|_| ParseVmIdError::InvalidGuid(rest.to_owned()))?;
                     return Ok(Self::HyperVId(guid));
                 }
 
-                if had_prefix || !pal::windows::fs::is_unix_socket(value.as_ref()).unwrap_or(false)
-                {
-                    return Ok(Self::HyperV(value.to_owned()));
+                if let Some(name) = s.strip_prefix("hyperv:") {
+                    return Ok(Self::HyperV(name.to_owned()));
+                }
+
+                if !pal::windows::fs::is_unix_socket(s.as_ref()).unwrap_or(false) {
+                    return Ok(Self::HyperV(s.to_owned()));
                 }
             }
             // Default to hybrid vsock since this is what OpenVMM supports for
@@ -382,6 +381,14 @@ impl FromStr for VmId {
             Ok(Self::HybridVsock(Path::new(s).to_owned()))
         }
     }
+}
+
+/// Error parsing a [`VmId`].
+#[derive(Debug, Error)]
+enum ParseVmIdError {
+    #[cfg(windows)]
+    #[error("invalid VM ID GUID '{0}' (expected a GUID, with or without braces)")]
+    InvalidGuid(String),
 }
 
 #[derive(Clone)]
@@ -1118,4 +1125,57 @@ async fn capture_packets(
         }
     }
     println!("All done.");
+}
+
+#[cfg(all(test, windows))]
+mod tests {
+    use super::VmId;
+
+    #[test]
+    fn bare_guid_is_treated_as_name() {
+        // Fleet VM names are GUID-shaped; a bare value must be a name, not an ID.
+        let id: VmId = "1965676a-8dd3-4b46-9439-40c6a30e5b1a".parse().unwrap();
+        assert!(matches!(id, VmId::HyperV(name) if name == "1965676a-8dd3-4b46-9439-40c6a30e5b1a"));
+    }
+
+    #[test]
+    fn hyperv_prefix_is_a_name() {
+        let id: VmId = "hyperv:my-vm".parse().unwrap();
+        assert!(matches!(id, VmId::HyperV(name) if name == "my-vm"));
+    }
+
+    #[test]
+    fn hyperv_prefix_with_guid_is_still_a_name() {
+        let id: VmId = "hyperv:1965676a-8dd3-4b46-9439-40c6a30e5b1a"
+            .parse()
+            .unwrap();
+        assert!(matches!(id, VmId::HyperV(name) if name == "1965676a-8dd3-4b46-9439-40c6a30e5b1a"));
+    }
+
+    #[test]
+    fn hyperv_id_prefix_parses_guid() {
+        let id: VmId = "hyperv-id:1965676a-8dd3-4b46-9439-40c6a30e5b1a"
+            .parse()
+            .unwrap();
+        assert!(matches!(id, VmId::HyperVId(_)));
+    }
+
+    #[test]
+    fn hyperv_id_prefix_parses_braced_guid() {
+        let id: VmId = "hyperv-id:{1965676a-8dd3-4b46-9439-40c6a30e5b1a}"
+            .parse()
+            .unwrap();
+        assert!(matches!(id, VmId::HyperVId(_)));
+    }
+
+    #[test]
+    fn hyperv_id_prefix_with_invalid_guid_errors() {
+        assert!("hyperv-id:not-a-guid".parse::<VmId>().is_err());
+    }
+
+    #[test]
+    fn vsock_prefix_is_hybrid_vsock() {
+        let id: VmId = "vsock:/tmp/vm.sock".parse().unwrap();
+        assert!(matches!(id, VmId::HybridVsock(_)));
+    }
 }


### PR DESCRIPTION
## Summary

Fixes a regression from #3753 that breaks all `ohcldiag-dev` interactions against fleet VMs (observed on TiP, blocking Underhill 1.8 memory validation).

## Problem

#3753 changed `VmId::from_str` to try `parse::<guid::Guid>()` **first** for bare and `hyperv:`-prefixed arguments, treating any successful parse as a VM **ID**. In the fleet, Hyper-V VM **names** are themselves GUID-shaped, so a name was misinterpreted as a VM ID and used directly as the AF_HYPERV connect address — instead of being resolved to the real VM ID via `hvc.exe id <name>` (`vm_id_from_name`). The bogus address produces:

```
Error: failed to connect
Caused by:
    0: failed to connect
    1: The requested address is not valid in its context. (os error 10049)   // WSAEADDRNOTAVAIL
```

## Fix

Make ID-vs-name resolution deterministic instead of inferring intent from the string's shape:

- `hyperv-id:GUID` → VM **ID** (new, explicit prefix — the only way to look up by ID)
- `hyperv:NAME` → **name** (even if GUID-shaped)
- bare value → **name** (unless it is a unix socket path → hybrid vsock)
- `vsock:PATH` → hybrid vsock (unchanged)

Also change `FromStr::Err` from `Infallible` to `ParseVmIdError` so an explicit `hyperv-id:` with an invalid GUID reports a clear parse error rather than silently falling through to a name lookup.

## Behavior change

Callers relying on a bare GUID being interpreted as a VM ID (introduced in #3753) must now use the `hyperv-id:` prefix.

## Testing

- Added Windows-guarded unit tests for `VmId::from_str` covering each parse path (bare GUID → name, `hyperv:` → name, `hyperv-id:` with/without braces → ID, invalid `hyperv-id:` → error, `vsock:` → hybrid vsock).
- `cargo check` / `cargo clippy --all-targets` / `cargo doc --no-deps` clean against `x86_64-pc-windows-msvc`.
- `cargo xtask fmt` clean.