### PR TITLE
nvme: drop shadow doorbell registration on controller reset

### DIFF
--- a/vm/devices/storage/nvme/src/queue.rs
+++ b/vm/devices/storage/nvme/src/queue.rs
@@ -60,6 +60,19 @@ impl DoorbellMemory {
         Ok(())
     }
 
+    /// Drop any shadow doorbell registration and go back to controller-internal
+    /// doorbell storage.
+    ///
+    /// The shadow doorbell and event index buffers only live until the next
+    /// controller reset, after which the host must re-issue Doorbell Buffer
+    /// Config. Continuing to use them would read and write guest pages that the
+    /// guest has since freed and reused.
+    pub fn reset(&mut self) {
+        self.mem = GuestMemory::allocate(self.wakers.len() << DOORBELL_STRIDE_BITS);
+        self.offset = 0;
+        self.event_idx_offset = None;
+    }
+
     pub fn try_write(&self, db_id: u16, value: u32) -> Result<(), InvalidDoorbell> {
         if (db_id as usize) >= self.wakers.len() {
             return Err(InvalidDoorbell);

--- a/vm/devices/storage/nvme/src/tests/shadow_doorbell_tests.rs
+++ b/vm/devices/storage/nvme/src/tests/shadow_doorbell_tests.rs
@@ -233,6 +233,70 @@ async fn test_setup_sq_ring_with_shadow(driver: DefaultDriver) {
     assert_eq!(sq_evt_idx, new_sq_db);
 }
 
+/// A controller reset ends the lifetime of the shadow doorbell and event index
+/// buffers. If the controller keeps using them, it writes into pages the guest
+/// has since freed and reused, corrupting guest memory.
+#[async_test]
+async fn test_shadow_doorbells_dropped_on_controller_reset(driver: DefaultDriver) {
+    let cq_buf = PrpRange::new(vec![CQ_BASE], 0, PAGE_SIZE64).unwrap();
+    let sq_buf = PrpRange::new(vec![SQ_BASE], 0, PAGE_SIZE64).unwrap();
+    let gm = test_memory();
+    let int_controller = TestPciInterruptController::new();
+    let mut backoff = Backoff::new(&driver);
+
+    let mut nvmec =
+        setup_shadow_doorbells(driver.clone(), &cq_buf, &sq_buf, &gm, &int_controller, None).await;
+
+    // Reset the controller by clearing CC.EN, and wait for CSTS.RDY to clear.
+    let mut dword = 0u32;
+    nvmec.read_bar0(0x14, dword.as_mut_bytes()).unwrap();
+    dword &= !1;
+    nvmec.write_bar0(0x14, dword.as_bytes()).unwrap();
+    let mut reset = false;
+    for _ in 0..5 {
+        nvmec.read_bar0(0x1c, dword.as_mut_bytes()).unwrap();
+        if !spec::Csts::from(dword).rdy() {
+            reset = true;
+            break;
+        }
+        backoff.back_off().await;
+    }
+    assert!(reset);
+
+    // Stand in for the guest freeing the buffers and handing the pages to
+    // something else.
+    const SENTINEL: u64 = 0x0123_4567_89ab_cdef;
+    gm.write_plain::<u64>(DOORBELL_BUFFER_BASE, &SENTINEL)
+        .unwrap();
+    gm.write_plain::<u64>(EVT_IDX_BUFFER_BASE, &SENTINEL)
+        .unwrap();
+
+    // Re-enable the controller, which rebuilds the admin queues.
+    nvmec.read_bar0(0x14, dword.as_mut_bytes()).unwrap();
+    dword |= 1;
+    nvmec.write_bar0(0x14, dword.as_bytes()).unwrap();
+    let mut ready = false;
+    for _ in 0..5 {
+        nvmec.read_bar0(0x1c, dword.as_mut_bytes()).unwrap();
+        if spec::Csts::from(dword).rdy() {
+            ready = true;
+            break;
+        }
+        backoff.back_off().await;
+    }
+    assert!(ready);
+
+    // Ring the admin submission queue doorbell without advancing it.
+    nvmec.write_bar0(0x1000, 0u32.as_bytes()).unwrap();
+    backoff.back_off().await;
+
+    assert_eq!(
+        gm.read_plain::<u64>(DOORBELL_BUFFER_BASE).unwrap(),
+        SENTINEL
+    );
+    assert_eq!(gm.read_plain::<u64>(EVT_IDX_BUFFER_BASE).unwrap(), SENTINEL);
+}
+
 #[async_test]
 async fn test_update_data_queues_with_shadow_doorbells(driver: DefaultDriver) {
     let cq_buf = PrpRange::new(vec![CQ_BASE], 0, PAGE_SIZE64).unwrap();

--- a/vm/devices/storage/nvme/src/workers/coordinator.rs
+++ b/vm/devices/storage/nvme/src/workers/coordinator.rs
@@ -147,6 +147,10 @@ impl NvmeWorkers {
         if let EnableState::Resetting(recv) = &mut self.state {
             if recv.now_or_never().is_some() {
                 self.state = EnableState::Disabled;
+                // The shadow doorbell buffers the guest registered are only
+                // valid until this reset; the guest is free to reuse those
+                // pages now.
+                self.doorbells.write().reset();
                 true
             } else {
                 false
@@ -174,6 +178,7 @@ impl NvmeWorkers {
                 }
             }
         }
+        self.doorbells.write().reset();
     }
 }
 

--- a/vm/devices/storage/nvme_test/src/queue.rs
+++ b/vm/devices/storage/nvme_test/src/queue.rs
@@ -60,6 +60,19 @@ impl DoorbellMemory {
         Ok(())
     }
 
+    /// Drop any shadow doorbell registration and go back to controller-internal
+    /// doorbell storage.
+    ///
+    /// The shadow doorbell and event index buffers only live until the next
+    /// controller reset, after which the host must re-issue Doorbell Buffer
+    /// Config. Continuing to use them would read and write guest pages that the
+    /// guest has since freed and reused.
+    pub fn reset(&mut self) {
+        self.mem = GuestMemory::allocate(self.wakers.len() << DOORBELL_STRIDE_BITS);
+        self.offset = 0;
+        self.event_idx_offset = None;
+    }
+
     pub fn try_write(&self, db_id: u16, value: u32) -> Result<(), InvalidDoorbell> {
         if (db_id as usize) >= self.wakers.len() {
             return Err(InvalidDoorbell);

--- a/vm/devices/storage/nvme_test/src/workers/coordinator.rs
+++ b/vm/devices/storage/nvme_test/src/workers/coordinator.rs
@@ -150,6 +150,10 @@ impl NvmeWorkers {
         if let EnableState::Resetting(recv) = &mut self.state {
             if recv.now_or_never().is_some() {
                 self.state = EnableState::Disabled;
+                // The shadow doorbell buffers the guest registered are only
+                // valid until this reset; the guest is free to reuse those
+                // pages now.
+                self.doorbells.write().reset();
                 true
             } else {
                 false
@@ -177,6 +181,7 @@ impl NvmeWorkers {
                 }
             }
         }
+        self.doorbells.write().reset();
     }
 }
 


### PR DESCRIPTION
## Problem

`multiarch::pcie::openvmm_linux_x64_pcie_hotplug` intermittently times out
(CI run 30466297922). After the test's reboot, the guest hits a
`BUG: kernel NULL pointer dereference` in `nvme_probe` and never reaches
init, so pipette never reconnects and petri times out after 10 minutes.

## Root cause

`DoorbellMemory` is shared out of `NvmeWorkers` via an `Arc<RwLock<..>>` and
was never restored on reset. Once the guest issued Doorbell Buffer Config,
`replace_mem` repointed it at guest pages and nothing ever pointed it back —
so after a reboot the emulator kept reading and writing the *previous boot's*
DBBUF pages. This violates NVMe Base 5.8, which ends the lifetime of the
Shadow Doorbell and EventIdx buffers at a Controller Level Reset.

The corruption is deterministic: on the next `CC.EN 0→1`,
`SubmissionQueue::new` (db_id 0) and `CompletionQueue::new` (db_id 1) each
write `0`, which with a 4-byte doorbell stride zeroes the first 8 bytes of the
stale page — a full 64-bit NULL wherever the new kernel happened to place a
pointer. Whether that crashes the guest depends on what the page was reused
for, which is where the flakiness comes from.

The failing run's `timeout_inspect_vmm.log` shows the fingerprint directly:
the stale doorbell page reads `[0, 0]` while the stale EventIdx page still
holds boot 1's `[11, 4]`, because the emulator only writes EventIdx when it
probes forward.

## Fix

- `DoorbellMemory::reset()` reallocates the controller-internal doorbell
  storage and clears `event_idx_offset`.
- Called when a controller reset completes (`poll_controller_reset`) and at
  the end of a device-level `reset`. Both paths matter: Linux's reboot uses
  `CC.SHN` and leaves `CC.EN` set, so only the device reset runs on a guest
  reboot.
- Mirrored in the `nvme_test` fault-injection copy of the emulator.

## Testing

New `test_shadow_doorbells_dropped_on_controller_reset` verifies that a
sentinel written into the guest's DBBUF pages after a controller reset
survives a re-enable and a doorbell write. Confirmed to fail without the fix
(`left: 0, right: 0x0123456789abcdef`) and stable over repeated runs.
`cargo nextest`, `clippy --all-targets`, `cargo doc`, and `cargo xtask fmt`
pass for `nvme` and `nvme_test`.