### PR TITLE
igvmfilegen: read IGVM from vmfirmwareigvm resource DLL in dump/dump-corim

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3776,6 +3776,7 @@ dependencies = [
  "loader",
  "loader_defs",
  "memory_range",
+ "object 0.37.3",
  "product_policy",
  "range_map_vec",
  "serde",

--- a/vm/loader/igvmfilegen/Cargo.toml
+++ b/vm/loader/igvmfilegen/Cargo.toml
@@ -29,6 +29,7 @@ fs-err.workspace = true
 hex = { workspace = true, features = ["serde"] }
 igvm = { workspace = true, features = ["corim"] }
 igvm_defs.workspace = true
+object = { workspace = true, features = ["read", "std"] }
 range_map_vec.workspace = true
 serde = { workspace = true, features = ["std", "derive"] }
 serde_json = { workspace = true, features = ["std"] }

--- a/vm/loader/igvmfilegen/src/firmware_dll.rs
+++ b/vm/loader/igvmfilegen/src/firmware_dll.rs
@@ -148,4 +148,3 @@ mod tests {
         assert!(!utf16le_eq(&[0x56, 0x00, 0x4d], "VM"));
     }
 }
-

--- a/vm/loader/igvmfilegen/src/firmware_dll.rs
+++ b/vm/loader/igvmfilegen/src/firmware_dll.rs
@@ -1,0 +1,151 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Read an IGVM image from either a raw IGVM file or a `vmfirmwareigvm`
+//! resource DLL.
+//!
+//! Production OpenHCL IGVM files are shipped encapsulated in a Windows
+//! resource-only DLL (`vmfirmwareigvm.dll` / `vmfirmwarecvm.dll`), where the
+//! IGVM payload is stored as a custom `VMFW` resource with id `1` -- see the
+//! `1 VMFW <igvm>` entry in `openhcl/vmfirmwareigvm_dll/resources.rc`. To let
+//! `dump` / `dump-corim` operate directly on those shipped DLLs (e.g. to
+//! confirm a CoRIM is present in the packaged firmware), this module detects a
+//! PE input and extracts the embedded IGVM from it.
+
+use anyhow::Context;
+use std::path::Path;
+
+/// Custom PE resource *type* name under which the IGVM payload is stored in a
+/// `vmfirmwareigvm` resource DLL (the `1 VMFW <igvm>` entry in `resources.rc`).
+const VMFW_RESOURCE_TYPE: &str = "VMFW";
+
+/// Read an IGVM image from `path`, transparently extracting it from a
+/// `vmfirmwareigvm` resource DLL when `path` points at a PE/DLL rather than a
+/// raw IGVM file.
+///
+/// A resource DLL is a PE image beginning with the `MZ` signature; a raw IGVM
+/// file does not. When a PE is detected, the embedded `VMFW` resource is
+/// returned; otherwise the file bytes are returned unchanged.
+pub fn read_igvm_image(path: &Path) -> anyhow::Result<Vec<u8>> {
+    let bytes = fs_err::read(path).context("reading input file")?;
+    if bytes.starts_with(b"MZ") {
+        extract_vmfw_resource(&bytes).with_context(|| {
+            format!(
+                "extracting embedded IGVM ({VMFW_RESOURCE_TYPE} resource) from resource DLL {}",
+                path.display()
+            )
+        })
+    } else {
+        Ok(bytes)
+    }
+}
+
+/// Extract the embedded IGVM payload (the `VMFW` resource) from a PE/DLL image.
+fn extract_vmfw_resource(pe_bytes: &[u8]) -> anyhow::Result<Vec<u8>> {
+    use object::read::pe::PeFile64;
+    use object::read::pe::ResourceDirectoryEntryData;
+    use object::read::pe::ResourceNameOrId;
+
+    let pe =
+        PeFile64::parse(pe_bytes).context("parsing PE image (expected a 64-bit resource DLL)")?;
+    let sections = pe.section_table();
+    let dir = pe
+        .data_directories()
+        .resource_directory(pe_bytes, &sections)
+        .context("reading resource directory")?
+        .context("PE image has no resource directory")?;
+    let root = dir.root().context("reading resource directory root")?;
+
+    // The resource tree has three levels: type -> id/name -> language -> data.
+    // Locate the custom `VMFW` resource type, then descend to the first (and
+    // only) id and language entry to reach the IGVM payload.
+    for type_entry in root.entries {
+        let ResourceNameOrId::Name(name) = type_entry.name_or_id() else {
+            // The IGVM is stored under a named type (`VMFW`), not a numeric one.
+            continue;
+        };
+        let raw_name = name.raw_data(dir).context("reading resource type name")?;
+        if !utf16le_eq(raw_name, VMFW_RESOURCE_TYPE) {
+            continue;
+        }
+
+        let ResourceDirectoryEntryData::Table(id_table) = type_entry
+            .data(dir)
+            .context("reading VMFW resource id table")?
+        else {
+            anyhow::bail!("VMFW resource type entry is not a subdirectory");
+        };
+        let id_entry = id_table
+            .entries
+            .first()
+            .context("VMFW resource type has no entries")?;
+
+        let ResourceDirectoryEntryData::Table(lang_table) = id_entry
+            .data(dir)
+            .context("reading VMFW resource language table")?
+        else {
+            anyhow::bail!("VMFW resource id entry is not a subdirectory");
+        };
+        let lang_entry = lang_table
+            .entries
+            .first()
+            .context("VMFW resource has no language entries")?;
+
+        let ResourceDirectoryEntryData::Data(data) = lang_entry
+            .data(dir)
+            .context("reading VMFW resource data entry")?
+        else {
+            anyhow::bail!("VMFW resource language entry is not a data entry");
+        };
+
+        // The data entry references the payload by RVA + size; resolve it via
+        // the section table and take exactly `size` bytes.
+        let rva = data.offset_to_data.get(object::LittleEndian);
+        let size = data.size.get(object::LittleEndian) as usize;
+        let payload = sections
+            .pe_data_at(pe_bytes, rva)
+            .context("resolving VMFW resource RVA in section table")?
+            .get(..size)
+            .context("VMFW resource size extends past its section")?;
+        return Ok(payload.to_vec());
+    }
+
+    anyhow::bail!(
+        "no '{VMFW_RESOURCE_TYPE}' resource found; input does not look like a vmfirmwareigvm resource DLL"
+    )
+}
+
+/// Compare a little-endian UTF-16 PE resource name to an ASCII string.
+fn utf16le_eq(utf16le: &[u8], ascii: &str) -> bool {
+    if utf16le.len() != ascii.len() * 2 {
+        return false;
+    }
+    utf16le
+        .chunks_exact(2)
+        .zip(ascii.chars())
+        .all(|(pair, c)| u16::from_le_bytes([pair[0], pair[1]]) == c as u16)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::utf16le_eq;
+
+    fn utf16le(s: &str) -> Vec<u8> {
+        s.encode_utf16().flat_map(u16::to_le_bytes).collect()
+    }
+
+    #[test]
+    fn utf16le_eq_matches() {
+        assert!(utf16le_eq(&utf16le("VMFW"), "VMFW"));
+    }
+
+    #[test]
+    fn utf16le_eq_rejects_mismatch_and_length() {
+        assert!(!utf16le_eq(&utf16le("VMFX"), "VMFW"));
+        assert!(!utf16le_eq(&utf16le("VMF"), "VMFW"));
+        assert!(!utf16le_eq(&utf16le("VMFWX"), "VMFW"));
+        // Odd-length (truncated) UTF-16 buffers never match.
+        assert!(!utf16le_eq(&[0x56, 0x00, 0x4d], "VM"));
+    }
+}
+

--- a/vm/loader/igvmfilegen/src/main.rs
+++ b/vm/loader/igvmfilegen/src/main.rs
@@ -10,6 +10,7 @@ crypto::ensure_single_backend!();
 
 mod corim_signature;
 mod file_loader;
+mod firmware_dll;
 mod identity_mapping;
 mod measurement_diag;
 mod platform_mask;
@@ -71,7 +72,11 @@ use zerocopy::IntoBytes;
 #[derive(Parser)]
 #[clap(name = "igvmfilegen", about = "Tool to generate IGVM files")]
 enum Options {
-    /// Dumps the contents of an IGVM file in a human-readable format
+    /// Dumps the contents of an IGVM file in a human-readable format.
+    ///
+    /// Accepts either a raw IGVM file or a `vmfirmwareigvm` resource DLL
+    /// (`vmfirmwareigvm.dll` / `vmfirmwarecvm.dll`); for a DLL, the embedded
+    /// IGVM is extracted automatically.
     // TODO: Move into its own tool.
     Dump {
         /// Dump file path
@@ -84,11 +89,15 @@ enum Options {
     /// extracts their contents. By default, all supported CoRIM headers for all platforms found
     /// in the file are dumped. Use `--header-type` and `--platform` to narrow the selection.
     ///
+    /// The input may be either a raw IGVM file or a `vmfirmwareigvm` resource DLL
+    /// (`vmfirmwareigvm.dll` / `vmfirmwarecvm.dll`); for a DLL, the embedded IGVM is
+    /// extracted automatically, so a shipped firmware DLL can be checked for a CoRIM directly.
+    ///
     /// A human-readable summary of the selected CoRIM headers is written to stdout. When
     /// `--output <dir>` is provided, the CoRIM payloads are also extracted to files in
     /// that directory and the file paths are reported.
     DumpCorim {
-        /// Input IGVM file path to read CoRIM headers and payloads from.
+        /// Input IGVM file (or `vmfirmwareigvm` resource DLL) to read CoRIM headers and payloads from.
         #[clap(short, long = "filepath")]
         file_path: PathBuf,
         /// Filter by CoRIM header type (e.g. document or signature). If not specified,
@@ -302,7 +311,7 @@ fn main() -> anyhow::Result<()> {
 
     match opts {
         Options::Dump { file_path } => {
-            let image = fs_err::read(file_path).context("reading input file")?;
+            let image = firmware_dll::read_igvm_image(&file_path)?;
             let fixed_header = IGVM_FIXED_HEADER::read_from_prefix(image.as_bytes())
                 .expect("Invalid fixed header")
                 .0; // TODO: zerocopy: use-rest-of-range (https://github.com/microsoft/openvmm/issues/759)
@@ -882,7 +891,7 @@ fn dump_corim_headers(
     platform_filter: Option<Platform>,
     output_dir: Option<PathBuf>,
 ) -> anyhow::Result<()> {
-    let image = fs_err::read(file_path).context("reading input file")?;
+    let image = firmware_dll::read_igvm_image(file_path)?;
 
     // Parse the IGVM file using the igvm crate's structured API.
     let igvm_file = IgvmFile::new_from_binary(&image, None).context("parsing IGVM file")?;


### PR DESCRIPTION
## Problem

The production OpenHCL IGVM is shipped encapsulated in a Windows resource-only DLL (`vmfirmwareigvm.dll` / `vmfirmwarecvm.dll`), where the IGVM payload is stored as a custom `VMFW` resource (id 1) — see `1 VMFW <igvm>` in `openhcl/vmfirmwareigvm_dll/resources.rc`. The `dump` and `dump-corim` subcommands only accepted a **raw** IGVM file, so there was no way to check the CoRIM embedded in a *shipped firmware DLL* without first extracting the IGVM by hand.

## Change

- Add a `firmware_dll` module that detects a PE input (`MZ` signature) and extracts the embedded `VMFW` resource using the `object` crate (safe, cross-platform — no Win32 APIs, keeps `#![forbid(unsafe_code)]`).
- Route `dump` and `dump-corim` through it. A raw IGVM file is passed through unchanged; a resource DLL has its IGVM extracted transparently.

This lets you check the packaged firmware directly:

```
igvmfilegen dump-corim --filepath vmfirmwarecvm.dll
```

## Validation

Ran against a real signed `vmfirmwarecvm.dll`:

```
Supported Platforms:
  SEV_SNP -> compatibility_mask 0x1
  TDX -> compatibility_mask 0x2
  VSM_ISOLATION -> compatibility_mask 0x4

CoRIM Document (snp): ... 330 bytes
CoRIM Document (vbs): ... 304 bytes
CoRIM Document (tdx): ... 310 bytes
CoRIM Signature (tdx): ... 6353 bytes
Summary: 3 document header(s), 1 signature header(s)
```

- `cargo clippy -p igvmfilegen --all-targets` — clean
- `cargo doc --no-deps -p igvmfilegen` — clean
- `cargo test -p igvmfilegen` — 47 passed (incl. new `firmware_dll` tests)
- `dump` on the same DLL prints the extracted IGVM fixed header (magic `IGVM`), confirming a valid raw IGVM is recovered.