### PR TITLE
sidecar: remove assert in sidecar node creation flow

### DIFF
--- a/openhcl/sidecar_client/src/lib.rs
+++ b/openhcl/sidecar_client/src/lib.rs
@@ -157,7 +157,6 @@ impl SidecarClient {
                     "sidecar node follows a gap; earlier node(s) skipped (no sidecar-started APs)"
                 );
             }
-            assert_eq!(node.cpus.start, expected_base);
             expected_base = node.cpus.end;
             nodes.push(node);
         }


### PR DESCRIPTION
The sidecar client initialization flow assumes that sidecar nodes are contiguous, and that the nodes' CPU range begin at CPU 0. This does not always hold; in scale tests in which we stress the IO path, most VPs need a full linux kernel, and the CPU range for the first sidecar client in nonzero.

This PR removes the assert.