### PR TITLE
hcl: tolerate EOPNOTSUPP for TDX-only timer virt cap on non-TDX guests

### DIFF
--- a/openhcl/hcl/src/ioctl.rs
+++ b/openhcl/hcl/src/ioctl.rs
@@ -1858,8 +1858,19 @@ impl Hcl {
         let supports_vtl_ret_action = mshv_fd.check_extension(HCL_CAP_VTL_RETURN_ACTION)?;
         let supports_register_page = mshv_fd.check_extension(HCL_CAP_REGISTER_PAGE)?;
         let dr6_shared = mshv_fd.check_extension(HCL_CAP_DR6_SHARED)?;
+        // This capability is TDX-only. On non-TDX guests treat EOPNOTSUPP as
+        // "not supported" rather than failing; on TDX propagate the error.
         let supports_lower_vtl_timer_virt =
-            mshv_fd.check_extension(HCL_CAP_LOWER_VTL_TIMER_VIRT)?;
+            match mshv_fd.check_extension(HCL_CAP_LOWER_VTL_TIMER_VIRT) {
+                Ok(supported) => supported,
+                Err(Error::CheckExtensions(_, nix::errno::Errno::EOPNOTSUPP))
+                    if isolation != IsolationType::Tdx =>
+                {
+                    false
+                }
+                Err(err) => return Err(err),
+            };
+
         tracing::debug!(
             supports_vtl_ret_action,
             supports_register_page,


### PR DESCRIPTION
The lower-VTL timer virtualization capability (HCL_CAP_LOWER_VTL_TIMER_VIRT) is TDX-only and is not present in the upstream Linux kernel, which returns EOPNOTSUPP for it. This previously caused check_extension to fail and aborted prototype partition creation for non-CVM guests.

Treat EOPNOTSUPP as 'not supported' for this capability on non-TDX guests so they are no longer broken, while still propagating the error on TDX so that a genuinely missing capability fails loudly as before.