### PR TITLE
openvmm_entry: don't add UEFI chipset device for OpenHCL VMs

### DIFF
--- a/openvmm/openvmm_entry/src/lib.rs
+++ b/openvmm/openvmm_entry/src/lib.rs
@@ -1219,7 +1219,7 @@ async fn vm_config_from_command_line(
         }
     };
 
-    if opt.uefi {
+    if opt.uefi && opt.igvm.is_none() && !opt.pcat {
         let log_level = match opt.efi_diagnostics_log_level.unwrap_or_default() {
             EfiDiagnosticsLogLevelCli::Default => firmware_uefi_resources::LogLevel::make_default(),
             EfiDiagnosticsLogLevelCli::Info => firmware_uefi_resources::LogLevel::make_info(),


### PR DESCRIPTION
Passing both --igvm and --uefi (an OpenHCL paravisor in VTL2 with a UEFI guest in VTL0) selected the HclHost base chipset but still added the host-side UEFI helper device based solely on the --uefi flag. VmManifestBuilder::with_uefi asserts the base chipset is HypervGen2Uefi, so this combination panicked before the VM could start.

In the OpenHCL case the guest UEFI firmware is delivered through the paravisor via the IGVM/GED path, not as a host chipset device, so no host-side UEFI device should be added. Guard the with_uefi call with the same conditions that select the HypervGen2Uefi chipset type (no --igvm, no --pcat) so it only runs when the host actually owns the UEFI firmware.