### PR TITLE
Add RSA_AES_KEY_WRAP_384 support to IGVM attest key release

### DIFF
--- a/openhcl/openhcl_attestation_protocol/src/igvm_attest/get.rs
+++ b/openhcl/openhcl_attestation_protocol/src/igvm_attest/get.rs
@@ -170,13 +170,21 @@ impl IgvmAttestRequestHeader {
 /// 0 - error_code: Requesting IGVM Agent Error code
 /// 1 - retry: Retry preference
 /// 2 - skip_hw_unsealing: Skip hardware unsealing in case key release request fails
+/// 3 - use_rsa_aes_key_wrap_384: Request that the IGVM Agent ask Azure Key Vault
+///     (AKV) to wrap and release the key with the SHA-384 variant of the
+///     composite RSA+AES key-wrap scheme (PKCS#11 CKM_RSA_AES_KEY_WRAP /
+///     AKV's RSA_AES_KEY_WRAP_384): RSA-OAEP-SHA384 (MGF1-SHA-384) wraps an
+///     AES-256 KEK that performs AES Key Wrap on the released key. The default
+///     is the same CKM_RSA_AES_KEY_WRAP scheme with the inner RSA-OAEP using
+///     SHA-1 (MGF1-SHA-1).
 #[bitfield(u32)]
 #[derive(IntoBytes, FromBytes, Immutable, KnownLayout)]
 pub struct IgvmCapabilityBitMap {
     pub error_code: bool,
     pub retry: bool,
     pub skip_hw_unsealing: bool,
-    #[bits(29)]
+    pub use_rsa_aes_key_wrap_384: bool,
+    #[bits(28)]
     _reserved: u32,
 }
 
@@ -234,12 +242,18 @@ impl IgvmAttestRequestDataExt {
 /// Bitmap indicates a signal to requestor
 /// 0 - IGVM_SIGNAL_RETRY_RECOMMENDED_BIT: Retry recommendation
 /// 1 - IGVM_SIGNAL_SKIP_HW_UNSEALING_RECOMMENDED_BIT: Skip hardware unsealing
+/// 2 - IGVM_SIGNAL_RSA_AES_KEY_WRAP_384_USED_BIT: Set by the IGVM Agent to
+///     indicate that the agent asked AKV for the SHA-384 variant
+///     (RSA_AES_KEY_WRAP_384) and AKV used it to wrap the key in the payload.
+///     If this bit is clear, AKV wrapped the key with the default
+///     CKM_RSA_AES_KEY_WRAP scheme (inner RSA-OAEP using SHA-1).
 #[bitfield(u32)]
 #[derive(IntoBytes, Immutable, KnownLayout, FromBytes)]
 pub struct IgvmSignal {
     pub retry: bool,
     pub skip_hw_unsealing: bool,
-    #[bits(30)]
+    pub rsa_aes_key_wrap_384_used: bool,
+    #[bits(29)]
     _reserved: u32,
 }
 

--- a/openhcl/underhill_attestation/src/igvm_attest/key_release.rs
+++ b/openhcl/underhill_attestation/src/igvm_attest/key_release.rs
@@ -30,23 +30,55 @@ pub(crate) enum KeyReleaseError {
     InvalidResponseVersion(u32),
 }
 
-/// Parse a `KEY_RELEASE_REQUEST` response and return a raw wrapped key blob.
+/// Parsed result of a `KEY_RELEASE_REQUEST` response.
+#[derive(Debug)]
+pub(crate) struct KeyReleaseResponse {
+    /// The raw RSA-AES-wrapped key blob.
+    pub wrapped_key: Vec<u8>,
+    /// Whether the IGVM Agent signaled that AKV used the SHA-384 variant of the
+    /// composite RSA+AES key-wrap scheme (`RSA_AES_KEY_WRAP_384`). When `false`,
+    /// the default scheme is used (inner RSA-OAEP using SHA-1).
+    pub rsa_aes_key_wrap_384_used: bool,
+}
+
+/// Parse a `KEY_RELEASE_REQUEST` response and return a raw wrapped key blob along
+/// with the IGVM Agent signal indicating which key-wrap scheme was used.
 ///
-/// Returns `Ok(Vec<u8>)` on successfully extracting a wrapped key blob from `response`,
-/// otherwise return an error.
+/// Returns `Ok(KeyReleaseResponse)` on successfully extracting a wrapped key blob
+/// from `response`, otherwise return an error.
 pub fn parse_response(
     response: &[u8],
     rsa_modulus_size: usize,
-) -> Result<Vec<u8>, KeyReleaseError> {
+) -> Result<KeyReleaseResponse, KeyReleaseError> {
     use openhcl_attestation_protocol::igvm_attest::get::IgvmAttestCommonResponseHeader;
     use openhcl_attestation_protocol::igvm_attest::get::IgvmAttestKeyReleaseResponseHeader;
     use openhcl_attestation_protocol::igvm_attest::get::IgvmAttestResponseVersion;
+    use zerocopy::FromBytes;
 
     // Minimum acceptable payload would look like {"ciphertext":"base64URL wrapped key"}
     const AES_IC_SIZE: usize = 8;
     const CIPHER_TEXT_KEY: &str = r#"{"ciphertext":""}"#;
 
     let header = parse_response_header(response).map_err(KeyReleaseError::ParseHeader)?;
+
+    // The `rsa_aes_key_wrap_384_used` signal is only present in the version 2+
+    // response header. When absent, fall back to the default (SHA-1) scheme.
+    let rsa_aes_key_wrap_384_used = match header.version {
+        IgvmAttestResponseVersion::VERSION_2 => {
+            let full_header = IgvmAttestKeyReleaseResponseHeader::read_from_prefix(response)
+                .map_err(|_| {
+                    KeyReleaseError::ParseHeader(CommonError::ResponseHeaderInvalidFormat {
+                        response_size: response.len(),
+                    })
+                })?
+                .0; // TODO: zerocopy: err (https://github.com/microsoft/openvmm/issues/759)
+            full_header
+                .error_info
+                .igvm_signal
+                .rsa_aes_key_wrap_384_used()
+        }
+        _ => false,
+    };
 
     // Extract payload as per header version
     let header_size = match header.version {
@@ -86,7 +118,10 @@ pub fn parse_response(
         }
     };
 
-    Ok(wrapped_key)
+    Ok(KeyReleaseResponse {
+        wrapped_key,
+        rsa_aes_key_wrap_384_used,
+    })
 }
 
 fn get_wrapped_key_blob(

--- a/openhcl/underhill_attestation/src/igvm_attest/mod.rs
+++ b/openhcl/underhill_attestation/src/igvm_attest/mod.rs
@@ -318,7 +318,8 @@ fn create_request(
         let capability_bitmap = IgvmCapabilityBitMap::new()
             .with_error_code(true)
             .with_retry(true)
-            .with_skip_hw_unsealing(true);
+            .with_skip_hw_unsealing(true)
+            .with_use_rsa_aes_key_wrap_384(true);
         let ext = IgvmAttestRequestDataExt::new(capability_bitmap);
         buffer.extend_from_slice(ext.as_bytes());
     }

--- a/openhcl/underhill_attestation/src/secure_key_release.rs
+++ b/openhcl/underhill_attestation/src/secure_key_release.rs
@@ -77,6 +77,7 @@ pub(crate) enum Pkcs11RsaAesKeyUnwrapError {
 fn pkcs11_rsa_aes_key_unwrap(
     unwrapping_rsa_key: &RsaKeyPair,
     wrapped_key_blob: &[u8],
+    rsa_aes_key_wrap_384_used: bool,
 ) -> Result<RsaKeyPair, Pkcs11RsaAesKeyUnwrapError> {
     let modulus_size = unwrapping_rsa_key.modulus_size();
 
@@ -91,8 +92,18 @@ fn pkcs11_rsa_aes_key_unwrap(
         return Err(Pkcs11RsaAesKeyUnwrapError::EmptyWrappedRsaKey);
     }
 
+    // The IGVM Agent signals via `rsa_aes_key_wrap_384_used` whether AKV wrapped
+    // the AES KEK using the SHA-384 variant (RSA_AES_KEY_WRAP_384, inner
+    // RSA-OAEP-SHA384). Otherwise fall back to the default scheme (inner
+    // RSA-OAEP-SHA1).
+    let oaep_hash_algorithm = if rsa_aes_key_wrap_384_used {
+        HashAlgorithm::Sha384
+    } else {
+        HashAlgorithm::Sha1
+    };
+
     let unwrapped_aes_key = unwrapping_rsa_key
-        .oaep_decrypt(wrapped_aes_key, HashAlgorithm::Sha1)
+        .oaep_decrypt(wrapped_aes_key, oaep_hash_algorithm)
         .map_err(Pkcs11RsaAesKeyUnwrapError::RsaUnwrap)?;
     let unwrapped_rsa_key = crypto::aes_kwp::AesKeyWrap::new(&unwrapped_aes_key)
         .and_then(|kw| kw.unwrapper()?.unwrap(wrapped_rsa_key))
@@ -109,6 +120,10 @@ struct WrappedKeyVmgsEncryptionKeys {
     rsa_aes_wrapped_key: Vec<u8>,
     /// Optional wrapped DiskEncryptionSettings key blob.
     wrapped_des_key: Option<Vec<u8>>,
+    /// Whether the IGVM Agent signaled that AKV used the SHA-384 variant of the
+    /// RSA+AES key-wrap scheme (`RSA_AES_KEY_WRAP_384`) for `rsa_aes_wrapped_key`.
+    /// When `false`, the default scheme (inner RSA-OAEP using SHA-1) is used.
+    rsa_aes_key_wrap_384_used: bool,
 }
 
 /// The return values of [`request_vmgs_encryption_keys`].
@@ -180,9 +195,14 @@ pub async fn request_vmgs_encryption_keys(
         Ok(WrappedKeyVmgsEncryptionKeys {
             rsa_aes_wrapped_key,
             wrapped_des_key,
+            rsa_aes_key_wrap_384_used,
         }) => {
-            let ingress_rsa_kek = pkcs11_rsa_aes_key_unwrap(&transfer_key, &rsa_aes_wrapped_key)
-                .map_err(|e| (RequestVmgsEncryptionKeysError::Pkcs11RsaAesKeyUnwrap(e), false))?;
+            let ingress_rsa_kek = pkcs11_rsa_aes_key_unwrap(
+                &transfer_key,
+                &rsa_aes_wrapped_key,
+                rsa_aes_key_wrap_384_used,
+            )
+            .map_err(|e| (RequestVmgsEncryptionKeysError::Pkcs11RsaAesKeyUnwrap(e), false))?;
 
             Ok(VmgsEncryptionKeys {
                 ingress_rsa_kek: Some(ingress_rsa_kek),
@@ -368,9 +388,13 @@ async fn make_igvm_attest_requests(
 
     match igvm_attest::key_release::parse_response(&response.response, transfer_key.modulus_size())
     {
-        Ok(rsa_aes_wrapped_key) => Ok(WrappedKeyVmgsEncryptionKeys {
+        Ok(igvm_attest::key_release::KeyReleaseResponse {
+            wrapped_key: rsa_aes_wrapped_key,
+            rsa_aes_key_wrap_384_used,
+        }) => Ok(WrappedKeyVmgsEncryptionKeys {
             rsa_aes_wrapped_key,
             wrapped_des_key,
+            rsa_aes_key_wrap_384_used,
         }),
         Err(e) => {
             // Notify host for diagnosis.
@@ -391,7 +415,7 @@ mod tests {
 
         // undersized aes key blob
         let wrapped_key_blob = vec![0; 256 - 1];
-        let result = pkcs11_rsa_aes_key_unwrap(&rsa, &wrapped_key_blob);
+        let result = pkcs11_rsa_aes_key_unwrap(&rsa, &wrapped_key_blob, false);
         assert!(matches!(
             result,
             Err(Pkcs11RsaAesKeyUnwrapError::UndersizedWrappedAesKey(
@@ -401,7 +425,7 @@ mod tests {
 
         // empty rsa key blob
         let wrapped_key_blob = vec![0; 256];
-        let result = pkcs11_rsa_aes_key_unwrap(&rsa, &wrapped_key_blob);
+        let result = pkcs11_rsa_aes_key_unwrap(&rsa, &wrapped_key_blob, false);
         assert!(matches!(
             result,
             Err(Pkcs11RsaAesKeyUnwrapError::EmptyWrappedRsaKey)
@@ -411,28 +435,37 @@ mod tests {
     #[test]
     #[expect(deprecated)]
     fn pkcs11_rsa_aes_key_unwrap_roundtrip() {
-        let target_key = RsaKeyPair::generate(2048).unwrap();
-        let pkcs8_target_key = target_key.to_pkcs8_der().unwrap();
+        // Exercise both the default (SHA-1) and SHA-384 key-wrap schemes.
+        for (rsa_aes_key_wrap_384_used, oaep_hash_algorithm) in
+            [(false, HashAlgorithm::Sha1), (true, HashAlgorithm::Sha384)]
+        {
+            let target_key = RsaKeyPair::generate(2048).unwrap();
+            let pkcs8_target_key = target_key.to_pkcs8_der().unwrap();
 
-        let mut wrapping_aes_key = [0u8; 32];
-        getrandom::fill(&mut wrapping_aes_key).expect("rng failure");
+            let mut wrapping_aes_key = [0u8; 32];
+            getrandom::fill(&mut wrapping_aes_key).expect("rng failure");
 
-        let wrapping_rsa_key = RsaKeyPair::generate(2048).unwrap();
-        let wrapped_aes_key = wrapping_rsa_key
-            .oaep_encrypt(&wrapping_aes_key, HashAlgorithm::Sha1)
+            let wrapping_rsa_key = RsaKeyPair::generate(2048).unwrap();
+            let wrapped_aes_key = wrapping_rsa_key
+                .oaep_encrypt(&wrapping_aes_key, oaep_hash_algorithm)
+                .unwrap();
+            let wrapped_target_key = crypto::aes_kwp::AesKeyWrap::new(&wrapping_aes_key)
+                .unwrap()
+                .wrapper()
+                .unwrap()
+                .wrap(&pkcs8_target_key)
+                .unwrap();
+            let wrapped_key_blob = [wrapped_aes_key, wrapped_target_key].concat();
+            let unwrapped_target_key = pkcs11_rsa_aes_key_unwrap(
+                &wrapping_rsa_key,
+                wrapped_key_blob.as_slice(),
+                rsa_aes_key_wrap_384_used,
+            )
             .unwrap();
-        let wrapped_target_key = crypto::aes_kwp::AesKeyWrap::new(&wrapping_aes_key)
-            .unwrap()
-            .wrapper()
-            .unwrap()
-            .wrap(&pkcs8_target_key)
-            .unwrap();
-        let wrapped_key_blob = [wrapped_aes_key, wrapped_target_key].concat();
-        let unwrapped_target_key =
-            pkcs11_rsa_aes_key_unwrap(&wrapping_rsa_key, wrapped_key_blob.as_slice()).unwrap();
-        assert_eq!(
-            unwrapped_target_key.to_pkcs8_der().unwrap(),
-            target_key.to_pkcs8_der().unwrap()
-        );
+            assert_eq!(
+                unwrapped_target_key.to_pkcs8_der().unwrap(),
+                target_key.to_pkcs8_der().unwrap()
+            );
+        }
     }
 }

--- a/vm/devices/get/test_igvm_agent_lib/src/lib.rs
+++ b/vm/devices/get/test_igvm_agent_lib/src/lib.rs
@@ -387,6 +387,18 @@ impl TestIgvmAgent {
         }
         let runtime_claims_bytes = &request_bytes[runtime_claims_start..runtime_claims_end];
 
+        // Extract the request capability bitmap, appended right after the
+        // request base. This tells the agent whether the guest requested the
+        // SHA-384 variant of the RSA+AES key-wrap scheme.
+        let request_data_ext = IgvmAttestRequestDataExt::read_from_prefix(
+            &request_bytes[size_of::<IgvmAttestRequestBase>()..],
+        )
+        .map_err(|_| Error::InvalidIgvmAttestRequest)?
+        .0; // TODO: zerocopy: map_err (https://github.com/microsoft/openvmm/issues/759)
+        let use_rsa_aes_key_wrap_384 = request_data_ext
+            .capability_bitmap
+            .use_rsa_aes_key_wrap_384();
+
         let (response, length) = if let Some(action) =
             self.take_next_action(request.header.request_type)
         {
@@ -423,7 +435,10 @@ impl TestIgvmAgent {
                                 self.initialize_keys()?;
                             }
                             let jwt = self
-                                .generate_mock_key_release_response(runtime_claims_bytes)
+                                .generate_mock_key_release_response(
+                                    runtime_claims_bytes,
+                                    use_rsa_aes_key_wrap_384,
+                                )
                                 .map_err(Error::KeyReleaseError)?;
                             let data = jwt.as_bytes().to_vec();
                             let header = IgvmAttestKeyReleaseResponseHeader {
@@ -431,7 +446,11 @@ impl TestIgvmAgent {
                                     + size_of::<IgvmAttestKeyReleaseResponseHeader>())
                                     as u32,
                                 version: IGVM_ATTEST_RESPONSE_CURRENT_VERSION,
-                                error_info: IgvmErrorInfo::default(),
+                                error_info: IgvmErrorInfo {
+                                    igvm_signal: IgvmSignal::default()
+                                        .with_rsa_aes_key_wrap_384_used(use_rsa_aes_key_wrap_384),
+                                    ..Default::default()
+                                },
                             };
                             let payload = [header.as_bytes(), &data].concat();
                             let payload_len = payload.len() as u32;
@@ -530,7 +549,10 @@ impl TestIgvmAgent {
 
                     // Generate a mock JWT response for testing - convert request to proper type
                     let jwt_response = self
-                        .generate_mock_key_release_response(runtime_claims_bytes)
+                        .generate_mock_key_release_response(
+                            runtime_claims_bytes,
+                            use_rsa_aes_key_wrap_384,
+                        )
                         .map_err(Error::KeyReleaseError)?;
                     let data = jwt_response.as_bytes().to_vec();
 
@@ -538,7 +560,11 @@ impl TestIgvmAgent {
                         data_size: (data.len() + size_of::<IgvmAttestKeyReleaseResponseHeader>())
                             as u32,
                         version: IGVM_ATTEST_RESPONSE_CURRENT_VERSION,
-                        error_info: IgvmErrorInfo::default(),
+                        error_info: IgvmErrorInfo {
+                            igvm_signal: IgvmSignal::default()
+                                .with_rsa_aes_key_wrap_384_used(use_rsa_aes_key_wrap_384),
+                            ..Default::default()
+                        },
                     };
                     let payload = [header.as_bytes(), &data].concat();
                     let payload_len = payload.len() as u32;
@@ -637,6 +663,7 @@ impl TestIgvmAgent {
     fn generate_mock_key_release_response(
         &self,
         runtime_claims_bytes: &[u8],
+        use_rsa_aes_key_wrap_384: bool,
     ) -> Result<String, KeyReleaseError> {
         use openhcl_attestation_protocol::igvm_attest::get::runtime_claims::RuntimeClaims;
 
@@ -671,7 +698,7 @@ impl TestIgvmAgent {
             .map_err(KeyReleaseError::ConvertJwkRsaFailed)?;
 
         // Generate the JWT response using the extracted RSA key
-        self.generate_jwt_with_rsa_key(rsa_public_key)
+        self.generate_jwt_with_rsa_key(rsa_public_key, use_rsa_aes_key_wrap_384)
     }
 
     /// Generate a mock JWT response for testing KEY_RELEASE_REQUEST
@@ -679,6 +706,7 @@ impl TestIgvmAgent {
     fn generate_jwt_with_rsa_key(
         &self,
         public_key: RsaPublicKey,
+        use_rsa_aes_key_wrap_384: bool,
     ) -> Result<String, KeyReleaseError> {
         use openhcl_attestation_protocol::igvm_attest::akv;
 
@@ -697,9 +725,16 @@ impl TestIgvmAgent {
             .and_then(|kw| kw.wrapper()?.wrap(priv_key_der.as_bytes()))
             .map_err(KeyReleaseError::AesKeyWrap)?;
 
-        // Encrypt the KEK using RSA-OAEP
+        // Encrypt the KEK using RSA-OAEP. Use the SHA-384 variant when the
+        // guest requested it (RSA_AES_KEY_WRAP_384), otherwise the default
+        // scheme with inner RSA-OAEP using SHA-1.
+        let oaep_hash_algorithm = if use_rsa_aes_key_wrap_384 {
+            crypto::HashAlgorithm::Sha384
+        } else {
+            crypto::HashAlgorithm::Sha1
+        };
         let encrypted_kek = public_key
-            .oaep_encrypt(&kek_bytes, crypto::HashAlgorithm::Sha1)
+            .oaep_encrypt(&kek_bytes, oaep_hash_algorithm)
             .map_err(KeyReleaseError::RsaEncryptionError)?;
 
         // Create the PKCS#11 RSA-AES-KEY-WRAP payload: RSA-encrypted KEK + AES-wrapped key


### PR DESCRIPTION
Introduce the IGVM_REQUEST_USE_RSA_AES_KEY_WRAP_384 capability bit and the corresponding IGVM_SIGNAL_RSA_AES_KEY_WRAP_384_USED response signal.

OpenHCL now requests the SHA-384 variant of the composite RSA+AES key-wrap scheme by default. When the KEY_RELEASE response also sets the signal bit, the wrapped AES KEK is unwrapped with RSA-OAEP-SHA384; otherwise it falls back to the existing RSA-OAEP-SHA1 scheme.