### PR TITLE
nvme: Quiet some noisy logs during vmm tests

### DIFF
--- a/vm/devices/storage/nvme/src/workers/admin.rs
+++ b/vm/devices/storage/nvme/src/workers/admin.rs
@@ -521,7 +521,7 @@ impl AdminHandler {
                 let command = command?;
                 let opcode = spec::AdminOpcode(command.cdw0.opcode());
 
-                tracing::debug!(?opcode, ?command, "command");
+                tracing::trace!(?opcode, ?command, "command");
 
                 let result = match opcode {
                     spec::AdminOpcode::IDENTIFY => self
@@ -654,7 +654,7 @@ impl AdminHandler {
                 } else {
                     // Valid but inactive namespace: return a zero-filled
                     // structure (the buffer is already zeroed).
-                    tracing::debug!(nsid = command.nsid, "inactive namespace id");
+                    tracing::trace!(nsid = command.nsid, "inactive namespace id");
                 }
             }
             spec::Cns::DESCRIPTOR_NAMESPACE => {
@@ -666,7 +666,7 @@ impl AdminHandler {
                 } else {
                     // Valid but inactive namespace: return a zero-filled
                     // structure (the buffer is already zeroed).
-                    tracing::debug!(nsid = command.nsid, "inactive namespace id");
+                    tracing::trace!(nsid = command.nsid, "inactive namespace id");
                 }
             }
             spec::Cns::SPECIFIC_CONTROLLER_IO_COMMAND_SET => {

--- a/vm/devices/storage/nvme_test/src/workers/admin.rs
+++ b/vm/devices/storage/nvme_test/src/workers/admin.rs
@@ -847,7 +847,7 @@ impl AdminHandler {
                 } else {
                     // Valid but inactive namespace: return a zero-filled
                     // structure (the buffer is already zeroed).
-                    tracing::debug!(nsid = command.nsid, "inactive namespace id");
+                    tracing::trace!(nsid = command.nsid, "inactive namespace id");
                 }
             }
             spec::Cns::DESCRIPTOR_NAMESPACE => {
@@ -859,7 +859,7 @@ impl AdminHandler {
                 } else {
                     // Valid but inactive namespace: return a zero-filled
                     // structure (the buffer is already zeroed).
-                    tracing::debug!(nsid = command.nsid, "inactive namespace id");
+                    tracing::trace!(nsid = command.nsid, "inactive namespace id");
                 }
             }
             spec::Cns::SPECIFIC_CONTROLLER_IO_COMMAND_SET => {


### PR DESCRIPTION
These tracing statements take up a lot of space in nvme tests runs (example: https://openvmm.dev/test-results/#/runs/30395677982/x64-windows-intel-mi-secure-vmm-tests-logs/multiarch__openvmm_openhcl_uefi_x64_windows_datacenter_core_2022_x64_uefi_force_dma_bounce?log=831). Lower them to trace level.