### PR TITLE
sidecar: Clear the response buffer before running

### DIFF
--- a/openhcl/sidecar_client/src/lib.rs
+++ b/openhcl/sidecar_client/src/lib.rs
@@ -379,7 +379,7 @@ impl<'a> SidecarVp<'a> {
     /// Runs the VP.
     pub fn run(&mut self) -> Result<SidecarRun<'_, 'a>, SidecarError> {
         tracing::trace!("run vp");
-        self.set_command::<_, u8>(SidecarCommand::RUN_VP, (), 0);
+        self.set_command::<_, u8>(SidecarCommand::RUN_VP, RunVpResponse { intercept: 0 }, 0);
         self.start_async()?;
         Ok(SidecarRun {
             vp: self,


### PR DESCRIPTION
Setting this value to `()` doesn't actually write anything, as unit is zero sized. Instead, set the value to something sized but harmless, in this case a RunVpResponse indicating a spurious exit with no real intercept.