### PR TITLE
openvmm: support UEFI boot over ttrpc

### DIFF
--- a/openvmm/openvmm_core/src/worker/dispatch.rs
+++ b/openvmm/openvmm_core/src/worker/dispatch.rs
@@ -218,7 +218,6 @@ impl Manifest {
             chipset_capabilities: config.chipset_capabilities,
             layout: config.layout,
             rtc_delta_milliseconds: config.rtc_delta_milliseconds,
-            automatic_guest_reset: config.automatic_guest_reset,
         }
     }
 }
@@ -262,7 +261,6 @@ pub struct Manifest {
     chipset_capabilities: VmChipsetCapabilities,
     layout: vmm_core_defs::LayoutConfig,
     rtc_delta_milliseconds: i64,
-    automatic_guest_reset: bool,
 }
 
 #[derive(Protobuf, SavedStateRoot)]
@@ -773,11 +771,9 @@ struct LoadedVmInner {
     #[cfg(target_os = "linux")]
     vfio_cdev_inspect: Option<vfio_assigned_device::manager::VfioCdevManagerClient>,
 
-    // relay halt messages, intercepting reset if configured.
+    // relay halt messages to the client, which decides what to do about them.
     halt_recv: mesh::Receiver<HaltReason>,
     client_notify_send: mesh::Sender<HaltReason>,
-    /// allow the guest to reset without notifying the client
-    automatic_guest_reset: bool,
     chipset: Arc<vmotherboard::Chipset>,
     /// Instantiated IOMMU devices (ACPI configs + per-RC shared state),
     /// keyed by IOMMU type. `IommuDevices::None` when no IOMMU is configured.
@@ -2972,7 +2968,6 @@ impl InitializedVm {
                 vfio_cdev_inspect,
                 halt_recv,
                 client_notify_send,
-                automatic_guest_reset: cfg.automatic_guest_reset,
                 chipset: chipset.chipset.clone(),
                 iommu_devices,
                 #[cfg(guest_arch = "x86_64")]
@@ -3774,15 +3769,7 @@ impl LoadedVm {
                 },
                 Event::Halt(Err(_)) => break,
                 Event::Halt(Ok(reason)) => {
-                    if matches!(reason, HaltReason::Reset) && self.inner.automatic_guest_reset {
-                        tracing::info!("guest-initiated reset");
-                        if let Err(err) = self.reset(true).await {
-                            tracing::error!(?err, "failed to reset VM");
-                            break;
-                        }
-                    } else {
-                        self.inner.client_notify_send.send(reason);
-                    }
+                    self.inner.client_notify_send.send(reason);
                 }
             }
         }
@@ -3943,7 +3930,6 @@ impl LoadedVm {
                 vtl2_chipset_mmio_size: 0,
             }, // TODO
             rtc_delta_milliseconds: 0, // TODO
-            automatic_guest_reset: self.inner.automatic_guest_reset,
         };
         #[expect(unreachable_code, reason = "TODO")]
         RestartState {

--- a/openvmm/openvmm_defs/src/config.rs
+++ b/openvmm/openvmm_defs/src/config.rs
@@ -60,8 +60,6 @@ pub struct Config {
     pub layout: vmm_core_defs::LayoutConfig,
     // This is used for testing. TODO: resourcify, and also store this in VMGS.
     pub rtc_delta_milliseconds: i64,
-    /// allow the guest to reset without notifying the client
-    pub automatic_guest_reset: bool,
 }
 
 pub const DEFAULT_GIC_DISTRIBUTOR_BASE: u64 = 0xFFFF_0000;

--- a/openvmm/openvmm_entry/src/lib.rs
+++ b/openvmm/openvmm_entry/src/lib.rs
@@ -31,7 +31,6 @@ use chipset_resources::battery::HostBatteryUpdate;
 use cli_args::DiskCliKind;
 use cli_args::EfiDiagnosticsLogLevelCli;
 use cli_args::EndpointConfigCli;
-use cli_args::GuestPowerAction;
 use cli_args::NicConfigCli;
 use cli_args::ProvisionVmgs;
 use cli_args::SerialConfigCli;
@@ -2037,10 +2036,6 @@ async fn vm_config_from_command_line(
         firmware_event_send: None,
         debugger_rpc: None,
         rtc_delta_milliseconds: 0,
-        // Only let the partition auto-reset when the reset action is `reset`.
-        // For `halt` or `exit`, the guest reset must surface as a halt event so
-        // the controller can hold the VM or exit instead of rebooting in place.
-        automatic_guest_reset: matches!(opt.guest_reset_action, GuestPowerAction::Reset),
     };
 
     storage.build_config(&mut cfg, &mut resources, opt.scsi_sub_channels)?;

--- a/openvmm/openvmm_entry/src/ttrpc/mod.rs
+++ b/openvmm/openvmm_entry/src/ttrpc/mod.rs
@@ -68,6 +68,7 @@ use openvmm_defs::config::PciePortConfig;
 use openvmm_defs::config::PcieRootComplexConfig;
 use openvmm_defs::config::PcieSwitchConfig;
 use openvmm_defs::config::ProcessorTopologyConfig;
+use openvmm_defs::config::UefiConsoleMode;
 use openvmm_defs::config::VirtioBus;
 use openvmm_defs::config::VmbusConfig;
 use openvmm_defs::config::VpAssignment;
@@ -101,6 +102,7 @@ use vm_resource::kind::PciDeviceHandleKind;
 use vm_resource::kind::SerialBackendHandle;
 use vm_resource::kind::VirtioDeviceHandle;
 use vm_resource::kind::VmbusDeviceHandleKind;
+use vmcore::non_volatile_store::resources::EphemeralNonVolatileStoreHandle;
 
 #[derive(mesh::MeshPayload)]
 pub struct Parameters {
@@ -694,30 +696,9 @@ impl VmService {
         // passed in over the fd-passing protocol.
         let registry = self.registry.clone();
 
-        let load_mode = match req_config
-            .boot_config
-            .context("missing boot configuration")?
-        {
-            vmservice::vm_config::BootConfig::DirectBoot(boot) => {
-                let kernel = File::open(boot.kernel_path).context("failed to open kernel")?;
-                let initrd = if boot.initrd_path.is_empty() {
-                    None
-                } else {
-                    Some(File::open(boot.initrd_path).context("failed to open initrd")?)
-                };
-                LoadMode::Linux {
-                    kernel,
-                    initrd,
-                    cmdline: boot.kernel_cmdline,
-                    enable_serial: true,
-                    boot_mode: openvmm_defs::config::LinuxDirectBootMode::Acpi,
-                }
-            }
-            vmservice::vm_config::BootConfig::Uefi(_) => {
-                anyhow::bail!("uefi not yet supported")
-            }
-        };
-
+        // Serial ports are set up before the boot configuration because UEFI
+        // needs to know whether any are present to decide whether to enable its
+        // serial console.
         let mut ports = [(); 4].map(|_| None);
         for port in req_config.serial_config.iter().flat_map(|c| &c.ports) {
             let pc = ports
@@ -728,17 +709,93 @@ impl VmService {
                 format!("failed to {} serial socket: {}", action, port.socket_path)
             })?);
         }
+        let any_serial_configured = ports.iter().any(|port| port.is_some());
+        let com1_configured = ports[0].is_some();
 
         #[cfg(guest_arch = "aarch64")]
         let arch = vm_manifest_builder::MachineArch::Aarch64;
         #[cfg(guest_arch = "x86_64")]
         let arch = vm_manifest_builder::MachineArch::X86_64;
 
-        let chipset_builder = VmManifestBuilder::new(
-            vm_manifest_builder::BaseChipsetType::HyperVGen2LinuxDirect,
-            arch,
-        )
-        .with_serial(ports);
+        // The boot configuration also determines the base chipset, since the
+        // firmware and the device model have to agree on the platform.
+        let (load_mode, base_chipset_type) = match req_config
+            .boot_config
+            .take()
+            .context("missing boot configuration")?
+        {
+            vmservice::vm_config::BootConfig::DirectBoot(boot) => {
+                let kernel = File::open(boot.kernel_path).context("failed to open kernel")?;
+                let initrd = if boot.initrd_path.is_empty() {
+                    None
+                } else {
+                    Some(File::open(boot.initrd_path).context("failed to open initrd")?)
+                };
+                (
+                    LoadMode::Linux {
+                        kernel,
+                        initrd,
+                        cmdline: boot.kernel_cmdline,
+                        enable_serial: true,
+                        boot_mode: openvmm_defs::config::LinuxDirectBootMode::Acpi,
+                    },
+                    vm_manifest_builder::BaseChipsetType::HyperVGen2LinuxDirect,
+                )
+            }
+            vmservice::vm_config::BootConfig::Uefi(uefi) => {
+                let firmware = File::open(&uefi.firmware_path).with_context(|| {
+                    format!("failed to open uefi firmware {}", uefi.firmware_path)
+                })?;
+                (
+                    LoadMode::Uefi {
+                        firmware,
+                        enable_serial: any_serial_configured,
+                        // Route the firmware console to COM1 when it is
+                        // available. The firmware's default console is the
+                        // video device, so without this the firmware and
+                        // anything it launches would have nowhere to write on a
+                        // VM with no graphics adapter.
+                        uefi_console_mode: com1_configured.then_some(UefiConsoleMode::Com1),
+                        bios_guid: Guid::new_random(),
+                        enable_vmbus: true,
+                        // Everything below is fixed for now. The proto has no
+                        // way to express these yet; fields will be added as
+                        // callers need them.
+                        //
+                        // Note that memory protections match the CLI in
+                        // defaulting to off, since Linux currently fails to
+                        // boot with them enabled.
+                        enable_memory_protections: false,
+                        enable_debugging: false,
+                        disable_frontpage: false,
+                        enable_tpm: false,
+                        enable_battery: false,
+                        enable_vpci_boot: false,
+                        default_boot_always_attempt: false,
+                        force_dma_bounce: false,
+                    },
+                    vm_manifest_builder::BaseChipsetType::HypervGen2Uefi,
+                )
+            }
+        };
+
+        let mut chipset_builder =
+            VmManifestBuilder::new(base_chipset_type, arch).with_serial(ports);
+        if matches!(load_mode, LoadMode::Uefi { .. }) {
+            // The UEFI helper device backs the firmware's variable store and
+            // runtime services, so it is required for a UEFI boot. The store is
+            // ephemeral: with no VMGS file configured there is nowhere to
+            // persist boot entries or secure boot state across reboots.
+            chipset_builder = chipset_builder.with_uefi(vm_manifest_builder::UefiManifest::new(
+                arch,
+                firmware_uefi_custom_vars::CustomVars::default(),
+                false,
+                firmware_uefi_resources::LogLevel::make_default(),
+                None,
+                EphemeralNonVolatileStoreHandle.into_resource(),
+                None,
+            ));
+        }
         let layout_config = chipset_builder.layout_config();
         let chipset = chipset_builder
             .build()

--- a/openvmm/openvmm_entry/src/ttrpc/mod.rs
+++ b/openvmm/openvmm_entry/src/ttrpc/mod.rs
@@ -719,7 +719,7 @@ impl VmService {
 
         // The boot configuration also determines the base chipset, since the
         // firmware and the device model have to agree on the platform.
-        let (load_mode, base_chipset_type) = match req_config
+        let (load_mode, base_chipset_type, uefi_config) = match req_config
             .boot_config
             .take()
             .context("missing boot configuration")?
@@ -740,12 +740,43 @@ impl VmService {
                         boot_mode: openvmm_defs::config::LinuxDirectBootMode::Acpi,
                     },
                     vm_manifest_builder::BaseChipsetType::HyperVGen2LinuxDirect,
+                    None,
                 )
             }
             vmservice::vm_config::BootConfig::Uefi(uefi) => {
                 let firmware = File::open(&uefi.firmware_path).with_context(|| {
                     format!("failed to open uefi firmware {}", uefi.firmware_path)
                 })?;
+                let initial_variables = uefi.initial_variables.unwrap_or_default();
+                let uefi_vars = match (arch, initial_variables.secure_boot_template()) {
+                    (_, vmservice::uefi::initial_variables::SecureBootTemplate::None) => {
+                        Default::default()
+                    }
+                    (
+                        vm_manifest_builder::MachineArch::X86_64,
+                        vmservice::uefi::initial_variables::SecureBootTemplate::MicrosoftWindows,
+                    ) => {
+                        hyperv_secure_boot_templates::x64::microsoft_windows()
+                    }
+                    (
+                        vm_manifest_builder::MachineArch::Aarch64,
+                        vmservice::uefi::initial_variables::SecureBootTemplate::MicrosoftWindows,
+                    ) => {
+                        hyperv_secure_boot_templates::aarch64::microsoft_windows()
+                    }
+                    (
+                        vm_manifest_builder::MachineArch::X86_64,
+                        vmservice::uefi::initial_variables::SecureBootTemplate::MicrosoftUefiCertificateAuthority,
+                    ) => {
+                        hyperv_secure_boot_templates::x64::microsoft_uefi_ca()
+                    }
+                    (
+                        vm_manifest_builder::MachineArch::Aarch64,
+                        vmservice::uefi::initial_variables::SecureBootTemplate::MicrosoftUefiCertificateAuthority,
+                    ) => {
+                        hyperv_secure_boot_templates::aarch64::microsoft_uefi_ca()
+                    }
+                };
                 (
                     LoadMode::Uefi {
                         firmware,
@@ -775,21 +806,22 @@ impl VmService {
                         force_dma_bounce: false,
                     },
                     vm_manifest_builder::BaseChipsetType::HypervGen2Uefi,
+                    Some((uefi_vars, uefi.secure_boot_enabled)),
                 )
             }
         };
 
         let mut chipset_builder =
             VmManifestBuilder::new(base_chipset_type, arch).with_serial(ports);
-        if matches!(load_mode, LoadMode::Uefi { .. }) {
+        if let Some((uefi_vars, secure_boot_enabled)) = uefi_config {
             // The UEFI helper device backs the firmware's variable store and
             // runtime services, so it is required for a UEFI boot. The store is
             // ephemeral: with no VMGS file configured there is nowhere to
             // persist boot entries or secure boot state across reboots.
             chipset_builder = chipset_builder.with_uefi(vm_manifest_builder::UefiManifest::new(
                 arch,
-                firmware_uefi_custom_vars::CustomVars::default(),
-                false,
+                uefi_vars,
+                secure_boot_enabled,
                 firmware_uefi_resources::LogLevel::make_default(),
                 None,
                 EphemeralNonVolatileStoreHandle.into_resource(),
@@ -893,7 +925,10 @@ impl VmService {
             chipset_capabilities: chipset.capabilities,
             layout: layout_config,
             rtc_delta_milliseconds: 0,
-            automatic_guest_reset: true,
+            automatic_guest_reset: match req_config.guest_reset_action() {
+                vmservice::vm_config::GuestResetAction::Restart => true,
+                vmservice::vm_config::GuestResetAction::Halt => false,
+            },
         };
 
         let mut scsi_rpc = None;

--- a/openvmm/openvmm_entry/src/ttrpc/mod.rs
+++ b/openvmm/openvmm_entry/src/ttrpc/mod.rs
@@ -19,6 +19,7 @@ use fd_passing::FdRegistry;
 #[derive(Clone, Default)]
 struct FdRegistry {}
 
+use crate::cli_args::GuestPowerAction;
 use crate::meshworker::VmmMesh;
 use crate::serial_io::bind_serial;
 use crate::serial_io::connect_serial;
@@ -925,10 +926,27 @@ impl VmService {
             chipset_capabilities: chipset.capabilities,
             layout: layout_config,
             rtc_delta_milliseconds: 0,
-            automatic_guest_reset: match req_config.guest_reset_action() {
-                vmservice::vm_config::GuestResetAction::Restart => true,
-                vmservice::vm_config::GuestResetAction::Halt => false,
-            },
+        };
+
+        let guest_power_actions = {
+            use vmservice::vm_config::GuestPowerAction as ProtoAction;
+
+            let requested = req_config.guest_power_actions.unwrap_or_default();
+            let defaults = GuestPowerActions::default();
+            let action = |value: i32, default| -> anyhow::Result<GuestPowerAction> {
+                Ok(match ProtoAction::from_i32(value) {
+                    Some(ProtoAction::Default) => default,
+                    Some(ProtoAction::Restart) => GuestPowerAction::Reset,
+                    Some(ProtoAction::Halt) => GuestPowerAction::Halt,
+                    None => bail!("unknown guest power action {value}"),
+                })
+            };
+            GuestPowerActions {
+                shutdown: action(requested.shutdown, defaults.shutdown)?,
+                reset: action(requested.reset, defaults.reset)?,
+                crash: action(requested.crash, defaults.crash)?,
+                watchdog: action(requested.watchdog, defaults.watchdog)?,
+            }
         };
 
         let mut scsi_rpc = None;
@@ -1080,10 +1098,7 @@ impl VmService {
             processors,
             log_file: None,
             crash_dump_path: None,
-            // The ttrpc/grpc server never exits on a guest power event; it uses
-            // the historical defaults (none of which is Exit), so the
-            // ExitRequested event handled below is unreachable here.
-            guest_power_actions: GuestPowerActions::default(),
+            guest_power_actions,
         };
 
         // Spawn the controller task.
@@ -1204,9 +1219,9 @@ impl VmService {
                 }
             }
             VmControllerEvent::ExitRequested { code } => {
-                // The server leaves the guest power actions at their defaults
-                // (none is `exit`), so this should not occur in ttrpc/grpc mode;
-                // log rather than exiting the server out from under its clients.
+                // The protocol has no `exit` power action, so this should not
+                // occur in ttrpc/grpc mode; log rather than exiting the server
+                // out from under its clients.
                 tracing::warn!(code, "unexpected exit request in server mode");
             }
             VmControllerEvent::WorkerStopped { error } => {

--- a/openvmm/openvmm_entry/src/vm_controller.rs
+++ b/openvmm/openvmm_entry/src/vm_controller.rs
@@ -308,10 +308,7 @@ impl VmController {
                             return;
                         }
                         GuestPowerAction::Reset => {
-                            // Reboot the VM in place. A guest reset with the default
-                            // action is handled by `automatic_guest_reset` and never
-                            // reaches here; this path covers a reset chosen for a
-                            // power-off or crash.
+                            // Reboot the VM in place.
                             tracing::info!("resetting VM on guest power event");
                             if let Err(err) = self.vm_rpc.call_failable(VmRpc::Reset, ()).await {
                                 tracing::error!(

--- a/openvmm/openvmm_ttrpc_vmservice/src/vmservice.proto
+++ b/openvmm/openvmm_ttrpc_vmservice/src/vmservice.proto
@@ -67,6 +67,25 @@ message DirectBoot {
 }
 
 message UEFI {
+    // Variables used to initialize an empty UEFI variable store. These are
+    // ignored when the store already contains any variables.
+    message InitialVariables {
+        // A predefined set of Secure Boot-related variables. Selecting a
+        // template initializes keys and signature databases but does not
+        // enable Secure Boot enforcement.
+        enum SecureBootTemplate {
+            // Do not initialize Secure Boot-related variables from a template.
+            NONE = 0;
+            // Initialize variables with the Microsoft Windows certificate set.
+            MICROSOFT_WINDOWS = 1;
+            // Initialize variables with the Microsoft UEFI CA certificate set.
+            MICROSOFT_UEFI_CERTIFICATE_AUTHORITY = 2;
+        }
+
+        // The predefined Secure Boot variable set to use for initialization.
+        SecureBootTemplate secure_boot_template = 1;
+    }
+
     // Path to the UEFI firmware image on the host.
     string firmware_path = 1;
 
@@ -74,6 +93,13 @@ message UEFI {
     // had no OpenVMM equivalent and were never honored.
     reserved 2, 3;
     reserved "device_path", "optional_data";
+
+    // Variables to inject when initializing an empty UEFI variable store.
+    InitialVariables initial_variables = 4;
+
+    // Whether the firmware enforces Secure Boot policy. This is independent
+    // of whether initial Secure Boot variables are supplied above.
+    bool secure_boot_enabled = 5;
 }
 
 message MemoryConfig {
@@ -462,6 +488,14 @@ message PcieAttachment {
 }
 
 message VMConfig {
+    // Action to take when the guest requests a reset.
+    enum GuestResetAction {
+        // Restart the guest automatically.
+        RESTART = 0;
+        // Leave the virtual machine halted.
+        HALT = 1;
+    }
+
     MemoryConfig memory_config = 1;
     ProcessorConfig processor_config = 2;
     DevicesConfig devices_config = 3;
@@ -481,6 +515,8 @@ message VMConfig {
     NumaConfig numa_config = 10;
     // PCIe root complexes / ports / switches.
     PcieTopologyConfig pcie = 11;
+    // Action to take when the guest requests a reset.
+    GuestResetAction guest_reset_action = 12;
 }
 
 // WindowsOptions contains virtual machine configurations that are only present on a Windows host.

--- a/openvmm/openvmm_ttrpc_vmservice/src/vmservice.proto
+++ b/openvmm/openvmm_ttrpc_vmservice/src/vmservice.proto
@@ -67,11 +67,13 @@ message DirectBoot {
 }
 
 message UEFI {
+    // Path to the UEFI firmware image on the host.
     string firmware_path = 1;
-    string device_path = 2;
-    // Optional data to include for uefi boot. For Linux this could be used as the kernel
-    // commandline.
-    string optional_data = 3;
+
+    // Fields 2 and 3 were previously `device_path` and `optional_data`. They
+    // had no OpenVMM equivalent and were never honored.
+    reserved 2, 3;
+    reserved "device_path", "optional_data";
 }
 
 message MemoryConfig {

--- a/openvmm/openvmm_ttrpc_vmservice/src/vmservice.proto
+++ b/openvmm/openvmm_ttrpc_vmservice/src/vmservice.proto
@@ -488,12 +488,26 @@ message PcieAttachment {
 }
 
 message VMConfig {
-    // Action to take when the guest requests a reset.
-    enum GuestResetAction {
-        // Restart the guest automatically.
-        RESTART = 0;
+    // Action for the VMM to take when the guest triggers a power event.
+    enum GuestPowerAction {
+        // Use the default for this event.
+        DEFAULT = 0;
+        // Restart the guest.
+        RESTART = 1;
         // Leave the virtual machine halted.
-        HALT = 1;
+        HALT = 2;
+    }
+
+    // Actions for the VMM to take on guest power events.
+    message GuestPowerActions {
+        // The guest powered off or hibernated. Defaults to HALT.
+        GuestPowerAction shutdown = 1;
+        // The guest requested a reset. Defaults to RESTART.
+        GuestPowerAction reset = 2;
+        // The guest triple faulted. Defaults to HALT.
+        GuestPowerAction crash = 3;
+        // The guest's watchdog timer expired. Defaults to RESTART.
+        GuestPowerAction watchdog = 4;
     }
 
     MemoryConfig memory_config = 1;
@@ -515,8 +529,9 @@ message VMConfig {
     NumaConfig numa_config = 10;
     // PCIe root complexes / ports / switches.
     PcieTopologyConfig pcie = 11;
-    // Action to take when the guest requests a reset.
-    GuestResetAction guest_reset_action = 12;
+    // Actions to take on guest power events. Each unset action uses its
+    // default.
+    GuestPowerActions guest_power_actions = 12;
 }
 
 // WindowsOptions contains virtual machine configurations that are only present on a Windows host.

--- a/petri/src/vm/openvmm/construct.rs
+++ b/petri/src/vm/openvmm/construct.rs
@@ -689,9 +689,6 @@ impl PetriVmConfigOpenVmm {
 
             vmgs,
 
-            // Don't automatically reset the guest by default
-            automatic_guest_reset: false,
-
             // Disabled for VMM tests by default
             #[cfg(windows)]
             kernel_vmnics: vec![],

--- a/vmm_tests/vmm_tests/tests/tests/ttrpc.rs
+++ b/vmm_tests/vmm_tests/tests/tests/ttrpc.rs
@@ -10,6 +10,7 @@
 mod fd_passing;
 
 use anyhow::Context;
+use futures::AsyncBufReadExt;
 use futures::AsyncReadExt;
 use guid::Guid;
 use mesh::CancelContext;
@@ -851,20 +852,18 @@ const UEFI_BANNER: &str = "UEFI vendor =";
 /// of the VM.
 async fn log_serial(
     log_file: petri::PetriLogFile,
-    mut reader: impl futures::AsyncRead + Unpin,
+    reader: impl futures::AsyncRead + Unpin,
     marker: &str,
     marker_send: mesh::OneshotSender<()>,
 ) {
     let mut marker_send = Some(marker_send);
-    // Only the text before the marker needs to be retained, to spot a marker
-    // split across two reads.
-    let mut seen = String::new();
-    let mut pending = String::new();
-    let mut buf = [0u8; 256];
+    let marker = marker.as_bytes();
+    let mut reader = futures::io::BufReader::new(reader);
+    let mut line = Vec::new();
     loop {
-        let n = match reader.read(&mut buf).await {
+        match reader.read_until(b'\n', &mut line).await {
             Ok(0) => break,
-            Ok(n) => n,
+            Ok(_) => {}
             Err(err) => {
                 tracing::warn!(
                     error = &err as &dyn std::error::Error,
@@ -872,33 +871,16 @@ async fn log_serial(
                 );
                 break;
             }
-        };
-
-        let chunk = String::from_utf8_lossy(&buf[..n]);
-
-        // Log whole lines only, so that partial reads don't split log entries.
-        pending.push_str(&chunk);
-        while let Some(i) = pending.find('\n') {
-            let line: String = pending.drain(..=i).collect();
-            log_file.write_entry(line.trim_end());
         }
 
-        if let Some(send) = marker_send.take() {
-            seen.push_str(&chunk);
-            if seen.contains(marker) {
-                seen = String::new();
+        if line.windows(marker.len()).any(|window| window == marker) {
+            if let Some(send) = marker_send.take() {
                 send.send(());
-            } else {
-                // Keep just enough context to match a marker spanning reads.
-                let keep = seen.len().saturating_sub(marker.len() - 1);
-                seen.drain(..keep);
-                marker_send = Some(send);
             }
         }
-    }
 
-    if !pending.trim_end().is_empty() {
-        log_file.write_entry(pending.trim_end());
+        log_file.write_entry(String::from_utf8_lossy(&line).trim_end());
+        line.clear();
     }
 }
 

--- a/vmm_tests/vmm_tests/tests/tests/ttrpc.rs
+++ b/vmm_tests/vmm_tests/tests/tests/ttrpc.rs
@@ -726,8 +726,13 @@ fn test_ttrpc_uefi_boot(
                         boot_config: Some(vmservice::vm_config::BootConfig::Uefi(
                             vmservice::Uefi {
                                 firmware_path: firmware_path.get().to_string_lossy().to_string(),
+                                initial_variables: Some(vmservice::uefi::InitialVariables {
+                                    secure_boot_template: vmservice::uefi::initial_variables::SecureBootTemplate::MicrosoftWindows as i32,
+                                }),
+                                secure_boot_enabled: false,
                             },
                         )),
+                        guest_reset_action: vmservice::vm_config::GuestResetAction::Halt as i32,
                         serial_config: Some(vmservice::SerialConfig {
                             ports: vec![vmservice::serial_config::Config {
                                 port: 0,
@@ -789,9 +794,9 @@ fn test_ttrpc_uefi_boot(
             .context("timed out waiting for the guest UEFI application to run")?
             .context("com1 closed before the guest UEFI application ran")?;
 
-        // `guest_test_uefi` deliberately triple faults once it has finished its
-        // run, so waiting for the halt confirms the guest ran to completion
-        // rather than just reaching its first line of output.
+        // `guest_test_uefi` deliberately halts once it has finished its run,
+        // so waiting for the halt confirms the guest ran to completion rather
+        // than just reaching its first line of output.
         CancelContext::new()
             .with_timeout(Duration::from_secs(120))
             .until_cancelled(waiter)
@@ -810,12 +815,16 @@ fn test_ttrpc_uefi_boot(
         assert_eq!(
             props.state,
             vmservice::VmState::Halted as i32,
-            "guest triple faulted, expected HALTED"
+            "guest stopped, expected HALTED"
         );
         let halt_reason = props.halt_reason.unwrap_or_default();
+        let expected_halt_reason = match petri_artifacts_common::tags::MachineArch::host() {
+            petri_artifacts_common::tags::MachineArch::X86_64 => "TripleFault",
+            petri_artifacts_common::tags::MachineArch::Aarch64 => "Reset",
+        };
         assert!(
-            halt_reason.contains("TripleFault"),
-            "expected a triple fault halt, got {halt_reason:?}"
+            halt_reason.contains(expected_halt_reason),
+            "expected a {expected_halt_reason} halt, got {halt_reason:?}"
         );
 
         // Tearing down a VM that has a SCSI controller used to hang here, so

--- a/vmm_tests/vmm_tests/tests/tests/ttrpc.rs
+++ b/vmm_tests/vmm_tests/tests/tests/ttrpc.rs
@@ -665,6 +665,243 @@ fn test_ttrpc_interface(
     })
 }
 
+petri::test!(test_ttrpc_uefi_boot, |resolver| {
+    let openvmm = resolver.require(artifacts::OPENVMM_NATIVE);
+    let (firmware, guest_disk) = match petri_artifacts_common::tags::MachineArch::host() {
+        petri_artifacts_common::tags::MachineArch::X86_64 => (
+            resolver
+                .require(artifacts::loadable::UEFI_FIRMWARE_X64)
+                .erase(),
+            resolver
+                .require(artifacts::test_vhd::GUEST_TEST_UEFI_X64)
+                .erase(),
+        ),
+        petri_artifacts_common::tags::MachineArch::Aarch64 => (
+            resolver
+                .require(artifacts::loadable::UEFI_FIRMWARE_AARCH64)
+                .erase(),
+            resolver
+                .require(artifacts::test_vhd::GUEST_TEST_UEFI_AARCH64)
+                .erase(),
+        ),
+    };
+    Some([openvmm.erase(), firmware, guest_disk])
+});
+
+/// Boots a VM with UEFI firmware over ttrpc, using the `guest_test_uefi` image
+/// as the boot disk on a vmbus SCSI controller.
+///
+/// The `guest_test_uefi` EFI application prints its banner to the UEFI console,
+/// which the firmware routes to COM1. Seeing that banner proves the firmware
+/// loaded, enumerated the SCSI disk, and launched the application off of it --
+/// rather than merely proving the firmware started.
+fn test_ttrpc_uefi_boot(
+    params: petri::PetriTestParams<'_>,
+    [openvmm, firmware_path, guest_disk_path]: [ResolvedArtifact; 3],
+) -> anyhow::Result<()> {
+    let tempdir = tempfile::tempdir()?;
+    let socket_path = tempdir.path().join("ttrpc.sock");
+    let pidfile_path = tempdir.path().join("openvmm.pid");
+    let com1_path = tempdir.path().join("com1.sock");
+
+    DefaultPool::run_with(async |driver| {
+        let (mut child, client, _stderr_task) =
+            launch_openvmm(&driver, &params, &openvmm, &socket_path, &pidfile_path).await?;
+
+        client
+            .call()
+            .start(
+                vmservice::Vm::CreateVm,
+                vmservice::CreateVmRequest {
+                    config: Some(vmservice::VmConfig {
+                        memory_config: Some(vmservice::MemoryConfig {
+                            memory_mb: 512,
+                            ..Default::default()
+                        }),
+                        processor_config: Some(vmservice::ProcessorConfig {
+                            processor_count: 1,
+                            ..Default::default()
+                        }),
+                        boot_config: Some(vmservice::vm_config::BootConfig::Uefi(
+                            vmservice::Uefi {
+                                firmware_path: firmware_path.get().to_string_lossy().to_string(),
+                            },
+                        )),
+                        serial_config: Some(vmservice::SerialConfig {
+                            ports: vec![vmservice::serial_config::Config {
+                                port: 0,
+                                socket_path: com1_path.to_string_lossy().into(),
+                                connect: false,
+                            }],
+                        }),
+                        devices_config: Some(vmservice::DevicesConfig {
+                            scsi_disks: vec![vmservice::ScsiDisk {
+                                controller: 0,
+                                lun: 0,
+                                host_path: guest_disk_path.get().to_string_lossy().to_string(),
+                                read_only: true,
+                                ..Default::default()
+                            }],
+                            ..Default::default()
+                        }),
+                        ..Default::default()
+                    }),
+                    log_id: String::new(),
+                },
+            )
+            .await
+            .unwrap();
+
+        let com1 = PolledSocket::new(&driver, UnixStream::connect(&com1_path)?)?;
+
+        // Drain COM1 for as long as the VM is alive, rather than stopping once
+        // the banner shows up. The 16550 only reports its transmit holding
+        // register empty once the backend has taken the data, so a guest that
+        // keeps printing with nothing draining the socket stalls indefinitely.
+        let (marker_send, marker_recv) = mesh::oneshot();
+        let _com1_task = driver.spawn(
+            "com1",
+            log_serial(
+                params.logger.log_file("uefi")?,
+                com1,
+                UEFI_BANNER,
+                marker_send,
+            ),
+        );
+
+        // Start waiting for the halt before resuming, so that a guest that
+        // reaches the end of its run quickly cannot beat us to it.
+        let waiter = client.call().start(vmservice::Vm::WaitVm, ());
+
+        client
+            .call()
+            .start(vmservice::Vm::ResumeVm, ())
+            .await
+            .unwrap();
+
+        // The firmware takes a while to initialize and enumerate the SCSI
+        // controller before it can launch anything off of the disk.
+        CancelContext::new()
+            .with_timeout(Duration::from_secs(120))
+            .until_cancelled(marker_recv)
+            .await
+            .context("timed out waiting for the guest UEFI application to run")?
+            .context("com1 closed before the guest UEFI application ran")?;
+
+        // `guest_test_uefi` deliberately triple faults once it has finished its
+        // run, so waiting for the halt confirms the guest ran to completion
+        // rather than just reaching its first line of output.
+        CancelContext::new()
+            .with_timeout(Duration::from_secs(120))
+            .until_cancelled(waiter)
+            .await
+            .context("timed out waiting for the guest to halt")?
+            .unwrap();
+
+        let props = client
+            .call()
+            .start(
+                vmservice::Vm::PropertiesVm,
+                vmservice::PropertiesVmRequest { types: Vec::new() },
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            props.state,
+            vmservice::VmState::Halted as i32,
+            "guest triple faulted, expected HALTED"
+        );
+        let halt_reason = props.halt_reason.unwrap_or_default();
+        assert!(
+            halt_reason.contains("TripleFault"),
+            "expected a triple fault halt, got {halt_reason:?}"
+        );
+
+        // Tearing down a VM that has a SCSI controller used to hang here, so
+        // this also covers that: the teardown has to drop the controller's
+        // request channel before waiting for the VM worker to stop.
+        client
+            .call()
+            .start(vmservice::Vm::TeardownVm, ())
+            .await
+            .unwrap();
+
+        let _ = client.call().start(vmservice::Vm::Quit, ()).await;
+
+        let exit_status = child.wait().await?;
+        tracing::info!(?exit_status, "openvmm exited");
+        assert!(
+            exit_status.success(),
+            "openvmm exited abnormally: {:?}",
+            exit_status
+        );
+
+        Ok(())
+    })
+}
+
+/// The first thing `guest_test_uefi` prints once the firmware hands off to it.
+const UEFI_BANNER: &str = "UEFI vendor =";
+
+/// Logs everything read from `reader` until the stream ends, signalling
+/// `marker_send` the first time `marker` appears in the output.
+///
+/// This keeps running after the marker is seen: the guest stalls if its serial
+/// output is not drained, so the reader has to stay attached for the lifetime
+/// of the VM.
+async fn log_serial(
+    log_file: petri::PetriLogFile,
+    mut reader: impl futures::AsyncRead + Unpin,
+    marker: &str,
+    marker_send: mesh::OneshotSender<()>,
+) {
+    let mut marker_send = Some(marker_send);
+    // Only the text before the marker needs to be retained, to spot a marker
+    // split across two reads.
+    let mut seen = String::new();
+    let mut pending = String::new();
+    let mut buf = [0u8; 256];
+    loop {
+        let n = match reader.read(&mut buf).await {
+            Ok(0) => break,
+            Ok(n) => n,
+            Err(err) => {
+                tracing::warn!(
+                    error = &err as &dyn std::error::Error,
+                    "error reading from com1"
+                );
+                break;
+            }
+        };
+
+        let chunk = String::from_utf8_lossy(&buf[..n]);
+
+        // Log whole lines only, so that partial reads don't split log entries.
+        pending.push_str(&chunk);
+        while let Some(i) = pending.find('\n') {
+            let line: String = pending.drain(..=i).collect();
+            log_file.write_entry(line.trim_end());
+        }
+
+        if let Some(send) = marker_send.take() {
+            seen.push_str(&chunk);
+            if seen.contains(marker) {
+                seen = String::new();
+                send.send(());
+            } else {
+                // Keep just enough context to match a marker spanning reads.
+                let keep = seen.len().saturating_sub(marker.len() - 1);
+                seen.drain(..keep);
+                marker_send = Some(send);
+            }
+        }
+    }
+
+    if !pending.trim_end().is_empty() {
+        log_file.write_entry(pending.trim_end());
+    }
+}
+
 /// Wraps a `PcieDeviceKind` as a device attachment behind a PCIe port.
 fn attachment_device(device: vmservice::PcieDeviceKind) -> vmservice::PcieAttachment {
     vmservice::PcieAttachment {

--- a/vmm_tests/vmm_tests/tests/tests/ttrpc.rs
+++ b/vmm_tests/vmm_tests/tests/tests/ttrpc.rs
@@ -732,7 +732,14 @@ fn test_ttrpc_uefi_boot(
                                 secure_boot_enabled: false,
                             },
                         )),
-                        guest_reset_action: vmservice::vm_config::GuestResetAction::Halt as i32,
+                        // The UEFI watchdog that ends `guest_test_uefi` reports
+                        // a reset on aarch64 but a triple fault on x64, so halt
+                        // on both rather than rebooting forever.
+                        guest_power_actions: Some(vmservice::vm_config::GuestPowerActions {
+                            reset: vmservice::vm_config::GuestPowerAction::Halt as i32,
+                            watchdog: vmservice::vm_config::GuestPowerAction::Halt as i32,
+                            ..Default::default()
+                        }),
                         serial_config: Some(vmservice::SerialConfig {
                             ports: vec![vmservice::serial_config::Config {
                                 port: 0,


### PR DESCRIPTION
CreateVM rejected any UEFI boot configuration outright, so the ttrpc interface could only start Linux direct-boot VMs. Wire up UEFI: the boot configuration now selects the base chipset alongside the load mode, since the firmware and device model must agree on the platform, and a UEFI boot attaches the helper device that provides the variable store and runtime services. Serial setup moves ahead of boot configuration so the firmware console can be enabled only when a port is configured and routed to COM1 when available; otherwise firmware in a VM without a graphics adapter has nowhere to write.

Extend the UEFI configuration with initial variables that are applied only when the variable store is empty. Callers can select the Microsoft Windows or Microsoft UEFI CA Secure Boot variable template independently from the Secure Boot policy boolean, so key enrollment and signature enforcement remain separate choices. The store remains ephemeral for now. The proto also removes `device_path` and `optional_data`, which had no OpenVMM equivalent and were never honored, while reserving their field numbers and names.

Add a guest reset action so callers can choose whether a guest reset automatically restarts the VM or leaves it halted. This is needed to observe completion consistently across architectures because the UEFI test image ends with a triple fault on x64 and a reset on aarch64.

Add a test that boots the `guest_test_uefi` image from a VMBus SCSI disk, initializes the Windows Secure Boot variables while leaving enforcement disabled, and waits for its banner on COM1. Seeing the banner proves the firmware started, enumerated the disk, and launched the application; observing the architecture-specific halt then proves the application completed. The test also covers clean teardown of a VM with a SCSI controller.