### PR TITLE
virt_mshv_vtl: Fixup handling of higher VTL permissions when emulating instructions

### DIFF
--- a/openhcl/virt_mshv_vtl/src/processor/mshv/arm64.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/mshv/arm64.rs
@@ -700,6 +700,14 @@ impl<T: CpuIo> EmulatorSupport for UhEmulationState<'_, '_, T, HypervisorBackedA
             // or with an initial translation.
             debug_assert!(self.vp.is_tlb_locked(Vtl::Vtl2, self.vtl));
 
+            // An intercept can report a gpa that is unmapped or even outside the
+            // partition's address space, and the hypervisor fails the whole
+            // hypercall for those rather than reporting a per-page result. Only
+            // mapped lower VTL RAM can carry VTL protections anyway.
+            if !self.vp.partition.is_gpa_lower_vtl_ram(gpa) {
+                return Ok(());
+            }
+
             let cpsr: Cpsr64 = self
                 .vp
                 .runner

--- a/openhcl/virt_mshv_vtl/src/processor/mshv/arm64.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/mshv/arm64.rs
@@ -680,20 +680,16 @@ impl<T: CpuIo> EmulatorSupport for UhEmulationState<'_, '_, T, HypervisorBackedA
         // For VTL 0, the alias map guards for read and write permissions, so only check VTL execute
         // permissions. Because VTL 2 will not restrict execute exclusively, only VTL 1 execute
         // permissions need to be checked and therefore only check permissions once VTL 1
-        // protections are enabled.
+        // protections are enabled. However on non-isolated partitions we don't intercept
+        // VTL 1 enablement, so we just check if VTL 1 is supported at all.
         //
         // Note: the restriction to VTL 1 support also means that for WHP, which doesn't support VTL 1
         // the HvCheckSparseGpaPageVtlAccess hypercall--which is unimplemented in whp--will never be made.
         if mode == emulate::TranslateMode::Execute
             && self.vtl == GuestVtl::Vtl0
-            && matches!(
+            && !matches!(
                 *self.vp.shared.guest_vsm.read(),
-                GuestVsmState::Enabled {
-                    vtl1: VbsIsolatedVtl1State {
-                        enable_vtl_protection: true,
-                        ..
-                    },
-                }
+                GuestVsmState::NotPlatformSupported,
             )
         {
             // Should always be called after translate gva with the tlb lock flag

--- a/openhcl/virt_mshv_vtl/src/processor/mshv/arm64.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/mshv/arm64.rs
@@ -679,15 +679,21 @@ impl<T: CpuIo> EmulatorSupport for UhEmulationState<'_, '_, T, HypervisorBackedA
         //
         // For VTL 0, the alias map guards for read and write permissions, so only check VTL execute
         // permissions. Because VTL 2 will not restrict execute exclusively, only VTL 1 execute
-        // permissions need to be checked and therefore only check permissions if VTL 1 is allowed.
+        // permissions need to be checked and therefore only check permissions once VTL 1
+        // protections are enabled.
         //
         // Note: the restriction to VTL 1 support also means that for WHP, which doesn't support VTL 1
         // the HvCheckSparseGpaPageVtlAccess hypercall--which is unimplemented in whp--will never be made.
         if mode == emulate::TranslateMode::Execute
             && self.vtl == GuestVtl::Vtl0
-            && !matches!(
+            && matches!(
                 *self.vp.shared.guest_vsm.read(),
-                GuestVsmState::NotPlatformSupported,
+                GuestVsmState::Enabled {
+                    vtl1: VbsIsolatedVtl1State {
+                        enable_vtl_protection: true,
+                        ..
+                    },
+                }
             )
         {
             // Should always be called after translate gva with the tlb lock flag

--- a/openhcl/virt_mshv_vtl/src/processor/mshv/x64.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/mshv/x64.rs
@@ -1260,20 +1260,16 @@ impl<T: CpuIo> EmulatorSupport for UhEmulationState<'_, '_, T, HypervisorBackedX
         // For VTL 0, the alias map guards for read and write permissions, so only check VTL execute
         // permissions. Because VTL 2 will not restrict execute exclusively, only VTL 1 execute
         // permissions need to be checked and therefore only check permissions once VTL 1
-        // protections are enabled.
+        // protections are enabled. However on non-isolated partitions we don't intercept
+        // VTL 1 enablement, so we just check if VTL 1 is supported at all.
         //
         // Note: the restriction to VTL 1 support also means that for WHP, which doesn't support VTL 1
         // the HvCheckSparseGpaPageVtlAccess hypercall--which is unimplemented in whp--will never be made.
         if mode == virt_support_x86emu::emulate::TranslateMode::Execute
             && self.vtl == GuestVtl::Vtl0
-            && matches!(
+            && !matches!(
                 *self.vp.shared.guest_vsm.read(),
-                GuestVsmState::Enabled {
-                    vtl1: VbsIsolatedVtl1State {
-                        enable_vtl_protection: true,
-                        ..
-                    },
-                }
+                GuestVsmState::NotPlatformSupported,
             )
         {
             // Should always be called after translate gva with the tlb lock flag

--- a/openhcl/virt_mshv_vtl/src/processor/mshv/x64.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/mshv/x64.rs
@@ -1259,15 +1259,21 @@ impl<T: CpuIo> EmulatorSupport for UhEmulationState<'_, '_, T, HypervisorBackedX
         //
         // For VTL 0, the alias map guards for read and write permissions, so only check VTL execute
         // permissions. Because VTL 2 will not restrict execute exclusively, only VTL 1 execute
-        // permissions need to be checked and therefore only check permissions if VTL 1 is allowed.
+        // permissions need to be checked and therefore only check permissions once VTL 1
+        // protections are enabled.
         //
         // Note: the restriction to VTL 1 support also means that for WHP, which doesn't support VTL 1
         // the HvCheckSparseGpaPageVtlAccess hypercall--which is unimplemented in whp--will never be made.
         if mode == virt_support_x86emu::emulate::TranslateMode::Execute
             && self.vtl == GuestVtl::Vtl0
-            && !matches!(
+            && matches!(
                 *self.vp.shared.guest_vsm.read(),
-                GuestVsmState::NotPlatformSupported,
+                GuestVsmState::Enabled {
+                    vtl1: VbsIsolatedVtl1State {
+                        enable_vtl_protection: true,
+                        ..
+                    },
+                }
             )
         {
             // Should always be called after translate gva with the tlb lock flag

--- a/openhcl/virt_mshv_vtl/src/processor/mshv/x64.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/mshv/x64.rs
@@ -1280,6 +1280,14 @@ impl<T: CpuIo> EmulatorSupport for UhEmulationState<'_, '_, T, HypervisorBackedX
             // or with an initial translation.
             debug_assert!(self.vp.is_tlb_locked(Vtl::Vtl2, self.vtl));
 
+            // An intercept can report a gpa that is unmapped or even outside the
+            // partition's address space, and the hypervisor fails the whole
+            // hypercall for those rather than reporting a per-page result. Only
+            // mapped lower VTL RAM can carry VTL protections anyway.
+            if !self.vp.partition.is_gpa_lower_vtl_ram(gpa) {
+                return Ok(());
+            }
+
             let mbec_user_execute = self
                 .vp
                 .runner

--- a/vm/aarch64/aarch64emu/src/cpu.rs
+++ b/vm/aarch64/aarch64emu/src/cpu.rs
@@ -22,10 +22,12 @@ pub trait Cpu: AccessCpuState {
     ) -> impl Future<Output = Result<(), Self::Error>>;
 
     /// Performs a memory read of 1, 2, 4, or 8 bytes on a guest physical address.
+    /// `exec` indicates whether the read is for execution (true) or data (false).
     fn read_physical_memory(
         &mut self,
         gpa: u64,
         bytes: &mut [u8],
+        exec: bool,
     ) -> impl Future<Output = Result<(), Self::Error>>;
 
     /// Performs a memory write of 1, 2, 4, or 8 bytes.
@@ -71,7 +73,7 @@ impl<T: Cpu + ?Sized> Cpu for &mut T {
         gva: u64,
         bytes: &mut [u8],
     ) -> impl Future<Output = Result<(), Self::Error>> {
-        (*self).read_memory(gva, bytes)
+        (*self).read_instruction(gva, bytes)
     }
 
     fn read_memory(
@@ -86,8 +88,9 @@ impl<T: Cpu + ?Sized> Cpu for &mut T {
         &mut self,
         gpa: u64,
         bytes: &mut [u8],
+        exec: bool,
     ) -> impl Future<Output = Result<(), Self::Error>> {
-        (*self).read_physical_memory(gpa, bytes)
+        (*self).read_physical_memory(gpa, bytes, exec)
     }
 
     fn write_memory(

--- a/vm/aarch64/aarch64emu/src/emulator.rs
+++ b/vm/aarch64/aarch64emu/src/emulator.rs
@@ -93,9 +93,10 @@ impl<T: Cpu> EmulatorOperations<T> {
         &mut self,
         gpa: u64,
         data: &mut [u8],
+        exec: bool,
     ) -> Result<(), Box<Error<T::Error>>> {
         self.cpu
-            .read_physical_memory(gpa, data)
+            .read_physical_memory(gpa, data, exec)
             .await
             .map_err(|err| Error::MemoryAccess(gpa, OperationKind::Read, err))?;
         Ok(())
@@ -223,7 +224,7 @@ impl<'a, T: Cpu> Emulator<'a, T> {
             let mut data = [0; 8];
             // tracing::info!(gpa, len = data.len(), "reading memory from syndrome decode");
             self.inner
-                .read_physical_memory(gpa, &mut data[..len])
+                .read_physical_memory(gpa, &mut data[..len], false)
                 .await?;
             let mut data = u64::from_ne_bytes(data);
             if sign_extend {

--- a/vm/aarch64/aarch64emu/tests/load_store.rs
+++ b/vm/aarch64/aarch64emu/tests/load_store.rs
@@ -117,6 +117,7 @@ impl Cpu for SingleCellCpu {
         &mut self,
         _gpa: u64,
         _bytes: &mut [u8],
+        _exec: bool,
     ) -> Result<(), Self::Error> {
         panic!("Not expected to be used during tests");
     }

--- a/vmm_core/virt_support_aarch64emu/src/emulate.rs
+++ b/vmm_core/virt_support_aarch64emu/src/emulate.rs
@@ -477,7 +477,7 @@ impl<T: EmulatorSupport, U: CpuIo> aarch64emu::Cpu for EmulatorCpu<'_, T, U> {
             Ok(g) => g,
             Err(e) => return Err(e),
         };
-        self.read_physical_memory(gpa, bytes).await
+        self.read_physical_memory(gpa, bytes, true).await
     }
 
     async fn read_memory(&mut self, gva: u64, bytes: &mut [u8]) -> Result<(), Self::Error> {
@@ -485,15 +485,23 @@ impl<T: EmulatorSupport, U: CpuIo> aarch64emu::Cpu for EmulatorCpu<'_, T, U> {
             Ok(g) => g,
             Err(e) => return Err(e),
         };
-        self.read_physical_memory(gpa, bytes).await
+        self.read_physical_memory(gpa, bytes, false).await
     }
 
     async fn read_physical_memory(
         &mut self,
         gpa: u64,
         bytes: &mut [u8],
+        exec: bool,
     ) -> Result<(), Self::Error> {
-        self.check_vtl_access(gpa, TranslateMode::Read)?;
+        self.check_vtl_access(
+            gpa,
+            if exec {
+                TranslateMode::Execute
+            } else {
+                TranslateMode::Read
+            },
+        )?;
 
         if self.check_monitor_read(gpa, bytes) {
             Ok(())


### PR DESCRIPTION
A bunch of small fixes to permission handling:
* Skip unmapped GPAs (they'll GP later)
* Check for execute permissions correctly on ARM