### PR TITLE
virt_kvm: restore the reference time via the kvm clock

### DIFF
--- a/vm/kvm/src/lib.rs
+++ b/vm/kvm/src/lib.rs
@@ -63,6 +63,7 @@ mod ioctl {
     ioctl_write_ptr!(kvm_set_gsi_routing, KVMIO, 0x6a, kvm_irq_routing);
     ioctl_write_ptr!(kvm_irqfd, KVMIO, 0x76, kvm_irqfd);
     ioctl_write_int_bad!(kvm_set_boot_cpu_id, request_code_none!(KVMIO, 0x78));
+    ioctl_write_ptr!(kvm_set_clock, KVMIO, 0x7b, kvm_clock_data);
     ioctl_read!(kvm_get_clock, KVMIO, 0x7c, kvm_clock_data);
     ioctl_write_int_bad!(kvm_run, request_code_none!(KVMIO, 0x80));
     // Is *NOT* defined for arm64
@@ -367,6 +368,10 @@ pub enum Error {
     SetDeviceAttr(#[source] nix::Error),
     #[error("CheckExtension")]
     CheckExtension(#[source] nix::Error),
+    #[error("GetClock")]
+    GetClock(#[source] nix::Error),
+    #[error("SetClock")]
+    SetClock(#[source] nix::Error),
 }
 
 type Result<T, E = Error> = std::result::Result<T, E>;
@@ -1176,9 +1181,22 @@ impl Partition {
         let mut clock = kvm_clock_data::default();
         // SAFETY: Calling IOCTL as documented, with no special requirements.
         unsafe {
-            ioctl::kvm_get_clock(self.vm.as_raw_fd(), &mut clock).map_err(Error::GetRegs)?;
+            ioctl::kvm_get_clock(self.vm.as_raw_fd(), &mut clock).map_err(Error::GetClock)?;
         }
         Ok(clock)
+    }
+
+    /// Sets the current kvmclock value.
+    pub fn set_clock_ns(&self, clock_ns: u64) -> Result<()> {
+        let clock = kvm_clock_data {
+            clock: clock_ns,
+            ..Default::default()
+        };
+        // SAFETY: Calling IOCTL as documented, with no special requirements.
+        unsafe {
+            ioctl::kvm_set_clock(self.vm.as_raw_fd(), &clock).map_err(Error::SetClock)?;
+        }
+        Ok(())
     }
 }
 

--- a/vmm_core/virt_kvm/src/arch/x86_64/vm_state.rs
+++ b/vmm_core/virt_kvm/src/arch/x86_64/vm_state.rs
@@ -36,12 +36,27 @@ impl AccessVmState for &'_ KvmPartition {
     }
 
     fn reftime(&mut self) -> Result<vm::ReferenceTime, Self::Error> {
-        super::vp_state::get_msrs_state(&self.inner.vp_kvm(VpIndex::BSP))
+        // The reference time counter is computed from the kvm clock, and the
+        // kvm clock is the only thing that can be set (see `set_reftime`), so
+        // query it here as well to keep save/restore self-consistent.
+        //
+        // Round up so that restoring this value never moves the kvm clock
+        // backwards, since the guest can observe the clock at nanosecond
+        // granularity.
+        let clock = self.inner.kvm.get_clock_ns()?;
+        Ok(vm::ReferenceTime {
+            value: clock.clock.div_ceil(100),
+        })
     }
 
-    fn set_reftime(&mut self, _value: &vm::ReferenceTime) -> Result<(), Self::Error> {
-        // TODO: KVM doesn't allow setting the reference time, since it's
-        // computed from the kvm clock. Figure out what we can do instead.
+    fn set_reftime(&mut self, value: &vm::ReferenceTime) -> Result<(), Self::Error> {
+        // KVM does not allow setting the reference time counter directly, but
+        // it is computed from the kvm clock, so set that instead. This also
+        // updates the reference TSC page parameters, so that the guest's view
+        // of the reference time is consistent however it queries it.
+        self.inner
+            .kvm
+            .set_clock_ns(value.value.saturating_mul(100))?;
         Ok(())
     }
 


### PR DESCRIPTION
Saving and restoring a KVM partition dropped the Hyper-V reference time counter on the floor, so a restored guest would see the reference counter jump forward to wherever the host's kvm clock happened to be. This was left as a TODO because the counter itself is read-only: KVM derives it from the kvm clock rather than storing it independently.

The kvm clock, however, is settable via KVM_SET_CLOCK, and moving it moves the reference counter with it. It also triggers a master clock update, which recomputes the reference TSC page parameters, so the guest sees a consistent value whether it reads the counter through the MSR or through the TSC page.

Read the reference time from the same place rather than from the MSR, so that the value saved is exactly the value that can be restored. Reading the MSR returns a TSC-page-derived value when the guest has enabled the reference TSC page, which would not round-trip precisely through a clock write. Round the nanosecond clock up when converting to 100ns units so that a restore never moves the clock backwards, since the guest observes the kvm clock at nanosecond granularity.