### PR TITLE
net_consomme: don't fail guest bind when host can't mirror a guest-local address

### DIFF
--- a/vm/devices/net/net_consomme/src/lib.rs
+++ b/vm/devices/net/net_consomme/src/lib.rs
@@ -231,7 +231,13 @@ enum ConsommeMessage {
 }
 
 impl ConsommeControl {
-    /// Binds a port to receive incoming packets.
+    /// Binds a host port to forward incoming packets to the guest, returning
+    /// the bound host port.
+    ///
+    /// Host-side forwarding is best-effort: if the host cannot bind the
+    /// requested address (e.g. `ip_addr` is a guest-local address the host
+    /// doesn't own), forwarding is skipped and the requested `host_port` is
+    /// returned so the guest's own bind can still proceed.
     pub async fn bind_port(
         &self,
         protocol: IpProtocol,

--- a/vm/devices/net/net_consomme/src/lib.rs
+++ b/vm/devices/net/net_consomme/src/lib.rs
@@ -239,8 +239,30 @@ impl ConsommeControl {
         host_port: u16,
         guest_port: u16,
     ) -> Result<u16, ConsommeMessageError> {
-        let socket = create_bound_socket(&protocol, ip_addr, host_port)
-            .map_err(|e| ConsommeMessageError::Bind(consomme::BindError::Io(e)))?;
+        let socket = match create_bound_socket(&protocol, ip_addr, host_port) {
+            Ok(socket) => socket,
+            // The guest bound an address the host doesn't own (e.g. a Docker
+            // bridge gateway), so the host mirror bind() fails with
+            // WSAEADDRNOTAVAIL. Forwarding is best-effort: skip it so the
+            // guest's own bind() still succeeds.
+            Err(e)
+                if ip_addr.is_some()
+                    && (e.kind() == std::io::ErrorKind::AddrNotAvailable
+                        || e.raw_os_error() == Some(10049)) =>
+            {
+                tracing::info!(
+                    ?protocol,
+                    ?ip_addr,
+                    host_port,
+                    guest_port,
+                    "host cannot bind guest-local address; skipping host port forward"
+                );
+                return Ok(host_port);
+            }
+            Err(e) => {
+                return Err(ConsommeMessageError::Bind(consomme::BindError::Io(e)));
+            }
+        };
         let host_addr = socket_addr(&socket).map_err(ConsommeMessageError::Bind)?;
         self.send
             .call(

--- a/vm/devices/net/net_consomme/src/lib.rs
+++ b/vm/devices/net/net_consomme/src/lib.rs
@@ -246,11 +246,12 @@ impl ConsommeControl {
             // WSAEADDRNOTAVAIL. Forwarding is best-effort: skip it so the
             // guest's own bind() still succeeds.
             Err(e)
-                if ip_addr.is_some()
+                if ip_addr.is_some_and(|addr| !addr.is_unspecified())
                     && (e.kind() == std::io::ErrorKind::AddrNotAvailable
-                        || e.raw_os_error() == Some(10049)) =>
+                        || (cfg!(windows) && e.raw_os_error() == Some(10049))) =>
             {
-                tracing::info!(
+                tracing::debug!(
+                    error = %e,
                     ?protocol,
                     ?ip_addr,
                     host_port,


### PR DESCRIPTION
## Problem

In **Consomme** networking mode (used by Docker-in-WSL), a service bound inside a container to a **guest-local address** — e.g. the Docker bridge gateway `172.30.0.1`, or a secondary interface IP — is **silently unreachable**, and the bind is quietly clobbered to `0.0.0.0:<ephemeral>`.

### Root cause

`ConsommeControl::bind_port` creates a host-side *mirror* socket so inbound host traffic can be forwarded to the guest listener. It passes the **guest's** chosen listen address straight to `bind()` on the **Windows host**. When the guest binds an address the host doesn't own, the host `bind()` fails with `WSAEADDRNOTAVAIL` (10049).

That failure was propagated back to WSL's seccomp `bind()` interceptor, which then does **not** set `SECCOMP_USER_NOTIF_FLAG_CONTINUE` — so the guest's own legitimate `bind()` never executes, and `listen()` autobinds to `0.0.0.0:<ephemeral>`. Net effect: the guest bind is silently lost.

## Fix

Host-side port forwarding is best-effort. When the host can't bind a guest-local address (`AddrNotAvailable` / raw OS error `10049`, and a specific `ip_addr` was requested), skip host forwarding and return `Ok` so the **guest's own bind succeeds**. Other errors and the unspecified-address (`0.0.0.0`) case propagate unchanged.

The fix returns `Ok` **without** creating any host socket, so nothing is ever bound on the host's `0.0.0.0` — no guest service is exposed host-wide.

## Scope notes

- The sync `execute_bind` path (openvmm config-time forwarding) is intentionally left unchanged: there the address is expected to be host-owned and a bind failure should surface.
- Considered also short-circuiting the paired `unbind_port` for skipped ports, but **reverted** it: WSL's port-mapping layer deliberately relies on `PortNotBound` propagating (a double-unmap is expected to fail), and swallowing it broke `WSLCTests::PortMapping*Consomme*`.

## Testing

Built a private `wsldevicehost.dll` from this change, deployed it, and ran the WSL consomme test suites in fast mode:

- `NetworkTests::ConsommeTests::*` — **20 passed, 0 failed**, 3 skipped (IPv6, no host IPv6 connectivity)
- `WSLCTests::*Consomme*` (port-mapping) — **5 passed, 0 failed**

Also verified directly: binding to `172.30.0.1:9092` inside the distro now binds correctly (`getsockname` returns `172.30.0.1:9092`) instead of being clobbered to `0.0.0.0:<ephemeral>`, and reverting the DLL reproduces the clobber.

Context: microsoft/WSL#41185.

> [!NOTE]
> Draft — feedback welcome on whether this belongs here or on the WSL guest side (only forwarding binds for host-owned addresses).
